### PR TITLE
Fix Stripe portal plan backsync

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "better-auth": "catalog:",
         "chalk": "^5.6.2",
         "drizzle-orm": "catalog:",
+        "model": "^6.0.1",
         "posthog-node": "^5.24.1",
         "tailwind-scrollbar-hide": "^4.0.0",
       },
@@ -5007,6 +5008,8 @@
 
     "modal": ["modal@0.8.0", "", { "dependencies": { "cbor-x": "^1.6.0", "long": "^5.3.1", "nice-grpc": "^2.1.12", "protobufjs": "^7.5.0", "smol-toml": "^1.3.3", "uuid": "^11.1.0" } }, "sha512-gxyeav0dXHkrNe/uDHKADtCuyHNaMorfcBW36ldU/ALoP4VNHoVrLIHHqna4pXKqtHPsBWalNVr+rv2cHasZ3g=="],
 
+    "model": ["model@6.0.1", "", { "dependencies": { "utilities": "1.0.x" } }, "sha512-khQLGVbt7qvMV7/lp990+CaLWJZC6KxtV8y9iJ7Qlj3+82JtJIZfRacVIC8YjTUTHFbUn91FOxWdhRGjRVjdsQ=="],
+
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
     "moment": ["moment@2.30.1", "", {}, "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="],
@@ -6208,6 +6211,8 @@
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "utilities": ["utilities@1.0.6", "", {}, "sha512-OYHwdtji3y636osVdsuLdXT4swOAAEwgznGZey9cgGtQma31eLsZ9NzEarQARcIQAv81EBZrCIKn6nIDmv9cZw=="],
 
     "utility-types": ["utility-types@3.11.0", "", {}, "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,6 @@
         "better-auth": "catalog:",
         "chalk": "^5.6.2",
         "drizzle-orm": "catalog:",
-        "model": "^6.0.1",
         "posthog-node": "^5.24.1",
         "tailwind-scrollbar-hide": "^4.0.0",
       },
@@ -5008,8 +5007,6 @@
 
     "modal": ["modal@0.8.0", "", { "dependencies": { "cbor-x": "^1.6.0", "long": "^5.3.1", "nice-grpc": "^2.1.12", "protobufjs": "^7.5.0", "smol-toml": "^1.3.3", "uuid": "^11.1.0" } }, "sha512-gxyeav0dXHkrNe/uDHKADtCuyHNaMorfcBW36ldU/ALoP4VNHoVrLIHHqna4pXKqtHPsBWalNVr+rv2cHasZ3g=="],
 
-    "model": ["model@6.0.1", "", { "dependencies": { "utilities": "1.0.x" } }, "sha512-khQLGVbt7qvMV7/lp990+CaLWJZC6KxtV8y9iJ7Qlj3+82JtJIZfRacVIC8YjTUTHFbUn91FOxWdhRGjRVjdsQ=="],
-
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
     "moment": ["moment@2.30.1", "", {}, "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="],
@@ -6211,8 +6208,6 @@
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
-
-    "utilities": ["utilities@1.0.6", "", {}, "sha512-OYHwdtji3y636osVdsuLdXT4swOAAEwgznGZey9cgGtQma31eLsZ9NzEarQARcIQAv81EBZrCIKn6nIDmv9cZw=="],
 
     "utility-types": ["utility-types@3.11.0", "", {}, "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw=="],
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 			"apps/website",
 			"apps/leaf",
 			"apps/sdk-test",
-		"apps/testbench",
+			"apps/testbench",
 			"packages/atmn",
 			"packages/atmn-tests",
 			"packages/auth",
@@ -182,6 +182,7 @@
 		"better-auth": "catalog:",
 		"chalk": "^5.6.2",
 		"drizzle-orm": "catalog:",
+		"model": "^6.0.1",
 		"posthog-node": "^5.24.1",
 		"tailwind-scrollbar-hide": "^4.0.0"
 	},

--- a/package.json
+++ b/package.json
@@ -182,7 +182,6 @@
 		"better-auth": "catalog:",
 		"chalk": "^5.6.2",
 		"drizzle-orm": "catalog:",
-		"model": "^6.0.1",
 		"posthog-node": "^5.24.1",
 		"tailwind-scrollbar-hide": "^4.0.0"
 	},

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/handleStripeSubscriptionUpdated.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/handleStripeSubscriptionUpdated.ts
@@ -4,6 +4,7 @@ import { syncAutumnSubscription } from "@/external/stripe/webhookHandlers/handle
 import type { StripeWebhookContext } from "../../webhookMiddlewares/stripeWebhookContext.js";
 import { emitBillingChangeWebhook, logCustomerProductUpdates } from "../common";
 import { setupStripeSubscriptionUpdatedContext } from "./setupStripeSubscriptionUpdatedContext.js";
+import { autoSyncUpdatedSubscription } from "./tasks/autoSyncUpdatedSubscription.js";
 import { handleCancelOnPastDue } from "./tasks/handleCancelOnPastDue.js";
 import { handleIgnorePastDue } from "./tasks/handleIgnorePastDue.js";
 import { handleSchedulePhaseChanges } from "./tasks/handleSchedulePhaseChanges/handleSchedulePhaseChanges.js";
@@ -74,6 +75,11 @@ export const handleStripeSubscriptionUpdated = async ({
 
 	// 6. Detect trial-end transition (tags only — no DB writes)
 	handleStripeSubscriptionTrialEnded({
+		ctx,
+		subscriptionUpdatedContext,
+	});
+
+	await autoSyncUpdatedSubscription({
 		ctx,
 		subscriptionUpdatedContext,
 	});

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts
@@ -59,13 +59,15 @@ const shouldSyncPlanChange = ({
 }) => {
 	const currentPhase = match.phaseMatches.find((phase) => phase.is_current);
 	const matchedPlan = currentPhase?.plans[0];
+	const matchedProductGroup = matchedPlan?.product.group;
 
 	return (
 		currentPhase?.plans.length === 1 &&
 		params.phases?.length === 1 &&
 		params.phases[0].plans.length === 1 &&
 		matchedPlan?.product.id !== linkedProduct.product.id &&
-		matchedPlan?.product.group === linkedProduct.product.group
+		matchedProductGroup != null &&
+		matchedProductGroup === linkedProduct.product.group
 	);
 };
 

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts
@@ -1,0 +1,139 @@
+import type Stripe from "stripe";
+import { filterCustomerProductsByStripeSubscriptionId } from "@autumn/shared";
+import { billingActions } from "@/internal/billing/v2/actions";
+import { canAutoSync } from "@/internal/billing/v2/actions/sync/canAutoSync";
+import { subscriptionToSyncParams } from "@/internal/billing/v2/actions/sync/subscriptionToSyncParams";
+import { isAutumnManagedSubscriptionMetadata } from "@/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
+import type { StripeWebhookContext } from "../../../webhookMiddlewares/stripeWebhookContext";
+import {
+	trackCustomerProductInsertion,
+	trackCustomerProductUpdate,
+} from "../../common/trackCustomerProductUpdate";
+import type { StripeSubscriptionUpdatedContext } from "../stripeSubscriptionUpdatedContext";
+
+const stripeProductId = (
+	product: string | Stripe.Product | Stripe.DeletedProduct,
+) =>
+	typeof product === "string" ? product : product.id;
+
+const priceOrProductChanged = ({
+	subscriptionUpdatedContext,
+}: {
+	subscriptionUpdatedContext: StripeSubscriptionUpdatedContext;
+}) => {
+	const { stripeSubscription, previousAttributes } = subscriptionUpdatedContext;
+	if (!previousAttributes.items?.data.length) return false;
+
+	const currentItems = new Map(
+		stripeSubscription.items.data.map((item) => [item.id, item]),
+	);
+	if (currentItems.size !== previousAttributes.items.data.length) return false;
+
+	return previousAttributes.items.data.some((previousItem) => {
+		const currentItem = currentItems.get(previousItem.id);
+		if (!currentItem) return false;
+
+		return (
+			currentItem.price.id !== previousItem.price.id ||
+			stripeProductId(currentItem.price.product) !==
+				stripeProductId(previousItem.price.product)
+		);
+	});
+};
+
+export const autoSyncUpdatedSubscription = async ({
+	ctx,
+	subscriptionUpdatedContext,
+}: {
+	ctx: StripeWebhookContext;
+	subscriptionUpdatedContext: StripeSubscriptionUpdatedContext;
+}) => {
+	const { logger } = ctx;
+	const { stripeSubscription, fullCustomer, customerProducts } =
+		subscriptionUpdatedContext;
+
+	if (!priceOrProductChanged({ subscriptionUpdatedContext })) return;
+	const metadataDecision = isAutumnManagedSubscriptionMetadata({
+		metadata: stripeSubscription.metadata,
+		requireRecent: true,
+		ignoreManagedSource: true,
+	});
+	if (metadataDecision.skip) {
+		logger.info(
+			`sub.updated auto-sync skipping ${stripeSubscription.id}: ${metadataDecision.reason}`,
+		);
+		return;
+	}
+
+	const linkedProducts = filterCustomerProductsByStripeSubscriptionId({
+		customerProducts,
+		stripeSubscriptionId: stripeSubscription.id,
+	});
+	if (linkedProducts.length !== 1) return;
+
+	const customerId = fullCustomer.id ?? fullCustomer.internal_id;
+	const { match, params } = await subscriptionToSyncParams({
+		ctx,
+		customerId,
+		subscription: stripeSubscription,
+		customerProducts,
+	});
+
+	const eligibility = canAutoSync({ match });
+	if (!eligibility.eligible) {
+		logger.info(
+			`sub.updated auto-sync skipping ${stripeSubscription.id}: ${eligibility.reason} - ${eligibility.details}`,
+		);
+		return;
+	}
+
+	const currentPhase = match.phaseMatches.find((phase) => phase.is_current);
+	const matchedPlan = currentPhase?.plans[0];
+	const linkedProduct = linkedProducts[0].product;
+	if (
+		!currentPhase ||
+		currentPhase.plans.length !== 1 ||
+		params.phases?.length !== 1 ||
+		params.phases[0].plans.length !== 1 ||
+		matchedPlan?.product.id === linkedProduct.id ||
+		matchedPlan?.product.group !== linkedProduct.group
+	) {
+		return;
+	}
+
+	const result = await billingActions.syncV2({ ctx, params });
+
+	for (const id of result.expired_cus_product_ids) {
+		const customerProduct =
+			customerProducts.find((cp) => cp.id === id) ??
+			linkedProducts.find((cp) => cp.id === id);
+		const syncedProduct = await CusProductService.getFull({ db: ctx.db, id });
+		if (!customerProduct || !syncedProduct) continue;
+
+		trackCustomerProductUpdate({
+			eventContext: subscriptionUpdatedContext,
+			customerProduct,
+			updates: {
+				status: syncedProduct.status,
+				canceled: syncedProduct.canceled,
+				canceled_at: syncedProduct.canceled_at,
+				ended_at: syncedProduct.ended_at,
+			},
+		});
+	}
+
+	for (const id of result.inserted_cus_product_ids) {
+		const customerProduct = await CusProductService.getFull({ db: ctx.db, id });
+		if (!customerProduct) continue;
+
+		if (!fullCustomer.customer_products.some((cp) => cp.id === id)) {
+			fullCustomer.customer_products.push(customerProduct);
+		}
+
+		trackCustomerProductInsertion({
+			eventContext: subscriptionUpdatedContext,
+			customerProduct,
+		});
+	}
+};

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts
@@ -1,8 +1,12 @@
 import type Stripe from "stripe";
-import { filterCustomerProductsByStripeSubscriptionId } from "@autumn/shared";
+import {
+	filterCustomerProductsByStripeSubscriptionId,
+	type FullCusProduct,
+} from "@autumn/shared";
 import { billingActions } from "@/internal/billing/v2/actions";
 import { canAutoSync } from "@/internal/billing/v2/actions/sync/canAutoSync";
 import { subscriptionToSyncParams } from "@/internal/billing/v2/actions/sync/subscriptionToSyncParams";
+import type { SyncV2Result } from "@/internal/billing/v2/actions/sync/syncV2";
 import { isAutumnManagedSubscriptionMetadata } from "@/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
 import type { StripeWebhookContext } from "../../../webhookMiddlewares/stripeWebhookContext";
@@ -11,6 +15,8 @@ import {
 	trackCustomerProductUpdate,
 } from "../../common/trackCustomerProductUpdate";
 import type { StripeSubscriptionUpdatedContext } from "../stripeSubscriptionUpdatedContext";
+
+type SyncParamsResult = Awaited<ReturnType<typeof subscriptionToSyncParams>>;
 
 const stripeProductId = (
 	product: string | Stripe.Product | Stripe.DeletedProduct,
@@ -40,6 +46,74 @@ const priceOrProductChanged = ({
 				stripeProductId(previousItem.price.product)
 		);
 	});
+};
+
+const shouldSyncPlanChange = ({
+	match,
+	params,
+	linkedProduct,
+}: {
+	match: SyncParamsResult["match"];
+	params: SyncParamsResult["params"];
+	linkedProduct: FullCusProduct;
+}) => {
+	const currentPhase = match.phaseMatches.find((phase) => phase.is_current);
+	const matchedPlan = currentPhase?.plans[0];
+
+	return (
+		currentPhase?.plans.length === 1 &&
+		params.phases?.length === 1 &&
+		params.phases[0].plans.length === 1 &&
+		matchedPlan?.product.id !== linkedProduct.product.id &&
+		matchedPlan?.product.group === linkedProduct.product.group
+	);
+};
+
+const trackSyncResult = async ({
+	ctx,
+	subscriptionUpdatedContext,
+	result,
+	linkedProducts,
+}: {
+	ctx: StripeWebhookContext;
+	subscriptionUpdatedContext: StripeSubscriptionUpdatedContext;
+	result: SyncV2Result;
+	linkedProducts: FullCusProduct[];
+}) => {
+	const { customerProducts, fullCustomer } = subscriptionUpdatedContext;
+
+	for (const id of result.expired_cus_product_ids) {
+		const customerProduct =
+			customerProducts.find((cp) => cp.id === id) ??
+			linkedProducts.find((cp) => cp.id === id);
+		const syncedProduct = await CusProductService.getFull({ db: ctx.db, id });
+		if (!customerProduct || !syncedProduct) continue;
+
+		trackCustomerProductUpdate({
+			eventContext: subscriptionUpdatedContext,
+			customerProduct,
+			updates: {
+				status: syncedProduct.status,
+				canceled: syncedProduct.canceled,
+				canceled_at: syncedProduct.canceled_at,
+				ended_at: syncedProduct.ended_at,
+			},
+		});
+	}
+
+	for (const id of result.inserted_cus_product_ids) {
+		const customerProduct = await CusProductService.getFull({ db: ctx.db, id });
+		if (!customerProduct) continue;
+
+		if (!fullCustomer.customer_products.some((cp) => cp.id === id)) {
+			fullCustomer.customer_products.push(customerProduct);
+		}
+
+		trackCustomerProductInsertion({
+			eventContext: subscriptionUpdatedContext,
+			customerProduct,
+		});
+	}
 };
 
 export const autoSyncUpdatedSubscription = async ({
@@ -88,52 +162,14 @@ export const autoSyncUpdatedSubscription = async ({
 		return;
 	}
 
-	const currentPhase = match.phaseMatches.find((phase) => phase.is_current);
-	const matchedPlan = currentPhase?.plans[0];
-	const linkedProduct = linkedProducts[0].product;
-	if (
-		!currentPhase ||
-		currentPhase.plans.length !== 1 ||
-		params.phases?.length !== 1 ||
-		params.phases[0].plans.length !== 1 ||
-		matchedPlan?.product.id === linkedProduct.id ||
-		matchedPlan?.product.group !== linkedProduct.group
-	) {
-		return;
-	}
+	const linkedProduct = linkedProducts[0];
+	if (!shouldSyncPlanChange({ match, params, linkedProduct })) return;
 
 	const result = await billingActions.syncV2({ ctx, params });
-
-	for (const id of result.expired_cus_product_ids) {
-		const customerProduct =
-			customerProducts.find((cp) => cp.id === id) ??
-			linkedProducts.find((cp) => cp.id === id);
-		const syncedProduct = await CusProductService.getFull({ db: ctx.db, id });
-		if (!customerProduct || !syncedProduct) continue;
-
-		trackCustomerProductUpdate({
-			eventContext: subscriptionUpdatedContext,
-			customerProduct,
-			updates: {
-				status: syncedProduct.status,
-				canceled: syncedProduct.canceled,
-				canceled_at: syncedProduct.canceled_at,
-				ended_at: syncedProduct.ended_at,
-			},
-		});
-	}
-
-	for (const id of result.inserted_cus_product_ids) {
-		const customerProduct = await CusProductService.getFull({ db: ctx.db, id });
-		if (!customerProduct) continue;
-
-		if (!fullCustomer.customer_products.some((cp) => cp.id === id)) {
-			fullCustomer.customer_products.push(customerProduct);
-		}
-
-		trackCustomerProductInsertion({
-			eventContext: subscriptionUpdatedContext,
-			customerProduct,
-		});
-	}
+	await trackSyncResult({
+		ctx,
+		subscriptionUpdatedContext,
+		result,
+		linkedProducts,
+	});
 };

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts
@@ -146,7 +146,12 @@ export const autoSyncUpdatedSubscription = async ({
 		customerProducts,
 		stripeSubscriptionId: stripeSubscription.id,
 	});
-	if (linkedProducts.length !== 1) return;
+	if (linkedProducts.length !== 1) {
+		logger.info(
+			`sub.updated auto-sync skipping ${stripeSubscription.id}: expected 1 linked product, found ${linkedProducts.length}`,
+		);
+		return;
+	}
 
 	const customerId = fullCustomer.id ?? fullCustomer.internal_id;
 	const { match, params } = await subscriptionToSyncParams({
@@ -165,7 +170,12 @@ export const autoSyncUpdatedSubscription = async ({
 	}
 
 	const linkedProduct = linkedProducts[0];
-	if (!shouldSyncPlanChange({ match, params, linkedProduct })) return;
+	if (!shouldSyncPlanChange({ match, params, linkedProduct })) {
+		logger.info(
+			`sub.updated auto-sync skipping ${stripeSubscription.id}: not a single same-group plan change`,
+		);
+		return;
+	}
 
 	const result = await billingActions.syncV2({ ctx, params });
 	await trackSyncResult({
@@ -174,4 +184,7 @@ export const autoSyncUpdatedSubscription = async ({
 		result,
 		linkedProducts,
 	});
+	logger.info(
+		`sub.updated auto-sync applied ${stripeSubscription.id}: expired=${result.expired_cus_product_ids.length}, inserted=${result.inserted_cus_product_ids.length}`,
+	);
 };

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts
@@ -34,11 +34,11 @@ const priceOrProductChanged = ({
 	const currentItems = new Map(
 		stripeSubscription.items.data.map((item) => [item.id, item]),
 	);
-	if (currentItems.size !== previousAttributes.items.data.length) return false;
+	if (currentItems.size !== previousAttributes.items.data.length) return true;
 
 	return previousAttributes.items.data.some((previousItem) => {
 		const currentItem = currentItems.get(previousItem.id);
-		if (!currentItem) return false;
+		if (!currentItem) return true;
 
 		return (
 			currentItem.price.id !== previousItem.price.id ||

--- a/server/src/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata.ts
@@ -38,16 +38,18 @@ export const isAutumnManagedSubscriptionMetadata = ({
 	windowMs = RECENT_AUTUMN_ACTION_WINDOW_MS,
 	now = Date.now(),
 	requireRecent = true,
+	ignoreManagedSource = false,
 }: {
 	metadata: Stripe.Metadata | null | undefined;
 	windowMs?: number;
 	now?: number;
 	requireRecent?: boolean;
+	ignoreManagedSource?: boolean;
 }): { skip: boolean; reason?: string } => {
 	if (!metadata) return { skip: false };
 
 	const source = metadata[AUTUMN_STRIPE_METADATA_KEYS.managedSource];
-	if (source) {
+	if (source && !ignoreManagedSource) {
 		return {
 			skip: true,
 			reason: `autumn_managed_source=${source}`,

--- a/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-portal-plan-sync.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-portal-plan-sync.test.ts
@@ -1,14 +1,3 @@
-/**
- * TDD test for Stripe Billing Portal plan changes.
- *
- * Red-failure mode (current behavior):
- *  - Stripe's customer.subscription.updated webhook changes the subscription
- *    item price from Ultra to Pro, but Autumn keeps Ultra active.
- *
- * Green-success criteria (after fix):
- *  - The webhook backsync expires Ultra and activates Pro.
- */
-
 import { test } from "bun:test";
 import type { ApiCustomerV3, ProductItem } from "@autumn/shared";
 import {
@@ -98,14 +87,25 @@ const expectProSynced = async ({
 	proId: string;
 	ultraId: string;
 }) => {
-	await timeout(10000);
+	const deadline = Date.now() + 30000;
+	let lastError: unknown;
 
-	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
-	await expectCustomerProducts({
-		customer,
-		active: [proId],
-		notPresent: [ultraId],
-	});
+	while (Date.now() < deadline) {
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		try {
+			await expectCustomerProducts({
+				customer,
+				active: [proId],
+				notPresent: [ultraId],
+			});
+			return;
+		} catch (error) {
+			lastError = error;
+			await timeout(2000);
+		}
+	}
+
+	throw lastError ?? new Error("Timed out waiting for Stripe portal sync");
 };
 
 test.concurrent(
@@ -129,7 +129,7 @@ test.concurrent(
 			ultraId: ultra.id,
 		});
 	},
-	30000,
+	60000,
 );
 
 test.concurrent(
@@ -169,5 +169,5 @@ test.concurrent(
 			ultraId: ultra.id,
 		});
 	},
-	30000,
+	60000,
 );

--- a/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-portal-plan-sync.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-portal-plan-sync.test.ts
@@ -10,8 +10,11 @@
  */
 
 import { test } from "bun:test";
-import type { ApiCustomerV3 } from "@autumn/shared";
-import { getFirstStripePriceId } from "@tests/integration/billing/sync/utils/syncTestUtils";
+import type { ApiCustomerV3, ProductItem } from "@autumn/shared";
+import {
+	getAllStripePriceIds,
+	getFirstStripePriceId,
+} from "@tests/integration/billing/sync/utils/syncTestUtils";
 import { getSubscriptionId } from "@tests/integration/billing/utils/stripe/getSubscriptionId";
 import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
 import { items } from "@tests/utils/fixtures/items";
@@ -21,70 +24,149 @@ import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 import { ProductService } from "@/internal/products/ProductService";
 
+type ScenarioContext = Awaited<ReturnType<typeof initScenario>>;
+
+const setupPortalPlanSync = async ({
+	customerId,
+	proItems = [items.monthlyMessages({ includedUsage: 100 })],
+}: {
+	customerId: string;
+	proItems?: ProductItem[];
+}) => {
+	const pro = products.pro({
+		id: "pro",
+		items: proItems,
+	});
+	const ultra = products.ultra({
+		id: "ultra",
+		items: [items.monthlyMessages({ includedUsage: 200 })],
+	});
+
+	const { autumnV1, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro, ultra] }),
+		],
+		actions: [s.billing.attach({ productId: ultra.id })],
+	});
+
+	const subscriptionId = await getSubscriptionId({
+		ctx,
+		customerId,
+		productId: ultra.id,
+	});
+	const subscription = await ctx.stripeCli.subscriptions.retrieve(subscriptionId);
+	const subscriptionItemId = subscription.items.data[0]?.id;
+	if (!subscriptionItemId) {
+		throw new Error(`Subscription ${subscriptionId} has no item to update`);
+	}
+	await ctx.stripeCli.subscriptions.update(subscriptionId, {
+		metadata: {
+			autumn_managed_at: "1",
+			autumn_managed_source: "attach",
+		},
+	});
+
+	const fullPro = await ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: pro.id,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+
+	return {
+		autumnV1,
+		ctx,
+		pro,
+		ultra,
+		subscriptionId,
+		subscriptionItemId,
+		proStripePriceIds: getAllStripePriceIds({ fullProduct: fullPro }),
+		proStripePriceId: getFirstStripePriceId({ fullProduct: fullPro }),
+	};
+};
+
+const expectProSynced = async ({
+	autumnV1,
+	customerId,
+	proId,
+	ultraId,
+}: {
+	autumnV1: ScenarioContext["autumnV1"];
+	customerId: string;
+	proId: string;
+	ultraId: string;
+}) => {
+	await timeout(10000);
+
+	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectCustomerProducts({
+		customer,
+		active: [proId],
+		notPresent: [ultraId],
+	});
+};
+
 test.concurrent(
 	chalk.yellowBright(
 		"sub.updated portal plan sync: Stripe item price change backsyncs Ultra to Pro",
 	),
 	async () => {
 		const customerId = "sub-updated-portal-plan-sync";
-
-		const pro = products.pro({
-			id: "pro",
-			items: [items.monthlyMessages({ includedUsage: 100 })],
-		});
-		const ultra = products.ultra({
-			id: "ultra",
-			items: [items.monthlyMessages({ includedUsage: 200 })],
-		});
-
-		const { autumnV1, ctx } = await initScenario({
-			customerId,
-			setup: [
-				s.customer({ paymentMethod: "success" }),
-				s.products({ list: [pro, ultra] }),
-			],
-			actions: [s.billing.attach({ productId: ultra.id })],
-		});
-
-		const subscriptionId = await getSubscriptionId({
-			ctx,
-			customerId,
-			productId: ultra.id,
-		});
-		const subscription = await ctx.stripeCli.subscriptions.retrieve(
-			subscriptionId,
-		);
-		const subscriptionItemId = subscription.items.data[0]?.id;
-		if (!subscriptionItemId) {
-			throw new Error(`Subscription ${subscriptionId} has no item to update`);
-		}
-		await ctx.stripeCli.subscriptions.update(subscriptionId, {
-			metadata: {
-				autumn_managed_at: "1",
-				autumn_managed_source: "attach",
-			},
-		});
-
-		const fullPro = await ProductService.getFull({
-			db: ctx.db,
-			idOrInternalId: pro.id,
-			orgId: ctx.org.id,
-			env: ctx.env,
-		});
-		const proStripePriceId = getFirstStripePriceId({ fullProduct: fullPro });
+		const { autumnV1, ctx, pro, ultra, subscriptionItemId, proStripePriceId } =
+			await setupPortalPlanSync({ customerId });
 
 		await ctx.stripeCli.subscriptionItems.update(subscriptionItemId, {
 			price: proStripePriceId,
 			proration_behavior: "none",
 		});
 
-		await timeout(10000);
+		await expectProSynced({
+			autumnV1,
+			customerId,
+			proId: pro.id,
+			ultraId: ultra.id,
+		});
+	},
+	30000,
+);
 
-		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
-		await expectCustomerProducts({
-			customer,
-			active: [pro.id],
-			notPresent: [ultra.id],
+test.concurrent(
+	chalk.yellowBright(
+		"sub.updated portal plan sync: replaced Stripe item backsyncs Ultra to Pro",
+	),
+	async () => {
+		const customerId = "sub-updated-portal-item-replace";
+		const {
+			autumnV1,
+			ctx,
+			pro,
+			ultra,
+			subscriptionId,
+			subscriptionItemId,
+			proStripePriceIds,
+		} = await setupPortalPlanSync({
+			customerId,
+			proItems: [
+				items.monthlyMessages({ includedUsage: 100 }),
+				items.consumableWords({ includedUsage: 0 }),
+			],
+		});
+
+		await ctx.stripeCli.subscriptions.update(subscriptionId, {
+			items: [
+				{ id: subscriptionItemId, deleted: true },
+				...proStripePriceIds.map((price) => ({ price })),
+			],
+			proration_behavior: "none",
+		});
+
+		await expectProSynced({
+			autumnV1,
+			customerId,
+			proId: pro.id,
+			ultraId: ultra.id,
 		});
 	},
 	30000,

--- a/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-portal-plan-sync.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-portal-plan-sync.test.ts
@@ -1,0 +1,91 @@
+/**
+ * TDD test for Stripe Billing Portal plan changes.
+ *
+ * Red-failure mode (current behavior):
+ *  - Stripe's customer.subscription.updated webhook changes the subscription
+ *    item price from Ultra to Pro, but Autumn keeps Ultra active.
+ *
+ * Green-success criteria (after fix):
+ *  - The webhook backsync expires Ultra and activates Pro.
+ */
+
+import { test } from "bun:test";
+import type { ApiCustomerV3 } from "@autumn/shared";
+import { getFirstStripePriceId } from "@tests/integration/billing/sync/utils/syncTestUtils";
+import { getSubscriptionId } from "@tests/integration/billing/utils/stripe/getSubscriptionId";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { timeout } from "@tests/utils/genUtils";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { ProductService } from "@/internal/products/ProductService";
+
+test.concurrent(
+	chalk.yellowBright(
+		"sub.updated portal plan sync: Stripe item price change backsyncs Ultra to Pro",
+	),
+	async () => {
+		const customerId = "sub-updated-portal-plan-sync";
+
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const ultra = products.ultra({
+			id: "ultra",
+			items: [items.monthlyMessages({ includedUsage: 200 })],
+		});
+
+		const { autumnV1, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, ultra] }),
+			],
+			actions: [s.billing.attach({ productId: ultra.id })],
+		});
+
+		const subscriptionId = await getSubscriptionId({
+			ctx,
+			customerId,
+			productId: ultra.id,
+		});
+		const subscription = await ctx.stripeCli.subscriptions.retrieve(
+			subscriptionId,
+		);
+		const subscriptionItemId = subscription.items.data[0]?.id;
+		if (!subscriptionItemId) {
+			throw new Error(`Subscription ${subscriptionId} has no item to update`);
+		}
+		await ctx.stripeCli.subscriptions.update(subscriptionId, {
+			metadata: {
+				autumn_managed_at: "1",
+				autumn_managed_source: "attach",
+			},
+		});
+
+		const fullPro = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: pro.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		const proStripePriceId = getFirstStripePriceId({ fullProduct: fullPro });
+
+		await ctx.stripeCli.subscriptionItems.update(subscriptionItemId, {
+			price: proStripePriceId,
+			proration_behavior: "none",
+		});
+
+		await timeout(10000);
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerProducts({
+			customer,
+			active: [pro.id],
+			notPresent: [ultra.id],
+		});
+	},
+	30000,
+);

--- a/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-portal-plan-sync.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-portal-plan-sync.test.ts
@@ -91,8 +91,8 @@ const expectProSynced = async ({
 	let lastError: unknown;
 
 	while (Date.now() < deadline) {
-		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
 		try {
+			const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
 			await expectCustomerProducts({
 				customer,
 				active: [proId],


### PR DESCRIPTION
## Summary
- auto-sync Stripe customer.subscription.updated item price/product changes through syncV2
- keep stale Autumn metadata from blocking external portal plan changes while preserving default managed-source behavior
- track syncV2 insert/update mutations so billing.updated/logging receive the changes
- clean up autoSyncUpdatedSubscription into a linear flow with small predicates/helpers

## Tests
- bun test ./server/tests/unit/billing/is-autumn-managed-subscription-metadata.test.ts
- bun test ./server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-portal-plan-sync.test.ts
- cd server && bunx tsgo --build --noEmit
- commit hook: knip + @autumn/server ts

## Note
- Broader subscription-updated folder run passes the new portal test and past-due tests, but two existing uncancel cases still fail on scheduled free products when run independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Back-sync plan changes from the Stripe Billing Portal by auto-syncing `customer.subscription.updated` price/product swaps through `syncV2`. Enforces same non-null product group and handles item replacements to expire the old plan and activate the new one.

- **Bug Fixes**
  - Auto-sync price/product swaps and replaced subscription items via `syncV2` when a portal plan change occurs (exactly one linked product, same non-null group).
  - Ignore stale `autumn_managed_*` metadata so portal changes aren’t blocked; preserve managed-source defaults with `ignoreManagedSource`.
  - Track `syncV2` insert/expire mutations so billing updates emit correctly; stabilized the portal sync integration test with retry polling.

- **Refactors**
  - Extracted `autoSyncUpdatedSubscription` into a linear flow with small predicates/helpers.
  - Added structured logs for auto-sync decisions and outcomes.

<sup>Written for commit c26329cd470601b28f10e00a0c9de9ae8d29a999. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes Stripe Billing Portal plan changes not being reflected in Autumn when users swap subscription plans outside of Autumn's control. It introduces a new `autoSyncUpdatedSubscription` task that detects price/product item swaps on incoming `customer.subscription.updated` webhooks and drives them through `syncV2`, while relaxing the `autumn_managed_source` short-circuit so stale Autumn metadata no longer blocks legitimate portal-initiated changes.

- **Bug fixes**: Adds `autoSyncUpdatedSubscription` to the webhook handler pipeline; when a portal plan swap is detected and the last Autumn-managed timestamp is outside the 10-minute recency window, `syncV2` is invoked to expire the old product and activate the new one.
- **Bug fixes / Improvements**: Introduces `ignoreManagedSource` option to `isAutumnManagedSubscriptionMetadata`, preserving the existing short-circuit for callers that still need it while letting the auto-sync path rely solely on the time-based `autumn_managed_at` recency check.
- **Improvements**: `trackSyncResult` wires `syncV2` insert/update mutations back into the shared `updatedCustomerProducts` / `insertedCustomerProducts` lists so downstream `logCustomerProductUpdates` and `emitBillingChangeWebhook` steps see the changes.
</details>

<h3>Confidence Score: 3/5</h3>

Safe to merge after resolving the null-group auto-sync edge case; the rest of the change is well-guarded and the new test covers the intended scenario.

The null-group comparison in shouldSyncPlanChange could silently auto-sync between two completely unrelated products for any org that hasn't explicitly assigned product groups. The condition succeeds whenever prices match a different null-group product, making the group guard ineffective for those setups. The recency window, the single-linked-product guard, and canAutoSync checks are solid, but this one condition could swap the wrong plan for affected customers in production.

server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts — specifically the shouldSyncPlanChange group comparison and the priceOrProductChanged item-count assumption.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts | New file implementing portal plan-change auto-sync; logic is well-structured with appropriate guards, but the item-count equality check in priceOrProductChanged makes an undocumented assumption about Stripe's previousAttributes format, and shouldSyncPlanChange's null-group comparison can match unrelated products. |
| server/src/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata.ts | Adds ignoreManagedSource opt-in parameter with a safe default of false, cleanly preserving existing caller behaviour; the time-window guard still prevents looping. |
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/handleStripeSubscriptionUpdated.ts | Inserts autoSyncUpdatedSubscription between the existing trial-end handler and the logging/webhook-emit steps; ordering is correct so tracking changes flow into both downstream steps. |
| server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-portal-plan-sync.test.ts | Integration test correctly exercises the stale-metadata path; uses notPresent to verify Ultra is fully expired, relies on a 10-second fixed timeout that may be brittle in slow CI environments. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Portal as Stripe Billing Portal
    participant Stripe
    participant Webhook as Webhook Handler
    participant AutoSync as autoSyncUpdatedSubscription
    participant Meta as isAutumnManagedMetadata
    participant SyncV2 as billingActions.syncV2
    participant Track as trackSyncResult

    Portal->>Stripe: Update subscription item price (Ultra→Pro)
    Stripe->>Webhook: customer.subscription.updated
    Webhook->>Webhook: handleSchedulePhaseChanges
    Webhook->>Webhook: syncCustomerProductStatus
    Webhook->>Webhook: handleStripeSubscriptionCanceled / Renewed
    Webhook->>Webhook: syncAutumnSubscription
    Webhook->>Webhook: handleCancelOnPastDue / handleIgnorePastDue
    Webhook->>AutoSync: autoSyncUpdatedSubscription()
    AutoSync->>AutoSync: priceOrProductChanged() → true
    AutoSync->>Meta: "isAutumnManagedSubscriptionMetadata(ignoreManagedSource=true, requireRecent=true)"
    alt autumn_managed_at within 10-min window
        Meta-->>AutoSync: "skip=true — bail out (loop prevention)"
    else stale or absent autumn_managed_at
        Meta-->>AutoSync: "skip=false — proceed"
        AutoSync->>AutoSync: "linkedProducts.length === 1"
        AutoSync->>AutoSync: subscriptionToSyncParams()
        AutoSync->>AutoSync: canAutoSync() → eligible
        AutoSync->>AutoSync: shouldSyncPlanChange() → same group, different product
        AutoSync->>SyncV2: syncV2(params)
        SyncV2-->>AutoSync: expired_cus_product_ids + inserted_cus_product_ids
        AutoSync->>Track: trackSyncResult()
        Track->>Track: trackCustomerProductUpdate (Ultra expired)
        Track->>Track: trackCustomerProductInsertion (Pro active)
    end
    AutoSync-->>Webhook: done
    Webhook->>Webhook: logCustomerProductUpdates
    Webhook->>Webhook: emitBillingChangeWebhook
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Portal as Stripe Billing Portal
    participant Stripe
    participant Webhook as Webhook Handler
    participant AutoSync as autoSyncUpdatedSubscription
    participant Meta as isAutumnManagedMetadata
    participant SyncV2 as billingActions.syncV2
    participant Track as trackSyncResult

    Portal->>Stripe: Update subscription item price (Ultra→Pro)
    Stripe->>Webhook: customer.subscription.updated
    Webhook->>Webhook: handleSchedulePhaseChanges
    Webhook->>Webhook: syncCustomerProductStatus
    Webhook->>Webhook: handleStripeSubscriptionCanceled / Renewed
    Webhook->>Webhook: syncAutumnSubscription
    Webhook->>Webhook: handleCancelOnPastDue / handleIgnorePastDue
    Webhook->>AutoSync: autoSyncUpdatedSubscription()
    AutoSync->>AutoSync: priceOrProductChanged() → true
    AutoSync->>Meta: "isAutumnManagedSubscriptionMetadata(ignoreManagedSource=true, requireRecent=true)"
    alt autumn_managed_at within 10-min window
        Meta-->>AutoSync: "skip=true — bail out (loop prevention)"
    else stale or absent autumn_managed_at
        Meta-->>AutoSync: "skip=false — proceed"
        AutoSync->>AutoSync: "linkedProducts.length === 1"
        AutoSync->>AutoSync: subscriptionToSyncParams()
        AutoSync->>AutoSync: canAutoSync() → eligible
        AutoSync->>AutoSync: shouldSyncPlanChange() → same group, different product
        AutoSync->>SyncV2: syncV2(params)
        SyncV2-->>AutoSync: expired_cus_product_ids + inserted_cus_product_ids
        AutoSync->>Track: trackSyncResult()
        Track->>Track: trackCustomerProductUpdate (Ultra expired)
        Track->>Track: trackCustomerProductInsertion (Pro active)
    end
    AutoSync-->>Webhook: done
    Webhook->>Webhook: logCustomerProductUpdates
    Webhook->>Webhook: emitBillingChangeWebhook
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts:34-37
The item-count equality guard silently skips auto-sync whenever the number of current items differs from the number of entries in `previousAttributes.items.data`. If Stripe populates `previousAttributes.items.data` with only the changed items (not the full previous list), a subscription with two items where only one price changed would see `currentItems.size (2) !== previousAttributes.items.data.length (1)` and return `false`. A comment stating the assumption — that `previousAttributes.items.data` always reflects the complete previous item list — would prevent future confusion and make any regression detectable.

```suggestion
	const currentItems = new Map(
		stripeSubscription.items.data.map((item) => [item.id, item]),
	);
	// Stripe includes the complete previous items list in previousAttributes.items.data
	// (not just changed items). A size mismatch means items were added or removed —
	// that's not a price swap, so skip auto-sync.
	if (currentItems.size !== previousAttributes.items.data.length) return false;
```

### Issue 2 of 2
server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts:63-69
`shouldSyncPlanChange` uses `===` to compare `product.group` values. When both the matched plan's product and the currently linked product have `group: null` (or `undefined`), this evaluates to `null === null → true`, effectively treating every null-group product as belonging to the same family. If an org has multiple unrelated products with no explicit group, a Stripe portal price change to any one of them could trigger an auto-sync that swaps a completely unrelated product. Adding an explicit null-group guard would prevent this.

```suggestion
	return (
		currentPhase?.plans.length === 1 &&
		params.phases?.length === 1 &&
		params.phases[0].plans.length === 1 &&
		matchedPlan?.product.id !== linkedProduct.product.id &&
		!!matchedPlan?.product.group &&
		matchedPlan?.product.group === linkedProduct.product.group
	);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: cleanup auto sync updated"](https://github.com/useautumn/autumn/commit/90efcf813b4dc8412cad751a192b500ece76c8aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40083586)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->