### PR TITLE
collapse useOrg sandbox cache key when no sandbox is active

### DIFF
--- a/vite/src/hooks/common/useOrg.tsx
+++ b/vite/src/hooks/common/useOrg.tsx
@@ -60,9 +60,9 @@ export const useOrg = (params?: { env?: AppEnv; skipSandbox?: boolean }) => {
 		error,
 		refetch,
 	} = useQuery({
-		queryKey: skipSandbox
-			? ["org", env, activeOrgId]
-			: ["org", env, activeOrgId, "sandbox", sandboxOrgId],
+		queryKey: sandboxOrgId
+			? ["org", env, activeOrgId, "sandbox", sandboxOrgId]
+			: ["org", env, activeOrgId],
 		queryFn: fetcher,
 		placeholderData: keepPreviousData,
 		refetchOnWindowFocus: true,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `useOrg` to collapse the query cache key when no sandbox is active. The key now includes `["sandbox", sandboxOrgId]` only when `sandboxOrgId` is set, preventing cache fragmentation and ensuring correct reuse and refetch behavior.

<sup>Written for commit 4ba92a4db3a6242c72c54f332b744e4a95812c30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR changes how the `useOrg` React Query cache key is determined when no sandbox is active. Previously, the key was conditioned on `skipSandbox`, meaning a caller with `skipSandbox=false` and no active sandbox would use a distinct key (`["org", env, activeOrgId, "sandbox", null]`) from a `skipSandbox=true` caller (`["org", env, activeOrgId]`). Now the key is conditioned on `sandboxOrgId` itself, so both paths collapse to the same base key when no sandbox is present.

- **Bug fixes** — When no sandbox is active, callers with `skipSandbox=false` were hitting a separate cache entry (containing a trailing `null`) instead of sharing the base key. This caused an unnecessary duplicate cache slot and potentially redundant network requests. The fix removes that distinction.
- **Improvements** — The condition is now semantically clearer: the sandbox segment is only appended when there is an actual sandbox ID to append, making the intent of the key obvious at a glance.
</details>

<h3>Confidence Score: 5/5</h3>

Single-line cache key condition change that correctly collapses two previously distinct cache entries into one when no sandbox is active. No data-fetching logic or side effects are altered.

The change is a clean three-line swap: the query key is now derived directly from `sandboxOrgId` (the already-computed nullable sandbox ID) rather than from `skipSandbox`. When no sandbox is active, both the skip-sandbox and no-active-sandbox callers now share a single cache entry, eliminating the stale `["...", "sandbox", null]` slot that offered no differentiation.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/hooks/common/useOrg.tsx | Cache key condition changed from `skipSandbox` to `sandboxOrgId`, collapsing the no-sandbox and skip-sandbox paths to the same query key. Logic is correct and aligns with the derived `sandboxOrgId` value. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[useOrg called] --> B{skipSandbox?}
    B -- true --> C[sandboxOrgId = null]
    B -- false --> D{env === AppEnv.Sandbox?}
    D -- false --> C
    D -- true --> E[sandboxOrgId = activeSandbox?.id ?? null]

    C --> F{sandboxOrgId truthy?}
    E --> F

    F -- No --> G["queryKey: ['org', env, activeOrgId]"]
    F -- Yes --> H["queryKey: ['org', env, activeOrgId, 'sandbox', sandboxOrgId]"]

    G --> I[Shared base cache entry]
    H --> J[Sandbox-specific cache entry]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[useOrg called] --> B{skipSandbox?}
    B -- true --> C[sandboxOrgId = null]
    B -- false --> D{env === AppEnv.Sandbox?}
    D -- false --> C
    D -- true --> E[sandboxOrgId = activeSandbox?.id ?? null]

    C --> F{sandboxOrgId truthy?}
    E --> F

    F -- No --> G["queryKey: ['org', env, activeOrgId]"]
    F -- Yes --> H["queryKey: ['org', env, activeOrgId, 'sandbox', sandboxOrgId]"]

    G --> I[Shared base cache entry]
    H --> J[Sandbox-specific cache entry]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["collapse useOrg sandbox cache key when n..."](https://github.com/useautumn/autumn/commit/4ba92a4db3a6242c72c54f332b744e4a95812c30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40513757)</sub>

<!-- /greptile_comment -->