### PR TITLE
release

### DIFF
--- a/server/src/internal/customers/CusBatchService.ts
+++ b/server/src/internal/customers/CusBatchService.ts
@@ -25,6 +25,7 @@ import type { CustomerListFilters } from "./customerListFilters.js";
 import { getApiCustomerBase } from "./cusUtils/apiCusUtils/getApiCustomerBase.js";
 import {
 	getPaginatedFullCusQuery,
+	parseDashboardIntervalFilter,
 	parseDashboardProcessorFilter,
 	parseDashboardStatusFilter,
 	parseDashboardVersionFilter,
@@ -316,12 +317,15 @@ export class CusBatchService {
 
 		const productVersionFilters = parseDashboardVersionFilter(filters?.version);
 
+		const intervalFilters = parseDashboardIntervalFilter(filters?.interval);
+
 		// Status/none/version filter on a different table (customer_products) than
 		// the cursor (customers). Folding it into the main query forces a merge join
 		// that abandons idx_customers_cursor and degrades to seconds.
 		const requiresResolveStep =
 			statusFilters.length > 0 ||
 			productVersionFilters.length > 0 ||
+			intervalFilters.length > 0 ||
 			!!filters?.none;
 
 		const tResolveStart = performance.now();

--- a/server/src/internal/customers/CusSearchService.ts
+++ b/server/src/internal/customers/CusSearchService.ts
@@ -26,9 +26,11 @@ import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { getOrgCusProductLimit } from "../misc/edgeConfig/orgLimitsStore.js";
 import type { CustomerListFilters } from "./customerListFilters.js";
 import {
+	type DashboardIntervalFilter,
 	type DashboardProductVersionFilter,
 	isCustomDashboardProductFilter,
 	isVersionDashboardProductFilter,
+	parseDashboardIntervalFilter,
 	parseDashboardVersionFilter,
 } from "./getFullCusQuery.js";
 
@@ -79,6 +81,18 @@ const dashboardProductFilterToRawSql = (
 	isCustomDashboardProductFilter(filter)
 		? sql`(${customerProducts.product_id} = ${filter.productId} AND ${customerProducts.is_custom} = true)`
 		: sql`(${products.id} = ${filter.productId} AND ${products.version} = ${filter.version})`;
+
+const dashboardIntervalFilterToRawSql = (intervals: DashboardIntervalFilter[]) =>
+	sql`EXISTS (
+		SELECT 1
+		FROM customer_prices cpr_interval
+		JOIN prices p_interval ON p_interval.id = cpr_interval.price_id
+		WHERE cpr_interval.customer_product_id = ${customerProducts.id}
+			AND p_interval.config->>'interval' = ANY(ARRAY[${sql.join(
+				intervals.map((interval) => sql`${interval}`),
+				sql`, `,
+			)}])
+	)`;
 
 type SearchFilters = CustomerListFilters;
 
@@ -967,8 +981,14 @@ const buildSearchPredicates = ({
 	const hasNumberedVersion = productVersionFilters.some(
 		isVersionDashboardProductFilter,
 	);
+	const intervalFilters = parseDashboardIntervalFilter(filters?.interval);
 
-	if (statuses.length === 0 && productVersionFilters.length === 0) {
+	const hasProductLevelFilter =
+		statuses.length > 0 ||
+		productVersionFilters.length > 0 ||
+		intervalFilters.length > 0;
+
+	if (!hasProductLevelFilter) {
 		return {
 			kind: "default",
 			where: and(...cusBaseClauses),
@@ -1014,6 +1034,11 @@ const buildSearchPredicates = ({
 				)})`
 			: null;
 
+	const intervalRaw =
+		intervalFilters.length > 0
+			? dashboardIntervalFilterToRawSql(intervalFilters)
+			: null;
+
 	const hasNonActiveStatus = statuses.some(
 		(status) => status !== "active" && status !== "",
 	);
@@ -1025,6 +1050,7 @@ const buildSearchPredicates = ({
 		shouldApplyActiveFilter ? activeProdRaw : null,
 		statusRaw,
 		versionRaw,
+		intervalRaw,
 	].filter((c): c is NonNullable<typeof c> => c !== null);
 
 	const whereRaw =
@@ -1041,6 +1067,9 @@ const buildSearchPredicates = ({
 			? or(
 					...productVersionFilters.map(dashboardProductFilterToDrizzleSql),
 				)
+			: undefined,
+		intervalFilters.length > 0
+			? dashboardIntervalFilterToRawSql(intervalFilters)
 			: undefined,
 		statuses.length > 0
 			? or(

--- a/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
+++ b/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
@@ -14,6 +14,7 @@ import {
 	customerProductsSeedSelect,
 } from "./getCustomerProductsPageQuery.js";
 import {
+	type DashboardIntervalFilter,
 	type DashboardProductVersionFilter,
 	type DashboardStatusFilter,
 	getCustomerListFilterSql,
@@ -37,6 +38,7 @@ export type CursorPaginatedFullCusQueryArgs = {
 	statusFilters?: DashboardStatusFilter[];
 	noneFilter?: boolean;
 	productVersionFilters?: DashboardProductVersionFilter[];
+	intervalFilters?: DashboardIntervalFilter[];
 	cusProductLimit: number;
 	customerId?: string;
 };
@@ -64,6 +66,7 @@ export const getCursorPaginatedFullCusQuery = ({
 	statusFilters,
 	noneFilter,
 	productVersionFilters,
+	intervalFilters,
 	cusProductLimit,
 	customerId,
 }: CursorPaginatedFullCusQueryArgs) => {
@@ -85,6 +88,7 @@ export const getCursorPaginatedFullCusQuery = ({
 		statusFilters,
 		noneFilter,
 		productVersionFilters,
+		intervalFilters,
 	});
 
 	const cursorPredicate = cursor

--- a/server/src/internal/customers/customerListFilters.ts
+++ b/server/src/internal/customers/customerListFilters.ts
@@ -5,6 +5,7 @@ export const CustomerListFiltersSchema = z.object({
 	version: z.array(z.string()).optional(),
 	none: z.boolean().optional(),
 	processor: z.array(z.string()).optional(),
+	interval: z.array(z.string()).optional(),
 });
 
 export type CustomerListFilters = z.infer<typeof CustomerListFiltersSchema>;

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -1,10 +1,29 @@
 import {
 	type AppEnv,
+	BillingInterval,
 	CusProductStatus,
 	type ListCustomersV2Params,
 	RELEVANT_STATUSES,
 } from "@autumn/shared";
 import { type SQL, sql } from "drizzle-orm";
+
+const RECURRING_BILLING_INTERVALS = [
+	BillingInterval.Week,
+	BillingInterval.Month,
+	BillingInterval.Quarter,
+	BillingInterval.SemiAnnual,
+	BillingInterval.Year,
+] as const;
+
+export type DashboardIntervalFilter =
+	(typeof RECURRING_BILLING_INTERVALS)[number];
+
+export const parseDashboardIntervalFilter = (
+	raw: string[] | undefined,
+): DashboardIntervalFilter[] =>
+	(raw ?? []).filter((value): value is DashboardIntervalFilter =>
+		RECURRING_BILLING_INTERVALS.includes(value as DashboardIntervalFilter),
+	);
 
 export type DashboardStatusFilter =
 	| "active"
@@ -82,6 +101,20 @@ const dashboardProductFilterToCustomerListSql = (
 						AND p_lookup.version = ${filter.version}
 				)`
 			: sql`(p_dash.id = ${filter.productId} AND p_dash.version = ${filter.version})`;
+
+const intervalFilterToCustomerListSql = (
+	intervals: DashboardIntervalFilter[],
+): SQL =>
+	sql`EXISTS (
+		SELECT 1
+		FROM customer_prices cpr_interval
+		JOIN prices p_interval ON p_interval.id = cpr_interval.price_id
+		WHERE cpr_interval.customer_product_id = cp_dash.id
+			AND p_interval.config->>'interval' = ANY(ARRAY[${sql.join(
+				intervals.map((interval) => sql`${interval}`),
+				sql`, `,
+			)}])
+	)`;
 
 const buildOptimizedCusProductsCTE = ({
 	inStatuses,
@@ -941,6 +974,7 @@ export const getCustomerListFilterSql = ({
 	statusFilters,
 	noneFilter,
 	productVersionFilters,
+	intervalFilters,
 }: {
 	internalCustomerIds?: string[];
 	orgId?: string;
@@ -952,6 +986,7 @@ export const getCustomerListFilterSql = ({
 	statusFilters?: DashboardStatusFilter[];
 	noneFilter?: boolean;
 	productVersionFilters?: DashboardProductVersionFilter[];
+	intervalFilters?: DashboardIntervalFilter[];
 }) => {
 	const filters = [];
 
@@ -1035,12 +1070,14 @@ export const getCustomerListFilterSql = ({
 	}
 
 	const productFilters = productVersionFilters ?? [];
+	const intervals = intervalFilters ?? [];
 	const hasStatus = statusFilters && statusFilters.length > 0;
 	const hasProductFilter = productFilters.length > 0;
+	const hasInterval = intervals.length > 0;
 	const hasVersion = productFilters.some(isVersionDashboardProductFilter);
 	const canUseProductCandidateSet =
 		orgId && env && productFilters.every(isVersionDashboardProductFilter);
-	if (hasStatus || hasProductFilter) {
+	if (hasStatus || hasProductFilter || hasInterval) {
 		const innerClauses: SQL[] = [];
 
 		// Mirrors CusSearchService.buildSearchPredicates productMode:
@@ -1085,6 +1122,10 @@ export const getCustomerListFilterSql = ({
 				(filter) => dashboardProductFilterToCustomerListSql(filter, { orgId, env }),
 			);
 			innerClauses.push(sql`(${sql.join(versionClauses, sql` OR `)})`);
+		}
+
+		if (hasInterval) {
+			innerClauses.push(intervalFilterToCustomerListSql(intervals));
 		}
 
 		if (canUseProductCandidateSet) {

--- a/vite/src/components/forms/shared/InvoiceSettingsSection.tsx
+++ b/vite/src/components/forms/shared/InvoiceSettingsSection.tsx
@@ -31,21 +31,21 @@ export function InvoiceSettingsSection({
 }) {
 	const { templates } = useInvoiceTemplatesQuery();
 	const hasTemplates = templates.length > 0;
-	const options: Pick<InvoiceTemplate, "id" | "name">[] = [
-		{ id: NO_TEMPLATE_VALUE, name: "None" },
-		...templates,
-	];
+	const options: Pick<InvoiceTemplate, "id" | "name">[] = hasTemplates
+		? [{ id: NO_TEMPLATE_VALUE, name: "None" }, ...templates]
+		: [];
 	return (
 		<SheetAccordion>
-			<SheetAccordionItem
-				value="invoice-more-settings"
-				title="More settings"
-				className={cn(disabled && "opacity-50 pointer-events-none")}
-			>
-				<div className="space-y-4">
+			<SheetAccordionItem value="invoice-more-settings" title="More settings">
+				<div
+					className={cn(
+						"space-y-4",
+						disabled && "opacity-50 pointer-events-none",
+					)}
+				>
 					{hasTemplates && (
 						<div className="flex flex-col gap-1.5">
-							<span className="text-form-label block mb-1">Template</span>
+							<span className="text-form-label">Template</span>
 							<SearchableSelect
 								value={value.templateId ?? NO_TEMPLATE_VALUE}
 								onValueChange={(next) => {

--- a/vite/src/components/forms/shared/InvoiceSettingsSection.tsx
+++ b/vite/src/components/forms/shared/InvoiceSettingsSection.tsx
@@ -2,12 +2,13 @@ import type { InvoiceTemplate } from "@autumn/shared";
 import {
 	Input,
 	SearchableSelect,
+	SheetAccordion,
+	SheetAccordionItem,
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
 } from "@autumn/ui";
 import { InfoIcon } from "lucide-react";
-import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
 import { useInvoiceTemplatesQuery } from "@/hooks/queries/useInvoiceTemplatesQuery";
 import { cn } from "@/lib/utils";
 
@@ -29,65 +30,67 @@ export function InvoiceSettingsSection({
 	disabled?: boolean;
 }) {
 	const { templates } = useInvoiceTemplatesQuery();
-	if (templates.length === 0) return null;
+	const hasTemplates = templates.length > 0;
 	const options: Pick<InvoiceTemplate, "id" | "name">[] = [
 		{ id: NO_TEMPLATE_VALUE, name: "None" },
 		...templates,
 	];
 	return (
-		<SheetSection
-			title="Invoice Settings"
-			withSeparator
-			className={cn(disabled && "opacity-50 pointer-events-none")}
-		>
-			<div className="space-y-4">
-				<div className="flex flex-col gap-1.5">
-					<span className="text-body-secondary">Template</span>
-					<SearchableSelect
-						value={value.templateId ?? NO_TEMPLATE_VALUE}
-						onValueChange={(next) => {
-							const templateId = next === NO_TEMPLATE_VALUE ? null : next;
-							const template = templates.find((t) => t.id === templateId);
-							onChange({
-								templateId,
-								netTermsDays: template?.net_terms_days ?? value.netTermsDays,
-							});
-						}}
-						options={options}
-						getOptionValue={(option) => option.id}
-						getOptionLabel={(option) => option.name}
-						placeholder="Select a template"
-						emptyText="No templates configured"
-					/>
-				</div>
-				<div className="flex flex-col gap-1.5">
-					<div className="flex items-center gap-1.5">
-						<span className="text-body-secondary">
-							Net payment terms (days)
-						</span>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<InfoIcon className="size-3.5 text-tertiary-foreground cursor-help" />
-							</TooltipTrigger>
-							<TooltipContent>
-								How long the customer has to pay before the invoice is due.
-							</TooltipContent>
-						</Tooltip>
+		<SheetAccordion>
+			<SheetAccordionItem
+				value="invoice-more-settings"
+				title="More settings"
+				className={cn(disabled && "opacity-50 pointer-events-none")}
+			>
+				<div className="space-y-4">
+					{hasTemplates && (
+						<div className="flex flex-col gap-1.5">
+							<span className="text-form-label block mb-1">Template</span>
+							<SearchableSelect
+								value={value.templateId ?? NO_TEMPLATE_VALUE}
+								onValueChange={(next) => {
+									const templateId = next === NO_TEMPLATE_VALUE ? null : next;
+									const template = templates.find((t) => t.id === templateId);
+									onChange({
+										templateId,
+										netTermsDays: template?.net_terms_days ?? value.netTermsDays,
+									});
+								}}
+								options={options}
+								getOptionValue={(option) => option.id}
+								getOptionLabel={(option) => option.name}
+								placeholder="Select a template"
+								emptyText="No templates configured"
+							/>
+						</div>
+					)}
+					<div className="flex flex-col gap-1.5">
+						<div className="flex items-center gap-1.5">
+							<span className="text-form-label">Net payment terms (days)</span>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<InfoIcon className="size-3.5 text-tertiary-foreground cursor-help" />
+								</TooltipTrigger>
+								<TooltipContent>
+									How long the customer has to pay before the invoice is due.
+								</TooltipContent>
+							</Tooltip>
+						</div>
+						<Input
+							type="number"
+							min={1}
+							value={String(value.netTermsDays)}
+							onChange={(e) => {
+								const parsed = Number.parseInt(e.target.value, 10);
+								onChange({
+									...value,
+									netTermsDays: Number.isNaN(parsed) ? 0 : parsed,
+								});
+							}}
+						/>
 					</div>
-					<Input
-						type="number"
-						min={1}
-						value={String(value.netTermsDays)}
-						onChange={(e) => {
-							const parsed = Number.parseInt(e.target.value, 10);
-							onChange({
-								...value,
-								netTermsDays: Number.isNaN(parsed) ? 0 : parsed,
-							});
-						}}
-					/>
 				</div>
-			</div>
-		</SheetSection>
+			</SheetAccordionItem>
+		</SheetAccordion>
 	);
 }

--- a/vite/src/components/v2/inline-custom-plan-editor/PlanEditorContext.tsx
+++ b/vite/src/components/v2/inline-custom-plan-editor/PlanEditorContext.tsx
@@ -11,7 +11,9 @@ import {
 	type ReactNode,
 	useCallback,
 	useContext,
+	useEffect,
 	useMemo,
+	useRef,
 } from "react";
 import {
 	disabledItemDraftController,
@@ -22,11 +24,13 @@ import { useProductStore } from "@/hooks/stores/useProductStore";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { getItemId } from "@/utils/product/productItemUtils";
 
+type SetProduct = (
+	product: FrontendProduct | ((prev: FrontendProduct) => FrontendProduct),
+) => void;
+
 interface ProductContextValue {
 	product: FrontendProduct;
-	setProduct: (
-		product: FrontendProduct | ((prev: FrontendProduct) => FrontendProduct),
-	) => void;
+	setProduct: SetProduct;
 	initialProduct?: FrontendProduct;
 	sheetType: string | null;
 	itemId: string | null;
@@ -41,57 +45,49 @@ interface ProductContextValue {
 const ProductContext = createContext<ProductContextValue | null>(null);
 
 /**
+ * Returns the index of the feature item matching `itemId`, or -1 if none.
+ * Base-price and other non-feature items are skipped so indexes line up with
+ * the ids produced by getItemId().
+ */
+function findFeatureItemIndex(
+	product: FrontendProduct,
+	itemId: string,
+): number {
+	const items = product.items;
+	if (!items) return -1;
+
+	const featureItems = productV2ToFeatureItems({ items });
+
+	return items.findIndex((item, index) => {
+		if (!item || !featureItems.includes(item)) return false;
+		return getItemId({ item, itemIndex: index }) === itemId;
+	});
+}
+
+/** Compares two products field-by-field, hiding the V2 casts at a single site. */
+function compareProducts(
+	product: FrontendProduct,
+	other: FrontendProduct,
+	features: Parameters<typeof productsAreSame>[0]["features"],
+) {
+	return productsAreSame({
+		newProductV2: product as unknown as ProductV2,
+		curProductV2: other as unknown as ProductV2,
+		features,
+	});
+}
+
+/**
  * Provider that allows overriding the product and sheet state source.
  * When wrapped with this provider, child components will use the provided
  * values instead of the Zustand stores.
  */
 export function ProductProvider({
 	children,
-	product,
-	setProduct,
-	initialProduct,
-	sheetType,
-	itemId,
-	initialItem,
-	setSheet,
-	setInitialItem,
-	updateItemId,
-	closeSheet,
-	itemDraft,
-}: {
-	children: ReactNode;
-	product: FrontendProduct;
-	setProduct: (
-		product: FrontendProduct | ((prev: FrontendProduct) => FrontendProduct),
-	) => void;
-	initialProduct?: FrontendProduct;
-	sheetType: string | null;
-	itemId: string | null;
-	initialItem: ProductItem | null;
-	setSheet: (params: { type: string | null; itemId?: string | null }) => void;
-	setInitialItem: (item: ProductItem | null) => void;
-	updateItemId: (itemId: string) => void;
-	closeSheet: () => void;
-	itemDraft: ItemDraftController;
-}) {
+	...value
+}: ProductContextValue & { children: ReactNode }) {
 	return (
-		<ProductContext.Provider
-			value={{
-				product,
-				setProduct,
-				initialProduct,
-				sheetType,
-				itemId,
-				initialItem,
-				setSheet,
-				setInitialItem,
-				updateItemId,
-				closeSheet,
-				itemDraft,
-			}}
-		>
-			{children}
-		</ProductContext.Provider>
+		<ProductContext.Provider value={value}>{children}</ProductContext.Provider>
 	);
 }
 
@@ -119,14 +115,13 @@ export function useProduct() {
 /** Hook to get sheet state and actions. Uses context if available, otherwise Zustand. */
 export function useSheet() {
 	const context = useContext(ProductContext);
-	const storeSheetType = useSheetStore((s) => s.type);
-	const storeItemId = useSheetStore((s) => s.itemId);
-	const storeInitialItem = useSheetStore((s) => s.initialItem);
-	const storeSetSheet = useSheetStore((s) => s.setSheet);
-	const storeSetInitialItem = useSheetStore((s) => s.setInitialItem);
-	const storeCloseSheet = useSheetStore((s) => s.closeSheet);
-
-	const storeUpdateItemId = useSheetStore((s) => s.updateItemId);
+	const sheetType = useSheetStore((s) => s.type);
+	const itemId = useSheetStore((s) => s.itemId);
+	const initialItem = useSheetStore((s) => s.initialItem);
+	const setSheet = useSheetStore((s) => s.setSheet);
+	const setInitialItem = useSheetStore((s) => s.setInitialItem);
+	const updateItemId = useSheetStore((s) => s.updateItemId);
+	const closeSheet = useSheetStore((s) => s.closeSheet);
 
 	if (context) {
 		return {
@@ -142,13 +137,13 @@ export function useSheet() {
 	}
 
 	return {
-		sheetType: storeSheetType,
-		itemId: storeItemId,
-		initialItem: storeInitialItem,
-		setSheet: storeSetSheet,
-		setInitialItem: storeSetInitialItem,
-		updateItemId: storeUpdateItemId,
-		closeSheet: storeCloseSheet,
+		sheetType,
+		itemId,
+		initialItem,
+		setSheet,
+		setInitialItem,
+		updateItemId,
+		closeSheet,
 		itemDraft: disabledItemDraftController,
 	};
 }
@@ -158,33 +153,15 @@ export function useCurrentItem() {
 	const context = useContext(ProductContext);
 	const { product } = useProduct();
 	const { itemId } = useSheet();
+	const draftSession = context?.itemDraft.session;
 
 	return useMemo(() => {
 		if (!itemId || !product?.items) return null;
-		if (
-			context?.itemDraft.session &&
-			context.itemDraft.session.itemId === itemId
-		) {
-			return context.itemDraft.session.draftItem;
-		}
+		if (draftSession?.itemId === itemId) return draftSession.draftItem;
 
-		const featureItems = productV2ToFeatureItems({ items: product.items });
-
-		for (let i = 0; i < product.items.length; i++) {
-			const item = product.items[i];
-			if (!item) continue;
-
-			const isFeatureItem = featureItems.some((fi) => fi === item);
-			if (!isFeatureItem) continue;
-
-			const currentItemId = getItemId({ item, itemIndex: i });
-			if (currentItemId === itemId) {
-				return item;
-			}
-		}
-
-		return null;
-	}, [context?.itemDraft.session, product, itemId]);
+		const index = findFeatureItemIndex(product, itemId);
+		return index === -1 ? null : (product.items[index] ?? null);
+	}, [draftSession, product, itemId]);
 }
 
 /** Hook to set the current item being edited. Uses context if available, otherwise Zustand. */
@@ -199,32 +176,16 @@ export function useSetCurrentItem() {
 				return;
 			}
 
-			if (!product || !product.items || !itemId) return;
+			if (!product?.items || !itemId) return;
 
-			let originalIndex = -1;
-			for (let i = 0; i < product.items.length; i++) {
-				const item = product.items[i];
-				if (!item) continue;
+			const index = findFeatureItemIndex(product, itemId);
+			if (index === -1) return;
 
-				const currentItemId = getItemId({ item, itemIndex: i });
-				if (currentItemId === itemId) {
-					originalIndex = i;
-					break;
-				}
-			}
-
-			if (originalIndex === -1) return;
-
-			const newItemId = getItemId({
-				item: updatedItem,
-				itemIndex: originalIndex,
-			});
-			if (newItemId !== itemId) {
-				updateItemId(newItemId);
-			}
+			const newItemId = getItemId({ item: updatedItem, itemIndex: index });
+			if (newItemId !== itemId) updateItemId(newItemId);
 
 			const updatedItems = [...product.items];
-			updatedItems[originalIndex] = updatedItem;
+			updatedItems[index] = updatedItem;
 			setProduct({ ...product, items: updatedItems });
 		},
 		[itemDraft, itemId, product, setProduct, updateItemId],
@@ -238,47 +199,71 @@ export function useHasItemChanges() {
 	const { features = [] } = useFeaturesQuery();
 
 	return useMemo(() => {
-		if (itemDraft.session) {
-			const { same } = itemsAreSame({
-				item1: itemDraft.session.draftItem,
-				item2: itemDraft.session.initialItem,
-				features,
-			});
+		const session = itemDraft.session;
+		const item1 = session ? session.draftItem : item;
+		const item2 = session ? session.initialItem : initialItem;
 
-			return !same;
-		}
+		if (!item1 || !item2) return false;
 
-		if (!item || !initialItem) {
-			return false;
-		}
-
-		const { same } = itemsAreSame({
-			item1: item,
-			item2: initialItem,
-			features,
-		});
-
+		const { same } = itemsAreSame({ item1, item2, features });
 		return !same;
 	}, [itemDraft.session, item, initialItem, features]);
 }
 
-/** Hook to discard item changes (restore to initial state) and close the sheet. Uses context if available, otherwise Zustand. */
-export function useDiscardItemAndClose() {
-	const setCurrentItem = useSetCurrentItem();
-	const { initialItem, closeSheet, itemDraft } = useSheet();
+interface PlanSheetState {
+	hasChanges: boolean;
+	discard: () => void;
+}
 
-	return useCallback(() => {
-		if (itemDraft.session) {
-			itemDraft.discardItem();
-			closeSheet();
-			return;
-		}
+/**
+ * Drives a plan-level sheet's change tracking: snapshots the product when the
+ * sheet opens (keyed to its type, so it re-snapshots per sheet and clears on
+ * close), reports whether it has been edited since, and reverts to the snapshot
+ * on discard. Host agnostic across the Zustand and context editor flows.
+ */
+export function usePlanSheet(sheetType: string | null): PlanSheetState {
+	const { product, setProduct } = useProduct();
+	const initialProduct = useSheetStore((s) => s.initialProduct);
+	const setInitialProduct = useSheetStore((s) => s.setInitialProduct);
+	const { features = [] } = useFeaturesQuery();
 
-		if (initialItem) {
-			setCurrentItem(initialItem);
-		}
-		closeSheet();
-	}, [itemDraft, initialItem, setCurrentItem, closeSheet]);
+	const productRef = useRef(product);
+	productRef.current = product;
+
+	useEffect(() => {
+		if (!sheetType) return;
+		setInitialProduct(structuredClone(productRef.current));
+		return () => setInitialProduct(null);
+	}, [sheetType, setInitialProduct]);
+
+	const hasChanges = useMemo(() => {
+		if (!initialProduct) return false;
+
+		const {
+			itemsSame,
+			freeTrialsSame,
+			detailsSame,
+			configSame,
+			optionsSame,
+			billingControlsSame,
+		} = compareProducts(product, initialProduct, features);
+
+		return !(
+			itemsSame &&
+			freeTrialsSame &&
+			detailsSame &&
+			configSame &&
+			optionsSame &&
+			billingControlsSame
+		);
+	}, [product, initialProduct, features]);
+
+	const discard = useCallback(() => {
+		if (!initialProduct) return;
+		setProduct(structuredClone(initialProduct));
+	}, [initialProduct, setProduct]);
+
+	return { hasChanges, discard };
 }
 
 /** Hook to check if the product has unsaved changes compared to initial state. Only works in context mode. */
@@ -294,11 +279,11 @@ export function useHasPlanChanges() {
 
 		if (!initialProduct) return false;
 
-		const { itemsSame, freeTrialsSame } = productsAreSame({
-			newProductV2: product as unknown as ProductV2,
-			curProductV2: initialProduct as unknown as ProductV2,
+		const { itemsSame, freeTrialsSame } = compareProducts(
+			product,
+			initialProduct,
 			features,
-		});
+		);
 
 		const versionsSame = product.version === initialProduct.version;
 

--- a/vite/src/components/v2/sheet-overlay/SheetOverlay.tsx
+++ b/vite/src/components/v2/sheet-overlay/SheetOverlay.tsx
@@ -1,33 +1,19 @@
-import type { ProductItem } from "@autumn/shared";
 import { AnimatePresence, motion } from "motion/react";
 import { createPortal } from "react-dom";
-import {
-	useCurrentItem,
-	useHasItemChanges,
-	useSheet,
-} from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
+import { useSheet } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 
 /**
  * Determines if the sheet should close based on the mouse down event.
- * Handles edge cases like unsaved changes and input blur behavior.
+ * Clicking out while an input inside the sheet is focused blurs it first instead
+ * of closing, so a stray click after typing doesn't unexpectedly dismiss the sheet.
  */
 function shouldCloseSheetOnMouseDown({
 	e,
-	item,
 	sheetType,
-	hasItemChanges,
 }: {
 	e: React.MouseEvent<HTMLDivElement>;
-	item: ProductItem | null;
 	sheetType: string | null;
-	hasItemChanges: boolean;
 }): boolean {
-	// Don't close if item has unsaved changes
-	if (hasItemChanges) {
-		return false;
-	}
-
-	// Get the active element before blur happens
 	const activeElement = document.activeElement;
 
 	if (
@@ -35,29 +21,25 @@ function shouldCloseSheetOnMouseDown({
 		activeElement !== document.body &&
 		activeElement instanceof HTMLElement
 	) {
-		// Only apply blur behavior to inputs, textareas, and selects
 		const isInputElement =
 			activeElement.tagName === "INPUT" ||
 			activeElement.tagName === "TEXTAREA" ||
 			activeElement.tagName === "SELECT";
 
 		if (!isInputElement) {
-			// Not an input, proceed with normal close behavior
 			return !!sheetType;
 		}
 
-		// Check if the active element is within the sheet (not in the main content area)
 		const clickTarget = e.target as HTMLElement;
 		const isActiveInSheet = !clickTarget.contains(activeElement);
 
 		if (isActiveInSheet) {
 			activeElement.blur();
-			e.preventDefault(); // Prevent default to stop the click from propagating
+			e.preventDefault();
 			return false;
 		}
 	}
 
-	// If the click is outside the sheet and no input is focused, close the sheet
 	return !!sheetType;
 }
 
@@ -67,11 +49,9 @@ function shouldCloseSheetOnMouseDown({
  */
 export function SheetOverlay({ inline = false }: { inline?: boolean }) {
 	const { sheetType, closeSheet } = useSheet();
-	const item = useCurrentItem();
-	const hasItemChanges = useHasItemChanges();
 
 	const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
-		if (shouldCloseSheetOnMouseDown({ e, item, sheetType, hasItemChanges })) {
+		if (shouldCloseSheetOnMouseDown({ e, sheetType })) {
 			closeSheet();
 		}
 	};

--- a/vite/src/components/v2/sheets/PlanSheetFooter.tsx
+++ b/vite/src/components/v2/sheets/PlanSheetFooter.tsx
@@ -1,0 +1,67 @@
+import { ShortcutButton } from "@autumn/ui";
+import { motion } from "motion/react";
+import { cn } from "@/lib/utils";
+import { LAYOUT_TRANSITION } from "./SharedSheetComponents";
+
+interface PlanSheetFooterProps {
+	isDirty: boolean;
+	onDiscard: () => void;
+	onClose: () => void;
+	onConfirm: () => void;
+	confirmLabel: string;
+	closeLabel?: string;
+	discardLabel?: string;
+	confirmDisabled?: boolean;
+	isLoading?: boolean;
+	className?: string;
+}
+
+export function PlanSheetFooter({
+	isDirty,
+	onDiscard,
+	onClose,
+	onConfirm,
+	confirmLabel,
+	closeLabel = "Close",
+	discardLabel = "Discard",
+	confirmDisabled = false,
+	isLoading = false,
+	className,
+}: PlanSheetFooterProps) {
+	const handleLeftAction = () => {
+		if (isDirty) {
+			onDiscard();
+			return;
+		}
+		onClose();
+	};
+
+	return (
+		<motion.div
+			layout
+			transition={{ layout: LAYOUT_TRANSITION }}
+			className={cn(
+				"shrink-0 pt-2 px-4 pb-4 w-full grid grid-cols-2 gap-2 border-t border-border/40",
+				className,
+			)}
+		>
+			<ShortcutButton
+				variant="secondary"
+				className="w-full"
+				onClick={handleLeftAction}
+				singleShortcut={isDirty ? undefined : "escape"}
+			>
+				{isDirty ? discardLabel : closeLabel}
+			</ShortcutButton>
+			<ShortcutButton
+				className="w-full"
+				onClick={onConfirm}
+				metaShortcut="enter"
+				disabled={confirmDisabled}
+				isLoading={isLoading}
+			>
+				{confirmLabel}
+			</ShortcutButton>
+		</motion.div>
+	);
+}

--- a/vite/src/components/v2/sheets/PlanSheetFooterContainer.tsx
+++ b/vite/src/components/v2/sheets/PlanSheetFooterContainer.tsx
@@ -1,0 +1,29 @@
+import {
+	usePlanSheet,
+	useSheet,
+} from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
+import { PlanSheetFooter } from "@/components/v2/sheets/PlanSheetFooter";
+
+/**
+ * Footer for plan-level sheets (plan details, price). Surfaces a Discard/Close
+ * button based on whether the sheet has been edited since it opened, reverting on
+ * discard. Edits are live, so Save simply closes.
+ */
+export function PlanSheetFooterContainer({
+	sheetType,
+}: {
+	sheetType: string | null;
+}) {
+	const { closeSheet } = useSheet();
+	const { hasChanges, discard } = usePlanSheet(sheetType);
+
+	return (
+		<PlanSheetFooter
+			isDirty={hasChanges}
+			onDiscard={discard}
+			onClose={closeSheet}
+			onConfirm={closeSheet}
+			confirmLabel="Save"
+		/>
+	);
+}

--- a/vite/src/hooks/stores/useSheetStore.ts
+++ b/vite/src/hooks/stores/useSheetStore.ts
@@ -1,4 +1,4 @@
-import type { ProductItem } from "@autumn/shared";
+import type { FrontendProduct, ProductItem } from "@autumn/shared";
 import { useEffect } from "react";
 import { create } from "zustand";
 
@@ -54,6 +54,8 @@ interface SheetState {
 	data: Record<string, unknown> | null;
 	// Initial item state when sheet opened (for change detection)
 	initialItem: ProductItem | null;
+	// Initial product snapshot when a plan-level sheet opened (for change detection)
+	initialProduct: FrontendProduct | null;
 
 	// Actions
 	setSheet: (params: {
@@ -62,6 +64,7 @@ interface SheetState {
 		data?: Record<string, unknown> | null;
 	}) => void;
 	setInitialItem: (item: ProductItem | null) => void;
+	setInitialProduct: (product: FrontendProduct | null) => void;
 	updateItemId: (itemId: string) => void;
 	closeSheet: () => void;
 	reset: () => void;
@@ -74,6 +77,7 @@ const initialState = {
 	itemId: null as string | null,
 	data: null as Record<string, unknown> | null,
 	initialItem: null as ProductItem | null,
+	initialProduct: null as FrontendProduct | null,
 };
 
 export const useSheetStore = create<SheetState>((set) => ({
@@ -86,12 +90,16 @@ export const useSheetStore = create<SheetState>((set) => ({
 			type,
 			itemId,
 			data,
-			// Clear initialItem when sheet changes
+			// Clear snapshots when sheet changes
 			initialItem: null,
+			initialProduct: null,
 		})),
 
 	// Set the initial item state for change detection
 	setInitialItem: (item) => set({ initialItem: item }),
+
+	// Set the initial product snapshot for plan-level change detection
+	setInitialProduct: (product) => set({ initialProduct: product }),
 
 	// Update just the itemId without clearing other state
 	updateItemId: (itemId) => set({ itemId }),
@@ -104,6 +112,7 @@ export const useSheetStore = create<SheetState>((set) => ({
 			itemId: null,
 			data: null,
 			initialItem: null,
+			initialProduct: null,
 		})),
 
 	// Reset to initial state

--- a/vite/src/views/customers/components/filter-dropdown/FilterCheckboxSubMenu.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/FilterCheckboxSubMenu.tsx
@@ -1,0 +1,60 @@
+import { Checkbox } from "@autumn/ui";
+import {
+	DropdownMenuItem,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
+} from "@autumn/ui";
+import type { ReactNode } from "react";
+
+export type FilterCheckboxOption = {
+	value: string;
+	label: string;
+	icon?: ReactNode;
+};
+
+export const FilterCheckboxSubMenu = ({
+	label,
+	options,
+	selected,
+	onToggle,
+}: {
+	label: string;
+	options: FilterCheckboxOption[];
+	selected: string[];
+	onToggle: (value: string) => void;
+}) => (
+	<DropdownMenuSub>
+		<DropdownMenuSubTrigger className="flex items-center gap-2 cursor-pointer">
+			{label}
+			{selected.length > 0 && (
+				<span className="text-xs text-tertiary-foreground bg-muted px-1 py-0 rounded-md">
+					{selected.length}
+				</span>
+			)}
+		</DropdownMenuSubTrigger>
+		<DropdownMenuSubContent>
+			{options.map(({ value, label: optionLabel, icon }) => (
+				<DropdownMenuItem
+					key={value}
+					closeOnClick={false}
+					onClick={(e) => {
+						e.preventDefault();
+						e.stopPropagation();
+						onToggle(value);
+					}}
+					className="flex items-center gap-2 cursor-pointer text-sm"
+				>
+					<Checkbox checked={selected.includes(value)} className="border-border" />
+					{icon}
+					{optionLabel}
+				</DropdownMenuItem>
+			))}
+		</DropdownMenuSubContent>
+	</DropdownMenuSub>
+);
+
+export const toggleFilterValue = (selected: string[], value: string) =>
+	selected.includes(value)
+		? selected.filter((v) => v !== value)
+		: [...selected, value];

--- a/vite/src/views/customers/components/filter-dropdown/FilterStatusSubMenu.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/FilterStatusSubMenu.tsx
@@ -1,12 +1,18 @@
-import { Checkbox } from "@autumn/ui";
-import {
-	DropdownMenuItem,
-	DropdownMenuSub,
-	DropdownMenuSubContent,
-	DropdownMenuSubTrigger,
-} from "@autumn/ui";
 import { keyToTitle } from "@/utils/formatUtils/formatTextUtils";
 import { useCustomerFilters } from "../../hooks/useCustomerFilters";
+import {
+	type FilterCheckboxOption,
+	FilterCheckboxSubMenu,
+	toggleFilterValue,
+} from "./FilterCheckboxSubMenu";
+
+const STATUS_OPTIONS: FilterCheckboxOption[] = [
+	"active",
+	"past_due",
+	"canceled",
+	"free_trial",
+	"expired",
+].map((value) => ({ value, label: keyToTitle(value) }));
 
 export const FilterStatusSubMenu = ({
 	onChange,
@@ -14,59 +20,17 @@ export const FilterStatusSubMenu = ({
 	onChange?: () => void;
 }) => {
 	const { queryStates, setFilters } = useCustomerFilters();
-
-	const statuses: string[] = [
-		"active",
-		"past_due",
-		"canceled",
-		"free_trial",
-		"expired",
-	];
-	const selectedStatuses = queryStates.status || [];
-	const hasSelections = selectedStatuses.length > 0;
-
-	const toggleStatus = (status: string) => {
-		const selected = queryStates.status || [];
-		const isSelected = selected.includes(status);
-
-		const updated = isSelected
-			? selected.filter((s: string) => s !== status)
-			: [...selected, status];
-
-		setFilters({ status: updated });
-		onChange?.();
-	};
+	const selected = queryStates.status || [];
 
 	return (
-		<DropdownMenuSub>
-			<DropdownMenuSubTrigger className="flex items-center gap-2 cursor-pointer">
-				Status
-				{hasSelections && (
-					<span className="text-xs text-tertiary-foreground bg-muted px-1 py-0 rounded-md">
-						{selectedStatuses.length}
-					</span>
-				)}
-			</DropdownMenuSubTrigger>
-			<DropdownMenuSubContent>
-				{statuses.map((status: any) => {
-					const isActive = selectedStatuses.includes(status);
-					return (
-						<DropdownMenuItem
-							key={status}
-							closeOnClick={false}
-							onClick={(e) => {
-								e.preventDefault();
-								e.stopPropagation();
-								toggleStatus(status);
-							}}
-							className="flex items-center gap-2 cursor-pointer text-sm"
-						>
-							<Checkbox checked={isActive} className="border-border" />
-							{keyToTitle(status)}
-						</DropdownMenuItem>
-					);
-				})}
-			</DropdownMenuSubContent>
-		</DropdownMenuSub>
+		<FilterCheckboxSubMenu
+			label="Status"
+			options={STATUS_OPTIONS}
+			selected={selected}
+			onToggle={(value) => {
+				setFilters({ status: toggleFilterValue(selected, value) });
+				onChange?.();
+			}}
+		/>
 	);
 };

--- a/vite/src/views/customers/components/filter-dropdown/IntervalSubMenu.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/IntervalSubMenu.tsx
@@ -1,0 +1,32 @@
+import { BillingInterval } from "@autumn/shared";
+import { useCustomerFilters } from "../../hooks/useCustomerFilters";
+import {
+	type FilterCheckboxOption,
+	FilterCheckboxSubMenu,
+	toggleFilterValue,
+} from "./FilterCheckboxSubMenu";
+
+const INTERVAL_OPTIONS: FilterCheckboxOption[] = [
+	{ value: BillingInterval.Week, label: "Weekly" },
+	{ value: BillingInterval.Month, label: "Monthly" },
+	{ value: BillingInterval.Quarter, label: "Quarterly" },
+	{ value: BillingInterval.SemiAnnual, label: "Semi-annual" },
+	{ value: BillingInterval.Year, label: "Yearly" },
+];
+
+export const IntervalSubMenu = ({ onChange }: { onChange?: () => void }) => {
+	const { queryStates, setFilters } = useCustomerFilters();
+	const selected = queryStates.interval || [];
+
+	return (
+		<FilterCheckboxSubMenu
+			label="Interval"
+			options={INTERVAL_OPTIONS}
+			selected={selected}
+			onToggle={(value) => {
+				setFilters({ interval: toggleFilterValue(selected, value) });
+				onChange?.();
+			}}
+		/>
+	);
+};

--- a/vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx
@@ -32,9 +32,10 @@ export const ProcessorSubMenu = ({ onChange }: { onChange?: () => void }) => {
 	const selected = queryStates.processor || [];
 
 	const visibleOptions = PROCESSOR_OPTIONS.filter(({ value }) => {
+		if (value === "stripe") return true;
 		if (value === "revenuecat") return flags.revenuecat;
 		if (value === "vercel") return flags.vercel;
-		return true;
+		return false;
 	});
 
 	return (

--- a/vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx
@@ -1,90 +1,51 @@
-import { Checkbox } from "@autumn/ui";
 import { CoinVerticalIcon, TriangleIcon } from "@phosphor-icons/react";
-import {
-	DropdownMenuItem,
-	DropdownMenuSub,
-	DropdownMenuSubContent,
-	DropdownMenuSubTrigger,
-} from "@autumn/ui";
 import { RevenueCatIcon } from "@/components/v2/icons/AutumnIcons";
 import { useAutumnFlags } from "@/hooks/common/useAutumnFlags";
 import { useCustomerFilters } from "../../hooks/useCustomerFilters";
+import {
+	type FilterCheckboxOption,
+	FilterCheckboxSubMenu,
+	toggleFilterValue,
+} from "./FilterCheckboxSubMenu";
 
-type Processor = "stripe" | "revenuecat" | "vercel";
-
-const PROCESSORS: { value: Processor; label: string; icon: React.ReactNode }[] =
-	[
-		{
-			value: "stripe",
-			label: "Stripe",
-			icon: <CoinVerticalIcon size={14} weight="fill" />,
-		},
-		{
-			value: "revenuecat",
-			label: "RevenueCat",
-			icon: <RevenueCatIcon size={14} />,
-		},
-		{
-			value: "vercel",
-			label: "Vercel",
-			icon: <TriangleIcon size={14} weight="fill" />,
-		},
-	];
+const PROCESSOR_OPTIONS: FilterCheckboxOption[] = [
+	{
+		value: "stripe",
+		label: "Stripe",
+		icon: <CoinVerticalIcon size={14} weight="fill" />,
+	},
+	{
+		value: "revenuecat",
+		label: "RevenueCat",
+		icon: <RevenueCatIcon size={14} />,
+	},
+	{
+		value: "vercel",
+		label: "Vercel",
+		icon: <TriangleIcon size={14} weight="fill" />,
+	},
+];
 
 export const ProcessorSubMenu = ({ onChange }: { onChange?: () => void }) => {
 	const flags = useAutumnFlags();
 	const { queryStates, setFilters } = useCustomerFilters();
+	const selected = queryStates.processor || [];
 
-	const visibleProcessors = PROCESSORS.filter(({ value }) => {
-		if (value === "stripe") return true;
+	const visibleOptions = PROCESSOR_OPTIONS.filter(({ value }) => {
 		if (value === "revenuecat") return flags.revenuecat;
 		if (value === "vercel") return flags.vercel;
-		return false;
+		return true;
 	});
 
-	const selectedProcessors = queryStates.processor || [];
-	const hasSelections = selectedProcessors.length > 0;
-
-	const toggleProcessor = (processor: Processor) => {
-		const isSelected = selectedProcessors.includes(processor);
-		const updated = isSelected
-			? selectedProcessors.filter((p: string) => p !== processor)
-			: [...selectedProcessors, processor];
-
-		setFilters({ processor: updated });
-		onChange?.();
-	};
-
 	return (
-		<DropdownMenuSub>
-			<DropdownMenuSubTrigger className="flex items-center gap-2 cursor-pointer">
-				Processors
-				{hasSelections && (
-					<span className="text-xs text-tertiary-foreground bg-muted px-1 py-0 rounded-md">
-						{selectedProcessors.length}
-					</span>
-				)}
-			</DropdownMenuSubTrigger>
-			<DropdownMenuSubContent>
-				{visibleProcessors.map(({ value, label, icon }) => {
-					const isActive = selectedProcessors.includes(value);
-					return (
-						<DropdownMenuItem
-							key={value}
-							closeOnClick={false}
-							onClick={(e) => {
-								e.preventDefault();
-								toggleProcessor(value);
-							}}
-							className="flex items-center gap-2 cursor-pointer text-sm"
-						>
-							<Checkbox checked={isActive} className="border-border" />
-							{icon}
-							{label}
-						</DropdownMenuItem>
-					);
-				})}
-			</DropdownMenuSubContent>
-		</DropdownMenuSub>
+		<FilterCheckboxSubMenu
+			label="Processors"
+			options={visibleOptions}
+			selected={selected}
+			onToggle={(value) => {
+				setFilters({ processor: toggleFilterValue(selected, value) });
+				onChange?.();
+			}}
+		/>
 	);
 };

--- a/vite/src/views/customers/components/filter-dropdown/SavedViews.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/SavedViews.tsx
@@ -43,6 +43,7 @@ export const SavedViews = ({
 			const versionParam = params.get("version") || "";
 			const noneParam = params.get("none");
 			const processorParam = params.get("processor") || "";
+			const intervalParam = params.get("interval") || "";
 
 			setFilters({
 				q: params.get("q") || "",
@@ -51,6 +52,9 @@ export const SavedViews = ({
 				none: noneParam === "true",
 				processor: processorParam
 					? processorParam.split(",").filter(Boolean)
+					: [],
+				interval: intervalParam
+					? intervalParam.split(",").filter(Boolean)
 					: [],
 			});
 

--- a/vite/src/views/customers/hooks/useCusSearchQuery.tsx
+++ b/vite/src/views/customers/hooks/useCusSearchQuery.tsx
@@ -3,7 +3,10 @@ import { keepPreviousData, useQuery } from "@tanstack/react-query";
 
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
-import { useCustomerFilters } from "./useCustomerFilters";
+import {
+	buildCustomerFilterPayload,
+	useCustomerFilters,
+} from "./useCustomerFilters";
 
 export const useCusSearchQuery = () => {
 	const { queryStates, isInitialized, currentCursor } = useCustomerFilters();
@@ -17,12 +20,7 @@ export const useCusSearchQuery = () => {
 			search: trimmedSearch,
 			cursor: currentCursor,
 			limit: queryStates.pageSize,
-			filters: {
-				status: queryStates.status,
-				version: queryStates.version,
-				none: queryStates.none,
-				processor: queryStates.processor,
-			},
+			filters: buildCustomerFilterPayload(queryStates),
 		});
 		return {
 			customers: data.customers as CustomerWithProducts[],
@@ -33,12 +31,7 @@ export const useCusSearchQuery = () => {
 	const countFetcher = async () => {
 		const { data } = await axiosInstance.post(`/customers/all/count`, {
 			search: trimmedSearch,
-			filters: {
-				status: queryStates.status,
-				version: queryStates.version,
-				none: queryStates.none,
-				processor: queryStates.processor,
-			},
+			filters: buildCustomerFilterPayload(queryStates),
 		});
 		return data.totalCount as number;
 	};
@@ -61,6 +54,7 @@ export const useCusSearchQuery = () => {
 			queryStates.version,
 			queryStates.none,
 			queryStates.processor,
+			queryStates.interval,
 			trimmedSearch,
 		]),
 		queryFn: fetcher,
@@ -75,6 +69,7 @@ export const useCusSearchQuery = () => {
 			queryStates.version,
 			queryStates.none,
 			queryStates.processor,
+			queryStates.interval,
 			trimmedSearch,
 		]),
 		queryFn: countFetcher,

--- a/vite/src/views/customers/hooks/useCustomerFilters.tsx
+++ b/vite/src/views/customers/hooks/useCustomerFilters.tsx
@@ -26,6 +26,7 @@ const FILTER_PARAM_KEYS = [
 	"version",
 	"none",
 	"processor",
+	"interval",
 	"pageSize",
 ] as const;
 
@@ -34,6 +35,7 @@ type PersistedCustomerFilters = {
 	version: string[];
 	none: boolean;
 	processor: string[];
+	interval: string[];
 	pageSize: number;
 };
 
@@ -67,6 +69,7 @@ function buildRestoredState({
 		version: filters?.version?.length ? filters.version : null,
 		none: filters?.none ? true : null,
 		processor: filters?.processor?.length ? filters.processor : null,
+		interval: filters?.interval?.length ? filters.interval : null,
 		pageSize:
 			filters?.pageSize && filters.pageSize !== DEFAULT_CUSTOMER_LIST_PAGE_SIZE
 				? filters.pageSize
@@ -80,10 +83,31 @@ const queryStatesConfig = {
 	version: parseAsArrayOf(parseAsString).withDefault([]),
 	none: parseAsBoolean.withDefault(false),
 	processor: parseAsArrayOf(parseAsString).withDefault([]),
+	interval: parseAsArrayOf(parseAsString).withDefault([]),
 	pageSize: parseAsInteger.withDefault(DEFAULT_CUSTOMER_LIST_PAGE_SIZE),
 };
 
 type QueryStates = ReturnType<typeof useQueryStates<typeof queryStatesConfig>>;
+
+export function hasActiveCustomerFilters(queryStates: QueryStates[0]) {
+	return (
+		queryStates.status.length > 0 ||
+		queryStates.version.length > 0 ||
+		queryStates.none ||
+		queryStates.processor.length > 0 ||
+		queryStates.interval.length > 0
+	);
+}
+
+export function buildCustomerFilterPayload(queryStates: QueryStates[0]) {
+	return {
+		status: queryStates.status,
+		version: queryStates.version,
+		none: queryStates.none,
+		processor: queryStates.processor,
+		interval: queryStates.interval,
+	};
+}
 
 type CursorStack = string[];
 
@@ -177,6 +201,7 @@ export function CustomerFiltersProvider({ children }: { children: ReactNode }) {
 					version: queryStates.version,
 					none: queryStates.none,
 					processor: queryStates.processor,
+					interval: queryStates.interval,
 					pageSize: queryStates.pageSize,
 				}),
 			);
@@ -189,6 +214,7 @@ export function CustomerFiltersProvider({ children }: { children: ReactNode }) {
 		queryStates.version,
 		queryStates.none,
 		queryStates.processor,
+		queryStates.interval,
 		queryStates.pageSize,
 	]);
 

--- a/vite/src/views/customers/hooks/useFullCusSearchQuery.tsx
+++ b/vite/src/views/customers/hooks/useFullCusSearchQuery.tsx
@@ -2,7 +2,10 @@ import type { FullCustomer } from "@autumn/shared";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
-import { useCustomerFilters } from "./useCustomerFilters";
+import {
+	buildCustomerFilterPayload,
+	useCustomerFilters,
+} from "./useCustomerFilters";
 
 export const FULL_CUSTOMERS_QUERY_KEY = "full_customers";
 
@@ -23,6 +26,7 @@ export const useFullCusSearchQuery = () => {
 			queryStates.version,
 			queryStates.none,
 			queryStates.processor,
+			queryStates.interval,
 			queryStates.q,
 		]),
 		queryFn: async ({ signal }) => {
@@ -32,12 +36,7 @@ export const useFullCusSearchQuery = () => {
 					search: queryStates.q,
 					cursor: currentCursor,
 					limit: queryStates.pageSize,
-					filters: {
-						status: queryStates.status,
-						version: queryStates.version,
-						none: queryStates.none,
-						processor: queryStates.processor,
-					},
+					filters: buildCustomerFilterPayload(queryStates),
 				},
 				{ signal },
 			);

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListFilterButton.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListFilterButton.tsx
@@ -11,11 +11,15 @@ import {
 } from "@autumn/ui";
 import { cn } from "@/lib/utils";
 import { FilterStatusSubMenu } from "@/views/customers/components/filter-dropdown/FilterStatusSubMenu";
+import { IntervalSubMenu } from "@/views/customers/components/filter-dropdown/IntervalSubMenu";
 import { ProcessorSubMenu } from "@/views/customers/components/filter-dropdown/ProcessorSubMenu";
 import { ProductsSubMenu } from "@/views/customers/components/filter-dropdown/ProductsSubMenu";
 import { SaveViewPopover } from "@/views/customers/components/filter-dropdown/SavedViewPopover";
 import { SavedViews } from "@/views/customers/components/filter-dropdown/SavedViews";
-import { useCustomerFilters } from "@/views/customers/hooks/useCustomerFilters";
+import {
+	hasActiveCustomerFilters,
+	useCustomerFilters,
+} from "@/views/customers/hooks/useCustomerFilters";
 import { useSavedViewsQuery } from "@/views/customers/hooks/useSavedViewsQuery";
 
 interface CustomerListFilterButtonProps {
@@ -37,18 +41,20 @@ export function CustomerListFilterButton({
 	const [open, setOpen] = useState(false);
 
 	const hasActiveFilters =
-		hasActiveExtraFilters ||
-		queryStates.status.length > 0 ||
-		queryStates.version.length > 0 ||
-		queryStates.none ||
-		queryStates.processor.length > 0;
+		hasActiveExtraFilters || hasActiveCustomerFilters(queryStates);
 
 	const { data, refetch: refetchSavedViews } = useSavedViewsQuery();
 
 	const views = data?.views || [];
 
 	const clearFilters = () => {
-		setFilters({ status: [], version: [], none: false, processor: [] });
+		setFilters({
+			status: [],
+			version: [],
+			none: false,
+			processor: [],
+			interval: [],
+		});
 		onFilterChange?.();
 		onClearExtra?.();
 	};
@@ -84,6 +90,7 @@ export function CustomerListFilterButton({
 					{extraMenuItems}
 					<FilterStatusSubMenu onChange={onFilterChange} />
 					<ProductsSubMenu onChange={onFilterChange} />
+					<IntervalSubMenu onChange={onFilterChange} />
 					<ProcessorSubMenu onChange={onFilterChange} />
 				</DropdownMenuGroup>
 				<DropdownMenuSeparator className="m-0" />

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
@@ -11,7 +11,10 @@ import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useColumnVisibility } from "@autumn/ui";
 import { useEnv } from "@/utils/envUtils";
 import { pushPage } from "@/utils/genUtils";
-import { useCustomerFilters } from "@/views/customers/hooks/useCustomerFilters";
+import {
+	hasActiveCustomerFilters,
+	useCustomerFilters,
+} from "@/views/customers/hooks/useCustomerFilters";
 import { FULL_CUSTOMERS_QUERY_KEY } from "@/views/customers/hooks/useFullCusSearchQuery";
 import { useCustomerListColumns } from "@/views/customers2/hooks/useCustomerListColumns";
 import { useCustomerTable } from "@/views/customers2/hooks/useCustomerTable";
@@ -135,11 +138,7 @@ export function CustomerListTable({
 
 	const hasRows = table.getRowModel().rows.length > 0;
 	const hasSearchQuery = Boolean(queryStates.q?.trim());
-	const hasFilters =
-		queryStates.status.length > 0 ||
-		queryStates.version.length > 0 ||
-		queryStates.none ||
-		queryStates.processor.length > 0;
+	const hasFilters = hasActiveCustomerFilters(queryStates);
 	const hasActiveFiltersOrSearch = hasSearchQuery || hasFilters;
 
 	if (!hasRows && !hasActiveFiltersOrSearch && !isFetchingUncached) {

--- a/vite/src/views/migrations/migration/operations/MigrationOperationSheet.tsx
+++ b/vite/src/views/migrations/migration/operations/MigrationOperationSheet.tsx
@@ -197,7 +197,7 @@ function MigrationSheetInner({
 		<div className="flex flex-col h-full">
 			<div className="flex-1 overflow-y-auto">
 				{sheetType === "select-feature" && <SelectFeatureSheet />}
-				{sheetType === "edit-plan-price" && <EditPlanPriceSheet />}
+				{sheetType === "edit-plan-price" && <EditPlanPriceSheet hideFooter />}
 				{sheetType === "edit-feature" && currentItem && (
 					<ProductItemContext.Provider
 						value={{

--- a/vite/src/views/products/plan/ProductSheets.tsx
+++ b/vite/src/views/products/plan/ProductSheets.tsx
@@ -1,7 +1,6 @@
 import { type ProductItem, productV2ToFeatureItems } from "@autumn/shared";
 import { useEffect, useRef } from "react";
 import {
-	useDiscardItemAndClose,
 	useProduct,
 	useSheet,
 } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
@@ -35,8 +34,6 @@ export const ProductSheets = () => {
 		commitItem: commitItemDraft,
 		clearItemSession: clearItemDraftSession,
 	} = itemDraft;
-
-	const discardAndClose = useDiscardItemAndClose();
 
 	const featureItems = productV2ToFeatureItems({ items: product.items });
 
@@ -188,7 +185,7 @@ export const ProductSheets = () => {
 	return (
 		<InlineSheetPanel
 			isOpen={!!sheetType}
-			onClose={discardAndClose}
+			onClose={closeSheet}
 			transition={SHEET_ANIMATION}
 		>
 			{renderSheet()}

--- a/vite/src/views/products/plan/components/EditPlanPriceSheet.tsx
+++ b/vite/src/views/products/plan/components/EditPlanPriceSheet.tsx
@@ -1,28 +1,38 @@
-import { useProduct } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
+import {
+	useProduct,
+	useSheet,
+} from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 import { SheetHeader } from "@/components/v2/sheets/InlineSheet";
+import { PlanSheetFooterContainer } from "@/components/v2/sheets/PlanSheetFooterContainer";
 import { BasePriceSection } from "./edit-plan-details/BasePriceSection";
 import { PlanTypeSection } from "./edit-plan-details/PlanTypeSection";
 
 export function EditPlanPriceSheet({
 	isOnboarding,
+	hideFooter,
 }: {
 	isOnboarding?: boolean;
+	hideFooter?: boolean;
 }) {
 	const { product } = useProduct();
+	const { sheetType } = useSheet();
 
 	if (!product) return null;
 
 	return (
-		<div className="h-full overflow-y-auto overscroll-none [scrollbar-gutter:stable]">
-			{!isOnboarding && (
-				<SheetHeader
-					title={`Configure ${product.name ? `${product.name} ` : ""}Price`}
-					description="Set whether this plan is free or paid, and configure a base price"
-					// noSeparator={true}
-				/>
-			)}
-			<PlanTypeSection />
-			<BasePriceSection withSeparator={false} />
+		<div className="flex flex-col h-full overflow-hidden">
+			<div className="flex-1 overflow-y-auto overscroll-none [scrollbar-gutter:stable]">
+				{!isOnboarding && (
+					<SheetHeader
+						title={`Configure ${product.name ? `${product.name} ` : ""}Price`}
+						description="Set whether this plan is free or paid, and configure a base price"
+					/>
+				)}
+				<PlanTypeSection />
+				<BasePriceSection withSeparator={false} />
+			</div>
+
+			{!hideFooter && <PlanSheetFooterContainer sheetType={sheetType} />}
 		</div>
 	);
 }

--- a/vite/src/views/products/plan/components/EditPlanSheet.tsx
+++ b/vite/src/views/products/plan/components/EditPlanSheet.tsx
@@ -6,18 +6,19 @@ import {
 	SheetAccordionItem,
 } from "@autumn/ui";
 import { useState } from "react";
-import { useProduct } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
+import {
+	useProduct,
+	useSheet,
+} from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 import { SheetHeader } from "@/components/v2/sheets/InlineSheet";
+import { PlanSheetFooterContainer } from "@/components/v2/sheets/PlanSheetFooterContainer";
 import { AdditionalOptions } from "./edit-plan-details/AdditionalOptions";
 import { MainDetailsSection } from "./edit-plan-details/MainDetailsSection";
 import { MetadataEditor } from "./edit-plan-details/MetadataEditor";
 
 export function EditPlanSheet({ isOnboarding }: { isOnboarding?: boolean }) {
 	const { product, setProduct } = useProduct();
-
-	const basePrice = productV2ToBasePrice({ product });
-
-	const hasGroup = notNullish(product.group);
+	const { sheetType } = useSheet();
 
 	const hasMetadata = Object.keys(product.metadata ?? {}).length > 0;
 	const [metadataOpened, setMetadataOpened] = useState(false);
@@ -25,81 +26,83 @@ export function EditPlanSheet({ isOnboarding }: { isOnboarding?: boolean }) {
 
 	if (!product) return null;
 
+	const basePrice = productV2ToBasePrice({ product });
+	const hasGroup = notNullish(product.group);
 	const showAdvanced =
 		product.planType === "paid" &&
 		!basePrice?.price &&
 		product.basePriceType !== "usage";
 
 	return (
-		<div className="h-full overflow-y-auto overscroll-none [scrollbar-gutter:stable]">
-			{!isOnboarding && (
-				<SheetHeader
-					title={`Configure ${product.name ? product.name : "your new plan"}`}
-					description="Configure the details of this plan"
-					noSeparator={true}
-				/>
-			)}
-			<MainDetailsSection />
-			{/* <PlanTypeSection /> */}
-			{/* <BasePriceSection /> */}
+		<div className="flex flex-col h-full overflow-hidden">
+			<div className="flex-1 overflow-y-auto overscroll-none [scrollbar-gutter:stable]">
+				{!isOnboarding && (
+					<SheetHeader
+						title={`Configure ${product.name ? product.name : "your new plan"}`}
+						description="Configure the details of this plan"
+						noSeparator={true}
+					/>
+				)}
+				<MainDetailsSection />
+				<AdditionalOptions />
 
-			{/* <FreeTrialSection /> */}
-			<AdditionalOptions />
-
-			{!showAdvanced && (
-				<SheetAccordion type="single" withSeparator={false}>
-					<SheetAccordionItem value="advanced" title="Advanced">
-						<div className="space-y-4">
-							<AreaCheckbox
-								title="Group"
-								description="If your app has multiple groups of subscription tiers, you can choose which group this plan belongs to."
-								checked={hasGroup}
-								onCheckedChange={(checked) =>
-									setProduct({ ...product, group: checked ? "" : null })
-								}
-							>
-								{hasGroup && (
-									<Input
-										placeholder="Enter group name"
-										value={product.group ?? undefined}
-										onChange={(e) =>
-											setProduct({ ...product, group: e.target.value })
-										}
-									/>
-								)}
-							</AreaCheckbox>
-							<AreaCheckbox
-								title="Ignore past due"
-								description="Customers on this plan won't be treated as past due — balances keep resetting normally"
-								checked={product.config?.ignore_past_due}
-								onCheckedChange={(checked) =>
-									setProduct({
-										...product,
-										config: { ...product.config, ignore_past_due: checked },
-									})
-								}
-							/>
-							<AreaCheckbox
-								title="Metadata"
-								description="Arbitrary JSON for your own use (e.g. UI copy). Shared across every version of the plan."
-								checked={showMetadata}
-								onCheckedChange={(checked) => {
-									if (checked) {
-										setMetadataOpened(true);
-									} else {
-										setMetadataOpened(false);
-										setProduct({ ...product, metadata: {} });
+				{!showAdvanced && (
+					<SheetAccordion type="single" withSeparator={false}>
+						<SheetAccordionItem value="advanced" title="Advanced">
+							<div className="space-y-4">
+								<AreaCheckbox
+									title="Group"
+									description="If your app has multiple groups of subscription tiers, you can choose which group this plan belongs to."
+									checked={hasGroup}
+									onCheckedChange={(checked) =>
+										setProduct({ ...product, group: checked ? "" : null })
 									}
-								}}
-							>
-								{showMetadata && (
-									<MetadataEditor key={product.internal_id ?? product.id} />
-								)}
-							</AreaCheckbox>
-						</div>
-					</SheetAccordionItem>
-				</SheetAccordion>
-			)}
+								>
+									{hasGroup && (
+										<Input
+											placeholder="Enter group name"
+											value={product.group ?? undefined}
+											onChange={(e) =>
+												setProduct({ ...product, group: e.target.value })
+											}
+										/>
+									)}
+								</AreaCheckbox>
+								<AreaCheckbox
+									title="Ignore past due"
+									description="Customers on this plan won't be treated as past due — balances keep resetting normally"
+									checked={product.config?.ignore_past_due}
+									onCheckedChange={(checked) =>
+										setProduct({
+											...product,
+											config: { ...product.config, ignore_past_due: checked },
+										})
+									}
+								/>
+								<AreaCheckbox
+									title="Metadata"
+									description="Arbitrary JSON for your own use (e.g. UI copy). Shared across every version of the plan."
+									checked={showMetadata}
+									onCheckedChange={(checked) => {
+										if (checked) {
+											setMetadataOpened(true);
+										} else {
+											setMetadataOpened(false);
+											setProduct({ ...product, metadata: {} });
+										}
+									}}
+								>
+									{showMetadata && (
+										<MetadataEditor key={product.internal_id ?? product.id} />
+									)}
+								</AreaCheckbox>
+							</div>
+						</SheetAccordionItem>
+					</SheetAccordion>
+				)}
+			</div>
+
+			<PlanSheetFooterContainer sheetType={sheetType} />
 		</div>
 	);
 }

--- a/vite/src/views/products/plan/components/edit-plan-details/PlanTypeSection.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-details/PlanTypeSection.tsx
@@ -1,10 +1,7 @@
 import {
-	type BillingInterval,
 	isPriceItem,
-	notNullish,
 	type ProductItem,
 	ProductItemInterval,
-	productV2ToBasePrice,
 	productV2ToPlanType,
 } from "@autumn/shared";
 import { PanelButton } from "@autumn/ui";
@@ -13,87 +10,10 @@ import { IncludedUsageIcon } from "@/components/v2/icons/AutumnIcons";
 import { useProduct } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 import { SheetSection } from "@/components/v2/sheets/InlineSheet";
 
-export const PlanTypeSection = ({
-	withSeparator = true,
-}: {
-	withSeparator?: boolean;
-}) => {
+export const PlanTypeSection = () => {
 	const { product, setProduct } = useProduct();
 
 	const planType = productV2ToPlanType({ product });
-
-	// if (!product.items) return null;
-
-	const basePrice = productV2ToBasePrice({ product });
-
-	const handleDeleteBasePrice = () => {
-		setProduct({
-			...product,
-			items: product.items.filter((item: ProductItem) => !isPriceItem(item)),
-		});
-	};
-
-	const getBasePriceIndex = () => {
-		return product.items.findIndex(
-			(item: ProductItem) =>
-				item.price === basePrice?.price && isPriceItem(item),
-		);
-	};
-
-	const setItem = (item: ProductItem) => {
-		const newItems = [...product.items];
-		newItems[getBasePriceIndex()] = item;
-		setProduct({
-			...product,
-			items: newItems,
-		});
-	};
-
-	const handleUpdateBasePrice = ({
-		amount = "",
-		interval,
-		intervalCount,
-	}: {
-		amount?: string;
-		interval?: BillingInterval;
-		intervalCount?: number;
-	}) => {
-		const newItems = [...product.items];
-
-		// Find base price item by isBasePrice flag, not by price match
-		const basePriceIndex = newItems.findIndex((item: ProductItem) =>
-			isPriceItem(item),
-		);
-
-		if (basePriceIndex !== -1) {
-			const newAmount =
-				amount === ""
-					? amount
-					: notNullish(amount)
-						? Number.parseFloat(amount ?? "")
-						: basePrice?.price;
-
-			newItems[basePriceIndex] = {
-				...newItems[basePriceIndex],
-				price: newAmount as number,
-				interval: interval as unknown as ProductItemInterval,
-				// 	? billingToItemInterval({ billingInterval: interval })
-				// 	: basePrice?.interval,
-				interval_count: interval ? intervalCount : basePrice?.interval_count,
-			};
-		} else {
-			newItems.push({
-				price: Number.parseFloat(amount ?? "") as number,
-				interval: interval as unknown as ProductItemInterval,
-				interval_count: intervalCount,
-			});
-		}
-
-		setProduct({
-			...product,
-			items: newItems,
-		});
-	};
 
 	return (
 		<SheetSection title="Select Plan Type">
@@ -103,7 +23,6 @@ export const PlanTypeSection = ({
 						<PanelButton
 							isSelected={planType === "free"}
 							onClick={() => {
-								// handleDeleteBasePrice();
 								setProduct({
 									...product,
 									planType: "free",

--- a/vite/src/views/products/plan/components/edit-plan-feature/EditPlanFeatureSheet.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/EditPlanFeatureSheet.tsx
@@ -124,7 +124,7 @@ export function EditPlanFeatureSheet({
 		item.tiers[0].amount === 0 &&
 		!item.included_usage;
 
-	const hasChanges = hasItemChanges || isZeroPriceItem || !isUpdate;
+	const canConfirm = hasItemChanges || isZeroPriceItem || !isUpdate;
 
 	return (
 		<div className="flex flex-col h-full overflow-hidden">
@@ -218,7 +218,8 @@ export function EditPlanFeatureSheet({
 
 			{/* Footer stays at bottom */}
 			<SheetFooterActions
-				hasChanges={hasChanges}
+				isDirty={hasItemChanges}
+				canConfirm={canConfirm}
 				onBeforeCommit={handleBeforeCommit}
 			/>
 

--- a/vite/src/views/products/plan/components/edit-plan-feature/SheetFooterActions.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/SheetFooterActions.tsx
@@ -1,20 +1,21 @@
-import { Button, ShortcutButton } from "@autumn/ui";
 import {
 	useSetCurrentItem,
 	useSheet,
 } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
-import { cn } from "@/lib/utils";
+import { PlanSheetFooter } from "@/components/v2/sheets/PlanSheetFooter";
 import { useProductItemContext } from "@/views/products/product/product-item/ProductItemContext";
 
 export function SheetFooterActions({
-	hasChanges,
+	isDirty,
+	canConfirm,
 	onBeforeCommit,
 }: {
-	hasChanges: boolean;
+	isDirty: boolean;
+	canConfirm: boolean;
 	onBeforeCommit?: () => void;
 }) {
 	const { handleUpdateProductItem } = useProductItemContext();
-	const { initialItem, itemDraft } = useSheet();
+	const { initialItem, itemDraft, closeSheet } = useSheet();
 	const setCurrentItem = useSetCurrentItem();
 
 	const handleDiscard = () => {
@@ -33,25 +34,13 @@ export function SheetFooterActions({
 	};
 
 	return (
-		<div className={cn("shrink-0 p-4 border-t border-border/40")}>
-			<div className="flex gap-2 w-full">
-				<Button
-					variant="secondary"
-					onClick={handleDiscard}
-					disabled={!hasChanges}
-					className="flex-1"
-				>
-					Discard
-				</Button>
-				<ShortcutButton
-					metaShortcut="enter"
-					onClick={handleUpdateItem}
-					disabled={!hasChanges}
-					className="flex-1"
-				>
-					Update Plan Feature
-				</ShortcutButton>
-			</div>
-		</div>
+		<PlanSheetFooter
+			isDirty={isDirty}
+			onDiscard={handleDiscard}
+			onClose={closeSheet}
+			onConfirm={handleUpdateItem}
+			confirmLabel="Save"
+			confirmDisabled={!canConfirm}
+		/>
 	);
 }

--- a/vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/UsageLimit.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/UsageLimit.tsx
@@ -17,12 +17,10 @@ export function UsageLimit() {
 				let usage_limit: number | null;
 
 				if (checked) {
-					usage_limit = 100; // Default value
+					usage_limit = 100;
 				} else {
 					usage_limit = null;
 				}
-
-				console.log("checked", checked, "setting usage limit to", usage_limit);
 
 				setItem({
 					...item,

--- a/vite/src/views/products/plan/components/new-feature/NewFeatureSheet.tsx
+++ b/vite/src/views/products/plan/components/new-feature/NewFeatureSheet.tsx
@@ -83,7 +83,10 @@ export function NewFeatureSheet({ isOnboarding }: { isOnboarding?: boolean }) {
 
 			await refetch();
 
-			if (!product || !newFeature.id) return;
+			if (!product || !newFeature.id) {
+				setIsCreating(false);
+				return;
+			}
 
 			const newItem = getDefaultItem({
 				feature: featureV1ToDbFeature({ apiFeature: newFeature }),

--- a/vite/src/views/products/plan/components/new-feature/NewFeatureSheet.tsx
+++ b/vite/src/views/products/plan/components/new-feature/NewFeatureSheet.tsx
@@ -5,7 +5,6 @@ import {
 	FeatureUsageType,
 	featureV1ToDbFeature,
 } from "@autumn/shared";
-import { ShortcutButton } from "@autumn/ui";
 import type { AxiosError } from "axios";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -14,6 +13,7 @@ import {
 	useSheet,
 } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 import { SheetHeader } from "@/components/v2/sheets/InlineSheet";
+import { PlanSheetFooter } from "@/components/v2/sheets/PlanSheetFooter";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useFeatureStore } from "@/hooks/stores/useFeatureStore";
 import { FeatureService } from "@/services/FeatureService";
@@ -29,20 +29,20 @@ import { NewFeatureDetails } from "./NewFeatureDetails";
 import { NewFeatureType } from "./NewFeatureType";
 
 export function NewFeatureSheet({ isOnboarding }: { isOnboarding?: boolean }) {
-	// Save/restore onboarding context and reset feature store for fresh creation
-	// This hook always resets on mount, but only saves/restores when enabled
 	useSaveRestoreFeature({ enabled: !!isOnboarding });
 
 	const feature = useFeatureStore((s) => s.feature);
 	const setFeature = useFeatureStore((s) => s.setFeature);
+	const resetFeature = useFeatureStore((s) => s.reset);
 	const { product, setProduct } = useProduct();
 	const { setSheet } = useSheet();
 	const axiosInstance = useAxiosInstance();
 	const { refetch } = useFeaturesQuery();
 	const [isCreating, setIsCreating] = useState(false);
 
+	const isDirty = !!feature.name || !!feature.id || feature.type !== null;
+
 	const handleCreateFeature = async () => {
-		// Validate credit system specific fields first
 		if (feature.type === FeatureType.CreditSystem) {
 			const validationError = validateCreditSystem(feature);
 			if (validationError) {
@@ -54,104 +54,94 @@ export function NewFeatureSheet({ isOnboarding }: { isOnboarding?: boolean }) {
 		setIsCreating(true);
 		const result = CreateFeatureSchema.safeParse(feature);
 		if (result.error) {
-			console.log(result.error.issues);
 			toast.error("Invalid feature", {
-				description: result.error.issues.map((x) => x.message).join(".\n"),
+				description: result.error.issues
+					.map((issue) => issue.message)
+					.join(".\n"),
 			});
 			setIsCreating(false);
-		} else {
-			try {
-				const { data: newFeature } = await FeatureService.createFeature(
-					axiosInstance,
-					{
-						name: feature.name,
-						id: feature.id,
-						type: feature.type,
-						consumable: feature.config?.usage_type === FeatureUsageType.Single,
-						credit_schema: feature.config?.schema?.map(
-							(x: CreditSchemaItem) => ({
-								metered_feature_id: x.metered_feature_id,
-								credit_cost: x.credit_amount,
-							}),
-						),
-						event_names: feature.event_names,
-					},
-				);
+			return;
+		}
 
-				await refetch();
+		try {
+			const { data: newFeature } = await FeatureService.createFeature(
+				axiosInstance,
+				{
+					name: feature.name,
+					id: feature.id,
+					type: feature.type,
+					consumable: feature.config?.usage_type === FeatureUsageType.Single,
+					credit_schema: feature.config?.schema?.map(
+						(schemaItem: CreditSchemaItem) => ({
+							metered_feature_id: schemaItem.metered_feature_id,
+							credit_cost: schemaItem.credit_amount,
+						}),
+					),
+					event_names: feature.event_names,
+				},
+			);
 
-				if (!product || !newFeature.id) return;
+			await refetch();
 
-				// Create a new item with the created feature
-				const newItem = getDefaultItem({
-					feature: featureV1ToDbFeature({ apiFeature: newFeature }),
-				});
+			if (!product || !newFeature.id) return;
 
-				// Add the new item to the product
-				const newItems = [...(product.items || []), newItem];
-				const updatedProduct = { ...product, items: newItems };
-				setProduct(updatedProduct);
+			const newItem = getDefaultItem({
+				feature: featureV1ToDbFeature({ apiFeature: newFeature }),
+			});
 
-				// Open edit sidebar for the new item
-				// Use the actual index in newItems where the item was added (at the end)
-				// NOT featureItems.length - 1, which causes index mismatch on paid plans with base price items
-				const itemIndex = newItems.length - 1;
-				const itemId = getItemId({ item: newItem, itemIndex });
+			const newItems = [...(product.items || []), newItem];
+			setProduct({ ...product, items: newItems });
 
-				// Use setTimeout to ensure state updates propagate
-				setTimeout(() => {
-					setSheet({ type: "edit-feature", itemId });
-				}, 0);
-			} catch (error: unknown) {
-				toast.error(
-					getBackendErr(error as AxiosError, "Failed to create feature"),
-				);
-				setIsCreating(false);
-			}
+			const itemIndex = newItems.length - 1;
+			const itemId = getItemId({ item: newItem, itemIndex });
+
+			setTimeout(() => {
+				setSheet({ type: "edit-feature", itemId });
+			}, 0);
+		} catch (error: unknown) {
+			toast.error(
+				getBackendErr(error as AxiosError, "Failed to create feature"),
+			);
+			setIsCreating(false);
 		}
 	};
 
-	const handleCancel = () => {
-		// Always go back to edit-plan sheet
-		// In both onboarding and normal flow, this is the expected behavior
+	const handleClose = () => {
 		setSheet({ type: "edit-plan" });
 	};
 
+	const handleDiscard = () => {
+		resetFeature();
+	};
+
 	return (
-		<div className="flex flex-col h-full">
-			{!isOnboarding && (
-				<SheetHeader
-					title="New Feature"
-					description="Create a feature to represent what customers on this plan can use. After, you can configure its limits and prices for each plan."
-				/>
-			)}
+		<div className="flex flex-col h-full overflow-hidden">
+			<div className="flex-1 overflow-y-auto overscroll-none [scrollbar-gutter:stable]">
+				{!isOnboarding && (
+					<SheetHeader
+						title="New Feature"
+						description="Create a feature to represent what customers on this plan can use. After, you can configure its limits and prices for each plan."
+					/>
+				)}
 
-			<NewFeatureDetails feature={feature} setFeature={setFeature} />
+				<NewFeatureDetails feature={feature} setFeature={setFeature} />
 
-			<NewFeatureType feature={feature} setFeature={setFeature} />
+				<NewFeatureType feature={feature} setFeature={setFeature} />
 
-			<NewFeatureBehaviour feature={feature} setFeature={setFeature} />
+				<NewFeatureBehaviour feature={feature} setFeature={setFeature} />
 
-			<NewFeatureAdvanced feature={feature} setFeature={setFeature} />
-
-			<div className="mt-auto p-4 w-full flex-row grid grid-cols-2 gap-2">
-				<ShortcutButton
-					variant="secondary"
-					className="w-full"
-					onClick={handleCancel}
-					singleShortcut="escape"
-				>
-					Cancel
-				</ShortcutButton>
-				<ShortcutButton
-					className="w-full"
-					onClick={handleCreateFeature}
-					metaShortcut="enter"
-					isLoading={isCreating}
-				>
-					Create feature
-				</ShortcutButton>
+				<NewFeatureAdvanced feature={feature} setFeature={setFeature} />
 			</div>
+
+			<PlanSheetFooter
+				isDirty={isDirty}
+				onDiscard={handleDiscard}
+				onClose={handleClose}
+				onConfirm={handleCreateFeature}
+				confirmLabel="Create"
+				closeLabel="Cancel"
+				isLoading={isCreating}
+			/>
 		</div>
 	);
 }


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a billing interval filter to the customer list and unifies plan editor sheet footers with discard/close/save and per-sheet change tracking. Also moves invoice settings into a “More settings” accordion and improves click-out behavior in sheet overlays.

- **New Features**
  - Customers: filter by billing interval (week, month, quarter, semi-annual, year); wired through API queries, counts, and saved views; new Interval menu in the filter dropdown.
  - Plan editor: shared sheet footer with Discard/Close/Save, snapshots product on open and restores on discard; applied to plan details, price, new feature, and feature edit sheets.
  - Invoice settings: surfaced under a “More settings” accordion; template options built only when templates exist.

- **Bug Fixes**
  - New feature: prevent the Create button from staying in a loading state on early returns.
  - Processor filter: preserve explicit allowlist in visibility logic.
  - Overlays: clicking outside while an input is focused blurs first instead of closing; status/processor menus use a reusable checkbox submenu for consistency.

<sup>Written for commit 3436d4d51ca1f561b6121420e00fa7ec6d2d9635. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This release adds billing-interval filtering to the customer list (server + UI), refactors plan-sheet footers into a reusable `PlanSheetFooter`/`PlanSheetFooterContainer` with proper change-tracking via `usePlanSheet`, and consolidates the three filter sub-menus into a shared `FilterCheckboxSubMenu` component.

- **Improvements** — `IntervalSubMenu` + server-side `parseDashboardIntervalFilter` / EXISTS subquery let users filter the customer list by billing interval (week/month/quarter/semi-annual/year); SQL values are whitelist-validated and fully parameterised.
- **Improvements** — `PlanSheetFooter` replaces ad-hoc footer markup in four plan sheets, surfacing a context-aware Discard/Close toggle driven by the new `usePlanSheet` snapshot hook stored in Zustand.
- **Improvements** — `InvoiceSettingsSection` migrated to `SheetAccordion`, always surfacing net-payment-terms (previously hidden when no templates were configured); `FilterStatusSubMenu` and `ProcessorSubMenu` now delegate to the shared `FilterCheckboxSubMenu`.
</details>

<h3>Confidence Score: 3/5</h3>

The interval-filter backend and the footer/change-tracking refactor are both solid, but the removal of the overlay close-guard for dirty item sheets introduces a path where in-flight item edits can be silently applied to local product state without the user ever clicking Save.

The `SheetOverlay` previously blocked the backdrop close when an item had unsaved edits. That guard is gone, so a misclick now bypasses the Discard/Save flow entirely. In the Zustand (non-context) edit path, `setCurrentItem` has already written changes into `product.items`, leaving the product in an intermediate state with no automatic revert. Everything else in the PR is well-contained and correctly implemented.

`vite/src/components/v2/sheet-overlay/SheetOverlay.tsx` and `vite/src/components/v2/inline-custom-plan-editor/PlanEditorContext.tsx` need a second look to confirm the intended close-on-click behaviour and whether per-sheet-type snapshot resets fit the expected discard semantics.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/CusBatchService.ts | Adds interval filter support: computes `intervalFilters`, includes it in `requiresResolveStep`, and delegates to `CusSearchService.resolveInternalIdsByCursor` via the full `filters` object — correct since the resolve step handles the join. |
| server/src/internal/customers/CusSearchService.ts | Adds `dashboardIntervalFilterToRawSql` and wires interval into both the raw-SQL `productClauses` path and the Drizzle `filtersDrizzle` path; parameterized via `sql`${interval}`` so no injection risk. |
| server/src/internal/customers/getFullCusQuery.ts | Introduces `DashboardIntervalFilter` type, `parseDashboardIntervalFilter` (whitelist-validated), and `intervalFilterToCustomerListSql` EXISTS subquery; threaded cleanly into `getCustomerListFilterSql`. |
| vite/src/components/v2/sheet-overlay/SheetOverlay.tsx | Removes the `hasItemChanges` guard that previously prevented overlay-close when an item sheet had unsaved edits; clicking outside now always closes, potentially leaving in-flight item mutations in product state without an explicit save. |
| vite/src/components/v2/inline-custom-plan-editor/PlanEditorContext.tsx | Large refactor: extracts `findFeatureItemIndex`/`compareProducts` helpers, introduces `usePlanSheet` for plan-level change tracking via Zustand, removes `useDiscardItemAndClose`, simplifies `ProductProvider` props. Snapshot re-taken per sheet-type transition may surprise callers expecting full-session discard. |
| vite/src/components/v2/sheets/PlanSheetFooter.tsx | New reusable footer: shows "Discard" vs "Close" on the left button based on `isDirty`, with keyboard shortcuts (Escape/Cmd+Enter). Clean, no issues. |
| vite/src/components/v2/sheets/PlanSheetFooterContainer.tsx | Thin container wiring `usePlanSheet` to `PlanSheetFooter`; "Save" label confirmed as close-only (edits are live), consistent with surrounding architecture. |
| vite/src/views/customers/components/filter-dropdown/FilterCheckboxSubMenu.tsx | New generic checkbox sub-menu component extracting duplicated dropdown logic from Status and Processor sub-menus; well-structured with exported `toggleFilterValue` helper. |
| vite/src/views/customers/components/filter-dropdown/IntervalSubMenu.tsx | New interval filter sub-menu for billing intervals (week/month/quarter/semi-annual/year), correctly backed by `BillingInterval` enum and `useCustomerFilters`. |
| vite/src/views/customers/hooks/useCustomerFilters.tsx | Adds `interval` to filter params, exports `hasActiveCustomerFilters` and `buildCustomerFilterPayload` helpers reducing duplication across query hooks. |
| vite/src/components/forms/shared/InvoiceSettingsSection.tsx | Converts invoice settings from a conditional `SheetSection` (hidden when no templates) to a `SheetAccordion` that always shows net payment terms; template selector conditionally rendered only when templates exist. |
| vite/src/views/products/plan/components/EditPlanSheet.tsx | Wraps content in scrollable flex container and appends `PlanSheetFooterContainer` for plan-detail change tracking and discard/save UI. |
| vite/src/views/products/plan/components/EditPlanPriceSheet.tsx | Adds `hideFooter` prop for migration context and `PlanSheetFooterContainer` for the default plan editor; correctly passes `sheetType` from `useSheet()`. |
| vite/src/views/products/plan/components/new-feature/NewFeatureSheet.tsx | Refactors to `PlanSheetFooter`; discard resets the feature form (leaving sheet open so user can re-fill), close navigates back to edit-plan. Intentional two-step UX for dirty discard. |
| vite/src/views/migrations/migration/operations/MigrationOperationSheet.tsx | Passes `hideFooter` to `EditPlanPriceSheet` to suppress duplicate footer in migration context. Minimal, correct change. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as IntervalSubMenu
    participant Hook as useCustomerFilters
    participant Query as useCusSearchQuery
    participant API as /customers/all
    participant Batch as CusBatchService
    participant Search as CusSearchService
    participant DB as PostgreSQL

    UI->>Hook: "setFilters({ interval: [...] })"
    Hook->>Query: queryStates.interval updated
    Query->>API: "POST filters: { interval }"
    API->>Batch: getDashboardCursorPage(filters)
    Batch->>Batch: parseDashboardIntervalFilter(filters.interval)
    Batch->>Batch: "requiresResolveStep = intervalFilters.length > 0"
    Batch->>Search: resolveInternalIdsByCursor(filters)
    Search->>Search: buildSearchPredicates — intervalRaw via EXISTS subquery
    Search->>DB: "SELECT internal_id WHERE ... AND EXISTS(...interval = ANY(ARRAY[...]))"
    DB-->>Search: internalIds[]
    Search-->>Batch: "{ internalIds, peek }"
    Batch->>DB: getCursorPaginatedFullCusQuery(internalCustomerIds)
    DB-->>Batch: full customer rows
    Batch-->>API: "{ fullCustomers, next_cursor }"
    API-->>Query: CustomerWithProducts[]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as IntervalSubMenu
    participant Hook as useCustomerFilters
    participant Query as useCusSearchQuery
    participant API as /customers/all
    participant Batch as CusBatchService
    participant Search as CusSearchService
    participant DB as PostgreSQL

    UI->>Hook: "setFilters({ interval: [...] })"
    Hook->>Query: queryStates.interval updated
    Query->>API: "POST filters: { interval }"
    API->>Batch: getDashboardCursorPage(filters)
    Batch->>Batch: parseDashboardIntervalFilter(filters.interval)
    Batch->>Batch: "requiresResolveStep = intervalFilters.length > 0"
    Batch->>Search: resolveInternalIdsByCursor(filters)
    Search->>Search: buildSearchPredicates — intervalRaw via EXISTS subquery
    Search->>DB: "SELECT internal_id WHERE ... AND EXISTS(...interval = ANY(ARRAY[...]))"
    DB-->>Search: internalIds[]
    Search-->>Batch: "{ internalIds, peek }"
    Batch->>DB: getCursorPaginatedFullCusQuery(internalCustomerIds)
    DB-->>Batch: full customer rows
    Batch-->>API: "{ fullCustomers, next_cursor }"
    API-->>Query: CustomerWithProducts[]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/components/v2/sheet-overlay/SheetOverlay.tsx:49-55
**Guard removal changes close-on-overlay behaviour for dirty item sheets**

The previous `shouldCloseSheetOnMouseDown` checked `hasItemChanges` and returned `false` when the item had unsaved edits. That check is gone, so clicking the backdrop now calls `closeSheet()` unconditionally. In the Zustand (non-context) flow `setCurrentItem` writes edits directly into `product.items`, so closing the sheet leaves those in-flight mutations applied to the local product without going through the "Save" path (`handleUpdateProductItem`). A user who accidentally clicks outside while editing a feature item will lose the in-progress changes silently.

### Issue 2 of 2
vite/src/components/v2/inline-custom-plan-editor/PlanEditorContext.tsx:233-237
**`usePlanSheet` snapshot re-taken mid-session when sheet type changes**

The effect fires on every `sheetType` change. When a user modifies plan details ("edit-plan"), then navigates to the price sheet ("edit-plan-price"), the "edit-plan" footer unmounts (cleanup sets `initialProduct` to `null`) and the price sheet mounts immediately, snapshotting the already-modified product as its baseline. If the user later clicks "Discard" in the price sheet, they revert only the price changes, and the plan-detail modifications from the previous sheet survive. The discard is not a full revert to the pre-session state. This may be intentional but the doc comment on `usePlanSheet` describes it as "reverts to the snapshot", which is misleading here.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #2038 from useautumn/..."](https://github.com/useautumn/autumn/commit/3436d4d51ca1f561b6121420e00fa7ec6d2d9635) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39805163)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->