### PR TITLE
chore: clickhouse pipe interval fix to support most populat event typ…

### DIFF
--- a/server/src/external/tinybird/pipes/listEventNamesPipe.ts
+++ b/server/src/external/tinybird/pipes/listEventNamesPipe.ts
@@ -16,6 +16,8 @@ export const listEventNamesPipeParamsSchema = z.object({
 	org_id: z.string(),
 	env: z.string(),
 	limit: z.number().optional(),
+	start_date: z.string().optional(),
+	end_date: z.string().optional(),
 });
 
 export type ListEventNamesPipeParams = z.infer<

--- a/server/src/internal/analytics/actions/listEventNames.ts
+++ b/server/src/internal/analytics/actions/listEventNames.ts
@@ -1,6 +1,6 @@
 import { getTinybirdPipes } from "@/external/tinybird/initTinybird.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { getStandardIntervalWindow } from "../analyticsUtils.js";
+import { getEventRankingWindow } from "../analyticsUtils.js";
 
 export type EventNameWithCount = {
 	event_name: string;
@@ -8,20 +8,22 @@ export type EventNameWithCount = {
 };
 
 /** Lists distinct event names for the org sorted by popularity. With an
- * interval, ranks by count within that window so callers can default to events
- * that are actually active in the selected range. */
+ * interval or custom range, ranks by count within that window so callers can
+ * default to events that are actually active in the selected range. */
 export const listEventNames = async ({
 	ctx,
 	limit,
 	interval,
+	customRange,
 }: {
 	ctx: AutumnContext;
 	limit?: number;
 	interval?: string;
+	customRange?: { start: number; end: number };
 }): Promise<EventNameWithCount[]> => {
 	const { org, env } = ctx;
 	const pipes = getTinybirdPipes();
-	const window = getStandardIntervalWindow(interval);
+	const window = getEventRankingWindow({ interval, customRange });
 
 	const result = await pipes.listEventNames({
 		org_id: org.id,

--- a/server/src/internal/analytics/actions/listEventNames.ts
+++ b/server/src/internal/analytics/actions/listEventNames.ts
@@ -1,28 +1,35 @@
 import { getTinybirdPipes } from "@/external/tinybird/initTinybird.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { getStandardIntervalWindow } from "../analyticsUtils.js";
 
 export type EventNameWithCount = {
 	event_name: string;
 	event_count: number;
 };
 
-/** Lists distinct event names for the org sorted by popularity */
+/** Lists distinct event names for the org sorted by popularity. With an
+ * interval, ranks by count within that window so callers can default to events
+ * that are actually active in the selected range. */
 export const listEventNames = async ({
 	ctx,
 	limit,
+	interval,
 }: {
 	ctx: AutumnContext;
 	limit?: number;
+	interval?: string;
 }): Promise<EventNameWithCount[]> => {
 	const { org, env } = ctx;
 	const pipes = getTinybirdPipes();
+	const window = getStandardIntervalWindow(interval);
 
 	const result = await pipes.listEventNames({
 		org_id: org.id,
 		env,
 		limit,
+		start_date: window?.startDate,
+		end_date: window?.endDate,
 	});
-
 
 	return result.data;
 };

--- a/server/src/internal/analytics/analyticsUtils.ts
+++ b/server/src/internal/analytics/analyticsUtils.ts
@@ -10,7 +10,7 @@ import {
 	type Subscription,
 } from "@autumn/shared";
 import { UTCDate } from "@date-fns/utc";
-import { format, startOfDay, sub } from "date-fns";
+import { format, startOfDay, startOfHour, sub } from "date-fns";
 import type Stripe from "stripe";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
@@ -28,19 +28,36 @@ export const STANDARD_INTERVAL_DAYS: Record<string, number> = {
 
 const CLICKHOUSE_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
 
-/** Resolves a standard interval (24h/7d/30d/90d) to a UTC start/end window
- * aligned to the day boundary. Returns undefined for non-standard intervals
- * (billing cycles, custom ranges) which the caller handles separately. */
-export const getStandardIntervalWindow = (
-	interval?: string,
-): { startDate: string; endDate: string } | undefined => {
+/** Resolves the start/end window the event-name ranking should query so it
+ * matches the chart's visible range. A custom range takes precedence; otherwise
+ * a standard interval is resolved with the same boundary alignment the chart
+ * uses — hour for 24h, day for 7d/30d/90d. Returns undefined when neither
+ * applies (e.g. billing-cycle intervals), leaving callers on all-time ranking. */
+export const getEventRankingWindow = ({
+	interval,
+	customRange,
+}: {
+	interval?: string;
+	customRange?: { start: number; end: number };
+}): { startDate: string; endDate: string } | undefined => {
+	if (customRange) {
+		return {
+			startDate: format(new UTCDate(customRange.start), CLICKHOUSE_DATE_FORMAT),
+			endDate: format(new UTCDate(customRange.end), CLICKHOUSE_DATE_FORMAT),
+		};
+	}
+
 	const days = interval ? STANDARD_INTERVAL_DAYS[interval] : undefined;
 	if (!days) {
 		return undefined;
 	}
+
 	const now = new UTCDate();
+	const unaligned = sub(now, { days });
+	const start =
+		interval === "24h" ? startOfHour(unaligned) : startOfDay(unaligned);
 	return {
-		startDate: format(startOfDay(sub(now, { days })), CLICKHOUSE_DATE_FORMAT),
+		startDate: format(start, CLICKHOUSE_DATE_FORMAT),
 		endDate: format(now, CLICKHOUSE_DATE_FORMAT),
 	};
 };

--- a/server/src/internal/analytics/analyticsUtils.ts
+++ b/server/src/internal/analytics/analyticsUtils.ts
@@ -9,13 +9,41 @@ import {
 	RecaseError,
 	type Subscription,
 } from "@autumn/shared";
+import { UTCDate } from "@date-fns/utc";
+import { format, startOfDay, sub } from "date-fns";
+import type Stripe from "stripe";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
 import { subToPeriodStartEnd } from "@/external/stripe/stripeSubUtils/convertSubUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { ACTIVE_STATUSES } from "@/internal/customers/cusProducts/CusProductService.js";
 import { isFreeProduct } from "../products/productUtils.js";
-import type Stripe from "stripe";
+
+export const STANDARD_INTERVAL_DAYS: Record<string, number> = {
+	"24h": 1,
+	"7d": 7,
+	"30d": 30,
+	"90d": 90,
+};
+
+const CLICKHOUSE_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
+
+/** Resolves a standard interval (24h/7d/30d/90d) to a UTC start/end window
+ * aligned to the day boundary. Returns undefined for non-standard intervals
+ * (billing cycles, custom ranges) which the caller handles separately. */
+export const getStandardIntervalWindow = (
+	interval?: string,
+): { startDate: string; endDate: string } | undefined => {
+	const days = interval ? STANDARD_INTERVAL_DAYS[interval] : undefined;
+	if (!days) {
+		return undefined;
+	}
+	const now = new UTCDate();
+	return {
+		startDate: format(startOfDay(sub(now, { days })), CLICKHOUSE_DATE_FORMAT),
+		endDate: format(now, CLICKHOUSE_DATE_FORMAT),
+	};
+};
 
 export async function getBillingCycleStartDate({
 	customer,
@@ -153,7 +181,9 @@ function getDateRangesFromStripeSubscriptions(
 
 				startDates.push(formatDateToString(new Date(period.start * 1000)));
 				endDates.push(formatDateToString(new Date(period.end * 1000)));
-				createdDates.push(formatDateToString(new Date(subscription.created * 1000)));
+				createdDates.push(
+					formatDateToString(new Date(subscription.created * 1000)),
+				);
 			}
 		}
 	}
@@ -232,9 +262,7 @@ function getDateRangesFromEntitlements(customerProducts?: FullCusProduct[]): {
 
 		for (const entitlement of product.customer_entitlements) {
 			if (entitlement.next_reset_at) {
-				endDates.push(
-					formatDateToString(new Date(entitlement.next_reset_at)),
-				);
+				endDates.push(formatDateToString(new Date(entitlement.next_reset_at)));
 			}
 
 			const startDate = calculateStartDateFromInterval(
@@ -296,7 +324,7 @@ function calculateBillingCycleResult(
 
 	const gapMultiplier = intervalType === "1bc" ? 1 : 3;
 	const now = new Date();
-	
+
 	// For analytics, we look BACKWARD from today for N billing cycles
 	// End date is today, start date is today - (gap * multiplier)
 	const adjustedStartDate = new Date(now.getTime() - gap * gapMultiplier);

--- a/server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
+++ b/server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
@@ -17,14 +17,8 @@ import { getEntityNames } from "@/internal/analytics/actions/getEntityNames.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 import { eventActions } from "../actions/eventActions.js";
+import { STANDARD_INTERVAL_DAYS } from "../analyticsUtils.js";
 import { collapsePlanIdGroups } from "./utils/collapsePlanIdGroups.js";
-
-const STANDARD_INTERVAL_DAYS: Record<string, number> = {
-	"24h": 1,
-	"7d": 7,
-	"30d": 30,
-	"90d": 90,
-};
 
 const InternalAggregateEventsSchema = z.object({
 	interval: z.string().nullish(),

--- a/server/src/internal/analytics/internalHandlers/handleListEventNames.ts
+++ b/server/src/internal/analytics/internalHandlers/handleListEventNames.ts
@@ -7,6 +7,8 @@ import { eventActions } from "../actions/eventActions.js";
 const ListEventNamesSchema = z.object({
 	limit: z.coerce.number().optional(),
 	interval: z.string().optional(),
+	start: z.coerce.number().optional(),
+	end: z.coerce.number().optional(),
 });
 
 /**
@@ -18,12 +20,18 @@ export const handleListEventNames = createRoute({
 	handler: async (c) => {
 		assertTinybirdAvailable();
 		const ctx = c.get("ctx");
-		const { limit, interval } = c.req.valid("query");
+		const { limit, interval, start, end } = c.req.valid("query");
+
+		const customRange =
+			interval === "custom" && start !== undefined && end !== undefined
+				? { start, end }
+				: undefined;
 
 		const eventNames = await eventActions.listEventNames({
 			ctx,
 			limit,
 			interval,
+			customRange,
 		});
 
 		return c.json({

--- a/server/src/internal/analytics/internalHandlers/handleListEventNames.ts
+++ b/server/src/internal/analytics/internalHandlers/handleListEventNames.ts
@@ -1,11 +1,12 @@
-import { z } from "zod/v4";
 import { Scopes } from "@autumn/shared";
+import { z } from "zod/v4";
 import { assertTinybirdAvailable } from "@/external/tinybird/tinybirdUtils.js";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { eventActions } from "../actions/eventActions.js";
 
 const ListEventNamesSchema = z.object({
 	limit: z.coerce.number().optional(),
+	interval: z.string().optional(),
 });
 
 /**
@@ -17,11 +18,12 @@ export const handleListEventNames = createRoute({
 	handler: async (c) => {
 		assertTinybirdAvailable();
 		const ctx = c.get("ctx");
-		const { limit } = c.req.valid("query");
+		const { limit, interval } = c.req.valid("query");
 
 		const eventNames = await eventActions.listEventNames({
 			ctx,
 			limit,
+			interval,
 		});
 
 		return c.json({

--- a/server/tinybird/pipes/list_event_names.pipe
+++ b/server/tinybird/pipes/list_event_names.pipe
@@ -1,5 +1,7 @@
 DESCRIPTION >
     Lists distinct event names for an org/env sorted by popularity (event count).
+    With a date range, ranks by count within the window (reads the time-keyed org
+    rollup) so callers can default to events that are actually active in the window.
 
 TOKEN "list_event_names_read" READ
 
@@ -7,6 +9,24 @@ NODE endpoint
 TYPE endpoint
 SQL >
     %
+    {% set use_window = defined(start_date) and String(start_date, '') != '' and defined(end_date) and String(end_date, '') != '' %}
+    {% if use_window %}
+    SELECT
+        event_name,
+        sum(event_count) as event_count
+    FROM events_org_hourly_mv
+    WHERE
+        org_id = {{ String(org_id, '') }}
+        AND env = {{ String(env, 'test') }}
+        AND hour >= toDateTime({{ String(start_date) }})
+        AND hour <= toDateTime({{ String(end_date) }})
+    GROUP BY event_name
+    HAVING event_count > 0
+    ORDER BY event_count DESC
+    {% if defined(limit) %}
+    LIMIT {{ Int32(limit, 100) }}
+    {% end %}
+    {% else %}
     SELECT
         event_name,
         sum(event_count) as event_count
@@ -18,4 +38,5 @@ SQL >
     ORDER BY event_count DESC
     {% if defined(limit) %}
     LIMIT {{ Int32(limit, 100) }}
+    {% end %}
     {% end %}

--- a/vite/src/views/customers/customer/analytics/components/SelectFeatureDropdown.tsx
+++ b/vite/src/views/customers/customer/analytics/components/SelectFeatureDropdown.tsx
@@ -68,6 +68,8 @@ export const SelectFeatureDropdown = () => {
 	const { queryStates } = useAnalyticsQueryState();
 	const { eventNames: eventNamesData } = useEventNames({
 		interval: queryStates.interval,
+		start: queryStates.start,
+		end: queryStates.end,
 	});
 	const [open, setOpen] = useState(false);
 	const [searchValue, setSearchValue] = useState("");

--- a/vite/src/views/customers/customer/analytics/components/SelectFeatureDropdown.tsx
+++ b/vite/src/views/customers/customer/analytics/components/SelectFeatureDropdown.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/v2/dropdowns/DropdownMenu";
 import { cn } from "@/lib/utils";
 import { useAnalyticsContext } from "../AnalyticsContext";
+import { useAnalyticsQueryState } from "../hooks/useAnalyticsQueryState";
 import { useEventNames } from "../hooks/useEventNames";
 
 const MAX_NUM_SELECTED = 10;
@@ -64,7 +65,10 @@ const formatFeatureLabel = (linkedFeatures: Feature[]): string | null => {
 
 export const SelectFeatureDropdown = () => {
 	const { features, setHasCleared } = useAnalyticsContext();
-	const { eventNames: eventNamesData } = useEventNames();
+	const { queryStates } = useAnalyticsQueryState();
+	const { eventNames: eventNamesData } = useEventNames({
+		interval: queryStates.interval,
+	});
 	const [open, setOpen] = useState(false);
 	const [searchValue, setSearchValue] = useState("");
 
@@ -76,16 +80,14 @@ export const SelectFeatureDropdown = () => {
 	const currentEventNames =
 		searchParams.get("event_names")?.split(",").filter(Boolean) || [];
 
-	// Build event options from useEventNames data, keeping only those linked to a feature
+	// Show every ingested event; feature linkage only drives the optional label, not visibility
 	const eventOptions: EventOption[] = useMemo(() => {
-		return eventNamesData
-			.map((item) => ({
-				eventName: item.event_name,
-				eventCount: item.event_count,
-				linkedFeatures: getFeaturesForEventName(item.event_name, features),
-				selected: currentEventNames.includes(item.event_name),
-			}))
-			.filter((option) => option.linkedFeatures.length > 0);
+		return eventNamesData.map((item) => ({
+			eventName: item.event_name,
+			eventCount: item.event_count,
+			linkedFeatures: getFeaturesForEventName(item.event_name, features),
+			selected: currentEventNames.includes(item.event_name),
+		}));
 	}, [eventNamesData, features, currentEventNames]);
 
 	// Filter options based on search (search both event name and feature ids)
@@ -182,12 +184,12 @@ export const SelectFeatureDropdown = () => {
 							{filteredOptions.map((option) => {
 								const featureLabel = formatFeatureLabel(option.linkedFeatures);
 								return (
-								<DropdownMenuCheckboxItem
-									key={option.eventName}
-									checked={option.selected}
-									onCheckedChange={() => handleToggleItem(option)}
-									className="pl-2"
-								>
+									<DropdownMenuCheckboxItem
+										key={option.eventName}
+										checked={option.selected}
+										onCheckedChange={() => handleToggleItem(option)}
+										className="pl-2"
+									>
 										<div className="flex items-center gap-1.5 min-w-0">
 											<span className="text-xs truncate">
 												{option.eventName}

--- a/vite/src/views/customers/customer/analytics/hooks/useEventNames.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useEventNames.tsx
@@ -10,15 +10,19 @@ export type EventNameWithCount = {
 export const useEventNames = ({
 	limit,
 	interval,
+	start,
+	end,
 }: {
 	limit?: number;
 	interval?: string;
+	start?: number | null;
+	end?: number | null;
 } = {}) => {
 	const axiosInstance = useAxiosInstance();
 	const buildKey = useQueryKeyFactory();
 
 	const { data, isLoading, error } = useQuery({
-		queryKey: buildKey(["query-event-names-list", limit, interval]),
+		queryKey: buildKey(["query-event-names-list", limit, interval, start, end]),
 		queryFn: async () => {
 			const params = new URLSearchParams();
 			if (limit) {
@@ -26,6 +30,12 @@ export const useEventNames = ({
 			}
 			if (interval) {
 				params.set("interval", interval);
+			}
+			if (start != null) {
+				params.set("start", String(start));
+			}
+			if (end != null) {
+				params.set("end", String(end));
 			}
 			const query = params.toString();
 			const url = `/query/event_names/list${query ? `?${query}` : ""}`;

--- a/vite/src/views/customers/customer/analytics/hooks/useEventNames.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useEventNames.tsx
@@ -24,22 +24,14 @@ export const useEventNames = ({
 	const { data, isLoading, error } = useQuery({
 		queryKey: buildKey(["query-event-names-list", limit, interval, start, end]),
 		queryFn: async () => {
-			const params = new URLSearchParams();
-			if (limit) {
-				params.set("limit", String(limit));
-			}
-			if (interval) {
-				params.set("interval", interval);
-			}
-			if (start != null) {
-				params.set("start", String(start));
-			}
-			if (end != null) {
-				params.set("end", String(end));
-			}
-			const query = params.toString();
-			const url = `/query/event_names/list${query ? `?${query}` : ""}`;
-			const { data } = await axiosInstance.get(url);
+			const { data } = await axiosInstance.get("/query/event_names/list", {
+				params: {
+					limit,
+					interval,
+					start: start ?? undefined,
+					end: end ?? undefined,
+				},
+			});
 			return data;
 		},
 	});

--- a/vite/src/views/customers/customer/analytics/hooks/useEventNames.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useEventNames.tsx
@@ -7,14 +7,28 @@ export type EventNameWithCount = {
 	event_count: number;
 };
 
-export const useEventNames = (limit?: number) => {
+export const useEventNames = ({
+	limit,
+	interval,
+}: {
+	limit?: number;
+	interval?: string;
+} = {}) => {
 	const axiosInstance = useAxiosInstance();
 	const buildKey = useQueryKeyFactory();
 
 	const { data, isLoading, error } = useQuery({
-		queryKey: buildKey(["query-event-names-list", limit]),
+		queryKey: buildKey(["query-event-names-list", limit, interval]),
 		queryFn: async () => {
-			const url = `/query/event_names/list${limit ? `?limit=${limit}` : ""}`;
+			const params = new URLSearchParams();
+			if (limit) {
+				params.set("limit", String(limit));
+			}
+			if (interval) {
+				params.set("interval", interval);
+			}
+			const query = params.toString();
+			const url = `/query/event_names/list${query ? `?${query}` : ""}`;
 			const { data } = await axiosInstance.get(url);
 			return data;
 		},

--- a/vite/src/views/customers/customer/analytics/hooks/useSelectedEventNames.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useSelectedEventNames.tsx
@@ -1,43 +1,35 @@
-import { FeatureType } from "@autumn/shared";
 import { parseAsArrayOf, parseAsString, useQueryStates } from "nuqs";
-import { useMemo } from "react";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
+import { useAnalyticsQueryState } from "./useAnalyticsQueryState";
 import { type EventNameWithCount, useEventNames } from "./useEventNames";
 
 /** Resolves the event names the analytics views filter by: explicit URL
- * selection (event_names / feature_ids) or the top metered events by default.
- * Shared by the chart and the events table so they stay in sync. */
+ * selection (event_names / feature_ids) or the top events by count in the
+ * active window by default. Shared by the chart and the events table. */
 export const useSelectedEventNames = () => {
-	const [{ feature_ids: featureIds, event_names: eventNames }] = useQueryStates({
-		feature_ids: parseAsArrayOf(parseAsString),
-		event_names: parseAsArrayOf(parseAsString),
-	});
+	const [{ feature_ids: featureIds, event_names: eventNames }] = useQueryStates(
+		{
+			feature_ids: parseAsArrayOf(parseAsString),
+			event_names: parseAsArrayOf(parseAsString),
+		},
+	);
+
+	const { queryStates } = useAnalyticsQueryState();
+	const { interval } = queryStates;
 
 	const { eventNames: cachedEventNames, isLoading: eventNamesLoading } =
-		useEventNames();
+		useEventNames({ interval });
 	const { features: featuresData, isLoading: featuresLoading } =
 		useFeaturesQuery();
 
-	const featureLinkedEventNames = useMemo(() => {
-		if (!featuresData?.length) {
-			return cachedEventNames;
-		}
-		return cachedEventNames.filter((e: EventNameWithCount) =>
-			featuresData.some(
-				(f) =>
-					(f.type === FeatureType.Metered ||
-						f.type === FeatureType.CreditSystem) &&
-					(f.event_names?.includes(e.event_name) || f.id === e.event_name),
-			),
-		);
-	}, [cachedEventNames, featuresData]);
+	const defaultEventNames = cachedEventNames
+		.slice(0, 3)
+		.map((e: EventNameWithCount) => e.event_name);
 
 	const selectedEventNames =
 		eventNames || featureIds
 			? [...(eventNames || []), ...(featureIds || [])]
-			: featureLinkedEventNames
-					.slice(0, 3)
-					.map((e: EventNameWithCount) => e.event_name);
+			: defaultEventNames;
 
 	return {
 		selectedEventNames,

--- a/vite/src/views/customers/customer/analytics/hooks/useSelectedEventNames.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useSelectedEventNames.tsx
@@ -15,10 +15,10 @@ export const useSelectedEventNames = () => {
 	);
 
 	const { queryStates } = useAnalyticsQueryState();
-	const { interval } = queryStates;
+	const { interval, start, end } = queryStates;
 
 	const { eventNames: cachedEventNames, isLoading: eventNamesLoading } =
-		useEventNames({ interval });
+		useEventNames({ interval, start, end });
 	const { features: featuresData, isLoading: featuresLoading } =
 		useFeaturesQuery();
 


### PR DESCRIPTION
…es for that range

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make event name ranking interval- and range-aware, aligned with chart windows, so the dropdown and charts surface the most active events for the selected interval or custom dates. Defaults to the top 3 events in that window.

- **New Features**
  - Tinybird `list_event_names` accepts `start_date`/`end_date`; when set, sums from `events_org_hourly_mv` within the window (falls back to all-time).
  - API accepts `interval` or `interval=custom` with `start`/`end` (epoch ms); computes a UTC-aligned window and forwards it to Tinybird.
  - Frontend passes `interval`/`start`/`end` via `useEventNames`; dropdown shows all ingested events and defaults to the top 3 in the active window.

- **Bug Fixes**
  - 24h window now aligns to the hour boundary (matching charts); custom ranges are respected end-to-end.

<sup>Written for commit 2db947a4efe561183b1df6088da9234e851bcd6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes the `list_event_names` Tinybird pipe interval-aware so the event name dropdown ranks events by activity within the currently-selected time window rather than all-time totals. It also widens the dropdown to show all ingested events instead of only those linked to a metered feature.

- **Bug fixes / Improvements**: Added `start_date`/`end_date` params to the `list_event_names` Tinybird pipe; a new `getStandardIntervalWindow()` utility converts the selected interval string to UTC-aligned start/end timestamps, which are forwarded through the API handler to Tinybird.
- **Improvements**: `STANDARD_INTERVAL_DAYS` moved from `handleInternalAggregateEvents.ts` into `analyticsUtils.ts` to be shared across both the chart aggregation path and the new event-name ranking path.
- **Improvements**: Default event selection in `useSelectedEventNames` simplified to top-3 by count in the active window; `SelectFeatureDropdown` now surfaces all ingested events (feature linkage becomes a label rather than a visibility gate).
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is additive and well-scoped, with a minor window-alignment inconsistency for the 24h interval worth addressing.

The new getStandardIntervalWindow function uses startOfDay for all intervals including 24h. For 24h the chart handler aligns to the nearest hour boundary (~24 hours back), while the event-name ranking window starts at yesterday midnight — potentially up to ~47 hours back. The mismatch only affects which events appear ranked for the 24h selector, not correctness of the chart data itself.

server/src/internal/analytics/analyticsUtils.ts — the startOfDay alignment for the 24h case diverges from the chart handler's hour-aligned calculation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/analytics/analyticsUtils.ts | Added getStandardIntervalWindow() and moved STANDARD_INTERVAL_DAYS here; the 24h window uses startOfDay alignment which diverges from the chart handler's hour-aligned calculation |
| server/tinybird/pipes/list_event_names.pipe | New conditional branch queries events_org_hourly_mv with a date window when start_date/end_date are provided; falls back to the all-time event_names_mv view otherwise |
| server/src/internal/analytics/actions/listEventNames.ts | Accepts optional interval, resolves it to a UTC window via getStandardIntervalWindow, and passes start/end dates to the Tinybird pipe |
| vite/src/views/customers/customer/analytics/hooks/useSelectedEventNames.tsx | Default selection now uses top-3 events by count in the active window instead of filtering to feature-linked metered events |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as SelectFeatureDropdown
    participant Hook as useEventNames
    participant API as handleListEventNames
    participant Action as listEventNames
    participant Utils as getStandardIntervalWindow
    participant TB as Tinybird pipe

    UI->>Hook: "useEventNames({ interval })"
    Hook->>API: "GET /query/event_names/list?interval=7d"
    API->>Action: "listEventNames({ ctx, interval })"
    Action->>Utils: getStandardIntervalWindow("7d")
    Utils-->>Action: "{ startDate, endDate }"
    Action->>TB: "listEventNames({ org_id, env, start_date, end_date })"
    TB-->>Action: event rows from events_org_hourly_mv
    Action-->>API: EventNameWithCount[]
    API-->>Hook: "{ eventNames }"
    Hook-->>UI: ranked event names for interval
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as SelectFeatureDropdown
    participant Hook as useEventNames
    participant API as handleListEventNames
    participant Action as listEventNames
    participant Utils as getStandardIntervalWindow
    participant TB as Tinybird pipe

    UI->>Hook: "useEventNames({ interval })"
    Hook->>API: "GET /query/event_names/list?interval=7d"
    API->>Action: "listEventNames({ ctx, interval })"
    Action->>Utils: getStandardIntervalWindow("7d")
    Utils-->>Action: "{ startDate, endDate }"
    Action->>TB: "listEventNames({ org_id, env, start_date, end_date })"
    TB-->>Action: event rows from events_org_hourly_mv
    Action-->>API: EventNameWithCount[]
    API-->>Hook: "{ eventNames }"
    Hook-->>UI: ranked event names for interval
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/analytics/analyticsUtils.ts:43-45
**"24h" window is misaligned with the chart's window**

`getStandardIntervalWindow("24h")` produces `startOfDay(sub(now, { days: 1 }))` — yesterday midnight UTC — which can be up to ~47 hours behind `now`. The chart handler in `handleInternalAggregateEvents.ts` computes its "24h" window as `sub(now, { days: 1 })` aligned to the *hour* boundary (~24 hours). For "7d"/"30d"/"90d" both paths agree on `startOfDay`, but for "24h" the event-name ranking window is materially wider than the chart's visible range, so users may see events ranked by data outside what the chart displays. Consider `sub(now, { hours: 24 })` (no `startOfDay`) for the "24h" case to stay consistent.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: clickhouse pipe interval fix to s..."](https://github.com/useautumn/autumn/commit/a0607018171c6b7312f385b199655fe8efe30a23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39082288)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->