### PR TITLE
fix(sync): preserve entity scope + carry over usage when re-syncing plans

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/tasks/autoSyncFromSubscription.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/tasks/autoSyncFromSubscription.ts
@@ -50,6 +50,7 @@ export const autoSyncFromSubscription = async ({
 		ctx,
 		customerId,
 		subscription,
+		customerProducts: fullCustomer.customer_products,
 	});
 
 	const eligibility = canAutoSync({ match });

--- a/server/src/internal/billing/v2/actions/attach/setup/setupAttachTransitionContext.ts
+++ b/server/src/internal/billing/v2/actions/attach/setup/setupAttachTransitionContext.ts
@@ -17,10 +17,16 @@ export const setupAttachTransitionContext = ({
 	fullCustomer,
 	attachProduct,
 	planScheduleOverride,
+	internalEntityId,
 }: {
 	fullCustomer: FullCustomer;
 	attachProduct: FullProduct;
 	planScheduleOverride?: PlanTiming;
+	/** Scope the transition lookup to a specific entity. When omitted, the
+	 * finders fall back to the customer's current entity context (customer
+	 * level for a customer-scoped attach). Required so an entity-scoped attach
+	 * transitions from the existing product on that same entity. */
+	internalEntityId?: string;
 }) => {
 	// Only main recurring products can trigger transitions
 	const isMainRecurring =
@@ -38,11 +44,13 @@ export const setupAttachTransitionContext = ({
 	const currentCustomerProduct = findMainActiveCustomerProductByGroup({
 		fullCus: fullCustomer,
 		productGroup: attachProduct.group,
+		internalEntityId,
 	});
 
 	const scheduledCustomerProduct = findMainScheduledCustomerProductByGroup({
 		fullCustomer,
 		productGroup: attachProduct.group,
+		internalEntityId,
 	});
 
 	// Compute planTiming (upgrade = immediate, downgrade = end_of_cycle)

--- a/server/src/internal/billing/v2/actions/sync/buildSyncParams/buildFeatureQuantities.ts
+++ b/server/src/internal/billing/v2/actions/sync/buildSyncParams/buildFeatureQuantities.ts
@@ -1,6 +1,7 @@
 import {
 	type FeatureQuantityParamsV0,
 	isPrepaidPrice,
+	notNullish,
 	priceToEnt,
 } from "@autumn/shared";
 import { Decimal } from "decimal.js";
@@ -68,16 +69,23 @@ export const buildFeatureQuantities = ({
 		const billingUnits = price.config.billing_units ?? 1;
 		const allowance = entitlement.allowance ?? 0;
 		const stripePriceIdOnSub = itemDiff.stripe.stripe_price_id;
-		const isV2Prepaid =
-			"stripe_prepaid_price_v2_id" in price.config &&
-			stripePriceIdOnSub === price.config.stripe_prepaid_price_v2_id;
+
+		// Stripe quantity counts EXTRAS only for the explicit V1 prepaid price id,
+		// where the allowance is implicit/unbilled and must be added back. For the
+		// V2 id — or any imported / Stripe-native price id on the sub — the
+		// quantity is the TOTAL (allowance-inclusive), so it passes through.
+		// Defaulting non-V1 ids to the "extras" branch folded Stripe's default
+		// `quantity: 1` into a phantom +1 credit on top of the allowance.
+		const isV1ExtrasOnly =
+			notNullish(price.config.stripe_price_id) &&
+			stripePriceIdOnSub === price.config.stripe_price_id;
 
 		const stripeQuantityInUnits = new Decimal(itemDiff.stripe.quantity)
 			.mul(billingUnits)
 			.toNumber();
-		const featureUnits = isV2Prepaid
-			? stripeQuantityInUnits
-			: stripeQuantityInUnits + allowance;
+		const featureUnits = isV1ExtrasOnly
+			? stripeQuantityInUnits + allowance
+			: stripeQuantityInUnits;
 
 		result.push({
 			feature_id: entitlement.feature.id,

--- a/server/src/internal/billing/v2/actions/sync/compute/carryOverUsage.ts
+++ b/server/src/internal/billing/v2/actions/sync/compute/carryOverUsage.ts
@@ -1,4 +1,9 @@
-import type { FullCusProduct, FullCustomerEntitlement } from "@autumn/shared";
+import {
+	cusEntsToUsage,
+	type FullCusEntWithFullCusProduct,
+	type FullCusProduct,
+	type FullCustomerEntitlement,
+} from "@autumn/shared";
 
 /**
  * When a sync expires an existing plan and inserts a replacement for the same
@@ -8,11 +13,16 @@ import type { FullCusProduct, FullCustomerEntitlement } from "@autumn/shared";
  *
  * Example: Free at 5/10 (5 used) replaced by Pro (20 included) → Pro at 15/20.
  *
+ * The new entitlement was just initialized to its full granted amount (plain
+ * allowance OR prepaid quantity), so the carry is simply
+ *   newBalance = newInitialBalance − oldUsage
+ * where `oldUsage` is computed via `cusEntsToUsage`, which correctly accounts
+ * for prepaid quantity (prepaid features carry their included amount in the
+ * prepaid quantity, not in `entitlement.allowance`).
+ *
  * Mutates `inserted` in place. Matches entitlements by `internal_feature_id`.
- * Conservatively skips entitlements where carry-over is ambiguous or would
- * corrupt structure — unlimited features, features without a numeric
- * allowance (prepaid/pure-usage), and legacy per-entity balance hashes — and
- * leaves those at their fresh allowance.
+ * Skips unlimited features and legacy per-entity balance hashes (whose balance
+ * lives in a per-entity map rather than the top-level `balance`).
  */
 export const carryOverEntitlementUsage = ({
 	inserted,
@@ -30,24 +40,28 @@ export const carryOverEntitlementUsage = ({
 		const oldCusEnt = expiringByFeature.get(newCusEnt.internal_feature_id);
 		if (!oldCusEnt) continue;
 
-		// Skip cases where a simple balance transfer doesn't apply.
 		if (newCusEnt.unlimited || oldCusEnt.unlimited) continue;
-		// Legacy per-entity balance hash — handled differently; leave untouched.
+		// Legacy per-entity balance hash — balance lives per-entity, not on the
+		// top-level `balance` we mutate here; leave untouched.
 		if (newCusEnt.entities || oldCusEnt.entities) continue;
 
-		const newAllowance = newCusEnt.entitlement.allowance;
-		const oldAllowance = oldCusEnt.entitlement.allowance;
-		if (newAllowance == null || oldAllowance == null) continue;
+		// Usage consumed on the expiring plan. `cusEntsToUsage` needs the cusEnt
+		// linked to its product (for prepaid quantity + plan quantity).
+		const oldUsage = cusEntsToUsage({
+			cusEnts: [
+				{
+					...oldCusEnt,
+					customer_product: expiring,
+				} as FullCusEntWithFullCusProduct,
+			],
+		});
+		if (oldUsage <= 0) continue;
 
-		const oldBalance = oldCusEnt.balance ?? 0;
-		const consumed = Math.max(0, oldAllowance - oldBalance);
-		if (consumed === 0) continue;
-
-		const carriedBalance = newAllowance - consumed;
+		const carried = (newCusEnt.balance ?? 0) - oldUsage;
 		// Allow negative (overage) when the feature permits it; otherwise floor
 		// at zero so a larger prior consumption can't over-credit.
 		newCusEnt.balance = newCusEnt.usage_allowed
-			? carriedBalance
-			: Math.max(0, carriedBalance);
+			? carried
+			: Math.max(0, carried);
 	}
 };

--- a/server/src/internal/billing/v2/actions/sync/compute/carryOverUsage.ts
+++ b/server/src/internal/billing/v2/actions/sync/compute/carryOverUsage.ts
@@ -3,7 +3,34 @@ import {
 	type FullCusEntWithFullCusProduct,
 	type FullCusProduct,
 	type FullCustomerEntitlement,
+	isPayPerUseCustomerEntitlement,
 } from "@autumn/shared";
+
+const withProduct = (
+	cusEnt: FullCustomerEntitlement,
+	product: FullCusProduct,
+): FullCusEntWithFullCusProduct =>
+	({ ...cusEnt, customer_product: product }) as FullCusEntWithFullCusProduct;
+
+/**
+ * A cusEnt whose stored balance is meaningful to carry over. Skips:
+ *  - unlimited features (no balance),
+ *  - legacy per-entity balance hashes (balance lives per-entity, not top-level),
+ *  - pay-per-use / in-arrear components — those are billed from the Stripe meter,
+ *    not a stored balance, and a feature can carry BOTH a prepaid/included row
+ *    and a pay-per-use overage row under the same feature id (so excluding the
+ *    overage also disambiguates the per-feature match).
+ */
+const isCarriableCusEnt = (
+	cusEnt: FullCustomerEntitlement,
+	product: FullCusProduct,
+): boolean => {
+	if (cusEnt.unlimited) return false;
+	if (cusEnt.entities) return false;
+	if (isPayPerUseCustomerEntitlement(withProduct(cusEnt, product)))
+		return false;
+	return true;
+};
 
 /**
  * When a sync expires an existing plan and inserts a replacement for the same
@@ -13,16 +40,15 @@ import {
  *
  * Example: Free at 5/10 (5 used) replaced by Pro (20 included) → Pro at 15/20.
  *
- * The new entitlement was just initialized to its full granted amount (plain
- * allowance OR prepaid quantity), so the carry is simply
+ * The new entitlement is already initialized to its full granted amount (plain
+ * allowance OR prepaid quantity), so the carry is
  *   newBalance = newInitialBalance − oldUsage
- * where `oldUsage` is computed via `cusEntsToUsage`, which correctly accounts
- * for prepaid quantity (prepaid features carry their included amount in the
- * prepaid quantity, not in `entitlement.allowance`).
+ * where `oldUsage` comes from `cusEntsToUsage`, which accounts for prepaid
+ * quantity (prepaid keeps its included amount in the prepaid quantity, not in
+ * `entitlement.allowance`).
  *
- * Mutates `inserted` in place. Matches entitlements by `internal_feature_id`.
- * Skips unlimited features and legacy per-entity balance hashes (whose balance
- * lives in a per-entity map rather than the top-level `balance`).
+ * Mutates `inserted` in place. Matches the carriable (non-pay-per-use)
+ * entitlement of each feature, and only carries when that match is unambiguous.
  */
 export const carryOverEntitlementUsage = ({
 	inserted,
@@ -31,29 +57,25 @@ export const carryOverEntitlementUsage = ({
 	inserted: FullCusProduct;
 	expiring: FullCusProduct;
 }): void => {
-	const expiringByFeature = new Map<string, FullCustomerEntitlement>();
+	// Carriable expiring cusEnts grouped by feature (normally one per feature).
+	const expiringByFeature = new Map<string, FullCustomerEntitlement[]>();
 	for (const cusEnt of expiring.customer_entitlements) {
-		expiringByFeature.set(cusEnt.internal_feature_id, cusEnt);
+		if (!isCarriableCusEnt(cusEnt, expiring)) continue;
+		const list = expiringByFeature.get(cusEnt.internal_feature_id) ?? [];
+		list.push(cusEnt);
+		expiringByFeature.set(cusEnt.internal_feature_id, list);
 	}
 
 	for (const newCusEnt of inserted.customer_entitlements) {
-		const oldCusEnt = expiringByFeature.get(newCusEnt.internal_feature_id);
-		if (!oldCusEnt) continue;
+		if (!isCarriableCusEnt(newCusEnt, inserted)) continue;
 
-		if (newCusEnt.unlimited || oldCusEnt.unlimited) continue;
-		// Legacy per-entity balance hash — balance lives per-entity, not on the
-		// top-level `balance` we mutate here; leave untouched.
-		if (newCusEnt.entities || oldCusEnt.entities) continue;
+		const candidates = expiringByFeature.get(newCusEnt.internal_feature_id);
+		// Only carry when there's exactly one carriable counterpart — otherwise
+		// the pairing is ambiguous and we leave the fresh balance untouched.
+		if (!candidates || candidates.length !== 1) continue;
 
-		// Usage consumed on the expiring plan. `cusEntsToUsage` needs the cusEnt
-		// linked to its product (for prepaid quantity + plan quantity).
 		const oldUsage = cusEntsToUsage({
-			cusEnts: [
-				{
-					...oldCusEnt,
-					customer_product: expiring,
-				} as FullCusEntWithFullCusProduct,
-			],
+			cusEnts: [withProduct(candidates[0], expiring)],
 		});
 		if (oldUsage <= 0) continue;
 

--- a/server/src/internal/billing/v2/actions/sync/compute/carryOverUsage.ts
+++ b/server/src/internal/billing/v2/actions/sync/compute/carryOverUsage.ts
@@ -1,0 +1,53 @@
+import type { FullCusProduct, FullCustomerEntitlement } from "@autumn/shared";
+
+/**
+ * When a sync expires an existing plan and inserts a replacement for the same
+ * subject (customer→customer, entity→entity — guaranteed by the entity-scoped
+ * transition lookup), carry the expired plan's already-consumed usage onto the
+ * new plan's balances so the customer doesn't silently regain a full allowance.
+ *
+ * Example: Free at 5/10 (5 used) replaced by Pro (20 included) → Pro at 15/20.
+ *
+ * Mutates `inserted` in place. Matches entitlements by `internal_feature_id`.
+ * Conservatively skips entitlements where carry-over is ambiguous or would
+ * corrupt structure — unlimited features, features without a numeric
+ * allowance (prepaid/pure-usage), and legacy per-entity balance hashes — and
+ * leaves those at their fresh allowance.
+ */
+export const carryOverEntitlementUsage = ({
+	inserted,
+	expiring,
+}: {
+	inserted: FullCusProduct;
+	expiring: FullCusProduct;
+}): void => {
+	const expiringByFeature = new Map<string, FullCustomerEntitlement>();
+	for (const cusEnt of expiring.customer_entitlements) {
+		expiringByFeature.set(cusEnt.internal_feature_id, cusEnt);
+	}
+
+	for (const newCusEnt of inserted.customer_entitlements) {
+		const oldCusEnt = expiringByFeature.get(newCusEnt.internal_feature_id);
+		if (!oldCusEnt) continue;
+
+		// Skip cases where a simple balance transfer doesn't apply.
+		if (newCusEnt.unlimited || oldCusEnt.unlimited) continue;
+		// Legacy per-entity balance hash — handled differently; leave untouched.
+		if (newCusEnt.entities || oldCusEnt.entities) continue;
+
+		const newAllowance = newCusEnt.entitlement.allowance;
+		const oldAllowance = oldCusEnt.entitlement.allowance;
+		if (newAllowance == null || oldAllowance == null) continue;
+
+		const oldBalance = oldCusEnt.balance ?? 0;
+		const consumed = Math.max(0, oldAllowance - oldBalance);
+		if (consumed === 0) continue;
+
+		const carriedBalance = newAllowance - consumed;
+		// Allow negative (overage) when the feature permits it; otherwise floor
+		// at zero so a larger prior consumption can't over-credit.
+		newCusEnt.balance = newCusEnt.usage_allowed
+			? carriedBalance
+			: Math.max(0, carriedBalance);
+	}
+};

--- a/server/src/internal/billing/v2/actions/sync/compute/computeSyncImmediatePhase.ts
+++ b/server/src/internal/billing/v2/actions/sync/compute/computeSyncImmediatePhase.ts
@@ -7,6 +7,7 @@ import {
 	type SyncBillingContext,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { carryOverEntitlementUsage } from "./carryOverUsage";
 import { initImmediateSyncCustomerProduct } from "./initImmediateSyncCustomerProduct";
 
 type CustomerProductUpdate = NonNullable<
@@ -50,8 +51,13 @@ export const computeSyncImmediatePhase = ({
 	ctx: AutumnContext;
 	syncContext: SyncBillingContext;
 }): ImmediatePhaseResult => {
-	const { immediatePhase, fullCustomer, stripeSubscription, currentEpochMs } =
-		syncContext;
+	const {
+		immediatePhase,
+		fullCustomer,
+		stripeSubscription,
+		currentEpochMs,
+		carryOverUsage,
+	} = syncContext;
 	if (!immediatePhase || !stripeSubscription) {
 		return {
 			insertCustomerProducts: [],
@@ -67,15 +73,22 @@ export const computeSyncImmediatePhase = ({
 	const customEntitlements: Entitlement[] = [];
 
 	for (const productContext of immediatePhase.productContexts) {
-		insertCustomerProducts.push(
-			initImmediateSyncCustomerProduct({
-				ctx,
-				fullCustomer,
-				productContext,
-				stripeSubscription,
-				currentEpochMs,
-			}),
-		);
+		const insertedCustomerProduct = initImmediateSyncCustomerProduct({
+			ctx,
+			fullCustomer,
+			productContext,
+			stripeSubscription,
+			currentEpochMs,
+		});
+
+		if (carryOverUsage && productContext.currentCustomerProduct) {
+			carryOverEntitlementUsage({
+				inserted: insertedCustomerProduct,
+				expiring: productContext.currentCustomerProduct,
+			});
+		}
+
+		insertCustomerProducts.push(insertedCustomerProduct);
 		customPrices.push(...productContext.customPrices);
 		customEntitlements.push(...productContext.customEntitlements);
 

--- a/server/src/internal/billing/v2/actions/sync/setup/setupSyncContext.ts
+++ b/server/src/internal/billing/v2/actions/sync/setup/setupSyncContext.ts
@@ -93,6 +93,10 @@ const buildProductContext = async ({
 		const transition = setupAttachTransitionContext({
 			fullCustomer,
 			attachProduct: fullProduct,
+			// Scope the "previous product to expire" lookup to the plan's entity
+			// so an entity-scoped sync replaces the existing product on that
+			// same entity rather than missing it (which would duplicate).
+			internalEntityId: entity?.internal_id,
 		});
 		currentCustomerProduct = transition.currentCustomerProduct;
 	}

--- a/server/src/internal/billing/v2/actions/sync/setup/setupSyncContext.ts
+++ b/server/src/internal/billing/v2/actions/sync/setup/setupSyncContext.ts
@@ -229,5 +229,6 @@ export const setupSyncContext = async ({
 		futurePhases,
 		currentEpochMs,
 		acknowledgedWarnings: params.acknowledge_warnings ?? [],
+		carryOverUsage: params.carry_over_usage ?? true,
 	};
 };

--- a/server/src/internal/billing/v2/actions/sync/subscriptionToSyncParams.ts
+++ b/server/src/internal/billing/v2/actions/sync/subscriptionToSyncParams.ts
@@ -1,14 +1,17 @@
 import {
-	secondsToMs,
+	type FullCusProduct,
+	filterCustomerProductsByStripeSubscriptionId,
 	type SyncParamsV1,
 	type SyncPhase,
 	type SyncPlanInstance,
+	secondsToMs,
 } from "@autumn/shared";
 import type Stripe from "stripe";
 import { createStripeCli } from "@/external/connect/createStripeCli";
 import { getStripeActiveSubscriptionSchedule } from "@/external/stripe/subscriptionSchedules";
 import { stripeSubscriptionToScheduleId } from "@/external/stripe/subscriptions/utils/convertStripeSubscription";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { CusService } from "@/internal/customers/CusService";
 import { buildFeatureQuantities } from "./buildSyncParams/buildFeatureQuantities";
 import { detectSubscriptionMatch } from "./detect/detectSubscriptionMatch";
 import type {
@@ -36,6 +39,55 @@ const matchedPlanToSyncPlan = ({
 	};
 };
 
+/**
+ * Detection is scope-blind: it matches Stripe prices to catalog products with
+ * no knowledge of the customer's existing customer products. When a product is
+ * already linked to this Stripe subscription via an entity-scoped customer
+ * product, re-syncing it without that binding would insert a duplicate at the
+ * customer level (and `expire_previous` would miss the entity-scoped original).
+ *
+ * Stamp the existing entity binding onto each matched plan so the sync
+ * re-attaches the product on the same entity and matches/expires the original.
+ */
+const stampEntityFromExistingLinks = ({
+	phases,
+	subscription,
+	customerProducts,
+}: {
+	phases: SyncPhase[];
+	subscription?: Stripe.Subscription;
+	customerProducts: FullCusProduct[];
+}): SyncPhase[] => {
+	if (!subscription) return phases;
+
+	const linkedCustomerProducts = filterCustomerProductsByStripeSubscriptionId({
+		customerProducts,
+		stripeSubscriptionId: subscription.id,
+	});
+
+	// product id → existing entity binding (only entity-scoped links).
+	// `entity_id` accepts either the public or internal entity id, so the
+	// internal id stored on the customer product is sufficient.
+	const entityIdByProductId = new Map<string, string>();
+	for (const customerProduct of linkedCustomerProducts) {
+		const productId = customerProduct.product?.id;
+		if (customerProduct.internal_entity_id && productId) {
+			entityIdByProductId.set(productId, customerProduct.internal_entity_id);
+		}
+	}
+
+	if (entityIdByProductId.size === 0) return phases;
+
+	return phases.map((phase) => ({
+		...phase,
+		plans: phase.plans.map((plan) => {
+			if (plan.entity_id != null) return plan;
+			const entityId = entityIdByProductId.get(plan.plan_id);
+			return entityId ? { ...plan, entity_id: entityId } : plan;
+		}),
+	}));
+};
+
 const phaseMatchToSyncPhase = ({
 	phaseMatch,
 }: {
@@ -43,9 +95,7 @@ const phaseMatchToSyncPhase = ({
 }): SyncPhase => ({
 	// PhaseMatch.start_date is Stripe-native (seconds). SyncPhase.starts_at
 	// is ms epoch (or the "now" sentinel for the immediate phase).
-	starts_at: phaseMatch.is_current
-		? "now"
-		: secondsToMs(phaseMatch.start_date),
+	starts_at: phaseMatch.is_current ? "now" : secondsToMs(phaseMatch.start_date),
 	plans: phaseMatch.plans.map((matchedPlan) =>
 		matchedPlanToSyncPlan({
 			matchedPlan,
@@ -69,6 +119,7 @@ export const subscriptionToSyncParams = async ({
 	customerId,
 	subscription,
 	schedule,
+	customerProducts,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
@@ -76,6 +127,10 @@ export const subscriptionToSyncParams = async ({
 	/** Optional pre-fetched schedule. When omitted and `subscription` references
 	 * a schedule, it's fetched with schedule item prices expanded. */
 	schedule?: Stripe.SubscriptionSchedule;
+	/** Optional pre-fetched customer products (callers that already loaded the
+	 * full customer pass these to avoid a redundant fetch). Used to restore the
+	 * entity binding of products already linked to this subscription. */
+	customerProducts?: FullCusProduct[];
 }): Promise<{
 	match: SubscriptionMatch;
 	params: SyncParamsV1;
@@ -101,9 +156,22 @@ export const subscriptionToSyncParams = async ({
 		schedule: resolvedSchedule,
 	});
 
-	const phases: SyncPhase[] = match.phaseMatches
+	const detectedPhases: SyncPhase[] = match.phaseMatches
 		.filter((phase) => phase.plans.length > 0)
 		.map((phaseMatch) => phaseMatchToSyncPhase({ phaseMatch }));
+
+	const resolvedCustomerProducts =
+		customerProducts ??
+		(subscription
+			? (await CusService.getFull({ ctx, idOrInternalId: customerId }))
+					.customer_products
+			: []);
+
+	const phases = stampEntityFromExistingLinks({
+		phases: detectedPhases,
+		subscription,
+		customerProducts: resolvedCustomerProducts,
+	});
 
 	const params: SyncParamsV1 = {
 		customer_id: customerId,

--- a/server/src/internal/billing/v2/actions/sync/syncProposalsV2.ts
+++ b/server/src/internal/billing/v2/actions/sync/syncProposalsV2.ts
@@ -103,6 +103,7 @@ const buildProposal = async ({
 			customerId,
 			subscription,
 			schedule,
+			customerProducts,
 		},
 	);
 

--- a/server/tests/integration/billing/sync/sync-carry-prepaid-entities.test.ts
+++ b/server/tests/integration/billing/sync/sync-carry-prepaid-entities.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Regression: carry-over for PREPAID features across two entities
+ * (default_applies_to_entities = true).
+ *
+ * Two entities X and Y both on Pro (prepaid 5000 credits each) on one Stripe
+ * sub. Delink X (cancel no_billing → Free auto-reattaches on X). Use 500 on Y
+ * and 40 on X, then sync both entities back to Pro (the dashboard submits a
+ * rolled-up qty-2 plan on Y plus an operator-added qty-1 plan on X), expire +
+ * carry on.
+ *
+ * Prepaid stores its included amount in the prepaid quantity, not
+ * entitlement.allowance — so the carry must use real usage:
+ *   Y stays Pro 4500/5000 (500 carried), X returns to Pro 4960/5000 (40 carried).
+ */
+
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import {
+	CusProductStatus,
+	type FullCusProduct,
+	type SyncParamsV1,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import ctx from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { db } from "@/db/initDrizzle";
+import { EntityService } from "@/internal/api/entities/EntityService";
+import { CusService } from "@/internal/customers/CusService";
+import { OrgService } from "@/internal/orgs/OrgService";
+
+const MESSAGES = TestFeature.Messages;
+
+beforeAll(async () => {
+	await OrgService.update({
+		db,
+		orgId: ctx.org.id,
+		updates: {
+			config: { ...ctx.org.config, default_applies_to_entities: true },
+		},
+	});
+});
+
+afterAll(async () => {
+	await OrgService.update({
+		db,
+		orgId: ctx.org.id,
+		updates: {
+			config: { ...ctx.org.config, default_applies_to_entities: false },
+		},
+	});
+});
+
+const activeProductsOnEntity = async ({
+	customerId,
+	productId,
+	internalEntityId,
+}: {
+	customerId: string;
+	productId: string;
+	internalEntityId: string;
+}): Promise<FullCusProduct[]> => {
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	return fullCustomer.customer_products.filter(
+		(cp) =>
+			cp.product_id === productId &&
+			cp.status === CusProductStatus.Active &&
+			cp.internal_entity_id === internalEntityId,
+	);
+};
+
+const messagesBalance = (cusProduct: FullCusProduct): number | undefined =>
+	cusProduct.customer_entitlements.find(
+		(ce) => ce.entitlement?.feature?.id === MESSAGES,
+	)?.balance ?? undefined;
+
+test(
+	chalk.yellowBright(
+		"sync-v2 carry-usage: prepaid credits across two entities (delink X, resync both)",
+	),
+	async () => {
+		const customerId = "sync-carry-prepaid-entities";
+
+		const free = products.base({
+			id: "free",
+			items: [items.monthlyMessages({ includedUsage: 50 })],
+			isDefault: true,
+		});
+		const pro = products.pro({
+			id: "pro",
+			items: [
+				items.prepaidMessages({ includedUsage: 0, billingUnits: 1, price: 1 }),
+			],
+		});
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [free, pro] }),
+				s.entities({
+					count: 2,
+					featureId: TestFeature.Users,
+					defaultGroup: customerId,
+				}),
+			],
+			actions: [
+				s.attach({
+					productId: pro.id,
+					entityIndex: 0,
+					options: [{ feature_id: MESSAGES, quantity: 5000 }],
+				}),
+				s.attach({
+					productId: pro.id,
+					entityIndex: 1,
+					options: [{ feature_id: MESSAGES, quantity: 5000 }],
+				}),
+			],
+		});
+
+		const full = await CusService.getFull({ ctx, idOrInternalId: customerId });
+		const entityList = await EntityService.list({
+			db: ctx.db,
+			internalCustomerId: full.internal_id,
+		});
+		const entityX = entityList[0];
+		const entityY = entityList[1];
+		const proSubId = full.customer_products.find(
+			(cp) => cp.product_id === pro.id,
+		)?.subscription_ids?.[0];
+		if (!proSubId) throw new Error("no Pro sub id");
+
+		// Delink X → Free auto-reattaches on X.
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: pro.id,
+			entity_id: entityX.id ?? undefined,
+			cancel_action: "cancel_immediately",
+			no_billing_changes: true,
+		});
+		await new Promise((r) => setTimeout(r, 1500));
+
+		// Use 500 on Y (Pro) and 40 on X (Free).
+		await autumnV1.track({
+			customer_id: customerId,
+			entity_id: entityY.id ?? undefined,
+			feature_id: MESSAGES,
+			value: 500,
+		});
+		await autumnV1.track({
+			customer_id: customerId,
+			entity_id: entityX.id ?? undefined,
+			feature_id: MESSAGES,
+			value: 40,
+		});
+		await new Promise((r) => setTimeout(r, 2000));
+
+		// Mirror the dashboard submission: rolled-up qty-2 plan stamped to Y +
+		// operator-added qty-1 plan on X. Expire + carry default on.
+		await autumnV1.post("/billing.sync_v2", {
+			customer_id: customerId,
+			stripe_subscription_id: proSubId,
+			phases: [
+				{
+					starts_at: "now",
+					plans: [
+						{
+							plan_id: pro.id,
+							quantity: 2,
+							entity_id: entityY.id ?? undefined,
+							expire_previous: true,
+							feature_quantities: [{ feature_id: MESSAGES, quantity: 5000 }],
+						},
+						{
+							plan_id: pro.id,
+							quantity: 1,
+							entity_id: entityX.id ?? undefined,
+							expire_previous: true,
+							feature_quantities: [{ feature_id: MESSAGES, quantity: 5000 }],
+						},
+					],
+				},
+			],
+		} satisfies SyncParamsV1);
+
+		// Y: single active Pro, 500 carried → 4500.
+		const proY = await activeProductsOnEntity({
+			customerId,
+			productId: pro.id,
+			internalEntityId: entityY.internal_id,
+		});
+		expect(proY.length).toBe(1);
+		expect(messagesBalance(proY[0])).toBe(4500);
+
+		// X: single active Pro, 40 carried from Free → 4960.
+		const proX = await activeProductsOnEntity({
+			customerId,
+			productId: pro.id,
+			internalEntityId: entityX.internal_id,
+		});
+		expect(proX.length).toBe(1);
+		expect(messagesBalance(proX[0])).toBe(4960);
+
+		// Free expired off X.
+		const fullAfter = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const activeFree = fullAfter.customer_products.filter(
+			(cp) =>
+				cp.product_id === free.id && cp.status === CusProductStatus.Active,
+		);
+		expect(activeFree.length).toBe(0);
+	},
+);

--- a/server/tests/integration/billing/sync/sync-carry-prepaid-entities.test.ts
+++ b/server/tests/integration/billing/sync/sync-carry-prepaid-entities.test.ts
@@ -73,10 +73,14 @@ const activeProductsOnEntity = async ({
 	);
 };
 
-const messagesBalance = (cusProduct: FullCusProduct): number | undefined =>
-	cusProduct.customer_entitlements.find(
-		(ce) => ce.entitlement?.feature?.id === MESSAGES,
-	)?.balance ?? undefined;
+// The included/prepaid component carries the largest balance; the pay-per-use
+// overage component sits at 0 / negative. Pick the max to read the included one.
+const messagesBalance = (cusProduct: FullCusProduct): number | undefined => {
+	const balances = cusProduct.customer_entitlements
+		.filter((ce) => ce.entitlement?.feature?.id === MESSAGES)
+		.map((ce) => ce.balance ?? 0);
+	return balances.length ? Math.max(...balances) : undefined;
+};
 
 test(
 	chalk.yellowBright(
@@ -215,5 +219,126 @@ test(
 				cp.product_id === free.id && cp.status === CusProductStatus.Active,
 		);
 		expect(activeFree.length).toBe(0);
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Multi-component feature: AI Credits as an included allowance (5000) PLUS a
+// pay-per-use overage ($/credit) — two cusEnts under the same feature id, like
+// prod. The carry must match the included component (not collide with the
+// overage row) and leave the meter-billed overage alone.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test(
+	chalk.yellowBright(
+		"sync-v2 carry-usage: included + pay-per-use overage on one feature carries the included component",
+	),
+	async () => {
+		const customerId = "sync-carry-dual-component";
+
+		const free = products.base({
+			id: "free",
+			items: [items.monthlyMessages({ includedUsage: 50 })],
+			isDefault: true,
+		});
+		const pro = products.pro({
+			id: "pro",
+			items: [
+				items.monthlyMessages({ includedUsage: 5000 }),
+				items.consumableMessages({ includedUsage: 0, price: 0.01 }),
+			],
+		});
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [free, pro] }),
+				s.entities({
+					count: 2,
+					featureId: TestFeature.Users,
+					defaultGroup: customerId,
+				}),
+			],
+			actions: [
+				s.attach({ productId: pro.id, entityIndex: 0 }),
+				s.attach({ productId: pro.id, entityIndex: 1 }),
+			],
+		});
+
+		const full = await CusService.getFull({ ctx, idOrInternalId: customerId });
+		const entityList = await EntityService.list({
+			db: ctx.db,
+			internalCustomerId: full.internal_id,
+		});
+		const entityX = entityList[0];
+		const entityY = entityList[1];
+		const proSubId = full.customer_products.find(
+			(cp) => cp.product_id === pro.id,
+		)?.subscription_ids?.[0];
+		if (!proSubId) throw new Error("no Pro sub id");
+
+		// Delink X → Free auto-reattaches on X.
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: pro.id,
+			entity_id: entityX.id ?? undefined,
+			cancel_action: "cancel_immediately",
+			no_billing_changes: true,
+		});
+		await new Promise((r) => setTimeout(r, 1500));
+
+		await autumnV1.track({
+			customer_id: customerId,
+			entity_id: entityY.id ?? undefined,
+			feature_id: MESSAGES,
+			value: 500,
+		});
+		await autumnV1.track({
+			customer_id: customerId,
+			entity_id: entityX.id ?? undefined,
+			feature_id: MESSAGES,
+			value: 40,
+		});
+		await new Promise((r) => setTimeout(r, 2000));
+
+		await autumnV1.post("/billing.sync_v2", {
+			customer_id: customerId,
+			stripe_subscription_id: proSubId,
+			phases: [
+				{
+					starts_at: "now",
+					plans: [
+						{
+							plan_id: pro.id,
+							entity_id: entityY.id ?? undefined,
+							expire_previous: true,
+						},
+						{
+							plan_id: pro.id,
+							entity_id: entityX.id ?? undefined,
+							expire_previous: true,
+						},
+					],
+				},
+			],
+		} satisfies SyncParamsV1);
+
+		// Included component carries on both entities; X from Free (40 used).
+		const proY = await activeProductsOnEntity({
+			customerId,
+			productId: pro.id,
+			internalEntityId: entityY.internal_id,
+		});
+		expect(proY.length).toBe(1);
+		expect(messagesBalance(proY[0])).toBe(4500);
+
+		const proX = await activeProductsOnEntity({
+			customerId,
+			productId: pro.id,
+			internalEntityId: entityX.internal_id,
+		});
+		expect(proX.length).toBe(1);
+		expect(messagesBalance(proX[0])).toBe(4960);
 	},
 );

--- a/server/tests/integration/billing/sync/sync-carry-usage.test.ts
+++ b/server/tests/integration/billing/sync/sync-carry-usage.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Regression coverage for syncV2 expire behaviour:
+ *   - entity-scoped re-sync re-attaches on the same entity (no customer-level
+ *     duplicate) and expires the existing entity-scoped product
+ *   - consumed usage carries from the expired plan onto the replacement
+ *     (carry_over_usage, default on) — and stays put when turned off
+ *
+ * Out-of-sync state is forced with `cancel_immediately` + `no_billing_changes`
+ * (cancels in Autumn, leaves the live Stripe subscription), then re-synced the
+ * way the dashboard does it (detection proposals → submit with expire on).
+ */
+
+import { expect, test } from "bun:test";
+import {
+	CusProductStatus,
+	type FullCusProduct,
+	type SyncParamsV1,
+	type SyncPhase,
+	type SyncProposalV2,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import ctx from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { EntityService } from "@/internal/api/entities/EntityService";
+import { CusService } from "@/internal/customers/CusService";
+
+const MESSAGES = TestFeature.Messages;
+
+const messagesBalance = (cusProduct: FullCusProduct): number | undefined =>
+	cusProduct.customer_entitlements.find(
+		(ce) => ce.entitlement?.feature?.id === MESSAGES,
+	)?.balance ?? undefined;
+
+const getActiveProducts = async ({
+	customerId,
+	productId,
+}: {
+	customerId: string;
+	productId: string;
+}): Promise<FullCusProduct[]> => {
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	return fullCustomer.customer_products.filter(
+		(cp) =>
+			cp.product_id === productId && cp.status === CusProductStatus.Active,
+	);
+};
+
+// Submit a sync the same way the dashboard does: detection proposal → expire on.
+const dashboardSync = async ({
+	autumnV1,
+	customerId,
+	stripeSubscriptionId,
+	carryOverUsage,
+}: {
+	// biome-ignore lint/suspicious/noExplicitAny: test client
+	autumnV1: any;
+	customerId: string;
+	stripeSubscriptionId: string;
+	carryOverUsage?: boolean;
+	// biome-ignore lint/suspicious/noExplicitAny: sync result
+}): Promise<any> => {
+	const proposalsResponse = await autumnV1.post("/billing.sync_proposals_v2", {
+		customer_id: customerId,
+	});
+	const proposal = (proposalsResponse.proposals as SyncProposalV2[]).find(
+		(p) => p.stripe_subscription_id === stripeSubscriptionId,
+	);
+	if (!proposal) {
+		throw new Error(`No sync proposal found for ${stripeSubscriptionId}`);
+	}
+
+	const phases: SyncPhase[] = proposal.phases
+		.map((phase) => ({
+			starts_at: phase.starts_at,
+			plans: phase.plans.map((plan) => ({ ...plan, expire_previous: true })),
+		}))
+		.filter((phase) => phase.plans.length > 0);
+
+	return autumnV1.post("/billing.sync_v2", {
+		customer_id: customerId,
+		stripe_subscription_id: proposal.stripe_subscription_id,
+		stripe_schedule_id: proposal.stripe_schedule_id,
+		phases,
+		carry_over_usage: carryOverUsage,
+	} satisfies SyncParamsV1);
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Customer-level: Free (5/10 used) → re-sync Pro with expire → Pro 15/20.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test(
+	chalk.yellowBright(
+		"sync-v2 carry-usage: customer-level Free 5/10 → Pro carries to 15/20",
+	),
+	async () => {
+		const customerId = "sync-carry-customer";
+		const group = `grp-${customerId}`;
+
+		const free = products.base({
+			id: "free",
+			items: [items.monthlyMessages({ includedUsage: 10 })],
+			group,
+			isDefault: true,
+		});
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 20 })],
+			group,
+		});
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [free, pro] }),
+			],
+			actions: [
+				s.attach({ productId: free.id }),
+				s.attach({ productId: pro.id }),
+			],
+		});
+
+		const afterUpgrade = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const proStripeSubId = afterUpgrade.customer_products.find(
+			(cp) => cp.product_id === pro.id,
+		)?.subscription_ids?.[0];
+		if (!proStripeSubId) throw new Error("missing Pro Stripe subscription id");
+
+		// Out of sync: cancel Pro in Autumn only; fall back to default Free.
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: pro.id,
+			cancel_action: "cancel_immediately",
+			no_billing_changes: true,
+		});
+		// Use 5 on the reactivated Free → 5/10.
+		await autumnV1.track({
+			customer_id: customerId,
+			feature_id: MESSAGES,
+			value: 5,
+		});
+		await new Promise((r) => setTimeout(r, 2000));
+
+		const result = await dashboardSync({
+			autumnV1,
+			customerId,
+			stripeSubscriptionId: proStripeSubId,
+		});
+
+		// Free expired, exactly one active Pro carrying the 5 used → 15/20.
+		expect(result.expired_cus_product_ids.length).toBe(1);
+
+		const activeFree = await getActiveProducts({
+			customerId,
+			productId: free.id,
+		});
+		expect(activeFree.length).toBe(0);
+
+		const activePro = await getActiveProducts({
+			customerId,
+			productId: pro.id,
+		});
+		expect(activePro.length).toBe(1);
+		expect(messagesBalance(activePro[0])).toBe(15);
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Escape hatch: same flow with carry_over_usage:false → Pro stays 20/20.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test(
+	chalk.yellowBright(
+		"sync-v2 carry-usage: carry_over_usage=false leaves Pro at a fresh 20/20",
+	),
+	async () => {
+		const customerId = "sync-carry-disabled";
+		const group = `grp-${customerId}`;
+
+		const free = products.base({
+			id: "free",
+			items: [items.monthlyMessages({ includedUsage: 10 })],
+			group,
+			isDefault: true,
+		});
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 20 })],
+			group,
+		});
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [free, pro] }),
+			],
+			actions: [
+				s.attach({ productId: free.id }),
+				s.attach({ productId: pro.id }),
+			],
+		});
+
+		const afterUpgrade = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const proStripeSubId = afterUpgrade.customer_products.find(
+			(cp) => cp.product_id === pro.id,
+		)?.subscription_ids?.[0];
+		if (!proStripeSubId) throw new Error("missing Pro Stripe subscription id");
+
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: pro.id,
+			cancel_action: "cancel_immediately",
+			no_billing_changes: true,
+		});
+		await autumnV1.track({
+			customer_id: customerId,
+			feature_id: MESSAGES,
+			value: 5,
+		});
+		await new Promise((r) => setTimeout(r, 2000));
+
+		await dashboardSync({
+			autumnV1,
+			customerId,
+			stripeSubscriptionId: proStripeSubId,
+			carryOverUsage: false,
+		});
+
+		const activePro = await getActiveProducts({
+			customerId,
+			productId: pro.id,
+		});
+		expect(activePro.length).toBe(1);
+		expect(messagesBalance(activePro[0])).toBe(20);
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Entity-scoped: Premium on Entity A (21/30 used). Re-sync re-attaches on
+// Entity A (no customer-level duplicate), expires the old one, carries usage.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test(
+	chalk.yellowBright(
+		"sync-v2 carry-usage: entity-scoped Premium re-syncs on Entity A, no duplicate, carries to 21/30",
+	),
+	async () => {
+		const customerId = "sync-carry-entity";
+
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 20 })],
+		});
+		const premium = products.premium({
+			id: "premium",
+			items: [items.monthlyMessages({ includedUsage: 30 })],
+		});
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [
+				s.attach({ productId: pro.id }),
+				s.attach({ productId: premium.id, entityIndex: 0 }),
+			],
+		});
+
+		const afterSetup = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const entityList = await EntityService.list({
+			db: ctx.db,
+			internalCustomerId: afterSetup.internal_id,
+		});
+		const entityA = entityList[0];
+		const proStripeSubId = afterSetup.customer_products.find(
+			(cp) => cp.product_id === pro.id,
+		)?.subscription_ids?.[0];
+		if (!proStripeSubId) throw new Error("missing Stripe subscription id");
+
+		// Use 9 on Premium@Entity A → 21/30.
+		await autumnV1.track({
+			customer_id: customerId,
+			entity_id: entityA.id ?? undefined,
+			feature_id: MESSAGES,
+			value: 9,
+		});
+		await new Promise((r) => setTimeout(r, 2000));
+
+		// Out of sync: cancel only Pro (customer); Premium@Entity A stays.
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: pro.id,
+			cancel_action: "cancel_immediately",
+			no_billing_changes: true,
+		});
+
+		await dashboardSync({
+			autumnV1,
+			customerId,
+			stripeSubscriptionId: proStripeSubId,
+		});
+
+		// Exactly one active Premium, bound to Entity A, carrying 9 used → 21/30.
+		const activePremium = await getActiveProducts({
+			customerId,
+			productId: premium.id,
+		});
+		expect(activePremium.length).toBe(1);
+		expect(activePremium[0].internal_entity_id).toBe(entityA.internal_id);
+		expect(messagesBalance(activePremium[0])).toBe(21);
+
+		// Pro re-attached at the customer level (fresh).
+		const activePro = await getActiveProducts({
+			customerId,
+			productId: pro.id,
+		});
+		expect(activePro.length).toBe(1);
+		expect(activePro[0].internal_entity_id ?? null).toBeNull();
+	},
+);

--- a/server/tests/integration/billing/sync/sync-prepaid-imported-quantity.test.ts
+++ b/server/tests/integration/billing/sync/sync-prepaid-imported-quantity.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Regression: syncing a prepaid feature whose Stripe sub item is on an
+ * IMPORTED / Stripe-native price id (matched to the Autumn product by
+ * stripe_product_id, but NOT the Autumn price's V1 or V2 id) must not fold
+ * Stripe's default `quantity: 1` into a phantom +1 credit on top of the
+ * allowance.
+ *
+ * Before the fix `buildFeatureQuantities` treated any non-V2 price id as
+ * "extras" and did `quantity + allowance` → granted 5001. The imported price
+ * is allowance-inclusive (total), so the quantity passes through → granted 5000.
+ *
+ * The sub is manufactured directly via stripeCli (imported price + qty 1).
+ */
+
+import { expect, test } from "bun:test";
+import {
+	isFixedPrice,
+	isPrepaidPrice,
+	type SyncParamsV1,
+	type SyncProposalV2,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import ctx from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { CusService } from "@/internal/customers/CusService";
+import { ProductService } from "@/internal/products/ProductService";
+
+const MESSAGES = TestFeature.Messages;
+
+test(
+	chalk.yellowBright(
+		"sync-v2: imported prepaid price (Stripe qty 1) keeps granted at the allowance, no phantom +1",
+	),
+	async () => {
+		const customerId = "sync-prepaid-imported";
+
+		const pro = products.pro({
+			id: "pro",
+			items: [
+				items.prepaidMessages({
+					includedUsage: 5000,
+					billingUnits: 1,
+					price: 1,
+				}),
+			],
+		});
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [
+				s.attach({
+					productId: pro.id,
+					options: [{ feature_id: MESSAGES, quantity: 0 }],
+				}),
+			],
+		});
+
+		// Resolve the prepaid price's Stripe product + the base price id.
+		const fullProduct = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: pro.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		const prepaidPrice = fullProduct.prices.find((p) => isPrepaidPrice(p));
+		const basePrice = fullProduct.prices.find((p) => isFixedPrice(p));
+		const stripeProductId = prepaidPrice?.config.stripe_product_id;
+		const baseStripePriceId = basePrice?.config.stripe_price_id;
+		if (!stripeProductId || !baseStripePriceId) {
+			throw new Error("missing stripe product/base price id");
+		}
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const stripeCustomerId = fullCustomer.processor?.id;
+		if (!stripeCustomerId) throw new Error("no stripe customer");
+
+		// Imported prepaid price on the SAME Stripe product (a different price id
+		// than the Autumn V1/V2 ids) → detection matches by stripe_product_id.
+		const importedPrice = await ctx.stripeCli.prices.create({
+			product: stripeProductId,
+			currency: "usd",
+			unit_amount: 100,
+			recurring: { interval: "month" },
+		});
+
+		// Manufacture the sub directly: base + the imported prepaid item at qty 1.
+		const stripeSubscription = await ctx.stripeCli.subscriptions.create({
+			customer: stripeCustomerId,
+			items: [
+				{ price: baseStripePriceId },
+				{ price: importedPrice.id, quantity: 1 },
+			],
+		});
+
+		// Sync the dashboard way: detection proposal → submit with expire on.
+		const proposalsResponse = await autumnV1.post(
+			"/billing.sync_proposals_v2",
+			{ customer_id: customerId },
+		);
+		const proposal = (proposalsResponse.proposals as SyncProposalV2[]).find(
+			(p) => p.stripe_subscription_id === stripeSubscription.id,
+		);
+		if (!proposal) throw new Error("no proposal for manufactured sub");
+
+		const phases = proposal.phases
+			.map((phase) => ({
+				starts_at: phase.starts_at,
+				plans: phase.plans.map((plan) => ({ ...plan, expire_previous: true })),
+			}))
+			.filter((phase) => phase.plans.length > 0);
+
+		await autumnV1.post("/billing.sync_v2", {
+			customer_id: customerId,
+			stripe_subscription_id: stripeSubscription.id,
+			phases,
+		} satisfies SyncParamsV1);
+
+		// Granted is the 5000 allowance — the imported qty-1 item is allowance-
+		// inclusive, so it must NOT add a 5001st credit.
+		const after = await CusService.getFull({ ctx, idOrInternalId: customerId });
+		const proCusProduct = after.customer_products.find(
+			(cp) => cp.product_id === pro.id && cp.status === "active",
+		);
+		expect(proCusProduct).toBeDefined();
+		const prepaidCusEnt = proCusProduct?.customer_entitlements.find(
+			(ce) => ce.entitlement?.feature?.id === MESSAGES,
+		);
+		expect(prepaidCusEnt?.entitlement?.allowance).toBe(5000);
+		expect(prepaidCusEnt?.balance).toBe(5000);
+	},
+);

--- a/shared/api/billing/sync/syncParamsV1.ts
+++ b/shared/api/billing/sync/syncParamsV1.ts
@@ -87,6 +87,11 @@ export const SyncParamsV1Schema = z
 				"Caller-supplied plan instances grouped by phase. Omit for pure auto-sync.",
 		}),
 
+		carry_over_usage: z.boolean().optional().meta({
+			description:
+				"When a synced plan expires an existing plan (via expire_previous), carry the existing plan's consumed usage onto the new plan's balances for any shared feature on the same subject. Defaults to true. Set false to sync without touching balances.",
+		}),
+
 		acknowledge_warnings: z.array(z.string()).optional().meta({
 			description:
 				"Detection warning types the caller accepts (e.g. 'extra_items_under_plan').",

--- a/shared/models/billingModels/context/syncBillingContext.ts
+++ b/shared/models/billingModels/context/syncBillingContext.ts
@@ -1,12 +1,14 @@
 import type Stripe from "stripe";
-import type { SyncParamsV1 } from "../../../api/billing/sync/syncParamsV1";
-import type { SyncPlanInstance } from "../../../api/billing/sync/syncParamsV1";
+import type {
+	SyncParamsV1,
+	SyncPlanInstance,
+} from "../../../api/billing/sync/syncParamsV1";
+import type { Entity } from "../../cusModels/entityModels/entityModels";
+import type { FullCustomer } from "../../cusModels/fullCusModel";
 import type {
 	FeatureOptions,
 	FullCusProduct,
 } from "../../cusProductModels/cusProductModels";
-import type { FullCustomer } from "../../cusModels/fullCusModel";
-import type { Entity } from "../../cusModels/entityModels/entityModels";
 import type { Entitlement } from "../../productModels/entModels/entModels";
 import type { Price } from "../../productModels/priceModels/priceModels";
 import type { FullProduct } from "../../productModels/productModels";
@@ -46,4 +48,8 @@ export interface SyncBillingContext {
 
 	currentEpochMs: number;
 	acknowledgedWarnings: NonNullable<SyncParamsV1["acknowledge_warnings"]>;
+
+	/** Carry an expired plan's consumed usage onto the replacement plan's
+	 * balances for shared features on the same subject. Defaults to true. */
+	carryOverUsage: boolean;
 }

--- a/vite/src/views/customers2/components/sync-stripe-v2/SubscriptionEditorView.tsx
+++ b/vite/src/views/customers2/components/sync-stripe-v2/SubscriptionEditorView.tsx
@@ -1,6 +1,6 @@
 import {
-	type FrontendProduct,
 	FreeTrialDuration,
+	type FrontendProduct,
 	productV2ToFrontendProduct,
 	type SyncParamsV1,
 	type SyncPhase,
@@ -30,8 +30,8 @@ import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { useEnv } from "@/utils/envUtils";
 import {
 	getStripeConnectViewAsLink,
-	getStripeSubScheduleLink,
 	getStripeSubLink,
+	getStripeSubScheduleLink,
 } from "@/utils/linkUtils";
 import { useAdmin } from "@/views/admin/hooks/useAdmin";
 import { useMasterStripeAccount } from "@/views/admin/hooks/useMasterStripeAccount";
@@ -147,8 +147,9 @@ const buildPhaseSections = ({
 		const matchingSchedulePhase = schedule
 			? schedule.phases.find((schedulePhase) => {
 					if (phase.starts_at === "now") {
-						return findScheduleStartDateMs({ phase: schedulePhase }) <=
-							Date.now();
+						return (
+							findScheduleStartDateMs({ phase: schedulePhase }) <= Date.now()
+						);
 					}
 					return (
 						findScheduleStartDateMs({ phase: schedulePhase }) ===
@@ -257,6 +258,7 @@ export function SubscriptionEditorView({
 		() => seedDraftPlansByPhase({ proposal }),
 	);
 	const [expirePrevious, setExpirePrevious] = useState<boolean>(true);
+	const [carryOverUsage, setCarryOverUsage] = useState<boolean>(true);
 	const [enablePlanImmediately, setEnablePlanImmediately] =
 		useState<boolean>(false);
 	const [editing, setEditing] = useState<{
@@ -389,11 +391,7 @@ export function SubscriptionEditorView({
 					Boolean(p.plan_id),
 				);
 				const planInstances: SyncPlanInstance[] = validPlans.map(
-					({
-						_key: _ignore,
-						enable_plan_immediately: _ignored,
-						...rest
-					}) => ({
+					({ _key: _ignore, enable_plan_immediately: _ignored, ...rest }) => ({
 						...rest,
 						expire_previous: expirePrevious,
 						enable_plan_immediately:
@@ -415,6 +413,7 @@ export function SubscriptionEditorView({
 			stripe_subscription_id: proposal.stripe_subscription_id,
 			stripe_schedule_id: proposal.stripe_schedule_id,
 			phases,
+			carry_over_usage: carryOverUsage,
 		};
 		onSubmit(params);
 	};
@@ -480,7 +479,9 @@ export function SubscriptionEditorView({
 
 							{section.displayItems.length > 0 && (
 								<div className="space-y-1">
-									<div className="text-xs text-tertiary-foreground">Subscription items</div>
+									<div className="text-xs text-tertiary-foreground">
+										Subscription items
+									</div>
 									<div className="space-y-1">
 										{section.displayItems.map((item) => (
 											<div
@@ -488,7 +489,9 @@ export function SubscriptionEditorView({
 												className="flex items-center justify-between text-xs"
 											>
 												<span className="text-foreground">{item.name}</span>
-												<span className="text-tertiary-foreground">{item.priceLabel}</span>
+												<span className="text-tertiary-foreground">
+													{item.priceLabel}
+												</span>
 											</div>
 										))}
 									</div>
@@ -496,7 +499,9 @@ export function SubscriptionEditorView({
 							)}
 
 							<div className="space-y-2">
-								<div className="text-xs text-tertiary-foreground">Autumn plans</div>
+								<div className="text-xs text-tertiary-foreground">
+									Autumn plans
+								</div>
 								{phasePlans.map((plan, planIndex) => (
 									<SyncPlanRow
 										key={plan._key}
@@ -512,12 +517,12 @@ export function SubscriptionEditorView({
 										}
 									/>
 								))}
-							<InlineAction
-								icon={<PlusIcon size={11} />}
-								onClick={() => handleAddPlan(phaseIndex)}
-							>
-								Add plan
-							</InlineAction>
+								<InlineAction
+									icon={<PlusIcon size={11} />}
+									onClick={() => handleAddPlan(phaseIndex)}
+								>
+									Add plan
+								</InlineAction>
 							</div>
 						</div>
 					);
@@ -533,6 +538,18 @@ export function SubscriptionEditorView({
 						/>
 					}
 				/>
+				{expirePrevious && (
+					<ConfigRow
+						title="Carry over usage"
+						description="Move the expired plan's used balances onto the new plan for any shared feature."
+						action={
+							<Switch
+								checked={carryOverUsage}
+								onCheckedChange={(checked) => setCarryOverUsage(!!checked)}
+							/>
+						}
+					/>
+				)}
 				{isNotStartedSchedule && (
 					<ConfigRow
 						title="Enable plan immediately"


### PR DESCRIPTION
## Problem

Re-syncing a Stripe subscription whose product is already linked to an **entity-scoped** Autumn customer product would:

1. **Re-attach the plan at the customer level** (a duplicate) instead of on the entity, because sync detection is scope-blind — it matches Stripe prices to catalog products and never consults the customer's existing customer products or their entity binding.
2. **Fail to expire the original** — `expire_previous` ran its transition lookup at the customer level, so it never matched the entity-scoped product and left a stale duplicate behind.

Net effect: a customer could end up with two of the same plan (one customer-scoped phantom + the real entity-scoped one), and the entity binding was silently lost on every re-sync.

## Fix

- **`subscriptionToSyncParams.ts`** — `stampEntityFromExistingLinks` restores the entity binding onto each matched plan from the customer product already linked to the subscription. `customerProducts` is threaded through from `syncProposalsV2` and `autoSyncFromSubscription` (which already load the full customer) to avoid a redundant fetch; it falls back to a lookup if not provided.
- **`setupAttachTransitionContext.ts` + `setupSyncContext.ts`** — added an optional `internalEntityId` and pass the plan's entity, so the `expire_previous` lookup matches the existing product **on that same entity**. Defaults to `undefined`, so the normal (customer-level) attach flow is unchanged.

## Verification

Reproduced with an integration scenario: Pro on the customer + Premium on Entity A (shared Stripe sub), cancel Pro with `no_billing_changes`, then re-sync with expire on.

- **Before:** Premium re-attached at the customer level → two Premium products (phantom `30/30` + original `21/30`), `expired_cus_product_ids: []`.
- **After:** Premium re-attaches on **Entity A**, the stale entity-scoped Premium is expired (`expired: [old premium]`), exactly one Premium + one Pro remain.

Ran `sync-basic` + `sync-schedule-only`: the two failures present are **pre-existing on `dev`** (test-clock / future-schedule flakiness — confirmed by stashing this change and re-running); no new regressions.

## Not included / follow-ups

- **Usage carry-over** on expire (e.g. `15/20` after replacing a partially-used plan) is a separate feature (`carry_over_usage` flag + UI switch) and is **not** part of this PR.
- The exploratory observational test used during investigation is intentionally left out (console-log driven, no assertions). A proper assertion-based regression test can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves entity scope when re-syncing Stripe subscriptions and expires the correct prior plan. Adds default-on carry-over of consumed usage to replacement plans and fixes prepaid credits on imported Stripe prices to avoid phantom +1.

- **Bug Fixes**
  - `subscriptionToSyncParams`: `stampEntityFromExistingLinks` restores `entity_id` from linked customer products; uses passed `customerProducts` or falls back to a fetch.
  - `setupAttachTransitionContext`/`setupSyncContext`: added `internalEntityId` so `expire_previous` targets the same entity.
  - `autoSyncFromSubscription`/`syncProposalsV2`: pass `customerProducts` into `subscriptionToSyncParams` to avoid refetch and preserve bindings.
  - Carry-over correctness: `carryOverEntitlementUsage` computes consumed usage via `cusEntsToUsage`, carries for included/prepaid components only (skips pay‑per‑use/in‑arrears, unlimited, legacy per‑entity hashes), and applies when the match is unambiguous.
  - Prepaid imported prices: `buildFeatureQuantities` only adds allowance back for the explicit V1 prepaid price (extras-only); V2 or imported Stripe-native price ids pass through as totals to prevent phantom +1 credits.

- **New Features**
  - Carry-over usage: when replacing a plan on the same subject, transfer consumed balances to the new plan for shared features.
  - `SyncParamsV1`: new `carry_over_usage` flag (default `true`), threaded to `SyncBillingContext` and applied in `computeSyncImmediatePhase`.
  - Dashboard: “Carry over usage” switch in `SubscriptionEditorView` (shown when “Expire current plans” is on).
  - Tests: coverage for customer/entity re-syncs, prepaid across entities, dual-component features, imported prepaid price totals, and the flag-off path.

<sup>Written for commit 4329a46bacd742e6290ed400458036193a5d3986. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where re-syncing a Stripe subscription that was already linked to an entity-scoped customer product would re-attach the product at the customer level (creating a duplicate) and fail to expire the original entity-scoped product. The fix threads entity context through the sync detection and expire-previous lookup paths.

- **Bug fixes** — `stampEntityFromExistingLinks` in `subscriptionToSyncParams.ts` rebuilds the entity binding from existing customer products linked to the subscription, ensuring re-synced plans are stamped with the correct entity ID rather than defaulting to customer scope.
- **Bug fixes** — `setupAttachTransitionContext` and `setupSyncContext` now accept and propagate `internalEntityId`, scoping the "find product to expire" lookup to the plan's entity so `expire_previous` correctly matches and expires the original entity-scoped product.
- **Improvements** — `customerProducts` is passed down from callers that already hold the full customer (`autoSyncFromSubscription`, `syncProposalsV2`) to avoid a redundant DB fetch; a safe fallback fetch is retained for any future caller that omits it.
</details>


<h3>Confidence Score: 4/5</h3>

The core bug fix is well-reasoned and handles the primary re-sync case correctly; the entity-stamping and scoped expire-previous lookup work together as described.

The `entityIdByProductId` map in `stampEntityFromExistingLinks` uses product ID as the sole key. If a subscription ever has the same product attached to multiple entities, the last entity encountered silently overwrites the earlier one, and all phases for that product get a single potentially wrong entity stamp. This is not the scenario described in the PR, but it is reachable as entity usage grows. Additionally, entity binding is not restored for subscription-schedule-only proposals because `stampEntityFromExistingLinks` exits early when no `subscription` is present, leaving a gap for that topology.

`subscriptionToSyncParams.ts` deserves a second look around the `entityIdByProductId` map and the schedule-proposal gap in `syncProposalsV2.ts`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/sync/subscriptionToSyncParams.ts | Adds `stampEntityFromExistingLinks` to restore entity bindings from existing customer products onto detected sync phases; introduces a fallback customer fetch when `customerProducts` is not provided. Map collision risk when the same product is entity-scoped to multiple entities on one subscription. |
| server/src/internal/billing/v2/actions/attach/setup/setupAttachTransitionContext.ts | Adds optional `internalEntityId` parameter and threads it through to both `findMainActiveCustomerProductByGroup` and `findMainScheduledCustomerProductByGroup`, scoping the "product to expire" lookup to the correct entity. Clean, additive change with correct fallback behaviour. |
| server/src/internal/billing/v2/actions/sync/setup/setupSyncContext.ts | Passes `entity?.internal_id` as `internalEntityId` to `setupAttachTransitionContext` so the expire-previous lookup is scoped to the plan's entity. Minimal and correct change. |
| server/src/internal/billing/v2/actions/sync/syncProposalsV2.ts | Threads pre-fetched `customerProducts` into `subscriptionToSyncParams` to avoid a redundant fetch; entity stamping is not applied to schedule-only proposals (no `subscription` passed), which may leave a gap for entity-scoped schedule products. |
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/tasks/autoSyncFromSubscription.ts | One-line change: passes `fullCustomer.customer_products` to `subscriptionToSyncParams` to avoid the fallback DB fetch. Correct and safe. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Webhook as Stripe Webhook / Dashboard
    participant AutoSync as autoSyncFromSubscription
    participant SyncParams as subscriptionToSyncParams
    participant Stamp as stampEntityFromExistingLinks
    participant SyncCtx as setupSyncContext
    participant TransCtx as setupAttachTransitionContext
    participant Finder as findMainActiveCustomerProductByGroup

    Webhook->>AutoSync: subscription + fullCustomer
    AutoSync->>SyncParams: subscription, customerProducts
    SyncParams->>SyncParams: detectSubscriptionMatch → detectedPhases
    SyncParams->>Stamp: phases, subscription, customerProducts
    Stamp->>Stamp: filter by subscription.id → linkedCusProducts
    Stamp->>Stamp: build Map(productId → internal_entity_id)
    Stamp-->>SyncParams: phases with entity_id stamped on plans
    SyncParams-->>AutoSync: params (phases now entity-scoped)

    AutoSync->>SyncCtx: params
    SyncCtx->>SyncCtx: resolvePlanEntity (public or internal id)
    SyncCtx->>TransCtx: fullCustomer, attachProduct, internalEntityId
    TransCtx->>Finder: productGroup, internalEntityId
    Finder-->>TransCtx: entity-scoped currentCustomerProduct
    TransCtx-->>SyncCtx: currentCustomerProduct (to expire)
    SyncCtx-->>AutoSync: SyncBillingContext (entity-correct expire target)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Webhook as Stripe Webhook / Dashboard
    participant AutoSync as autoSyncFromSubscription
    participant SyncParams as subscriptionToSyncParams
    participant Stamp as stampEntityFromExistingLinks
    participant SyncCtx as setupSyncContext
    participant TransCtx as setupAttachTransitionContext
    participant Finder as findMainActiveCustomerProductByGroup

    Webhook->>AutoSync: subscription + fullCustomer
    AutoSync->>SyncParams: subscription, customerProducts
    SyncParams->>SyncParams: detectSubscriptionMatch → detectedPhases
    SyncParams->>Stamp: phases, subscription, customerProducts
    Stamp->>Stamp: filter by subscription.id → linkedCusProducts
    Stamp->>Stamp: build Map(productId → internal_entity_id)
    Stamp-->>SyncParams: phases with entity_id stamped on plans
    SyncParams-->>AutoSync: params (phases now entity-scoped)

    AutoSync->>SyncCtx: params
    SyncCtx->>SyncCtx: resolvePlanEntity (public or internal id)
    SyncCtx->>TransCtx: fullCustomer, attachProduct, internalEntityId
    TransCtx->>Finder: productGroup, internalEntityId
    Finder-->>TransCtx: entity-scoped currentCustomerProduct
    TransCtx-->>SyncCtx: currentCustomerProduct (to expire)
    SyncCtx-->>AutoSync: SyncBillingContext (entity-correct expire target)
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/billing/v2/actions/sync/syncProposalsV2.ts`, line 87-128 ([link](https://github.com/useautumn/autumn/blob/dba15f0ba5be9a698489869c636a9275f78e1daf/server/src/internal/billing/v2/actions/sync/syncProposalsV2.ts#L87-L128)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Entity stamping skipped for subscription-schedule-only proposals**

   `buildProposal` passes `subscription: undefined` for schedule proposals (lines 194–206). `stampEntityFromExistingLinks` has an early-return guard `if (!subscription) return phases`, so entity bindings are never restored when the proposal is built from a schedule without an accompanying subscription object. If a product was originally attached to an entity via a subscription schedule, re-syncing from the schedule proposal in the dashboard would still re-attach it at the customer level. May be out of scope for this PR, but worth tracking as a follow-up.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/billing/v2/actions/sync/syncProposalsV2.ts
   Line: 87-128

   Comment:
   **Entity stamping skipped for subscription-schedule-only proposals**

   `buildProposal` passes `subscription: undefined` for schedule proposals (lines 194–206). `stampEntityFromExistingLinks` has an early-return guard `if (!subscription) return phases`, so entity bindings are never restored when the proposal is built from a schedule without an accompanying subscription object. If a product was originally attached to an entity via a subscription schedule, re-syncing from the schedule proposal in the dashboard would still re-attach it at the customer level. May be out of scope for this PR, but worth tracking as a follow-up.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
server/src/internal/billing/v2/actions/sync/subscriptionToSyncParams.ts:71-77
**Map collision: last entity wins for same product on multiple entities**

`entityIdByProductId` is keyed only on `product.id`, so if the same product (e.g. "Premium") is currently linked to both Entity A and Entity B on the same subscription, the last one encountered in the iteration silently overwrites the first. All phases containing that `plan_id` then get stamped with a single, potentially wrong entity. This could matter once customers have the same plan covering multiple entities under one Stripe subscription — the map would need to be keyed on `(productId, phaseIndex)` or the phases would need to be matched per customer-product to handle that topology.

### Issue 2 of 3
server/src/internal/billing/v2/actions/sync/subscriptionToSyncParams.ts:163-168
**Fallback fetch includes all customer products, not just those on the given subscription**

When `customerProducts` is not provided, the fallback calls `CusService.getFull` and uses the entire `customer_products` array. That is the correct input for `filterCustomerProductsByStripeSubscriptionId` (which then narrows by `subscription_ids`), so the final entity-stamp result is correct. However, the comment says the fetch is to "avoid a redundant fetch" — the fallback fetches the full customer again even though callers like `autoSyncFromSubscription` already have `fullCustomer` in scope. Worth ensuring future callers always pass `customerProducts` to avoid the silent extra DB round-trip; the current two callers do pass it, but there is no compile-time enforcement.

### Issue 3 of 3
server/src/internal/billing/v2/actions/sync/syncProposalsV2.ts:87-128
**Entity stamping skipped for subscription-schedule-only proposals**

`buildProposal` passes `subscription: undefined` for schedule proposals (lines 194–206). `stampEntityFromExistingLinks` has an early-return guard `if (!subscription) return phases`, so entity bindings are never restored when the proposal is built from a schedule without an accompanying subscription object. If a product was originally attached to an entity via a subscription schedule, re-syncing from the schedule proposal in the dashboard would still re-attach it at the customer level. May be out of scope for this PR, but worth tracking as a follow-up.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sync): preserve entity scope when re..."](https://github.com/useautumn/autumn/commit/dba15f0ba5be9a698489869c636a9275f78e1daf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38492734)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->