### PR TITLE
feat(account): add email change and org passkey enforcement

### DIFF
--- a/server/src/internal/auth/handleListAuthOrganizations.ts
+++ b/server/src/internal/auth/handleListAuthOrganizations.ts
@@ -27,6 +27,11 @@ export const handleListAuthOrganizations = async (c: Context) => {
 			logo: organizations.logo,
 			createdAt: organizations.createdAt,
 			metadata: organizations.metadata,
+			// Surfaced so the client can disable selection of passkey-gated
+			// orgs in the org switcher (see useOrgAccess). Not part of the
+			// upstream better-auth Organization type — we hand-roll this
+			// route to override its default 100-member join cap anyway.
+			config: organizations.config,
 		})
 		.from(member)
 		.innerJoin(organizations, eq(member.organizationId, organizations.id))
@@ -38,5 +43,18 @@ export const handleListAuthOrganizations = async (c: Context) => {
 		)
 		.limit(AUTH_ORGANIZATION_LIST_LIMIT);
 
-	return c.json(orgs);
+	const sanitized = orgs.map((org) => ({
+		id: org.id,
+		name: org.name,
+		slug: org.slug,
+		logo: org.logo,
+		createdAt: org.createdAt,
+		metadata: org.metadata,
+		// Promote the single client-relevant config flag into a flat field so
+		// the rest of `config` (Stripe/feature-flag internals) stays inside
+		// the server boundary.
+		requirePasskey: org.config?.require_passkey === true,
+	}));
+
+	return c.json(sanitized);
 };

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -24,6 +24,7 @@ import { afterOrgCreated } from "./authUtils/afterOrgCreated.js";
 import { afterSessionCreated } from "./authUtils/afterSessionCreated.js";
 import { afterSessionDeleted } from "./authUtils/afterSessionDeleted.js";
 import { beforeSessionCreated } from "./authUtils/beforeSessionCreated.js";
+import { beforeSessionUpdated } from "./authUtils/beforeSessionUpdated.js";
 import { getScopesForUserInOrg } from "./authUtils/customSessionScopes.js";
 import { ADMIN_USER_IDs } from "./constants.js";
 
@@ -200,6 +201,9 @@ const options = {
 				before: beforeSessionCreated,
 				after: afterSessionCreated,
 			},
+			update: {
+				before: beforeSessionUpdated,
+			},
 			delete: {
 				after: afterSessionDeleted,
 			},
@@ -262,6 +266,14 @@ const options = {
 					email,
 					otp,
 				});
+			},
+			// Allows /email-otp/request-email-change + /email-otp/change-email.
+			// The OAuth `account` row is keyed by (providerId, accountId), not
+			// user.email, so updating user.email does NOT break Google sign-in:
+			// the account stays linked to the original Google identity. See
+			// better-auth/oauth2/link-account.ts → findOAuthUser().
+			changeEmail: {
+				enabled: true,
 			},
 		}),
 		admin({

--- a/server/src/utils/authUtils/beforeSessionCreated.ts
+++ b/server/src/utils/authUtils/beforeSessionCreated.ts
@@ -3,6 +3,11 @@ import type { Session } from "better-auth";
 import { desc, eq } from "drizzle-orm";
 import { db } from "@/db/initDrizzle.js";
 import { createDefaultOrg } from "@/utils/authUtils/createDefaultOrg.js";
+import {
+	orgRequiresPasskey,
+	pickPasskeyAllowedOrg,
+	userHasPasskey,
+} from "@/utils/authUtils/passkeyEnforcement.js";
 
 export const beforeSessionCreated = async (session: Session) => {
 	try {
@@ -18,10 +23,20 @@ export const beforeSessionCreated = async (session: Session) => {
 		});
 
 		if (membership) {
+			// If the most-recent org is passkey-gated and the user has no
+			// credential, walk back through their other memberships and
+			// surface the first non-gated one. Falls through to null if
+			// every org gates them — DashboardGate renders the no-org
+			// state, prompting them to register a passkey from settings.
+			const activeOrgId = await resolveAllowedActiveOrg({
+				userId: session.userId,
+				preferredOrgId: membership.organizationId,
+			});
+
 			return {
 				data: {
 					...session,
-					activeOrganizationId: membership.organizationId,
+					activeOrganizationId: activeOrgId,
 				},
 			};
 		}
@@ -35,4 +50,21 @@ export const beforeSessionCreated = async (session: Session) => {
 			},
 		};
 	} catch (error) {}
+};
+
+const resolveAllowedActiveOrg = async ({
+	userId,
+	preferredOrgId,
+}: {
+	userId: string;
+	preferredOrgId: string;
+}): Promise<string | null> => {
+	const requiresPasskey = await orgRequiresPasskey({ orgId: preferredOrgId });
+	if (!requiresPasskey) return preferredOrgId;
+	if (await userHasPasskey({ userId })) return preferredOrgId;
+	const fallback = await pickPasskeyAllowedOrg({
+		userId,
+		excludeOrgId: preferredOrgId,
+	});
+	return fallback;
 };

--- a/server/src/utils/authUtils/beforeSessionUpdated.ts
+++ b/server/src/utils/authUtils/beforeSessionUpdated.ts
@@ -1,0 +1,64 @@
+import type { GenericEndpointContext } from "@better-auth/core";
+import type { BetterAuthOptions, Session } from "better-auth";
+import {
+	orgRequiresPasskey,
+	pickPasskeyAllowedOrg,
+	userHasPasskey,
+} from "@/utils/authUtils/passkeyEnforcement.js";
+
+/**
+ * Hook called before any `session` row update — including the one
+ * better-auth's organization plugin issues from `/organization/set-active`.
+ *
+ * If the incoming change targets a passkey-gated org and the session's
+ * user has no passkey, we rewrite the update to either fall back to a
+ * different allowed org or clear `activeOrganizationId` entirely. We do
+ * NOT return `false`: better-auth's `/set-active` swallows that result
+ * and the client would just see a stale active org without a meaningful
+ * error message. The client also gates the switcher up front; this hook
+ * is the defence-in-depth backstop.
+ *
+ * better-auth invokes update hooks with `(data, ctx)` where `data` is the
+ * partial patch (just `{ activeOrganizationId }` for `set-active`) — the
+ * `where` clause is NOT passed. The current user is therefore resolved
+ * from `ctx.context.session`, populated by the org plugin's
+ * `orgSessionMiddleware` before this hook fires.
+ */
+export const beforeSessionUpdated = async (
+	patch: Partial<Session> & Record<string, unknown>,
+	context: GenericEndpointContext<BetterAuthOptions> | null,
+) => {
+	try {
+		const incoming = patch as { activeOrganizationId?: string | null };
+		if (!incoming.activeOrganizationId) return;
+
+		const userId =
+			(typeof patch.userId === "string" ? patch.userId : null) ??
+			context?.context.session?.user?.id ??
+			null;
+		if (!userId) return;
+
+		const orgId = incoming.activeOrganizationId;
+		const requiresPasskey = await orgRequiresPasskey({ orgId });
+		if (!requiresPasskey) return;
+		if (await userHasPasskey({ userId })) return;
+
+		const fallback = await pickPasskeyAllowedOrg({
+			userId,
+			excludeOrgId: orgId,
+		});
+
+		return {
+			data: {
+				...patch,
+				activeOrganizationId: fallback,
+			},
+		};
+	} catch (error) {
+		// Hook errors are swallowed so we don't break the broader update
+		// path; the client-side gate keeps the UX honest if this ever
+		// fails. Log via console so it shows up in dev tail without
+		// pulling in the logtail wrapper.
+		console.error("[beforeSessionUpdated] failed to enforce passkey:", error);
+	}
+};

--- a/server/src/utils/authUtils/passkeyEnforcement.ts
+++ b/server/src/utils/authUtils/passkeyEnforcement.ts
@@ -1,0 +1,71 @@
+import { member, organizations, passkey } from "@autumn/shared";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db/initDrizzle.js";
+
+/**
+ * Returns true iff the org has the `require_passkey` config flag set.
+ *
+ * Cheap lookup — the row is in pg, the column is jsonb, and we only need
+ * one boolean. Called from the session-update hook on every org switch.
+ */
+export const orgRequiresPasskey = async ({
+	orgId,
+}: {
+	orgId: string;
+}): Promise<boolean> => {
+	const row = await db.query.organizations.findFirst({
+		columns: { config: true },
+		where: eq(organizations.id, orgId),
+	});
+	return row?.config?.require_passkey === true;
+};
+
+/** True iff the user has at least one registered WebAuthn credential. */
+export const userHasPasskey = async ({
+	userId,
+}: {
+	userId: string;
+}): Promise<boolean> => {
+	const row = await db.query.passkey.findFirst({
+		columns: { id: true },
+		where: eq(passkey.userId, userId),
+	});
+	return Boolean(row);
+};
+
+/**
+ * Pick the first org the user is a member of (most-recently-joined first)
+ * that is NOT gated behind a passkey requirement. Used to override the
+ * resolved active org during session create when the stored membership
+ * points at a gated org and the user has no passkey.
+ *
+ * Returns null when every membership is gated — DashboardGate handles the
+ * "no eligible org" case by rendering an empty state.
+ */
+export const pickPasskeyAllowedOrg = async ({
+	userId,
+	excludeOrgId,
+}: {
+	userId: string;
+	excludeOrgId?: string;
+}): Promise<string | null> => {
+	const rows = await db
+		.select({
+			organizationId: member.organizationId,
+			config: organizations.config,
+			createdAt: member.createdAt,
+		})
+		.from(member)
+		.innerJoin(organizations, eq(member.organizationId, organizations.id))
+		.where(eq(member.userId, userId));
+
+	const sorted = rows.sort(
+		(a, b) => (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0),
+	);
+	for (const row of sorted) {
+		if (excludeOrgId && row.organizationId === excludeOrgId) continue;
+		if (row.config?.require_passkey === true) continue;
+		return row.organizationId;
+	}
+	return null;
+};

--- a/shared/models/orgModels/orgConfig.ts
+++ b/shared/models/orgModels/orgConfig.ts
@@ -46,6 +46,10 @@ export const OrgConfigSchema = z.object({
 	// When true, Stripe writes pass `automatic_tax: { enabled: true }`.
 	// Customer must have a tax-resolvable address.
 	automatic_tax: z.boolean().default(false),
+	// When true, the org won't accept session selection from a user that
+	// doesn't have at least one passkey credential. Only blocks org switch,
+	// not initial sign-in, because users can belong to multiple orgs.
+	require_passkey: z.boolean().default(false),
 });
 
 export type OrgConfig = z.infer<typeof OrgConfigSchema>;

--- a/vite/src/app/DashboardGate.tsx
+++ b/vite/src/app/DashboardGate.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import { Navigate, Outlet, useLocation } from "react-router";
+import { toast } from "sonner";
+import { useHasPasskey } from "@/hooks/common/useHasPasskey";
 import {
 	clearLastSwitchedOrgId,
 	getLastSwitchedOrgId,
@@ -15,18 +17,46 @@ export const DashboardGate = () => {
 	const { data: orgList } = useListOrganizations();
 	const switchActiveOrg = useSwitchActiveOrg();
 	const { org, isLoading: orgLoading, error: orgError } = useOrg();
+	const { hasPasskey } = useHasPasskey();
 	const [switchingToLastOrg, setSwitchingToLastOrg] = useState(false);
 	const [ignoredLastOrgId, setIgnoredLastOrgId] = useState<string | null>(null);
 	const lastOrgId = getLastSwitchedOrgId();
 	const activeOrgId = session?.session.activeOrganizationId;
 	const onImpersonateRoute = pathname.includes("impersonate-redirect");
+
+	// The hand-rolled /api/auth/organization/list response includes
+	// requirePasskey per org; better-auth's plugin type doesn't know
+	// about it. See handleListAuthOrganizations.ts.
+	const typedOrgList = orgList as
+		| Array<{ id: string; requirePasskey?: boolean }>
+		| undefined;
+	const lastOrgEntry = typedOrgList?.find((o) => o.id === lastOrgId);
+	const lastOrgGated =
+		lastOrgEntry?.requirePasskey === true && !hasPasskey;
+
 	const shouldSwitchToLastOrg =
 		!onImpersonateRoute &&
 		!!lastOrgId &&
 		lastOrgId !== ignoredLastOrgId &&
 		!!activeOrgId &&
 		lastOrgId !== activeOrgId &&
-		!!orgList?.some((org) => org.id === lastOrgId);
+		!!typedOrgList?.some((o) => o.id === lastOrgId) &&
+		// Skip the auto-switch when the remembered org requires a passkey
+		// the user doesn't have. The server hook would silently rewrite
+		// the active org back to a non-gated one, creating an infinite
+		// switch loop here.
+		!lastOrgGated;
+
+	useEffect(() => {
+		if (!lastOrgId) return;
+		if (lastOrgGated && lastOrgId !== ignoredLastOrgId) {
+			toast.error(
+				"You need a passkey to access that organization. Add one from account settings.",
+			);
+			clearLastSwitchedOrgId(lastOrgId);
+			setIgnoredLastOrgId(lastOrgId);
+		}
+	}, [lastOrgId, lastOrgGated, ignoredLastOrgId]);
 
 	useEffect(() => {
 		if (!lastOrgId || !shouldSwitchToLastOrg || switchingToLastOrg) return;

--- a/vite/src/hooks/common/useHasPasskey.tsx
+++ b/vite/src/hooks/common/useHasPasskey.tsx
@@ -1,0 +1,18 @@
+import { authClient } from "@/lib/auth-client";
+
+/**
+ * Reads the user's current passkey credentials from better-auth and exposes
+ * a single boolean. Used to gate org switching to passkey-required orgs.
+ *
+ * The query is cached by better-auth's nanostore; this hook is cheap to call
+ * from multiple components in the same render.
+ */
+export const useHasPasskey = () => {
+	const { data, isPending, error } = authClient.useListPasskeys();
+	const passkeys = Array.isArray(data) ? data : [];
+	return {
+		hasPasskey: passkeys.length > 0,
+		isLoading: isPending,
+		error,
+	};
+};

--- a/vite/src/hooks/common/useOrg.tsx
+++ b/vite/src/hooks/common/useOrg.tsx
@@ -82,11 +82,43 @@ export const useOrg = (params?: { env?: AppEnv }) => {
 				return;
 			}
 
+			// Honor passkey-gating: only auto-pick orgs the user is actually
+			// allowed to land on. Otherwise the post-pick session.update hook
+			// would rewrite activeOrgId back to null and we'd loop here.
+			const passkeys = await authClient
+				.listPasskeys()
+				.catch(() => ({ data: [] as unknown[] }));
+			const hasPasskey = Array.isArray(passkeys.data)
+				? passkeys.data.length > 0
+				: false;
+			const typedOrgList = orgList as Array<{
+				id: string;
+				requirePasskey?: boolean;
+			}>;
+			const isAllowed = (orgId: string) => {
+				const entry = typedOrgList.find((o) => o.id === orgId);
+				if (!entry) return false;
+				if (entry.requirePasskey && !hasPasskey) return false;
+				return true;
+			};
+
 			const lastOrgId = getLastSwitchedOrgId();
-			const preferredOrg = lastOrgId
-				? orgList.find((o) => o.id === lastOrgId)
-				: null;
-			const targetOrgId = preferredOrg?.id ?? orgList[0].id;
+			const preferredOrg =
+				lastOrgId && isAllowed(lastOrgId)
+					? orgList.find((o) => o.id === lastOrgId)
+					: null;
+			const firstAllowed = typedOrgList.find((o) => isAllowed(o.id));
+			const targetOrgId = preferredOrg?.id ?? firstAllowed?.id;
+
+			if (!targetOrgId) {
+				// Every membership is passkey-gated and the user has no
+				// credential — there's nowhere to land them. Bounce to
+				// sign-in; they can hit the account page from there once a
+				// passkey is registered.
+				await authClient.signOut();
+				window.location.href = "/sign-in?passkey_required=1";
+				return;
+			}
 
 			await setActiveOrg(targetOrgId);
 			window.location.reload();

--- a/vite/src/views/main-sidebar/components/OrgDropdown.tsx
+++ b/vite/src/views/main-sidebar/components/OrgDropdown.tsx
@@ -1,6 +1,7 @@
-import { Button, Skeleton } from "@autumn/ui";
+import { Badge, Button, Skeleton } from "@autumn/ui";
 import {
 	ChevronDown,
+	KeyRound,
 	Monitor,
 	Moon,
 	PanelRight,
@@ -11,6 +12,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { AdminHover } from "@/components/general/AdminHover";
+import { useHasPasskey } from "@/hooks/common/useHasPasskey";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -46,7 +48,18 @@ export const OrgDropdown = () => {
 	const navigate = useNavigate();
 
 	const { data: orgsData } = useListOrganizations();
-	let orgs = Array.isArray(orgsData) ? orgsData : undefined;
+	// `/api/auth/organization/list` is hand-rolled in our server (see
+	// handleListAuthOrganizations.ts) so the response includes
+	// `requirePasskey` even though better-auth's plugin type doesn't
+	// know about it. Re-narrow once at the boundary instead of casting
+	// at every consumer.
+	let orgs = Array.isArray(orgsData)
+		? (orgsData as Array<{
+				id: string;
+				name: string;
+				requirePasskey?: boolean;
+			}>)
+		: undefined;
 	const { data: activeOrganization } = authClient.useActiveOrganization();
 
 	if (activeOrganization && orgs) {
@@ -247,24 +260,48 @@ const SwitchOrgItem = ({
 	org,
 	setDropdownOpen,
 }: {
-	org: { id: string; name: string };
+	org: { id: string; name: string; requirePasskey?: boolean };
 	setDropdownOpen: (open: boolean) => void;
 }) => {
 	const [loading, setLoading] = useState(false);
 	const switchOrg = useOrgSwitch();
+	const { hasPasskey } = useHasPasskey();
+	// Server `beforeSessionUpdated` hook is the real backstop; we surface
+	// the gate up-front so the user gets an explanation instead of a
+	// silent no-op when the server rewrites the session away.
+	const gated = org.requirePasskey === true && !hasPasskey;
 
 	return (
 		<DropdownMenuItem
 			key={org.id}
 			onClick={async (e) => {
 				e.preventDefault();
+				if (gated) {
+					toast.error(
+						`${org.name} requires a passkey. Add one from account settings to continue.`,
+					);
+					setDropdownOpen(false);
+					return;
+				}
 				await switchOrg({ orgId: org.id, setLoading });
 				setDropdownOpen(false);
 			}}
 			shimmer={loading}
-			className="flex justify-between"
+			className={cn(
+				"flex items-center justify-between gap-2",
+				gated && "opacity-60",
+			)}
 		>
-			<span className={cn("text-muted-foreground")}>{org.name}</span>
+			<span className={cn("text-muted-foreground truncate")}>{org.name}</span>
+			{gated && (
+				<Badge
+					variant="muted"
+					className="gap-1 text-[10px] uppercase tracking-wide shrink-0"
+				>
+					<KeyRound size={10} />
+					Passkey
+				</Badge>
+			)}
 		</DropdownMenuItem>
 	);
 };

--- a/vite/src/views/main-sidebar/components/UserDetails.tsx
+++ b/vite/src/views/main-sidebar/components/UserDetails.tsx
@@ -1,14 +1,44 @@
-import { Button, FormLabel, Input } from "@autumn/ui";
-import { useMemo, useState } from "react";
+import {
+	Button,
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	FormLabel,
+	Input,
+	InputOTP,
+	InputOTPGroup,
+	InputOTPSeparator,
+	InputOTPSlot,
+} from "@autumn/ui";
+import { Mail } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { authClient, useSession } from "@/lib/auth-client";
+import { cn } from "@/lib/utils";
 
+const emailRegex = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+
+type ChangeEmailStep = "input" | "verify";
+
+/**
+ * Account-profile form. Name updates via `authClient.updateUser`; the email
+ * field gets its own OTP-gated change flow via the email-OTP plugin
+ * (`request-email-change` → `change-email`).
+ *
+ * The user.email update does NOT touch the Google OAuth `account` row —
+ * better-auth's OAuth lookup goes through (providerId, accountId), so a
+ * Google sign-in still resolves to the same user even after rename.
+ */
 export const UserDetails = () => {
 	const { data: session, refetch } = useSession();
 	const user = session?.user;
 
 	const [name, setName] = useState(user?.name || "");
 	const [saving, setSaving] = useState(false);
+	const [changeEmailOpen, setChangeEmailOpen] = useState(false);
 
 	const canSave = useMemo(() => {
 		return name !== user?.name && name.trim() !== "";
@@ -51,11 +81,21 @@ export const UserDetails = () => {
 					<FormLabel>
 						<span className="text-muted-foreground">Email</span>
 					</FormLabel>
-					<Input
-						value={user?.email || ""}
-						disabled
-						className="text-tertiary-foreground"
-					/>
+					<div className="flex items-center gap-2">
+						<Input
+							value={user?.email || ""}
+							disabled
+							className="text-tertiary-foreground flex-1"
+						/>
+						<Button
+							variant="secondary"
+							onClick={() => setChangeEmailOpen(true)}
+							className="gap-2 shrink-0"
+						>
+							<Mail size={14} />
+							Change
+						</Button>
+					</div>
 				</div>
 			</div>
 			<div>
@@ -69,6 +109,244 @@ export const UserDetails = () => {
 					Save
 				</Button>
 			</div>
+
+			<ChangeEmailDialog
+				open={changeEmailOpen}
+				onOpenChange={setChangeEmailOpen}
+				currentEmail={user?.email ?? ""}
+				onChanged={async () => {
+					await refetch();
+				}}
+			/>
 		</div>
+	);
+};
+
+const ChangeEmailDialog = ({
+	open,
+	onOpenChange,
+	currentEmail,
+	onChanged,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	currentEmail: string;
+	onChanged: () => Promise<void>;
+}) => {
+	const [step, setStep] = useState<ChangeEmailStep>("input");
+	const [newEmail, setNewEmail] = useState("");
+	const [otp, setOtp] = useState("");
+	const [requesting, setRequesting] = useState(false);
+	const [verifying, setVerifying] = useState(false);
+	const [resending, setResending] = useState(false);
+	const [resendCountdown, setResendCountdown] = useState(0);
+
+	useEffect(() => {
+		if (!open) {
+			// Defer reset so the close transition doesn't flash the input
+			// step before the dialog fades out.
+			const t = setTimeout(() => {
+				setStep("input");
+				setNewEmail("");
+				setOtp("");
+				setRequesting(false);
+				setVerifying(false);
+				setResending(false);
+				setResendCountdown(0);
+			}, 150);
+			return () => clearTimeout(t);
+		}
+	}, [open]);
+
+	useEffect(() => {
+		if (resendCountdown <= 0) return;
+		const t = setTimeout(() => setResendCountdown((c) => c - 1), 1000);
+		return () => clearTimeout(t);
+	}, [resendCountdown]);
+
+	const handleRequest = async () => {
+		const trimmed = newEmail.trim().toLowerCase();
+		if (!emailRegex.test(trimmed)) {
+			toast.error("Enter a valid email address");
+			return;
+		}
+		if (trimmed === currentEmail.toLowerCase()) {
+			toast.error("That's already your current email");
+			return;
+		}
+		setRequesting(true);
+		try {
+			const { error } = await authClient.emailOtp.requestEmailChange({
+				newEmail: trimmed,
+			});
+			if (error) {
+				toast.error(error.message || "Failed to send verification code");
+				return;
+			}
+			setStep("verify");
+			setResendCountdown(30);
+		} catch (err) {
+			toast.error(
+				err instanceof Error ? err.message : "Failed to send verification code",
+			);
+		} finally {
+			setRequesting(false);
+		}
+	};
+
+	const handleVerify = async (otpValue: string) => {
+		const trimmed = newEmail.trim().toLowerCase();
+		setVerifying(true);
+		try {
+			const { error } = await authClient.emailOtp.changeEmail({
+				newEmail: trimmed,
+				otp: otpValue,
+			});
+			if (error) {
+				toast.error(error.message || "Failed to verify code");
+				setOtp("");
+				return;
+			}
+			toast.success(`Email updated to ${trimmed}`);
+			await onChanged();
+			onOpenChange(false);
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : "Failed to verify code");
+			setOtp("");
+		} finally {
+			setVerifying(false);
+		}
+	};
+
+	const handleResend = async () => {
+		const trimmed = newEmail.trim().toLowerCase();
+		if (!trimmed) return;
+		setResending(true);
+		try {
+			const { error } = await authClient.emailOtp.requestEmailChange({
+				newEmail: trimmed,
+			});
+			if (error) {
+				toast.error(error.message || "Failed to resend code");
+				return;
+			}
+			setResendCountdown(30);
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : "Failed to resend code");
+		} finally {
+			setResending(false);
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="w-md bg-card">
+				<DialogHeader>
+					<DialogTitle>
+						{step === "input" ? "Change email" : "Verify your new email"}
+					</DialogTitle>
+					<DialogDescription>
+						{step === "input" ? (
+							<>
+								We'll send a verification code to the new address. Your Google
+								sign-in stays linked to the same account.
+							</>
+						) : (
+							<>
+								We sent a 6-digit code to{" "}
+								<span className="font-medium text-foreground">
+									{newEmail.trim().toLowerCase()}
+								</span>
+								. Enter it to confirm the change.
+							</>
+						)}
+					</DialogDescription>
+				</DialogHeader>
+
+				{step === "input" ? (
+					<div className="flex flex-col gap-3">
+						<FormLabel>
+							<span className="text-muted-foreground">New email</span>
+						</FormLabel>
+						<Input
+							autoFocus
+							type="email"
+							value={newEmail}
+							onChange={(e) => setNewEmail(e.target.value)}
+							placeholder="you@example.com"
+							onKeyDown={(e) => {
+								if (e.key === "Enter") handleRequest();
+							}}
+						/>
+					</div>
+				) : (
+					<div className="flex flex-col items-center justify-center gap-4 py-2">
+						<div className={cn(verifying && "shimmer")}>
+							<InputOTP
+								autoFocus
+								maxLength={6}
+								value={otp}
+								onChange={setOtp}
+								onComplete={handleVerify}
+								disabled={verifying}
+							>
+								<InputOTPGroup>
+									<InputOTPSlot index={0} />
+									<InputOTPSlot index={1} />
+									<InputOTPSlot index={2} />
+								</InputOTPGroup>
+								<InputOTPSeparator />
+								<InputOTPGroup>
+									<InputOTPSlot index={3} />
+									<InputOTPSlot index={4} />
+									<InputOTPSlot index={5} />
+								</InputOTPGroup>
+							</InputOTP>
+						</div>
+						<Button
+							variant="skeleton"
+							onClick={handleResend}
+							disabled={resending || resendCountdown > 0}
+							className={cn(
+								"text-xs underline-offset-4 hover:underline text-primary",
+								resending && "shimmer",
+							)}
+						>
+							Didn't get it? Resend
+							{resendCountdown > 0 ? ` (${resendCountdown})` : ""}
+						</Button>
+					</div>
+				)}
+
+				<DialogFooter>
+					<Button
+						variant="muted"
+						onClick={() => onOpenChange(false)}
+						disabled={requesting || verifying}
+					>
+						Cancel
+					</Button>
+					{step === "input" ? (
+						<Button
+							variant="primary"
+							onClick={handleRequest}
+							isLoading={requesting}
+							disabled={!newEmail.trim()}
+						>
+							Send code
+						</Button>
+					) : (
+						<Button
+							variant="primary"
+							onClick={() => handleVerify(otp)}
+							isLoading={verifying}
+							disabled={otp.length !== 6}
+						>
+							Verify & update
+						</Button>
+					)}
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
 	);
 };

--- a/vite/src/views/settings/sections/OrganizationSection.tsx
+++ b/vite/src/views/settings/sections/OrganizationSection.tsx
@@ -1,17 +1,32 @@
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@autumn/ui";
 import { OrgDetails } from "@/views/main-sidebar/components/OrgDetails";
 import { SettingsSection } from "../SettingsSection";
+import { OrgSecurityCard } from "./components/OrgSecurityCard";
 
 export const OrganizationSection = () => {
 	return (
 		<SettingsSection
 			title="Organization"
 			description="Manage your organization name, logo, and settings"
-			card={{
-				title: "General",
-				description: "Update your organization details and branding",
-			}}
 		>
-			<OrgDetails />
+			<Card className="shadow-none bg-interactive-secondary">
+				<CardHeader>
+					<CardTitle>General</CardTitle>
+					<CardDescription>
+						Update your organization details and branding
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<OrgDetails />
+				</CardContent>
+			</Card>
+			<OrgSecurityCard />
 		</SettingsSection>
 	);
 };

--- a/vite/src/views/settings/sections/components/OrgSecurityCard.tsx
+++ b/vite/src/views/settings/sections/components/OrgSecurityCard.tsx
@@ -1,0 +1,101 @@
+import type { FrontendOrg, OrgConfig } from "@autumn/shared";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+	Switch,
+} from "@autumn/ui";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { KeyRound } from "lucide-react";
+import { toast } from "sonner";
+import { useOrg } from "@/hooks/common/useOrg";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { useEnv } from "@/utils/envUtils";
+import { useCurrentMembership } from "@/views/main-sidebar/org-dropdown/hooks/useCurrentMembership";
+
+/**
+ * Org-wide security toggles. Today this is just "require passkey" — owners
+ * can flip it on to lock the org behind passkey auth. The toggle writes via
+ * the existing `/organization/config` PATCH endpoint, which the server uses
+ * along with `beforeSessionUpdated` to gate org switching.
+ *
+ * Owner-only intentionally: a regular admin can't fence other members out.
+ */
+export const OrgSecurityCard = () => {
+	const { org } = useOrg();
+	const { isOwner } = useCurrentMembership();
+	const axiosInstance = useAxiosInstance();
+	const queryClient = useQueryClient();
+	const env = useEnv();
+	const activeOrgId = org?.id;
+	const queryKey = ["org", env, activeOrgId];
+
+	const requirePasskey = org?.config?.require_passkey === true;
+
+	const { mutate, isPending } = useMutation({
+		mutationFn: async (value: boolean) => {
+			const { data } = await axiosInstance.patch("/organization/config", {
+				require_passkey: value,
+			});
+			return data as { config: OrgConfig };
+		},
+		onSuccess: (data, value) => {
+			queryClient.setQueryData<FrontendOrg>(queryKey, (old) =>
+				old ? { ...old, config: data.config } : old,
+			);
+			// Also refresh better-auth's org list so the gate badge in the
+			// switcher reflects the new state without a page reload.
+			queryClient.invalidateQueries({ queryKey: ["organization-members"] });
+			toast.success(
+				value
+					? "Passkeys are now required for this organization"
+					: "Passkey requirement removed",
+			);
+		},
+		onError: () => {
+			toast.error("Failed to update security settings");
+			queryClient.invalidateQueries({ queryKey });
+		},
+	});
+
+	if (!org) return null;
+
+	return (
+		<Card className="shadow-none bg-interactive-secondary">
+			<CardHeader>
+				<CardTitle>Security</CardTitle>
+				<CardDescription>
+					Lock down how members of this organization sign in
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<div className="flex items-center justify-between gap-4">
+					<div className="flex items-start gap-3">
+						<div className="rounded-md bg-muted/50 p-2 mt-0.5">
+							<KeyRound size={14} className="text-muted-foreground" />
+						</div>
+						<div className="flex flex-col gap-0.5">
+							<span className="text-sm font-medium">Require passkeys</span>
+							<span className="text-xs text-muted-foreground">
+								Members without a passkey can't select this organization.
+								They keep access to their other orgs.
+							</span>
+							{!isOwner && (
+								<span className="text-xs text-tertiary-foreground italic mt-1">
+									Only the organization owner can change this.
+								</span>
+							)}
+						</div>
+					</div>
+					<Switch
+						checked={requirePasskey}
+						onCheckedChange={(value) => mutate(value)}
+						disabled={isPending || !isOwner}
+					/>
+				</div>
+			</CardContent>
+		</Card>
+	);
+};


### PR DESCRIPTION
This PR adds account email change via the better-auth email-OTP plugin and an org-wide `require_passkey` configuration that allows owners to enforce passkey-only access. Both features are fully wired with UI and server-side enforcement.

**Backend**
- Enable `changeEmail` in email-OTP plugin config (`server/src/utils/auth.ts`) — OAuth accounts stay linked via `(providerId, accountId)` so `user.email` changes don’t break Google sign-in.
- Add `require_passkey` flag to `OrgConfigSchema` (`shared/models/orgModels/orgConfig.ts`).
- Wire `beforeSessionUpdated` hook to rewrite `activeOrganizationId` to a non-gated org when a user without passkeys switches to a `require_passkey=true` org (`server/src/utils/authUtils/beforeSessionUpdated.ts`, `passkeyEnforcement.ts`).
- Extend `beforeSessionCreated` to pick a passkey-allowed org when the last-active org gating would otherwise leave the user with no eligible org (`server/src/utils/authUtils/beforeSessionCreated.ts`).
- Add `requirePasskey` to the `/api/auth/organization/list` response so the client can gate UI up-front (`server/src/internal/auth/handleListAuthOrganizations.ts`).

**Frontend**
- Add email change dialog and OTP flow from the account sidebar (`vite/src/views/main-sidebar/components/UserDetails.tsx`).
- Add `OrgSecurityCard` with a Require passkeys toggle to the Org settings section (`vite/src/views/settings/sections/components/OrgSecurityCard.tsx`).
- Gate org dropdown items: show PASSKEY badge on gated orgs and disable selection with a toast (`vite/src/views/main-sidebar/components/OrgDropdown.tsx`, `useHasPasskey.tsx`).
- Prevent DashboardGate from auto-switching to a remembered gated org; redirect when every membership is gated (`vite/src/app/DashboardGate.tsx`).
- Make `useOrg` respect passkey gating when picking a landing org during init (`vite/src/hooks/common/useOrg.tsx`).

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/b9b9b2db-8e33-4da8-b8b8-12b6d45acaed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-029" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/b9b9b2db-8e33-4da8-b8b8-12b6d45acaed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-029&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-029"><img alt="SCO-029" src="https://capy.ai/api/badge/thread.svg?label=SCO-029"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds account email change via `better-auth` email OTP and an org-wide passkey requirement with full UI and server enforcement. Addresses SCO-029 by letting owners require passkeys and blocking org selection for users without a passkey.

- **New Features**
  - Email change: new dialog and OTP flow; server enables `changeEmail` in `better-auth`. OAuth accounts stay linked (Google sign-in unaffected).
  - Passkey enforcement: new `require_passkey` in org config with a toggle in Org settings. `/api/auth/organization/list` now returns `requirePasskey` to gate the UI.
  - Enforcement logic: server `beforeSessionCreated`/`beforeSessionUpdated` prevent switching into gated orgs without a passkey and fall back to an allowed org. Client adds PASSKEY badges and toasts in the org switcher, stops auto-switches in `DashboardGate`, and updates `useOrg` to pick an allowed org or sign out when none. New `useHasPasskey` hook.

<sup>Written for commit ed6c903c94becdfcf88bba787f789e65514c2e00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds two security features: an email-change flow gated by an OTP sent to the new address, and an org-level `require_passkey` toggle that prevents users without a registered WebAuthn credential from switching into gated orgs. Both features are wired end-to-end with server-side session hooks (`beforeSessionCreated`, `beforeSessionUpdated`) and client-side UI guards.

- **Improvements** — Email change dialog with OTP verification in `UserDetails`, resend countdown, and deferred reset on close.
- **Improvements / API changes** — `require_passkey` flag added to `OrgConfigSchema`; `handleListAuthOrganizations` sanitizes the config and exposes `requirePasskey` as a flat boolean so internal Stripe/feature-flag config stays server-side.
- **Bug fixes** — `DashboardGate` now skips the auto-switch to a gated org (avoiding a silent server-side rewrite loop), and `useOrg` falls back to a passkey-allowed org when initiating a session with no active org.
</details>

<h3>Confidence Score: 3/5</h3>

The server-side enforcement is solid; the client-side gating in DashboardGate has a timing bug that fires a misleading toast and destroys the remembered org for users who already have a passkey.

The passkey-loading race in DashboardGate is a real behavioural defect: the effect fires before useListPasskeys resolves, so a user with a passkey trying to return to a gated org sees an incorrect error toast and loses the auto-switch — every time they log in.

vite/src/app/DashboardGate.tsx — the lastOrgGated derivation needs to guard on isLoading from useHasPasskey before acting on hasPasskey=false

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/app/DashboardGate.tsx | Adds passkey-gating check before auto-switching to a remembered org; contains a race condition where hasPasskey=false while loading fires a false toast and clears the localStorage entry for users who do have a passkey |
| server/src/utils/authUtils/beforeSessionUpdated.ts | New hook that intercepts org-switch updates and rewrites activeOrganizationId to a passkey-allowed fallback; correctly resolves userId from both the patch and context, and handles the null-fallback case cleanly |
| server/src/utils/authUtils/passkeyEnforcement.ts | Three utility functions (orgRequiresPasskey, userHasPasskey, pickPasskeyAllowedOrg) for enforcement logic; DB-level filtering is correct, post-fetch JS sort for fallback ordering is sound |
| vite/src/views/settings/sections/components/OrgSecurityCard.tsx | Toggle for require_passkey correctly patches org config and updates local cache; the queryClient.invalidateQueries call targets the wrong cache (react-query vs better-auth nanostore) so the PASSKEY badge in the org switcher won't refresh immediately |
| server/src/internal/auth/handleListAuthOrganizations.ts | Sanitizes org response to include requirePasskey while keeping internal config fields (Stripe, feature flags) server-side; correct approach |
| vite/src/views/main-sidebar/components/UserDetails.tsx | Adds email-change dialog with OTP flow; input validation, case-normalisation, resend countdown, and reset-on-close logic are all correct |
| server/src/utils/authUtils/beforeSessionCreated.ts | Extends session creation to pick a passkey-allowed org; correctly handles impersonation bypass and falls through to null when all orgs are gated |
| vite/src/hooks/common/useOrg.tsx | Extends handleNoActiveOrg to check passkey-gating before auto-picking a landing org; sign-out and redirect when all orgs are gated is the designed behaviour per the comments |
| vite/src/views/main-sidebar/components/OrgDropdown.tsx | Adds PASSKEY badge and click-gate for orgs with requirePasskey; gated check uses hasPasskey which could transiently show incorrect state during load, but effect is limited to a visual flicker with no localStorage mutation |
| shared/models/orgModels/orgConfig.ts | Adds require_passkey boolean with default false to OrgConfigSchema; safe addition, no migration needed for jsonb column |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User (with passkey)
    participant C as Client (DashboardGate)
    participant BA as better-auth server
    participant H as beforeSessionUpdated hook
    participant DB as DB (passkeyEnforcement)

    U->>C: Navigate to dashboard (gated org in localStorage)
    C->>C: "useHasPasskey() loading — hasPasskey=false"
    Note over C: lastOrgGated=true (race) → toast fires ⚠️
    C->>C: clearLastSwitchedOrgId() + setIgnoredLastOrgId()
    C->>C: "useListPasskeys resolves — hasPasskey=true"
    Note over C: Too late: localStorage cleared, auto-switch blocked

    Note over U,DB: Server-side defence-in-depth (bypassed client):
    U->>BA: POST /organization/set-active
    BA->>H: beforeSessionUpdated(patch, ctx)
    H->>DB: orgRequiresPasskey(orgId)
    DB-->>H: true
    H->>DB: userHasPasskey(userId)
    DB-->>H: false
    H->>DB: pickPasskeyAllowedOrg(userId)
    DB-->>H: fallbackOrgId
    H-->>BA: rewritten activeOrganizationId
    BA-->>U: session updated to fallback

    U->>C: Owner toggles require_passkey ON
    C->>BA: PATCH /organization/config
    BA-->>C: updated config
    C->>C: setQueryData (org cache updated)
    Note over C: invalidateQueries org-members — nanostore unaffected
    Note over C: PASSKEY badge stale until page reload
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User (with passkey)
    participant C as Client (DashboardGate)
    participant BA as better-auth server
    participant H as beforeSessionUpdated hook
    participant DB as DB (passkeyEnforcement)

    U->>C: Navigate to dashboard (gated org in localStorage)
    C->>C: "useHasPasskey() loading — hasPasskey=false"
    Note over C: lastOrgGated=true (race) → toast fires ⚠️
    C->>C: clearLastSwitchedOrgId() + setIgnoredLastOrgId()
    C->>C: "useListPasskeys resolves — hasPasskey=true"
    Note over C: Too late: localStorage cleared, auto-switch blocked

    Note over U,DB: Server-side defence-in-depth (bypassed client):
    U->>BA: POST /organization/set-active
    BA->>H: beforeSessionUpdated(patch, ctx)
    H->>DB: orgRequiresPasskey(orgId)
    DB-->>H: true
    H->>DB: userHasPasskey(userId)
    DB-->>H: false
    H->>DB: pickPasskeyAllowedOrg(userId)
    DB-->>H: fallbackOrgId
    H-->>BA: rewritten activeOrganizationId
    BA-->>U: session updated to fallback

    U->>C: Owner toggles require_passkey ON
    C->>BA: PATCH /organization/config
    BA-->>C: updated config
    C->>C: setQueryData (org cache updated)
    Note over C: invalidateQueries org-members — nanostore unaffected
    Note over C: PASSKEY badge stale until page reload
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/app/DashboardGate.tsx:34-35
**Passkey-loading race fires false toast and destroys remembered org**

`hasPasskey` is `false` while `useListPasskeys` is still in-flight (`isPending = true`), so for any user with a passkey-gated org stored as their last-switched org, `lastOrgGated` evaluates to `true` before passkeys finish loading. The effect below immediately fires the "You need a passkey" toast, calls `clearLastSwitchedOrgId`, and sets `ignoredLastOrgId`. Once passkeys finish loading and `hasPasskey` becomes `true`, `lastOrgGated` flips to `false`, but by then the localStorage entry is gone and `ignoredLastOrgId === lastOrgId`, so `shouldSwitchToLastOrg` stays `false` — the user is never switched to the gated org they intended to reach.

Fix: also destructure `isLoading` from `useHasPasskey()` and guard `lastOrgGated` behind `!passkeyLoading`.

### Issue 2 of 2
vite/src/views/settings/sections/components/OrgSecurityCard.tsx:49-51
**`useListOrganizations` is not backed by react-query — invalidation is a no-op**

`authClient.useListOrganizations()` (used by `OrgDropdown`) is managed by better-auth's nanostore, not by react-query's `QueryClient`. Calling `queryClient.invalidateQueries({ queryKey: ["organization-members"] })` only refetches the org-member list (`useMemberships`); it has no effect on the nanostore powering the org switcher. After an owner enables or disables the passkey requirement, the PASSKEY badge in other components' org dropdowns won't reflect the new state until the user reloads the page.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Enable personal email change via OTP and..."](https://github.com/useautumn/autumn/commit/ed6c903c94becdfcf88bba787f789e65514c2e00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40302591)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->