### PR TITLE
feat: add bydefault tracking to website proxy

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -9,6 +9,7 @@
 		"lint": "eslint"
 	},
 	"dependencies": {
+		"@bydefault/vercel": "^0.1.4",
 		"@gsap/react": "^2.1.2",
 		"@mdx-js/loader": "^3.1.1",
 		"@mdx-js/mdx": "^3.1.1",

--- a/apps/website/proxy.ts
+++ b/apps/website/proxy.ts
@@ -1,0 +1,24 @@
+import { Tracker } from "@bydefault/vercel"
+import { after, NextResponse, type NextRequest } from "next/server"
+
+const tracker = new Tracker({
+  token: process.env.BYDEFAULT_TOKEN as string,
+  exclude: ["/api"],
+})
+
+export function proxy(request: NextRequest) {
+  after(async () => {
+    await tracker.track(request)
+  })
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: [
+    {
+      source: "/((?!_next/|api(?:/|$)|favicon.ico|.*\\..*).*)",
+      missing: [{ type: "header", key: "next-router-prefetch" }],
+    },
+  ],
+}

--- a/bun.lock
+++ b/bun.lock
@@ -155,6 +155,7 @@
       "name": "@autumn/website",
       "version": "0.1.0",
       "dependencies": {
+        "@bydefault/vercel": "^0.1.4",
         "@gsap/react": "^2.1.2",
         "@mdx-js/loader": "^3.1.1",
         "@mdx-js/mdx": "^3.1.1",
@@ -1134,6 +1135,8 @@
     "@bufbuild/protobuf": ["@bufbuild/protobuf@2.12.0", "", {}, "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA=="],
 
     "@bugsnag/cuid": ["@bugsnag/cuid@3.2.2", "", {}, "sha512-7onuYLTMqMmHE9BBPG0YER4nFsU1rB+me1/YIeMusqcLbVbKKuG9u9+BDVDpje5e0llkkrVNOKYwmzM9DRIo7A=="],
+
+    "@bydefault/vercel": ["@bydefault/vercel@0.1.4", "", {}, "sha512-sw5GSwCZ9JE8bpLd0tG8kTPWLt6iJStmRnomfB1wX65biAbu1W+Fz67IMPmHafaF7oBaLNw10+sSnvedQk6PYw=="],
 
     "@canvas/image-data": ["@canvas/image-data@1.1.0", "", {}, "sha512-QdObRRjRbcXGmM1tmJ+MrHcaz1MftF2+W7YI+MsphnsCrmtyfS0d5qJbk0MeSbUeyM/jCb0hmnkXPsy026L7dA=="],
 


### PR DESCRIPTION
This PR adds AI traffic tracking with ByDefault. We track inside of an `after()` function so there is zero performance impact.

BEFORE MERGING: Add the BYDEFAULT_TOKEN to .env

<img width="1470" height="920" alt="Screenshot 2026-06-21 at 21 27 30" src="https://github.com/user-attachments/assets/487f8181-bff9-4fba-8266-31fd189442b5" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ByDefault traffic tracking to the website via a Next middleware proxy. Tracking runs in an after() hook to avoid adding latency.

- **New Features**
  - Track non-static, non-API requests using a middleware `proxy` and matcher config.
  - Adds `@bydefault/vercel` and sends tracking events after the response.

- **Migration**
  - Set BYDEFAULT_TOKEN in the environment (e.g., .env) before merging/deploying.

<sup>Written for commit 6a57d837b17c4df022b6bdae8c01a23e73f92db0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

