### PR TITLE
Plan editor: consistent sheet footers + discard/close/resume

### DIFF
--- a/vite/src/components/v2/inline-custom-plan-editor/PlanEditorContext.tsx
+++ b/vite/src/components/v2/inline-custom-plan-editor/PlanEditorContext.tsx
@@ -11,7 +11,9 @@ import {
 	type ReactNode,
 	useCallback,
 	useContext,
+	useEffect,
 	useMemo,
+	useRef,
 } from "react";
 import {
 	disabledItemDraftController,
@@ -22,11 +24,13 @@ import { useProductStore } from "@/hooks/stores/useProductStore";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { getItemId } from "@/utils/product/productItemUtils";
 
+type SetProduct = (
+	product: FrontendProduct | ((prev: FrontendProduct) => FrontendProduct),
+) => void;
+
 interface ProductContextValue {
 	product: FrontendProduct;
-	setProduct: (
-		product: FrontendProduct | ((prev: FrontendProduct) => FrontendProduct),
-	) => void;
+	setProduct: SetProduct;
 	initialProduct?: FrontendProduct;
 	sheetType: string | null;
 	itemId: string | null;
@@ -41,57 +45,49 @@ interface ProductContextValue {
 const ProductContext = createContext<ProductContextValue | null>(null);
 
 /**
+ * Returns the index of the feature item matching `itemId`, or -1 if none.
+ * Base-price and other non-feature items are skipped so indexes line up with
+ * the ids produced by getItemId().
+ */
+function findFeatureItemIndex(
+	product: FrontendProduct,
+	itemId: string,
+): number {
+	const items = product.items;
+	if (!items) return -1;
+
+	const featureItems = productV2ToFeatureItems({ items });
+
+	return items.findIndex((item, index) => {
+		if (!item || !featureItems.includes(item)) return false;
+		return getItemId({ item, itemIndex: index }) === itemId;
+	});
+}
+
+/** Compares two products field-by-field, hiding the V2 casts at a single site. */
+function compareProducts(
+	product: FrontendProduct,
+	other: FrontendProduct,
+	features: Parameters<typeof productsAreSame>[0]["features"],
+) {
+	return productsAreSame({
+		newProductV2: product as unknown as ProductV2,
+		curProductV2: other as unknown as ProductV2,
+		features,
+	});
+}
+
+/**
  * Provider that allows overriding the product and sheet state source.
  * When wrapped with this provider, child components will use the provided
  * values instead of the Zustand stores.
  */
 export function ProductProvider({
 	children,
-	product,
-	setProduct,
-	initialProduct,
-	sheetType,
-	itemId,
-	initialItem,
-	setSheet,
-	setInitialItem,
-	updateItemId,
-	closeSheet,
-	itemDraft,
-}: {
-	children: ReactNode;
-	product: FrontendProduct;
-	setProduct: (
-		product: FrontendProduct | ((prev: FrontendProduct) => FrontendProduct),
-	) => void;
-	initialProduct?: FrontendProduct;
-	sheetType: string | null;
-	itemId: string | null;
-	initialItem: ProductItem | null;
-	setSheet: (params: { type: string | null; itemId?: string | null }) => void;
-	setInitialItem: (item: ProductItem | null) => void;
-	updateItemId: (itemId: string) => void;
-	closeSheet: () => void;
-	itemDraft: ItemDraftController;
-}) {
+	...value
+}: ProductContextValue & { children: ReactNode }) {
 	return (
-		<ProductContext.Provider
-			value={{
-				product,
-				setProduct,
-				initialProduct,
-				sheetType,
-				itemId,
-				initialItem,
-				setSheet,
-				setInitialItem,
-				updateItemId,
-				closeSheet,
-				itemDraft,
-			}}
-		>
-			{children}
-		</ProductContext.Provider>
+		<ProductContext.Provider value={value}>{children}</ProductContext.Provider>
 	);
 }
 
@@ -119,14 +115,13 @@ export function useProduct() {
 /** Hook to get sheet state and actions. Uses context if available, otherwise Zustand. */
 export function useSheet() {
 	const context = useContext(ProductContext);
-	const storeSheetType = useSheetStore((s) => s.type);
-	const storeItemId = useSheetStore((s) => s.itemId);
-	const storeInitialItem = useSheetStore((s) => s.initialItem);
-	const storeSetSheet = useSheetStore((s) => s.setSheet);
-	const storeSetInitialItem = useSheetStore((s) => s.setInitialItem);
-	const storeCloseSheet = useSheetStore((s) => s.closeSheet);
-
-	const storeUpdateItemId = useSheetStore((s) => s.updateItemId);
+	const sheetType = useSheetStore((s) => s.type);
+	const itemId = useSheetStore((s) => s.itemId);
+	const initialItem = useSheetStore((s) => s.initialItem);
+	const setSheet = useSheetStore((s) => s.setSheet);
+	const setInitialItem = useSheetStore((s) => s.setInitialItem);
+	const updateItemId = useSheetStore((s) => s.updateItemId);
+	const closeSheet = useSheetStore((s) => s.closeSheet);
 
 	if (context) {
 		return {
@@ -142,13 +137,13 @@ export function useSheet() {
 	}
 
 	return {
-		sheetType: storeSheetType,
-		itemId: storeItemId,
-		initialItem: storeInitialItem,
-		setSheet: storeSetSheet,
-		setInitialItem: storeSetInitialItem,
-		updateItemId: storeUpdateItemId,
-		closeSheet: storeCloseSheet,
+		sheetType,
+		itemId,
+		initialItem,
+		setSheet,
+		setInitialItem,
+		updateItemId,
+		closeSheet,
 		itemDraft: disabledItemDraftController,
 	};
 }
@@ -158,33 +153,15 @@ export function useCurrentItem() {
 	const context = useContext(ProductContext);
 	const { product } = useProduct();
 	const { itemId } = useSheet();
+	const draftSession = context?.itemDraft.session;
 
 	return useMemo(() => {
 		if (!itemId || !product?.items) return null;
-		if (
-			context?.itemDraft.session &&
-			context.itemDraft.session.itemId === itemId
-		) {
-			return context.itemDraft.session.draftItem;
-		}
+		if (draftSession?.itemId === itemId) return draftSession.draftItem;
 
-		const featureItems = productV2ToFeatureItems({ items: product.items });
-
-		for (let i = 0; i < product.items.length; i++) {
-			const item = product.items[i];
-			if (!item) continue;
-
-			const isFeatureItem = featureItems.some((fi) => fi === item);
-			if (!isFeatureItem) continue;
-
-			const currentItemId = getItemId({ item, itemIndex: i });
-			if (currentItemId === itemId) {
-				return item;
-			}
-		}
-
-		return null;
-	}, [context?.itemDraft.session, product, itemId]);
+		const index = findFeatureItemIndex(product, itemId);
+		return index === -1 ? null : (product.items[index] ?? null);
+	}, [draftSession, product, itemId]);
 }
 
 /** Hook to set the current item being edited. Uses context if available, otherwise Zustand. */
@@ -199,32 +176,16 @@ export function useSetCurrentItem() {
 				return;
 			}
 
-			if (!product || !product.items || !itemId) return;
+			if (!product?.items || !itemId) return;
 
-			let originalIndex = -1;
-			for (let i = 0; i < product.items.length; i++) {
-				const item = product.items[i];
-				if (!item) continue;
+			const index = findFeatureItemIndex(product, itemId);
+			if (index === -1) return;
 
-				const currentItemId = getItemId({ item, itemIndex: i });
-				if (currentItemId === itemId) {
-					originalIndex = i;
-					break;
-				}
-			}
-
-			if (originalIndex === -1) return;
-
-			const newItemId = getItemId({
-				item: updatedItem,
-				itemIndex: originalIndex,
-			});
-			if (newItemId !== itemId) {
-				updateItemId(newItemId);
-			}
+			const newItemId = getItemId({ item: updatedItem, itemIndex: index });
+			if (newItemId !== itemId) updateItemId(newItemId);
 
 			const updatedItems = [...product.items];
-			updatedItems[originalIndex] = updatedItem;
+			updatedItems[index] = updatedItem;
 			setProduct({ ...product, items: updatedItems });
 		},
 		[itemDraft, itemId, product, setProduct, updateItemId],
@@ -238,47 +199,71 @@ export function useHasItemChanges() {
 	const { features = [] } = useFeaturesQuery();
 
 	return useMemo(() => {
-		if (itemDraft.session) {
-			const { same } = itemsAreSame({
-				item1: itemDraft.session.draftItem,
-				item2: itemDraft.session.initialItem,
-				features,
-			});
+		const session = itemDraft.session;
+		const item1 = session ? session.draftItem : item;
+		const item2 = session ? session.initialItem : initialItem;
 
-			return !same;
-		}
+		if (!item1 || !item2) return false;
 
-		if (!item || !initialItem) {
-			return false;
-		}
-
-		const { same } = itemsAreSame({
-			item1: item,
-			item2: initialItem,
-			features,
-		});
-
+		const { same } = itemsAreSame({ item1, item2, features });
 		return !same;
 	}, [itemDraft.session, item, initialItem, features]);
 }
 
-/** Hook to discard item changes (restore to initial state) and close the sheet. Uses context if available, otherwise Zustand. */
-export function useDiscardItemAndClose() {
-	const setCurrentItem = useSetCurrentItem();
-	const { initialItem, closeSheet, itemDraft } = useSheet();
+interface PlanSheetState {
+	hasChanges: boolean;
+	discard: () => void;
+}
 
-	return useCallback(() => {
-		if (itemDraft.session) {
-			itemDraft.discardItem();
-			closeSheet();
-			return;
-		}
+/**
+ * Drives a plan-level sheet's change tracking: snapshots the product when the
+ * sheet opens (keyed to its type, so it re-snapshots per sheet and clears on
+ * close), reports whether it has been edited since, and reverts to the snapshot
+ * on discard. Host agnostic across the Zustand and context editor flows.
+ */
+export function usePlanSheet(sheetType: string | null): PlanSheetState {
+	const { product, setProduct } = useProduct();
+	const initialProduct = useSheetStore((s) => s.initialProduct);
+	const setInitialProduct = useSheetStore((s) => s.setInitialProduct);
+	const { features = [] } = useFeaturesQuery();
 
-		if (initialItem) {
-			setCurrentItem(initialItem);
-		}
-		closeSheet();
-	}, [itemDraft, initialItem, setCurrentItem, closeSheet]);
+	const productRef = useRef(product);
+	productRef.current = product;
+
+	useEffect(() => {
+		if (!sheetType) return;
+		setInitialProduct(structuredClone(productRef.current));
+		return () => setInitialProduct(null);
+	}, [sheetType, setInitialProduct]);
+
+	const hasChanges = useMemo(() => {
+		if (!initialProduct) return false;
+
+		const {
+			itemsSame,
+			freeTrialsSame,
+			detailsSame,
+			configSame,
+			optionsSame,
+			billingControlsSame,
+		} = compareProducts(product, initialProduct, features);
+
+		return !(
+			itemsSame &&
+			freeTrialsSame &&
+			detailsSame &&
+			configSame &&
+			optionsSame &&
+			billingControlsSame
+		);
+	}, [product, initialProduct, features]);
+
+	const discard = useCallback(() => {
+		if (!initialProduct) return;
+		setProduct(structuredClone(initialProduct));
+	}, [initialProduct, setProduct]);
+
+	return { hasChanges, discard };
 }
 
 /** Hook to check if the product has unsaved changes compared to initial state. Only works in context mode. */
@@ -294,11 +279,11 @@ export function useHasPlanChanges() {
 
 		if (!initialProduct) return false;
 
-		const { itemsSame, freeTrialsSame } = productsAreSame({
-			newProductV2: product as unknown as ProductV2,
-			curProductV2: initialProduct as unknown as ProductV2,
+		const { itemsSame, freeTrialsSame } = compareProducts(
+			product,
+			initialProduct,
 			features,
-		});
+		);
 
 		const versionsSame = product.version === initialProduct.version;
 

--- a/vite/src/components/v2/sheet-overlay/SheetOverlay.tsx
+++ b/vite/src/components/v2/sheet-overlay/SheetOverlay.tsx
@@ -1,33 +1,19 @@
-import type { ProductItem } from "@autumn/shared";
 import { AnimatePresence, motion } from "motion/react";
 import { createPortal } from "react-dom";
-import {
-	useCurrentItem,
-	useHasItemChanges,
-	useSheet,
-} from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
+import { useSheet } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 
 /**
  * Determines if the sheet should close based on the mouse down event.
- * Handles edge cases like unsaved changes and input blur behavior.
+ * Clicking out while an input inside the sheet is focused blurs it first instead
+ * of closing, so a stray click after typing doesn't unexpectedly dismiss the sheet.
  */
 function shouldCloseSheetOnMouseDown({
 	e,
-	item,
 	sheetType,
-	hasItemChanges,
 }: {
 	e: React.MouseEvent<HTMLDivElement>;
-	item: ProductItem | null;
 	sheetType: string | null;
-	hasItemChanges: boolean;
 }): boolean {
-	// Don't close if item has unsaved changes
-	if (hasItemChanges) {
-		return false;
-	}
-
-	// Get the active element before blur happens
 	const activeElement = document.activeElement;
 
 	if (
@@ -35,29 +21,25 @@ function shouldCloseSheetOnMouseDown({
 		activeElement !== document.body &&
 		activeElement instanceof HTMLElement
 	) {
-		// Only apply blur behavior to inputs, textareas, and selects
 		const isInputElement =
 			activeElement.tagName === "INPUT" ||
 			activeElement.tagName === "TEXTAREA" ||
 			activeElement.tagName === "SELECT";
 
 		if (!isInputElement) {
-			// Not an input, proceed with normal close behavior
 			return !!sheetType;
 		}
 
-		// Check if the active element is within the sheet (not in the main content area)
 		const clickTarget = e.target as HTMLElement;
 		const isActiveInSheet = !clickTarget.contains(activeElement);
 
 		if (isActiveInSheet) {
 			activeElement.blur();
-			e.preventDefault(); // Prevent default to stop the click from propagating
+			e.preventDefault();
 			return false;
 		}
 	}
 
-	// If the click is outside the sheet and no input is focused, close the sheet
 	return !!sheetType;
 }
 
@@ -67,11 +49,9 @@ function shouldCloseSheetOnMouseDown({
  */
 export function SheetOverlay({ inline = false }: { inline?: boolean }) {
 	const { sheetType, closeSheet } = useSheet();
-	const item = useCurrentItem();
-	const hasItemChanges = useHasItemChanges();
 
 	const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
-		if (shouldCloseSheetOnMouseDown({ e, item, sheetType, hasItemChanges })) {
+		if (shouldCloseSheetOnMouseDown({ e, sheetType })) {
 			closeSheet();
 		}
 	};

--- a/vite/src/components/v2/sheets/PlanSheetFooter.tsx
+++ b/vite/src/components/v2/sheets/PlanSheetFooter.tsx
@@ -1,0 +1,67 @@
+import { ShortcutButton } from "@autumn/ui";
+import { motion } from "motion/react";
+import { cn } from "@/lib/utils";
+import { LAYOUT_TRANSITION } from "./SharedSheetComponents";
+
+interface PlanSheetFooterProps {
+	isDirty: boolean;
+	onDiscard: () => void;
+	onClose: () => void;
+	onConfirm: () => void;
+	confirmLabel: string;
+	closeLabel?: string;
+	discardLabel?: string;
+	confirmDisabled?: boolean;
+	isLoading?: boolean;
+	className?: string;
+}
+
+export function PlanSheetFooter({
+	isDirty,
+	onDiscard,
+	onClose,
+	onConfirm,
+	confirmLabel,
+	closeLabel = "Close",
+	discardLabel = "Discard",
+	confirmDisabled = false,
+	isLoading = false,
+	className,
+}: PlanSheetFooterProps) {
+	const handleLeftAction = () => {
+		if (isDirty) {
+			onDiscard();
+			return;
+		}
+		onClose();
+	};
+
+	return (
+		<motion.div
+			layout
+			transition={{ layout: LAYOUT_TRANSITION }}
+			className={cn(
+				"shrink-0 pt-2 px-4 pb-4 w-full grid grid-cols-2 gap-2 border-t border-border/40",
+				className,
+			)}
+		>
+			<ShortcutButton
+				variant="secondary"
+				className="w-full"
+				onClick={handleLeftAction}
+				singleShortcut={isDirty ? undefined : "escape"}
+			>
+				{isDirty ? discardLabel : closeLabel}
+			</ShortcutButton>
+			<ShortcutButton
+				className="w-full"
+				onClick={onConfirm}
+				metaShortcut="enter"
+				disabled={confirmDisabled}
+				isLoading={isLoading}
+			>
+				{confirmLabel}
+			</ShortcutButton>
+		</motion.div>
+	);
+}

--- a/vite/src/components/v2/sheets/PlanSheetFooterContainer.tsx
+++ b/vite/src/components/v2/sheets/PlanSheetFooterContainer.tsx
@@ -1,0 +1,29 @@
+import {
+	usePlanSheet,
+	useSheet,
+} from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
+import { PlanSheetFooter } from "@/components/v2/sheets/PlanSheetFooter";
+
+/**
+ * Footer for plan-level sheets (plan details, price). Surfaces a Discard/Close
+ * button based on whether the sheet has been edited since it opened, reverting on
+ * discard. Edits are live, so Save simply closes.
+ */
+export function PlanSheetFooterContainer({
+	sheetType,
+}: {
+	sheetType: string | null;
+}) {
+	const { closeSheet } = useSheet();
+	const { hasChanges, discard } = usePlanSheet(sheetType);
+
+	return (
+		<PlanSheetFooter
+			isDirty={hasChanges}
+			onDiscard={discard}
+			onClose={closeSheet}
+			onConfirm={closeSheet}
+			confirmLabel="Save"
+		/>
+	);
+}

--- a/vite/src/hooks/stores/useSheetStore.ts
+++ b/vite/src/hooks/stores/useSheetStore.ts
@@ -1,4 +1,4 @@
-import type { ProductItem } from "@autumn/shared";
+import type { FrontendProduct, ProductItem } from "@autumn/shared";
 import { useEffect } from "react";
 import { create } from "zustand";
 
@@ -54,6 +54,8 @@ interface SheetState {
 	data: Record<string, unknown> | null;
 	// Initial item state when sheet opened (for change detection)
 	initialItem: ProductItem | null;
+	// Initial product snapshot when a plan-level sheet opened (for change detection)
+	initialProduct: FrontendProduct | null;
 
 	// Actions
 	setSheet: (params: {
@@ -62,6 +64,7 @@ interface SheetState {
 		data?: Record<string, unknown> | null;
 	}) => void;
 	setInitialItem: (item: ProductItem | null) => void;
+	setInitialProduct: (product: FrontendProduct | null) => void;
 	updateItemId: (itemId: string) => void;
 	closeSheet: () => void;
 	reset: () => void;
@@ -74,6 +77,7 @@ const initialState = {
 	itemId: null as string | null,
 	data: null as Record<string, unknown> | null,
 	initialItem: null as ProductItem | null,
+	initialProduct: null as FrontendProduct | null,
 };
 
 export const useSheetStore = create<SheetState>((set) => ({
@@ -86,12 +90,16 @@ export const useSheetStore = create<SheetState>((set) => ({
 			type,
 			itemId,
 			data,
-			// Clear initialItem when sheet changes
+			// Clear snapshots when sheet changes
 			initialItem: null,
+			initialProduct: null,
 		})),
 
 	// Set the initial item state for change detection
 	setInitialItem: (item) => set({ initialItem: item }),
+
+	// Set the initial product snapshot for plan-level change detection
+	setInitialProduct: (product) => set({ initialProduct: product }),
 
 	// Update just the itemId without clearing other state
 	updateItemId: (itemId) => set({ itemId }),
@@ -104,6 +112,7 @@ export const useSheetStore = create<SheetState>((set) => ({
 			itemId: null,
 			data: null,
 			initialItem: null,
+			initialProduct: null,
 		})),
 
 	// Reset to initial state

--- a/vite/src/views/migrations/migration/operations/MigrationOperationSheet.tsx
+++ b/vite/src/views/migrations/migration/operations/MigrationOperationSheet.tsx
@@ -197,7 +197,7 @@ function MigrationSheetInner({
 		<div className="flex flex-col h-full">
 			<div className="flex-1 overflow-y-auto">
 				{sheetType === "select-feature" && <SelectFeatureSheet />}
-				{sheetType === "edit-plan-price" && <EditPlanPriceSheet />}
+				{sheetType === "edit-plan-price" && <EditPlanPriceSheet hideFooter />}
 				{sheetType === "edit-feature" && currentItem && (
 					<ProductItemContext.Provider
 						value={{

--- a/vite/src/views/products/plan/ProductSheets.tsx
+++ b/vite/src/views/products/plan/ProductSheets.tsx
@@ -1,7 +1,6 @@
 import { type ProductItem, productV2ToFeatureItems } from "@autumn/shared";
 import { useEffect, useRef } from "react";
 import {
-	useDiscardItemAndClose,
 	useProduct,
 	useSheet,
 } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
@@ -35,8 +34,6 @@ export const ProductSheets = () => {
 		commitItem: commitItemDraft,
 		clearItemSession: clearItemDraftSession,
 	} = itemDraft;
-
-	const discardAndClose = useDiscardItemAndClose();
 
 	const featureItems = productV2ToFeatureItems({ items: product.items });
 
@@ -188,7 +185,7 @@ export const ProductSheets = () => {
 	return (
 		<InlineSheetPanel
 			isOpen={!!sheetType}
-			onClose={discardAndClose}
+			onClose={closeSheet}
 			transition={SHEET_ANIMATION}
 		>
 			{renderSheet()}

--- a/vite/src/views/products/plan/components/EditPlanPriceSheet.tsx
+++ b/vite/src/views/products/plan/components/EditPlanPriceSheet.tsx
@@ -1,28 +1,38 @@
-import { useProduct } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
+import {
+	useProduct,
+	useSheet,
+} from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 import { SheetHeader } from "@/components/v2/sheets/InlineSheet";
+import { PlanSheetFooterContainer } from "@/components/v2/sheets/PlanSheetFooterContainer";
 import { BasePriceSection } from "./edit-plan-details/BasePriceSection";
 import { PlanTypeSection } from "./edit-plan-details/PlanTypeSection";
 
 export function EditPlanPriceSheet({
 	isOnboarding,
+	hideFooter,
 }: {
 	isOnboarding?: boolean;
+	hideFooter?: boolean;
 }) {
 	const { product } = useProduct();
+	const { sheetType } = useSheet();
 
 	if (!product) return null;
 
 	return (
-		<div className="h-full overflow-y-auto overscroll-none [scrollbar-gutter:stable]">
-			{!isOnboarding && (
-				<SheetHeader
-					title={`Configure ${product.name ? `${product.name} ` : ""}Price`}
-					description="Set whether this plan is free or paid, and configure a base price"
-					// noSeparator={true}
-				/>
-			)}
-			<PlanTypeSection />
-			<BasePriceSection withSeparator={false} />
+		<div className="flex flex-col h-full overflow-hidden">
+			<div className="flex-1 overflow-y-auto overscroll-none [scrollbar-gutter:stable]">
+				{!isOnboarding && (
+					<SheetHeader
+						title={`Configure ${product.name ? `${product.name} ` : ""}Price`}
+						description="Set whether this plan is free or paid, and configure a base price"
+					/>
+				)}
+				<PlanTypeSection />
+				<BasePriceSection withSeparator={false} />
+			</div>
+
+			{!hideFooter && <PlanSheetFooterContainer sheetType={sheetType} />}
 		</div>
 	);
 }

--- a/vite/src/views/products/plan/components/EditPlanSheet.tsx
+++ b/vite/src/views/products/plan/components/EditPlanSheet.tsx
@@ -6,18 +6,19 @@ import {
 	SheetAccordionItem,
 } from "@autumn/ui";
 import { useState } from "react";
-import { useProduct } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
+import {
+	useProduct,
+	useSheet,
+} from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 import { SheetHeader } from "@/components/v2/sheets/InlineSheet";
+import { PlanSheetFooterContainer } from "@/components/v2/sheets/PlanSheetFooterContainer";
 import { AdditionalOptions } from "./edit-plan-details/AdditionalOptions";
 import { MainDetailsSection } from "./edit-plan-details/MainDetailsSection";
 import { MetadataEditor } from "./edit-plan-details/MetadataEditor";
 
 export function EditPlanSheet({ isOnboarding }: { isOnboarding?: boolean }) {
 	const { product, setProduct } = useProduct();
-
-	const basePrice = productV2ToBasePrice({ product });
-
-	const hasGroup = notNullish(product.group);
+	const { sheetType } = useSheet();
 
 	const hasMetadata = Object.keys(product.metadata ?? {}).length > 0;
 	const [metadataOpened, setMetadataOpened] = useState(false);
@@ -25,81 +26,83 @@ export function EditPlanSheet({ isOnboarding }: { isOnboarding?: boolean }) {
 
 	if (!product) return null;
 
+	const basePrice = productV2ToBasePrice({ product });
+	const hasGroup = notNullish(product.group);
 	const showAdvanced =
 		product.planType === "paid" &&
 		!basePrice?.price &&
 		product.basePriceType !== "usage";
 
 	return (
-		<div className="h-full overflow-y-auto overscroll-none [scrollbar-gutter:stable]">
-			{!isOnboarding && (
-				<SheetHeader
-					title={`Configure ${product.name ? product.name : "your new plan"}`}
-					description="Configure the details of this plan"
-					noSeparator={true}
-				/>
-			)}
-			<MainDetailsSection />
-			{/* <PlanTypeSection /> */}
-			{/* <BasePriceSection /> */}
+		<div className="flex flex-col h-full overflow-hidden">
+			<div className="flex-1 overflow-y-auto overscroll-none [scrollbar-gutter:stable]">
+				{!isOnboarding && (
+					<SheetHeader
+						title={`Configure ${product.name ? product.name : "your new plan"}`}
+						description="Configure the details of this plan"
+						noSeparator={true}
+					/>
+				)}
+				<MainDetailsSection />
+				<AdditionalOptions />
 
-			{/* <FreeTrialSection /> */}
-			<AdditionalOptions />
-
-			{!showAdvanced && (
-				<SheetAccordion type="single" withSeparator={false}>
-					<SheetAccordionItem value="advanced" title="Advanced">
-						<div className="space-y-4">
-							<AreaCheckbox
-								title="Group"
-								description="If your app has multiple groups of subscription tiers, you can choose which group this plan belongs to."
-								checked={hasGroup}
-								onCheckedChange={(checked) =>
-									setProduct({ ...product, group: checked ? "" : null })
-								}
-							>
-								{hasGroup && (
-									<Input
-										placeholder="Enter group name"
-										value={product.group ?? undefined}
-										onChange={(e) =>
-											setProduct({ ...product, group: e.target.value })
-										}
-									/>
-								)}
-							</AreaCheckbox>
-							<AreaCheckbox
-								title="Ignore past due"
-								description="Customers on this plan won't be treated as past due — balances keep resetting normally"
-								checked={product.config?.ignore_past_due}
-								onCheckedChange={(checked) =>
-									setProduct({
-										...product,
-										config: { ...product.config, ignore_past_due: checked },
-									})
-								}
-							/>
-							<AreaCheckbox
-								title="Metadata"
-								description="Arbitrary JSON for your own use (e.g. UI copy). Shared across every version of the plan."
-								checked={showMetadata}
-								onCheckedChange={(checked) => {
-									if (checked) {
-										setMetadataOpened(true);
-									} else {
-										setMetadataOpened(false);
-										setProduct({ ...product, metadata: {} });
+				{!showAdvanced && (
+					<SheetAccordion type="single" withSeparator={false}>
+						<SheetAccordionItem value="advanced" title="Advanced">
+							<div className="space-y-4">
+								<AreaCheckbox
+									title="Group"
+									description="If your app has multiple groups of subscription tiers, you can choose which group this plan belongs to."
+									checked={hasGroup}
+									onCheckedChange={(checked) =>
+										setProduct({ ...product, group: checked ? "" : null })
 									}
-								}}
-							>
-								{showMetadata && (
-									<MetadataEditor key={product.internal_id ?? product.id} />
-								)}
-							</AreaCheckbox>
-						</div>
-					</SheetAccordionItem>
-				</SheetAccordion>
-			)}
+								>
+									{hasGroup && (
+										<Input
+											placeholder="Enter group name"
+											value={product.group ?? undefined}
+											onChange={(e) =>
+												setProduct({ ...product, group: e.target.value })
+											}
+										/>
+									)}
+								</AreaCheckbox>
+								<AreaCheckbox
+									title="Ignore past due"
+									description="Customers on this plan won't be treated as past due — balances keep resetting normally"
+									checked={product.config?.ignore_past_due}
+									onCheckedChange={(checked) =>
+										setProduct({
+											...product,
+											config: { ...product.config, ignore_past_due: checked },
+										})
+									}
+								/>
+								<AreaCheckbox
+									title="Metadata"
+									description="Arbitrary JSON for your own use (e.g. UI copy). Shared across every version of the plan."
+									checked={showMetadata}
+									onCheckedChange={(checked) => {
+										if (checked) {
+											setMetadataOpened(true);
+										} else {
+											setMetadataOpened(false);
+											setProduct({ ...product, metadata: {} });
+										}
+									}}
+								>
+									{showMetadata && (
+										<MetadataEditor key={product.internal_id ?? product.id} />
+									)}
+								</AreaCheckbox>
+							</div>
+						</SheetAccordionItem>
+					</SheetAccordion>
+				)}
+			</div>
+
+			<PlanSheetFooterContainer sheetType={sheetType} />
 		</div>
 	);
 }

--- a/vite/src/views/products/plan/components/edit-plan-details/PlanTypeSection.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-details/PlanTypeSection.tsx
@@ -1,10 +1,7 @@
 import {
-	type BillingInterval,
 	isPriceItem,
-	notNullish,
 	type ProductItem,
 	ProductItemInterval,
-	productV2ToBasePrice,
 	productV2ToPlanType,
 } from "@autumn/shared";
 import { PanelButton } from "@autumn/ui";
@@ -13,87 +10,10 @@ import { IncludedUsageIcon } from "@/components/v2/icons/AutumnIcons";
 import { useProduct } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 import { SheetSection } from "@/components/v2/sheets/InlineSheet";
 
-export const PlanTypeSection = ({
-	withSeparator = true,
-}: {
-	withSeparator?: boolean;
-}) => {
+export const PlanTypeSection = () => {
 	const { product, setProduct } = useProduct();
 
 	const planType = productV2ToPlanType({ product });
-
-	// if (!product.items) return null;
-
-	const basePrice = productV2ToBasePrice({ product });
-
-	const handleDeleteBasePrice = () => {
-		setProduct({
-			...product,
-			items: product.items.filter((item: ProductItem) => !isPriceItem(item)),
-		});
-	};
-
-	const getBasePriceIndex = () => {
-		return product.items.findIndex(
-			(item: ProductItem) =>
-				item.price === basePrice?.price && isPriceItem(item),
-		);
-	};
-
-	const setItem = (item: ProductItem) => {
-		const newItems = [...product.items];
-		newItems[getBasePriceIndex()] = item;
-		setProduct({
-			...product,
-			items: newItems,
-		});
-	};
-
-	const handleUpdateBasePrice = ({
-		amount = "",
-		interval,
-		intervalCount,
-	}: {
-		amount?: string;
-		interval?: BillingInterval;
-		intervalCount?: number;
-	}) => {
-		const newItems = [...product.items];
-
-		// Find base price item by isBasePrice flag, not by price match
-		const basePriceIndex = newItems.findIndex((item: ProductItem) =>
-			isPriceItem(item),
-		);
-
-		if (basePriceIndex !== -1) {
-			const newAmount =
-				amount === ""
-					? amount
-					: notNullish(amount)
-						? Number.parseFloat(amount ?? "")
-						: basePrice?.price;
-
-			newItems[basePriceIndex] = {
-				...newItems[basePriceIndex],
-				price: newAmount as number,
-				interval: interval as unknown as ProductItemInterval,
-				// 	? billingToItemInterval({ billingInterval: interval })
-				// 	: basePrice?.interval,
-				interval_count: interval ? intervalCount : basePrice?.interval_count,
-			};
-		} else {
-			newItems.push({
-				price: Number.parseFloat(amount ?? "") as number,
-				interval: interval as unknown as ProductItemInterval,
-				interval_count: intervalCount,
-			});
-		}
-
-		setProduct({
-			...product,
-			items: newItems,
-		});
-	};
 
 	return (
 		<SheetSection title="Select Plan Type">
@@ -103,7 +23,6 @@ export const PlanTypeSection = ({
 						<PanelButton
 							isSelected={planType === "free"}
 							onClick={() => {
-								// handleDeleteBasePrice();
 								setProduct({
 									...product,
 									planType: "free",

--- a/vite/src/views/products/plan/components/edit-plan-feature/EditPlanFeatureSheet.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/EditPlanFeatureSheet.tsx
@@ -124,7 +124,7 @@ export function EditPlanFeatureSheet({
 		item.tiers[0].amount === 0 &&
 		!item.included_usage;
 
-	const hasChanges = hasItemChanges || isZeroPriceItem || !isUpdate;
+	const canConfirm = hasItemChanges || isZeroPriceItem || !isUpdate;
 
 	return (
 		<div className="flex flex-col h-full overflow-hidden">
@@ -218,7 +218,8 @@ export function EditPlanFeatureSheet({
 
 			{/* Footer stays at bottom */}
 			<SheetFooterActions
-				hasChanges={hasChanges}
+				isDirty={hasItemChanges}
+				canConfirm={canConfirm}
 				onBeforeCommit={handleBeforeCommit}
 			/>
 

--- a/vite/src/views/products/plan/components/edit-plan-feature/SheetFooterActions.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/SheetFooterActions.tsx
@@ -1,20 +1,21 @@
-import { Button, ShortcutButton } from "@autumn/ui";
 import {
 	useSetCurrentItem,
 	useSheet,
 } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
-import { cn } from "@/lib/utils";
+import { PlanSheetFooter } from "@/components/v2/sheets/PlanSheetFooter";
 import { useProductItemContext } from "@/views/products/product/product-item/ProductItemContext";
 
 export function SheetFooterActions({
-	hasChanges,
+	isDirty,
+	canConfirm,
 	onBeforeCommit,
 }: {
-	hasChanges: boolean;
+	isDirty: boolean;
+	canConfirm: boolean;
 	onBeforeCommit?: () => void;
 }) {
 	const { handleUpdateProductItem } = useProductItemContext();
-	const { initialItem, itemDraft } = useSheet();
+	const { initialItem, itemDraft, closeSheet } = useSheet();
 	const setCurrentItem = useSetCurrentItem();
 
 	const handleDiscard = () => {
@@ -33,25 +34,13 @@ export function SheetFooterActions({
 	};
 
 	return (
-		<div className={cn("shrink-0 p-4 border-t border-border/40")}>
-			<div className="flex gap-2 w-full">
-				<Button
-					variant="secondary"
-					onClick={handleDiscard}
-					disabled={!hasChanges}
-					className="flex-1"
-				>
-					Discard
-				</Button>
-				<ShortcutButton
-					metaShortcut="enter"
-					onClick={handleUpdateItem}
-					disabled={!hasChanges}
-					className="flex-1"
-				>
-					Update Plan Feature
-				</ShortcutButton>
-			</div>
-		</div>
+		<PlanSheetFooter
+			isDirty={isDirty}
+			onDiscard={handleDiscard}
+			onClose={closeSheet}
+			onConfirm={handleUpdateItem}
+			confirmLabel="Save"
+			confirmDisabled={!canConfirm}
+		/>
 	);
 }

--- a/vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/UsageLimit.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/UsageLimit.tsx
@@ -17,12 +17,10 @@ export function UsageLimit() {
 				let usage_limit: number | null;
 
 				if (checked) {
-					usage_limit = 100; // Default value
+					usage_limit = 100;
 				} else {
 					usage_limit = null;
 				}
-
-				console.log("checked", checked, "setting usage limit to", usage_limit);
 
 				setItem({
 					...item,

--- a/vite/src/views/products/plan/components/new-feature/NewFeatureSheet.tsx
+++ b/vite/src/views/products/plan/components/new-feature/NewFeatureSheet.tsx
@@ -83,7 +83,10 @@ export function NewFeatureSheet({ isOnboarding }: { isOnboarding?: boolean }) {
 
 			await refetch();
 
-			if (!product || !newFeature.id) return;
+			if (!product || !newFeature.id) {
+				setIsCreating(false);
+				return;
+			}
 
 			const newItem = getDefaultItem({
 				feature: featureV1ToDbFeature({ apiFeature: newFeature }),

--- a/vite/src/views/products/plan/components/new-feature/NewFeatureSheet.tsx
+++ b/vite/src/views/products/plan/components/new-feature/NewFeatureSheet.tsx
@@ -5,7 +5,6 @@ import {
 	FeatureUsageType,
 	featureV1ToDbFeature,
 } from "@autumn/shared";
-import { ShortcutButton } from "@autumn/ui";
 import type { AxiosError } from "axios";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -14,6 +13,7 @@ import {
 	useSheet,
 } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 import { SheetHeader } from "@/components/v2/sheets/InlineSheet";
+import { PlanSheetFooter } from "@/components/v2/sheets/PlanSheetFooter";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useFeatureStore } from "@/hooks/stores/useFeatureStore";
 import { FeatureService } from "@/services/FeatureService";
@@ -29,20 +29,20 @@ import { NewFeatureDetails } from "./NewFeatureDetails";
 import { NewFeatureType } from "./NewFeatureType";
 
 export function NewFeatureSheet({ isOnboarding }: { isOnboarding?: boolean }) {
-	// Save/restore onboarding context and reset feature store for fresh creation
-	// This hook always resets on mount, but only saves/restores when enabled
 	useSaveRestoreFeature({ enabled: !!isOnboarding });
 
 	const feature = useFeatureStore((s) => s.feature);
 	const setFeature = useFeatureStore((s) => s.setFeature);
+	const resetFeature = useFeatureStore((s) => s.reset);
 	const { product, setProduct } = useProduct();
 	const { setSheet } = useSheet();
 	const axiosInstance = useAxiosInstance();
 	const { refetch } = useFeaturesQuery();
 	const [isCreating, setIsCreating] = useState(false);
 
+	const isDirty = !!feature.name || !!feature.id || feature.type !== null;
+
 	const handleCreateFeature = async () => {
-		// Validate credit system specific fields first
 		if (feature.type === FeatureType.CreditSystem) {
 			const validationError = validateCreditSystem(feature);
 			if (validationError) {
@@ -54,104 +54,94 @@ export function NewFeatureSheet({ isOnboarding }: { isOnboarding?: boolean }) {
 		setIsCreating(true);
 		const result = CreateFeatureSchema.safeParse(feature);
 		if (result.error) {
-			console.log(result.error.issues);
 			toast.error("Invalid feature", {
-				description: result.error.issues.map((x) => x.message).join(".\n"),
+				description: result.error.issues
+					.map((issue) => issue.message)
+					.join(".\n"),
 			});
 			setIsCreating(false);
-		} else {
-			try {
-				const { data: newFeature } = await FeatureService.createFeature(
-					axiosInstance,
-					{
-						name: feature.name,
-						id: feature.id,
-						type: feature.type,
-						consumable: feature.config?.usage_type === FeatureUsageType.Single,
-						credit_schema: feature.config?.schema?.map(
-							(x: CreditSchemaItem) => ({
-								metered_feature_id: x.metered_feature_id,
-								credit_cost: x.credit_amount,
-							}),
-						),
-						event_names: feature.event_names,
-					},
-				);
+			return;
+		}
 
-				await refetch();
+		try {
+			const { data: newFeature } = await FeatureService.createFeature(
+				axiosInstance,
+				{
+					name: feature.name,
+					id: feature.id,
+					type: feature.type,
+					consumable: feature.config?.usage_type === FeatureUsageType.Single,
+					credit_schema: feature.config?.schema?.map(
+						(schemaItem: CreditSchemaItem) => ({
+							metered_feature_id: schemaItem.metered_feature_id,
+							credit_cost: schemaItem.credit_amount,
+						}),
+					),
+					event_names: feature.event_names,
+				},
+			);
 
-				if (!product || !newFeature.id) return;
+			await refetch();
 
-				// Create a new item with the created feature
-				const newItem = getDefaultItem({
-					feature: featureV1ToDbFeature({ apiFeature: newFeature }),
-				});
+			if (!product || !newFeature.id) return;
 
-				// Add the new item to the product
-				const newItems = [...(product.items || []), newItem];
-				const updatedProduct = { ...product, items: newItems };
-				setProduct(updatedProduct);
+			const newItem = getDefaultItem({
+				feature: featureV1ToDbFeature({ apiFeature: newFeature }),
+			});
 
-				// Open edit sidebar for the new item
-				// Use the actual index in newItems where the item was added (at the end)
-				// NOT featureItems.length - 1, which causes index mismatch on paid plans with base price items
-				const itemIndex = newItems.length - 1;
-				const itemId = getItemId({ item: newItem, itemIndex });
+			const newItems = [...(product.items || []), newItem];
+			setProduct({ ...product, items: newItems });
 
-				// Use setTimeout to ensure state updates propagate
-				setTimeout(() => {
-					setSheet({ type: "edit-feature", itemId });
-				}, 0);
-			} catch (error: unknown) {
-				toast.error(
-					getBackendErr(error as AxiosError, "Failed to create feature"),
-				);
-				setIsCreating(false);
-			}
+			const itemIndex = newItems.length - 1;
+			const itemId = getItemId({ item: newItem, itemIndex });
+
+			setTimeout(() => {
+				setSheet({ type: "edit-feature", itemId });
+			}, 0);
+		} catch (error: unknown) {
+			toast.error(
+				getBackendErr(error as AxiosError, "Failed to create feature"),
+			);
+			setIsCreating(false);
 		}
 	};
 
-	const handleCancel = () => {
-		// Always go back to edit-plan sheet
-		// In both onboarding and normal flow, this is the expected behavior
+	const handleClose = () => {
 		setSheet({ type: "edit-plan" });
 	};
 
+	const handleDiscard = () => {
+		resetFeature();
+	};
+
 	return (
-		<div className="flex flex-col h-full">
-			{!isOnboarding && (
-				<SheetHeader
-					title="New Feature"
-					description="Create a feature to represent what customers on this plan can use. After, you can configure its limits and prices for each plan."
-				/>
-			)}
+		<div className="flex flex-col h-full overflow-hidden">
+			<div className="flex-1 overflow-y-auto overscroll-none [scrollbar-gutter:stable]">
+				{!isOnboarding && (
+					<SheetHeader
+						title="New Feature"
+						description="Create a feature to represent what customers on this plan can use. After, you can configure its limits and prices for each plan."
+					/>
+				)}
 
-			<NewFeatureDetails feature={feature} setFeature={setFeature} />
+				<NewFeatureDetails feature={feature} setFeature={setFeature} />
 
-			<NewFeatureType feature={feature} setFeature={setFeature} />
+				<NewFeatureType feature={feature} setFeature={setFeature} />
 
-			<NewFeatureBehaviour feature={feature} setFeature={setFeature} />
+				<NewFeatureBehaviour feature={feature} setFeature={setFeature} />
 
-			<NewFeatureAdvanced feature={feature} setFeature={setFeature} />
-
-			<div className="mt-auto p-4 w-full flex-row grid grid-cols-2 gap-2">
-				<ShortcutButton
-					variant="secondary"
-					className="w-full"
-					onClick={handleCancel}
-					singleShortcut="escape"
-				>
-					Cancel
-				</ShortcutButton>
-				<ShortcutButton
-					className="w-full"
-					onClick={handleCreateFeature}
-					metaShortcut="enter"
-					isLoading={isCreating}
-				>
-					Create feature
-				</ShortcutButton>
+				<NewFeatureAdvanced feature={feature} setFeature={setFeature} />
 			</div>
+
+			<PlanSheetFooter
+				isDirty={isDirty}
+				onDiscard={handleDiscard}
+				onClose={handleClose}
+				onConfirm={handleCreateFeature}
+				confirmLabel="Create"
+				closeLabel="Cancel"
+				isLoading={isCreating}
+			/>
 		</div>
 	);
 }


### PR DESCRIPTION
Cleans up the plan-editor sheet UX: consistent footer buttons, working discard/close, and resume-on-reopen. Branched fresh off \`dev\` (no unrelated billing-controls work).

## Footer buttons
- New shared \`PlanSheetFooter\` used across all plan-editor sheets (edit plan, edit price, edit feature, new feature) — replaces three divergent ad-hoc footers.
- Standardized labels: confirm = **Save**/**Create**, left button = **Discard** when there are unsaved changes, **Close**/**Cancel** when clean.
- Added footers to the plan & price sheets (previously had none).
- The **Esc** shortcut chip only shows on Close (not Discard), since Esc closes the sheet.

## Discard / close / resume
- **Discard** reverts the sheet's edits and keeps it open (button flips to Close).
- **Close / Esc / backdrop click** dismiss the sheet while **preserving** in-progress edits — reopening a feature or plan sheet resumes where you left off. Reverting is now an explicit Discard action only.
- Plan & price sheets snapshot the product on open (via a single \`usePlanSheet(sheetType)\` hook) so change detection and discard work consistently in both editor hosts.

## Cleanup
- Extracted \`PlanSheetFooterContainer\` + \`usePlanSheet\` to remove duplicated footer wiring across sheets.
- Centralized the \`productsAreSame\` casts behind a \`compareProducts\` helper.
- Removed dead duplicated base-price logic in \`PlanTypeSection\`, a stray \`console.log\`, and commented-out code.

Resolved against \`dev\`'s new plan **metadata** feature in \`EditPlanSheet\` (both kept) and the \`@autumn/ui\` table move. Vite \`bun ts\` + biome clean; app verified rendering with no console errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies plan-editor sheet footers and standardizes discard/close behavior. Adds resume-on-reopen and consistent Save/Create actions, and fixes a stuck loading state when creating a new feature.

- **New Features**
  - Added shared `PlanSheetFooter` across edit plan, price, feature, and new feature; plan and price sheets now have footers.
  - Left button shows Discard when dirty, Close/Cancel when clean; Esc chip only on Close. Close/Esc/backdrop preserves in-progress edits; reopening resumes; Discard reverts and keeps the sheet open.
  - Plan-level sheets snapshot the product on open via `usePlanSheet` for reliable change detection and revert; `EditPlanPriceSheet` supports `hideFooter` for migrations.

- **Bug Fixes**
  - Fixed New Feature sheet loading state: reset `isCreating` on early return when `product` or `newFeature.id` is missing to prevent the Create button from getting stuck.

<sup>Written for commit 8d540ed92661ee5cfde28a16ac0892cfdc2a0c4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Introduces a unified `PlanSheetFooter` component and `usePlanSheet` hook that standardise footer UX across all four plan-editor sheets (edit plan, edit price, edit feature, new feature), while shifting the close/discard model so that Esc/backdrop/Close preserve in-progress edits and an explicit Discard button is the only revert action.

- **Improvements** — New `PlanSheetFooter` replaces three divergent ad-hoc footers; `PlanSheetFooterContainer` wraps plan-level change tracking; `PlanTypeSection` dead code removed; `console.log` and commented-out code cleaned up.
- **Improvements** — `usePlanSheet` snapshots the product on sheet open (via Zustand `initialProduct`) and exposes `hasChanges` / `discard`; `SheetOverlay` backdrop click no longer blocks close when there are unsaved item edits (edits survive close and resume on reopen).
- **Bug fixes** — `EditPlanSheet` now correctly computes `basePrice` / `hasGroup` after the `!product` null guard; `hasChanges` renamed to `isDirty` / `canConfirm` for clearer semantics in `EditPlanFeatureSheet`.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge with one small fix; the UX redesign is coherent and the core snapshot/discard flow is correctly wired.

The `isCreating` flag in `NewFeatureSheet` is never reset when `!product || !newFeature.id` is truthy after a successful API call, leaving the Create button stuck in a loading state. This is a narrow edge case and the fix is one-line, so it does not put the overall change at risk.

`NewFeatureSheet.tsx` for the stuck loading state; `PlanEditorContext.tsx` and `EditPlanSheet.tsx` for the dual-initialProduct concern and missing `hideFooter` parity.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/v2/inline-custom-plan-editor/PlanEditorContext.tsx | Adds usePlanSheet hook for plan-level change tracking, centralizes productsAreSame casts in compareProducts, and refactors ProductProvider to spread props; snapshot uses Zustand store even in context flow (two separate initialProduct references in play) |
| vite/src/components/v2/sheets/PlanSheetFooter.tsx | New shared footer component with Discard/Close toggle based on isDirty; clean, well-structured presentation component |
| vite/src/components/v2/sheets/PlanSheetFooterContainer.tsx | Wires usePlanSheet + closeSheet to PlanSheetFooter; Save just closes (edits are live), Discard reverts to snapshot |
| vite/src/hooks/stores/useSheetStore.ts | Adds initialProduct field and setInitialProduct action to Zustand store; correctly cleared on setSheet and closeSheet |
| vite/src/views/products/plan/components/new-feature/NewFeatureSheet.tsx | Migrates to PlanSheetFooter with Discard/Close UX; isCreating not reset when !product || !newFeature.id causes stuck loading state |
| vite/src/views/products/plan/components/EditPlanSheet.tsx | Adds PlanSheetFooterContainer (always rendered, no hideFooter prop unlike EditPlanPriceSheet); moves basePrice/hasGroup after null guard (correct fix) |
| vite/src/views/products/plan/components/EditPlanPriceSheet.tsx | Adds PlanSheetFooterContainer with hideFooter prop; layout refactored to flex column for sticky footer; MigrationOperationSheet correctly passes hideFooter |
| vite/src/components/v2/sheet-overlay/SheetOverlay.tsx | Removes unsaved-changes block on backdrop click (intentional — edits are now preserved on close, not discarded) |
| vite/src/views/products/plan/components/edit-plan-feature/SheetFooterActions.tsx | Replaces ad-hoc buttons with PlanSheetFooter; renames hasChanges → isDirty/canConfirm for clarity; closeSheet now wired to Close button |
| vite/src/views/products/plan/components/edit-plan-details/PlanTypeSection.tsx | Removes dead duplicated base-price mutation helpers (handleDeleteBasePrice, handleUpdateBasePrice, setItem) that were already handled in BasePriceSection |
| vite/src/views/products/plan/ProductSheets.tsx | Replaces discardAndClose with plain closeSheet for the InlineSheetPanel onClose — edits are now preserved when the panel closes |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens sheet
edit-plan / edit-plan-price] --> B[usePlanSheet effect fires
structuredClone product → Zustand initialProduct]
    B --> C{User edits?}
    C -- Yes --> D[hasChanges = true
Footer shows Discard]
    C -- No --> E[hasChanges = false
Footer shows Close]
    D --> F{User action}
    F -- Discard --> G[setProduct initialProduct clone
hasChanges → false
Footer flips to Close]
    F -- Save / Close --> H[closeSheet
Zustand: type=null, initialProduct=null]
    E --> H
    H --> I{Reopen sheet?}
    I -- Yes --> B
    I -- No --> J[Done]
    K[Backdrop click / Esc] --> H
    subgraph edit-feature flow
        L[User edits feature] --> M{hasItemChanges?}
        M -- Yes --> N[Footer: Discard]
        M -- No --> O[Footer: Close]
        N --> P[discardItem / setCurrentItem initialItem
Sheet stays open]
        O --> Q[closeSheet
Edits preserved in store]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User opens sheet
edit-plan / edit-plan-price] --> B[usePlanSheet effect fires
structuredClone product → Zustand initialProduct]
    B --> C{User edits?}
    C -- Yes --> D[hasChanges = true
Footer shows Discard]
    C -- No --> E[hasChanges = false
Footer shows Close]
    D --> F{User action}
    F -- Discard --> G[setProduct initialProduct clone
hasChanges → false
Footer flips to Close]
    F -- Save / Close --> H[closeSheet
Zustand: type=null, initialProduct=null]
    E --> H
    H --> I{Reopen sheet?}
    I -- Yes --> B
    I -- No --> J[Done]
    K[Backdrop click / Esc] --> H
    subgraph edit-feature flow
        L[User edits feature] --> M{hasItemChanges?}
        M -- Yes --> N[Footer: Discard]
        M -- No --> O[Footer: Close]
        N --> P[discardItem / setCurrentItem initialItem
Sheet stays open]
        O --> Q[closeSheet
Edits preserved in store]
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
vite/src/views/products/plan/components/EditPlanSheet.tsx:97
**`EditPlanSheet` missing `hideFooter` prop parity with `EditPlanPriceSheet`**

`EditPlanPriceSheet` received a `hideFooter` prop specifically because `MigrationOperationSheet` embeds it without wanting a plan-level footer. `EditPlanSheet` has the same embedded-in-migration risk and now always renders `PlanSheetFooterContainer` unconditionally. If another host (e.g. an onboarding wizard or a future migration sheet) renders `EditPlanSheet`, the Save/Close footer will appear where none is expected — and the `PlanSheetFooterContainer`'s `usePlanSheet` hook will also snapshot and potentially clobber `initialProduct` in Zustand.

### Issue 2 of 3
vite/src/components/v2/inline-custom-plan-editor/PlanEditorContext.tsx:224-237
**`usePlanSheet` snapshot always goes to Zustand, even inside `ProductProvider` context**

`usePlanSheet` reads `initialProduct` from `useSheetStore` regardless of whether a `ProductProvider` context is active. When used inside the inline editor (`ProductProvider`), `product`/`setProduct` resolve to context values, but `initialProduct` is stored in and read from the Zustand store. `ProductContextValue` already carries its own `initialProduct` (used by `useHasPlanChanges`) — that field is separate from the Zustand snapshot taken here, creating two independent "original product" references. If both the inline-editor context and the Zustand flow are ever active simultaneously, the two snapshots would diverge silently. The current conditional rendering prevents this in practice, but the asymmetry is worth documenting or guarding against.

### Issue 3 of 3
vite/src/views/products/plan/components/new-feature/NewFeatureSheet.tsx:86-88
If `product` or `newFeature.id` is falsy after a successful API call, `setIsCreating` is never reset to `false`, leaving the Create button permanently in a loading state with no recovery path for the user.

```suggestion
			if (!product || !newFeature.id) {
				setIsCreating(false);
				return;
			}

			const newItem = getDefaultItem({
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: cleanup update logic in plan edit..."](https://github.com/useautumn/autumn/commit/5a7457ad3cda115e8116f0eff38c8282677a8e0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39794869)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->