### PR TITLE
fix: grant Leaf scopes when MCP client requests only OIDC scopes

### DIFF
--- a/packages/auth/src/oauth/leafOAuth.ts
+++ b/packages/auth/src/oauth/leafOAuth.ts
@@ -7,6 +7,9 @@ import {
 const leafScopeSet = new Set<string>(LEAF_OAUTH_SCOPES);
 const oauthProtocolScopeSet = new Set<string>(OPENID_SCOPES);
 
+const isLeafScope = (scope: string) =>
+	leafScopeSet.has(LEGACY_SCOPE_ALIASES[scope] ?? scope);
+
 export const getDefaultOAuthScopes = (requestedScopes?: string[] | null) => {
 	const requested =
 		requestedScopes && requestedScopes.length > 0
@@ -15,11 +18,19 @@ export const getDefaultOAuthScopes = (requestedScopes?: string[] | null) => {
 
 	// Issued scopes must echo the client's request verbatim (better-auth
 	// rejects rewrites), so legacy CRUDL aliases are used for filtering only.
-	return [...new Set(requested)].filter(
-		(scope) =>
-			leafScopeSet.has(LEGACY_SCOPE_ALIASES[scope] ?? scope) ||
-			oauthProtocolScopeSet.has(scope),
+	const filtered = [...new Set(requested)].filter(
+		(scope) => isLeafScope(scope) || oauthProtocolScopeSet.has(scope),
 	);
+
+	// Clients that only request OIDC protocol scopes (e.g. Claude Code sends
+	// "openid profile email offline_access") would otherwise receive a token
+	// with no resource scopes, which 401s on every API call. Grant the full
+	// Leaf scope set so the token can actually reach the MCP API.
+	if (!filtered.some(isLeafScope)) {
+		return [...LEAF_OAUTH_SCOPES, ...filtered];
+	}
+
+	return filtered;
 };
 
 export const getOAuthResourceScopes = <T extends string>(scopes: readonly T[]) =>

--- a/server/tests/unit/auth/registerMcpOAuthClient.test.ts
+++ b/server/tests/unit/auth/registerMcpOAuthClient.test.ts
@@ -45,13 +45,22 @@ describe("getRequestedScopesForMcpClient", () => {
 		]);
 	});
 
-	test("preserves OIDC protocol scopes that Claude requests", () => {
+	test("grants Leaf scopes when Claude requests only OIDC protocol scopes", () => {
 		expect(
 			getRequestedScopesForMcpClient({
 				clientType: "claude",
 				scope: "openid profile email offline_access",
 			}),
-		).toEqual(["openid", "profile", "email", OFFLINE_ACCESS_SCOPE]);
+		).toEqual([...LEAF_OAUTH_SCOPES, "openid", "profile", "email", OFFLINE_ACCESS_SCOPE]);
+	});
+
+	test("does not inject Leaf scopes when the client already requests one", () => {
+		expect(
+			getRequestedScopesForMcpClient({
+				clientType: "dynamic",
+				scope: `${Scopes.Customers.Read} openid offline_access`,
+			}),
+		).toEqual([Scopes.Customers.Read, "openid", OFFLINE_ACCESS_SCOPE]);
 	});
 
 	test("preserves OIDC scopes in default OAuth scopes", () => {


### PR DESCRIPTION
Claude Code registers with scope="openid profile email offline_access" and no leaf resource scopes. getDefaultOAuthScopes echoed those back verbatim, so the issued token carried only OIDC scopes. The resource scope filter (getOAuthResourceScopes) then strips OIDC scopes, leaving the token with zero resource scopes — every MCP API call 401s with "Invalid or expired access token", and the consent grant has no resource scopes to grant.

When the filtered scope set contains no leaf scope, inject the full LEAF_OAUTH_SCOPES set alongside the requested OIDC scopes so the token can actually reach the MCP API. Clients that request specific leaf scopes are unaffected (no over-granting).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure MCP OAuth tokens include Leaf resource scopes when clients request only OIDC scopes (e.g., Claude Code), preventing 401s and allowing access to the MCP API.

- **Bug Fixes**
  - In `getDefaultOAuthScopes`, when no Leaf scope is requested, append `LEAF_OAUTH_SCOPES` alongside requested OIDC scopes.
  - Preserve requested Leaf scopes when present to avoid over-granting.

<sup>Written for commit caf7ebe09a29174e33156caf8a77feec8ebd895c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes an OAuth scope mismatch that caused all MCP API calls from Claude Code to return 401. When Claude Code registers as an MCP client it only requests OIDC scopes (`openid profile email offline_access`); the previous `getDefaultOAuthScopes` echoed those back verbatim, so the issued token carried zero resource scopes and was rejected by the resource-scope filter on every request.

- **Bug fixes** — `getDefaultOAuthScopes` now detects when the filtered scope set contains no leaf scope and injects the full `LEAF_OAUTH_SCOPES` set alongside the requested OIDC scopes, so the token can reach the MCP API. Clients that already request at least one leaf scope are unaffected.
- **Improvements** — The `isLeafScope` predicate is extracted to a module-level helper, eliminating the inline duplicate used in the old filter.
- **Bug fixes** — Tests are updated: the existing Claude-OIDC test is corrected to match the new grant-all-leaf behavior, and a new test confirms the injection is skipped when the client already requests a leaf scope.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the fix is well-targeted and the new tests cover both the corrected path and the no-injection guard.

The logic change is small and new test coverage is solid. One untested edge case exists: a client submitting only unrecognised/invalid scopes ends up with an empty filtered array, which also triggers the injection path and silently receives all leaf scopes. This could be closed with a one-line guard, but it does not affect the primary Claude Code use-case and is unlikely to be exercised in a real OAuth flow where scopes are validated at registration time.

packages/auth/src/oauth/leafOAuth.ts — the empty-filtered-array edge case in the injection guard.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/auth/src/oauth/leafOAuth.ts | Adds OIDC-only detection in getDefaultOAuthScopes and injects full LEAF_OAUTH_SCOPES when no leaf scope is present in the filtered set; also extracts isLeafScope as a shared predicate. Edge case: an empty filtered array (all-invalid scopes) also triggers the injection. |
| server/tests/unit/auth/registerMcpOAuthClient.test.ts | Updates the Claude-only-OIDC test to match the new grant-all-leaf behavior and adds a new guard test that confirms leaf injection is skipped when at least one leaf scope is already present. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["getDefaultOAuthScopes(requestedScopes)"] --> B{requestedScopes\nnon-empty?}
    B -- No --> C["requested = [...LEAF_OAUTH_SCOPES, ...OPENID_SCOPES]"]
    B -- Yes --> D["requested = requestedScopes"]
    C --> E
    D --> E["filtered = deduplicated requested\nkeeping only leafScope OR OIDC scopes"]
    E --> F{filtered.some\nisLeafScope?}
    F -- Yes --> G["return filtered\n(client already has leaf scopes)"]
    F -- No --> J["NEW: return\n[...LEAF_OAUTH_SCOPES, ...filtered]\n(inject full leaf scope set)"]
    J --> K["✅ Token carries all leaf scopes\n+ requested OIDC scopes"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["getDefaultOAuthScopes(requestedScopes)"] --> B{requestedScopes\nnon-empty?}
    B -- No --> C["requested = [...LEAF_OAUTH_SCOPES, ...OPENID_SCOPES]"]
    B -- Yes --> D["requested = requestedScopes"]
    C --> E
    D --> E["filtered = deduplicated requested\nkeeping only leafScope OR OIDC scopes"]
    E --> F{filtered.some\nisLeafScope?}
    F -- Yes --> G["return filtered\n(client already has leaf scopes)"]
    F -- No --> J["NEW: return\n[...LEAF_OAUTH_SCOPES, ...filtered]\n(inject full leaf scope set)"]
    J --> K["✅ Token carries all leaf scopes\n+ requested OIDC scopes"]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/auth/src/oauth/leafOAuth.ts:29-31
The injection guard fires on any `filtered` array that contains no leaf scope — including an empty array produced when a client submits only unknown/invalid scopes. In that situation the client requested nothing valid, yet it would receive every scope in `LEAF_OAUTH_SCOPES`. Adding a guard that at least one recognised OIDC scope was present limits injection to the intended OIDC-only case and avoids silently over-granting on malformed requests.

```suggestion
	if (filtered.some((s) => oauthProtocolScopeSet.has(s)) && !filtered.some(isLeafScope)) {
		return [...LEAF_OAUTH_SCOPES, ...filtered];
	}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: grant Leaf scopes when MCP client r..."](https://github.com/useautumn/autumn/commit/caf7ebe09a29174e33156caf8a77feec8ebd895c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39345937)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->