### PR TITLE
feat(revenuecat): show product id and platforms in raw mappings

### DIFF
--- a/scripts/tw/helpers/ingress.ts
+++ b/scripts/tw/helpers/ingress.ts
@@ -98,7 +98,7 @@ export const createIngress = async ({
 	// output through the shared log sink, so during the RUN phase (Ink mounted) the
 	// `[ingress] …` firehose lands in the run log file instead of fighting the TUI
 	// for stdout.
-	const ingressCommand = await runDetached(sandbox, ["node", INGRESS_SCRIPT], {
+	const ingressCommand = await runDetached(sandbox, ["bun", INGRESS_SCRIPT], {
 		cwd: sandboxRepoRoot(),
 		onChunk: (text) =>
 			sinkLine(chalk.gray(`[ingress] ${text.replace(/\n$/, "")}`)),

--- a/scripts/tw/helpers/modalImage.ts
+++ b/scripts/tw/helpers/modalImage.ts
@@ -13,7 +13,8 @@
  *   - goaws (native Go SQS, via crane) → /opt/autumn-tw/bin/goaws
  *   - goaws config → /opt/autumn-tw/goaws/goaws.yaml (port 9324, AccountId
  *     "000000000000", EnableDuplicates env-level, queues autumn.fifo + autumn-track.fifo)
- *   - bun → /usr/local/bin/bun ; node (Debian) for the ingress script
+ *   - bun (pinned to .bun-version) → /usr/local/bin/bun, with `node` symlinked
+ *     to bun so the whole image runs on one runtime (ingress + native installs)
  *
  * What's NOT baked here (done per-run by warmup.sh on Modal, since the repo isn't
  * present at image-build time): `bun install`, `bun db migrate`, the seed, and
@@ -27,7 +28,16 @@
  * chowned to `postgres` here and the service scripts run `pg_ctl` via
  * `runuser -u postgres` when EUID=0 (a no-op on the non-root Vercel µVM).
  */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { App, Image, ModalClient } from "modal";
+
+/** Bun version pinned for the swarm — matches the repo's `.bun-version` so the
+ * image runtime equals what the server is developed against. */
+const BUN_VERSION = readFileSync(
+	join(import.meta.dir, "../../../.bun-version"),
+	"utf8",
+).trim();
 
 /** Inputs for baking node_modules into the base image (see buildBaseImage). */
 export type BaseImageDeps = {
@@ -68,13 +78,14 @@ export const buildBaseImage = (
 ): Promise<Image> =>
 	modal.images
 		.fromRegistry("debian:bookworm-slim")
-		// 1. Base system packages (+ redis-tools for redis-cli, nodejs for ingress).
-		//    Pre-create /repo so the sandbox's default workdir exists before the
-		//    warm parent's clone runs (execing in a missing cwd is a git-128 error).
+		// 1. Base system packages (+ redis-tools for redis-cli). No `nodejs`: bun
+		//    is the only runtime (step 6 symlinks `node` → bun). Pre-create /repo so
+		//    the sandbox's default workdir exists before the warm parent's clone runs
+		//    (execing in a missing cwd is a git-128 error).
 		.dockerfileCommands([
 			"RUN apt-get update && apt-get install -y --no-install-recommends " +
 				"ca-certificates curl wget gnupg bash git xz-utils procps tar gzip " +
-				"locales unzip redis-tools nodejs && rm -rf /var/lib/apt/lists/* && " +
+				"locales unzip redis-tools && rm -rf /var/lib/apt/lists/* && " +
 				"mkdir -p /repo",
 		])
 		// 2. PostgreSQL 18 + contrib (pg_trgm) from the PGDG apt repo.
@@ -117,10 +128,15 @@ export const buildBaseImage = (
 				"'  Queues:' '    - Name: autumn.fifo' '    - Name: autumn-track.fifo' " +
 				`> ${TW_PREFIX}/goaws/goaws.yaml`,
 		])
-		// 6. bun → /usr/local/bin/bun (so `bun` resolves for warmup / boot / tests).
+		// 6. bun → /usr/local/bin/bun (pinned to .bun-version, so `bun` resolves for
+		//    warmup / boot / tests). `node` → bun too: the ingress server and any
+		//    `env node` install shebang (e.g. better-sqlite3's prebuild-install) run
+		//    on bun's Node 24 compat, which HAS prebuilds — no native compile, no
+		//    Python/build toolchain needed.
 		.dockerfileCommands([
-			"RUN curl -fsSL https://bun.sh/install | bash && " +
-				"ln -sf /root/.bun/bin/bun /usr/local/bin/bun && bun --version",
+			`RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" && ` +
+				"ln -sf /root/.bun/bin/bun /usr/local/bin/bun && " +
+				"ln -sf /root/.bun/bin/bun /usr/local/bin/node && bun --version",
 		])
 		// 7. initdb the PG18 cluster (as postgres), tune for ephemeral test DBs,
 		//    createdb autumn + pg_trgm on an EMPTY schema, then clean-stop. PGDATA +
@@ -170,7 +186,7 @@ export const buildBaseImage = (
 		.dockerfileCommands([
 			"# chromium bake\n" +
 				"RUN export PATH=/root/.bun/bin:/usr/local/bin:$PATH && cd /repo && " +
-				"PWV=$(node -p \"require('playwright-core/package.json').version\" 2>/dev/null || echo 1.60.0) && " +
+				"PWV=$(bun -p \"require('playwright-core/package.json').version\" 2>/dev/null || echo 1.60.0) && " +
 				"apt-get update && " +
 				"bun x playwright@$PWV install --with-deps chromium && " +
 				"rm -rf /var/lib/apt/lists/*",

--- a/scripts/tw/image/build-base.sh
+++ b/scripts/tw/image/build-base.sh
@@ -211,8 +211,13 @@ fi
 # 6. bun
 # ---------------------------------------------------------------------------
 if ! command -v bun >/dev/null 2>&1; then
-  log "Installing bun"
-  curl -fsSL https://bun.sh/install | bash
+  BUN_VERSION="$(cat "$REPO_ROOT/.bun-version" 2>/dev/null | tr -d '[:space:]')"
+  log "Installing bun ${BUN_VERSION:-latest}"
+  if [ -n "$BUN_VERSION" ]; then
+    curl -fsSL https://bun.sh/install | bash -s "bun-v$BUN_VERSION"
+  else
+    curl -fsSL https://bun.sh/install | bash
+  fi
 fi
 # bun installs to ~/.bun/bin; surface it for the rest of this script.
 export PATH="$HOME/.bun/bin:$PATH"
@@ -225,7 +230,10 @@ log "bun $(bun --version)"
 # with "executable file not found in $PATH: bun".
 BUN_BIN="$(command -v bun)"
 sudo ln -sf "$BUN_BIN" /usr/local/bin/bun
-log "linked bun -> /usr/local/bin/bun ($BUN_BIN)"
+# `node` → bun too: the ingress server and any `env node` install shebang run on
+# one runtime (matches modalImage.ts; no separate node install).
+sudo ln -sf "$BUN_BIN" /usr/local/bin/node
+log "linked bun -> /usr/local/bin/bun + node ($BUN_BIN)"
 
 # ---------------------------------------------------------------------------
 # 7. initdb a PG18 cluster, role postgres/postgres SUPERUSER, createdb autumn,

--- a/server/src/external/revenueCat/misc/initRevenuecatCli.ts
+++ b/server/src/external/revenueCat/misc/initRevenuecatCli.ts
@@ -20,7 +20,7 @@ import type {
 } from "../revenuecatTypes";
 
 type ListRevenuecatProductsResponse = {
-	products: { id: string; name: string }[];
+	products: { id: string; name: string; platforms: string[] }[];
 };
 
 type ListRevenuecatProjectsResponse = {
@@ -271,22 +271,44 @@ export const initRevenuecatCli = ({
 				nextPage = data.next_page;
 			}
 
-			// Group products by store_identifier and combine names
-			const productMap = new Map<string, string[]>();
+			// Resolve each app's store type so products can be labelled by platform.
+			const appsUrl = new URL(
+				`https://api.revenuecat.com/v2/projects/${projectId}/apps`,
+			);
+			appsUrl.searchParams.set("limit", "50");
+			const appsResponse = await fetchImpl(appsUrl, { headers: authHeaders });
+			await checkOk(appsResponse);
+			const appsData = (await appsResponse.json()) as RevenueCatAppsResponse;
+			const appTypeById = new Map(
+				(appsData.items ?? []).map((app) => [app.id, app.type]),
+			);
+
+			// Group products by store_identifier, combining names and platforms.
+			const productMap = new Map<
+				string,
+				{ names: string[]; platforms: Set<string> }
+			>();
 			for (const product of items) {
-				const existing = productMap.get(product.store_identifier);
-				if (existing) {
-					existing.push(product.display_name);
-				} else {
-					productMap.set(product.store_identifier, [product.display_name]);
+				const entry = productMap.get(product.store_identifier) ?? {
+					names: [],
+					platforms: new Set<string>(),
+				};
+				entry.names.push(product.display_name);
+				const platform = appTypeById.get(product.app_id);
+				if (platform) {
+					entry.platforms.add(platform);
 				}
+				productMap.set(product.store_identifier, entry);
 			}
 
 			return {
-				products: Array.from(productMap.entries()).map(([id, names]) => ({
-					id,
-					name: names.join(", "),
-				})),
+				products: Array.from(productMap.entries()).map(
+					([id, { names, platforms }]) => ({
+						id,
+						name: names.join(", "),
+						platforms: Array.from(platforms),
+					}),
+				),
 			} satisfies ListRevenuecatProductsResponse;
 		},
 

--- a/vite/src/hooks/queries/revcat/useRCProducts.tsx
+++ b/vite/src/hooks/queries/revcat/useRCProducts.tsx
@@ -5,6 +5,7 @@ import { useAxiosInstance } from "@/services/useAxiosInstance";
 interface RevenueCatProduct {
 	id: string;
 	name: string;
+	platforms: string[];
 }
 
 interface RevenueCatProductsResponse {

--- a/vite/src/views/developer/configure-revenuecat/components/RevenueCatMappingSheet.tsx
+++ b/vite/src/views/developer/configure-revenuecat/components/RevenueCatMappingSheet.tsx
@@ -34,6 +34,19 @@ interface RevenueCatMappingSheetProps {
 interface RCProduct {
 	id: string;
 	name: string;
+	platforms: string[];
+}
+
+// Show the store identifier alongside the (possibly grouped, possibly empty)
+// display name, plus the platforms it spans, e.g.
+// "Annual, Annual (annual) [ios/android]". Falls back to just the id when the
+// product has no display name so the option is never blank.
+function formatRcProductLabel(product: RCProduct): string {
+	const base = product.name ? `${product.name} (${product.id})` : product.id;
+	if (product.platforms.length === 0) {
+		return base;
+	}
+	return `${base} [${product.platforms.join("/")}]`;
 }
 
 const MappingRow = memo(function MappingRow({
@@ -81,7 +94,9 @@ const MappingRow = memo(function MappingRow({
 								key={productId}
 								className="flex items-center gap-1 border border-zinc-300 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800 rounded-lg pl-3 pr-2 py-1 text-xs"
 							>
-								<span className="text-tiny">{product?.name || productId}</span>
+								<span className="text-tiny">
+									{product ? formatRcProductLabel(product) : productId}
+								</span>
 								<button
 									type="button"
 									onClick={() =>
@@ -117,7 +132,10 @@ const MappingRow = memo(function MappingRow({
 						}
 					}}
 					items={Object.fromEntries(
-						availableProducts.map((product) => [product.id, product.name]),
+						availableProducts.map((product) => [
+							product.id,
+							formatRcProductLabel(product),
+						]),
 					)}
 				>
 					<SelectTrigger className="w-full">
@@ -126,7 +144,7 @@ const MappingRow = memo(function MappingRow({
 					<SelectContent>
 						{availableProducts.map((product) => (
 							<SelectItem key={product.id} value={product.id}>
-								{product.name}
+								{formatRcProductLabel(product)}
 							</SelectItem>
 						))}
 					</SelectContent>


### PR DESCRIPTION
## What

In the RevenueCat **raw mappings** mode (`vite/src/views/developer/configure-revenuecat/`), product options now display:

- the **store identifier** in parentheses — e.g. `Yearly (pro_yearly)`
- the **platforms** the product spans in square brackets — e.g. `Yearly (pro_yearly) [app_store/play_store]`
- a fallback to the bare **id** when a product has no display name, so options are never rendered as a blank/thin row

## How

- **Backend** (`initRevenuecatCli.ts`): `listProducts` now also fetches the project's apps, maps `app_id → app.type`, and collects the set of platforms while grouping products by `store_identifier`. Platform labels come straight from RevenueCat's app `type` (no hardcoded mapping). Response gains `platforms: string[]`.
- **Frontend** (`useRCProducts.tsx`, `RevenueCatMappingSheet.tsx`): added `platforms` to the product type and a `formatRcProductLabel()` helper applied to the selected tag, the `Select` items map, and the dropdown items.

> Note: this branch also contains a pre-existing `chore: swap base image to bun` commit that was already ahead of `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the RevenueCat product’s store identifier and platforms in raw mappings to make product selection clear and unambiguous. Also consolidates the runtime to `bun` (pinned) and symlinks `node` to `bun` so ingress and installs run on one runtime.

- **New Features**
  - Backend groups products by `store_identifier`, aggregates names, and returns `platforms` from each app’s `type`.
  - UI shows labels like "Yearly (pro_yearly) [app_store/play_store]" and falls back to the id when the name is empty.

- **Dependencies**
  - Switches ingress and the base image to `bun`, pinned via `.bun-version`.
  - Symlinks `node` → `bun`, removes `nodejs` apt install, and uses `bun` for tooling where needed.

<sup>Written for commit 0bc938ea2f175df2b155472d1838e05013935877. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR enriches the RevenueCat raw-mappings UI by surfacing the store identifier and platform list alongside each product's display name, and migrates the Modal base image from a `node` + `bun` dual-runtime to bun-only (with `node` symlinked to bun, version-pinned via `.bun-version`).

- **Improvements** — `listProducts` (backend) now fetches the project's apps in a second API call, maps each `app_id → app.type`, and exposes `platforms: string[]` per grouped product; `formatRcProductLabel` (frontend) applies this to every display site so product options are never blank.
- **Improvements** — The Modal/sandbox base image drops `nodejs` from `apt-get`, pins bun to `.bun-version`, and symlinks `/usr/local/bin/node → bun`, eliminating the second runtime for both the ingress server and native-module prebuilds.
- **API changes** — `ListRevenuecatProductsResponse` gains `platforms: string[]`; `RevenueCatProduct` interface in the frontend is updated to match.
</details>

<h3>Confidence Score: 4/5</h3>

The RevenueCat and frontend changes are straightforward and well-contained; the base-image migration is the riskiest part but is consistent across all three script files.

The apps fetch in `listProducts` silently drops platform labels for any app beyond the 50th — correct data is returned for the vast majority of projects, but there is no fallback warning or pagination. The `readFileSync` at module load in `modalImage.ts` is a minor reliability gap. Both issues are non-blocking for normal usage.

`server/src/external/revenueCat/misc/initRevenuecatCli.ts` — the apps fetch has no pagination; `scripts/tw/helpers/modalImage.ts` — synchronous file read at import time lacks error handling.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/revenueCat/misc/initRevenuecatCli.ts | Adds a secondary apps-API call inside `listProducts` to map `app_id → platform`, but the fetch is capped at 50 apps with no pagination; projects with >50 apps silently produce products with empty `platforms[]`. |
| scripts/tw/helpers/modalImage.ts | Pins bun to `.bun-version` and symlinks `node → bun`; `readFileSync` at module load has no error handling and will crash with ENOENT if `.bun-version` is missing. |
| vite/src/hooks/queries/revcat/useRCProducts.tsx | Minimal addition of `platforms: string[]` to the `RevenueCatProduct` interface to align with the updated backend response shape. |
| vite/src/views/developer/configure-revenuecat/components/RevenueCatMappingSheet.tsx | Adds `formatRcProductLabel` helper and applies it consistently to the selected tag, dropdown items map, and `SelectItem` children; fallback to bare `id` when name is absent is correctly handled. |
| scripts/tw/helpers/ingress.ts | Swaps `node` → `bun` for the detached ingress process, consistent with the base image now symlinking `node` to bun. |
| scripts/tw/image/build-base.sh | Adds bun version pinning from `.bun-version` and creates `node → bun` symlink; handles missing `.bun-version` gracefully with a fallback to latest. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as RevenueCatMappingSheet
    participant Hook as useRCProducts
    participant Server as initRevenuecatCli.listProducts
    participant RC as RevenueCat API

    UI->>Hook: mount / open sheet
    Hook->>Server: POST /v1/organization/revenuecat/products
    Server->>RC: "GET /v2/projects/:id/products?limit=100 (paginated)"
    RC-->>Server: RevenueCatProductsResponse (items, next_page)
    Server->>RC: "GET /v2/projects/:id/apps?limit=50 (no pagination)"
    RC-->>Server: RevenueCatAppsResponse (items, next_page ignored)
    Note over Server: Build appTypeById map, group products by store_identifier, collect platforms
    Server-->>Hook: "{ products: [{id, name, platforms[]}] }"
    Hook-->>UI: rcProducts[]
    Note over UI: formatRcProductLabel to Name (store_id) [platform/platform]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as RevenueCatMappingSheet
    participant Hook as useRCProducts
    participant Server as initRevenuecatCli.listProducts
    participant RC as RevenueCat API

    UI->>Hook: mount / open sheet
    Hook->>Server: POST /v1/organization/revenuecat/products
    Server->>RC: "GET /v2/projects/:id/products?limit=100 (paginated)"
    RC-->>Server: RevenueCatProductsResponse (items, next_page)
    Server->>RC: "GET /v2/projects/:id/apps?limit=50 (no pagination)"
    RC-->>Server: RevenueCatAppsResponse (items, next_page ignored)
    Note over Server: Build appTypeById map, group products by store_identifier, collect platforms
    Server-->>Hook: "{ products: [{id, name, platforms[]}] }"
    Hook-->>UI: rcProducts[]
    Note over UI: formatRcProductLabel to Name (store_id) [platform/platform]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/external/revenueCat/misc/initRevenuecatCli.ts:275-284
**Apps pagination not followed — platforms silently absent beyond 50 apps**

The apps fetch uses a hardcoded `limit=50` and never checks `appsData.next_page`, so any `app_id` outside the first page is silently absent from `appTypeById`. Products tied to those apps will produce an entry with `platforms: []` and display without a platform label. The existing `listApps` method has the same gap. If a customer has a large project (many regional variants, multiple storefronts, etc.), the platform data is silently incomplete with no error surfaced to the caller.

### Issue 2 of 2
scripts/tw/helpers/modalImage.ts:37-40
**`readFileSync` at module level will throw on missing `.bun-version` file**

Unlike `build-base.sh`, which handles a missing `.bun-version` gracefully with `2>/dev/null`, this `readFileSync` call happens at import time with no error handling. If the file is absent (e.g., a shallow clone or accidental deletion), the entire module fails to load with a raw Node/Bun ENOENT rather than a clear message. Wrapping it in a try/catch gives the same behaviour as the shell script.

```suggestion
let BUN_VERSION: string;
try {
	BUN_VERSION = readFileSync(
		join(import.meta.dir, "../../../.bun-version"),
		"utf8",
	).trim();
} catch {
	throw new Error(
		"Could not read .bun-version — make sure the file exists at the repo root.",
	);
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(revenuecat): 🎸 show product id and..."](https://github.com/useautumn/autumn/commit/0bc938ea2f175df2b155472d1838e05013935877) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40506907)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->