### PR TITLE
cluster-wide FullSubject gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   #   staging repo (autumn-staging) -> us-east-1
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/past-due-cancel-immediate-void
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/past-due-cancel-immediate-void feat/gate-cluster-wide
 
 jobs:
   checks:

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -140,6 +140,13 @@ export const isFullSubjectGateRejection = (error: unknown): boolean => {
 	);
 };
 
+// Configured caps are cluster-wide; each process enforces an even share.
+export const toPerProcessLimit = (
+	clusterWideTarget: number,
+	fleetProcessCount: number,
+): number =>
+	Math.max(1, Math.round(clusterWideTarget / Math.max(1, fleetProcessCount)));
+
 export const runWithFullSubjectGate = async <T>({
 	customerId,
 	orgId,
@@ -159,11 +166,21 @@ export const runWithFullSubjectGate = async <T>({
 		max_wait_ms,
 		per_customer_pending_max,
 		per_org_pending_max,
+		fleet_process_count,
 	} = getRuntimeFullSubjectGateConfig();
 	const enqueuedAt = Date.now();
 	const labels = attrs({ orgId, env });
 
-	const orgLimiter = getOrgLimiter({ orgId, env, limit: per_org_limit });
+	const perProcessOrgLimit = toPerProcessLimit(
+		per_org_limit,
+		fleet_process_count,
+	);
+	const perProcessOrgPendingMax = toPerProcessLimit(
+		per_org_pending_max,
+		fleet_process_count,
+	);
+
+	const orgLimiter = getOrgLimiter({ orgId, env, limit: perProcessOrgLimit });
 
 	let customerLimiter: LimitFunction | undefined;
 	if (customerId) {
@@ -171,12 +188,15 @@ export const runWithFullSubjectGate = async <T>({
 			orgId,
 			env,
 			customerId,
-			limit: per_customer_limit,
+			limit: toPerProcessLimit(per_customer_limit, fleet_process_count),
 		});
-		if (customerLimiter.pendingCount >= per_customer_pending_max) {
+		if (
+			customerLimiter.pendingCount >=
+			toPerProcessLimit(per_customer_pending_max, fleet_process_count)
+		) {
 			rejectOverloaded({ reason: "per_customer_queue_full", labels });
 		}
-	} else if (orgLimiter.pendingCount >= per_org_pending_max) {
+	} else if (orgLimiter.pendingCount >= perProcessOrgPendingMax) {
 		rejectOverloaded({ reason: "per_org_queue_full", labels });
 	}
 
@@ -207,7 +227,7 @@ export const runWithFullSubjectGate = async <T>({
 
 	if (customerLimiter) {
 		return customerLimiter(() => {
-			if (orgLimiter.pendingCount >= per_org_pending_max) {
+			if (orgLimiter.pendingCount >= perProcessOrgPendingMax) {
 				rejectOverloaded({ reason: "per_org_queue_full", labels });
 			}
 			return orgLimiter(execute);

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -141,11 +141,12 @@ export const isFullSubjectGateRejection = (error: unknown): boolean => {
 };
 
 // Configured caps are cluster-wide; each process enforces an even share.
+// Floor (not round) so cluster-wide capacity never EXCEEDS the configured target.
 export const toPerProcessLimit = (
 	clusterWideTarget: number,
 	fleetProcessCount: number,
 ): number =>
-	Math.max(1, Math.round(clusterWideTarget / Math.max(1, fleetProcessCount)));
+	Math.max(1, Math.floor(clusterWideTarget / Math.max(1, fleetProcessCount)));
 
 export const runWithFullSubjectGate = async <T>({
 	customerId,

--- a/server/src/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigSchemas.ts
+++ b/server/src/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigSchemas.ts
@@ -13,6 +13,9 @@ export const FullSubjectGateEdgeConfigSchema = z.object({
 	// (org,env) before rejecting new ones with 429 — bounds memory + wait time.
 	per_customer_pending_max: z.number().int().min(1).max(100_000).default(500),
 	per_org_pending_max: z.number().int().min(1).max(100_000).default(1_000),
+	// Caps above are cluster-wide targets; each process enforces
+	// target / fleet_process_count. Default 1 = per-process (no-op).
+	fleet_process_count: z.number().int().min(1).max(100_000).default(1),
 });
 
 export type FullSubjectGateEdgeConfig = z.infer<

--- a/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
+++ b/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
@@ -1,6 +1,9 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { AppEnv } from "@autumn/shared";
-import { runWithFullSubjectGate } from "@/internal/customers/repos/getFullSubject/getFullSubjectGate.js";
+import {
+	runWithFullSubjectGate,
+	toPerProcessLimit,
+} from "@/internal/customers/repos/getFullSubject/getFullSubjectGate.js";
 import { _setFullSubjectGateConfigForTesting } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
 
 beforeAll(() => {
@@ -258,12 +261,14 @@ describe("runWithFullSubjectGate", () => {
 			.filter((r) => r.status === "rejected")
 			.map(
 				(r) =>
-					(r as PromiseRejectedResult).reason.data?.reason as string | undefined,
+					(r as PromiseRejectedResult).reason.data?.reason as
+						| string
+						| undefined,
 			);
 		expect(rejectedReasons.length).toBeGreaterThan(0);
-		expect(rejectedReasons.some((reason) => reason === "per_org_queue_full")).toBe(
-			true,
-		);
+		expect(
+			rejectedReasons.some((reason) => reason === "per_org_queue_full"),
+		).toBe(true);
 		for (const r of results.filter(
 			(x) => x.status === "rejected",
 		) as PromiseRejectedResult[]) {
@@ -308,8 +313,7 @@ describe("runWithFullSubjectGate", () => {
 		const timeouts = results.filter(
 			(r) =>
 				r.status === "rejected" &&
-				(r as PromiseRejectedResult).reason.code ===
-					"rate_limit_exceeded",
+				(r as PromiseRejectedResult).reason.code === "rate_limit_exceeded",
 		);
 		expect(timeouts.length).toBeGreaterThan(0);
 
@@ -360,5 +364,83 @@ describe("runWithFullSubjectGate", () => {
 		);
 		expect(followUp).toEqual([0, 1, 2, 3]);
 		expect(counter.current).toBe(0);
+	});
+});
+
+describe("toPerProcessLimit", () => {
+	test("divides a cluster-wide target by fleet size, rounding and flooring at 1", () => {
+		expect(toPerProcessLimit(16, 1)).toBe(16);
+		expect(toPerProcessLimit(16, 4)).toBe(4);
+		expect(toPerProcessLimit(200, 44)).toBe(5);
+		expect(toPerProcessLimit(16, 44)).toBe(1);
+		expect(toPerProcessLimit(1, 1)).toBe(1);
+	});
+
+	test("treats a fleet size below 1 as 1 (no divide-by-zero)", () => {
+		expect(toPerProcessLimit(16, 0)).toBe(16);
+	});
+});
+
+describe("runWithFullSubjectGate cluster-wide caps", () => {
+	test("fleet_process_count divides the per-org concurrency cap", async () => {
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 100,
+				per_org_limit: 8,
+				fleet_process_count: 4,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
+		});
+
+		const counter = makeCounter();
+		const queryFn = makeQueryFn(counter, 30);
+		const tasks = Array.from({ length: 12 }, (_, index) =>
+			runWithFullSubjectGate({
+				customerId: `cus-${index}`,
+				orgId: "org-clusterwide-org",
+				env: AppEnv.Live,
+				queryFn: () => queryFn(index),
+			}),
+		);
+		await Promise.all(tasks);
+		// 8 cluster-wide / 4 processes = 2 per process
+		expect(counter.peak).toBeLessThanOrEqual(2);
+		expect(counter.peak).toBeGreaterThan(1);
+		expect(counter.current).toBe(0);
+
+		_setFullSubjectGateConfigForTesting({ config: {} });
+	});
+
+	test("fleet_process_count divides the per-customer concurrency cap", async () => {
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 8,
+				per_org_limit: 100,
+				fleet_process_count: 4,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
+		});
+
+		const counter = makeCounter();
+		const queryFn = makeQueryFn(counter, 30);
+		const tasks = Array.from({ length: 12 }, (_, index) =>
+			runWithFullSubjectGate({
+				customerId: "cus-clusterwide-single",
+				orgId: "org-clusterwide-cus",
+				env: AppEnv.Live,
+				queryFn: () => queryFn(index),
+			}),
+		);
+		await Promise.all(tasks);
+		// 8 cluster-wide / 4 processes = 2 per process
+		expect(counter.peak).toBeLessThanOrEqual(2);
+		expect(counter.peak).toBeGreaterThan(1);
+		expect(counter.current).toBe(0);
+
+		_setFullSubjectGateConfigForTesting({ config: {} });
 	});
 });

--- a/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
+++ b/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
@@ -368,16 +368,29 @@ describe("runWithFullSubjectGate", () => {
 });
 
 describe("toPerProcessLimit", () => {
-	test("divides a cluster-wide target by fleet size, rounding and flooring at 1", () => {
+	test("floors the cluster-wide target divided by fleet size, with a floor of 1", () => {
 		expect(toPerProcessLimit(16, 1)).toBe(16);
 		expect(toPerProcessLimit(16, 4)).toBe(4);
-		expect(toPerProcessLimit(200, 44)).toBe(5);
+		expect(toPerProcessLimit(200, 44)).toBe(4);
 		expect(toPerProcessLimit(16, 44)).toBe(1);
 		expect(toPerProcessLimit(1, 1)).toBe(1);
 	});
 
 	test("treats a fleet size below 1 as 1 (no divide-by-zero)", () => {
 		expect(toPerProcessLimit(16, 0)).toBe(16);
+	});
+
+	test("never lets cluster-wide capacity exceed the configured target", () => {
+		for (const target of [8, 10, 16, 17, 50, 200, 500]) {
+			for (const fleet of [1, 3, 4, 20, 44]) {
+				const perProcess = toPerProcessLimit(target, fleet);
+				if (target >= fleet) {
+					expect(perProcess * fleet).toBeLessThanOrEqual(target);
+				} else {
+					expect(perProcess).toBe(1);
+				}
+			}
+		}
 	});
 });
 

--- a/vite/src/views/admin/components/FullSubjectGateDialog.tsx
+++ b/vite/src/views/admin/components/FullSubjectGateDialog.tsx
@@ -21,6 +21,7 @@ type FullSubjectGateConfig = {
 	max_wait_ms: number;
 	per_customer_pending_max: number;
 	per_org_pending_max: number;
+	fleet_process_count: number;
 	configHealthy?: boolean;
 	configConfigured?: boolean;
 	lastSuccessAt?: string | null;
@@ -33,6 +34,7 @@ const DEFAULT_CONFIG: FullSubjectGateConfig = {
 	max_wait_ms: 2_000,
 	per_customer_pending_max: 500,
 	per_org_pending_max: 1_000,
+	fleet_process_count: 1,
 };
 
 const FIELDS: Array<{
@@ -43,6 +45,7 @@ const FIELDS: Array<{
 		| "max_wait_ms"
 		| "per_customer_pending_max"
 		| "per_org_pending_max"
+		| "fleet_process_count"
 	>;
 	label: string;
 	description: string;
@@ -50,10 +53,18 @@ const FIELDS: Array<{
 	max: number;
 }> = [
 	{
+		key: "fleet_process_count",
+		label: "Fleet process count",
+		description:
+			"Number of app processes in the fleet. The caps below are cluster-wide targets, divided by this per process. Set to the live replica count; 1 = legacy per-process caps.",
+		min: 1,
+		max: 100_000,
+	},
+	{
 		key: "per_customer_limit",
 		label: "Per-customer concurrent limit",
 		description:
-			"Max DB hydrations in flight at once for a single (org, env, customer). Per process — multiply by replica count for cluster-wide cap.",
+			"Max concurrent DB hydrations for a single (org, env, customer), cluster-wide (enforced as this ÷ fleet process count per process).",
 		min: 1,
 		max: 10_000,
 	},
@@ -61,7 +72,7 @@ const FIELDS: Array<{
 		key: "per_org_limit",
 		label: "Per-org concurrent limit",
 		description:
-			"Max DB hydrations in flight at once for a single (org, env). Per process.",
+			"Max concurrent DB hydrations for a single (org, env), cluster-wide.",
 		min: 1,
 		max: 10_000,
 	},

--- a/vite/src/views/admin/components/FullSubjectGateDialog.tsx
+++ b/vite/src/views/admin/components/FullSubjectGateDialog.tsx
@@ -88,7 +88,7 @@ const FIELDS: Array<{
 		key: "per_customer_pending_max",
 		label: "Per-customer queue depth cap",
 		description:
-			"Reject with 429 before queueing if the per-customer pending count is at or above this. Bounds heap memory + worst-case wait.",
+			"Max queued (pending) DB hydrations for a single (org, env, customer), cluster-wide (enforced as this ÷ fleet process count per process) — reject with 429 before queueing at or above it. Bounds heap memory + worst-case wait.",
 		min: 1,
 		max: 100_000,
 	},
@@ -96,7 +96,7 @@ const FIELDS: Array<{
 		key: "per_org_pending_max",
 		label: "Per-org queue depth cap",
 		description:
-			"Reject with 429 before queueing if the per-org pending count is at or above this.",
+			"Max queued (pending) DB hydrations for a single (org, env), cluster-wide (enforced as this ÷ fleet process count per process) — reject with 429 before queueing at or above it.",
 		min: 1,
 		max: 100_000,
 	},


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the FullSubject gate cluster-wide by sharing limits across processes. Adds `fleet_process_count` and floors per‑process caps so the cluster-wide capacity never exceeds the target; default 1 preserves current behavior.

- **New Features**
  - Added `fleet_process_count` to edge config; caps are cluster-wide targets divided per process, floored with a minimum of 1.
  - Implemented `toPerProcessLimit` and applied to org/customer limits and pending queue caps.
  - Admin UI: new “Fleet process count” field; updated all limit and pending-max field copy to say “cluster-wide” and note per-process enforcement as value ÷ fleet process count.
  - Expanded tests: unit tests for `toPerProcessLimit` and integration tests verifying cluster-wide org/customer caps.

- **Migration**
  - Set `fleet_process_count` to your production replica/process count to enable cluster-wide caps.
  - Leave it at 1 to keep existing per-process limits.

<sup>Written for commit 590794ac142209114c9d6baa010f4b76e2f67b0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Makes the FullSubject gate cluster-aware by introducing a `fleet_process_count` edge config value; all per-org and per-customer concurrency and queue-depth caps are now treated as cluster-wide targets and divided per-process via a new `toPerProcessLimit` helper. The default value of 1 means existing deployments are entirely unaffected.

- **[Improvements]** `toPerProcessLimit` floors division to ensure actual cluster-wide capacity never exceeds the configured target, and guards against zero-divisor; unit tests verify the invariant across a matrix of targets and fleet sizes.
- **[Improvements]** All five existing cap fields in the admin UI have their descriptions updated to communicate the cluster-wide semantics; `fleet_process_count` is added as the first field so operators set it before interpreting the caps below.
- **[Improvements]** Integration tests confirm the org-wide and customer-wide concurrency caps are applied correctly when `fleet_process_count > 1`.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge; default fleet_process_count of 1 makes this a pure no-op for existing deployments until operators explicitly opt in.

The core division logic is simple, correctly floored, and guarded against zero. The default of 1 means no existing deployment changes behavior. All new code paths are covered by both unit and integration tests. The only nit is a missing per-process enforcement note on one UI description field.

No files require special attention; the suggestion in FullSubjectGateDialog.tsx is a minor documentation consistency fix.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts | Introduces `toPerProcessLimit` helper and applies it to all per-org and per-customer concurrency/queue-depth caps; logic is correct, division-by-zero guarded, backward compatible at fleet_process_count=1. |
| server/src/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigSchemas.ts | Adds `fleet_process_count` integer field (min 1, max 100000, default 1); default preserves existing per-process semantics unchanged. |
| server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts | Adds unit tests for `toPerProcessLimit` (floor, zero-divisor guard, never-exceeds-target invariant) and integration tests exercising the cluster-wide org and customer caps end-to-end; good coverage. |
| vite/src/views/admin/components/FullSubjectGateDialog.tsx | Adds `fleet_process_count` input field at the top of the config form; updates descriptions for per_customer_limit, per_org_limit, and both pending-max fields to say cluster-wide; minor: per_org_limit description omits the per-process enforcement note present on all other fields. |


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request enters runWithFullSubjectGate] --> B[Read config from edge config store]
    B --> C[toPerProcessLimit: floor orgLimit / fleetSize, min 1]
    C --> D{customerId provided?}
    D -- Yes --> E[Get customerLimiter with per-process customer limit]
    E --> F{customer pendingCount >= per-process customer pending max?}
    F -- Yes --> G[Reject 429 - per_customer_queue_full]
    F -- No --> H[startedCounter++]
    D -- No --> I{org pendingCount >= per-process org pending max?}
    I -- Yes --> J[Reject 429 - per_org_queue_full]
    I -- No --> H
    H --> K{customerLimiter exists?}
    K -- Yes --> L[Acquire customerLimiter slot]
    L --> M{org pendingCount >= per-process org pending max?}
    M -- Yes --> N[Reject 429 - per_org_queue_full]
    M -- No --> O[Acquire orgLimiter slot and execute queryFn]
    K -- No --> O
    O --> P{waitMs >= max_wait_ms?}
    P -- Yes --> Q[Reject 429 - wait_timeout]
    P -- No --> R[Run queryFn and return result]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Request enters runWithFullSubjectGate] --> B[Read config from edge config store]
    B --> C[toPerProcessLimit: floor orgLimit / fleetSize, min 1]
    C --> D{customerId provided?}
    D -- Yes --> E[Get customerLimiter with per-process customer limit]
    E --> F{customer pendingCount >= per-process customer pending max?}
    F -- Yes --> G[Reject 429 - per_customer_queue_full]
    F -- No --> H[startedCounter++]
    D -- No --> I{org pendingCount >= per-process org pending max?}
    I -- Yes --> J[Reject 429 - per_org_queue_full]
    I -- No --> H
    H --> K{customerLimiter exists?}
    K -- Yes --> L[Acquire customerLimiter slot]
    L --> M{org pendingCount >= per-process org pending max?}
    M -- Yes --> N[Reject 429 - per_org_queue_full]
    M -- No --> O[Acquire orgLimiter slot and execute queryFn]
    K -- No --> O
    O --> P{waitMs >= max_wait_ms?}
    P -- Yes --> Q[Reject 429 - wait_timeout]
    P -- No --> R[Run queryFn and return result]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/src/views/admin/components/FullSubjectGateDialog.tsx`, line 87-102 ([link](https://github.com/useautumn/autumn/blob/4338b923ecf9ad5ead33bb05adb9859d5b1690ba/vite/src/views/admin/components/FullSubjectGateDialog.tsx#L87-L102)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `per_customer_pending_max` and `per_org_pending_max` descriptions were not updated to reflect that these values are now cluster-wide targets divided by `fleet_process_count`, unlike `per_customer_limit` and `per_org_limit` which were updated. An operator who sets `per_customer_pending_max: 500` with `fleet_process_count: 10` will get a per-process queue cap of 50, not 500 — the opposite of what the description implies.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/views/admin/components/FullSubjectGateDialog.tsx
   Line: 87-102

   Comment:
   The `per_customer_pending_max` and `per_org_pending_max` descriptions were not updated to reflect that these values are now cluster-wide targets divided by `fleet_process_count`, unlike `per_customer_limit` and `per_org_limit` which were updated. An operator who sets `per_customer_pending_max: 500` with `fleet_process_count: 10` will get a per-process queue cap of 50, not 500 — the opposite of what the description implies.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: clarify pending-max gate fields are..."](https://github.com/useautumn/autumn/commit/590794ac142209114c9d6baa010f4b76e2f67b0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39349610)</sub>

<!-- /greptile_comment -->