### PR TITLE
chore: allow colons in cus ids

### DIFF
--- a/shared/api/common/customerId.ts
+++ b/shared/api/common/customerId.ts
@@ -1,5 +1,7 @@
 import { z } from "zod/v4";
 
+const allowedChars = "Use only letters, numbers, underscores, hyphens, and colons.";
+
 export const CustomerIdSchema = z
 	.string()
 	.refine(
@@ -8,30 +10,21 @@ export const CustomerIdSchema = z
 			if (val.includes("@")) return false;
 			if (val.includes(" ")) return false;
 			if (val.includes(".")) return false;
-			return /^[a-zA-Z0-9_-]+$/.test(val);
+			return /^[a-zA-Z0-9_:-]+$/.test(val);
 		},
 		{
 			error: (issue) => {
 				const input = issue.input as string;
 				if (input === "") return { message: "can't be an empty string" };
 				if (input.includes("@"))
-					return {
-						message:
-							"cannot contain @ symbol. Use only letters, numbers, underscores, and hyphens.",
-					};
+					return { message: `cannot contain @ symbol. ${allowedChars}` };
 				if (input.includes(" "))
-					return {
-						message:
-							"cannot contain spaces. Use only letters, numbers, underscores, and hyphens.",
-					};
+					return { message: `cannot contain spaces. ${allowedChars}` };
 				if (input.includes("."))
-					return {
-						message:
-							"cannot contain periods. Use only letters, numbers, underscores, and hyphens.",
-					};
-				const invalidChar = input.match(/[^a-zA-Z0-9_-]/)?.[0];
+					return { message: `cannot contain periods. ${allowedChars}` };
+				const invalidChar = input.match(/[^a-zA-Z0-9_:-]/)?.[0];
 				return {
-					message: `cannot contain '${invalidChar}'. Use only letters, numbers, underscores, and hyphens.`,
+					message: `cannot contain '${invalidChar}'. ${allowedChars}`,
 				};
 			},
 		},


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow colons in customer IDs by updating `CustomerIdSchema` to accept `:` and standardizing validation errors with a shared hint. This enables IDs like "team:project" while still blocking spaces, periods, and "@".

<sup>Written for commit c7527b179b51e704abdd792f7230abb947f331fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR relaxes the `CustomerIdSchema` validation to permit colons (`:`) in customer IDs, updating both the `refine` regex and the fallback error-detection regex from `[a-zA-Z0-9_-]` to `[a-zA-Z0-9_:-]`, and extracts the repeated "allowed chars" hint into a shared constant.

- **Improvements**: Colons are now accepted in customer IDs, enabling use cases like namespaced IDs (e.g. `org:user123`). Both the pass/fail regex and the error-reporting regex are updated consistently, so error messages remain accurate.
</details>

<h3>Confidence Score: 5/5</h3>

This is a small, self-contained schema change with no logic errors — safe to merge.

Both the validation regex and the fallback error-detection regex are updated consistently to include `:`, and the shared `allowedChars` constant keeps error messages accurate. No pre-existing issues are disturbed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/api/common/customerId.ts | Extends the CustomerIdSchema to allow colons in customer IDs by updating both the validation regex and the error-detection regex, while extracting the allowed-chars hint into a shared constant. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Input string] --> B{empty?}
    B -- yes --> E1[error: cannot be empty]
    B -- no --> C{contains at-sign?}
    C -- yes --> E2[error: cannot contain at-sign]
    C -- no --> D{contains space?}
    D -- yes --> E3[error: cannot contain spaces]
    D -- no --> F{contains period?}
    F -- yes --> E4[error: cannot contain periods]
    F -- no --> G{matches allowed charset}
    G -- yes --> OK[valid customer ID]
    G -- no --> E5[error: cannot contain invalid char]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Input string] --> B{empty?}
    B -- yes --> E1[error: cannot be empty]
    B -- no --> C{contains at-sign?}
    C -- yes --> E2[error: cannot contain at-sign]
    C -- no --> D{contains space?}
    D -- yes --> E3[error: cannot contain spaces]
    D -- no --> F{contains period?}
    F -- yes --> E4[error: cannot contain periods]
    F -- no --> G{matches allowed charset}
    G -- yes --> OK[valid customer ID]
    G -- no --> E5[error: cannot contain invalid char]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: allow colons in cus ids"](https://github.com/useautumn/autumn/commit/c7527b179b51e704abdd792f7230abb947f331fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39002167)</sub>

<!-- /greptile_comment -->