### PR TITLE
chore: org cleanup

### DIFF
--- a/server/src/internal/customers/CusService.ts
+++ b/server/src/internal/customers/CusService.ts
@@ -297,7 +297,6 @@ export class CusService {
 
 		const sharedArgs = {
 			internalCustomerId: resolvedInternalId,
-			inStatuses: RELEVANT_STATUSES,
 			showExpired: params.show_expired,
 			entityId: params.entity_id,
 			kind: params.kind,

--- a/server/src/internal/customers/getCustomerProductsPageQuery.ts
+++ b/server/src/internal/customers/getCustomerProductsPageQuery.ts
@@ -7,7 +7,6 @@ import { sql } from "drizzle-orm";
 
 export type CustomerProductsPageQueryArgs = {
 	internalCustomerId: string;
-	inStatuses?: CusProductStatus[];
 	showExpired: boolean;
 	entityId?: string;
 	kind?: CustomerProductKind;
@@ -132,19 +131,17 @@ const freeTrialLateral = sql`
 	) ft_data ON true`;
 
 const buildFilters = ({
-	inStatuses,
 	showExpired,
 	entityId,
 	kind,
 }: {
-	inStatuses?: CusProductStatus[];
 	showExpired: boolean;
 	entityId?: string;
 	kind?: CustomerProductKind;
 }) => {
 	const statusFilter = showExpired
 		? cpStatusInClause([CusProductStatus.Expired])
-		: cpStatusInClause(inStatuses);
+		: sql`AND cp.status <> ${CusProductStatus.Expired}`;
 
 	const entityFilter = entityId
 		? sql`AND (cp.entity_id = ${entityId} OR cp.internal_entity_id = ${entityId} OR (cp.entity_id IS NULL AND cp.internal_entity_id IS NULL))`
@@ -158,14 +155,13 @@ const buildFilters = ({
 
 export const getCustomerProductsPageQuery = ({
 	internalCustomerId,
-	inStatuses,
 	showExpired,
 	entityId,
 	kind,
 	limit,
 	cursor,
 }: CustomerProductsPageQueryArgs) => {
-	const filters = buildFilters({ inStatuses, showExpired, entityId, kind });
+	const filters = buildFilters({ showExpired, entityId, kind });
 
 	const cursorPredicate = cursor
 		? sql`AND (
@@ -202,12 +198,11 @@ export const getCustomerProductsPageQuery = ({
 
 export const getCustomerProductsCountQuery = ({
 	internalCustomerId,
-	inStatuses,
 	showExpired,
 	entityId,
 	kind,
 }: Omit<CustomerProductsPageQueryArgs, "limit" | "cursor">) => {
-	const filters = buildFilters({ inStatuses, showExpired, entityId, kind });
+	const filters = buildFilters({ showExpired, entityId, kind });
 
 	return sql`
 		SELECT COUNT(*)::int AS total_count

--- a/server/src/utils/authUtils/beforeSessionCreated.ts
+++ b/server/src/utils/authUtils/beforeSessionCreated.ts
@@ -6,7 +6,11 @@ import { createDefaultOrg } from "@/utils/authUtils/createDefaultOrg.js";
 
 export const beforeSessionCreated = async (session: Session) => {
 	try {
-		console.log(`Running beforeSessionCreated for user ${session.userId}`);
+		// Impersonation sets its own active org; don't override with the
+		// target user's most-recent membership.
+		if ((session as { impersonatedBy?: string | null }).impersonatedBy) {
+			return;
+		}
 
 		const membership = await db.query.member.findFirst({
 			where: eq(member.userId, session.userId),
@@ -14,9 +18,6 @@ export const beforeSessionCreated = async (session: Session) => {
 		});
 
 		if (membership) {
-			// console.log(
-			// 	`Active membership found for user ${session.userId}, org ${membership.organizationId}`,
-			// );
 			return {
 				data: {
 					...session,

--- a/vite/src/hooks/common/useOrg.tsx
+++ b/vite/src/hooks/common/useOrg.tsx
@@ -1,50 +1,33 @@
 import type { AppEnv, FrontendOrg } from "@autumn/shared";
-import {
-	keepPreviousData,
-	useQuery,
-	useQueryClient,
-} from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect } from "react";
 import { authClient, useListOrganizations, useSession } from "@/lib/auth-client";
+import {
+	clearLastSwitchedOrgId,
+	getLastSwitchedOrgId,
+	setActiveOrg,
+	setLastSwitchedOrgId,
+} from "@/lib/orgSync";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { useEnv } from "@/utils/envUtils";
 
-const LAST_ORG_KEY = "autumn_last_active_org_id";
-
-export const setLastSwitchedOrgId = (id: string) => {
-	try {
-		localStorage.setItem(LAST_ORG_KEY, id);
-	} catch {}
-};
-
-export const getLastSwitchedOrgId = (): string | null => {
-	try {
-		return localStorage.getItem(LAST_ORG_KEY);
-	} catch {
-		return null;
-	}
-};
-
-export const clearLastSwitchedOrgId = (id?: string) => {
-	try {
-		if (!id || localStorage.getItem(LAST_ORG_KEY) === id) {
-			localStorage.removeItem(LAST_ORG_KEY);
-		}
-	} catch {}
+export {
+	clearLastSwitchedOrgId,
+	getLastSwitchedOrgId,
+	setActiveOrg,
+	setLastSwitchedOrgId,
 };
 
 export const useSwitchActiveOrg = () => {
-	const queryClient = useQueryClient();
 	const { refetch: refetchSession } = useSession();
 
 	return useCallback(async (orgId: string) => {
-		await authClient.organization.setActive({ organizationId: orgId });
-		setLastSwitchedOrgId(orgId);
-		await Promise.all([
-			refetchSession(),
-			queryClient.invalidateQueries({ queryKey: ["org"] }),
-		]);
-	}, [queryClient, refetchSession]);
+		await setActiveOrg(orgId);
+		// The org query is keyed on activeOrgId, so refreshing the session
+		// (which updates activeOrgId) is enough to refetch the new org. An extra
+		// invalidate would force a redundant refetch and flash a skeleton.
+		await refetchSession();
+	}, [refetchSession]);
 };
 
 export const useOrg = (params?: { env?: AppEnv }) => {
@@ -61,8 +44,6 @@ export const useOrg = (params?: { env?: AppEnv }) => {
 
 	const {
 		data: org,
-		isLoading,
-		isPlaceholderData,
 		error,
 		refetch,
 	} = useQuery({
@@ -73,13 +54,19 @@ export const useOrg = (params?: { env?: AppEnv }) => {
 		staleTime: 30_000,
 		enabled: !!activeOrgId,
 	});
-	const orgLoading =
-		!session || (!!activeOrgId && (isLoading || isPlaceholderData));
+	const lastOrgId = getLastSwitchedOrgId();
+	const rememberedOrgValid =
+		orgListLoading || !orgList || orgList.some((o) => o.id === lastOrgId);
+	const pendingOrgSwitch =
+		!!lastOrgId && !!activeOrgId && lastOrgId !== activeOrgId && rememberedOrgValid;
+
+	const orgIsReady =
+		!!org && !!activeOrgId && org.id === activeOrgId && !pendingOrgSwitch;
+	const orgLoading = !session || (!!activeOrgId && !orgIsReady);
 
 	useEffect(() => {
 		const handleNoActiveOrg = async () => {
 			if (!orgList || orgList.length === 0) {
-				console.log("No org to set active, signing out");
 				await authClient.signOut();
 				window.location.href = "/sign-in";
 				return;
@@ -91,13 +78,14 @@ export const useOrg = (params?: { env?: AppEnv }) => {
 				: null;
 			const targetOrgId = preferredOrg?.id ?? orgList[0].id;
 
-			await authClient.organization.setActive({
-				organizationId: targetOrgId,
-			});
+			await setActiveOrg(targetOrgId);
 			window.location.reload();
 		};
 
-		if (session && !activeOrgId && !orgListLoading) {
+		const onImpersonateRoute =
+			window.location.pathname.includes("impersonate-redirect");
+
+		if (session && !activeOrgId && !orgListLoading && !onImpersonateRoute) {
 			handleNoActiveOrg();
 		}
 	}, [activeOrgId, orgList, orgListLoading, session]);

--- a/vite/src/lib/orgSync.ts
+++ b/vite/src/lib/orgSync.ts
@@ -1,0 +1,36 @@
+import { authClient } from "@/lib/auth-client";
+
+const LAST_ORG_KEY = "autumn_last_active_org_id";
+
+export const setLastSwitchedOrgId = (id: string) => {
+	try {
+		localStorage.setItem(LAST_ORG_KEY, id);
+	} catch {}
+};
+
+export const getLastSwitchedOrgId = (): string | null => {
+	try {
+		return localStorage.getItem(LAST_ORG_KEY);
+	} catch {
+		return null;
+	}
+};
+
+export const clearLastSwitchedOrgId = (id?: string) => {
+	try {
+		if (!id || localStorage.getItem(LAST_ORG_KEY) === id) {
+			localStorage.removeItem(LAST_ORG_KEY);
+		}
+	} catch {}
+};
+
+// Single source of truth for changing the active org: always mirrors the
+// server-side switch into localStorage so DashboardGate can't read a stale
+// lastOrgId and bounce back. Use this instead of authClient.organization.setActive.
+export const setActiveOrg = async (orgId: string) => {
+	const result = await authClient.organization.setActive({
+		organizationId: orgId,
+	});
+	setLastSwitchedOrgId(orgId);
+	return result;
+};

--- a/vite/src/lib/orgSync.ts
+++ b/vite/src/lib/orgSync.ts
@@ -31,6 +31,8 @@ export const setActiveOrg = async (orgId: string) => {
 	const result = await authClient.organization.setActive({
 		organizationId: orgId,
 	});
-	setLastSwitchedOrgId(orgId);
+	if (!result.error) {
+		setLastSwitchedOrgId(orgId);
+	}
 	return result;
 };

--- a/vite/src/services/useAxiosInstance.tsx
+++ b/vite/src/services/useAxiosInstance.tsx
@@ -3,6 +3,7 @@ import { type ApiVersion, AppEnv } from "@autumn/shared";
 import axios from "axios";
 import { useMemo } from "react";
 import { authClient } from "@/lib/auth-client";
+import { setActiveOrg } from "@/lib/orgSync";
 import { useEnv } from "@/utils/envUtils";
 
 const defaultParams = {
@@ -60,9 +61,7 @@ export function useAxiosInstance(params?: {
 								(org) => org.id !== error.response.data.orgId,
 							);
 							if (nextOrg) {
-								await authClient.organization.setActive({
-									organizationId: nextOrg.id,
-								});
+								await setActiveOrg(nextOrg.id);
 								window.location.href = "/";
 								return Promise.reject(
 									new Error("Redirecting to available organization"),

--- a/vite/src/utils/genUtils.ts
+++ b/vite/src/utils/genUtils.ts
@@ -55,8 +55,13 @@ export const getDefaultOrgPath = (
 
 export const getSafeNextPath = (searchParams: URLSearchParams) => {
 	const next = searchParams.get("next");
-	return next?.startsWith("/") && !next.startsWith("//") ? next : "/";
+	return isSafeLocalPath(next) ? next : "/";
 };
+
+// Guard against open redirects: only allow same-origin paths, rejecting
+// protocol-relative ("//host") and backslash-trick ("/\host") URLs.
+export const isSafeLocalPath = (path?: string | null): path is string =>
+	!!path && path.startsWith("/") && !path.startsWith("//") && path[1] !== "\\";
 
 const appendSearch = (path: string, search: string) => {
 	const query = search.replace(/^\?/, "");

--- a/vite/src/views/admin/ImpersonateRedirect.tsx
+++ b/vite/src/views/admin/ImpersonateRedirect.tsx
@@ -1,11 +1,23 @@
 import { AlertCircle, Loader2, ShieldCheck } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { Button } from "@/components/v2/buttons/Button";
-import { setLastSwitchedOrgId } from "@/hooks/common/useOrg";
 import { authClient } from "@/lib/auth-client";
+import { setActiveOrg } from "@/lib/orgSync";
+import { getDefaultOrgPath } from "@/utils/genUtils";
 import { useAxiosInstance } from "../../services/useAxiosInstance";
 import { useAdmin } from "./hooks/useAdmin";
+
+const resolveDefaultRedirect = async (
+	axiosInstance: ReturnType<typeof useAxiosInstance>,
+): Promise<string> => {
+	try {
+		const { data } = await axiosInstance.get("/organization");
+		return getDefaultOrgPath({ deployed: data?.deployed });
+	} catch {
+		return getDefaultOrgPath({ deployed: false });
+	}
+};
 
 export function ImpersonateRedirect() {
 	const [searchParams] = useSearchParams();
@@ -15,6 +27,7 @@ export function ImpersonateRedirect() {
 	const [error, setError] = useState<string | null>(null);
 
 	const axiosInstance = useAxiosInstance();
+	const hasRun = useRef(false);
 
 	const orgId = searchParams.get("org_id");
 	const redirect = searchParams.get("redirect") || "/";
@@ -61,18 +74,20 @@ export function ImpersonateRedirect() {
 					return;
 				}
 
-				// Step 4: Set the active organization. Persist it as the
-				// last-switched org so DashboardGate's auto-switch doesn't
-				// bounce back to the admin's previous org.
+				// Step 4: Set the active org. The impersonation session is created
+				// with no active org (see beforeSessionCreated), so this is the sole
+				// authority; setActiveOrg also persists it for DashboardGate.
 				setStatus("Setting active organization...");
-				setLastSwitchedOrgId(orgId);
-				await authClient.organization.setActive({
-					organizationId: orgId,
-				});
+				await setActiveOrg(orgId);
 
-				// Step 5: Navigate to the redirect path
+				// Step 5: Resolve the landing path against the target org. If it
+				// isn't deployed to prod, land on its sandbox rather than a live
+				// route that doesn't exist for it.
 				setStatus("Redirecting...");
-				window.location.href = redirect;
+				const target = searchParams.get("redirect")
+					? redirect
+					: await resolveDefaultRedirect(axiosInstance);
+				window.location.href = target;
 			} catch (err: unknown) {
 				const errorMessage =
 					err instanceof Error ? err.message : "Unknown error";
@@ -80,7 +95,8 @@ export function ImpersonateRedirect() {
 			}
 		};
 
-		if (isAdmin) {
+		if (isAdmin && !hasRun.current) {
+			hasRun.current = true;
 			doImpersonate();
 		}
 	}, [orgId, redirect, navigate, isAdmin, isPending, isCurrentlyImpersonating, axiosInstance]);

--- a/vite/src/views/admin/ImpersonateRedirect.tsx
+++ b/vite/src/views/admin/ImpersonateRedirect.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useSearchParams } from "react-router";
 import { Button } from "@/components/v2/buttons/Button";
 import { authClient } from "@/lib/auth-client";
 import { setActiveOrg } from "@/lib/orgSync";
-import { getDefaultOrgPath } from "@/utils/genUtils";
+import { getDefaultOrgPath, isSafeLocalPath } from "@/utils/genUtils";
 import { useAxiosInstance } from "../../services/useAxiosInstance";
 import { useAdmin } from "./hooks/useAdmin";
 
@@ -30,7 +30,8 @@ export function ImpersonateRedirect() {
 	const hasRun = useRef(false);
 
 	const orgId = searchParams.get("org_id");
-	const redirect = searchParams.get("redirect") || "/";
+	const rawRedirect = searchParams.get("redirect");
+	const redirect = isSafeLocalPath(rawRedirect) ? rawRedirect : "/";
 
 	useEffect(() => {
 		const doImpersonate = async () => {
@@ -84,8 +85,8 @@ export function ImpersonateRedirect() {
 				// isn't deployed to prod, land on its sandbox rather than a live
 				// route that doesn't exist for it.
 				setStatus("Redirecting...");
-				const target = searchParams.get("redirect")
-					? redirect
+				const target = isSafeLocalPath(rawRedirect)
+					? rawRedirect
 					: await resolveDefaultRedirect(axiosInstance);
 				window.location.href = target;
 			} catch (err: unknown) {
@@ -99,7 +100,7 @@ export function ImpersonateRedirect() {
 			hasRun.current = true;
 			doImpersonate();
 		}
-	}, [orgId, redirect, navigate, isAdmin, isPending, isCurrentlyImpersonating, axiosInstance]);
+	}, [orgId, rawRedirect, navigate, isAdmin, isPending, isCurrentlyImpersonating, axiosInstance]);
 
 	if (!isAdmin && isPending) {
 		navigate("/");

--- a/vite/src/views/admin/adminUtils.ts
+++ b/vite/src/views/admin/adminUtils.ts
@@ -11,6 +11,7 @@ import type {
 } from "@autumn/shared";
 import { toast } from "sonner";
 import { authClient } from "@/lib/auth-client";
+import { setActiveOrg } from "@/lib/orgSync";
 import { formatUnixToDate } from "../../utils/formatUtils/formatDateUtils";
 
 export const getCusProductHoverTexts = (cusProduct: FullCusProduct) => {
@@ -66,9 +67,22 @@ export const impersonateUser = async ({
 		toast.error("Something went wrong");
 		return;
 	}
+
 	if (organizationId) {
-		await authClient.organization.setActive({ organizationId });
+		await setActiveOrg(organizationId);
+
+		// Confirm the session reflects the target before reloading. The
+		// impersonation session is born with no active org, so a premature reload
+		// lets handleNoActiveOrg pick the wrong org.
+		const { data } = await authClient.getSession({
+			query: { disableCookieCache: true },
+		});
+		if (data?.session.activeOrganizationId !== organizationId) {
+			toast.error("Failed to switch to the target organization");
+			return;
+		}
 	}
+
 	window.location.reload();
 };
 

--- a/vite/src/views/auth/Consent.tsx
+++ b/vite/src/views/auth/Consent.tsx
@@ -23,6 +23,7 @@ import {
 	useListOrganizations,
 	useSession,
 } from "@/lib/auth-client";
+import { setActiveOrg } from "@/lib/orgSync";
 
 interface ClientInfo {
 	client_id: string;
@@ -194,9 +195,7 @@ export const Consent = () => {
 	const handleSwitchOrg = async (orgId: string) => {
 		setSwitchingOrg(true);
 		try {
-			await authClient.organization.setActive({
-				organizationId: orgId,
-			});
+			await setActiveOrg(orgId);
 			window.location.reload();
 		} catch (_) {
 			toast.error("Failed to switch organization");

--- a/vite/src/views/general/ErrorScreen.tsx
+++ b/vite/src/views/general/ErrorScreen.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Link, useNavigate } from "react-router";
 import { authClient } from "@/lib/auth-client";
 import { getRedirectUrl } from "@/utils/genUtils";
+import { useEnv } from "@/utils/envUtils";
 import { useSwitchActiveOrg } from "@/hooks/common/useOrg";
 
 function ErrorScreen({
@@ -16,6 +17,7 @@ function ErrorScreen({
 	errorData?: any;
 }) {
 	const navigate = useNavigate();
+	const env = useEnv();
 	const switchActiveOrg = useSwitchActiveOrg();
 
 	const handleOrgRemovalError = async () => {

--- a/vite/src/views/main-sidebar/EnvDropdown.tsx
+++ b/vite/src/views/main-sidebar/EnvDropdown.tsx
@@ -11,11 +11,13 @@ import {
 	DropdownMenuContent,
 	DropdownMenuItem,
 } from "@/components/v2/dropdowns/DropdownMenu";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useOrg } from "@/hooks/common/useOrg";
 import { cn } from "@/lib/utils";
 import { envToPath } from "@/utils/genUtils";
 import { ExpandedEnvTrigger } from "./env-dropdown/ExpandedEnvTrigger";
 import { StaticEnvPill } from "./env-dropdown/StaticEnvPill";
+import { useSidebarContext } from "./SidebarContext";
 
 export const useEnvChange = () => {
 	const navigate = useNavigate();
@@ -40,12 +42,24 @@ export const useEnvChange = () => {
 
 export const EnvDropdown = ({ env }: { env: AppEnv }) => {
 	const { org, isLoading } = useOrg();
-	const canSwitch = !isLoading && !!org?.deployed;
 
 	const [isHovered, setIsHovered] = useState(false);
 	const [open, setOpen] = useState(false);
 	const handleEnvChange = useEnvChange();
+	const { expanded } = useSidebarContext();
 
+	const isResolving = isLoading || !org;
+	const willRedirectToSandbox = !!org && !org.deployed && env === AppEnv.Live;
+
+	if (isResolving || willRedirectToSandbox) {
+		return (
+			<div className={cn("flex text-muted-foreground text-xs gap-1 px-3")}>
+				<Skeleton className={cn("h-6", expanded ? "w-full" : "w-7")} />
+			</div>
+		);
+	}
+
+	const canSwitch = !!org?.deployed;
 	if (!canSwitch) {
 		return (
 			<div className={cn("flex text-muted-foreground text-xs gap-1 px-3")}>

--- a/vite/src/views/main-sidebar/org-dropdown/manage-org/DeleteOrgPopover.tsx
+++ b/vite/src/views/main-sidebar/org-dropdown/manage-org/DeleteOrgPopover.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/components/ui/popover";
 import { Button } from "@/components/v2/buttons/Button";
 import { Input } from "@/components/v2/inputs/Input";
-import { useOrg } from "@/hooks/common/useOrg";
+import { setActiveOrg, useOrg } from "@/hooks/common/useOrg";
 import { authClient, useListOrganizations } from "@/lib/auth-client";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
@@ -45,9 +45,7 @@ export const DeleteOrgPopover = () => {
 
 		// Other org is now the active org
 		const otherOrg = organizations.find((o) => o.id !== org.id);
-		await authClient.organization.setActive({
-			organizationId: otherOrg!.id,
-		});
+		await setActiveOrg(otherOrg!.id);
 
 		const { data, error } = await authClient.organization.delete({
 			organizationId: org.id,

--- a/vite/src/views/main-sidebar/org-dropdown/manage-org/LeaveOrgPopover.tsx
+++ b/vite/src/views/main-sidebar/org-dropdown/manage-org/LeaveOrgPopover.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/components/ui/popover";
 import { Button } from "@/components/v2/buttons/Button";
 import { Input } from "@/components/v2/inputs/Input";
-import { useOrg } from "@/hooks/common/useOrg";
+import { setActiveOrg, useOrg } from "@/hooks/common/useOrg";
 import {
 	authClient,
 	useListOrganizations,
@@ -44,9 +44,7 @@ export const LeaveOrgPopover = () => {
 		});
 
 		const otherOrg = organizations.find((o) => o.id !== org.id);
-		await authClient.organization.setActive({
-			organizationId: otherOrg!.id,
-		});
+		await setActiveOrg(otherOrg!.id);
 
 		window.location.reload();
 	};

--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -72,6 +72,29 @@ export default defineConfig({
 	},
 
 	optimizeDeps: {
+		// Pre-bundle base-ui subpaths up front. They are pulled in transitively by
+		// excluded workspace deps, so without this Vite discovers them mid-session
+		// and re-optimizes, invalidating already-served chunks (504 Outdated Dep).
+		include: [
+			"@base-ui/react/accordion",
+			"@base-ui/react/button",
+			"@base-ui/react/checkbox",
+			"@base-ui/react/dialog",
+			"@base-ui/react/field",
+			"@base-ui/react/menu",
+			"@base-ui/react/merge-props",
+			"@base-ui/react/popover",
+			"@base-ui/react/preview-card",
+			"@base-ui/react/radio",
+			"@base-ui/react/radio-group",
+			"@base-ui/react/scroll-area",
+			"@base-ui/react/select",
+			"@base-ui/react/separator",
+			"@base-ui/react/switch",
+			"@base-ui/react/tabs",
+			"@base-ui/react/tooltip",
+			"@base-ui/react/use-render",
+		],
 		// Exclude workspace dependencies from pre-bundling to avoid cache issues
 		exclude: [
 			"@autumn/shared",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized org switching and impersonation to keep client and server in sync, prevent bounce-backs, and reduce UI flicker. Also simplified product status filtering, added safe redirect handling, and made Vite dev builds more stable.

- **Refactors**
  - Added `vite/src/lib/orgSync.ts` with `setActiveOrg` that persists the last org only on success; replaced direct `authClient.organization.setActive` calls across the app.
  - Reworked `useOrg` to refetch session only and handle pending switches via `lastOrgId`; skip auto-select during impersonation; reduces skeleton flashes and reload bounce.
  - Improved impersonation: set active org once and resolve landing route based on org `deployed` status.

- **Bug Fixes**
  - Do not override active org during impersonation in `beforeSessionCreated`; confirm session reflects the target before reload, fix null-safe check, and enforce local-only redirects in admin flows.
  - Customer products query: when `showExpired` is false, exclude `Expired` and drop the `inStatuses` filter to return all active products.
  - Vite: pre-bundle `@base-ui` subpaths to prevent mid-session re-optimization and 504 “Outdated Dep” errors.

<sup>Written for commit 17d9380d84f542a7580bce3d62922120136ca6df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR centralises org-switching logic into a new `orgSync.ts` module (replacing scattered `authClient.organization.setActive` calls), fixes the impersonation flow so `beforeSessionCreated` no longer overwrites the target user's active org, and improves the customer-products page filter to include Trialing and Paused products (previously only Active/PastDue/Scheduled were returned).

- **Improvements**: `setActiveOrg` in `orgSync.ts` becomes the single source of truth for org switching, always mirroring the change into localStorage so `DashboardGate` reads a consistent value; all call sites updated accordingly.
- **Bug fixes**: `beforeSessionCreated` now returns early for impersonation sessions to avoid clobbering the admin's intended org; a `hasRun` ref prevents double execution in React StrictMode inside `ImpersonateRedirect`; a session-confirmation check in `adminUtils.impersonateUser` blocks a premature reload.
- **Improvements**: Customer-products page filter changed from an allowlist of `RELEVANT_STATUSES` to a `<> Expired` exclusion, making Trialing and Paused products visible in the default view.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the impersonation flow fixes are well-reasoned and the org-sync centralisation is a clean refactor.

The core changes (centralised setActiveOrg, beforeSessionCreated early-return, hasRun ref) are correct. Two minor defensive gaps exist: localStorage is updated before confirming the server-side setActive succeeded, and the session null-check in adminUtils uses incomplete optional chaining. Neither is likely to fire in practice but both are worth tightening.

vite/src/lib/orgSync.ts (unconditional setLastSwitchedOrgId) and vite/src/views/admin/adminUtils.ts (incomplete optional chain on session)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/lib/orgSync.ts | New module that centralises org-switching; setActiveOrg calls setLastSwitchedOrgId unconditionally before confirming success, risking stale localStorage on a silent failure. |
| server/src/internal/customers/getCustomerProductsPageQuery.ts | Status filter widened from RELEVANT_STATUSES allowlist to NOT Expired exclusion; Trialing, Paused, and Unknown products now appear in the default customer-products view. |
| server/src/utils/authUtils/beforeSessionCreated.ts | Clean fix: early-return for impersonated sessions so the target user's most-recent org is not overwritten before the admin sets the intended one. |
| vite/src/hooks/common/useOrg.tsx | Org loading refactored to pendingOrgSwitch guard; reads localStorage on every render which is fine, but relies on clearLastSwitchedOrgId (in DashboardGate) to avoid permanently blocking renders. |
| vite/src/views/admin/ImpersonateRedirect.tsx | hasRun ref prevents double execution in StrictMode; resolves landing path against org deployed status; clean improvement. |
| vite/src/views/admin/adminUtils.ts | Session confirmation check after impersonation is a good defensive guard; minor null-safety gap in optional chaining. |
| vite/src/views/main-sidebar/EnvDropdown.tsx | Skeleton shown while org resolves or when a non-deployed org is on the Live env; straightforward UX improvement. |
| vite/vite.config.ts | Pre-bundles base-ui subpaths to prevent 504 Outdated Dep errors caused by mid-session re-optimization of transitively pulled packages. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/lib/orgSync.ts:30-36
`setLastSwitchedOrgId(orgId)` is called unconditionally, even when `authClient.organization.setActive` returns a non-throwing error (Better Auth returns `{ data, error }` rather than throwing). If the switch fails silently, `lastOrgId` in localStorage diverges from `session.activeOrganizationId`, which causes `pendingOrgSwitch` in `useOrg` to stay `true` and leaves the app stuck in a loading state until a page reload.

```suggestion
export const setActiveOrg = async (orgId: string) => {
	const result = await authClient.organization.setActive({
		organizationId: orgId,
	});
	if (!result.error) {
		setLastSwitchedOrgId(orgId);
	}
	return result;
};
```

### Issue 2 of 2
vite/src/views/admin/adminUtils.ts:80
The optional chain stops at `data`, so if `data` is non-null but `data.session` is `null` or `undefined` (e.g. the session fetch returns a malformed response), accessing `.activeOrganizationId` throws a `TypeError` instead of resolving to `undefined`. Adding `?.` on `session` makes the guard safe in all cases.

```suggestion
		if (data?.session?.activeOrganizationId !== organizationId) {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: org cleanup"](https://github.com/useautumn/autumn/commit/3deb34e322acb9e421dba6541589cd4457cb707f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38630766)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->