### PR TITLE
fix(revenuecat): paginate product list + raw-mappings escape hatch

### DIFF
--- a/server/src/external/revenueCat/misc/initRevenuecatCli.ts
+++ b/server/src/external/revenueCat/misc/initRevenuecatCli.ts
@@ -255,19 +255,25 @@ export const initRevenuecatCli = ({
 		},
 
 		listProducts: async () => {
-			const url = new URL(
-				`https://api.revenuecat.com/v2/projects/${projectId}/products`,
-			);
-			url.searchParams.set("limit", "20");
+			const items: RevenueCatProduct[] = [];
+			let nextPage:
+				| string
+				| null = `/v2/projects/${projectId}/products?limit=100`;
 
-			const response = await fetchImpl(url, { headers: authHeaders });
-			await checkOk(response);
-
-			const data = (await response.json()) as RevenueCatProductsResponse;
+			while (nextPage) {
+				const response = await fetchImpl(
+					new URL(`https://api.revenuecat.com${nextPage}`),
+					{ headers: authHeaders },
+				);
+				await checkOk(response);
+				const data = (await response.json()) as RevenueCatProductsResponse;
+				items.push(...data.items);
+				nextPage = data.next_page;
+			}
 
 			// Group products by store_identifier and combine names
 			const productMap = new Map<string, string[]>();
-			for (const product of data.items) {
+			for (const product of items) {
 				const existing = productMap.get(product.store_identifier);
 				if (existing) {
 					existing.push(product.display_name);

--- a/vite/src/views/developer/configure-revenuecat/ConfigureRevenueCat.tsx
+++ b/vite/src/views/developer/configure-revenuecat/ConfigureRevenueCat.tsx
@@ -280,6 +280,10 @@ export const ConfigureRevenueCat = () => {
 			<RevenueCatSyncSheet
 				open={showSyncSheet}
 				onOpenChange={setShowSyncSheet}
+				onEditRawMappings={() => {
+					setShowSyncSheet(false);
+					setShowMappingSheet(true);
+				}}
 			/>
 		</div>
 	);

--- a/vite/src/views/developer/configure-revenuecat/components/RevenueCatSyncSheet.tsx
+++ b/vite/src/views/developer/configure-revenuecat/components/RevenueCatSyncSheet.tsx
@@ -1,5 +1,6 @@
 import {
 	Badge,
+	Button,
 	Checkbox,
 	Sheet,
 	SheetContent,
@@ -27,6 +28,7 @@ import { getBackendErr } from "@/utils/genUtils";
 interface RevenueCatSyncSheetProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
+	onEditRawMappings: () => void;
 }
 
 type SyncAction = "create" | "rename" | "in_sync";
@@ -49,6 +51,7 @@ const getPriceWarning = (item?: RCPreflightItem): string | null => {
 export function RevenueCatSyncSheet({
 	open,
 	onOpenChange,
+	onEditRawMappings,
 }: RevenueCatSyncSheetProps) {
 	const env = useEnv();
 	const { org } = useOrg();
@@ -188,6 +191,13 @@ export function RevenueCatSyncSheet({
 				</div>
 
 				<SheetFooter>
+					<Button
+						variant="skeleton"
+						className="col-span-2 w-full"
+						onClick={onEditRawMappings}
+					>
+						Edit raw mappings
+					</Button>
 					<ShortcutButton
 						variant="secondary"
 						className="w-full"


### PR DESCRIPTION
## Why

Two RevenueCat mapping issues, reported by Rohit (org `runable`):

1. **Only 3 of 6 products mappable.** When mapping RevenueCat products onto Autumn plans, the "Add product…" dropdown was missing products. Root cause: `listProducts()` fetched `/v2/projects/{id}/products` with a hardcoded `limit=20` and **no pagination**. Projects with >20 RevenueCat products (runable has many legacy `runable_pro_*` + `runable_topup_*` entries) get truncated, and the target products fall outside the first 20. Confirmed in Axiom: the `/revenuecat/products` response for `runable` contained exactly the 3 products he *could* map and excluded exactly the 3 he *couldn't* (`runable_v3_5_monthly`, `runable_v3_100_monthly`, `runable_v3_100_yearly`).

2. **No escape hatch for OAuth users.** OAuth-path users only get the new Sync flow; there was no way to fall back to the original store-identifier mapping UI.

## Changes

- `server/.../initRevenuecatCli.ts` — `listProducts()` now paginates at 100/page following `next_page`, matching the existing `listAllProducts()` / `listWebhookIntegrations()` helpers in the same file. Grouping/return shape unchanged, so callers and the mapping UI need no changes.
- `vite/.../RevenueCatSyncSheet.tsx` — new full-width **"Edit raw mappings"** button at the top of the footer (above Cancel/Sync), gated behind a new `onEditRawMappings` prop. Only appears in the OAuth sync sheet.
- `vite/.../ConfigureRevenueCat.tsx` — wires the button to close the sync sheet and open the existing `RevenueCatMappingSheet`.

## Test

- `bun ts` green for both `@autumn/server` and `@autumn/vite` (also enforced by pre-push hook).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Paginate RevenueCat product fetches so all products appear in the mapping UI, and add an "Edit raw mappings" escape hatch in the OAuth sync sheet. Fixes truncated lists when a project has more than 20 products.

- **Bug Fixes**
  - `listProducts()` now follows `next_page` at 100/page to return all products, not just the first 20.

- **New Features**
  - Added a full-width "Edit raw mappings" button to the OAuth sync sheet that opens the original store-identifier mapping sheet.

<sup>Written for commit a87b4b3050240a11363176a70909d38db5b08143. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two RevenueCat mapping issues: product list truncation (only the first 20 of potentially many products were fetched) and the lack of a raw-mapping escape hatch for OAuth users.

- **Bug fix**: `listProducts()` in `initRevenuecatCli.ts` now paginates at 100/page following `next_page`, matching the pattern already used by `listAllProducts()` and other helpers — resolving the missing-products bug for projects with >20 RC products.
- **Improvement**: `RevenueCatSyncSheet` gains an \"Edit raw mappings\" footer button wired via a new `onEditRawMappings` prop, letting OAuth users fall back to the manual store-identifier mapping UI from the sync sheet.
- **Improvement**: `ConfigureRevenueCat` wires the new callback to close the sync sheet and open the existing `RevenueCatMappingSheet`.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge — the pagination fix is a targeted, low-risk correction, and the new UI button has a single wired call site.

Both changes are well-scoped. The pagination loop in `listProducts` mirrors the existing `listAllProducts` helper exactly, making the fix easy to verify. The new "Edit raw mappings" button introduces a required prop on `RevenueCatSyncSheet`, but the only call site (`ConfigureRevenueCat`) was updated in the same PR. No data mutations, no new network paths, and the grouping/return shape of `listProducts` is unchanged.

No files require special attention; the two style suggestions are minor quality improvements that do not affect runtime behaviour.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/revenueCat/misc/initRevenuecatCli.ts | Fixes product truncation by replacing the hardcoded limit=20 single-fetch in `listProducts` with a paginated loop at 100/page, matching the existing helpers. The new loop is a verbatim copy of `listAllProducts`, which is a minor duplication but does not affect correctness. |
| vite/src/views/developer/configure-revenuecat/components/RevenueCatSyncSheet.tsx | Adds an "Edit raw mappings" escape-hatch button to the sheet footer via a new required `onEditRawMappings` prop; the button is always rendered rather than conditionally gated, but currently has only one call site so no breakage occurs. |
| vite/src/views/developer/configure-revenuecat/ConfigureRevenueCat.tsx | Wires `onEditRawMappings` to close the sync sheet and open the mapping sheet; minimal, correct change. |


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User (OAuth)
    participant SS as RevenueCatSyncSheet
    participant CC as ConfigureRevenueCat
    participant MS as RevenueCatMappingSheet
    participant RC as RevenueCat API

    U->>CC: click "Sync"
    CC->>SS: "open (showSyncSheet=true)"
    SS->>RC: "listProducts() — page 1 (limit=100)"
    RC-->>SS: "{ items, next_page }"
    SS->>RC: listProducts() — page 2…N
    RC-->>SS: "{ items, next_page: null }"
    SS-->>U: show full product list

    U->>SS: click "Edit raw mappings"
    SS->>CC: onEditRawMappings()
    CC->>SS: setShowSyncSheet(false)
    CC->>MS: setShowMappingSheet(true)
    MS-->>U: manual store-identifier mapping UI
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User (OAuth)
    participant SS as RevenueCatSyncSheet
    participant CC as ConfigureRevenueCat
    participant MS as RevenueCatMappingSheet
    participant RC as RevenueCat API

    U->>CC: click "Sync"
    CC->>SS: "open (showSyncSheet=true)"
    SS->>RC: "listProducts() — page 1 (limit=100)"
    RC-->>SS: "{ items, next_page }"
    SS->>RC: listProducts() — page 2…N
    RC-->>SS: "{ items, next_page: null }"
    SS-->>U: show full product list

    U->>SS: click "Edit raw mappings"
    SS->>CC: onEditRawMappings()
    CC->>SS: setShowSyncSheet(false)
    CC->>MS: setShowMappingSheet(true)
    MS-->>U: manual store-identifier mapping UI
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/external/revenueCat/misc/initRevenuecatCli.ts`, line 257-291 ([link](https://github.com/useautumn/autumn/blob/a87b4b3050240a11363176a70909d38db5b08143/server/src/external/revenueCat/misc/initRevenuecatCli.ts#L257-L291)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Pagination loop duplicates `listAllProducts`**

   The new pagination block in `listProducts` (lines 258–272) is identical to the one already present in `listAllProducts` (lines 154–172). `listProducts` could simply call `listAllProducts` internally and then apply the grouping step, eliminating the duplicated loop. As more callers are added or the pagination pattern needs changing, having two copies increases the maintenance surface.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/external/revenueCat/misc/initRevenuecatCli.ts
   Line: 257-291

   Comment:
   **Pagination loop duplicates `listAllProducts`**

   The new pagination block in `listProducts` (lines 258–272) is identical to the one already present in `listAllProducts` (lines 154–172). `listProducts` could simply call `listAllProducts` internally and then apply the grouping step, eliminating the duplicated loop. As more callers are added or the pagination pattern needs changing, having two copies increases the maintenance surface.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
server/src/external/revenueCat/misc/initRevenuecatCli.ts:257-291
**Pagination loop duplicates `listAllProducts`**

The new pagination block in `listProducts` (lines 258–272) is identical to the one already present in `listAllProducts` (lines 154–172). `listProducts` could simply call `listAllProducts` internally and then apply the grouping step, eliminating the duplicated loop. As more callers are added or the pagination pattern needs changing, having two copies increases the maintenance surface.

### Issue 2 of 3
vite/src/views/developer/configure-revenuecat/components/RevenueCatSyncSheet.tsx:28-32
`onEditRawMappings` is declared as a required prop but the button it drives is intended as an optional escape hatch. If `RevenueCatSyncSheet` is ever reused in a context where the raw-mappings flow isn't applicable, callers will be forced to provide a no-op callback. Making the prop optional and conditionally rendering the button is more defensive and matches the PR description's "only appears" framing.

```suggestion
interface RevenueCatSyncSheetProps {
	open: boolean;
	onOpenChange: (open: boolean) => void;
	onEditRawMappings?: () => void;
}
```

### Issue 3 of 3
vite/src/views/developer/configure-revenuecat/components/RevenueCatSyncSheet.tsx:193-200
**Conditionally render the button when prop is optional**

If `onEditRawMappings` is later made optional (see the interface suggestion), the button should be wrapped in `{onEditRawMappings && (...)}` so it only renders when the prop is provided. As written with a required prop there is no immediate problem, but pairing the conditional render with an optional prop keeps the "only appears for OAuth users" semantics described in the PR clean for future call sites.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(revenuecat): paginate product list +..."](https://github.com/useautumn/autumn/commit/a87b4b3050240a11363176a70909d38db5b08143) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39814819)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->