### PR TITLE
Charlie/mobile UI cleanup

### DIFF
--- a/server/src/internal/customers/CusService.ts
+++ b/server/src/internal/customers/CusService.ts
@@ -239,13 +239,19 @@ export class CusService {
 					orgId === "GG6tnmO7cHb40PNhwYBTZtxQdeL74NHF" &&
 					idOrInternalId === "698fb72e4c5fa12c1cd11ddc"
 				) {
-					fullCus.customer_products = (
-						fullCus.customer_products as FullCusProduct[]
-					)
-						.sort((a, b) => b.customer_prices.length - a.customer_prices.length)
-						.slice(0, 5);
+					if (fullCus.customer_products) {
+						fullCus.customer_products = (
+							fullCus.customer_products as FullCusProduct[]
+						)
+							.sort(
+								(a, b) => b.customer_prices.length - a.customer_prices.length,
+							)
+							.slice(0, 5);
+					}
 
-					fullCus.entities = (fullCus.entities as Entity[]).slice(0, 50);
+					if (fullCus.entities) {
+						fullCus.entities = (fullCus.entities as Entity[]).slice(0, 50);
+					}
 				}
 				if (!usedReplica && !skipReset) {
 					// Skip reset only when executeWithHealthTracking explicitly chose the

--- a/vite/src/components/general/table/table-body-virtualized.tsx
+++ b/vite/src/components/general/table/table-body-virtualized.tsx
@@ -131,6 +131,10 @@ export function TableBodyVirtualized() {
 	// Memoize virtual items to prevent unnecessary recalculations
 	const virtualRows = virtualizer.getVirtualItems();
 
+	// Mobile browsers can measure the scroll container at 0 height on init,
+	// leaving zero virtual items despite having rows — render them all instead.
+	const useFallbackRender = hasRows && virtualRows.length === 0;
+
 	// Memoize padding calculations
 	const { paddingTop, paddingBottom } = useMemo(() => {
 		const top = virtualRows[0]?.start ?? 0;
@@ -214,6 +218,39 @@ export function TableBodyVirtualized() {
 						</div>
 					</TableCell>
 				</TableRow>
+			</MotionTbody>
+		);
+	}
+
+	if (useFallbackRender) {
+		return (
+			<MotionTbody
+				key="content"
+				{...TABLE_FADE_IN}
+				transition={TABLE_TRANSITION}
+				className="bg-interactive-secondary"
+			>
+				{rows.map((row, index) => {
+					const isSelected =
+						selectedItemId === (row.original as { id?: string }).id;
+					const rowHref = getRowHref?.(row.original);
+
+					return (
+						<VirtualRow
+							key={row.id}
+							row={row}
+							virtualRow={{ index } as VirtualItem}
+							isSelected={isSelected}
+							rowHref={rowHref}
+							rowClassName={rowClassName}
+							enableSelection={enableSelection}
+							flexibleTableColumns={flexibleTableColumns}
+							onRowClick={memoizedOnRowClick}
+							onRowDoubleClick={memoizedOnRowDoubleClick}
+							visibleColumnKey={visibleColumnKey}
+						/>
+					);
+				})}
 			</MotionTbody>
 		);
 	}

--- a/vite/src/components/general/table/table-content-virtualized.tsx
+++ b/vite/src/components/general/table/table-content-virtualized.tsx
@@ -2,8 +2,13 @@ import React, { useCallback, useMemo, useRef, useState } from "react";
 import { Table } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import { TableColumnVisibility } from "./table-column-visibility";
-import { TableContext, useTableContext } from "./table-context";
+import {
+	TableContext,
+	useShowMobileCards,
+	useTableContext,
+} from "./table-context";
 import { TableHeader } from "./table-header";
+import { TableMobileCards } from "./table-mobile-cards";
 
 export function TableContentVirtualized({
 	children,
@@ -23,6 +28,7 @@ export function TableContentVirtualized({
 	} = context;
 	const { isLoading, isTransitioning } = context;
 	const rows = table.getRowModel().rows;
+	const showMobileCards = useShowMobileCards();
 
 	// Use state instead of ref so changes trigger re-renders for virtualizer
 	const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(
@@ -83,6 +89,10 @@ export function TableContentVirtualized({
 	};
 
 	const isFlexFill = virtualization?.containerHeight === "100%";
+
+	if (showMobileCards) {
+		return <TableMobileCards />;
+	}
 
 	return (
 		<TableContext.Provider value={contextWithRef}>

--- a/vite/src/components/general/table/table-content.tsx
+++ b/vite/src/components/general/table/table-content.tsx
@@ -1,7 +1,8 @@
 import { Table } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import { TableColumnVisibility } from "./table-column-visibility";
-import { useTableContext } from "./table-context";
+import { useShowMobileCards, useTableContext } from "./table-context";
+import { TableMobileCards } from "./table-mobile-cards";
 
 export function TableContent({
 	children,
@@ -10,15 +11,25 @@ export function TableContent({
 	children: React.ReactNode;
 	className?: string;
 }) {
-	const { flexibleTableColumns, enableColumnVisibility, isLoading, isTransitioning, table } =
-		useTableContext();
+	const {
+		flexibleTableColumns,
+		enableColumnVisibility,
+		isLoading,
+		isTransitioning,
+		table,
+	} = useTableContext();
 	const rows = table.getRowModel().rows;
+	const showMobileCards = useShowMobileCards();
+
+	if (showMobileCards) {
+		return <TableMobileCards />;
+	}
 
 	return (
 		<div
 			className={cn(
-"rounded-lg border relative z-50 min-w-0",
-			!rows.length && "border-dashed",
+				"rounded-lg border relative z-50 min-w-0",
+				!rows.length && "border-dashed",
 				className,
 			)}
 		>

--- a/vite/src/components/general/table/table-context.tsx
+++ b/vite/src/components/general/table/table-context.tsx
@@ -1,6 +1,7 @@
 import type { Table as TanstackTable } from "@tanstack/react-table";
 import { createContext, type ReactNode, useContext } from "react";
 import type { ColumnGroup } from "@/hooks/useColumnVisibility";
+import { useIsMobile } from "@/hooks/useIsMobile";
 
 export interface VirtualizationConfig {
 	/** Height of the scroll container, e.g., "calc(100vh - 240px)" */
@@ -42,6 +43,7 @@ export interface TableProps<T> {
 	emptyStateChildren?: ReactNode;
 	emptyStateText?: string;
 	flexibleTableColumns?: boolean;
+	mobileCards?: boolean;
 	selectedItemId?: string | null;
 	/** Virtualization config - only needed when using VirtualizedContent/VirtualizedBody */
 	virtualization?: VirtualizationConfig;
@@ -60,4 +62,10 @@ export function useTableContext<T>(): TableProps<T> {
 	}
 
 	return context as TableProps<T>;
+}
+
+export function useShowMobileCards(): boolean {
+	const { mobileCards } = useTableContext();
+	const isMobile = useIsMobile();
+	return Boolean(mobileCards) && isMobile;
 }

--- a/vite/src/components/general/table/table-mobile-cards.tsx
+++ b/vite/src/components/general/table/table-mobile-cards.tsx
@@ -90,7 +90,8 @@ function MobileCard<T>({
 			cell.column.columnDef.meta?.mobileCard !== "hidden",
 	);
 
-	const handleClick = onRowClick ? () => onRowClick(row.original) : undefined;
+	const handleClick =
+		onRowClick && !rowHref ? () => onRowClick(row.original) : undefined;
 
 	const card = (
 		<div

--- a/vite/src/components/general/table/table-mobile-cards.tsx
+++ b/vite/src/components/general/table/table-mobile-cards.tsx
@@ -1,0 +1,172 @@
+import type { Cell, Row } from "@tanstack/react-table";
+import { flexRender } from "@tanstack/react-table";
+import { Link } from "react-router";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import { useTableContext } from "./table-context";
+
+const SKELETON_CARD_COUNT = 3;
+
+const CONTROL_COLUMNS = new Set(["actions", "select"]);
+const NON_TITLE_COLUMNS = new Set(["actions", "select", "scope"]);
+
+export function TableMobileCards() {
+	const {
+		table,
+		isLoading,
+		isTransitioning,
+		getRowHref,
+		onRowClick,
+		emptyStateChildren,
+		emptyStateText,
+		selectedItemId,
+	} = useTableContext();
+
+	const rows = table.getRowModel().rows;
+	const showSkeleton = isLoading || isTransitioning;
+
+	if (showSkeleton && !rows.length) {
+		return (
+			<div className="flex flex-col gap-2.5">
+				{Array.from({ length: SKELETON_CARD_COUNT }).map((_, cardIndex) => (
+					<div
+						key={`skeleton-card-${cardIndex}`}
+						className="rounded-xl border bg-interactive-secondary p-4 flex flex-col gap-3"
+					>
+						<Skeleton className="h-4 w-28 rounded-sm" />
+						<div className="flex flex-col gap-2">
+							<Skeleton className="h-3 w-40 rounded-sm" />
+							<Skeleton className="h-3 w-32 rounded-sm" />
+						</div>
+					</div>
+				))}
+			</div>
+		);
+	}
+
+	if (!rows.length) {
+		return (
+			<div className="rounded-xl border border-dashed bg-interactive-secondary dark:bg-transparent p-6 text-center text-subtle text-xs">
+				{emptyStateChildren || emptyStateText}
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-2.5">
+			{rows.map((row) => (
+				<MobileCard
+					key={row.id}
+					row={row}
+					rowHref={getRowHref?.(row.original)}
+					isSelected={selectedItemId === (row.original as { id?: string }).id}
+					onRowClick={onRowClick}
+				/>
+			))}
+		</div>
+	);
+}
+
+function MobileCard<T>({
+	row,
+	rowHref,
+	isSelected,
+	onRowClick,
+}: {
+	row: Row<T>;
+	rowHref?: string;
+	isSelected: boolean;
+	onRowClick?: (row: T) => void;
+}) {
+	const cells = row.getVisibleCells();
+	const titleCell = cells.find(
+		(cell) => !NON_TITLE_COLUMNS.has(cell.column.id),
+	);
+	const actionsCell = cells.find((cell) => cell.column.id === "actions");
+	const detailCells = cells.filter(
+		(cell) =>
+			cell.column.id !== titleCell?.column.id &&
+			!CONTROL_COLUMNS.has(cell.column.id) &&
+			cell.column.columnDef.meta?.mobileCard !== "hidden",
+	);
+
+	const handleClick = onRowClick ? () => onRowClick(row.original) : undefined;
+
+	const card = (
+		<div
+			className={cn(
+				"rounded-xl border bg-interactive-secondary p-4 flex flex-col gap-3 transition-colors",
+				isSelected ? "border-primary" : "active:bg-interactive-secondary-hover",
+				(handleClick || rowHref) && "cursor-pointer",
+			)}
+			onClick={handleClick}
+			onKeyDown={
+				handleClick
+					? (e) => {
+							if (e.key === "Enter" || e.key === " ") {
+								e.preventDefault();
+								handleClick();
+							}
+						}
+					: undefined
+			}
+			role={handleClick ? "button" : undefined}
+			tabIndex={handleClick ? 0 : undefined}
+		>
+			<div className="flex items-center justify-between gap-3">
+				<div className="min-w-0 flex-1 text-foreground font-medium text-[15px] truncate">
+					{titleCell &&
+						flexRender(titleCell.column.columnDef.cell, titleCell.getContext())}
+				</div>
+				{actionsCell && (
+					<div className="shrink-0 -mr-1.5 -my-1">
+						{flexRender(
+							actionsCell.column.columnDef.cell,
+							actionsCell.getContext(),
+						)}
+					</div>
+				)}
+			</div>
+
+			{detailCells.length > 0 && (
+				<dl className="flex flex-col gap-1.5 border-t border-border/60 pt-3">
+					{detailCells.map((cell) => (
+						<CardDetailRow key={cell.id} cell={cell} />
+					))}
+				</dl>
+			)}
+		</div>
+	);
+
+	if (rowHref) {
+		return (
+			<Link to={rowHref} className="block">
+				{card}
+			</Link>
+		);
+	}
+
+	return card;
+}
+
+function CardDetailRow<T>({ cell }: { cell: Cell<T, unknown> }) {
+	const { header, meta } = cell.column.columnDef;
+	const cellContent = meta?.mobileCardCell
+		? meta.mobileCardCell(cell.row)
+		: flexRender(cell.column.columnDef.cell, cell.getContext());
+
+	if (meta?.mobileCard === "full") {
+		return <div className="text-sm text-foreground">{cellContent}</div>;
+	}
+
+	return (
+		<div className="flex items-baseline justify-between gap-4 text-sm">
+			<dt className="text-tertiary-foreground shrink-0">
+				{typeof header === "string" ? header : null}
+			</dt>
+			<dd className="text-foreground text-right min-w-0 truncate">
+				{cellContent}
+			</dd>
+		</div>
+	);
+}

--- a/vite/src/components/v2/VirtualizedJson.tsx
+++ b/vite/src/components/v2/VirtualizedJson.tsx
@@ -1,0 +1,60 @@
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { useMemo, useRef } from "react";
+import { highlightJsonLine } from "@/lib/highlightJson";
+import { cn } from "@/lib/utils";
+
+const LINE_HEIGHT = 21;
+const OVERSCAN = 20;
+
+/**
+ * Renders large JSON fast by virtualizing lines — only the visible ~30 lines
+ * are highlighted and mounted, keeping DOM node count constant regardless of
+ * payload size. A single <pre> with thousands of spans stalls layout/paint.
+ */
+export function VirtualizedJson({
+	json,
+	className,
+}: {
+	json: string;
+	className?: string;
+}) {
+	const lines = useMemo(() => json.split("\n"), [json]);
+	const scrollRef = useRef<HTMLDivElement>(null);
+
+	const virtualizer = useVirtualizer({
+		count: lines.length,
+		getScrollElement: () => scrollRef.current,
+		estimateSize: () => LINE_HEIGHT,
+		overscan: OVERSCAN,
+	});
+
+	return (
+		<div
+			ref={scrollRef}
+			className={cn(
+				"overflow-auto font-mono font-medium text-[13px] leading-[1.6]",
+				className,
+			)}
+		>
+			<div
+				className="relative w-max min-w-full"
+				style={{ height: virtualizer.getTotalSize() }}
+			>
+				{virtualizer.getVirtualItems().map((item) => (
+					<div
+						key={item.key}
+						className="absolute left-0 top-0 whitespace-pre px-4"
+						style={{
+							height: LINE_HEIGHT,
+							transform: `translateY(${item.start}px)`,
+						}}
+						// biome-ignore lint/security/noDangerouslySetInnerHtml: highlightJsonLine escapes all input
+						dangerouslySetInnerHTML={{
+							__html: highlightJsonLine(lines[item.index]) || "​",
+						}}
+					/>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/vite/src/hooks/useSheetScopeEntityId.ts
+++ b/vite/src/hooks/useSheetScopeEntityId.ts
@@ -18,17 +18,19 @@ function pickDefaultScopeEntityId({
 	return activePlans.find((cp) => !!cp.entity_id)?.entity_id ?? undefined;
 }
 
+/** The scope the sheet seeds to: URL `entity_id` param, else the smart default. */
+export function getInitialScopeEntityId(
+	customer: FullCustomer | undefined,
+): string | undefined {
+	const fromUrl =
+		new URLSearchParams(window.location.search).get("entity_id") ?? undefined;
+	return fromUrl ?? pickDefaultScopeEntityId({ customer });
+}
+
 // Sheet-local scope state for Attach / Create Schedule flows. Seeds from the
 // `entity_id` URL param if present, otherwise applies the smart default based
 // on the customer's existing plans. Changes stay local to the sheet.
 export function useSheetScopeEntityId(customer: FullCustomer | undefined) {
-	const initialFromUrl = useMemo(
-		() =>
-			new URLSearchParams(window.location.search).get("entity_id") ?? undefined,
-		[],
-	);
-
-	return useState<string | undefined>(
-		initialFromUrl ?? pickDefaultScopeEntityId({ customer }),
-	);
+	const initial = useMemo(() => getInitialScopeEntityId(customer), [customer]);
+	return useState<string | undefined>(initial);
 }

--- a/vite/src/lib/highlightJson.ts
+++ b/vite/src/lib/highlightJson.ts
@@ -1,0 +1,57 @@
+const HTML_ESCAPES: Record<string, string> = {
+	"&": "&amp;",
+	"<": "&lt;",
+	">": "&gt;",
+	'"': "&quot;",
+	"'": "&#039;",
+};
+
+const escapeHtml = (value: string): string =>
+	value.replace(/[&<>"']/g, (char) => HTML_ESCAPES[char]);
+
+const JSON_TOKEN =
+	/("(?:\\.|[^"\\])*")(\s*:)?|\b(true|false|null)\b|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g;
+
+/**
+ * Highlight a single line of pretty-printed JSON. Strings never span lines in
+ * 2-space-indented JSON, so each line tokenizes independently — letting callers
+ * virtualize and highlight only the visible lines.
+ */
+export function highlightJsonLine(line: string): string {
+	let result = "";
+	let lastIndex = 0;
+
+	for (const match of line.matchAll(JSON_TOKEN)) {
+		const [full, string, colon, keyword, number] = match;
+		const index = match.index;
+		result += escapeHtml(line.slice(lastIndex, index));
+
+		if (string !== undefined) {
+			const isKey = colon !== undefined;
+			const className = isKey
+				? "text-sky-700 dark:text-sky-300"
+				: "text-emerald-700 dark:text-emerald-300";
+			result += `<span class="${className}">${escapeHtml(string)}</span>`;
+			if (colon) result += escapeHtml(colon);
+		} else if (keyword !== undefined) {
+			const className =
+				keyword === "null"
+					? "text-tertiary-foreground"
+					: "text-purple-700 dark:text-purple-300";
+			result += `<span class="${className}">${keyword}</span>`;
+		} else if (number !== undefined) {
+			result += `<span class="text-amber-700 dark:text-amber-400">${number}</span>`;
+		}
+
+		lastIndex = index + full.length;
+	}
+
+	result += escapeHtml(line.slice(lastIndex));
+	return result;
+}
+
+/** Highlight a full JSON document. Prefer the virtualized viewer for rendering;
+ * use this only for non-DOM consumers (e.g. copy-to-clipboard fallbacks). */
+export function highlightJson(json: string): string {
+	return json.split("\n").map(highlightJsonLine).join("\n");
+}

--- a/vite/src/types/tanstack-table.d.ts
+++ b/vite/src/types/tanstack-table.d.ts
@@ -1,7 +1,11 @@
+import type { ReactNode } from "react";
+import type { Row } from "@tanstack/react-table";
 import type { ColumnSkeletonMeta } from "@/components/general/table/table-row-cells";
 
 declare module "@tanstack/react-table" {
 	interface ColumnMeta<TData, TValue> {
 		skeleton?: ColumnSkeletonMeta;
+		mobileCard?: "hidden" | "full";
+		mobileCardCell?: (row: Row<TData>) => ReactNode;
 	}
 }

--- a/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/utils/linkUtils";
 import { useAdmin } from "@/views/admin/hooks/useAdmin";
 import { useMasterStripeAccount } from "@/views/admin/hooks/useMasterStripeAccount";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { CustomerInvoiceStatus } from "../table/customer-invoices/CustomerInvoiceStatus";
 import { RefundInvoiceDialog } from "./RefundInvoiceDialog";
 
@@ -77,7 +78,13 @@ export function InvoiceDetailSheet({
 	taxedAmount: taxedAmountProp,
 }: InvoiceDetailSheetProps = {}) {
 	const sheetData = useSheetStore((s) => s.data);
-	const invoice = invoiceProp ?? (sheetData?.invoice as Invoice | undefined);
+	const snapshotInvoice =
+		invoiceProp ?? (sheetData?.invoice as Invoice | undefined);
+	const { customer } = useCusQuery();
+	const liveInvoice = customer?.invoices?.find(
+		(inv: Invoice) => inv.id === snapshotInvoice?.id,
+	);
+	const invoice = liveInvoice ?? snapshotInvoice;
 	const lineItems =
 		lineItemsProp ?? ((sheetData?.lineItems as InvoiceLineItem[]) || []);
 	const taxedAmount =

--- a/vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx
+++ b/vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx
@@ -2,7 +2,7 @@ import { formatAmount, type Invoice } from "@autumn/shared";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
-import { Button } from "@/components/v2/buttons/Button";
+import { ShortcutButton } from "@/components/v2/buttons/ShortcutButton";
 import {
 	Dialog,
 	DialogContent,
@@ -150,20 +150,15 @@ export function RefundInvoiceDialog({
 				</div>
 
 				<DialogFooter>
-					<Button
-						variant="secondary"
-						onClick={() => onOpenChange(false)}
-						disabled={refundMutation.isPending}
-					>
-						Cancel
-					</Button>
-					<Button
+					<ShortcutButton
 						variant="primary"
+						className="w-full"
 						onClick={handleSubmit}
 						isLoading={refundMutation.isPending}
+						metaShortcut="enter"
 					>
 						Refund
-					</Button>
+					</ShortcutButton>
 				</DialogFooter>
 			</DialogContent>
 		</Dialog>

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
@@ -151,6 +151,7 @@ export function CustomerBalanceTable({
 					isLoading,
 					onRowClick: handleRowClick,
 					flexibleTableColumns: true,
+					mobileCards: true,
 					selectedItemId: getSelectedRowId(),
 					rowClassName: "h-10 py-0",
 				}}

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
@@ -492,6 +492,69 @@ function BalanceActionsCell({
 	);
 }
 
+function MobileBalanceBar({
+	ent,
+	fullCustomer,
+	entityId,
+	customerEntitlements,
+}: {
+	ent: FullCusEntWithFullCusProduct;
+	fullCustomer: FullCustomer | null | undefined;
+	entityId: string | null;
+	customerEntitlements: FullCusEntWithFullCusProduct[];
+}) {
+	const { allowance, balance, quantity } = useFeatureUsageBalance({
+		fullCustomer,
+		featureId: ent.entitlement.feature.id,
+		entityId,
+		customerEntitlements,
+	});
+
+	if (ent.unlimited || (allowance ?? 0) <= 0) return null;
+
+	return (
+		<div className="w-24 shrink-0 flex items-center h-4">
+			<CustomerFeatureUsageBar
+				allowance={allowance}
+				balance={balance}
+				quantity={quantity}
+				horizontal
+			/>
+		</div>
+	);
+}
+
+function MobileUsageWithBar({
+	row,
+	fullCustomer,
+	entityId,
+}: {
+	row: Row<CustomerBalanceRowData>;
+	fullCustomer: FullCustomer | null | undefined;
+	entityId: string | null;
+}) {
+	const customerEntitlements = row.original.subRows?.length
+		? row.original.subRows
+		: [row.original];
+
+	return (
+		<div className="flex items-center justify-between gap-3">
+			<UsageCell
+				row={row}
+				fullCustomer={fullCustomer}
+				entityId={entityId}
+				customerEntitlements={customerEntitlements}
+			/>
+			<MobileBalanceBar
+				ent={row.original}
+				fullCustomer={fullCustomer}
+				entityId={entityId}
+				customerEntitlements={customerEntitlements}
+			/>
+		</div>
+	);
+}
+
 // --- Column definitions ---
 
 export const CustomerBalanceTableColumns = ({
@@ -600,6 +663,16 @@ export const CustomerBalanceTableColumns = ({
 	{
 		header: "Usage",
 		accessorKey: "usage",
+		meta: {
+			mobileCard: "full" as const,
+			mobileCardCell: (row: Row<CustomerBalanceRowData>) => (
+				<MobileUsageWithBar
+					row={row}
+					fullCustomer={fullCustomer}
+					entityId={entityId}
+				/>
+			),
+		},
 		cell: ({ row }: { row: Row<CustomerBalanceRowData> }) => (
 			<UsageCell
 				row={row}
@@ -615,6 +688,7 @@ export const CustomerBalanceTableColumns = ({
 		header: "Bar",
 		size: 220,
 		accessorKey: "bar",
+		meta: { mobileCard: "hidden" as const },
 		cell: ({ row }: { row: Row<CustomerBalanceRowData> }) => (
 			<BarCell
 				row={row}

--- a/vite/src/views/customers2/components/table/customer-invoices/CustomerInvoicesTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-invoices/CustomerInvoicesTable.tsx
@@ -89,6 +89,7 @@ export function CustomerInvoicesTable() {
 				onRowClick: handleRowClick,
 				emptyStateText: "Invoices will display when a customer makes a payment",
 				flexibleTableColumns: false,
+				mobileCards: true,
 				rowClassName: "h-10 py-0",
 			}}
 		>

--- a/vite/src/views/customers2/components/table/customer-products/CustomerProductsTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-products/CustomerProductsTable.tsx
@@ -201,6 +201,7 @@ export function CustomerProductsTable() {
 					onRowClick: handleRowClick,
 					emptyStateChildren,
 					flexibleTableColumns: true,
+					mobileCards: true,
 					selectedItemId,
 					virtualization: { containerHeight: "428px", skeletonRowCount: 3 },
 				}}

--- a/vite/src/views/customers2/customer/CustomerPageDetails.tsx
+++ b/vite/src/views/customers2/customer/CustomerPageDetails.tsx
@@ -21,8 +21,8 @@ export const CustomerPageDetails = () => {
 		customer.fingerprint ?? "This user's fingerprint is undefined";
 
 	return (
-		<div className="flex min-w-0 items-center">
-			<div className="flex gap-2 flex-wrap">
+		<div className="flex w-full sm:w-auto min-w-0 items-center justify-between gap-2 sm:justify-start">
+			<div className="flex gap-2 flex-wrap min-w-0">
 				{customer.email && (
 					<CopyButton
 						text={customer.email ?? placeholderText}
@@ -53,8 +53,8 @@ export const CustomerPageDetails = () => {
 						<span className="truncate">{appliedCoupon.coupon}</span>
 					</div>
 				)}
-				<CustomerActions />
 			</div>
+			<CustomerActions />
 		</div>
 	);
 };

--- a/vite/src/views/customers2/customer/CustomerView2.tsx
+++ b/vite/src/views/customers2/customer/CustomerView2.tsx
@@ -117,7 +117,7 @@ export default function CustomerView2() {
 										<CustomerBreadcrumbs />
 										<CustomerHeaderActions />
 									</div>
-									<div className="flex items-center justify-between w-full pt-2 gap-2">
+									<div className="flex flex-col sm:flex-row sm:items-center sm:justify-between w-full pt-2 gap-2">
 										<div className="flex items-center gap-2 min-w-0">
 											<h3
 												className={`text-md font-semibold truncate min-w-0 ${

--- a/vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx
+++ b/vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx
@@ -1,11 +1,14 @@
+import type { FullCustomer } from "@autumn/shared";
 import { ProcessorType } from "@autumn/shared";
 import { BracketsSquareIcon, UserCircleGearIcon } from "@phosphor-icons/react";
 import { useState } from "react";
+import { useParams } from "react-router";
 import { toast } from "sonner";
 import { IconTooltipButton } from "@/components/v2/buttons/IconTooltipButton";
 import { StripeIcon } from "@/components/v2/icons/AutumnIcons";
 import { useOrg } from "@/hooks/common/useOrg";
 import { useOrgStripeQuery } from "@/hooks/queries/useOrgStripeQuery";
+import { getInitialScopeEntityId } from "@/hooks/useSheetScopeEntityId";
 import { CusService } from "@/services/customers/CusService";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { useEnv } from "@/utils/envUtils";
@@ -17,6 +20,7 @@ import {
 import { useAdmin } from "@/views/admin/hooks/useAdmin";
 import { useMasterStripeAccount } from "@/views/admin/hooks/useMasterStripeAccount";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { useCustomerObjectQuery } from "../hooks/useCustomerObjectQuery";
 import { CustomButtons } from "./CustomButtons";
 import { ShowCustomerObjectSheet } from "./ShowCustomerObjectSheet";
 
@@ -28,6 +32,15 @@ export function CustomerHeaderActions() {
 	const { masterStripeAccount } = useMasterStripeAccount();
 	const env = useEnv();
 	const axiosInstance = useAxiosInstance();
+	const { customer_id } = useParams();
+
+	useCustomerObjectQuery({
+		customerId: customer_id,
+		scopeEntityId: getInitialScopeEntityId(
+			customer as FullCustomer | undefined,
+		),
+		enabled: !!customer,
+	});
 
 	const [portalLoading, setPortalLoading] = useState(false);
 	const [showObjectOpen, setShowObjectOpen] = useState(false);

--- a/vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx
+++ b/vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx
@@ -1,6 +1,7 @@
 import type { FullCustomer } from "@autumn/shared";
 import { ProcessorType } from "@autumn/shared";
 import { BracketsSquareIcon, UserCircleGearIcon } from "@phosphor-icons/react";
+import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import { useParams } from "react-router";
 import { toast } from "sonner";
@@ -42,7 +43,6 @@ export function CustomerHeaderActions() {
 		enabled: !!customer,
 	});
 
-	const [portalLoading, setPortalLoading] = useState(false);
 	const [showObjectOpen, setShowObjectOpen] = useState(false);
 
 	const stripeCustomerId = customer?.processor?.id;
@@ -74,21 +74,16 @@ export function CustomerHeaderActions() {
 		);
 	};
 
-	const handleOpenBillingPortal = async () => {
-		if (!customer) return;
-		setPortalLoading(true);
-		try {
-			const { url } = await CusService.createBillingPortalSession({
+	const billingPortalMutation = useMutation({
+		mutationFn: () =>
+			CusService.createBillingPortalSession({
 				axios: axiosInstance,
 				customer_id: customer.id || customer.internal_id,
-			});
-			window.open(url, "_blank");
-		} catch (error) {
-			toast.error(getBackendErr(error, "Failed to open billing portal"));
-		} finally {
-			setPortalLoading(false);
-		}
-	};
+			}),
+		onSuccess: ({ url }) => window.open(url, "_blank"),
+		onError: (error) =>
+			toast.error(getBackendErr(error, "Failed to open billing portal")),
+	});
 
 	return (
 		<div className="flex items-center gap-1">
@@ -105,8 +100,8 @@ export function CustomerHeaderActions() {
 			<IconTooltipButton
 				tooltip="Open customer portal"
 				icon={<UserCircleGearIcon size={14} />}
-				onClick={handleOpenBillingPortal}
-				disabled={portalLoading}
+				onClick={() => billingPortalMutation.mutate()}
+				disabled={billingPortalMutation.isPending}
 			/>
 			{showStripe && (
 				<IconTooltipButton

--- a/vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx
+++ b/vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx
@@ -75,11 +75,13 @@ export function CustomerHeaderActions() {
 	};
 
 	const billingPortalMutation = useMutation({
-		mutationFn: () =>
-			CusService.createBillingPortalSession({
+		mutationFn: () => {
+			if (!customer) throw new Error("Customer not loaded");
+			return CusService.createBillingPortalSession({
 				axios: axiosInstance,
 				customer_id: customer.id || customer.internal_id,
-			}),
+			});
+		},
 		onSuccess: ({ url }) => window.open(url, "_blank"),
 		onError: (error) =>
 			toast.error(getBackendErr(error, "Failed to open billing portal")),
@@ -101,7 +103,7 @@ export function CustomerHeaderActions() {
 				tooltip="Open customer portal"
 				icon={<UserCircleGearIcon size={14} />}
 				onClick={() => billingPortalMutation.mutate()}
-				disabled={billingPortalMutation.isPending}
+				disabled={!customer || billingPortalMutation.isPending}
 			/>
 			{showStripe && (
 				<IconTooltipButton

--- a/vite/src/views/customers2/customer/components/ShowCustomerObjectSheet.tsx
+++ b/vite/src/views/customers2/customer/components/ShowCustomerObjectSheet.tsx
@@ -41,6 +41,7 @@ export function ShowCustomerObjectSheet({
 		customerId: customer_id,
 		scopeEntityId,
 		enabled: open,
+		staleTime: 0,
 	});
 
 	const formattedJson = useMemo(

--- a/vite/src/views/customers2/customer/components/ShowCustomerObjectSheet.tsx
+++ b/vite/src/views/customers2/customer/components/ShowCustomerObjectSheet.tsx
@@ -1,11 +1,9 @@
 import type { FullCustomer } from "@autumn/shared";
-import { LATEST_VERSION } from "@autumn/shared";
 import { Spinner } from "@phosphor-icons/react";
-import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { useParams } from "react-router";
 import {
 	CodeGroup,
-	CodeGroupCode,
 	CodeGroupCopyButton,
 	CodeGroupList,
 	CodeGroupTab,
@@ -16,58 +14,39 @@ import {
 	SheetHeader,
 	SheetTitle,
 } from "@/components/v2/sheets/Sheet";
-import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
+import { VirtualizedJson } from "@/components/v2/VirtualizedJson";
 import { useSheetScopeEntityId } from "@/hooks/useSheetScopeEntityId";
-import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { EntityScopeSelector } from "../../components/sheets/EntityScopeSelector";
+import { useCustomerObjectQuery } from "../hooks/useCustomerObjectQuery";
 
 interface ShowCustomerObjectSheetProps {
 	open: boolean;
 	setOpen: (open: boolean) => void;
 }
 
-const CUSTOMER_EXPAND_PARAMS = [
-	"invoices",
-	"trials_used",
-	"rewards",
-	"entities",
-	"referrals",
-	"payment_method",
-	"billing_controls.auto_topups.purchase_limit",
-].join(",");
-
-const ENTITY_EXPAND_PARAMS = "invoices";
-
 export function ShowCustomerObjectSheet({
 	open,
 	setOpen,
 }: ShowCustomerObjectSheetProps) {
 	const { customer_id } = useParams();
-	const axiosInstance = useAxiosInstance({ version: LATEST_VERSION });
-	const buildKey = useQueryKeyFactory();
 
 	const { customer } = useCusQuery();
 	const fullCustomer = customer as FullCustomer | undefined;
 	const entities = fullCustomer?.entities ?? [];
 	const [scopeEntityId, setScopeEntityId] = useSheetScopeEntityId(fullCustomer);
 
-	const { data, isLoading, error } = useQuery({
-		queryKey: buildKey(["customer-object", customer_id, scopeEntityId]),
-		queryFn: async () => {
-			const url = scopeEntityId
-				? `/v1/customers/${customer_id}/entities/${scopeEntityId}?expand=${ENTITY_EXPAND_PARAMS}`
-				: `/v1/customers/${customer_id}?expand=${CUSTOMER_EXPAND_PARAMS}`;
-			const { data } = await axiosInstance.get(url);
-			return data;
-		},
-		enabled: open && !!customer_id,
-		gcTime: 0,
-		staleTime: 0,
+	const { data, isLoading, error } = useCustomerObjectQuery({
+		customerId: customer_id,
+		scopeEntityId,
+		enabled: open,
 	});
 
-	const formattedJson = data ? JSON.stringify(data, null, 2) : "";
+	const formattedJson = useMemo(
+		() => (data ? JSON.stringify(data, null, 2) : ""),
+		[data],
+	);
 
 	const description = scopeEntityId
 		? "From entities.get"
@@ -75,7 +54,7 @@ export function ShowCustomerObjectSheet({
 
 	return (
 		<Sheet open={open} onOpenChange={setOpen}>
-			<SheetContent className="flex flex-col overflow-hidden bg-background min-w-xl">
+			<SheetContent className="flex flex-col overflow-hidden bg-background sm:min-w-xl">
 				<SheetHeader>
 					<SheetTitle>
 						{scopeEntityId ? "Entity Object" : "Customer Object"}
@@ -112,9 +91,10 @@ export function ShowCustomerObjectSheet({
 									onCopy={() => navigator.clipboard.writeText(formattedJson)}
 								/>
 							</CodeGroupList>
-							<div className="flex-1 h-0 overflow-y-auto border border-t-0 rounded-b-lg bg-white dark:bg-background p-4">
-								<CodeGroupCode language="json">{formattedJson}</CodeGroupCode>
-							</div>
+							<VirtualizedJson
+								json={formattedJson}
+								className="flex-1 h-0 border border-t-0 rounded-b-lg bg-white dark:bg-background py-4"
+							/>
 						</CodeGroup>
 					)}
 				</div>

--- a/vite/src/views/customers2/customer/hooks/useCustomerObjectQuery.ts
+++ b/vite/src/views/customers2/customer/hooks/useCustomerObjectQuery.ts
@@ -1,0 +1,49 @@
+import { LATEST_VERSION } from "@autumn/shared";
+import { useQuery } from "@tanstack/react-query";
+import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+
+const CUSTOMER_EXPAND_PARAMS = [
+	"invoices",
+	"trials_used",
+	"rewards",
+	"entities",
+	"referrals",
+	"payment_method",
+	"billing_controls.auto_topups.purchase_limit",
+].join(",");
+
+const ENTITY_EXPAND_PARAMS = "invoices";
+
+const CUSTOMER_OBJECT_GC_TIME = 5 * 60 * 1000;
+
+const buildUrl = (customerId: string, scopeEntityId?: string | null) =>
+	scopeEntityId
+		? `/v1/customers/${customerId}/entities/${scopeEntityId}?expand=${ENTITY_EXPAND_PARAMS}`
+		: `/v1/customers/${customerId}?expand=${CUSTOMER_EXPAND_PARAMS}`;
+
+export function useCustomerObjectQuery({
+	customerId,
+	scopeEntityId,
+	enabled,
+}: {
+	customerId?: string;
+	scopeEntityId?: string | null;
+	enabled: boolean;
+}) {
+	const axiosInstance = useAxiosInstance({ version: LATEST_VERSION });
+	const buildKey = useQueryKeyFactory();
+
+	return useQuery({
+		queryKey: buildKey(["customer-object", customerId, scopeEntityId]),
+		queryFn: async () => {
+			const { data } = await axiosInstance.get(
+				buildUrl(customerId as string, scopeEntityId),
+			);
+			return data;
+		},
+		enabled: enabled && !!customerId,
+		gcTime: CUSTOMER_OBJECT_GC_TIME,
+		staleTime: CUSTOMER_OBJECT_GC_TIME,
+	});
+}

--- a/vite/src/views/customers2/customer/hooks/useCustomerObjectQuery.ts
+++ b/vite/src/views/customers2/customer/hooks/useCustomerObjectQuery.ts
@@ -26,10 +26,12 @@ export function useCustomerObjectQuery({
 	customerId,
 	scopeEntityId,
 	enabled,
+	staleTime = CUSTOMER_OBJECT_GC_TIME,
 }: {
 	customerId?: string;
 	scopeEntityId?: string | null;
 	enabled: boolean;
+	staleTime?: number;
 }) {
 	const axiosInstance = useAxiosInstance({ version: LATEST_VERSION });
 	const buildKey = useQueryKeyFactory();
@@ -44,6 +46,6 @@ export function useCustomerObjectQuery({
 		},
 		enabled: enabled && !!customerId,
 		gcTime: CUSTOMER_OBJECT_GC_TIME,
-		staleTime: CUSTOMER_OBJECT_GC_TIME,
+		staleTime,
 	});
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the mobile customer experience with a card view for tables, a fast virtualized JSON viewer, and safer mobile fallbacks. Also fixes the billing portal button race and keeps the customer-object sheet fresh while prefetch stays warm.

- **New Features**
  - Table card view on mobile: opt-in with `mobileCards: true`, auto-switches via `useIsMobile`; supports column meta `mobileCard`/`mobileCardCell`; enabled for balance, invoices, and products. Row clicks only fire when there’s no `rowHref` to match table behavior.
  - Virtualized JSON viewer: `VirtualizedJson` with per-line syntax highlighting via `highlightJson`; used in the customer/object sheet for smooth scrolling on large payloads.
  - Customer object data: shared `useCustomerObjectQuery` with a 5‑minute warm cache for header prefetch; the sheet passes `staleTime: 0` for fresh data; scope seeds from URL via `getInitialScopeEntityId`.

- **Bug Fixes**
  - Virtualized tables render all rows if mobile reports a 0‑height scroll container (prevents empty lists on first paint).
  - Billing portal: restore customer null guard and disable the button until the customer loads.
  - Invoice details: displays the live invoice from `useCusQuery` before falling back to the sheet snapshot.
  - Server `CusService`: guard slicing of `customer_products` and `entities` to avoid runtime errors.

<sup>Written for commit 0ce12cf46a74169eb11e430a51ac6803bb4c4a8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds responsive mobile UI improvements across the customer detail view, including a new mobile card layout for tables, a virtualized JSON viewer for the customer object sheet, layout fixes for the customer header, and minor server-side null-safety fixes.

- **[Improvements]** New `TableMobileCards` component renders tables as card lists on mobile, controlled by a `mobileCards` prop and `useShowMobileCards` hook; enabled for balance, invoices, and products tables.
- **[Improvements]** `ShowCustomerObjectSheet` now uses a `VirtualizedJson` renderer (with a dedicated `highlightJson` utility) to handle large payloads efficiently, and shares a new `useCustomerObjectQuery` hook that also prefetches data from `CustomerHeaderActions` for instant sheet opens.
- **[Bug fixes]** `CusService` null-guards the hardcoded org/customer fast path before slicing `customer_products` and `entities`; `InvoiceDetailSheet` resolves the live invoice from the query cache rather than relying solely on the sheet snapshot.
</details>

<h3>Confidence Score: 3/5</h3>

Safe to merge after restoring the null guard on `customer` in the billing portal mutation.

The billing portal refactor dropped the original `if (!customer) return;` guard without adding a compensating disabled state on the button, so clicking it before the customer query resolves will throw at runtime. Everything else — the new mobile card components, the virtualized JSON viewer, the shared query hook, and the server-side null-safety fixes — looks correct and well-structured.

vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx needs the null guard restored on the billing portal mutation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx | Refactored billing portal handler to useMutation; added prefetch call via useCustomerObjectQuery — but removed the original null guard on `customer`, leaving the portal button able to throw at runtime when clicked before the customer query resolves. |
| vite/src/views/customers2/customer/hooks/useCustomerObjectQuery.ts | New shared hook that extracts the customer-object query; introduces a 5-minute staleTime/gcTime (up from 0) to support background prefetching, which may serve stale data in the debugging sheet. |
| vite/src/components/general/table/table-mobile-cards.tsx | New mobile card view for tables; correctly handles loading skeletons, empty state, row click, selection highlight, and per-column meta overrides (hidden/full). Safe to merge. |
| vite/src/components/v2/VirtualizedJson.tsx | New virtualized JSON renderer using @tanstack/react-virtual; uses dangerouslySetInnerHTML but delegates to highlightJsonLine which escapes all user-controlled input before injection. |
| vite/src/components/general/table/table-body-virtualized.tsx | Adds a fallback render path for mobile browsers that measure scroll container at 0 height; the partial VirtualItem cast ({ index } as VirtualItem) is safe because VirtualRow only reads virtualRow.index. |
| vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx | Now resolves the live invoice from the customer query cache before falling back to the sheet snapshot, keeping displayed invoice data fresh after mutations without requiring a full re-open. |
| vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx | Swaps Button for ShortcutButton with a meta+Enter shortcut and full-width layout; removes the Cancel button (dialog can still be closed via Escape/X). |
| server/src/internal/customers/CusService.ts | Adds null guards before accessing customer_products and entities on the hardcoded org/customer ID fast path; safe defensive fix. |
| vite/src/views/customers2/customer/components/ShowCustomerObjectSheet.tsx | Refactored to use the new shared useCustomerObjectQuery hook and VirtualizedJson for large payload rendering; responsive min-width fix for mobile. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CH as CustomerHeaderActions
    participant SOS as ShowCustomerObjectSheet
    participant COQ as useCustomerObjectQuery
    participant API as /v1/customers API

    Note over CH: Customer page mounts
    CH->>COQ: enabled: !!customer (prefetch)
    COQ->>API: "GET /v1/customers/:id?expand=..."
    API-->>COQ: customer object (cached 5 min)

    Note over SOS: User opens sheet
    SOS->>COQ: enabled: open
    COQ-->>SOS: returns cached data instantly
    SOS->>SOS: VirtualizedJson renders lines

    Note over SOS: User changes scope selector
    SOS->>COQ: scopeEntityId changes
    COQ->>API: GET /v1/customers/:id/entities/:eid
    API-->>COQ: entity object
    COQ-->>SOS: new data rendered
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CH as CustomerHeaderActions
    participant SOS as ShowCustomerObjectSheet
    participant COQ as useCustomerObjectQuery
    participant API as /v1/customers API

    Note over CH: Customer page mounts
    CH->>COQ: enabled: !!customer (prefetch)
    COQ->>API: "GET /v1/customers/:id?expand=..."
    API-->>COQ: customer object (cached 5 min)

    Note over SOS: User opens sheet
    SOS->>COQ: enabled: open
    COQ-->>SOS: returns cached data instantly
    SOS->>SOS: VirtualizedJson renders lines

    Note over SOS: User changes scope selector
    SOS->>COQ: scopeEntityId changes
    COQ->>API: GET /v1/customers/:id/entities/:eid
    API-->>COQ: entity object
    COQ-->>SOS: new data rendered
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx:77-86
**Missing null guard on `customer` in `mutationFn`**

The original handler checked `if (!customer) return;` before accessing `customer.id`. That guard was dropped in the refactor. The "Open customer portal" button is rendered unconditionally in this component (no `disabled={!customer}` guard either), so clicking it before the customer query resolves will throw `TypeError: Cannot read properties of undefined (reading 'id')` at the point `customer.id || customer.internal_id` is evaluated inside `mutationFn`.

```suggestion
	const billingPortalMutation = useMutation({
		mutationFn: () => {
			if (!customer) throw new Error("Customer not loaded");
			return CusService.createBillingPortalSession({
				axios: axiosInstance,
				customer_id: customer.id || customer.internal_id,
			});
		},
```

### Issue 2 of 2
vite/src/views/customers2/customer/hooks/useCustomerObjectQuery.ts:18-47
**Stale cache may show outdated data in the "Show Customer Object" sheet**

The original query used `gcTime: 0, staleTime: 0` so every sheet open triggered a fresh fetch. The new shared hook sets both to 5 minutes, which is correct for the background prefetch in `CustomerHeaderActions`, but means the sheet may display customer-object data that is up to 5 minutes old without any refetch. For an admin/debugging tool where freshness matters, consider passing a `staleTime` override from the sheet call site (e.g. `staleTime: 0`) while keeping the warm-cache behaviour for the prefetch.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add table mobile cards"](https://github.com/useautumn/autumn/commit/0dcd6026b1d8cf769084cfa8e106aa35fece4e88) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39265235)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->