### PR TITLE
fix: pass through OIDC scopes for Claude MCP OAuth clients

### DIFF
--- a/packages/auth/src/oauth/leafOAuth.ts
+++ b/packages/auth/src/oauth/leafOAuth.ts
@@ -5,21 +5,20 @@ import {
 } from "@autumn/shared/scopeDefinitions";
 
 const leafScopeSet = new Set<string>(LEAF_OAUTH_SCOPES);
-const oauthPassthroughScopeSet = new Set<string>(["offline_access"]);
 const oauthProtocolScopeSet = new Set<string>(OPENID_SCOPES);
 
 export const getDefaultOAuthScopes = (requestedScopes?: string[] | null) => {
 	const requested =
 		requestedScopes && requestedScopes.length > 0
 			? requestedScopes
-			: [...LEAF_OAUTH_SCOPES, ...oauthPassthroughScopeSet];
+			: [...LEAF_OAUTH_SCOPES, ...OPENID_SCOPES];
 
 	// Issued scopes must echo the client's request verbatim (better-auth
 	// rejects rewrites), so legacy CRUDL aliases are used for filtering only.
 	return [...new Set(requested)].filter(
 		(scope) =>
 			leafScopeSet.has(LEGACY_SCOPE_ALIASES[scope] ?? scope) ||
-			oauthPassthroughScopeSet.has(scope),
+			oauthProtocolScopeSet.has(scope),
 	);
 };
 

--- a/server/tests/unit/auth/registerMcpOAuthClient.test.ts
+++ b/server/tests/unit/auth/registerMcpOAuthClient.test.ts
@@ -4,26 +4,26 @@ import {
 	getOAuthResourceScopes,
 } from "@autumn/auth/oauth";
 import { LEAF_OAUTH_SCOPES } from "@autumn/shared";
-import { Scopes } from "@autumn/shared/scopeDefinitions";
+import { OPENID_SCOPES, Scopes } from "@autumn/shared/scopeDefinitions";
 import { getRequestedScopesForMcpClient } from "@/internal/auth/actions/registerMcpOAuthClient.js";
 
 const OFFLINE_ACCESS_SCOPE = "offline_access";
-const DEFAULT_MCP_SCOPES = [...LEAF_OAUTH_SCOPES, OFFLINE_ACCESS_SCOPE];
+const DEFAULT_MCP_SCOPES = [...LEAF_OAUTH_SCOPES, ...OPENID_SCOPES];
 
 describe("getRequestedScopesForMcpClient", () => {
-	test("defaults Slack MCP clients to Leaf scopes plus offline access", () => {
+	test("defaults Slack MCP clients to Leaf scopes plus OIDC scopes", () => {
 		expect(
 			getRequestedScopesForMcpClient({ clientType: "slack", scope: undefined }),
 		).toEqual(DEFAULT_MCP_SCOPES);
 	});
 
-	test("defaults Codex MCP clients to Leaf scopes plus offline access", () => {
+	test("defaults Codex MCP clients to Leaf scopes plus OIDC scopes", () => {
 		expect(
 			getRequestedScopesForMcpClient({ clientType: "codex", scope: undefined }),
 		).toEqual(DEFAULT_MCP_SCOPES);
 	});
 
-	test("defaults dynamic MCP clients to Leaf scopes plus offline access", () => {
+	test("defaults dynamic MCP clients to Leaf scopes plus OIDC scopes", () => {
 		expect(
 			getRequestedScopesForMcpClient({
 				clientType: "dynamic",
@@ -32,7 +32,7 @@ describe("getRequestedScopesForMcpClient", () => {
 		).toEqual(DEFAULT_MCP_SCOPES);
 	});
 
-	test("caps explicit requested scopes to Leaf scopes plus offline access", () => {
+	test("caps explicit requested scopes to Leaf and OIDC scopes", () => {
 		expect(
 			getRequestedScopesForMcpClient({
 				clientType: "slack",
@@ -45,11 +45,20 @@ describe("getRequestedScopesForMcpClient", () => {
 		]);
 	});
 
-	test("preserves offline access in default OAuth scopes", () => {
+	test("preserves OIDC protocol scopes that Claude requests", () => {
+		expect(
+			getRequestedScopesForMcpClient({
+				clientType: "claude",
+				scope: "openid profile email offline_access",
+			}),
+		).toEqual(["openid", "profile", "email", OFFLINE_ACCESS_SCOPE]);
+	});
+
+	test("preserves OIDC scopes in default OAuth scopes", () => {
 		expect(getDefaultOAuthScopes()).toEqual(DEFAULT_MCP_SCOPES);
 	});
 
-	test("caps OAuth grants to Leaf scopes plus offline access", () => {
+	test("caps OAuth grants to Leaf and OIDC scopes", () => {
 		expect(
 			getDefaultOAuthScopes([
 				Scopes.Customers.Read,


### PR DESCRIPTION
## Problem

Claude Code's MCP OAuth connection to `api.useautumn.com` failed at `/authorize` with `invalid_scope`.

**Root cause:** `getDefaultOAuthScopes` in `packages/auth/src/oauth/leafOAuth.ts` filtered each client's requested scopes down to leaf resource scopes + `offline_access`, dropping the OIDC protocol scopes `openid`, `profile`, `email`. Claude Code registers with `scope="openid profile email offline_access"`, so the persisted `autumn_mcp_claude` client row stored a broken scope set. better-auth then validates Claude's `/authorize` request against that stored set → `invalid_scope`.

## How it was confirmed (live against prod)

- `.well-known/oauth-authorization-server` lists `offline_access` globally → the June 12 fix is deployed (not a global-config / stale-row issue).
- `/oauth2/register` as "Claude Code" → returned `client_id: autumn_mcp_claude` with `scope: "offline_access"` only (OIDC scopes stripped).
- `/oauth2/authorize`: requesting `openid profile email offline_access` rejected `openid`/`profile`/`email`; `offline_access` alone passed → isolated the per-client stored scopes as the culprit.

## Fix

Pass through the full `OPENID_SCOPES` set (which already contains `offline_access`) instead of just `offline_access`, so `openid`/`profile`/`email` survive the filter.

Updated `server/tests/unit/auth/registerMcpOAuthClient.test.ts` to match, including a Claude-specific assertion.

## Notes

- No DB cleanup needed: the registration path overwrites scopes on every register, so the `autumn_mcp_claude` row self-heals on Claude's next connect once deployed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invalid_scope errors for Claude MCP OAuth by preserving OIDC scopes during client registration and grant filtering. getDefaultOAuthScopes now passes through OPENID_SCOPES (includes offline_access) so openid, profile, and email are kept.

- **Bug Fixes**
  - Preserve OIDC scopes by defaulting/filtering with OPENID_SCOPES in getDefaultOAuthScopes.
  - Fixes /authorize for Claude MCP clients (autumn_mcp_claude) requesting openid profile email offline_access.
  - Update tests to expect Leaf + OIDC scopes and verify Claude’s scope set.
  - No migration needed; scopes are overwritten on next registration.

<sup>Written for commit e5edbd353d935bbefc78d9815a18b3cdaab4a765. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes an `invalid_scope` error for Claude Code's MCP OAuth flow by including the full `OPENID_SCOPES` set (`openid`, `profile`, `email`, `offline_access`) in the scope filter and default scope list, rather than only `offline_access`. The corresponding test file is updated to match and gains a new Claude-specific assertion.

- **Bug fixes**: Replaced the narrow `oauthPassthroughScopeSet` (containing only `offline_access`) with `oauthProtocolScopeSet` (all four OIDC scopes) so `openid`, `profile`, and `email` survive the scope filter during client registration.
- **Bug fixes / Improvements**: Updated `DEFAULT_MCP_SCOPES` in the test helper and added a dedicated test case verifying that Claude Code's exact scope string `"openid profile email offline_access"` passes through intact.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted one-line filter swap with no side effects on existing OAuth clients.

The only modification is replacing a single-element passthrough set with the already-defined OPENID_SCOPES constant, which includes offline_access as before plus the three OIDC scopes that were being incorrectly dropped. All existing behaviour is preserved, the new Claude-specific test directly validates the bug scenario, and the self-healing registration path means no manual DB remediation is needed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/auth/src/oauth/leafOAuth.ts | Removes the narrow oauthPassthroughScopeSet (offline_access only) and replaces all usages with the existing oauthProtocolScopeSet (all four OPENID_SCOPES). Change is minimal, correct, and backward-compatible — offline_access is still in OPENID_SCOPES so no existing behaviour is removed. |
| server/tests/unit/auth/registerMcpOAuthClient.test.ts | Updates DEFAULT_MCP_SCOPES to spread OPENID_SCOPES, rewrites four test descriptions, and adds a new test that asserts Claude Code's scope string is preserved verbatim — good coverage of the bug being fixed. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CC as Claude Code
    participant Reg as /oauth2/register
    participant Auth as /oauth2/authorize
    participant LA as getDefaultOAuthScopes()

    CC->>Reg: "POST scope="openid profile email offline_access""
    Reg->>LA: "getRequestedScopesForMcpClient({clientType:"claude", scope:"openid profile email offline_access"})"
    Note over LA: Before fix: filter kept only offline_access<br/>After fix: filter keeps all 4 OIDC scopes
    LA-->>Reg: ["openid","profile","email","offline_access"]
    Reg-->>CC: "client_id=autumn_mcp_claude, scope="openid profile email offline_access""
    CC->>Auth: "GET ?scope=openid profile email offline_access"
    Auth-->>CC: authorization code (success)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CC as Claude Code
    participant Reg as /oauth2/register
    participant Auth as /oauth2/authorize
    participant LA as getDefaultOAuthScopes()

    CC->>Reg: "POST scope="openid profile email offline_access""
    Reg->>LA: "getRequestedScopesForMcpClient({clientType:"claude", scope:"openid profile email offline_access"})"
    Note over LA: Before fix: filter kept only offline_access<br/>After fix: filter keeps all 4 OIDC scopes
    LA-->>Reg: ["openid","profile","email","offline_access"]
    Reg-->>CC: "client_id=autumn_mcp_claude, scope="openid profile email offline_access""
    CC->>Auth: "GET ?scope=openid profile email offline_access"
    Auth-->>CC: authorization code (success)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: pass through OIDC scopes for Claude..."](https://github.com/useautumn/autumn/commit/e5edbd353d935bbefc78d9815a18b3cdaab4a765) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39261835)</sub>

<!-- /greptile_comment -->