### PR TITLE
release

### DIFF
--- a/packages/auth/src/oauth/leafOAuth.ts
+++ b/packages/auth/src/oauth/leafOAuth.ts
@@ -5,21 +5,20 @@ import {
 } from "@autumn/shared/scopeDefinitions";
 
 const leafScopeSet = new Set<string>(LEAF_OAUTH_SCOPES);
-const oauthPassthroughScopeSet = new Set<string>(["offline_access"]);
 const oauthProtocolScopeSet = new Set<string>(OPENID_SCOPES);
 
 export const getDefaultOAuthScopes = (requestedScopes?: string[] | null) => {
 	const requested =
 		requestedScopes && requestedScopes.length > 0
 			? requestedScopes
-			: [...LEAF_OAUTH_SCOPES, ...oauthPassthroughScopeSet];
+			: [...LEAF_OAUTH_SCOPES, ...OPENID_SCOPES];
 
 	// Issued scopes must echo the client's request verbatim (better-auth
 	// rejects rewrites), so legacy CRUDL aliases are used for filtering only.
 	return [...new Set(requested)].filter(
 		(scope) =>
 			leafScopeSet.has(LEGACY_SCOPE_ALIASES[scope] ?? scope) ||
-			oauthPassthroughScopeSet.has(scope),
+			oauthProtocolScopeSet.has(scope),
 	);
 };
 

--- a/server/src/internal/customers/CusService.ts
+++ b/server/src/internal/customers/CusService.ts
@@ -239,13 +239,19 @@ export class CusService {
 					orgId === "GG6tnmO7cHb40PNhwYBTZtxQdeL74NHF" &&
 					idOrInternalId === "698fb72e4c5fa12c1cd11ddc"
 				) {
-					fullCus.customer_products = (
-						fullCus.customer_products as FullCusProduct[]
-					)
-						.sort((a, b) => b.customer_prices.length - a.customer_prices.length)
-						.slice(0, 5);
+					if (fullCus.customer_products) {
+						fullCus.customer_products = (
+							fullCus.customer_products as FullCusProduct[]
+						)
+							.sort(
+								(a, b) => b.customer_prices.length - a.customer_prices.length,
+							)
+							.slice(0, 5);
+					}
 
-					fullCus.entities = (fullCus.entities as Entity[]).slice(0, 50);
+					if (fullCus.entities) {
+						fullCus.entities = (fullCus.entities as Entity[]).slice(0, 50);
+					}
 				}
 				if (!usedReplica && !skipReset) {
 					// Skip reset only when executeWithHealthTracking explicitly chose the

--- a/server/tests/unit/auth/registerMcpOAuthClient.test.ts
+++ b/server/tests/unit/auth/registerMcpOAuthClient.test.ts
@@ -4,26 +4,26 @@ import {
 	getOAuthResourceScopes,
 } from "@autumn/auth/oauth";
 import { LEAF_OAUTH_SCOPES } from "@autumn/shared";
-import { Scopes } from "@autumn/shared/scopeDefinitions";
+import { OPENID_SCOPES, Scopes } from "@autumn/shared/scopeDefinitions";
 import { getRequestedScopesForMcpClient } from "@/internal/auth/actions/registerMcpOAuthClient.js";
 
 const OFFLINE_ACCESS_SCOPE = "offline_access";
-const DEFAULT_MCP_SCOPES = [...LEAF_OAUTH_SCOPES, OFFLINE_ACCESS_SCOPE];
+const DEFAULT_MCP_SCOPES = [...LEAF_OAUTH_SCOPES, ...OPENID_SCOPES];
 
 describe("getRequestedScopesForMcpClient", () => {
-	test("defaults Slack MCP clients to Leaf scopes plus offline access", () => {
+	test("defaults Slack MCP clients to Leaf scopes plus OIDC scopes", () => {
 		expect(
 			getRequestedScopesForMcpClient({ clientType: "slack", scope: undefined }),
 		).toEqual(DEFAULT_MCP_SCOPES);
 	});
 
-	test("defaults Codex MCP clients to Leaf scopes plus offline access", () => {
+	test("defaults Codex MCP clients to Leaf scopes plus OIDC scopes", () => {
 		expect(
 			getRequestedScopesForMcpClient({ clientType: "codex", scope: undefined }),
 		).toEqual(DEFAULT_MCP_SCOPES);
 	});
 
-	test("defaults dynamic MCP clients to Leaf scopes plus offline access", () => {
+	test("defaults dynamic MCP clients to Leaf scopes plus OIDC scopes", () => {
 		expect(
 			getRequestedScopesForMcpClient({
 				clientType: "dynamic",
@@ -32,7 +32,7 @@ describe("getRequestedScopesForMcpClient", () => {
 		).toEqual(DEFAULT_MCP_SCOPES);
 	});
 
-	test("caps explicit requested scopes to Leaf scopes plus offline access", () => {
+	test("caps explicit requested scopes to Leaf and OIDC scopes", () => {
 		expect(
 			getRequestedScopesForMcpClient({
 				clientType: "slack",
@@ -45,11 +45,20 @@ describe("getRequestedScopesForMcpClient", () => {
 		]);
 	});
 
-	test("preserves offline access in default OAuth scopes", () => {
+	test("preserves OIDC protocol scopes that Claude requests", () => {
+		expect(
+			getRequestedScopesForMcpClient({
+				clientType: "claude",
+				scope: "openid profile email offline_access",
+			}),
+		).toEqual(["openid", "profile", "email", OFFLINE_ACCESS_SCOPE]);
+	});
+
+	test("preserves OIDC scopes in default OAuth scopes", () => {
 		expect(getDefaultOAuthScopes()).toEqual(DEFAULT_MCP_SCOPES);
 	});
 
-	test("caps OAuth grants to Leaf scopes plus offline access", () => {
+	test("caps OAuth grants to Leaf and OIDC scopes", () => {
 		expect(
 			getDefaultOAuthScopes([
 				Scopes.Customers.Read,

--- a/vite/src/components/general/table/table-body-virtualized.tsx
+++ b/vite/src/components/general/table/table-body-virtualized.tsx
@@ -131,6 +131,10 @@ export function TableBodyVirtualized() {
 	// Memoize virtual items to prevent unnecessary recalculations
 	const virtualRows = virtualizer.getVirtualItems();
 
+	// Mobile browsers can measure the scroll container at 0 height on init,
+	// leaving zero virtual items despite having rows — render them all instead.
+	const useFallbackRender = hasRows && virtualRows.length === 0;
+
 	// Memoize padding calculations
 	const { paddingTop, paddingBottom } = useMemo(() => {
 		const top = virtualRows[0]?.start ?? 0;
@@ -214,6 +218,39 @@ export function TableBodyVirtualized() {
 						</div>
 					</TableCell>
 				</TableRow>
+			</MotionTbody>
+		);
+	}
+
+	if (useFallbackRender) {
+		return (
+			<MotionTbody
+				key="content"
+				{...TABLE_FADE_IN}
+				transition={TABLE_TRANSITION}
+				className="bg-interactive-secondary"
+			>
+				{rows.map((row, index) => {
+					const isSelected =
+						selectedItemId === (row.original as { id?: string }).id;
+					const rowHref = getRowHref?.(row.original);
+
+					return (
+						<VirtualRow
+							key={row.id}
+							row={row}
+							virtualRow={{ index } as VirtualItem}
+							isSelected={isSelected}
+							rowHref={rowHref}
+							rowClassName={rowClassName}
+							enableSelection={enableSelection}
+							flexibleTableColumns={flexibleTableColumns}
+							onRowClick={memoizedOnRowClick}
+							onRowDoubleClick={memoizedOnRowDoubleClick}
+							visibleColumnKey={visibleColumnKey}
+						/>
+					);
+				})}
 			</MotionTbody>
 		);
 	}

--- a/vite/src/components/general/table/table-content-virtualized.tsx
+++ b/vite/src/components/general/table/table-content-virtualized.tsx
@@ -2,8 +2,13 @@ import React, { useCallback, useMemo, useRef, useState } from "react";
 import { Table } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import { TableColumnVisibility } from "./table-column-visibility";
-import { TableContext, useTableContext } from "./table-context";
+import {
+	TableContext,
+	useShowMobileCards,
+	useTableContext,
+} from "./table-context";
 import { TableHeader } from "./table-header";
+import { TableMobileCards } from "./table-mobile-cards";
 
 export function TableContentVirtualized({
 	children,
@@ -23,6 +28,7 @@ export function TableContentVirtualized({
 	} = context;
 	const { isLoading, isTransitioning } = context;
 	const rows = table.getRowModel().rows;
+	const showMobileCards = useShowMobileCards();
 
 	// Use state instead of ref so changes trigger re-renders for virtualizer
 	const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(
@@ -83,6 +89,10 @@ export function TableContentVirtualized({
 	};
 
 	const isFlexFill = virtualization?.containerHeight === "100%";
+
+	if (showMobileCards) {
+		return <TableMobileCards />;
+	}
 
 	return (
 		<TableContext.Provider value={contextWithRef}>

--- a/vite/src/components/general/table/table-content.tsx
+++ b/vite/src/components/general/table/table-content.tsx
@@ -1,7 +1,8 @@
 import { Table } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import { TableColumnVisibility } from "./table-column-visibility";
-import { useTableContext } from "./table-context";
+import { useShowMobileCards, useTableContext } from "./table-context";
+import { TableMobileCards } from "./table-mobile-cards";
 
 export function TableContent({
 	children,
@@ -10,15 +11,25 @@ export function TableContent({
 	children: React.ReactNode;
 	className?: string;
 }) {
-	const { flexibleTableColumns, enableColumnVisibility, isLoading, isTransitioning, table } =
-		useTableContext();
+	const {
+		flexibleTableColumns,
+		enableColumnVisibility,
+		isLoading,
+		isTransitioning,
+		table,
+	} = useTableContext();
 	const rows = table.getRowModel().rows;
+	const showMobileCards = useShowMobileCards();
+
+	if (showMobileCards) {
+		return <TableMobileCards />;
+	}
 
 	return (
 		<div
 			className={cn(
-"rounded-lg border relative z-50 min-w-0",
-			!rows.length && "border-dashed",
+				"rounded-lg border relative z-50 min-w-0",
+				!rows.length && "border-dashed",
 				className,
 			)}
 		>

--- a/vite/src/components/general/table/table-context.tsx
+++ b/vite/src/components/general/table/table-context.tsx
@@ -1,6 +1,7 @@
 import type { Table as TanstackTable } from "@tanstack/react-table";
 import { createContext, type ReactNode, useContext } from "react";
 import type { ColumnGroup } from "@/hooks/useColumnVisibility";
+import { useIsMobile } from "@/hooks/useIsMobile";
 
 export interface VirtualizationConfig {
 	/** Height of the scroll container, e.g., "calc(100vh - 240px)" */
@@ -42,6 +43,7 @@ export interface TableProps<T> {
 	emptyStateChildren?: ReactNode;
 	emptyStateText?: string;
 	flexibleTableColumns?: boolean;
+	mobileCards?: boolean;
 	selectedItemId?: string | null;
 	/** Virtualization config - only needed when using VirtualizedContent/VirtualizedBody */
 	virtualization?: VirtualizationConfig;
@@ -60,4 +62,10 @@ export function useTableContext<T>(): TableProps<T> {
 	}
 
 	return context as TableProps<T>;
+}
+
+export function useShowMobileCards(): boolean {
+	const { mobileCards } = useTableContext();
+	const isMobile = useIsMobile();
+	return Boolean(mobileCards) && isMobile;
 }

--- a/vite/src/components/general/table/table-mobile-cards.tsx
+++ b/vite/src/components/general/table/table-mobile-cards.tsx
@@ -90,7 +90,8 @@ function MobileCard<T>({
 			cell.column.columnDef.meta?.mobileCard !== "hidden",
 	);
 
-	const handleClick = onRowClick ? () => onRowClick(row.original) : undefined;
+	const handleClick =
+		onRowClick && !rowHref ? () => onRowClick(row.original) : undefined;
 
 	const card = (
 		<div

--- a/vite/src/components/general/table/table-mobile-cards.tsx
+++ b/vite/src/components/general/table/table-mobile-cards.tsx
@@ -1,0 +1,172 @@
+import type { Cell, Row } from "@tanstack/react-table";
+import { flexRender } from "@tanstack/react-table";
+import { Link } from "react-router";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import { useTableContext } from "./table-context";
+
+const SKELETON_CARD_COUNT = 3;
+
+const CONTROL_COLUMNS = new Set(["actions", "select"]);
+const NON_TITLE_COLUMNS = new Set(["actions", "select", "scope"]);
+
+export function TableMobileCards() {
+	const {
+		table,
+		isLoading,
+		isTransitioning,
+		getRowHref,
+		onRowClick,
+		emptyStateChildren,
+		emptyStateText,
+		selectedItemId,
+	} = useTableContext();
+
+	const rows = table.getRowModel().rows;
+	const showSkeleton = isLoading || isTransitioning;
+
+	if (showSkeleton && !rows.length) {
+		return (
+			<div className="flex flex-col gap-2.5">
+				{Array.from({ length: SKELETON_CARD_COUNT }).map((_, cardIndex) => (
+					<div
+						key={`skeleton-card-${cardIndex}`}
+						className="rounded-xl border bg-interactive-secondary p-4 flex flex-col gap-3"
+					>
+						<Skeleton className="h-4 w-28 rounded-sm" />
+						<div className="flex flex-col gap-2">
+							<Skeleton className="h-3 w-40 rounded-sm" />
+							<Skeleton className="h-3 w-32 rounded-sm" />
+						</div>
+					</div>
+				))}
+			</div>
+		);
+	}
+
+	if (!rows.length) {
+		return (
+			<div className="rounded-xl border border-dashed bg-interactive-secondary dark:bg-transparent p-6 text-center text-subtle text-xs">
+				{emptyStateChildren || emptyStateText}
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-2.5">
+			{rows.map((row) => (
+				<MobileCard
+					key={row.id}
+					row={row}
+					rowHref={getRowHref?.(row.original)}
+					isSelected={selectedItemId === (row.original as { id?: string }).id}
+					onRowClick={onRowClick}
+				/>
+			))}
+		</div>
+	);
+}
+
+function MobileCard<T>({
+	row,
+	rowHref,
+	isSelected,
+	onRowClick,
+}: {
+	row: Row<T>;
+	rowHref?: string;
+	isSelected: boolean;
+	onRowClick?: (row: T) => void;
+}) {
+	const cells = row.getVisibleCells();
+	const titleCell = cells.find(
+		(cell) => !NON_TITLE_COLUMNS.has(cell.column.id),
+	);
+	const actionsCell = cells.find((cell) => cell.column.id === "actions");
+	const detailCells = cells.filter(
+		(cell) =>
+			cell.column.id !== titleCell?.column.id &&
+			!CONTROL_COLUMNS.has(cell.column.id) &&
+			cell.column.columnDef.meta?.mobileCard !== "hidden",
+	);
+
+	const handleClick = onRowClick ? () => onRowClick(row.original) : undefined;
+
+	const card = (
+		<div
+			className={cn(
+				"rounded-xl border bg-interactive-secondary p-4 flex flex-col gap-3 transition-colors",
+				isSelected ? "border-primary" : "active:bg-interactive-secondary-hover",
+				(handleClick || rowHref) && "cursor-pointer",
+			)}
+			onClick={handleClick}
+			onKeyDown={
+				handleClick
+					? (e) => {
+							if (e.key === "Enter" || e.key === " ") {
+								e.preventDefault();
+								handleClick();
+							}
+						}
+					: undefined
+			}
+			role={handleClick ? "button" : undefined}
+			tabIndex={handleClick ? 0 : undefined}
+		>
+			<div className="flex items-center justify-between gap-3">
+				<div className="min-w-0 flex-1 text-foreground font-medium text-[15px] truncate">
+					{titleCell &&
+						flexRender(titleCell.column.columnDef.cell, titleCell.getContext())}
+				</div>
+				{actionsCell && (
+					<div className="shrink-0 -mr-1.5 -my-1">
+						{flexRender(
+							actionsCell.column.columnDef.cell,
+							actionsCell.getContext(),
+						)}
+					</div>
+				)}
+			</div>
+
+			{detailCells.length > 0 && (
+				<dl className="flex flex-col gap-1.5 border-t border-border/60 pt-3">
+					{detailCells.map((cell) => (
+						<CardDetailRow key={cell.id} cell={cell} />
+					))}
+				</dl>
+			)}
+		</div>
+	);
+
+	if (rowHref) {
+		return (
+			<Link to={rowHref} className="block">
+				{card}
+			</Link>
+		);
+	}
+
+	return card;
+}
+
+function CardDetailRow<T>({ cell }: { cell: Cell<T, unknown> }) {
+	const { header, meta } = cell.column.columnDef;
+	const cellContent = meta?.mobileCardCell
+		? meta.mobileCardCell(cell.row)
+		: flexRender(cell.column.columnDef.cell, cell.getContext());
+
+	if (meta?.mobileCard === "full") {
+		return <div className="text-sm text-foreground">{cellContent}</div>;
+	}
+
+	return (
+		<div className="flex items-baseline justify-between gap-4 text-sm">
+			<dt className="text-tertiary-foreground shrink-0">
+				{typeof header === "string" ? header : null}
+			</dt>
+			<dd className="text-foreground text-right min-w-0 truncate">
+				{cellContent}
+			</dd>
+		</div>
+	);
+}

--- a/vite/src/components/general/table/table-mobile-cards.tsx
+++ b/vite/src/components/general/table/table-mobile-cards.tsx
@@ -1,6 +1,6 @@
 import type { Cell, Row } from "@tanstack/react-table";
 import { flexRender } from "@tanstack/react-table";
-import { Link } from "react-router";
+import { useNavigate } from "react-router";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import { useTableContext } from "./table-context";
@@ -90,15 +90,24 @@ function MobileCard<T>({
 			cell.column.columnDef.meta?.mobileCard !== "hidden",
 	);
 
-	const handleClick =
-		onRowClick && !rowHref ? () => onRowClick(row.original) : undefined;
+	const navigate = useNavigate();
 
-	const card = (
+	// Navigate programmatically rather than wrapping the card in a Link so nested
+	// action controls (e.g. the actions dropdown) can stopPropagation and not
+	// trigger navigation. Matches onRowClick behavior.
+	const getClickHandler = () => {
+		if (rowHref) return () => navigate(rowHref);
+		if (onRowClick) return () => onRowClick(row.original);
+		return undefined;
+	};
+	const handleClick = getClickHandler();
+
+	return (
 		<div
 			className={cn(
 				"rounded-xl border bg-interactive-secondary p-4 flex flex-col gap-3 transition-colors",
 				isSelected ? "border-primary" : "active:bg-interactive-secondary-hover",
-				(handleClick || rowHref) && "cursor-pointer",
+				handleClick && "cursor-pointer",
 			)}
 			onClick={handleClick}
 			onKeyDown={
@@ -138,16 +147,6 @@ function MobileCard<T>({
 			)}
 		</div>
 	);
-
-	if (rowHref) {
-		return (
-			<Link to={rowHref} className="block">
-				{card}
-			</Link>
-		);
-	}
-
-	return card;
 }
 
 function CardDetailRow<T>({ cell }: { cell: Cell<T, unknown> }) {

--- a/vite/src/components/v2/VirtualizedJson.tsx
+++ b/vite/src/components/v2/VirtualizedJson.tsx
@@ -1,0 +1,60 @@
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { useMemo, useRef } from "react";
+import { highlightJsonLine } from "@/lib/highlightJson";
+import { cn } from "@/lib/utils";
+
+const LINE_HEIGHT = 21;
+const OVERSCAN = 20;
+
+/**
+ * Renders large JSON fast by virtualizing lines — only the visible ~30 lines
+ * are highlighted and mounted, keeping DOM node count constant regardless of
+ * payload size. A single <pre> with thousands of spans stalls layout/paint.
+ */
+export function VirtualizedJson({
+	json,
+	className,
+}: {
+	json: string;
+	className?: string;
+}) {
+	const lines = useMemo(() => json.split("\n"), [json]);
+	const scrollRef = useRef<HTMLDivElement>(null);
+
+	const virtualizer = useVirtualizer({
+		count: lines.length,
+		getScrollElement: () => scrollRef.current,
+		estimateSize: () => LINE_HEIGHT,
+		overscan: OVERSCAN,
+	});
+
+	return (
+		<div
+			ref={scrollRef}
+			className={cn(
+				"overflow-auto font-mono font-medium text-[13px] leading-[1.6]",
+				className,
+			)}
+		>
+			<div
+				className="relative w-max min-w-full"
+				style={{ height: virtualizer.getTotalSize() }}
+			>
+				{virtualizer.getVirtualItems().map((item) => (
+					<div
+						key={item.key}
+						className="absolute left-0 top-0 whitespace-pre px-4"
+						style={{
+							height: LINE_HEIGHT,
+							transform: `translateY(${item.start}px)`,
+						}}
+						// biome-ignore lint/security/noDangerouslySetInnerHtml: highlightJsonLine escapes all input
+						dangerouslySetInnerHTML={{
+							__html: highlightJsonLine(lines[item.index]) || "​",
+						}}
+					/>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/vite/src/hooks/useSheetScopeEntityId.ts
+++ b/vite/src/hooks/useSheetScopeEntityId.ts
@@ -18,17 +18,19 @@ function pickDefaultScopeEntityId({
 	return activePlans.find((cp) => !!cp.entity_id)?.entity_id ?? undefined;
 }
 
+/** The scope the sheet seeds to: URL `entity_id` param, else the smart default. */
+export function getInitialScopeEntityId(
+	customer: FullCustomer | undefined,
+): string | undefined {
+	const fromUrl =
+		new URLSearchParams(window.location.search).get("entity_id") ?? undefined;
+	return fromUrl ?? pickDefaultScopeEntityId({ customer });
+}
+
 // Sheet-local scope state for Attach / Create Schedule flows. Seeds from the
 // `entity_id` URL param if present, otherwise applies the smart default based
 // on the customer's existing plans. Changes stay local to the sheet.
 export function useSheetScopeEntityId(customer: FullCustomer | undefined) {
-	const initialFromUrl = useMemo(
-		() =>
-			new URLSearchParams(window.location.search).get("entity_id") ?? undefined,
-		[],
-	);
-
-	return useState<string | undefined>(
-		initialFromUrl ?? pickDefaultScopeEntityId({ customer }),
-	);
+	const initial = useMemo(() => getInitialScopeEntityId(customer), [customer]);
+	return useState<string | undefined>(initial);
 }

--- a/vite/src/lib/highlightJson.ts
+++ b/vite/src/lib/highlightJson.ts
@@ -1,0 +1,57 @@
+const HTML_ESCAPES: Record<string, string> = {
+	"&": "&amp;",
+	"<": "&lt;",
+	">": "&gt;",
+	'"': "&quot;",
+	"'": "&#039;",
+};
+
+const escapeHtml = (value: string): string =>
+	value.replace(/[&<>"']/g, (char) => HTML_ESCAPES[char]);
+
+const JSON_TOKEN =
+	/("(?:\\.|[^"\\])*")(\s*:)?|\b(true|false|null)\b|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g;
+
+/**
+ * Highlight a single line of pretty-printed JSON. Strings never span lines in
+ * 2-space-indented JSON, so each line tokenizes independently — letting callers
+ * virtualize and highlight only the visible lines.
+ */
+export function highlightJsonLine(line: string): string {
+	let result = "";
+	let lastIndex = 0;
+
+	for (const match of line.matchAll(JSON_TOKEN)) {
+		const [full, string, colon, keyword, number] = match;
+		const index = match.index;
+		result += escapeHtml(line.slice(lastIndex, index));
+
+		if (string !== undefined) {
+			const isKey = colon !== undefined;
+			const className = isKey
+				? "text-sky-700 dark:text-sky-300"
+				: "text-emerald-700 dark:text-emerald-300";
+			result += `<span class="${className}">${escapeHtml(string)}</span>`;
+			if (colon) result += escapeHtml(colon);
+		} else if (keyword !== undefined) {
+			const className =
+				keyword === "null"
+					? "text-tertiary-foreground"
+					: "text-purple-700 dark:text-purple-300";
+			result += `<span class="${className}">${keyword}</span>`;
+		} else if (number !== undefined) {
+			result += `<span class="text-amber-700 dark:text-amber-400">${number}</span>`;
+		}
+
+		lastIndex = index + full.length;
+	}
+
+	result += escapeHtml(line.slice(lastIndex));
+	return result;
+}
+
+/** Highlight a full JSON document. Prefer the virtualized viewer for rendering;
+ * use this only for non-DOM consumers (e.g. copy-to-clipboard fallbacks). */
+export function highlightJson(json: string): string {
+	return json.split("\n").map(highlightJsonLine).join("\n");
+}

--- a/vite/src/types/tanstack-table.d.ts
+++ b/vite/src/types/tanstack-table.d.ts
@@ -1,7 +1,11 @@
+import type { ReactNode } from "react";
+import type { Row } from "@tanstack/react-table";
 import type { ColumnSkeletonMeta } from "@/components/general/table/table-row-cells";
 
 declare module "@tanstack/react-table" {
 	interface ColumnMeta<TData, TValue> {
 		skeleton?: ColumnSkeletonMeta;
+		mobileCard?: "hidden" | "full";
+		mobileCardCell?: (row: Row<TData>) => ReactNode;
 	}
 }

--- a/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/utils/linkUtils";
 import { useAdmin } from "@/views/admin/hooks/useAdmin";
 import { useMasterStripeAccount } from "@/views/admin/hooks/useMasterStripeAccount";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { CustomerInvoiceStatus } from "../table/customer-invoices/CustomerInvoiceStatus";
 import { RefundInvoiceDialog } from "./RefundInvoiceDialog";
 
@@ -77,7 +78,13 @@ export function InvoiceDetailSheet({
 	taxedAmount: taxedAmountProp,
 }: InvoiceDetailSheetProps = {}) {
 	const sheetData = useSheetStore((s) => s.data);
-	const invoice = invoiceProp ?? (sheetData?.invoice as Invoice | undefined);
+	const snapshotInvoice =
+		invoiceProp ?? (sheetData?.invoice as Invoice | undefined);
+	const { customer } = useCusQuery();
+	const liveInvoice = customer?.invoices?.find(
+		(inv: Invoice) => inv.id === snapshotInvoice?.id,
+	);
+	const invoice = liveInvoice ?? snapshotInvoice;
 	const lineItems =
 		lineItemsProp ?? ((sheetData?.lineItems as InvoiceLineItem[]) || []);
 	const taxedAmount =

--- a/vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx
+++ b/vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx
@@ -2,7 +2,7 @@ import { formatAmount, type Invoice } from "@autumn/shared";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
-import { Button } from "@/components/v2/buttons/Button";
+import { ShortcutButton } from "@/components/v2/buttons/ShortcutButton";
 import {
 	Dialog,
 	DialogContent,
@@ -150,20 +150,15 @@ export function RefundInvoiceDialog({
 				</div>
 
 				<DialogFooter>
-					<Button
-						variant="secondary"
-						onClick={() => onOpenChange(false)}
-						disabled={refundMutation.isPending}
-					>
-						Cancel
-					</Button>
-					<Button
+					<ShortcutButton
 						variant="primary"
+						className="w-full"
 						onClick={handleSubmit}
 						isLoading={refundMutation.isPending}
+						metaShortcut="enter"
 					>
 						Refund
-					</Button>
+					</ShortcutButton>
 				</DialogFooter>
 			</DialogContent>
 		</Dialog>

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
@@ -151,6 +151,7 @@ export function CustomerBalanceTable({
 					isLoading,
 					onRowClick: handleRowClick,
 					flexibleTableColumns: true,
+					mobileCards: true,
 					selectedItemId: getSelectedRowId(),
 					rowClassName: "h-10 py-0",
 				}}

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
@@ -492,6 +492,69 @@ function BalanceActionsCell({
 	);
 }
 
+function MobileBalanceBar({
+	ent,
+	fullCustomer,
+	entityId,
+	customerEntitlements,
+}: {
+	ent: FullCusEntWithFullCusProduct;
+	fullCustomer: FullCustomer | null | undefined;
+	entityId: string | null;
+	customerEntitlements: FullCusEntWithFullCusProduct[];
+}) {
+	const { allowance, balance, quantity } = useFeatureUsageBalance({
+		fullCustomer,
+		featureId: ent.entitlement.feature.id,
+		entityId,
+		customerEntitlements,
+	});
+
+	if (ent.unlimited || (allowance ?? 0) <= 0) return null;
+
+	return (
+		<div className="w-24 shrink-0 flex items-center h-4">
+			<CustomerFeatureUsageBar
+				allowance={allowance}
+				balance={balance}
+				quantity={quantity}
+				horizontal
+			/>
+		</div>
+	);
+}
+
+function MobileUsageWithBar({
+	row,
+	fullCustomer,
+	entityId,
+}: {
+	row: Row<CustomerBalanceRowData>;
+	fullCustomer: FullCustomer | null | undefined;
+	entityId: string | null;
+}) {
+	const customerEntitlements = row.original.subRows?.length
+		? row.original.subRows
+		: [row.original];
+
+	return (
+		<div className="flex items-center justify-between gap-3">
+			<UsageCell
+				row={row}
+				fullCustomer={fullCustomer}
+				entityId={entityId}
+				customerEntitlements={customerEntitlements}
+			/>
+			<MobileBalanceBar
+				ent={row.original}
+				fullCustomer={fullCustomer}
+				entityId={entityId}
+				customerEntitlements={customerEntitlements}
+			/>
+		</div>
+	);
+}
+
 // --- Column definitions ---
 
 export const CustomerBalanceTableColumns = ({
@@ -600,6 +663,16 @@ export const CustomerBalanceTableColumns = ({
 	{
 		header: "Usage",
 		accessorKey: "usage",
+		meta: {
+			mobileCard: "full" as const,
+			mobileCardCell: (row: Row<CustomerBalanceRowData>) => (
+				<MobileUsageWithBar
+					row={row}
+					fullCustomer={fullCustomer}
+					entityId={entityId}
+				/>
+			),
+		},
 		cell: ({ row }: { row: Row<CustomerBalanceRowData> }) => (
 			<UsageCell
 				row={row}
@@ -615,6 +688,7 @@ export const CustomerBalanceTableColumns = ({
 		header: "Bar",
 		size: 220,
 		accessorKey: "bar",
+		meta: { mobileCard: "hidden" as const },
 		cell: ({ row }: { row: Row<CustomerBalanceRowData> }) => (
 			<BarCell
 				row={row}

--- a/vite/src/views/customers2/components/table/customer-invoices/CustomerInvoicesTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-invoices/CustomerInvoicesTable.tsx
@@ -89,6 +89,7 @@ export function CustomerInvoicesTable() {
 				onRowClick: handleRowClick,
 				emptyStateText: "Invoices will display when a customer makes a payment",
 				flexibleTableColumns: false,
+				mobileCards: true,
 				rowClassName: "h-10 py-0",
 			}}
 		>

--- a/vite/src/views/customers2/components/table/customer-products/CustomerProductsTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-products/CustomerProductsTable.tsx
@@ -201,6 +201,7 @@ export function CustomerProductsTable() {
 					onRowClick: handleRowClick,
 					emptyStateChildren,
 					flexibleTableColumns: true,
+					mobileCards: true,
 					selectedItemId,
 					virtualization: { containerHeight: "428px", skeletonRowCount: 3 },
 				}}

--- a/vite/src/views/customers2/components/table/customer-products/TransferProductDialog.tsx
+++ b/vite/src/views/customers2/components/table/customer-products/TransferProductDialog.tsx
@@ -97,7 +97,7 @@ export const TransferProductDialog = ({
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
 			<DialogContent
-				className="w-md bg-card"
+				className="w-full max-w-[calc(100vw-2rem)] sm:max-w-md bg-card"
 				onClick={(e) => e.stopPropagation()}
 			>
 				<DialogHeader>

--- a/vite/src/views/customers2/customer/CustomerPageDetails.tsx
+++ b/vite/src/views/customers2/customer/CustomerPageDetails.tsx
@@ -21,8 +21,8 @@ export const CustomerPageDetails = () => {
 		customer.fingerprint ?? "This user's fingerprint is undefined";
 
 	return (
-		<div className="flex min-w-0 items-center">
-			<div className="flex gap-2 flex-wrap">
+		<div className="flex w-full sm:w-auto min-w-0 items-center justify-between gap-2 sm:justify-start">
+			<div className="flex gap-2 flex-wrap min-w-0">
 				{customer.email && (
 					<CopyButton
 						text={customer.email ?? placeholderText}
@@ -53,8 +53,8 @@ export const CustomerPageDetails = () => {
 						<span className="truncate">{appliedCoupon.coupon}</span>
 					</div>
 				)}
-				<CustomerActions />
 			</div>
+			<CustomerActions />
 		</div>
 	);
 };

--- a/vite/src/views/customers2/customer/CustomerView2.tsx
+++ b/vite/src/views/customers2/customer/CustomerView2.tsx
@@ -117,7 +117,7 @@ export default function CustomerView2() {
 										<CustomerBreadcrumbs />
 										<CustomerHeaderActions />
 									</div>
-									<div className="flex items-center justify-between w-full pt-2 gap-2">
+									<div className="flex flex-col sm:flex-row sm:items-center sm:justify-between w-full pt-2 gap-2">
 										<div className="flex items-center gap-2 min-w-0">
 											<h3
 												className={`text-md font-semibold truncate min-w-0 ${

--- a/vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx
+++ b/vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx
@@ -1,11 +1,14 @@
+import type { FullCustomer } from "@autumn/shared";
 import { ProcessorType } from "@autumn/shared";
 import { BracketsSquareIcon, UserCircleGearIcon } from "@phosphor-icons/react";
 import { useState } from "react";
+import { useParams } from "react-router";
 import { toast } from "sonner";
 import { IconTooltipButton } from "@/components/v2/buttons/IconTooltipButton";
 import { StripeIcon } from "@/components/v2/icons/AutumnIcons";
 import { useOrg } from "@/hooks/common/useOrg";
 import { useOrgStripeQuery } from "@/hooks/queries/useOrgStripeQuery";
+import { getInitialScopeEntityId } from "@/hooks/useSheetScopeEntityId";
 import { CusService } from "@/services/customers/CusService";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { useEnv } from "@/utils/envUtils";
@@ -17,6 +20,7 @@ import {
 import { useAdmin } from "@/views/admin/hooks/useAdmin";
 import { useMasterStripeAccount } from "@/views/admin/hooks/useMasterStripeAccount";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { useCustomerObjectQuery } from "../hooks/useCustomerObjectQuery";
 import { CustomButtons } from "./CustomButtons";
 import { ShowCustomerObjectSheet } from "./ShowCustomerObjectSheet";
 
@@ -28,6 +32,15 @@ export function CustomerHeaderActions() {
 	const { masterStripeAccount } = useMasterStripeAccount();
 	const env = useEnv();
 	const axiosInstance = useAxiosInstance();
+	const { customer_id } = useParams();
+
+	useCustomerObjectQuery({
+		customerId: customer_id,
+		scopeEntityId: getInitialScopeEntityId(
+			customer as FullCustomer | undefined,
+		),
+		enabled: !!customer,
+	});
 
 	const [portalLoading, setPortalLoading] = useState(false);
 	const [showObjectOpen, setShowObjectOpen] = useState(false);

--- a/vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx
+++ b/vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx
@@ -1,6 +1,7 @@
 import type { FullCustomer } from "@autumn/shared";
 import { ProcessorType } from "@autumn/shared";
 import { BracketsSquareIcon, UserCircleGearIcon } from "@phosphor-icons/react";
+import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import { useParams } from "react-router";
 import { toast } from "sonner";
@@ -42,7 +43,6 @@ export function CustomerHeaderActions() {
 		enabled: !!customer,
 	});
 
-	const [portalLoading, setPortalLoading] = useState(false);
 	const [showObjectOpen, setShowObjectOpen] = useState(false);
 
 	const stripeCustomerId = customer?.processor?.id;
@@ -74,21 +74,16 @@ export function CustomerHeaderActions() {
 		);
 	};
 
-	const handleOpenBillingPortal = async () => {
-		if (!customer) return;
-		setPortalLoading(true);
-		try {
-			const { url } = await CusService.createBillingPortalSession({
+	const billingPortalMutation = useMutation({
+		mutationFn: () =>
+			CusService.createBillingPortalSession({
 				axios: axiosInstance,
 				customer_id: customer.id || customer.internal_id,
-			});
-			window.open(url, "_blank");
-		} catch (error) {
-			toast.error(getBackendErr(error, "Failed to open billing portal"));
-		} finally {
-			setPortalLoading(false);
-		}
-	};
+			}),
+		onSuccess: ({ url }) => window.open(url, "_blank"),
+		onError: (error) =>
+			toast.error(getBackendErr(error, "Failed to open billing portal")),
+	});
 
 	return (
 		<div className="flex items-center gap-1">
@@ -105,8 +100,8 @@ export function CustomerHeaderActions() {
 			<IconTooltipButton
 				tooltip="Open customer portal"
 				icon={<UserCircleGearIcon size={14} />}
-				onClick={handleOpenBillingPortal}
-				disabled={portalLoading}
+				onClick={() => billingPortalMutation.mutate()}
+				disabled={billingPortalMutation.isPending}
 			/>
 			{showStripe && (
 				<IconTooltipButton

--- a/vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx
+++ b/vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx
@@ -75,11 +75,13 @@ export function CustomerHeaderActions() {
 	};
 
 	const billingPortalMutation = useMutation({
-		mutationFn: () =>
-			CusService.createBillingPortalSession({
+		mutationFn: () => {
+			if (!customer) throw new Error("Customer not loaded");
+			return CusService.createBillingPortalSession({
 				axios: axiosInstance,
 				customer_id: customer.id || customer.internal_id,
-			}),
+			});
+		},
 		onSuccess: ({ url }) => window.open(url, "_blank"),
 		onError: (error) =>
 			toast.error(getBackendErr(error, "Failed to open billing portal")),
@@ -101,7 +103,7 @@ export function CustomerHeaderActions() {
 				tooltip="Open customer portal"
 				icon={<UserCircleGearIcon size={14} />}
 				onClick={() => billingPortalMutation.mutate()}
-				disabled={billingPortalMutation.isPending}
+				disabled={!customer || billingPortalMutation.isPending}
 			/>
 			{showStripe && (
 				<IconTooltipButton

--- a/vite/src/views/customers2/customer/components/ShowCustomerObjectSheet.tsx
+++ b/vite/src/views/customers2/customer/components/ShowCustomerObjectSheet.tsx
@@ -41,6 +41,7 @@ export function ShowCustomerObjectSheet({
 		customerId: customer_id,
 		scopeEntityId,
 		enabled: open,
+		staleTime: 0,
 	});
 
 	const formattedJson = useMemo(

--- a/vite/src/views/customers2/customer/components/ShowCustomerObjectSheet.tsx
+++ b/vite/src/views/customers2/customer/components/ShowCustomerObjectSheet.tsx
@@ -1,11 +1,9 @@
 import type { FullCustomer } from "@autumn/shared";
-import { LATEST_VERSION } from "@autumn/shared";
 import { Spinner } from "@phosphor-icons/react";
-import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { useParams } from "react-router";
 import {
 	CodeGroup,
-	CodeGroupCode,
 	CodeGroupCopyButton,
 	CodeGroupList,
 	CodeGroupTab,
@@ -16,58 +14,39 @@ import {
 	SheetHeader,
 	SheetTitle,
 } from "@/components/v2/sheets/Sheet";
-import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
+import { VirtualizedJson } from "@/components/v2/VirtualizedJson";
 import { useSheetScopeEntityId } from "@/hooks/useSheetScopeEntityId";
-import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { EntityScopeSelector } from "../../components/sheets/EntityScopeSelector";
+import { useCustomerObjectQuery } from "../hooks/useCustomerObjectQuery";
 
 interface ShowCustomerObjectSheetProps {
 	open: boolean;
 	setOpen: (open: boolean) => void;
 }
 
-const CUSTOMER_EXPAND_PARAMS = [
-	"invoices",
-	"trials_used",
-	"rewards",
-	"entities",
-	"referrals",
-	"payment_method",
-	"billing_controls.auto_topups.purchase_limit",
-].join(",");
-
-const ENTITY_EXPAND_PARAMS = "invoices";
-
 export function ShowCustomerObjectSheet({
 	open,
 	setOpen,
 }: ShowCustomerObjectSheetProps) {
 	const { customer_id } = useParams();
-	const axiosInstance = useAxiosInstance({ version: LATEST_VERSION });
-	const buildKey = useQueryKeyFactory();
 
 	const { customer } = useCusQuery();
 	const fullCustomer = customer as FullCustomer | undefined;
 	const entities = fullCustomer?.entities ?? [];
 	const [scopeEntityId, setScopeEntityId] = useSheetScopeEntityId(fullCustomer);
 
-	const { data, isLoading, error } = useQuery({
-		queryKey: buildKey(["customer-object", customer_id, scopeEntityId]),
-		queryFn: async () => {
-			const url = scopeEntityId
-				? `/v1/customers/${customer_id}/entities/${scopeEntityId}?expand=${ENTITY_EXPAND_PARAMS}`
-				: `/v1/customers/${customer_id}?expand=${CUSTOMER_EXPAND_PARAMS}`;
-			const { data } = await axiosInstance.get(url);
-			return data;
-		},
-		enabled: open && !!customer_id,
-		gcTime: 0,
-		staleTime: 0,
+	const { data, isLoading, error } = useCustomerObjectQuery({
+		customerId: customer_id,
+		scopeEntityId,
+		enabled: open,
 	});
 
-	const formattedJson = data ? JSON.stringify(data, null, 2) : "";
+	const formattedJson = useMemo(
+		() => (data ? JSON.stringify(data, null, 2) : ""),
+		[data],
+	);
 
 	const description = scopeEntityId
 		? "From entities.get"
@@ -75,7 +54,7 @@ export function ShowCustomerObjectSheet({
 
 	return (
 		<Sheet open={open} onOpenChange={setOpen}>
-			<SheetContent className="flex flex-col overflow-hidden bg-background min-w-xl">
+			<SheetContent className="flex flex-col overflow-hidden bg-background sm:min-w-xl">
 				<SheetHeader>
 					<SheetTitle>
 						{scopeEntityId ? "Entity Object" : "Customer Object"}
@@ -112,9 +91,10 @@ export function ShowCustomerObjectSheet({
 									onCopy={() => navigator.clipboard.writeText(formattedJson)}
 								/>
 							</CodeGroupList>
-							<div className="flex-1 h-0 overflow-y-auto border border-t-0 rounded-b-lg bg-white dark:bg-background p-4">
-								<CodeGroupCode language="json">{formattedJson}</CodeGroupCode>
-							</div>
+							<VirtualizedJson
+								json={formattedJson}
+								className="flex-1 h-0 border border-t-0 rounded-b-lg bg-white dark:bg-background py-4"
+							/>
 						</CodeGroup>
 					)}
 				</div>

--- a/vite/src/views/customers2/customer/hooks/useCustomerObjectQuery.ts
+++ b/vite/src/views/customers2/customer/hooks/useCustomerObjectQuery.ts
@@ -1,0 +1,49 @@
+import { LATEST_VERSION } from "@autumn/shared";
+import { useQuery } from "@tanstack/react-query";
+import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+
+const CUSTOMER_EXPAND_PARAMS = [
+	"invoices",
+	"trials_used",
+	"rewards",
+	"entities",
+	"referrals",
+	"payment_method",
+	"billing_controls.auto_topups.purchase_limit",
+].join(",");
+
+const ENTITY_EXPAND_PARAMS = "invoices";
+
+const CUSTOMER_OBJECT_GC_TIME = 5 * 60 * 1000;
+
+const buildUrl = (customerId: string, scopeEntityId?: string | null) =>
+	scopeEntityId
+		? `/v1/customers/${customerId}/entities/${scopeEntityId}?expand=${ENTITY_EXPAND_PARAMS}`
+		: `/v1/customers/${customerId}?expand=${CUSTOMER_EXPAND_PARAMS}`;
+
+export function useCustomerObjectQuery({
+	customerId,
+	scopeEntityId,
+	enabled,
+}: {
+	customerId?: string;
+	scopeEntityId?: string | null;
+	enabled: boolean;
+}) {
+	const axiosInstance = useAxiosInstance({ version: LATEST_VERSION });
+	const buildKey = useQueryKeyFactory();
+
+	return useQuery({
+		queryKey: buildKey(["customer-object", customerId, scopeEntityId]),
+		queryFn: async () => {
+			const { data } = await axiosInstance.get(
+				buildUrl(customerId as string, scopeEntityId),
+			);
+			return data;
+		},
+		enabled: enabled && !!customerId,
+		gcTime: CUSTOMER_OBJECT_GC_TIME,
+		staleTime: CUSTOMER_OBJECT_GC_TIME,
+	});
+}

--- a/vite/src/views/customers2/customer/hooks/useCustomerObjectQuery.ts
+++ b/vite/src/views/customers2/customer/hooks/useCustomerObjectQuery.ts
@@ -26,10 +26,12 @@ export function useCustomerObjectQuery({
 	customerId,
 	scopeEntityId,
 	enabled,
+	staleTime = CUSTOMER_OBJECT_GC_TIME,
 }: {
 	customerId?: string;
 	scopeEntityId?: string | null;
 	enabled: boolean;
+	staleTime?: number;
 }) {
 	const axiosInstance = useAxiosInstance({ version: LATEST_VERSION });
 	const buildKey = useQueryKeyFactory();
@@ -44,6 +46,6 @@ export function useCustomerObjectQuery({
 		},
 		enabled: enabled && !!customerId,
 		gcTime: CUSTOMER_OBJECT_GC_TIME,
-		staleTime: CUSTOMER_OBJECT_GC_TIME,
+		staleTime,
 	});
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth scope filtering to pass through OIDC scopes and adds a responsive mobile card view for tables, plus a fast, virtualized JSON viewer in the Customer Object sheet.

- New Features
  - Mobile card view for tables when `mobileCards: true` (Balance, Invoices, Products). Columns can opt in with `meta.mobileCard` and custom `mobileCardCell`.
  - Virtualized JSON viewer with syntax highlighting for large payloads; used in the Customer Object sheet. `useCustomerObjectQuery` extracted and prefetched from `CustomerHeaderActions`; the sheet requests fresh data with `staleTime: 0`, while cached data stays warm. `getInitialScopeEntityId` added for consistent sheet scoping. Virtualized table fallback renders all rows when mobile browsers report 0-height containers.
  - Mobile UI tweaks: customer header reflows on small screens and the transfer product dialog uses full-width constraints on mobile.

- Bug Fixes
  - OAuth: default and grant scope filtering now preserves OIDC scopes (`openid`, `profile`, `email`, `offline_access`) to fix Claude MCP registration errors.
  - Guarded `customer_products` and `entities` in `CusService` to avoid undefined crashes.
  - Invoice sheet prefers the live invoice from the customer query cache to reflect post-refund status changes.
  - Billing portal action uses a mutation, disables until the customer loads, and surfaces errors reliably.
  - Refund dialog uses a full-width `ShortcutButton` with Enter (Meta+Enter) to submit.
  - Table row click on mobile is gated behind absence of `rowHref` for consistent navigation.

<sup>Written for commit 5062c4c6c7549effc712dc868a18d296c7489db6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This release bundles several improvements across OAuth scope handling, customer page mobile responsiveness, and a virtualized JSON viewer for the customer object sheet. The changes are well-structured with good test coverage for the auth changes.

- **[Improvements]** Mobile table layout: new `TableMobileCards` component renders rows as cards on small screens; `mobileCards` prop added to balance, invoices, and products tables; `CustomerView2` header reflows to a column on mobile.
- **[Improvements]** Customer object sheet: query logic extracted into the shared `useCustomerObjectQuery` hook (enabling eager prefetch from `CustomerHeaderActions`), and the JSON display replaced with a virtualized line-by-line renderer (`VirtualizedJson` + `highlightJson`) to keep DOM node count constant for large payloads.
- **[Bug fixes]** `CusService`: null guards added around the hardcoded customer-products/entities truncation block so it no longer throws when either field is absent. `InvoiceDetailSheet` now resolves the live invoice from the customer cache to reflect post-refund status changes.
- **[API changes / Improvements]** OAuth scopes: `oauthPassthroughScopeSet` (offline_access only) replaced by the canonical `OPENID_SCOPES` constant (`openid`, `profile`, `email`, `offline_access`), aligning the filter and the default scope list with the full OIDC spec.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge — changes are well-scoped improvements with no critical regressions identified.

The three flagged items are all minor: a misleading useMemo dependency that has no behavioral effect, a type cast that is safe in practice because browsers silently discard invalid translateY(undefinedpx) in block flow, and the intentional removal of the Cancel button from the refund dialog. The core logic — OAuth scope consolidation, null guards in CusService, the prefetch/cache strategy, and the virtualized JSON renderer — all look correct.

The fallback render in table-body-virtualized.tsx deserves a quick look to confirm VirtualRow handles an undefined start gracefully. All other files are straightforward.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/auth/src/oauth/leafOAuth.ts | Replaces the ad-hoc oauthPassthroughScopeSet (offline_access only) with oauthProtocolScopeSet backed by the canonical OPENID_SCOPES constant (openid, profile, email, offline_access). Tests updated accordingly. |
| server/src/internal/customers/CusService.ts | Adds null guards around the hardcoded customer product/entity truncation block so it safely no-ops when either field is absent. |
| server/tests/unit/auth/registerMcpOAuthClient.test.ts | Updates test expectations to reflect OPENID_SCOPES replacing the old offline_access-only set; adds a new test for OIDC scopes requested by the Claude client. |
| vite/src/components/general/table/table-body-virtualized.tsx | Adds a fallback render path for mobile browsers that measure the scroll container at 0 height; uses { index } as VirtualItem cast that omits start/end which may cause layout issues depending on how VirtualRow uses those fields. |
| vite/src/components/general/table/table-mobile-cards.tsx | New component rendering table rows as mobile cards using the shared table context; handles loading skeleton, empty state, row click, href navigation, and column-level metadata overrides. |
| vite/src/components/v2/VirtualizedJson.tsx | New virtualized JSON viewer using TanStack Virtual; renders only visible lines for large payloads. Uses dangerouslySetInnerHTML with properly HTML-escaped output from highlightJsonLine. |
| vite/src/lib/highlightJson.ts | New per-line JSON syntax highlighter; correctly HTML-escapes all interpolated content before building the innerHTML string. |
| vite/src/views/customers2/customer/hooks/useCustomerObjectQuery.ts | Extracts the customer object fetch into a shared hook with a 5-minute gcTime to support prefetching; staleTime is configurable per caller. |
| vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx | Adds eager prefetch of customer object via useCustomerObjectQuery; refactors billing portal open to useMutation; removes manual portalLoading state. |
| vite/src/views/customers2/customer/components/ShowCustomerObjectSheet.tsx | Migrates to the shared useCustomerObjectQuery hook, replaces static CodeGroupCode renderer with VirtualizedJson for large-payload performance, and removes the hardcoded min-width on mobile. |
| vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx | Resolves stale invoice status in the sheet by looking up the live invoice from the customer query cache; falls back to the snapshot invoice if not found. |
| vite/src/hooks/useSheetScopeEntityId.ts | Extracts getInitialScopeEntityId for reuse; the new useMemo([customer]) dependency is misleading since useState ignores re-computed initial values after first mount. |
| vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx | Replaces Cancel+Refund button pair with a single full-width ShortcutButton (meta+enter) — Cancel button removed from the footer. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CH as CustomerHeaderActions
    participant CQ as useCustomerObjectQuery
    participant SC as ShowCustomerObjectSheet
    participant API as /v1/customers/:id

    Note over CH: Customer page loads
    CH->>CQ: "enabled=!!customer, scopeEntityId=getInitialScopeEntityId()"
    CQ->>API: "GET /v1/customers/:id?expand=..."
    API-->>CQ: customer object (cached 5min)

    Note over SC: User clicks Show Object
    SC->>CQ: "enabled=open, staleTime=0"
    CQ-->>SC: returns cached data immediately
    CQ->>API: "refetch (staleTime=0 triggers fresh fetch)"
    API-->>CQ: fresh customer object
    CQ-->>SC: updates with fresh data, VirtualizedJson renders
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CH as CustomerHeaderActions
    participant CQ as useCustomerObjectQuery
    participant SC as ShowCustomerObjectSheet
    participant API as /v1/customers/:id

    Note over CH: Customer page loads
    CH->>CQ: "enabled=!!customer, scopeEntityId=getInitialScopeEntityId()"
    CQ->>API: "GET /v1/customers/:id?expand=..."
    API-->>CQ: customer object (cached 5min)

    Note over SC: User clicks Show Object
    SC->>CQ: "enabled=open, staleTime=0"
    CQ-->>SC: returns cached data immediately
    CQ->>API: "refetch (staleTime=0 triggers fresh fetch)"
    API-->>CQ: fresh customer object
    CQ-->>SC: updates with fresh data, VirtualizedJson renders
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `vite/src/hooks/useSheetScopeEntityId.ts`, line 569-571 ([link](https://github.com/useautumn/autumn/blob/cb06440859d146254934544ebe5efa35298d393b/vite/src/hooks/useSheetScopeEntityId.ts#L569-L571)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Misleading `useMemo` dependency on `customer`**

   `useState` only reads its initializer argument on the very first render; subsequent re-renders ignore it. The `[customer]` dependency causes `useMemo` to recompute `getInitialScopeEntityId(customer)` every time `customer` changes, but that recomputed value is silently discarded because `useState` already has a value in state. Using `[]` (or a lazy `useState` initializer) would accurately express that the value is computed once and never re-seeded from `customer`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/hooks/useSheetScopeEntityId.ts
   Line: 569-571

   Comment:
   **Misleading `useMemo` dependency on `customer`**

   `useState` only reads its initializer argument on the very first render; subsequent re-renders ignore it. The `[customer]` dependency causes `useMemo` to recompute `getInitialScopeEntityId(customer)` every time `customer` changes, but that recomputed value is silently discarded because `useState` already has a value in state. Using `[]` (or a lazy `useState` initializer) would accurately express that the value is computed once and never re-seeded from `customer`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


2. `vite/src/components/general/table/table-body-virtualized.tsx`, line 162 ([link](https://github.com/useautumn/autumn/blob/cb06440859d146254934544ebe5efa35298d393b/vite/src/components/general/table/table-body-virtualized.tsx#L162)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Incomplete `VirtualItem` cast may break `VirtualRow` layout**

   `{ index } as VirtualItem` omits `start`, `end`, `size`, and `key`. If `VirtualRow` renders `transform: translateY(${virtualRow.start}px)` (the canonical TanStack Virtual pattern), every row in the fallback path gets `translateY(undefinedpx)` — an invalid CSS value that browsers silently discard. In a block-flow `<tbody>` this renders correctly, but if the row applies `position: absolute`, all items collapse to y=0 and overlap. Consider passing `start: 0` or rendering rows without the `VirtualRow` wrapper in the fallback path to remove the ambiguity.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/components/general/table/table-body-virtualized.tsx
   Line: 162

   Comment:
   **Incomplete `VirtualItem` cast may break `VirtualRow` layout**

   `{ index } as VirtualItem` omits `start`, `end`, `size`, and `key`. If `VirtualRow` renders `transform: translateY(${virtualRow.start}px)` (the canonical TanStack Virtual pattern), every row in the fallback path gets `translateY(undefinedpx)` — an invalid CSS value that browsers silently discard. In a block-flow `<tbody>` this renders correctly, but if the row applies `position: absolute`, all items collapse to y=0 and overlap. Consider passing `start: 0` or rendering rows without the `VirtualRow` wrapper in the fallback path to remove the ambiguity.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
vite/src/hooks/useSheetScopeEntityId.ts:569-571
**Misleading `useMemo` dependency on `customer`**

`useState` only reads its initializer argument on the very first render; subsequent re-renders ignore it. The `[customer]` dependency causes `useMemo` to recompute `getInitialScopeEntityId(customer)` every time `customer` changes, but that recomputed value is silently discarded because `useState` already has a value in state. Using `[]` (or a lazy `useState` initializer) would accurately express that the value is computed once and never re-seeded from `customer`.

### Issue 2 of 3
vite/src/components/general/table/table-body-virtualized.tsx:162
**Incomplete `VirtualItem` cast may break `VirtualRow` layout**

`{ index } as VirtualItem` omits `start`, `end`, `size`, and `key`. If `VirtualRow` renders `transform: translateY(${virtualRow.start}px)` (the canonical TanStack Virtual pattern), every row in the fallback path gets `translateY(undefinedpx)` — an invalid CSS value that browsers silently discard. In a block-flow `<tbody>` this renders correctly, but if the row applies `position: absolute`, all items collapse to y=0 and overlap. Consider passing `start: 0` or rendering rows without the `VirtualRow` wrapper in the fallback path to remove the ambiguity.

### Issue 3 of 3
vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx:153-161
**Cancel button removed from refund dialog**

The `DialogFooter` now only renders the "Refund" `ShortcutButton`; the explicit "Cancel" button is gone. Users can still dismiss via the sheet's close icon, Escape, or clicking the overlay, but the absence of an explicit cancel is a noticeable UX change for a destructive-ish action. Worth confirming this is intentional.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into dev"](https://github.com/useautumn/autumn/commit/cb06440859d146254934544ebe5efa35298d393b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39267689)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->