### PR TITLE
snap create_schedule phases onto the cycle boundary

### DIFF
--- a/server/src/internal/billing/v2/actions/createSchedule/errors/normalizeCreateSchedulePhases.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/errors/normalizeCreateSchedulePhases.ts
@@ -2,6 +2,7 @@ import {
 	addDuration,
 	type CreateScheduleParamsV0,
 	ErrCode,
+	ms,
 	RecaseError,
 	type ResolvedCreateSchedulePhaseV0,
 } from "@autumn/shared";
@@ -100,13 +101,51 @@ export const getInitialCreateSchedulePhase = ({
 	return firstPhase;
 };
 
+// The schedule date picker defaults a phase to noon, so a switch meant for the renewal date
+// lands within 12h of the anchor; snap onto the boundary to bill a full period, not a sliver.
+const CYCLE_BOUNDARY_SNAP_WINDOW_MS = ms.hours(12);
+
+const snapResolvedPhasesToCycleBoundary = ({
+	phases,
+	cycleBoundaryMs,
+}: {
+	phases: ResolvedPhase[];
+	cycleBoundaryMs: number;
+}): ResolvedPhase[] =>
+	phases.map((phase, index) => {
+		// The first phase is the immediate one ("now"); never move it.
+		if (index === 0) return phase;
+		if (
+			Math.abs(phase.starts_at - cycleBoundaryMs) >
+			CYCLE_BOUNDARY_SNAP_WINDOW_MS
+		) {
+			return phase;
+		}
+
+		// Only snap when the boundary stays strictly between neighbours, so we never
+		// turn a valid schedule into a non-increasing one.
+		const previousPhase = phases[index - 1];
+		const nextPhase = phases[index + 1];
+		if (previousPhase && cycleBoundaryMs <= previousPhase.starts_at)
+			return phase;
+		if (nextPhase && cycleBoundaryMs >= nextPhase.starts_at) return phase;
+
+		return { ...phase, starts_at: cycleBoundaryMs };
+	});
+
 /** Sort phases for downstream create_schedule setup and execution. */
 export const normalizeCreateSchedulePhases = ({
 	phases,
 	currentEpochMs,
+	cycleBoundaryMs,
 }: {
 	phases: CreateScheduleParamsV0["phases"];
 	currentEpochMs: number;
+	/**
+	 * Active subscription's next cycle boundary, when there is one. Future phases that
+	 * land within {@link CYCLE_BOUNDARY_SNAP_WINDOW_MS} of it snap onto it.
+	 */
+	cycleBoundaryMs?: number;
 }): [ResolvedPhase, ...ResolvedPhase[]] => {
 	const orderedPhases = hasRelativeTiming({ phases })
 		? [...phases]
@@ -147,7 +186,8 @@ export const normalizeCreateSchedulePhases = ({
 			});
 		} else {
 			throw new RecaseError({
-				message: "Each phase must include exactly one of starts_at or starting_after",
+				message:
+					"Each phase must include exactly one of starts_at or starting_after",
 				code: ErrCode.InvalidRequest,
 				statusCode: 400,
 			});
@@ -156,7 +196,15 @@ export const normalizeCreateSchedulePhases = ({
 		resolvedPhases.push(phaseToResolvedPhase({ phase, startsAt }));
 	}
 
-	assertStrictlyIncreasing({ phases: resolvedPhases });
+	const snappedPhases =
+		cycleBoundaryMs === undefined
+			? resolvedPhases
+			: snapResolvedPhasesToCycleBoundary({
+					phases: resolvedPhases,
+					cycleBoundaryMs,
+				});
 
-	return toNonEmptyResolvedPhases({ phases: resolvedPhases });
+	assertStrictlyIncreasing({ phases: snappedPhases });
+
+	return toNonEmptyResolvedPhases({ phases: snappedPhases });
 };

--- a/server/src/internal/billing/v2/actions/createSchedule/errors/normalizeCreateSchedulePhases.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/errors/normalizeCreateSchedulePhases.ts
@@ -101,8 +101,6 @@ export const getInitialCreateSchedulePhase = ({
 	return firstPhase;
 };
 
-// The schedule date picker defaults a phase to noon, so a switch meant for the renewal date
-// lands within 12h of the anchor; snap onto the boundary to bill a full period, not a sliver.
 const CYCLE_BOUNDARY_SNAP_WINDOW_MS = ms.hours(12);
 
 const snapResolvedPhasesToCycleBoundary = ({
@@ -111,27 +109,31 @@ const snapResolvedPhasesToCycleBoundary = ({
 }: {
 	phases: ResolvedPhase[];
 	cycleBoundaryMs: number;
-}): ResolvedPhase[] =>
-	phases.map((phase, index) => {
-		// The first phase is the immediate one ("now"); never move it.
-		if (index === 0) return phase;
-		if (
-			Math.abs(phase.starts_at - cycleBoundaryMs) >
-			CYCLE_BOUNDARY_SNAP_WINDOW_MS
-		) {
-			return phase;
+}): ResolvedPhase[] => {
+	let snapIndex = -1;
+	let snapDistance = CYCLE_BOUNDARY_SNAP_WINDOW_MS;
+	for (let index = 1; index < phases.length; index++) {
+		const phase = phases[index];
+		if (!phase) continue;
+		const distance = Math.abs(phase.starts_at - cycleBoundaryMs);
+		if (distance <= snapDistance) {
+			snapDistance = distance;
+			snapIndex = index;
 		}
+	}
 
-		// Only snap when the boundary stays strictly between neighbours, so we never
-		// turn a valid schedule into a non-increasing one.
-		const previousPhase = phases[index - 1];
-		const nextPhase = phases[index + 1];
-		if (previousPhase && cycleBoundaryMs <= previousPhase.starts_at)
-			return phase;
-		if (nextPhase && cycleBoundaryMs >= nextPhase.starts_at) return phase;
+	if (snapIndex === -1) return phases;
 
-		return { ...phase, starts_at: cycleBoundaryMs };
-	});
+	const previousPhase = phases[snapIndex - 1];
+	const nextPhase = phases[snapIndex + 1];
+	if (previousPhase && cycleBoundaryMs <= previousPhase.starts_at)
+		return phases;
+	if (nextPhase && cycleBoundaryMs >= nextPhase.starts_at) return phases;
+
+	return phases.map((phase, index) =>
+		index === snapIndex ? { ...phase, starts_at: cycleBoundaryMs } : phase,
+	);
+};
 
 /** Sort phases for downstream create_schedule setup and execution. */
 export const normalizeCreateSchedulePhases = ({
@@ -141,10 +143,6 @@ export const normalizeCreateSchedulePhases = ({
 }: {
 	phases: CreateScheduleParamsV0["phases"];
 	currentEpochMs: number;
-	/**
-	 * Active subscription's next cycle boundary, when there is one. Future phases that
-	 * land within {@link CYCLE_BOUNDARY_SNAP_WINDOW_MS} of it snap onto it.
-	 */
 	cycleBoundaryMs?: number;
 }): [ResolvedPhase, ...ResolvedPhase[]] => {
 	const orderedPhases = hasRelativeTiming({ phases })

--- a/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
@@ -8,6 +8,7 @@ import {
 	type MultiAttachParamsV0,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { setupAttachEndOfCycleMs } from "@/internal/billing/v2/actions/attach/setup/setupAttachEndOfCycleMs";
 import { setupAnchorResetRefund } from "@/internal/billing/v2/setup/setupAnchorResetRefund";
 import { setupBillingCycleAnchor } from "@/internal/billing/v2/setup/setupBillingCycleAnchor";
 import { setupResetCycleAnchor } from "@/internal/billing/v2/setup/setupResetCycleAnchor";
@@ -116,9 +117,22 @@ export const setupCreateScheduleBillingContext = async ({
 		fullProducts: billingContext.fullProducts,
 	});
 
+	// Snap near-boundary future phases onto the active sub's cycle end (see
+	// normalizeCreateSchedulePhases). Skipped on cycle reset, since the boundary moves.
+	const cycleBoundaryMs =
+		params.billing_cycle_anchor === undefined
+			? setupAttachEndOfCycleMs({
+					planTiming: "end_of_cycle",
+					stripeSubscription: billingContext.stripeSubscription,
+					billingCycleAnchorMs: billingContext.billingCycleAnchorMs,
+					currentEpochMs: billingContext.currentEpochMs,
+				})
+			: undefined;
+
 	const normalizedPhases = normalizeCreateSchedulePhases({
 		phases: params.phases,
 		currentEpochMs: billingContext.currentEpochMs,
+		cycleBoundaryMs,
 	});
 	const [immediatePhase, ...futurePhases] = normalizedPhases;
 

--- a/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
@@ -117,8 +117,6 @@ export const setupCreateScheduleBillingContext = async ({
 		fullProducts: billingContext.fullProducts,
 	});
 
-	// Snap near-boundary future phases onto the active sub's cycle end (see
-	// normalizeCreateSchedulePhases). Skipped on cycle reset, since the boundary moves.
 	const cycleBoundaryMs =
 		params.billing_cycle_anchor === undefined
 			? setupAttachEndOfCycleMs({

--- a/server/tests/integration/billing/create-schedule/preview/create-schedule-preview.test.ts
+++ b/server/tests/integration/billing/create-schedule/preview/create-schedule-preview.test.ts
@@ -9,10 +9,12 @@ import {
 	ms,
 	truncateMsToSecondPrecision,
 } from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
 import { TestFeature } from "@tests/setup/v2Features";
 import { items } from "@tests/utils/fixtures/items";
 import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
 import { products } from "@tests/utils/fixtures/products";
+import { advanceTestClock } from "@tests/utils/stripeUtils";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 import { addMonths } from "date-fns";
@@ -953,5 +955,151 @@ test.concurrent(
 				(line) => line.description === "Unrelated pending Stripe invoice item",
 			),
 		).toBe(false);
+	},
+);
+
+/**
+ * TDD regression for the "preview numbers are cooked" report: a scheduled plan
+ * swap dated on the current cycle's renewal *date* but at an incidental wall-clock
+ * time (the dashboard date picker emits the selected date with a time-of-day that
+ * does not equal the subscription's anchor instant) lands a few hours short of the
+ * real cycle boundary.
+ *
+ * Red-failure mode (pre-fix):
+ *  - The transition is classified as a mid-cycle scheduled_change and the new plan
+ *    is prorated over the tiny gap to the anchor boundary, so next_cycle.total is a
+ *    near-zero sliver and next_cycle.starts_at is the offset timestamp, not the
+ *    renewal boundary. The full charge is silently deferred to a separate invoice.
+ *
+ * Green-success criteria (after fix):
+ *  - The phase snaps to the exact cycle boundary, so next_cycle bills the new plan's
+ *    full first period ($50) at the renewal boundary.
+ */
+test.concurrent(
+	`${chalk.yellowBright("create-schedule preview 16: replacement landing on the cycle boundary charges the full new plan, not a sliver")}`,
+	async () => {
+		const pro = products.pro({
+			id: "preview-boundary-snap-pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const premium = products.premium({
+			id: "preview-boundary-snap-premium",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		const { customerId, autumnV1, advancedTo } = await initScenario({
+			customerId: "create-schedule-preview-boundary-snap",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [s.billing.attach({ productId: pro.id })],
+		});
+
+		// Anchor == advancedTo, so the next renewal boundary is one month out.
+		const renewalAt = truncateMsToSecondPrecision(
+			addMonths(advancedTo, 1).getTime(),
+		);
+		// Dashboard sends the renewal *date* with an incidental time-of-day, so the
+		// scheduled switch lands a few hours short of the real anchor instant.
+		const transitionAt = renewalAt - ms.hours(6);
+
+		await expectPreviewToMatchCreateSchedule({
+			autumnV1,
+			params: {
+				customer_id: customerId,
+				phases: [
+					{ starts_at: advancedTo, plans: [{ plan_id: pro.id }] },
+					{ starts_at: transitionAt, plans: [{ plan_id: premium.id }] },
+				],
+			},
+			expectedTotal: 0,
+			assertPreview: (preview) => {
+				expect(preview.line_items).toHaveLength(0);
+				expect(preview.next_cycle).toBeDefined();
+				// Snapped onto the real cycle boundary (Stripe's anchor instant, a few
+				// seconds off a naive month-add), not the offset the dashboard sent.
+				expect(preview.next_cycle?.starts_at).not.toBe(transitionAt);
+				expect(
+					Math.abs((preview.next_cycle?.starts_at ?? 0) - renewalAt),
+				).toBeLessThan(ms.hours(1));
+				// Full new-plan first period, not a proration sliver.
+				expectCloseToCents({
+					actual: preview.next_cycle?.total ?? 0,
+					expected: 50,
+				});
+			},
+		});
+	},
+);
+
+/**
+ * End-to-end billing proof for the boundary snap: advancing past the renewal must
+ * produce a single full charge for the new plan, not a tiny proration sliver at the
+ * offset time followed by the full charge at the anchor (the pre-fix double-invoice).
+ */
+test.concurrent(
+	`${chalk.yellowBright("create-schedule preview 17: snapped boundary bills one full renewal invoice, no sliver")}`,
+	async () => {
+		const pro = products.pro({
+			id: "preview-boundary-snap-billing-pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const premium = products.premium({
+			id: "preview-boundary-snap-billing-premium",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		const { customerId, autumnV1, ctx, testClockId, advancedTo } =
+			await initScenario({
+				customerId: "create-schedule-preview-boundary-snap-billing",
+				setup: [
+					s.customer({ paymentMethod: "success" }),
+					s.products({ list: [pro, premium] }),
+				],
+				actions: [s.billing.attach({ productId: pro.id })],
+			});
+
+		const renewalAt = truncateMsToSecondPrecision(
+			addMonths(advancedTo, 1).getTime(),
+		);
+		const transitionAt = renewalAt - ms.hours(6);
+
+		await autumnV1.billing.createSchedule({
+			customer_id: customerId,
+			phases: [
+				{ starts_at: advancedTo, plans: [{ plan_id: pro.id }] },
+				{ starts_at: transitionAt, plans: [{ plan_id: premium.id }] },
+			],
+		});
+
+		// Only the Pro attach has billed; the swap is scheduled for the boundary.
+		const beforeRenewal =
+			await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({
+			customer: beforeRenewal,
+			count: 1,
+			latestTotal: 20,
+		});
+
+		await advanceTestClock({
+			stripeCli: ctx.stripeCli,
+			testClockId: testClockId!,
+			advanceTo: renewalAt + ms.days(1),
+			waitForSeconds: 30,
+		});
+
+		// Assert against Stripe directly (the source of truth for what billed). With the
+		// snap there is no mid-cycle sliver: exactly two invoices, the $20 Pro attach and
+		// the full $50 renewal. The pre-fix bug would add a third tiny proration invoice.
+		const stripeInvoices = await ctx.stripeCli.invoices.list({
+			customer: beforeRenewal.stripe_id!,
+			limit: 20,
+		});
+		const invoiceTotals = stripeInvoices.data
+			.map((invoice) => invoice.total)
+			.filter((total) => total !== 0)
+			.sort((a, b) => a - b);
+		expect(invoiceTotals).toEqual([2000, 5000]);
 	},
 );

--- a/server/tests/integration/billing/create-schedule/preview/create-schedule-preview.test.ts
+++ b/server/tests/integration/billing/create-schedule/preview/create-schedule-preview.test.ts
@@ -958,23 +958,6 @@ test.concurrent(
 	},
 );
 
-/**
- * TDD regression for the "preview numbers are cooked" report: a scheduled plan
- * swap dated on the current cycle's renewal *date* but at an incidental wall-clock
- * time (the dashboard date picker emits the selected date with a time-of-day that
- * does not equal the subscription's anchor instant) lands a few hours short of the
- * real cycle boundary.
- *
- * Red-failure mode (pre-fix):
- *  - The transition is classified as a mid-cycle scheduled_change and the new plan
- *    is prorated over the tiny gap to the anchor boundary, so next_cycle.total is a
- *    near-zero sliver and next_cycle.starts_at is the offset timestamp, not the
- *    renewal boundary. The full charge is silently deferred to a separate invoice.
- *
- * Green-success criteria (after fix):
- *  - The phase snaps to the exact cycle boundary, so next_cycle bills the new plan's
- *    full first period ($50) at the renewal boundary.
- */
 test.concurrent(
 	`${chalk.yellowBright("create-schedule preview 16: replacement landing on the cycle boundary charges the full new plan, not a sliver")}`,
 	async () => {
@@ -996,12 +979,9 @@ test.concurrent(
 			actions: [s.billing.attach({ productId: pro.id })],
 		});
 
-		// Anchor == advancedTo, so the next renewal boundary is one month out.
 		const renewalAt = truncateMsToSecondPrecision(
 			addMonths(advancedTo, 1).getTime(),
 		);
-		// Dashboard sends the renewal *date* with an incidental time-of-day, so the
-		// scheduled switch lands a few hours short of the real anchor instant.
 		const transitionAt = renewalAt - ms.hours(6);
 
 		await expectPreviewToMatchCreateSchedule({
@@ -1017,13 +997,10 @@ test.concurrent(
 			assertPreview: (preview) => {
 				expect(preview.line_items).toHaveLength(0);
 				expect(preview.next_cycle).toBeDefined();
-				// Snapped onto the real cycle boundary (Stripe's anchor instant, a few
-				// seconds off a naive month-add), not the offset the dashboard sent.
 				expect(preview.next_cycle?.starts_at).not.toBe(transitionAt);
 				expect(
 					Math.abs((preview.next_cycle?.starts_at ?? 0) - renewalAt),
 				).toBeLessThan(ms.hours(1));
-				// Full new-plan first period, not a proration sliver.
 				expectCloseToCents({
 					actual: preview.next_cycle?.total ?? 0,
 					expected: 50,
@@ -1033,11 +1010,6 @@ test.concurrent(
 	},
 );
 
-/**
- * End-to-end billing proof for the boundary snap: advancing past the renewal must
- * produce a single full charge for the new plan, not a tiny proration sliver at the
- * offset time followed by the full charge at the anchor (the pre-fix double-invoice).
- */
 test.concurrent(
 	`${chalk.yellowBright("create-schedule preview 17: snapped boundary bills one full renewal invoice, no sliver")}`,
 	async () => {
@@ -1073,7 +1045,6 @@ test.concurrent(
 			],
 		});
 
-		// Only the Pro attach has billed; the swap is scheduled for the boundary.
 		const beforeRenewal =
 			await autumnV1.customers.get<ApiCustomerV3>(customerId);
 		await expectCustomerInvoiceCorrect({
@@ -1089,9 +1060,6 @@ test.concurrent(
 			waitForSeconds: 30,
 		});
 
-		// Assert against Stripe directly (the source of truth for what billed). With the
-		// snap there is no mid-cycle sliver: exactly two invoices, the $20 Pro attach and
-		// the full $50 renewal. The pre-fix bug would add a third tiny proration invoice.
 		const stripeInvoices = await ctx.stripeCli.invoices.list({
 			customer: beforeRenewal.stripe_id!,
 			limit: 20,

--- a/server/tests/unit/billing/create-schedule/normalize-create-schedule-phases.spec.ts
+++ b/server/tests/unit/billing/create-schedule/normalize-create-schedule-phases.spec.ts
@@ -88,9 +88,6 @@ describe(chalk.yellowBright("normalizeCreateSchedulePhases"), () => {
 		]);
 	});
 
-	// Regression: the date picker defaults a phase to noon, so an "end of current cycle"
-	// switch lands a few hours off the subscription's anchor instant. Such a phase must
-	// snap to the exact cycle boundary so the new plan bills a full first period.
 	test("snaps a near-boundary future phase onto the cycle boundary", () => {
 		const currentEpochMs = Date.UTC(2026, 0, 14);
 		const cycleBoundaryMs = currentEpochMs + ms.days(30);
@@ -135,8 +132,6 @@ describe(chalk.yellowBright("normalizeCreateSchedulePhases"), () => {
 		]);
 	});
 
-	// A deliberate `now + 30 days` phase sits a full day from the boundary on a 31-day
-	// cycle; that gap must stay outside the snap window so it is never silently moved.
 	test("leaves a phase a full day from the boundary unchanged", () => {
 		const currentEpochMs = Date.UTC(2026, 0, 14);
 		const cycleBoundaryMs = currentEpochMs + ms.days(31);
@@ -155,6 +150,31 @@ describe(chalk.yellowBright("normalizeCreateSchedulePhases"), () => {
 		expect(result.map((phase) => phase.starts_at)).toEqual([
 			currentEpochMs,
 			deliberateStartsAt,
+		]);
+	});
+
+	test("snaps only the nearest phase when several bracket the boundary", () => {
+		const currentEpochMs = Date.UTC(2026, 0, 14);
+		const cycleBoundaryMs = currentEpochMs + ms.days(30);
+		const phases: CreateScheduleParamsV0["phases"] = [
+			{ starts_at: currentEpochMs, plans: [{ plan_id: "base" }] },
+			{ starts_at: cycleBoundaryMs - ms.hours(6), plans: [{ plan_id: "pro" }] },
+			{
+				starts_at: cycleBoundaryMs + ms.hours(1),
+				plans: [{ plan_id: "premium" }],
+			},
+		];
+
+		const result = normalizeCreateSchedulePhases({
+			phases,
+			currentEpochMs,
+			cycleBoundaryMs,
+		});
+
+		expect(result.map((phase) => phase.starts_at)).toEqual([
+			currentEpochMs,
+			cycleBoundaryMs - ms.hours(6),
+			cycleBoundaryMs,
 		]);
 	});
 

--- a/server/tests/unit/billing/create-schedule/normalize-create-schedule-phases.spec.ts
+++ b/server/tests/unit/billing/create-schedule/normalize-create-schedule-phases.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	addDuration,
 	type CreateScheduleParamsV0,
+	ms,
 	StartingAfterDuration,
 } from "@autumn/shared";
 import chalk from "chalk";
@@ -84,6 +85,76 @@ describe(chalk.yellowBright("normalizeCreateSchedulePhases"), () => {
 				starts_at: phase3StartsAt,
 				plans: [{ plan_id: "premium" }],
 			},
+		]);
+	});
+
+	// Regression: the date picker defaults a phase to noon, so an "end of current cycle"
+	// switch lands a few hours off the subscription's anchor instant. Such a phase must
+	// snap to the exact cycle boundary so the new plan bills a full first period.
+	test("snaps a near-boundary future phase onto the cycle boundary", () => {
+		const currentEpochMs = Date.UTC(2026, 0, 14);
+		const cycleBoundaryMs = currentEpochMs + ms.days(30);
+		const phases: CreateScheduleParamsV0["phases"] = [
+			{ starts_at: currentEpochMs, plans: [{ plan_id: "pro" }] },
+			{
+				starts_at: cycleBoundaryMs - ms.hours(6),
+				plans: [{ plan_id: "premium" }],
+			},
+		];
+
+		const result = normalizeCreateSchedulePhases({
+			phases,
+			currentEpochMs,
+			cycleBoundaryMs,
+		});
+
+		expect(result.map((phase) => phase.starts_at)).toEqual([
+			currentEpochMs,
+			cycleBoundaryMs,
+		]);
+	});
+
+	test("leaves a genuinely mid-cycle future phase unchanged", () => {
+		const currentEpochMs = Date.UTC(2026, 0, 14);
+		const cycleBoundaryMs = currentEpochMs + ms.days(30);
+		const midCycleStartsAt = cycleBoundaryMs - ms.days(15);
+		const phases: CreateScheduleParamsV0["phases"] = [
+			{ starts_at: currentEpochMs, plans: [{ plan_id: "pro" }] },
+			{ starts_at: midCycleStartsAt, plans: [{ plan_id: "premium" }] },
+		];
+
+		const result = normalizeCreateSchedulePhases({
+			phases,
+			currentEpochMs,
+			cycleBoundaryMs,
+		});
+
+		expect(result.map((phase) => phase.starts_at)).toEqual([
+			currentEpochMs,
+			midCycleStartsAt,
+		]);
+	});
+
+	// A deliberate `now + 30 days` phase sits a full day from the boundary on a 31-day
+	// cycle; that gap must stay outside the snap window so it is never silently moved.
+	test("leaves a phase a full day from the boundary unchanged", () => {
+		const currentEpochMs = Date.UTC(2026, 0, 14);
+		const cycleBoundaryMs = currentEpochMs + ms.days(31);
+		const deliberateStartsAt = currentEpochMs + ms.days(30);
+		const phases: CreateScheduleParamsV0["phases"] = [
+			{ starts_at: currentEpochMs, plans: [{ plan_id: "pro" }] },
+			{ starts_at: deliberateStartsAt, plans: [{ plan_id: "premium" }] },
+		];
+
+		const result = normalizeCreateSchedulePhases({
+			phases,
+			currentEpochMs,
+			cycleBoundaryMs,
+		});
+
+		expect(result.map((phase) => phase.starts_at)).toEqual([
+			currentEpochMs,
+			deliberateStartsAt,
 		]);
 	});
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Snap future `create_schedule` phases near renewal to the exact cycle boundary so renewal bills a full period, not a tiny proration. Now snaps only the single nearest phase to avoid duplicate timestamps and keep phase order valid.

- **Bug Fixes**
  - In `normalizeCreateSchedulePhases`, snap only the nearest future phase within 12h of `cycleBoundaryMs`; never move the first phase; snap only if the boundary is strictly between neighbors to preserve strictly increasing order and avoid duplicate `starts_at`.
  - Compute `cycleBoundaryMs` in `setupCreateScheduleBillingContext` via `setupAttachEndOfCycleMs`; skip when `billing_cycle_anchor` is provided.
  - Added unit tests for nearest-phase selection and no-snap cases; integration tests confirm previews show a full next-cycle charge and Stripe produces one renewal invoice (no mid-cycle sliver).

<sup>Written for commit 2f96932f8c3af7e11a6d2493891fc2a35c539932. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a billing edge case where a `create_schedule` phase timed just before a billing renewal would generate a short prorated "sliver" charge instead of billing the full next-cycle amount. It resolves this by snapping the single nearest future phase within a 12-hour window onto the exact cycle boundary before Stripe sees the schedule.

- **Bug fix**: `snapResolvedPhasesToCycleBoundary` finds the one closest phase (skipping index 0) within `CYCLE_BOUNDARY_SNAP_WINDOW_MS` (12 h) and, after strict-order safety guards, moves it to `cycleBoundaryMs` — fixing the double-snap collision identified in prior review.
- **Improvements**: `setupCreateScheduleBillingContext` now derives `cycleBoundaryMs` from the existing subscription's `current_period_end` (via `setupAttachEndOfCycleMs`) and passes it through to `normalizeCreateSchedulePhases`; snapping is skipped entirely when `billing_cycle_anchor` is explicitly provided.
- **Improvements**: Unit tests cover snap, no-snap (mid-cycle, 1-day-out), and nearest-only selection; integration tests verify that the preview shows a full next-cycle charge and that Stripe produces exactly two invoices after clock advancement (no sliver).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to phase snapping and does not affect schedules where no existing subscription is present or where billing_cycle_anchor is explicitly set.

The snap logic correctly selects only the single nearest phase, the safety guards prevent any duplicate or out-of-order timestamps, and the new unit and integration tests exercise the key scenarios including the previously identified double-snap edge case.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/createSchedule/errors/normalizeCreateSchedulePhases.ts | Adds `snapResolvedPhasesToCycleBoundary` which selects the single nearest post-first phase within a 12 h window and snaps it to the cycle boundary, with guards preventing duplicate or out-of-order timestamps; logic is correct and the previous double-snap issue is resolved. |
| server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts | Derives `cycleBoundaryMs` from the existing subscription's period end via `setupAttachEndOfCycleMs` and threads it into `normalizeCreateSchedulePhases`; correctly skips snapping when `billing_cycle_anchor` is explicitly set. |
| server/tests/unit/billing/create-schedule/normalize-create-schedule-phases.spec.ts | Adds four new unit tests covering snap, no-snap (mid-cycle), no-snap (just outside window), and nearest-only selection; all cases are meaningful and correctly assert expected timestamps. |
| server/tests/integration/billing/create-schedule/preview/create-schedule-preview.test.ts | Adds integration tests 16 and 17: preview 16 verifies the snapped next_cycle total equals the full plan price, and test 17 confirms Stripe emits exactly two non-zero invoices after clock advancement (no sliver). |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[setupCreateScheduleBillingContext] --> B{billing_cycle_anchor\nprovided?}
    B -- yes --> C[cycleBoundaryMs = undefined\nno snapping]
    B -- no --> D[setupAttachEndOfCycleMs\nplanTiming='end_of_cycle']
    D --> E{stripeSubscription\nexists?}
    E -- yes --> F[cycleBoundaryMs =\ncurrent_period_end]
    E -- no --> G[cycleBoundaryMs = undefined\nno snapping]
    F --> H[normalizeCreateSchedulePhases\nwith cycleBoundaryMs]
    C --> H
    G --> H
    H --> I[Resolve relative timing\nto absolute timestamps]
    I --> J{cycleBoundaryMs\ndefined?}
    J -- no --> K[resolvedPhases unchanged]
    J -- yes --> L[snapResolvedPhasesToCycleBoundary]
    L --> M[Find nearest phase\nindex > 0 within 12h window]
    M --> N{Any phase\nwithin window?}
    N -- no --> O[return phases unchanged]
    N -- yes --> P{Safety guards:\ncycleBoundary > prev AND\ncycleBoundary < next?}
    P -- fail --> O
    P -- pass --> Q[Snap nearest phase\nstarts_at = cycleBoundaryMs]
    Q --> R[assertStrictlyIncreasing]
    K --> R
    O --> R
    R --> S[return normalized phases]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[setupCreateScheduleBillingContext] --> B{billing_cycle_anchor\nprovided?}
    B -- yes --> C[cycleBoundaryMs = undefined\nno snapping]
    B -- no --> D[setupAttachEndOfCycleMs\nplanTiming='end_of_cycle']
    D --> E{stripeSubscription\nexists?}
    E -- yes --> F[cycleBoundaryMs =\ncurrent_period_end]
    E -- no --> G[cycleBoundaryMs = undefined\nno snapping]
    F --> H[normalizeCreateSchedulePhases\nwith cycleBoundaryMs]
    C --> H
    G --> H
    H --> I[Resolve relative timing\nto absolute timestamps]
    I --> J{cycleBoundaryMs\ndefined?}
    J -- no --> K[resolvedPhases unchanged]
    J -- yes --> L[snapResolvedPhasesToCycleBoundary]
    L --> M[Find nearest phase\nindex > 0 within 12h window]
    M --> N{Any phase\nwithin window?}
    N -- no --> O[return phases unchanged]
    N -- yes --> P{Safety guards:\ncycleBoundary > prev AND\ncycleBoundary < next?}
    P -- fail --> O
    P -- pass --> Q[Snap nearest phase\nstarts_at = cycleBoundaryMs]
    Q --> R[assertStrictlyIncreasing]
    K --> R
    O --> R
    R --> S[return normalized phases]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["snap only the nearest phase to the cycle..."](https://github.com/useautumn/autumn/commit/2f96932f8c3af7e11a6d2493891fc2a35c539932) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38461200)</sub>

<!-- /greptile_comment -->