### PR TITLE
release

### DIFF
--- a/vite/src/utils/linkUtils.ts
+++ b/vite/src/utils/linkUtils.ts
@@ -12,16 +12,20 @@ const CUSTOM_BUTTON_VARS: Record<
 	"{customerEmail}": (customer) => customer.email ?? "",
 };
 
+// mailto:/tel: recipients are not URL path/query segments — per RFC 6068 the
+// `@` in an address must stay literal, so percent-encoding would break them.
+const NON_ENCODED_SCHEMES = /^(mailto|tel):/i;
+
 export const resolveCustomButtonUrl = (
 	template: string,
 	customer: CustomButtonCustomer,
 ) => {
+	const encode = NON_ENCODED_SCHEMES.test(template)
+		? (value: string) => value
+		: encodeURIComponent;
 	let resolved = template;
 	for (const [token, getValue] of Object.entries(CUSTOM_BUTTON_VARS)) {
-		resolved = resolved.replaceAll(
-			token,
-			encodeURIComponent(getValue(customer)),
-		);
+		resolved = resolved.replaceAll(token, encode(getValue(customer)));
 	}
 	return resolved;
 };

--- a/vite/src/utils/linkUtils.ts
+++ b/vite/src/utils/linkUtils.ts
@@ -2,13 +2,19 @@
 
 import { AppEnv } from "@autumn/shared";
 
-const CUSTOM_BUTTON_VARS = {
-	"{customerId}": (customer: { id?: string | null }) => customer.id ?? "",
-} as const;
+type CustomButtonCustomer = { id?: string | null; email?: string | null };
+
+const CUSTOM_BUTTON_VARS: Record<
+	string,
+	(customer: CustomButtonCustomer) => string
+> = {
+	"{customerId}": (customer) => customer.id ?? "",
+	"{customerEmail}": (customer) => customer.email ?? "",
+};
 
 export const resolveCustomButtonUrl = (
 	template: string,
-	customer: { id?: string | null },
+	customer: CustomButtonCustomer,
 ) => {
 	let resolved = template;
 	for (const [token, getValue] of Object.entries(CUSTOM_BUTTON_VARS)) {
@@ -20,7 +26,7 @@ export const resolveCustomButtonUrl = (
 	return resolved;
 };
 
-const SAFE_PROTOCOLS = new Set(["http:", "https:"]);
+const SAFE_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
 
 export const isSafeCustomButtonUrl = (url: string) => {
 	try {

--- a/vite/src/views/customers2/customer/components/CustomButtons.tsx
+++ b/vite/src/views/customers2/customer/components/CustomButtons.tsx
@@ -23,7 +23,7 @@ export function CustomButtons({
 	customer,
 }: {
 	buttons: CustomButton[];
-	customer: { id?: string | null } | undefined;
+	customer: { id?: string | null; email?: string | null } | undefined;
 }) {
 	const [overflowOpen, setOverflowOpen] = useState(false);
 

--- a/vite/src/views/settings/sections/components/CustomButtonDialog.tsx
+++ b/vite/src/views/settings/sections/components/CustomButtonDialog.tsx
@@ -61,82 +61,85 @@ export const CustomButtonDialog = ({
 						Renders on every customer page, linking out to your own tools.
 					</DialogDescription>
 				</DialogHeader>
-				<div className="flex flex-col gap-4">
-					<div className="flex items-end gap-2">
-						<form.Field name="icon">
-							{(field) => (
-								<div>
-									<FormLabel>Icon</FormLabel>
-									<IconPicker
-										value={field.state.value}
-										onChange={(name) => field.handleChange(name)}
-									/>
-								</div>
-							)}
-						</form.Field>
-						<form.Field name="label">
-							{(field) => (
-								<div className="flex-1">
-									<FormLabel>Label</FormLabel>
-									<Input
-										placeholder="Internal dashboard"
-										value={field.state.value}
-										onBlur={field.handleBlur}
-										onChange={(e) => field.handleChange(e.target.value)}
-									/>
-									<FieldInfo field={field} />
-								</div>
-							)}
-						</form.Field>
-					</div>
-					<form.Field name="url">
-						{(field) => (
-							<div>
-								<FormLabel>URL</FormLabel>
-								<Input
-									placeholder="https://internal.firecrawl.dev/{customerId}"
-									value={field.state.value}
-									onBlur={field.handleBlur}
-									onChange={(e) => field.handleChange(e.target.value)}
-								/>
-								<p className="mt-1.5 text-xs text-tertiary-foreground">
-									Use{" "}
-									<code className="rounded bg-interactive-secondary px-1 py-0.5 font-mono text-purple-500">
-										{"{customerId}"}
-									</code>{" "}
-									to insert the customer's ID.
-								</p>
-								<FieldInfo field={field} />
+				<form.Subscribe selector={(state) => state.submissionAttempts > 0}>
+					{(submitted) => (
+						<div className="flex flex-col gap-4">
+							<div className="flex items-start gap-2">
+								<form.Field name="icon">
+									{(field) => (
+										<div className="flex flex-col">
+											<FormLabel>Icon</FormLabel>
+											<IconPicker
+												value={field.state.value}
+												onChange={(name) => field.handleChange(name)}
+											/>
+										</div>
+									)}
+								</form.Field>
+								<form.Field name="label">
+									{(field) => (
+										<div className="flex flex-1 flex-col">
+											<FormLabel>Label</FormLabel>
+											<Input
+												placeholder="Internal dashboard"
+												value={field.state.value}
+												onBlur={field.handleBlur}
+												onChange={(e) => field.handleChange(e.target.value)}
+											/>
+											{submitted && <FieldInfo field={field} />}
+										</div>
+									)}
+								</form.Field>
 							</div>
-						)}
-					</form.Field>
-					<form.Field name="open_in_new_tab">
-						{(field) => (
-							<div className="flex items-center justify-between">
-								<FormLabel className="mb-0">Open in new tab</FormLabel>
-								<Switch
-									checked={field.state.value}
-									onCheckedChange={(value) => field.handleChange(value)}
-								/>
-							</div>
-						)}
-					</form.Field>
-				</div>
+							<form.Field name="url">
+								{(field) => (
+									<div>
+										<FormLabel>URL</FormLabel>
+										<Input
+											placeholder="https://internal.firecrawl.dev/{customerId}"
+											value={field.state.value}
+											onBlur={field.handleBlur}
+											onChange={(e) => field.handleChange(e.target.value)}
+										/>
+										<p className="mt-1.5 text-xs text-tertiary-foreground">
+											Use{" "}
+											<code className="rounded bg-interactive-secondary px-1 py-0.5 font-mono text-purple-500">
+												{"{customerId}"}
+											</code>{" "}
+											or{" "}
+											<code className="rounded bg-interactive-secondary px-1 py-0.5 font-mono text-purple-500">
+												{"{customerEmail}"}
+											</code>{" "}
+											to insert customer details.
+										</p>
+										{submitted && <FieldInfo field={field} />}
+									</div>
+								)}
+							</form.Field>
+							<form.Field name="open_in_new_tab">
+								{(field) => (
+									<div className="flex items-center justify-between">
+										<FormLabel className="mb-0">Open in new tab</FormLabel>
+										<Switch
+											checked={field.state.value}
+											onCheckedChange={(value) => field.handleChange(value)}
+										/>
+									</div>
+								)}
+							</form.Field>
+						</div>
+					)}
+				</form.Subscribe>
 				<DialogFooter>
-					<form.Subscribe selector={(state) => state.canSubmit}>
-						{(canSubmit) => (
-							<ShortcutButton
-								variant="primary"
-								className="w-full"
-								onClick={() => form.handleSubmit()}
-								metaShortcut="enter"
-								isLoading={isSaving}
-								disabled={!canSubmit}
-							>
-								{isEdit ? "Save" : "Add"}
-							</ShortcutButton>
-						)}
-					</form.Subscribe>
+					<ShortcutButton
+						variant="primary"
+						className="w-full"
+						onClick={() => form.handleSubmit()}
+						metaShortcut="enter"
+						isLoading={isSaving}
+					>
+						{isEdit ? "Save" : "Add"}
+					</ShortcutButton>
 				</DialogFooter>
 			</DialogContent>
 		</Dialog>

--- a/vite/src/views/settings/sections/components/IconPicker.tsx
+++ b/vite/src/views/settings/sections/components/IconPicker.tsx
@@ -68,9 +68,8 @@ export function IconPicker({
 							aria-label={humanize(name)}
 							onClick={() => select(name)}
 							className={cn(
-								"flex aspect-square items-center justify-center rounded-md text-tertiary-foreground transition-colors hover:bg-interactive-secondary-hover hover:text-foreground",
-								value === name &&
-									"bg-interactive-secondary-hover text-foreground ring-1 ring-primary",
+								"flex aspect-square items-center justify-center rounded-md text-tertiary-foreground outline-none transition-colors hover:bg-interactive-secondary-hover hover:text-foreground focus-visible:bg-interactive-secondary-hover focus-visible:text-foreground",
+								value === name && "bg-interactive-secondary text-foreground",
 							)}
 						>
 							<PhosphorIcon name={name} className="size-4" />

--- a/vite/src/views/settings/sections/components/customButtonFormSchema.ts
+++ b/vite/src/views/settings/sections/components/customButtonFormSchema.ts
@@ -12,8 +12,11 @@ export const CustomButtonFormSchema = z.object({
 		.trim()
 		.min(1, "URL is required")
 		.refine(
-			(url) => isSafeCustomButtonUrl(resolveCustomButtonUrl(url, { id: "id" })),
-			"Must be a valid http:// or https:// URL",
+			(url) =>
+				isSafeCustomButtonUrl(
+					resolveCustomButtonUrl(url, { id: "id", email: "email" }),
+				),
+			"Must be a valid http, https, mailto, or tel URL",
 		),
 	open_in_new_tab: z.boolean(),
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `{customerEmail}` to custom button URLs and enable `mailto:`/`tel:` links so buttons can email or call customers. Also improves the dialog UX and icon picker styling, and fixes encoding so these links work.

- **New Features**
  - Add `{customerEmail}` token for URL templates.
  - Allow `mailto:` and `tel:` in URL validation.
  - Update helper text to include `{customerEmail}`.

- **Bug Fixes**
  - Skip URI encoding for `mailto:`/`tel:` recipients in the resolver to keep `@`/`+` intact; include both in the safe protocol list.

<sup>Written for commit 5fa8d23cfea6ee1a4d482070f7b580a1a4f08c9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the custom button feature by adding `{customerEmail}` as a template variable alongside the existing `{customerId}`, and broadens the allowed URL schemes from `http`/`https` only to also include `mailto:` and `tel:`. It also improves form UX by deferring validation error display until after the first submission attempt.

- **[Improvements]** `{customerEmail}` template variable added to `CUSTOM_BUTTON_VARS`; `mailto:` and `tel:` added to `SAFE_PROTOCOLS`, with updated schema error message and hint text.
- **[Improvements]** `CustomButtonDialog` now uses `form.Subscribe` on `submissionAttempts > 0` to hide field errors until the user first tries to submit, reducing noise on a fresh form.
- **[Improvements]** `IconPicker` selected-state styling updated: uses `bg-interactive-secondary` instead of `bg-interactive-secondary-hover` and adds `focus-visible` styles for keyboard accessibility.
</details>


<h3>Confidence Score: 3/5</h3>

The mailto: and tel: support is incomplete — email addresses passed through encodeURIComponent will have @ encoded to %40, making generated mailto: links non-functional.

The two headline features of this PR — {customerEmail} substitution and mailto: URL support — are broken in combination. Every mailto:{customerEmail} button will generate a link with a percent-encoded @ sign that mail clients cannot parse as a valid address. The bug is on the core substitution path introduced by this PR and will affect any user who creates a mailto: button using the new variable.

vite/src/utils/linkUtils.ts — the resolveCustomButtonUrl substitution loop unconditionally calls encodeURIComponent, which corrupts the @ character needed for mailto: links.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/utils/linkUtils.ts | Adds {customerEmail} template var and mailto:/tel: safe protocols, but encodeURIComponent breaks mailto: links by percent-encoding @ in email addresses |
| vite/src/views/settings/sections/components/CustomButtonDialog.tsx | Wraps form fields in form.Subscribe(submissionAttempts > 0) to defer error display until first submit; removes button disabled={!canSubmit} in favour of always-enabled submit |
| vite/src/views/settings/sections/components/customButtonFormSchema.ts | Passes email dummy value for validation and updates error message to reflect new supported schemes; logic is correct |
| vite/src/views/customers2/customer/components/CustomButtons.tsx | Widens customer prop type to include email field; logic is unchanged and correct |
| vite/src/views/settings/sections/components/IconPicker.tsx | Tweaks selected/focus-visible styles for icon buttons; purely cosmetic, no logic changes |

</details>



<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks Custom Button] --> B[resolveCustomButtonUrl]
    B --> C{Template tokens present?}
    C -- "{customerId}" --> D[encodeURIComponent customer.id]
    C -- "{customerEmail}" --> E[encodeURIComponent customer.email]
    C -- none --> F[Use URL as-is]
    D --> G[Resolved URL]
    E --> G
    F --> G
    G --> H[isSafeCustomButtonUrl]
    H -- "http: / https:" --> I[window.open or location.href]
    H -- "mailto: / tel:" --> J[window.open or location.href]
    H -- invalid --> K[toast.error]
    E -.->|⚠️ @ encoded as %40| J
    J -.->|broken mailto: link| L[Mail client fails]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User clicks Custom Button] --> B[resolveCustomButtonUrl]
    B --> C{Template tokens present?}
    C -- "{customerId}" --> D[encodeURIComponent customer.id]
    C -- "{customerEmail}" --> E[encodeURIComponent customer.email]
    C -- none --> F[Use URL as-is]
    D --> G[Resolved URL]
    E --> G
    F --> G
    G --> H[isSafeCustomButtonUrl]
    H -- "http: / https:" --> I[window.open or location.href]
    H -- "mailto: / tel:" --> J[window.open or location.href]
    H -- invalid --> K[toast.error]
    E -.->|⚠️ @ encoded as %40| J
    J -.->|broken mailto: link| L[Mail client fails]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/src/utils/linkUtils.ts`, line 21-24 ([link](https://github.com/useautumn/autumn/blob/90a741a5a7f50262416b25af09138062e2f6fd7e/vite/src/utils/linkUtils.ts#L21-L24)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`encodeURIComponent` breaks `mailto:{customerEmail}` links**

   `encodeURIComponent` converts `@` to `%40`, so a customer email like `user@example.com` resolves to `mailto:user%40example.com`. Mail clients receive a literal `%40` rather than `@` and cannot parse it as a valid email address. The PR intentionally pairs `{customerEmail}` support with `mailto:` protocol support, but the substitution logic makes them incompatible. For `mailto:` URIs the local part of the address must not have the `@` percent-encoded; for `tel:` URIs the `+` country-code prefix would similarly be mangled (`%2B`).

   The fix is to skip URI encoding when the resolved URL uses a non-HTTP scheme, or to encode only the query portion of `mailto:` URLs rather than the address itself.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/utils/linkUtils.ts
   Line: 21-24

   Comment:
   **`encodeURIComponent` breaks `mailto:{customerEmail}` links**

   `encodeURIComponent` converts `@` to `%40`, so a customer email like `user@example.com` resolves to `mailto:user%40example.com`. Mail clients receive a literal `%40` rather than `@` and cannot parse it as a valid email address. The PR intentionally pairs `{customerEmail}` support with `mailto:` protocol support, but the substitution logic makes them incompatible. For `mailto:` URIs the local part of the address must not have the `@` percent-encoded; for `tel:` URIs the `+` country-code prefix would similarly be mangled (`%2B`).

   The fix is to skip URI encoding when the resolved URL uses a non-HTTP scheme, or to encode only the query portion of `mailto:` URLs rather than the address itself.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/utils/linkUtils.ts:21-24
**`encodeURIComponent` breaks `mailto:{customerEmail}` links**

`encodeURIComponent` converts `@` to `%40`, so a customer email like `user@example.com` resolves to `mailto:user%40example.com`. Mail clients receive a literal `%40` rather than `@` and cannot parse it as a valid email address. The PR intentionally pairs `{customerEmail}` support with `mailto:` protocol support, but the substitution logic makes them incompatible. For `mailto:` URIs the local part of the address must not have the `@` percent-encoded; for `tel:` URIs the `+` country-code prefix would similarly be mangled (`%2B`).

The fix is to skip URI encoding when the resolved URL uses a non-HTTP scheme, or to encode only the query portion of `mailto:` URLs rather than the address itself.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #1991 from useautumn/..."](https://github.com/useautumn/autumn/commit/90a741a5a7f50262416b25af09138062e2f6fd7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38802977)</sub>

<!-- /greptile_comment -->