### PR TITLE
fix: graduated price tooltip shows included usage & correct boundaries

### DIFF
--- a/vite/src/components/v2/PlanItemLabel.tsx
+++ b/vite/src/components/v2/PlanItemLabel.tsx
@@ -111,25 +111,38 @@ function priceTierRows(
 	item: ProductItem,
 	currency: string,
 ): { range: string; value: string }[] {
-	let from = 0;
-	return (item.tiers ?? []).map((tier) => {
-		const isInfinite = tier.to === TierInfinite;
-		const range = isInfinite ? `${from}+` : `${from}–${tier.to}`;
-		if (!isInfinite && typeof tier.to === "number") from = tier.to;
+	// Tiers store `to` relative to the granted usage, so add it back to show the
+	// same absolute boundaries as the editor (PriceTiers' getTierToDisplay).
+	const includedUsage =
+		typeof item.included_usage === "number" ? item.included_usage : 0;
 
-		const fmt = (amount: number) =>
-			formatAmount({
-				currency,
-				amount,
-				amountFormatOptions: { currencyDisplay: "narrowSymbol" },
-			});
+	const fmt = (amount: number) =>
+		formatAmount({
+			currency,
+			amount,
+			amountFormatOptions: { currencyDisplay: "narrowSymbol" },
+		});
+
+	const rows: { range: string; value: string }[] = [];
+	if (includedUsage > 0) {
+		rows.push({ range: `0–${includedUsage}`, value: "Included" });
+	}
+
+	let from = includedUsage;
+	for (const tier of item.tiers ?? []) {
+		const isInfinite = tier.to === TierInfinite;
+		const to = typeof tier.to === "number" ? tier.to + includedUsage : tier.to;
+		const range = isInfinite ? `${from}+` : `${from}–${to}`;
+		if (!isInfinite && typeof to === "number") from = to;
 
 		const parts: string[] = [];
 		if (tier.amount) parts.push(fmt(tier.amount));
 		if (tier.flat_amount) parts.push(`${fmt(tier.flat_amount)} flat`);
 
-		return { range, value: parts.length > 0 ? parts.join(" + ") : "Free" };
-	});
+		rows.push({ range, value: parts.length > 0 ? parts.join(" + ") : "Free" });
+	}
+
+	return rows;
 }
 
 function KeyValueRow({ label, value }: { label: string; value: string }) {


### PR DESCRIPTION
## Problem

The graduated-price tooltip in the plan editor showed the **wrong tier boundaries** and never displayed the **included (granted) usage**.

Tiers store their `to` value *relative to the granted usage*. The editor adds `included_usage` back when rendering boundaries (`getTierToDisplay` in `PriceTiers.tsx`), but the tooltip's `priceTierRows` read `tier.to` raw — so with a grant of 10000, a stored `to` of 40000 rendered as `40000` instead of `50000`, and the free band was missing entirely.

## Fix

In `PlanItemLabel.tsx`:
- Add `included_usage` back to each tier boundary so ranges match the editor.
- Lead with a `0–<grant>` **Included** row when there's granted usage.

### Before → After (grant 10000)

```
0–40000        $0.0015        0–10000        Included
40000–90000    $0.00135       10000–50000    $0.0015
90000–240000   $0.0011        50000–100000   $0.00135
...                           100000–250000  $0.0011
990000+        $0.0007        ...
                              1000000+       $0.0007
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the graduated-price tooltip to show correct tier boundaries and include the free band, matching the plan editor.

- **Bug Fixes**
  - Add `included_usage` back to each tier’s `to` value when computing ranges (handles infinite top tier).
  - Prepend a 0–{included_usage} “Included” row when a grant exists.

<sup>Written for commit be6a13a7770120a4732bad2410653c23d363019e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes the graduated-price tooltip in the plan editor, which was displaying raw stored tier boundaries instead of the absolute values shown in the tier editor. Tiers store their `to` values relative to the granted (included) usage, so the tooltip was showing each boundary without the `includedUsage` offset, and the free "included" band was missing entirely.

- **Bug fixes** — `priceTierRows` now adds `includedUsage` back to every tier boundary, aligning the tooltip with `PriceTiers`'s `getTierToDisplay`, and prepends a `0–<grant> Included` row when there is granted usage.
- **Bug fixes** — `from` now initialises to `includedUsage` instead of `0`, so subsequent tier ranges start from the correct absolute boundary rather than from 0.
</details>

<h3>Confidence Score: 5/5</h3>

Tooltip-only display change with no data mutations; safe to merge.

The change is confined to a single pure rendering function that produces tooltip rows. It correctly mirrors the existing getTierToDisplay offset logic from PriceTiers.tsx, handles the infinite-tier sentinel string "inf" safely (isInfinite is checked before to is used in range/from), and degrades gracefully to the old behaviour when includedUsage is 0 or absent.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/v2/PlanItemLabel.tsx | Fixes priceTierRows to offset each tier boundary by includedUsage and prepend a 0–<grant> "Included" row, matching the editor's getTierToDisplay logic; no regressions when includedUsage is 0. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[priceTierRows called] --> B{item.included_usage is number?}
    B -- Yes --> C[includedUsage = item.included_usage]
    B -- No --> D[includedUsage = 0]
    C --> E{includedUsage > 0?}
    D --> F[from = 0]
    E -- Yes --> G[Push row: 0–includedUsage → Included]
    E -- No --> F
    G --> H[from = includedUsage]
    H --> I[Iterate over item.tiers]
    F --> I
    I --> J{tier.to === TierInfinite?}
    J -- Yes --> K[range = from+]
    J -- No --> L[to = tier.to + includedUsage\nrange = from–to\nfrom = to]
    K --> M[Build value from tier.amount / tier.flat_amount]
    L --> M
    M --> N[Push row to rows]
    N --> O{More tiers?}
    O -- Yes --> I
    O -- No --> P[Return rows]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[priceTierRows called] --> B{item.included_usage is number?}
    B -- Yes --> C[includedUsage = item.included_usage]
    B -- No --> D[includedUsage = 0]
    C --> E{includedUsage > 0?}
    D --> F[from = 0]
    E -- Yes --> G[Push row: 0–includedUsage → Included]
    E -- No --> F
    G --> H[from = includedUsage]
    H --> I[Iterate over item.tiers]
    F --> I
    I --> J{tier.to === TierInfinite?}
    J -- Yes --> K[range = from+]
    J -- No --> L[to = tier.to + includedUsage\nrange = from–to\nfrom = to]
    K --> M[Build value from tier.amount / tier.flat_amount]
    L --> M
    M --> N[Push row to rows]
    N --> O{More tiers?}
    O -- Yes --> I
    O -- No --> P[Return rows]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: show included usage and correct bou..."](https://github.com/useautumn/autumn/commit/be6a13a7770120a4732bad2410653c23d363019e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40437976)</sub>

<!-- /greptile_comment -->