### PR TITLE
chore: track response

### DIFF
--- a/server/src/internal/balances/handlers/handleBatchTrack.ts
+++ b/server/src/internal/balances/handlers/handleBatchTrack.ts
@@ -16,6 +16,6 @@ export const handleBatchTrack = createRoute({
 
 		await runBatchTrack({ ctx, body });
 
-		return c.json({ success: true }, 202);
+		return c.body(null, 204);
 	},
 });

--- a/server/src/internal/balances/handlers/handleBatchTrackTokens.ts
+++ b/server/src/internal/balances/handlers/handleBatchTrackTokens.ts
@@ -16,6 +16,6 @@ export const handleBatchTrackTokens = createRoute({
 
 		await runBatchTrackTokens({ ctx, body });
 
-		return c.json({ success: true }, 202);
+		return c.body(null, 204);
 	},
 });

--- a/server/src/internal/balances/handlers/handleTrack.ts
+++ b/server/src/internal/balances/handlers/handleTrack.ts
@@ -25,7 +25,7 @@ export const handleTrack = createRoute({
 
 		if (body.async === true) {
 			await runAsyncTrack({ ctx, body });
-			return c.json({ success: true }, 202);
+			return c.body(null, 204);
 		}
 
 		const response = await runTrackWithRollout({

--- a/server/src/internal/balances/handlers/handleTrackTokens.ts
+++ b/server/src/internal/balances/handlers/handleTrackTokens.ts
@@ -23,7 +23,7 @@ export const handleTrackTokens = createRoute({
 
 		if (trackBody.async === true) {
 			await runAsyncTrack({ ctx, body: trackBody });
-			return c.json({ success: true }, 202);
+			return c.body(null, 204);
 		}
 
 		const response = await runTrackWithRollout({

--- a/server/src/internal/balances/track/runAsyncTrack.ts
+++ b/server/src/internal/balances/track/runAsyncTrack.ts
@@ -24,7 +24,13 @@ export const runAsyncTrack = async ({
 		});
 	}
 
-	const queued = await queueTrack({ ctx, body, queueUrl });
+	const queued = await queueTrack({
+		ctx,
+		body,
+		queueUrl,
+		logFallback: false,
+		markQueuedForReplay: false,
+	});
 	if (!queued) {
 		throw new RecaseError({
 			message: ASYNC_TRACK_UNAVAILABLE_MESSAGE,

--- a/server/src/internal/balances/track/utils/queueTrack.ts
+++ b/server/src/internal/balances/track/utils/queueTrack.ts
@@ -10,11 +10,15 @@ export const queueTrack = async ({
 	body,
 	queueUrl,
 	messageDeduplicationId,
+	logFallback = true,
+	markQueuedForReplay = true,
 }: {
 	ctx: AutumnContext;
 	body: TrackParams;
 	queueUrl?: string;
 	messageDeduplicationId?: string;
+	logFallback?: boolean;
+	markQueuedForReplay?: boolean;
 }) => {
 	try {
 		const resolvedQueueUrl = queueUrl ?? process.env.TRACK_SQS_QUEUE_URL;
@@ -41,19 +45,23 @@ export const queueTrack = async ({
 			},
 		});
 
-		ctx.logger.warn("[track] Redis unavailable, queued track fallback", {
-			type: "track_queue_fallback",
-			feature_id: body.feature_id,
-			event_name: body.event_name,
-			env: ctx.env,
-			queue_name: resolvedQueueUrl.split("/").pop(),
-		});
-		addToExtraLogs({
-			ctx,
-			extras: {
-				trackQueuedForReplay: true,
-			},
-		});
+		if (logFallback) {
+			ctx.logger.warn("[track] Redis unavailable, queued track fallback", {
+				type: "track_queue_fallback",
+				feature_id: body.feature_id,
+				event_name: body.event_name,
+				env: ctx.env,
+				queue_name: resolvedQueueUrl.split("/").pop(),
+			});
+		}
+		if (markQueuedForReplay) {
+			addToExtraLogs({
+				ctx,
+				extras: {
+					trackQueuedForReplay: true,
+				},
+			});
+		}
 
 		return getQueuedTrackResponse({
 			ctx,

--- a/server/tests/balances/track/track-async.test.ts
+++ b/server/tests/balances/track/track-async.test.ts
@@ -23,7 +23,7 @@ const free = constructProduct({
 	],
 });
 
-describe(`${chalk.yellowBright("track-async: async=true returns 202 + success")}`, () => {
+describe(`${chalk.yellowBright("track-async: async=true returns 204")}`, () => {
 	const autumn: AutumnInt = new AutumnInt({ version: ApiVersion.V1_2 });
 
 	beforeAll(async () => {
@@ -44,7 +44,7 @@ describe(`${chalk.yellowBright("track-async: async=true returns 202 + success")}
 		await autumn.attach({ customer_id: customerId, product_id: free.id });
 	});
 
-	test("POST /v1/track with async=true returns 202 and { success: true }", async () => {
+	test("POST /v1/track with async=true returns 204 and no body", async () => {
 		const response = await fetch(`${autumn["baseUrl"]}/track`, {
 			method: "POST",
 			headers: autumn["headers"],
@@ -56,8 +56,7 @@ describe(`${chalk.yellowBright("track-async: async=true returns 202 + success")}
 			}),
 		});
 
-		expect(response.status).toBe(202);
-		const body = await response.json();
-		expect(body).toEqual({ success: true });
+		expect(response.status).toBe(204);
+		expect(await response.text()).toBe("");
 	});
 });

--- a/server/tests/integration/balances/batch-track/batch-track-contract.test.ts
+++ b/server/tests/integration/balances/batch-track/batch-track-contract.test.ts
@@ -10,7 +10,7 @@
  *   New endpoint:
  *     - POST /v1/balances.batch_track
  *         request body:  BatchTrackParams = TrackParams[] where 1 <= len <= 1000
- *         response:      202, body { success: true }
+ *         response:      204, no body
  *         auth:          requires Scopes.Balances.Write
  *         rate limit:    BatchTrack (10 req/sec per org)
  *
@@ -20,7 +20,7 @@
  *       the handler throws and NOTHING is enqueued.
  *     - Items are enqueued via SQS SendMessageBatch (chunks of 10).
  *     - On partial SQS failure (some entries fail, others succeed),
- *       the handler returns 202 success and logs the failed entries.
+ *       the handler returns 204 success and logs the failed entries.
  *       Clients are NOT asked to retry, because retrying re-enqueues
  *       the already-succeeded items (no client-supplied idempotency key
  *       exists yet — see batch-track-retry-dedup.test.ts for the pin).
@@ -49,7 +49,7 @@
  * Split of coverage:
  *
  *   THIS FILE (HTTP integration, against the live dev server):
- *     - 202 happy path with { success: true }
+ *     - 204 happy path with no body
  *     - 422 validation: empty array, > 1000 items, item with neither
  *       feature_id nor event_name, item with BOTH (refine rejects)
  *     - 429 BatchTrack rate limit kicks in past 10 req/sec/org
@@ -80,7 +80,7 @@
  *
  * "Happy path" assertion shape: dev SQS health is independent of the
  * HTTP-layer contract this file enforces. A successful HTTP path can
- * land as 202 { success: true } (full happy path, dev SQS healthy) OR
+ * land as 204 with no body (full happy path, dev SQS healthy) OR
  * as 503 { code: "internal_error", message: "Async track is not
  * available right now" } (validation/auth/routing all passed, handler
  * was reached, downstream SQS choked). Both prove the HTTP contract
@@ -209,7 +209,7 @@ describe(chalk.yellowBright(testCase), () => {
 
 	// ── Assertion 1: validation passes for a valid single-item batch ────────
 	// Contract: route exists, auth accepted, schema parsed, handler reached.
-	// Full 202 happy path is contingent on dev SQS being healthy.
+	// Full 204 happy path is contingent on dev SQS being healthy.
 	test("valid single-item batch reaches the handler past validation/auth", async () => {
 		const result = await postBatchTrack({
 			autumn,
@@ -217,8 +217,8 @@ describe(chalk.yellowBright(testCase), () => {
 		});
 
 		expect(isHandlerReached(result)).toBe(true);
-		if (result.status === 202) {
-			expect(result.body).toEqual({ success: true });
+		if (result.status === 204) {
+			expect(result.body).toBeNull();
 		}
 	});
 
@@ -232,8 +232,8 @@ describe(chalk.yellowBright(testCase), () => {
 		const result = await postBatchTrack({ autumn, body });
 
 		expect(isHandlerReached(result)).toBe(true);
-		if (result.status === 202) {
-			expect(result.body).toEqual({ success: true });
+		if (result.status === 204) {
+			expect(result.body).toBeNull();
 		}
 	});
 
@@ -246,14 +246,14 @@ describe(chalk.yellowBright(testCase), () => {
 		status >= 400 && status < 500 && status !== 401 && status !== 429;
 
 	// Helper: a "request reached the handler and passed validation" is either
-	// 202 (full happy path — SQS enqueue succeeded) or 503 with the handler's
+	// 204 (full happy path — SQS enqueue succeeded) or 503 with the handler's
 	// own "Async track is not available right now" message (validation passed,
 	// auth passed, route matched; SQS-side failed downstream). Both responses
 	// prove the HTTP-layer contract held. The 503 path is shape-matched so we
 	// only accept the handler's own RecaseError — a 503 from infra (proxy,
 	// nginx, lambda) without that exact code would correctly fail this gate.
 	const isHandlerReached = (result: BatchTrackHttpResult): boolean => {
-		if (result.status === 202) return true;
+		if (result.status === 204) return true;
 		if (result.status === 503) {
 			const body = result.body as
 				| { message?: unknown; code?: unknown }

--- a/server/tests/unit/balances/track/handle-batch-track-status.test.ts
+++ b/server/tests/unit/balances/track/handle-batch-track-status.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
+import { Hono } from "hono";
+import type { AutumnContext, HonoEnv } from "@/honoUtils/HonoEnv.js";
+
+const mockState = {
+	batchTrackBodies: [] as unknown[],
+	batchTrackTokenBodies: [] as unknown[],
+};
+
+mock.module("@/internal/balances/track/runBatchTrack.js", () => ({
+	runBatchTrack: async ({ body }: { body: unknown }) => {
+		mockState.batchTrackBodies.push(body);
+	},
+}));
+
+mock.module("@/internal/balances/track/runBatchTrackTokens.js", () => ({
+	runBatchTrackTokens: async ({ body }: { body: unknown }) => {
+		mockState.batchTrackTokenBodies.push(body);
+	},
+}));
+
+import { handleBatchTrack } from "@/internal/balances/handlers/handleBatchTrack.js";
+import { handleBatchTrackTokens } from "@/internal/balances/handlers/handleBatchTrackTokens.js";
+
+const createCtx = () =>
+	({
+		id: "req_batch_status",
+		org: { id: "org_123" },
+		env: AppEnv.Sandbox,
+		logger: {},
+	}) as AutumnContext;
+
+const createApp = ({ ctx }: { ctx: AutumnContext }) => {
+	const app = new Hono<HonoEnv>();
+	app.use("*", async (c, next) => {
+		c.set("ctx", ctx);
+		await next();
+	});
+	app.post("/balances.batch_track", ...handleBatchTrack);
+	app.post("/balances.batch_track_tokens", ...handleBatchTrackTokens);
+	return app;
+};
+
+describe("batch track handlers", () => {
+	beforeEach(() => {
+		mockState.batchTrackBodies = [];
+		mockState.batchTrackTokenBodies = [];
+	});
+
+	test("returns 204 with no body after enqueueing batch track", async () => {
+		const body = [{ customer_id: "cus_123", feature_id: "messages" }];
+		const response = await createApp({ ctx: createCtx() }).request(
+			"/balances.batch_track",
+			{
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify(body),
+			},
+		);
+
+		expect(response.status).toBe(204);
+		expect(await response.text()).toBe("");
+		expect(mockState.batchTrackBodies).toEqual([body]);
+	});
+
+	test("returns 204 with no body after enqueueing batch track tokens", async () => {
+		const body = [
+			{
+				customer_id: "cus_123",
+				model_id: "openai/gpt-4o",
+				input_tokens: 100,
+				output_tokens: 50,
+			},
+		];
+		const response = await createApp({ ctx: createCtx() }).request(
+			"/balances.batch_track_tokens",
+			{
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify(body),
+			},
+		);
+
+		expect(response.status).toBe(204);
+		expect(await response.text()).toBe("");
+		expect(mockState.batchTrackTokenBodies).toEqual([body]);
+	});
+});

--- a/server/tests/unit/balances/track/handle-track-tokens.test.ts
+++ b/server/tests/unit/balances/track/handle-track-tokens.test.ts
@@ -172,7 +172,7 @@ describe("handleTrackTokens", () => {
 		expect(mockState.queueCommands).toHaveLength(0);
 	});
 
-	test("returns 202 and queues when async passthrough is true", async () => {
+	test("returns 204 and queues when async passthrough is true", async () => {
 		process.env.TRACK_ASYNC_SQS_QUEUE_URL = trackAsyncQueueUrl;
 		const sqsClient = getSqsClient({ queueUrl: trackAsyncQueueUrl });
 		mockState.originalSend = sqsClient.send.bind(sqsClient);
@@ -193,8 +193,8 @@ describe("handleTrackTokens", () => {
 			}),
 		});
 
-		expect(response.status).toBe(202);
-		expect(await response.json()).toEqual({ success: true });
+		expect(response.status).toBe(204);
+		expect(await response.text()).toBe("");
 		expect(mockState.getTokenTrackParamsCalls).toHaveLength(1);
 		expect(mockState.getTokenTrackParamsCalls[0]).toMatchObject({
 			input: {

--- a/server/tests/unit/balances/track/runAsyncTrack.test.ts
+++ b/server/tests/unit/balances/track/runAsyncTrack.test.ts
@@ -71,6 +71,8 @@ describe("runAsyncTrack", () => {
 		await runAsyncTrack({ ctx, body });
 
 		expect(mockState.queueCommands).toHaveLength(1);
+		expect(ctx.logger.warn).not.toHaveBeenCalled();
+		expect(ctx.extraLogs.trackQueuedForReplay).toBeUndefined();
 		expect(mockState.queueCommands[0]).toMatchObject({
 			QueueUrl: trackAsyncQueueUrl,
 			MessageGroupId: "org_123:sandbox:cus_123:none",

--- a/shared/api/balances/track/trackParams.ts
+++ b/shared/api/balances/track/trackParams.ts
@@ -54,7 +54,7 @@ export const TrackParamsSchema = BalanceParamsBaseSchema.extend({
 
 	async: z.boolean().optional().meta({
 		description:
-			"If true, enqueue the event for asynchronous processing and return 202 immediately. The response will not include balance information.",
+			"If true, enqueue the event for asynchronous processing and return 204 immediately. The response will not include balance information.",
 	}),
 
 	lock: LockParamsSchema.optional(),

--- a/shared/api/balances/track/trackTokensParams.ts
+++ b/shared/api/balances/track/trackTokensParams.ts
@@ -63,7 +63,7 @@ export const TrackTokensParamsSchema = z.object({
 	}),
 	async: z.boolean().optional().meta({
 		description:
-			"If true, enqueue the event for asynchronous processing and return 202 immediately. The response will not include balance information.",
+			"If true, enqueue the event for asynchronous processing and return 204 immediately. The response will not include balance information.",
 	}),
 });
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Return 204 No Content for async tracking and batch-track routes, replacing the old 202 { success: true } response. Also quiet the async queue path by disabling fallback warnings and replay markers.

- **Migration**
  - Treat 204 with an empty body as success.
  - Affected routes: POST /v1/track (async=true), POST /v1/track_tokens (async=true), POST /v1/balances.batch_track, POST /v1/balances.batch_track_tokens.
  - Remove any parsing of { success: true } from responses.

- **Refactors**
  - `queueTrack` adds `logFallback` and `markQueuedForReplay` (default true).
  - `runAsyncTrack` sets both to false, preventing fallback warn logs and `trackQueuedForReplay` extra logs.
  - Tests and `TrackParamsSchema`/`TrackTokensParamsSchema` updated to reflect 204.

<sup>Written for commit 35d0bbbb55b1e39c5d517bf7dcd1bb13be89ef97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes the response code for async track and batch track endpoints from `202 Accepted` with `{ success: true }` body to `204 No Content` with no body. It also adds `logFallback` and `markQueuedForReplay` flags to `queueTrack` so that the intentional async path doesn't emit misleading "Redis unavailable, queued track fallback" warnings or incorrectly mark requests for replay.

- **[API changes]** All async and batch track endpoints now return `204` instead of `202`, and no response body — tests, contract docs, and schema descriptions are updated consistently.
- **[Improvements]** `runAsyncTrack` passes `logFallback: false` and `markQueuedForReplay: false` to `queueTrack`, preventing false "Redis unavailable" warnings and stale `trackQueuedForReplay` log metadata when the SQS enqueue is the intended primary path rather than a fallback.
- **[Improvements]** New unit test `handle-batch-track-status.test.ts` explicitly covers the `204` contract for both batch track handlers.
</details>

<h3>Confidence Score: 5/5</h3>

Straightforward, well-scoped API contract change with consistent updates across handlers, tests, and schema docs.

All four async/batch track endpoints are updated in lockstep — handlers, unit tests, integration contract tests, and schema descriptions all reflect the new `204` contract. The `logFallback`/`markQueuedForReplay` flags correctly prevent misleading log warnings on the intentional async path without affecting the existing Redis-fallback code path, which still defaults to `true` for both flags.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/track/utils/queueTrack.ts | Adds optional `logFallback` and `markQueuedForReplay` flags (defaulting to `true`) so callers can suppress the Redis-fallback warning log and replay marker when SQS is the primary path. |
| server/src/internal/balances/track/runAsyncTrack.ts | Passes `logFallback: false` and `markQueuedForReplay: false` to `queueTrack` so the intentional async queue path does not emit false "Redis unavailable" warnings. |
| server/src/internal/balances/handlers/handleTrack.ts | Async branch now returns `204 No Content`; sync path continues returning `202`/`200` depending on `trackQueuedForReplay`. |
| server/tests/unit/balances/track/handle-batch-track-status.test.ts | New unit test verifying both batch track handlers return `204` with empty body; mocks `runBatchTrack` and `runBatchTrackTokens`. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Handler as handleTrack / handleBatchTrack
    participant RunAsync as runAsyncTrack
    participant Queue as queueTrack (SQS)

    Client->>Handler: "POST /track { async: true }"
    Handler->>RunAsync: "runAsyncTrack({ ctx, body })"
    RunAsync->>Queue: "queueTrack({ logFallback: false, markQueuedForReplay: false })"
    Queue-->>RunAsync: queued response
    RunAsync-->>Handler: void
    Handler-->>Client: 204 No Content

    Note over Client,Handler: Previously: 202 + { success: true }

    Client->>Handler: POST /balances.batch_track [...]
    Handler->>Queue: runBatchTrack (uses default logFallback: true)
    Queue-->>Handler: queued
    Handler-->>Client: 204 No Content
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Handler as handleTrack / handleBatchTrack
    participant RunAsync as runAsyncTrack
    participant Queue as queueTrack (SQS)

    Client->>Handler: "POST /track { async: true }"
    Handler->>RunAsync: "runAsyncTrack({ ctx, body })"
    RunAsync->>Queue: "queueTrack({ logFallback: false, markQueuedForReplay: false })"
    Queue-->>RunAsync: queued response
    RunAsync-->>Handler: void
    Handler-->>Client: 204 No Content

    Note over Client,Handler: Previously: 202 + { success: true }

    Client->>Handler: POST /balances.batch_track [...]
    Handler->>Queue: runBatchTrack (uses default logFallback: true)
    Queue-->>Handler: queued
    Handler-->>Client: 204 No Content
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["clean up track"](https://github.com/useautumn/autumn/commit/35d0bbbb55b1e39c5d517bf7dcd1bb13be89ef97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38621172)</sub>

<!-- /greptile_comment -->