### PR TITLE
chore: docs

### DIFF
--- a/server/src/queue/createWorkerContext.ts
+++ b/server/src/queue/createWorkerContext.ts
@@ -13,6 +13,7 @@ export const createWorkerContext = async ({
 	db,
 	payload,
 	logger,
+	skipCache = true,
 }: {
 	db: DrizzleCli;
 	payload: {
@@ -22,6 +23,7 @@ export const createWorkerContext = async ({
 		requestId?: string;
 	};
 	logger: Logger;
+	skipCache?: boolean;
 }) => {
 	const { orgId, env, customerId, requestId } = payload;
 	if (!orgId || !env) return;
@@ -83,7 +85,7 @@ export const createWorkerContext = async ({
 		apiVersion,
 		scopes: [],
 		expand: [],
-		skipCache: true,
+		skipCache,
 		extraLogs: {},
 		rolloutSnapshot,
 	};

--- a/server/src/queue/processMessage.ts
+++ b/server/src/queue/processMessage.ts
@@ -118,6 +118,7 @@ export const processMessage = async ({
 			db,
 			payload: job.data,
 			logger: workerLogger,
+			skipCache: job.name !== JobName.Track,
 		});
 		workerCtx = ctx;
 

--- a/server/tests/unit/queue/processMessage-track.test.ts
+++ b/server/tests/unit/queue/processMessage-track.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { AppEnv, ApiVersion } from "@autumn/shared";
+import type { Message } from "@aws-sdk/client-sqs";
+import { JobName } from "@/queue/JobName.js";
+
+const mockState = {
+	createWorkerContextCalls: [] as Record<string, unknown>[],
+};
+
+mock.module("@/queue/createWorkerContext.js", () => ({
+	createWorkerContext: async (args: Record<string, unknown>) => {
+		mockState.createWorkerContextCalls.push(args);
+		return {
+			logger: { error: mock(() => {}) },
+			skipCache: args.skipCache ?? true,
+			extraLogs: {},
+		};
+	},
+}));
+
+const { processMessage } = await import(
+	// @ts-expect-error - Bun test cache-busting import query isolates module mocks.
+	"@/queue/processMessage.js?trackSkipCache"
+);
+
+describe("processMessage track jobs", () => {
+	beforeEach(() => {
+		mockState.createWorkerContextCalls = [];
+	});
+
+	test("creates a Redis-capable worker context for queued track replay", async () => {
+		const message = {
+			MessageId: "msg_123",
+			Body: JSON.stringify({
+				name: JobName.Track,
+				data: {
+					orgId: "org_123",
+					env: AppEnv.Sandbox,
+					customerId: "cus_123",
+					requestId: "req_123",
+					apiVersion: ApiVersion.V2_1,
+					body: {
+						customer_id: "cus_123",
+						feature_id: "usage_in_usd",
+						value: 1,
+						async: true,
+					},
+				},
+			}),
+		} satisfies Pick<Message, "MessageId" | "Body">;
+
+		await processMessage({ message: message as Message, db: {} as never });
+
+		expect(mockState.createWorkerContextCalls).toHaveLength(1);
+		expect(mockState.createWorkerContextCalls[0]).toMatchObject({
+			payload: expect.objectContaining({ requestId: "req_123" }),
+			skipCache: false,
+		});
+	});
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure queued Track jobs use cache in the worker context to fix async track replay. Adds a `skipCache` control and disables it for Track jobs so they can read/write cache.

- **Bug Fixes**
  - `createWorkerContext` now accepts `skipCache` (default `true`).
  - `processMessage` sets `skipCache: false` for `JobName.Track` jobs; all others keep `true`.
  - Added a unit test to verify Track messages create a caching-enabled worker context.

<sup>Written for commit e3093e3789dc031b22b485f1f609b1bf3c197b8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Enables Redis cache access for queued `Track` job replays by making `skipCache` a configurable parameter in `createWorkerContext` (defaulting to `true`) and passing `false` specifically for `JobName.Track` in `processMessage`. A targeted unit test is added to lock in this behaviour.

- **[Improvements]** `createWorkerContext` now accepts an optional `skipCache` param (default `true`), replacing the previous hardcoded value — all existing callers are unaffected.
- **[Improvements]** `processMessage` passes `skipCache: false` only for `JobName.Track`, allowing queued track replays to interact with the Redis cache while all other worker jobs continue to bypass it.
- **[Improvements]** New unit test `processMessage-track.test.ts` verifies that a Track job triggers `createWorkerContext` with `skipCache: false`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped, backward compatible, and covered by a dedicated unit test.

The `skipCache` parameterisation defaults to `true`, so every caller that didn't previously pass it is unaffected. The only new behaviour is `skipCache: false` for `JobName.Track`, which gives queued track replays access to the Redis cache as intended. The unit test directly validates this path, and the rest of the worker pipeline is unchanged.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/queue/createWorkerContext.ts | Extracts the hardcoded `skipCache: true` into a configurable parameter (defaulting to `true` for backward compatibility); no behavior change for existing callers. |
| server/src/queue/processMessage.ts | Passes `skipCache: false` when the job is a `Track` job, so queued track replays can read and write the Redis cache; all other jobs continue with `skipCache: true`. |
| server/tests/unit/queue/processMessage-track.test.ts | New unit test that mocks `createWorkerContext` and verifies Track jobs receive `skipCache: false`; only covers the Track path — no coverage for the default (`skipCache: true`) path for other job types. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant SQS
    participant processMessage
    participant createWorkerContext
    participant Redis
    participant runQueuedTrack

    SQS->>processMessage: message (JobName.Track)
    processMessage->>createWorkerContext: "{ skipCache: false }"
    createWorkerContext->>Redis: resolveRedisV2 + getCtxWithCustomerRedis
    Redis-->>createWorkerContext: redisClient
    createWorkerContext-->>processMessage: "ctx (skipCache=false)"
    processMessage->>runQueuedTrack: ctx, body, apiVersion
    Note over runQueuedTrack,Redis: Can read/write Redis cache
    runQueuedTrack-->>processMessage: done

    Note over processMessage: All other jobs
    SQS->>processMessage: message (any other JobName)
    processMessage->>createWorkerContext: "{ skipCache: true }"
    createWorkerContext-->>processMessage: "ctx (skipCache=true)"
    Note over processMessage: Cache reads bypassed
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant SQS
    participant processMessage
    participant createWorkerContext
    participant Redis
    participant runQueuedTrack

    SQS->>processMessage: message (JobName.Track)
    processMessage->>createWorkerContext: "{ skipCache: false }"
    createWorkerContext->>Redis: resolveRedisV2 + getCtxWithCustomerRedis
    Redis-->>createWorkerContext: redisClient
    createWorkerContext-->>processMessage: "ctx (skipCache=false)"
    processMessage->>runQueuedTrack: ctx, body, apiVersion
    Note over runQueuedTrack,Redis: Can read/write Redis cache
    runQueuedTrack-->>processMessage: done

    Note over processMessage: All other jobs
    SQS->>processMessage: message (any other JobName)
    processMessage->>createWorkerContext: "{ skipCache: true }"
    createWorkerContext-->>processMessage: "ctx (skipCache=true)"
    Note over processMessage: Cache reads bypassed
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into chore/docs"](https://github.com/useautumn/autumn/commit/a73a526c560001029942c6ce75a98c6cc3433045) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38498747)</sub>

<!-- /greptile_comment -->