### PR TITLE
Charlie/invoice unpaid fix

### DIFF
--- a/server/src/external/stripe/stripeInvoiceUtils.ts
+++ b/server/src/external/stripe/stripeInvoiceUtils.ts
@@ -88,9 +88,20 @@ export const payForInvoice = async ({
 		const invoice = await stripeCli.invoices.pay(invoiceId, {
 			payment_method: paymentMethod?.id,
 		});
+		const paid = invoice.status === "paid";
+		const error = paid
+			? null
+			: new RecaseError({
+					message: `Invoice ${invoiceId} is ${invoice.status ?? "not paid"}`,
+					code: ErrCode.PayInvoiceFailed,
+					data: invoice,
+				});
+
+		if (!paid && errorOnFail) throw error;
+
 		return {
-			paid: true,
-			error: null,
+			paid,
+			error,
 			invoice,
 		};
 	} catch (error: any) {

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/payStripeInvoice.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/payStripeInvoice.ts
@@ -69,6 +69,17 @@ export const payStripeInvoice = async ({
 		return handleInvoicePaymentFailure({ invoice, error });
 	}
 
+	if (paidInvoice.status !== "paid") {
+		return {
+			paid: false,
+			invoice: paidInvoice,
+			requiredAction: {
+				code: "payment_failed",
+				reason: `Invoice is ${paidInvoice.status ?? "not paid"}`,
+			},
+		};
+	}
+
 	return {
 		paid: true,
 		invoice: paidInvoice,

--- a/server/tests/integration/billing/legacy/attach/new/legacy-new-oneoff-open-invoice.test.ts
+++ b/server/tests/integration/billing/legacy/attach/new/legacy-new-oneoff-open-invoice.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression: ACH invoice.pay can resolve while the invoice is still open.
+ * Autumn must not grant prepaid one-off balance then.
+ */
+
+/** biome-ignore-all lint/suspicious/noExplicitAny: legacy response shape */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV3,
+	LegacyVersion,
+	SuccessCode,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import ctx from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { createHonoApp } from "@/initHono.js";
+
+const request = async <T>(
+	app: ReturnType<typeof createHonoApp>,
+	path: string,
+	init?: RequestInit,
+) => {
+	const res = await app.fetch(
+		new Request(`http://localhost/v1${path}`, {
+			...init,
+			headers: {
+				Authorization: `Bearer ${ctx.orgSecretKey}`,
+				"Content-Type": "application/json",
+				"x-api-version": LegacyVersion.v1_4.toString(),
+			},
+		}),
+	);
+
+	expect(res.status).toBe(200);
+	return (await res.json()) as T;
+};
+
+const attachAchProcessingPaymentMethod = async (stripeCustomerId: string) => {
+	const paymentMethod = await ctx.stripeCli.paymentMethods.attach(
+		"pm_usBankAccount_processing",
+		{
+			customer: stripeCustomerId,
+		},
+	);
+	await ctx.stripeCli.customers.update(stripeCustomerId, {
+		invoice_settings: {
+			default_payment_method: paymentMethod.id,
+		},
+	});
+};
+
+test.concurrent(`${chalk.yellowBright("legacy-oneoff: ACH open invoice pay response does not grant balance")}`, async () => {
+	const customerId = "legacy-oneoff-open-invoice";
+	const oneOff = products.oneOff({
+		id: "one-off-open-invoice",
+		items: [items.oneOffMessages({ billingUnits: 250, price: 8 })],
+	});
+
+	const { customer } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.products({ list: [oneOff] }),
+		],
+		actions: [],
+	});
+
+	await attachAchProcessingPaymentMethod(customer.processor.id!);
+	const app = createHonoApp();
+
+	const attach = await request<any>(app, "/attach", {
+		method: "POST",
+		body: JSON.stringify({
+			customer_id: customerId,
+			product_id: oneOff.id,
+			options: [{ feature_id: TestFeature.Messages, quantity: 500 }],
+		}),
+	});
+
+	const latestInvoice = (
+		await ctx.stripeCli.invoices.list({
+			customer: customer.processor.id!,
+			limit: 1,
+		})
+	).data[0];
+	expect(latestInvoice.status).toBe("open");
+	expect(latestInvoice.amount_paid).toBe(0);
+
+	expect(attach.code).toBe(SuccessCode.InvoiceActionRequired);
+	expect(attach.checkout_url).toContain("invoice.stripe.com");
+
+	const customerAfterAttach = await request<ApiCustomerV3>(
+		app,
+		`/customers/${customerId}?expand=invoices`,
+	);
+
+	expect(customerAfterAttach.features?.[TestFeature.Messages]?.balance ?? 0).toBe(
+		0,
+	);
+	expect(
+		customerAfterAttach.products.some((product) => product.id === oneOff.id),
+	).toBe(false);
+});

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
@@ -57,6 +57,7 @@ export function CustomerListTable({
 			queryStates.version,
 			queryStates.none,
 			queryStates.processor,
+			queryStates.interval,
 			queryStates.q,
 		]),
 		queryFn: () => Promise.resolve({ fullCustomers: [], next_cursor: null }),


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes ACH invoice payments where Stripe returns “open” after invoice.pay, so we don’t grant one‑off prepaid balance until the invoice is actually paid. Also fixes a customer list table query key bug.

- **Bug Fixes**
  - Stripe billing: treat non-"paid" invoices as unpaid, propagate an error or `requiredAction` from `payStripeInvoice`, preventing balance grants on ACH “processing/open” invoices; added a regression test to cover this case.
  - UI: include `queryStates.interval` in the customer list table query key to prevent stale column state.

<sup>Written for commit 72482793c1f06a1898406a282a6204ca919fced2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a regression where ACH (bank debit) invoices that resolve as `"open"` (processing, not yet settled) were incorrectly treated as paid, allowing prepaid one-off balances to be granted before funds cleared. It adds a post-payment status check in both the legacy (`payForInvoice`) and v2 (`payStripeInvoice`) billing paths, and adds a regression test covering the one-off product attach scenario.

- **Bug fixes**: `payStripeInvoice.ts` now returns `paid: false` with a `requiredAction` when the invoice status is not `"paid"` after a successful API call, preventing premature balance grants on ACH.
- **Bug fixes**: `stripeInvoiceUtils.ts` similarly checks `invoice.status` after `invoices.pay` resolves, but the `throw` is placed inside the existing `try` block, which causes the outer `catch` to fire — a new regression that can trigger `voidIfFailed` and cancel a legitimately in-flight ACH payment for proration invoice paths.
- **Improvements**: `CustomerListTable.tsx` adds `queryStates.interval` to the React Query cache key so the customer list re-fetches when the interval filter changes.
</details>

<h3>Confidence Score: 3/5</h3>

The one-off attach path is fixed and well-tested, but the legacy stripeInvoiceUtils change introduces a control-flow issue that can void an in-progress ACH invoice for subscription proration paths using default parameters.

The throw-inside-try in stripeInvoiceUtils.ts causes the outer catch to absorb what should be a clean 'not paid' return. For callers of createAndFinalizeInvoice that rely on default voidIfFailed=true (e.g., createUpgradeProrationInvoice), an ACH payment that is legitimately processing could be voided immediately after Stripe accepts it — potentially cancelling a real payment in production.

server/src/external/stripe/stripeInvoiceUtils.ts needs the throw relocated outside the try/catch block to prevent the catch handler from running on a normal 'open' ACH response.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/stripeInvoiceUtils.ts | Fixes the 'always returns paid=true' bug but introduces a new regression: the throw inside the try block is caught by the outer catch, which can trigger voidIfFailed and cancel a legitimately processing ACH invoice for callers using default parameters (e.g., createUpgradeProrationInvoice). |
| server/src/internal/billing/v2/providers/stripe/utils/invoices/payStripeInvoice.ts | Adds a post-payment status check so that an open/processing invoice is no longer treated as paid; uses 'payment_failed' code for what is actually an in-flight ACH payment, which is semantically misleading. |
| server/tests/integration/billing/legacy/attach/new/legacy-new-oneoff-open-invoice.test.ts | New regression test for the ACH open-invoice scenario; covers the handleOneOffFunction path correctly and asserts no balance is granted and no product is attached when the invoice remains open. |
| vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx | Adds queryStates.interval to the React Query cache key so that the customer list is properly invalidated when the interval filter changes. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[stripeCli.invoices.pay] --> B{API throws?}
    B -- yes --> C[catch block]
    B -- no --> D{invoice.status === 'paid'?}

    D -- yes --> E[return paid: true]
    D -- no --> F{errorOnFail?}

    F -- false --> G[return paid: false, error]
    F -- true --> H[throw error inside try]
    H --> C

    C --> I{voidIfFailed?}
    I -- true --> J["voidInvoice() ⚠️ may cancel ACH"]
    I -- false --> K{errorOnFail?}
    J --> K
    K -- true --> L[re-throw RecaseError]
    K -- false --> M[return paid: false]

    style H fill:#f99,stroke:#c00
    style J fill:#f99,stroke:#c00
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[stripeCli.invoices.pay] --> B{API throws?}
    B -- yes --> C[catch block]
    B -- no --> D{invoice.status === 'paid'?}

    D -- yes --> E[return paid: true]
    D -- no --> F{errorOnFail?}

    F -- false --> G[return paid: false, error]
    F -- true --> H[throw error inside try]
    H --> C

    C --> I{voidIfFailed?}
    I -- true --> J["voidInvoice() ⚠️ may cancel ACH"]
    I -- false --> K{errorOnFail?}
    J --> K
    K -- true --> L[re-throw RecaseError]
    K -- false --> M[return paid: false]

    style H fill:#f99,stroke:#c00
    style J fill:#f99,stroke:#c00
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/external/stripe/stripeInvoiceUtils.ts:100
**Throw inside `try` leaks into `catch` and may void a processing ACH invoice**

`throw error` at line 100 is inside the `try` block whose catch runs at line 107, so every time the invoice comes back "open" with `errorOnFail=true` the catch handler fires. If `voidIfFailed` is also `true` (the default in `createAndFinalizeInvoice`), the handler immediately calls `stripeCli.invoices.voidInvoice(invoiceId)` on line 114 — cancelling a legitimately in-flight ACH payment. The path through `createUpgradeProrationInvoice` uses all defaults and is exposed to this.

Move the not-paid guard outside the try/catch so that only genuine Stripe API errors land in the catch block, or use a sentinel variable inside the try and rethrow outside.

### Issue 2 of 2
server/src/internal/billing/v2/providers/stripe/utils/invoices/payStripeInvoice.ts:72-80
**`"payment_failed"` is inaccurate for an ACH "open" invoice**

When `invoices.pay` returns with `status === "open"` (e.g., ACH bank debit still processing), the new branch uses `code: "payment_failed"`. The payment has not failed — it is in flight. Downstream consumers see `required_action.code: "payment_failed"` in the API response, which could prompt the user to retry or switch payment methods when they should simply wait. A more accurate code such as `"payment_processing"` (if supported by `PaymentFailureCode`) would prevent that confusion.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: invoice ACH unpaid fix"](https://github.com/useautumn/autumn/commit/72482793c1f06a1898406a282a6204ca919fced2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40075053)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->