### PR TITLE
release

### DIFF
--- a/apps/website/proxy.ts
+++ b/apps/website/proxy.ts
@@ -32,7 +32,9 @@ async function negotiateMarkdown(
 	}
 
 	if (decision === "html") {
-		return null;
+		const response = NextResponse.next();
+		response.headers.set("Vary", "Accept");
+		return response;
 	}
 
 	return serveMarkdown(request, markdownTarget);
@@ -64,11 +66,13 @@ async function serveMarkdown(
 }
 
 export async function proxy(request: NextRequest) {
-	track(request);
-
+	// The internal markdown sub-request must not be tracked or re-negotiated;
+	// return before track() so analytics counts the user request only once.
 	if (request.headers.get("x-markdown-proxy")) {
 		return NextResponse.next();
 	}
+
+	track(request);
 
 	const negotiated = await negotiateMarkdown(request);
 	if (negotiated) return negotiated;

--- a/apps/website/proxy.ts
+++ b/apps/website/proxy.ts
@@ -9,60 +9,85 @@ const token = process.env.BYDEFAULT_TOKEN;
 const tracker = token ? new Tracker({ token, exclude: ["/api"] }) : null;
 
 function track(request: NextRequest) {
-  if (tracker) {
-    after(async () => {
-      await tracker.track(request);
-    });
-  }
+	if (tracker) {
+		after(async () => {
+			await tracker.track(request);
+		});
+	}
 }
 
-function negotiateMarkdown(request: NextRequest): NextResponse | null {
-  const markdownTarget = markdownTargetFor(request.nextUrl.pathname);
-  if (!markdownTarget) return null;
+async function negotiateMarkdown(
+	request: NextRequest,
+): Promise<NextResponse | null> {
+	const markdownTarget = markdownTargetFor(request.nextUrl.pathname);
+	if (!markdownTarget) return null;
 
-  const decision = negotiate(request.headers.get("accept"));
+	const decision = negotiate(request.headers.get("accept"));
 
-  if (decision === "not-acceptable") {
-    return new NextResponse("Not Acceptable", {
-      status: 406,
-      headers: { Vary: "Accept", "Content-Type": "text/plain; charset=utf-8" },
-    });
-  }
+	if (decision === "not-acceptable") {
+		return new NextResponse("Not Acceptable", {
+			status: 406,
+			headers: { Vary: "Accept", "Content-Type": "text/plain; charset=utf-8" },
+		});
+	}
 
-  if (decision === "markdown") {
-    const url = request.nextUrl.clone();
-    url.pathname = markdownTarget;
-    const response = NextResponse.rewrite(url);
-    response.headers.set("Vary", "Accept");
-    return response;
-  }
+	if (decision === "html") {
+		return null;
+	}
 
-  const response = NextResponse.next();
-  response.headers.set("Vary", "Accept");
-  return response;
+	return serveMarkdown(request, markdownTarget);
 }
 
-export function proxy(request: NextRequest) {
-  track(request);
+// Return the markdown body in this response rather than rewriting to the .md
+// route: a rewrite lets the framework overwrite Vary with its own rsc value and
+// drop Accept, whereas a response we own keeps a clean Vary: Accept.
+async function serveMarkdown(
+	request: NextRequest,
+	markdownTarget: string,
+): Promise<NextResponse | null> {
+	const source = request.nextUrl.clone();
+	source.pathname = markdownTarget;
+	const upstream = await fetch(source, {
+		headers: { "x-markdown-proxy": "1" },
+	});
+	if (!upstream.ok) return null;
 
-  const negotiated = negotiateMarkdown(request);
-  if (negotiated) return negotiated;
+	const body = await upstream.text();
 
-  return NextResponse.next();
+	return new NextResponse(body, {
+		status: 200,
+		headers: {
+			"Content-Type": "text/markdown; charset=utf-8",
+			Vary: "Accept",
+		},
+	});
+}
+
+export async function proxy(request: NextRequest) {
+	track(request);
+
+	if (request.headers.get("x-markdown-proxy")) {
+		return NextResponse.next();
+	}
+
+	const negotiated = await negotiateMarkdown(request);
+	if (negotiated) return negotiated;
+
+	return NextResponse.next();
 }
 
 export const config = {
-  matcher: [
-    {
-      source: "/((?!_next/|api(?:/|$)|favicon.ico|.*\\..*).*)",
-      missing: [{ type: "header", key: "next-router-prefetch" }],
-    },
-    // AI/agent text routes are dotted paths excluded above; track them explicitly.
-    { source: "/llms.txt" },
-    { source: "/llms-full.txt" },
-    { source: "/alog.md" },
-    { source: "/alog/:path*.md" },
-    { source: "/blog.md" },
-    { source: "/blog/:path*.md" },
-  ],
+	matcher: [
+		{
+			source: "/((?!_next/|api(?:/|$)|favicon.ico|.*\\..*).*)",
+			missing: [{ type: "header", key: "next-router-prefetch" }],
+		},
+		// AI/agent text routes are dotted paths excluded above; track them explicitly.
+		{ source: "/llms.txt" },
+		{ source: "/llms-full.txt" },
+		{ source: "/alog.md" },
+		{ source: "/alog/:path*.md" },
+		{ source: "/blog.md" },
+		{ source: "/blog/:path*.md" },
+	],
 };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve negotiated markdown directly from the proxy to preserve Vary: Accept under `next@16`, and fix analytics double-counting and HTML Vary on negotiable routes.

- **Bug Fixes**
  - Fetch the upstream `.md` and return it from the proxy with `Content-Type: text/markdown; charset=utf-8` and `Vary: Accept`; guard `x-markdown-proxy` and return before `track()` to avoid internal re-tracking and loops.
  - When the client prefers HTML, pass through with `Vary: Accept` so caches don’t mix HTML and markdown for the same URL.

<sup>Written for commit 71d1461aa27d7c21dadd15c564965405c6f61591. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refactors the middleware proxy to serve markdown responses directly via an internal `fetch` call rather than a `NextResponse.rewrite`, preserving a clean `Vary: Accept` header that the framework would otherwise overwrite. An `x-markdown-proxy` sentinel header prevents re-entrant middleware execution on the internal request.

- **[Improvements]** `serveMarkdown` now owns the response object and sets `Content-Type: text/markdown` and `Vary: Accept` directly, avoiding the framework's RSC header injection that broke the previous rewrite-based approach.
- **[Bug fixes]** `negotiateMarkdown` now explicitly handles the `\"html\"` negotiation outcome instead of relying on a silent fallthrough.
</details>

<h3>Confidence Score: 3/5</h3>

The change introduces two functional regressions — analytics double-counting on every markdown request and dropped Vary: Accept on HTML responses for negotiable routes — that should be fixed before merging.

Every markdown page view triggers the middleware twice (once for the user request, once for the internal fetch), and track() fires on both passes, so analytics will overcount. HTML responses for negotiable routes also lose the Vary: Accept header that the old code set explicitly, which can cause caches to mix HTML and markdown responses for the same URL.

apps/website/proxy.ts — the order of the x-markdown-proxy guard relative to track(), and the missing Vary: Accept on HTML pass-throughs.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/website/proxy.ts | Refactors markdown negotiation to serve content via an internal fetch instead of a rewrite, but introduces two regressions: analytics double-counting for markdown requests, and missing Vary: Accept on HTML responses for negotiable routes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Client
    participant M as Middleware (proxy.ts)
    participant T as Tracker
    participant N as Next.js Router

    C->>M: GET /blog/post (Accept: text/markdown)
    M->>T: track(request) [schedules via after()]
    M->>M: negotiateMarkdown()
    M->>M: serveMarkdown()
    M->>M: "fetch(/blog/post.md, {x-markdown-proxy: 1})"
    Note over M: Internal fetch triggers middleware again
    M->>T: track(request) double-counts internal request
    M->>N: NextResponse.next() (x-markdown-proxy guard)
    N-->>M: .md file contents
    M-->>C: 200 text/markdown, Vary: Accept

    C->>M: GET /blog/post (Accept: text/html)
    M->>T: track(request)
    M->>M: negotiateMarkdown() returns html then null
    M-->>C: NextResponse.next() — no Vary: Accept header
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Client
    participant M as Middleware (proxy.ts)
    participant T as Tracker
    participant N as Next.js Router

    C->>M: GET /blog/post (Accept: text/markdown)
    M->>T: track(request) [schedules via after()]
    M->>M: negotiateMarkdown()
    M->>M: serveMarkdown()
    M->>M: "fetch(/blog/post.md, {x-markdown-proxy: 1})"
    Note over M: Internal fetch triggers middleware again
    M->>T: track(request) double-counts internal request
    M->>N: NextResponse.next() (x-markdown-proxy guard)
    N-->>M: .md file contents
    M-->>C: 200 text/markdown, Vary: Accept

    C->>M: GET /blog/post (Accept: text/html)
    M->>T: track(request)
    M->>M: negotiateMarkdown() returns html then null
    M-->>C: NextResponse.next() — no Vary: Accept header
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/website/proxy.ts:66-71
`track()` is called before the `x-markdown-proxy` guard, so every internal `serveMarkdown` fetch is tracked as a real user request. For any markdown-negotiated page, the tracker records two events: one for the browser request and one for the internal `fetch` to the `.md` route. Moving the guard above `track()` fixes the double-count.

```suggestion
export async function proxy(request: NextRequest) {
	if (request.headers.get("x-markdown-proxy")) {
		return NextResponse.next();
	}

	track(request);
```

### Issue 2 of 2
apps/website/proxy.ts:34-36
**Missing `Vary: Accept` on HTML responses for markdown-capable routes**

The old fallthrough case in `negotiateMarkdown` explicitly called `response.headers.set("Vary", "Accept")` before returning `NextResponse.next()`, ensuring HTML responses for markdown-negotiable URLs told caches they vary by `Accept`. The new code returns `null` here and lets `proxy` return a bare `NextResponse.next()` with no `Vary` header. Any cache layer (browser, CDN, or otherwise) that stores the HTML response without `Vary: Accept` may later serve it to a client whose `Accept` header would normally trigger markdown negotiation, bypassing the middleware entirely for that cached URL.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #2007 from useautumn/..."](https://github.com/useautumn/autumn/commit/a6b7ee1f37ee9fb89d3de3f436b005c363b8ab94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39118681)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->