### PR TITLE
chore: disable stripe product creation

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
@@ -1,4 +1,5 @@
 import {
+	AppEnv,
 	type AutumnBillingPlan,
 	type BillingContext,
 	copyStripeResourcesToMatchingPrice,
@@ -17,6 +18,7 @@ import {
 	applyCustomerProductPatch,
 	getPatchCustomerProducts,
 } from "@/internal/billing/v2/utils/billingPlan/customerProductPlanMutations";
+import { orgDisableStripeWrites } from "@/internal/orgs/orgUtils/convertOrgUtils";
 import { PriceService } from "@/internal/products/prices/PriceService";
 import { checkStripeProductExists } from "@/internal/products/productUtils";
 
@@ -30,6 +32,8 @@ export const initStripeResourcesForProducts = async ({
 	internalEntityId?: string;
 }) => {
 	const { db, org, env, logger } = ctx;
+	if (env === AppEnv.Live) return;
+	if (orgDisableStripeWrites({ ctx, includeSandbox: true })) return;
 
 	const batchProductUpdates = [];
 	for (const product of products) {
@@ -120,6 +124,8 @@ export const initStripeResourcesForBillingPlan = async ({
 		});
 		return;
 	}
+
+	if (orgDisableStripeWrites({ ctx })) return;
 
 	const { fullCustomer } = billingContext;
 	const { insertCustomerProducts } = autumnBillingPlan;

--- a/server/src/internal/orgs/orgUtils/convertOrgUtils.ts
+++ b/server/src/internal/orgs/orgUtils/convertOrgUtils.ts
@@ -1,4 +1,4 @@
-import { AppEnv, type Organization } from "@autumn/shared";
+import { AppEnv, type Organization, type SharedContext } from "@autumn/shared";
 
 export const toSuccessUrl = ({
 	org,
@@ -12,4 +12,17 @@ export const toSuccessUrl = ({
 	} else {
 		return org.stripe_config?.success_url || "https://useautumn.com";
 	}
+};
+
+export const orgDisableStripeWrites = ({
+	ctx,
+	includeSandbox = false,
+}: {
+	ctx: SharedContext;
+	includeSandbox?: boolean;
+}) => {
+	if (ctx.env === AppEnv.Sandbox && !includeSandbox) {
+		return false;
+	}
+	return ctx.org.config.disable_stripe_writes;
 };

--- a/server/src/internal/products/handlers/handleCreateProduct/handleCreatePlan.ts
+++ b/server/src/internal/products/handlers/handleCreateProduct/handleCreatePlan.ts
@@ -19,17 +19,16 @@ import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { JobName } from "@/queue/JobName.js";
 import { addTaskToQueue } from "@/queue/queueUtils.js";
 import { captureOrgEvent } from "@/utils/posthog.js";
+import { validateDefaultFlag } from "../../../product/actions/validateDefaultFlag.js";
 import { getEntsWithFeature } from "../../entitlements/entitlementUtils.js";
 import {
 	handleNewFreeTrial,
 	validateOneOffTrial,
 } from "../../free-trials/freeTrialUtils.js";
-
 import { ProductService } from "../../ProductService.js";
 import { handleNewProductItems } from "../../product-items/productItemUtils/handleNewProductItems.js";
 import { getPlanResponse } from "../../productUtils/productResponseUtils/getPlanResponse.js";
 import { constructProduct, initProductInStripe } from "../../productUtils.js";
-import { validateDefaultFlag } from "../../../product/actions/validateDefaultFlag.js";
 
 /**
  * Route: POST /products - Create a product

--- a/server/src/internal/products/productUtils.ts
+++ b/server/src/internal/products/productUtils.ts
@@ -1,5 +1,5 @@
 import {
-	type AppEnv,
+	AppEnv,
 	BillingInterval,
 	BillingType,
 	type CreateProductV2Params,
@@ -11,13 +11,13 @@ import {
 	type FullProduct,
 	nullish,
 	type Organization,
-	pickBillingControlColumns,
 	type Price,
 	PriceSchema,
 	PriceType,
 	ProcessorType,
 	type Product,
 	ProductSchema,
+	pickBillingControlColumns,
 	isProductUpgrade as sharedIsProductUpgrade,
 	type UsagePriceConfig,
 } from "@autumn/shared";
@@ -34,6 +34,7 @@ import type {
 	AttachParams,
 	InsertCusProductParams,
 } from "../customers/cusProducts/AttachParams.js";
+import { orgDisableStripeWrites } from "../orgs/orgUtils/convertOrgUtils.js";
 import { isStripeConnected } from "../orgs/orgUtils.js";
 import { EntitlementService } from "./entitlements/EntitlementService.js";
 import { getEntitlementsForProduct } from "./entitlements/entitlementUtils.js";
@@ -515,7 +516,9 @@ export const initProductInStripe = async ({
 	product: FullProduct;
 }): Promise<undefined> => {
 	const { org, env, logger, db } = ctx;
+	if (env === AppEnv.Live) return;
 	if (!isStripeConnected({ org, env })) return;
+	if (orgDisableStripeWrites({ ctx, includeSandbox: true })) return;
 
 	await checkStripeProductExists({
 		db,

--- a/shared/utils/orgUtils/convertOrgUtils.ts
+++ b/shared/utils/orgUtils/convertOrgUtils.ts
@@ -35,8 +35,14 @@ export const orgDefaultAppliesToEntities = ({
 	return ctx.org.config.default_applies_to_entities;
 };
 
-export const orgDisableStripeWrites = ({ ctx }: { ctx: SharedContext }) => {
-	if (ctx.env === AppEnv.Sandbox) {
+export const orgDisableStripeWrites = ({
+	ctx,
+	includeSandbox = false,
+}: {
+	ctx: SharedContext;
+	includeSandbox?: boolean;
+}) => {
+	if (ctx.env === AppEnv.Sandbox && !includeSandbox) {
 		return false;
 	}
 	return ctx.org.config.disable_stripe_writes;


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable Stripe product initialization in product and billing flows when orgs have `disable_stripe_writes` enabled and in the `Live` environment to prevent unintended Stripe writes.

- **Bug Fixes**
  - Added `orgDisableStripeWrites(ctx, includeSandbox)` and used it to short-circuit `initProductInStripe` and `initStripeResourcesForProducts/BillingPlan` (sandbox can now respect the flag when `includeSandbox` is true).
  - Early-return in `Live` env to avoid creating Stripe product resources.

<sup>Written for commit 3258408d1eec54c779a8d31a43661f6bc423fbce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR disables eager Stripe product and price creation in Live environments and extends the `disable_stripe_writes` org-config flag to also cover Sandbox environments via a new `includeSandbox` parameter on `orgDisableStripeWrites`.

- **Improvements**: `initProductInStripe` and `initStripeResourcesForProducts` now return early for `AppEnv.Live`, preventing proactive Stripe product/price creation at product-setup time in Live.
- **Improvements**: `orgDisableStripeWrites` gains an `includeSandbox` flag (mirrored in both the server and shared packages), allowing the `disable_stripe_writes` org config to take effect in Sandbox when callers opt in with `includeSandbox: true`.
- **Improvements**: `initStripeResourcesForBillingPlan` receives an `orgDisableStripeWrites` guard so billing-plan initialization also respects the org config (Sandbox-excluded by default).
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge with a clarification: proactive product initialization is disabled for Live, but the billing-plan path can still create Stripe products at checkout time for Live orgs that don't have disable_stripe_writes set.

The two product-initialization functions are cleanly guarded for Live. The only open question is whether initStripeResourcesForBillingPlan should carry the same AppEnv.Live guard — if lazy creation during checkout is intentional, the code is correct; if not, it is an incomplete disable. Either way, no data-loss or crash path is introduced by this PR.

initStripeResourcesForProducts.ts — the Live/Sandbox guard inconsistency between the two exported functions warrants a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts | Added AppEnv.Live early-return to initStripeResourcesForProducts (making the orgDisableStripeWrites call below it unreachable for Live), and added orgDisableStripeWrites check to initStripeResourcesForBillingPlan — but the latter function has no AppEnv.Live guard, leaving an inconsistency. |
| server/src/internal/orgs/orgUtils/convertOrgUtils.ts | Extended orgDisableStripeWrites with an includeSandbox flag; when true the function respects disable_stripe_writes in Sandbox environments too. Clean, straightforward change mirrored in the shared package. |
| server/src/internal/products/productUtils.ts | Added AppEnv.Live guard and orgDisableStripeWrites(includeSandbox:true) check to initProductInStripe. Same Live-guard pattern as initStripeResourcesForProducts; the orgDisableStripeWrites check is only meaningful for Sandbox. |
| shared/utils/orgUtils/convertOrgUtils.ts | Shared package version of orgDisableStripeWrites updated identically to add the includeSandbox parameter. No issues. |
| server/src/internal/products/handlers/handleCreateProduct/handleCreatePlan.ts | Import reordering only; no functional changes. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Product created / billing plan attached] --> B{Which code path?}

    B --> C[initProductInStripe\ninitStripeResourcesForProducts]
    B --> D[initStripeResourcesForBillingPlan]

    C --> E{env === AppEnv.Live?}
    E -- Yes --> F[return — no Stripe writes]
    E -- No / Sandbox --> G{orgDisableStripeWrites\nincludeSandbox: true}
    G -- true --> F
    G -- false --> H[checkStripeProductExists\ncreateStripePriceIfNotExist]

    D --> I{dryRunStripe?}
    I -- Yes --> J[Apply preview resources & return]
    I -- No --> K{orgDisableStripeWrites\nincludeSandbox: false}
    K -- Sandbox --> L[Always false → continue]
    K -- Live → check org config --> M{disable_stripe_writes?}
    M -- true --> N[return — no Stripe writes]
    M -- false --> O[checkStripeProductExists\ncreateStripePriceIfNotExist]
    L --> O
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Product created / billing plan attached] --> B{Which code path?}

    B --> C[initProductInStripe\ninitStripeResourcesForProducts]
    B --> D[initStripeResourcesForBillingPlan]

    C --> E{env === AppEnv.Live?}
    E -- Yes --> F[return — no Stripe writes]
    E -- No / Sandbox --> G{orgDisableStripeWrites\nincludeSandbox: true}
    G -- true --> F
    G -- false --> H[checkStripeProductExists\ncreateStripePriceIfNotExist]

    D --> I{dryRunStripe?}
    I -- Yes --> J[Apply preview resources & return]
    I -- No --> K{orgDisableStripeWrites\nincludeSandbox: false}
    K -- Sandbox --> L[Always false → continue]
    K -- Live → check org config --> M{disable_stripe_writes?}
    M -- true --> N[return — no Stripe writes]
    M -- false --> O[checkStripeProductExists\ncreateStripePriceIfNotExist]
    L --> O
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts:35-36
**Incomplete Live guard — billing plan path still creates Stripe products**

`initStripeResourcesForProducts` now returns unconditionally for `AppEnv.Live` (line 35), so the `orgDisableStripeWrites` call on line 36 is dead code for the Live case — it is only reachable in Sandbox. More importantly, `initStripeResourcesForBillingPlan` in the same file has no `AppEnv.Live` guard, only `orgDisableStripeWrites({ ctx })`. For any Live org that does **not** have `disable_stripe_writes: true`, that function will still call `checkStripeProductExists` and `createStripePriceIFNotExist`, creating Stripe products and prices at billing time.

If the goal of this PR is to fully stop Stripe product creation in Live, `initStripeResourcesForBillingPlan` needs the same early-return guard. If the design is intentional — proactive creation is disabled, but lazy creation at checkout is still allowed — a brief comment would prevent future confusion.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: disable stripe writes doesn&#39;t cre..."](https://github.com/useautumn/autumn/commit/3258408d1eec54c779a8d31a43661f6bc423fbce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40433992)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->