### PR TITLE
put the active sandbox name in the dashboard URL

### DIFF
--- a/server/src/internal/sandboxes/createSandbox.ts
+++ b/server/src/internal/sandboxes/createSandbox.ts
@@ -109,6 +109,32 @@ export const assertSandboxCapacity = async ({
 	}
 };
 
+export const assertSandboxNameUnique = async ({
+	db,
+	masterOrgId,
+	name,
+	excludeOrgId,
+}: {
+	db: DrizzleCli;
+	masterOrgId: string;
+	name: string;
+	excludeOrgId?: string;
+}): Promise<void> => {
+	const slug = slugify(name, "dash");
+	const existing = await OrgService.listSandboxes({ db, masterOrgId });
+	const taken = existing.some(
+		(sandbox) =>
+			sandbox.id !== excludeOrgId && slugify(sandbox.name, "dash") === slug,
+	);
+	if (taken) {
+		throw new RecaseError({
+			message: `A sandbox named "${name}" already exists`,
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+};
+
 export const createSandboxForOrg = async ({
 	db,
 	masterOrg,
@@ -125,6 +151,7 @@ export const createSandboxForOrg = async ({
 	icon?: SandboxIcon;
 }): Promise<{ org: Organization; secret_key: string }> => {
 	await assertSandboxCapacity({ db, masterOrgId: masterOrg.id });
+	await assertSandboxNameUnique({ db, masterOrgId: masterOrg.id, name });
 
 	const slug = `${slugify(name, "dash")}-${generateId()}|${masterOrg.id}`;
 

--- a/server/src/internal/sandboxes/createSandbox.ts
+++ b/server/src/internal/sandboxes/createSandbox.ts
@@ -8,6 +8,8 @@ import {
 	RecaseError,
 	type SandboxColor,
 	type SandboxIcon,
+	sandboxSlug,
+	validateSandboxName,
 } from "@autumn/shared";
 import { Autumn } from "autumn-js";
 import type { User } from "better-auth";
@@ -18,7 +20,6 @@ import { createKey } from "@/internal/dev/api-keys/apiKeyUtils.js";
 import { deletePlatformSubOrg } from "@/internal/orgs/deleteOrg/deletePlatformSubOrg.js";
 import { OrgService } from "@/internal/orgs/OrgService.js";
 import { provisionSubOrg } from "@/internal/orgs/orgUtils/provisionSubOrg.js";
-import { slugify } from "@/utils/genUtils.js";
 
 /**
  * Sandbox creation is a dashboard action: it needs the acting user (for Stripe
@@ -90,15 +91,18 @@ export const assertSandboxCapacity = async ({
 	db,
 	masterOrgId,
 	checkCapacity = defaultSandboxCapacityCheck,
+	existing,
 }: {
 	db: DrizzleCli;
 	masterOrgId: string;
 	checkCapacity?: SandboxCapacityCheck;
+	existing?: Awaited<ReturnType<typeof OrgService.listSandboxes>>;
 }): Promise<void> => {
-	const existing = await OrgService.listSandboxes({ db, masterOrgId });
+	const sandboxes =
+		existing ?? (await OrgService.listSandboxes({ db, masterOrgId }));
 	const { allowed } = await checkCapacity({
 		customerId: masterOrgId,
-		requiredBalance: existing.length + 1,
+		requiredBalance: sandboxes.length + 1,
 	});
 	if (allowed === false) {
 		throw new RecaseError({
@@ -114,21 +118,35 @@ export const assertSandboxNameUnique = async ({
 	masterOrgId,
 	name,
 	excludeOrgId,
+	existing,
 }: {
 	db: DrizzleCli;
 	masterOrgId: string;
 	name: string;
 	excludeOrgId?: string;
+	existing?: Awaited<ReturnType<typeof OrgService.listSandboxes>>;
 }): Promise<void> => {
-	const slug = slugify(name, "dash");
-	const existing = await OrgService.listSandboxes({ db, masterOrgId });
-	const taken = existing.some(
+	const slug = sandboxSlug(name);
+	const sandboxes =
+		existing ?? (await OrgService.listSandboxes({ db, masterOrgId }));
+	const taken = sandboxes.some(
 		(sandbox) =>
-			sandbox.id !== excludeOrgId && slugify(sandbox.name, "dash") === slug,
+			sandbox.id !== excludeOrgId && sandboxSlug(sandbox.name) === slug,
 	);
 	if (taken) {
 		throw new RecaseError({
 			message: `A sandbox named "${name}" already exists`,
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+};
+
+export const assertSandboxNameValid = ({ name }: { name: string }): void => {
+	const error = validateSandboxName(name);
+	if (error) {
+		throw new RecaseError({
+			message: error,
 			code: ErrCode.InvalidRequest,
 			statusCode: 400,
 		});
@@ -150,10 +168,20 @@ export const createSandboxForOrg = async ({
 	color?: SandboxColor;
 	icon?: SandboxIcon;
 }): Promise<{ org: Organization; secret_key: string }> => {
-	await assertSandboxCapacity({ db, masterOrgId: masterOrg.id });
-	await assertSandboxNameUnique({ db, masterOrgId: masterOrg.id, name });
+	assertSandboxNameValid({ name });
+	const existing = await OrgService.listSandboxes({
+		db,
+		masterOrgId: masterOrg.id,
+	});
+	await assertSandboxCapacity({ db, masterOrgId: masterOrg.id, existing });
+	await assertSandboxNameUnique({
+		db,
+		masterOrgId: masterOrg.id,
+		name,
+		existing,
+	});
 
-	const slug = `${slugify(name, "dash")}-${generateId()}|${masterOrg.id}`;
+	const slug = `${sandboxSlug(name)}-${generateId()}|${masterOrg.id}`;
 
 	const org = await provisionSubOrg({
 		db,

--- a/server/src/internal/sandboxes/updateSandbox.ts
+++ b/server/src/internal/sandboxes/updateSandbox.ts
@@ -1,6 +1,7 @@
 import type { Organization, SandboxColor, SandboxIcon } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { OrgService } from "@/internal/orgs/OrgService.js";
+import { assertSandboxNameUnique } from "./createSandbox.js";
 import { getOwnedSandbox } from "./getOwnedSandbox.js";
 
 export const updateSandboxForOrg = async ({
@@ -15,6 +16,15 @@ export const updateSandboxForOrg = async ({
 	updates: { name?: string; color?: SandboxColor; icon?: SandboxIcon };
 }): Promise<void> => {
 	await getOwnedSandbox({ db, masterOrg, sandboxId });
+
+	if (updates.name !== undefined) {
+		await assertSandboxNameUnique({
+			db,
+			masterOrgId: masterOrg.id,
+			name: updates.name,
+			excludeOrgId: sandboxId,
+		});
+	}
 
 	const orgUpdates: Partial<Organization> = {};
 	if (updates.name !== undefined) {

--- a/server/src/internal/sandboxes/updateSandbox.ts
+++ b/server/src/internal/sandboxes/updateSandbox.ts
@@ -1,7 +1,10 @@
 import type { Organization, SandboxColor, SandboxIcon } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { OrgService } from "@/internal/orgs/OrgService.js";
-import { assertSandboxNameUnique } from "./createSandbox.js";
+import {
+	assertSandboxNameUnique,
+	assertSandboxNameValid,
+} from "./createSandbox.js";
 import { getOwnedSandbox } from "./getOwnedSandbox.js";
 
 export const updateSandboxForOrg = async ({
@@ -18,6 +21,7 @@ export const updateSandboxForOrg = async ({
 	await getOwnedSandbox({ db, masterOrg, sandboxId });
 
 	if (updates.name !== undefined) {
+		assertSandboxNameValid({ name: updates.name });
 		await assertSandboxNameUnique({
 			db,
 			masterOrgId: masterOrg.id,

--- a/server/tests/unit/sandboxes/sandbox-capacity.test.ts
+++ b/server/tests/unit/sandboxes/sandbox-capacity.test.ts
@@ -9,6 +9,7 @@ const state = {
 	autumnArgs: null as null | Record<string, unknown>,
 	provisionCalled: false,
 	teardownCalled: false,
+	listSandboxesCalls: 0,
 };
 
 mock.module("@/db/initDrizzle.js", () => ({
@@ -32,7 +33,10 @@ mock.module("autumn-js", () => ({
 }));
 mock.module("@/internal/orgs/OrgService.js", () => ({
 	OrgService: {
-		listSandboxes: async () => state.existing,
+		listSandboxes: async () => {
+			state.listSandboxesCalls++;
+			return state.existing;
+		},
 	},
 }));
 mock.module("@/internal/orgs/orgUtils/provisionSubOrg.js", () => ({
@@ -74,6 +78,7 @@ beforeEach(() => {
 	state.autumnArgs = null;
 	state.provisionCalled = false;
 	state.teardownCalled = false;
+	state.listSandboxesCalls = 0;
 	process.env.AUTUMN_SECRET_KEY = "test_key";
 });
 
@@ -163,5 +168,28 @@ describe("createSandboxForOrg enforces the cap before provisioning", () => {
 			createSandboxForOrg({ db, masterOrg, actorUser, name: "My Sandbox" }),
 		).rejects.toMatchObject({ code: ErrCode.InvalidRequest });
 		expect(state.provisionCalled).toBe(false);
+	});
+
+	test("rejects a reserved-slug name and never provisions", async () => {
+		state.autumn = { allowed: true };
+		await expect(
+			createSandboxForOrg({ db, masterOrg, actorUser, name: "Products" }),
+		).rejects.toMatchObject({ code: ErrCode.InvalidRequest });
+		expect(state.provisionCalled).toBe(false);
+	});
+
+	test("rejects a name that slugifies to empty and never provisions", async () => {
+		state.autumn = { allowed: true };
+		await expect(
+			createSandboxForOrg({ db, masterOrg, actorUser, name: "🚀🎉" }),
+		).rejects.toMatchObject({ code: ErrCode.InvalidRequest });
+		expect(state.provisionCalled).toBe(false);
+	});
+
+	test("fetches the sandbox list once per create", async () => {
+		seedSandboxes(1);
+		state.autumn = { allowed: true };
+		await createSandboxForOrg({ db, masterOrg, actorUser, name: "My Sandbox" });
+		expect(state.listSandboxesCalls).toBe(1);
 	});
 });

--- a/server/tests/unit/sandboxes/sandbox-capacity.test.ts
+++ b/server/tests/unit/sandboxes/sandbox-capacity.test.ts
@@ -60,7 +60,10 @@ const actorUser = { id: "u1", email: "a@b.c" } as never;
 const db = {} as never;
 
 const seedSandboxes = (n: number) => {
-	state.existing = Array.from({ length: n }, (_, i) => ({ id: `s${i}` }));
+	state.existing = Array.from({ length: n }, (_, i) => ({
+		id: `s${i}`,
+		name: `Seed Sandbox ${i}`,
+	}));
 };
 
 beforeEach(() => {
@@ -151,5 +154,14 @@ describe("createSandboxForOrg enforces the cap before provisioning", () => {
 		expect(state.provisionCalled).toBe(true);
 		expect(res.secret_key).toBe("am_sk_test_generated");
 		expect(res.org.id).toBe("org_sandbox");
+	});
+
+	test("rejects a duplicate name and never provisions", async () => {
+		state.autumn = { allowed: true };
+		state.existing = [{ id: "s0", name: "My Sandbox" }];
+		await expect(
+			createSandboxForOrg({ db, masterOrg, actorUser, name: "My Sandbox" }),
+		).rejects.toMatchObject({ code: ErrCode.InvalidRequest });
+		expect(state.provisionCalled).toBe(false);
 	});
 });

--- a/server/tests/unit/sandboxes/update-sandbox.test.ts
+++ b/server/tests/unit/sandboxes/update-sandbox.test.ts
@@ -4,6 +4,7 @@ import { ErrCode, RecaseError } from "@autumn/shared";
 const state = {
 	target: null as null | Record<string, unknown>,
 	updateCalls: [] as Array<Record<string, unknown>>,
+	existing: [] as Array<Record<string, unknown>>,
 };
 
 mock.module("@/db/initDrizzle.js", () => ({
@@ -25,6 +26,7 @@ mock.module("@/internal/orgs/OrgService.js", () => ({
 		update: async (args: Record<string, unknown>) => {
 			state.updateCalls.push(args);
 		},
+		listSandboxes: async () => state.existing,
 	},
 }));
 
@@ -54,9 +56,18 @@ const call = (
 beforeEach(() => {
 	state.target = null;
 	state.updateCalls = [];
+	state.existing = [];
 });
 
 describe("updateSandboxForOrg (ownership-guarded)", () => {
+	test("rejects a rename to a name already used by another sandbox", async () => {
+		state.target = sandbox();
+		state.existing = [{ id: "org_other", name: "Taken" }];
+		await expect(call("org_sandbox", { name: "Taken" })).rejects.toMatchObject({
+			code: ErrCode.InvalidRequest,
+		});
+	});
+
 	test("updates an owned sandbox, mapping tokens to columns", async () => {
 		state.target = sandbox();
 		await call("org_sandbox", {

--- a/server/tests/unit/sandboxes/update-sandbox.test.ts
+++ b/server/tests/unit/sandboxes/update-sandbox.test.ts
@@ -68,6 +68,22 @@ describe("updateSandboxForOrg (ownership-guarded)", () => {
 		});
 	});
 
+	test("rejects a rename to a reserved-slug name, no update", async () => {
+		state.target = sandbox();
+		await expect(
+			call("org_sandbox", { name: "Products" }),
+		).rejects.toMatchObject({ code: ErrCode.InvalidRequest });
+		expect(state.updateCalls.length).toBe(0);
+	});
+
+	test("rejects a rename to a name that slugifies to empty, no update", async () => {
+		state.target = sandbox();
+		await expect(call("org_sandbox", { name: "🚀🎉" })).rejects.toMatchObject({
+			code: ErrCode.InvalidRequest,
+		});
+		expect(state.updateCalls.length).toBe(0);
+	});
+
 	test("updates an owned sandbox, mapping tokens to columns", async () => {
 		state.target = sandbox();
 		await call("org_sandbox", {

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -162,6 +162,7 @@ export * from "./models/orgModels/fullOrgModel";
 export * from "./models/orgModels/orgConfig";
 export * from "./models/orgModels/orgTable";
 export * from "./models/orgModels/sandboxDisplay";
+export * from "./models/orgModels/sandboxName";
 export * from "./models/otherModels/metadataTable";
 // Duration Types
 export * from "./models/productModels/durationTypes/rolloverExpiryDurationType";
@@ -228,6 +229,8 @@ export * from "./models/subModels/subTable";
 export * from "./types";
 // Agent Types (for pricing agent AI)
 export * from "./utils/agentTypes";
+export * from "./utils/auth/autumnOAuthScopes";
+export * from "./utils/auth/oauthScopeUtils";
 export * from "./utils/authAccessControl";
 export * from "./utils/billingUtils/index";
 // Checkout Utils
@@ -245,8 +248,6 @@ export * from "./utils/fullSubjectUtils";
 export * from "./utils/index";
 export * from "./utils/intervalUtils";
 export * from "./utils/invoices/index";
-export * from "./utils/auth/autumnOAuthScopes";
-export * from "./utils/auth/oauthScopeUtils";
 export * from "./utils/planFeatureUtils/planToDbFreeTrial";
 export * from "./utils/productDisplayUtils";
 export * from "./utils/productDisplayUtils/sortProductItems";

--- a/shared/models/orgModels/sandboxName.ts
+++ b/shared/models/orgModels/sandboxName.ts
@@ -1,0 +1,33 @@
+// Single source of truth for sandbox-name -> URL-slug rules, consumed by the
+// dashboard router and the server create/update guards. The reserved set mirrors
+// the top-level /sandbox/<page> route names so a slug can't shadow a real route.
+export const RESERVED_SANDBOX_SLUGS = new Set([
+	"products",
+	"customers",
+	"features",
+	"migrations",
+	"dev",
+	"analytics",
+	"settings",
+	"admin",
+	"quickstart",
+	"impersonate-redirect",
+	"trmnl",
+]);
+
+export const sandboxSlug = (name: string): string =>
+	name
+		.toLowerCase()
+		.replace(/ /g, "-")
+		.replace(/[^\w\s-]/g, "");
+
+export const validateSandboxName = (name: string): string | null => {
+	const slug = sandboxSlug(name);
+	if (!slug) {
+		return "Name must include at least one letter or number";
+	}
+	if (RESERVED_SANDBOX_SLUGS.has(slug)) {
+		return `"${name}" is a reserved name, pick another`;
+	}
+	return null;
+};

--- a/vite/src/App.tsx
+++ b/vite/src/App.tsx
@@ -3,7 +3,7 @@ import * as Sentry from "@sentry/react";
 import { init } from "@squircle/core";
 import * as React from "react";
 import { useEffect } from "react";
-import { BrowserRouter, Route, Routes } from "react-router";
+import { BrowserRouter, Navigate, Route, Routes } from "react-router";
 import { DashboardGate } from "./app/DashboardGate";
 import { MainLayout } from "./app/layout";
 import { OnboardingLayout } from "./app/OnboardingLayout";
@@ -49,6 +49,11 @@ const envRoutes = (
 		path={`/sandbox/${path}`}
 		element={sandboxElement}
 	/>,
+	<Route
+		key={`sandbox-named-${path}`}
+		path={`/sandbox/:sandboxSlug/${path}`}
+		element={sandboxElement}
+	/>,
 ];
 
 export default function App() {
@@ -87,6 +92,11 @@ export default function App() {
 				<Route path="/consent" element={<Consent />} />
 				<Route path="/accept" element={<AcceptInvitation />} />
 				<Route path="/close" element={<CloseScreen />} />
+
+				<Route
+					path="/sandbox/:sandboxSlug"
+					element={<Navigate replace to="products" />}
+				/>
 
 				{/* Onboarding routes without sidebar */}
 				<Route element={<OnboardingLayout />}>

--- a/vite/src/app/layout.tsx
+++ b/vite/src/app/layout.tsx
@@ -1,12 +1,11 @@
 import { AppEnv } from "@autumn/shared";
-import { IconButton } from "@autumn/ui";
+import { IconButton, SandboxBanner } from "@autumn/ui";
 import { ArrowRightIcon } from "@phosphor-icons/react";
 import { AutumnProvider } from "autumn-js/react";
 import { NuqsAdapter } from "nuqs/adapters/react-router/v7";
 import { useEffect, useRef, useState } from "react";
 import { Outlet } from "react-router";
 import { CustomToaster } from "@/components/general/CustomToaster";
-import { SandboxBanner } from "@autumn/ui";
 import { PortalContainerContext } from "@/contexts/PortalContainerContext";
 import { useAutumnFlags } from "@/hooks/common/useAutumnFlags";
 import { useGlobalErrorHandler } from "@/hooks/common/useGlobalErrorHandler";
@@ -14,6 +13,7 @@ import { useOrg } from "@/hooks/common/useOrg";
 import { useDevQuery } from "@/hooks/queries/useDevQuery";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useRewardsQuery } from "@/hooks/queries/useRewardsQuery";
+import { useSyncSandboxFromUrl } from "@/hooks/sandbox/useSyncSandboxFromUrl";
 import { useFeatureFlags } from "@/hooks/useFeatureFlags";
 import { cn } from "@/lib/utils";
 import { useEnv } from "@/utils/envUtils";
@@ -54,26 +54,51 @@ export function MainLayout() {
 				<PortalContainerContext.Provider value={containerRef}>
 					<div className="w-screen h-screen flex bg-outer-background">
 						<CustomToaster />
-						<div className="hidden sm:flex">
-							<MainSidebar />
-						</div>
-						<MobileSidebar
-							open={mobileSidebarOpen}
-							onOpenChange={setMobileSidebarOpen}
-						/>
-						<InviteNotifications />
-						<MainContent
+						<DashboardShell
 							containerRef={containerRef}
-							onOpenMobileSidebar={() => setMobileSidebarOpen(true)}
+							mobileSidebarOpen={mobileSidebarOpen}
+							onMobileSidebarOpenChange={setMobileSidebarOpen}
 						/>
-						{/* <ChatWidget /> */}
-						<CommandBar />
 					</div>
 				</PortalContainerContext.Provider>
 			</NuqsAdapter>
 		</AutumnProvider>
 	);
 }
+
+const DashboardShell = ({
+	containerRef,
+	mobileSidebarOpen,
+	onMobileSidebarOpenChange,
+}: {
+	containerRef: React.RefObject<HTMLDivElement>;
+	mobileSidebarOpen: boolean;
+	onMobileSidebarOpenChange: (open: boolean) => void;
+}) => {
+	const { sandboxUrlResolved } = useSyncSandboxFromUrl();
+
+	if (!sandboxUrlResolved) {
+		return <LoadingScreen fullPage />;
+	}
+
+	return (
+		<>
+			<div className="hidden sm:flex">
+				<MainSidebar />
+			</div>
+			<MobileSidebar
+				open={mobileSidebarOpen}
+				onOpenChange={onMobileSidebarOpenChange}
+			/>
+			<InviteNotifications />
+			<MainContent
+				containerRef={containerRef}
+				onOpenMobileSidebar={() => onMobileSidebarOpenChange(true)}
+			/>
+			<CommandBar />
+		</>
+	);
+};
 
 const MainContent = ({
 	containerRef,

--- a/vite/src/hooks/common/useQueryKeyFactory.ts
+++ b/vite/src/hooks/common/useQueryKeyFactory.ts
@@ -1,3 +1,4 @@
+import { AppEnv } from "@autumn/shared";
 import { useActiveSandbox } from "@/hooks/sandbox/useActiveSandbox";
 import { useEnv } from "@/utils/envUtils";
 import { useOrg } from "./useOrg";
@@ -15,6 +16,6 @@ export const useQueryKeyFactory = () => {
 		...key,
 		env,
 		org?.id,
-		activeSandbox?.id ?? null,
+		env === AppEnv.Sandbox ? (activeSandbox?.id ?? null) : null,
 	];
 };

--- a/vite/src/hooks/common/useTab.tsx
+++ b/vite/src/hooks/common/useTab.tsx
@@ -1,51 +1,33 @@
 import { useLocation } from "react-router";
+import { stripSandboxPrefix } from "@/hooks/sandbox/sandboxUrl";
 
 export const useTab = () => {
 	const { pathname } = useLocation();
-	if (
-		pathname.startsWith("/settings") ||
-		pathname.startsWith("/sandbox/settings")
-	) {
+	const path = stripSandboxPrefix(pathname);
+
+	if (path.startsWith("/settings")) {
 		return "settings";
 	}
-
-	if (pathname.startsWith("/admin") || pathname.startsWith("/sandbox/admin")) {
+	if (path.startsWith("/admin")) {
 		return "admin";
 	}
-
-	if (
-		pathname.startsWith("/analytics") ||
-		pathname.startsWith("/sandbox/analytics")
-	) {
+	if (path.startsWith("/analytics")) {
 		return "analytics";
 	}
-
-	if (
-		pathname.startsWith("/features") ||
-		pathname.startsWith("/sandbox/features")
-	) {
+	if (path.startsWith("/features")) {
 		return "features";
-	} else if (
-		pathname.startsWith("/products") ||
-		pathname.startsWith("/sandbox/products")
-	) {
-		return "products";
-	} else if (
-		pathname.startsWith("/migrations") ||
-		pathname.startsWith("/sandbox/migrations")
-	) {
-		return "migrations";
-	} else if (
-		pathname.startsWith("/customers") ||
-		pathname.startsWith("/sandbox/customers")
-	) {
-		return "customers";
-	} else if (
-		pathname.startsWith("/dev") ||
-		pathname.startsWith("/sandbox/dev")
-	) {
-		return "dev";
-	} else {
-		return "";
 	}
+	if (path.startsWith("/products")) {
+		return "products";
+	}
+	if (path.startsWith("/migrations")) {
+		return "migrations";
+	}
+	if (path.startsWith("/customers")) {
+		return "customers";
+	}
+	if (path.startsWith("/dev")) {
+		return "dev";
+	}
+	return "";
 };

--- a/vite/src/hooks/queries/useSandboxesQuery.tsx
+++ b/vite/src/hooks/queries/useSandboxesQuery.tsx
@@ -61,6 +61,7 @@ export const useSandboxesQuery = ({
 		sandboxes,
 		isLoading,
 		isFetching,
+		isSuccess,
 		error,
 		refetch,
 	};

--- a/vite/src/hooks/sandbox/sandboxUrl.ts
+++ b/vite/src/hooks/sandbox/sandboxUrl.ts
@@ -1,0 +1,70 @@
+import { slugify } from "@/utils/formatUtils/formatTextUtils";
+import { getActiveSandbox } from "./useActiveSandbox";
+
+export const SANDBOX_PREFIX = "/sandbox";
+
+// Reserved because they're legacy /sandbox/<page> routes: a sandbox whose slug is
+// one of these would have its URLs captured by the page route.
+export const RESERVED_SANDBOX_SLUGS = new Set([
+	"products",
+	"customers",
+	"features",
+	"migrations",
+	"dev",
+	"analytics",
+	"settings",
+	"admin",
+	"quickstart",
+	"impersonate-redirect",
+	"trmnl",
+]);
+
+export const sandboxSlug = (name: string) => slugify(name, "dash");
+
+export const isReservedSandboxSlug = (name: string) =>
+	RESERVED_SANDBOX_SLUGS.has(sandboxSlug(name));
+
+export const validateSandboxName = (name: string): string | null => {
+	const slug = sandboxSlug(name);
+	if (!slug) {
+		return "Name must include at least one letter or number";
+	}
+	if (RESERVED_SANDBOX_SLUGS.has(slug)) {
+		return `"${name}" is a reserved name, pick another`;
+	}
+	return null;
+};
+
+export const getSandboxSlugFromPath = (pathname: string): string | null => {
+	if (!pathname.startsWith(`${SANDBOX_PREFIX}/`)) {
+		return null;
+	}
+	const segment = pathname
+		.slice(SANDBOX_PREFIX.length + 1)
+		.split("/")[0]
+		.toLowerCase();
+	if (!segment || RESERVED_SANDBOX_SLUGS.has(segment)) {
+		return null;
+	}
+	return segment;
+};
+
+export const sandboxBasePath = (): string => {
+	const active = getActiveSandbox();
+	return active
+		? `${SANDBOX_PREFIX}/${sandboxSlug(active.name)}`
+		: SANDBOX_PREFIX;
+};
+
+export const stripSandboxPrefix = (pathname: string): string => {
+	if (!pathname.startsWith(SANDBOX_PREFIX)) {
+		return pathname;
+	}
+	const slug = getSandboxSlugFromPath(pathname);
+	const prefix = slug ? `${SANDBOX_PREFIX}/${slug}` : SANDBOX_PREFIX;
+	const bare = pathname.slice(prefix.length);
+	if (!bare) {
+		return "/";
+	}
+	return bare.startsWith("/") ? bare : `/${bare}`;
+};

--- a/vite/src/hooks/sandbox/sandboxUrl.ts
+++ b/vite/src/hooks/sandbox/sandboxUrl.ts
@@ -1,39 +1,7 @@
-import { slugify } from "@/utils/formatUtils/formatTextUtils";
+import { RESERVED_SANDBOX_SLUGS, sandboxSlug } from "@autumn/shared";
 import { getActiveSandbox } from "./useActiveSandbox";
 
 export const SANDBOX_PREFIX = "/sandbox";
-
-// Reserved because they're legacy /sandbox/<page> routes: a sandbox whose slug is
-// one of these would have its URLs captured by the page route.
-export const RESERVED_SANDBOX_SLUGS = new Set([
-	"products",
-	"customers",
-	"features",
-	"migrations",
-	"dev",
-	"analytics",
-	"settings",
-	"admin",
-	"quickstart",
-	"impersonate-redirect",
-	"trmnl",
-]);
-
-export const sandboxSlug = (name: string) => slugify(name, "dash");
-
-export const isReservedSandboxSlug = (name: string) =>
-	RESERVED_SANDBOX_SLUGS.has(sandboxSlug(name));
-
-export const validateSandboxName = (name: string): string | null => {
-	const slug = sandboxSlug(name);
-	if (!slug) {
-		return "Name must include at least one letter or number";
-	}
-	if (RESERVED_SANDBOX_SLUGS.has(slug)) {
-		return `"${name}" is a reserved name, pick another`;
-	}
-	return null;
-};
 
 export const getSandboxSlugFromPath = (pathname: string): string | null => {
 	if (!pathname.startsWith(`${SANDBOX_PREFIX}/`)) {
@@ -57,7 +25,10 @@ export const sandboxBasePath = (): string => {
 };
 
 export const stripSandboxPrefix = (pathname: string): string => {
-	if (!pathname.startsWith(SANDBOX_PREFIX)) {
+	if (
+		pathname !== SANDBOX_PREFIX &&
+		!pathname.startsWith(`${SANDBOX_PREFIX}/`)
+	) {
 		return pathname;
 	}
 	const slug = getSandboxSlugFromPath(pathname);

--- a/vite/src/hooks/sandbox/useSyncSandboxFromUrl.ts
+++ b/vite/src/hooks/sandbox/useSyncSandboxFromUrl.ts
@@ -1,3 +1,4 @@
+import { sandboxSlug } from "@autumn/shared";
 import { useEffect, useMemo } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { useOrg } from "@/hooks/common/useOrg";
@@ -5,7 +6,6 @@ import { useSandboxesQuery } from "@/hooks/queries/useSandboxesQuery";
 import {
 	getSandboxSlugFromPath,
 	SANDBOX_PREFIX,
-	sandboxSlug,
 } from "@/hooks/sandbox/sandboxUrl";
 import {
 	getActiveSandbox,

--- a/vite/src/hooks/sandbox/useSyncSandboxFromUrl.ts
+++ b/vite/src/hooks/sandbox/useSyncSandboxFromUrl.ts
@@ -1,0 +1,71 @@
+import { useEffect, useMemo } from "react";
+import { useLocation, useNavigate } from "react-router";
+import { useOrg } from "@/hooks/common/useOrg";
+import { useSandboxesQuery } from "@/hooks/queries/useSandboxesQuery";
+import {
+	getSandboxSlugFromPath,
+	SANDBOX_PREFIX,
+	sandboxSlug,
+} from "@/hooks/sandbox/sandboxUrl";
+import {
+	getActiveSandbox,
+	setActiveSandbox,
+	useActiveSandbox,
+} from "@/hooks/sandbox/useActiveSandbox";
+
+export const useSyncSandboxFromUrl = () => {
+	const { pathname } = useLocation();
+	const navigate = useNavigate();
+	const { org, isLoading: orgLoading } = useOrg();
+	const { sandboxes, isSuccess, error } = useSandboxesQuery({
+		enabled: !!org?.deployed,
+	});
+	const active = useActiveSandbox();
+
+	const slug = getSandboxSlugFromPath(pathname);
+	const inSandboxEnv = pathname.startsWith(SANDBOX_PREFIX);
+
+	// The list can never resolve the slug — it errored, or the org has no
+	// production env so it owns no named sandboxes. Stop gating instead of hanging.
+	const listUnavailable = !!error || (!orgLoading && !!org && !org.deployed);
+
+	const match = useMemo(
+		() =>
+			slug && isSuccess
+				? sandboxes.find((sandbox) => sandboxSlug(sandbox.name) === slug)
+				: undefined,
+		[slug, isSuccess, sandboxes],
+	);
+
+	useEffect(() => {
+		if (!slug) {
+			if (inSandboxEnv && getActiveSandbox()) {
+				setActiveSandbox(null);
+			}
+			return;
+		}
+		if (!isSuccess) {
+			return;
+		}
+		if (match) {
+			if (getActiveSandbox()?.id !== match.id) {
+				setActiveSandbox({
+					id: match.id,
+					name: match.name,
+					color: match.color,
+					icon: match.icon,
+				});
+			}
+			return;
+		}
+		setActiveSandbox(null);
+		navigate(`${SANDBOX_PREFIX}/products`, { replace: true });
+	}, [slug, inSandboxEnv, isSuccess, match, navigate]);
+
+	const matchesActive =
+		active != null && slug != null && sandboxSlug(active.name) === slug;
+
+	const sandboxUrlResolved = !slug || matchesActive || listUnavailable;
+
+	return { sandboxUrlResolved };
+};

--- a/vite/src/utils/genUtils.ts
+++ b/vite/src/utils/genUtils.ts
@@ -2,6 +2,10 @@ import { AppEnv } from "@autumn/shared";
 import { AxiosError } from "axios";
 import type { NavigateFunction } from "react-router-dom";
 import { ZodError } from "zod/v3";
+import {
+	sandboxBasePath,
+	stripSandboxPrefix,
+} from "@/hooks/sandbox/sandboxUrl";
 
 const compareStatus = (statusA: string, statusB: string) => {
 	const statusOrder = ["scheduled", "active", "past_due", "expired"];
@@ -42,7 +46,7 @@ const getBackendErrObj = (error: AxiosError) => {
 };
 
 export const getEnvFromPath = (path: string) => {
-	if (path.includes("/sandbox")) {
+	if (path === "/sandbox" || path.startsWith("/sandbox/")) {
 		return AppEnv.Sandbox;
 	}
 	return AppEnv.Live;
@@ -90,31 +94,13 @@ export const getOrgRouteRedirect = ({
 };
 
 export const envToPath = (env: AppEnv, currentPath: string) => {
-	// Check if we're on a customer detail page
-	const customerDetailPattern = /^(\/sandbox)?\/customers\/[^/]+/;
-	const isCustomerDetailPage = customerDetailPattern.test(currentPath);
-
-	if (isCustomerDetailPage) {
-		// Redirect to customers list instead of trying to preserve customer ID
-		return env === AppEnv.Sandbox ? "/sandbox/customers" : "/customers";
+	let bare = stripSandboxPrefix(currentPath);
+	// Detail routes carry an env-scoped id that does not exist in the other env;
+	// collapse to the list so the switch never lands on a 404.
+	if (/^\/(customers|products|migrations)\/[^/]+/.test(bare)) {
+		bare = `/${bare.split("/")[1]}`;
 	}
-
-	// Check if we're on a product detail page
-	const productDetailPattern = /^(\/sandbox)?\/products\/[^/]+/;
-	const isProductDetailPage = productDetailPattern.test(currentPath);
-
-	if (isProductDetailPage) {
-		// Redirect to products list instead of trying to preserve product ID
-		return env === AppEnv.Sandbox ? "/sandbox/products" : "/products";
-	}
-
-	if (env === AppEnv.Sandbox && !currentPath.includes("/sandbox")) {
-		return `/sandbox${currentPath}`;
-	} else if (env === AppEnv.Live && currentPath.includes("/sandbox")) {
-		return currentPath.replace("/sandbox", "");
-	}
-
-	return null;
+	return env === AppEnv.Sandbox ? `${sandboxBasePath()}${bare}` : bare;
 };
 
 export const navigateTo = (
@@ -127,7 +113,7 @@ export const navigateTo = (
 
 	path = path.replace("@", "%40");
 	if (curEnv === AppEnv.Sandbox) {
-		navigate(`/sandbox${path}`);
+		navigate(`${sandboxBasePath()}${path}`);
 	} else {
 		navigate(path);
 	}
@@ -175,7 +161,7 @@ export const pushPage = ({
 	}
 
 	if (curEnv === AppEnv.Sandbox) {
-		path = `/sandbox${path}`;
+		path = `${sandboxBasePath()}${path}`;
 	}
 
 	if (navigate) {
@@ -189,7 +175,7 @@ export const getRedirectUrl = (path: string, env: AppEnv) => {
 	// Replace @ with %40
 	path = path.replace("@", "%40");
 	if (env === AppEnv.Sandbox) {
-		return `/sandbox${path}`;
+		return `${sandboxBasePath()}${path}`;
 	} else {
 		return path;
 	}

--- a/vite/src/views/DefaultView.tsx
+++ b/vite/src/views/DefaultView.tsx
@@ -1,13 +1,16 @@
 import { Link } from "react-router";
+import { useEnv } from "@/utils/envUtils";
+import { getRedirectUrl } from "@/utils/genUtils";
 import ErrorScreen from "./general/ErrorScreen";
 
 export const DefaultView = () => {
+	const env = useEnv();
 	return (
 		<ErrorScreen>
 			<p className="mb-4">🚩 This page is not found</p>
 			<Link
 				className="text-tertiary-foreground hover:underline"
-				to="/customers"
+				to={getRedirectUrl("/customers", env)}
 			>
 				Return to dashboard
 			</Link>

--- a/vite/src/views/admin/AdminView.tsx
+++ b/vite/src/views/admin/AdminView.tsx
@@ -1,4 +1,3 @@
-import { AppEnv } from "@autumn/shared";
 import { Button, Tabs, TabsContent, TabsList, TabsTrigger } from "@autumn/ui";
 import { Globe, Sliders } from "@phosphor-icons/react";
 import { useState } from "react";
@@ -6,6 +5,7 @@ import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { authClient } from "@/lib/auth-client";
 import { useEnv } from "@/utils/envUtils";
+import { getRedirectUrl } from "@/utils/genUtils";
 import { AdminOrgTable } from "@/views/admin/AdminOrgTable";
 import { AdminUserTable } from "@/views/admin/AdminUserTable";
 import { DefaultView } from "../DefaultView";
@@ -19,7 +19,7 @@ export const AdminView = () => {
 	const navigate = useNavigate();
 	const env = useEnv();
 	const { isAdmin, isPending } = useAdmin();
-	const adminBasePath = env === AppEnv.Sandbox ? "/sandbox/admin" : "/admin";
+	const adminBasePath = getRedirectUrl("/admin", env);
 	const [activeTab, setActiveTab] = useState("orgs");
 
 	if (isPending) {

--- a/vite/src/views/admin/edge-config/EdgeConfigView.tsx
+++ b/vite/src/views/admin/edge-config/EdgeConfigView.tsx
@@ -1,4 +1,3 @@
-import { AppEnv } from "@autumn/shared";
 import {
 	Badge,
 	Button,
@@ -23,7 +22,7 @@ import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { useEnv } from "@/utils/envUtils";
-import { getBackendErr } from "@/utils/genUtils";
+import { getBackendErr, getRedirectUrl } from "@/utils/genUtils";
 import { DefaultView } from "../../DefaultView";
 import LoadingScreen from "../../general/LoadingScreen";
 import { useAdmin } from "../hooks/useAdmin";
@@ -325,7 +324,7 @@ export const EdgeConfigView = () => {
 	const env = useEnv();
 	const { isAdmin, isPending } = useAdmin();
 	const axiosInstance = useAxiosInstance();
-	const adminBasePath = env === AppEnv.Sandbox ? "/sandbox/admin" : "/admin";
+	const adminBasePath = getRedirectUrl("/admin", env);
 	const [addOrgRolloutId, setAddOrgRolloutId] = useState<string>();
 	const [createRolloutOpen, setCreateRolloutOpen] = useState(false);
 

--- a/vite/src/views/admin/oauth/OAuthClientsView.tsx
+++ b/vite/src/views/admin/oauth/OAuthClientsView.tsx
@@ -1,4 +1,3 @@
-import { AppEnv } from "@autumn/shared";
 import { Badge, CopyButton, IconButton } from "@autumn/ui";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import {
@@ -18,7 +17,7 @@ import { authClient } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { useEnv } from "@/utils/envUtils";
-import { getBackendErr } from "@/utils/genUtils";
+import { getBackendErr, getRedirectUrl } from "@/utils/genUtils";
 import { DefaultView } from "../../DefaultView";
 import LoadingScreen from "../../general/LoadingScreen";
 import { useAdmin } from "../hooks/useAdmin";
@@ -48,7 +47,7 @@ export const OAuthClientsView = () => {
 	const [createDialogOpen, setCreateDialogOpen] = useState(false);
 	const [editDialogOpen, setEditDialogOpen] = useState(false);
 	const [editingClient, setEditingClient] = useState<OAuthClient | null>(null);
-	const adminBasePath = env === AppEnv.Sandbox ? "/sandbox/admin" : "/admin";
+	const adminBasePath = getRedirectUrl("/admin", env);
 
 	const axiosInstance = useAxiosInstance();
 

--- a/vite/src/views/main-sidebar/EnvDropdown.tsx
+++ b/vite/src/views/main-sidebar/EnvDropdown.tsx
@@ -19,6 +19,7 @@ import {
 	useSandboxesQuery,
 } from "@/hooks/queries/useSandboxesQuery";
 import { sandboxColorClass } from "@/hooks/sandbox/sandboxDisplay";
+import { sandboxBasePath } from "@/hooks/sandbox/sandboxUrl";
 import {
 	type ActiveSandbox,
 	setActiveSandbox,
@@ -37,18 +38,18 @@ export const useEnvChange = () => {
 	const navigate = useNavigate();
 
 	const handleEnvChange = (targetEnv: AppEnv, reset?: boolean) => {
-		const newPath = envToPath(targetEnv, location.pathname);
-
-		if (newPath && !reset) {
-			const params = new URLSearchParams(location.search);
-			const tab = params.get("tab");
-			const url = tab ? `${newPath}?tab=${encodeURIComponent(tab)}` : newPath;
-			navigate(url);
-		} else {
+		if (reset) {
 			navigate(
-				targetEnv === AppEnv.Sandbox ? "/sandbox/products" : "/products",
+				targetEnv === AppEnv.Sandbox
+					? `${sandboxBasePath()}/products`
+					: "/products",
 			);
+			return;
 		}
+		const newPath = envToPath(targetEnv, location.pathname);
+		const params = new URLSearchParams(location.search);
+		const tab = params.get("tab");
+		navigate(tab ? `${newPath}?tab=${encodeURIComponent(tab)}` : newPath);
 	};
 
 	return handleEnvChange;

--- a/vite/src/views/main-sidebar/components/AdminDropdownItems.tsx
+++ b/vite/src/views/main-sidebar/components/AdminDropdownItems.tsx
@@ -1,14 +1,10 @@
-import { AppEnv } from "@autumn/shared";
+import { DropdownMenuItem, DropdownMenuSeparator } from "@autumn/ui";
 import { LogOut, Shield } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
-import {
-	DropdownMenuItem,
-	DropdownMenuSeparator,
-} from "@autumn/ui";
 import { authClient, useSession } from "@/lib/auth-client";
 import { useEnv } from "@/utils/envUtils";
-import { getBackendErr, notNullish } from "@/utils/genUtils";
+import { getBackendErr, getRedirectUrl, notNullish } from "@/utils/genUtils";
 import { AdminOnly } from "@/views/admin/components/AdminOnly";
 
 export const AdminDropdownItems = () => {
@@ -18,7 +14,7 @@ export const AdminDropdownItems = () => {
 	const [stopImpersonatingLoading, setStopImpersonatingLoading] =
 		useState(false);
 	const isImpersonating = notNullish(data?.session?.impersonatedBy);
-	const adminPath = env === AppEnv.Sandbox ? "/sandbox/admin" : "/admin";
+	const adminPath = getRedirectUrl("/admin", env);
 
 	if (isPending) return null;
 	return (

--- a/vite/src/views/main-sidebar/env-dropdown/CreateSandboxDialog.tsx
+++ b/vite/src/views/main-sidebar/env-dropdown/CreateSandboxDialog.tsx
@@ -1,7 +1,4 @@
 import { DEFAULT_SANDBOX_COLOR, DEFAULT_SANDBOX_ICON } from "@autumn/shared";
-import { useState } from "react";
-import { useNavigate } from "react-router";
-import { toast } from "sonner";
 import {
 	Dialog,
 	DialogContent,
@@ -11,7 +8,11 @@ import {
 	DialogTitle,
 	ShortcutButton,
 } from "@autumn/ui";
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import { toast } from "sonner";
 import { useCreateSandbox } from "@/hooks/queries/useSandboxesQuery";
+import { sandboxSlug, validateSandboxName } from "@/hooks/sandbox/sandboxUrl";
 import { setActiveSandbox } from "@/hooks/sandbox/useActiveSandbox";
 import { getBackendErr } from "@/utils/genUtils";
 import { SandboxFormFields } from "./SandboxFormFields";
@@ -47,6 +48,11 @@ export const CreateSandboxDialog = ({
 		if (!trimmed) {
 			return;
 		}
+		const nameError = validateSandboxName(trimmed);
+		if (nameError) {
+			toast.error(nameError);
+			return;
+		}
 
 		try {
 			const sandbox = await createSandbox.mutateAsync({
@@ -63,7 +69,7 @@ export const CreateSandboxDialog = ({
 			toast.success("Sandbox created");
 			resetSelections();
 			onOpenChange(false);
-			navigate("/sandbox/products");
+			navigate(`/sandbox/${sandboxSlug(sandbox.name)}/products`);
 		} catch (error) {
 			toast.error(getBackendErr(error, "Failed to create sandbox"));
 		}

--- a/vite/src/views/main-sidebar/env-dropdown/CreateSandboxDialog.tsx
+++ b/vite/src/views/main-sidebar/env-dropdown/CreateSandboxDialog.tsx
@@ -1,4 +1,9 @@
-import { DEFAULT_SANDBOX_COLOR, DEFAULT_SANDBOX_ICON } from "@autumn/shared";
+import {
+	DEFAULT_SANDBOX_COLOR,
+	DEFAULT_SANDBOX_ICON,
+	sandboxSlug,
+	validateSandboxName,
+} from "@autumn/shared";
 import {
 	Dialog,
 	DialogContent,
@@ -12,7 +17,6 @@ import { useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { useCreateSandbox } from "@/hooks/queries/useSandboxesQuery";
-import { sandboxSlug, validateSandboxName } from "@/hooks/sandbox/sandboxUrl";
 import { setActiveSandbox } from "@/hooks/sandbox/useActiveSandbox";
 import { getBackendErr } from "@/utils/genUtils";
 import { SandboxFormFields } from "./SandboxFormFields";

--- a/vite/src/views/main-sidebar/env-dropdown/EditSandboxDialog.tsx
+++ b/vite/src/views/main-sidebar/env-dropdown/EditSandboxDialog.tsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-import { toast } from "sonner";
 import {
 	Dialog,
 	DialogContent,
@@ -8,10 +6,13 @@ import {
 	DialogTitle,
 	ShortcutButton,
 } from "@autumn/ui";
+import { useState } from "react";
+import { toast } from "sonner";
 import {
 	type SandboxSummary,
 	useUpdateSandbox,
 } from "@/hooks/queries/useSandboxesQuery";
+import { validateSandboxName } from "@/hooks/sandbox/sandboxUrl";
 import { getBackendErr } from "@/utils/genUtils";
 import { SandboxFormFields } from "./SandboxFormFields";
 
@@ -32,6 +33,11 @@ export const EditSandboxDialog = ({
 	const handleSave = async () => {
 		const trimmed = name.trim();
 		if (!trimmed) {
+			return;
+		}
+		const nameError = validateSandboxName(trimmed);
+		if (nameError) {
+			toast.error(nameError);
 			return;
 		}
 

--- a/vite/src/views/main-sidebar/env-dropdown/EditSandboxDialog.tsx
+++ b/vite/src/views/main-sidebar/env-dropdown/EditSandboxDialog.tsx
@@ -1,3 +1,4 @@
+import { validateSandboxName } from "@autumn/shared";
 import {
 	Dialog,
 	DialogContent,
@@ -12,7 +13,6 @@ import {
 	type SandboxSummary,
 	useUpdateSandbox,
 } from "@/hooks/queries/useSandboxesQuery";
-import { validateSandboxName } from "@/hooks/sandbox/sandboxUrl";
 import { getBackendErr } from "@/utils/genUtils";
 import { SandboxFormFields } from "./SandboxFormFields";
 
@@ -35,10 +35,12 @@ export const EditSandboxDialog = ({
 		if (!trimmed) {
 			return;
 		}
-		const nameError = validateSandboxName(trimmed);
-		if (nameError) {
-			toast.error(nameError);
-			return;
+		if (trimmed !== sandbox.name) {
+			const nameError = validateSandboxName(trimmed);
+			if (nameError) {
+				toast.error(nameError);
+				return;
+			}
 		}
 
 		try {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the active sandbox name to dashboard URLs (e.g., /sandbox/my-sandbox/products) and sync the active sandbox from the URL. Also enforce server-side name validation to prevent reserved or invalid slugs.

- **New Features**
  - Added named sandbox routes: `/sandbox/:sandboxSlug/<page>`, with `/sandbox/:slug` redirecting to `products`.
  - Synced active sandbox from the URL via `useSyncSandboxFromUrl`, gating the dashboard until resolved to prevent flashes.
  - Centralized slug rules and reserved names in shared code; server validates name uniqueness and reserved/invalid names on create/update (tests added).
  - Client-side name validation uses the same shared rules; creation navigates to `/sandbox/<slug>/products`.
  - Navigation and tab logic updated to handle slugged base paths and env switching (`sandboxUrl`, `genUtils`, `useTab`); legacy `/sandbox/<page>` routes still work.

- **Migration**
  - No changes required for existing links; old `/sandbox/<page>` URLs remain supported.
  - New/renamed sandboxes must use unique, non-reserved names; invalid names are rejected.
  - Unknown slugs auto-redirect to `/sandbox/products`.
  - Prefer linking to `/sandbox/<slug>/<page>` going forward.

<sup>Written for commit 1b64ecf2c7032add823828dc43a2ea3667cfb3bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces named sandbox URLs (`/sandbox/:slug/page`), syncs the active sandbox from the URL via `useSyncSandboxFromUrl`, and centralises slug/reserved-name rules in a shared module consumed by both the client router and server create/update guards.

- **Improvements** — `DashboardShell` gates rendering until the sandbox URL is resolved, preventing flash-of-wrong-context on hard-refresh; `envToPath`, `useTab`, and the admin views all updated to use the shared `stripSandboxPrefix`/`sandboxBasePath` helpers.
- **Improvements** — `assertSandboxCapacity` and `assertSandboxNameUnique` now share one pre-fetched sandbox list, eliminating the duplicate DB round-trip that was flagged in the previous review.
- **API changes** — Server-side `assertSandboxNameValid` and `assertSandboxNameUnique` now reject reserved slugs, duplicate-slug names, and empty slugs on both create and update paths; tests added for all three cases.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge with the rename-navigation fix tracked separately; all other code paths are well-guarded.

The core URL-sync logic is correct and handles all the tricky cases (unknown slug → redirect, error → fail open, localStorage pre-warm to avoid flash). The outstanding rename-navigation issue in EditSandboxDialog — where saving a new name causes useSyncSandboxFromUrl to detect a URL/state mismatch and eject the user to /sandbox/products — was flagged in the previous review cycle and is still unaddressed in this diff.

vite/src/views/main-sidebar/env-dropdown/EditSandboxDialog.tsx — rename success path needs to navigate to the new slug URL before useSyncSandboxFromUrl can detect the mismatch.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/models/orgModels/sandboxName.ts | New shared module defining sandboxSlug, validateSandboxName, and RESERVED_SANDBOX_SLUGS — the single source of truth for slug rules used by both client and server. The sandboxSlug regex preserves non-space whitespace (tabs, NBSP) due to \s in the second replace pattern. |
| vite/src/hooks/sandbox/useSyncSandboxFromUrl.ts | New hook that syncs the active sandbox from the URL slug on every route change. Correctly gates the dashboard with a loading screen until resolved, handles error and disabled-query cases via listUnavailable, and avoids infinite loops by using getActiveSandbox() (synchronous read) inside the effect. |
| vite/src/hooks/sandbox/sandboxUrl.ts | New utility providing getSandboxSlugFromPath, sandboxBasePath, and stripSandboxPrefix — all correctly handle legacy /sandbox/page routes, reserved slugs, and named /sandbox/:slug/page routes. |
| server/src/internal/sandboxes/createSandbox.ts | Adds assertSandboxNameValid (reserved/empty slug check) and assertSandboxNameUnique (slug collision check), called in sequence from createSandboxForOrg. Pre-fetches the sandbox list once and passes it to both guards, eliminating the duplicate DB round-trip flagged in previous reviews. |
| server/src/internal/sandboxes/updateSandbox.ts | Adds name validation and uniqueness check on rename, correctly placed after the ownership guard. Uses excludeOrgId to allow renaming a sandbox to its own current name (idempotent). |
| vite/src/views/main-sidebar/env-dropdown/EditSandboxDialog.tsx | Adds client-side validateSandboxName check before rename, but still does not navigate to the new slug URL after a successful rename — causing useSyncSandboxFromUrl to detect a URL/state mismatch and redirect the user to /sandbox/products (flagged in previous comments). |
| vite/src/views/main-sidebar/env-dropdown/CreateSandboxDialog.tsx | Adds client-side name validation before create and correctly navigates to /sandbox/<slug>/products after creation, setting the active sandbox first to avoid a loading flash. |
| vite/src/utils/genUtils.ts | envToPath refactored to use stripSandboxPrefix and sandboxBasePath, now always returns a string. The detail-page collapse logic (customers/products/migrations) is preserved. navigateTo, pushPage, and getRedirectUrl updated to use sandboxBasePath. |
| vite/src/App.tsx | Adds /sandbox/:sandboxSlug redirect to products and /sandbox/:sandboxSlug/:page routes via envRoutes helper. Route ordering correctly prioritizes static segments over dynamic :sandboxSlug so reserved slugs hit the legacy routes first. |
| vite/src/app/layout.tsx | Extracts DashboardShell component that wraps useSyncSandboxFromUrl and gates rendering with a loading screen until sandboxUrlResolved is true, preventing visual flashes on named sandbox URLs. |
| vite/src/hooks/common/useTab.tsx | Refactored to use stripSandboxPrefix before path matching, eliminating the manual /sandbox/X pattern duplication for each tab name. |
| server/tests/unit/sandboxes/sandbox-capacity.test.ts | Adds test coverage for duplicate name rejection, reserved slug rejection, empty-slug rejection, and verifies only one DB list call per create operation. |


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant Router as React Router
    participant DS as DashboardShell
    participant Sync as useSyncSandboxFromUrl
    participant Store as ActiveSandbox Store
    participant API as Sandboxes API

    User->>Router: Navigate to /sandbox/:slug/products
    Router->>DS: Render DashboardShell
    DS->>Sync: useSyncSandboxFromUrl()
    Sync->>Store: getActiveSandbox() (localStorage)
    Sync->>API: useSandboxesQuery (if org.deployed)
    alt active matches URL slug
        Sync-->>DS: "sandboxUrlResolved = true (no flash)"
    else waiting for API
        DS-->>User: LoadingScreen
    end
    API-->>Sync: sandboxes list
    Sync->>Sync: "find match by sandboxSlug(name) === slug"
    alt match found
        Sync->>Store: setActiveSandbox(match)
        Sync-->>DS: "sandboxUrlResolved = true"
        DS-->>User: Dashboard renders
    else no match (unknown slug)
        Sync->>Store: setActiveSandbox(null)
        Sync->>Router: navigate(/sandbox/products, replace)
        Router-->>User: Redirect to legacy products page
    end

    User->>Router: Select sandbox from dropdown
    Router->>Store: setActiveSandbox(selected)
    Router->>Router: navigate(sandboxBasePath() + currentPage)
    Router-->>User: /sandbox/selected-slug/page
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant Router as React Router
    participant DS as DashboardShell
    participant Sync as useSyncSandboxFromUrl
    participant Store as ActiveSandbox Store
    participant API as Sandboxes API

    User->>Router: Navigate to /sandbox/:slug/products
    Router->>DS: Render DashboardShell
    DS->>Sync: useSyncSandboxFromUrl()
    Sync->>Store: getActiveSandbox() (localStorage)
    Sync->>API: useSandboxesQuery (if org.deployed)
    alt active matches URL slug
        Sync-->>DS: "sandboxUrlResolved = true (no flash)"
    else waiting for API
        DS-->>User: LoadingScreen
    end
    API-->>Sync: sandboxes list
    Sync->>Sync: "find match by sandboxSlug(name) === slug"
    alt match found
        Sync->>Store: setActiveSandbox(match)
        Sync-->>DS: "sandboxUrlResolved = true"
        DS-->>User: Dashboard renders
    else no match (unknown slug)
        Sync->>Store: setActiveSandbox(null)
        Sync->>Router: navigate(/sandbox/products, replace)
        Router-->>User: Redirect to legacy products page
    end

    User->>Router: Select sandbox from dropdown
    Router->>Store: setActiveSandbox(selected)
    Router->>Router: navigate(sandboxBasePath() + currentPage)
    Router-->>User: /sandbox/selected-slug/page
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/src/views/main-sidebar/env-dropdown/EditSandboxDialog.tsx`, line 44-56 ([link](https://github.com/useautumn/autumn/blob/a912c7ad540809a2afb64ee61c913bcaadf28fc7/vite/src/views/main-sidebar/env-dropdown/EditSandboxDialog.tsx#L44-L56)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Renaming the active sandbox navigates the user to `/sandbox/products`**

   After a successful rename, `useUpdateSandbox.onSuccess` updates the sandbox list. `reconcileActiveSandbox` then updates the in-memory active sandbox name to the new value. `useSyncSandboxFromUrl` immediately detects that the URL slug (old name) no longer matches the active sandbox's name (new value), so `sandboxUrlResolved` becomes `false` and the effect fires `setActiveSandbox(null)` + `navigate("/sandbox/products", { replace: true })`. The user is ejected from the current page and loses the sandbox context.

   The dialog needs to navigate to the new-slug URL after a successful rename — for example using `useNavigate` and `sandboxSlug` — and, if the edited sandbox is the active one, call `setActiveSandbox` with the updated data before the automatic reconciliation can interfere.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/views/main-sidebar/env-dropdown/EditSandboxDialog.tsx
   Line: 44-56

   Comment:
   **Renaming the active sandbox navigates the user to `/sandbox/products`**

   After a successful rename, `useUpdateSandbox.onSuccess` updates the sandbox list. `reconcileActiveSandbox` then updates the in-memory active sandbox name to the new value. `useSyncSandboxFromUrl` immediately detects that the URL slug (old name) no longer matches the active sandbox's name (new value), so `sandboxUrlResolved` becomes `false` and the effect fires `setActiveSandbox(null)` + `navigate("/sandbox/products", { replace: true })`. The user is ejected from the current page and loses the sandbox context.

   The dialog needs to navigate to the new-slug URL after a successful rename — for example using `useNavigate` and `sandboxSlug` — and, if the edited sandbox is the active one, call `setActiveSandbox` with the updated data before the automatic reconciliation can interfere.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["enforce name validation server-side and ..."](https://github.com/useautumn/autumn/commit/1b64ecf2c7032add823828dc43a2ea3667cfb3bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40117721)</sub>

<!-- /greptile_comment -->