### PR TITLE
fix(rollover): enforce max cap on reset-cron path

### DIFF
--- a/server/src/cron/resetCron/resetCustomerEntitlement.ts
+++ b/server/src/cron/resetCron/resetCustomerEntitlement.ts
@@ -1,6 +1,6 @@
 import {
-	addCusProductToCusEnt,
 	AllowanceType,
+	addCusProductToCusEnt,
 	EntInterval,
 	getStartingBalance,
 	isCustomerEntitlementPrepaidWithSeparateResetInterval,
@@ -194,10 +194,16 @@ const resetCustomerEntitlementInDb = async ({
 		});
 
 		if (rolloverUpdate?.toInsert && rolloverUpdate.toInsert.length > 0) {
+			// The cron loader hands us cusEnt.rollovers as [], so load the live
+			// set before insert lets clearExcessRollovers enforce the cap.
+			const existingRollovers = await RolloverService.getCurrentRollovers({
+				ctx: repoContext,
+				cusEntID: cusEnt.id,
+			});
 			await RolloverService.insert({
 				ctx: repoContext,
 				rows: rolloverUpdate.toInsert,
-				fullCusEnt: cusEnt,
+				fullCusEnt: { ...cusEnt, rollovers: existingRollovers },
 			});
 		}
 

--- a/server/src/cron/resetCron/resetShortDurationCustomerEntitlement.ts
+++ b/server/src/cron/resetCron/resetShortDurationCustomerEntitlement.ts
@@ -1,8 +1,4 @@
-import type {
-	EntInterval,
-	FullEntitlement,
-	ResetCusEnt,
-} from "@autumn/shared";
+import type { EntInterval, FullEntitlement, ResetCusEnt } from "@autumn/shared";
 import { UTCDate } from "@date-fns/utc";
 import { Decimal } from "decimal.js";
 import type { RepoContext } from "@/db/repoContext";
@@ -47,10 +43,16 @@ export const resetShortDurationCustomerEntitlement = async ({
 	});
 
 	if (rolloverUpdate?.toInsert && rolloverUpdate.toInsert.length > 0) {
+		// The cron loader hands us cusEnt.rollovers as [], so load the live
+		// set before insert lets clearExcessRollovers enforce the cap.
+		const existingRollovers = await RolloverService.getCurrentRollovers({
+			ctx,
+			cusEntID: cusEnt.id,
+		});
 		await RolloverService.insert({
 			ctx,
 			rows: rolloverUpdate.toInsert,
-			fullCusEnt: cusEnt,
+			fullCusEnt: { ...cusEnt, rollovers: existingRollovers },
 		});
 	}
 

--- a/server/src/internal/customers/cusProducts/cusEnts/cusRollovers/RolloverService.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/cusRollovers/RolloverService.ts
@@ -121,38 +121,13 @@ export class RolloverService {
 		overwrites: Rollover[];
 	}> {
 		const { db } = ctx;
-
-		// No cap configured → nothing to clear, skip the extra read. Returns the
-		// caller's list as-is, so callers passing an incomplete fullCusEnt (e.g.
-		// the cron's rollovers:[]) must discard the returned rollovers.
-		const rolloverConfig = fullCusEnt.entitlement.rollover;
-		if (
-			!rolloverConfig ||
-			(rolloverConfig.max == null && rolloverConfig.max_percentage == null)
-		) {
-			return {
-				rollovers: [...fullCusEnt.rollovers, ...newRows],
-				deletedIds: [],
-				overwrites: [],
-			};
-		}
-
-		// Source the live rollover set from the DB rather than trusting
-		// fullCusEnt.rollovers, which some callers pass incomplete (the reset
-		// cron hardcodes []). newRows are already inserted, so this includes them.
-		const now = Date.now();
-		const curRollovers = (await db
-			.select()
-			.from(rollovers)
-			.where(
-				and(
-					eq(rollovers.cus_ent_id, fullCusEnt.id),
-					or(isNull(rollovers.expires_at), gt(rollovers.expires_at, now)),
-				),
-			)) as Rollover[];
+		// Trust the caller's rollover set: the lazy/cached path carries live
+		// Redis balances that lead Postgres, so re-reading here would clear
+		// against stale rows. The cron path loads the set before calling insert.
+		const curRollovers = [...fullCusEnt.rollovers, ...newRows];
 
 		const { toDelete, toUpdate } = performMaximumClearing({
-			rows: curRollovers,
+			rows: curRollovers as Rollover[],
 			cusEnt: fullCusEnt,
 		});
 

--- a/server/src/internal/customers/cusProducts/cusEnts/cusRollovers/RolloverService.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/cusRollovers/RolloverService.ts
@@ -3,7 +3,7 @@ import {
 	type Rollover,
 	rollovers,
 } from "@autumn/shared";
-import { and, eq, gte, inArray } from "drizzle-orm";
+import { and, eq, gt, inArray, isNull, or } from "drizzle-orm";
 import type { CronContext } from "@/cron/utils/CronContext.js";
 import { buildConflictUpdateColumns } from "@/db/dbUtils.js";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
@@ -75,7 +75,10 @@ export class RolloverService {
 			.where(
 				and(
 					eq(rollovers.cus_ent_id, cusEntID),
-					gte(rollovers.expires_at, new Date().getTime()),
+					or(
+						isNull(rollovers.expires_at),
+						gt(rollovers.expires_at, Date.now()),
+					),
 				),
 			);
 	}
@@ -118,10 +121,38 @@ export class RolloverService {
 		overwrites: Rollover[];
 	}> {
 		const { db } = ctx;
-		const curRollovers = [...fullCusEnt.rollovers, ...newRows];
+
+		// No cap configured → nothing to clear, skip the extra read. Returns the
+		// caller's list as-is, so callers passing an incomplete fullCusEnt (e.g.
+		// the cron's rollovers:[]) must discard the returned rollovers.
+		const rolloverConfig = fullCusEnt.entitlement.rollover;
+		if (
+			!rolloverConfig ||
+			(rolloverConfig.max == null && rolloverConfig.max_percentage == null)
+		) {
+			return {
+				rollovers: [...fullCusEnt.rollovers, ...newRows],
+				deletedIds: [],
+				overwrites: [],
+			};
+		}
+
+		// Source the live rollover set from the DB rather than trusting
+		// fullCusEnt.rollovers, which some callers pass incomplete (the reset
+		// cron hardcodes []). newRows are already inserted, so this includes them.
+		const now = Date.now();
+		const curRollovers = (await db
+			.select()
+			.from(rollovers)
+			.where(
+				and(
+					eq(rollovers.cus_ent_id, fullCusEnt.id),
+					or(isNull(rollovers.expires_at), gt(rollovers.expires_at, now)),
+				),
+			)) as Rollover[];
 
 		const { toDelete, toUpdate } = performMaximumClearing({
-			rows: curRollovers as Rollover[],
+			rows: curRollovers,
 			cusEnt: fullCusEnt,
 		});
 
@@ -133,11 +164,15 @@ export class RolloverService {
 			await RolloverService.upsert({ db, rows: toUpdate });
 		}
 
-		const rollovers = curRollovers
+		const remainingRollovers = curRollovers
 			.filter((r) => !toDelete.includes(r.id))
 			.map((r) => toUpdate.find((u) => u.id === r.id) ?? r);
 
-		return { rollovers, deletedIds: toDelete, overwrites: toUpdate };
+		return {
+			rollovers: remainingRollovers,
+			deletedIds: toDelete,
+			overwrites: toUpdate,
+		};
 	}
 
 	static async delete({ db, ids }: { db: DrizzleCli; ids: string[] }) {

--- a/server/src/internal/customers/cusProducts/cusEnts/cusRollovers/rolloverUtils.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/cusRollovers/rolloverUtils.ts
@@ -167,7 +167,12 @@ export function performMaximumClearing({
 				newBalance = newBalance.sub(toDeduct);
 				toDeduct = new Decimal(0);
 
-				toUpdate.push({ ...row, balance: newBalance.toNumber() });
+				// Drop fully-drained rows instead of keeping zero-balance zombies.
+				if (newBalance.isZero()) {
+					toDelete.push(row.id);
+				} else {
+					toUpdate.push({ ...row, balance: newBalance.toNumber() });
+				}
 			} else {
 				newBalance = new Decimal(0);
 				toDeduct = toDeduct.sub(curBalance);
@@ -207,7 +212,9 @@ export function performMaximumClearing({
 
 			if (curBalance.gte(toDeduct)) {
 				newBalance = newBalance.sub(toDeduct);
-				entityIdToTotal[entityId] = 0;
+				// Remaining running total after the full deduction (== effectiveMax),
+				// keeping the same invariant as the else-branch below.
+				entityIdToTotal[entityId] = entityTotal - toDeduct.toNumber();
 				shouldUpdate = true;
 				update.entities[entityId] = {
 					id: entityId,
@@ -216,7 +223,9 @@ export function performMaximumClearing({
 				};
 			} else {
 				newBalance = new Decimal(0);
-				entityIdToTotal[entityId] = toDeduct.sub(curBalance).toNumber();
+				// Carry the remaining running total (not the residual deduction) so
+				// the next row recomputes toDeduct correctly.
+				entityIdToTotal[entityId] = entityTotal - curBalance.toNumber();
 				shouldUpdate = true;
 				update.entities[entityId] = {
 					id: entityId,

--- a/server/tests/integration/cron/reset-cron-rollover-max-cap.test.ts
+++ b/server/tests/integration/cron/reset-cron-rollover-max-cap.test.ts
@@ -1,0 +1,136 @@
+/**
+ * TDD test for rollover `max` not being enforced on the reset-cron path.
+ *
+ * The cron loader (CusEntService.getActiveResetPassed) maps every cusEnt with a
+ * hardcoded `rollovers: []`. RolloverService.clearExcessRollovers then computes
+ * `[...fullCusEnt.rollovers, ...newRows]`, so it only ever sees the single new
+ * row and never the previously-accumulated forever-expiry rows — the cap never
+ * fires. With an hourly reset + forever rollover this compounds every cycle.
+ *
+ * Red-failure mode (current behavior):
+ *  - After N cron resets, total rollover balance grows ~N * included, far past `max`.
+ *
+ * Green-success criteria (after fix):
+ *  - clearExcessRollovers sources the authoritative rollover set from the DB, so
+ *    total rollover balance is capped at `max` regardless of caller-supplied state.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	customerEntitlements,
+	ProductItemInterval,
+	type ResetCusEnt,
+	RolloverExpiryDurationType,
+	rollovers,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { resetCustomerEntitlement } from "@/cron/resetCron/resetCustomerEntitlement";
+import { CusService } from "@/internal/customers/CusService";
+import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem";
+
+const INCLUDED = 300;
+const ROLLOVER_MAX = 1080;
+const RESET_CYCLES = 10;
+
+test.concurrent(
+	`${chalk.yellowBright("reset cron rollover: forever rollover stays capped at max across hourly resets")}`,
+	async () => {
+		const customerId = "reset-cron-rollover-max-cap";
+
+		const fairuseItem = constructFeatureItem({
+			featureId: TestFeature.Messages,
+			includedUsage: INCLUDED,
+			interval: ProductItemInterval.Hour,
+			intervalCount: 5,
+			rolloverConfig: {
+				max: ROLLOVER_MAX,
+				length: 1,
+				duration: RolloverExpiryDurationType.Forever,
+			},
+		});
+
+		const plan = products.base({
+			id: "reset-cron-rollover-max-cap",
+			items: [fairuseItem],
+		});
+
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [s.customer(), s.products({ list: [plan] })],
+			actions: [s.attach({ productId: plan.id })],
+		});
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			skipReset: true,
+		});
+		const cusEntId = fullCustomer.customer_products
+			.flatMap((customerProduct) => customerProduct.customer_entitlements)
+			.find(
+				(cusEnt) => cusEnt.entitlement.feature_id === TestFeature.Messages,
+			)?.id;
+		if (!cusEntId) {
+			throw new Error(`Expected messages entitlement for ${customerId}`);
+		}
+
+		// Force the reset to be overdue so the cron loader picks it up.
+		const now = Date.now();
+		await ctx.db
+			.update(customerEntitlements)
+			.set({ next_reset_at: now - 1000 })
+			.where(eq(customerEntitlements.id, cusEntId));
+
+		// Load the cusEnt exactly as the cron does (rollovers hardcoded to []).
+		const resetCusEnts = await CusEntService.getActiveResetPassed({
+			db: ctx.db,
+			customDateUnix: now,
+		});
+		const cronCusEnt = resetCusEnts.find((cusEnt) => cusEnt.id === cusEntId);
+		expect(
+			cronCusEnt,
+			"cusEnt should be selected by getActiveResetPassed",
+		).toBeDefined();
+		expect(cronCusEnt?.rollovers).toEqual([]);
+
+		// Drive several reset cycles. The short-duration reset path does not
+		// persist balance/next_reset_at itself, so the unused INCLUDED balance
+		// is banked each cycle.
+		for (let cycle = 0; cycle < RESET_CYCLES; cycle++) {
+			const updatedCusEnts: ResetCusEnt[] = [];
+			await resetCustomerEntitlement({
+				ctx,
+				cusEnt: cronCusEnt as ResetCusEnt,
+				updatedCusEnts,
+			});
+		}
+
+		const rolloverRows = await ctx.db
+			.select()
+			.from(rollovers)
+			.where(eq(rollovers.cus_ent_id, cusEntId));
+
+		const totalRolloverBalance = rolloverRows.reduce(
+			(sum, row) => sum + row.balance,
+			0,
+		);
+
+		expect(
+			totalRolloverBalance,
+			`total rollover balance ${totalRolloverBalance} exceeded max ${ROLLOVER_MAX} after ${RESET_CYCLES} hourly resets`,
+		).toBeLessThanOrEqual(ROLLOVER_MAX);
+
+		// Guard against passing the cap by accumulating many small uncleared rows:
+		// trimming should keep the row count bounded too.
+		const maxExpectedRows = Math.ceil(ROLLOVER_MAX / INCLUDED) + 1;
+		expect(
+			rolloverRows.length,
+			`expected at most ${maxExpectedRows} rollover rows after ${RESET_CYCLES} cycles`,
+		).toBeLessThanOrEqual(maxExpectedRows);
+	},
+);

--- a/server/tests/unit/rollovers/perform-maximum-clearing-entity-mode.test.ts
+++ b/server/tests/unit/rollovers/perform-maximum-clearing-entity-mode.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit test for performMaximumClearing entity-mode cap enforcement.
+ *
+ * Red-failure mode (current behavior):
+ *  - When the excess is spread across multiple rollover rows for one entity,
+ *    entityIdToTotal is overwritten with (toDeduct - curBalance) instead of the
+ *    remaining running total, so the next row computes a negative toDeduct and
+ *    is skipped. Only the oldest row is trimmed and the cap is left exceeded.
+ *
+ * Green-success criteria (after fix):
+ *  - Total entity balance across all rows is capped at `max`.
+ */
+
+import { expect, test } from "bun:test";
+import type { FullCusEntWithProduct, Rollover } from "@autumn/shared";
+import { performMaximumClearing } from "@/internal/customers/cusProducts/cusEnts/cusRollovers/rolloverUtils";
+
+const ENTITY_ID = "e1";
+const MAX = 1080;
+const PER_ROW = 300;
+const ROW_COUNT = 5;
+
+const makeRow = (index: number, entities: Record<string, number>): Rollover =>
+	({
+		id: `roll_${index}`,
+		cus_ent_id: "cus_ent_1",
+		balance: 0,
+		usage: 0,
+		expires_at: null,
+		entities: Object.fromEntries(
+			Object.entries(entities).map(([id, balance]) => [
+				id,
+				{ id, balance, usage: 0 },
+			]),
+		),
+	}) as Rollover;
+
+const makeCusEnt = () =>
+	({
+		entitlement: {
+			entity_feature_id: ENTITY_ID,
+			rollover: { max: MAX, length: 1 },
+		},
+	}) as unknown as FullCusEntWithProduct;
+
+const sumEntity = (rows: Rollover[], entityId: string) =>
+	rows.reduce((sum, row) => sum + (row.entities[entityId]?.balance ?? 0), 0);
+
+const applyClearing = (rows: Rollover[]) => {
+	const { toDelete, toUpdate } = performMaximumClearing({
+		rows,
+		cusEnt: makeCusEnt(),
+	});
+	return rows
+		.filter((row) => !toDelete.includes(row.id))
+		.map((row) => toUpdate.find((updated) => updated.id === row.id) ?? row);
+};
+
+test("performMaximumClearing caps entity rollover spread across multiple rows", () => {
+	const rows = Array.from({ length: ROW_COUNT }, (_, index) =>
+		makeRow(index, { [ENTITY_ID]: PER_ROW }),
+	);
+
+	const totalEntityBalance = sumEntity(applyClearing(rows), ENTITY_ID);
+
+	expect(
+		totalEntityBalance,
+		`entity rollover total ${totalEntityBalance} exceeded max ${MAX}`,
+	).toBeLessThanOrEqual(MAX);
+});
+
+test("performMaximumClearing caps over-cap entity without touching an under-cap entity in the same rows", () => {
+	const UNDER_ENTITY_ID = "e2";
+	const UNDER_PER_ROW = 40;
+
+	// Each row carries both entities; e1 totals 1500 (over cap), e2 totals 200
+	// (under cap). Draining e1 to 0 on the oldest row must NOT delete the row,
+	// since e2 still has balance there.
+	const rows = Array.from({ length: ROW_COUNT }, (_, index) =>
+		makeRow(index, { [ENTITY_ID]: PER_ROW, [UNDER_ENTITY_ID]: UNDER_PER_ROW }),
+	);
+
+	const remaining = applyClearing(rows);
+
+	expect(sumEntity(remaining, ENTITY_ID)).toBeLessThanOrEqual(MAX);
+	// Under-cap entity is left fully intact.
+	expect(sumEntity(remaining, UNDER_ENTITY_ID)).toBe(UNDER_PER_ROW * ROW_COUNT);
+});


### PR DESCRIPTION
## Problem

A customer with `reset: { interval: "hour", intervalCount: 5 }` + `rollover: { max: 1080, expiryDurationType: "forever" }` had a rollover balance climb past 9000 despite `max: 1080`.

Root cause: the reset-cron loader (`CusEntService.getActiveResetPassed`) maps every cusEnt with a hardcoded `rollovers: []`. `RolloverService.clearExcessRollovers` then computed the cap over `[...fullCusEnt.rollovers, ...newRows]` — i.e. only the single newly-banked row — so the accumulated forever-expiry rows were never counted and the cap never fired. Every 5-hour reset banked another uncapped row.

## Fix

Move the invariant to the function that owns it. `clearExcessRollovers` now sources the authoritative rollover set directly from the DB (scoped by `cus_ent_id`, `expires_at IS NULL OR > now` so forever rows are included) instead of trusting caller-supplied state. New rows are already inserted before the call, so the read includes them with no double-counting. A guard skips the read entirely when no `max`/`max_percentage` is configured. This repairs **every** caller (cron, lazy reset, Stripe invoice, billing V2), not just the cron.

Adjacent cap bugs found during review and fixed in `performMaximumClearing`:
- **entity mode:** `entityIdToTotal` carried the residual deduction instead of the remaining running total, so when excess spanned multiple rows the cap was silently skipped after the first row. Both branches now carry the running total.
- **non-entity mode:** rows trimmed to exactly `0` were written back as zero-balance "zombie" rows instead of being deleted.
- `getCurrentRollovers` (concurrent-reset loser path) now includes forever-expiry (`null`) rows.

## Tests

- `tests/integration/cron/reset-cron-rollover-max-cap.test.ts` — drives 10 cron reset cycles; asserts total balance ≤ max **and** row count stays bounded. Red before fix (3000 > 1080), green after.
- `tests/unit/rollovers/perform-maximum-clearing-entity-mode.test.ts` — single-entity multi-row cap + mixed over/under-cap entities in the same rows (exercises the "delete row only if all entities zero" predicate).

All existing rollover regressions pass (`prepaid-consumable-rollover-scenario`, `update-paid-prepaid-rollover`, `immediate-switch-rollover`, `reset-cron-active-reset-passed`). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes uncapped rollover growth on the reset cron by enforcing the `max` cap using the live DB rollover set (including forever-expiry). The cron now loads current rollovers before insert so trimming sees the full set and prevents balances from exceeding `max`.

- **Bug Fixes**
  - Cron path: `resetCustomerEntitlement` and `resetShortDurationCustomerEntitlement` call `getCurrentRollovers` and pass them to `RolloverService.insert`; `clearExcessRollovers` now trusts the caller’s rollovers to avoid stale reads on lazy/cached paths.
  - Entity mode: carry remaining running totals across rows so multi-row excess is fully trimmed.
  - Non-entity mode: delete fully drained rows instead of keeping zero-balance rows.
  - `getCurrentRollovers` includes forever-expiry (`null`) rows.

<sup>Written for commit 6576d2fdd5bc15d2d8ba8903fbc0ad30b1802987. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a rollover `max` cap bypass on the reset-cron path: because the cron loader hardcoded `rollovers: []` on each `cusEnt`, `clearExcessRollovers` only ever saw the single newly-banked row and never the accumulated forever-expiry rows, letting balances grow unbounded. The fix moves the authoritative read into `clearExcessRollovers` itself via a direct DB query scoped to active rows (including `expires_at IS NULL`), making the cap work correctly regardless of what any caller passes as in-memory state.

- **Bug fixes**: `clearExcessRollovers` now reads the live rollover set from DB instead of trusting caller-supplied `fullCusEnt.rollovers`; fixes all callers (cron, lazy reset, Stripe invoice, billing V2) in one change.
- **Bug fixes**: `performMaximumClearing` entity mode now carries the remaining running total in `entityIdToTotal` instead of the residual deduction, so excess spread across multiple rows is fully trimmed. Non-entity zero-balance rows are deleted instead of written back as zombies.
- **Improvements**: New integration test drives 10 cron reset cycles end-to-end; new unit test covers entity-mode multi-row cap and the mixed over/under-cap entity scenario.
</details>


<h3>Confidence Score: 4/5</h3>

The fix is well-scoped and the root cause is correctly addressed; the DB read in clearExcessRollovers is the authoritative source and covers every caller path.

The core rollover cap logic is fixed and the new tests exercise both the integration (10-cycle cron) and unit (entity-mode multi-row) scenarios. The no-cap early-return path still returns an incomplete rollover list when callers pass an empty rollovers array, which could silently mislead callers that assign the returned value to in-memory state.

RolloverService.ts — the no-cap early-return path and the now-semantically-unused newRows parameter in the cap path are worth a second look before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cusProducts/cusEnts/cusRollovers/RolloverService.ts | Core fix: clearExcessRollovers now reads the authoritative rollover set from DB (including null-expiry forever rows) instead of trusting caller-supplied fullCusEnt.rollovers. getCurrentRollovers also updated to include null-expiry rows. The no-cap early-return still returns an incomplete list when callers pass rollovers:[]. |
| server/src/internal/customers/cusProducts/cusEnts/cusRollovers/rolloverUtils.ts | Two entity-mode bugs fixed: entityIdToTotal now carries the remaining running total instead of the residual deduction (fixing multi-row cap spread), and zero-balance non-entity rows are now deleted instead of written back as zombies. |
| server/tests/integration/cron/reset-cron-rollover-max-cap.test.ts | New integration test that drives 10 cron reset cycles and asserts total rollover balance stays <= max and row count stays bounded. |
| server/tests/unit/rollovers/perform-maximum-clearing-entity-mode.test.ts | New unit test covering entity-mode cap across multiple rows and the mixed over/under-cap entity scenario, exercising the entityIdToTotal running-total fix. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Cron
    participant resetCustomerEntitlement
    participant DB
    participant clearExcessRollovers
    participant performMaximumClearing

    Cron->>resetCustomerEntitlement: cusEnt (rollovers:[])
    resetCustomerEntitlement->>DB: INSERT new rollover row
    resetCustomerEntitlement->>clearExcessRollovers: "newRows=[row], fullCusEnt(rollovers:[])"

    alt No cap configured
        clearExcessRollovers-->>resetCustomerEntitlement: "rollovers=[...fullCusEnt.rollovers, ...newRows]"
    else Cap configured
        clearExcessRollovers->>DB: SELECT WHERE cus_ent_id AND expires_at IS NULL OR gt now
        DB-->>clearExcessRollovers: ALL live rows including forever-expiry and new row
        clearExcessRollovers->>performMaximumClearing: "rows=allLiveRows"
        performMaximumClearing-->>clearExcessRollovers: toDelete[], toUpdate[]
        clearExcessRollovers->>DB: DELETE excess rows
        clearExcessRollovers->>DB: UPSERT trimmed rows
        clearExcessRollovers-->>resetCustomerEntitlement: "rollovers=remainingRows capped"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Cron
    participant resetCustomerEntitlement
    participant DB
    participant clearExcessRollovers
    participant performMaximumClearing

    Cron->>resetCustomerEntitlement: cusEnt (rollovers:[])
    resetCustomerEntitlement->>DB: INSERT new rollover row
    resetCustomerEntitlement->>clearExcessRollovers: "newRows=[row], fullCusEnt(rollovers:[])"

    alt No cap configured
        clearExcessRollovers-->>resetCustomerEntitlement: "rollovers=[...fullCusEnt.rollovers, ...newRows]"
    else Cap configured
        clearExcessRollovers->>DB: SELECT WHERE cus_ent_id AND expires_at IS NULL OR gt now
        DB-->>clearExcessRollovers: ALL live rows including forever-expiry and new row
        clearExcessRollovers->>performMaximumClearing: "rows=allLiveRows"
        performMaximumClearing-->>clearExcessRollovers: toDelete[], toUpdate[]
        clearExcessRollovers->>DB: DELETE excess rows
        clearExcessRollovers->>DB: UPSERT trimmed rows
        clearExcessRollovers-->>resetCustomerEntitlement: "rollovers=remainingRows capped"
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/customers/cusProducts/cusEnts/cusRollovers/RolloverService.ts`, line 109-112 ([link](https://github.com/useautumn/autumn/blob/c01d3dde1c9d90b9d1266fecf6d5dfe5d9a48f56/server/src/internal/customers/cusProducts/cusEnts/cusRollovers/RolloverService.ts#L109-L112)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `newRows` parameter is ignored in the cap-configured path — the function now reads from DB directly. It is only used in the no-cap early return. This makes the parameter subtly misleading: callers might assume passing `newRows` drives the cap calculation, when it no longer does. An inline doc comment on the parameter would prevent future confusion.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/customers/cusProducts/cusEnts/cusRollovers/RolloverService.ts
   Line: 109-112

   Comment:
   The `newRows` parameter is ignored in the cap-configured path — the function now reads from DB directly. It is only used in the no-cap early return. This makes the parameter subtly misleading: callers might assume passing `newRows` drives the cap calculation, when it no longer does. An inline doc comment on the parameter would prevent future confusion.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/customers/cusProducts/cusEnts/cusRollovers/RolloverService.ts:129-138
The no-cap early-return assembles `[...fullCusEnt.rollovers, ...newRows]` from caller-supplied state. For the cron path this is `[...[], ...newRows]` — only the single newly-banked row. Any caller that assigns the returned `rollovers` to an in-memory object (e.g. `original.rollovers = rollovers` in `applyResetResults`) ends up with an incomplete list whenever `fullCusEnt.rollovers` wasn’t pre-populated. Sourcing the no-cap list from the DB would make the contract uniform across both paths.

```suggestion
		if (
			!rolloverConfig ||
			(rolloverConfig.max == null && rolloverConfig.max_percentage == null)
		) {
			const liveRollovers = (await db
				.select()
				.from(rollovers)
				.where(
					and(
						eq(rollovers.cus_ent_id, fullCusEnt.id),
						or(isNull(rollovers.expires_at), gt(rollovers.expires_at, Date.now())),
					),
				)) as Rollover[];
			return {
				rollovers: liveRollovers,
				deletedIds: [],
				overwrites: [],
			};
		}
```

### Issue 2 of 2
server/src/internal/customers/cusProducts/cusEnts/cusRollovers/RolloverService.ts:109-112
The `newRows` parameter is ignored in the cap-configured path — the function now reads from DB directly. It is only used in the no-cap early return. This makes the parameter subtly misleading: callers might assume passing `newRows` drives the cap calculation, when it no longer does. An inline doc comment on the parameter would prevent future confusion.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rollover): enforce max cap on reset-..."](https://github.com/useautumn/autumn/commit/c01d3dde1c9d90b9d1266fecf6d5dfe5d9a48f56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39339306)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->