### PR TITLE
chore: fix dashboard gate

### DIFF
--- a/vite/src/app/DashboardGate.tsx
+++ b/vite/src/app/DashboardGate.tsx
@@ -14,7 +14,7 @@ export const DashboardGate = () => {
 	const { data: session, isPending: sessionLoading } = useSession();
 	const { data: orgList } = useListOrganizations();
 	const switchActiveOrg = useSwitchActiveOrg();
-	const { org, error: orgError } = useOrg();
+	const { org, isLoading: orgLoading, error: orgError } = useOrg();
 	const [switchingToLastOrg, setSwitchingToLastOrg] = useState(false);
 	const [ignoredLastOrgId, setIgnoredLastOrgId] = useState<string | null>(null);
 	const lastOrgId = getLastSwitchedOrgId();
@@ -75,7 +75,12 @@ export const DashboardGate = () => {
 		);
 	}
 
-	if (org) {
+	// Only resolve the env redirect once the org is settled. Redirecting on a
+	// transitional org (e.g. a stale sandbox-only org during the login switch)
+	// would strand a user with production in sandbox.
+	const orgSettled =
+		!orgLoading && !shouldSwitchToLastOrg && !switchingToLastOrg;
+	if (org && orgSettled) {
 		const redirect = getOrgRouteRedirect({
 			pathname,
 			search,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes dashboard redirect timing by waiting for a stable org before resolving the environment redirect. Prevents users from landing in the wrong env (e.g., sandbox) during login or org switch.

- **Bug Fixes**
  - Read `isLoading` from `useOrg` and gate redirect behind an `orgSettled` check to avoid acting on transitional orgs.
  - Prevents stale-org redirects that could strand users in sandbox when production is selected.

<sup>Written for commit d200d04ffa5c3d6a07baf132246a82f7744e3a01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a race condition in `DashboardGate` where an environment redirect (sandbox ↔ production) could fire against a transitional org — such as a stale sandbox org still active during a login org-switch — stranding users in the wrong environment.

- **Bug fixes** — Extracts `isLoading` from `useOrg()` and introduces an `orgSettled` guard (`!orgLoading && !shouldSwitchToLastOrg && !switchingToLastOrg`) so the env redirect is deferred until the org state is fully resolved.
- **Bug fixes** — The added inline comment precisely documents the failure scenario this guards against, making future maintenance easier.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, well-commented guard that only delays the env redirect until the org is in a stable state, without altering any other code paths.

The three-part `orgSettled` flag correctly covers all transitional states: org data still fetching, a pending org-list-triggered switch, and an in-flight switch operation. The `finally` block in the switch effect ensures `switchingToLastOrg` always returns to `false`, so `orgSettled` can never be permanently stuck. Fallback behaviour while settling is unchanged — the `Outlet` renders as before.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/app/DashboardGate.tsx | Guards the environment-redirect logic behind an `orgSettled` flag so transitional org states (loading, pending switch) no longer trigger a premature redirect that could strand users in the wrong environment. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DashboardGate renders] --> B{sessionLoading && !session?}
    B -- yes --> C[Navigate to /sign-in]
    B -- no --> D{orgError?}
    D -- yes --> E[Show error UI]
    D -- no --> F{Compute orgSettled
!orgLoading &&
!shouldSwitchToLastOrg &&
!switchingToLastOrg}
    F --> G{org && orgSettled?}
    G -- no --> H[Render Outlet]
    G -- yes --> I{getOrgRouteRedirect
returns a path?}
    I -- yes --> J[Navigate to redirect]
    I -- no --> H
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[DashboardGate renders] --> B{sessionLoading && !session?}
    B -- yes --> C[Navigate to /sign-in]
    B -- no --> D{orgError?}
    D -- yes --> E[Show error UI]
    D -- no --> F{Compute orgSettled
!orgLoading &&
!shouldSwitchToLastOrg &&
!switchingToLastOrg}
    F --> G{org && orgSettled?}
    G -- no --> H[Render Outlet]
    G -- yes --> I{getOrgRouteRedirect
returns a path?}
    I -- yes --> J[Navigate to redirect]
    I -- no --> H
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix dashboard gate"](https://github.com/useautumn/autumn/commit/d200d04ffa5c3d6a07baf132246a82f7744e3a01) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38659208)</sub>

<!-- /greptile_comment -->