### PR TITLE
 scope sandbox config panels to the active sub-org

### DIFF
--- a/server/tests/integration/sandbox/stripe-disconnect-suborg.test.ts
+++ b/server/tests/integration/sandbox/stripe-disconnect-suborg.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { AppEnv, organizations, type Organization } from "@autumn/shared";
+import defaultCtx from "@tests/utils/testInitUtils/createTestContext.js";
+import chalk from "chalk";
+import type { User } from "better-auth";
+import { eq } from "drizzle-orm";
+import { initDrizzle } from "@/db/initDrizzle.js";
+import { logger } from "@/external/logtail/logtailUtils.js";
+import { deletePlatformSubOrg } from "@/internal/orgs/deleteOrg/deletePlatformSubOrg.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import { isStripeConnected } from "@/internal/orgs/orgUtils.js";
+import { createSandboxForOrg } from "@/internal/sandboxes/createSandbox.js";
+import { encryptData } from "@/utils/encryptUtils.js";
+
+const { db } = initDrizzle();
+const apiBase = `${(process.env.AUTUMN_TEST_BASE_URL ?? "http://localhost:8080").replace(/\/$/, "")}/v1`;
+
+let createdOrg: Organization | undefined;
+
+afterAll(async () => {
+	if (createdOrg) {
+		await deletePlatformSubOrg({
+			db,
+			org: createdOrg,
+			logger,
+			skipLiveCustomerCheck: true,
+		});
+	}
+});
+
+const fetchOrg = async (orgId: string): Promise<Organization> => {
+	const [row] = await db
+		.select()
+		.from(organizations)
+		.where(eq(organizations.id, orgId));
+	return row as Organization;
+};
+
+describe("sandbox sub-org: Stripe secret-key disconnect", () => {
+	test(
+		`${chalk.yellowBright("sandbox stripe: disconnecting a sub-org's secret key clears it on that sub-org")}`,
+		async () => {
+			const actorUser = (await db.query.user.findFirst()) as unknown as User;
+
+			const { org, secret_key } = await createSandboxForOrg({
+				db,
+				masterOrg: defaultCtx.org,
+				actorUser,
+				name: "QA Disconnect Sandbox",
+			});
+			createdOrg = org;
+
+			await OrgService.update({
+				db,
+				orgId: org.id,
+				updates: {
+					stripe_config: {
+						...(org.stripe_config ?? {}),
+						test_api_key: encryptData("sk_test_disconnect_repro"),
+					},
+				},
+			});
+
+			const connected = await fetchOrg(org.id);
+			expect(
+				isStripeConnected({
+					org: connected,
+					env: AppEnv.Sandbox,
+					throughSecretKey: true,
+				}),
+			).toBe(true);
+
+			const res = await fetch(`${apiBase}/organization/stripe`, {
+				method: "DELETE",
+				headers: {
+					Authorization: `Bearer ${secret_key}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ channel: "secret_key" }),
+			});
+			expect(res.status).toBe(200);
+
+			const after = await fetchOrg(org.id);
+			expect(after.stripe_config?.test_api_key ?? null).toBeNull();
+			expect(
+				isStripeConnected({
+					org: after,
+					env: AppEnv.Sandbox,
+					throughSecretKey: true,
+				}),
+			).toBe(false);
+		},
+		120_000,
+	);
+});

--- a/vite/src/hooks/common/useOrg.tsx
+++ b/vite/src/hooks/common/useOrg.tsx
@@ -1,6 +1,7 @@
-import type { AppEnv, FrontendOrg } from "@autumn/shared";
+import { AppEnv, type FrontendOrg } from "@autumn/shared";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect } from "react";
+import { useActiveSandbox } from "@/hooks/sandbox/useActiveSandbox";
 import {
 	authClient,
 	useListOrganizations,
@@ -37,12 +38,17 @@ export const useSwitchActiveOrg = () => {
 	);
 };
 
-export const useOrg = (params?: { env?: AppEnv }) => {
+export const useOrg = (params?: { env?: AppEnv; skipSandbox?: boolean }) => {
+	const skipSandbox = params?.skipSandbox ?? true;
 	const currentEnv = useEnv();
-	const axiosInstance = useAxiosInstance({ env: params?.env, skipSandbox: true });
+	const env = params?.env ?? currentEnv;
+	const activeSandbox = useActiveSandbox();
+	const axiosInstance = useAxiosInstance({ env: params?.env, skipSandbox });
 	const { data: orgList, isPending: orgListLoading } = useListOrganizations();
 	const { data: session } = useSession();
 	const activeOrgId = session?.session.activeOrganizationId;
+	const sandboxOrgId =
+		!skipSandbox && env === AppEnv.Sandbox ? (activeSandbox?.id ?? null) : null;
 
 	const fetcher = async () => {
 		const { data } = await axiosInstance.get("/organization");
@@ -54,7 +60,9 @@ export const useOrg = (params?: { env?: AppEnv }) => {
 		error,
 		refetch,
 	} = useQuery({
-		queryKey: ["org", params?.env ?? currentEnv, activeOrgId],
+		queryKey: skipSandbox
+			? ["org", env, activeOrgId]
+			: ["org", env, activeOrgId, "sandbox", sandboxOrgId],
 		queryFn: fetcher,
 		placeholderData: keepPreviousData,
 		refetchOnWindowFocus: true,
@@ -70,8 +78,9 @@ export const useOrg = (params?: { env?: AppEnv }) => {
 		lastOrgId !== activeOrgId &&
 		rememberedOrgValid;
 
+	const expectedOrgId = sandboxOrgId ?? activeOrgId;
 	const orgIsReady =
-		!!org && !!activeOrgId && org.id === activeOrgId && !pendingOrgSwitch;
+		!!org && !!activeOrgId && org.id === expectedOrgId && !pendingOrgSwitch;
 	const orgLoading = !session || (!!activeOrgId && !orgIsReady);
 
 	useEffect(() => {

--- a/vite/src/views/customers2/customer/CustomerActions.tsx
+++ b/vite/src/views/customers2/customer/CustomerActions.tsx
@@ -44,7 +44,7 @@ export function CustomerActions() {
 	const [actionsOpen, setActionsOpen] = useState(false);
 	const [clearCacheLoading, setClearCacheLoading] = useState(false);
 	const { customer } = useCusQuery();
-	const { org } = useOrg();
+	const { org } = useOrg({ skipSandbox: false });
 	const { isAdmin } = useAdmin();
 	const setSheet = useSheetStore((s) => s.setSheet);
 	const env = useEnv();

--- a/vite/src/views/developer/configure-stripe/ConfigureStripe.tsx
+++ b/vite/src/views/developer/configure-stripe/ConfigureStripe.tsx
@@ -31,7 +31,7 @@ import { StripeDuplicateAccountDialog } from "./StripeDuplicateAccountDialog";
 import { useStripeOAuthParams } from "./useStripeOAuthParams";
 
 export const ConfigureStripe = () => {
-	const { org, mutate } = useOrg();
+	const { org, mutate } = useOrg({ skipSandbox: false });
 	const { stripeAccount, isLoading: isLoadingStripeAccount } =
 		useOrgStripeQuery();
 	const axiosInstance = useAxiosInstance();

--- a/vite/src/views/developer/configure-stripe/StripeCheckoutSettings.tsx
+++ b/vite/src/views/developer/configure-stripe/StripeCheckoutSettings.tsx
@@ -21,7 +21,7 @@ const isValidUrl = (url: string) =>
 	!url || url.startsWith("http://") || url.startsWith("https://");
 
 export const StripeCheckoutSettings = () => {
-	const { org, mutate } = useOrg();
+	const { org, mutate } = useOrg({ skipSandbox: false });
 	const axiosInstance = useAxiosInstance();
 
 	const [successUrl, setSuccessUrl] = useState(org?.success_url ?? "");

--- a/vite/src/views/developer/configure-vercel/ConfigureVercel.tsx
+++ b/vite/src/views/developer/configure-vercel/ConfigureVercel.tsx
@@ -45,7 +45,7 @@ type VercelConfigState = {
 };
 
 export const ConfigureVercel = () => {
-	const { org, isLoading, mutate } = useOrg();
+	const { org, isLoading, mutate } = useOrg({ skipSandbox: false });
 	const {
 		svixDashboardUrl,
 		isLoading: isVercelLoading,

--- a/vite/src/views/developer/publishable-key.tsx
+++ b/vite/src/views/developer/publishable-key.tsx
@@ -4,7 +4,7 @@ import { useOrg } from "@/hooks/common/useOrg";
 import { useEnv } from "@/utils/envUtils";
 
 export const PublishableKeySection = () => {
-	const { org } = useOrg();
+	const { org } = useOrg({ skipSandbox: false });
 	const env = useEnv();
 	return (
 		<div>

--- a/vite/src/views/onboarding2/ConnectStripeDialog.tsx
+++ b/vite/src/views/onboarding2/ConnectStripeDialog.tsx
@@ -25,7 +25,7 @@ export default function ConnectStripeDialog({
 	setOpen: (open: boolean) => void;
 	onMismatch?: (message: string) => void;
 }) {
-	const { mutate: mutateOrg } = useOrg();
+	const { mutate: mutateOrg } = useOrg({ skipSandbox: false });
 
 	const axiosInstance = useAxiosInstance();
 

--- a/vite/src/views/products/plan/components/EditPlanHeader.tsx
+++ b/vite/src/views/products/plan/components/EditPlanHeader.tsx
@@ -61,7 +61,7 @@ export const EditPlanHeader = () => {
 	const isCusPlanEditor = useIsCusPlanEditor();
 	const flags = useAutumnFlags();
 	const { mappings } = useRCMappings();
-	const { org } = useOrg();
+	const { org } = useOrg({ skipSandbox: false });
 	const env = useEnv();
 	const currency = org?.default_currency ?? "USD";
 	const [migrateDialogOpen, setMigrateDialogOpen] = useState(false);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Sandbox config and related panels to the active sub-org so they read and write the correct org. Stripe connect/disconnect state and settings now stay in sync with the selected sandbox org.

- **Bug Fixes**
  - `useOrg` adds `skipSandbox` (default true). When false in Sandbox, it scopes the query key and readiness to the active sub-org via `useActiveSandbox`, and passes `skipSandbox` to `useAxiosInstance`.
  - Updated Configure/Checkout Stripe, Configure Vercel, Publishable Key, Customer Actions, and Edit Plan Header to use `useOrg({ skipSandbox: false })`.
  - `ConnectStripeDialog` now uses sandbox-scoped `mutateOrg` by default (`useOrg({ skipSandbox: false })`) and still supports optional `onConnected`.
  - Added server integration test for DELETE `/v1/organization/stripe` to confirm a sandbox sub-org’s secret key is cleared when authed as that sub-org.

<sup>Written for commit 8b5724a872d7687d1f0e83f44a1fd6fce85df983. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR scopes the sandbox config panels (`ConfigureStripe`, `ConfigureVercel`, `PublishableKey`, `StripeCheckoutSettings`, `CustomerActions`, `EditPlanHeader`, and `ConnectStripeDialog`) to the active sandbox sub-org by adding a `skipSandbox` option to `useOrg` (defaulting to `true` for backward compatibility) and wiring it through to `useAxiosInstance` and the React Query cache key.

- **Bug fixes** — `useOrg` gains `skipSandbox?: boolean` (default `true`); passing `false` scopes the query key to the active sub-org ID and adds `x-sandbox-org-id` to requests, so Stripe connect/disconnect state and settings now read and write the correct sandbox org.
- **Bug fixes** — `orgIsReady` is updated to compare `org.id` against `sandboxOrgId ?? activeOrgId`, preventing the hook from staying stuck in a loading state when the fetched org is a sub-org.
- **Improvements** — `ConnectStripeDialog` now calls `useOrg({ skipSandbox: false })` directly, ensuring its `mutateOrg` always invalidates the sandbox-scoped cache entry — addressing the previously flagged wrong-cache-entry issue where `onConnected` was optional.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed components correctly adopt the sandbox-scoped useOrg pattern and the core hook changes are backward compatible.

The hook change is additive and defaults to the existing behavior. All sandbox-panel callsites are updated consistently, orgIsReady now correctly validates against the sub-org ID, and an integration test covers the Stripe disconnect path. The one remaining gap (useOrgStripeQuery's cache key not including the sandbox org ID) is a pre-existing issue that causes only a brief visual inconsistency in the Stripe account name when switching sub-orgs, not data corruption or incorrect mutations.

vite/src/hooks/queries/useOrgStripeQuery.tsx — its query key does not yet include the sandbox org ID, which can cause stale Stripe account name display after a sub-org switch.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/hooks/common/useOrg.tsx | Adds skipSandbox param (default true for backward compat). When false in sandbox env, scopes query key to active sub-org ID and passes skipSandbox to useAxiosInstance, correctly gating orgIsReady on the expected (sandbox or main) org ID. |
| vite/src/views/developer/configure-stripe/ConfigureStripe.tsx | Switches to useOrg({ skipSandbox: false }) so org connect/disconnect state and the mutate callback are scoped to the active sandbox sub-org. |
| vite/src/views/onboarding2/ConnectStripeDialog.tsx | Fixes mutateOrg to use useOrg({ skipSandbox: false }), ensuring the sandbox-scoped cache entry is invalidated after connecting a Stripe key. |
| server/tests/integration/sandbox/stripe-disconnect-suborg.test.ts | New integration test verifying DELETE /v1/organization/stripe clears the secret key on the sandbox sub-org when authenticated as that sub-org. |
| vite/src/views/developer/configure-stripe/StripeCheckoutSettings.tsx | useOrg scoped to skipSandbox: false; the axiosInstance (no params) correctly includes x-sandbox-org-id, and key={org.id} in the parent ensures state resets on sub-org switch. |
| vite/src/views/developer/configure-vercel/ConfigureVercel.tsx | One-line change to use useOrg({ skipSandbox: false }), consistent with rest of the developer panel updates. |
| vite/src/views/developer/publishable-key.tsx | useOrg scoped to sandbox sub-org so the displayed publishable key matches the active sandbox. |
| vite/src/views/customers2/customer/CustomerActions.tsx | useOrg scoped with skipSandbox: false so customer actions operate against the active sandbox org. |
| vite/src/views/products/plan/components/EditPlanHeader.tsx | Default currency is now read from the sandbox sub-org, so plan pricing reflects the correct org context. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["useOrg(params)"] --> B{skipSandbox\ndefault: true}
    B -- true --> C["queryKey: [org, env, activeOrgId]"]
    B -- false --> D{env === Sandbox\n&& activeSandbox set?}
    D -- no --> E["queryKey: [org, env, activeOrgId, sandbox, null]"]
    D -- yes --> F["queryKey: [org, env, activeOrgId, sandbox, sandboxOrgId]"]
    C --> G["axiosInstance (skipSandbox: true)\nno x-sandbox-org-id header"]
    E --> H["axiosInstance (skipSandbox: false)\nno header (no active sandbox)"]
    F --> I["axiosInstance (skipSandbox: false)\nx-sandbox-org-id: sandboxOrgId"]
    I --> J["orgIsReady: org.id === sandboxOrgId"]
    G --> K["orgIsReady: org.id === activeOrgId"]
    H --> K
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["useOrg(params)"] --> B{skipSandbox\ndefault: true}
    B -- true --> C["queryKey: [org, env, activeOrgId]"]
    B -- false --> D{env === Sandbox\n&& activeSandbox set?}
    D -- no --> E["queryKey: [org, env, activeOrgId, sandbox, null]"]
    D -- yes --> F["queryKey: [org, env, activeOrgId, sandbox, sandboxOrgId]"]
    C --> G["axiosInstance (skipSandbox: true)\nno x-sandbox-org-id header"]
    E --> H["axiosInstance (skipSandbox: false)\nno header (no active sandbox)"]
    F --> I["axiosInstance (skipSandbox: false)\nx-sandbox-org-id: sandboxOrgId"]
    I --> J["orgIsReady: org.id === sandboxOrgId"]
    G --> K["orgIsReady: org.id === activeOrgId"]
    H --> K
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["scope sandbox Stripe panel to the active..."](https://github.com/useautumn/autumn/commit/8b5724a872d7687d1f0e83f44a1fd6fce85df983) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40497477)</sub>

<!-- /greptile_comment -->