### PR TITLE
feat(plan): add usage percentage to plan spend limits

### DIFF
--- a/server/src/internal/api/check/checkUtils/getCheckData.ts
+++ b/server/src/internal/api/check/checkUtils/getCheckData.ts
@@ -21,6 +21,10 @@ import { resolveCheckSpendLimits } from "@/internal/balances/check/resolveCheckS
 import { getApiCustomerBase } from "@/internal/customers/cusUtils/apiCusUtils/getApiCustomerBase.js";
 import { getOrCreateCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/getOrCreateCachedFullCustomer.js";
 import { getOrSetCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/getOrSetCachedFullCustomer.js";
+import {
+	getOrCreateCachedPartialFullSubject,
+	getOrSetCachedPartialFullSubject,
+} from "@/internal/customers/cache/fullSubject/index.js";
 import { getApiEntityBase } from "@/internal/entities/entityUtils/apiEntityUtils/getApiEntityBase.js";
 import { getCreditSystemsFromFeature } from "@/internal/features/creditSystemUtils.js";
 import type { CheckData } from "../checkTypes/CheckData.js";
@@ -64,6 +68,9 @@ export const getCheckData = async ({
 	if (!feature) {
 		throw new FeatureNotFoundError({ featureId: feature_id });
 	}
+	const featureIds = Array.from(
+		new Set([feature_id, ...creditSystems.map((creditSystem) => creditSystem.id)]),
+	);
 
 	let apiSubject: ApiCustomerV5 | ApiEntityV2 | undefined;
 	const start = performance.now();
@@ -89,6 +96,25 @@ export const getCheckData = async ({
 	);
 
 	apiSubject = apiCustomer;
+	const fullSubjectForAggregates = !entity_id
+		? ctx.apiVersion.gte(ApiVersion.V2_1)
+			? await getOrSetCachedPartialFullSubject({
+					ctx,
+					customerId: customer_id,
+					featureIds,
+					source: "getCheckData",
+				})
+			: await getOrCreateCachedPartialFullSubject({
+					ctx,
+					params: body,
+					featureIds,
+					source: "getCheckData",
+				})
+		: undefined;
+	const additionalAllowanceForFeature = (featureId: string) =>
+		fullSubjectForAggregates?.aggregated_customer_entitlements?.find(
+			(entitlement) => entitlement.feature_id === featureId,
+		)?.allowance_total ?? 0;
 	const cusEntsForFeature = (featureId: string) =>
 		fullCustomerToCustomerEntitlements({
 			fullCustomer,
@@ -108,6 +134,7 @@ export const getCheckData = async ({
 				spendLimit: control,
 				cusEnts: cusEntsForFeature(control.feature_id),
 				entityId: entity_id,
+				additionalAllowance: additionalAllowanceForFeature(control.feature_id),
 			}),
 			limit_type: "absolute",
 		};
@@ -149,6 +176,7 @@ export const getCheckData = async ({
 				inStatuses: DEFAULT_PLAN_CONTROL_STATUSES,
 			}),
 		entityId: entity_id,
+		additionalAllowanceForFeature,
 	});
 
 	const featureToUseMin = getFeatureToUseForCheck({

--- a/server/src/internal/api/check/checkUtils/getCheckData.ts
+++ b/server/src/internal/api/check/checkUtils/getCheckData.ts
@@ -3,6 +3,7 @@ import {
 	type ApiEntityV2,
 	ApiVersion,
 	type CheckParams,
+	type DbSpendLimit,
 	type Feature,
 	FeatureNotFoundError,
 	findFeatureById,
@@ -11,6 +12,7 @@ import {
 	InternalError,
 	mergeCustomerBillingControlsForCheck,
 	mergePlanBillingControlsForCheck,
+	resolveSpendLimitOverageLimit,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { triggerAutoTopUp } from "@/internal/balances/autoTopUp/triggerAutoTopUp.js";
@@ -86,6 +88,31 @@ export const getCheckData = async ({
 	);
 
 	apiSubject = apiCustomer;
+	// Normalize percentage-typed plan spend limits to absolute units *before*
+	// the most-restrictive merge picks across plans, so a `200%` cap can't lose
+	// to a `1000` absolute cap on raw-number comparison.
+	const cusEntsForFeature = (featureId: string) =>
+		fullCustomerToCustomerEntitlements({
+			fullCustomer,
+			featureId,
+			entity: fullCustomer.entity,
+		});
+	const normalizeSpendLimitForCompare = (
+		control: DbSpendLimit,
+	): DbSpendLimit => {
+		if (control.limit_type !== "usage_percentage" || !control.feature_id) {
+			return control;
+		}
+		return {
+			...control,
+			overage_limit: resolveSpendLimitOverageLimit({
+				spendLimit: control,
+				cusEnts: cusEntsForFeature(control.feature_id),
+				entityId: entity_id,
+			}),
+			limit_type: "absolute",
+		};
+	};
 	if (entity_id && fullCustomer.entity) {
 		const { apiEntity: apiEntityResult } = await getApiEntityBase({
 			ctx,
@@ -97,11 +124,13 @@ export const getCheckData = async ({
 			entityApiSubject: apiEntityResult,
 			customerApiSubject: apiCustomer,
 			planCustomerProducts: fullCustomer.customer_products,
+			normalizeSpendLimitForCompare,
 		});
 	} else {
 		apiSubject = mergePlanBillingControlsForCheck({
 			customerApiSubject: apiCustomer,
 			planCustomerProducts: fullCustomer.customer_products,
+			normalizeSpendLimitForCompare,
 		});
 	}
 

--- a/server/src/internal/api/check/checkUtils/getCheckData.ts
+++ b/server/src/internal/api/check/checkUtils/getCheckData.ts
@@ -4,6 +4,7 @@ import {
 	ApiVersion,
 	type CheckParams,
 	type DbSpendLimit,
+	DEFAULT_PLAN_CONTROL_STATUSES,
 	type Feature,
 	FeatureNotFoundError,
 	findFeatureById,
@@ -88,14 +89,12 @@ export const getCheckData = async ({
 	);
 
 	apiSubject = apiCustomer;
-	// Normalize percentage-typed plan spend limits to absolute units *before*
-	// the most-restrictive merge picks across plans, so a `200%` cap can't lose
-	// to a `1000` absolute cap on raw-number comparison.
 	const cusEntsForFeature = (featureId: string) =>
 		fullCustomerToCustomerEntitlements({
 			fullCustomer,
 			featureId,
 			entity: fullCustomer.entity,
+			inStatuses: DEFAULT_PLAN_CONTROL_STATUSES,
 		});
 	const normalizeSpendLimitForCompare = (
 		control: DbSpendLimit,
@@ -147,6 +146,7 @@ export const getCheckData = async ({
 				fullCustomer,
 				featureId,
 				entity: fullCustomer.entity,
+				inStatuses: DEFAULT_PLAN_CONTROL_STATUSES,
 			}),
 		entityId: entity_id,
 	});

--- a/server/src/internal/balances/check/getCheckDataV2.ts
+++ b/server/src/internal/balances/check/getCheckDataV2.ts
@@ -4,6 +4,7 @@ import {
 	ApiVersion,
 	type CheckParams,
 	type DbSpendLimit,
+	DEFAULT_PLAN_CONTROL_STATUSES,
 	type Feature,
 	FeatureNotFoundError,
 	findFeatureById,
@@ -95,14 +96,16 @@ export const getCheckDataV2 = async ({
 		includeAggregations: false,
 	});
 
-	// Normalize percentage-typed plan spend limits to absolute units *before*
-	// the most-restrictive merge picks across plans, so a `200%` cap can't lose
-	// to a `1000` absolute cap on raw-number comparison.
 	const cusEntsForFeature = (featureId: string) =>
 		fullSubjectToCustomerEntitlements({
 			fullSubject,
 			featureIds: [featureId],
+			inStatuses: DEFAULT_PLAN_CONTROL_STATUSES,
 		});
+	const additionalAllowanceForFeature = (featureId: string) =>
+		fullSubject.aggregated_customer_entitlements?.find(
+			(entitlement) => entitlement.feature_id === featureId,
+		)?.allowance_total ?? 0;
 	const normalizeSpendLimitForCompare = (
 		control: DbSpendLimit,
 	): DbSpendLimit => {
@@ -115,6 +118,7 @@ export const getCheckDataV2 = async ({
 				spendLimit: control,
 				cusEnts: cusEntsForFeature(control.feature_id),
 				entityId: entity_id,
+				additionalAllowance: additionalAllowanceForFeature(control.feature_id),
 			}),
 			limit_type: "absolute",
 		};
@@ -151,8 +155,10 @@ export const getCheckDataV2 = async ({
 			fullSubjectToCustomerEntitlements({
 				fullSubject,
 				featureIds: [featureId],
+				inStatuses: DEFAULT_PLAN_CONTROL_STATUSES,
 			}),
 		entityId: entity_id,
+		additionalAllowanceForFeature,
 	});
 
 	const featureToUseMin = getFeatureToUseForCheck({

--- a/server/src/internal/balances/check/getCheckDataV2.ts
+++ b/server/src/internal/balances/check/getCheckDataV2.ts
@@ -3,6 +3,7 @@ import {
 	type ApiEntityV2,
 	ApiVersion,
 	type CheckParams,
+	type DbSpendLimit,
 	type Feature,
 	FeatureNotFoundError,
 	findFeatureById,
@@ -11,6 +12,7 @@ import {
 	getFeatureToUseForCheck,
 	mergeCustomerBillingControlsForCheck,
 	mergePlanBillingControlsForCheck,
+	resolveSpendLimitOverageLimit,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import {
@@ -93,6 +95,31 @@ export const getCheckDataV2 = async ({
 		includeAggregations: false,
 	});
 
+	// Normalize percentage-typed plan spend limits to absolute units *before*
+	// the most-restrictive merge picks across plans, so a `200%` cap can't lose
+	// to a `1000` absolute cap on raw-number comparison.
+	const cusEntsForFeature = (featureId: string) =>
+		fullSubjectToCustomerEntitlements({
+			fullSubject,
+			featureIds: [featureId],
+		});
+	const normalizeSpendLimitForCompare = (
+		control: DbSpendLimit,
+	): DbSpendLimit => {
+		if (control.limit_type !== "usage_percentage" || !control.feature_id) {
+			return control;
+		}
+		return {
+			...control,
+			overage_limit: resolveSpendLimitOverageLimit({
+				spendLimit: control,
+				cusEnts: cusEntsForFeature(control.feature_id),
+				entityId: entity_id,
+			}),
+			limit_type: "absolute",
+		};
+	};
+
 	if (fullSubject.subjectType === "entity") {
 		const { apiCustomer } = await getApiCustomerBaseV2({
 			ctx,
@@ -108,11 +135,13 @@ export const getCheckDataV2 = async ({
 			entityApiSubject: evaluationApiSubject as ApiEntityV2,
 			customerApiSubject: apiCustomer,
 			planCustomerProducts: fullSubject.customer_products,
+			normalizeSpendLimitForCompare,
 		});
 	} else {
 		evaluationApiSubject = mergePlanBillingControlsForCheck({
 			customerApiSubject: evaluationApiSubject as ApiCustomerV5,
 			planCustomerProducts: fullSubject.customer_products,
+			normalizeSpendLimitForCompare,
 		});
 	}
 

--- a/server/src/internal/balances/check/resolveCheckSpendLimits.ts
+++ b/server/src/internal/balances/check/resolveCheckSpendLimits.ts
@@ -12,10 +12,12 @@ export const resolveCheckSpendLimits = <
 	subject,
 	cusEntsForFeature,
 	entityId,
+	additionalAllowanceForFeature,
 }: {
 	subject: Subject;
 	cusEntsForFeature: (featureId: string) => FullCusEntWithFullCusProduct[];
 	entityId?: string;
+	additionalAllowanceForFeature?: (featureId: string) => number;
 }): Subject => {
 	const spendLimits = subject.billing_controls?.spend_limits;
 	if (!spendLimits || spendLimits.length === 0) {
@@ -30,6 +32,9 @@ export const resolveCheckSpendLimits = <
 			spendLimit,
 			cusEnts,
 			entityId,
+			additionalAllowance: spendLimit.feature_id
+				? additionalAllowanceForFeature?.(spendLimit.feature_id)
+				: undefined,
 		});
 		return overageLimit === undefined
 			? []

--- a/server/tests/unit/billing/pick-stricter-spend-limit-percent.test.ts
+++ b/server/tests/unit/billing/pick-stricter-spend-limit-percent.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
+	type ApiCustomerV5,
 	CusProductStatus,
 	type DbSpendLimit,
 	type FullCusProduct,
 	resolveBillingControlWithProduct,
 	resolveSpendLimitOverageLimit,
 } from "@autumn/shared";
+import { resolveCheckSpendLimits } from "@/internal/balances/check/resolveCheckSpendLimits.js";
 
 const FEATURE = "messages";
 const NOW = Date.UTC(2026, 5, 15, 12, 0, 0);
@@ -215,5 +217,21 @@ describe("findPlanBillingControlWithProduct — spend_limits with mixed limit_ty
 		});
 
 		expect(resolved).toBe(100);
+	});
+
+	test("check spend-limit resolution includes aggregate allowance", () => {
+		const subject = {
+			billing_controls: { spend_limits: [percent(50)] },
+		} as unknown as ApiCustomerV5;
+
+		const resolved = resolveCheckSpendLimits({
+			subject,
+			cusEntsForFeature: () => [],
+			additionalAllowanceForFeature: () => 200,
+		});
+		const spendLimit = resolved.billing_controls?.spend_limits?.[0];
+
+		expect(spendLimit?.overage_limit).toBe(100);
+		expect(spendLimit?.limit_type).toBe("absolute");
 	});
 });

--- a/server/tests/unit/billing/pick-stricter-spend-limit-percent.test.ts
+++ b/server/tests/unit/billing/pick-stricter-spend-limit-percent.test.ts
@@ -1,21 +1,10 @@
-/**
- * Multi-plan collapse for spend_limits across mixed `limit_type` values.
- *
- * `pickStricterSpendLimit` compares raw `overage_limit` numbers, so without
- * normalization a `200%` cap can lose to a `1000` absolute cap on the
- * 200<1000 raw comparison even when the resolved percentage cap is far
- * higher. `findPlanBillingControlWithProduct` accepts a `normalizeForCompare`
- * projection that resolves percentage caps to absolute units before invoking
- * the comparator; the original (un-normalized) control is still returned to
- * the caller so downstream resolution still sees `limit_type: "usage_percentage"`.
- */
-
 import { describe, expect, test } from "bun:test";
 import {
 	CusProductStatus,
 	type DbSpendLimit,
 	type FullCusProduct,
 	resolveBillingControlWithProduct,
+	resolveSpendLimitOverageLimit,
 } from "@autumn/shared";
 
 const FEATURE = "messages";
@@ -59,9 +48,6 @@ const percent = (percentage: number): DbSpendLimit => ({
 
 describe("findPlanBillingControlWithProduct — spend_limits with mixed limit_type", () => {
 	test("without normalization, a looser 200% cap wrongly beats a stricter $1000 absolute cap", () => {
-		// Raw comparator: 200 < 1000 -> picks 200% (a 200% cap of a 5000 allowance
-		// resolves to 10000 absolute, far looser than $1000). Captures the bug
-		// the normalizer fixes.
 		const cheap = planProduct({
 			id: "cp_absolute",
 			internalProductId: "prod_absolute",
@@ -131,8 +117,6 @@ describe("findPlanBillingControlWithProduct — spend_limits with mixed limit_ty
 			normalizeForCompare,
 		});
 
-		// Picked control is the original — downstream resolveSpendLimitOverageLimit
-		// still sees the absolute cap directly.
 		expect(resolved?.control.limit_type).toBe("absolute");
 		expect(resolved?.control.overage_limit).toBe(1000);
 		expect(resolved?.customerProduct?.internal_product_id).toBe(
@@ -141,9 +125,6 @@ describe("findPlanBillingControlWithProduct — spend_limits with mixed limit_ty
 	});
 
 	test("with normalization, a 50% cap of a 5000 allowance ($2500) correctly beats a $4000 absolute cap", () => {
-		// Mirror of the previous test: now the percent IS the stricter resolved
-		// cap. Raw comparison would have picked the percent here too (50 < 4000)
-		// but for the wrong reason.
 		const loose = planProduct({
 			id: "cp_loose",
 			internalProductId: "prod_loose",
@@ -192,9 +173,6 @@ describe("findPlanBillingControlWithProduct — spend_limits with mixed limit_ty
 	});
 
 	test("unresolvable percent (no allowance) is treated as no-cap and absolute wins", () => {
-		// resolveSpendLimitOverageLimit returns undefined when denominator is 0;
-		// pickStricterSpendLimit's `?? Number.POSITIVE_INFINITY` then means the
-		// percent is the loosest possible cap, so any absolute cap wins.
 		const cheap = planProduct({
 			id: "cp_absolute",
 			internalProductId: "prod_absolute",
@@ -227,5 +205,15 @@ describe("findPlanBillingControlWithProduct — spend_limits with mixed limit_ty
 
 		expect(resolved?.control.limit_type).toBe("absolute");
 		expect(resolved?.control.overage_limit).toBe(50);
+	});
+
+	test("aggregate allowance contributes to percentage resolution", () => {
+		const resolved = resolveSpendLimitOverageLimit({
+			spendLimit: percent(50),
+			cusEnts: [],
+			additionalAllowance: 200,
+		});
+
+		expect(resolved).toBe(100);
 	});
 });

--- a/server/tests/unit/billing/pick-stricter-spend-limit-percent.test.ts
+++ b/server/tests/unit/billing/pick-stricter-spend-limit-percent.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Multi-plan collapse for spend_limits across mixed `limit_type` values.
+ *
+ * `pickStricterSpendLimit` compares raw `overage_limit` numbers, so without
+ * normalization a `200%` cap can lose to a `1000` absolute cap on the
+ * 200<1000 raw comparison even when the resolved percentage cap is far
+ * higher. `findPlanBillingControlWithProduct` accepts a `normalizeForCompare`
+ * projection that resolves percentage caps to absolute units before invoking
+ * the comparator; the original (un-normalized) control is still returned to
+ * the caller so downstream resolution still sees `limit_type: "usage_percentage"`.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	CusProductStatus,
+	type DbSpendLimit,
+	type FullCusProduct,
+	resolveBillingControlWithProduct,
+} from "@autumn/shared";
+
+const FEATURE = "messages";
+const NOW = Date.UTC(2026, 5, 15, 12, 0, 0);
+
+const planProduct = ({
+	id,
+	internalProductId,
+	createdAt,
+	spendLimit,
+}: {
+	id: string;
+	internalProductId: string;
+	createdAt: number;
+	spendLimit: DbSpendLimit;
+}): FullCusProduct =>
+	({
+		id,
+		internal_product_id: internalProductId,
+		status: CusProductStatus.Active,
+		starts_at: NOW - 10_000,
+		access_starts_at: NOW - 10_000,
+		ended_at: null,
+		created_at: createdAt,
+		product: { spend_limits: [spendLimit] },
+	}) as unknown as FullCusProduct;
+
+const absolute = (overageLimit: number): DbSpendLimit => ({
+	feature_id: FEATURE,
+	enabled: true,
+	limit_type: "absolute",
+	overage_limit: overageLimit,
+});
+
+const percent = (percentage: number): DbSpendLimit => ({
+	feature_id: FEATURE,
+	enabled: true,
+	limit_type: "usage_percentage",
+	overage_limit: percentage,
+});
+
+describe("findPlanBillingControlWithProduct — spend_limits with mixed limit_type", () => {
+	test("without normalization, a looser 200% cap wrongly beats a stricter $1000 absolute cap", () => {
+		// Raw comparator: 200 < 1000 -> picks 200% (a 200% cap of a 5000 allowance
+		// resolves to 10000 absolute, far looser than $1000). Captures the bug
+		// the normalizer fixes.
+		const cheap = planProduct({
+			id: "cp_absolute",
+			internalProductId: "prod_absolute",
+			createdAt: NOW - 5000,
+			spendLimit: absolute(1000),
+		});
+		const percentPlan = planProduct({
+			id: "cp_percent",
+			internalProductId: "prod_percent",
+			createdAt: NOW - 4000,
+			spendLimit: percent(200),
+		});
+
+		const resolved = resolveBillingControlWithProduct<
+			DbSpendLimit,
+			"spend_limits"
+		>({
+			controlLists: [],
+			customerProducts: [cheap, percentPlan],
+			controlKey: "spend_limits",
+			matches: (control) => control.feature_id === FEATURE,
+			now: NOW,
+		});
+
+		expect(resolved?.control.limit_type).toBe("usage_percentage");
+		expect(resolved?.control.overage_limit).toBe(200);
+	});
+
+	test("with normalization, the absolute $1000 cap correctly wins over a 200% cap of a 5000 allowance", () => {
+		const cheap = planProduct({
+			id: "cp_absolute",
+			internalProductId: "prod_absolute",
+			createdAt: NOW - 5000,
+			spendLimit: absolute(1000),
+		});
+		const percentPlan = planProduct({
+			id: "cp_percent",
+			internalProductId: "prod_percent",
+			createdAt: NOW - 4000,
+			spendLimit: percent(200),
+		});
+
+		const mainPlanAllowance = 5000;
+		const normalizeForCompare = (control: DbSpendLimit): DbSpendLimit => {
+			if (
+				control.limit_type !== "usage_percentage" ||
+				control.overage_limit === undefined
+			) {
+				return control;
+			}
+			return {
+				...control,
+				overage_limit: (control.overage_limit / 100) * mainPlanAllowance,
+				limit_type: "absolute",
+			};
+		};
+
+		const resolved = resolveBillingControlWithProduct<
+			DbSpendLimit,
+			"spend_limits"
+		>({
+			controlLists: [],
+			customerProducts: [cheap, percentPlan],
+			controlKey: "spend_limits",
+			matches: (control) => control.feature_id === FEATURE,
+			now: NOW,
+			normalizeForCompare,
+		});
+
+		// Picked control is the original — downstream resolveSpendLimitOverageLimit
+		// still sees the absolute cap directly.
+		expect(resolved?.control.limit_type).toBe("absolute");
+		expect(resolved?.control.overage_limit).toBe(1000);
+		expect(resolved?.customerProduct?.internal_product_id).toBe(
+			"prod_absolute",
+		);
+	});
+
+	test("with normalization, a 50% cap of a 5000 allowance ($2500) correctly beats a $4000 absolute cap", () => {
+		// Mirror of the previous test: now the percent IS the stricter resolved
+		// cap. Raw comparison would have picked the percent here too (50 < 4000)
+		// but for the wrong reason.
+		const loose = planProduct({
+			id: "cp_loose",
+			internalProductId: "prod_loose",
+			createdAt: NOW - 5000,
+			spendLimit: absolute(4000),
+		});
+		const strictPercent = planProduct({
+			id: "cp_percent",
+			internalProductId: "prod_percent",
+			createdAt: NOW - 4000,
+			spendLimit: percent(50),
+		});
+
+		const mainPlanAllowance = 5000;
+		const normalizeForCompare = (control: DbSpendLimit): DbSpendLimit => {
+			if (
+				control.limit_type !== "usage_percentage" ||
+				control.overage_limit === undefined
+			) {
+				return control;
+			}
+			return {
+				...control,
+				overage_limit: (control.overage_limit / 100) * mainPlanAllowance,
+				limit_type: "absolute",
+			};
+		};
+
+		const resolved = resolveBillingControlWithProduct<
+			DbSpendLimit,
+			"spend_limits"
+		>({
+			controlLists: [],
+			customerProducts: [loose, strictPercent],
+			controlKey: "spend_limits",
+			matches: (control) => control.feature_id === FEATURE,
+			now: NOW,
+			normalizeForCompare,
+		});
+
+		expect(resolved?.control.limit_type).toBe("usage_percentage");
+		expect(resolved?.control.overage_limit).toBe(50);
+		expect(resolved?.customerProduct?.internal_product_id).toBe(
+			"prod_percent",
+		);
+	});
+
+	test("unresolvable percent (no allowance) is treated as no-cap and absolute wins", () => {
+		// resolveSpendLimitOverageLimit returns undefined when denominator is 0;
+		// pickStricterSpendLimit's `?? Number.POSITIVE_INFINITY` then means the
+		// percent is the loosest possible cap, so any absolute cap wins.
+		const cheap = planProduct({
+			id: "cp_absolute",
+			internalProductId: "prod_absolute",
+			createdAt: NOW - 5000,
+			spendLimit: absolute(50),
+		});
+		const percentPlan = planProduct({
+			id: "cp_percent",
+			internalProductId: "prod_percent",
+			createdAt: NOW - 4000,
+			spendLimit: percent(500),
+		});
+
+		const normalizeForCompare = (control: DbSpendLimit): DbSpendLimit => {
+			if (control.limit_type !== "usage_percentage") return control;
+			return { ...control, overage_limit: undefined, limit_type: "absolute" };
+		};
+
+		const resolved = resolveBillingControlWithProduct<
+			DbSpendLimit,
+			"spend_limits"
+		>({
+			controlLists: [],
+			customerProducts: [cheap, percentPlan],
+			controlKey: "spend_limits",
+			matches: (control) => control.feature_id === FEATURE,
+			now: NOW,
+			normalizeForCompare,
+		});
+
+		expect(resolved?.control.limit_type).toBe("absolute");
+		expect(resolved?.control.overage_limit).toBe(50);
+	});
+});

--- a/shared/utils/cusEntUtils/convertCusEntUtils/resolveSpendLimitOverageLimit.ts
+++ b/shared/utils/cusEntUtils/convertCusEntUtils/resolveSpendLimitOverageLimit.ts
@@ -7,10 +7,12 @@ export const resolveSpendLimitOverageLimit = ({
 	spendLimit,
 	cusEnts,
 	entityId,
+	additionalAllowance = 0,
 }: {
 	spendLimit: DbSpendLimit;
 	cusEnts: FullCusEntWithFullCusProduct[];
 	entityId?: string;
+	additionalAllowance?: number;
 }): number | undefined => {
 	if (spendLimit.overage_limit === undefined) return undefined;
 
@@ -18,7 +20,9 @@ export const resolveSpendLimitOverageLimit = ({
 		return spendLimit.overage_limit;
 	}
 
-	const denominator = cusEntsToMainPlanAllowance({ cusEnts, entityId });
+	const denominator =
+		cusEntsToMainPlanAllowance({ cusEnts, entityId }) +
+		additionalAllowance;
 	if (denominator === 0) return undefined;
 
 	return new Decimal(spendLimit.overage_limit)

--- a/shared/utils/cusUtils/fullCusUtils/fullCustomerToSpendLimit.ts
+++ b/shared/utils/cusUtils/fullCusUtils/fullCustomerToSpendLimit.ts
@@ -2,6 +2,7 @@ import type { DbSpendLimit } from "@models/cusModels/billingControls/spendLimit.
 import type { FullCustomer } from "@models/cusModels/fullCusModel.js";
 import { resolveSpendLimitOverageLimit } from "@utils/cusEntUtils";
 import {
+	DEFAULT_PLAN_CONTROL_STATUSES,
 	fullCustomerToPlanProducts,
 	resolveBillingControl,
 } from "../../fullSubjectUtils/planBillingControlUtils.js";
@@ -37,15 +38,11 @@ export const fullCustomerToSpendLimitByFeatureId = ({
 			candidate.feature_id === featureId &&
 			candidate.overage_limit !== undefined;
 
-		// Compute cusEnts up front so percentage-typed plan spend limits can
-		// be resolved to absolute units *before* the most-restrictive merge
-		// compares them — otherwise e.g. a `200%` cap would lose to a `1000`
-		// absolute cap on raw-number comparison even when its resolved value
-		// is far higher.
 		const cusEnts = fullCustomerToCustomerEntitlements({
 			fullCustomer,
 			featureIds: [featureId],
 			entity,
+			inStatuses: DEFAULT_PLAN_CONTROL_STATUSES,
 		});
 		const entityIdForResolve = entity?.id ?? entity?.internal_id ?? undefined;
 		const normalizeForCompare = (control: DbSpendLimit): DbSpendLimit => {

--- a/shared/utils/cusUtils/fullCusUtils/fullCustomerToSpendLimit.ts
+++ b/shared/utils/cusUtils/fullCusUtils/fullCustomerToSpendLimit.ts
@@ -37,23 +37,43 @@ export const fullCustomerToSpendLimitByFeatureId = ({
 			candidate.feature_id === featureId &&
 			candidate.overage_limit !== undefined;
 
+		// Compute cusEnts up front so percentage-typed plan spend limits can
+		// be resolved to absolute units *before* the most-restrictive merge
+		// compares them — otherwise e.g. a `200%` cap would lose to a `1000`
+		// absolute cap on raw-number comparison even when its resolved value
+		// is far higher.
+		const cusEnts = fullCustomerToCustomerEntitlements({
+			fullCustomer,
+			featureIds: [featureId],
+			entity,
+		});
+		const entityIdForResolve = entity?.id ?? entity?.internal_id ?? undefined;
+		const normalizeForCompare = (control: DbSpendLimit): DbSpendLimit => {
+			if (control.limit_type !== "usage_percentage") return control;
+			return {
+				...control,
+				overage_limit: resolveSpendLimitOverageLimit({
+					spendLimit: control,
+					cusEnts,
+					entityId: entityIdForResolve,
+				}),
+				limit_type: "absolute",
+			};
+		};
+
 		const spendLimit = resolveBillingControl<DbSpendLimit, "spend_limits">({
 			controlLists: [entitySpendLimits, customerSpendLimits],
 			customerProducts: fullCustomerToPlanProducts({ fullCustomer }),
 			controlKey: "spend_limits",
 			matches: isMatch,
+			normalizeForCompare,
 		});
 
 		if (spendLimit?.enabled) {
-			const cusEnts = fullCustomerToCustomerEntitlements({
-				fullCustomer,
-				featureIds: [featureId],
-				entity,
-			});
 			const resolved = resolveSpendLimitOverageLimit({
 				spendLimit,
 				cusEnts,
-				entityId: entity?.id ?? entity?.internal_id ?? undefined,
+				entityId: entityIdForResolve,
 			});
 
 			// Resolve to absolute so Lua deduction reads overage_limit as absolute units.

--- a/shared/utils/fullSubjectUtils/fullSubjectToSpendLimit.ts
+++ b/shared/utils/fullSubjectUtils/fullSubjectToSpendLimit.ts
@@ -29,19 +29,38 @@ export const fullSubjectToSpendLimitByFeatureId = ({
 		const isMatch = (candidate: DbSpendLimit) =>
 			candidate.feature_id === featureId && candidate.overage_limit !== undefined;
 
+		// Compute cusEnts up front so percentage-typed plan spend limits can
+		// be resolved to absolute units *before* the most-restrictive merge
+		// compares them — otherwise e.g. a `200%` cap would lose to a `1000`
+		// absolute cap on raw-number comparison even when its resolved value
+		// is far higher.
+		const cusEnts = fullSubjectToCustomerEntitlements({
+			fullSubject,
+			featureIds: [featureId],
+		});
+		const entityId = fullSubject.entity?.id ?? undefined;
+		const normalizeForCompare = (control: DbSpendLimit): DbSpendLimit => {
+			if (control.limit_type !== "usage_percentage") return control;
+			return {
+				...control,
+				overage_limit: resolveSpendLimitOverageLimit({
+					spendLimit: control,
+					cusEnts,
+					entityId,
+				}),
+				limit_type: "absolute",
+			};
+		};
+
 		const spendLimit = resolveBillingControl<DbSpendLimit, "spend_limits">({
 			controlLists: [entitySpendLimits, customerSpendLimits],
 			customerProducts: fullSubjectToPlanProducts({ fullSubject }),
 			controlKey: "spend_limits",
 			matches: isMatch,
+			normalizeForCompare,
 		});
 
 		if (spendLimit?.enabled) {
-			const cusEnts = fullSubjectToCustomerEntitlements({
-				fullSubject,
-				featureIds: [featureId],
-			});
-			const entityId = fullSubject.entity?.id ?? undefined;
 			const resolved = resolveSpendLimitOverageLimit({
 				spendLimit,
 				cusEnts,

--- a/shared/utils/fullSubjectUtils/fullSubjectToSpendLimit.ts
+++ b/shared/utils/fullSubjectUtils/fullSubjectToSpendLimit.ts
@@ -3,6 +3,7 @@ import type { FullSubject } from "../../models/cusModels/fullSubject/fullSubject
 import { resolveSpendLimitOverageLimit } from "../cusEntUtils/index.js";
 import { fullSubjectToCustomerEntitlements } from "./fullSubjectToCustomerEntitlements.js";
 import {
+	DEFAULT_PLAN_CONTROL_STATUSES,
 	fullSubjectToPlanProducts,
 	resolveBillingControl,
 } from "./planBillingControlUtils.js";
@@ -29,16 +30,16 @@ export const fullSubjectToSpendLimitByFeatureId = ({
 		const isMatch = (candidate: DbSpendLimit) =>
 			candidate.feature_id === featureId && candidate.overage_limit !== undefined;
 
-		// Compute cusEnts up front so percentage-typed plan spend limits can
-		// be resolved to absolute units *before* the most-restrictive merge
-		// compares them — otherwise e.g. a `200%` cap would lose to a `1000`
-		// absolute cap on raw-number comparison even when its resolved value
-		// is far higher.
 		const cusEnts = fullSubjectToCustomerEntitlements({
 			fullSubject,
 			featureIds: [featureId],
+			inStatuses: DEFAULT_PLAN_CONTROL_STATUSES,
 		});
 		const entityId = fullSubject.entity?.id ?? undefined;
+		const additionalAllowance =
+			fullSubject.aggregated_customer_entitlements?.find(
+				(entitlement) => entitlement.feature_id === featureId,
+			)?.allowance_total ?? 0;
 		const normalizeForCompare = (control: DbSpendLimit): DbSpendLimit => {
 			if (control.limit_type !== "usage_percentage") return control;
 			return {
@@ -47,6 +48,7 @@ export const fullSubjectToSpendLimitByFeatureId = ({
 					spendLimit: control,
 					cusEnts,
 					entityId,
+					additionalAllowance,
 				}),
 				limit_type: "absolute",
 			};
@@ -65,6 +67,7 @@ export const fullSubjectToSpendLimitByFeatureId = ({
 				spendLimit,
 				cusEnts,
 				entityId,
+				additionalAllowance,
 			});
 
 			// Resolve to absolute so Lua deduction reads overage_limit as absolute units.

--- a/shared/utils/fullSubjectUtils/index.ts
+++ b/shared/utils/fullSubjectUtils/index.ts
@@ -8,6 +8,7 @@ export {
 	findPlanBillingControlWithProduct,
 	fullCustomerToPlanProducts,
 	fullSubjectToPlanProducts,
+	DEFAULT_PLAN_CONTROL_STATUSES,
 	getPlanBillingControlProducts,
 	resolveBillingControl,
 	resolveBillingControlWithProduct,

--- a/shared/utils/fullSubjectUtils/mergeCustomerBillingControlsForCheck.ts
+++ b/shared/utils/fullSubjectUtils/mergeCustomerBillingControlsForCheck.ts
@@ -89,13 +89,7 @@ export const mergeCustomerBillingControlsForCheck = ({
 	entityApiSubject: ApiEntityV2;
 	customerApiSubject: ApiCustomerV5;
 	planCustomerProducts?: FullCusProduct[];
-	/**
-	 * Optional projection that resolves a percentage-typed spend limit to an
-	 * absolute one so the most-restrictive merge across plans can compare
-	 * percent and absolute caps on the same axis. Pass when callers have the
-	 * customer's main-plan allowance available (typically via
-	 * `fullCustomerToCustomerEntitlements` + `resolveSpendLimitOverageLimit`).
-	 */
+	/** Normalizes spend limits only for most-restrictive plan comparisons. */
 	normalizeSpendLimitForCompare?: (control: DbSpendLimit) => DbSpendLimit;
 }): ApiEntityV2 => {
 	const entitySpendLimits =
@@ -159,11 +153,7 @@ export const mergePlanBillingControlsForCheck = ({
 }: {
 	customerApiSubject: ApiCustomerV5;
 	planCustomerProducts?: FullCusProduct[];
-	/**
-	 * Optional projection that resolves a percentage-typed spend limit to an
-	 * absolute one so the most-restrictive merge across plans can compare
-	 * percent and absolute caps on the same axis.
-	 */
+	/** Normalizes spend limits only for most-restrictive plan comparisons. */
 	normalizeSpendLimitForCompare?: (control: DbSpendLimit) => DbSpendLimit;
 }): ApiCustomerV5 => {
 	const customerSpendLimits =

--- a/shared/utils/fullSubjectUtils/mergeCustomerBillingControlsForCheck.ts
+++ b/shared/utils/fullSubjectUtils/mergeCustomerBillingControlsForCheck.ts
@@ -17,11 +17,13 @@ const mergeControlsByFeature = <
 	customerControls,
 	planCustomerProducts,
 	controlKey,
+	normalizeForCompare,
 }: {
 	entityControls: TControl[];
 	customerControls: TControl[];
 	planCustomerProducts: FullCusProduct[];
 	controlKey: TKey;
+	normalizeForCompare?: (control: TControl) => TControl;
 }): TControl[] => {
 	const inheritedFeatureIds = new Set(
 		entityControls
@@ -58,6 +60,7 @@ const mergeControlsByFeature = <
 			customerProducts: planCustomerProducts,
 			controlKey,
 			matches: (entry) => entry.feature_id === featureId,
+			normalizeForCompare,
 		});
 
 		return control ? [control] : [];
@@ -81,10 +84,19 @@ export const mergeCustomerBillingControlsForCheck = ({
 	entityApiSubject,
 	customerApiSubject,
 	planCustomerProducts = [],
+	normalizeSpendLimitForCompare,
 }: {
 	entityApiSubject: ApiEntityV2;
 	customerApiSubject: ApiCustomerV5;
 	planCustomerProducts?: FullCusProduct[];
+	/**
+	 * Optional projection that resolves a percentage-typed spend limit to an
+	 * absolute one so the most-restrictive merge across plans can compare
+	 * percent and absolute caps on the same axis. Pass when callers have the
+	 * customer's main-plan allowance available (typically via
+	 * `fullCustomerToCustomerEntitlements` + `resolveSpendLimitOverageLimit`).
+	 */
+	normalizeSpendLimitForCompare?: (control: DbSpendLimit) => DbSpendLimit;
 }): ApiEntityV2 => {
 	const entitySpendLimits =
 		entityApiSubject.billing_controls?.spend_limits ?? [];
@@ -103,6 +115,7 @@ export const mergeCustomerBillingControlsForCheck = ({
 		customerControls: customerSpendLimits,
 		planCustomerProducts,
 		controlKey: "spend_limits",
+		normalizeForCompare: normalizeSpendLimitForCompare,
 	});
 	const usageLimits = mergeControlsByFeature<DbUsageLimit, "usage_limits">({
 		entityControls: entityUsageLimits,
@@ -142,9 +155,16 @@ export const mergeCustomerBillingControlsForCheck = ({
 export const mergePlanBillingControlsForCheck = ({
 	customerApiSubject,
 	planCustomerProducts = [],
+	normalizeSpendLimitForCompare,
 }: {
 	customerApiSubject: ApiCustomerV5;
 	planCustomerProducts?: FullCusProduct[];
+	/**
+	 * Optional projection that resolves a percentage-typed spend limit to an
+	 * absolute one so the most-restrictive merge across plans can compare
+	 * percent and absolute caps on the same axis.
+	 */
+	normalizeSpendLimitForCompare?: (control: DbSpendLimit) => DbSpendLimit;
 }): ApiCustomerV5 => {
 	const customerSpendLimits =
 		customerApiSubject.billing_controls?.spend_limits ?? [];
@@ -157,6 +177,7 @@ export const mergePlanBillingControlsForCheck = ({
 		customerControls: [],
 		planCustomerProducts,
 		controlKey: "spend_limits",
+		normalizeForCompare: normalizeSpendLimitForCompare,
 	});
 	const usageLimits = mergeControlsByFeature<DbUsageLimit, "usage_limits">({
 		entityControls: customerUsageLimits,

--- a/shared/utils/fullSubjectUtils/planBillingControlUtils.ts
+++ b/shared/utils/fullSubjectUtils/planBillingControlUtils.ts
@@ -16,7 +16,7 @@ const MOST_RESTRICTIVE_BY_KEY: Partial<Record<BillingControlKey, Comparator>> =
 		overage_allowed: pickStricterOverageAllowed as Comparator,
 	};
 
-const DEFAULT_PLAN_CONTROL_STATUSES = [
+export const DEFAULT_PLAN_CONTROL_STATUSES = [
 	CusProductStatus.Active,
 	CusProductStatus.PastDue,
 	CusProductStatus.Trialing,
@@ -71,13 +71,7 @@ export const findPlanBillingControlWithProduct = <
 	matches: (control: TControl) => boolean;
 	now?: number;
 	inStatuses?: CusProductStatus[];
-	/**
-	 * Optional projection invoked on each candidate before invoking the
-	 * most-restrictive comparator. Used by spend_limits to normalize percentage
-	 * caps to absolute units so cross-type comparisons don't compare apples
-	 * (e.g. `200%`) against oranges (e.g. `1000` absolute). The original
-	 * (un-normalized) control is still returned to the caller.
-	 */
+	/** Projection used only for comparison; the original control is returned. */
 	normalizeForCompare?: (control: TControl) => TControl;
 }): { control: TControl; customerProduct: FullCusProduct } | undefined => {
 	const mostRestrictive = MOST_RESTRICTIVE_BY_KEY[controlKey] as
@@ -104,7 +98,6 @@ export const findPlanBillingControlWithProduct = <
 			continue;
 		}
 		const candidateNormalized = normalizeForCompare?.(control) ?? control;
-		// `winnerNormalized` is set whenever `winner` is set.
 		const stricter = mostRestrictive(
 			winnerNormalized as TControl,
 			candidateNormalized,

--- a/shared/utils/fullSubjectUtils/planBillingControlUtils.ts
+++ b/shared/utils/fullSubjectUtils/planBillingControlUtils.ts
@@ -64,18 +64,28 @@ export const findPlanBillingControlWithProduct = <
 	matches,
 	now,
 	inStatuses,
+	normalizeForCompare,
 }: {
 	customerProducts: FullCusProduct[];
 	controlKey: TKey;
 	matches: (control: TControl) => boolean;
 	now?: number;
 	inStatuses?: CusProductStatus[];
+	/**
+	 * Optional projection invoked on each candidate before invoking the
+	 * most-restrictive comparator. Used by spend_limits to normalize percentage
+	 * caps to absolute units so cross-type comparisons don't compare apples
+	 * (e.g. `200%`) against oranges (e.g. `1000` absolute). The original
+	 * (un-normalized) control is still returned to the caller.
+	 */
+	normalizeForCompare?: (control: TControl) => TControl;
 }): { control: TControl; customerProduct: FullCusProduct } | undefined => {
 	const mostRestrictive = MOST_RESTRICTIVE_BY_KEY[controlKey] as
 		| ((left: TControl, right: TControl) => TControl)
 		| undefined;
 
 	let winner: { control: TControl; customerProduct: FullCusProduct } | undefined;
+	let winnerNormalized: TControl | undefined;
 	for (const customerProduct of getPlanBillingControlProducts({
 		customerProducts,
 		now,
@@ -88,10 +98,21 @@ export const findPlanBillingControlWithProduct = <
 		const control = controls?.find(matches);
 		if (!control) continue;
 		if (!mostRestrictive) return { control, customerProduct };
-		winner =
-			winner && mostRestrictive(winner.control, control) === winner.control
-				? winner
-				: { control, customerProduct };
+		if (!winner) {
+			winner = { control, customerProduct };
+			winnerNormalized = normalizeForCompare?.(control) ?? control;
+			continue;
+		}
+		const candidateNormalized = normalizeForCompare?.(control) ?? control;
+		// `winnerNormalized` is set whenever `winner` is set.
+		const stricter = mostRestrictive(
+			winnerNormalized as TControl,
+			candidateNormalized,
+		);
+		if (stricter !== winnerNormalized) {
+			winner = { control, customerProduct };
+			winnerNormalized = candidateNormalized;
+		}
 	}
 	return winner;
 };
@@ -105,6 +126,7 @@ export const findPlanBillingControl = <
 	matches: (control: TControl) => boolean;
 	now?: number;
 	inStatuses?: CusProductStatus[];
+	normalizeForCompare?: (control: TControl) => TControl;
 }): TControl | undefined =>
 	findPlanBillingControlWithProduct<TControl, TKey>(args)?.control;
 
@@ -123,6 +145,7 @@ export const resolveBillingControlWithProduct = <
 	matches,
 	now,
 	inStatuses,
+	normalizeForCompare,
 }: {
 	controlLists: Array<TControl[] | null | undefined>;
 	customerProducts?: FullCusProduct[];
@@ -130,6 +153,7 @@ export const resolveBillingControlWithProduct = <
 	matches: (control: TControl) => boolean;
 	now?: number;
 	inStatuses?: CusProductStatus[];
+	normalizeForCompare?: (control: TControl) => TControl;
 }): { control: TControl; customerProduct?: FullCusProduct } | undefined => {
 	for (const controls of controlLists) {
 		const control = controls?.find(matches);
@@ -144,6 +168,7 @@ export const resolveBillingControlWithProduct = <
 		matches,
 		now,
 		inStatuses,
+		normalizeForCompare,
 	});
 };
 
@@ -157,6 +182,7 @@ export const resolveBillingControl = <
 	matches: (control: TControl) => boolean;
 	now?: number;
 	inStatuses?: CusProductStatus[];
+	normalizeForCompare?: (control: TControl) => TControl;
 }) => resolveBillingControlWithProduct<TControl, TKey>(args)?.control;
 
 export const fullSubjectToPlanProducts = ({

--- a/vite/src/components/billing-controls/BillingControlsDisplay.tsx
+++ b/vite/src/components/billing-controls/BillingControlsDisplay.tsx
@@ -246,29 +246,34 @@ export const SpendLimitRow = ({
 	featureNameById,
 	rowBadge,
 	onClick,
-}: EditableRowProps<DbSpendLimit>) => (
-	<RowButton enabled={spendLimit.enabled} onClick={onClick}>
-		<RowHeader
-			enabled={spendLimit.enabled}
-			name={getFeatureLabel({
-				featureId: spendLimit.feature_id,
-				featureNameById,
-			})}
-			badge={rowBadge}
-		/>
-		<RowMeta
-			entries={[
-				{
-					label: "Overage limit",
-					value:
-						spendLimit.overage_limit === undefined
-							? "none"
-							: spendLimit.overage_limit.toLocaleString(),
-				},
-			]}
-		/>
-	</RowButton>
-);
+}: EditableRowProps<DbSpendLimit>) => {
+	const isPercent = spendLimit.limit_type === "usage_percentage";
+	const overageLimitValue =
+		spendLimit.overage_limit === undefined
+			? "none"
+			: isPercent
+				? `${spendLimit.overage_limit.toLocaleString()}%`
+				: spendLimit.overage_limit.toLocaleString();
+
+	return (
+		<RowButton enabled={spendLimit.enabled} onClick={onClick}>
+			<RowHeader
+				enabled={spendLimit.enabled}
+				name={getFeatureLabel({
+					featureId: spendLimit.feature_id,
+					featureNameById,
+				})}
+				badge={rowBadge}
+			/>
+			<RowMeta
+				entries={[
+					{ label: "Type", value: isPercent ? "Usage %" : "Absolute" },
+					{ label: "Overage limit", value: overageLimitValue },
+				]}
+			/>
+		</RowButton>
+	);
+};
 
 export const UsageLimitRow = ({
 	item: usageLimit,

--- a/vite/src/views/products/plan/components/edit-plan-details/PlanBillingControlsSection.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-details/PlanBillingControlsSection.tsx
@@ -6,6 +6,7 @@ import {
 	FeatureUsageType,
 	PurchaseLimitInterval,
 	ResetInterval,
+	type SpendLimitType,
 } from "@autumn/shared";
 import {
 	Button,
@@ -77,6 +78,11 @@ const THRESHOLD_TYPE_OPTIONS: SelectOption[] = [
 	{ value: "usage_percentage", label: "% used of allowance" },
 	{ value: "remaining", label: "Absolute remaining" },
 	{ value: "remaining_percentage", label: "% remaining of allowance" },
+];
+
+const SPEND_LIMIT_TYPE_OPTIONS: SelectOption[] = [
+	{ value: "absolute", label: "Absolute" },
+	{ value: "usage_percentage", label: "Usage %" },
 ];
 
 const UNIQUE_FEATURE_KEYS = [
@@ -330,13 +336,52 @@ function AutoTopupFields({ form }: { form: UsePlanBillingControlForm }) {
 function SpendLimitFields({ form }: { form: UsePlanBillingControlForm }) {
 	return (
 		<div className="flex flex-col gap-2.5">
-			<NumberFieldRow
-				form={form}
-				name="overage_limit"
-				label="Overage limit"
-				placeholder="No limit"
-				parse="float"
-			/>
+			<form.Field name="limit_type">
+				{(field) => (
+					<div>
+						<FormLabel className="mb-0.5 text-tertiary-foreground text-xs">
+							Limit type
+						</FormLabel>
+						<Select
+							value={field.state.value}
+							onValueChange={(value) => {
+								field.handleChange(value as SpendLimitType);
+								// Units and percent aren't interchangeable.
+								form.setFieldValue("overage_limit", null);
+							}}
+							items={SPEND_LIMIT_TYPE_OPTIONS}
+						>
+							<SelectTrigger className="w-full">
+								<SelectValue placeholder="Type" />
+							</SelectTrigger>
+							<SelectContent>
+								{SPEND_LIMIT_TYPE_OPTIONS.map((option) => (
+									<SelectItem key={option.value} value={option.value}>
+										{option.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				)}
+			</form.Field>
+			<form.Subscribe selector={(state) => state.values.limit_type}>
+				{(limitType) => (
+					<NumberFieldRow
+						form={form}
+						name="overage_limit"
+						label={
+							limitType === "usage_percentage"
+								? "Overage limit (%)"
+								: "Overage limit"
+						}
+						placeholder={
+							limitType === "usage_percentage" ? "eg. 120" : "No limit"
+						}
+						parse="float"
+					/>
+				)}
+			</form.Subscribe>
 		</div>
 	);
 }

--- a/vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts
+++ b/vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts
@@ -7,6 +7,7 @@ import {
 	type DbUsageLimit,
 	PurchaseLimitInterval,
 	ResetInterval,
+	type SpendLimitType,
 } from "@autumn/shared";
 import { useRef } from "react";
 import { z } from "zod/v4";
@@ -29,6 +30,7 @@ export type PlanBillingControlFormValues = {
 	purchase_limit_interval_count: number | null;
 	purchase_limit_limit: number | null;
 	invoice_mode: boolean;
+	limit_type: SpendLimitType;
 	overage_limit: number | null;
 	usage_limit: number | null;
 	usage_interval: ResetInterval;
@@ -64,6 +66,7 @@ const AutoTopupFormSchema = z
 const SpendLimitFormSchema = z
 	.object({
 		feature_id: z.string(),
+		limit_type: z.enum(["absolute", "usage_percentage"]),
 		overage_limit: z.number().nullable(),
 	})
 	.check((ctx) => {
@@ -155,6 +158,7 @@ export function buildControlItem(
 		return {
 			feature_id: emptyToUndefined(values.feature_id),
 			enabled: values.enabled,
+			limit_type: values.limit_type,
 			overage_limit: values.overage_limit ?? undefined,
 		} satisfies DbSpendLimit;
 	}
@@ -222,6 +226,7 @@ function toDefaultValues(
 			autoTopup?.purchase_limit?.interval_count ?? 1,
 		purchase_limit_limit: autoTopup?.purchase_limit?.limit ?? null,
 		invoice_mode: autoTopup?.invoice_mode ?? false,
+		limit_type: spendLimit?.limit_type ?? "absolute",
 		overage_limit: spendLimit?.overage_limit ?? null,
 		usage_limit: usageLimit?.limit ?? null,
 		usage_interval: usageLimit?.interval ?? ResetInterval.Month,


### PR DESCRIPTION
## Summary by cubic

Adds limit_type (usage_percentage) option to plan-level spend limit controls, matching the existing customer-level spend limit behavior. The overage limit can now be configured as an absolute value or a percentage of the plan's included allowance.

- **UI Changes**
  - Added `limit_type` select dropdown with "Absolute" and "Usage %" options to `SpendLimitFields` in `vite/src/views/products/plan/components/edit-plan-details/PlanBillingControlsSection.tsx`.
  - Overaged limit input label and placeholder adapt based on selected type ("Overage limit (%)" with "eg. 120" for percentage mode).
  - Updated `SpendLimitRow` in `vite/src/components/billing-controls/BillingControlsDisplay.tsx` to display the limit type ("Usage %" or "Absolute") and format percentage values with "%" suffix.

- **Form Logic**
  - Added `limit_type` field to `PlanBillingControlFormValues` type, `SpendLimitFormSchema`, and `toDefaultValues` in `vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts`.
  - `buildControlItem` now includes `limit_type` when constructing `DbSpendLimit` objects.
  - Form clears overage_limit when switching between absolute and percentage modes.

- **Backend/Shared**
  - Uses existing `SpendLimitType` enum from `@autumn/shared/models/cusModels/billingControls/spendLimit.ts` (`absolute` | `usage_percentage`).
  - No server changes needed — the limit_type field and its resolution logic (`resolveSpendLimitOverageLimit`) already exist for customer-level controls.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add usage-percentage support to plan-level spend limits and fix mixed-type comparisons by normalizing % caps to absolute units using plan and aggregated allowances. The UI adds a Limit type selector and percent formatting; backend resolves and compares correctly in plan merges and check paths with no API changes.

- New Features
  - Added “Limit type” select (“Absolute” | “Usage %”); switching types clears `overage_limit`.
  - Added `limit_type` to form schema/defaults and builder; display shows type and formats with “%”.

- Bug Fixes
  - Normalize percentage spend limits to absolute for plan comparisons (uses aggregated allowance and `DEFAULT_PLAN_CONTROL_STATUSES`); applied via a `normalizeForCompare` hook in selection/merges and in `getCheckData`/`getCheckDataV2`.
  - Check-time resolution now includes aggregated allowance; updated resolution utilities and added unit tests to ensure stricter caps are chosen across mixed types.

<sup>Written for commit 31aea9995cdf8fc4407983e3086112c6cb780132. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Extends the plan-level spend limit form with a `limit_type` selector (`"absolute"` | `"usage_percentage"`), matching the already-supported customer-level behavior. Overage values stored as a percentage are resolved to absolute units at runtime by the existing `resolveSpendLimitOverageLimit` helper, so no backend changes were needed.

- **Improvements** — `SpendLimitFields` gains a \"Limit type\" dropdown; switching types clears `overage_limit` to prevent unit-mismatch data from being saved.
- **Improvements** — `SpendLimitRow` in the display layer now shows a \"Type\" entry and formats percentage-mode values with a `%` suffix.
- **Improvements** — `PlanBillingControlFormValues`, `SpendLimitFormSchema`, `toDefaultValues`, and `buildControlItem` are extended with `limit_type`, defaulting to `"absolute"` for new and legacy limits.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is purely additive UI work over an already-working backend, and legacy data without limit_type is handled gracefully.

The form and display logic are correct and consistent with existing patterns. The only gap is that the schema permits a usage_percentage value of 0, which resolves to zero absolute units at enforcement time — effectively blocking all usage without any validation feedback. This is a minor edge case with no data-loss risk.

usePlanBillingControlForm.ts — the SpendLimitFormSchema cross-field check does not guard against a zero percentage value.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts | Adds limit_type to the form type, schema, default values, and buildControlItem. No type-specific validation is applied for usage_percentage (e.g. no minimum threshold). |
| vite/src/views/products/plan/components/edit-plan-details/PlanBillingControlsSection.tsx | Adds a limit_type select and reactive label/placeholder to SpendLimitFields; follows the existing SelectFieldRow + form.Subscribe pattern correctly. Clearing overage_limit on type switch is the right behavior. |
| vite/src/components/billing-controls/BillingControlsDisplay.tsx | Converts SpendLimitRow from a functional expression to a statement for the derived isPercent/overageLimitValue variables. Gracefully handles limit_type === undefined (legacy data) by falling back to Absolute. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens Spend Limit form] --> B{Edit existing?}
    B -- Yes --> C["toDefaultValues: limit_type = spendLimit.limit_type ?? absolute"]
    B -- No --> D["toDefaultValues: limit_type = absolute"]
    C --> E[SpendLimitFields rendered]
    D --> E
    E --> F[User selects limit_type]
    F -- Switch type --> G[Clear overage_limit to null]
    G --> H{limit_type?}
    F -- Keep type --> H
    H -- absolute --> I["Label: Overage limit | Placeholder: No limit"]
    H -- usage_percentage --> J["Label: Overage limit pct | Placeholder: eg. 120"]
    I --> K[Submit buildControlItem]
    J --> K
    K --> L[DbSpendLimit saved with limit_type field]
    L --> M[SpendLimitRow display]
    M --> N{limit_type?}
    N -- usage_percentage --> O["Show value with percent suffix | Type: Usage pct"]
    N -- absolute or undefined --> P["Show raw value | Type: Absolute"]
    L --> Q[resolveSpendLimitOverageLimit at runtime]
    Q --> R{limit_type?}
    R -- usage_percentage --> S["overage_limit / 100 x plan_allowance"]
    R -- absolute or undefined --> T[overage_limit as-is]
    S --> U[Lua enforcement with absolute units]
    T --> U
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User opens Spend Limit form] --> B{Edit existing?}
    B -- Yes --> C["toDefaultValues: limit_type = spendLimit.limit_type ?? absolute"]
    B -- No --> D["toDefaultValues: limit_type = absolute"]
    C --> E[SpendLimitFields rendered]
    D --> E
    E --> F[User selects limit_type]
    F -- Switch type --> G[Clear overage_limit to null]
    G --> H{limit_type?}
    F -- Keep type --> H
    H -- absolute --> I["Label: Overage limit | Placeholder: No limit"]
    H -- usage_percentage --> J["Label: Overage limit pct | Placeholder: eg. 120"]
    I --> K[Submit buildControlItem]
    J --> K
    K --> L[DbSpendLimit saved with limit_type field]
    L --> M[SpendLimitRow display]
    M --> N{limit_type?}
    N -- usage_percentage --> O["Show value with percent suffix | Type: Usage pct"]
    N -- absolute or undefined --> P["Show raw value | Type: Absolute"]
    L --> Q[resolveSpendLimitOverageLimit at runtime]
    Q --> R{limit_type?}
    R -- usage_percentage --> S["overage_limit / 100 x plan_allowance"]
    R -- absolute or undefined --> T[overage_limit as-is]
    S --> U[Lua enforcement with absolute units]
    T --> U
```

</a>
</details>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts`, line 66-92 ([link](https://github.com/useautumn/autumn/blob/3b2cf749c0c84968ffdb1e29ae1edd765bd31fbd/vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts#L66-L92)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> When `limit_type` is `"usage_percentage"` the validation only ensures the value is non-negative, so a user can save `0` (resolves to 0 absolute units — effectively blocking all usage) without any feedback. Consider adding a cross-field check that enforces a positive value when in percentage mode, mirroring the intent of the "eg. 120" placeholder.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts
   Line: 66-92

   Comment:
   When `limit_type` is `"usage_percentage"` the validation only ensures the value is non-negative, so a user can save `0` (resolves to 0 absolute units — effectively blocking all usage) without any feedback. Consider adding a cross-field check that enforces a positive value when in percentage mode, mirroring the intent of the "eg. 120" placeholder.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts:66-92
When `limit_type` is `"usage_percentage"` the validation only ensures the value is non-negative, so a user can save `0` (resolves to 0 absolute units — effectively blocking all usage) without any feedback. Consider adding a cross-field check that enforces a positive value when in percentage mode, mirroring the intent of the "eg. 120" placeholder.

```suggestion
const SpendLimitFormSchema = z
	.object({
		feature_id: z.string(),
		limit_type: z.enum(["absolute", "usage_percentage"]),
		overage_limit: z.number().nullable(),
	})
	.check((ctx) => {
		const { overage_limit, limit_type, feature_id } = ctx.value;
		if (overage_limit == null) return;
		if (overage_limit < 0) {
			ctx.issues.push({
				code: "custom",
				input: overage_limit,
				path: ["overage_limit"],
				message: "Please enter a valid overage limit",
			});
			return;
		}
		if (limit_type === "usage_percentage" && overage_limit === 0) {
			ctx.issues.push({
				code: "custom",
				input: overage_limit,
				path: ["overage_limit"],
				message: "Usage percentage must be greater than 0",
			});
			return;
		}
		if (!feature_id) {
			ctx.issues.push({
				code: "custom",
				input: feature_id,
				path: ["feature_id"],
				message: "Feature is required when overage limit is set",
			});
		}
	});
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add limit\_type field to plan-level spend..."](https://github.com/useautumn/autumn/commit/3b2cf749c0c84968ffdb1e29ae1edd765bd31fbd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40535414)</sub>

<!-- /greptile_comment -->

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/85cd5f31-fdfe-4144-9a4e-ee83bd98cb48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-030" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/85cd5f31-fdfe-4144-9a4e-ee83bd98cb48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-030&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-030"><img alt="SCO-030" src="https://capy.ai/api/badge/thread.svg?label=SCO-030"></picture></a>
<!-- capy-pr-badge:end -->