### PR TITLE
chore: add email to custom buttons

### DIFF
--- a/vite/src/utils/linkUtils.ts
+++ b/vite/src/utils/linkUtils.ts
@@ -2,13 +2,19 @@
 
 import { AppEnv } from "@autumn/shared";
 
-const CUSTOM_BUTTON_VARS = {
-	"{customerId}": (customer: { id?: string | null }) => customer.id ?? "",
-} as const;
+type CustomButtonCustomer = { id?: string | null; email?: string | null };
+
+const CUSTOM_BUTTON_VARS: Record<
+	string,
+	(customer: CustomButtonCustomer) => string
+> = {
+	"{customerId}": (customer) => customer.id ?? "",
+	"{customerEmail}": (customer) => customer.email ?? "",
+};
 
 export const resolveCustomButtonUrl = (
 	template: string,
-	customer: { id?: string | null },
+	customer: CustomButtonCustomer,
 ) => {
 	let resolved = template;
 	for (const [token, getValue] of Object.entries(CUSTOM_BUTTON_VARS)) {
@@ -20,7 +26,7 @@ export const resolveCustomButtonUrl = (
 	return resolved;
 };
 
-const SAFE_PROTOCOLS = new Set(["http:", "https:"]);
+const SAFE_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
 
 export const isSafeCustomButtonUrl = (url: string) => {
 	try {

--- a/vite/src/views/customers2/customer/components/CustomButtons.tsx
+++ b/vite/src/views/customers2/customer/components/CustomButtons.tsx
@@ -23,7 +23,7 @@ export function CustomButtons({
 	customer,
 }: {
 	buttons: CustomButton[];
-	customer: { id?: string | null } | undefined;
+	customer: { id?: string | null; email?: string | null } | undefined;
 }) {
 	const [overflowOpen, setOverflowOpen] = useState(false);
 

--- a/vite/src/views/settings/sections/components/CustomButtonDialog.tsx
+++ b/vite/src/views/settings/sections/components/CustomButtonDialog.tsx
@@ -61,82 +61,85 @@ export const CustomButtonDialog = ({
 						Renders on every customer page, linking out to your own tools.
 					</DialogDescription>
 				</DialogHeader>
-				<div className="flex flex-col gap-4">
-					<div className="flex items-end gap-2">
-						<form.Field name="icon">
-							{(field) => (
-								<div>
-									<FormLabel>Icon</FormLabel>
-									<IconPicker
-										value={field.state.value}
-										onChange={(name) => field.handleChange(name)}
-									/>
-								</div>
-							)}
-						</form.Field>
-						<form.Field name="label">
-							{(field) => (
-								<div className="flex-1">
-									<FormLabel>Label</FormLabel>
-									<Input
-										placeholder="Internal dashboard"
-										value={field.state.value}
-										onBlur={field.handleBlur}
-										onChange={(e) => field.handleChange(e.target.value)}
-									/>
-									<FieldInfo field={field} />
-								</div>
-							)}
-						</form.Field>
-					</div>
-					<form.Field name="url">
-						{(field) => (
-							<div>
-								<FormLabel>URL</FormLabel>
-								<Input
-									placeholder="https://internal.firecrawl.dev/{customerId}"
-									value={field.state.value}
-									onBlur={field.handleBlur}
-									onChange={(e) => field.handleChange(e.target.value)}
-								/>
-								<p className="mt-1.5 text-xs text-tertiary-foreground">
-									Use{" "}
-									<code className="rounded bg-interactive-secondary px-1 py-0.5 font-mono text-purple-500">
-										{"{customerId}"}
-									</code>{" "}
-									to insert the customer's ID.
-								</p>
-								<FieldInfo field={field} />
+				<form.Subscribe selector={(state) => state.submissionAttempts > 0}>
+					{(submitted) => (
+						<div className="flex flex-col gap-4">
+							<div className="flex items-start gap-2">
+								<form.Field name="icon">
+									{(field) => (
+										<div className="flex flex-col">
+											<FormLabel>Icon</FormLabel>
+											<IconPicker
+												value={field.state.value}
+												onChange={(name) => field.handleChange(name)}
+											/>
+										</div>
+									)}
+								</form.Field>
+								<form.Field name="label">
+									{(field) => (
+										<div className="flex flex-1 flex-col">
+											<FormLabel>Label</FormLabel>
+											<Input
+												placeholder="Internal dashboard"
+												value={field.state.value}
+												onBlur={field.handleBlur}
+												onChange={(e) => field.handleChange(e.target.value)}
+											/>
+											{submitted && <FieldInfo field={field} />}
+										</div>
+									)}
+								</form.Field>
 							</div>
-						)}
-					</form.Field>
-					<form.Field name="open_in_new_tab">
-						{(field) => (
-							<div className="flex items-center justify-between">
-								<FormLabel className="mb-0">Open in new tab</FormLabel>
-								<Switch
-									checked={field.state.value}
-									onCheckedChange={(value) => field.handleChange(value)}
-								/>
-							</div>
-						)}
-					</form.Field>
-				</div>
+							<form.Field name="url">
+								{(field) => (
+									<div>
+										<FormLabel>URL</FormLabel>
+										<Input
+											placeholder="https://internal.firecrawl.dev/{customerId}"
+											value={field.state.value}
+											onBlur={field.handleBlur}
+											onChange={(e) => field.handleChange(e.target.value)}
+										/>
+										<p className="mt-1.5 text-xs text-tertiary-foreground">
+											Use{" "}
+											<code className="rounded bg-interactive-secondary px-1 py-0.5 font-mono text-purple-500">
+												{"{customerId}"}
+											</code>{" "}
+											or{" "}
+											<code className="rounded bg-interactive-secondary px-1 py-0.5 font-mono text-purple-500">
+												{"{customerEmail}"}
+											</code>{" "}
+											to insert customer details.
+										</p>
+										{submitted && <FieldInfo field={field} />}
+									</div>
+								)}
+							</form.Field>
+							<form.Field name="open_in_new_tab">
+								{(field) => (
+									<div className="flex items-center justify-between">
+										<FormLabel className="mb-0">Open in new tab</FormLabel>
+										<Switch
+											checked={field.state.value}
+											onCheckedChange={(value) => field.handleChange(value)}
+										/>
+									</div>
+								)}
+							</form.Field>
+						</div>
+					)}
+				</form.Subscribe>
 				<DialogFooter>
-					<form.Subscribe selector={(state) => state.canSubmit}>
-						{(canSubmit) => (
-							<ShortcutButton
-								variant="primary"
-								className="w-full"
-								onClick={() => form.handleSubmit()}
-								metaShortcut="enter"
-								isLoading={isSaving}
-								disabled={!canSubmit}
-							>
-								{isEdit ? "Save" : "Add"}
-							</ShortcutButton>
-						)}
-					</form.Subscribe>
+					<ShortcutButton
+						variant="primary"
+						className="w-full"
+						onClick={() => form.handleSubmit()}
+						metaShortcut="enter"
+						isLoading={isSaving}
+					>
+						{isEdit ? "Save" : "Add"}
+					</ShortcutButton>
 				</DialogFooter>
 			</DialogContent>
 		</Dialog>

--- a/vite/src/views/settings/sections/components/IconPicker.tsx
+++ b/vite/src/views/settings/sections/components/IconPicker.tsx
@@ -68,9 +68,8 @@ export function IconPicker({
 							aria-label={humanize(name)}
 							onClick={() => select(name)}
 							className={cn(
-								"flex aspect-square items-center justify-center rounded-md text-tertiary-foreground transition-colors hover:bg-interactive-secondary-hover hover:text-foreground",
-								value === name &&
-									"bg-interactive-secondary-hover text-foreground ring-1 ring-primary",
+								"flex aspect-square items-center justify-center rounded-md text-tertiary-foreground outline-none transition-colors hover:bg-interactive-secondary-hover hover:text-foreground focus-visible:bg-interactive-secondary-hover focus-visible:text-foreground",
+								value === name && "bg-interactive-secondary text-foreground",
 							)}
 						>
 							<PhosphorIcon name={name} className="size-4" />

--- a/vite/src/views/settings/sections/components/customButtonFormSchema.ts
+++ b/vite/src/views/settings/sections/components/customButtonFormSchema.ts
@@ -12,8 +12,11 @@ export const CustomButtonFormSchema = z.object({
 		.trim()
 		.min(1, "URL is required")
 		.refine(
-			(url) => isSafeCustomButtonUrl(resolveCustomButtonUrl(url, { id: "id" })),
-			"Must be a valid http:// or https:// URL",
+			(url) =>
+				isSafeCustomButtonUrl(
+					resolveCustomButtonUrl(url, { id: "id", email: "email" }),
+				),
+			"Must be a valid http, https, mailto, or tel URL",
 		),
 	open_in_new_tab: z.boolean(),
 });


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added support for `{customerEmail}` in custom button URLs and enabled `mailto:`/`tel:` links. This lets you add email and phone actions directly from customer pages with safe URL handling.

- **New Features**
  - `{customerEmail}` token for URL templates (alongside `{customerId}`).
  - Safe URLs now include `http`, `https`, `mailto`, and `tel`; validation updated.
  - Dialog copy clarifies tokens; field errors show after first submit; improved icon picker focus/selection.

<sup>Written for commit d35bba4128cf0ec1444e13b42449a1886efc31e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends custom buttons with `{customerEmail}` template support and expands the allowed URL protocols to include `mailto:` and `tel:`, letting admins wire buttons directly to email compose or phone dialers. The dialog also improves form UX by deferring validation errors until after the first submit attempt.

- **Improvements**: Added `{customerEmail}` template variable in `linkUtils.ts` and `CustomButtons.tsx`, mirroring the existing `{customerId}` pattern.
- **Improvements**: Expanded `SAFE_PROTOCOLS` to include `mailto:` and `tel:`, with a matching validation error message update in `customButtonFormSchema.ts`.
- **Improvements**: Refactored `CustomButtonDialog.tsx` to wrap form fields in `form.Subscribe` so validation errors appear only after the user first clicks Submit; removed the now-redundant `disabled={!canSubmit}` prop from the submit button.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge, but the mailto: use-case for {customerEmail} will produce percent-encoded @ signs that some mail handlers may not decode correctly.

The resolveCustomButtonUrl function always calls encodeURIComponent on the substituted value, so a customer email like user@company.com becomes user%40company.com inside a mailto: link. Major desktop browsers happen to decode this before invoking the system mail handler, but RFC 6068 forbids encoding @ in the recipient field and non-browser handlers (webmail hooks, custom protocol handlers) may receive a malformed address. The fix is localised to linkUtils.ts and does not affect the http/https path.

vite/src/utils/linkUtils.ts — the URL token replacement logic needs scheme-aware encoding to avoid mangling email addresses in mailto: links.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/utils/linkUtils.ts | Adds {customerEmail} template variable and expands safe protocols to include mailto: and tel:; encodeURIComponent applied to the email will percent-encode @ when used in mailto: URLs, which breaks RFC 6068 compliance and may fail in some handlers. |
| vite/src/views/settings/sections/components/CustomButtonDialog.tsx | Updates dialog to document {customerEmail} variable, wraps form content in form.Subscribe to defer validation error display until after the first submission attempt, and removes the now-redundant disabled prop from the submit button. |
| vite/src/views/settings/sections/components/customButtonFormSchema.ts | Correctly passes { id: 'id', email: 'email' } stub to the URL resolver during validation, and updates the error message to reflect the newly allowed mailto/tel schemes. |
| vite/src/views/customers2/customer/components/CustomButtons.tsx | Minimal type update to thread the email field through to resolveCustomButtonUrl; logic is unchanged and correct. |
| vite/src/views/settings/sections/components/IconPicker.tsx | Styling-only change: selected state ring replaced with bg-interactive-secondary, focus-visible styles added for keyboard accessibility. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Admin Saves Button\nURL Template] --> B[Customer Page Loads]
    B --> C[User Clicks Button]
    C --> D[resolveCustomButtonUrl\ntemplate + customer]
    D --> E{Token in template?}
    E -- customerId --> F[encodeURIComponent\ncustomer.id]
    E -- customerEmail --> G[encodeURIComponent\ncustomer.email\n⚠️ encodes @ sign]
    E -- none --> H[Use template as-is]
    F --> I[isSafeCustomButtonUrl]
    G --> I
    H --> I
    I -- http / https / tel / mailto --> J{open_in_new_tab?}
    I -- other / invalid --> K[toast.error Invalid URL]
    J -- true --> L[window.open _blank noopener]
    J -- false --> M[window.location.href]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Admin Saves Button\nURL Template] --> B[Customer Page Loads]
    B --> C[User Clicks Button]
    C --> D[resolveCustomButtonUrl\ntemplate + customer]
    D --> E{Token in template?}
    E -- customerId --> F[encodeURIComponent\ncustomer.id]
    E -- customerEmail --> G[encodeURIComponent\ncustomer.email\n⚠️ encodes @ sign]
    E -- none --> H[Use template as-is]
    F --> I[isSafeCustomButtonUrl]
    G --> I
    H --> I
    I -- http / https / tel / mailto --> J{open_in_new_tab?}
    I -- other / invalid --> K[toast.error Invalid URL]
    J -- true --> L[window.open _blank noopener]
    J -- false --> M[window.location.href]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/utils/linkUtils.ts:7-13
`encodeURIComponent` applied unconditionally to `{customerEmail}` will percent-encode the `@` sign (`user@example.com` → `user%40example.com`). For `mailto:{customerEmail}`, RFC 6068 specifies that the `@` in the recipient address must not be encoded, and while many desktop browsers tolerate this, some webmail handlers and custom mailto protocol handlers will receive a broken address like `user%40example.com` rather than `user@example.com`.

```suggestion
const CUSTOM_BUTTON_VARS: Record<
	string,
	(customer: CustomButtonCustomer, template: string) => string
> = {
	"{customerId}": (customer) => customer.id ?? "",
	"{customerEmail}": (customer, template) =>
		template.startsWith("mailto:")
			? (customer.email ?? "")
			: encodeURIComponent(customer.email ?? ""),
};

export const resolveCustomButtonUrl = (
	template: string,
	customer: CustomButtonCustomer,
) => {
	let resolved = template;
	for (const [token, getValue] of Object.entries(CUSTOM_BUTTON_VARS)) {
		resolved = resolved.replaceAll(token, getValue(customer, template));
	}
	return resolved;
};
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add email to custom buttons"](https://github.com/useautumn/autumn/commit/d35bba4128cf0ec1444e13b42449a1886efc31e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38802807)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->