### PR TITLE
chore: event overflow fix

### DIFF
--- a/packages/ui/src/components/general/copyable-pre.tsx
+++ b/packages/ui/src/components/general/copyable-pre.tsx
@@ -4,10 +4,10 @@ import React from "react";
 
 export function CopyablePre({ text }: { text: string }) {
 	return (
-		<div className="relative w-full">
+		<div className="relative w-full min-w-0">
 			<pre className="text-sm bg-muted/50 p-4 rounded-lg overflow-auto border w-full h-full">
 				<CopyButton text={text} className="absolute top-2 right-2 z-10" />
-				<code className="text-sm block w-full break-words whitespace-pre-wrap">
+				<code className="text-sm block w-full whitespace-pre-wrap [overflow-wrap:anywhere]">
 					{text}
 				</code>
 			</pre>


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix text overflow in the `packages/ui` CopyablePre so long event text wraps and doesn’t break the layout.

- **Bug Fixes**
  - Added min-w-0 to the container to allow proper shrinking in flex layouts.
  - Switched to whitespace-pre-wrap and overflow-wrap:anywhere on code to wrap long strings.

<sup>Written for commit 06bdd18a8a9b6368106ee8fd01cb2f7277bb5de5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes event/content overflow in the `CopyablePre` component by applying two standard CSS tweaks.

- **[Bug fixes]** Adds `min-w-0` to the wrapper `div`, the canonical fix for flex/grid children that need to shrink below their intrinsic content width. Without it, the wrapper retains `min-width: auto` and cannot contract, letting long content bleed outside its container.
- **[Bug fixes]** Replaces `break-words` (Tailwind's `overflow-wrap: break-word`) with `[overflow-wrap:anywhere]`, which is a stricter wrapping rule that also counts forced break opportunities in `min-content` size calculations — this lets the element participate correctly in shrink-to-fit contexts while still breaking long tokens that have no natural whitespace.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are a two-line CSS-only fix with no logic or API impact.

Both changes (`min-w-0` on the wrapper and `overflow-wrap:anywhere` on the code element) are well-understood, widely used CSS patterns with broad browser support. They correct visible overflow without affecting any other component behavior, state, or API surface.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/general/copyable-pre.tsx | Two-line CSS fix: adds `min-w-0` to the wrapper div and replaces `break-words` with `[overflow-wrap:anywhere]` on the code element to prevent content overflow in flex/grid layouts. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["CopyablePre wrapper div\n(relative w-full min-w-0)"] --> B["pre\n(overflow-auto border rounded-lg)"]
    B --> C["CopyButton\n(absolute top-2 right-2 z-10)"]
    B --> D["code\n(whitespace-pre-wrap\noverflow-wrap:anywhere)"]
    D --> E["text content"]

    style A fill:#e8f4fd,stroke:#3b82f6
    style D fill:#e8f4fd,stroke:#3b82f6
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["CopyablePre wrapper div\n(relative w-full min-w-0)"] --> B["pre\n(overflow-auto border rounded-lg)"]
    B --> C["CopyButton\n(absolute top-2 right-2 z-10)"]
    B --> D["code\n(whitespace-pre-wrap\noverflow-wrap:anywhere)"]
    D --> E["text content"]

    style A fill:#e8f4fd,stroke:#3b82f6
    style D fill:#e8f4fd,stroke:#3b82f6
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: event overflow fix"](https://github.com/useautumn/autumn/commit/06bdd18a8a9b6368106ee8fd01cb2f7277bb5de5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39885363)</sub>

<!-- /greptile_comment -->