### PR TITLE
adjust redis monitor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   #   staging repo (autumn-staging) -> us-east-1
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/past-due-cancel-immediate-void feat/gate-cluster-wide
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix
 
 jobs:
   checks:

--- a/server/src/external/redis/initUtils/createRedisAvailability.ts
+++ b/server/src/external/redis/initUtils/createRedisAvailability.ts
@@ -1,3 +1,4 @@
+import { monitorEventLoopDelay } from "node:perf_hooks";
 import type { Redis } from "ioredis";
 import { logger } from "@/external/logtail/logtailUtils.js";
 import { withTimeout } from "@/utils/withTimeout.js";
@@ -9,8 +10,17 @@ const REDIS_PROBE_TIMEOUT_MS = 1_000;
 const REDIS_STALE_RECONNECT_MS = 5_000;
 const REDIS_FAILURES_TO_DEGRADE = 5;
 const REDIS_SUCCESSES_TO_RECOVER = 3;
+const REDIS_LOOP_LAG_INCONCLUSIVE_MS = 500;
+const REDIS_MAX_CONSECUTIVE_INCONCLUSIVE = 300;
 
 type RedisAvailabilityState = "healthy" | "degraded";
+
+export type ProbeOutcome =
+	| "available"
+	| "connection_down"
+	| "unresponsive_while_ready";
+
+export type ProbeClassification = "available" | "unavailable" | "inconclusive";
 
 export type RedisAvailabilitySnapshot = {
 	configured: boolean;
@@ -18,24 +28,79 @@ export type RedisAvailabilitySnapshot = {
 	status: string;
 };
 
+export const classifyProbe = ({
+	outcome,
+	eventLoopLagMs,
+	thresholdMs,
+}: {
+	outcome: ProbeOutcome;
+	eventLoopLagMs: number;
+	thresholdMs: number;
+}): ProbeClassification => {
+	if (outcome === "available") return "available";
+	if (outcome === "connection_down") return "unavailable";
+	return eventLoopLagMs > thresholdMs ? "inconclusive" : "unavailable";
+};
+
+export const histogramMaxToMs = (maxNanoseconds: number): number =>
+	maxNanoseconds / 1e6;
+
 export const createRedisAvailability = ({
 	redis,
 	hasConfig,
 	logPrefix,
 	logType,
+	getEventLoopLagMs,
+	maxConsecutiveInconclusive = REDIS_MAX_CONSECUTIVE_INCONCLUSIVE,
 }: {
 	redis: Redis;
 	hasConfig: boolean;
 	logPrefix: string;
 	logType: string;
+	getEventLoopLagMs?: () => number;
+	maxConsecutiveInconclusive?: number;
 }) => {
 	let redisAvailabilityState: RedisAvailabilityState = "degraded";
 	let redisMonitorInterval: ReturnType<typeof setInterval> | null = null;
 	let redisTickInFlight = false;
 	let lastAvailabilityLogAt = 0;
+	let lastInconclusiveLogAt = 0;
 	let consecutiveFailures = 0;
 	let consecutiveSuccesses = 0;
+	let consecutiveInconclusive = 0;
 	let reconnectStartedAt: number | null = null;
+	let lastEventLoopLagMs = 0;
+
+	const loopLagSampler = ((): { begin: () => void; end: () => number } => {
+		if (getEventLoopLagMs) {
+			return { begin: () => {}, end: () => getEventLoopLagMs() };
+		}
+
+		let histogram: ReturnType<typeof monitorEventLoopDelay> | null = null;
+		try {
+			histogram = monitorEventLoopDelay({ resolution: 20 });
+			histogram.enable();
+		} catch {
+			histogram = null;
+		}
+
+		if (!histogram) {
+			logger.warn(
+				`[${logPrefix}] Event-loop delay monitor unavailable; lag-aware degrade suppression disabled`,
+				{ type: logType },
+			);
+			return { begin: () => {}, end: () => 0 };
+		}
+
+		const activeHistogram = histogram;
+		return {
+			begin: () => activeHistogram.reset(),
+			end: () => {
+				const maxMs = histogramMaxToMs(activeHistogram.max);
+				return Number.isFinite(maxMs) && maxMs > 0 ? maxMs : 0;
+			},
+		};
+	})();
 
 	const setRedisAvailabilityState = (state: RedisAvailabilityState) => {
 		const previousState = redisAvailabilityState;
@@ -60,13 +125,20 @@ export const createRedisAvailability = ({
 				redisStatus: redis.status,
 				consecutiveFailures,
 				consecutiveSuccesses,
+				eventLoopLagMs: lastEventLoopLagMs,
 				failuresToDegrade: REDIS_FAILURES_TO_DEGRADE,
 				successesToRecover: REDIS_SUCCESSES_TO_RECOVER,
 			},
 		);
 	};
 
-	const recordRedisAvailability = (available: boolean) => {
+	const recordRedisAvailability = (classification: ProbeClassification) => {
+		if (classification === "inconclusive") {
+			consecutiveSuccesses = 0;
+			return;
+		}
+
+		const available = classification === "available";
 		consecutiveSuccesses = available ? consecutiveSuccesses + 1 : 0;
 		consecutiveFailures = available ? 0 : consecutiveFailures + 1;
 
@@ -74,6 +146,19 @@ export const createRedisAvailability = ({
 			setRedisAvailabilityState("healthy");
 		if (consecutiveFailures >= REDIS_FAILURES_TO_DEGRADE)
 			setRedisAvailabilityState("degraded");
+	};
+
+	const logInconclusiveProbe = () => {
+		const now = Date.now();
+		if (now - lastInconclusiveLogAt < REDIS_ERROR_LOG_INTERVAL_MS) return;
+		lastInconclusiveLogAt = now;
+		logger.warn(`[${logPrefix}] Probe inconclusive under event-loop lag`, {
+			type: logType,
+			redisStatus: redis.status,
+			consecutiveFailures,
+			eventLoopLagMs: lastEventLoopLagMs,
+			loopLagThresholdMs: REDIS_LOOP_LAG_INCONCLUSIVE_MS,
+		});
 	};
 
 	const pingRedisClient = async () => {
@@ -100,19 +185,25 @@ export const createRedisAvailability = ({
 		}
 	};
 
-	const probeRedisAvailability = async (): Promise<boolean> => {
-		if (!hasConfig) return false;
+	const classifyPing = (pingOk: boolean): ProbeOutcome => {
+		if (pingOk) return "available";
+		return redis.status === "ready"
+			? "unresponsive_while_ready"
+			: "connection_down";
+	};
 
-		let failedWhileReady = false;
+	const probeRedisAvailability = async (): Promise<ProbeOutcome> => {
+		if (!hasConfig) return "connection_down";
+
+		let pingOk = false;
 		try {
-			if (await pingRedisClient()) {
-				return true;
-			}
-			failedWhileReady = redis.status === "ready";
+			pingOk = await pingRedisClient();
 		} catch {
-			failedWhileReady = redis.status === "ready";
+			pingOk = false;
 		}
+		if (pingOk) return "available";
 
+		const failedWhileReady = redis.status === "ready";
 		const shouldReconnectReadyClient =
 			failedWhileReady && consecutiveFailures + 1 >= REDIS_FAILURES_TO_DEGRADE;
 
@@ -122,21 +213,45 @@ export const createRedisAvailability = ({
 			if (redis.status === "connecting" || redis.status === "reconnecting") {
 				reconnectStartedAt ??= Date.now();
 				if (Date.now() - reconnectStartedAt < REDIS_STALE_RECONNECT_MS) {
-					return false;
+					return "connection_down";
 				}
 			}
 
 			await reconnectRedis();
 		}
 
-		return await pingRedisClient().catch(() => false);
+		return classifyPing(await pingRedisClient().catch(() => false));
+	};
+
+	const probeAndClassify = async (): Promise<ProbeClassification> => {
+		loopLagSampler.begin();
+		const outcome = await probeRedisAvailability();
+		lastEventLoopLagMs = loopLagSampler.end();
+		return classifyProbe({
+			outcome,
+			eventLoopLagMs: lastEventLoopLagMs,
+			thresholdMs: REDIS_LOOP_LAG_INCONCLUSIVE_MS,
+		});
 	};
 
 	const runTick = async () => {
 		if (redisTickInFlight) return;
 		redisTickInFlight = true;
 		try {
-			recordRedisAvailability(await probeRedisAvailability());
+			let classification = await probeAndClassify();
+
+			if (classification === "inconclusive") {
+				consecutiveInconclusive += 1;
+				if (consecutiveInconclusive > maxConsecutiveInconclusive) {
+					classification = "unavailable";
+				} else {
+					logInconclusiveProbe();
+				}
+			} else {
+				consecutiveInconclusive = 0;
+			}
+
+			recordRedisAvailability(classification);
 		} finally {
 			redisTickInFlight = false;
 		}
@@ -148,10 +263,21 @@ export const createRedisAvailability = ({
 			if (redis.status === "connecting" || redis.status === "reconnecting") {
 				await waitForRedisReady(redis, logPrefix).catch(() => undefined);
 			}
-			const available = await probeRedisAvailability();
-			consecutiveSuccesses = available ? REDIS_SUCCESSES_TO_RECOVER : 0;
-			consecutiveFailures = available ? 0 : REDIS_FAILURES_TO_DEGRADE;
-			setRedisAvailabilityState(available ? "healthy" : "degraded");
+
+			const classification = await probeAndClassify();
+			consecutiveInconclusive = 0;
+
+			if (classification === "unavailable") {
+				consecutiveSuccesses = 0;
+				consecutiveFailures = REDIS_FAILURES_TO_DEGRADE;
+				setRedisAvailabilityState("degraded");
+				return;
+			}
+
+			consecutiveSuccesses =
+				classification === "available" ? REDIS_SUCCESSES_TO_RECOVER : 0;
+			consecutiveFailures = 0;
+			setRedisAvailabilityState("healthy");
 		},
 		startMonitor: () => {
 			if (!hasConfig || redisMonitorInterval) return;
@@ -173,5 +299,6 @@ export const createRedisAvailability = ({
 			state: redisAvailabilityState,
 			status: redis.status,
 		}),
+		_runTickForTesting: () => runTick(),
 	};
 };

--- a/server/tests/integration/others/redis/create-redis-availability.test.ts
+++ b/server/tests/integration/others/redis/create-redis-availability.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { createRedisAvailability } from "@/external/redis/initUtils/createRedisAvailability.js";
+import {
+	classifyProbe,
+	createRedisAvailability,
+	histogramMaxToMs,
+} from "@/external/redis/initUtils/createRedisAvailability.js";
 
 class FakeRedis {
 	status = "ready";
@@ -47,8 +51,7 @@ class ConnectingFakeRedis extends HealthyFakeRedis {
 	}
 }
 
-const wait = (ms: number) =>
-	new Promise((resolve) => setTimeout(resolve, ms));
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const waitUntil = async (check: () => boolean, timeoutMs: number) => {
 	const startedAt = Date.now();
@@ -64,10 +67,10 @@ describe("createRedisAvailability", () => {
 	test("does not start monitoring when Redis is not configured", () => {
 		const originalSetInterval = globalThis.setInterval;
 		let intervalCalls = 0;
-		globalThis.setInterval = (((handler: TimerHandler) => {
+		globalThis.setInterval = ((handler: TimerHandler) => {
 			intervalCalls++;
 			return 0 as unknown as ReturnType<typeof setInterval>;
-		}) as unknown) as typeof setInterval;
+		}) as unknown as typeof setInterval;
 
 		try {
 			const redis = new FakeRedis();
@@ -132,23 +135,315 @@ describe("createRedisAvailability", () => {
 		expect(availability.shouldUseRedis()).toBe(true);
 	});
 
-	test(
-		"reconnects after repeated probe failures while the client still reports ready",
-		async () => {
-			const redis = new FakeRedis();
-			const availability = createRedisAvailability({
-				redis: redis as never,
-				hasConfig: true,
-				logPrefix: "RedisV2",
-				logType: "redis_v2_availability_state_set",
-			});
+	test("reconnects after repeated probe failures while the client still reports ready", async () => {
+		const redis = new FakeRedis();
+		const availability = createRedisAvailability({
+			redis: redis as never,
+			hasConfig: true,
+			logPrefix: "RedisV2",
+			logType: "redis_v2_availability_state_set",
+		});
 
-			availability.startMonitor();
-			await waitUntil(() => redis.connectCalls > 0, 22_000);
-			availability.stopMonitor();
+		availability.startMonitor();
+		await waitUntil(() => redis.connectCalls > 0, 22_000);
+		availability.stopMonitor();
 
-			expect(redis.disconnectCalls).toContain(false);
-		},
-		30_000,
-	);
+		expect(redis.disconnectCalls).toContain(false);
+	}, 30_000);
+});
+
+class FlippableFakeRedis extends FakeRedis {
+	pingOk = true;
+
+	override async ping() {
+		this.pingCalls++;
+		return this.pingOk ? "PONG" : "NOPE";
+	}
+}
+
+describe("classifyProbe", () => {
+	const thresholdMs = 500;
+
+	test("a successful ping is available regardless of loop lag", () => {
+		expect(
+			classifyProbe({ outcome: "available", eventLoopLagMs: 0, thresholdMs }),
+		).toBe("available");
+		expect(
+			classifyProbe({
+				outcome: "available",
+				eventLoopLagMs: 9_999,
+				thresholdMs,
+			}),
+		).toBe("available");
+	});
+
+	test("a dropped connection is unavailable regardless of loop lag", () => {
+		expect(
+			classifyProbe({
+				outcome: "connection_down",
+				eventLoopLagMs: 0,
+				thresholdMs,
+			}),
+		).toBe("unavailable");
+		expect(
+			classifyProbe({
+				outcome: "connection_down",
+				eventLoopLagMs: 9_999,
+				thresholdMs,
+			}),
+		).toBe("unavailable");
+	});
+
+	test("ping timeout while ready with a healthy loop is unavailable (redis genuinely hung)", () => {
+		expect(
+			classifyProbe({
+				outcome: "unresponsive_while_ready",
+				eventLoopLagMs: 0,
+				thresholdMs,
+			}),
+		).toBe("unavailable");
+		expect(
+			classifyProbe({
+				outcome: "unresponsive_while_ready",
+				eventLoopLagMs: 499,
+				thresholdMs,
+			}),
+		).toBe("unavailable");
+	});
+
+	test("ping timeout while ready with a jammed loop is inconclusive (false-degrade fix)", () => {
+		expect(
+			classifyProbe({
+				outcome: "unresponsive_while_ready",
+				eventLoopLagMs: 501,
+				thresholdMs,
+			}),
+		).toBe("inconclusive");
+		expect(
+			classifyProbe({
+				outcome: "unresponsive_while_ready",
+				eventLoopLagMs: 5_000,
+				thresholdMs,
+			}),
+		).toBe("inconclusive");
+	});
+
+	test("lag exactly at the threshold is unavailable (strict greater-than boundary)", () => {
+		expect(
+			classifyProbe({
+				outcome: "unresponsive_while_ready",
+				eventLoopLagMs: 500,
+				thresholdMs,
+			}),
+		).toBe("unavailable");
+	});
+});
+
+describe("createRedisAvailability loop-lag awareness", () => {
+	test("sustained event-loop lag does NOT degrade a healthy monitor", async () => {
+		const redis = new FlippableFakeRedis();
+		const availability = createRedisAvailability({
+			redis: redis as never,
+			hasConfig: true,
+			logPrefix: "RedisV2",
+			logType: "redis_v2_availability_state_set",
+			getEventLoopLagMs: () => 5_000,
+		});
+
+		await availability.prime();
+		expect(availability.shouldUseRedis()).toBe(true);
+
+		redis.pingOk = false;
+		for (let i = 0; i < 10; i++) {
+			await availability._runTickForTesting();
+		}
+
+		expect(availability.shouldUseRedis()).toBe(true);
+	});
+
+	test("sustained ping failure with a healthy loop still degrades (real-failure detection preserved)", async () => {
+		const redis = new FlippableFakeRedis();
+		const availability = createRedisAvailability({
+			redis: redis as never,
+			hasConfig: true,
+			logPrefix: "RedisV2",
+			logType: "redis_v2_availability_state_set",
+			getEventLoopLagMs: () => 0,
+		});
+
+		await availability.prime();
+		expect(availability.shouldUseRedis()).toBe(true);
+
+		redis.pingOk = false;
+		for (let i = 0; i < 10; i++) {
+			await availability._runTickForTesting();
+		}
+
+		expect(availability.shouldUseRedis()).toBe(false);
+	});
+
+	test("degrades once consecutive inconclusive probes exceed the cap (bounded suppression)", async () => {
+		const redis = new FlippableFakeRedis();
+		const availability = createRedisAvailability({
+			redis: redis as never,
+			hasConfig: true,
+			logPrefix: "RedisV2",
+			logType: "redis_v2_availability_state_set",
+			getEventLoopLagMs: () => 5_000,
+			maxConsecutiveInconclusive: 3,
+		});
+
+		await availability.prime();
+		expect(availability.shouldUseRedis()).toBe(true);
+
+		redis.pingOk = false;
+		for (let i = 0; i < 12; i++) {
+			await availability._runTickForTesting();
+		}
+
+		expect(availability.shouldUseRedis()).toBe(false);
+	});
+
+	test("a successful ping resets the inconclusive budget so transient lag never trips the cap", async () => {
+		const redis = new FlippableFakeRedis();
+		const availability = createRedisAvailability({
+			redis: redis as never,
+			hasConfig: true,
+			logPrefix: "RedisV2",
+			logType: "redis_v2_availability_state_set",
+			getEventLoopLagMs: () => 5_000,
+			maxConsecutiveInconclusive: 3,
+		});
+
+		await availability.prime();
+
+		for (let i = 0; i < 30; i++) {
+			redis.pingOk = i % 3 === 2;
+			await availability._runTickForTesting();
+		}
+
+		expect(availability.shouldUseRedis()).toBe(true);
+	});
+});
+
+class DownFakeRedis extends FakeRedis {
+	override status = "end";
+
+	override async ping(): Promise<string> {
+		this.pingCalls++;
+		throw new Error("connection closed");
+	}
+
+	override async connect() {
+		this.connectCalls++;
+		this.status = "end";
+		throw new Error("redis down");
+	}
+}
+
+describe("createRedisAvailability prime() loop-lag awareness", () => {
+	test("does NOT degrade when the initial boot probe times out under event-loop lag", async () => {
+		const redis = new FlippableFakeRedis();
+		redis.pingOk = false;
+		const availability = createRedisAvailability({
+			redis: redis as never,
+			hasConfig: true,
+			logPrefix: "RedisV2",
+			logType: "redis_v2_availability_state_set",
+			getEventLoopLagMs: () => 5_000,
+		});
+
+		await availability.prime();
+
+		expect(availability.shouldUseRedis()).toBe(true);
+	});
+
+	test("still degrades at boot on a genuine connection failure regardless of lag", async () => {
+		const redis = new DownFakeRedis();
+		const availability = createRedisAvailability({
+			redis: redis as never,
+			hasConfig: true,
+			logPrefix: "RedisV2",
+			logType: "redis_v2_availability_state_set",
+			getEventLoopLagMs: () => 5_000,
+		});
+
+		await availability.prime();
+
+		expect(availability.shouldUseRedis()).toBe(false);
+	});
+});
+
+describe("createRedisAvailability recovery-streak integrity", () => {
+	test("an inconclusive probe breaks the recovery streak so a flapping redis cannot return to healthy", async () => {
+		let lag = 0;
+		const redis = new FlippableFakeRedis();
+		const availability = createRedisAvailability({
+			redis: redis as never,
+			hasConfig: true,
+			logPrefix: "RedisV2",
+			logType: "redis_v2_availability_state_set",
+			getEventLoopLagMs: () => lag,
+		});
+
+		redis.pingOk = false;
+		await availability.prime();
+		expect(availability.shouldUseRedis()).toBe(false);
+
+		lag = 5_000;
+		for (let i = 0; i < 12; i++) {
+			redis.pingOk = i % 3 !== 2;
+			await availability._runTickForTesting();
+		}
+
+		expect(availability.shouldUseRedis()).toBe(false);
+	});
+});
+
+describe("createRedisAvailability real event-loop sampler", () => {
+	test("uses the real sampler when no override is injected and stays healthy on a quiet loop", async () => {
+		const redis = new HealthyFakeRedis();
+		const availability = createRedisAvailability({
+			redis: redis as never,
+			hasConfig: true,
+			logPrefix: "RedisV2",
+			logType: "redis_v2_availability_state_set",
+		});
+
+		await availability.prime();
+		expect(availability.shouldUseRedis()).toBe(true);
+
+		await availability._runTickForTesting();
+		expect(availability.shouldUseRedis()).toBe(true);
+	});
+});
+
+describe("histogramMaxToMs", () => {
+	test("converts event-loop delay nanoseconds to milliseconds", () => {
+		expect(histogramMaxToMs(500_000_000)).toBe(500);
+		expect(histogramMaxToMs(1_000_000)).toBe(1);
+		expect(histogramMaxToMs(0)).toBe(0);
+	});
+});
+
+describe("createRedisAvailability real probe-timeout path", () => {
+	test("a real ping timeout under event-loop lag is inconclusive and does not degrade", async () => {
+		const redis = new FakeRedis();
+		const availability = createRedisAvailability({
+			redis: redis as never,
+			hasConfig: true,
+			logPrefix: "RedisV2",
+			logType: "redis_v2_availability_state_set",
+			getEventLoopLagMs: () => 5_000,
+		});
+
+		await availability.prime();
+		expect(availability.shouldUseRedis()).toBe(true);
+
+		await availability._runTickForTesting();
+		await availability._runTickForTesting();
+
+		expect(availability.shouldUseRedis()).toBe(true);
+		expect(redis.connectCalls).toBe(0);
+	}, 20_000);
 });


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the Redis availability monitor lag-aware to prevent false degradations when the Node event loop is jammed. Probes are now classified and bounded to avoid flapping while still detecting real failures.

- **Bug Fixes**
  - Treat ping timeouts while `redis.status === "ready"` as inconclusive when event-loop lag > 500ms; do not degrade on these.
  - Cap suppression at 300 consecutive inconclusive ticks; degrade after the cap to avoid masking real issues.
  - Apply the same logic in `prime()`: don’t degrade on lag-induced timeouts; still degrade on actual connection drops and reconnect when repeated failures occur.

- **New Features**
  - Add event-loop delay sampling via `node:perf_hooks` `monitorEventLoopDelay` with a safe fallback; injectable `getEventLoopLagMs` for tests.
  - Export `classifyProbe` and `histogramMaxToMs`; expose `_runTickForTesting` for deterministic test ticks.
  - Log inconclusive probes with lag metrics at a throttled interval.

<sup>Written for commit 50cee927b682a9bc2c9dd6f610de195cf6e1ec77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds event-loop lag awareness to the Redis availability monitor to prevent false-positive degradation when a busy Node.js event loop causes ping timeouts that look like Redis failures. A new `classifyProbe` layer uses `monitorEventLoopDelay` to distinguish genuine Redis unresponsiveness from probe timeouts caused by a blocked event loop.

- **[Bug fixes / Improvements]** Introduces `ProbeOutcome` / `ProbeClassification` types and a `probeAndClassify` pipeline that marks a ping timeout as `"inconclusive"` (rather than `"unavailable"`) when the event-loop lag exceeds 500 ms, preventing spurious degradation under CPU pressure.
- **[Improvements]** Adds a bounded `maxConsecutiveInconclusive` cap (default 300) so a genuinely unreachable Redis cannot be suppressed indefinitely, and resets the recovery streak on inconclusive probes to prevent a flapping Redis from slipping back to healthy.
- **[Improvements]** Extensive new test coverage across all new code paths: `classifyProbe` unit tests, `prime()` lag-awareness, recovery-streak integrity, the real `monitorEventLoopDelay` sampler, and bounded suppression behavior.
</details>

<h3>Confidence Score: 4/5</h3>

The core logic change is well-reasoned and thoroughly tested; the main outstanding item is a histogram timer that is not cleaned up when the monitor is stopped.

The classification pipeline is correct and all boundary cases are covered by tests. Two minor gaps exist: the monitorEventLoopDelay histogram is enabled in the IIFE but never disable()d in stopMonitor(), leaving an active 20 ms timer after the monitor stops; and _runTickForTesting leaks onto the production return type. Neither affects runtime correctness of the monitor in production, but the histogram leak can accumulate across test instances.

server/src/external/redis/initUtils/createRedisAvailability.ts — the loopLagSampler IIFE and the stopMonitor return value.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/redis/initUtils/createRedisAvailability.ts | Core logic refactor: adds event-loop lag awareness (monitorEventLoopDelay histogram) to avoid false-positive Redis degradation when the Node.js event loop is blocked. Introduces ProbeOutcome/ProbeClassification types, classifyProbe, histogramMaxToMs, probeAndClassify, and a bounded consecutive-inconclusive cap. The histogram is enabled but never disabled on stopMonitor(), leaking an internal timer. _runTickForTesting is exposed on the production return type. |
| server/tests/integration/others/redis/create-redis-availability.test.ts | Extensive new test coverage for loop-lag awareness, prime() behavior, recovery-streak integrity, and the real event-loop sampler path. Tests are well-structured and cover both happy and failure-boundary cases. |
| .github/workflows/build.yml | Adds feat/redis-monitor-fix to the staging deploy allowlist. Short-lived branch entry that should be cleaned up post-merge. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runTick / prime] --> B[loopLagSampler.begin]
    B --> C[probeRedisAvailability]
    C -->|pingOk| D[outcome: available]
    C -->|status != ready| E[outcome: connection_down]
    C -->|status == ready, ping failed| F[outcome: unresponsive_while_ready]
    D --> G[loopLagSampler.end]
    E --> G
    F --> G
    G --> H{classifyProbe}
    H -->|available| I[classification: available]
    H -->|connection_down| J[classification: unavailable]
    H -->|unresponsive_while_ready
lag > 500ms| K[classification: inconclusive]
    H -->|unresponsive_while_ready
lag <= 500ms| J
    I --> L{runTick only}
    J --> L
    K --> L
    L -->|inconclusive| M{consecutiveInconclusive
> maxCap?}
    M -->|yes| N[reclassify as unavailable]
    M -->|no| O[logInconclusiveProbe
reset consecutiveSuccesses]
    N --> P[recordRedisAvailability]
    O --> Q[return, no state change]
    L -->|available / unavailable| P
    P -->|consecutiveSuccesses >= 3| R[state: healthy]
    P -->|consecutiveFailures >= 5| S[state: degraded]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[runTick / prime] --> B[loopLagSampler.begin]
    B --> C[probeRedisAvailability]
    C -->|pingOk| D[outcome: available]
    C -->|status != ready| E[outcome: connection_down]
    C -->|status == ready, ping failed| F[outcome: unresponsive_while_ready]
    D --> G[loopLagSampler.end]
    E --> G
    F --> G
    G --> H{classifyProbe}
    H -->|available| I[classification: available]
    H -->|connection_down| J[classification: unavailable]
    H -->|unresponsive_while_ready
lag > 500ms| K[classification: inconclusive]
    H -->|unresponsive_while_ready
lag <= 500ms| J
    I --> L{runTick only}
    J --> L
    K --> L
    L -->|inconclusive| M{consecutiveInconclusive
> maxCap?}
    M -->|yes| N[reclassify as unavailable]
    M -->|no| O[logInconclusiveProbe
reset consecutiveSuccesses]
    N --> P[recordRedisAvailability]
    O --> Q[return, no state change]
    L -->|available / unavailable| P
    P -->|consecutiveSuccesses >= 3| R[state: healthy]
    P -->|consecutiveFailures >= 5| S[state: degraded]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
server/src/external/redis/initUtils/createRedisAvailability.ts:74-103
**Histogram never disabled on `stopMonitor()`**

The `monitorEventLoopDelay` histogram is `enable()`d eagerly inside the IIFE but there is no corresponding `disable()` call anywhere — including in `stopMonitor()`. An `IntervalHistogram` maintains its own internal `setInterval` at the configured resolution (20 ms here) and keeps the event loop alive until it is explicitly disabled or the process exits. In production this is harmless because the monitor runs for the process lifetime, but in tests that call `createRedisAvailability` without a `getEventLoopLagMs` override (e.g. the "uses the real sampler" and "a real ping timeout" suites), each instance starts a live timer that is never cleaned up, leaking into subsequent tests.

### Issue 2 of 3
server/src/external/redis/initUtils/createRedisAvailability.ts:302
**Test-only hook exposed on the production return type**

`_runTickForTesting` is part of the public shape returned by `createRedisAvailability`, meaning every production caller can accidentally (or intentionally) invoke it. The underscore prefix is a convention, not a TypeScript access-level guard. Consider returning it only in a separate test helper or stripping it via a conditional type, or at least typing it `never` in a production ambient declaration file.

### Issue 3 of 3
.github/workflows/build.yml:29
**Short-lived branch added to staging allowlist**

`feat/redis-monitor-fix` has been appended to `STAGING_DEPLOY_BRANCH_ALLOWLIST`. This is fine for now, but remember to remove it once the branch is merged to `dev` — stale entries in this list can quietly allow unreviewed branches to deploy to staging in the future.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["adjust redis monitor"](https://github.com/useautumn/autumn/commit/50cee927b682a9bc2c9dd6f610de195cf6e1ec77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39799164)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->