### PR TITLE
release

### DIFF
--- a/vite/src/app/DashboardGate.tsx
+++ b/vite/src/app/DashboardGate.tsx
@@ -14,7 +14,7 @@ export const DashboardGate = () => {
 	const { data: session, isPending: sessionLoading } = useSession();
 	const { data: orgList } = useListOrganizations();
 	const switchActiveOrg = useSwitchActiveOrg();
-	const { org, error: orgError } = useOrg();
+	const { org, isLoading: orgLoading, error: orgError } = useOrg();
 	const [switchingToLastOrg, setSwitchingToLastOrg] = useState(false);
 	const [ignoredLastOrgId, setIgnoredLastOrgId] = useState<string | null>(null);
 	const lastOrgId = getLastSwitchedOrgId();
@@ -75,7 +75,12 @@ export const DashboardGate = () => {
 		);
 	}
 
-	if (org) {
+	// Only resolve the env redirect once the org is settled. Redirecting on a
+	// transitional org (e.g. a stale sandbox-only org during the login switch)
+	// would strand a user with production in sandbox.
+	const orgSettled =
+		!orgLoading && !shouldSwitchToLastOrg && !switchingToLastOrg;
+	if (org && orgSettled) {
 		const redirect = getOrgRouteRedirect({
 			pathname,
 			search,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Delay dashboard redirects until the active org is settled to prevent sending users to the wrong environment during login or org switches.

- **Bug Fixes**
  - Use `orgLoading` from `useOrg()` and gate redirects behind an `orgSettled` check.
  - Skip env redirects while switching to the last org to avoid sandbox/production mismatches.

<sup>Written for commit 01370d0f4d5fbf918a42880258ee78030269c559. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Prevents the environment-redirect logic in `DashboardGate` from firing while the active org is still transitioning. The root cause was that `useOrg` retains stale org data via `keepPreviousData`, so a user logging in with a sandbox-only org as the active org could be redirected to `/sandbox/…` before the hook finished switching to the remembered production org.

- **[Bug fixes]** Extracts `isLoading` from `useOrg` and computes `orgSettled` (`!orgLoading && !shouldSwitchToLastOrg && !switchingToLastOrg`); `getOrgRouteRedirect` is now only called when all three conditions are satisfied, preventing a mis-redirect on transient org state.
- **[Improvements]** The existing comment explains the intent clearly, making the guard self-documenting for future maintainers.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change narrows a single conditional to prevent redirecting on transitional org state, with no new side-effects or altered data flows.

The change is small and well-scoped: it adds a guard so `getOrgRouteRedirect` only runs when the active org is fully settled. The `orgSettled` computation composes three already-existing boolean signals (`orgLoading`, `shouldSwitchToLastOrg`, `switchingToLastOrg`) without introducing new state or async work. `useOrg.isLoading` was already exported; the PR simply consumes it. No logic outside this guard is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/app/DashboardGate.tsx | Guards the env-redirect logic behind `orgSettled` so that stale org data (kept by `keepPreviousData`) cannot trigger an incorrect sandbox/production redirect while an org switch is in flight. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DashboardGate renders] --> B{sessionLoading?}
    B -- "no session" --> C[Navigate /sign-in]
    B -- "session exists" --> D{orgError?}
    D -- "yes" --> E[Show error UI]
    D -- "no" --> F{org data exists?}
    F -- "no" --> K[Render Outlet]
    F -- "yes" --> G{orgSettled?\n!orgLoading &&\n!shouldSwitchToLastOrg &&\n!switchingToLastOrg}
    G -- "false\n(org in transition)" --> K
    G -- "true\n(org stable)" --> H[getOrgRouteRedirect]
    H -- "redirect needed" --> I[Navigate to env-correct path]
    H -- "no redirect" --> K
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[DashboardGate renders] --> B{sessionLoading?}
    B -- "no session" --> C[Navigate /sign-in]
    B -- "session exists" --> D{orgError?}
    D -- "yes" --> E[Show error UI]
    D -- "no" --> F{org data exists?}
    F -- "no" --> K[Render Outlet]
    F -- "yes" --> G{orgSettled?\n!orgLoading &&\n!shouldSwitchToLastOrg &&\n!switchingToLastOrg}
    G -- "false\n(org in transition)" --> K
    G -- "true\n(org stable)" --> H[getOrgRouteRedirect]
    H -- "redirect needed" --> I[Navigate to env-correct path]
    H -- "no redirect" --> K
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #1984 from useautumn/..."](https://github.com/useautumn/autumn/commit/01370d0f4d5fbf918a42880258ee78030269c559) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38661388)</sub>

<!-- /greptile_comment -->