### PR TITLE
fix(rewards): reject duplicate reward id/promo code and clean up promos on delete

### DIFF
--- a/server/src/internal/api/rewards/handlers/rewards/handleCreateCoupon.ts
+++ b/server/src/internal/api/rewards/handlers/rewards/handleCreateCoupon.ts
@@ -1,6 +1,8 @@
 import {
 	CreateRewardSchema,
+	ErrCode,
 	isFixedPrice,
+	RecaseError,
 	RewardCategory,
 	Scopes,
 } from "@autumn/shared";
@@ -38,6 +40,45 @@ export const handleCreateCoupon = createRoute({
 			env,
 			features: ctx.features,
 		});
+
+		// Reject duplicate reward id / promo code before any Stripe side effects.
+		const codes = newReward.promo_codes.map((promo) => promo.code);
+
+		if (new Set(codes).size !== codes.length) {
+			throw new RecaseError({
+				message: "Promo codes must be unique within a reward",
+				code: ErrCode.DuplicatePromoCode,
+				statusCode: 400,
+			});
+		}
+
+		const existingRewards = await rewardRepo.getByIdOrCode({
+			db,
+			codes: [newReward.id, ...codes],
+			orgId: org.id,
+			env,
+		});
+
+		if (existingRewards.some((reward) => reward.id === newReward.id)) {
+			throw new RecaseError({
+				message: `Reward with id ${newReward.id} already exists`,
+				code: ErrCode.DuplicateRewardId,
+				statusCode: 400,
+			});
+		}
+
+		const takenCode = codes.find((code) =>
+			existingRewards.some((reward) =>
+				reward.promo_codes.some((promo) => promo.code === code),
+			),
+		);
+		if (takenCode) {
+			throw new RecaseError({
+				message: `Promo code ${takenCode} is already in use by another reward`,
+				code: ErrCode.DuplicatePromoCode,
+				statusCode: 400,
+			});
+		}
 
 		if (getRewardCat(newReward) === RewardCategory.Discount) {
 			const discountConfig = newReward.discount_config;

--- a/server/src/internal/api/rewards/handlers/rewards/handleDeleteCoupon.ts
+++ b/server/src/internal/api/rewards/handlers/rewards/handleDeleteCoupon.ts
@@ -56,10 +56,11 @@ export const handleDeleteCoupon = createRoute({
 
 		// Deactivate this reward's promo codes so the code is free to reuse, even if
 		// the coupon deletion above failed (a stale active promo blocks recreation).
-		for (const promoCode of reward.promo_codes) {
+		for (const promoCode of reward.promo_codes ?? []) {
 			try {
 				for await (const promo of stripeCli.promotionCodes.list({
 					code: promoCode.code,
+					coupon: reward.id,
 					active: true,
 					limit: 100,
 				})) {

--- a/server/src/internal/api/rewards/handlers/rewards/handleDeleteCoupon.ts
+++ b/server/src/internal/api/rewards/handlers/rewards/handleDeleteCoupon.ts
@@ -64,13 +64,20 @@ export const handleDeleteCoupon = createRoute({
 					active: true,
 					limit: 100,
 				})) {
-					await stripeCli.promotionCodes.update(promo.id, { active: false });
+					// Isolate each update so one failure doesn't skip the remaining
+					// promos for this code (a stale active one blocks recreation).
+					try {
+						await stripeCli.promotionCodes.update(promo.id, { active: false });
+					} catch (error) {
+						logger.warn(
+							`Failed to deactivate promo code ${promoCode.code} (${promo.id}) in stripe after deleting reward ${reward.id}`,
+							{ rewardId: reward.id, code: promoCode.code, promoId: promo.id, error },
+						);
+					}
 				}
 			} catch (error) {
-				// Code stays active in Stripe; a later recreate may hit the Stripe
-				// guard, so surface this for operators to retry.
 				logger.warn(
-					`Failed to deactivate promo code ${promoCode.code} in stripe after deleting reward ${reward.id}`,
+					`Failed to list promo codes for ${promoCode.code} in stripe after deleting reward ${reward.id}`,
 					{ rewardId: reward.id, code: promoCode.code, error },
 				);
 			}

--- a/server/src/internal/api/rewards/handlers/rewards/handleDeleteCoupon.ts
+++ b/server/src/internal/api/rewards/handlers/rewards/handleDeleteCoupon.ts
@@ -13,7 +13,7 @@ export const handleDeleteCoupon = createRoute({
 	params: DeleteCouponParamsSchema,
 	handler: async (c) => {
 		const ctx = c.get("ctx");
-		const { org, env, db } = ctx;
+		const { org, env, db, logger } = ctx;
 		const { id } = c.req.param();
 
 		const stripeCli = createStripeCli({
@@ -39,17 +39,41 @@ export const handleDeleteCoupon = createRoute({
 		try {
 			await stripeCli.coupons.del(reward.id);
 		} catch (error) {
-			console.log(
+			logger.warn(
 				`Failed to delete coupon from stripe: ${(error as { message: string }).message}`,
+				{ rewardId: reward.id, error },
 			);
 		}
 
+		// Delete the DB row first: if it fails, the create-side duplicate guard must
+		// still see the reward as alive, so we keep its promo codes active too.
 		await rewardRepo.delete({
 			db,
 			internalId: reward.internal_id,
 			env,
 			orgId: org.id,
 		});
+
+		// Deactivate this reward's promo codes so the code is free to reuse, even if
+		// the coupon deletion above failed (a stale active promo blocks recreation).
+		for (const promoCode of reward.promo_codes) {
+			try {
+				for await (const promo of stripeCli.promotionCodes.list({
+					code: promoCode.code,
+					active: true,
+					limit: 100,
+				})) {
+					await stripeCli.promotionCodes.update(promo.id, { active: false });
+				}
+			} catch (error) {
+				// Code stays active in Stripe; a later recreate may hit the Stripe
+				// guard, so surface this for operators to retry.
+				logger.warn(
+					`Failed to deactivate promo code ${promoCode.code} in stripe after deleting reward ${reward.id}`,
+					{ rewardId: reward.id, code: promoCode.code, error },
+				);
+			}
+		}
 
 		return c.json({
 			success: true,

--- a/server/tests/integration/rewards/rewards-create-dupe-id-code.test.ts
+++ b/server/tests/integration/rewards/rewards-create-dupe-id-code.test.ts
@@ -1,0 +1,179 @@
+/**
+ * TDD repro for two reported reward/coupon bugs.
+ *
+ * Bug 1 — duplicate id+code allowed:
+ *  POST /rewards twice with the SAME id and SAME promo code but different
+ *  discount config succeeds both times, leaving two reward rows.
+ *  Red (current): second create succeeds. Green (after fix): second create errors.
+ *
+ * Bug 2 — reusing a promo code leaks a raw "already exists in Stripe" error:
+ *  Because Bug 1 allows duplicate codes, creating a second reward whose promo
+ *  code is already owned by an active reward surfaces the low-level Stripe guard
+ *  (PromoCodeAlreadyExistsInStripe) instead of a clean reward-layer rejection.
+ *  This is the same error the customer hit recreating after a sibling duplicate
+ *  kept an active promo. Note: a plain delete→recreate of the SAME id works in
+ *  this harness — delete deactivates the promo — so the conflict only arises
+ *  from the duplicate-code situation Bug 1 permits.
+ *  Red (current): create leaks PromoCodeAlreadyExistsInStripe.
+ *  Green (after fix): duplicate code is rejected at the reward layer (or handled).
+ */
+
+import { test, expect } from "bun:test";
+import chalk from "chalk";
+import {
+	CouponDurationType,
+	type CreateReward,
+	ErrCode,
+	RewardType,
+} from "@autumn/shared";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+
+const buildReward = ({
+	id,
+	code,
+	type,
+	value,
+}: {
+	id: string;
+	code: string;
+	type: RewardType;
+	value: number;
+}): CreateReward => ({
+	id,
+	name: id,
+	type,
+	promo_codes: [{ code }],
+	discount_config: {
+		discount_value: value,
+		duration_type: CouponDurationType.OneOff,
+		duration_value: 1,
+		apply_to_all: true,
+		price_ids: [],
+	},
+});
+
+test(
+	`${chalk.yellowBright("rewards bug1: duplicate id+code with different discount is rejected")}`,
+	async () => {
+		const customerId = "rcd-bug1-cust";
+		const suffix = `${Date.now()}`.slice(-7);
+		const rewardId = `rcd-dupe-${suffix}`;
+		const code = `RCDDUPE${suffix}`;
+
+		const { autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [s.customer({})],
+			actions: [],
+		});
+
+		// First create: fixed $3000 off
+		await autumnV2_2.post(
+			"/rewards",
+			buildReward({
+				id: rewardId,
+				code,
+				type: RewardType.FixedDiscount,
+				value: 3000,
+			}),
+		);
+
+		// Second create: SAME id + code, but 100% percentage off
+		let errorCode: string | undefined;
+		try {
+			await autumnV2_2.post(
+				"/rewards",
+				buildReward({
+					id: rewardId,
+					code,
+					type: RewardType.PercentageDiscount,
+					value: 100,
+				}),
+			);
+		} catch (e) {
+			errorCode = (e as { code?: string }).code;
+		}
+
+		// Duplicate id must be rejected with the specific reward-layer error, not
+		// silently accepted (which used to create a 2nd row).
+		expect(errorCode).toBe(ErrCode.DuplicateRewardId);
+	},
+);
+
+test(
+	`${chalk.yellowBright("rewards bug1b: duplicate promo codes within one payload are rejected before Stripe")}`,
+	async () => {
+		const customerId = "rcd-bug1b-cust";
+		const suffix = `${Date.now()}`.slice(-7);
+		const code = `RCDINTRA${suffix}`;
+
+		const { autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [s.customer({})],
+			actions: [],
+		});
+
+		const reward = buildReward({
+			id: `rcd-intra-${suffix}`,
+			code,
+			type: RewardType.FixedDiscount,
+			value: 3000,
+		});
+		reward.promo_codes = [{ code }, { code }];
+
+		let errorCode: string | undefined;
+		try {
+			await autumnV2_2.post("/rewards", reward);
+		} catch (e) {
+			errorCode = (e as { code?: string }).code;
+		}
+
+		// Must be caught at the reward layer, not leak PromoCodeAlreadyExistsInStripe.
+		expect(errorCode).toBe(ErrCode.DuplicatePromoCode);
+	},
+);
+
+test(
+	`${chalk.yellowBright("rewards bug2: reusing an active promo code must not leak a raw Stripe error")}`,
+	async () => {
+		const customerId = "rcd-bug2-cust";
+		const suffix = `${Date.now()}`.slice(-7);
+		const code = `RCDRECREATE${suffix}`;
+
+		const { autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [s.customer({})],
+			actions: [],
+		});
+
+		// First reward owns an active promo for `code`.
+		await autumnV2_2.post(
+			"/rewards",
+			buildReward({
+				id: `rcd-recreate-a-${suffix}`,
+				code,
+				type: RewardType.FixedDiscount,
+				value: 3000,
+			}),
+		);
+
+		// Second reward reuses the same code (Bug 1 lets this through to Stripe).
+		let errorCode: string | undefined;
+		try {
+			await autumnV2_2.post(
+				"/rewards",
+				buildReward({
+					id: `rcd-recreate-b-${suffix}`,
+					code,
+					type: RewardType.PercentageDiscount,
+					value: 100,
+				}),
+			);
+		} catch (e) {
+			errorCode = (e as { code?: string }).code;
+		}
+
+		// Must reject the duplicate code cleanly at the reward layer, not leak the
+		// low-level Stripe guard (PromoCodeAlreadyExistsInStripe).
+		expect(errorCode).toBe(ErrCode.DuplicatePromoCode);
+	},
+);

--- a/shared/enums/ErrCode.ts
+++ b/shared/enums/ErrCode.ts
@@ -127,6 +127,8 @@ export const ErrCode = {
 
 	// Rewards
 	InvalidReward: "invalid_reward",
+	DuplicateRewardId: "duplicate_reward_id",
+	DuplicatePromoCode: "duplicate_promo_code",
 	PromoCodeAlreadyExistsInStripe: "promo_code_already_exists_in_stripe",
 	PromoCodeFirstTimeOnly: "promo_code_first_time_only",
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate reward IDs and promo codes on create, and deactivate related Stripe promo codes on delete to prevent conflicts and leaked Stripe errors. Adds clear error codes and tests.

- **Bug Fixes**
  - Create: pre-validate duplicate reward IDs and promo codes (within payload and across org) and return 400 with `ErrCode.DuplicateRewardId` or `ErrCode.DuplicatePromoCode`.
  - Delete: after deleting the reward, deactivate its active Stripe promotion codes filtered by `coupon`; guard missing `promo_codes`; isolate per-promo update failures so remaining promos still deactivate; use `logger.warn` with context on failures.
  - Tests: added integration tests reproducing the duplicate id/code and Stripe error leakage scenarios.
  - Errors: added `DuplicateRewardId` and `DuplicatePromoCode` to `ErrCode`.

<sup>Written for commit 501467153d23e74e960e0dde8bd89055e5d5e544. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related reward/coupon bugs: (1) duplicate reward IDs and promo codes were silently accepted, and (2) deleting a reward left its Stripe promo codes active, causing raw Stripe errors when recreating with the same code. The fix adds application-level pre-flight duplicate guards on create and wires in Stripe promo-code deactivation on delete.

- **Bug fixes** — `handleCreateCoupon` now rejects duplicate reward IDs, intra-payload duplicate promo codes, and promo codes already owned by another reward before any Stripe side effects occur.
- **Bug fixes** — `handleDeleteCoupon` deactivates all active Stripe promo codes for a reward after the DB row is deleted, so a recreate with the same code is no longer blocked by a stale active promo.
- **Improvements** — `console.log` on Stripe coupon deletion failure is replaced with structured `logger.warn`, and two new `ErrCode` entries (`DuplicateRewardId`, `DuplicatePromoCode`) give callers clean, typed errors instead of leaking internal Stripe error strings.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the changes close a real user-visible bug and are strictly additive; no existing behaviour is removed.

The duplicate guard in handleCreateCoupon is an application-level read-then-write with no backing DB unique constraint on (org_id, env, id). Two concurrent creates with the same reward ID can both pass the check and produce a double-row insert. The promo-code deactivation loop in handleDeleteCoupon can also exit early on a single update failure, leaving remaining active promo records in Stripe.

handleCreateCoupon.ts — the duplicate-id guard and handleDeleteCoupon.ts — the promo-code deactivation loop warrant a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/api/rewards/handlers/rewards/handleCreateCoupon.ts | Adds application-level pre-flight checks for duplicate reward ID and promo codes before touching Stripe; logic is correct but lacks a DB unique constraint, leaving a narrow concurrent-creation gap. |
| server/src/internal/api/rewards/handlers/rewards/handleDeleteCoupon.ts | Upgrades console.log to logger.warn and adds Stripe promo-code deactivation after DB delete; partial-deactivation edge case is possible but acknowledged via warn logging. |
| server/tests/integration/rewards/rewards-create-dupe-id-code.test.ts | New integration tests covering duplicate reward ID, intra-payload duplicate promo codes, and cross-reward promo code reuse; test structure and assertions are sound. |
| shared/enums/ErrCode.ts | Adds two new error codes DuplicateRewardId and DuplicatePromoCode in the correct grouping; no issues. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant CreateHandler as handleCreateCoupon
    participant DB as Database (rewards)
    participant Stripe

    Client->>CreateHandler: "POST /rewards {id, promo_codes}"
    CreateHandler->>CreateHandler: Check intra-payload duplicate codes
    CreateHandler->>DB: getByIdOrCode(id + codes)
    DB-->>CreateHandler: existingRewards[]
    alt id already exists
        CreateHandler-->>Client: 400 DuplicateRewardId
    else promo code already in use
        CreateHandler-->>Client: 400 DuplicatePromoCode
    else no conflict
        CreateHandler->>Stripe: create coupon + promo codes
        Stripe-->>CreateHandler: ok
        CreateHandler->>DB: insert reward row
        DB-->>CreateHandler: inserted
        CreateHandler-->>Client: 200 reward
    end

    Note over Client,Stripe: DELETE flow

    participant DeleteHandler as handleDeleteCoupon

    Client->>DeleteHandler: DELETE /rewards/:id
    DeleteHandler->>Stripe: coupons.del(id) [errors swallowed]
    DeleteHandler->>DB: delete reward row
    DB-->>DeleteHandler: ok
    loop each promo_code
        DeleteHandler->>Stripe: "promotionCodes.list(code, active=true)"
        Stripe-->>DeleteHandler: active promo records
        loop each active promo
            DeleteHandler->>Stripe: "promotionCodes.update(id, active=false)"
        end
    end
    DeleteHandler-->>Client: 200 success
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant CreateHandler as handleCreateCoupon
    participant DB as Database (rewards)
    participant Stripe

    Client->>CreateHandler: "POST /rewards {id, promo_codes}"
    CreateHandler->>CreateHandler: Check intra-payload duplicate codes
    CreateHandler->>DB: getByIdOrCode(id + codes)
    DB-->>CreateHandler: existingRewards[]
    alt id already exists
        CreateHandler-->>Client: 400 DuplicateRewardId
    else promo code already in use
        CreateHandler-->>Client: 400 DuplicatePromoCode
    else no conflict
        CreateHandler->>Stripe: create coupon + promo codes
        Stripe-->>CreateHandler: ok
        CreateHandler->>DB: insert reward row
        DB-->>CreateHandler: inserted
        CreateHandler-->>Client: 200 reward
    end

    Note over Client,Stripe: DELETE flow

    participant DeleteHandler as handleDeleteCoupon

    Client->>DeleteHandler: DELETE /rewards/:id
    DeleteHandler->>Stripe: coupons.del(id) [errors swallowed]
    DeleteHandler->>DB: delete reward row
    DB-->>DeleteHandler: ok
    loop each promo_code
        DeleteHandler->>Stripe: "promotionCodes.list(code, active=true)"
        Stripe-->>DeleteHandler: active promo records
        loop each active promo
            DeleteHandler->>Stripe: "promotionCodes.update(id, active=false)"
        end
    end
    DeleteHandler-->>Client: 200 success
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
server/src/internal/api/rewards/handlers/rewards/handleCreateCoupon.ts:55-81
**TOCTOU gap — no DB unique constraint backs this check**

The `rewardRepo.getByIdOrCode` read and the eventual `rewardRepo.insert` (line 138) are not atomic. The `rewards` table has no unique constraint on `(org_id, env, id)` — only `internal_id` (a UUID) is the primary key. Two concurrent requests with the same `id` or promo code can both pass the check here, both create Stripe coupons/promo codes, and both succeed at insert, recreating the very double-row bug this PR fixes.

Adding a `uniqueIndex` on `(org_id, env, id)` to the schema and handling the resulting DB conflict as `ErrCode.DuplicateRewardId` would make the guard race-proof without changing the API contract.

### Issue 2 of 3
server/src/internal/api/rewards/handlers/rewards/handleDeleteCoupon.ts:48-49
The comment says "Delete the DB row first" but the Stripe coupon deletion on line 40 already ran before this line, making "first" ambiguous. The intent — that the DB delete precedes promo-code deactivation — would be clearer with a slight rewording.

```suggestion
		// Delete the DB row before deactivating promo codes: if this throws, the
		// create-side duplicate guard still sees the reward as alive and blocks
		// recreation, so promo codes should stay active too.
```

### Issue 3 of 3
server/src/internal/api/rewards/handlers/rewards/handleDeleteCoupon.ts:59-76
**Partial deactivation on `promotionCodes.update` failure**

If `stripeCli.promotionCodes.update(promo.id, { active: false })` throws for one Stripe promotion-code record inside the `for await` loop, the `catch` exits the inner loop immediately. Any remaining pages of active promotion codes for that same `promoCode.code` are never deactivated, leaving a mix of active/inactive Stripe records for the same code string. A subsequent recreate with the same promo code would still surface `PromoCodeAlreadyExistsInStripe` from Stripe. The `logger.warn` is good for alerting operators, but it may be worth noting in the warn message that only a partial deactivation occurred so operators know to manually finish the cleanup.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rewards): reject duplicate reward id..."](https://github.com/useautumn/autumn/commit/7a3264b9f1d7b7872cd76507f882d57676bb96f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39600468)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->