### PR TITLE
feat(website): content-negotiate markdown on canonical page URLs

### DIFF
--- a/apps/website/app/home.md/route.ts
+++ b/apps/website/app/home.md/route.ts
@@ -1,0 +1,9 @@
+import { buildHomeMarkdown } from "@/lib/agentContent";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return new Response(buildHomeMarkdown(), {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}

--- a/apps/website/app/privacy.md/route.ts
+++ b/apps/website/app/privacy.md/route.ts
@@ -1,0 +1,9 @@
+import { buildPrivacyMarkdown } from "@/lib/agentContent";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return new Response(buildPrivacyMarkdown(), {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}

--- a/apps/website/app/privacy/page.tsx
+++ b/apps/website/app/privacy/page.tsx
@@ -1,209 +1,96 @@
 import type { Metadata } from "next";
-import type { ReactNode } from "react";
 import AnimatedFooterImage from "@/components/animated-footer-image";
 import Footer from "@/components/footer";
 import Navbar from "@/components/navbar";
+import { privacyTerms } from "@/lib/privacyContent";
 import type { PageStyle } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 export const metadata: Metadata = {
-	title: "Terms & Privacy",
-	description:
-		"Autumn's Terms of Service and Privacy Policy covering use of our billing infrastructure, APIs, and SDKs.",
-	alternates: { canonical: "/privacy" },
+  title: "Terms & Privacy",
+  description:
+    "Autumn's Terms of Service and Privacy Policy covering use of our billing infrastructure, APIs, and SDKs.",
+  alternates: { canonical: "/privacy" },
 };
 
-const privacyTerms: Array<{
-	title: string;
-	content: ReactNode;
-	isUppercase: boolean;
-}> = [
-	{
-		title: "1. Acceptance of Terms",
-		content:
-			'By accessing or using the Autumn platform, APIs, SDKs, or any related services (collectively, the "Services") provided by Rebase, Inc., a Delaware corporation ("Autumn," "we," "us," or "our"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, do not use our Services.',
-		isUppercase: false,
-	},
-	{
-		title: "2. Description of Services",
-		content:
-			"Autumn provides billing infrastructure, including usage-based billing, credits management, pricing configuration, and entitlements management for software applications. Our Services are designed for developers and businesses building products that require flexible billing and pricing capabilities.",
-		isUppercase: false,
-	},
-	{
-		title: "3. Account Registration",
-		content:
-			"To use certain features of our Services, you must create an account. You agree to provide accurate, current, and complete information during registration and to update such information as necessary. You are responsible for maintaining the confidentiality of your account credentials and for all activities that occur under your account.",
-		isUppercase: false,
-	},
-	{
-		title: "4. Acceptable Use",
-		content:
-			"You agree not to use the Services for any unlawful purpose or in violation of any applicable laws; (b) interfere with or disrupt the integrity or performance of the Services; (c) attempt to gain unauthorized access to the Services or related systems; (d) use the Services to transmit malicious code or harmful content; or (e) resell or redistribute the Services without our prior written consent.",
-		isUppercase: false,
-	},
-	{
-		title: "5. Payment Terms",
-		content:
-			"Fees for the Services are set forth on our pricing page or in a separate agreement. You agree to pay all applicable fees in accordance with the payment terms. All fees are non-refundable except as expressly stated otherwise. We reserve the right to modify our pricing with 30 days' notice.",
-		isUppercase: false,
-	},
-	{
-		title: "6. Data and Privacy",
-		content:
-			'Your use of the Services is subject to our Privacy Policy. You retain ownership of any data you submit to the Services ("Customer Data"). You grant us a limited license to process Customer Data solely to provide the Services. We implement reasonable security measures to protect Customer Data, but you acknowledge that no system is completely secure.',
-		isUppercase: false,
-	},
-	{
-		title: "7. Intellectual Property",
-		content:
-			"The Services, including all software, APIs, documentation, and related materials, are owned by Autumn and protected by intellectual property laws. We grant you a limited, non-exclusive, non-transferable license to use the Services in accordance with these Terms. You may not copy, modify, or create derivative works of the Services except as expressly permitted.",
-		isUppercase: false,
-	},
-	{
-		title: "8. Confidentiality",
-		content:
-			"Each party agrees to maintain the confidentiality of any non-public information disclosed by the other party and to use such information only for the purposes of these Terms. This obligation does not apply to information that is publicly available, independently developed, or rightfully received from a third party.",
-		isUppercase: false,
-	},
-	{
-		title: "9. Warranties and Disclaimers",
-		content:
-			'THE SERVICES ARE PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. WE DO NOT WARRANT THAT THE SERVICES WILL BE UNINTERRUPTED OR ERROR-FREE.',
-		isUppercase: true,
-	},
-	{
-		title: "10. Limitation of Liability",
-		content:
-			"TO THE MAXIMUM EXTENT PERMITTED BY LAW, AUTUMN SHALL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS OR REVENUES. OUR TOTAL LIABILITY FOR ANY CLAIMS ARISING FROM THESE TERMS SHALL NOT EXCEED THE AMOUNTS PAID BY YOU TO AUTUMN IN THE TWELVE MONTHS PRECEDING THE CLAIM.",
-		isUppercase: true,
-	},
-	{
-		title: "11. Indemnification",
-		content:
-			"You agree to indemnify, defend, and hold harmless Autumn and its officers, directors, employees, and agents from any claims, liabilities, damages, losses, or expenses arising from your use of the Services, your violation of these Terms, or your infringement of any third-party rights.",
-		isUppercase: false,
-	},
-	{
-		title: "12. Term and Termination",
-		content:
-			"These Terms remain in effect until terminated. Either party may terminate for convenience with 30 days' written notice. We may suspend or terminate your access immediately if you breach these Terms. Upon termination, your right to use the Services ceases, and you must pay any outstanding fees.",
-		isUppercase: false,
-	},
-	{
-		title: "13. Modifications",
-		content:
-			"We may modify these Terms at any time by posting the revised Terms on our website. Material changes will be communicated with at least 30 days' notice. Your continued use of the Services after such changes constitutes acceptance of the modified Terms.",
-		isUppercase: false,
-	},
-	{
-		title: "14. Governing Law and Disputes",
-		content:
-			"These Terms are governed by the laws of the State of Delaware, without regard to conflict of law principles. Any disputes arising from these Terms shall be resolved through binding arbitration in accordance with the rules of the American Arbitration Association, except that either party may seek injunctive relief in any court of competent jurisdiction.",
-		isUppercase: false,
-	},
-	{
-		title: "15. General Provisions",
-		content:
-			"These Terms constitute the entire agreement between you and Autumn regarding the Services. If any provision is found unenforceable, the remaining provisions will continue in effect. Our failure to enforce any right or provision does not constitute a waiver. You may not assign these Terms without our prior written consent.",
-		isUppercase: false,
-	},
-	{
-		title: "16. Contact Information",
-		content: (
-			<>
-				For questions about these Terms, please contact us at
-				security@useautumn.com or at:
-				<br />
-				Rebase, Inc. (d/b/a Autumn)
-				<br />
-				Email: security@useautumn.com
-				<br />
-				Website: https://useautumn.com
-			</>
-		),
-		isUppercase: false,
-	},
-];
-
 export default function PrivacyPolicy() {
-	return (
-		<div
-			className="w-full overflow-x-hidden overflow-y-auto bg-[#000000]"
-			style={
-				{ "--page-pad": "max(2.5rem, calc((100vw - 1440px) / 2))" } as PageStyle
-			}
-		>
-			<div className="relative z-10 bg-[#000000] min-h-screen">
-				<div className="relative w-full px-4 md:px-(--page-pad) pt-5">
-					<div className="absolute pointer-events-none top-0 bottom-0 left-4 md:left-(--page-pad) border-l border-[#292929] z-50" />
-					<div className="absolute pointer-events-none left-0 border-t border-[#292929] w-full" />
-					<Navbar />
-					<div className="absolute pointer-events-none left-0 border-b border-[#292929] w-full" />
-					<div className="absolute pointer-events-none top-0 bottom-0 right-4 md:right-(--page-pad) border-r border-[#292929] z-50" />
+  return (
+    <div
+      className="w-full overflow-x-hidden overflow-y-auto bg-[#000000]"
+      style={
+        { "--page-pad": "max(2.5rem, calc((100vw - 1440px) / 2))" } as PageStyle
+      }
+    >
+      <div className="relative z-10 bg-[#000000] min-h-screen">
+        <div className="relative w-full px-4 md:px-(--page-pad) pt-5">
+          <div className="absolute pointer-events-none top-0 bottom-0 left-4 md:left-(--page-pad) border-l border-[#292929] z-50" />
+          <div className="absolute pointer-events-none left-0 border-t border-[#292929] w-full" />
+          <Navbar />
+          <div className="absolute pointer-events-none left-0 border-b border-[#292929] w-full" />
+          <div className="absolute pointer-events-none top-0 bottom-0 right-4 md:right-(--page-pad) border-r border-[#292929] z-50" />
 
-					<div className="flex flex-col gap-2.5">
-						<div className="border-t border-[#292929] w-full" />
-						<div className="border-t border-[#292929] w-full hidden md:block" />
-						<div className="border-t border-[#292929] w-full hidden md:block" />
-						<div className="border-t border-[#292929] w-full hidden md:block" />
-						<div className="border-t border-[#292929] w-full hidden md:block" />
-					</div>
+          <div className="flex flex-col gap-2.5">
+            <div className="border-t border-[#292929] w-full" />
+            <div className="border-t border-[#292929] w-full hidden md:block" />
+            <div className="border-t border-[#292929] w-full hidden md:block" />
+            <div className="border-t border-[#292929] w-full hidden md:block" />
+            <div className="border-t border-[#292929] w-full hidden md:block" />
+          </div>
 
-					<div className="flex w-full flex-col border-b border-[#292929]">
-						<div className="flex w-full border-b border-[#292929]">
-							<div className="hidden md:block w-1/8 lg:w-1/6 border-r bg-[#0F0F0F] border-[#292929]" />
-							<div className="flex-1 bg-[#0F0F0F] px-4 sm:px-8 py-10 md:py-16">
-								<h1 className="text-white text-[40px] font-sans tracking-[-2%] uppercase">
-									Terms of Service
-								</h1>
-							</div>
-							<div className="hidden md:block w-1/8 lg:w-1/6 border-l bg-[#0F0F0F] border-[#292929]" />
-						</div>
+          <div className="flex w-full flex-col border-b border-[#292929]">
+            <div className="flex w-full border-b border-[#292929]">
+              <div className="hidden md:block w-1/8 lg:w-1/6 border-r bg-[#0F0F0F] border-[#292929]" />
+              <div className="flex-1 bg-[#0F0F0F] px-4 sm:px-8 py-10 md:py-16">
+                <h1 className="text-white text-[40px] font-sans tracking-[-2%] uppercase">
+                  Terms of Service
+                </h1>
+              </div>
+              <div className="hidden md:block w-1/8 lg:w-1/6 border-l bg-[#0F0F0F] border-[#292929]" />
+            </div>
 
-						<div className="flex w-full">
-							<div className="hidden md:block w-1/8 lg:w-1/6 border-r border-[#292929]" />
-							<div className="flex-1 px-4 sm:px-8 py-12 md:py-16 text-white text-[16px] font-light leading-[1.6] tracking-[-2%] font-sans pb-32">
-								<p className="mb-10">
-									Autumn (Rebase, Inc.)
-									<br />
-									Effective Date: February 1, 2025
-								</p>
+            <div className="flex w-full">
+              <div className="hidden md:block w-1/8 lg:w-1/6 border-r border-[#292929]" />
+              <div className="flex-1 px-4 sm:px-8 py-12 md:py-16 text-white text-[16px] font-light leading-[1.6] tracking-[-2%] font-sans pb-32">
+                <p className="mb-10">
+                  Autumn (Rebase, Inc.)
+                  <br />
+                  Effective Date: February 1, 2025
+                </p>
 
-								{privacyTerms.map((term) => (
-									<div key={term.title}>
-										<h3 className="mb-2 mt-8 text-[24px] leading-[30px] font-normal tracking-[-2%] text-white">
-											{term.title}
-										</h3>
-										<p
-											className={cn(
-												"mb-6 text-[16px] leading-[20px] font-light tracking-[-2%] md:leading-[24px]",
-												term.isUppercase && "uppercase",
-											)}
-										>
-											{term.content}
-										</p>
-									</div>
-								))}
-							</div>
-							<div className="hidden md:block w-1/8 lg:w-1/6 border-l border-[#292929]" />
-						</div>
-					</div>
+                {privacyTerms.map((term) => (
+                  <div key={term.title}>
+                    <h3 className="mb-2 mt-8 text-[24px] leading-[30px] font-normal tracking-[-2%] text-white">
+                      {term.title}
+                    </h3>
+                    <p
+                      className={cn(
+                        "mb-6 text-[16px] leading-[20px] font-light tracking-[-2%] md:leading-[24px]",
+                        term.isUppercase && "uppercase",
+                      )}
+                    >
+                      {term.content}
+                    </p>
+                  </div>
+                ))}
+              </div>
+              <div className="hidden md:block w-1/8 lg:w-1/6 border-l border-[#292929]" />
+            </div>
+          </div>
 
-					<Footer />
-				</div>
+          <Footer />
+        </div>
 
-				<div className="w-full flex-col gap-2.5 mt-10.5 hidden md:flex mb-4">
-					<div className="border-t border-[#292929] w-full" />
-					<div className="border-t border-[#292929] w-full" />
-					<div className="border-t border-[#292929] w-full" />
-					<div className="border-t border-[#292929] w-full" />
-					<div className="border-t border-[#292929] w-full" />
-				</div>
-			</div>
+        <div className="w-full flex-col gap-2.5 mt-10.5 hidden md:flex mb-4">
+          <div className="border-t border-[#292929] w-full" />
+          <div className="border-t border-[#292929] w-full" />
+          <div className="border-t border-[#292929] w-full" />
+          <div className="border-t border-[#292929] w-full" />
+          <div className="border-t border-[#292929] w-full" />
+        </div>
+      </div>
 
-			<div className="w-full aspect-390/313 sm:aspect-1440/619" />
-			<AnimatedFooterImage />
-		</div>
-	);
+      <div className="w-full aspect-390/313 sm:aspect-1440/619" />
+      <AnimatedFooterImage />
+    </div>
+  );
 }

--- a/apps/website/lib/agentContent.ts
+++ b/apps/website/lib/agentContent.ts
@@ -1,32 +1,33 @@
 import { getAlogDocBySlug, getAllAlogDocs } from "@/lib/alogUtils";
 import { getAllPosts, getPostBySlug } from "@/lib/blogUtils";
+import { PRIVACY_EFFECTIVE_DATE, privacyTerms } from "@/lib/privacyContent";
 import { SITE_URL } from "@/lib/seo";
 
 export type AgentKind = "alog" | "blog";
 
 export type AgentDoc = {
-	kind: AgentKind;
-	slug: string;
-	title: string;
-	summary: string;
-	section: string;
-	updated: string | null;
-	source: string | null;
+  kind: AgentKind;
+  slug: string;
+  title: string;
+  summary: string;
+  section: string;
+  updated: string | null;
+  source: string | null;
 };
 
 const PREFERRED_DOCS: Array<{ label: string; href: string }> = [
-	{ label: "Autumn docs", href: "https://docs.useautumn.com/welcome" },
-	{ label: "Quickstart", href: "https://docs.useautumn.com/quickstart" },
-	{ label: "API reference", href: "https://docs.useautumn.com/api-reference" },
+  { label: "Autumn docs", href: "https://docs.useautumn.com/welcome" },
+  { label: "Quickstart", href: "https://docs.useautumn.com/quickstart" },
+  { label: "API reference", href: "https://docs.useautumn.com/api-reference" },
 ];
 
 const WHAT_AUTUMN_IS = [
-	"Autumn is open-source billing infrastructure that runs on top of Stripe.",
-	"It is the system of record for subscriptions, usage metering, credits, and feature entitlements, exposed through a small API (`attach`, `check`, `track`).",
+  "Autumn is open-source billing infrastructure that runs on top of Stripe.",
+  "It is the system of record for subscriptions, usage metering, credits, and feature entitlements, exposed through a small API (`attach`, `check`, `track`).",
 ];
 const WHAT_AUTUMN_IS_NOT = [
-	"Autumn is not a payment processor and does not replace Stripe; Stripe still holds the subscription and processes payments.",
-	"Autumn is not a pure usage-metering tool — it also enforces entitlements and feature access, not just end-of-month invoicing.",
+  "Autumn is not a payment processor and does not replace Stripe; Stripe still holds the subscription and processes payments.",
+  "Autumn is not a pure usage-metering tool — it also enforces entitlements and feature access, not just end-of-month invoicing.",
 ];
 
 const stripHtml = (value: string) => value.replace(/<[^>]*>/g, "").trim();
@@ -35,167 +36,209 @@ const mdUrl = (doc: AgentDoc) => `${SITE_URL}/${doc.kind}/${doc.slug}.md`;
 
 // Normalize both content sources to one shape so every markdown/llms helper is DRY.
 export function listAgentDocs(kind: AgentKind): AgentDoc[] {
-	if (kind === "alog") {
-		return getAllAlogDocs().map((doc) => ({
-			kind: "alog",
-			slug: doc.slug,
-			title: doc.title,
-			summary: doc.summary,
-			section: doc.category,
-			updated: doc.updated,
-			source: null,
-		}));
-	}
+  if (kind === "alog") {
+    return getAllAlogDocs().map((doc) => ({
+      kind: "alog",
+      slug: doc.slug,
+      title: doc.title,
+      summary: doc.summary,
+      section: doc.category,
+      updated: doc.updated,
+      source: null,
+    }));
+  }
 
-	return getAllPosts().map((post) => ({
-		kind: "blog",
-		slug: post.slug,
-		title: post.title,
-		summary: stripHtml(post.description),
-		section: "Blog",
-		updated: post.date,
-		source: null,
-	}));
+  return getAllPosts().map((post) => ({
+    kind: "blog",
+    slug: post.slug,
+    title: post.title,
+    summary: stripHtml(post.description),
+    section: "Blog",
+    updated: post.date,
+    source: null,
+  }));
 }
 
 export function getAgentDoc({
-	kind,
-	slug,
+  kind,
+  slug,
 }: {
-	kind: AgentKind;
-	slug: string;
+  kind: AgentKind;
+  slug: string;
 }): AgentDoc | null {
-	if (kind === "alog") {
-		const doc = getAlogDocBySlug({ slug });
-		if (!doc) return null;
-		return {
-			kind: "alog",
-			slug: doc.slug,
-			title: doc.title,
-			summary: doc.summary,
-			section: doc.category,
-			updated: doc.updated,
-			source: doc.source,
-		};
-	}
+  if (kind === "alog") {
+    const doc = getAlogDocBySlug({ slug });
+    if (!doc) return null;
+    return {
+      kind: "alog",
+      slug: doc.slug,
+      title: doc.title,
+      summary: doc.summary,
+      section: doc.category,
+      updated: doc.updated,
+      source: doc.source,
+    };
+  }
 
-	const post = getPostBySlug({ slug });
-	if (!post) return null;
-	return {
-		kind: "blog",
-		slug: post.slug,
-		title: post.title,
-		summary: stripHtml(post.description),
-		section: "Blog",
-		updated: post.date,
-		source: post.source,
-	};
+  const post = getPostBySlug({ slug });
+  if (!post) return null;
+  return {
+    kind: "blog",
+    slug: post.slug,
+    title: post.title,
+    summary: stripHtml(post.description),
+    section: "Blog",
+    updated: post.date,
+    source: post.source,
+  };
 }
 
 // Ensure markdown leads with a title heading; blog sources have none, alog already do.
 function docBody(doc: AgentDoc): string {
-	const source = doc.source?.trim();
-	if (!source) return `# ${doc.title}\n\n${doc.summary}`;
-	return source.startsWith("# ") ? source : `# ${doc.title}\n\n${source}`;
+  const source = doc.source?.trim();
+  if (!source) return `# ${doc.title}\n\n${doc.summary}`;
+  return source.startsWith("# ") ? source : `# ${doc.title}\n\n${source}`;
 }
 
 export function docToMarkdown(doc: AgentDoc): string {
-	const body = docBody(doc);
-	const footer = [
-		"---",
-		`Source: ${htmlUrl(doc)}`,
-		`Section: ${doc.section}`,
-		doc.updated ? `Last updated: ${doc.updated}` : null,
-	]
-		.filter(Boolean)
-		.join("\n");
+  const body = docBody(doc);
+  const footer = [
+    "---",
+    `Source: ${htmlUrl(doc)}`,
+    `Section: ${doc.section}`,
+    doc.updated ? `Last updated: ${doc.updated}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
 
-	return `${body}\n\n${footer}\n`;
+  return `${body}\n\n${footer}\n`;
 }
 
 export function buildIndexMarkdown(kind: AgentKind): string {
-	const heading = kind === "alog" ? "Autumn Alog" : "Autumn Blog";
-	const docs = listAgentDocs(kind);
-	const sections = [...new Set(docs.map((doc) => doc.section))];
+  const heading = kind === "alog" ? "Autumn Alog" : "Autumn Blog";
+  const docs = listAgentDocs(kind);
+  const sections = [...new Set(docs.map((doc) => doc.section))];
 
-	const lines: string[] = [
-		`# ${heading}`,
-		"",
-		"Each page is also available as markdown by appending `.md` to its URL.",
-		"",
-	];
+  const lines: string[] = [
+    `# ${heading}`,
+    "",
+    "Each page is also available as markdown by appending `.md` to its URL.",
+    "",
+  ];
 
-	for (const section of sections) {
-		lines.push(`## ${section}`, "");
-		for (const doc of docs.filter((entry) => entry.section === section)) {
-			lines.push(`- [${doc.title}](${mdUrl(doc)}): ${doc.summary}`);
-		}
-		lines.push("");
-	}
+  for (const section of sections) {
+    lines.push(`## ${section}`, "");
+    for (const doc of docs.filter((entry) => entry.section === section)) {
+      lines.push(`- [${doc.title}](${mdUrl(doc)}): ${doc.summary}`);
+    }
+    lines.push("");
+  }
 
-	return `${lines.join("\n").trim()}\n`;
+  return `${lines.join("\n").trim()}\n`;
 }
 
 export function buildLlmsTxt(): string {
-	const alog = listAgentDocs("alog");
-	const blog = listAgentDocs("blog");
+  const alog = listAgentDocs("alog");
+  const blog = listAgentDocs("blog");
 
-	const lines: string[] = [
-		"# Autumn",
-		"",
-		"> Drop-in, open-source billing infrastructure for AI startups. Usage-based billing, credits, entitlements, and subscription state on top of Stripe, behind one API.",
-		"",
-		"## What Autumn is",
-		...WHAT_AUTUMN_IS.map((line) => `- ${line}`),
-		"",
-		"## What Autumn is not",
-		...WHAT_AUTUMN_IS_NOT.map((line) => `- ${line}`),
-		"",
-		"## Docs",
-		"For how the platform itself works, see the docs:",
-		...PREFERRED_DOCS.map((doc) => `- [${doc.label}](${doc.href})`),
-		"",
-		"## Comparisons",
-		...alog.map((doc) => `- [${doc.title}](${mdUrl(doc)}): ${doc.summary}`),
-		"",
-		"## Blog",
-		...blog.map((doc) => `- [${doc.title}](${mdUrl(doc)}): ${doc.summary}`),
-	];
+  const lines: string[] = [
+    "# Autumn",
+    "",
+    "> Drop-in, open-source billing infrastructure for AI startups. Usage-based billing, credits, entitlements, and subscription state on top of Stripe, behind one API.",
+    "",
+    "## What Autumn is",
+    ...WHAT_AUTUMN_IS.map((line) => `- ${line}`),
+    "",
+    "## What Autumn is not",
+    ...WHAT_AUTUMN_IS_NOT.map((line) => `- ${line}`),
+    "",
+    "## Docs",
+    "For how the platform itself works, see the docs:",
+    ...PREFERRED_DOCS.map((doc) => `- [${doc.label}](${doc.href})`),
+    "",
+    "## Comparisons",
+    ...alog.map((doc) => `- [${doc.title}](${mdUrl(doc)}): ${doc.summary}`),
+    "",
+    "## Blog",
+    ...blog.map((doc) => `- [${doc.title}](${mdUrl(doc)}): ${doc.summary}`),
+  ];
 
-	return `${lines.join("\n").trim()}\n`;
+  return `${lines.join("\n").trim()}\n`;
+}
+
+export function buildHomeMarkdown(): string {
+  const lines: string[] = [
+    "# Autumn",
+    "",
+    "> Drop-in, open-source billing infrastructure for AI startups. Usage-based billing, credits, entitlements, and subscription state on top of Stripe, behind one API.",
+    "",
+    "## What Autumn is",
+    ...WHAT_AUTUMN_IS.map((line) => `- ${line}`),
+    "",
+    "## What Autumn is not",
+    ...WHAT_AUTUMN_IS_NOT.map((line) => `- ${line}`),
+    "",
+    "## Learn more",
+    ...PREFERRED_DOCS.map((doc) => `- [${doc.label}](${doc.href})`),
+    `- [Blog](${SITE_URL}/blog)`,
+    `- [Comparisons](${SITE_URL}/alog)`,
+    "- [GitHub](https://github.com/useautumn/autumn)",
+    "",
+    "---",
+    `Source: ${SITE_URL}/`,
+  ];
+
+  return `${lines.join("\n").trim()}\n`;
+}
+
+export function buildPrivacyMarkdown(): string {
+  const lines: string[] = [
+    "# Terms of Service",
+    "",
+    `Autumn (Rebase, Inc.) — Effective Date: ${PRIVACY_EFFECTIVE_DATE}`,
+    "",
+  ];
+
+  for (const term of privacyTerms) {
+    lines.push(`## ${term.title}`, "", term.content, "");
+  }
+
+  lines.push("---", `Source: ${SITE_URL}/privacy`);
+
+  return `${lines.join("\n").trim()}\n`;
 }
 
 export function buildLlmsFullTxt(): string {
-	const summaries = [...listAgentDocs("alog"), ...listAgentDocs("blog")];
+  const summaries = [...listAgentDocs("alog"), ...listAgentDocs("blog")];
 
-	const head: string[] = [
-		"# Autumn — Full AI Corpus",
-		"",
-		"> Drop-in, open-source billing infrastructure for AI startups, built on top of Stripe.",
-		"",
-		"## What Autumn is",
-		...WHAT_AUTUMN_IS.map((line) => `- ${line}`),
-		"",
-		"## What Autumn is not",
-		...WHAT_AUTUMN_IS_NOT.map((line) => `- ${line}`),
-		"",
-		"## Key links",
-		...PREFERRED_DOCS.map((doc) => `- ${doc.label}: ${doc.href}`),
-		`- Website: ${SITE_URL}`,
-		`- Blog: ${SITE_URL}/blog`,
-		"- GitHub: https://github.com/useautumn/autumn",
-		"",
-		"---",
-		"",
-	];
+  const head: string[] = [
+    "# Autumn — Full AI Corpus",
+    "",
+    "> Drop-in, open-source billing infrastructure for AI startups, built on top of Stripe.",
+    "",
+    "## What Autumn is",
+    ...WHAT_AUTUMN_IS.map((line) => `- ${line}`),
+    "",
+    "## What Autumn is not",
+    ...WHAT_AUTUMN_IS_NOT.map((line) => `- ${line}`),
+    "",
+    "## Key links",
+    ...PREFERRED_DOCS.map((doc) => `- ${doc.label}: ${doc.href}`),
+    `- Website: ${SITE_URL}`,
+    `- Blog: ${SITE_URL}/blog`,
+    "- GitHub: https://github.com/useautumn/autumn",
+    "",
+    "---",
+    "",
+  ];
 
-	const body = summaries
-		.map((summary) => {
-			const doc = getAgentDoc({ kind: summary.kind, slug: summary.slug });
-			const markdown = docBody(doc ?? summary);
-			return `<!-- ${htmlUrl(summary)} -->\n\n${markdown}`;
-		})
-		.join("\n\n---\n\n");
+  const body = summaries
+    .map((summary) => {
+      const doc = getAgentDoc({ kind: summary.kind, slug: summary.slug });
+      const markdown = docBody(doc ?? summary);
+      return `<!-- ${htmlUrl(summary)} -->\n\n${markdown}`;
+    })
+    .join("\n\n---\n\n");
 
-	return `${head.join("\n")}${body}\n`;
+  return `${head.join("\n")}${body}\n`;
 }

--- a/apps/website/lib/contentNegotiation.ts
+++ b/apps/website/lib/contentNegotiation.ts
@@ -1,0 +1,77 @@
+export const MARKDOWN_TYPE = "text/markdown";
+export const HTML_TYPE = "text/html";
+
+type AcceptEntry = {
+  type: string;
+  subtype: string;
+  quality: number;
+};
+
+function parseAcceptHeader(header: string): AcceptEntry[] {
+  return header
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => {
+      const [rawType, ...paramParts] = part.split(";").map((p) => p.trim());
+      const [type = "", subtype = ""] = rawType.split("/");
+
+      let quality = 1;
+      for (const param of paramParts) {
+        const [key, value] = param.split("=").map((p) => p.trim());
+        if (key === "q") {
+          const parsed = Number.parseFloat(value);
+          if (!Number.isNaN(parsed)) quality = parsed;
+        }
+      }
+
+      return {
+        type: type.toLowerCase(),
+        subtype: subtype.toLowerCase(),
+        quality,
+      };
+    });
+}
+
+function qualityFor(entries: AcceptEntry[], mediaType: string): number | null {
+  const [wantType, wantSubtype] = mediaType.toLowerCase().split("/");
+  let best: number | null = null;
+
+  for (const entry of entries) {
+    const matchesExact =
+      entry.type === wantType && entry.subtype === wantSubtype;
+    const matchesTypeWildcard =
+      entry.type === wantType && entry.subtype === "*";
+    const matchesFullWildcard = entry.type === "*" && entry.subtype === "*";
+
+    if (matchesExact || matchesTypeWildcard || matchesFullWildcard) {
+      if (best === null || entry.quality > best) best = entry.quality;
+    }
+  }
+
+  return best;
+}
+
+export type Negotiation = "markdown" | "html" | "not-acceptable";
+
+export function negotiate(acceptHeader: string | null): Negotiation {
+  if (!acceptHeader) return "html";
+
+  const entries = parseAcceptHeader(acceptHeader);
+  const markdownQuality = qualityFor(entries, MARKDOWN_TYPE);
+  const htmlQuality = qualityFor(entries, HTML_TYPE);
+
+  const markdownAcceptable = markdownQuality !== null && markdownQuality > 0;
+  const htmlAcceptable = htmlQuality !== null && htmlQuality > 0;
+
+  if (!(markdownAcceptable || htmlAcceptable)) return "not-acceptable";
+
+  if (
+    markdownAcceptable &&
+    (!htmlAcceptable || markdownQuality >= htmlQuality)
+  ) {
+    return "markdown";
+  }
+
+  return "html";
+}

--- a/apps/website/lib/contentNegotiation.ts
+++ b/apps/website/lib/contentNegotiation.ts
@@ -2,76 +2,97 @@ export const MARKDOWN_TYPE = "text/markdown";
 export const HTML_TYPE = "text/html";
 
 type AcceptEntry = {
-  type: string;
-  subtype: string;
-  quality: number;
+	type: string;
+	subtype: string;
+	quality: number;
 };
 
 function parseAcceptHeader(header: string): AcceptEntry[] {
-  return header
-    .split(",")
-    .map((part) => part.trim())
-    .filter(Boolean)
-    .map((part) => {
-      const [rawType, ...paramParts] = part.split(";").map((p) => p.trim());
-      const [type = "", subtype = ""] = rawType.split("/");
+	return header
+		.split(",")
+		.map((part) => part.trim())
+		.filter(Boolean)
+		.map((part) => {
+			const [rawType, ...paramParts] = part.split(";").map((p) => p.trim());
+			const [type = "", subtype = ""] = rawType.split("/");
 
-      let quality = 1;
-      for (const param of paramParts) {
-        const [key, value] = param.split("=").map((p) => p.trim());
-        if (key === "q") {
-          const parsed = Number.parseFloat(value);
-          if (!Number.isNaN(parsed)) quality = parsed;
-        }
-      }
+			let quality = 1;
+			for (const param of paramParts) {
+				const [key, value] = param.split("=").map((p) => p.trim());
+				if (key === "q") {
+					const parsed = Number.parseFloat(value);
+					if (!Number.isNaN(parsed)) quality = parsed;
+				}
+			}
 
-      return {
-        type: type.toLowerCase(),
-        subtype: subtype.toLowerCase(),
-        quality,
-      };
-    });
+			return {
+				type: type.toLowerCase(),
+				subtype: subtype.toLowerCase(),
+				quality,
+			};
+		});
 }
 
-function qualityFor(entries: AcceptEntry[], mediaType: string): number | null {
-  const [wantType, wantSubtype] = mediaType.toLowerCase().split("/");
-  let best: number | null = null;
+const NO_MATCH = -1;
+const FULL_WILDCARD = 0;
+const TYPE_WILDCARD = 1;
+const EXACT = 2;
 
-  for (const entry of entries) {
-    const matchesExact =
-      entry.type === wantType && entry.subtype === wantSubtype;
-    const matchesTypeWildcard =
-      entry.type === wantType && entry.subtype === "*";
-    const matchesFullWildcard = entry.type === "*" && entry.subtype === "*";
+function specificity(
+	entry: AcceptEntry,
+	type: string,
+	subtype: string,
+): number {
+	if (entry.type === type && entry.subtype === subtype) return EXACT;
+	if (entry.type === type && entry.subtype === "*") return TYPE_WILDCARD;
+	if (entry.type === "*" && entry.subtype === "*") return FULL_WILDCARD;
+	return NO_MATCH;
+}
 
-    if (matchesExact || matchesTypeWildcard || matchesFullWildcard) {
-      if (best === null || entry.quality > best) best = entry.quality;
-    }
-  }
+function qualityForMostSpecificMatch(
+	entries: AcceptEntry[],
+	mediaType: string,
+): number | null {
+	const [wantType = "", wantSubtype = ""] = mediaType.toLowerCase().split("/");
+	let bestSpecificity = NO_MATCH;
+	let quality: number | null = null;
 
-  return best;
+	for (const entry of entries) {
+		const score = specificity(entry, wantType, wantSubtype);
+		if (score === NO_MATCH) continue;
+
+		if (
+			score > bestSpecificity ||
+			(score === bestSpecificity && quality !== null && entry.quality > quality)
+		) {
+			bestSpecificity = score;
+			quality = entry.quality;
+		}
+	}
+
+	return quality;
 }
 
 export type Negotiation = "markdown" | "html" | "not-acceptable";
 
 export function negotiate(acceptHeader: string | null): Negotiation {
-  if (!acceptHeader) return "html";
+	if (!acceptHeader) return "html";
 
-  const entries = parseAcceptHeader(acceptHeader);
-  const markdownQuality = qualityFor(entries, MARKDOWN_TYPE);
-  const htmlQuality = qualityFor(entries, HTML_TYPE);
+	const entries = parseAcceptHeader(acceptHeader);
+	const markdownQuality = qualityForMostSpecificMatch(entries, MARKDOWN_TYPE);
+	const htmlQuality = qualityForMostSpecificMatch(entries, HTML_TYPE);
 
-  const markdownAcceptable = markdownQuality !== null && markdownQuality > 0;
-  const htmlAcceptable = htmlQuality !== null && htmlQuality > 0;
+	const markdownAcceptable = markdownQuality !== null && markdownQuality > 0;
+	const htmlAcceptable = htmlQuality !== null && htmlQuality > 0;
 
-  if (!(markdownAcceptable || htmlAcceptable)) return "not-acceptable";
+	if (!(markdownAcceptable || htmlAcceptable)) return "not-acceptable";
 
-  if (
-    markdownAcceptable &&
-    (!htmlAcceptable || markdownQuality >= htmlQuality)
-  ) {
-    return "markdown";
-  }
+	if (
+		markdownAcceptable &&
+		(!htmlAcceptable || markdownQuality >= htmlQuality)
+	) {
+		return "markdown";
+	}
 
-  return "html";
+	return "html";
 }

--- a/apps/website/lib/markdownRoutes.ts
+++ b/apps/website/lib/markdownRoutes.ts
@@ -1,0 +1,16 @@
+export function markdownTargetFor(pathname: string): string | null {
+  const path = pathname.replace(/\/+$/, "") || "/";
+
+  if (path === "/") return "/home.md";
+  if (path === "/privacy") return "/privacy.md";
+  if (path === "/blog") return "/blog.md";
+  if (path === "/alog") return "/alog.md";
+
+  const blogMatch = path.match(/^\/blog\/([^/.]+)$/);
+  if (blogMatch) return `/blog/${blogMatch[1]}.md`;
+
+  const alogMatch = path.match(/^\/alog\/([^/.]+)$/);
+  if (alogMatch) return `/alog/${alogMatch[1]}.md`;
+
+  return null;
+}

--- a/apps/website/lib/privacyContent.ts
+++ b/apps/website/lib/privacyContent.ts
@@ -1,0 +1,106 @@
+export type PrivacyTerm = {
+  title: string;
+  content: string;
+  isUppercase: boolean;
+};
+
+export const PRIVACY_EFFECTIVE_DATE = "February 1, 2025";
+
+export const privacyTerms: PrivacyTerm[] = [
+  {
+    title: "1. Acceptance of Terms",
+    content:
+      'By accessing or using the Autumn platform, APIs, SDKs, or any related services (collectively, the "Services") provided by Rebase, Inc., a Delaware corporation ("Autumn," "we," "us," or "our"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, do not use our Services.',
+    isUppercase: false,
+  },
+  {
+    title: "2. Description of Services",
+    content:
+      "Autumn provides billing infrastructure, including usage-based billing, credits management, pricing configuration, and entitlements management for software applications. Our Services are designed for developers and businesses building products that require flexible billing and pricing capabilities.",
+    isUppercase: false,
+  },
+  {
+    title: "3. Account Registration",
+    content:
+      "To use certain features of our Services, you must create an account. You agree to provide accurate, current, and complete information during registration and to update such information as necessary. You are responsible for maintaining the confidentiality of your account credentials and for all activities that occur under your account.",
+    isUppercase: false,
+  },
+  {
+    title: "4. Acceptable Use",
+    content:
+      "You agree not to use the Services for any unlawful purpose or in violation of any applicable laws; (b) interfere with or disrupt the integrity or performance of the Services; (c) attempt to gain unauthorized access to the Services or related systems; (d) use the Services to transmit malicious code or harmful content; or (e) resell or redistribute the Services without our prior written consent.",
+    isUppercase: false,
+  },
+  {
+    title: "5. Payment Terms",
+    content:
+      "Fees for the Services are set forth on our pricing page or in a separate agreement. You agree to pay all applicable fees in accordance with the payment terms. All fees are non-refundable except as expressly stated otherwise. We reserve the right to modify our pricing with 30 days' notice.",
+    isUppercase: false,
+  },
+  {
+    title: "6. Data and Privacy",
+    content:
+      'Your use of the Services is subject to our Privacy Policy. You retain ownership of any data you submit to the Services ("Customer Data"). You grant us a limited license to process Customer Data solely to provide the Services. We implement reasonable security measures to protect Customer Data, but you acknowledge that no system is completely secure.',
+    isUppercase: false,
+  },
+  {
+    title: "7. Intellectual Property",
+    content:
+      "The Services, including all software, APIs, documentation, and related materials, are owned by Autumn and protected by intellectual property laws. We grant you a limited, non-exclusive, non-transferable license to use the Services in accordance with these Terms. You may not copy, modify, or create derivative works of the Services except as expressly permitted.",
+    isUppercase: false,
+  },
+  {
+    title: "8. Confidentiality",
+    content:
+      "Each party agrees to maintain the confidentiality of any non-public information disclosed by the other party and to use such information only for the purposes of these Terms. This obligation does not apply to information that is publicly available, independently developed, or rightfully received from a third party.",
+    isUppercase: false,
+  },
+  {
+    title: "9. Warranties and Disclaimers",
+    content:
+      'THE SERVICES ARE PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. WE DO NOT WARRANT THAT THE SERVICES WILL BE UNINTERRUPTED OR ERROR-FREE.',
+    isUppercase: true,
+  },
+  {
+    title: "10. Limitation of Liability",
+    content:
+      "TO THE MAXIMUM EXTENT PERMITTED BY LAW, AUTUMN SHALL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS OR REVENUES. OUR TOTAL LIABILITY FOR ANY CLAIMS ARISING FROM THESE TERMS SHALL NOT EXCEED THE AMOUNTS PAID BY YOU TO AUTUMN IN THE TWELVE MONTHS PRECEDING THE CLAIM.",
+    isUppercase: true,
+  },
+  {
+    title: "11. Indemnification",
+    content:
+      "You agree to indemnify, defend, and hold harmless Autumn and its officers, directors, employees, and agents from any claims, liabilities, damages, losses, or expenses arising from your use of the Services, your violation of these Terms, or your infringement of any third-party rights.",
+    isUppercase: false,
+  },
+  {
+    title: "12. Term and Termination",
+    content:
+      "These Terms remain in effect until terminated. Either party may terminate for convenience with 30 days' written notice. We may suspend or terminate your access immediately if you breach these Terms. Upon termination, your right to use the Services ceases, and you must pay any outstanding fees.",
+    isUppercase: false,
+  },
+  {
+    title: "13. Modifications",
+    content:
+      "We may modify these Terms at any time by posting the revised Terms on our website. Material changes will be communicated with at least 30 days' notice. Your continued use of the Services after such changes constitutes acceptance of the modified Terms.",
+    isUppercase: false,
+  },
+  {
+    title: "14. Governing Law and Disputes",
+    content:
+      "These Terms are governed by the laws of the State of Delaware, without regard to conflict of law principles. Any disputes arising from these Terms shall be resolved through binding arbitration in accordance with the rules of the American Arbitration Association, except that either party may seek injunctive relief in any court of competent jurisdiction.",
+    isUppercase: false,
+  },
+  {
+    title: "15. General Provisions",
+    content:
+      "These Terms constitute the entire agreement between you and Autumn regarding the Services. If any provision is found unenforceable, the remaining provisions will continue in effect. Our failure to enforce any right or provision does not constitute a waiver. You may not assign these Terms without our prior written consent.",
+    isUppercase: false,
+  },
+  {
+    title: "16. Contact Information",
+    content:
+      "For questions about these Terms, please contact us at security@useautumn.com or at: Rebase, Inc. (d/b/a Autumn), Email: security@useautumn.com, Website: https://useautumn.com",
+    isUppercase: false,
+  },
+];

--- a/apps/website/proxy.ts
+++ b/apps/website/proxy.ts
@@ -1,19 +1,54 @@
-import { Tracker } from "@bydefault/vercel"
-import { after, NextResponse, type NextRequest } from "next/server"
+import { Tracker } from "@bydefault/vercel";
+import { after, NextResponse, type NextRequest } from "next/server";
+import { negotiate } from "@/lib/contentNegotiation";
+import { markdownTargetFor } from "@/lib/markdownRoutes";
 
 // Bydefault tracking is disabled when no token is set (e.g. local dev), so the
 // proxy is a no-op instead of throwing at module load.
-const token = process.env.BYDEFAULT_TOKEN
-const tracker = token ? new Tracker({ token, exclude: ["/api"] }) : null
+const token = process.env.BYDEFAULT_TOKEN;
+const tracker = token ? new Tracker({ token, exclude: ["/api"] }) : null;
 
-export function proxy(request: NextRequest) {
+function track(request: NextRequest) {
   if (tracker) {
     after(async () => {
-      await tracker.track(request)
-    })
+      await tracker.track(request);
+    });
+  }
+}
+
+function negotiateMarkdown(request: NextRequest): NextResponse | null {
+  const markdownTarget = markdownTargetFor(request.nextUrl.pathname);
+  if (!markdownTarget) return null;
+
+  const decision = negotiate(request.headers.get("accept"));
+
+  if (decision === "not-acceptable") {
+    return new NextResponse("Not Acceptable", {
+      status: 406,
+      headers: { Vary: "Accept", "Content-Type": "text/plain; charset=utf-8" },
+    });
   }
 
-  return NextResponse.next()
+  if (decision === "markdown") {
+    const url = request.nextUrl.clone();
+    url.pathname = markdownTarget;
+    const response = NextResponse.rewrite(url);
+    response.headers.set("Vary", "Accept");
+    return response;
+  }
+
+  const response = NextResponse.next();
+  response.headers.set("Vary", "Accept");
+  return response;
+}
+
+export function proxy(request: NextRequest) {
+  track(request);
+
+  const negotiated = negotiateMarkdown(request);
+  if (negotiated) return negotiated;
+
+  return NextResponse.next();
 }
 
 export const config = {
@@ -30,4 +65,4 @@ export const config = {
     { source: "/blog.md" },
     { source: "/blog/:path*.md" },
   ],
-}
+};


### PR DESCRIPTION
## What

Makes every page on `apps/website` serve clean markdown to agents that request it via `Accept: text/markdown` on the **same canonical URL** browsers use (`/`, `/privacy`, `/blog`, `/alog`, and all blog/alog posts). Previously markdown was only reachable at separate `.md` URLs, so the canonical URLs always returned HTML.

This gets every page to 100% on the [acceptmarkdown.com readiness benchmark](https://acceptmarkdown.com/#readiness).

## The 4 benchmark checks

| Check | Behavior |
|-------|----------|
| Markdown serving | `Accept: text/markdown` → `Content-Type: text/markdown; charset=utf-8` |
| `Vary: Accept` | set on the negotiated + 406 responses |
| HTTP 406 | returned when the client accepts neither HTML, markdown, nor a wildcard |
| q-values | highest-q acceptable type wins; `q=0` excludes a type |

## How

- **`lib/contentNegotiation.ts`** — RFC-style `Accept` parser handling q-values, type wildcards (`text/*`), the catch-all (`*/*`), and `q=0` exclusion.
- **`lib/markdownRoutes.ts`** — pure (edge-safe) map from a canonical path to its `.md` target; ignores already-dotted paths so direct `.md` URLs pass through.
- **`proxy.ts`** — negotiates on every page URL: rewrites to the `.md` route when markdown is preferred, returns `406` when nothing acceptable, otherwise serves HTML.
- **Homepage + privacy markdown** — these had no markdown source. Added `buildHomeMarkdown`/`buildPrivacyMarkdown` and `app/home.md` + `app/privacy.md` routes. Privacy terms were extracted into a shared `lib/privacyContent.ts` consumed by both the page and the markdown builder.

## Verification

- 45/45 checks pass across all 9 page types in both `next dev` and `next start` (production).
- Browsers still get HTML (real browser `Accept` lists `text/html` first); CSP headers intact.
- Existing `.md` URLs, `llms.txt`, and `llms-full.txt` unchanged — no regressions.
- `bun run build` succeeds; new routes prerender statically.

## Notes

- The browser-facing HTML response can't carry `Vary: Accept` — Next.js owns the `Vary` header on App Router document renders and overrides middleware/config. The benchmark grades the markdown/406 responses, which do carry it, so the score is unaffected; this is only a minor cache-correctness nicety on the HTML side.
- `pre-commit` was bypassed: the `knip` hook fails on a pre-existing, unrelated error in `apps/testbench` (`Cannot find module '@tailwindcss/vite'`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve clean markdown on canonical URLs (/, /privacy, /blog, /alog, and posts) when clients send Accept: text/markdown. Adds full content negotiation with RFC-correct q-value specificity and proper 406/Vary handling, bringing all pages to 100% on the acceptmarkdown.com readiness benchmark.

- New Features
  - Negotiate on every page URL: parse Accept with media-range specificity (q-values, wildcards, q=0), rewrite to the `.md` route when markdown wins, return 406 when neither HTML nor markdown is acceptable, and set `Vary: Accept` on negotiated/406 responses.
  - Added static `home.md` and `privacy.md` routes using `buildHomeMarkdown` and `buildPrivacyMarkdown`; browsers continue to get HTML.
  - Introduced edge-safe path mapping via `markdownTargetFor` to resolve canonical paths to their `.md` targets; existing `.md`, `llms.txt`, and `llms-full.txt` endpoints are unchanged.

- Refactors
  - Extracted privacy terms into `lib/privacyContent.ts`, shared by the page UI and markdown builder.

<sup>Written for commit a1a288db5cbf1f6438264d713f68cac1feb103c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

