### PR TITLE
Surface invoice settings in a More settings accordion

### DIFF
--- a/vite/src/components/forms/shared/InvoiceSettingsSection.tsx
+++ b/vite/src/components/forms/shared/InvoiceSettingsSection.tsx
@@ -31,21 +31,21 @@ export function InvoiceSettingsSection({
 }) {
 	const { templates } = useInvoiceTemplatesQuery();
 	const hasTemplates = templates.length > 0;
-	const options: Pick<InvoiceTemplate, "id" | "name">[] = [
-		{ id: NO_TEMPLATE_VALUE, name: "None" },
-		...templates,
-	];
+	const options: Pick<InvoiceTemplate, "id" | "name">[] = hasTemplates
+		? [{ id: NO_TEMPLATE_VALUE, name: "None" }, ...templates]
+		: [];
 	return (
 		<SheetAccordion>
-			<SheetAccordionItem
-				value="invoice-more-settings"
-				title="More settings"
-				className={cn(disabled && "opacity-50 pointer-events-none")}
-			>
-				<div className="space-y-4">
+			<SheetAccordionItem value="invoice-more-settings" title="More settings">
+				<div
+					className={cn(
+						"space-y-4",
+						disabled && "opacity-50 pointer-events-none",
+					)}
+				>
 					{hasTemplates && (
 						<div className="flex flex-col gap-1.5">
-							<span className="text-form-label block mb-1">Template</span>
+							<span className="text-form-label">Template</span>
 							<SearchableSelect
 								value={value.templateId ?? NO_TEMPLATE_VALUE}
 								onValueChange={(next) => {

--- a/vite/src/components/forms/shared/InvoiceSettingsSection.tsx
+++ b/vite/src/components/forms/shared/InvoiceSettingsSection.tsx
@@ -2,12 +2,13 @@ import type { InvoiceTemplate } from "@autumn/shared";
 import {
 	Input,
 	SearchableSelect,
+	SheetAccordion,
+	SheetAccordionItem,
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
 } from "@autumn/ui";
 import { InfoIcon } from "lucide-react";
-import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
 import { useInvoiceTemplatesQuery } from "@/hooks/queries/useInvoiceTemplatesQuery";
 import { cn } from "@/lib/utils";
 
@@ -29,65 +30,67 @@ export function InvoiceSettingsSection({
 	disabled?: boolean;
 }) {
 	const { templates } = useInvoiceTemplatesQuery();
-	if (templates.length === 0) return null;
+	const hasTemplates = templates.length > 0;
 	const options: Pick<InvoiceTemplate, "id" | "name">[] = [
 		{ id: NO_TEMPLATE_VALUE, name: "None" },
 		...templates,
 	];
 	return (
-		<SheetSection
-			title="Invoice Settings"
-			withSeparator
-			className={cn(disabled && "opacity-50 pointer-events-none")}
-		>
-			<div className="space-y-4">
-				<div className="flex flex-col gap-1.5">
-					<span className="text-body-secondary">Template</span>
-					<SearchableSelect
-						value={value.templateId ?? NO_TEMPLATE_VALUE}
-						onValueChange={(next) => {
-							const templateId = next === NO_TEMPLATE_VALUE ? null : next;
-							const template = templates.find((t) => t.id === templateId);
-							onChange({
-								templateId,
-								netTermsDays: template?.net_terms_days ?? value.netTermsDays,
-							});
-						}}
-						options={options}
-						getOptionValue={(option) => option.id}
-						getOptionLabel={(option) => option.name}
-						placeholder="Select a template"
-						emptyText="No templates configured"
-					/>
-				</div>
-				<div className="flex flex-col gap-1.5">
-					<div className="flex items-center gap-1.5">
-						<span className="text-body-secondary">
-							Net payment terms (days)
-						</span>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<InfoIcon className="size-3.5 text-tertiary-foreground cursor-help" />
-							</TooltipTrigger>
-							<TooltipContent>
-								How long the customer has to pay before the invoice is due.
-							</TooltipContent>
-						</Tooltip>
+		<SheetAccordion>
+			<SheetAccordionItem
+				value="invoice-more-settings"
+				title="More settings"
+				className={cn(disabled && "opacity-50 pointer-events-none")}
+			>
+				<div className="space-y-4">
+					{hasTemplates && (
+						<div className="flex flex-col gap-1.5">
+							<span className="text-form-label block mb-1">Template</span>
+							<SearchableSelect
+								value={value.templateId ?? NO_TEMPLATE_VALUE}
+								onValueChange={(next) => {
+									const templateId = next === NO_TEMPLATE_VALUE ? null : next;
+									const template = templates.find((t) => t.id === templateId);
+									onChange({
+										templateId,
+										netTermsDays: template?.net_terms_days ?? value.netTermsDays,
+									});
+								}}
+								options={options}
+								getOptionValue={(option) => option.id}
+								getOptionLabel={(option) => option.name}
+								placeholder="Select a template"
+								emptyText="No templates configured"
+							/>
+						</div>
+					)}
+					<div className="flex flex-col gap-1.5">
+						<div className="flex items-center gap-1.5">
+							<span className="text-form-label">Net payment terms (days)</span>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<InfoIcon className="size-3.5 text-tertiary-foreground cursor-help" />
+								</TooltipTrigger>
+								<TooltipContent>
+									How long the customer has to pay before the invoice is due.
+								</TooltipContent>
+							</Tooltip>
+						</div>
+						<Input
+							type="number"
+							min={1}
+							value={String(value.netTermsDays)}
+							onChange={(e) => {
+								const parsed = Number.parseInt(e.target.value, 10);
+								onChange({
+									...value,
+									netTermsDays: Number.isNaN(parsed) ? 0 : parsed,
+								});
+							}}
+						/>
 					</div>
-					<Input
-						type="number"
-						min={1}
-						value={String(value.netTermsDays)}
-						onChange={(e) => {
-							const parsed = Number.parseInt(e.target.value, 10);
-							onChange({
-								...value,
-								netTermsDays: Number.isNaN(parsed) ? 0 : parsed,
-							});
-						}}
-					/>
 				</div>
-			</div>
-		</SheetSection>
+			</SheetAccordionItem>
+		</SheetAccordion>
 	);
 }


### PR DESCRIPTION
## What

Reworks the invoice settings on the Send Invoice stage so net payment terms is always reachable.

- Wraps invoice settings in a collapsible **"More settings"** accordion (`SheetAccordion`).
- Removes the `templates.length === 0` early-return that previously hid the entire section — **net payment terms now always renders** (defaults to 30), even for orgs with no invoice templates.
- The **Template** select still only shows when at least one template exists (a picker with nothing to pick is useless), but it no longer gates the net-terms input.
- Labels switched to `text-form-label` for consistency with other field labels in the customer sheets.

## Why

Net payment terms (`invoice_mode.net_terms_days`) is independent of templates, but the UI hid it behind the template gate, so it was unreachable without first creating a template. This decouples them.

## Scope

Single file: `vite/src/components/forms/shared/InvoiceSettingsSection.tsx`. No backend changes — `netTermsDays` already flows through `buildSubmitParams` → `invoice_mode.net_terms_days`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Net payment terms are now always accessible on Send Invoice, independent of templates. Settings moved into a "More settings" accordion; the trigger stays interactive when disabled, the Template select only renders when templates exist (options built lazily), and labels/spacing use the standard form style.

<sup>Written for commit cdfb7b9be206e70d2cd9fe5bc7d6c8b273009b8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR decouples net payment terms from invoice templates in the Send Invoice stage by removing the `templates.length === 0` early-return and wrapping the section in a collapsible `SheetAccordion` ("More settings"). The template picker still only appears when templates exist, but the net-terms input is now always accessible.

- **[Improvements]** Net payment terms (`netTermsDays`) is no longer gated behind invoice template existence — the accordion always renders, defaulting to 30 days, so orgs without templates can still configure payment terms.
- **[Improvements]** Labels updated to `text-form-label` for consistency with other field labels in customer sheets; `SheetSection` wrapper replaced with `SheetAccordion`/`SheetAccordionItem` matching the pattern used in `AdvancedSection`.
</details>

<h3>Confidence Score: 4/5</h3>

Single-file UI change that always renders the net-terms accordion — no backend or state-management changes, low risk.

The logic change is small and correct: the `templates.length === 0` guard is gone, the template picker is conditionally shown, and the net-terms input is unconditional. Two minor style inconsistencies (an extra `block mb-1` on the Template label and the options array being computed when unused) are the only findings.

No files require special attention beyond the two cosmetic suggestions in `InvoiceSettingsSection.tsx`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/forms/shared/InvoiceSettingsSection.tsx | Wraps invoice settings in a SheetAccordion, removes the early null-return that gated net payment terms behind template existence — two minor style issues (label class inconsistency, unconditional options array). |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[InvoiceSettingsSection renders] --> B{templates.length > 0?}
    B -- "Yes (hasTemplates)" --> C[Show Template SearchableSelect]
    B -- "No" --> D[Skip Template select]
    C --> E[Always show Net payment terms input]
    D --> E
    E --> F[Wrapped in SheetAccordion\nMore settings accordion]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[InvoiceSettingsSection renders] --> B{templates.length > 0?}
    B -- "Yes (hasTemplates)" --> C[Show Template SearchableSelect]
    B -- "No" --> D[Skip Template select]
    C --> E[Always show Net payment terms input]
    D --> E
    E --> F[Wrapped in SheetAccordion\nMore settings accordion]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/components/forms/shared/InvoiceSettingsSection.tsx:33-37
The `options` array is built unconditionally on every render, even when `hasTemplates` is `false` and the `SearchableSelect` will never mount. Moving the declaration inside the `hasTemplates` branch avoids the unnecessary allocation and makes the data flow clearer.

```suggestion
	const hasTemplates = templates.length > 0;
	const options: Pick<InvoiceTemplate, "id" | "name">[] = hasTemplates
		? [{ id: NO_TEMPLATE_VALUE, name: "None" }, ...templates]
		: [];
```

### Issue 2 of 2
vite/src/components/forms/shared/InvoiceSettingsSection.tsx:46-48
The Template label has an extra `block mb-1` that is absent from the Net payment terms label. Both fields sit inside identical `flex flex-col gap-1.5` containers, so the extra `mb-1` adds 4 px of bottom margin only on the Template label, creating visual asymmetry between the two fields in the same accordion.

```suggestion
					{hasTemplates && (
						<div className="flex flex-col gap-1.5">
							<span className="text-form-label">Template</span>
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: update net payment terms ui"](https://github.com/useautumn/autumn/commit/a0c53f852a3a6579cf9260871d88f40d9972feb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39650872)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->