### PR TITLE
chore: fix create schedule inconsistencies

### DIFF
--- a/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
@@ -109,11 +109,13 @@ export const setupImmediateMultiProductBillingContext = async ({
 	params,
 	preview = false,
 	billingStartsAt,
+	billingStartsAtToleranceMs,
 }: {
 	ctx: AutumnContext;
 	params: MultiAttachParamsV0;
 	preview?: boolean;
 	billingStartsAt?: number;
+	billingStartsAtToleranceMs?: number;
 }): Promise<MultiAttachBillingContext> => {
 	const fullCustomer = await setupFullCustomerContext({
 		ctx,
@@ -207,6 +209,7 @@ export const setupImmediateMultiProductBillingContext = async ({
 		trialContext,
 		currentEpochMs,
 		billingStartsAt,
+		billingStartsAtToleranceMs,
 	});
 
 	if (trialContext?.trialEndsAt) {

--- a/server/src/internal/billing/v2/actions/createSchedule/errors/handleFirstPhaseStartDateErrors.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/errors/handleFirstPhaseStartDateErrors.ts
@@ -8,7 +8,7 @@ import {
 import { assertNoBackdateWithExistingSubscription } from "@/internal/billing/v2/utils/backdate/assertNoBackdateWithExistingSubscription";
 import { assertStripeBackdateInvoiceLineItemLimit } from "@/internal/billing/v2/utils/backdate/stripeBackdateInvoiceLimit";
 
-const FIRST_PHASE_TOLERANCE_MS = ms.minutes(15);
+export const FIRST_PHASE_TOLERANCE_MS = ms.minutes(15);
 
 export const handleFirstPhaseStartDateErrors = ({
 	billingContext,

--- a/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
@@ -13,6 +13,7 @@ import { setupAnchorResetRefund } from "@/internal/billing/v2/setup/setupAnchorR
 import { setupBillingCycleAnchor } from "@/internal/billing/v2/setup/setupBillingCycleAnchor";
 import { setupResetCycleAnchor } from "@/internal/billing/v2/setup/setupResetCycleAnchor";
 import { setupImmediateMultiProductBillingContext } from "../../common/immediateMultiProduct/setupImmediateMultiProductBillingContext";
+import { FIRST_PHASE_TOLERANCE_MS } from "../errors/handleFirstPhaseStartDateErrors";
 import {
 	getInitialCreateSchedulePhase,
 	normalizeCreateSchedulePhases,
@@ -111,6 +112,7 @@ export const setupCreateScheduleBillingContext = async ({
 		billingStartsAt: phaseHasNumericStart(initialPhase)
 			? initialPhase.starts_at
 			: undefined,
+		billingStartsAtToleranceMs: FIRST_PHASE_TOLERANCE_MS,
 	});
 
 	validateCreateSchedulePhasePlans({
@@ -176,6 +178,7 @@ export const setupCreateScheduleBillingContext = async ({
 		subscriptionBackdateStartMs: isPastStartDate(
 			immediatePhase.starts_at,
 			billingContext.currentEpochMs,
+			FIRST_PHASE_TOLERANCE_MS,
 		)
 			? immediatePhase.starts_at
 			: undefined,

--- a/server/src/internal/billing/v2/setup/setupBillingCycleAnchor.ts
+++ b/server/src/internal/billing/v2/setup/setupBillingCycleAnchor.ts
@@ -24,6 +24,7 @@ export const setupBillingCycleAnchor = ({
 	currentEpochMs,
 	requestedBillingCycleAnchor,
 	billingStartsAt,
+	billingStartsAtToleranceMs,
 }: {
 	stripeSubscription?: Stripe.Subscription;
 	customerProduct?: FullCusProduct;
@@ -32,6 +33,7 @@ export const setupBillingCycleAnchor = ({
 	currentEpochMs: number;
 	requestedBillingCycleAnchor?: number | "now";
 	billingStartsAt?: number;
+	billingStartsAtToleranceMs?: number;
 }): number | "now" => {
 	if (requestedBillingCycleAnchor !== undefined) {
 		return requestedBillingCycleAnchor;
@@ -43,7 +45,11 @@ export const setupBillingCycleAnchor = ({
 	// free/one-off products have no recurring cycle to anchor.
 	if (
 		billingStartsAt !== undefined &&
-		isPastStartDate(billingStartsAt, currentEpochMs) &&
+		isPastStartDate(
+			billingStartsAt,
+			currentEpochMs,
+			billingStartsAtToleranceMs,
+		) &&
 		!customerProduct &&
 		isProductPaidAndRecurring(newFullProduct)
 	) {

--- a/server/tests/integration/billing/create-schedule/preview/create-schedule-preview.test.ts
+++ b/server/tests/integration/billing/create-schedule/preview/create-schedule-preview.test.ts
@@ -785,6 +785,50 @@ test.concurrent(
 );
 
 test.concurrent(
+	`${chalk.yellowBright("create-schedule preview 13b: stale immediate first phase does not backdate an existing subscription")}`,
+	async () => {
+		const pro = products.pro({
+			id: "preview-stale-immediate-pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const premium = products.premium({
+			id: "preview-stale-immediate-premium",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		const { customerId, autumnV1, advancedTo } = await initScenario({
+			customerId: "create-schedule-preview-stale-immediate",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [s.billing.attach({ productId: pro.id })],
+		});
+
+		const transitionAt = truncateMsToSecondPrecision(advancedTo + ms.days(15));
+		const preview = await previewCreateSchedule({
+			autumnV1,
+			params: {
+				customer_id: customerId,
+				phases: [
+					{
+						starts_at: advancedTo - ms.minutes(2),
+						plans: [{ plan_id: pro.id }],
+					},
+					{
+						starts_at: transitionAt,
+						plans: [{ plan_id: premium.id }],
+					},
+				],
+			},
+		});
+
+		expect(preview.line_items).toHaveLength(0);
+		expect(preview.next_cycle?.starts_at).toBe(transitionAt);
+	},
+);
+
+test.concurrent(
 	`${chalk.yellowBright("create-schedule preview 14: phase boundary prorates annual and monthly items independently")}`,
 	async () => {
 		const group = "preview-mixed-interval-phase";

--- a/shared/utils/common/unixUtils.ts
+++ b/shared/utils/common/unixUtils.ts
@@ -93,7 +93,8 @@ export const isFutureStartDate = (
 export const isPastStartDate = (
 	startDate: number,
 	currentEpochMs: number,
-): boolean => startDate < currentEpochMs - START_DATE_TOLERANCE_MS;
+	toleranceMs = START_DATE_TOLERANCE_MS,
+): boolean => startDate < currentEpochMs - toleranceMs;
 
 export const stripePhaseStartsInFuture = (
 	startDate: number | "now" | undefined,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes inconsistent create-schedule behavior by applying a 15-minute tolerance for “stale” immediate first phases, avoiding unintended backdating and incorrect previews. Also propagates this tolerance to billing cycle anchor calculations.

- **Bug Fixes**
  - Apply `FIRST_PHASE_TOLERANCE_MS` (15 min) to create-schedule and immediate multi-product flows; pass to `setupBillingCycleAnchor` and `isPastStartDate`.
  - Export `FIRST_PHASE_TOLERANCE_MS` and allow `isPastStartDate` to accept a custom tolerance.
  - Add integration test verifying a first phase 2 minutes in the past does not backdate an existing subscription and preserves the future transition.

<sup>Written for commit 8b868498879946bbfb0b7fbc816ba78138bba6ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a tolerance inconsistency in the create-schedule billing flow: `handleFirstPhaseStartDateErrors` gates on a 15-minute stale window (`FIRST_PHASE_TOLERANCE_MS`), but `setupBillingCycleAnchor` and `subscriptionBackdateStartMs` were still using the default 1-minute window, so a phase starting 2–14 minutes in the past would skip the error guard yet still incorrectly trigger backdating logic.

- **Bug fixes** — Exports `FIRST_PHASE_TOLERANCE_MS` (15 min) and threads it as `billingStartsAtToleranceMs` through `setupImmediateMultiProductBillingContext` → `setupBillingCycleAnchor`, and uses it when computing `subscriptionBackdateStartMs`, making all three checks consistent.
- **Improvements** — Makes `isPastStartDate` in `unixUtils.ts` accept an optional custom `toleranceMs` parameter (default unchanged at 1 min), keeping existing callers unaffected.
- **Improvements** — Adds integration test `preview 13b` that verifies a first phase 2 minutes in the past produces no backdate line items and correctly sets `next_cycle.starts_at` to the future phase boundary.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted consistency fix with no new external surface area and direct test coverage for the corrected behavior.

All three tolerance checks in the create-schedule path now agree on 15 minutes, eliminating the window where a stale start date would silently trigger backdating without going through the error guard. Existing callers of `isPastStartDate` and `setupBillingCycleAnchor` that omit the new optional parameter retain their original 1-minute behaviour unchanged. The new integration test directly exercises the fixed scenario.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/common/unixUtils.ts | Adds optional `toleranceMs` parameter to `isPastStartDate` with backward-compatible default; change is minimal and correct. |
| server/src/internal/billing/v2/actions/createSchedule/errors/handleFirstPhaseStartDateErrors.ts | Exports `FIRST_PHASE_TOLERANCE_MS` so other modules in the create-schedule flow can reference the same 15-minute constant; logic is unchanged. |
| server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts | Passes `billingStartsAtToleranceMs: FIRST_PHASE_TOLERANCE_MS` to the immediate billing context builder and aligns `subscriptionBackdateStartMs` check to the same 15-minute tolerance, closing the inconsistency. |
| server/src/internal/billing/v2/setup/setupBillingCycleAnchor.ts | Accepts and forwards the new optional `billingStartsAtToleranceMs` to `isPastStartDate`; callers that omit it retain the original 1-minute default. |
| server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts | Threads `billingStartsAtToleranceMs` through to `setupBillingCycleAnchor`; no other logic changed. |
| server/tests/integration/billing/create-schedule/preview/create-schedule-preview.test.ts | Adds test 13b: verifies a first phase 2 minutes stale (within 15-min tolerance) does not produce backdate line items and sets `next_cycle.starts_at` correctly. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["setupCreateScheduleBillingContext\n(params + FIRST_PHASE_TOLERANCE_MS)"] --> B["setupImmediateMultiProductBillingContext\n(billingStartsAt, billingStartsAtToleranceMs=15min)"]
    B --> C["setupBillingCycleAnchor\n(billingStartsAtToleranceMs=15min)"]
    C --> D{"isPastStartDate\n(startDate, now, toleranceMs=15min)"}
    D -- "true (>15min ago)" --> E["anchor = billingStartsAt\n(backdating triggered)"]
    D -- "false (<=15min ago)" --> F["anchor = stripeAnchor / now\n(no backdating)"]
    A --> G{"isPastStartDate\n(immediatePhase.starts_at, now, 15min)"}
    G -- "true" --> H["subscriptionBackdateStartMs = starts_at"]
    G -- "false" --> I["subscriptionBackdateStartMs = undefined"]
    J["handleFirstPhaseStartDateErrors\n(FIRST_PHASE_TOLERANCE_MS=15min)"] --> K{"firstPhaseStartsInPast?\n(starts_at < now - 15min)"}
    K -- "true" --> L["validate backdate constraints"]
    K -- "false" --> M["no error"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["setupCreateScheduleBillingContext\n(params + FIRST_PHASE_TOLERANCE_MS)"] --> B["setupImmediateMultiProductBillingContext\n(billingStartsAt, billingStartsAtToleranceMs=15min)"]
    B --> C["setupBillingCycleAnchor\n(billingStartsAtToleranceMs=15min)"]
    C --> D{"isPastStartDate\n(startDate, now, toleranceMs=15min)"}
    D -- "true (>15min ago)" --> E["anchor = billingStartsAt\n(backdating triggered)"]
    D -- "false (<=15min ago)" --> F["anchor = stripeAnchor / now\n(no backdating)"]
    A --> G{"isPastStartDate\n(immediatePhase.starts_at, now, 15min)"}
    G -- "true" --> H["subscriptionBackdateStartMs = starts_at"]
    G -- "false" --> I["subscriptionBackdateStartMs = undefined"]
    J["handleFirstPhaseStartDateErrors\n(FIRST_PHASE_TOLERANCE_MS=15min)"] --> K{"firstPhaseStartsInPast?\n(starts_at < now - 15min)"}
    K -- "true" --> L["validate backdate constraints"]
    K -- "false" --> M["no error"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix create schedule inconsistenci..."](https://github.com/useautumn/autumn/commit/8b868498879946bbfb0b7fbc816ba78138bba6ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40115757)</sub>

<!-- /greptile_comment -->