### PR TITLE
fix: auto-topup charges the most recently attached plan's one-off price

### DIFF
--- a/server/src/internal/balances/autoTopUp/helpers/fullCustomerToAutoTopupObjects.ts
+++ b/server/src/internal/balances/autoTopUp/helpers/fullCustomerToAutoTopupObjects.ts
@@ -37,8 +37,10 @@ export const fullCustomerToAutoTopupObjects = ({
 
 	if (cusEnts.length === 0) return null;
 
-	// 3. Find the one-off prepaid cusEnt
-	const customerEntitlement = cusEnts.find((ce) => {
+	// 3. Find the one-off prepaid cusEnt to charge. When the customer is on
+	// multiple plans with a one-off prepaid price for this feature, charge the
+	// MOST RECENTLY attached plan's price (not an arbitrary first match).
+	const isOneOffPrepaid = (ce: FullCusEntWithFullCusProduct) => {
 		const cp = cusEntToCusPrice({ cusEnt: ce });
 		return (
 			cp &&
@@ -46,7 +48,14 @@ export const fullCustomerToAutoTopupObjects = ({
 			isPrepaidPrice(cp.price) &&
 			!isVolumeBasedCusEnt(ce)
 		);
-	});
+	};
+	const customerEntitlement = cusEnts
+		.filter(isOneOffPrepaid)
+		.sort(
+			(left, right) =>
+				(right.customer_product?.created_at ?? 0) -
+				(left.customer_product?.created_at ?? 0),
+		)[0];
 
 	if (!customerEntitlement || !customerEntitlement.customer_product) {
 		return null;

--- a/server/tests/unit/balances/auto-topup/full-customer-to-auto-topup-objects.test.ts
+++ b/server/tests/unit/balances/auto-topup/full-customer-to-auto-topup-objects.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Auto-topup price selection across plans.
+ *
+ * When a customer is on multiple plans that each carry a one-off prepaid price
+ * for the same feature, the top-up must charge the MOST RECENTLY attached
+ * plan's price — not an arbitrary first match.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	BillingInterval,
+	BillWhen,
+	type FullCustomer,
+	PriceType,
+} from "@autumn/shared";
+import { fullCustomerToAutoTopupObjects } from "@/internal/balances/autoTopUp/helpers/fullCustomerToAutoTopupObjects.js";
+
+const FEATURE = "messages";
+
+const oneOffPrepaidPrice = ({
+	priceId,
+	entitlementId,
+	customerProductId,
+	amount,
+}: {
+	priceId: string;
+	entitlementId: string;
+	customerProductId: string;
+	amount: number;
+}) => ({
+	id: priceId,
+	customer_product_id: customerProductId,
+	price: {
+		id: priceId,
+		entitlement_id: entitlementId,
+		config: {
+			type: PriceType.Usage,
+			interval: BillingInterval.OneOff,
+			bill_when: BillWhen.InAdvance,
+			usage_tiers: [{ from: 0, to: -1, amount }],
+			billing_units: 1,
+		},
+	},
+});
+
+/** A customer_product attached at `createdAt` with a one-off prepaid price. */
+const planWithOneOff = ({
+	id,
+	createdAt,
+	amount,
+}: {
+	id: string;
+	createdAt: number;
+	amount: number;
+}) => {
+	const entitlementId = `ent_${id}`;
+	const cusEntId = `cusent_${id}`;
+	return {
+		id,
+		internal_product_id: `prod_${id}`,
+		status: "active",
+		created_at: createdAt,
+		starts_at: createdAt,
+		customer_prices: [
+			oneOffPrepaidPrice({
+				priceId: `price_${id}`,
+				entitlementId,
+				customerProductId: id,
+				amount,
+			}),
+		],
+		customer_entitlements: [
+			{
+				id: cusEntId,
+				customer_product_id: id,
+				balance: 0,
+				entitlement: {
+					id: entitlementId,
+					feature_id: FEATURE,
+					feature: { id: FEATURE },
+					allowance: 0,
+				},
+			},
+		],
+	};
+};
+
+const buildFullCustomer = ({
+	plans,
+	threshold = 20,
+	quantity = 100,
+}: {
+	plans: Array<{ id: string; createdAt: number; amount: number }>;
+	threshold?: number;
+	quantity?: number;
+}) =>
+	({
+		auto_topups: [{ feature_id: FEATURE, enabled: true, threshold, quantity }],
+		customer_products: plans.map(planWithOneOff),
+		extra_customer_entitlements: [],
+	}) as unknown as FullCustomer;
+
+const NOW = Date.UTC(2026, 5, 25, 12, 0, 0);
+
+describe("fullCustomerToAutoTopupObjects — most-recently-attached price wins", () => {
+	test("picks the cusEnt from the plan attached last (cheap first, pricey last)", () => {
+		const result = fullCustomerToAutoTopupObjects({
+			fullCustomer: buildFullCustomer({
+				plans: [
+					{ id: "cp_cheap", createdAt: NOW - 5000, amount: 5 },
+					{ id: "cp_pricey", createdAt: NOW - 1000, amount: 10 },
+				],
+			}),
+			featureId: FEATURE,
+		});
+
+		expect(result?.customerEntitlement.customer_product_id).toBe("cp_pricey");
+	});
+
+	test("picks the cusEnt from the plan attached last regardless of array order", () => {
+		const result = fullCustomerToAutoTopupObjects({
+			fullCustomer: buildFullCustomer({
+				plans: [
+					// Pricey (most recent) listed FIRST in the array.
+					{ id: "cp_pricey", createdAt: NOW - 1000, amount: 10 },
+					{ id: "cp_cheap", createdAt: NOW - 5000, amount: 5 },
+				],
+			}),
+			featureId: FEATURE,
+		});
+
+		expect(result?.customerEntitlement.customer_product_id).toBe("cp_pricey");
+	});
+
+	test("picks the cheaper plan when IT was attached last", () => {
+		const result = fullCustomerToAutoTopupObjects({
+			fullCustomer: buildFullCustomer({
+				plans: [
+					{ id: "cp_pricey", createdAt: NOW - 5000, amount: 10 },
+					{ id: "cp_cheap", createdAt: NOW - 1000, amount: 5 },
+				],
+			}),
+			featureId: FEATURE,
+		});
+
+		expect(result?.customerEntitlement.customer_product_id).toBe("cp_cheap");
+	});
+
+	test("single plan still resolves its one-off prepaid cusEnt", () => {
+		const result = fullCustomerToAutoTopupObjects({
+			fullCustomer: buildFullCustomer({
+				plans: [{ id: "cp_only", createdAt: NOW, amount: 7 }],
+			}),
+			featureId: FEATURE,
+		});
+
+		expect(result?.customerEntitlement.customer_product_id).toBe("cp_only");
+	});
+});


### PR DESCRIPTION
## Problem

When a customer is on **multiple plans** that each carry a one-off prepaid price for the **same feature** (both usable for auto top-ups), the auto-topup flow picked the one-off prepaid `customer_entitlement` via a plain `.find()` — an **arbitrary first match**. So the top-up could charge the *wrong plan's price*.

## Fix

`fullCustomerToAutoTopupObjects` step 3 now filters to one-off prepaid cusEnts and **sorts by the plan's attach time** (`customer_product.created_at`), charging the **most recently attached** plan's price. Config resolution and the balance/threshold check are unchanged.

```diff
- const customerEntitlement = cusEnts.find(isOneOffPrepaid);
+ const customerEntitlement = cusEnts
+   .filter(isOneOffPrepaid)
+   .sort((l, r) => (r.customer_product?.created_at ?? 0) - (l.customer_product?.created_at ?? 0))[0];
```

## Tests

New deterministic unit test (`full-customer-to-auto-topup-objects.test.ts`, 4 cases) proving the most-recently-attached plan's price always wins:
- cheap-first / pricey-last → pricey
- array-order-independent → pricey
- pricey-first / cheap-last → cheap
- single plan → resolves

All 14 auto-topup unit tests pass; server typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-topup now charges the one-off prepaid price from the most recently attached plan for a feature, instead of an arbitrary first match. This fixes incorrect pricing when customers have multiple eligible plans.

- **Bug Fixes**
  - Updated `fullCustomerToAutoTopupObjects` to filter one-off prepaid entitlements and sort by `customer_product.created_at` (desc) to pick the latest.
  - Added deterministic unit tests covering multi-plan recency and single-plan scenarios; all existing auto-topup tests pass.

<sup>Written for commit 40b01a3c783e6fe387f227b2471b158f047e2474. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug in the auto-topup flow where, when a customer holds multiple plans each carrying a one-off prepaid price for the same feature, the top-up would charge an arbitrary plan's price instead of a deterministic one. The fix replaces a plain `.find()` with `.filter().sort()[0]` that orders candidates by `customer_product.created_at` descending, always selecting the most recently attached plan's price.

- **[Bug fixes]** Replace `.find(isOneOffPrepaid)` with `.filter(isOneOffPrepaid).sort(by created_at desc)[0]` in `fullCustomerToAutoTopupObjects`, making the selection deterministic when a customer is on multiple plans with overlapping one-off prepaid prices for the same feature.
- **[Improvements]** Add 4 deterministic unit tests covering cheap-first/pricey-last, array-order-independent, pricey-first/cheap-last, and single-plan scenarios, confirming the most-recently-attached plan always wins.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a two-line surgical fix to a determinism bug with no side-effects on the balance computation or config resolution paths.

The sort comparator operates on `created_at`, which the schema types as a non-nullable `number`, so the arithmetic subtraction is always valid. The `?? 0` guard on the nullable `customer_product` wrapper is correct and unreachable in practice (null products are excluded by the `isOneOffPrepaid` filter). Four new unit tests cover array-order independence and both winner-orderings, giving good confidence the logic is correct.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/autoTopUp/helpers/fullCustomerToAutoTopupObjects.ts | Replaces `.find(isOneOffPrepaid)` with a `.filter().sort()[0]` pattern; `created_at` is typed as `z.number()` so the numeric subtraction comparator is safe |
| server/tests/unit/balances/auto-topup/full-customer-to-auto-topup-objects.test.ts | New unit tests cover 4 ordering scenarios; mock uses `as unknown as FullCustomer` but provides all fields the function actually accesses |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[fullCustomerToAutoTopupObjects] --> B{auto_topup config enabled for feature?}
    B -- No --> Z1[return null]
    B -- Yes --> C[fullCustomerToCustomerEntitlements get all cusEnts for feature]
    C --> D{cusEnts.length > 0?}
    D -- No --> Z2[return null]
    D -- Yes --> E[filter: isOneOffPrepaid]
    E --> F[sort descending by customer_product.created_at]
    F --> G[take first - most recently attached plan]
    G --> H{customerEntitlement exists?}
    H -- No --> Z3[return null]
    H -- Yes --> I[cusEntsToBalance compute aggregate balance]
    I --> J{balance <= threshold?}
    J --> K[return autoTopupConfig, customerEntitlement, balanceBelowThreshold]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[fullCustomerToAutoTopupObjects] --> B{auto_topup config enabled for feature?}
    B -- No --> Z1[return null]
    B -- Yes --> C[fullCustomerToCustomerEntitlements get all cusEnts for feature]
    C --> D{cusEnts.length > 0?}
    D -- No --> Z2[return null]
    D -- Yes --> E[filter: isOneOffPrepaid]
    E --> F[sort descending by customer_product.created_at]
    F --> G[take first - most recently attached plan]
    G --> H{customerEntitlement exists?}
    H -- No --> Z3[return null]
    H -- Yes --> I[cusEntsToBalance compute aggregate balance]
    I --> J{balance <= threshold?}
    J --> K[return autoTopupConfig, customerEntitlement, balanceBelowThreshold]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: auto-topup charges the most recentl..."](https://github.com/useautumn/autumn/commit/40b01a3c783e6fe387f227b2471b158f047e2474) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39895525)</sub>

<!-- /greptile_comment -->