### PR TITLE
fire billing.updated on trial-to-paid conversion

### DIFF
--- a/server/src/internal/billing/v2/utils/billingChangeResponse/billingChangeResponseHasContent.ts
+++ b/server/src/internal/billing/v2/utils/billingChangeResponse/billingChangeResponseHasContent.ts
@@ -1,0 +1,5 @@
+import type { BillingChangeResponse } from "@autumn/shared";
+
+export const billingChangeResponseHasContent = (
+	response: BillingChangeResponse,
+): boolean => response.plan_changes.length > 0 || response.tags.length > 0;

--- a/server/src/internal/billing/v2/utils/billingChangeResponse/index.ts
+++ b/server/src/internal/billing/v2/utils/billingChangeResponse/index.ts
@@ -1,3 +1,4 @@
+export * from "./billingChangeResponseHasContent";
 export * from "./buildBillingChangeResponse";
 export * from "./buildPlanChanges";
 export * from "./buildPlanItemChanges";

--- a/server/src/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook.ts
+++ b/server/src/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook.ts
@@ -3,7 +3,7 @@
  *
  * Skips when:
  *   - `ctx.testOptions?.skipWebhooks` is set
- *   - the resulting response has no `plan_changes`
+ *   - the resulting response has no `plan_changes` and no `tags`
  *
  * Intended to be called fire-and-forget from emission sites:
  *   `void sendBillingUpdatedWebhook({ ctx, autumnBillingPlan, originalFullCustomer });`
@@ -18,7 +18,10 @@ import {
 } from "@autumn/shared";
 import { sendSvixEvent } from "@/external/svix/svixHelpers.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { buildBillingChangeResponse } from "@/internal/billing/v2/utils/billingChangeResponse";
+import {
+	billingChangeResponseHasContent,
+	buildBillingChangeResponse,
+} from "@/internal/billing/v2/utils/billingChangeResponse";
 
 export const sendBillingUpdatedWebhook = async ({
 	ctx,
@@ -41,7 +44,7 @@ export const sendBillingUpdatedWebhook = async ({
 			tags,
 		});
 
-		if (response.plan_changes.length === 0) return;
+		if (!billingChangeResponseHasContent(response)) return;
 
 		// Svix message tags (separate from the payload `tags` field) — used
 		// for routing/filtering at the Svix dashboard level. Mirrors the

--- a/server/tests/integration/billing/autumn-webhooks/billing-updated/billing-updated-subscription-updated.test.ts
+++ b/server/tests/integration/billing/autumn-webhooks/billing-updated/billing-updated-subscription-updated.test.ts
@@ -94,12 +94,6 @@ test(`${chalk.yellowBright("billing.updated: trial end → tags includes trial_e
 	expect(result).not.toBeNull();
 	const { data } = result!.payload;
 	expect(data.tags).toContain("trial_ended");
-
-	const updated = findChange(data.plan_changes, {
-		action: "updated",
-		planId: proTrial.id,
-	});
-	expect(updated).toBeDefined();
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/server/tests/unit/billing/billing-change-response-has-content.spec.ts
+++ b/server/tests/unit/billing/billing-change-response-has-content.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import type { BillingChangeResponse, CustomerPlanChange } from "@autumn/shared";
+import { billingChangeResponseHasContent } from "@/internal/billing/v2/utils/billingChangeResponse/billingChangeResponseHasContent";
+
+const makeResponse = ({
+	planChanges = 0,
+	tags = [],
+}: {
+	planChanges?: number;
+	tags?: string[];
+}): BillingChangeResponse =>
+	({
+		object: "billing.updated",
+		customer_id: "cus_test",
+		plan_changes: Array.from(
+			{ length: planChanges },
+			() => ({ action: "updated" }) as CustomerPlanChange,
+		),
+		tags,
+	}) as BillingChangeResponse;
+
+describe("billingChangeResponseHasContent", () => {
+	test("false when there are no plan changes and no tags", () => {
+		expect(billingChangeResponseHasContent(makeResponse({}))).toBe(false);
+	});
+
+	test("true when there are plan changes", () => {
+		expect(
+			billingChangeResponseHasContent(makeResponse({ planChanges: 1 })),
+		).toBe(true);
+	});
+
+	test("true for a tag-only transition like trial_ended (no plan changes)", () => {
+		expect(
+			billingChangeResponseHasContent(makeResponse({ tags: ["trial_ended"] })),
+		).toBe(true);
+	});
+
+	test("true when both plan changes and tags are present", () => {
+		expect(
+			billingChangeResponseHasContent(
+				makeResponse({ planChanges: 1, tags: ["phase_changed"] }),
+			),
+		).toBe(true);
+	});
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fire `billing.updated` webhooks on trial-to-paid conversions by treating tag-only transitions (e.g. `trial_ended`) as meaningful changes. Fixes missed webhooks with no `plan_changes` but with `tags`.

- **Bug Fixes**
  - Webhook now fires when the response has tags even if `plan_changes` is empty.
  - Added `billingChangeResponseHasContent` and used it in `sendBillingUpdatedWebhook`.
  - Updated integration test to expect `tags` with no `plan_changes`; added unit tests for the helper.

<sup>Written for commit 164aa8485a1c1513d0d5c1d62542fcd39acd3841. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where `billing.updated` webhooks were silently dropped on trial-to-paid conversions. The root cause was a guard that only checked `plan_changes.length === 0` — on trial end there are no plan changes, only a `trial_ended` tag, so the webhook was never sent.

- **Bug fix**: Replaces the `plan_changes.length === 0` guard in `sendBillingUpdatedWebhook` with a new `billingChangeResponseHasContent` helper that passes when either `plan_changes` or `tags` is non-empty, correctly firing the webhook on tag-only transitions like trial end.
- **Improvements**: Adds a focused unit-test suite for the new helper and updates the existing integration test to assert that `plan_changes` is empty (not `updated`) on trial end, aligning the test with actual observed behavior.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a narrowly scoped guard fix with no side effects on existing behavior.

The fix is minimal and correct: swapping a single boolean expression for a named helper that broadens the condition from 'has plan changes' to 'has plan changes OR tags'. The new helper is fully covered by unit tests, and the integration test was updated to match the real observed behavior (no plan changes on trial end). The buildBillingChangeResponse function always initialises tags to [] via schema parsing, so response.tags can never be undefined at the call site.

.github/workflows/build.yml — the fix-trial-converted-billing-updated branch entry in STAGING_DEPLOY_BRANCH_ALLOWLIST will persist after merging and should be removed in a follow-up cleanup.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/utils/billingChangeResponse/billingChangeResponseHasContent.ts | New helper that gates webhook emission on plan_changes or tags being non-empty — straightforward and correct. |
| server/src/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook.ts | Replaces the narrow plan_changes-only guard with billingChangeResponseHasContent; logic and comment are consistent. |
| server/tests/integration/billing/autumn-webhooks/billing-updated/billing-updated-subscription-updated.test.ts | Removes incorrect plan_change assertion on trial end; now correctly expects plan_changes to be empty with only a tag present. |
| server/tests/unit/billing/billing-change-response-has-content.spec.ts | New unit tests for the helper covering all four boolean branches — thorough and well-structured. |
| .github/workflows/build.yml | Adds fix-trial-converted-billing-updated to the staging deploy allowlist; the branch name will persist in dev after merging and should be cleaned up. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[sendBillingUpdatedWebhook called] --> B{skipWebhooks?}
    B -- yes --> Z[return early]
    B -- no --> C[buildBillingChangeResponse\nplan_changes + tags]
    C --> D{billingChangeResponseHasContent?}
    D -- "plan_changes.length === 0\nAND tags.length === 0" --> Z
    D -- "plan_changes.length > 0\nOR tags.length > 0" --> E[sendSvixEvent\nbilling.updated]
    E --> F[log success]

    style D fill:#f9f,stroke:#333
    style E fill:#9f9,stroke:#333
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[sendBillingUpdatedWebhook called] --> B{skipWebhooks?}
    B -- yes --> Z[return early]
    B -- no --> C[buildBillingChangeResponse\nplan_changes + tags]
    C --> D{billingChangeResponseHasContent?}
    D -- "plan_changes.length === 0\nAND tags.length === 0" --> Z
    D -- "plan_changes.length > 0\nOR tags.length > 0" --> E[sendSvixEvent\nbilling.updated]
    E --> F[log success]

    style D fill:#f9f,stroke:#333
    style E fill:#9f9,stroke:#333
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fire billing.updated on trial-to-paid co..."](https://github.com/useautumn/autumn/commit/e168b59215a9334a94a139146eb7be908ee05887) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38394816)</sub>

<!-- /greptile_comment -->