### PR TITLE
fix(website): markdown proxy double-count + HTML Vary regressions

### DIFF
--- a/apps/website/proxy.ts
+++ b/apps/website/proxy.ts
@@ -32,7 +32,9 @@ async function negotiateMarkdown(
 	}
 
 	if (decision === "html") {
-		return null;
+		const response = NextResponse.next();
+		response.headers.set("Vary", "Accept");
+		return response;
 	}
 
 	return serveMarkdown(request, markdownTarget);
@@ -64,11 +66,13 @@ async function serveMarkdown(
 }
 
 export async function proxy(request: NextRequest) {
-	track(request);
-
+	// The internal markdown sub-request must not be tracked or re-negotiated;
+	// return before track() so analytics counts the user request only once.
 	if (request.headers.get("x-markdown-proxy")) {
 		return NextResponse.next();
 	}
+
+	track(request);
 
 	const negotiated = await negotiateMarkdown(request);
 	if (negotiated) return negotiated;


### PR DESCRIPTION
Follow-up to #2007. The bot review on #2008 (dev → main promotion) flagged two regressions in the markdown proxy that are now on `dev`:

1. **Analytics double-count** — `track()` ran before the `x-markdown-proxy` guard, so the internal `.md` sub-request fired analytics a second time on every markdown page view. Fixed by returning on the guard before `track()`.

2. **HTML responses lost `Vary: Accept`** — the `decision === "html"` branch returned `null`, dropping the `Vary: Accept` the old code set on pass-throughs. A CDN keying only on the framework's `rsc` Vary could mix HTML and markdown for the same URL. Fixed by setting `Vary: Accept` on the HTML pass-through.

Verified 36/36 against a local `next build && next start` (markdown serving, Vary contains Accept, 406, q-values incl. RFC `q=0` exclusion).

Should land on `dev` before #2008 promotes to `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two regressions in the markdown proxy: stops analytics double-counting on markdown pages and restores correct caching by setting Vary: Accept on HTML pass-throughs.

- **Bug Fixes**
  - Return on `x-markdown-proxy` guard before `track()` so the internal `.md` sub-request isn’t tracked.
  - In the `decision === "html"` path, return `NextResponse.next()` and set `Vary: Accept` to prevent caches from mixing HTML and markdown for the same URL.

<sup>Written for commit bfee0000c2c49cdc88d82fe52b1025465c91a2ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two regressions in the Next.js middleware markdown proxy introduced by #2007: an analytics double-count caused by `track()` firing before the internal-request guard, and HTML responses losing their `Vary: Accept` header when the CDN needs it for correct cache keying.

- **Bug fixes** — `track()` is now called only after the `x-markdown-proxy` guard, ensuring internal `.md` sub-requests triggered by `serveMarkdown`'s `fetch` do not fire a second analytics event.
- **Bug fixes** — The `decision === "html"` branch now returns `NextResponse.next()` with `Vary: Accept` set (previously returned `null`, falling through to a bare `NextResponse.next()` that carried no `Vary` header), preventing CDNs from mixing HTML and markdown responses for the same URL.
</details>

<h3>Confidence Score: 5/5</h3>

Both changes are narrow, targeted, and address clearly identified bugs; no correctness concerns found.

The two fixes are minimal and well-scoped: reordering three lines to move `track()` after the guard, and replacing a `null` return with a `NextResponse.next()` that carries the `Vary: Accept` header. The logic for all three decision branches (`html`, `markdown`, `not-acceptable`) is now consistent in setting `Vary: Accept`. The `x-markdown-proxy` guard correctly short-circuits before any side-effects for the internal sub-request. No pre-existing error handling for failed upstream fetches is altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/website/proxy.ts | Two targeted bug fixes: moved `track()` after the `x-markdown-proxy` guard to prevent double-counting analytics on internal sub-requests, and changed the `decision === "html"` branch to return `NextResponse.next()` with `Vary: Accept` instead of `null` so CDNs key HTML and markdown responses separately. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant Middleware as proxy() Middleware
    participant Analytics as track() / Bydefault
    participant Next as Next.js Handler
    participant InternalFetch as Internal fetch (x-markdown-proxy)

    Browser->>Middleware: GET /blog/foo (Accept: text/markdown)
    Note over Middleware: No x-markdown-proxy header
    Middleware->>Analytics: track(request) [called ONCE]
    Middleware->>Middleware: "negotiateMarkdown() → decision=markdown"
    Middleware->>InternalFetch: "fetch(/blog/foo.md, {x-markdown-proxy: 1})"
    InternalFetch->>Middleware: Middleware re-triggered (matched by .md matcher)
    Note over Middleware: x-markdown-proxy header present → return early (NO track)
    Middleware-->>InternalFetch: NextResponse.next()
    InternalFetch-->>Middleware: 200 .md body
    Middleware-->>Browser: 200 text/markdown + Vary: Accept

    Browser->>Middleware: GET /blog/foo (Accept: text/html)
    Note over Middleware: No x-markdown-proxy header
    Middleware->>Analytics: track(request) [called ONCE]
    Middleware->>Middleware: "negotiateMarkdown() → decision=html"
    Note over Middleware: Returns NextResponse.next() + Vary: Accept (FIXED)
    Middleware-->>Browser: 200 HTML + Vary: Accept

    Browser->>Middleware: GET /blog/foo (Accept: application/json)
    Middleware->>Analytics: track(request)
    Middleware->>Middleware: "negotiateMarkdown() → decision=not-acceptable"
    Middleware-->>Browser: 406 Not Acceptable + Vary: Accept
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant Middleware as proxy() Middleware
    participant Analytics as track() / Bydefault
    participant Next as Next.js Handler
    participant InternalFetch as Internal fetch (x-markdown-proxy)

    Browser->>Middleware: GET /blog/foo (Accept: text/markdown)
    Note over Middleware: No x-markdown-proxy header
    Middleware->>Analytics: track(request) [called ONCE]
    Middleware->>Middleware: "negotiateMarkdown() → decision=markdown"
    Middleware->>InternalFetch: "fetch(/blog/foo.md, {x-markdown-proxy: 1})"
    InternalFetch->>Middleware: Middleware re-triggered (matched by .md matcher)
    Note over Middleware: x-markdown-proxy header present → return early (NO track)
    Middleware-->>InternalFetch: NextResponse.next()
    InternalFetch-->>Middleware: 200 .md body
    Middleware-->>Browser: 200 text/markdown + Vary: Accept

    Browser->>Middleware: GET /blog/foo (Accept: text/html)
    Note over Middleware: No x-markdown-proxy header
    Middleware->>Analytics: track(request) [called ONCE]
    Middleware->>Middleware: "negotiateMarkdown() → decision=html"
    Note over Middleware: Returns NextResponse.next() + Vary: Accept (FIXED)
    Middleware-->>Browser: 200 HTML + Vary: Accept

    Browser->>Middleware: GET /blog/foo (Accept: application/json)
    Middleware->>Analytics: track(request)
    Middleware->>Middleware: "negotiateMarkdown() → decision=not-acceptable"
    Middleware-->>Browser: 406 Not Acceptable + Vary: Accept
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(website): avoid markdown sub-request..."](https://github.com/useautumn/autumn/commit/bfee0000c2c49cdc88d82fe52b1025465c91a2ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39120384)</sub>

<!-- /greptile_comment -->