### PR TITLE
feat: add billing interval filter to customers list

### DIFF
--- a/server/src/internal/customers/CusBatchService.ts
+++ b/server/src/internal/customers/CusBatchService.ts
@@ -25,6 +25,7 @@ import type { CustomerListFilters } from "./customerListFilters.js";
 import { getApiCustomerBase } from "./cusUtils/apiCusUtils/getApiCustomerBase.js";
 import {
 	getPaginatedFullCusQuery,
+	parseDashboardIntervalFilter,
 	parseDashboardProcessorFilter,
 	parseDashboardStatusFilter,
 	parseDashboardVersionFilter,
@@ -316,12 +317,15 @@ export class CusBatchService {
 
 		const productVersionFilters = parseDashboardVersionFilter(filters?.version);
 
+		const intervalFilters = parseDashboardIntervalFilter(filters?.interval);
+
 		// Status/none/version filter on a different table (customer_products) than
 		// the cursor (customers). Folding it into the main query forces a merge join
 		// that abandons idx_customers_cursor and degrades to seconds.
 		const requiresResolveStep =
 			statusFilters.length > 0 ||
 			productVersionFilters.length > 0 ||
+			intervalFilters.length > 0 ||
 			!!filters?.none;
 
 		const tResolveStart = performance.now();

--- a/server/src/internal/customers/CusSearchService.ts
+++ b/server/src/internal/customers/CusSearchService.ts
@@ -26,9 +26,11 @@ import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { getOrgCusProductLimit } from "../misc/edgeConfig/orgLimitsStore.js";
 import type { CustomerListFilters } from "./customerListFilters.js";
 import {
+	type DashboardIntervalFilter,
 	type DashboardProductVersionFilter,
 	isCustomDashboardProductFilter,
 	isVersionDashboardProductFilter,
+	parseDashboardIntervalFilter,
 	parseDashboardVersionFilter,
 } from "./getFullCusQuery.js";
 
@@ -79,6 +81,18 @@ const dashboardProductFilterToRawSql = (
 	isCustomDashboardProductFilter(filter)
 		? sql`(${customerProducts.product_id} = ${filter.productId} AND ${customerProducts.is_custom} = true)`
 		: sql`(${products.id} = ${filter.productId} AND ${products.version} = ${filter.version})`;
+
+const dashboardIntervalFilterToRawSql = (intervals: DashboardIntervalFilter[]) =>
+	sql`EXISTS (
+		SELECT 1
+		FROM customer_prices cpr_interval
+		JOIN prices p_interval ON p_interval.id = cpr_interval.price_id
+		WHERE cpr_interval.customer_product_id = ${customerProducts.id}
+			AND p_interval.config->>'interval' = ANY(ARRAY[${sql.join(
+				intervals.map((interval) => sql`${interval}`),
+				sql`, `,
+			)}])
+	)`;
 
 type SearchFilters = CustomerListFilters;
 
@@ -967,8 +981,14 @@ const buildSearchPredicates = ({
 	const hasNumberedVersion = productVersionFilters.some(
 		isVersionDashboardProductFilter,
 	);
+	const intervalFilters = parseDashboardIntervalFilter(filters?.interval);
 
-	if (statuses.length === 0 && productVersionFilters.length === 0) {
+	const hasProductLevelFilter =
+		statuses.length > 0 ||
+		productVersionFilters.length > 0 ||
+		intervalFilters.length > 0;
+
+	if (!hasProductLevelFilter) {
 		return {
 			kind: "default",
 			where: and(...cusBaseClauses),
@@ -1014,6 +1034,11 @@ const buildSearchPredicates = ({
 				)})`
 			: null;
 
+	const intervalRaw =
+		intervalFilters.length > 0
+			? dashboardIntervalFilterToRawSql(intervalFilters)
+			: null;
+
 	const hasNonActiveStatus = statuses.some(
 		(status) => status !== "active" && status !== "",
 	);
@@ -1025,6 +1050,7 @@ const buildSearchPredicates = ({
 		shouldApplyActiveFilter ? activeProdRaw : null,
 		statusRaw,
 		versionRaw,
+		intervalRaw,
 	].filter((c): c is NonNullable<typeof c> => c !== null);
 
 	const whereRaw =
@@ -1041,6 +1067,9 @@ const buildSearchPredicates = ({
 			? or(
 					...productVersionFilters.map(dashboardProductFilterToDrizzleSql),
 				)
+			: undefined,
+		intervalFilters.length > 0
+			? dashboardIntervalFilterToRawSql(intervalFilters)
 			: undefined,
 		statuses.length > 0
 			? or(

--- a/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
+++ b/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
@@ -14,6 +14,7 @@ import {
 	customerProductsSeedSelect,
 } from "./getCustomerProductsPageQuery.js";
 import {
+	type DashboardIntervalFilter,
 	type DashboardProductVersionFilter,
 	type DashboardStatusFilter,
 	getCustomerListFilterSql,
@@ -37,6 +38,7 @@ export type CursorPaginatedFullCusQueryArgs = {
 	statusFilters?: DashboardStatusFilter[];
 	noneFilter?: boolean;
 	productVersionFilters?: DashboardProductVersionFilter[];
+	intervalFilters?: DashboardIntervalFilter[];
 	cusProductLimit: number;
 	customerId?: string;
 };
@@ -64,6 +66,7 @@ export const getCursorPaginatedFullCusQuery = ({
 	statusFilters,
 	noneFilter,
 	productVersionFilters,
+	intervalFilters,
 	cusProductLimit,
 	customerId,
 }: CursorPaginatedFullCusQueryArgs) => {
@@ -85,6 +88,7 @@ export const getCursorPaginatedFullCusQuery = ({
 		statusFilters,
 		noneFilter,
 		productVersionFilters,
+		intervalFilters,
 	});
 
 	const cursorPredicate = cursor

--- a/server/src/internal/customers/customerListFilters.ts
+++ b/server/src/internal/customers/customerListFilters.ts
@@ -5,6 +5,7 @@ export const CustomerListFiltersSchema = z.object({
 	version: z.array(z.string()).optional(),
 	none: z.boolean().optional(),
 	processor: z.array(z.string()).optional(),
+	interval: z.array(z.string()).optional(),
 });
 
 export type CustomerListFilters = z.infer<typeof CustomerListFiltersSchema>;

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -1,10 +1,29 @@
 import {
 	type AppEnv,
+	BillingInterval,
 	CusProductStatus,
 	type ListCustomersV2Params,
 	RELEVANT_STATUSES,
 } from "@autumn/shared";
 import { type SQL, sql } from "drizzle-orm";
+
+const RECURRING_BILLING_INTERVALS = [
+	BillingInterval.Week,
+	BillingInterval.Month,
+	BillingInterval.Quarter,
+	BillingInterval.SemiAnnual,
+	BillingInterval.Year,
+] as const;
+
+export type DashboardIntervalFilter =
+	(typeof RECURRING_BILLING_INTERVALS)[number];
+
+export const parseDashboardIntervalFilter = (
+	raw: string[] | undefined,
+): DashboardIntervalFilter[] =>
+	(raw ?? []).filter((value): value is DashboardIntervalFilter =>
+		RECURRING_BILLING_INTERVALS.includes(value as DashboardIntervalFilter),
+	);
 
 export type DashboardStatusFilter =
 	| "active"
@@ -82,6 +101,20 @@ const dashboardProductFilterToCustomerListSql = (
 						AND p_lookup.version = ${filter.version}
 				)`
 			: sql`(p_dash.id = ${filter.productId} AND p_dash.version = ${filter.version})`;
+
+const intervalFilterToCustomerListSql = (
+	intervals: DashboardIntervalFilter[],
+): SQL =>
+	sql`EXISTS (
+		SELECT 1
+		FROM customer_prices cpr_interval
+		JOIN prices p_interval ON p_interval.id = cpr_interval.price_id
+		WHERE cpr_interval.customer_product_id = cp_dash.id
+			AND p_interval.config->>'interval' = ANY(ARRAY[${sql.join(
+				intervals.map((interval) => sql`${interval}`),
+				sql`, `,
+			)}])
+	)`;
 
 const buildOptimizedCusProductsCTE = ({
 	inStatuses,
@@ -941,6 +974,7 @@ export const getCustomerListFilterSql = ({
 	statusFilters,
 	noneFilter,
 	productVersionFilters,
+	intervalFilters,
 }: {
 	internalCustomerIds?: string[];
 	orgId?: string;
@@ -952,6 +986,7 @@ export const getCustomerListFilterSql = ({
 	statusFilters?: DashboardStatusFilter[];
 	noneFilter?: boolean;
 	productVersionFilters?: DashboardProductVersionFilter[];
+	intervalFilters?: DashboardIntervalFilter[];
 }) => {
 	const filters = [];
 
@@ -1035,12 +1070,14 @@ export const getCustomerListFilterSql = ({
 	}
 
 	const productFilters = productVersionFilters ?? [];
+	const intervals = intervalFilters ?? [];
 	const hasStatus = statusFilters && statusFilters.length > 0;
 	const hasProductFilter = productFilters.length > 0;
+	const hasInterval = intervals.length > 0;
 	const hasVersion = productFilters.some(isVersionDashboardProductFilter);
 	const canUseProductCandidateSet =
 		orgId && env && productFilters.every(isVersionDashboardProductFilter);
-	if (hasStatus || hasProductFilter) {
+	if (hasStatus || hasProductFilter || hasInterval) {
 		const innerClauses: SQL[] = [];
 
 		// Mirrors CusSearchService.buildSearchPredicates productMode:
@@ -1085,6 +1122,10 @@ export const getCustomerListFilterSql = ({
 				(filter) => dashboardProductFilterToCustomerListSql(filter, { orgId, env }),
 			);
 			innerClauses.push(sql`(${sql.join(versionClauses, sql` OR `)})`);
+		}
+
+		if (hasInterval) {
+			innerClauses.push(intervalFilterToCustomerListSql(intervals));
 		}
 
 		if (canUseProductCandidateSet) {

--- a/vite/src/views/customers/components/filter-dropdown/FilterCheckboxSubMenu.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/FilterCheckboxSubMenu.tsx
@@ -1,0 +1,60 @@
+import { Checkbox } from "@autumn/ui";
+import {
+	DropdownMenuItem,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
+} from "@autumn/ui";
+import type { ReactNode } from "react";
+
+export type FilterCheckboxOption = {
+	value: string;
+	label: string;
+	icon?: ReactNode;
+};
+
+export const FilterCheckboxSubMenu = ({
+	label,
+	options,
+	selected,
+	onToggle,
+}: {
+	label: string;
+	options: FilterCheckboxOption[];
+	selected: string[];
+	onToggle: (value: string) => void;
+}) => (
+	<DropdownMenuSub>
+		<DropdownMenuSubTrigger className="flex items-center gap-2 cursor-pointer">
+			{label}
+			{selected.length > 0 && (
+				<span className="text-xs text-tertiary-foreground bg-muted px-1 py-0 rounded-md">
+					{selected.length}
+				</span>
+			)}
+		</DropdownMenuSubTrigger>
+		<DropdownMenuSubContent>
+			{options.map(({ value, label: optionLabel, icon }) => (
+				<DropdownMenuItem
+					key={value}
+					closeOnClick={false}
+					onClick={(e) => {
+						e.preventDefault();
+						e.stopPropagation();
+						onToggle(value);
+					}}
+					className="flex items-center gap-2 cursor-pointer text-sm"
+				>
+					<Checkbox checked={selected.includes(value)} className="border-border" />
+					{icon}
+					{optionLabel}
+				</DropdownMenuItem>
+			))}
+		</DropdownMenuSubContent>
+	</DropdownMenuSub>
+);
+
+export const toggleFilterValue = (selected: string[], value: string) =>
+	selected.includes(value)
+		? selected.filter((v) => v !== value)
+		: [...selected, value];

--- a/vite/src/views/customers/components/filter-dropdown/FilterStatusSubMenu.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/FilterStatusSubMenu.tsx
@@ -1,12 +1,18 @@
-import { Checkbox } from "@autumn/ui";
-import {
-	DropdownMenuItem,
-	DropdownMenuSub,
-	DropdownMenuSubContent,
-	DropdownMenuSubTrigger,
-} from "@autumn/ui";
 import { keyToTitle } from "@/utils/formatUtils/formatTextUtils";
 import { useCustomerFilters } from "../../hooks/useCustomerFilters";
+import {
+	type FilterCheckboxOption,
+	FilterCheckboxSubMenu,
+	toggleFilterValue,
+} from "./FilterCheckboxSubMenu";
+
+const STATUS_OPTIONS: FilterCheckboxOption[] = [
+	"active",
+	"past_due",
+	"canceled",
+	"free_trial",
+	"expired",
+].map((value) => ({ value, label: keyToTitle(value) }));
 
 export const FilterStatusSubMenu = ({
 	onChange,
@@ -14,59 +20,17 @@ export const FilterStatusSubMenu = ({
 	onChange?: () => void;
 }) => {
 	const { queryStates, setFilters } = useCustomerFilters();
-
-	const statuses: string[] = [
-		"active",
-		"past_due",
-		"canceled",
-		"free_trial",
-		"expired",
-	];
-	const selectedStatuses = queryStates.status || [];
-	const hasSelections = selectedStatuses.length > 0;
-
-	const toggleStatus = (status: string) => {
-		const selected = queryStates.status || [];
-		const isSelected = selected.includes(status);
-
-		const updated = isSelected
-			? selected.filter((s: string) => s !== status)
-			: [...selected, status];
-
-		setFilters({ status: updated });
-		onChange?.();
-	};
+	const selected = queryStates.status || [];
 
 	return (
-		<DropdownMenuSub>
-			<DropdownMenuSubTrigger className="flex items-center gap-2 cursor-pointer">
-				Status
-				{hasSelections && (
-					<span className="text-xs text-tertiary-foreground bg-muted px-1 py-0 rounded-md">
-						{selectedStatuses.length}
-					</span>
-				)}
-			</DropdownMenuSubTrigger>
-			<DropdownMenuSubContent>
-				{statuses.map((status: any) => {
-					const isActive = selectedStatuses.includes(status);
-					return (
-						<DropdownMenuItem
-							key={status}
-							closeOnClick={false}
-							onClick={(e) => {
-								e.preventDefault();
-								e.stopPropagation();
-								toggleStatus(status);
-							}}
-							className="flex items-center gap-2 cursor-pointer text-sm"
-						>
-							<Checkbox checked={isActive} className="border-border" />
-							{keyToTitle(status)}
-						</DropdownMenuItem>
-					);
-				})}
-			</DropdownMenuSubContent>
-		</DropdownMenuSub>
+		<FilterCheckboxSubMenu
+			label="Status"
+			options={STATUS_OPTIONS}
+			selected={selected}
+			onToggle={(value) => {
+				setFilters({ status: toggleFilterValue(selected, value) });
+				onChange?.();
+			}}
+		/>
 	);
 };

--- a/vite/src/views/customers/components/filter-dropdown/IntervalSubMenu.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/IntervalSubMenu.tsx
@@ -1,0 +1,32 @@
+import { BillingInterval } from "@autumn/shared";
+import { useCustomerFilters } from "../../hooks/useCustomerFilters";
+import {
+	type FilterCheckboxOption,
+	FilterCheckboxSubMenu,
+	toggleFilterValue,
+} from "./FilterCheckboxSubMenu";
+
+const INTERVAL_OPTIONS: FilterCheckboxOption[] = [
+	{ value: BillingInterval.Week, label: "Weekly" },
+	{ value: BillingInterval.Month, label: "Monthly" },
+	{ value: BillingInterval.Quarter, label: "Quarterly" },
+	{ value: BillingInterval.SemiAnnual, label: "Semi-annual" },
+	{ value: BillingInterval.Year, label: "Yearly" },
+];
+
+export const IntervalSubMenu = ({ onChange }: { onChange?: () => void }) => {
+	const { queryStates, setFilters } = useCustomerFilters();
+	const selected = queryStates.interval || [];
+
+	return (
+		<FilterCheckboxSubMenu
+			label="Interval"
+			options={INTERVAL_OPTIONS}
+			selected={selected}
+			onToggle={(value) => {
+				setFilters({ interval: toggleFilterValue(selected, value) });
+				onChange?.();
+			}}
+		/>
+	);
+};

--- a/vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx
@@ -32,9 +32,10 @@ export const ProcessorSubMenu = ({ onChange }: { onChange?: () => void }) => {
 	const selected = queryStates.processor || [];
 
 	const visibleOptions = PROCESSOR_OPTIONS.filter(({ value }) => {
+		if (value === "stripe") return true;
 		if (value === "revenuecat") return flags.revenuecat;
 		if (value === "vercel") return flags.vercel;
-		return true;
+		return false;
 	});
 
 	return (

--- a/vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx
@@ -1,90 +1,51 @@
-import { Checkbox } from "@autumn/ui";
 import { CoinVerticalIcon, TriangleIcon } from "@phosphor-icons/react";
-import {
-	DropdownMenuItem,
-	DropdownMenuSub,
-	DropdownMenuSubContent,
-	DropdownMenuSubTrigger,
-} from "@autumn/ui";
 import { RevenueCatIcon } from "@/components/v2/icons/AutumnIcons";
 import { useAutumnFlags } from "@/hooks/common/useAutumnFlags";
 import { useCustomerFilters } from "../../hooks/useCustomerFilters";
+import {
+	type FilterCheckboxOption,
+	FilterCheckboxSubMenu,
+	toggleFilterValue,
+} from "./FilterCheckboxSubMenu";
 
-type Processor = "stripe" | "revenuecat" | "vercel";
-
-const PROCESSORS: { value: Processor; label: string; icon: React.ReactNode }[] =
-	[
-		{
-			value: "stripe",
-			label: "Stripe",
-			icon: <CoinVerticalIcon size={14} weight="fill" />,
-		},
-		{
-			value: "revenuecat",
-			label: "RevenueCat",
-			icon: <RevenueCatIcon size={14} />,
-		},
-		{
-			value: "vercel",
-			label: "Vercel",
-			icon: <TriangleIcon size={14} weight="fill" />,
-		},
-	];
+const PROCESSOR_OPTIONS: FilterCheckboxOption[] = [
+	{
+		value: "stripe",
+		label: "Stripe",
+		icon: <CoinVerticalIcon size={14} weight="fill" />,
+	},
+	{
+		value: "revenuecat",
+		label: "RevenueCat",
+		icon: <RevenueCatIcon size={14} />,
+	},
+	{
+		value: "vercel",
+		label: "Vercel",
+		icon: <TriangleIcon size={14} weight="fill" />,
+	},
+];
 
 export const ProcessorSubMenu = ({ onChange }: { onChange?: () => void }) => {
 	const flags = useAutumnFlags();
 	const { queryStates, setFilters } = useCustomerFilters();
+	const selected = queryStates.processor || [];
 
-	const visibleProcessors = PROCESSORS.filter(({ value }) => {
-		if (value === "stripe") return true;
+	const visibleOptions = PROCESSOR_OPTIONS.filter(({ value }) => {
 		if (value === "revenuecat") return flags.revenuecat;
 		if (value === "vercel") return flags.vercel;
-		return false;
+		return true;
 	});
 
-	const selectedProcessors = queryStates.processor || [];
-	const hasSelections = selectedProcessors.length > 0;
-
-	const toggleProcessor = (processor: Processor) => {
-		const isSelected = selectedProcessors.includes(processor);
-		const updated = isSelected
-			? selectedProcessors.filter((p: string) => p !== processor)
-			: [...selectedProcessors, processor];
-
-		setFilters({ processor: updated });
-		onChange?.();
-	};
-
 	return (
-		<DropdownMenuSub>
-			<DropdownMenuSubTrigger className="flex items-center gap-2 cursor-pointer">
-				Processors
-				{hasSelections && (
-					<span className="text-xs text-tertiary-foreground bg-muted px-1 py-0 rounded-md">
-						{selectedProcessors.length}
-					</span>
-				)}
-			</DropdownMenuSubTrigger>
-			<DropdownMenuSubContent>
-				{visibleProcessors.map(({ value, label, icon }) => {
-					const isActive = selectedProcessors.includes(value);
-					return (
-						<DropdownMenuItem
-							key={value}
-							closeOnClick={false}
-							onClick={(e) => {
-								e.preventDefault();
-								toggleProcessor(value);
-							}}
-							className="flex items-center gap-2 cursor-pointer text-sm"
-						>
-							<Checkbox checked={isActive} className="border-border" />
-							{icon}
-							{label}
-						</DropdownMenuItem>
-					);
-				})}
-			</DropdownMenuSubContent>
-		</DropdownMenuSub>
+		<FilterCheckboxSubMenu
+			label="Processors"
+			options={visibleOptions}
+			selected={selected}
+			onToggle={(value) => {
+				setFilters({ processor: toggleFilterValue(selected, value) });
+				onChange?.();
+			}}
+		/>
 	);
 };

--- a/vite/src/views/customers/components/filter-dropdown/SavedViews.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/SavedViews.tsx
@@ -43,6 +43,7 @@ export const SavedViews = ({
 			const versionParam = params.get("version") || "";
 			const noneParam = params.get("none");
 			const processorParam = params.get("processor") || "";
+			const intervalParam = params.get("interval") || "";
 
 			setFilters({
 				q: params.get("q") || "",
@@ -51,6 +52,9 @@ export const SavedViews = ({
 				none: noneParam === "true",
 				processor: processorParam
 					? processorParam.split(",").filter(Boolean)
+					: [],
+				interval: intervalParam
+					? intervalParam.split(",").filter(Boolean)
 					: [],
 			});
 

--- a/vite/src/views/customers/hooks/useCusSearchQuery.tsx
+++ b/vite/src/views/customers/hooks/useCusSearchQuery.tsx
@@ -3,7 +3,10 @@ import { keepPreviousData, useQuery } from "@tanstack/react-query";
 
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
-import { useCustomerFilters } from "./useCustomerFilters";
+import {
+	buildCustomerFilterPayload,
+	useCustomerFilters,
+} from "./useCustomerFilters";
 
 export const useCusSearchQuery = () => {
 	const { queryStates, isInitialized, currentCursor } = useCustomerFilters();
@@ -17,12 +20,7 @@ export const useCusSearchQuery = () => {
 			search: trimmedSearch,
 			cursor: currentCursor,
 			limit: queryStates.pageSize,
-			filters: {
-				status: queryStates.status,
-				version: queryStates.version,
-				none: queryStates.none,
-				processor: queryStates.processor,
-			},
+			filters: buildCustomerFilterPayload(queryStates),
 		});
 		return {
 			customers: data.customers as CustomerWithProducts[],
@@ -33,12 +31,7 @@ export const useCusSearchQuery = () => {
 	const countFetcher = async () => {
 		const { data } = await axiosInstance.post(`/customers/all/count`, {
 			search: trimmedSearch,
-			filters: {
-				status: queryStates.status,
-				version: queryStates.version,
-				none: queryStates.none,
-				processor: queryStates.processor,
-			},
+			filters: buildCustomerFilterPayload(queryStates),
 		});
 		return data.totalCount as number;
 	};
@@ -61,6 +54,7 @@ export const useCusSearchQuery = () => {
 			queryStates.version,
 			queryStates.none,
 			queryStates.processor,
+			queryStates.interval,
 			trimmedSearch,
 		]),
 		queryFn: fetcher,
@@ -75,6 +69,7 @@ export const useCusSearchQuery = () => {
 			queryStates.version,
 			queryStates.none,
 			queryStates.processor,
+			queryStates.interval,
 			trimmedSearch,
 		]),
 		queryFn: countFetcher,

--- a/vite/src/views/customers/hooks/useCustomerFilters.tsx
+++ b/vite/src/views/customers/hooks/useCustomerFilters.tsx
@@ -26,6 +26,7 @@ const FILTER_PARAM_KEYS = [
 	"version",
 	"none",
 	"processor",
+	"interval",
 	"pageSize",
 ] as const;
 
@@ -34,6 +35,7 @@ type PersistedCustomerFilters = {
 	version: string[];
 	none: boolean;
 	processor: string[];
+	interval: string[];
 	pageSize: number;
 };
 
@@ -67,6 +69,7 @@ function buildRestoredState({
 		version: filters?.version?.length ? filters.version : null,
 		none: filters?.none ? true : null,
 		processor: filters?.processor?.length ? filters.processor : null,
+		interval: filters?.interval?.length ? filters.interval : null,
 		pageSize:
 			filters?.pageSize && filters.pageSize !== DEFAULT_CUSTOMER_LIST_PAGE_SIZE
 				? filters.pageSize
@@ -80,10 +83,31 @@ const queryStatesConfig = {
 	version: parseAsArrayOf(parseAsString).withDefault([]),
 	none: parseAsBoolean.withDefault(false),
 	processor: parseAsArrayOf(parseAsString).withDefault([]),
+	interval: parseAsArrayOf(parseAsString).withDefault([]),
 	pageSize: parseAsInteger.withDefault(DEFAULT_CUSTOMER_LIST_PAGE_SIZE),
 };
 
 type QueryStates = ReturnType<typeof useQueryStates<typeof queryStatesConfig>>;
+
+export function hasActiveCustomerFilters(queryStates: QueryStates[0]) {
+	return (
+		queryStates.status.length > 0 ||
+		queryStates.version.length > 0 ||
+		queryStates.none ||
+		queryStates.processor.length > 0 ||
+		queryStates.interval.length > 0
+	);
+}
+
+export function buildCustomerFilterPayload(queryStates: QueryStates[0]) {
+	return {
+		status: queryStates.status,
+		version: queryStates.version,
+		none: queryStates.none,
+		processor: queryStates.processor,
+		interval: queryStates.interval,
+	};
+}
 
 type CursorStack = string[];
 
@@ -177,6 +201,7 @@ export function CustomerFiltersProvider({ children }: { children: ReactNode }) {
 					version: queryStates.version,
 					none: queryStates.none,
 					processor: queryStates.processor,
+					interval: queryStates.interval,
 					pageSize: queryStates.pageSize,
 				}),
 			);
@@ -189,6 +214,7 @@ export function CustomerFiltersProvider({ children }: { children: ReactNode }) {
 		queryStates.version,
 		queryStates.none,
 		queryStates.processor,
+		queryStates.interval,
 		queryStates.pageSize,
 	]);
 

--- a/vite/src/views/customers/hooks/useFullCusSearchQuery.tsx
+++ b/vite/src/views/customers/hooks/useFullCusSearchQuery.tsx
@@ -2,7 +2,10 @@ import type { FullCustomer } from "@autumn/shared";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
-import { useCustomerFilters } from "./useCustomerFilters";
+import {
+	buildCustomerFilterPayload,
+	useCustomerFilters,
+} from "./useCustomerFilters";
 
 export const FULL_CUSTOMERS_QUERY_KEY = "full_customers";
 
@@ -23,6 +26,7 @@ export const useFullCusSearchQuery = () => {
 			queryStates.version,
 			queryStates.none,
 			queryStates.processor,
+			queryStates.interval,
 			queryStates.q,
 		]),
 		queryFn: async ({ signal }) => {
@@ -32,12 +36,7 @@ export const useFullCusSearchQuery = () => {
 					search: queryStates.q,
 					cursor: currentCursor,
 					limit: queryStates.pageSize,
-					filters: {
-						status: queryStates.status,
-						version: queryStates.version,
-						none: queryStates.none,
-						processor: queryStates.processor,
-					},
+					filters: buildCustomerFilterPayload(queryStates),
 				},
 				{ signal },
 			);

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListFilterButton.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListFilterButton.tsx
@@ -11,11 +11,15 @@ import {
 } from "@autumn/ui";
 import { cn } from "@/lib/utils";
 import { FilterStatusSubMenu } from "@/views/customers/components/filter-dropdown/FilterStatusSubMenu";
+import { IntervalSubMenu } from "@/views/customers/components/filter-dropdown/IntervalSubMenu";
 import { ProcessorSubMenu } from "@/views/customers/components/filter-dropdown/ProcessorSubMenu";
 import { ProductsSubMenu } from "@/views/customers/components/filter-dropdown/ProductsSubMenu";
 import { SaveViewPopover } from "@/views/customers/components/filter-dropdown/SavedViewPopover";
 import { SavedViews } from "@/views/customers/components/filter-dropdown/SavedViews";
-import { useCustomerFilters } from "@/views/customers/hooks/useCustomerFilters";
+import {
+	hasActiveCustomerFilters,
+	useCustomerFilters,
+} from "@/views/customers/hooks/useCustomerFilters";
 import { useSavedViewsQuery } from "@/views/customers/hooks/useSavedViewsQuery";
 
 interface CustomerListFilterButtonProps {
@@ -37,18 +41,20 @@ export function CustomerListFilterButton({
 	const [open, setOpen] = useState(false);
 
 	const hasActiveFilters =
-		hasActiveExtraFilters ||
-		queryStates.status.length > 0 ||
-		queryStates.version.length > 0 ||
-		queryStates.none ||
-		queryStates.processor.length > 0;
+		hasActiveExtraFilters || hasActiveCustomerFilters(queryStates);
 
 	const { data, refetch: refetchSavedViews } = useSavedViewsQuery();
 
 	const views = data?.views || [];
 
 	const clearFilters = () => {
-		setFilters({ status: [], version: [], none: false, processor: [] });
+		setFilters({
+			status: [],
+			version: [],
+			none: false,
+			processor: [],
+			interval: [],
+		});
 		onFilterChange?.();
 		onClearExtra?.();
 	};
@@ -84,6 +90,7 @@ export function CustomerListFilterButton({
 					{extraMenuItems}
 					<FilterStatusSubMenu onChange={onFilterChange} />
 					<ProductsSubMenu onChange={onFilterChange} />
+					<IntervalSubMenu onChange={onFilterChange} />
 					<ProcessorSubMenu onChange={onFilterChange} />
 				</DropdownMenuGroup>
 				<DropdownMenuSeparator className="m-0" />

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
@@ -11,7 +11,10 @@ import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useColumnVisibility } from "@autumn/ui";
 import { useEnv } from "@/utils/envUtils";
 import { pushPage } from "@/utils/genUtils";
-import { useCustomerFilters } from "@/views/customers/hooks/useCustomerFilters";
+import {
+	hasActiveCustomerFilters,
+	useCustomerFilters,
+} from "@/views/customers/hooks/useCustomerFilters";
 import { FULL_CUSTOMERS_QUERY_KEY } from "@/views/customers/hooks/useFullCusSearchQuery";
 import { useCustomerListColumns } from "@/views/customers2/hooks/useCustomerListColumns";
 import { useCustomerTable } from "@/views/customers2/hooks/useCustomerTable";
@@ -135,11 +138,7 @@ export function CustomerListTable({
 
 	const hasRows = table.getRowModel().rows.length > 0;
 	const hasSearchQuery = Boolean(queryStates.q?.trim());
-	const hasFilters =
-		queryStates.status.length > 0 ||
-		queryStates.version.length > 0 ||
-		queryStates.none ||
-		queryStates.processor.length > 0;
+	const hasFilters = hasActiveCustomerFilters(queryStates);
 	const hasActiveFiltersOrSearch = hasSearchQuery || hasFilters;
 
 	if (!hasRows && !hasActiveFiltersOrSearch && !isFetchingUncached) {


### PR DESCRIPTION
## What

Adds an **Interval** filter to the Customers list, alongside Status / Plans / Processors. Multi-select across recurring billing intervals: Weekly, Monthly, Quarterly, Semi-annual, Yearly (one-off excluded).

A customer matches if they have a product whose price config interval is in the selection. It composes with the existing filters — the interval predicate folds into the same `customer_products` candidate set that Status/Plans build, so it inherits the active/expired scoping from the Status filter and ANDs independently with the Plans filter.

## How it works

Interval lives in `prices.config->>'interval'` (jsonb), reached via `customer_prices.customer_product_id → price_id`. The predicate is an `EXISTS` correlated to the candidate `customer_products` row, added to the existing resolve-step filter chain in `buildSearchPredicates` / `getCustomerListFilterSql`. Interval-only filters trigger the resolve step (like status/version/none).

## Changes

**Backend**
- `customerListFilters.ts` — `interval: string[]` on the schema.
- `getFullCusQuery.ts` — `parseDashboardIntervalFilter` (recurring intervals only), `intervalFilterToCustomerListSql`, wired into `getCustomerListFilterSql`.
- `CusSearchService.ts` — interval raw + drizzle predicates in `buildSearchPredicates`.
- `CusBatchService.ts` — interval triggers `requiresResolveStep`.
- `cursorPaginatedFullCusQuery.ts` — forwards `intervalFilters`.

**Frontend**
- New `IntervalSubMenu.tsx` + shared `FilterCheckboxSubMenu.tsx` (extracted from the now-deduplicated Status/Processor/Interval submenus).
- `useCustomerFilters.tsx` — param key, nuqs config, persistence; plus shared `hasActiveCustomerFilters` + `buildCustomerFilterPayload` helpers.
- `useFullCusSearchQuery.tsx` / `useCusSearchQuery.tsx` — interval in request body, count, and query keys (table and count both respect it).
- `CustomerListFilterButton.tsx` / `CustomerListTable.tsx` — render submenu, active-filter indicator, clear, empty-state.
- `SavedViews.tsx` — saved views capture & restore interval.

## Scope

Scoped to the dashboard cursor path only; does not touch the public v2 `ListCustomersV2Params` API.

## Testing

- Frontend typecheck: 0 errors.
- Backend typecheck: no new errors (pre-existing baseline unchanged).
- Verified locally via `bun dw` — filter renders between Plans and Processors and composes with the other filters.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a multi-select Interval filter (Weekly, Monthly, Quarterly, Semi-annual, Yearly) to the Customers list. It composes with Status, Versions/Plans, and Processors, and updates both results and counts in the dashboard cursor view.

- **New Features**
  - Backend: parsed as recurring-only and applied via an SQL EXISTS on `prices.config->>'interval'`; included in both raw and Drizzle predicates, forwarded through the cursor-paginated query, and triggers the resolve step when used.
  - Frontend: adds an Interval submenu and persists the selection in URL state and Saved Views. Requests and query keys include `interval`; clear-all resets it; the filter badge shows the count. Scoped to the dashboard path only; no changes to the public `ListCustomersV2Params` API.

- **Refactors**
  - Extracted `FilterCheckboxSubMenu` and `toggleFilterValue`; Status and Processor menus now use it. Centralized `buildCustomerFilterPayload` and `hasActiveCustomerFilters` in `useCustomerFilters` to keep list and count endpoints consistent.
  - Processor dropdown keeps an explicit allowlist for visibility (Stripe always, `revenuecat`/`vercel` behind flags) to preserve prior behavior.

<sup>Written for commit 35bb77b32b02d8f68a336842d7c3a90c2e7ff5ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a billing interval filter to the customer list dashboard, allowing multi-select filtering by recurring intervals (Weekly, Monthly, Quarterly, Semi-annual, Yearly). The filter integrates into the existing resolve-step pipeline alongside Status/Version, uses correlated EXISTS subqueries on `customer_prices → prices.config->>'interval'`, and a shared `FilterCheckboxSubMenu` component is extracted to reduce duplication across Status, Processor, and Interval submenus.

- **[Improvements]** New `interval` filter in `CustomerListFiltersSchema`, `parseDashboardIntervalFilter`, and `intervalFilterToCustomerListSql` compose correctly with existing Status/Plans/Processor filters via the resolve step in `CusBatchService` and raw SQL in `CusSearchService`.
- **[Improvements]** `FilterCheckboxSubMenu` extracts repeated checkbox dropdown pattern from `FilterStatusSubMenu` and `ProcessorSubMenu`, and `hasActiveCustomerFilters` / `buildCustomerFilterPayload` centralize filter state helpers previously inlined in multiple components.
- **[Improvements]** `SavedViews`, query hooks (`useCusSearchQuery`, `useFullCusSearchQuery`), query keys, and clear-filter logic all updated consistently to include the new `interval` param.
</details>

<h3>Confidence Score: 4/5</h3>

The feature is safe to merge. SQL predicates are correctly parameterized through Drizzle's sql tagged template, interval values are whitelist-validated via parseDashboardIntervalFilter before reaching the query layer, and the resolve-step flag correctly triggers for non-empty interval selections.

The backend SQL logic, resolve-step wiring, and frontend state management are all consistent with existing patterns and appear correct. The only notable change is the ProcessorSubMenu default filter shifting from opt-in to opt-out for any future processor options, which is a low-risk concern in this PR.

ProcessorSubMenu.tsx is worth a second look due to the default filter change; all other files look straightforward.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/getFullCusQuery.ts | Adds parseDashboardIntervalFilter, DashboardIntervalFilter type, and intervalFilterToCustomerListSql; wires correctly into getCustomerListFilterSql alongside existing status/version paths. |
| server/src/internal/customers/CusSearchService.ts | Adds dashboardIntervalFilterToRawSql and wires intervalFilters into both the raw SQL (whereRaw) and Drizzle ORM (filtersDrizzle) paths of buildSearchPredicates; customer_products table is in scope in both execution contexts. |
| server/src/internal/customers/CusBatchService.ts | intervalFilters.length > 0 correctly triggers requiresResolveStep so filtering is handled by resolveInternalIdsByCursor before getCursorPaginatedFullCusQuery is called with pre-filtered internalIds. |
| vite/src/views/customers/components/filter-dropdown/FilterCheckboxSubMenu.tsx | New shared checkbox submenu component; clean extraction of the repeated dropdown pattern used by Status, Processor, and Interval submenus. |
| vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx | Refactored to use FilterCheckboxSubMenu; default filter return changed from false to true, which is functionally equivalent for current processors but means any future processor added to PROCESSOR_OPTIONS would be visible without an explicit feature-flag guard. |
| vite/src/views/customers/hooks/useCustomerFilters.tsx | Adds interval to nuqs config, persistence, and extracted hasActiveCustomerFilters / buildCustomerFilterPayload helpers; consistent with existing filter params. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as IntervalSubMenu (UI)
    participant Hook as useCustomerFilters
    participant Query as useCusSearchQuery / useFullCusSearchQuery
    participant API as /customers/all (POST)
    participant Batch as CusBatchService
    participant Search as CusSearchService
    participant DB as PostgreSQL

    UI->>Hook: "setFilters({ interval: [...] })"
    Hook->>Query: queryStates.interval changes (query key updated)
    Query->>API: "POST { filters: buildCustomerFilterPayload() }"
    API->>Batch: getDashboardCursorPage(filters)
    Batch->>Batch: parseDashboardIntervalFilter(filters.interval)
    Batch->>Batch: "requiresResolveStep = intervalFilters.length > 0"
    Batch->>Search: resolveInternalIdsByCursor(filters)
    Search->>Search: buildSearchPredicates → productMode
    Search->>Search: dashboardIntervalFilterToRawSql(intervalFilters)
    Search->>DB: SELECT DISTINCT internal_id FROM customer_products JOIN customers WHERE intervalRaw AND ...
    DB-->>Search: internalIds[]
    Search-->>Batch: "{ internalIds, peek }"
    Batch->>DB: getCursorPaginatedFullCusQuery(internalCustomerIds)
    DB-->>Batch: full customer rows
    Batch-->>API: "{ fullCustomers, next_cursor }"
    API-->>Query: response
    Query-->>UI: updated customer list
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as IntervalSubMenu (UI)
    participant Hook as useCustomerFilters
    participant Query as useCusSearchQuery / useFullCusSearchQuery
    participant API as /customers/all (POST)
    participant Batch as CusBatchService
    participant Search as CusSearchService
    participant DB as PostgreSQL

    UI->>Hook: "setFilters({ interval: [...] })"
    Hook->>Query: queryStates.interval changes (query key updated)
    Query->>API: "POST { filters: buildCustomerFilterPayload() }"
    API->>Batch: getDashboardCursorPage(filters)
    Batch->>Batch: parseDashboardIntervalFilter(filters.interval)
    Batch->>Batch: "requiresResolveStep = intervalFilters.length > 0"
    Batch->>Search: resolveInternalIdsByCursor(filters)
    Search->>Search: buildSearchPredicates → productMode
    Search->>Search: dashboardIntervalFilterToRawSql(intervalFilters)
    Search->>DB: SELECT DISTINCT internal_id FROM customer_products JOIN customers WHERE intervalRaw AND ...
    DB-->>Search: internalIds[]
    Search-->>Batch: "{ internalIds, peek }"
    Batch->>DB: getCursorPaginatedFullCusQuery(internalCustomerIds)
    DB-->>Batch: full customer rows
    Batch-->>API: "{ fullCustomers, next_cursor }"
    API-->>Query: response
    Query-->>UI: updated customer list
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx:34-38
The refactored filter's default branch changed from `return false` to `return true`. For the current three processors the behavior is identical, but any processor added to `PROCESSOR_OPTIONS` in the future will be shown by default rather than requiring an explicit feature-flag guard. Keeping the explicit `stripe` check preserves the original intent.

```suggestion
	const visibleOptions = PROCESSOR_OPTIONS.filter(({ value }) => {
		if (value === "stripe") return true;
		if (value === "revenuecat") return flags.revenuecat;
		if (value === "vercel") return flags.vercel;
		return false;
	});
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add interval filter to customers ..."](https://github.com/useautumn/autumn/commit/582ccfa38abcbf9971f52dcfadd2c1f67fba924b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39803631)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->