### PR TITLE
release

### DIFF
--- a/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
@@ -35,13 +35,19 @@ export const useAnalyticsData = ({
 	const customRange =
 		interval === "custom" && start && end ? { start, end } : undefined;
 
-	const { selectedEventNames, featuresData, featuresLoading, eventNamesLoading } =
-		useSelectedEventNames();
+	const {
+		selectedEventNames,
+		featuresData,
+		featuresLoading,
+		eventNamesLoading,
+	} = useSelectedEventNames();
 
 	const timezone = useMemo(() => getUserTimezone(), []);
 
 	const formattedGroupBy = groupBy
-		? groupBy === "customer_id" || groupBy === "entity_id" || groupBy === "plan_id"
+		? groupBy === "customer_id" ||
+			groupBy === "entity_id" ||
+			groupBy === "plan_id"
 			? groupBy
 			: `properties.${groupBy}`
 		: undefined;
@@ -120,17 +126,24 @@ export const useRawAnalyticsData = () => {
 	const customRange =
 		interval === "custom" && start && end ? { start, end } : undefined;
 
-	const { selectedEventNames, featuresData, featuresLoading, eventNamesLoading } =
-		useSelectedEventNames();
+	const {
+		selectedEventNames,
+		hasExplicitSelection,
+		featuresData,
+		featuresLoading,
+		eventNamesLoading,
+	} = useSelectedEventNames();
 
 	const isReady = !eventNamesLoading && !featuresLoading;
+
+	const tableEventNames = hasExplicitSelection ? selectedEventNames : undefined;
 
 	const postBody = {
 		customer_id: customerId || undefined,
 		entity_id: entityId || undefined,
 		interval: customRange ? undefined : interval,
 		custom_range: customRange,
-		event_names: selectedEventNames,
+		event_names: tableEventNames,
 	};
 
 	const { data, isLoading, error } = useQuery({
@@ -142,7 +155,7 @@ export const useRawAnalyticsData = () => {
 			interval,
 			String(start ?? ""),
 			String(end ?? ""),
-			...selectedEventNames.sort(),
+			...(tableEventNames ?? []).sort(),
 		]),
 		queryFn: async () => {
 			const { data } = await axiosInstance.post("/query/raw", postBody);

--- a/vite/src/views/customers/customer/analytics/hooks/useSelectedEventNames.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useSelectedEventNames.tsx
@@ -26,13 +26,15 @@ export const useSelectedEventNames = () => {
 		.slice(0, 3)
 		.map((e: EventNameWithCount) => e.event_name);
 
-	const selectedEventNames =
-		eventNames || featureIds
-			? [...(eventNames || []), ...(featureIds || [])]
-			: defaultEventNames;
+	const hasExplicitSelection = Boolean(eventNames || featureIds);
+
+	const selectedEventNames = hasExplicitSelection
+		? [...(eventNames || []), ...(featureIds || [])]
+		: defaultEventNames;
 
 	return {
 		selectedEventNames,
+		hasExplicitSelection,
 		featuresData,
 		featuresLoading,
 		eventNamesLoading,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes event table filtering by applying event filters only when the user explicitly selects events. Prevents unintended narrowing of results in the raw analytics table.

- **Bug Fixes**
  - Added `hasExplicitSelection` to `useSelectedEventNames` to detect user-selected events.
  - In `useRawAnalyticsData`, send `event_names` only when `hasExplicitSelection` is true and update the query key to match.

<sup>Written for commit d3acec1de870be76cad6be3a8ec8282f4bb25d31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where the raw analytics events table was always pre-filtered to the top-3 default events even when the user hadn't selected any filter. It also refactors `useSelectedEventNames` to expose an explicit `hasExplicitSelection` flag, and reformats a few long lines for readability.

- **Bug fixes** — `useRawAnalyticsData` now passes `event_names: undefined` (no filter) to `POST /query/raw` when no explicit event names or feature IDs are selected, so the raw events table shows all events by default instead of being silently restricted to the top 3.
- **Improvements** — `useSelectedEventNames` extracts `hasExplicitSelection = Boolean(eventNames || featureIds)`, making the selection-source intent explicit and reusable.
- **Improvements** — Reformats multiline destructuring and ternary chains in `useAnalyticsData` for readability.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is small, well-scoped, and only affects the raw events query path.

The raw events table previously sent the top-3 default event names as a filter on every request, even with no user selection. The fix correctly passes `undefined` instead, letting the backend return the full unfiltered set. The chart hook (`useAnalyticsData`) is untouched in behavior. The `hasExplicitSelection` extraction is an exact logical equivalent of the previous inline ternary condition, so no regressions are introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers/customer/analytics/hooks/useSelectedEventNames.tsx | Extracts `hasExplicitSelection` boolean and exposes it from the hook; logic is equivalent to the previous ternary and no regressions introduced. |
| vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx | Reformats destructuring/ternary for readability in `useAnalyticsData`; in `useRawAnalyticsData` switches from always filtering by selectedEventNames to omitting the filter (`undefined`) when there is no explicit user selection, fixing the raw-events table defaulting to just the top 3 events. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[URL query params\nevent_names / feature_ids] --> B{hasExplicitSelection?}
    B -- "null / null" --> C[false]
    B -- "array present" --> D[true]

    C --> E[selectedEventNames =\ntop 3 by count]
    D --> F[selectedEventNames =\nevent_names ++ feature_ids]

    E --> G[useAnalyticsData\nchart]
    F --> G

    E --> H{useRawAnalyticsData\ntableEventNames}
    F --> H

    H -- "hasExplicit = false" --> I[tableEventNames = undefined\n→ event_names omitted\n→ ALL events returned]
    H -- "hasExplicit = true" --> J[tableEventNames = selectedEventNames\n→ filtered events returned]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[URL query params\nevent_names / feature_ids] --> B{hasExplicitSelection?}
    B -- "null / null" --> C[false]
    B -- "array present" --> D[true]

    C --> E[selectedEventNames =\ntop 3 by count]
    D --> F[selectedEventNames =\nevent_names ++ feature_ids]

    E --> G[useAnalyticsData\nchart]
    F --> G

    E --> H{useRawAnalyticsData\ntableEventNames}
    F --> H

    H -- "hasExplicit = false" --> I[tableEventNames = undefined\n→ event_names omitted\n→ ALL events returned]
    H -- "hasExplicit = true" --> J[tableEventNames = selectedEventNames\n→ filtered events returned]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #2005 from useautumn/..."](https://github.com/useautumn/autumn/commit/d3acec1de870be76cad6be3a8ec8282f4bb25d31) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39114427)</sub>

<!-- /greptile_comment -->