### PR TITLE
chore(cron): clear next_reset_at on expired products

### DIFF
--- a/server/src/cron/cronInit.ts
+++ b/server/src/cron/cronInit.ts
@@ -16,6 +16,7 @@ import { runInvoiceCron } from "./invoiceCron/runInvoiceCron.js";
 import { runOneOffCleanup } from "./oneoffCron/runOneOffCleanup.js";
 import { runOneOffExpiry } from "./oneoffCron/runOneOffExpiry.js";
 import { runProductCron } from "./productCron/runProductCron.js";
+import { runClearExpiredResetCron } from "./resetCron/runClearExpiredResetCron.js";
 import { runResetCron } from "./resetCron/runResetCron.js";
 import type { CronContext } from "./utils/CronContext.js";
 
@@ -65,6 +66,7 @@ const main = async () => {
 		runInvoiceCron({ ctx }),
 		runOneOffCleanup({ ctx }),
 		runOneOffExpiry({ ctx }),
+		runClearExpiredResetCron({ ctx }),
 	]);
 };
 

--- a/server/src/cron/resetCron/runClearExpiredResetCron.ts
+++ b/server/src/cron/resetCron/runClearExpiredResetCron.ts
@@ -1,0 +1,60 @@
+import { CusProductStatus } from "@autumn/shared";
+import { sql } from "drizzle-orm";
+import type { CronContext } from "../utils/CronContext.js";
+
+const BATCH_SIZE = 5000;
+const TICK_MS = 30_000;
+const RUN_BUDGET_MS = 55_000;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Backfill: clear next_reset_at on entitlements of expired (terminal) products
+// so the reset cron stops scanning ~12M stale rows. Self-terminating once the
+// backlog drains; remove this job after it idles. See forward fix at expiry sites.
+const clearExpiredBatch = async ({ ctx }: { ctx: CronContext }) => {
+	const { db } = ctx;
+	const updated = await db.execute<{ id: string }>(sql`
+		WITH batch AS (
+			SELECT ce.id
+			FROM customer_entitlements ce
+			JOIN customer_products cp ON ce.customer_product_id = cp.id
+			WHERE ce.next_reset_at IS NOT NULL
+				AND cp.status = ${CusProductStatus.Expired}
+			LIMIT ${BATCH_SIZE}
+			FOR UPDATE OF ce SKIP LOCKED
+		)
+		UPDATE customer_entitlements ce
+		SET next_reset_at = NULL
+		FROM batch
+		WHERE ce.id = batch.id
+		RETURNING ce.id
+	`);
+	return updated.length;
+};
+
+export const runClearExpiredResetCron = async ({ ctx }: { ctx: CronContext }) => {
+	const { logger } = ctx;
+
+	if (process.env.DISABLE_CLEAR_EXPIRED_RESET_CRON === "true") return;
+
+	const startTime = Date.now();
+	let total = 0;
+
+	while (Date.now() - startTime < RUN_BUDGET_MS) {
+		let count: number;
+		try {
+			count = await clearExpiredBatch({ ctx });
+		} catch (error) {
+			logger.error(`clearExpiredReset: batch failed ${error}`);
+			return;
+		}
+
+		total += count;
+		logger.info(`clearExpiredReset: nulled ${count} (run total ${total})`);
+
+		// Drained: fewer than a full batch means no more stale rows.
+		if (count < BATCH_SIZE) break;
+		if (Date.now() - startTime + TICK_MS >= RUN_BUDGET_MS) break;
+		await sleep(TICK_MS);
+	}
+};


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a backfill cron to clear next_reset_at on entitlements for expired products. This stops the reset cron from scanning millions of stale rows and reduces DB load.

- **New Features**
  - Added `runClearExpiredResetCron` and wired it into cron init (batched 5k, SKIP LOCKED, 55s budget, 30s tick).
  - Self-terminates when drained; can be disabled via `DISABLE_CLEAR_EXPIRED_RESET_CRON=true`.

<sup>Written for commit e0f661456b578818a1f596f4d3317afac571b183. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a self-terminating backfill cron job (`runClearExpiredResetCron`) that NULLs `next_reset_at` on `customer_entitlements` rows whose associated `customer_products` have an `Expired` status, preventing the main reset cron from scanning ~12M stale rows on every tick.

- **Bug fixes / Improvements**: `runClearExpiredResetCron` processes rows in batches of 5,000 using a CTE with `FOR UPDATE SKIP LOCKED` to avoid collisions with concurrent writers, and respects a 55-second run budget per cron invocation to stay within the 1-minute tick window.
- **Improvements**: A `DISABLE_CLEAR_EXPIRED_RESET_CRON` env-var escape hatch is provided, and the job is designed to be removed once the backlog drains (it idles at zero rows and logs accordingly).
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the backfill job is additive and self-terminating, and the SQL update is scoped only to entitlements of expired products.

The SQL logic is sound, FOR UPDATE SKIP LOCKED correctly prevents concurrent double-processing, and the 55-second run budget fits cleanly within the 1-minute cron tick. The only gap is that batch errors are logged but not forwarded to Sentry, unlike the sibling reset cron, so a persistent failure could go unnoticed.

runClearExpiredResetCron.ts — worth adding Sentry capture for batch errors before shipping to production at scale.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/cron/resetCron/runClearExpiredResetCron.ts | New backfill cron that NULLs next_reset_at on customer_entitlements belonging to expired products. SQL logic is correct; uses FOR UPDATE SKIP LOCKED to avoid concurrent collisions. Minor: no Sentry capture on batch errors, inconsistent with the sibling runResetCron. |
| server/src/cron/cronInit.ts | Adds runClearExpiredResetCron to the Promise.all of parallel cron jobs; import and registration are correct. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CronJob as CronJob (every 1 min)
    participant main as cronInit main()
    participant clearJob as runClearExpiredResetCron
    participant DB as PostgreSQL

    CronJob->>main: tick
    main->>clearJob: await (in Promise.all)
    loop until RUN_BUDGET_MS (55s) or backlog drained
        clearJob->>DB: "CTE UPDATE next_reset_at = NULL WHERE status = expired LIMIT 5000 FOR UPDATE SKIP LOCKED"
        DB-->>clearJob: updated rows (count)
        alt "count < BATCH_SIZE"
            clearJob-->>main: done (break)
        else "elapsed + TICK_MS >= RUN_BUDGET_MS"
            clearJob-->>main: done (break)
        else
            clearJob->>clearJob: sleep(30s)
        end
    end
    main-->>CronJob: complete
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CronJob as CronJob (every 1 min)
    participant main as cronInit main()
    participant clearJob as runClearExpiredResetCron
    participant DB as PostgreSQL

    CronJob->>main: tick
    main->>clearJob: await (in Promise.all)
    loop until RUN_BUDGET_MS (55s) or backlog drained
        clearJob->>DB: "CTE UPDATE next_reset_at = NULL WHERE status = expired LIMIT 5000 FOR UPDATE SKIP LOCKED"
        DB-->>clearJob: updated rows (count)
        alt "count < BATCH_SIZE"
            clearJob-->>main: done (break)
        else "elapsed + TICK_MS >= RUN_BUDGET_MS"
            clearJob-->>main: done (break)
        else
            clearJob->>clearJob: sleep(30s)
        end
    end
    main-->>CronJob: complete
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/cron/resetCron/runClearExpiredResetCron.ts:43-50
**Missing Sentry capture on batch failure**

Errors are only logged locally, but `runResetCron` (the sibling job) also calls `Sentry.captureException` so production batch failures are observable there. If the `UPDATE` query fails here (e.g., lock timeout, schema mismatch), the job silently stops iterating without an alert, making it easy to miss in production until the stale-rows problem resurfaces.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(cron): 🤖 add cron to clear next\_r..."](https://github.com/useautumn/autumn/commit/e0f661456b578818a1f596f4d3317afac571b183) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40494480)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->