### PR TITLE
chore: comment customer portal rate limit

### DIFF
--- a/server/src/internal/misc/rateLimiter/rateLimitConfigs.ts
+++ b/server/src/internal/misc/rateLimiter/rateLimitConfigs.ts
@@ -64,7 +64,7 @@ const RATE_LIMIT_ROUTE_GROUPS: RateLimitRouteGroup[] = [
 			route({ method: "POST", url: "/v1/billing.update" }),
 
 			route({ method: "POST", url: "/v1/billing.setup_payment" }),
-			route({ method: "POST", url: "/v1/billing.open_customer_portal" }),
+			// route({ method: "POST", url: "/v1/billing.open_customer_portal" }),
 			route({ method: "POST", url: "/v1/billing.sync_proposals" }),
 			route({ method: "POST", url: "/v1/billing.sync_proposals_v2" }),
 			route({ method: "POST", url: "/v1/billing.sync" }),

--- a/server/tests/unit/rate-limits/get-rate-limit-type.test.ts
+++ b/server/tests/unit/rate-limits/get-rate-limit-type.test.ts
@@ -127,7 +127,7 @@ describe("getRateLimitType", () => {
 					path: "/v1/billing.open_customer_portal",
 				}),
 			),
-		).toBe(RateLimitType.Attach);
+		).toBe(RateLimitType.General);
 	});
 
 	test("classifies entities.get into its dedicated per-customer bucket", () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily relax rate limiting for the customer portal to avoid throttling when users open it. Commented out `POST /v1/billing.open_customer_portal` from the Attach group so it falls back to `RateLimitType.General`, and updated the unit test to expect the new classification.

<sup>Written for commit 2dd358e719ef96d9f0c03162fd4ab8ea00d2546f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR comments out the `POST /v1/billing.open_customer_portal` route from the `Attach` rate-limit group, meaning the endpoint now falls through to the `General` rate-limit config instead of being subject to the stricter per-customer cap.

- **Improvements**: Removes the `Attach` rate-limit (30 req/60 s per customer) on the customer portal endpoint, allowing it to be governed by the `General` limit (25 req/s per org) — consistent with the existing commented-out routes at the top of the same group.
</details>

<h3>Confidence Score: 5/5</h3>

Single-line intentional config change with no logic errors; the endpoint retains org-wide General rate limiting.

The only change is removing one route from the Attach group so it falls through to the General limit. The endpoint is still rate-limited at the org level, and the PR title makes the intent explicit. No logic, security, or correctness issues were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/misc/rateLimiter/rateLimitConfigs.ts | Comments out the /v1/billing.open_customer_portal route from the Attach rate-limit group (30 req/min per customer), causing it to fall through to the General limit (25 req/sec per org); change is intentional but the effective rate limit semantics shift significantly. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["POST /v1/billing.open_customer_portal"] --> B{getRateLimitType}

    B -->|Before PR: matched Attach group| C["RateLimitType.Attach\n30 req / 60 s per customer"]
    B -->|After PR: no group match| D["RateLimitType.General\n25 req / 1 s per org"]

    C --> E["Rate limit enforced\n(strict, per-customer)"]
    D --> F["Rate limit enforced\n(lenient, per-org)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["POST /v1/billing.open_customer_portal"] --> B{getRateLimitType}

    B -->|Before PR: matched Attach group| C["RateLimitType.Attach\n30 req / 60 s per customer"]
    B -->|After PR: no group match| D["RateLimitType.General\n25 req / 1 s per org"]

    C --> E["Rate limit enforced\n(strict, per-customer)"]
    D --> F["Rate limit enforced\n(lenient, per-org)"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: comment customer portal rate limi..."](https://github.com/useautumn/autumn/commit/44b4593130598074256a0aa19e2d86a738af2fac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39641543)</sub>

<!-- /greptile_comment -->