### PR TITLE
feat(web): add create more mode to create entity dialog

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/tasks/autoSyncFromSubscription.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/tasks/autoSyncFromSubscription.ts
@@ -50,6 +50,7 @@ export const autoSyncFromSubscription = async ({
 		ctx,
 		customerId,
 		subscription,
+		customerProducts: fullCustomer.customer_products,
 	});
 
 	const eligibility = canAutoSync({ match });

--- a/server/src/internal/billing/v2/actions/attach/setup/setupAttachTransitionContext.ts
+++ b/server/src/internal/billing/v2/actions/attach/setup/setupAttachTransitionContext.ts
@@ -17,10 +17,16 @@ export const setupAttachTransitionContext = ({
 	fullCustomer,
 	attachProduct,
 	planScheduleOverride,
+	internalEntityId,
 }: {
 	fullCustomer: FullCustomer;
 	attachProduct: FullProduct;
 	planScheduleOverride?: PlanTiming;
+	/** Scope the transition lookup to a specific entity. When omitted, the
+	 * finders fall back to the customer's current entity context (customer
+	 * level for a customer-scoped attach). Required so an entity-scoped attach
+	 * transitions from the existing product on that same entity. */
+	internalEntityId?: string;
 }) => {
 	// Only main recurring products can trigger transitions
 	const isMainRecurring =
@@ -38,11 +44,13 @@ export const setupAttachTransitionContext = ({
 	const currentCustomerProduct = findMainActiveCustomerProductByGroup({
 		fullCus: fullCustomer,
 		productGroup: attachProduct.group,
+		internalEntityId,
 	});
 
 	const scheduledCustomerProduct = findMainScheduledCustomerProductByGroup({
 		fullCustomer,
 		productGroup: attachProduct.group,
+		internalEntityId,
 	});
 
 	// Compute planTiming (upgrade = immediate, downgrade = end_of_cycle)

--- a/server/src/internal/billing/v2/actions/sync/compute/carryOverUsage.ts
+++ b/server/src/internal/billing/v2/actions/sync/compute/carryOverUsage.ts
@@ -1,4 +1,9 @@
-import type { FullCusProduct, FullCustomerEntitlement } from "@autumn/shared";
+import {
+	cusEntsToUsage,
+	type FullCusEntWithFullCusProduct,
+	type FullCusProduct,
+	type FullCustomerEntitlement,
+} from "@autumn/shared";
 
 /**
  * When a sync expires an existing plan and inserts a replacement for the same
@@ -8,11 +13,16 @@ import type { FullCusProduct, FullCustomerEntitlement } from "@autumn/shared";
  *
  * Example: Free at 5/10 (5 used) replaced by Pro (20 included) → Pro at 15/20.
  *
+ * The new entitlement was just initialized to its full granted amount (plain
+ * allowance OR prepaid quantity), so the carry is simply
+ *   newBalance = newInitialBalance − oldUsage
+ * where `oldUsage` is computed via `cusEntsToUsage`, which correctly accounts
+ * for prepaid quantity (prepaid features carry their included amount in the
+ * prepaid quantity, not in `entitlement.allowance`).
+ *
  * Mutates `inserted` in place. Matches entitlements by `internal_feature_id`.
- * Conservatively skips entitlements where carry-over is ambiguous or would
- * corrupt structure — unlimited features, features without a numeric
- * allowance (prepaid/pure-usage), and legacy per-entity balance hashes — and
- * leaves those at their fresh allowance.
+ * Skips unlimited features and legacy per-entity balance hashes (whose balance
+ * lives in a per-entity map rather than the top-level `balance`).
  */
 export const carryOverEntitlementUsage = ({
 	inserted,
@@ -30,24 +40,28 @@ export const carryOverEntitlementUsage = ({
 		const oldCusEnt = expiringByFeature.get(newCusEnt.internal_feature_id);
 		if (!oldCusEnt) continue;
 
-		// Skip cases where a simple balance transfer doesn't apply.
 		if (newCusEnt.unlimited || oldCusEnt.unlimited) continue;
-		// Legacy per-entity balance hash — handled differently; leave untouched.
+		// Legacy per-entity balance hash — balance lives per-entity, not on the
+		// top-level `balance` we mutate here; leave untouched.
 		if (newCusEnt.entities || oldCusEnt.entities) continue;
 
-		const newAllowance = newCusEnt.entitlement.allowance;
-		const oldAllowance = oldCusEnt.entitlement.allowance;
-		if (newAllowance == null || oldAllowance == null) continue;
+		// Usage consumed on the expiring plan. `cusEntsToUsage` needs the cusEnt
+		// linked to its product (for prepaid quantity + plan quantity).
+		const oldUsage = cusEntsToUsage({
+			cusEnts: [
+				{
+					...oldCusEnt,
+					customer_product: expiring,
+				} as FullCusEntWithFullCusProduct,
+			],
+		});
+		if (oldUsage <= 0) continue;
 
-		const oldBalance = oldCusEnt.balance ?? 0;
-		const consumed = Math.max(0, oldAllowance - oldBalance);
-		if (consumed === 0) continue;
-
-		const carriedBalance = newAllowance - consumed;
+		const carried = (newCusEnt.balance ?? 0) - oldUsage;
 		// Allow negative (overage) when the feature permits it; otherwise floor
 		// at zero so a larger prior consumption can't over-credit.
 		newCusEnt.balance = newCusEnt.usage_allowed
-			? carriedBalance
-			: Math.max(0, carriedBalance);
+			? carried
+			: Math.max(0, carried);
 	}
 };

--- a/server/src/internal/billing/v2/actions/sync/compute/carryOverUsage.ts
+++ b/server/src/internal/billing/v2/actions/sync/compute/carryOverUsage.ts
@@ -1,0 +1,53 @@
+import type { FullCusProduct, FullCustomerEntitlement } from "@autumn/shared";
+
+/**
+ * When a sync expires an existing plan and inserts a replacement for the same
+ * subject (customer→customer, entity→entity — guaranteed by the entity-scoped
+ * transition lookup), carry the expired plan's already-consumed usage onto the
+ * new plan's balances so the customer doesn't silently regain a full allowance.
+ *
+ * Example: Free at 5/10 (5 used) replaced by Pro (20 included) → Pro at 15/20.
+ *
+ * Mutates `inserted` in place. Matches entitlements by `internal_feature_id`.
+ * Conservatively skips entitlements where carry-over is ambiguous or would
+ * corrupt structure — unlimited features, features without a numeric
+ * allowance (prepaid/pure-usage), and legacy per-entity balance hashes — and
+ * leaves those at their fresh allowance.
+ */
+export const carryOverEntitlementUsage = ({
+	inserted,
+	expiring,
+}: {
+	inserted: FullCusProduct;
+	expiring: FullCusProduct;
+}): void => {
+	const expiringByFeature = new Map<string, FullCustomerEntitlement>();
+	for (const cusEnt of expiring.customer_entitlements) {
+		expiringByFeature.set(cusEnt.internal_feature_id, cusEnt);
+	}
+
+	for (const newCusEnt of inserted.customer_entitlements) {
+		const oldCusEnt = expiringByFeature.get(newCusEnt.internal_feature_id);
+		if (!oldCusEnt) continue;
+
+		// Skip cases where a simple balance transfer doesn't apply.
+		if (newCusEnt.unlimited || oldCusEnt.unlimited) continue;
+		// Legacy per-entity balance hash — handled differently; leave untouched.
+		if (newCusEnt.entities || oldCusEnt.entities) continue;
+
+		const newAllowance = newCusEnt.entitlement.allowance;
+		const oldAllowance = oldCusEnt.entitlement.allowance;
+		if (newAllowance == null || oldAllowance == null) continue;
+
+		const oldBalance = oldCusEnt.balance ?? 0;
+		const consumed = Math.max(0, oldAllowance - oldBalance);
+		if (consumed === 0) continue;
+
+		const carriedBalance = newAllowance - consumed;
+		// Allow negative (overage) when the feature permits it; otherwise floor
+		// at zero so a larger prior consumption can't over-credit.
+		newCusEnt.balance = newCusEnt.usage_allowed
+			? carriedBalance
+			: Math.max(0, carriedBalance);
+	}
+};

--- a/server/src/internal/billing/v2/actions/sync/compute/computeSyncImmediatePhase.ts
+++ b/server/src/internal/billing/v2/actions/sync/compute/computeSyncImmediatePhase.ts
@@ -7,6 +7,7 @@ import {
 	type SyncBillingContext,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { carryOverEntitlementUsage } from "./carryOverUsage";
 import { initImmediateSyncCustomerProduct } from "./initImmediateSyncCustomerProduct";
 
 type CustomerProductUpdate = NonNullable<
@@ -50,8 +51,13 @@ export const computeSyncImmediatePhase = ({
 	ctx: AutumnContext;
 	syncContext: SyncBillingContext;
 }): ImmediatePhaseResult => {
-	const { immediatePhase, fullCustomer, stripeSubscription, currentEpochMs } =
-		syncContext;
+	const {
+		immediatePhase,
+		fullCustomer,
+		stripeSubscription,
+		currentEpochMs,
+		carryOverUsage,
+	} = syncContext;
 	if (!immediatePhase || !stripeSubscription) {
 		return {
 			insertCustomerProducts: [],
@@ -67,15 +73,22 @@ export const computeSyncImmediatePhase = ({
 	const customEntitlements: Entitlement[] = [];
 
 	for (const productContext of immediatePhase.productContexts) {
-		insertCustomerProducts.push(
-			initImmediateSyncCustomerProduct({
-				ctx,
-				fullCustomer,
-				productContext,
-				stripeSubscription,
-				currentEpochMs,
-			}),
-		);
+		const insertedCustomerProduct = initImmediateSyncCustomerProduct({
+			ctx,
+			fullCustomer,
+			productContext,
+			stripeSubscription,
+			currentEpochMs,
+		});
+
+		if (carryOverUsage && productContext.currentCustomerProduct) {
+			carryOverEntitlementUsage({
+				inserted: insertedCustomerProduct,
+				expiring: productContext.currentCustomerProduct,
+			});
+		}
+
+		insertCustomerProducts.push(insertedCustomerProduct);
 		customPrices.push(...productContext.customPrices);
 		customEntitlements.push(...productContext.customEntitlements);
 

--- a/server/src/internal/billing/v2/actions/sync/setup/setupSyncContext.ts
+++ b/server/src/internal/billing/v2/actions/sync/setup/setupSyncContext.ts
@@ -93,6 +93,10 @@ const buildProductContext = async ({
 		const transition = setupAttachTransitionContext({
 			fullCustomer,
 			attachProduct: fullProduct,
+			// Scope the "previous product to expire" lookup to the plan's entity
+			// so an entity-scoped sync replaces the existing product on that
+			// same entity rather than missing it (which would duplicate).
+			internalEntityId: entity?.internal_id,
 		});
 		currentCustomerProduct = transition.currentCustomerProduct;
 	}

--- a/server/src/internal/billing/v2/actions/sync/setup/setupSyncContext.ts
+++ b/server/src/internal/billing/v2/actions/sync/setup/setupSyncContext.ts
@@ -229,5 +229,6 @@ export const setupSyncContext = async ({
 		futurePhases,
 		currentEpochMs,
 		acknowledgedWarnings: params.acknowledge_warnings ?? [],
+		carryOverUsage: params.carry_over_usage ?? true,
 	};
 };

--- a/server/src/internal/billing/v2/actions/sync/subscriptionToSyncParams.ts
+++ b/server/src/internal/billing/v2/actions/sync/subscriptionToSyncParams.ts
@@ -1,14 +1,17 @@
 import {
-	secondsToMs,
+	type FullCusProduct,
+	filterCustomerProductsByStripeSubscriptionId,
 	type SyncParamsV1,
 	type SyncPhase,
 	type SyncPlanInstance,
+	secondsToMs,
 } from "@autumn/shared";
 import type Stripe from "stripe";
 import { createStripeCli } from "@/external/connect/createStripeCli";
 import { getStripeActiveSubscriptionSchedule } from "@/external/stripe/subscriptionSchedules";
 import { stripeSubscriptionToScheduleId } from "@/external/stripe/subscriptions/utils/convertStripeSubscription";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { CusService } from "@/internal/customers/CusService";
 import { buildFeatureQuantities } from "./buildSyncParams/buildFeatureQuantities";
 import { detectSubscriptionMatch } from "./detect/detectSubscriptionMatch";
 import type {
@@ -36,6 +39,55 @@ const matchedPlanToSyncPlan = ({
 	};
 };
 
+/**
+ * Detection is scope-blind: it matches Stripe prices to catalog products with
+ * no knowledge of the customer's existing customer products. When a product is
+ * already linked to this Stripe subscription via an entity-scoped customer
+ * product, re-syncing it without that binding would insert a duplicate at the
+ * customer level (and `expire_previous` would miss the entity-scoped original).
+ *
+ * Stamp the existing entity binding onto each matched plan so the sync
+ * re-attaches the product on the same entity and matches/expires the original.
+ */
+const stampEntityFromExistingLinks = ({
+	phases,
+	subscription,
+	customerProducts,
+}: {
+	phases: SyncPhase[];
+	subscription?: Stripe.Subscription;
+	customerProducts: FullCusProduct[];
+}): SyncPhase[] => {
+	if (!subscription) return phases;
+
+	const linkedCustomerProducts = filterCustomerProductsByStripeSubscriptionId({
+		customerProducts,
+		stripeSubscriptionId: subscription.id,
+	});
+
+	// product id → existing entity binding (only entity-scoped links).
+	// `entity_id` accepts either the public or internal entity id, so the
+	// internal id stored on the customer product is sufficient.
+	const entityIdByProductId = new Map<string, string>();
+	for (const customerProduct of linkedCustomerProducts) {
+		const productId = customerProduct.product?.id;
+		if (customerProduct.internal_entity_id && productId) {
+			entityIdByProductId.set(productId, customerProduct.internal_entity_id);
+		}
+	}
+
+	if (entityIdByProductId.size === 0) return phases;
+
+	return phases.map((phase) => ({
+		...phase,
+		plans: phase.plans.map((plan) => {
+			if (plan.entity_id != null) return plan;
+			const entityId = entityIdByProductId.get(plan.plan_id);
+			return entityId ? { ...plan, entity_id: entityId } : plan;
+		}),
+	}));
+};
+
 const phaseMatchToSyncPhase = ({
 	phaseMatch,
 }: {
@@ -43,9 +95,7 @@ const phaseMatchToSyncPhase = ({
 }): SyncPhase => ({
 	// PhaseMatch.start_date is Stripe-native (seconds). SyncPhase.starts_at
 	// is ms epoch (or the "now" sentinel for the immediate phase).
-	starts_at: phaseMatch.is_current
-		? "now"
-		: secondsToMs(phaseMatch.start_date),
+	starts_at: phaseMatch.is_current ? "now" : secondsToMs(phaseMatch.start_date),
 	plans: phaseMatch.plans.map((matchedPlan) =>
 		matchedPlanToSyncPlan({
 			matchedPlan,
@@ -69,6 +119,7 @@ export const subscriptionToSyncParams = async ({
 	customerId,
 	subscription,
 	schedule,
+	customerProducts,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
@@ -76,6 +127,10 @@ export const subscriptionToSyncParams = async ({
 	/** Optional pre-fetched schedule. When omitted and `subscription` references
 	 * a schedule, it's fetched with schedule item prices expanded. */
 	schedule?: Stripe.SubscriptionSchedule;
+	/** Optional pre-fetched customer products (callers that already loaded the
+	 * full customer pass these to avoid a redundant fetch). Used to restore the
+	 * entity binding of products already linked to this subscription. */
+	customerProducts?: FullCusProduct[];
 }): Promise<{
 	match: SubscriptionMatch;
 	params: SyncParamsV1;
@@ -101,9 +156,22 @@ export const subscriptionToSyncParams = async ({
 		schedule: resolvedSchedule,
 	});
 
-	const phases: SyncPhase[] = match.phaseMatches
+	const detectedPhases: SyncPhase[] = match.phaseMatches
 		.filter((phase) => phase.plans.length > 0)
 		.map((phaseMatch) => phaseMatchToSyncPhase({ phaseMatch }));
+
+	const resolvedCustomerProducts =
+		customerProducts ??
+		(subscription
+			? (await CusService.getFull({ ctx, idOrInternalId: customerId }))
+					.customer_products
+			: []);
+
+	const phases = stampEntityFromExistingLinks({
+		phases: detectedPhases,
+		subscription,
+		customerProducts: resolvedCustomerProducts,
+	});
 
 	const params: SyncParamsV1 = {
 		customer_id: customerId,

--- a/server/src/internal/billing/v2/actions/sync/syncProposalsV2.ts
+++ b/server/src/internal/billing/v2/actions/sync/syncProposalsV2.ts
@@ -103,6 +103,7 @@ const buildProposal = async ({
 			customerId,
 			subscription,
 			schedule,
+			customerProducts,
 		},
 	);
 

--- a/server/tests/integration/billing/sync/sync-carry-prepaid-entities.test.ts
+++ b/server/tests/integration/billing/sync/sync-carry-prepaid-entities.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Regression: carry-over for PREPAID features across two entities
+ * (default_applies_to_entities = true).
+ *
+ * Two entities X and Y both on Pro (prepaid 5000 credits each) on one Stripe
+ * sub. Delink X (cancel no_billing → Free auto-reattaches on X). Use 500 on Y
+ * and 40 on X, then sync both entities back to Pro (the dashboard submits a
+ * rolled-up qty-2 plan on Y plus an operator-added qty-1 plan on X), expire +
+ * carry on.
+ *
+ * Prepaid stores its included amount in the prepaid quantity, not
+ * entitlement.allowance — so the carry must use real usage:
+ *   Y stays Pro 4500/5000 (500 carried), X returns to Pro 4960/5000 (40 carried).
+ */
+
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import {
+	CusProductStatus,
+	type FullCusProduct,
+	type SyncParamsV1,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import ctx from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { db } from "@/db/initDrizzle";
+import { EntityService } from "@/internal/api/entities/EntityService";
+import { CusService } from "@/internal/customers/CusService";
+import { OrgService } from "@/internal/orgs/OrgService";
+
+const MESSAGES = TestFeature.Messages;
+
+beforeAll(async () => {
+	await OrgService.update({
+		db,
+		orgId: ctx.org.id,
+		updates: {
+			config: { ...ctx.org.config, default_applies_to_entities: true },
+		},
+	});
+});
+
+afterAll(async () => {
+	await OrgService.update({
+		db,
+		orgId: ctx.org.id,
+		updates: {
+			config: { ...ctx.org.config, default_applies_to_entities: false },
+		},
+	});
+});
+
+const activeProductsOnEntity = async ({
+	customerId,
+	productId,
+	internalEntityId,
+}: {
+	customerId: string;
+	productId: string;
+	internalEntityId: string;
+}): Promise<FullCusProduct[]> => {
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	return fullCustomer.customer_products.filter(
+		(cp) =>
+			cp.product_id === productId &&
+			cp.status === CusProductStatus.Active &&
+			cp.internal_entity_id === internalEntityId,
+	);
+};
+
+const messagesBalance = (cusProduct: FullCusProduct): number | undefined =>
+	cusProduct.customer_entitlements.find(
+		(ce) => ce.entitlement?.feature?.id === MESSAGES,
+	)?.balance ?? undefined;
+
+test(
+	chalk.yellowBright(
+		"sync-v2 carry-usage: prepaid credits across two entities (delink X, resync both)",
+	),
+	async () => {
+		const customerId = "sync-carry-prepaid-entities";
+
+		const free = products.base({
+			id: "free",
+			items: [items.monthlyMessages({ includedUsage: 50 })],
+			isDefault: true,
+		});
+		const pro = products.pro({
+			id: "pro",
+			items: [
+				items.prepaidMessages({ includedUsage: 0, billingUnits: 1, price: 1 }),
+			],
+		});
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [free, pro] }),
+				s.entities({
+					count: 2,
+					featureId: TestFeature.Users,
+					defaultGroup: customerId,
+				}),
+			],
+			actions: [
+				s.attach({
+					productId: pro.id,
+					entityIndex: 0,
+					options: [{ feature_id: MESSAGES, quantity: 5000 }],
+				}),
+				s.attach({
+					productId: pro.id,
+					entityIndex: 1,
+					options: [{ feature_id: MESSAGES, quantity: 5000 }],
+				}),
+			],
+		});
+
+		const full = await CusService.getFull({ ctx, idOrInternalId: customerId });
+		const entityList = await EntityService.list({
+			db: ctx.db,
+			internalCustomerId: full.internal_id,
+		});
+		const entityX = entityList[0];
+		const entityY = entityList[1];
+		const proSubId = full.customer_products.find(
+			(cp) => cp.product_id === pro.id,
+		)?.subscription_ids?.[0];
+		if (!proSubId) throw new Error("no Pro sub id");
+
+		// Delink X → Free auto-reattaches on X.
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: pro.id,
+			entity_id: entityX.id ?? undefined,
+			cancel_action: "cancel_immediately",
+			no_billing_changes: true,
+		});
+		await new Promise((r) => setTimeout(r, 1500));
+
+		// Use 500 on Y (Pro) and 40 on X (Free).
+		await autumnV1.track({
+			customer_id: customerId,
+			entity_id: entityY.id ?? undefined,
+			feature_id: MESSAGES,
+			value: 500,
+		});
+		await autumnV1.track({
+			customer_id: customerId,
+			entity_id: entityX.id ?? undefined,
+			feature_id: MESSAGES,
+			value: 40,
+		});
+		await new Promise((r) => setTimeout(r, 2000));
+
+		// Mirror the dashboard submission: rolled-up qty-2 plan stamped to Y +
+		// operator-added qty-1 plan on X. Expire + carry default on.
+		await autumnV1.post("/billing.sync_v2", {
+			customer_id: customerId,
+			stripe_subscription_id: proSubId,
+			phases: [
+				{
+					starts_at: "now",
+					plans: [
+						{
+							plan_id: pro.id,
+							quantity: 2,
+							entity_id: entityY.id ?? undefined,
+							expire_previous: true,
+							feature_quantities: [{ feature_id: MESSAGES, quantity: 5000 }],
+						},
+						{
+							plan_id: pro.id,
+							quantity: 1,
+							entity_id: entityX.id ?? undefined,
+							expire_previous: true,
+							feature_quantities: [{ feature_id: MESSAGES, quantity: 5000 }],
+						},
+					],
+				},
+			],
+		} satisfies SyncParamsV1);
+
+		// Y: single active Pro, 500 carried → 4500.
+		const proY = await activeProductsOnEntity({
+			customerId,
+			productId: pro.id,
+			internalEntityId: entityY.internal_id,
+		});
+		expect(proY.length).toBe(1);
+		expect(messagesBalance(proY[0])).toBe(4500);
+
+		// X: single active Pro, 40 carried from Free → 4960.
+		const proX = await activeProductsOnEntity({
+			customerId,
+			productId: pro.id,
+			internalEntityId: entityX.internal_id,
+		});
+		expect(proX.length).toBe(1);
+		expect(messagesBalance(proX[0])).toBe(4960);
+
+		// Free expired off X.
+		const fullAfter = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const activeFree = fullAfter.customer_products.filter(
+			(cp) =>
+				cp.product_id === free.id && cp.status === CusProductStatus.Active,
+		);
+		expect(activeFree.length).toBe(0);
+	},
+);

--- a/server/tests/integration/billing/sync/sync-carry-usage.test.ts
+++ b/server/tests/integration/billing/sync/sync-carry-usage.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Regression coverage for syncV2 expire behaviour:
+ *   - entity-scoped re-sync re-attaches on the same entity (no customer-level
+ *     duplicate) and expires the existing entity-scoped product
+ *   - consumed usage carries from the expired plan onto the replacement
+ *     (carry_over_usage, default on) — and stays put when turned off
+ *
+ * Out-of-sync state is forced with `cancel_immediately` + `no_billing_changes`
+ * (cancels in Autumn, leaves the live Stripe subscription), then re-synced the
+ * way the dashboard does it (detection proposals → submit with expire on).
+ */
+
+import { expect, test } from "bun:test";
+import {
+	CusProductStatus,
+	type FullCusProduct,
+	type SyncParamsV1,
+	type SyncPhase,
+	type SyncProposalV2,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import ctx from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { EntityService } from "@/internal/api/entities/EntityService";
+import { CusService } from "@/internal/customers/CusService";
+
+const MESSAGES = TestFeature.Messages;
+
+const messagesBalance = (cusProduct: FullCusProduct): number | undefined =>
+	cusProduct.customer_entitlements.find(
+		(ce) => ce.entitlement?.feature?.id === MESSAGES,
+	)?.balance ?? undefined;
+
+const getActiveProducts = async ({
+	customerId,
+	productId,
+}: {
+	customerId: string;
+	productId: string;
+}): Promise<FullCusProduct[]> => {
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	return fullCustomer.customer_products.filter(
+		(cp) =>
+			cp.product_id === productId && cp.status === CusProductStatus.Active,
+	);
+};
+
+// Submit a sync the same way the dashboard does: detection proposal → expire on.
+const dashboardSync = async ({
+	autumnV1,
+	customerId,
+	stripeSubscriptionId,
+	carryOverUsage,
+}: {
+	// biome-ignore lint/suspicious/noExplicitAny: test client
+	autumnV1: any;
+	customerId: string;
+	stripeSubscriptionId: string;
+	carryOverUsage?: boolean;
+	// biome-ignore lint/suspicious/noExplicitAny: sync result
+}): Promise<any> => {
+	const proposalsResponse = await autumnV1.post("/billing.sync_proposals_v2", {
+		customer_id: customerId,
+	});
+	const proposal = (proposalsResponse.proposals as SyncProposalV2[]).find(
+		(p) => p.stripe_subscription_id === stripeSubscriptionId,
+	);
+	if (!proposal) {
+		throw new Error(`No sync proposal found for ${stripeSubscriptionId}`);
+	}
+
+	const phases: SyncPhase[] = proposal.phases
+		.map((phase) => ({
+			starts_at: phase.starts_at,
+			plans: phase.plans.map((plan) => ({ ...plan, expire_previous: true })),
+		}))
+		.filter((phase) => phase.plans.length > 0);
+
+	return autumnV1.post("/billing.sync_v2", {
+		customer_id: customerId,
+		stripe_subscription_id: proposal.stripe_subscription_id,
+		stripe_schedule_id: proposal.stripe_schedule_id,
+		phases,
+		carry_over_usage: carryOverUsage,
+	} satisfies SyncParamsV1);
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Customer-level: Free (5/10 used) → re-sync Pro with expire → Pro 15/20.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test(
+	chalk.yellowBright(
+		"sync-v2 carry-usage: customer-level Free 5/10 → Pro carries to 15/20",
+	),
+	async () => {
+		const customerId = "sync-carry-customer";
+		const group = `grp-${customerId}`;
+
+		const free = products.base({
+			id: "free",
+			items: [items.monthlyMessages({ includedUsage: 10 })],
+			group,
+			isDefault: true,
+		});
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 20 })],
+			group,
+		});
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [free, pro] }),
+			],
+			actions: [
+				s.attach({ productId: free.id }),
+				s.attach({ productId: pro.id }),
+			],
+		});
+
+		const afterUpgrade = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const proStripeSubId = afterUpgrade.customer_products.find(
+			(cp) => cp.product_id === pro.id,
+		)?.subscription_ids?.[0];
+		if (!proStripeSubId) throw new Error("missing Pro Stripe subscription id");
+
+		// Out of sync: cancel Pro in Autumn only; fall back to default Free.
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: pro.id,
+			cancel_action: "cancel_immediately",
+			no_billing_changes: true,
+		});
+		// Use 5 on the reactivated Free → 5/10.
+		await autumnV1.track({
+			customer_id: customerId,
+			feature_id: MESSAGES,
+			value: 5,
+		});
+		await new Promise((r) => setTimeout(r, 2000));
+
+		const result = await dashboardSync({
+			autumnV1,
+			customerId,
+			stripeSubscriptionId: proStripeSubId,
+		});
+
+		// Free expired, exactly one active Pro carrying the 5 used → 15/20.
+		expect(result.expired_cus_product_ids.length).toBe(1);
+
+		const activeFree = await getActiveProducts({
+			customerId,
+			productId: free.id,
+		});
+		expect(activeFree.length).toBe(0);
+
+		const activePro = await getActiveProducts({
+			customerId,
+			productId: pro.id,
+		});
+		expect(activePro.length).toBe(1);
+		expect(messagesBalance(activePro[0])).toBe(15);
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Escape hatch: same flow with carry_over_usage:false → Pro stays 20/20.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test(
+	chalk.yellowBright(
+		"sync-v2 carry-usage: carry_over_usage=false leaves Pro at a fresh 20/20",
+	),
+	async () => {
+		const customerId = "sync-carry-disabled";
+		const group = `grp-${customerId}`;
+
+		const free = products.base({
+			id: "free",
+			items: [items.monthlyMessages({ includedUsage: 10 })],
+			group,
+			isDefault: true,
+		});
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 20 })],
+			group,
+		});
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [free, pro] }),
+			],
+			actions: [
+				s.attach({ productId: free.id }),
+				s.attach({ productId: pro.id }),
+			],
+		});
+
+		const afterUpgrade = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const proStripeSubId = afterUpgrade.customer_products.find(
+			(cp) => cp.product_id === pro.id,
+		)?.subscription_ids?.[0];
+		if (!proStripeSubId) throw new Error("missing Pro Stripe subscription id");
+
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: pro.id,
+			cancel_action: "cancel_immediately",
+			no_billing_changes: true,
+		});
+		await autumnV1.track({
+			customer_id: customerId,
+			feature_id: MESSAGES,
+			value: 5,
+		});
+		await new Promise((r) => setTimeout(r, 2000));
+
+		await dashboardSync({
+			autumnV1,
+			customerId,
+			stripeSubscriptionId: proStripeSubId,
+			carryOverUsage: false,
+		});
+
+		const activePro = await getActiveProducts({
+			customerId,
+			productId: pro.id,
+		});
+		expect(activePro.length).toBe(1);
+		expect(messagesBalance(activePro[0])).toBe(20);
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Entity-scoped: Premium on Entity A (21/30 used). Re-sync re-attaches on
+// Entity A (no customer-level duplicate), expires the old one, carries usage.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test(
+	chalk.yellowBright(
+		"sync-v2 carry-usage: entity-scoped Premium re-syncs on Entity A, no duplicate, carries to 21/30",
+	),
+	async () => {
+		const customerId = "sync-carry-entity";
+
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 20 })],
+		});
+		const premium = products.premium({
+			id: "premium",
+			items: [items.monthlyMessages({ includedUsage: 30 })],
+		});
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [
+				s.attach({ productId: pro.id }),
+				s.attach({ productId: premium.id, entityIndex: 0 }),
+			],
+		});
+
+		const afterSetup = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const entityList = await EntityService.list({
+			db: ctx.db,
+			internalCustomerId: afterSetup.internal_id,
+		});
+		const entityA = entityList[0];
+		const proStripeSubId = afterSetup.customer_products.find(
+			(cp) => cp.product_id === pro.id,
+		)?.subscription_ids?.[0];
+		if (!proStripeSubId) throw new Error("missing Stripe subscription id");
+
+		// Use 9 on Premium@Entity A → 21/30.
+		await autumnV1.track({
+			customer_id: customerId,
+			entity_id: entityA.id ?? undefined,
+			feature_id: MESSAGES,
+			value: 9,
+		});
+		await new Promise((r) => setTimeout(r, 2000));
+
+		// Out of sync: cancel only Pro (customer); Premium@Entity A stays.
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: pro.id,
+			cancel_action: "cancel_immediately",
+			no_billing_changes: true,
+		});
+
+		await dashboardSync({
+			autumnV1,
+			customerId,
+			stripeSubscriptionId: proStripeSubId,
+		});
+
+		// Exactly one active Premium, bound to Entity A, carrying 9 used → 21/30.
+		const activePremium = await getActiveProducts({
+			customerId,
+			productId: premium.id,
+		});
+		expect(activePremium.length).toBe(1);
+		expect(activePremium[0].internal_entity_id).toBe(entityA.internal_id);
+		expect(messagesBalance(activePremium[0])).toBe(21);
+
+		// Pro re-attached at the customer level (fresh).
+		const activePro = await getActiveProducts({
+			customerId,
+			productId: pro.id,
+		});
+		expect(activePro.length).toBe(1);
+		expect(activePro[0].internal_entity_id ?? null).toBeNull();
+	},
+);

--- a/shared/api/billing/sync/syncParamsV1.ts
+++ b/shared/api/billing/sync/syncParamsV1.ts
@@ -87,6 +87,11 @@ export const SyncParamsV1Schema = z
 				"Caller-supplied plan instances grouped by phase. Omit for pure auto-sync.",
 		}),
 
+		carry_over_usage: z.boolean().optional().meta({
+			description:
+				"When a synced plan expires an existing plan (via expire_previous), carry the existing plan's consumed usage onto the new plan's balances for any shared feature on the same subject. Defaults to true. Set false to sync without touching balances.",
+		}),
+
 		acknowledge_warnings: z.array(z.string()).optional().meta({
 			description:
 				"Detection warning types the caller accepts (e.g. 'extra_items_under_plan').",

--- a/shared/models/billingModels/context/syncBillingContext.ts
+++ b/shared/models/billingModels/context/syncBillingContext.ts
@@ -1,12 +1,14 @@
 import type Stripe from "stripe";
-import type { SyncParamsV1 } from "../../../api/billing/sync/syncParamsV1";
-import type { SyncPlanInstance } from "../../../api/billing/sync/syncParamsV1";
+import type {
+	SyncParamsV1,
+	SyncPlanInstance,
+} from "../../../api/billing/sync/syncParamsV1";
+import type { Entity } from "../../cusModels/entityModels/entityModels";
+import type { FullCustomer } from "../../cusModels/fullCusModel";
 import type {
 	FeatureOptions,
 	FullCusProduct,
 } from "../../cusProductModels/cusProductModels";
-import type { FullCustomer } from "../../cusModels/fullCusModel";
-import type { Entity } from "../../cusModels/entityModels/entityModels";
 import type { Entitlement } from "../../productModels/entModels/entModels";
 import type { Price } from "../../productModels/priceModels/priceModels";
 import type { FullProduct } from "../../productModels/productModels";
@@ -46,4 +48,8 @@ export interface SyncBillingContext {
 
 	currentEpochMs: number;
 	acknowledgedWarnings: NonNullable<SyncParamsV1["acknowledge_warnings"]>;
+
+	/** Carry an expired plan's consumed usage onto the replacement plan's
+	 * balances for shared features on the same subject. Defaults to true. */
+	carryOverUsage: boolean;
 }

--- a/vite/src/views/customers2/components/sync-stripe-v2/SubscriptionEditorView.tsx
+++ b/vite/src/views/customers2/components/sync-stripe-v2/SubscriptionEditorView.tsx
@@ -1,6 +1,6 @@
 import {
-	type FrontendProduct,
 	FreeTrialDuration,
+	type FrontendProduct,
 	productV2ToFrontendProduct,
 	type SyncParamsV1,
 	type SyncPhase,
@@ -30,8 +30,8 @@ import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { useEnv } from "@/utils/envUtils";
 import {
 	getStripeConnectViewAsLink,
-	getStripeSubScheduleLink,
 	getStripeSubLink,
+	getStripeSubScheduleLink,
 } from "@/utils/linkUtils";
 import { useAdmin } from "@/views/admin/hooks/useAdmin";
 import { useMasterStripeAccount } from "@/views/admin/hooks/useMasterStripeAccount";
@@ -147,8 +147,9 @@ const buildPhaseSections = ({
 		const matchingSchedulePhase = schedule
 			? schedule.phases.find((schedulePhase) => {
 					if (phase.starts_at === "now") {
-						return findScheduleStartDateMs({ phase: schedulePhase }) <=
-							Date.now();
+						return (
+							findScheduleStartDateMs({ phase: schedulePhase }) <= Date.now()
+						);
 					}
 					return (
 						findScheduleStartDateMs({ phase: schedulePhase }) ===
@@ -257,6 +258,7 @@ export function SubscriptionEditorView({
 		() => seedDraftPlansByPhase({ proposal }),
 	);
 	const [expirePrevious, setExpirePrevious] = useState<boolean>(true);
+	const [carryOverUsage, setCarryOverUsage] = useState<boolean>(true);
 	const [enablePlanImmediately, setEnablePlanImmediately] =
 		useState<boolean>(false);
 	const [editing, setEditing] = useState<{
@@ -389,11 +391,7 @@ export function SubscriptionEditorView({
 					Boolean(p.plan_id),
 				);
 				const planInstances: SyncPlanInstance[] = validPlans.map(
-					({
-						_key: _ignore,
-						enable_plan_immediately: _ignored,
-						...rest
-					}) => ({
+					({ _key: _ignore, enable_plan_immediately: _ignored, ...rest }) => ({
 						...rest,
 						expire_previous: expirePrevious,
 						enable_plan_immediately:
@@ -415,6 +413,7 @@ export function SubscriptionEditorView({
 			stripe_subscription_id: proposal.stripe_subscription_id,
 			stripe_schedule_id: proposal.stripe_schedule_id,
 			phases,
+			carry_over_usage: carryOverUsage,
 		};
 		onSubmit(params);
 	};
@@ -480,7 +479,9 @@ export function SubscriptionEditorView({
 
 							{section.displayItems.length > 0 && (
 								<div className="space-y-1">
-									<div className="text-xs text-tertiary-foreground">Subscription items</div>
+									<div className="text-xs text-tertiary-foreground">
+										Subscription items
+									</div>
 									<div className="space-y-1">
 										{section.displayItems.map((item) => (
 											<div
@@ -488,7 +489,9 @@ export function SubscriptionEditorView({
 												className="flex items-center justify-between text-xs"
 											>
 												<span className="text-foreground">{item.name}</span>
-												<span className="text-tertiary-foreground">{item.priceLabel}</span>
+												<span className="text-tertiary-foreground">
+													{item.priceLabel}
+												</span>
 											</div>
 										))}
 									</div>
@@ -496,7 +499,9 @@ export function SubscriptionEditorView({
 							)}
 
 							<div className="space-y-2">
-								<div className="text-xs text-tertiary-foreground">Autumn plans</div>
+								<div className="text-xs text-tertiary-foreground">
+									Autumn plans
+								</div>
 								{phasePlans.map((plan, planIndex) => (
 									<SyncPlanRow
 										key={plan._key}
@@ -512,12 +517,12 @@ export function SubscriptionEditorView({
 										}
 									/>
 								))}
-							<InlineAction
-								icon={<PlusIcon size={11} />}
-								onClick={() => handleAddPlan(phaseIndex)}
-							>
-								Add plan
-							</InlineAction>
+								<InlineAction
+									icon={<PlusIcon size={11} />}
+									onClick={() => handleAddPlan(phaseIndex)}
+								>
+									Add plan
+								</InlineAction>
 							</div>
 						</div>
 					);
@@ -533,6 +538,18 @@ export function SubscriptionEditorView({
 						/>
 					}
 				/>
+				{expirePrevious && (
+					<ConfigRow
+						title="Carry over usage"
+						description="Move the expired plan's used balances onto the new plan for any shared feature."
+						action={
+							<Switch
+								checked={carryOverUsage}
+								onCheckedChange={(checked) => setCarryOverUsage(!!checked)}
+							/>
+						}
+					/>
+				)}
 				{isNotStartedSchedule && (
 					<ConfigRow
 						title="Enable plan immediately"

--- a/vite/src/views/customers2/customer/components/CreateEntity.tsx
+++ b/vite/src/views/customers2/customer/components/CreateEntity.tsx
@@ -1,8 +1,10 @@
 import type { Feature } from "@autumn/shared";
 import { FeatureUsageType } from "@autumn/shared";
+import { CaretDownIcon } from "@phosphor-icons/react";
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
+import { Button } from "@/components/v2/buttons/Button";
 import { ShortcutButton } from "@/components/v2/buttons/ShortcutButton";
 import {
 	Dialog,
@@ -12,6 +14,13 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/v2/dialogs/Dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuTrigger,
+} from "@/components/v2/dropdowns/DropdownMenu";
 import { LabelInput } from "@/components/v2/inputs/LabelInput";
 import {
 	Select,
@@ -42,6 +51,11 @@ export const CreateEntity = ({
 	const { features } = useFeaturesQuery();
 
 	const [isLoading, setIsLoading] = useState(false);
+	// When true, the dialog stays open after a successful create so the user can
+	// add another entity. Not persisted — resets to false each time it reopens.
+	const [createMore, setCreateMore] = useState(false);
+	// Bumped after each "create more" so the Name field remounts and refocuses.
+	const [formKey, setFormKey] = useState(0);
 	const [entity, setEntity] = useState<{
 		id: string;
 		name: string;
@@ -54,7 +68,7 @@ export const CreateEntity = ({
 
 	const axiosInstance = useAxiosInstance();
 
-	// Reset form when dialog closes
+	// Reset form and mode when dialog closes
 	useEffect(() => {
 		if (!open) {
 			setEntity({
@@ -62,6 +76,7 @@ export const CreateEntity = ({
 				name: "",
 				feature_id: "",
 			});
+			setCreateMore(false);
 		}
 	}, [open]);
 
@@ -87,6 +102,18 @@ export const CreateEntity = ({
 
 			await refetch();
 			onCreated?.();
+
+			if (createMore) {
+				// Keep the dialog open: clear id/name and refocus for the next
+				// entity, but keep the selected feature since it's usually the same
+				// across entities. Don't navigate to / select the new entity, which
+				// would pull the user out of the create flow.
+				setEntity((prev) => ({ ...prev, id: "", name: "" }));
+				setFormKey((key) => key + 1);
+				toast.success("Entity created successfully");
+				return;
+			}
+
 			setOpen(false);
 
 			const params = new URLSearchParams(location.search);
@@ -124,6 +151,8 @@ export const CreateEntity = ({
 				<div className="flex flex-col gap-4">
 					<div className="flex gap-2">
 						<LabelInput
+							key={formKey}
+							autoFocus
 							label="Name"
 							placeholder="Enter name"
 							value={entity.name}
@@ -140,16 +169,21 @@ export const CreateEntity = ({
 					</div>
 					<div>
 						<div className="text-form-label block mb-1">Feature ID</div>
-					<Select
-						value={entity.feature_id}
-						onValueChange={(value) =>
-							setEntity({ ...entity, feature_id: value })
-						}
-						items={Object.fromEntries(continuousFeatures.map((feature: Feature) => [feature.id, feature.name]))}
-					>
-						<SelectTrigger className="w-full">
-							<SelectValue placeholder="Select feature" />
-						</SelectTrigger>
+						<Select
+							value={entity.feature_id}
+							onValueChange={(value) =>
+								setEntity({ ...entity, feature_id: value })
+							}
+							items={Object.fromEntries(
+								continuousFeatures.map((feature: Feature) => [
+									feature.id,
+									feature.name,
+								]),
+							)}
+						>
+							<SelectTrigger className="w-full">
+								<SelectValue placeholder="Select feature" />
+							</SelectTrigger>
 							<SelectContent>
 								{hasContinuousFeatures ? (
 									continuousFeatures.map((feature: Feature) => (
@@ -159,8 +193,7 @@ export const CreateEntity = ({
 									))
 								) : (
 									<div className="px-2 py-1.5 text-sm text-muted-foreground">
-										Create a non-consumable feature first (e.g. seats,
-										projects)
+										Create a non-consumable feature first (e.g. seats, projects)
 									</div>
 								)}
 							</SelectContent>
@@ -169,15 +202,41 @@ export const CreateEntity = ({
 				</div>
 
 				<DialogFooter>
-					<ShortcutButton
-						onClick={handleCreateClicked}
-						isLoading={isLoading}
-						variant="primary"
-						metaShortcut="enter"
-						className="w-full"
-					>
-						Create Entity
-					</ShortcutButton>
+					<div className="flex w-full items-center">
+						<ShortcutButton
+							onClick={handleCreateClicked}
+							isLoading={isLoading}
+							variant="primary"
+							metaShortcut="enter"
+							className="flex-1 rounded-r-none"
+						>
+							{createMore ? "Create & create more" : "Create Entity"}
+						</ShortcutButton>
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<Button
+									variant="primary"
+									className="rounded-l-none border-l border-l-purple-medium px-1.5 dark:border-l-[#5611BA]"
+									disabled={isLoading}
+								>
+									<CaretDownIcon className="size-3" />
+								</Button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent align="end" sideOffset={4}>
+								<DropdownMenuRadioGroup
+									value={createMore ? "more" : "close"}
+									onValueChange={(value) => setCreateMore(value === "more")}
+								>
+									<DropdownMenuRadioItem closeOnClick value="close">
+										Create &amp; close
+									</DropdownMenuRadioItem>
+									<DropdownMenuRadioItem closeOnClick value="more">
+										Create &amp; create more
+									</DropdownMenuRadioItem>
+								</DropdownMenuRadioGroup>
+							</DropdownMenuContent>
+						</DropdownMenu>
+					</div>
 				</DialogFooter>
 			</DialogContent>
 		</Dialog>


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR delivers two independent improvements: a \"create more\" mode for the entity creation dialog (keeps the dialog open after each successful create for bulk entity workflows), and a `carry_over_usage` feature for `sync_v2` that prevents customers from silently regaining a full usage allowance when an existing plan is expired and replaced during a sync operation.

- **[Bug fixes, API changes]** Add `carry_over_usage` field to `SyncParamsV1` (defaults to `true`) — when a sync expires an existing plan via `expire_previous`, the old plan's consumed usage is carried onto the replacement plan's balances for any shared feature on the same subject; a new `carryOverEntitlementUsage` utility handles the math correctly for both plain-allowance and prepaid features.
- **[Bug fixes]** Fix entity-scoped sync to scope the \"previous product to expire\" lookup by `internalEntityId`, preventing customer-level duplicate insertions when re-syncing entity-bound products; add `stampEntityFromExistingLinks` to restore entity bindings during auto-sync (Stripe webhook path).
- **[Improvements]** Add \"Create & create more\" split-button to the `CreateEntity` dialog, keeping the dialog open and auto-focusing the Name field after each successful create while preserving the selected feature ID.
</details>

<h3>Confidence Score: 3/5</h3>

The billing sync changes are well-tested and structurally sound, but the default-on carry-over changes observable customer balance behavior for all existing sync operations without an opt-out requirement, and the entity-binding Map approach drops bindings when multiple entities share a product on one subscription.

The `carry_over_usage ?? true` default in `setupSyncContext` means every existing `sync_v2` call that uses `expire_previous: true` — including the Stripe webhook auto-sync path — will now reduce the new plan's balances by previously consumed usage. The old behavior was a fresh reset; the new default is carryover. API consumers and operators who expect a clean slate on re-sync will be silently affected without changing any of their own code. Separately, `stampEntityFromExistingLinks` uses a `Map<productId, entityId>` that silently discards all but the last entity binding when multiple entity-scoped products for the same product share a subscription.

Focus on `setupSyncContext.ts` (default carry-over behavior) and `subscriptionToSyncParams.ts` (entity binding Map logic); the remaining files are clean.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/sync/setup/setupSyncContext.ts | Adds `carryOverUsage` to context, defaulting to `true` — silently changes balance behavior for all existing callers with `expire_previous: true`. |
| server/src/internal/billing/v2/actions/sync/subscriptionToSyncParams.ts | Adds `stampEntityFromExistingLinks` to restore entity bindings during auto-sync; Map keyed by product_id drops all but the last binding when multiple entities share the same product on a subscription. |
| server/src/internal/billing/v2/actions/sync/compute/carryOverUsage.ts | New utility that carries consumed usage from an expiring plan onto the replacement plan's balances; correctly skips unlimited and per-entity-hash entitlements, floors at zero when overage is disallowed. |
| server/src/internal/billing/v2/actions/sync/compute/computeSyncImmediatePhase.ts | Calls `carryOverEntitlementUsage` when `carryOverUsage` is enabled and a `currentCustomerProduct` exists; guard is correct. |
| vite/src/views/customers2/components/sync-stripe-v2/SubscriptionEditorView.tsx | Adds "Carry over usage" toggle (shown only when `expirePrevious` is true) and wires `carryOverUsage` into the submitted sync params; also includes minor formatting fixes. |
| vite/src/views/customers2/customer/components/CreateEntity.tsx | Adds "create more" mode with a split-button dropdown; dialog stays open after success, clears id/name and bumps formKey for auto-focus, resets mode when dialog closes. |
| server/tests/integration/billing/sync/sync-carry-usage.test.ts | New integration tests covering customer-level carry, `carry_over_usage=false` escape hatch, and entity-scoped re-sync with no duplicate; good coverage of the primary cases. |
| server/tests/integration/billing/sync/sync-carry-prepaid-entities.test.ts | New integration test for prepaid features across two entities; exercises the carry math for `cusEntsToUsage` prepaid path and verifies correct per-entity balance after sync. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as SubscriptionEditorView
    participant API as sync_v2 API
    participant SC as setupSyncContext
    participant CP as computeSyncImmediatePhase
    participant COU as carryOverEntitlementUsage

    UI->>API: "POST /billing.sync_v2 { phases, carry_over_usage }"
    API->>SC: setupSyncContext(params)
    SC->>SC: "carryOverUsage = params.carry_over_usage ?? true"
    SC-->>API: "SyncBillingContext { immediatePhase, carryOverUsage }"
    API->>CP: "computeSyncImmediatePhase({ syncContext })"
    loop each productContext
        CP->>CP: initImmediateSyncCustomerProduct()
        alt "carryOverUsage && currentCustomerProduct exists"
            CP->>COU: "carryOverEntitlementUsage({ inserted, expiring })"
            COU->>COU: "for each shared feature: newBalance = newBalance - oldUsage"
        end
        CP->>CP: push insertedCustomerProduct
    end
    CP-->>API: "{ insertCustomerProducts, expireCustomerProductIds }"
    API-->>UI: "{ expired_cus_product_ids, ... }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as SubscriptionEditorView
    participant API as sync_v2 API
    participant SC as setupSyncContext
    participant CP as computeSyncImmediatePhase
    participant COU as carryOverEntitlementUsage

    UI->>API: "POST /billing.sync_v2 { phases, carry_over_usage }"
    API->>SC: setupSyncContext(params)
    SC->>SC: "carryOverUsage = params.carry_over_usage ?? true"
    SC-->>API: "SyncBillingContext { immediatePhase, carryOverUsage }"
    API->>CP: "computeSyncImmediatePhase({ syncContext })"
    loop each productContext
        CP->>CP: initImmediateSyncCustomerProduct()
        alt "carryOverUsage && currentCustomerProduct exists"
            CP->>COU: "carryOverEntitlementUsage({ inserted, expiring })"
            COU->>COU: "for each shared feature: newBalance = newBalance - oldUsage"
        end
        CP->>CP: push insertedCustomerProduct
    end
    CP-->>API: "{ insertCustomerProducts, expireCustomerProductIds }"
    API-->>UI: "{ expired_cus_product_ids, ... }"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/billing/v2/actions/sync/setup/setupSyncContext.ts:232
**Silent behavior change for existing `sync_v2` callers**

Before this PR, usage carry-over did not exist — syncing with `expire_previous: true` always initialized the new plan's balances at their full granted amount. The default `?? true` opts every pre-existing caller (including Stripe webhook-triggered auto-syncs in `autoSyncFromSubscription`) into carry-over silently. Any integration that relied on a fresh-balance reset on re-sync will now receive reduced balances without having passed the new field. A safe default would be `false` with an explicit opt-in, or at minimum this should be documented as a breaking default change.

### Issue 2 of 2
server/src/internal/billing/v2/actions/sync/subscriptionToSyncParams.ts:71-76
**Multiple entities on same product silently loses all but last binding**

`entityIdByProductId` is a `Map<productId, entityId>`, so when two entity-scoped customer products for the same product are both linked to this subscription (e.g., entity X and entity Y both on "Pro" under subscription S), the second `.set()` call overwrites the first. `stampEntityFromExistingLinks` then stamps only one entity binding onto the detected plan, and the other entity's product is re-attached without an entity scope — creating a customer-level duplicate instead of two correctly scoped products. The tests cover the single-entity case; the dual-entity case in `sync-carry-prepaid-entities` passes explicit `entity_id` on each plan and bypasses this code path.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): 🎸 add create more mode to cr..."](https://github.com/useautumn/autumn/commit/d7a23d9445054efc75854d5bae6f9e600d3c3bf3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38684256)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->