### PR TITLE
release: fleet_process_count +  rollover fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   #   staging repo (autumn-staging) -> us-east-1
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/past-due-cancel-immediate-void
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/past-due-cancel-immediate-void feat/gate-cluster-wide
 
 jobs:
   checks:

--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -92,10 +92,10 @@ export default function RootLayout({ children }: LayoutProps) {
 			className={cn(
 				geistSans.variable,
 				geistMono.variable,
-				"h-full bg-black antialiased",
+				"h-full max-w-full overflow-x-clip overscroll-x-none bg-black antialiased",
 			)}
 		>
-			<body className="min-h-full flex flex-col">{children}</body>
+			<body className="min-h-full max-w-full overflow-x-clip overscroll-x-none flex flex-col">{children}</body>
 		</html>
 	);
 }

--- a/apps/website/components/navbar.tsx
+++ b/apps/website/components/navbar.tsx
@@ -212,7 +212,7 @@ export default function Navbar({
 			}
 			ref={containerRef}
 		>
-			<div className="absolute pointer-events-none left-0 border-t border-[#292929] w-screen z-50" />
+			<div className="absolute pointer-events-none left-0 border-t border-[#292929] w-full z-50" />
 			{scrolled && !recoilHidden && (
 				<div className="h-[56px] md:h-[44px] w-fit" />
 			)}

--- a/server/src/cron/resetCron/resetCustomerEntitlement.ts
+++ b/server/src/cron/resetCron/resetCustomerEntitlement.ts
@@ -1,6 +1,6 @@
 import {
-	addCusProductToCusEnt,
 	AllowanceType,
+	addCusProductToCusEnt,
 	EntInterval,
 	getStartingBalance,
 	isCustomerEntitlementPrepaidWithSeparateResetInterval,
@@ -194,10 +194,16 @@ const resetCustomerEntitlementInDb = async ({
 		});
 
 		if (rolloverUpdate?.toInsert && rolloverUpdate.toInsert.length > 0) {
+			// The cron loader hands us cusEnt.rollovers as [], so load the live
+			// set before insert lets clearExcessRollovers enforce the cap.
+			const existingRollovers = await RolloverService.getCurrentRollovers({
+				ctx: repoContext,
+				cusEntID: cusEnt.id,
+			});
 			await RolloverService.insert({
 				ctx: repoContext,
 				rows: rolloverUpdate.toInsert,
-				fullCusEnt: cusEnt,
+				fullCusEnt: { ...cusEnt, rollovers: existingRollovers },
 			});
 		}
 

--- a/server/src/cron/resetCron/resetShortDurationCustomerEntitlement.ts
+++ b/server/src/cron/resetCron/resetShortDurationCustomerEntitlement.ts
@@ -1,8 +1,4 @@
-import type {
-	EntInterval,
-	FullEntitlement,
-	ResetCusEnt,
-} from "@autumn/shared";
+import type { EntInterval, FullEntitlement, ResetCusEnt } from "@autumn/shared";
 import { UTCDate } from "@date-fns/utc";
 import { Decimal } from "decimal.js";
 import type { RepoContext } from "@/db/repoContext";
@@ -47,10 +43,16 @@ export const resetShortDurationCustomerEntitlement = async ({
 	});
 
 	if (rolloverUpdate?.toInsert && rolloverUpdate.toInsert.length > 0) {
+		// The cron loader hands us cusEnt.rollovers as [], so load the live
+		// set before insert lets clearExcessRollovers enforce the cap.
+		const existingRollovers = await RolloverService.getCurrentRollovers({
+			ctx,
+			cusEntID: cusEnt.id,
+		});
 		await RolloverService.insert({
 			ctx,
 			rows: rolloverUpdate.toInsert,
-			fullCusEnt: cusEnt,
+			fullCusEnt: { ...cusEnt, rollovers: existingRollovers },
 		});
 	}
 

--- a/server/src/internal/customers/cusProducts/cusEnts/cusRollovers/RolloverService.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/cusRollovers/RolloverService.ts
@@ -121,38 +121,13 @@ export class RolloverService {
 		overwrites: Rollover[];
 	}> {
 		const { db } = ctx;
-
-		// No cap configured → nothing to clear, skip the extra read. Returns the
-		// caller's list as-is, so callers passing an incomplete fullCusEnt (e.g.
-		// the cron's rollovers:[]) must discard the returned rollovers.
-		const rolloverConfig = fullCusEnt.entitlement.rollover;
-		if (
-			!rolloverConfig ||
-			(rolloverConfig.max == null && rolloverConfig.max_percentage == null)
-		) {
-			return {
-				rollovers: [...fullCusEnt.rollovers, ...newRows],
-				deletedIds: [],
-				overwrites: [],
-			};
-		}
-
-		// Source the live rollover set from the DB rather than trusting
-		// fullCusEnt.rollovers, which some callers pass incomplete (the reset
-		// cron hardcodes []). newRows are already inserted, so this includes them.
-		const now = Date.now();
-		const curRollovers = (await db
-			.select()
-			.from(rollovers)
-			.where(
-				and(
-					eq(rollovers.cus_ent_id, fullCusEnt.id),
-					or(isNull(rollovers.expires_at), gt(rollovers.expires_at, now)),
-				),
-			)) as Rollover[];
+		// Trust the caller's rollover set: the lazy/cached path carries live
+		// Redis balances that lead Postgres, so re-reading here would clear
+		// against stale rows. The cron path loads the set before calling insert.
+		const curRollovers = [...fullCusEnt.rollovers, ...newRows];
 
 		const { toDelete, toUpdate } = performMaximumClearing({
-			rows: curRollovers,
+			rows: curRollovers as Rollover[],
 			cusEnt: fullCusEnt,
 		});
 

--- a/server/src/internal/customers/cusProducts/cusEnts/cusRollovers/RolloverService.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/cusRollovers/RolloverService.ts
@@ -3,7 +3,7 @@ import {
 	type Rollover,
 	rollovers,
 } from "@autumn/shared";
-import { and, eq, gte, inArray } from "drizzle-orm";
+import { and, eq, gt, inArray, isNull, or } from "drizzle-orm";
 import type { CronContext } from "@/cron/utils/CronContext.js";
 import { buildConflictUpdateColumns } from "@/db/dbUtils.js";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
@@ -75,7 +75,10 @@ export class RolloverService {
 			.where(
 				and(
 					eq(rollovers.cus_ent_id, cusEntID),
-					gte(rollovers.expires_at, new Date().getTime()),
+					or(
+						isNull(rollovers.expires_at),
+						gt(rollovers.expires_at, Date.now()),
+					),
 				),
 			);
 	}
@@ -118,10 +121,38 @@ export class RolloverService {
 		overwrites: Rollover[];
 	}> {
 		const { db } = ctx;
-		const curRollovers = [...fullCusEnt.rollovers, ...newRows];
+
+		// No cap configured → nothing to clear, skip the extra read. Returns the
+		// caller's list as-is, so callers passing an incomplete fullCusEnt (e.g.
+		// the cron's rollovers:[]) must discard the returned rollovers.
+		const rolloverConfig = fullCusEnt.entitlement.rollover;
+		if (
+			!rolloverConfig ||
+			(rolloverConfig.max == null && rolloverConfig.max_percentage == null)
+		) {
+			return {
+				rollovers: [...fullCusEnt.rollovers, ...newRows],
+				deletedIds: [],
+				overwrites: [],
+			};
+		}
+
+		// Source the live rollover set from the DB rather than trusting
+		// fullCusEnt.rollovers, which some callers pass incomplete (the reset
+		// cron hardcodes []). newRows are already inserted, so this includes them.
+		const now = Date.now();
+		const curRollovers = (await db
+			.select()
+			.from(rollovers)
+			.where(
+				and(
+					eq(rollovers.cus_ent_id, fullCusEnt.id),
+					or(isNull(rollovers.expires_at), gt(rollovers.expires_at, now)),
+				),
+			)) as Rollover[];
 
 		const { toDelete, toUpdate } = performMaximumClearing({
-			rows: curRollovers as Rollover[],
+			rows: curRollovers,
 			cusEnt: fullCusEnt,
 		});
 
@@ -133,11 +164,15 @@ export class RolloverService {
 			await RolloverService.upsert({ db, rows: toUpdate });
 		}
 
-		const rollovers = curRollovers
+		const remainingRollovers = curRollovers
 			.filter((r) => !toDelete.includes(r.id))
 			.map((r) => toUpdate.find((u) => u.id === r.id) ?? r);
 
-		return { rollovers, deletedIds: toDelete, overwrites: toUpdate };
+		return {
+			rollovers: remainingRollovers,
+			deletedIds: toDelete,
+			overwrites: toUpdate,
+		};
 	}
 
 	static async delete({ db, ids }: { db: DrizzleCli; ids: string[] }) {

--- a/server/src/internal/customers/cusProducts/cusEnts/cusRollovers/rolloverUtils.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/cusRollovers/rolloverUtils.ts
@@ -167,7 +167,12 @@ export function performMaximumClearing({
 				newBalance = newBalance.sub(toDeduct);
 				toDeduct = new Decimal(0);
 
-				toUpdate.push({ ...row, balance: newBalance.toNumber() });
+				// Drop fully-drained rows instead of keeping zero-balance zombies.
+				if (newBalance.isZero()) {
+					toDelete.push(row.id);
+				} else {
+					toUpdate.push({ ...row, balance: newBalance.toNumber() });
+				}
 			} else {
 				newBalance = new Decimal(0);
 				toDeduct = toDeduct.sub(curBalance);
@@ -207,7 +212,9 @@ export function performMaximumClearing({
 
 			if (curBalance.gte(toDeduct)) {
 				newBalance = newBalance.sub(toDeduct);
-				entityIdToTotal[entityId] = 0;
+				// Remaining running total after the full deduction (== effectiveMax),
+				// keeping the same invariant as the else-branch below.
+				entityIdToTotal[entityId] = entityTotal - toDeduct.toNumber();
 				shouldUpdate = true;
 				update.entities[entityId] = {
 					id: entityId,
@@ -216,7 +223,9 @@ export function performMaximumClearing({
 				};
 			} else {
 				newBalance = new Decimal(0);
-				entityIdToTotal[entityId] = toDeduct.sub(curBalance).toNumber();
+				// Carry the remaining running total (not the residual deduction) so
+				// the next row recomputes toDeduct correctly.
+				entityIdToTotal[entityId] = entityTotal - curBalance.toNumber();
 				shouldUpdate = true;
 				update.entities[entityId] = {
 					id: entityId,

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -140,6 +140,13 @@ export const isFullSubjectGateRejection = (error: unknown): boolean => {
 	);
 };
 
+// Configured caps are cluster-wide; each process enforces an even share.
+export const toPerProcessLimit = (
+	clusterWideTarget: number,
+	fleetProcessCount: number,
+): number =>
+	Math.max(1, Math.round(clusterWideTarget / Math.max(1, fleetProcessCount)));
+
 export const runWithFullSubjectGate = async <T>({
 	customerId,
 	orgId,
@@ -159,11 +166,21 @@ export const runWithFullSubjectGate = async <T>({
 		max_wait_ms,
 		per_customer_pending_max,
 		per_org_pending_max,
+		fleet_process_count,
 	} = getRuntimeFullSubjectGateConfig();
 	const enqueuedAt = Date.now();
 	const labels = attrs({ orgId, env });
 
-	const orgLimiter = getOrgLimiter({ orgId, env, limit: per_org_limit });
+	const perProcessOrgLimit = toPerProcessLimit(
+		per_org_limit,
+		fleet_process_count,
+	);
+	const perProcessOrgPendingMax = toPerProcessLimit(
+		per_org_pending_max,
+		fleet_process_count,
+	);
+
+	const orgLimiter = getOrgLimiter({ orgId, env, limit: perProcessOrgLimit });
 
 	let customerLimiter: LimitFunction | undefined;
 	if (customerId) {
@@ -171,12 +188,15 @@ export const runWithFullSubjectGate = async <T>({
 			orgId,
 			env,
 			customerId,
-			limit: per_customer_limit,
+			limit: toPerProcessLimit(per_customer_limit, fleet_process_count),
 		});
-		if (customerLimiter.pendingCount >= per_customer_pending_max) {
+		if (
+			customerLimiter.pendingCount >=
+			toPerProcessLimit(per_customer_pending_max, fleet_process_count)
+		) {
 			rejectOverloaded({ reason: "per_customer_queue_full", labels });
 		}
-	} else if (orgLimiter.pendingCount >= per_org_pending_max) {
+	} else if (orgLimiter.pendingCount >= perProcessOrgPendingMax) {
 		rejectOverloaded({ reason: "per_org_queue_full", labels });
 	}
 
@@ -207,7 +227,7 @@ export const runWithFullSubjectGate = async <T>({
 
 	if (customerLimiter) {
 		return customerLimiter(() => {
-			if (orgLimiter.pendingCount >= per_org_pending_max) {
+			if (orgLimiter.pendingCount >= perProcessOrgPendingMax) {
 				rejectOverloaded({ reason: "per_org_queue_full", labels });
 			}
 			return orgLimiter(execute);

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -141,11 +141,12 @@ export const isFullSubjectGateRejection = (error: unknown): boolean => {
 };
 
 // Configured caps are cluster-wide; each process enforces an even share.
+// Floor (not round) so cluster-wide capacity never EXCEEDS the configured target.
 export const toPerProcessLimit = (
 	clusterWideTarget: number,
 	fleetProcessCount: number,
 ): number =>
-	Math.max(1, Math.round(clusterWideTarget / Math.max(1, fleetProcessCount)));
+	Math.max(1, Math.floor(clusterWideTarget / Math.max(1, fleetProcessCount)));
 
 export const runWithFullSubjectGate = async <T>({
 	customerId,

--- a/server/src/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigSchemas.ts
+++ b/server/src/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigSchemas.ts
@@ -13,6 +13,9 @@ export const FullSubjectGateEdgeConfigSchema = z.object({
 	// (org,env) before rejecting new ones with 429 — bounds memory + wait time.
 	per_customer_pending_max: z.number().int().min(1).max(100_000).default(500),
 	per_org_pending_max: z.number().int().min(1).max(100_000).default(1_000),
+	// Caps above are cluster-wide targets; each process enforces
+	// target / fleet_process_count. Default 1 = per-process (no-op).
+	fleet_process_count: z.number().int().min(1).max(100_000).default(1),
 });
 
 export type FullSubjectGateEdgeConfig = z.infer<

--- a/server/tests/integration/cron/reset-cron-rollover-max-cap.test.ts
+++ b/server/tests/integration/cron/reset-cron-rollover-max-cap.test.ts
@@ -1,0 +1,136 @@
+/**
+ * TDD test for rollover `max` not being enforced on the reset-cron path.
+ *
+ * The cron loader (CusEntService.getActiveResetPassed) maps every cusEnt with a
+ * hardcoded `rollovers: []`. RolloverService.clearExcessRollovers then computes
+ * `[...fullCusEnt.rollovers, ...newRows]`, so it only ever sees the single new
+ * row and never the previously-accumulated forever-expiry rows — the cap never
+ * fires. With an hourly reset + forever rollover this compounds every cycle.
+ *
+ * Red-failure mode (current behavior):
+ *  - After N cron resets, total rollover balance grows ~N * included, far past `max`.
+ *
+ * Green-success criteria (after fix):
+ *  - clearExcessRollovers sources the authoritative rollover set from the DB, so
+ *    total rollover balance is capped at `max` regardless of caller-supplied state.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	customerEntitlements,
+	ProductItemInterval,
+	type ResetCusEnt,
+	RolloverExpiryDurationType,
+	rollovers,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { resetCustomerEntitlement } from "@/cron/resetCron/resetCustomerEntitlement";
+import { CusService } from "@/internal/customers/CusService";
+import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem";
+
+const INCLUDED = 300;
+const ROLLOVER_MAX = 1080;
+const RESET_CYCLES = 10;
+
+test.concurrent(
+	`${chalk.yellowBright("reset cron rollover: forever rollover stays capped at max across hourly resets")}`,
+	async () => {
+		const customerId = "reset-cron-rollover-max-cap";
+
+		const fairuseItem = constructFeatureItem({
+			featureId: TestFeature.Messages,
+			includedUsage: INCLUDED,
+			interval: ProductItemInterval.Hour,
+			intervalCount: 5,
+			rolloverConfig: {
+				max: ROLLOVER_MAX,
+				length: 1,
+				duration: RolloverExpiryDurationType.Forever,
+			},
+		});
+
+		const plan = products.base({
+			id: "reset-cron-rollover-max-cap",
+			items: [fairuseItem],
+		});
+
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [s.customer(), s.products({ list: [plan] })],
+			actions: [s.attach({ productId: plan.id })],
+		});
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			skipReset: true,
+		});
+		const cusEntId = fullCustomer.customer_products
+			.flatMap((customerProduct) => customerProduct.customer_entitlements)
+			.find(
+				(cusEnt) => cusEnt.entitlement.feature_id === TestFeature.Messages,
+			)?.id;
+		if (!cusEntId) {
+			throw new Error(`Expected messages entitlement for ${customerId}`);
+		}
+
+		// Force the reset to be overdue so the cron loader picks it up.
+		const now = Date.now();
+		await ctx.db
+			.update(customerEntitlements)
+			.set({ next_reset_at: now - 1000 })
+			.where(eq(customerEntitlements.id, cusEntId));
+
+		// Load the cusEnt exactly as the cron does (rollovers hardcoded to []).
+		const resetCusEnts = await CusEntService.getActiveResetPassed({
+			db: ctx.db,
+			customDateUnix: now,
+		});
+		const cronCusEnt = resetCusEnts.find((cusEnt) => cusEnt.id === cusEntId);
+		expect(
+			cronCusEnt,
+			"cusEnt should be selected by getActiveResetPassed",
+		).toBeDefined();
+		expect(cronCusEnt?.rollovers).toEqual([]);
+
+		// Drive several reset cycles. The short-duration reset path does not
+		// persist balance/next_reset_at itself, so the unused INCLUDED balance
+		// is banked each cycle.
+		for (let cycle = 0; cycle < RESET_CYCLES; cycle++) {
+			const updatedCusEnts: ResetCusEnt[] = [];
+			await resetCustomerEntitlement({
+				ctx,
+				cusEnt: cronCusEnt as ResetCusEnt,
+				updatedCusEnts,
+			});
+		}
+
+		const rolloverRows = await ctx.db
+			.select()
+			.from(rollovers)
+			.where(eq(rollovers.cus_ent_id, cusEntId));
+
+		const totalRolloverBalance = rolloverRows.reduce(
+			(sum, row) => sum + row.balance,
+			0,
+		);
+
+		expect(
+			totalRolloverBalance,
+			`total rollover balance ${totalRolloverBalance} exceeded max ${ROLLOVER_MAX} after ${RESET_CYCLES} hourly resets`,
+		).toBeLessThanOrEqual(ROLLOVER_MAX);
+
+		// Guard against passing the cap by accumulating many small uncleared rows:
+		// trimming should keep the row count bounded too.
+		const maxExpectedRows = Math.ceil(ROLLOVER_MAX / INCLUDED) + 1;
+		expect(
+			rolloverRows.length,
+			`expected at most ${maxExpectedRows} rollover rows after ${RESET_CYCLES} cycles`,
+		).toBeLessThanOrEqual(maxExpectedRows);
+	},
+);

--- a/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
+++ b/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
@@ -1,6 +1,9 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { AppEnv } from "@autumn/shared";
-import { runWithFullSubjectGate } from "@/internal/customers/repos/getFullSubject/getFullSubjectGate.js";
+import {
+	runWithFullSubjectGate,
+	toPerProcessLimit,
+} from "@/internal/customers/repos/getFullSubject/getFullSubjectGate.js";
 import { _setFullSubjectGateConfigForTesting } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
 
 beforeAll(() => {
@@ -258,12 +261,14 @@ describe("runWithFullSubjectGate", () => {
 			.filter((r) => r.status === "rejected")
 			.map(
 				(r) =>
-					(r as PromiseRejectedResult).reason.data?.reason as string | undefined,
+					(r as PromiseRejectedResult).reason.data?.reason as
+						| string
+						| undefined,
 			);
 		expect(rejectedReasons.length).toBeGreaterThan(0);
-		expect(rejectedReasons.some((reason) => reason === "per_org_queue_full")).toBe(
-			true,
-		);
+		expect(
+			rejectedReasons.some((reason) => reason === "per_org_queue_full"),
+		).toBe(true);
 		for (const r of results.filter(
 			(x) => x.status === "rejected",
 		) as PromiseRejectedResult[]) {
@@ -308,8 +313,7 @@ describe("runWithFullSubjectGate", () => {
 		const timeouts = results.filter(
 			(r) =>
 				r.status === "rejected" &&
-				(r as PromiseRejectedResult).reason.code ===
-					"rate_limit_exceeded",
+				(r as PromiseRejectedResult).reason.code === "rate_limit_exceeded",
 		);
 		expect(timeouts.length).toBeGreaterThan(0);
 
@@ -360,5 +364,83 @@ describe("runWithFullSubjectGate", () => {
 		);
 		expect(followUp).toEqual([0, 1, 2, 3]);
 		expect(counter.current).toBe(0);
+	});
+});
+
+describe("toPerProcessLimit", () => {
+	test("divides a cluster-wide target by fleet size, rounding and flooring at 1", () => {
+		expect(toPerProcessLimit(16, 1)).toBe(16);
+		expect(toPerProcessLimit(16, 4)).toBe(4);
+		expect(toPerProcessLimit(200, 44)).toBe(5);
+		expect(toPerProcessLimit(16, 44)).toBe(1);
+		expect(toPerProcessLimit(1, 1)).toBe(1);
+	});
+
+	test("treats a fleet size below 1 as 1 (no divide-by-zero)", () => {
+		expect(toPerProcessLimit(16, 0)).toBe(16);
+	});
+});
+
+describe("runWithFullSubjectGate cluster-wide caps", () => {
+	test("fleet_process_count divides the per-org concurrency cap", async () => {
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 100,
+				per_org_limit: 8,
+				fleet_process_count: 4,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
+		});
+
+		const counter = makeCounter();
+		const queryFn = makeQueryFn(counter, 30);
+		const tasks = Array.from({ length: 12 }, (_, index) =>
+			runWithFullSubjectGate({
+				customerId: `cus-${index}`,
+				orgId: "org-clusterwide-org",
+				env: AppEnv.Live,
+				queryFn: () => queryFn(index),
+			}),
+		);
+		await Promise.all(tasks);
+		// 8 cluster-wide / 4 processes = 2 per process
+		expect(counter.peak).toBeLessThanOrEqual(2);
+		expect(counter.peak).toBeGreaterThan(1);
+		expect(counter.current).toBe(0);
+
+		_setFullSubjectGateConfigForTesting({ config: {} });
+	});
+
+	test("fleet_process_count divides the per-customer concurrency cap", async () => {
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 8,
+				per_org_limit: 100,
+				fleet_process_count: 4,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
+		});
+
+		const counter = makeCounter();
+		const queryFn = makeQueryFn(counter, 30);
+		const tasks = Array.from({ length: 12 }, (_, index) =>
+			runWithFullSubjectGate({
+				customerId: "cus-clusterwide-single",
+				orgId: "org-clusterwide-cus",
+				env: AppEnv.Live,
+				queryFn: () => queryFn(index),
+			}),
+		);
+		await Promise.all(tasks);
+		// 8 cluster-wide / 4 processes = 2 per process
+		expect(counter.peak).toBeLessThanOrEqual(2);
+		expect(counter.peak).toBeGreaterThan(1);
+		expect(counter.current).toBe(0);
+
+		_setFullSubjectGateConfigForTesting({ config: {} });
 	});
 });

--- a/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
+++ b/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
@@ -368,16 +368,29 @@ describe("runWithFullSubjectGate", () => {
 });
 
 describe("toPerProcessLimit", () => {
-	test("divides a cluster-wide target by fleet size, rounding and flooring at 1", () => {
+	test("floors the cluster-wide target divided by fleet size, with a floor of 1", () => {
 		expect(toPerProcessLimit(16, 1)).toBe(16);
 		expect(toPerProcessLimit(16, 4)).toBe(4);
-		expect(toPerProcessLimit(200, 44)).toBe(5);
+		expect(toPerProcessLimit(200, 44)).toBe(4);
 		expect(toPerProcessLimit(16, 44)).toBe(1);
 		expect(toPerProcessLimit(1, 1)).toBe(1);
 	});
 
 	test("treats a fleet size below 1 as 1 (no divide-by-zero)", () => {
 		expect(toPerProcessLimit(16, 0)).toBe(16);
+	});
+
+	test("never lets cluster-wide capacity exceed the configured target", () => {
+		for (const target of [8, 10, 16, 17, 50, 200, 500]) {
+			for (const fleet of [1, 3, 4, 20, 44]) {
+				const perProcess = toPerProcessLimit(target, fleet);
+				if (target >= fleet) {
+					expect(perProcess * fleet).toBeLessThanOrEqual(target);
+				} else {
+					expect(perProcess).toBe(1);
+				}
+			}
+		}
 	});
 });
 

--- a/server/tests/unit/rollovers/perform-maximum-clearing-entity-mode.test.ts
+++ b/server/tests/unit/rollovers/perform-maximum-clearing-entity-mode.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit test for performMaximumClearing entity-mode cap enforcement.
+ *
+ * Red-failure mode (current behavior):
+ *  - When the excess is spread across multiple rollover rows for one entity,
+ *    entityIdToTotal is overwritten with (toDeduct - curBalance) instead of the
+ *    remaining running total, so the next row computes a negative toDeduct and
+ *    is skipped. Only the oldest row is trimmed and the cap is left exceeded.
+ *
+ * Green-success criteria (after fix):
+ *  - Total entity balance across all rows is capped at `max`.
+ */
+
+import { expect, test } from "bun:test";
+import type { FullCusEntWithProduct, Rollover } from "@autumn/shared";
+import { performMaximumClearing } from "@/internal/customers/cusProducts/cusEnts/cusRollovers/rolloverUtils";
+
+const ENTITY_ID = "e1";
+const MAX = 1080;
+const PER_ROW = 300;
+const ROW_COUNT = 5;
+
+const makeRow = (index: number, entities: Record<string, number>): Rollover =>
+	({
+		id: `roll_${index}`,
+		cus_ent_id: "cus_ent_1",
+		balance: 0,
+		usage: 0,
+		expires_at: null,
+		entities: Object.fromEntries(
+			Object.entries(entities).map(([id, balance]) => [
+				id,
+				{ id, balance, usage: 0 },
+			]),
+		),
+	}) as Rollover;
+
+const makeCusEnt = () =>
+	({
+		entitlement: {
+			entity_feature_id: ENTITY_ID,
+			rollover: { max: MAX, length: 1 },
+		},
+	}) as unknown as FullCusEntWithProduct;
+
+const sumEntity = (rows: Rollover[], entityId: string) =>
+	rows.reduce((sum, row) => sum + (row.entities[entityId]?.balance ?? 0), 0);
+
+const applyClearing = (rows: Rollover[]) => {
+	const { toDelete, toUpdate } = performMaximumClearing({
+		rows,
+		cusEnt: makeCusEnt(),
+	});
+	return rows
+		.filter((row) => !toDelete.includes(row.id))
+		.map((row) => toUpdate.find((updated) => updated.id === row.id) ?? row);
+};
+
+test("performMaximumClearing caps entity rollover spread across multiple rows", () => {
+	const rows = Array.from({ length: ROW_COUNT }, (_, index) =>
+		makeRow(index, { [ENTITY_ID]: PER_ROW }),
+	);
+
+	const totalEntityBalance = sumEntity(applyClearing(rows), ENTITY_ID);
+
+	expect(
+		totalEntityBalance,
+		`entity rollover total ${totalEntityBalance} exceeded max ${MAX}`,
+	).toBeLessThanOrEqual(MAX);
+});
+
+test("performMaximumClearing caps over-cap entity without touching an under-cap entity in the same rows", () => {
+	const UNDER_ENTITY_ID = "e2";
+	const UNDER_PER_ROW = 40;
+
+	// Each row carries both entities; e1 totals 1500 (over cap), e2 totals 200
+	// (under cap). Draining e1 to 0 on the oldest row must NOT delete the row,
+	// since e2 still has balance there.
+	const rows = Array.from({ length: ROW_COUNT }, (_, index) =>
+		makeRow(index, { [ENTITY_ID]: PER_ROW, [UNDER_ENTITY_ID]: UNDER_PER_ROW }),
+	);
+
+	const remaining = applyClearing(rows);
+
+	expect(sumEntity(remaining, ENTITY_ID)).toBeLessThanOrEqual(MAX);
+	// Under-cap entity is left fully intact.
+	expect(sumEntity(remaining, UNDER_ENTITY_ID)).toBe(UNDER_PER_ROW * ROW_COUNT);
+});

--- a/vite/src/views/admin/components/FullSubjectGateDialog.tsx
+++ b/vite/src/views/admin/components/FullSubjectGateDialog.tsx
@@ -21,6 +21,7 @@ type FullSubjectGateConfig = {
 	max_wait_ms: number;
 	per_customer_pending_max: number;
 	per_org_pending_max: number;
+	fleet_process_count: number;
 	configHealthy?: boolean;
 	configConfigured?: boolean;
 	lastSuccessAt?: string | null;
@@ -33,6 +34,7 @@ const DEFAULT_CONFIG: FullSubjectGateConfig = {
 	max_wait_ms: 2_000,
 	per_customer_pending_max: 500,
 	per_org_pending_max: 1_000,
+	fleet_process_count: 1,
 };
 
 const FIELDS: Array<{
@@ -43,6 +45,7 @@ const FIELDS: Array<{
 		| "max_wait_ms"
 		| "per_customer_pending_max"
 		| "per_org_pending_max"
+		| "fleet_process_count"
 	>;
 	label: string;
 	description: string;
@@ -50,10 +53,18 @@ const FIELDS: Array<{
 	max: number;
 }> = [
 	{
+		key: "fleet_process_count",
+		label: "Fleet process count",
+		description:
+			"Number of app processes in the fleet. The caps below are cluster-wide targets, divided by this per process. Set to the live replica count; 1 = legacy per-process caps.",
+		min: 1,
+		max: 100_000,
+	},
+	{
 		key: "per_customer_limit",
 		label: "Per-customer concurrent limit",
 		description:
-			"Max DB hydrations in flight at once for a single (org, env, customer). Per process — multiply by replica count for cluster-wide cap.",
+			"Max concurrent DB hydrations for a single (org, env, customer), cluster-wide (enforced as this ÷ fleet process count per process).",
 		min: 1,
 		max: 10_000,
 	},
@@ -61,7 +72,7 @@ const FIELDS: Array<{
 		key: "per_org_limit",
 		label: "Per-org concurrent limit",
 		description:
-			"Max DB hydrations in flight at once for a single (org, env). Per process.",
+			"Max concurrent DB hydrations for a single (org, env), cluster-wide.",
 		min: 1,
 		max: 10_000,
 	},

--- a/vite/src/views/admin/components/FullSubjectGateDialog.tsx
+++ b/vite/src/views/admin/components/FullSubjectGateDialog.tsx
@@ -88,7 +88,7 @@ const FIELDS: Array<{
 		key: "per_customer_pending_max",
 		label: "Per-customer queue depth cap",
 		description:
-			"Reject with 429 before queueing if the per-customer pending count is at or above this. Bounds heap memory + worst-case wait.",
+			"Max queued (pending) DB hydrations for a single (org, env, customer), cluster-wide (enforced as this ÷ fleet process count per process) — reject with 429 before queueing at or above it. Bounds heap memory + worst-case wait.",
 		min: 1,
 		max: 100_000,
 	},
@@ -96,7 +96,7 @@ const FIELDS: Array<{
 		key: "per_org_pending_max",
 		label: "Per-org queue depth cap",
 		description:
-			"Reject with 429 before queueing if the per-org pending count is at or above this.",
+			"Max queued (pending) DB hydrations for a single (org, env), cluster-wide (enforced as this ÷ fleet process count per process) — reject with 429 before queueing at or above it.",
 		min: 1,
 		max: 100_000,
 	},


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rollover max enforcement during cron resets and adds a cluster-wide FullSubject gate via `fleet_process_count` so concurrency and queue limits are respected across replicas. Also prevents horizontal overscroll on the website.

- **New Features**
  - Introduced `fleet_process_count` in gate config and admin UI; per-process limits and pending caps are computed as floor(target ÷ fleet size) to keep cluster-wide capacity within the target.

- **Bug Fixes**
  - Cron reset path now loads current rollover rows before insert, ensuring `max` caps apply even when the loader provides `rollovers: []`.
  - Included forever-expiry (null) rows when fetching current rollovers.
  - Entity-mode clearing now carries the remaining running total across rows, correctly trimming excess spread over multiple rows.
  - Dropped fully drained rollover rows to avoid zero-balance zombies.
  - Website: clipped horizontal overflow and switched navbar border width to `w-full` to prevent horizontal scrolling.
  - Added integration and unit tests covering cron rollover caps and gate math.

<sup>Written for commit 7d97333912777102e4f751215e7d6016a7cff2b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR ships two independent fixes and a new fleet-aware concurrency configuration. The rollover cap enforcement was broken on the cron path because the cron loader hardcodes `rollovers: []` on every `ResetCusEnt`, causing `clearExcessRollovers` to see only the single new row and never the accumulated rows — the fix adds a live DB fetch of existing rollovers before calling `insert`. A second fix corrects the entity-mode running-total tracking in `performMaximumClearing`, where `entityIdToTotal` was being set to the residual deduction amount rather than the remaining entity total, causing all subsequent rows to compute a negative `toDeduct` and be skipped entirely.

- **Bug fixes / Improvements**: Rollover `max` cap now correctly enforced on the reset-cron path by fetching live rollovers from the DB before cap enforcement (`resetCustomerEntitlement.ts`, `resetShortDurationCustomerEntitlement.ts`, `RolloverService.ts`).
- **Bug fixes**: Entity-mode `performMaximumClearing` now carries the correct running total across rows, ensuring multi-row entity rollovers are trimmed to the configured `max` (`rolloverUtils.ts`).
- **Improvements / API changes**: `fleet_process_count` field added to the `FullSubjectGateEdgeConfig` schema and admin UI; per-process concurrency and queue-depth limits are now computed as `floor(clusterWideTarget / fleet_process_count)`, making the caps cluster-aware (`getFullSubjectGate.ts`, `fullSubjectGateEdgeConfigSchemas.ts`, `FullSubjectGateDialog.tsx`).
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the two rollover cap bugs are well-understood and the fixes are covered by new integration and unit tests.

All three core changes (cron-path live rollover fetch, entity-mode running-total tracking, fleet_process_count division) are correct and backed by targeted tests. The only open items are a style inconsistency in how per-customer limits are computed and the temporary staging branch in the CI allowlist, neither of which affects runtime correctness.

No files require special attention; rolloverUtils.ts and RolloverService.ts carry the most complex logic changes and are the highest-value files to double-check.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cusProducts/cusEnts/cusRollovers/rolloverUtils.ts | Two correctness fixes: entity-mode entityIdToTotal now tracks the remaining running total (not the residual deduction), and non-entity mode now deletes fully-drained zero-balance rows instead of keeping them as zombies. |
| server/src/internal/customers/cusProducts/cusEnts/cusRollovers/RolloverService.ts | getCurrentRollovers query fixed to include never-expiring rows (isNull check added); clearExcessRollovers now trusts caller-supplied rollover set; local variable renamed from `rollovers` to `remainingRollovers` to avoid shadowing the drizzle schema import. |
| server/src/cron/resetCron/resetCustomerEntitlement.ts | Fetches live rollovers from DB before calling RolloverService.insert, overriding the cron loader's hardcoded empty array so cap enforcement sees the full accumulated set. |
| server/src/cron/resetCron/resetShortDurationCustomerEntitlement.ts | Same cron-path rollover fix as resetCustomerEntitlement — live DB fetch before insert ensures cap is enforced. |
| server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts | Adds toPerProcessLimit helper and applies it to all four concurrency/queue-depth caps; per_customer_pending_max limit is computed inline rather than cached in a named variable, unlike the other three. |
| server/src/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigSchemas.ts | Adds fleet_process_count field (int, 1–100 000, default 1) to the edge config schema with backward-compatible default. |
| vite/src/views/admin/components/FullSubjectGateDialog.tsx | Adds fleet_process_count to the admin dialog type, default config, and FIELDS array; updates existing field descriptions to reflect cluster-wide semantics. |
| server/tests/integration/cron/reset-cron-rollover-max-cap.test.ts | New integration test for the cron-path rollover cap bug; simulates N reset cycles and asserts total rollover balance ≤ max and row count is bounded. |
| server/tests/unit/rollovers/perform-maximum-clearing-entity-mode.test.ts | New unit tests for entity-mode cap spreading across multiple rows, including multi-entity rows where only one entity is over cap. |
| server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts | Adds toPerProcessLimit unit tests (boundary, floor, cluster-wide invariant) and two new runWithFullSubjectGate tests verifying fleet_process_count divides per-org and per-customer concurrency caps. |
| .github/workflows/build.yml | Appends feat/gate-cluster-wide to the staging deploy branch allowlist; temporary change to enable staging deployment of this branch. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Cron
    participant DB
    participant RolloverService
    participant performMaximumClearing

    note over Cron: resetCustomerEntitlement / resetShortDurationCustomerEntitlement
    Cron->>DB: getActiveResetPassed() → cusEnt (rollovers: [])
    Cron->>DB: getCurrentRollovers(cusEntID) → existingRollovers
    note over Cron: Override stale rollovers: [] with live DB set
    Cron->>RolloverService: "insert({ rows: newRows, fullCusEnt: { ...cusEnt, rollovers: existingRollovers } })"
    RolloverService->>DB: INSERT new rollover rows
    RolloverService->>performMaximumClearing: "rows = existingRollovers + newRows"
    performMaximumClearing-->>RolloverService: "{ toDelete, toUpdate }"
    RolloverService->>DB: DELETE excess rows / UPDATE trimmed balances
    RolloverService-->>Cron: "{ rollovers, deletedIds, overwrites }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Cron
    participant DB
    participant RolloverService
    participant performMaximumClearing

    note over Cron: resetCustomerEntitlement / resetShortDurationCustomerEntitlement
    Cron->>DB: getActiveResetPassed() → cusEnt (rollovers: [])
    Cron->>DB: getCurrentRollovers(cusEntID) → existingRollovers
    note over Cron: Override stale rollovers: [] with live DB set
    Cron->>RolloverService: "insert({ rows: newRows, fullCusEnt: { ...cusEnt, rollovers: existingRollovers } })"
    RolloverService->>DB: INSERT new rollover rows
    RolloverService->>performMaximumClearing: "rows = existingRollovers + newRows"
    performMaximumClearing-->>RolloverService: "{ toDelete, toUpdate }"
    RolloverService->>DB: DELETE excess rows / UPDATE trimmed balances
    RolloverService-->>Cron: "{ rollovers, deletedIds, overwrites }"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts:186-197
The `per_customer_pending_max` per-process limit is computed inline at the call site, while all the other three limits are stored in named variables (`perProcessOrgLimit`, `perProcessOrgPendingMax`). Extracting it makes the intent symmetric and avoids recomputing the same value on every hot path invocation.

```suggestion
	const perProcessCustomerLimit = toPerProcessLimit(
		per_customer_limit,
		fleet_process_count,
	);
	const perProcessCustomerPendingMax = toPerProcessLimit(
		per_customer_pending_max,
		fleet_process_count,
	);

	let customerLimiter: LimitFunction | undefined;
	if (customerId) {
		customerLimiter = getCustomerLimiter({
			orgId,
			env,
			customerId,
			limit: perProcessCustomerLimit,
		});
		if (customerLimiter.pendingCount >= perProcessCustomerPendingMax) {
```

### Issue 2 of 2
.github/workflows/build.yml:29
**Temporary staging branch in allowlist** — `feat/gate-cluster-wide` has been added to `STAGING_DEPLOY_BRANCH_ALLOWLIST`. This should be removed once the branch is merged to `dev`/`main` to keep the allowlist tidy and prevent unintended future staging deploys from a stale branch name.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #2022 from useautumn/..."](https://github.com/useautumn/autumn/commit/014e1f0028875da4bedc0dc64c4d14e3cbc0c18e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39566859)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->