### PR TITLE
fix: revert cron

### DIFF
--- a/server/src/cron/resetCron/runResetCron.ts
+++ b/server/src/cron/resetCron/runResetCron.ts
@@ -74,6 +74,7 @@ export const runResetCron = async ({ ctx }: { ctx: CronContext }) => {
 				db,
 				batchSize: 5_000,
 				limit: 5_000,
+				includeSeparateIntervalResets: false,
 			});
 
 			if (cusEnts.length < 5_000) {

--- a/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
@@ -171,11 +171,13 @@ export class CusEntService {
 		customDateUnix,
 		batchSize = 1000,
 		limit,
+		includeSeparateIntervalResets = true,
 	}: {
 		db: DrizzleCli;
 		customDateUnix?: number;
 		batchSize?: number;
 		limit?: number;
+		includeSeparateIntervalResets?: boolean;
 	}) {
 		const allResults: FullCusEntWithProduct[] = [];
 		let offset = 0;
@@ -224,7 +226,9 @@ export class CusEntService {
 			);
 
 		const resetOwnedByAutumn = () =>
-			or(eq(customerEntitlements.separate_interval, true), notPriceBacked());
+			includeSeparateIntervalResets
+				? or(eq(customerEntitlements.separate_interval, true), notPriceBacked())
+				: notPriceBacked();
 
 		while (hasMore) {
 			// Branch 1: cusEnts with no customer_product. Left-join to

--- a/server/tests/integration/cron/reset-cron-active-reset-passed.test.ts
+++ b/server/tests/integration/cron/reset-cron-active-reset-passed.test.ts
@@ -103,10 +103,27 @@ test.concurrent(
 		const resetCusEnts = await CusEntService.getActiveResetPassed({
 			db: ctx.db,
 			customDateUnix: now,
+			includeSeparateIntervalResets: true,
 		});
 		const resetCusEntIds = resetCusEnts.map((cusEnt) => cusEnt.id);
 
 		expect(resetCusEntIds).not.toContain(stripeOwnedCusEnt.id);
 		expect(resetCusEntIds).toContain(autumnOwnedCusEnt.id);
+
+		const resetCusEntsWithoutSeparateIntervals =
+			await CusEntService.getActiveResetPassed({
+				db: ctx.db,
+				customDateUnix: now,
+				includeSeparateIntervalResets: false,
+			});
+		const resetCusEntIdsWithoutSeparateIntervals =
+			resetCusEntsWithoutSeparateIntervals.map((cusEnt) => cusEnt.id);
+
+		expect(resetCusEntIdsWithoutSeparateIntervals).not.toContain(
+			stripeOwnedCusEnt.id,
+		);
+		expect(resetCusEntIdsWithoutSeparateIntervals).not.toContain(
+			autumnOwnedCusEnt.id,
+		);
 	},
 );


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reverts the reset cron to skip separate-interval entitlement resets to prevent unintended resets. Adds an opt-in flag so queries can include them when needed.

- **Bug Fixes**
  - Reset cron now calls getActiveResetPassed with includeSeparateIntervalResets: false.
  - getActiveResetPassed adds includeSeparateIntervalResets (default true) to control filtering; when false, separate-interval entitlements are excluded.
  - Tests updated to assert inclusion when true and exclusion when false.

<sup>Written for commit 78dc28b3d70af40f25486facf18686fb9ecad83b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Reverts the reset cron to skip separate-interval entitlement resets, fixing a bug where those entitlements were being unintentionally reset by the cron rather than the lazy-reset path. The opt-in `includeSeparateIntervalResets` flag (default `true`) is added to `getActiveResetPassed` so callers that need to include them can still do so explicitly.

- **Bug fixes**: `runResetCron` now passes `includeSeparateIntervalResets: false`, so separate-interval entitlements are excluded from the cron batch and left to the lazy-reset handler.
- **API changes**: `CusEntService.getActiveResetPassed` gains an optional `includeSeparateIntervalResets` parameter (default `true`) that gates whether `separate_interval = true` cusEnts are included in the `resetOwnedByAutumn` predicate.
- **Improvements**: Integration test extended to assert both `true` and `false` variants of the new flag.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is a targeted revert of cron behaviour with backward-compatible API and new test coverage.

The fix is small and well-tested. The one gap is that Branch 1 (detached cusEnts with no customer_product_id) ignores includeSeparateIntervalResets entirely, so any separate_interval = true row in that state would still be returned when the flag is false. This is unlikely in practice but the flag's contract is incomplete for that path.

CusEntitlementService.ts — Branch 1 does not apply the resetOwnedByAutumn filter, meaning the includeSeparateIntervalResets flag has no effect on detached cusEnts.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/cron/resetCron/runResetCron.ts | Single-line fix: passes `includeSeparateIntervalResets: false` to prevent the cron from processing separate-interval entitlements (defers them to lazy reset). |
| server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts | Adds `includeSeparateIntervalResets` (default `true`) to `getActiveResetPassed`; when `false`, `resetOwnedByAutumn()` returns only `notPriceBacked()`. Branch 1 (no customer_product_id) is unaffected by the flag. |
| server/tests/integration/cron/reset-cron-active-reset-passed.test.ts | Extends the existing test to assert both `includeSeparateIntervalResets: true` (autumnOwnedCusEnt included) and `false` (autumnOwnedCusEnt excluded) paths. |

</details>



<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runResetCron] -->|includeSeparateIntervalResets: false| B[getActiveResetPassed]
    B --> C{Build resetOwnedByAutumn predicate}
    C -->|includeSeparateIntervalResets = true| D["OR(separate_interval = true, notPriceBacked())"]
    C -->|includeSeparateIntervalResets = false| E["notPriceBacked() only"]
    D --> F[Branch 2 & 3 WHERE clause]
    E --> F
    B --> G[Branch 1: customer_product_id IS NULL]
    G -->|resetOwnedByAutumn NOT applied| H[commonResetPredicates only]
    F --> I[UNION ALL result]
    H --> I
    I --> J{cusEnts.length < 5000?}
    J -->|Yes| K[Break — lazy reset handles remainder]
    J -->|No| L[Process batch & continue]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[runResetCron] -->|includeSeparateIntervalResets: false| B[getActiveResetPassed]
    B --> C{Build resetOwnedByAutumn predicate}
    C -->|includeSeparateIntervalResets = true| D["OR(separate_interval = true, notPriceBacked())"]
    C -->|includeSeparateIntervalResets = false| E["notPriceBacked() only"]
    D --> F[Branch 2 & 3 WHERE clause]
    E --> F
    B --> G[Branch 1: customer_product_id IS NULL]
    G -->|resetOwnedByAutumn NOT applied| H[commonResetPredicates only]
    F --> I[UNION ALL result]
    H --> I
    I --> J{cusEnts.length < 5000?}
    J -->|Yes| K[Break — lazy reset handles remainder]
    J -->|No| L[Process batch & continue]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts`, line 253-258 ([link](https://github.com/useautumn/autumn/blob/78dc28b3d70af40f25486facf18686fb9ecad83b/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts#L253-L258)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`includeSeparateIntervalResets: false` has no effect on Branch 1**

   Branch 1 (cusEnts with `customer_product_id = null`) only applies `commonResetPredicates()` and never calls `resetOwnedByAutumn()`. This means any `separate_interval = true` entitlement that happens to have no `customer_product_id` will still be returned even when the caller passes `includeSeparateIntervalResets: false`. Semantically this is probably fine today (a detached cusEnt with a separate interval is unlikely), but the flag's contract is silently incomplete for Branch 1, which could be surprising if that state ever arises.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
   Line: 253-258

   Comment:
   **`includeSeparateIntervalResets: false` has no effect on Branch 1**

   Branch 1 (cusEnts with `customer_product_id = null`) only applies `commonResetPredicates()` and never calls `resetOwnedByAutumn()`. This means any `separate_interval = true` entitlement that happens to have no `customer_product_id` will still be returned even when the caller passes `includeSeparateIntervalResets: false`. Semantically this is probably fine today (a detached cusEnt with a separate interval is unlikely), but the flag's contract is silently incomplete for Branch 1, which could be surprising if that state ever arises.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts:253-258
**`includeSeparateIntervalResets: false` has no effect on Branch 1**

Branch 1 (cusEnts with `customer_product_id = null`) only applies `commonResetPredicates()` and never calls `resetOwnedByAutumn()`. This means any `separate_interval = true` entitlement that happens to have no `customer_product_id` will still be returned even when the caller passes `includeSeparateIntervalResets: false`. Semantically this is probably fine today (a detached cusEnt with a separate interval is unlikely), but the flag's contract is silently incomplete for Branch 1, which could be surprising if that state ever arises.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: revert cron"](https://github.com/useautumn/autumn/commit/78dc28b3d70af40f25486facf18686fb9ecad83b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38534413)</sub>

<!-- /greptile_comment -->