### PR TITLE
fix: prevent website horizontal scrolling

### DIFF
--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -92,10 +92,10 @@ export default function RootLayout({ children }: LayoutProps) {
 			className={cn(
 				geistSans.variable,
 				geistMono.variable,
-				"h-full bg-black antialiased",
+				"h-full max-w-full overflow-x-clip overscroll-x-none bg-black antialiased",
 			)}
 		>
-			<body className="min-h-full flex flex-col">{children}</body>
+			<body className="min-h-full max-w-full overflow-x-clip overscroll-x-none flex flex-col">{children}</body>
 		</html>
 	);
 }

--- a/apps/website/components/navbar.tsx
+++ b/apps/website/components/navbar.tsx
@@ -212,7 +212,7 @@ export default function Navbar({
 			}
 			ref={containerRef}
 		>
-			<div className="absolute pointer-events-none left-0 border-t border-[#292929] w-screen z-50" />
+			<div className="absolute pointer-events-none left-0 border-t border-[#292929] w-full z-50" />
 			{scrolled && !recoilHidden && (
 				<div className="h-[56px] md:h-[44px] w-fit" />
 			)}


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/29011484-ed03-4785-afba-ec4d94ab5c9b

- prevent root-level horizontal overscroll on the website by clipping x-overflow on `html` and `body`
- change the navbar decorative border from `w-screen` to `w-full` so it cannot overhang its padded container

## Testing

- `bun -F @autumn/website build`
- manually verified at 375px, 768px, and 1440px widths that `scrollWidth === viewport`, `scrollX` remains `0`, and horizontal overscroll is disabled

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents horizontal scrolling site‑wide by clipping x‑overflow at the root and fixing the navbar border so it can’t overhang its container. This removes accidental sideways scroll on all viewports.

- **Bug Fixes**
  - Clipped horizontal overflow on `html` and `body` with `overflow-x-clip` and `overscroll-x-none`.
  - Changed navbar decorative border from `w-screen` to `w-full` to stay within the padded container.

<sup>Written for commit 453309aa31c02e32ba1cb4d1f6a3f7874c17f6ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

