### PR TITLE
chore: org switching fixes

### DIFF
--- a/server/src/internal/orgs/handlers/crudHandlers/handleGetOrg.ts
+++ b/server/src/internal/orgs/handlers/crudHandlers/handleGetOrg.ts
@@ -1,11 +1,40 @@
+import { AppEnv } from "@autumn/shared";
 import { createRoute } from "../../../../honoMiddlewares/routeHandler.js";
-import { createOrgResponse } from "../../orgUtils.js";
+import { isDeploymentApiKeyMeta } from "../../orgDeploymentUtils.js";
+import { createOrgResponse, isStripeConnected } from "../../orgUtils.js";
 
 export const handleGetOrg = createRoute({
 	scopes: [],
 	handler: async (c) => {
 		const ctx = c.get("ctx");
-		const { org, env } = ctx;
-		return c.json(createOrgResponse({ org, env }));
+		const { db, org, env } = ctx;
+		const response = createOrgResponse({ org, env });
+
+		if (!response.deployed) {
+			const [liveProduct, liveFeature, liveApiKeys] = await Promise.all([
+				db.query.products.findFirst({
+					columns: { internal_id: true },
+					where: (products, { and, eq }) =>
+						and(eq(products.org_id, org.id), eq(products.env, AppEnv.Live)),
+				}),
+				db.query.features.findFirst({
+					columns: { internal_id: true },
+					where: (features, { and, eq }) =>
+						and(eq(features.org_id, org.id), eq(features.env, AppEnv.Live)),
+				}),
+				db.query.apiKeys.findMany({
+					columns: { id: true, meta: true },
+					where: (apiKeys, { and, eq }) =>
+						and(eq(apiKeys.org_id, org.id), eq(apiKeys.env, AppEnv.Live)),
+				}),
+			]);
+			response.deployed =
+				!!liveProduct ||
+				!!liveFeature ||
+				liveApiKeys.some((key) => isDeploymentApiKeyMeta(key.meta)) ||
+				isStripeConnected({ org, env: AppEnv.Live });
+		}
+
+		return c.json(response);
 	},
 });

--- a/server/src/internal/orgs/orgDeploymentUtils.ts
+++ b/server/src/internal/orgs/orgDeploymentUtils.ts
@@ -1,0 +1,8 @@
+export const isDeploymentApiKeyMeta = (meta: unknown) => {
+	const value = meta && typeof meta === "object" ? meta : {};
+	return (
+		(value as { fromCli?: unknown }).fromCli !== true &&
+		(value as { fromCli?: unknown }).fromCli !== "true" &&
+		(value as { created_via?: unknown }).created_via !== "oauth"
+	);
+};

--- a/server/src/internal/products/handlers/handleCopyEnvironment/handleCopyEnvironment.ts
+++ b/server/src/internal/products/handlers/handleCopyEnvironment/handleCopyEnvironment.ts
@@ -1,6 +1,7 @@
 import { AppEnv, Scopes } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { FeatureService } from "@/internal/features/FeatureService.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
 import { invalidateProductsCache } from "../../productCacheUtils.js";
 import { handleCopyFeatures } from "./handleCopyFeatures.js";
 import { handleCopyProducts } from "./handleCopyProducts.js";
@@ -47,7 +48,10 @@ export const handleCopyEnvironment = createRoute({
 			toEnv,
 		});
 
-		await invalidateProductsCache({ orgId: org.id, env: toEnv });
+		await Promise.all([
+			OrgService.update({ db, orgId: org.id, updates: { deployed: true } }),
+			invalidateProductsCache({ orgId: org.id, env: toEnv }),
+		]);
 
 		return c.json({
 			message: "Products copied to production",

--- a/server/src/utils/authUtils/beforeSessionCreated.ts
+++ b/server/src/utils/authUtils/beforeSessionCreated.ts
@@ -1,6 +1,6 @@
 import { member } from "@autumn/shared";
 import type { Session } from "better-auth";
-import { eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { db } from "@/db/initDrizzle.js";
 import { createDefaultOrg } from "@/utils/authUtils/createDefaultOrg.js";
 
@@ -10,6 +10,7 @@ export const beforeSessionCreated = async (session: Session) => {
 
 		const membership = await db.query.member.findFirst({
 			where: eq(member.userId, session.userId),
+			orderBy: [desc(member.createdAt)],
 		});
 
 		if (membership) {

--- a/server/tests/unit/orgs/orgDeploymentUtils.test.ts
+++ b/server/tests/unit/orgs/orgDeploymentUtils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { isDeploymentApiKeyMeta } from "@/internal/orgs/orgDeploymentUtils";
+
+describe("isDeploymentApiKeyMeta", () => {
+	test("allows dashboard-created live keys", () => {
+		expect(isDeploymentApiKeyMeta({ author: "Charlie" })).toBe(true);
+		expect(isDeploymentApiKeyMeta({ created_via: "autumn_support" })).toBe(
+			true,
+		);
+	});
+
+	test("ignores auto-generated CLI and OAuth keys", () => {
+		expect(isDeploymentApiKeyMeta({ fromCli: true })).toBe(false);
+		expect(isDeploymentApiKeyMeta({ fromCli: "true" })).toBe(false);
+		expect(isDeploymentApiKeyMeta({ created_via: "oauth" })).toBe(false);
+	});
+});

--- a/vite/src/App.tsx
+++ b/vite/src/App.tsx
@@ -4,6 +4,7 @@ import { init } from "@squircle/core";
 import * as React from "react";
 import { useEffect } from "react";
 import { BrowserRouter, Route, Routes } from "react-router";
+import { DashboardGate } from "./app/DashboardGate";
 import { MainLayout } from "./app/layout";
 import { OnboardingLayout } from "./app/OnboardingLayout";
 import { useSession } from "./lib/auth-client";
@@ -36,6 +37,19 @@ function SquircleProvider({ children }: { children: React.ReactNode }) {
 	React.useEffect(() => void init(), []);
 	return children;
 }
+
+const envRoutes = (
+	path: string,
+	element: React.ReactNode,
+	sandboxElement = element,
+) => [
+	<Route key={path} path={`/${path}`} element={element} />,
+	<Route
+		key={`sandbox-${path}`}
+		path={`/sandbox/${path}`}
+		element={sandboxElement}
+	/>,
+];
 
 export default function App() {
 	const { data } = useSession();
@@ -79,84 +93,40 @@ export default function App() {
 					<Route path="/sandbox/quickstart" element={<QuickstartView />} />
 				</Route>
 
-				<Route element={<MainLayout />}>
-					<Route path="*" element={<DefaultView />} />
-					<Route path="/settings" element={<SettingsView />} />
-					<Route path="/sandbox/settings" element={<SettingsView />} />
-					<Route path="/admin" element={<AdminView />} />
-					<Route path="/sandbox/admin" element={<AdminView />} />
-					<Route path="/admin/oauth" element={<OAuthClientsView />} />
-					<Route path="/sandbox/admin/oauth" element={<OAuthClientsView />} />
-					<Route path="/admin/edge-config" element={<EdgeConfigView />} />
-					<Route
-						path="/sandbox/admin/edge-config"
-						element={<EdgeConfigView />}
-					/>
-					<Route
-						path="/sandbox/impersonate-redirect"
-						element={<ImpersonateRedirect />}
-					/>
-					<Route
-						path="/impersonate-redirect"
-						element={<ImpersonateRedirect />}
-					/>
-					<Route path="/trmnl" element={<TerminalView />} />
+				<Route element={<DashboardGate />}>
+					<Route element={<MainLayout />}>
+						<Route path="*" element={<DefaultView />} />
+						{envRoutes("settings", <SettingsView />)}
+						{envRoutes("admin", <AdminView />)}
+						{envRoutes("admin/oauth", <OAuthClientsView />)}
+						{envRoutes("admin/edge-config", <EdgeConfigView />)}
+						{envRoutes("impersonate-redirect", <ImpersonateRedirect />)}
+						<Route path="/trmnl" element={<TerminalView />} />
 
-					<Route
-						path="/products"
-						element={<ProductsView env={AppEnv.Live} />}
-					/>
-					<Route
-						path="/sandbox/products"
-						element={<ProductsView env={AppEnv.Sandbox} />}
-					/>
-					<Route path="/migrations" element={<MigrationsView />} />
-					<Route path="/sandbox/migrations" element={<MigrationsView />} />
-					<Route path="/migrations/:migration_id" element={<MigrationView />} />
-					<Route
-						path="/sandbox/migrations/:migration_id"
-						element={<MigrationView />}
-					/>
-					<Route
-						path="/products/:product_id"
-						element={
+						{envRoutes(
+							"products",
+							<ProductsView env={AppEnv.Live} />,
+							<ProductsView env={AppEnv.Sandbox} />,
+						)}
+						{envRoutes("migrations", <MigrationsView />)}
+						{envRoutes("migrations/:migration_id", <MigrationView />)}
+						{envRoutes(
+							"products/:product_id",
 							<SquircleProvider>
 								<PlanEditorView />
-							</SquircleProvider>
-						}
-					/>
-					<Route
-						path="/sandbox/products/:product_id"
-						element={
-							<SquircleProvider>
-								<PlanEditorView />
-							</SquircleProvider>
-						}
-					/>
+							</SquircleProvider>,
+						)}
 
-					<Route path="/customers" element={<CustomersPage />} />
-					<Route path="/sandbox/customers" element={<CustomersPage />} />
-					<Route path="/customers/:customer_id" element={<CustomerView2 />} />
-					<Route
-						path="/sandbox/customers/:customer_id"
-						element={<CustomerView2 />}
-					/>
-					<Route
-						path="/customers/:customer_id/:product_id"
-						// element={<CustomerProductView />}
-						element={<CustomerPlanEditor />}
-					/>
-					<Route
-						path="/sandbox/customers/:customer_id/:product_id"
-						// element={<CustomerProductView />}
-						element={<CustomerPlanEditor />}
-					/>
-					<Route path="/dev" element={<DevScreen />} />
-					<Route path="/sandbox/dev" element={<DevScreen />} />
-					<Route path="/analytics" element={<AnalyticsView />} />
-					<Route path="/sandbox/analytics" element={<AnalyticsView />} />
-					<Route path="/dev/cli" element={<Otp />} />
-					<Route path="/sandbox/dev/cli" element={<Otp />} />
+						{envRoutes("customers", <CustomersPage />)}
+						{envRoutes("customers/:customer_id", <CustomerView2 />)}
+						{envRoutes(
+							"customers/:customer_id/:product_id",
+							<CustomerPlanEditor />,
+						)}
+						{envRoutes("dev", <DevScreen />)}
+						{envRoutes("analytics", <AnalyticsView />)}
+						{envRoutes("dev/cli", <Otp />)}
+					</Route>
 				</Route>
 			</Routes>
 		</BrowserRouter>

--- a/vite/src/app/DashboardGate.tsx
+++ b/vite/src/app/DashboardGate.tsx
@@ -1,0 +1,57 @@
+import { Navigate, Outlet, useLocation } from "react-router";
+import { useEffect, useState } from "react";
+import {
+	getLastSwitchedOrgId,
+	useOrg,
+	useSwitchActiveOrg,
+} from "@/hooks/common/useOrg";
+import { useListOrganizations, useSession } from "@/lib/auth-client";
+import { getOrgRouteRedirect } from "@/utils/genUtils";
+import LoadingScreen from "@/views/general/LoadingScreen";
+
+export const DashboardGate = () => {
+	const { pathname, search } = useLocation();
+	const { data: session, isPending: sessionLoading } = useSession();
+	const { data: orgList, isPending: orgListLoading } = useListOrganizations();
+	const switchActiveOrg = useSwitchActiveOrg();
+	const { org, isLoading: orgLoading } = useOrg();
+	const [switchingToLastOrg, setSwitchingToLastOrg] = useState(false);
+	const lastOrgId = getLastSwitchedOrgId();
+	const activeOrgId = session?.session.activeOrganizationId;
+	const shouldSwitchToLastOrg =
+		!!lastOrgId &&
+		!!activeOrgId &&
+		lastOrgId !== activeOrgId &&
+		!!orgList?.some((org) => org.id === lastOrgId);
+
+	useEffect(() => {
+		if (!lastOrgId || !shouldSwitchToLastOrg || switchingToLastOrg) return;
+
+		setSwitchingToLastOrg(true);
+		switchActiveOrg(lastOrgId).finally(() => {
+			setSwitchingToLastOrg(false);
+		});
+	}, [
+		lastOrgId,
+		shouldSwitchToLastOrg,
+		switchActiveOrg,
+		switchingToLastOrg,
+	]);
+
+	if (sessionLoading) return <LoadingScreen fullPage />;
+	if (!session) return <Navigate to="/sign-in" replace />;
+	if (orgListLoading || shouldSwitchToLastOrg || switchingToLastOrg) {
+		return <LoadingScreen fullPage />;
+	}
+	if (orgLoading) return <LoadingScreen fullPage />;
+	if (!org) return <LoadingScreen fullPage />;
+
+	const redirect = getOrgRouteRedirect({
+		pathname,
+		search,
+		deployed: org.deployed,
+	});
+	if (redirect) return <Navigate to={redirect} replace />;
+
+	return <Outlet />;
+};

--- a/vite/src/app/DashboardGate.tsx
+++ b/vite/src/app/DashboardGate.tsx
@@ -15,7 +15,7 @@ export const DashboardGate = () => {
 	const { data: session, isPending: sessionLoading } = useSession();
 	const { data: orgList, isPending: orgListLoading } = useListOrganizations();
 	const switchActiveOrg = useSwitchActiveOrg();
-	const { org, isLoading: orgLoading } = useOrg();
+	const { org, isLoading: orgLoading, error: orgError } = useOrg();
 	const [switchingToLastOrg, setSwitchingToLastOrg] = useState(false);
 	const [ignoredLastOrgId, setIgnoredLastOrgId] = useState<string | null>(null);
 	const lastOrgId = getLastSwitchedOrgId();
@@ -58,6 +58,24 @@ export const DashboardGate = () => {
 		return <LoadingScreen fullPage />;
 	}
 	if (orgLoading) return <LoadingScreen fullPage />;
+	if (orgError) {
+		return (
+			<div className="flex min-h-screen w-full items-center justify-center">
+				<div className="flex max-w-sm flex-col items-center gap-3 text-center">
+					<p className="text-sm text-muted-foreground">
+						We couldn't load your organization.
+					</p>
+					<button
+						type="button"
+						className="text-sm text-tertiary-foreground hover:underline"
+						onClick={() => window.location.reload()}
+					>
+						Refresh
+					</button>
+				</div>
+			</div>
+		);
+	}
 	if (!org) return <LoadingScreen fullPage />;
 
 	const redirect = getOrgRouteRedirect({

--- a/vite/src/app/DashboardGate.tsx
+++ b/vite/src/app/DashboardGate.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Outlet, useLocation } from "react-router";
 import { useEffect, useState } from "react";
 import {
+	clearLastSwitchedOrgId,
 	getLastSwitchedOrgId,
 	useOrg,
 	useSwitchActiveOrg,
@@ -16,10 +17,12 @@ export const DashboardGate = () => {
 	const switchActiveOrg = useSwitchActiveOrg();
 	const { org, isLoading: orgLoading } = useOrg();
 	const [switchingToLastOrg, setSwitchingToLastOrg] = useState(false);
+	const [ignoredLastOrgId, setIgnoredLastOrgId] = useState<string | null>(null);
 	const lastOrgId = getLastSwitchedOrgId();
 	const activeOrgId = session?.session.activeOrganizationId;
 	const shouldSwitchToLastOrg =
 		!!lastOrgId &&
+		lastOrgId !== ignoredLastOrgId &&
 		!!activeOrgId &&
 		lastOrgId !== activeOrgId &&
 		!!orgList?.some((org) => org.id === lastOrgId);
@@ -27,11 +30,22 @@ export const DashboardGate = () => {
 	useEffect(() => {
 		if (!lastOrgId || !shouldSwitchToLastOrg || switchingToLastOrg) return;
 
-		setSwitchingToLastOrg(true);
-		switchActiveOrg(lastOrgId).finally(() => {
-			setSwitchingToLastOrg(false);
-		});
+		const switchToLastOrg = async () => {
+			setSwitchingToLastOrg(true);
+			try {
+				await switchActiveOrg(lastOrgId);
+			} catch (error) {
+				console.warn("Failed to switch to remembered org", error);
+				clearLastSwitchedOrgId(lastOrgId);
+				setIgnoredLastOrgId(lastOrgId);
+			} finally {
+				setSwitchingToLastOrg(false);
+			}
+		};
+
+		switchToLastOrg();
 	}, [
+		ignoredLastOrgId,
 		lastOrgId,
 		shouldSwitchToLastOrg,
 		switchActiveOrg,

--- a/vite/src/app/layout.tsx
+++ b/vite/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { ArrowRightIcon } from "@phosphor-icons/react";
 import { AutumnProvider } from "autumn-js/react";
 import { NuqsAdapter } from "nuqs/adapters/react-router/v7";
 import { useEffect, useRef, useState } from "react";
-import { Navigate, Outlet, useNavigate } from "react-router";
+import { Outlet } from "react-router";
 import { CustomToaster } from "@/components/general/CustomToaster";
 import { SandboxBanner } from "@/components/general/SandboxBanner";
 import { IconButton } from "@/components/v2/buttons/IconButton";
@@ -11,11 +11,10 @@ import { PortalContainerContext } from "@/contexts/PortalContainerContext";
 import { useAutumnFlags } from "@/hooks/common/useAutumnFlags";
 import { useFeatureFlags } from "@/hooks/useFeatureFlags";
 import { useGlobalErrorHandler } from "@/hooks/common/useGlobalErrorHandler";
-import { getLastSwitchedOrgId, useOrg } from "@/hooks/common/useOrg";
+import { useOrg } from "@/hooks/common/useOrg";
 import { useDevQuery } from "@/hooks/queries/useDevQuery";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useRewardsQuery } from "@/hooks/queries/useRewardsQuery";
-import { useSession } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 import { useEnv } from "@/utils/envUtils";
 import CommandBar from "@/views/command-bar/CommandBar";
@@ -29,14 +28,9 @@ import { MobileTopBar } from "@/views/main-sidebar/MobileTopBar";
 import { AppContext } from "./AppContext";
 
 export function MainLayout() {
-	const env = useEnv();
-	const { data, isPending } = useSession();
-	const { org, isLoading: orgLoading } = useOrg();
 	const { handleApiError } = useGlobalErrorHandler();
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
-
-	const navigate = useNavigate();
 
 	// Global error handler for API errors
 	useEffect(() => {
@@ -49,51 +43,6 @@ export function MainLayout() {
 		window.addEventListener("error", handleGlobalError);
 		return () => window.removeEventListener("error", handleGlobalError);
 	}, [handleApiError]);
-
-	// Redirect to sign in if no session
-	useEffect(() => {
-		if (!isPending && !data) {
-			navigate("/sign-in");
-		}
-	}, [isPending, data, navigate]);
-
-	// Redirect to sandbox if not deployed
-	useEffect(() => {
-		if (!orgLoading && org && !org.deployed && env !== AppEnv.Sandbox) {
-			const lastSwitchedId = getLastSwitchedOrgId();
-			if (lastSwitchedId && org.id !== lastSwitchedId) return;
-			const pathname = window.location.pathname;
-			const search = window.location.search;
-			navigate(`/sandbox${pathname}${search}`);
-		}
-	}, [orgLoading, org, env, navigate]);
-
-	if (isPending) {
-		return (
-			<AutumnProvider
-				backendUrl={import.meta.env.VITE_BACKEND_URL}
-				includeCredentials={true}
-			>
-				<div className="w-screen h-screen flex bg-outer-background">
-					<div className="hidden sm:flex">
-						<MainSidebar />
-					</div>
-					<div className="w-full h-screen flex flex-col overflow-hidden sm:py-3 sm:pr-3">
-						<div className="w-full h-full flex flex-col overflow-hidden sm:rounded-lg sm:border">
-							{env === AppEnv.Sandbox && <SandboxBanner />}
-							<div className="flex bg-background flex-col h-full">
-								<LoadingScreen />
-							</div>
-						</div>
-					</div>
-				</div>
-			</AutumnProvider>
-		);
-	}
-
-	if (!data) {
-		return <Navigate to="/sign-in" replace={true} />;
-	}
 
 	return (
 		<AutumnProvider

--- a/vite/src/hooks/common/useGlobalErrorHandler.tsx
+++ b/vite/src/hooks/common/useGlobalErrorHandler.tsx
@@ -1,11 +1,10 @@
-import { AppEnv } from "@autumn/shared";
 import { useNavigate } from "react-router";
 import { authClient } from "@/lib/auth-client";
-import { useEnv } from "@/utils/envUtils";
+import { useSwitchActiveOrg } from "./useOrg";
 
 export const useGlobalErrorHandler = () => {
 	const navigate = useNavigate();
-	const env = useEnv();
+	const switchActiveOrg = useSwitchActiveOrg();
 
 	const handleOrganizationRemoval = async (orgId: string) => {
 		try {
@@ -16,12 +15,8 @@ export const useGlobalErrorHandler = () => {
 				// User has other organizations, switch to the first available one
 				const nextOrg = organizations.find((org) => org.id !== orgId);
 				if (nextOrg) {
-					await authClient.organization.setActive({
-						organizationId: nextOrg.id,
-					});
-					// Redirect to products page of the new organization
-					const envPath = env === AppEnv.Sandbox ? "sandbox" : "production";
-					navigate(`/${envPath}/products`);
+					await switchActiveOrg(nextOrg.id);
+					navigate("/");
 					return true;
 				}
 			}

--- a/vite/src/hooks/common/useOrg.tsx
+++ b/vite/src/hooks/common/useOrg.tsx
@@ -1,7 +1,11 @@
 import type { AppEnv, FrontendOrg } from "@autumn/shared";
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
-import { useEffect } from "react";
-import { authClient, useListOrganizations } from "@/lib/auth-client";
+import {
+	keepPreviousData,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import { useCallback, useEffect } from "react";
+import { authClient, useListOrganizations, useSession } from "@/lib/auth-client";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { useEnv } from "@/utils/envUtils";
 
@@ -21,38 +25,48 @@ export const getLastSwitchedOrgId = (): string | null => {
 	}
 };
 
+export const useSwitchActiveOrg = () => {
+	const queryClient = useQueryClient();
+	const { refetch: refetchSession } = useSession();
+
+	return useCallback(async (orgId: string) => {
+		await authClient.organization.setActive({ organizationId: orgId });
+		setLastSwitchedOrgId(orgId);
+		await Promise.all([
+			refetchSession(),
+			queryClient.invalidateQueries({ queryKey: ["org"] }),
+		]);
+	}, [queryClient, refetchSession]);
+};
+
 export const useOrg = (params?: { env?: AppEnv }) => {
 	const currentEnv = useEnv();
 	const axiosInstance = useAxiosInstance({ env: params?.env });
-	const { data: orgList } = useListOrganizations();
+	const { data: orgList, isPending: orgListLoading } = useListOrganizations();
+	const { data: session } = useSession();
+	const activeOrgId = session?.session.activeOrganizationId;
 
 	const fetcher = async () => {
-		try {
-			const { data } = await axiosInstance.get("/organization");
-			return data;
-		} catch {
-			return null;
-		}
+		const { data } = await axiosInstance.get("/organization");
+		return data;
 	};
 
 	const {
 		data: org,
 		isLoading,
+		isPlaceholderData,
 		error,
 		refetch,
 	} = useQuery({
-		queryKey: params?.env ? ["org", params.env] : ["org", currentEnv],
+		queryKey: ["org", params?.env ?? currentEnv, activeOrgId],
 		queryFn: fetcher,
 		placeholderData: keepPreviousData,
 		refetchOnWindowFocus: true,
 		staleTime: 30_000,
+		enabled: !!activeOrgId,
 	});
-
-	useEffect(() => {
-		if (org?.id) {
-			setLastSwitchedOrgId(org.id);
-		}
-	}, [org?.id]);
+	const orgLoading =
+		!session || (!!activeOrgId && (isLoading || isPlaceholderData));
 
 	useEffect(() => {
 		const handleNoActiveOrg = async () => {
@@ -75,10 +89,15 @@ export const useOrg = (params?: { env?: AppEnv }) => {
 			window.location.reload();
 		};
 
-		if (!org && !isLoading) {
+		if (session && !activeOrgId && !orgListLoading) {
 			handleNoActiveOrg();
 		}
-	}, [org, orgList, isLoading]);
+	}, [activeOrgId, orgList, orgListLoading, session]);
 
-	return { org: org as FrontendOrg, isLoading, error, mutate: refetch };
+	return {
+		org: org as FrontendOrg,
+		isLoading: orgLoading,
+		error,
+		mutate: refetch,
+	};
 };

--- a/vite/src/hooks/common/useOrg.tsx
+++ b/vite/src/hooks/common/useOrg.tsx
@@ -25,6 +25,14 @@ export const getLastSwitchedOrgId = (): string | null => {
 	}
 };
 
+export const clearLastSwitchedOrgId = (id?: string) => {
+	try {
+		if (!id || localStorage.getItem(LAST_ORG_KEY) === id) {
+			localStorage.removeItem(LAST_ORG_KEY);
+		}
+	} catch {}
+};
+
 export const useSwitchActiveOrg = () => {
 	const queryClient = useQueryClient();
 	const { refetch: refetchSession } = useSession();

--- a/vite/src/services/useAxiosInstance.tsx
+++ b/vite/src/services/useAxiosInstance.tsx
@@ -63,8 +63,7 @@ export function useAxiosInstance(params?: {
 								await authClient.organization.setActive({
 									organizationId: nextOrg.id,
 								});
-								// Redirect to products page of the new organization
-								window.location.href = `/${currentEnv === AppEnv.Sandbox ? "sandbox" : "production"}/products`;
+								window.location.href = "/";
 								return Promise.reject(
 									new Error("Redirecting to available organization"),
 								);

--- a/vite/src/utils/genUtils.ts
+++ b/vite/src/utils/genUtils.ts
@@ -53,6 +53,17 @@ export const getDefaultOrgPath = (
 	path = "/products?tab=products",
 ) => (org?.deployed ? path : `/sandbox${path}`);
 
+export const getSafeNextPath = (searchParams: URLSearchParams) => {
+	const next = searchParams.get("next");
+	return next?.startsWith("/") && !next.startsWith("//") ? next : "/";
+};
+
+const appendSearch = (path: string, search: string) => {
+	const query = search.replace(/^\?/, "");
+	if (!query) return path;
+	return `${path}${path.includes("?") ? "&" : "?"}${query}`;
+};
+
 export const getOrgRouteRedirect = ({
 	pathname,
 	search = "",
@@ -63,7 +74,7 @@ export const getOrgRouteRedirect = ({
 	deployed: boolean;
 }) => {
 	if (pathname === "/") {
-		return getDefaultOrgPath({ deployed });
+		return appendSearch(getDefaultOrgPath({ deployed }), search);
 	}
 
 	if (!deployed && !pathname.startsWith("/sandbox")) {

--- a/vite/src/utils/genUtils.ts
+++ b/vite/src/utils/genUtils.ts
@@ -48,6 +48,31 @@ export const getEnvFromPath = (path: string) => {
 	return AppEnv.Live;
 };
 
+export const getDefaultOrgPath = (
+	org?: { deployed?: boolean } | null,
+	path = "/products?tab=products",
+) => (org?.deployed ? path : `/sandbox${path}`);
+
+export const getOrgRouteRedirect = ({
+	pathname,
+	search = "",
+	deployed,
+}: {
+	pathname: string;
+	search?: string;
+	deployed: boolean;
+}) => {
+	if (pathname === "/") {
+		return getDefaultOrgPath({ deployed });
+	}
+
+	if (!deployed && !pathname.startsWith("/sandbox")) {
+		return `/sandbox${pathname}${search}`;
+	}
+
+	return null;
+};
+
 export const envToPath = (env: AppEnv, currentPath: string) => {
 	// Check if we're on a customer detail page
 	const customerDetailPattern = /^(\/sandbox)?\/customers\/[^/]+/;

--- a/vite/src/views/DefaultView.tsx
+++ b/vite/src/views/DefaultView.tsx
@@ -1,13 +1,7 @@
-import { Link, Navigate, useLocation } from "react-router";
+import { Link } from "react-router";
 import ErrorScreen from "./general/ErrorScreen";
 
 export const DefaultView = () => {
-	const { pathname } = useLocation();
-
-	if (pathname === "/") {
-		return <Navigate to="/customers" replace={true} />;
-	}
-
 	return (
 		<ErrorScreen>
 			<p className="mb-4">🚩 This page is not found</p>

--- a/vite/src/views/auth/AcceptInvitation.tsx
+++ b/vite/src/views/auth/AcceptInvitation.tsx
@@ -1,22 +1,62 @@
-import { useNavigate } from "react-router";
-import { useSession } from "@/lib/auth-client";
+import type { FullInvite } from "@autumn/shared";
+import { useQuery } from "@tanstack/react-query";
+import { Navigate, useSearchParams } from "react-router";
+import { useSwitchActiveOrg } from "@/hooks/common/useOrg";
+import { authClient, useSession } from "@/lib/auth-client";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
 import LoadingScreen from "../general/LoadingScreen";
 
 export const AcceptInvitation = () => {
-	const { data, isPending } = useSession();
-	const navigate = useNavigate();
+	const { data: session, isPending } = useSession();
+	const [searchParams] = useSearchParams();
+	const invitationId = searchParams.get("id");
+	const axiosInstance = useAxiosInstance();
+	const switchActiveOrg = useSwitchActiveOrg();
 
-	if (isPending)
+	const { data: accepted, isError } = useQuery({
+		queryKey: ["accept-invitation", invitationId],
+		enabled: !!session && !!invitationId,
+		retry: false,
+		refetchOnWindowFocus: false,
+		queryFn: async () => {
+			if (!invitationId) return true;
+
+			const { data } = await axiosInstance.get<{ invites: FullInvite[] }>(
+				"/organization/invites",
+			);
+			const invite = data.invites.find((invite) => invite.id === invitationId);
+			if (!invite) return true;
+
+			const { error } = await authClient.organization.acceptInvitation({
+				invitationId,
+			});
+			if (error) throw error;
+
+			await switchActiveOrg(invite.organization.id);
+			return true;
+		},
+	});
+
+	if (isPending) return <LoadingScreen fullPage />;
+	if (!invitationId) return <Navigate to="/" replace />;
+	if (!session) {
 		return (
-			<div className="w-screen h-screen flex items-center justify-center">
-				<LoadingScreen />
+			<Navigate
+				to={`/sign-in?next=${encodeURIComponent(`/accept?id=${invitationId}`)}`}
+				replace
+			/>
+		);
+	}
+	if (isError) {
+		return (
+			<div className="flex min-h-screen w-full items-center justify-center">
+				<p className="text-sm text-muted-foreground">
+					This invitation is unavailable or has expired.
+				</p>
 			</div>
 		);
-
-	if (!data) {
-		navigate("/sign-in");
-		return;
 	}
+	if (accepted) return <Navigate to="/" replace />;
 
-	return <div>AcceptInvitation!</div>;
+	return <LoadingScreen fullPage />;
 };

--- a/vite/src/views/auth/SignIn.tsx
+++ b/vite/src/views/auth/SignIn.tsx
@@ -45,8 +45,8 @@ export const SignIn = () => {
 		[searchParams],
 	);
 
-	const defaultNewPath = "/sandbox/products?tab=products";
-	const defaultCallbackPath = "/sandbox/products?tab=products";
+	const defaultNewPath = "/";
+	const defaultCallbackPath = "/";
 
 	const newPath = oauthRedirectUrl || defaultNewPath;
 	const callbackPath = oauthRedirectUrl || defaultCallbackPath;

--- a/vite/src/views/auth/SignIn.tsx
+++ b/vite/src/views/auth/SignIn.tsx
@@ -8,7 +8,7 @@ import { CustomToaster } from "@/components/general/CustomToaster";
 import { IconButton } from "@/components/v2/buttons/IconButton";
 import { Input } from "@/components/v2/inputs/Input";
 import { authClient, signIn, useSession } from "@/lib/auth-client";
-import { getBackendErr } from "@/utils/genUtils";
+import { getBackendErr, getSafeNextPath } from "@/utils/genUtils";
 import { AuthBackground } from "./components/AuthBackground";
 import { AutumnWordmark } from "./components/AutumnWordmark";
 import { OTPSignIn } from "./components/OTPSignIn";
@@ -45,18 +45,16 @@ export const SignIn = () => {
 		[searchParams],
 	);
 
-	const defaultNewPath = "/";
-	const defaultCallbackPath = "/";
-
-	const newPath = oauthRedirectUrl || defaultNewPath;
-	const callbackPath = oauthRedirectUrl || defaultCallbackPath;
+	const defaultPath = getSafeNextPath(searchParams);
+	const newPath = oauthRedirectUrl || defaultPath;
+	const callbackPath = oauthRedirectUrl || defaultPath;
 
 	useEffect(() => {
 		if (oauthRedirectUrl) return;
 		if (session) {
-			navigate("/", { replace: true });
+			navigate(defaultPath, { replace: true });
 		}
-	}, [session, navigate, oauthRedirectUrl]);
+	}, [session, navigate, oauthRedirectUrl, defaultPath]);
 
 	// Passkey Conditional UI: browsers surface saved passkeys directly in the
 	// email field's autocomplete dropdown (no extra button needed). Requires
@@ -114,9 +112,8 @@ export const SignIn = () => {
 		try {
 			const frontendUrl = import.meta.env.VITE_FRONTEND_URL;
 			const googleCallbackUrl =
-				oauthRedirectUrl || `${frontendUrl}${defaultCallbackPath}`;
-			const googleNewUserUrl =
-				oauthRedirectUrl || `${frontendUrl}${defaultNewPath}`;
+				oauthRedirectUrl || `${frontendUrl}${defaultPath}`;
+			const googleNewUserUrl = oauthRedirectUrl || `${frontendUrl}${defaultPath}`;
 			const { error } = await signIn.social({
 				provider: "google",
 				callbackURL: googleCallbackUrl,

--- a/vite/src/views/auth/components/PasswordSignIn.tsx
+++ b/vite/src/views/auth/components/PasswordSignIn.tsx
@@ -40,7 +40,7 @@ export const PasswordSignIn = () => {
 			if (error) {
 				toast.error(error.message || "Something went wrong. Please try again.");
 			} else {
-				window.location.href = "/sandbox/products";
+				window.location.href = "/";
 			}
 		} catch (error) {
 			toast.error("Something went wrong. Please try again.");

--- a/vite/src/views/general/ErrorScreen.tsx
+++ b/vite/src/views/general/ErrorScreen.tsx
@@ -1,9 +1,8 @@
-import { AppEnv } from "@autumn/shared";
 import React from "react";
 import { Link, useNavigate } from "react-router";
 import { authClient } from "@/lib/auth-client";
-import { useEnv } from "@/utils/envUtils";
 import { getRedirectUrl } from "@/utils/genUtils";
+import { useSwitchActiveOrg } from "@/hooks/common/useOrg";
 
 function ErrorScreen({
 	children,
@@ -16,8 +15,8 @@ function ErrorScreen({
 	errorCode?: string;
 	errorData?: any;
 }) {
-	const env = useEnv();
 	const navigate = useNavigate();
+	const switchActiveOrg = useSwitchActiveOrg();
 
 	const handleOrgRemovalError = async () => {
 		if (errorCode === "USER_REMOVED_FROM_ORG" && errorData) {
@@ -31,12 +30,8 @@ function ErrorScreen({
 						(org) => org.id !== errorData.orgId,
 					);
 					if (nextOrg) {
-						await authClient.organization.setActive({
-							organizationId: nextOrg.id,
-						});
-						// Redirect to products page of the new organization
-						const envPath = env === AppEnv.Sandbox ? "sandbox" : "production";
-						navigate(`/${envPath}/products`);
+						await switchActiveOrg(nextOrg.id);
+						navigate("/");
 						return;
 					}
 				}

--- a/vite/src/views/general/LoadingScreen.tsx
+++ b/vite/src/views/general/LoadingScreen.tsx
@@ -2,8 +2,9 @@
 
 import React from "react";
 import { LoadingShimmerText } from "@/components/v2/LoadingShimmerText";
+import { cn } from "@/lib/utils";
 
-function LoadingScreen() {
+function LoadingScreen({ fullPage = false }: { fullPage?: boolean }) {
 	const texts = [
 		"Counting pennies",
 		"Forging plans",
@@ -37,10 +38,15 @@ function LoadingScreen() {
 	// 	</div>
 	// );
 	return (
-		<div className="flex h-full w-full items-center justify-center flex-col gap-4">
+		<div
+			className={cn(
+				"flex w-full items-center justify-center flex-col gap-4",
+				fullPage ? "min-h-screen" : "h-full",
+			)}
+		>
 			<LoadingShimmerText
 				text={loadingText}
-				className="py-4 text-tiny-id w-48 justify-start whitespace-nowrap overflow-visible translate-x-[25%]"
+				className="py-4 text-tiny-id justify-center whitespace-nowrap"
 			/>
 		</div>
 	);

--- a/vite/src/views/general/notifications/InviteNotifications.tsx
+++ b/vite/src/views/general/notifications/InviteNotifications.tsx
@@ -6,10 +6,12 @@ import { createPortal } from "react-dom";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/v2/buttons/Button";
+import { useSwitchActiveOrg } from "@/hooks/common/useOrg";
 import { useInvitesQuery } from "@/hooks/queries/useInvitesQuery";
 import { authClient } from "@/lib/auth-client";
 
 export const InviteNotifications = () => {
+	const switchActiveOrg = useSwitchActiveOrg();
 	const [loading, setLoading] = useState(false);
 	const [inviteStatus, setInviteStatus] = useState<
 		Map<string, "unavailable" | "dismissed">
@@ -30,12 +32,8 @@ export const InviteNotifications = () => {
 
 				if (error) throw error;
 
-				// Switch to that org
-				await authClient.organization.setActive({
-					organizationId: invite.organization.id,
-				});
-
-				window.location.reload();
+				await switchActiveOrg(invite.organization.id);
+				window.location.href = "/";
 			} else {
 				await authClient.organization.rejectInvitation({
 					invitationId: invite.id,

--- a/vite/src/views/main-sidebar/components/CreateNewOrg.tsx
+++ b/vite/src/views/main-sidebar/components/CreateNewOrg.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/v2/dialogs/Dialog";
 import { FormLabel as FieldLabel } from "@/components/v2/form/FormLabel";
 import { Input } from "@/components/v2/inputs/Input";
-import { useOrg } from "@/hooks/common/useOrg";
+import { useSwitchActiveOrg } from "@/hooks/common/useOrg";
 import { authClient } from "@/lib/auth-client";
 import { slugify } from "@/utils/formatUtils/formatTextUtils";
 
@@ -24,7 +24,7 @@ export const CreateNewOrg = ({
 	setDialogType: (dialogType: "create" | "manage" | null) => void;
 }) => {
 	const navigate = useNavigate();
-	const { mutate } = useOrg();
+	const switchActiveOrg = useSwitchActiveOrg();
 	const [name, setName] = useState("");
 	const [slugChanged, setSlugChanged] = useState(false);
 	const [slug, setSlug] = useState("");
@@ -40,11 +40,7 @@ export const CreateNewOrg = ({
 
 			if (error) throw error;
 
-			await authClient.organization.setActive({
-				organizationId: data.id,
-			});
-
-			await mutate();
+			await switchActiveOrg(data.id);
 
 			toast.success("Organization created");
 			setDialogType(null);

--- a/vite/src/views/main-sidebar/components/OrgDropdown.tsx
+++ b/vite/src/views/main-sidebar/components/OrgDropdown.tsx
@@ -1,4 +1,3 @@
-import { useQueryClient } from "@tanstack/react-query";
 import {
 	ChevronDown,
 	Monitor,
@@ -26,15 +25,13 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/v2/dropdowns/DropdownMenu";
 import { useTheme } from "@/contexts/ThemeProvider";
-import { setLastSwitchedOrgId, useOrg } from "@/hooks/common/useOrg";
+import { useOrg, useSwitchActiveOrg } from "@/hooks/common/useOrg";
 import {
 	authClient,
 	useListOrganizations,
 	useSession,
 } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
-import { useAxiosInstance } from "@/services/useAxiosInstance";
-import { useEnv } from "@/utils/envUtils";
 import { OrgLogo } from "../org-dropdown/components/OrgLogo";
 import { useMemberships } from "../org-dropdown/hooks/useMemberships";
 import { useSidebarContext } from "../SidebarContext";
@@ -222,10 +219,8 @@ export const OrgDropdown = () => {
 
 /** Switches the active org via client-side state update (no page reload). */
 export const useOrgSwitch = () => {
-	const queryClient = useQueryClient();
 	const navigate = useNavigate();
-	const axiosInstance = useAxiosInstance();
-	const env = useEnv();
+	const switchActiveOrg = useSwitchActiveOrg();
 
 	return async ({
 		orgId,
@@ -236,26 +231,8 @@ export const useOrgSwitch = () => {
 	}) => {
 		setLoading?.(true);
 		try {
-			await authClient.organization.setActive({
-				organizationId: orgId,
-			});
-
-			const { data: newOrg } = await axiosInstance.get("/organization");
-
-			if (newOrg?.id) setLastSwitchedOrgId(newOrg.id);
-
-			queryClient.setQueryData(["org", env], newOrg);
-			queryClient.invalidateQueries({ queryKey: ["org"] });
-
-			if (
-				newOrg &&
-				!newOrg.deployed &&
-				!window.location.pathname.includes("/sandbox")
-			) {
-				const pathname = window.location.pathname;
-				const search = window.location.search;
-				navigate(`/sandbox${pathname}${search}`);
-			}
+			await switchActiveOrg(orgId);
+			navigate("/");
 		} catch (error) {
 			toast.error(
 				error instanceof Error

--- a/vite/tests/utils/gen-utils.test.ts
+++ b/vite/tests/utils/gen-utils.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { getDefaultOrgPath, getOrgRouteRedirect } from "@/utils/genUtils";
+
+describe("getDefaultOrgPath", () => {
+	test("defaults deployed orgs to production", () => {
+		expect(getDefaultOrgPath({ deployed: true })).toBe(
+			"/products?tab=products",
+		);
+	});
+
+	test("defaults undeployed orgs to sandbox", () => {
+		expect(getDefaultOrgPath({ deployed: false })).toBe(
+			"/sandbox/products?tab=products",
+		);
+	});
+
+	test("defaults missing orgs to sandbox", () => {
+		expect(getDefaultOrgPath(null)).toBe("/sandbox/products?tab=products");
+	});
+});
+
+describe("getOrgRouteRedirect", () => {
+	test("routes root to production for deployed orgs", () => {
+		expect(getOrgRouteRedirect({ pathname: "/", deployed: true })).toBe(
+			"/products?tab=products",
+		);
+	});
+
+	test("routes root to sandbox for undeployed orgs", () => {
+		expect(getOrgRouteRedirect({ pathname: "/", deployed: false })).toBe(
+			"/sandbox/products?tab=products",
+		);
+	});
+
+	test("blocks live routes for undeployed orgs", () => {
+		expect(
+			getOrgRouteRedirect({
+				pathname: "/products",
+				search: "?tab=products",
+				deployed: false,
+			}),
+		).toBe("/sandbox/products?tab=products");
+	});
+
+	test("allows sandbox routes for undeployed orgs", () => {
+		expect(
+			getOrgRouteRedirect({
+				pathname: "/sandbox/products",
+				search: "?tab=products",
+				deployed: false,
+			}),
+		).toBeNull();
+	});
+
+	test("allows live routes for deployed orgs", () => {
+		expect(
+			getOrgRouteRedirect({
+				pathname: "/products",
+				search: "?tab=products",
+				deployed: true,
+			}),
+		).toBeNull();
+	});
+});

--- a/vite/tests/utils/gen-utils.test.ts
+++ b/vite/tests/utils/gen-utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { getDefaultOrgPath, getOrgRouteRedirect } from "@/utils/genUtils";
+import {
+	getDefaultOrgPath,
+	getOrgRouteRedirect,
+	getSafeNextPath,
+} from "@/utils/genUtils";
 
 describe("getDefaultOrgPath", () => {
 	test("defaults deployed orgs to production", () => {
@@ -19,11 +23,38 @@ describe("getDefaultOrgPath", () => {
 	});
 });
 
+describe("getSafeNextPath", () => {
+	test("allows local absolute paths", () => {
+		expect(getSafeNextPath(new URLSearchParams("next=/accept?id=inv_123"))).toBe(
+			"/accept?id=inv_123",
+		);
+	});
+
+	test("rejects external redirects", () => {
+		expect(
+			getSafeNextPath(new URLSearchParams("next=https://example.com")),
+		).toBe("/");
+		expect(getSafeNextPath(new URLSearchParams("next=//example.com"))).toBe(
+			"/",
+		);
+	});
+});
+
 describe("getOrgRouteRedirect", () => {
 	test("routes root to production for deployed orgs", () => {
 		expect(getOrgRouteRedirect({ pathname: "/", deployed: true })).toBe(
 			"/products?tab=products",
 		);
+	});
+
+	test("preserves root search params on default redirects", () => {
+		expect(
+			getOrgRouteRedirect({
+				pathname: "/",
+				search: "?invite=inv_123",
+				deployed: true,
+			}),
+		).toBe("/products?tab=products&invite=inv_123");
 	});
 
 	test("routes root to sandbox for undeployed orgs", () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens org switching and routing with a resilient `DashboardGate` that restores the last org, handles errors, and preserves query params on redirects. Centralizes org switching via `useSwitchActiveOrg` and routes flows through “/” for a single source of truth.

- **New Features**
  - `DashboardGate` restores the last org, gates access, and shows a lightweight error UI with refresh if org load fails.
  - Centralized switching with `useSwitchActiveOrg` (refetches session, invalidates org query); used by Org dropdown, new org creation, invitation acceptance, global error handling, and request interceptor; all navigate to “/”.
  - Safer routing utils: `getDefaultOrgPath`/`getOrgRouteRedirect` now keep search params; added `getSafeNextPath` and tests; `AcceptInvitation` reads `?id`, switches org, and returns to “/”; sign-in honors a safe `next` param.

- **Bug Fixes**
  - Fixed infinite retry loop when switching to the remembered org by clearing/ignoring the stored org on error.
  - Prevented stuck loading on org fetch errors; `useOrg` no longer swallows errors, keys queries by `activeOrgId`, enables only when it exists, and surfaces errors to `DashboardGate`.
  - Consistent post-action routing (org removal, invite acceptance, password sign-in) by redirecting to “/” and letting the gate choose the right env.

<sup>Written for commit 2735abf0a173690bb8b403eec8b2daa2f01ec6aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refactors org switching across the frontend and backend, centralising auth/redirect logic into a new `DashboardGate` component and a shared `useSwitchActiveOrg` hook, while also improving the accuracy of the `deployed` status check on the server.

- **Bug fixes / Improvements** — `DashboardGate` replaces scattered session-guard and sandbox-redirect `useEffect`s in `MainLayout` with a single declarative gate that also restores the user's last active org on page load; `useSwitchActiveOrg` ensures `lastSwitchedOrgId`, session cache, and query cache are all updated atomically on every org switch.
- **Bug fixes** — `beforeSessionCreated` now orders membership by `createdAt DESC` so newly joined orgs are correctly preferred as the default active org on sign-in.
- **Improvements** — `handleGetOrg` now computes `deployed` from live products/features/API keys when the DB flag is still `false`, preventing orgs from being stuck in sandbox mode indefinitely.
</details>

<h3>Confidence Score: 3/5</h3>

The org-switching refactor is mostly clean but DashboardGate introduces two correctness problems reachable on any network hiccup.

When switchActiveOrg throws, .finally() resets switchingToLastOrg to false while shouldSwitchToLastOrg stays true, so the effect immediately re-fires and retries indefinitely. Separately, because the fetcher no longer swallows errors, a failed /organization request leaves org undefined after retries, rendering a LoadingScreen the user cannot escape without a hard refresh.

vite/src/app/DashboardGate.tsx — the retry loop and stuck loading screen are both in this file

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/app/DashboardGate.tsx | New gate component handling session checks, org switching to last-used org, and deployment-based route redirects — has an infinite retry loop when switchActiveOrg fails and shows a permanent loading screen on org-fetch errors |
| vite/src/hooks/common/useOrg.tsx | Adds useSwitchActiveOrg centralizing org-switch logic; removes error swallowing from fetcher and adds activeOrgId to query key for proper cache separation across orgs |
| vite/src/utils/genUtils.ts | Adds getDefaultOrgPath and getOrgRouteRedirect for deployment-aware routing; getOrgRouteRedirect drops search params when redirecting from '/' — minor data-loss issue |
| server/src/internal/orgs/orgDeploymentUtils.ts | New utility with isDeploymentApiKeyMeta using exclusion-list logic; well-tested with accompanying unit tests |
| server/src/internal/orgs/handlers/crudHandlers/handleGetOrg.ts | Enhances deployed detection with DB fallback queries when the persisted deployed flag is false; adds 3 parallel DB queries per GET /org for undeployed orgs |
| server/src/utils/authUtils/beforeSessionCreated.ts | Adds orderBy desc(createdAt) to membership lookup so the most recently joined org is selected as default on session creation |
| server/src/internal/products/handlers/handleCopyEnvironment/handleCopyEnvironment.ts | Now sets org.deployed = true in parallel with cache invalidation when copying products to production |
| vite/src/App.tsx | Route tree refactored with envRoutes helper and wrapped in new DashboardGate; no functional route coverage changes detected |
| vite/src/app/layout.tsx | Auth/session guards and sandbox-redirect logic removed and moved to DashboardGate; MainLayout is now a pure layout with no redirect side-effects |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User navigates to route] --> B[DashboardGate]
    B --> C{Session loading?}
    C -- yes --> LS1[LoadingScreen]
    C -- no --> D{Session exists?}
    D -- no --> NAV1[Navigate /sign-in]
    D -- yes --> E{orgList loading OR shouldSwitchToLastOrg OR switchingToLastOrg?}
    E -- yes --> LS2[LoadingScreen]
    E -- no --> F{org loading?}
    F -- yes --> LS3[LoadingScreen]
    F -- no --> G{org exists?}
    G -- no --> LS4[LoadingScreen stuck on error]
    G -- yes --> H{getOrgRouteRedirect}
    H -- redirect needed --> NAV2[Navigate to redirect]
    H -- no redirect --> OUT[Outlet / MainLayout]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User navigates to route] --> B[DashboardGate]
    B --> C{Session loading?}
    C -- yes --> LS1[LoadingScreen]
    C -- no --> D{Session exists?}
    D -- no --> NAV1[Navigate /sign-in]
    D -- yes --> E{orgList loading OR shouldSwitchToLastOrg OR switchingToLastOrg?}
    E -- yes --> LS2[LoadingScreen]
    E -- no --> F{org loading?}
    F -- yes --> LS3[LoadingScreen]
    F -- no --> G{org exists?}
    G -- no --> LS4[LoadingScreen stuck on error]
    G -- yes --> H{getOrgRouteRedirect}
    H -- redirect needed --> NAV2[Navigate to redirect]
    H -- no redirect --> OUT[Outlet / MainLayout]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
vite/src/app/DashboardGate.tsx:27-38
**Infinite retry loop on failed org switch**

When `switchActiveOrg` throws (e.g., network error or auth failure), the `.finally()` callback resets `switchingToLastOrg` to `false`. Since the underlying `activeOrgId` never changed, `shouldSwitchToLastOrg` remains `true`. On the next render the effect fires again immediately, calls `switchActiveOrg` again, and the cycle repeats indefinitely — hammering the auth server with failing requests until the page is closed.

A simple fix is to track an error state and bail out, or clear the stored last-org-id in the error path so the invariant `lastOrgId !== activeOrgId` can no longer be satisfied after a failed attempt.

### Issue 2 of 3
vite/src/app/DashboardGate.tsx:46-47
**Permanent loading screen on org fetch error**

The previous `useOrg` fetcher swallowed errors by returning `null`, which allowed the `handleNoActiveOrg` path to take over. After this PR the fetcher lets errors propagate to React Query. If the `/organization` request fails (e.g., a 5xx after retries are exhausted), `org` is `undefined` and `orgLoading` is `false`, so this block shows `<LoadingScreen fullPage />` indefinitely with no error message and no escape path for the user. The `error` field is returned from `useOrg` but never consumed in `DashboardGate`.

### Issue 3 of 3
vite/src/utils/genUtils.ts:65-67
When `pathname` is `"/"` the `search` parameter is silently dropped. A user landing on `/?invite=xyz` would lose that query string after the redirect to the default org path. The fix threads `search` through `getDefaultOrgPath` when it is present.

```suggestion
	if (pathname === "/") {
		const base = getDefaultOrgPath({ deployed });
		return search ? `${base}${search.startsWith("?") ? "&" : "?"}${search.replace(/^\?/, "")}` : base;
	}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: cubic comments"](https://github.com/useautumn/autumn/commit/1321431e710b6de5ab8641dd80b9fdeb4b261a93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38375360)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->