### PR TITLE
chore: fix plan types logic

### DIFF
--- a/server/tests/unit/products/product-v2-one-off-classification.test.ts
+++ b/server/tests/unit/products/product-v2-one-off-classification.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import {
+	ProductItemFeatureType,
+	ProductItemInterval,
+	UsageModel,
+	type ProductItem,
+	isOneOffProductV2,
+	type ProductV2,
+} from "@autumn/shared";
+import { productV2ToProperties } from "../../../../shared/utils/productV2Utils/productV2ToProperties.js";
+
+const prepaidSeats = (priceInterval: ProductItemInterval | null): ProductItem =>
+	({
+		feature_id: "seats",
+		feature_type: ProductItemFeatureType.ContinuousUse,
+		included_usage: 90,
+		interval: null,
+		price_interval: priceInterval,
+		usage_model: UsageModel.Prepaid,
+		price: 90,
+	}) as ProductItem;
+
+describe("product v2 one-off classification", () => {
+	test("prepaid priced features with recurring price intervals are subscriptions", () => {
+		const items = [prepaidSeats(ProductItemInterval.Year)];
+
+		expect(isOneOffProductV2({ items })).toBe(false);
+		expect(
+			productV2ToProperties({
+				productV2: { items } as ProductV2,
+				trialAvailable: false,
+			}).is_one_off,
+		).toBe(false);
+	});
+
+	test("priced items without a recurring price interval are one-off", () => {
+		const items = [prepaidSeats(null)];
+
+		expect(isOneOffProductV2({ items })).toBe(true);
+		expect(
+			productV2ToProperties({
+				productV2: { items } as ProductV2,
+				trialAvailable: false,
+			}).is_one_off,
+		).toBe(true);
+	});
+});

--- a/shared/utils/productUtils/productUtils.ts
+++ b/shared/utils/productUtils/productUtils.ts
@@ -11,7 +11,9 @@ import {
 	isFeaturePriceItem,
 	isPriceItem,
 } from "../productV2Utils/productItemUtils/getItemType.js";
+import { itemToBillingInterval } from "../productV2Utils/productItemUtils/itemIntervalUtils.js";
 import { nullish } from "../utils.js";
+import { BillingInterval } from "../../models/productModels/intervals/billingInterval.js";
 
 export const isDefaultTrialV2 = ({
 	freeTrial,
@@ -32,14 +34,14 @@ export const isDefaultTrialV2 = ({
 };
 
 export const isOneOffProductV2 = ({ items }: { items: ProductItem[] }) => {
+	const pricedItems = items.filter(
+		(i) => isPriceItem(i) || isFeaturePriceItem(i),
+	);
 	return (
-		items.some((i) => isPriceItem(i) || isFeaturePriceItem(i)) &&
-		items.every((i) => {
-			if (isPriceItem(i) || isFeaturePriceItem(i)) {
-				return i.interval === null;
-			}
-			return true;
-		})
+		pricedItems.length > 0 &&
+		pricedItems.every(
+			(i) => itemToBillingInterval({ item: i }) === BillingInterval.OneOff,
+		)
 	);
 };
 

--- a/shared/utils/productV2Utils/productV2ToProperties.ts
+++ b/shared/utils/productV2Utils/productV2ToProperties.ts
@@ -25,11 +25,15 @@ export const productV2ToProperties = ({
 	// 1. Is free
 	const isFree = items.every(isFeatureItem);
 
+	const pricedItems = items.filter(
+		(i) => isPriceItem(i) || isFeaturePriceItem(i),
+	);
 	const isOneOff =
 		!isFree &&
-		items
-			.filter((i) => isPriceItem(i) || isFeaturePriceItem(i))
-			.some((i) => i.interval === null);
+		pricedItems.length > 0 &&
+		pricedItems.every(
+			(i) => itemToBillingInterval({ item: i }) === BillingInterval.OneOff,
+		);
 
 	// Get largest interval
 	// Interval group:


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes plan type classification for Product V2. One-off plans are now detected only when all priced items resolve to the OneOff billing interval; recurring price intervals are treated as subscriptions.

- **Bug Fixes**
  - Updated isOneOffProductV2 to use `itemToBillingInterval` and check only priced items.
  - Aligned productV2ToProperties `is_one_off` with the same logic.
  - Added unit tests covering prepaid items with yearly price intervals (subscription) and null intervals (one-off).

<sup>Written for commit de3fa2296aaac26077ac3ecbc4767516c18bbf03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the one-off product classification logic to correctly account for `price_interval` alongside `interval` when determining whether a product is a one-off purchase, and aligns the semantics in both `isOneOffProductV2` and `productV2ToProperties` to use `every` rather than `some`.

- **Bug fixes** — `isOneOffProductV2` now uses `itemToBillingInterval` (`price_interval ?? interval`) instead of checking only `i.interval === null`, so prepaid items with a recurring `price_interval` are no longer misclassified as one-off.
- **Bug fixes** — `productV2ToProperties` switches its `isOneOff` check from `.some(interval === null)` to `.every(itemToBillingInterval === OneOff)`, preventing a product with mixed recurring and null-interval items from being wrongly marked one-off.
- **Improvements** — A new unit test covers both classification cases (recurring `price_interval` → subscription, null `price_interval` → one-off) for both `isOneOffProductV2` and `productV2ToProperties`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes tighten classification logic and are fully covered by a new unit test.

Both fixes are small, targeted, and self-consistent. The new `itemToBillingInterval` path correctly prefers `price_interval` over `interval`, and swapping `.some` for `.every` in `productV2ToProperties` aligns it with the intended contract. The accompanying test exercises both the subscription and one-off branches of the updated logic.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/productUtils/productUtils.ts | Refactors `isOneOffProductV2` to use `itemToBillingInterval` which considers `price_interval ?? interval`, fixing a bug where items with a recurring `price_interval` but a null `interval` were incorrectly classified as one-off. |
| shared/utils/productV2Utils/productV2ToProperties.ts | Fixes `isOneOff` logic: replaces `.some(interval === null)` with `.every(itemToBillingInterval === OneOff)`, making classification consistent with `isOneOffProductV2` and correct for mixed-interval products. |
| server/tests/unit/products/product-v2-one-off-classification.test.ts | New unit test covering the two key classification cases: prepaid items with a recurring `price_interval` (subscription) and prepaid items with no price interval (one-off). |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ProductItem] --> B{isPriceItem or\nisFeaturePriceItem?}
    B -- No --> C[Excluded from\none-off check]
    B -- Yes --> D[itemToBillingInterval]
    D --> E{price_interval\nnullish?}
    E -- No --> F[Return price_interval\nas BillingInterval]
    E -- Yes --> G{interval\nnullish?}
    G -- No --> H[Return interval\nas BillingInterval]
    G -- Yes --> I[Return BillingInterval.OneOff]
    F --> J{All priced items\n=== OneOff?}
    H --> J
    I --> J
    J -- Yes --> K[is_one_off = true]
    J -- No --> L[is_one_off = false]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ProductItem] --> B{isPriceItem or\nisFeaturePriceItem?}
    B -- No --> C[Excluded from\none-off check]
    B -- Yes --> D[itemToBillingInterval]
    D --> E{price_interval\nnullish?}
    E -- No --> F[Return price_interval\nas BillingInterval]
    E -- Yes --> G{interval\nnullish?}
    G -- No --> H[Return interval\nas BillingInterval]
    G -- Yes --> I[Return BillingInterval.OneOff]
    F --> J{All priced items\n=== OneOff?}
    H --> J
    I --> J
    J -- Yes --> K[is_one_off = true]
    J -- No --> L[is_one_off = false]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix plan types logic"](https://github.com/useautumn/autumn/commit/de3fa2296aaac26077ac3ecbc4767516c18bbf03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39830784)</sub>

<!-- /greptile_comment -->