### PR TITLE
chore: correct event table filtering

### DIFF
--- a/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
@@ -35,13 +35,19 @@ export const useAnalyticsData = ({
 	const customRange =
 		interval === "custom" && start && end ? { start, end } : undefined;
 
-	const { selectedEventNames, featuresData, featuresLoading, eventNamesLoading } =
-		useSelectedEventNames();
+	const {
+		selectedEventNames,
+		featuresData,
+		featuresLoading,
+		eventNamesLoading,
+	} = useSelectedEventNames();
 
 	const timezone = useMemo(() => getUserTimezone(), []);
 
 	const formattedGroupBy = groupBy
-		? groupBy === "customer_id" || groupBy === "entity_id" || groupBy === "plan_id"
+		? groupBy === "customer_id" ||
+			groupBy === "entity_id" ||
+			groupBy === "plan_id"
 			? groupBy
 			: `properties.${groupBy}`
 		: undefined;
@@ -120,17 +126,24 @@ export const useRawAnalyticsData = () => {
 	const customRange =
 		interval === "custom" && start && end ? { start, end } : undefined;
 
-	const { selectedEventNames, featuresData, featuresLoading, eventNamesLoading } =
-		useSelectedEventNames();
+	const {
+		selectedEventNames,
+		hasExplicitSelection,
+		featuresData,
+		featuresLoading,
+		eventNamesLoading,
+	} = useSelectedEventNames();
 
 	const isReady = !eventNamesLoading && !featuresLoading;
+
+	const tableEventNames = hasExplicitSelection ? selectedEventNames : undefined;
 
 	const postBody = {
 		customer_id: customerId || undefined,
 		entity_id: entityId || undefined,
 		interval: customRange ? undefined : interval,
 		custom_range: customRange,
-		event_names: selectedEventNames,
+		event_names: tableEventNames,
 	};
 
 	const { data, isLoading, error } = useQuery({
@@ -142,7 +155,7 @@ export const useRawAnalyticsData = () => {
 			interval,
 			String(start ?? ""),
 			String(end ?? ""),
-			...selectedEventNames.sort(),
+			...(tableEventNames ?? []).sort(),
 		]),
 		queryFn: async () => {
 			const { data } = await axiosInstance.post("/query/raw", postBody);

--- a/vite/src/views/customers/customer/analytics/hooks/useSelectedEventNames.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useSelectedEventNames.tsx
@@ -26,13 +26,15 @@ export const useSelectedEventNames = () => {
 		.slice(0, 3)
 		.map((e: EventNameWithCount) => e.event_name);
 
-	const selectedEventNames =
-		eventNames || featureIds
-			? [...(eventNames || []), ...(featureIds || [])]
-			: defaultEventNames;
+	const hasExplicitSelection = Boolean(eventNames || featureIds);
+
+	const selectedEventNames = hasExplicitSelection
+		? [...(eventNames || []), ...(featureIds || [])]
+		: defaultEventNames;
 
 	return {
 		selectedEventNames,
+		hasExplicitSelection,
 		featuresData,
 		featuresLoading,
 		eventNamesLoading,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes event table filtering so it only applies when users explicitly select events or features. When nothing is selected, the table fetches unfiltered results instead of defaulting to the top events.

- **Bug Fixes**
  - Added `hasExplicitSelection` to `useSelectedEventNames` to detect real user-selected filters.
  - In `useRawAnalyticsData`, only send `event_names` (and include them in the query key) when `hasExplicitSelection` is true, preventing unintended default filtering.

<sup>Written for commit c899aeccf9df1ac8358e8a60b26237767d32084f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The events table (`/query/raw`) was incorrectly inheriting the chart's default top-3 event filter even when the user had not selected anything. This PR fixes that by introducing a `hasExplicitSelection` flag in `useSelectedEventNames` and using it in `useRawAnalyticsData` to pass `event_names: undefined` (show all events) when no explicit filter is set.

- **Bug fixes** — `useRawAnalyticsData` no longer sends a default top-3 `event_names` filter to the raw-events endpoint; it now sends `undefined`, letting the server return all events when the user hasn't made an explicit selection.
- **Improvements** — `useSelectedEventNames` exposes `hasExplicitSelection` so callers can cleanly distinguish between a user-driven filter and the computed default, without duplicating that logic.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to the raw-events table query and does not touch the chart path or any shared state.

Both changed files are React hooks confined to the analytics view. The fix is a one-liner conditional and the refactored hasExplicitSelection flag is a straightforward extraction of the existing ternary logic. The chart hook is intentionally left unchanged, and the raw-events query key is updated in lockstep with the new tableEventNames value, so no stale cache issues are introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers/customer/analytics/hooks/useSelectedEventNames.tsx | Adds hasExplicitSelection flag to distinguish user-chosen filters from default top-3 fallback; returned alongside existing fields. |
| vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx | useRawAnalyticsData now passes event_names=undefined when no explicit selection exists, fixing the table from being silently filtered to the chart's default top-3 events; chart hook is unchanged. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as Analytics UI
    participant uSEN as useSelectedEventNames
    participant uAD as useAnalyticsData (chart)
    participant uRAD as useRawAnalyticsData (table)
    participant API_E as /query/events
    participant API_R as /query/raw

    UI->>uSEN: read URL params (event_names, feature_ids)
    uSEN-->>uAD: selectedEventNames, hasExplicitSelection
    uSEN-->>uRAD: selectedEventNames, hasExplicitSelection

    note over uAD: Always uses selectedEventNames (defaults to top-3 events)
    uAD->>API_E: "POST { event_names: selectedEventNames }"

    note over uRAD: NEW: only filters when user made an explicit selection
    alt "hasExplicitSelection = true"
        uRAD->>API_R: "POST { event_names: selectedEventNames }"
    else "hasExplicitSelection = false"
        uRAD->>API_R: "POST { event_names: undefined } → all events"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as Analytics UI
    participant uSEN as useSelectedEventNames
    participant uAD as useAnalyticsData (chart)
    participant uRAD as useRawAnalyticsData (table)
    participant API_E as /query/events
    participant API_R as /query/raw

    UI->>uSEN: read URL params (event_names, feature_ids)
    uSEN-->>uAD: selectedEventNames, hasExplicitSelection
    uSEN-->>uRAD: selectedEventNames, hasExplicitSelection

    note over uAD: Always uses selectedEventNames (defaults to top-3 events)
    uAD->>API_E: "POST { event_names: selectedEventNames }"

    note over uRAD: NEW: only filters when user made an explicit selection
    alt "hasExplicitSelection = true"
        uRAD->>API_R: "POST { event_names: selectedEventNames }"
    else "hasExplicitSelection = false"
        uRAD->>API_R: "POST { event_names: undefined } → all events"
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: correct event table filtering"](https://github.com/useautumn/autumn/commit/c899aeccf9df1ac8358e8a60b26237767d32084f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39113769)</sub>

<!-- /greptile_comment -->