### PR TITLE
fix: 🐛 new ui pacakge imports

### DIFF
--- a/apps/testbench/src/index.css
+++ b/apps/testbench/src/index.css
@@ -1,11 +1,11 @@
-/* Reuse the MAIN vite app's stylesheet verbatim — identical tokens, @theme,
-   fonts, presets, scrollbars. */
-@import "../../../vite/src/index.css";
+/* Reuse the shared UI stylesheet verbatim — identical tokens, @theme, fonts,
+   presets, scrollbars (same entrypoint the main vite app loads). */
+@import "../../../packages/ui/src/styles/index.css";
 
 /* Tailwind v4 must scan both testbench's own files and the reused vite
    components for class names. */
 @source "./**/*.tsx";
-@source "../../../vite/src/components/**/*.tsx";
+@source "../../../packages/ui/src/components/**/*.tsx";
 
 /* Single-screen shell: the app is h-dvh and scrolls only inside its panels (the
    vite app's convention — `w-screen h-screen overflow-hidden`). The page itself

--- a/apps/testbench/src/views/Overall.tsx
+++ b/apps/testbench/src/views/Overall.tsx
@@ -2,10 +2,10 @@ import { Activity, FileText, Zap } from "lucide-react";
 import type { ReactNode } from "react";
 // Light section primitives imported DIRECTLY (not via the barrel, which pulls in
 // motion/react-router/ErrorScreen) — these only depend on `cn`.
-import { TableActions } from "@/components/general/table/table-actions";
-import { TableContainer } from "@/components/general/table/table-container";
-import { TableHeading } from "@/components/general/table/table-heading";
-import { TableToolbar } from "@/components/general/table/table-toolbar";
+import { TableActions } from "@/components/table/table-actions";
+import { TableContainer } from "@/components/table/table-container";
+import { TableHeading } from "@/components/table/table-heading";
+import { TableToolbar } from "@/components/table/table-toolbar";
 import {
 	TableBody,
 	TableCell,
@@ -14,7 +14,7 @@ import {
 	TableRow,
 	Table as UiTable,
 } from "@/components/ui/table";
-import { InfoRow } from "@/components/v2/InfoRow";
+import { InfoRow } from "@/components/general/info-row";
 import type { Phase, Snapshot } from "../types";
 import {
 	Elapsed,

--- a/apps/testbench/tsconfig.app.json
+++ b/apps/testbench/tsconfig.app.json
@@ -2,7 +2,8 @@
 	"compilerOptions": {
 		"baseUrl": ".",
 		"paths": {
-			"@/*": ["../../vite/src/*"],
+			"@/*": ["../../packages/ui/src/*"],
+			"@autumn/ui/*": ["../../packages/ui/src/*"],
 			"@api/*": ["../../shared/api/*"],
 			"@models/*": ["../../shared/models/*"],
 			"@utils/*": ["../../shared/utils/*"]

--- a/apps/testbench/tsconfig.json
+++ b/apps/testbench/tsconfig.json
@@ -6,7 +6,7 @@
 	],
 	"compilerOptions": {
 		"paths": {
-			"@/*": ["../../vite/src/*"]
+			"@/*": ["../../packages/ui/src/*"]
 		}
 	}
 }

--- a/apps/testbench/vite.config.ts
+++ b/apps/testbench/vite.config.ts
@@ -12,10 +12,10 @@ export default defineConfig({
 	resolve: {
 		dedupe: ["react", "react-dom"],
 		alias: [
-			// `@` resolves into the MAIN vite app's src so its reused components find
-			// their own `@/components/ui/...` + `@/lib/utils` imports unmodified.
-			// Testbench's own files import each other via relative paths.
-			{ find: "@", replacement: path.resolve(__dirname, "../../vite/src") },
+			// `@` resolves into the shared @autumn/ui package src so reused components
+			// find their `@/components/ui/...` + `@/lib/utils` paths. Testbench's own
+			// files import each other via relative paths.
+			{ find: "@", replacement: path.resolve(__dirname, "../../packages/ui/src") },
 			{ find: /^react$/, replacement: require.resolve("react") },
 			{ find: /^react-dom$/, replacement: require.resolve("react-dom") },
 			{


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pointed the Testbench to the shared UI package (`@autumn/ui`) for components and styles, replacing references to the main Vite app. Fixes broken imports and ensures Tailwind v4 scans the right files.

- **Bug Fixes**
  - CSS: import `packages/ui/src/styles/index.css`; update Tailwind `@source` to `packages/ui/src/components`.
  - TS: adjust `@/components` imports (table primitives) and `InfoRow` to new paths.
  - Config: map `@/*` and `@autumn/ui/*` to `../../packages/ui/src/*` in tsconfig.
  - Vite: set `@` alias to `../../packages/ui/src`; keep React dedupe.

<sup>Written for commit da7320469b68f66041abeeb85949ca6d717779f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the `testbench` app after the UI components were extracted from `apps/vite/src` into a new shared `packages/ui` package, updating all import paths, path aliases, and CSS sources accordingly.

- **Bug fixes** — CSS `@import` and `@source` directives updated from `vite/src` to `packages/ui/src/styles` and `packages/ui/src/components`; all resolved targets confirmed to exist.
- **Bug fixes** — `Overall.tsx` component imports corrected to their new locations under `@/components/table/` and `@/components/general/info-row`.
- **Bug fixes** — TypeScript path alias `@/*` and Vite `resolve.alias` both re-pointed to `packages/ui/src`; a new `@autumn/ui/*` alias is also added to `tsconfig.app.json`.
</details>

<h3>Confidence Score: 4/5</h3>

The change is a straightforward import re-pointing; all target files exist at their new paths and the build should work correctly.

All resolved paths were verified to exist in packages/ui/src. The only loose end is the @autumn/ui/* alias added to tsconfig.app.json but not to tsconfig.json, which means IDE language servers may not resolve that alias — but no current code uses it, so there is no runtime impact today.

apps/testbench/tsconfig.json — missing the @autumn/ui/* alias that was added to tsconfig.app.json

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/testbench/src/index.css | Updates CSS import and @source paths from the old vite/src location to packages/ui/src/styles; both targets confirmed to exist. |
| apps/testbench/src/views/Overall.tsx | Updates four component imports (table primitives and InfoRow) to their new paths under packages/ui/src; all resolved targets verified to exist. |
| apps/testbench/tsconfig.app.json | Redirects @/* alias to packages/ui/src and adds a new @autumn/ui/* alias; the @autumn/ui/* entry is not mirrored in tsconfig.json so IDE language server may not resolve it when using the root config. |
| apps/testbench/tsconfig.json | Updates the root @/* path alias to packages/ui/src, consistent with the app tsconfig and vite config changes. |
| apps/testbench/vite.config.ts | Updates the explicit @ alias from vite/src to packages/ui/src, consistent with both tsconfig files; no runtime concerns. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    TB[testbench app] -->|"@/* alias"| UI[packages/ui/src]
    TB -->|"@autumn/ui/* alias\n(tsconfig.app.json only)"| UI
    UI --> C[components/table/]
    UI --> G[components/general/]
    UI --> S[styles/index.css]
    TB -->|"CSS @import"| S
    TB -->|"CSS @source"| C

    subgraph OLD ["Before (removed)"]
        V[vite/src]
    end

    style OLD fill:#fee2e2,stroke:#ef4444
    style UI fill:#dcfce7,stroke:#16a34a
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    TB[testbench app] -->|"@/* alias"| UI[packages/ui/src]
    TB -->|"@autumn/ui/* alias\n(tsconfig.app.json only)"| UI
    UI --> C[components/table/]
    UI --> G[components/general/]
    UI --> S[styles/index.css]
    TB -->|"CSS @import"| S
    TB -->|"CSS @source"| C

    subgraph OLD ["Before (removed)"]
        V[vite/src]
    end

    style OLD fill:#fee2e2,stroke:#ef4444
    style UI fill:#dcfce7,stroke:#16a34a
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/testbench/tsconfig.json:7-11
The `@autumn/ui/*` alias was added to `tsconfig.app.json` but not here in `tsconfig.json`. IDEs commonly use the root `tsconfig.json` as their language-server project, so `@autumn/ui/...` imports will appear unresolved in the editor even though the Vite build succeeds via `vite-tsconfig-paths`. Mirroring the alias keeps IDE resolution in sync.

```suggestion
	"compilerOptions": {
		"paths": {
			"@/*": ["../../packages/ui/src/*"],
			"@autumn/ui/*": ["../../packages/ui/src/*"]
		}
	}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 new ui pacakge imports"](https://github.com/useautumn/autumn/commit/da7320469b68f66041abeeb85949ca6d717779f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40107225)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->