### PR TITLE
fix(website): keep Vary: Accept on negotiated markdown responses

### DIFF
--- a/apps/website/proxy.ts
+++ b/apps/website/proxy.ts
@@ -9,60 +9,85 @@ const token = process.env.BYDEFAULT_TOKEN;
 const tracker = token ? new Tracker({ token, exclude: ["/api"] }) : null;
 
 function track(request: NextRequest) {
-  if (tracker) {
-    after(async () => {
-      await tracker.track(request);
-    });
-  }
+	if (tracker) {
+		after(async () => {
+			await tracker.track(request);
+		});
+	}
 }
 
-function negotiateMarkdown(request: NextRequest): NextResponse | null {
-  const markdownTarget = markdownTargetFor(request.nextUrl.pathname);
-  if (!markdownTarget) return null;
+async function negotiateMarkdown(
+	request: NextRequest,
+): Promise<NextResponse | null> {
+	const markdownTarget = markdownTargetFor(request.nextUrl.pathname);
+	if (!markdownTarget) return null;
 
-  const decision = negotiate(request.headers.get("accept"));
+	const decision = negotiate(request.headers.get("accept"));
 
-  if (decision === "not-acceptable") {
-    return new NextResponse("Not Acceptable", {
-      status: 406,
-      headers: { Vary: "Accept", "Content-Type": "text/plain; charset=utf-8" },
-    });
-  }
+	if (decision === "not-acceptable") {
+		return new NextResponse("Not Acceptable", {
+			status: 406,
+			headers: { Vary: "Accept", "Content-Type": "text/plain; charset=utf-8" },
+		});
+	}
 
-  if (decision === "markdown") {
-    const url = request.nextUrl.clone();
-    url.pathname = markdownTarget;
-    const response = NextResponse.rewrite(url);
-    response.headers.set("Vary", "Accept");
-    return response;
-  }
+	if (decision === "html") {
+		return null;
+	}
 
-  const response = NextResponse.next();
-  response.headers.set("Vary", "Accept");
-  return response;
+	return serveMarkdown(request, markdownTarget);
 }
 
-export function proxy(request: NextRequest) {
-  track(request);
+// Return the markdown body in this response rather than rewriting to the .md
+// route: a rewrite lets the framework overwrite Vary with its own rsc value and
+// drop Accept, whereas a response we own keeps a clean Vary: Accept.
+async function serveMarkdown(
+	request: NextRequest,
+	markdownTarget: string,
+): Promise<NextResponse | null> {
+	const source = request.nextUrl.clone();
+	source.pathname = markdownTarget;
+	const upstream = await fetch(source, {
+		headers: { "x-markdown-proxy": "1" },
+	});
+	if (!upstream.ok) return null;
 
-  const negotiated = negotiateMarkdown(request);
-  if (negotiated) return negotiated;
+	const body = await upstream.text();
 
-  return NextResponse.next();
+	return new NextResponse(body, {
+		status: 200,
+		headers: {
+			"Content-Type": "text/markdown; charset=utf-8",
+			Vary: "Accept",
+		},
+	});
+}
+
+export async function proxy(request: NextRequest) {
+	track(request);
+
+	if (request.headers.get("x-markdown-proxy")) {
+		return NextResponse.next();
+	}
+
+	const negotiated = await negotiateMarkdown(request);
+	if (negotiated) return negotiated;
+
+	return NextResponse.next();
 }
 
 export const config = {
-  matcher: [
-    {
-      source: "/((?!_next/|api(?:/|$)|favicon.ico|.*\\..*).*)",
-      missing: [{ type: "header", key: "next-router-prefetch" }],
-    },
-    // AI/agent text routes are dotted paths excluded above; track them explicitly.
-    { source: "/llms.txt" },
-    { source: "/llms-full.txt" },
-    { source: "/alog.md" },
-    { source: "/alog/:path*.md" },
-    { source: "/blog.md" },
-    { source: "/blog/:path*.md" },
-  ],
+	matcher: [
+		{
+			source: "/((?!_next/|api(?:/|$)|favicon.ico|.*\\..*).*)",
+			missing: [{ type: "header", key: "next-router-prefetch" }],
+		},
+		// AI/agent text routes are dotted paths excluded above; track them explicitly.
+		{ source: "/llms.txt" },
+		{ source: "/llms-full.txt" },
+		{ source: "/alog.md" },
+		{ source: "/alog/:path*.md" },
+		{ source: "/blog.md" },
+		{ source: "/blog/:path*.md" },
+	],
 };


### PR DESCRIPTION
## Why

PR #2004 added markdown content negotiation, but the **Vary: Accept** check still fails on the deployed site (acceptmarkdown.com shows 75/100). The fix commit for this never made it into #2004 — it landed on the branch after that PR merged, so production runs the old rewrite-based proxy.

Live probe of `https://useautumn.com/blog/active-active-redis-cache` with `Accept: text/markdown`:

```
content-type: text/markdown; charset=utf-8        ✅
vary: rsc, next-router-state-tree, ...            ❌ no Accept
```

## Root cause

Next.js 16 hard-sets `Vary: rsc, …` on every App Router response via `getVaryHeader()`. When the proxy uses `NextResponse.rewrite()` to the `.md` route, the framework overwrites the `Vary: Accept` we set — and on Vercel's edge it's dropped entirely, leaving only the rsc value. A CDN keying only on `rsc` will also serve markdown to browsers, so this is a correctness bug, not just a benchmark miss.

## Fix

Instead of rewriting, the proxy **fetches the `.md` body and returns it as its own terminal response**, which keeps a clean `Vary: Accept`. An `x-markdown-proxy` guard prevents the internal fetch from looping.

## Verification

- 54/54 checks pass against a local `next build && next start` (markdown serving, Vary contains Accept, 406, q-values incl. RFC `q=0` exclusion).
- Browsers still get HTML; direct `.md` URLs still 200.
- **Pending: confirming the Vary header survives on the Vercel preview edge before merge** (local `next start` and Vercel handle middleware Vary differently, so this needs preview verification).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve negotiated markdown directly from the proxy to preserve the Vary: Accept header. Fixes edge/CDN caching so browsers don’t get markdown.

- **Bug Fixes**
  - Fetch the `.md` content and return it as the final response instead of rewriting, keeping `Vary: Accept` and `Content-Type: text/markdown; charset=utf-8`.
  - Add `x-markdown-proxy` guard to avoid proxy fetch loops.
  - Preserve behavior: HTML by default, 406 on unacceptable `Accept`, direct `.md` URLs still 200.

<sup>Written for commit 17ebf25abe3adfdb334b2eadc5c480be81d24f44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes an incomplete `Vary: Accept` implementation from #2004 by replacing `NextResponse.rewrite()` with a fetch-and-return pattern in the markdown content negotiation proxy, preventing Next.js 16's framework-level `Vary` header from overwriting the `Accept` token on markdown responses.

- **Bug fixes**: `serveMarkdown` now fetches the `.md` body internally and returns it as a terminal `NextResponse` with an explicit `Vary: Accept` header, rather than rewriting to the `.md` route and having the framework clobber the header.
- **Bug fixes / Improvements**: An `x-markdown-proxy` guard prevents the internal fetch from re-entering the negotiation loop; `proxy()` is now `async` to support the await chain.
- **Improvements**: The `decision === \"html\"` branch is simplified to return `null` (falling through to `NextResponse.next()`), removing the now-redundant attempt to set `Vary` on a pass-through response that Next.js 16 would overwrite anyway.
</details>

<h3>Confidence Score: 3/5</h3>

The markdown serving path works correctly for the described fix, but HTML responses for markdown-capable routes still carry no Vary: Accept, leaving CDN misdelivery possible; the loop-guard is also externally spoofable.

The core fix (returning a new Response rather than rewriting) is sound and well-reasoned. However, the HTML side of the same routes now explicitly omits Vary: Accept — a CDN that caches an HTML response with no Vary can serve it to a later markdown client, negating the fix for the opposite request order. The x-markdown-proxy guard is also settable by any external caller, which is a minor but real design gap.

apps/website/proxy.ts — specifically the html decision branch and the x-markdown-proxy guard logic.

<details open><summary><h3>Security Review</h3></summary>

- **Spoofable internal guard** (`apps/website/proxy.ts` line 69): The `x-markdown-proxy` header used to prevent infinite fetch loops is a plain custom HTTP header. Any external client can include it in a request, causing the middleware to skip all content negotiation and return `NextResponse.next()` directly. Impact is low (the client receives an HTML page instead of negotiated content), but the guard has no secret or non-spoofable signal distinguishing internal from external requests.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/website/proxy.ts | Fixes Vary: Accept on markdown responses by fetching .md content internally rather than rewriting; introduces a spoofable x-markdown-proxy guard and drops Vary: Accept from HTML responses for markdown-capable routes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Client
    participant M as Middleware proxy.ts
    participant N as negotiate
    participant S as serveMarkdown
    participant O as Origin md route

    C->>M: GET /blog/slug with Accept text/markdown
    M->>M: track request
    M->>M: check x-markdown-proxy header - not set
    M->>N: negotiateMarkdown request
    N->>N: markdownTargetFor pathname returns /blog/slug.md
    N->>N: negotiate Accept header returns markdown
    N->>S: serveMarkdown request /blog/slug.md
    S->>S: clone URL set pathname to /blog/slug.md
    S->>O: fetch source with x-markdown-proxy 1
    O->>M: hits middleware again
    M->>M: x-markdown-proxy is 1 skip negotiation
    M-->>O: NextResponse.next pass through
    O-->>S: 200 plus md body
    S-->>M: NextResponse body with Vary Accept and text/markdown
    M-->>C: 200 text/markdown with Vary Accept

    C->>M: GET /blog/slug with Accept text/html
    M->>N: negotiateMarkdown request
    N->>N: negotiate returns html
    N-->>M: null
    M-->>C: NextResponse.next HTML without Vary Accept
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Client
    participant M as Middleware proxy.ts
    participant N as negotiate
    participant S as serveMarkdown
    participant O as Origin md route

    C->>M: GET /blog/slug with Accept text/markdown
    M->>M: track request
    M->>M: check x-markdown-proxy header - not set
    M->>N: negotiateMarkdown request
    N->>N: markdownTargetFor pathname returns /blog/slug.md
    N->>N: negotiate Accept header returns markdown
    N->>S: serveMarkdown request /blog/slug.md
    S->>S: clone URL set pathname to /blog/slug.md
    S->>O: fetch source with x-markdown-proxy 1
    O->>M: hits middleware again
    M->>M: x-markdown-proxy is 1 skip negotiation
    M-->>O: NextResponse.next pass through
    O-->>S: 200 plus md body
    S-->>M: NextResponse body with Vary Accept and text/markdown
    M-->>C: 200 text/markdown with Vary Accept

    C->>M: GET /blog/slug with Accept text/html
    M->>N: negotiateMarkdown request
    N->>N: negotiate returns html
    N-->>M: null
    M-->>C: NextResponse.next HTML without Vary Accept
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/website/proxy.ts:34-36
**Missing Vary: Accept on HTML responses for markdown-capable routes**

When a markdown-capable route (e.g. `/blog/slug`) is served with `decision === "html"`, the middleware returns `null` and `proxy()` falls through to `NextResponse.next()` — a response that carries no `Vary: Accept`. A CDN caching that HTML response with no Vary directive will key the entry purely on the URL; a subsequent request with `Accept: text/markdown` will then receive the cached HTML page, undoing the content-negotiation fix this PR implements for the markdown path.

The old code attempted `response.headers.set("Vary", "Accept")` on the `NextResponse.next()` response; while you correctly note that Next.js 16 overwrites Vary on pass-through responses, the asymmetry means the problem is now explicitly unaddressed on the HTML side. To be safe (especially pending Vercel edge verification), it would be worth either restoring the best-effort Vary header on `NextResponse.next()`, or serving HTML responses via the same fetch-and-return technique used for markdown.

### Issue 2 of 3
apps/website/proxy.ts:69-71
**Spoofable loop-guard header allows external bypass of content negotiation**

The `x-markdown-proxy` header is a plain custom HTTP header that any external client can include in their request. When present, the middleware skips all content negotiation and returns `NextResponse.next()` directly. This means an attacker can force any markdown-capable route to return an HTML response regardless of their `Accept` header. The guard should use a shared secret or be verified against a non-spoofable signal so only the internal `serveMarkdown` fetch can trigger it.

```suggestion
	if (request.headers.get("x-markdown-proxy") === process.env.MARKDOWN_PROXY_SECRET) {
		return NextResponse.next();
	}
```

### Issue 3 of 3
apps/website/proxy.ts:53
**Silent HTML fallback when upstream markdown fetch fails**

If the internal `fetch` to the `.md` route returns a non-2xx status, `serveMarkdown` returns `null`, and `proxy()` falls through to `NextResponse.next()`, silently serving the HTML page. A client that sent `Accept: text/markdown` (and explicitly did not include `text/html`) will receive HTML with no indication that the requested representation is unavailable. Consider returning a 503 or propagating the upstream status code so the failure is surfaced rather than silently downgraded.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(website): serve negotiated markdown ..."](https://github.com/useautumn/autumn/commit/17ebf25abe3adfdb334b2eadc5c480be81d24f44) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39117871)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->