### PR TITLE
fix sandboxes

### DIFF
--- a/vite/src/services/useAxiosInstance.tsx
+++ b/vite/src/services/useAxiosInstance.tsx
@@ -1,5 +1,5 @@
 // import { endpoint } from "@/utils/constants/constants";
-import type { ApiVersion, AppEnv } from "@autumn/shared";
+import { AppEnv, type ApiVersion } from "@autumn/shared";
 import axios from "axios";
 import { useMemo } from "react";
 import { useActiveSandbox } from "@/hooks/sandbox/useActiveSandbox";

--- a/vite/src/views/main-sidebar/EnvDropdown.tsx
+++ b/vite/src/views/main-sidebar/EnvDropdown.tsx
@@ -9,7 +9,7 @@ import {
 	DropdownMenuSeparator,
 	Skeleton,
 } from "@autumn/ui";
-import { Check, Pencil, Trash2 } from "lucide-react";
+import { Check, Pencil, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { PhosphorIcon } from "@/components/v2/icons/PhosphorIcon";
@@ -201,7 +201,7 @@ export const EnvDropdown = ({ env }: { env: AppEnv }) => {
 						);
 					})}
 
-					{/* <DropdownMenuSeparator />
+					<DropdownMenuSeparator />
 					<DropdownMenuItem
 						className="flex items-center gap-2 text-muted-foreground"
 						onClick={() => {
@@ -211,7 +211,7 @@ export const EnvDropdown = ({ env }: { env: AppEnv }) => {
 					>
 						<Plus size={12} className="!h-3 w-3 shrink-0" />
 						<span>New sandbox</span>
-					</DropdownMenuItem> */}
+					</DropdownMenuItem>
 				</DropdownMenuContent>
 			</DropdownMenu>
 			<CreateSandboxDialog open={createOpen} onOpenChange={setCreateOpen} />


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Re-enables the “New sandbox” option in the environment dropdown and fixes a runtime import so sandbox creation works again.

- **Bug Fixes**
  - Restored “New sandbox” menu item in EnvDropdown with a `Plus` icon; opens the create dialog.
  - Changed `AppEnv` to a runtime import from `@autumn/shared` (was type-only) to avoid runtime undefined in the Axios instance.

<sup>Written for commit 58b506f9e8eab888f85d6ab8f802d478e6583575. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR re-enables the "New sandbox" dropdown item in the sidebar environment switcher and fixes a runtime import issue that was breaking sandbox org-ID forwarding.

- **Bug fix**: Changes `import type { ApiVersion, AppEnv }` to `import { AppEnv, type ApiVersion }` so that `AppEnv` is available as a runtime value; previously the `type`-only import was erased at build time, making `envToUse === AppEnv.Sandbox` always `false` and silently skipping the `x-sandbox-org-id` header. [Bug fixes]
- **Improvements**: Uncomments the "New sandbox" `DropdownMenuItem` and its preceding `DropdownMenuSeparator` in `EnvDropdown.tsx`, re-enabling the UI path to create sandboxes, and adds the required `Plus` icon import from lucide-react. [Improvements]
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are narrow, well-scoped fixes with no side effects on unrelated paths.

The import fix restores correct sandbox header forwarding that was silently broken by the type-only import erasure, and the UI change simply re-enables a previously working 'New sandbox' entry with the correct separator placement in all scenarios (empty and non-empty sandbox list).

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/services/useAxiosInstance.tsx | Fixes a critical import-type erasure bug: AppEnv is now imported as a value so the runtime check `envToUse === AppEnv.Sandbox` works correctly and the x-sandbox-org-id header is properly forwarded. |
| vite/src/views/main-sidebar/EnvDropdown.tsx | Uncomments the 'New sandbox' menu item and separator, and adds the missing Plus icon import; separator logic is correct for both the empty and non-empty sandbox list cases. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as EnvDropdown
    participant Hook as useAxiosInstance
    participant Axios as Axios Interceptor
    participant API as Backend API

    UI->>Hook: Request with sandbox env
    Hook->>Axios: Attach headers
    Note over Axios: AppEnv now imported as value<br/>(was erased by `import type`)
    alt "envToUse === AppEnv.Sandbox"
        Axios->>API: x-sandbox-org-id header set ✅
    else "envToUse !== AppEnv.Sandbox"
        Axios->>API: No sandbox header (correct)
    end

    UI->>UI: User clicks "New sandbox"
    Note over UI: DropdownMenuItem now active<br/>(was commented out)
    UI->>UI: setCreateOpen(true)
    UI->>UI: CreateSandboxDialog opens
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as EnvDropdown
    participant Hook as useAxiosInstance
    participant Axios as Axios Interceptor
    participant API as Backend API

    UI->>Hook: Request with sandbox env
    Hook->>Axios: Attach headers
    Note over Axios: AppEnv now imported as value<br/>(was erased by `import type`)
    alt "envToUse === AppEnv.Sandbox"
        Axios->>API: x-sandbox-org-id header set ✅
    else "envToUse !== AppEnv.Sandbox"
        Axios->>API: No sandbox header (correct)
    end

    UI->>UI: User clicks "New sandbox"
    Note over UI: DropdownMenuItem now active<br/>(was commented out)
    UI->>UI: setCreateOpen(true)
    UI->>UI: CreateSandboxDialog opens
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix sandboxes"](https://github.com/useautumn/autumn/commit/58b506f9e8eab888f85d6ab8f802d478e6583575) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39915146)</sub>

<!-- /greptile_comment -->