### PR TITLE
feat(atmn): add plan-level billingControls DSL

### DIFF
--- a/packages/atmn/src/commands/push/push.ts
+++ b/packages/atmn/src/commands/push/push.ts
@@ -38,6 +38,7 @@ import {
 	transformFeatureToApi,
 	transformPlanToApi,
 } from "../../lib/transforms/sdkToApi/index.js";
+import { transformBillingControlsToApi } from "../../lib/transforms/sdkToApi/billingControls.js";
 import { writeConfig } from "../pull/writeConfig.js";
 import type {
 	CatalogPreviewUpdateResponse,
@@ -647,7 +648,11 @@ function toApiCustomizePlan(customize: CustomizePlan): Record<string, unknown> {
 				}
 			: {}),
 		...(customize.billingControls !== undefined
-			? { billing_controls: customize.billingControls }
+			? {
+					billing_controls: transformBillingControlsToApi(
+						customize.billingControls,
+					),
+				}
 			: {}),
 	};
 }

--- a/packages/atmn/src/commands/push/validate.ts
+++ b/packages/atmn/src/commands/push/validate.ts
@@ -1,4 +1,5 @@
 import type { Feature, PlanItem } from "../../compose/models/index.js";
+import type { BillingControls } from "../../compose/models/billingControlModels.js";
 import type { Plan } from "../../compose/models/variantModels.js";
 
 /**
@@ -203,6 +204,108 @@ function validateFeatureReference({
 	];
 }
 
+function validateBillingControls({
+	billingControls,
+	features,
+	path,
+}: {
+	billingControls: BillingControls | undefined;
+	features: Feature[];
+	path: string;
+}): ValidationError[] {
+	if (!billingControls) return [];
+
+	const errors: ValidationError[] = [];
+	const spendLimitFeatureIds = new Set<string>();
+	const usageLimitFeatureIds = new Set<string>();
+	const overageAllowedFeatureIds = new Set<string>();
+
+	for (const [index, spendLimit] of (
+		billingControls.spendLimits ?? []
+	).entries()) {
+		if (spendLimit.featureId) {
+			errors.push(
+				...validateFeatureReference({
+					featureId: spendLimit.featureId,
+					features,
+					path: `${path} → billingControls.spendLimits[${index}]`,
+				}),
+			);
+
+			if (spendLimitFeatureIds.has(spendLimit.featureId)) {
+				errors.push({
+					path: `${path} → billingControls.spendLimits[${index}]`,
+					message: `Only one spend limit entry is allowed per featureId.`,
+				});
+			}
+			spendLimitFeatureIds.add(spendLimit.featureId);
+		}
+	}
+
+	for (const [index, usageLimit] of (
+		billingControls.usageLimits ?? []
+	).entries()) {
+		errors.push(
+			...validateFeatureReference({
+				featureId: usageLimit.featureId,
+				features,
+				path: `${path} → billingControls.usageLimits[${index}]`,
+			}),
+		);
+
+		if (usageLimitFeatureIds.has(usageLimit.featureId)) {
+			errors.push({
+				path: `${path} → billingControls.usageLimits[${index}]`,
+				message: `Only one usage limit entry is allowed per featureId.`,
+			});
+		}
+		usageLimitFeatureIds.add(usageLimit.featureId);
+	}
+
+	for (const [index, overageAllowed] of (
+		billingControls.overageAllowed ?? []
+	).entries()) {
+		errors.push(
+			...validateFeatureReference({
+				featureId: overageAllowed.featureId,
+				features,
+				path: `${path} → billingControls.overageAllowed[${index}]`,
+			}),
+		);
+
+		if (overageAllowedFeatureIds.has(overageAllowed.featureId)) {
+			errors.push({
+				path: `${path} → billingControls.overageAllowed[${index}]`,
+				message: `Only one overageAllowed entry is allowed per featureId.`,
+			});
+		}
+		overageAllowedFeatureIds.add(overageAllowed.featureId);
+	}
+
+	for (const [index, autoTopup] of (billingControls.autoTopups ?? []).entries()) {
+		errors.push(
+			...validateFeatureReference({
+				featureId: autoTopup.featureId,
+				features,
+				path: `${path} → billingControls.autoTopups[${index}]`,
+			}),
+		);
+	}
+
+	for (const [index, usageAlert] of (billingControls.usageAlerts ?? []).entries()) {
+		if (!usageAlert.featureId) continue;
+		errors.push(
+			...validateFeatureReference({
+				featureId: usageAlert.featureId,
+				features,
+				path: `${path} → billingControls.usageAlerts[${index}]`,
+			}),
+		);
+	}
+
+	return errors;
+}
+
 /**
  * Validate a plan has all required fields.
  */
@@ -268,6 +371,14 @@ function validatePlan(plan: Plan, features: Feature[]): ValidationError[] {
 		}
 	}
 
+	errors.push(
+		...validateBillingControls({
+			billingControls: plan.billingControls,
+			features,
+			path: `plan "${planId}"`,
+		}),
+	);
+
 	for (const [variantIndex, variant] of (plan.variants ?? []).entries()) {
 		const variantPath = `plan "${planId}" → variants[${variantIndex}] (${variant.id})`;
 		for (const [itemIndex, item] of (
@@ -299,6 +410,13 @@ function validatePlan(plan: Plan, features: Feature[]): ValidationError[] {
 				}),
 			);
 		}
+		errors.push(
+			...validateBillingControls({
+				billingControls: variant.customize?.billingControls,
+				features,
+				path: variantPath,
+			}),
+		);
 	}
 
 	return errors;

--- a/packages/atmn/src/compose/index.ts
+++ b/packages/atmn/src/compose/index.ts
@@ -12,10 +12,12 @@ import type {
 	PlanItemFilter,
 	Variant,
 } from "./models/variantModels.js";
+import type { BillingControls } from "./models/billingControlModels.js";
 
 export { plan, feature, item };
 
 export type {
+	BillingControls,
 	CustomizePlan,
 	Feature,
 	FreeTrial,

--- a/packages/atmn/src/compose/models/billingControlModels.ts
+++ b/packages/atmn/src/compose/models/billingControlModels.ts
@@ -1,0 +1,54 @@
+export type AutoTopupPurchaseLimit = {
+	interval: "hour" | "day" | "week" | "month";
+	intervalCount?: number;
+	limit: number;
+};
+
+export type AutoTopup = {
+	featureId: string;
+	enabled?: boolean;
+	threshold: number;
+	quantity: number;
+	purchaseLimit?: AutoTopupPurchaseLimit;
+	invoiceMode?: boolean;
+};
+
+export type SpendLimit = {
+	featureId?: string;
+	enabled?: boolean;
+	limitType?: "absolute" | "usage_percentage";
+	overageLimit?: number;
+};
+
+export type UsageLimit = {
+	featureId: string;
+	enabled?: boolean;
+	limit: number;
+	interval: "day" | "week" | "month" | "year";
+};
+
+export type UsageAlert = {
+	featureId?: string;
+	enabled?: boolean;
+	threshold: number;
+	thresholdType:
+		| "usage"
+		| "usage_percentage"
+		| "remaining"
+		| "remaining_percentage";
+	name?: string;
+};
+
+export type OverageAllowed = {
+	featureId: string;
+	enabled?: boolean;
+};
+
+/** Plan-level billing controls used as customer defaults. */
+export type BillingControls = {
+	autoTopups?: AutoTopup[];
+	spendLimits?: SpendLimit[];
+	usageLimits?: UsageLimit[];
+	usageAlerts?: UsageAlert[];
+	overageAllowed?: OverageAllowed[];
+};

--- a/packages/atmn/src/compose/models/planModels.ts
+++ b/packages/atmn/src/compose/models/planModels.ts
@@ -2,6 +2,7 @@
 // Generated from @autumn/shared schemas
 // Run `pnpm gen:atmn` to regenerate
 
+import type { BillingControls } from "./billingControlModels.js";
 import { z } from "zod/v4";
 
 export const UsageTierSchema = z.object({
@@ -347,6 +348,9 @@ export type Plan = {
 
   /** Free trial period before billing begins */
   freeTrial?: FreeTrial | null;
+
+  /** Plan-level billing controls used as customer defaults. */
+  billingControls?: BillingControls;
 
   /** Whether the plan is archived */
   archived?: boolean;

--- a/packages/atmn/src/compose/models/variantModels.ts
+++ b/packages/atmn/src/compose/models/variantModels.ts
@@ -1,7 +1,5 @@
-import type {
-	CustomizePlanV1,
-	PlanItemFilter as ApiPlanItemFilter,
-} from "@autumn/shared";
+import type { CustomizePlanV1, PlanItemFilter as ApiPlanItemFilter } from "@autumn/shared";
+import type { BillingControls } from "./billingControlModels.js";
 import type { FreeTrial, Plan as BasePlan, PlanItem } from "./planModels.js";
 
 type ApiBasePrice = NonNullable<CustomizePlanV1["price"]>;
@@ -23,7 +21,7 @@ export type CustomizePlan = {
 	addItems?: PlanItem[];
 	removeItems?: PlanItemFilter[];
 	freeTrial?: FreeTrial | null;
-	billingControls?: CustomizePlanV1["billing_controls"];
+	billingControls?: BillingControls;
 };
 
 export type Variant = {

--- a/packages/atmn/src/lib/transforms/apiToSdk/billingControls.ts
+++ b/packages/atmn/src/lib/transforms/apiToSdk/billingControls.ts
@@ -1,0 +1,90 @@
+import type { CustomerBillingControlsParams } from "@autumn/shared";
+import type { BillingControls } from "../../../compose/models/billingControlModels.js";
+
+export function transformApiBillingControls(
+	api: CustomerBillingControlsParams | null | undefined,
+): BillingControls | undefined {
+	if (!api) return undefined;
+
+	const result: BillingControls = {};
+
+	if (api.auto_topups?.length) {
+		result.autoTopups = api.auto_topups.map((autoTopup) => ({
+			featureId: autoTopup.feature_id,
+			...(autoTopup.enabled !== undefined
+				? { enabled: autoTopup.enabled }
+				: {}),
+			threshold: autoTopup.threshold,
+			quantity: autoTopup.quantity,
+			...(autoTopup.purchase_limit
+				? {
+						purchaseLimit: {
+							interval: autoTopup.purchase_limit.interval,
+							...(autoTopup.purchase_limit.interval_count !== undefined
+								? {
+										intervalCount: autoTopup.purchase_limit.interval_count,
+									}
+								: {}),
+							limit: autoTopup.purchase_limit.limit,
+						},
+					}
+				: {}),
+			...(autoTopup.invoice_mode !== undefined
+				? { invoiceMode: autoTopup.invoice_mode }
+				: {}),
+		}));
+	}
+
+	if (api.spend_limits?.length) {
+		result.spendLimits = api.spend_limits.map((spendLimit) => ({
+			...(spendLimit.feature_id !== undefined
+				? { featureId: spendLimit.feature_id }
+				: {}),
+			...(spendLimit.enabled !== undefined
+				? { enabled: spendLimit.enabled }
+				: {}),
+			...(spendLimit.limit_type !== undefined
+				? { limitType: spendLimit.limit_type }
+				: {}),
+			...(spendLimit.overage_limit !== undefined
+				? { overageLimit: spendLimit.overage_limit }
+				: {}),
+		}));
+	}
+
+	if (api.usage_limits?.length) {
+		result.usageLimits = api.usage_limits.map((usageLimit) => ({
+			featureId: usageLimit.feature_id,
+			...(usageLimit.enabled !== undefined
+				? { enabled: usageLimit.enabled }
+				: {}),
+			limit: usageLimit.limit,
+			interval: usageLimit.interval,
+		}));
+	}
+
+	if (api.usage_alerts?.length) {
+		result.usageAlerts = api.usage_alerts.map((usageAlert) => ({
+			...(usageAlert.feature_id !== undefined
+				? { featureId: usageAlert.feature_id }
+				: {}),
+			...(usageAlert.enabled !== undefined
+				? { enabled: usageAlert.enabled }
+				: {}),
+			threshold: usageAlert.threshold,
+			thresholdType: usageAlert.threshold_type,
+			...(usageAlert.name !== undefined ? { name: usageAlert.name } : {}),
+		}));
+	}
+
+	if (api.overage_allowed?.length) {
+		result.overageAllowed = api.overage_allowed.map((overageAllowed) => ({
+			featureId: overageAllowed.feature_id,
+			...(overageAllowed.enabled !== undefined
+				? { enabled: overageAllowed.enabled }
+				: {}),
+		}));
+	}
+
+	return Object.keys(result).length > 0 ? result : undefined;
+}

--- a/packages/atmn/src/lib/transforms/apiToSdk/plan.ts
+++ b/packages/atmn/src/lib/transforms/apiToSdk/plan.ts
@@ -6,6 +6,7 @@ import type {
 	Variant,
 } from "../../../compose/models/variantModels.js";
 import type { ApiPlan } from "../../api/types/index.js";
+import { transformApiBillingControls } from "./billingControls.js";
 import { transformApiPlanItem } from "./planItem.js";
 import { createTransformer } from "./Transformer.js";
 
@@ -54,6 +55,8 @@ export const planTransformer = createTransformer<ApiPlan, BasePlan>({
 						cardRequired: api.free_trial.card_required,
 					}
 				: undefined,
+
+		billingControls: (api) => transformApiBillingControls(api.billing_controls),
 	},
 });
 
@@ -129,7 +132,11 @@ const transformApiCustomizePlan = (
 				}
 			: {}),
 		...(customize.billing_controls !== undefined
-			? { billingControls: customize.billing_controls }
+			? {
+					billingControls: transformApiBillingControls(
+						customize.billing_controls,
+					),
+				}
 			: {}),
 	};
 

--- a/packages/atmn/src/lib/transforms/sdkToApi/billingControls.ts
+++ b/packages/atmn/src/lib/transforms/sdkToApi/billingControls.ts
@@ -1,0 +1,90 @@
+import type { CustomerBillingControlsParams } from "@autumn/shared";
+import type { BillingControls } from "../../../compose/models/billingControlModels.js";
+
+export function transformBillingControlsToApi(
+	controls: BillingControls | undefined,
+): CustomerBillingControlsParams | undefined {
+	if (!controls) return undefined;
+
+	const result: CustomerBillingControlsParams = {};
+
+	if (controls.autoTopups?.length) {
+		result.auto_topups = controls.autoTopups.map((autoTopup) => ({
+			feature_id: autoTopup.featureId,
+			...(autoTopup.enabled !== undefined
+				? { enabled: autoTopup.enabled }
+				: {}),
+			threshold: autoTopup.threshold,
+			quantity: autoTopup.quantity,
+			...(autoTopup.purchaseLimit
+				? {
+						purchase_limit: {
+							interval: autoTopup.purchaseLimit.interval,
+							...(autoTopup.purchaseLimit.intervalCount !== undefined
+								? {
+										interval_count: autoTopup.purchaseLimit.intervalCount,
+									}
+								: {}),
+							limit: autoTopup.purchaseLimit.limit,
+						},
+					}
+				: {}),
+			...(autoTopup.invoiceMode !== undefined
+				? { invoice_mode: autoTopup.invoiceMode }
+				: {}),
+		}));
+	}
+
+	if (controls.spendLimits?.length) {
+		result.spend_limits = controls.spendLimits.map((spendLimit) => ({
+			...(spendLimit.featureId !== undefined
+				? { feature_id: spendLimit.featureId }
+				: {}),
+			...(spendLimit.enabled !== undefined
+				? { enabled: spendLimit.enabled }
+				: {}),
+			...(spendLimit.limitType !== undefined
+				? { limit_type: spendLimit.limitType }
+				: {}),
+			...(spendLimit.overageLimit !== undefined
+				? { overage_limit: spendLimit.overageLimit }
+				: {}),
+		}));
+	}
+
+	if (controls.usageLimits?.length) {
+		result.usage_limits = controls.usageLimits.map((usageLimit) => ({
+			feature_id: usageLimit.featureId,
+			...(usageLimit.enabled !== undefined
+				? { enabled: usageLimit.enabled }
+				: {}),
+			limit: usageLimit.limit,
+			interval: usageLimit.interval,
+		}));
+	}
+
+	if (controls.usageAlerts?.length) {
+		result.usage_alerts = controls.usageAlerts.map((usageAlert) => ({
+			...(usageAlert.featureId !== undefined
+				? { feature_id: usageAlert.featureId }
+				: {}),
+			...(usageAlert.enabled !== undefined
+				? { enabled: usageAlert.enabled }
+				: {}),
+			threshold: usageAlert.threshold,
+			threshold_type: usageAlert.thresholdType,
+			...(usageAlert.name !== undefined ? { name: usageAlert.name } : {}),
+		}));
+	}
+
+	if (controls.overageAllowed?.length) {
+		result.overage_allowed = controls.overageAllowed.map((overageAllowed) => ({
+			feature_id: overageAllowed.featureId,
+			...(overageAllowed.enabled !== undefined
+				? { enabled: overageAllowed.enabled }
+				: {}),
+		}));
+	}
+
+	return Object.keys(result).length > 0 ? result : undefined;
+}

--- a/packages/atmn/src/lib/transforms/sdkToApi/plan.ts
+++ b/packages/atmn/src/lib/transforms/sdkToApi/plan.ts
@@ -1,4 +1,5 @@
 import type { Plan, PlanItem } from "../../../compose/models/index.js";
+import { transformBillingControlsToApi } from "./billingControls.js";
 
 /**
  * API plan format expected by the server's CreatePlanParams schema
@@ -20,6 +21,7 @@ export interface ApiPlanParams {
 		duration_length: number;
 		card_required: boolean;
 	};
+	billing_controls?: ReturnType<typeof transformBillingControlsToApi>;
 }
 
 export interface ApiPlanItemParams {
@@ -193,6 +195,11 @@ export function transformPlanToApi(plan: Plan): ApiPlanParams {
 			duration_length: plan.freeTrial.durationLength,
 			card_required: plan.freeTrial.cardRequired,
 		};
+	}
+
+	const billingControls = transformBillingControlsToApi(plan.billingControls);
+	if (billingControls !== undefined) {
+		result.billing_controls = billingControls;
 	}
 
 	return result;

--- a/packages/atmn/src/lib/transforms/sdkToCode/plan.ts
+++ b/packages/atmn/src/lib/transforms/sdkToCode/plan.ts
@@ -75,6 +75,10 @@ export function buildPlanCode(
 		lines.push(`\tfreeTrial: ${formatValue(plan.freeTrial)},`);
 	}
 
+	if (plan.billingControls) {
+		lines.push(`\tbillingControls: ${formatValue(plan.billingControls)},`);
+	}
+
 	lines.push(`});`);
 
 	return lines.join("\n");

--- a/packages/atmn/test/codegen/variants.test.ts
+++ b/packages/atmn/test/codegen/variants.test.ts
@@ -194,4 +194,63 @@ describe("variant config generation", () => {
 		expect(code).toContain("item({ featureId: engagementTracking.id }),");
 		expect(code).not.toContain("included: 0");
 	});
+
+	test("transformApiPlans maps variant customize billing controls to camelCase", () => {
+		const plans = transformApiPlans([
+			baseApiPlan({ id: "pro", name: "Pro" }),
+			baseApiPlan({
+				id: "pro_enterprise",
+				name: "Pro Enterprise",
+				variant_details: {
+					base_plan_id: "pro",
+					customize: {
+						billing_controls: {
+							spend_limits: [
+								{
+									feature_id: "messages",
+									enabled: true,
+									overage_limit: 100,
+								},
+							],
+						},
+					},
+				},
+			}),
+		]);
+
+		expect(plans[0]?.variants?.[0]?.customize?.billingControls).toEqual({
+			spendLimits: [
+				{
+					featureId: "messages",
+					enabled: true,
+					overageLimit: 100,
+				},
+			],
+		});
+	});
+
+	test("buildConfigFile emits plan-level billing controls", () => {
+		const plans: Plan[] = [
+			{
+				id: "pro",
+				name: "Pro",
+				items: [],
+				billingControls: {
+					spendLimits: [
+						{
+							featureId: "messages",
+							enabled: true,
+							overageLimit: 25,
+						},
+					],
+				},
+			},
+		];
+
+		const code = buildConfigFile([], plans);
+
+		expect(code).toContain("billingControls:");
+		expect(code).toContain("spendLimits:");
+		expect(code).toContain("overageLimit: 25");
+	});
 });

--- a/packages/atmn/test/push/validate.test.ts
+++ b/packages/atmn/test/push/validate.test.ts
@@ -32,3 +32,67 @@ test("validateConfig rejects plan items that reference unexported features", () 
 		]),
 	);
 });
+
+test("validateConfig rejects billing controls that reference unexported features", () => {
+	const result = validateConfig(
+		[{ id: "messages", name: "Messages", type: "metered", consumable: true }],
+		[
+			{
+				id: "pro",
+				name: "Pro",
+				billingControls: {
+					spendLimits: [{ featureId: "analytics", enabled: true, overageLimit: 25 }],
+				},
+				variants: [
+					{
+						id: "pro_annual",
+						name: "Pro Annual",
+						customize: {
+							billingControls: {
+								autoTopups: [
+									{
+										featureId: "seats",
+										enabled: true,
+										threshold: 10,
+										quantity: 100,
+									},
+								],
+							},
+						},
+					},
+				],
+			},
+		],
+	);
+
+	expect(result.valid).toBe(false);
+	expect(result.errors.map((error) => error.message)).toEqual(
+		expect.arrayContaining([
+			`Feature "analytics" is referenced here but is not exported from your config.`,
+			`Feature "seats" is referenced here but is not exported from your config.`,
+		]),
+	);
+});
+
+test("validateConfig rejects duplicate spend limits per feature", () => {
+	const result = validateConfig(
+		[{ id: "messages", name: "Messages", type: "metered", consumable: true }],
+		[
+			{
+				id: "pro",
+				name: "Pro",
+				billingControls: {
+					spendLimits: [
+						{ featureId: "messages", enabled: true, overageLimit: 25 },
+						{ featureId: "messages", enabled: true, overageLimit: 50 },
+					],
+				},
+			},
+		],
+	);
+
+	expect(result.valid).toBe(false);
+	expect(result.errors[0]?.message).toBe(
+		`Only one spend limit entry is allowed per featureId.`,
+	);
+});

--- a/packages/atmn/test/transforms/billingControls.test.ts
+++ b/packages/atmn/test/transforms/billingControls.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+import { transformApiBillingControls } from "../../src/lib/transforms/apiToSdk/billingControls.js";
+import { transformBillingControlsToApi } from "../../src/lib/transforms/sdkToApi/billingControls.js";
+import { transformApiPlan } from "../../src/lib/transforms/apiToSdk/plan.js";
+import { transformPlanToApi } from "../../src/lib/transforms/sdkToApi/plan.js";
+import type { ApiPlan } from "../../src/lib/api/types/index.js";
+
+const sampleApiBillingControls = {
+	spend_limits: [
+		{
+			feature_id: "messages",
+			enabled: true,
+			limit_type: "usage_percentage" as const,
+			overage_limit: 120,
+		},
+	],
+	usage_limits: [
+		{
+			feature_id: "messages",
+			enabled: true,
+			limit: 5000,
+			interval: "month" as const,
+		},
+	],
+	auto_topups: [
+		{
+			feature_id: "messages",
+			enabled: true,
+			threshold: 20,
+			quantity: 100,
+			purchase_limit: { interval: "day" as const, interval_count: 1, limit: 3 },
+			invoice_mode: false,
+		},
+	],
+	usage_alerts: [
+		{
+			feature_id: "messages",
+			enabled: true,
+			threshold: 80,
+			threshold_type: "usage_percentage" as const,
+			name: "80% warning",
+		},
+	],
+	overage_allowed: [{ feature_id: "messages", enabled: true }],
+};
+
+const sampleSdkBillingControls = {
+	spendLimits: [
+		{
+			featureId: "messages",
+			enabled: true,
+			limitType: "usage_percentage" as const,
+			overageLimit: 120,
+		},
+	],
+	usageLimits: [
+		{
+			featureId: "messages",
+			enabled: true,
+			limit: 5000,
+			interval: "month" as const,
+		},
+	],
+	autoTopups: [
+		{
+			featureId: "messages",
+			enabled: true,
+			threshold: 20,
+			quantity: 100,
+			purchaseLimit: { interval: "day" as const, intervalCount: 1, limit: 3 },
+			invoiceMode: false,
+		},
+	],
+	usageAlerts: [
+		{
+			featureId: "messages",
+			enabled: true,
+			threshold: 80,
+			thresholdType: "usage_percentage" as const,
+			name: "80% warning",
+		},
+	],
+	overageAllowed: [{ featureId: "messages", enabled: true }],
+};
+
+describe("billing control transforms", () => {
+	test("transformApiBillingControls maps snake_case API to camelCase SDK", () => {
+		expect(transformApiBillingControls(sampleApiBillingControls)).toEqual(
+			sampleSdkBillingControls,
+		);
+	});
+
+	test("transformApiBillingControls returns undefined for empty controls", () => {
+		expect(transformApiBillingControls({})).toBeUndefined();
+		expect(transformApiBillingControls(undefined)).toBeUndefined();
+	});
+
+	test("transformBillingControlsToApi maps camelCase SDK to snake_case API", () => {
+		expect(transformBillingControlsToApi(sampleSdkBillingControls)).toEqual(
+			sampleApiBillingControls,
+		);
+	});
+
+	test("plan transforms round-trip billing controls", () => {
+		const apiPlan = {
+			id: "pro",
+			name: "Pro",
+			description: null,
+			group: null,
+			version: 1,
+			add_on: false,
+			auto_enable: false,
+			price: null,
+			items: [],
+			created_at: 0,
+			env: "sandbox",
+			archived: false,
+			base_variant_id: null,
+			config: { ignore_past_due: false },
+			billing_controls: sampleApiBillingControls,
+			metadata: {},
+		} as ApiPlan;
+
+		const sdkPlan = transformApiPlan(apiPlan);
+		expect(sdkPlan.billingControls).toEqual(sampleSdkBillingControls);
+
+		const apiParams = transformPlanToApi({ ...sdkPlan });
+		expect(apiParams.billing_controls).toEqual(sampleApiBillingControls);
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Option A** plan-level `billingControls` to the ATMN DSL, matching the `CreatePlanParamsV1` / `ApiPlanV1` OpenAPI contracts.

Plans can now define spend limits, usage limits, auto top-ups, usage alerts, and overage allowed as customer defaults:

```typescript
export const pro = plan({
  id: 'pro',
  name: 'Pro',
  items: [/* ... */],
  billingControls: {
    spendLimits: [{ featureId: messages.id, enabled: true, overageLimit: 25 }],
    autoTopups: [{ featureId: messages.id, enabled: true, threshold: 20, quantity: 100 }],
    usageLimits: [{ featureId: messages.id, limit: 5000, interval: 'month' }],
    usageAlerts: [{ featureId: messages.id, threshold: 80, thresholdType: 'usage_percentage' }],
    overageAllowed: [{ featureId: messages.id, enabled: true }],
  },
});
```

Variant `customize.billingControls` uses the same camelCase shape and now round-trips correctly (previously passed through raw snake_case API fields).

## Changes

- Add `BillingControls` types and `billingControls` field on `Plan`
- Add `apiToSdk` / `sdkToApi` billing control transforms
- Wire push (`transformPlanToApi`), pull (`transformApiPlan`), and codegen (`buildPlanCode`)
- Fix variant customize push/pull to use camelCase transforms
- Add push-time validation (feature references, one entry per feature for spend/usage/overage)
- Export `BillingControls` from `atmn` package

## Test plan

- [x] `bun test test/transforms/billingControls.test.ts`
- [x] `bun test test/codegen/variants.test.ts`
- [x] `bun test test/push/validate.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1782743765049819?thread_ts=1782743765.049819&cid=C0BCAQQK0KS)

<div><a href="https://cursor.com/agents/bc-c788feb2-3916-57cd-bfe0-c9da788b3a7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c788feb2-3916-57cd-bfe0-c9da788b3a7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds plan-level `billingControls` to the `atmn` DSL with camelCase types and transforms. Plans and variants can now set defaults for spend/usage limits, auto top-ups, usage alerts, and overage settings, with full push/pull/codegen support and validation.

- **New Features**
  - Add `BillingControls` and `plan.billingControls` (plus `customize.billingControls`) for spend/usage limits, auto top-ups, alerts, and overage.
  - Add snake_case ↔ camelCase transforms and wire into push, pull, and codegen round-trips.
  - Validate feature references and enforce one entry per feature for spend limits, usage limits, and overage allowed.
  - Export `BillingControls` from `atmn`.

- **Bug Fixes**
  - `variant.customize.billingControls` now uses camelCase and round-trips correctly (previously passed through raw snake_case).

<sup>Written for commit b63add03a896faf3393d97824a6b91607e6f8f47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

