### PR TITLE
chore: fix plan types logic

### DIFF
--- a/server/tests/unit/products/product-v2-one-off-classification.test.ts
+++ b/server/tests/unit/products/product-v2-one-off-classification.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import {
+	ProductItemFeatureType,
+	ProductItemInterval,
+	UsageModel,
+	type ProductItem,
+	isOneOffProductV2,
+	type ProductV2,
+} from "@autumn/shared";
+import { productV2ToProperties } from "../../../../shared/utils/productV2Utils/productV2ToProperties.js";
+
+const prepaidSeats = (priceInterval: ProductItemInterval | null): ProductItem =>
+	({
+		feature_id: "seats",
+		feature_type: ProductItemFeatureType.ContinuousUse,
+		included_usage: 90,
+		interval: null,
+		price_interval: priceInterval,
+		usage_model: UsageModel.Prepaid,
+		price: 90,
+	}) as ProductItem;
+
+describe("product v2 one-off classification", () => {
+	test("prepaid priced features with recurring price intervals are subscriptions", () => {
+		const items = [prepaidSeats(ProductItemInterval.Year)];
+
+		expect(isOneOffProductV2({ items })).toBe(false);
+		expect(
+			productV2ToProperties({
+				productV2: { items } as ProductV2,
+				trialAvailable: false,
+			}).is_one_off,
+		).toBe(false);
+	});
+
+	test("priced items without a recurring price interval are one-off", () => {
+		const items = [prepaidSeats(null)];
+
+		expect(isOneOffProductV2({ items })).toBe(true);
+		expect(
+			productV2ToProperties({
+				productV2: { items } as ProductV2,
+				trialAvailable: false,
+			}).is_one_off,
+		).toBe(true);
+	});
+});

--- a/shared/utils/productUtils/productUtils.ts
+++ b/shared/utils/productUtils/productUtils.ts
@@ -11,7 +11,9 @@ import {
 	isFeaturePriceItem,
 	isPriceItem,
 } from "../productV2Utils/productItemUtils/getItemType.js";
+import { itemToBillingInterval } from "../productV2Utils/productItemUtils/itemIntervalUtils.js";
 import { nullish } from "../utils.js";
+import { BillingInterval } from "../../models/productModels/intervals/billingInterval.js";
 
 export const isDefaultTrialV2 = ({
 	freeTrial,
@@ -32,14 +34,14 @@ export const isDefaultTrialV2 = ({
 };
 
 export const isOneOffProductV2 = ({ items }: { items: ProductItem[] }) => {
+	const pricedItems = items.filter(
+		(i) => isPriceItem(i) || isFeaturePriceItem(i),
+	);
 	return (
-		items.some((i) => isPriceItem(i) || isFeaturePriceItem(i)) &&
-		items.every((i) => {
-			if (isPriceItem(i) || isFeaturePriceItem(i)) {
-				return i.interval === null;
-			}
-			return true;
-		})
+		pricedItems.length > 0 &&
+		pricedItems.every(
+			(i) => itemToBillingInterval({ item: i }) === BillingInterval.OneOff,
+		)
 	);
 };
 

--- a/shared/utils/productV2Utils/productV2ToProperties.ts
+++ b/shared/utils/productV2Utils/productV2ToProperties.ts
@@ -25,11 +25,15 @@ export const productV2ToProperties = ({
 	// 1. Is free
 	const isFree = items.every(isFeatureItem);
 
+	const pricedItems = items.filter(
+		(i) => isPriceItem(i) || isFeaturePriceItem(i),
+	);
 	const isOneOff =
 		!isFree &&
-		items
-			.filter((i) => isPriceItem(i) || isFeaturePriceItem(i))
-			.some((i) => i.interval === null);
+		pricedItems.length > 0 &&
+		pricedItems.every(
+			(i) => itemToBillingInterval({ item: i }) === BillingInterval.OneOff,
+		);
 
 	// Get largest interval
 	// Interval group:


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix plan type classification in Product V2. Priced items with recurring price intervals are now subscriptions; plans are marked one-off only when all priced items are one-off.

- **Bug Fixes**
  - Use `itemToBillingInterval` to classify only priced items and require all to be `OneOff`.
  - Update `isOneOffProductV2` and `productV2ToProperties` to use consistent billing interval logic.
  - Prevent misclassifying prepaid features with recurring intervals as one-off.

- **Tests**
  - Add unit tests for prepaid features with yearly interval (subscription) and no interval (one-off).

<sup>Written for commit 80ad992ffa53dfa51a9ba41c62c8fbdd0a98f734. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related bugs in product one-off classification where `price_interval` was not being considered alongside `interval` when determining if a product is a one-off purchase, and aligns the `every`/`some` semantics between `isOneOffProductV2` and `productV2ToProperties`.

- **Bug fixes** — `isOneOffProductV2` previously checked only `i.interval === null`; it now delegates to `itemToBillingInterval` which correctly resolves `price_interval ?? interval`, preventing prepaid items with a recurring `price_interval` from being misclassified as one-off.
- **Bug fixes** — `productV2ToProperties.isOneOff` previously returned `true` when _any_ priced item had a null interval (`some`); it now requires _all_ priced items to be one-off (`every`), matching `isOneOffProductV2` semantics.
- **Improvements** — A new unit test suite (`product-v2-one-off-classification.test.ts`) directly exercises both functions for the affected edge case.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are targeted bug fixes with well-scoped logic and accompanying unit tests.

Both utility functions are corrected consistently, the new itemToBillingInterval delegation is already used elsewhere in the codebase for the same purpose, and the added tests directly exercise the fixed edge case. No unguarded regressions were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/productUtils/productUtils.ts | isOneOffProductV2 now checks price_interval ?? interval via itemToBillingInterval instead of only interval, fixing misclassification of prepaid items with a recurring price_interval |
| shared/utils/productV2Utils/productV2ToProperties.ts | isOneOff logic corrected from some(interval === null) to every(itemToBillingInterval === OneOff), aligning semantics with isOneOffProductV2 |
| server/tests/unit/products/product-v2-one-off-classification.test.ts | New unit tests covering both functions for prepaid items with and without a recurring price_interval; validates the core bug fix |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ProductItem] --> B{isPriceItem or isFeaturePriceItem?}
    B -- No --> C[Skip — not a priced item]
    B -- Yes --> D[itemToBillingInterval]
    D --> E{price_interval is set?}
    E -- Yes --> F[Use price_interval]
    E -- No --> G{interval is set?}
    G -- Yes --> H[Use interval]
    G -- No --> I[BillingInterval.OneOff]
    F --> J{== OneOff?}
    H --> J
    I --> J
    J -- No --> K[Item is recurring]
    J -- Yes --> L[Item is one-off]
    K --> M{ALL priced items one-off?}
    L --> M
    M -- All OneOff --> N[isOneOff = true]
    M -- Any recurring --> O[isOneOff = false]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ProductItem] --> B{isPriceItem or isFeaturePriceItem?}
    B -- No --> C[Skip — not a priced item]
    B -- Yes --> D[itemToBillingInterval]
    D --> E{price_interval is set?}
    E -- Yes --> F[Use price_interval]
    E -- No --> G{interval is set?}
    G -- Yes --> H[Use interval]
    G -- No --> I[BillingInterval.OneOff]
    F --> J{== OneOff?}
    H --> J
    I --> J
    J -- No --> K[Item is recurring]
    J -- Yes --> L[Item is one-off]
    K --> M{ALL priced items one-off?}
    L --> M
    M -- All OneOff --> N[isOneOff = true]
    M -- Any recurring --> O[isOneOff = false]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix plan types logic"](https://github.com/useautumn/autumn/commit/80ad992ffa53dfa51a9ba41c62c8fbdd0a98f734) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39830558)</sub>

<!-- /greptile_comment -->