### PR TITLE
chore: cleanup variants ui

### DIFF
--- a/packages/ui/src/components/table/table-body.tsx
+++ b/packages/ui/src/components/table/table-body.tsx
@@ -29,6 +29,7 @@ export function TableBody() {
 		emptyStateText,
 		selectedItemId,
 		flexibleTableColumns,
+		getRowClassName,
 	} = useTableContext();
 	const rows = table.getRowModel().rows;
 	const lastRowCountRef = useRef(DEFAULT_SKELETON_ROWS);
@@ -104,6 +105,7 @@ export function TableBody() {
 						className={cn(
 							"text-tertiary-foreground transition-none h-12 py-4 relative",
 							rowClassName,
+							getRowClassName?.(row.original),
 							isSelected ? "z-100" : "hover:bg-interactive-secondary-hover",
 							(onRowClick || rowHref) && "cursor-pointer",
 						)}

--- a/packages/ui/src/components/table/table-context.tsx
+++ b/packages/ui/src/components/table/table-context.tsx
@@ -53,6 +53,8 @@ export interface TableProps<T> {
 	/** For double-click actions (e.g. opening external links) */
 	onRowDoubleClick?: (row: T) => void;
 	rowClassName?: string;
+	/** Per-row className (e.g. to style nested/variant rows differently) */
+	getRowClassName?: (row: T) => string | undefined;
 	emptyStateChildren?: ReactNode;
 	emptyStateText?: string;
 	flexibleTableColumns?: boolean;

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -71,6 +71,18 @@ function DialogOverlay({
 	);
 }
 
+function DialogCloseButton() {
+	return (
+		<DialogPrimitive.Close
+			data-slot="dialog-close"
+			className="ring-offset-background focus:ring-ring data-open:bg-accent data-open:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+		>
+			<XIcon />
+			<span className="sr-only">Close</span>
+		</DialogPrimitive.Close>
+	);
+}
+
 const DialogContent = React.forwardRef<
 	HTMLDivElement,
 	DialogPrimitive.Popup.Props & {
@@ -91,15 +103,7 @@ const DialogContent = React.forwardRef<
 			{...props}
 		>
 			{children}
-			{showCloseButton && (
-				<DialogPrimitive.Close
-					data-slot="dialog-close"
-					className="ring-offset-background focus:ring-ring data-open:bg-accent data-open:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
-				>
-					<XIcon />
-					<span className="sr-only">Close</span>
-				</DialogPrimitive.Close>
-			)}
+			{showCloseButton && <DialogCloseButton />}
 		</DialogPrimitive.Popup>
 	</DialogPortal>
 ));

--- a/vite/src/hooks/useMeasuredHeight.ts
+++ b/vite/src/hooks/useMeasuredHeight.ts
@@ -1,0 +1,23 @@
+import { useLayoutEffect, useRef, useState } from "react";
+
+/**
+ * Tracks an element's content height via ResizeObserver so a wrapper can
+ * tween between sizes. Returns null until first measured to avoid a 0→h jump.
+ */
+export function useMeasuredHeight<T extends HTMLElement>() {
+	const ref = useRef<T>(null);
+	const [height, setHeight] = useState<number | null>(null);
+
+	useLayoutEffect(() => {
+		const element = ref.current;
+		if (!element) return;
+
+		const observer = new ResizeObserver(([entry]) => {
+			setHeight(entry.contentRect.height);
+		});
+		observer.observe(element);
+		return () => observer.disconnect();
+	}, []);
+
+	return { ref, height };
+}

--- a/vite/src/views/products/plan/components/CreateVariantButton.tsx
+++ b/vite/src/views/products/plan/components/CreateVariantButton.tsx
@@ -1,0 +1,40 @@
+import { IconButton } from "@autumn/ui";
+import { GitForkIcon } from "lucide-react";
+import { useMemo } from "react";
+import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
+import { useProductStore } from "@/hooks/stores/useProductStore";
+import { useCreateVariant } from "../hooks/useCreateVariant";
+import { CreateVariantDialog } from "./CreateVariantDialog";
+
+export const CreateVariantButton = () => {
+	const product = useProductStore((s) => s.product);
+	const { products } = useProductsQuery();
+	const createVariant = useCreateVariant(product);
+
+	const isVariant = !!product.base_internal_product_id;
+	// base_id is only populated on products-list entries, not the store product.
+	const hasVariants = useMemo(
+		() => products.some((p) => p.base_id === product.id),
+		[products, product.id],
+	);
+
+	if (isVariant || hasVariants) return null;
+
+	return (
+		<>
+			<IconButton
+				onClick={() => createVariant.setOpen(true)}
+				aria-label="Create variant"
+				variant="secondary"
+				iconOrientation="left"
+				icon={<GitForkIcon />}
+				size="mini"
+			>
+				Create variant
+			</IconButton>
+			{createVariant.open && (
+				<CreateVariantDialog {...createVariant.dialogProps} />
+			)}
+		</>
+	);
+};

--- a/vite/src/views/products/plan/components/CreateVariantDialog.tsx
+++ b/vite/src/views/products/plan/components/CreateVariantDialog.tsx
@@ -1,6 +1,5 @@
 import type { ProductV2 } from "@autumn/shared";
 import {
-	Button,
 	Dialog,
 	DialogContent,
 	DialogDescription,
@@ -9,6 +8,7 @@ import {
 	DialogTitle,
 	FormLabel,
 	Input,
+	ShortcutButton,
 } from "@autumn/ui";
 import { useCallback, useEffect } from "react";
 import { useAutoSlug } from "@/hooks/common/useAutoSlug";
@@ -100,15 +100,16 @@ export function CreateVariantDialog({
 					</div>
 				</div>
 				<DialogFooter>
-					<Button
+					<ShortcutButton
 						variant="primary"
+						metaShortcut="enter"
 						onClick={onCreate}
 						isLoading={isLoading}
 						disabled={isLoading || !variantId.trim() || !variantName.trim()}
-						className="w-full"
+						className="w-full justify-center"
 					>
 						Create variant
-					</Button>
+					</ShortcutButton>
 				</DialogFooter>
 			</DialogContent>
 		</Dialog>

--- a/vite/src/views/products/plan/components/EditPlanHeader.tsx
+++ b/vite/src/views/products/plan/components/EditPlanHeader.tsx
@@ -46,6 +46,7 @@ import {
 	MigrateCustomersDialog,
 	useMigratableVersions,
 } from "../versioning/MigrateCustomersDialog";
+import { CreateVariantButton } from "./CreateVariantButton";
 import { PlanToolbar } from "./PlanToolbar.tsx";
 
 const MIGRATE_CUSTOMERS = "__migrate_customers__";
@@ -276,10 +277,7 @@ export const EditPlanHeader = () => {
 								{showAllVariants ? (
 									<Tooltip>
 										<TooltipTrigger render={<span />}>
-											<SelectTrigger
-												className="w-fit min-w-28 !h-6"
-												size="sm"
-											>
+											<SelectTrigger className="w-fit min-w-28 !h-6" size="sm">
 												<SelectValue placeholder="Version" />
 											</SelectTrigger>
 										</TooltipTrigger>
@@ -328,7 +326,12 @@ export const EditPlanHeader = () => {
 								</SelectContent>
 							</Select>
 						)}
-						{!isCusPlanEditor && <PlanToolbar />}
+						{!isCusPlanEditor && (
+							<>
+								<CreateVariantButton />
+								<PlanToolbar />
+							</>
+						)}
 					</div>
 				</div>
 			</div>

--- a/vite/src/views/products/plan/components/PlanToolbar.tsx
+++ b/vite/src/views/products/plan/components/PlanToolbar.tsx
@@ -5,69 +5,21 @@ import {
 	DropdownMenuTrigger,
 	IconButton,
 } from "@autumn/ui";
-import {
-	Copy,
-	EllipsisVerticalIcon,
-	GitForkIcon,
-	Trash2,
-} from "lucide-react";
+import { Copy, EllipsisVerticalIcon, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router";
-import { toast } from "sonner";
 import { useProductStore } from "@/hooks/stores/useProductStore";
-import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { cn } from "@/lib/utils";
-import { ProductService } from "@/services/products/ProductService";
-import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { pushPage } from "@/utils/genUtils";
 import { CopyProductDialog } from "../../products/components/CopyProductDialog";
-import { CreateVariantDialog } from "./CreateVariantDialog";
 import { DeletePlanDialog } from "./DeletePlanDialog";
 
 export const PlanToolbar = () => {
 	const [deleteOpen, setDeleteOpen] = useState(false);
 	const [copyOpen, setCopyOpen] = useState(false);
-	const [createVariantOpen, setCreateVariantOpen] = useState(false);
-	const [isCreatingVariant, setIsCreatingVariant] = useState(false);
-	const [variantId, setVariantId] = useState("");
-	const [variantName, setVariantName] = useState("");
 	const navigate = useNavigate();
-	const axiosInstance = useAxiosInstance();
 	const product = useProductStore((s) => s.product);
-	const { invalidate: invalidateProducts } = useProductsQuery();
 	const [dropdownOpen, setDropdownOpen] = useState(false);
-
-	const isVariant = !!product.base_internal_product_id;
-
-	const handleCreateVariant = async () => {
-		if (!variantId.trim() || !variantName.trim()) {
-			toast.error("Variant ID and name are required");
-			return;
-		}
-		setIsCreatingVariant(true);
-		try {
-			await ProductService.createVariant(axiosInstance, {
-				base_plan_id: product.id,
-				variant_plan_id: variantId.trim(),
-				name: variantName.trim(),
-			});
-			toast.success("Variant created");
-			setCreateVariantOpen(false);
-			setVariantId("");
-			setVariantName("");
-			await invalidateProducts();
-			pushPage({
-				navigate,
-				path: `/products/${variantId.trim()}`,
-				preserveParams: true,
-			});
-		} catch (error) {
-			const message = (error as { response?: { data?: { message?: string } } })?.response?.data?.message;
-			toast.error(message ?? "Failed to create variant");
-		} finally {
-			setIsCreatingVariant(false);
-		}
-	};
 
 	return (
 		<>
@@ -99,24 +51,8 @@ export const PlanToolbar = () => {
 						className={cn("!h-6", dropdownOpen && "btn-secondary-active")}
 					/>
 				</DropdownMenuTrigger>
-			<DropdownMenuContent align="end">
-				{!isVariant && (
+				<DropdownMenuContent align="end">
 					<DropdownMenuItem
-						className="flex items-center text-xs"
-						onClick={(e) => {
-							e.stopPropagation();
-							e.preventDefault();
-							setDropdownOpen(false);
-							setCreateVariantOpen(true);
-						}}
-					>
-						<div className="flex items-center justify-between w-full gap-2">
-							Create Variant
-							<GitForkIcon size={12} className="text-tertiary-foreground" />
-						</div>
-					</DropdownMenuItem>
-				)}
-				<DropdownMenuItem
 						className="flex items-center text-xs"
 						onClick={(e) => {
 							e.stopPropagation();
@@ -146,19 +82,6 @@ export const PlanToolbar = () => {
 					</DropdownMenuItem>
 				</DropdownMenuContent>
 			</DropdownMenu>
-			{createVariantOpen && (
-				<CreateVariantDialog
-					open={createVariantOpen}
-					setOpen={setCreateVariantOpen}
-					product={product}
-					variantId={variantId}
-					setVariantId={setVariantId}
-					variantName={variantName}
-					setVariantName={setVariantName}
-					isLoading={isCreatingVariant}
-					onCreate={handleCreateVariant}
-				/>
-			)}
 		</>
 	);
 };

--- a/vite/src/views/products/plan/hooks/useCreateVariant.ts
+++ b/vite/src/views/products/plan/hooks/useCreateVariant.ts
@@ -1,0 +1,64 @@
+import type { ProductV2 } from "@autumn/shared";
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import { toast } from "sonner";
+import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
+import { ProductService } from "@/services/products/ProductService";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { pushPage } from "@/utils/genUtils";
+
+export function useCreateVariant(product: ProductV2) {
+	const navigate = useNavigate();
+	const axiosInstance = useAxiosInstance();
+	const { invalidate: invalidateProducts } = useProductsQuery();
+
+	const [open, setOpen] = useState(false);
+	const [isLoading, setIsLoading] = useState(false);
+	const [variantId, setVariantId] = useState("");
+	const [variantName, setVariantName] = useState("");
+
+	const onCreate = async () => {
+		if (!(variantId.trim() && variantName.trim())) {
+			toast.error("Variant ID and name are required");
+			return;
+		}
+		setIsLoading(true);
+		try {
+			await ProductService.createVariant(axiosInstance, {
+				base_plan_id: product.id,
+				variant_plan_id: variantId.trim(),
+				name: variantName.trim(),
+			});
+			toast.success("Variant created");
+			setOpen(false);
+			setVariantId("");
+			setVariantName("");
+			await invalidateProducts();
+			pushPage({
+				navigate,
+				path: `/products/${variantId.trim()}`,
+				preserveParams: true,
+			});
+		} catch (error) {
+			const message = (error as { response?: { data?: { message?: string } } })
+				?.response?.data?.message;
+			toast.error(message ?? "Failed to create variant");
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	const dialogProps = {
+		open,
+		setOpen,
+		product,
+		variantId,
+		setVariantId,
+		variantName,
+		setVariantName,
+		isLoading,
+		onCreate,
+	};
+
+	return { open, setOpen, dialogProps };
+}

--- a/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
+++ b/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
@@ -13,12 +13,19 @@ import {
 	ShortcutButton,
 	Switch,
 } from "@autumn/ui";
+import {
+	GitForkIcon,
+	SealCheckIcon,
+	SlidersIcon,
+	StackIcon,
+} from "@phosphor-icons/react";
 import { motion } from "motion/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { PlanPriceHeader } from "@/components/forms/shared/plan-items/PlanPriceHeader";
 import { ItemChangeList } from "@/components/v2/ItemChangeList";
+import { LAYOUT_TRANSITION } from "@/components/v2/sheets/SharedSheetComponents";
 import { useOrg } from "@/hooks/common/useOrg";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useMigrationsQuery } from "@/hooks/queries/useMigrationsQuery";
@@ -26,6 +33,7 @@ import { usePlanUpdatePreview } from "@/hooks/queries/usePlanUpdatePreview";
 import { usePlanVariants } from "@/hooks/queries/usePlanVariants";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { useProductStore } from "@/hooks/stores/useProductStore";
+import { useMeasuredHeight } from "@/hooks/useMeasuredHeight";
 import { ProductService } from "@/services/products/ProductService";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr, navigateTo } from "@/utils/genUtils";
@@ -159,6 +167,8 @@ export default function PlanChangeDialog({
 	const [confirmText, setConfirmText] = useState("");
 	const [isLoading, setIsLoading] = useState(false);
 	const [selectedVariantIds, setSelectedVariantIds] = useState<string[]>([]);
+	const { ref: bodyRef, height: bodyHeight } =
+		useMeasuredHeight<HTMLDivElement>();
 
 	const confirmed = confirmText === product.id;
 	const currency = org?.default_currency ?? "USD";
@@ -311,10 +321,14 @@ export default function PlanChangeDialog({
 
 	const steps: StepperStep[] = useMemo(
 		() => [
-			{ key: "review", label: "Changes" },
-			...(isMetadataOnly ? [] : [{ key: "strategy", label: "Versions" }]),
-			...(showScope ? [{ key: "scope", label: "Variants" }] : []),
-			{ key: "migrate", label: "Review" },
+			{ key: "review", label: "Changes", icon: SlidersIcon },
+			...(isMetadataOnly
+				? []
+				: [{ key: "strategy", label: "Versions", icon: StackIcon }]),
+			...(showScope
+				? [{ key: "scope", label: "Variants", icon: GitForkIcon }]
+				: []),
+			{ key: "migrate", label: "Review", icon: SealCheckIcon },
 		],
 		[showScope, isMetadataOnly],
 	);
@@ -455,27 +469,63 @@ export default function PlanChangeDialog({
 	}, [isFinalStep, migrateNeeded, isMetadataOnly, versionChoice, isLatest]);
 
 	const title = "Save plan changes";
+	const description = useMemo(() => {
+		switch (step) {
+			case "review":
+				return "Review what's changing before you save.";
+			case "strategy":
+				return "Choose how this applies across versions.";
+			case "scope":
+				return "Pick which variants to update alongside this plan.";
+			default:
+				return migrateNeeded
+					? "Confirm and migrate existing customers."
+					: "Confirm the changes you're about to save.";
+		}
+	}, [step, migrateNeeded]);
+	const migrateSubtitle = useMemo(() => {
+		if (isMetadataOnly) return "Applies across every version and variant.";
+		if (migrateNeeded)
+			return "Customers you don't migrate stay on their current version.";
+		return "Existing customers stay on their current version.";
+	}, [isMetadataOnly, migrateNeeded]);
 
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>
 			<DialogContent className="max-w-lg max-h-[85vh] flex flex-col gap-0 p-0 overflow-hidden">
-				<DialogHeader className="gap-3.5 p-5 pb-4 border-b border-border/60">
-					<DialogTitle className="text-[15px]">{title}</DialogTitle>
-					{steps.length > 1 && <Stepper steps={steps} currentKey={step} />}
+				<DialogHeader className="gap-3 p-4 pb-3">
+					<div className="flex flex-col gap-1.5">
+						<DialogTitle>{title}</DialogTitle>
+						<DialogDescription>{description}</DialogDescription>
+					</div>
+					{steps.length > 1 && (
+						<Stepper
+							steps={steps}
+							currentKey={step}
+							onStepSelect={(key) => setStep(key as StepKey)}
+						/>
+					)}
 				</DialogHeader>
 
-				<div className="overflow-y-auto min-h-0 flex-1 px-5 py-5">
-					<DialogDescription asChild>
+				<motion.div
+					initial={false}
+					animate={{ height: bodyHeight ?? "auto" }}
+					transition={LAYOUT_TRANSITION}
+					style={{ overflow: "clip" }}
+					className="min-h-0 shrink-0"
+				>
+					<div ref={bodyRef} className="px-4 pt-1 pb-4">
 						<motion.div
 							key={step}
-							initial={{ opacity: 0, y: 4 }}
-							animate={{ opacity: 1, y: 0 }}
-							transition={{ duration: 0.18, ease: [0.23, 1, 0.32, 1] }}
-							className="text-sm flex flex-col gap-6"
+							initial={{ opacity: 0 }}
+							animate={{ opacity: 1 }}
+							transition={{ duration: 0.15, ease: "easeOut" }}
+							className="text-sm flex flex-col gap-4"
 						>
 							{step === "review" && (
-								<div className="flex flex-col gap-3">
-									<div className="rounded-xl bg-secondary/40 px-3.5 py-3 flex flex-col gap-2">
+								<div className="flex flex-col gap-2.5">
+									<FieldLabel>Preview changes</FieldLabel>
+									<div className="rounded-lg bg-secondary/40 px-3 py-2.5 flex flex-col gap-2">
 										{priceChange && (
 											<PlanPriceHeader
 												priceChange={priceChange}
@@ -490,17 +540,20 @@ export default function PlanChangeDialog({
 							)}
 
 							{step === "scope" && (
-								<PropagateVariantsStep
-									variants={variantConflicts}
-									selectedIds={selectedVariantIds}
-									onToggle={(id) =>
-										setSelectedVariantIds((prev) =>
-											prev.includes(id)
-												? prev.filter((v) => v !== id)
-												: [...prev, id],
-										)
-									}
-								/>
+								<div className="flex flex-col gap-2.5">
+									<FieldLabel>Apply to variants</FieldLabel>
+									<PropagateVariantsStep
+										variants={variantConflicts}
+										selectedIds={selectedVariantIds}
+										onToggle={(id) =>
+											setSelectedVariantIds((prev) =>
+												prev.includes(id)
+													? prev.filter((v) => v !== id)
+													: [...prev, id],
+											)
+										}
+									/>
+								</div>
 							)}
 
 							{step === "strategy" && (
@@ -547,33 +600,27 @@ export default function PlanChangeDialog({
 
 							{step === "migrate" && (
 								<>
-									{isMetadataOnly ? (
-										<>
+									<div className="flex flex-col gap-2.5">
+										<div className="flex flex-col gap-0.5">
+											<FieldLabel>Review &amp; confirm</FieldLabel>
 											<span className="text-xs text-muted-foreground">
-												These settings apply across every version of this plan
-												and its variants.
+												{migrateSubtitle}
 											</span>
-											<div className="rounded-xl bg-secondary/40 px-3.5 py-3">
+										</div>
+										{isMetadataOnly ? (
+											<div className="rounded-lg bg-secondary/40 px-3 py-2.5">
 												<PlanSettingsChanges changes={settingsChanges} />
 											</div>
-										</>
-									) : (
-										<>
-											<span className="text-xs text-muted-foreground">
-												{migrateNeeded
-													? "Versions with customers will be migrated to the updated plan. Customers you don't migrate stay as they are."
-													: "Everything that will change. Existing customers stay on their current versions."}
-											</span>
-
+										) : (
 											<MigrateTargetsStep
 												showCustomers={migrateNeeded}
 												targets={migrateTargets}
 											/>
-										</>
-									)}
+										)}
+									</div>
 
 									{migrateNeeded && customCount > 0 && (
-										<div className="flex items-center justify-between gap-4 rounded-xl border border-border/60 px-3.5 py-3">
+										<div className="flex items-center justify-between gap-4 rounded-lg border border-border/60 px-3 py-2.5">
 											<div className="flex flex-col gap-0.5">
 												<span className="text-sm font-medium text-foreground">
 													Apply to custom plans
@@ -592,11 +639,11 @@ export default function PlanChangeDialog({
 								</>
 							)}
 						</motion.div>
-					</DialogDescription>
-				</div>
+					</div>
+				</motion.div>
 
 				{step === "migrate" && (
-					<div className="px-5 py-4 border-t border-border/60">
+					<div className="px-4 pb-1">
 						<ConfirmInput
 							productId={product.id}
 							value={confirmText}
@@ -605,10 +652,8 @@ export default function PlanChangeDialog({
 					</div>
 				)}
 
-				<DialogFooter className="flex-row justify-between gap-2 sm:justify-between p-5 pt-4 border-t border-border/60">
-					{step === "review" ? (
-						<span />
-					) : (
+				<DialogFooter className="flex-row items-center gap-2 p-4 pt-2">
+					{step !== "review" && (
 						<ShortcutButton
 							variant="secondary"
 							onClick={handleBack}
@@ -617,27 +662,25 @@ export default function PlanChangeDialog({
 							Back
 						</ShortcutButton>
 					)}
-
-					<div className="flex items-center gap-2">
-						{step === "migrate" && migrateNeeded && (
-							<ShortcutButton
-								variant="secondary"
-								onClick={() => applyChanges({ migrate: false })}
-								disabled={isLoading || !confirmed}
-							>
-								Skip
-							</ShortcutButton>
-						)}
+					{step === "migrate" && migrateNeeded && (
 						<ShortcutButton
-							variant="primary"
-							metaShortcut="enter"
-							onClick={advance}
-							isLoading={isLoading}
-							disabled={isLoading || (step === "migrate" && !confirmed)}
+							variant="secondary"
+							onClick={() => applyChanges({ migrate: false })}
+							disabled={isLoading || !confirmed}
 						>
-							{primaryText}
+							Skip
 						</ShortcutButton>
-					</div>
+					)}
+					<ShortcutButton
+						variant="primary"
+						metaShortcut="enter"
+						onClick={advance}
+						isLoading={isLoading}
+						disabled={isLoading || (step === "migrate" && !confirmed)}
+						className="flex-1 justify-center"
+					>
+						{primaryText}
+					</ShortcutButton>
 				</DialogFooter>
 			</DialogContent>
 		</Dialog>

--- a/vite/src/views/products/plan/versioning/Stepper.tsx
+++ b/vite/src/views/products/plan/versioning/Stepper.tsx
@@ -1,56 +1,57 @@
-import { CheckIcon } from "@phosphor-icons/react";
+import { CaretRightIcon, type Icon } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 
 export interface StepperStep {
 	key: string;
 	label: string;
+	icon: Icon;
 }
 
 /**
- * Horizontal numbered stepper with forward visibility — current step
- * highlighted, completed steps checked, upcoming steps dimmed.
+ * Horizontal icon stepper — current step highlighted, completed steps
+ * clickable to navigate back, upcoming steps dimmed.
  */
 export function Stepper({
 	steps,
 	currentKey,
+	onStepSelect,
 }: {
 	steps: StepperStep[];
 	currentKey: string;
+	onStepSelect?: (key: string) => void;
 }) {
 	const currentIndex = steps.findIndex((s) => s.key === currentKey);
 
 	return (
-		<div className="flex items-center gap-2.5">
+		<div className="flex items-center gap-2">
 			{steps.map((step, index) => {
-				const current = index === currentIndex;
+				const isCurrent = index === currentIndex;
 				const isComplete = index < currentIndex;
+				const StepIcon = step.icon;
 				return (
-					<div key={step.key} className="flex items-center gap-2.5">
-						<div className="flex items-center gap-2">
-							<span
-								className={cn(
-									"flex items-center justify-center size-[18px] rounded-full text-[10px] font-semibold tabular-nums transition-colors duration-200 shrink-0",
-									current && "bg-foreground text-background",
-									isComplete && "bg-foreground/10 text-foreground",
-									!current && !isComplete && "bg-transparent text-tertiary-foreground ring-1 ring-inset ring-border",
-								)}
-							>
-								{isComplete ? <CheckIcon size={10} weight="bold" /> : index + 1}
-							</span>
-							<span
-								className={cn(
-									"text-[13px] transition-colors duration-200 whitespace-nowrap",
-									current
-										? "text-foreground font-medium"
-										: "text-tertiary-foreground",
-								)}
-							>
-								{step.label}
-							</span>
-						</div>
-						{index < steps.length - 1 && (
-							<div className="h-px w-5 bg-border" />
+					<div key={step.key} className="flex items-center gap-2">
+						{index > 0 && (
+							<CaretRightIcon size={14} className="shrink-0 text-subtle" />
 						)}
+						<button
+							type="button"
+							disabled={!isComplete}
+							onClick={() => onStepSelect?.(step.key)}
+							className={cn(
+								"flex items-center gap-1.5 text-[13px] transition-colors",
+								isComplete && "cursor-pointer hover:text-muted-foreground",
+								isCurrent
+									? "text-foreground font-medium"
+									: "text-tertiary-foreground",
+							)}
+						>
+							<StepIcon
+								size={15}
+								weight={isCurrent ? "fill" : "regular"}
+								className={cn(!isCurrent && "text-subtle")}
+							/>
+							{step.label}
+						</button>
 					</div>
 				);
 			})}

--- a/vite/src/views/products/products/components/product-list/ProductListColumns.tsx
+++ b/vite/src/views/products/products/components/product-list/ProductListColumns.tsx
@@ -1,14 +1,10 @@
 import type { ProductV2 } from "@autumn/shared";
 import { MiniCopyButton } from "@autumn/ui";
-import { CaretRightIcon } from "@phosphor-icons/react";
 import type { Row } from "@tanstack/react-table";
-import { AdminHover } from "@/components/general/AdminHover";
-import { PlanTypeBadges } from "@/components/v2/badges/PlanTypeBadges";
-import { cn } from "@/lib/utils";
 import { formatUnixToDateTime } from "@/utils/formatUtils/formatDateUtils";
-import { getPlanHoverTexts } from "@/views/admin/adminUtils";
 import { ProductCountsTooltip } from "@/views/products/products/product-row-toolbar/ProductCountsTooltip";
 import { ProductListRowToolbar } from "./ProductListRowToolbar";
+import { ProductNameCell } from "./ProductNameCell";
 
 export const createProductListColumns = ({
 	showGroup = false,
@@ -22,57 +18,7 @@ export const createProductListColumns = ({
 		header: "Name",
 		accessorKey: "name",
 		enableSorting: true,
-		cell: ({ row }: { row: Row<ProductV2> }) => {
-			const isVariant = row.depth > 0;
-			const canExpand = row.getCanExpand();
-			return (
-				<div className="font-medium text-foreground flex items-center gap-1">
-					{canExpand && (
-						<button
-							type="button"
-							aria-label={row.getIsExpanded() ? "Collapse" : "Expand"}
-							onMouseDown={(e) => {
-								e.preventDefault();
-								e.stopPropagation();
-							}}
-							onClick={(e) => {
-								e.preventDefault();
-								e.stopPropagation();
-								row.toggleExpanded();
-							}}
-							className="flex items-center justify-center size-5 -ml-1 rounded cursor-pointer text-tertiary-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/10 transition-colors"
-						>
-							<CaretRightIcon
-								size={12}
-								className={cn(
-									"transition-transform duration-150",
-									row.getIsExpanded() && "rotate-90",
-								)}
-							/>
-						</button>
-					)}
-					{isVariant && (
-						<>
-							{/* Spacer matches the chevron so the variant marker aligns
-							    with the base plan's name. */}
-							<span className="size-5 -ml-1 shrink-0" aria-hidden />
-							<span className="text-tertiary-foreground pr-1">└</span>
-						</>
-					)}
-					<AdminHover
-						texts={getPlanHoverTexts({ plan: row.original })}
-						side="right"
-					>
-						{row.original.name}
-					</AdminHover>
-					<PlanTypeBadges
-						product={row.original}
-						iconOnly
-						className="bg-transparent"
-					/>
-				</div>
-			);
-		},
+		cell: ({ row }: { row: Row<ProductV2> }) => <ProductNameCell row={row} />,
 	},
 	{
 		header: "ID",

--- a/vite/src/views/products/products/components/product-list/ProductListTable.tsx
+++ b/vite/src/views/products/products/components/product-list/ProductListTable.tsx
@@ -209,6 +209,10 @@ export function ProductListTable() {
 								enableSorting,
 								isLoading: isCountsLoading,
 								getRowHref,
+								getRowClassName: (product: ProductWithCounts) =>
+									product.base_id
+										? "bg-background hover:bg-background dark:hover:bg-background"
+										: undefined,
 								emptyStateText: queryStates.showArchivedProducts
 									? "You haven't archived any plans yet"
 									: "Recurring plans that bill customers on a regular schedule",

--- a/vite/src/views/products/products/components/product-list/ProductNameCell.tsx
+++ b/vite/src/views/products/products/components/product-list/ProductNameCell.tsx
@@ -1,0 +1,75 @@
+import type { ProductV2 } from "@autumn/shared";
+import { CaretRightIcon, GitPullRequestIcon } from "@phosphor-icons/react";
+import type { Row } from "@tanstack/react-table";
+import { AdminHover } from "@/components/general/AdminHover";
+import { PlanTypeBadges } from "@/components/v2/badges/PlanTypeBadges";
+import { cn } from "@/lib/utils";
+import { getPlanHoverTexts } from "@/views/admin/adminUtils";
+
+function ExpandToggle({ row }: { row: Row<ProductV2> }) {
+	return (
+		<button
+			type="button"
+			aria-label={row.getIsExpanded() ? "Collapse variants" : "Expand variants"}
+			onMouseDown={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+			}}
+			onClick={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				row.toggleExpanded();
+			}}
+			className="-m-1 flex size-6 shrink-0 cursor-pointer items-center justify-center text-tertiary-foreground transition-colors hover:text-foreground"
+		>
+			<CaretRightIcon
+				size={12}
+				className={cn(
+					"transition-transform duration-150",
+					row.getIsExpanded() && "rotate-90",
+				)}
+			/>
+		</button>
+	);
+}
+
+function LeadSlot({ row }: { row: Row<ProductV2> }) {
+	if (row.depth > 0) {
+		return (
+			<GitPullRequestIcon
+				size={13}
+				weight="bold"
+				className="shrink-0 text-tertiary-foreground"
+				aria-hidden
+			/>
+		);
+	}
+	if (row.getCanExpand()) return <ExpandToggle row={row} />;
+	return null;
+}
+
+export function ProductNameCell({ row }: { row: Row<ProductV2> }) {
+	const isVariant = row.depth > 0;
+
+	return (
+		<div
+			className={cn(
+				"flex h-full items-center gap-1.5 font-medium text-foreground",
+				isVariant && "pl-[22px] font-normal text-muted-foreground",
+			)}
+		>
+			<LeadSlot row={row} />
+			<AdminHover
+				texts={getPlanHoverTexts({ plan: row.original })}
+				side="right"
+			>
+				{row.original.name}
+			</AdminHover>
+			<PlanTypeBadges
+				product={row.original}
+				iconOnly
+				className="bg-transparent"
+			/>
+		</div>
+	);
+}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Streamlined the variants UI: added a clear “Create variant” entry point, refreshed the plan change flow, and improved how variants render in the product list.

- New Features
  - Added CreateVariantButton with `useCreateVariant`; only shows for base plans, opens the dialog, supports Enter to submit, and navigates after creation.
  - PlanChangeDialog: icon stepper with clickable completed steps, contextual descriptions, smoother animated body via `useMeasuredHeight`, clearer migrate copy, and simplified Back/Skip/Primary actions.
  - Product list: new ProductNameCell with expand toggle or variant icon, indentation, and de-emphasized variant rows using table `getRowClassName`.
  - Dialog: extracted reusable close button in `@autumn/ui` dialog content.

- Refactors
  - Removed variant creation logic from PlanToolbar; the dropdown no longer includes “Create Variant.”
  - Extracted ProductNameCell and removed inline name/expand/variant rendering from ProductListColumns.
  - CreateVariantDialog now uses ShortcutButton with Meta/Ctrl+Enter to submit.
  - Minor layout/style tweaks in EditPlanHeader, Stepper, and PlanChangeDialog.

<sup>Written for commit 5f1806386908a17916c4cf2137f8fca9972da560. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR cleans up the variants UI by refactoring variant-creation logic into a dedicated `useCreateVariant` hook and `CreateVariantButton` component, overhauling the `PlanChangeDialog` with animated height transitions between steps, an icon-based stepper with backward navigation, and per-step descriptions, and extracting `ProductNameCell` for cleaner product list rendering.

- **Improvements**: `useCreateVariant` + `CreateVariantButton` extract variant creation from `PlanToolbar`, and the table gains a generic `getRowClassName` prop used to visually distinguish variant rows.
- **Improvements**: `PlanChangeDialog` step transitions are now animated via `useMeasuredHeight` + Framer Motion; the `Stepper` is redesigned with icons and supports clicking back to completed steps.
- **Improvements**: `ProductNameCell` splits expand-toggle and variant-indicator rendering into focused sub-components (`ExpandToggle`, `LeadSlot`), replacing inline JSX in `ProductListColumns`.
</details>

<h3>Confidence Score: 3/5</h3>

Most of the changes are safe refactors, but the animated body in PlanChangeDialog removes the existing scroll container, which can silently clip content on shorter viewports or with many plan changes.

The variant-creation extraction, table getRowClassName, stepper redesign, and ProductNameCell split are all straightforward and low-risk. The main concern is PlanChangeDialog: replacing flex-1 overflow-y-auto with a shrink-0 + overflow: clip animated wrapper removes the body's ability to scroll when content exceeds the dialog's 85vh cap — the footer or bottom of the review list can be silently clipped on shorter screens or with many item/variant changes. Additionally, CreateVariantButton now hides when the plan already has any variants, which narrows the old behavior and may be unintentional.

vite/src/views/products/plan/versioning/PlanChangeDialog.tsx — the animated body container and its interaction with the dialog's max-height constraint.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/versioning/PlanChangeDialog.tsx | Major UI rework: adds animated step transitions via useMeasuredHeight + Framer Motion, step-description text, icon-based stepper with back-navigation. Removing flex-1 overflow-y-auto from the body introduces a scrollability regression when content is tall. |
| vite/src/views/products/plan/versioning/Stepper.tsx | Redesigned from numbered circles to icon-based steps; adds optional backward navigation via onStepSelect. Future steps remain disabled correctly. |
| vite/src/hooks/useMeasuredHeight.ts | New hook using ResizeObserver + useLayoutEffect to track an element's content height for animated height tweens. Returns null on first render to avoid a 0→h jump. |
| vite/src/views/products/plan/hooks/useCreateVariant.ts | New hook extracting variant-creation state and logic from PlanToolbar. Clean extraction with no functional changes. |
| vite/src/views/products/plan/components/CreateVariantButton.tsx | New dedicated button component for variant creation; hides on variants AND on any plan that already has variants — the latter is a narrowing from the old behavior (which only hid it for variants themselves). |
| vite/src/views/products/plan/components/PlanToolbar.tsx | Removed variant-creation logic and CreateVariantDialog — moved to useCreateVariant hook and CreateVariantButton. Remaining toolbar is cleaner. |
| vite/src/views/products/products/components/product-list/ProductNameCell.tsx | New component splitting the name-cell rendering out of ProductListColumns. Uses a GitPullRequestIcon for variant rows and an ExpandToggle for expandable base plans — cleaner than the inline JSX it replaces. |
| vite/src/views/products/products/components/product-list/ProductListTable.tsx | Adds getRowClassName to give variant rows a distinct non-hoverable background, using the new table API. |
| packages/ui/src/components/table/table-context.tsx | Adds optional getRowClassName prop to TableProps for per-row dynamic class names. |
| packages/ui/src/components/ui/dialog.tsx | Extracts the close-button JSX into a DialogCloseButton sub-component for reuse. Pure refactor, no behavior change. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[EditPlanHeader] --> B[CreateVariantButton]
    A --> C[PlanToolbar]

    B --> D{isVariant OR hasVariants?}
    D -- Yes --> E[Hidden]
    D -- No --> F[IconButton: Create variant]
    F --> G[CreateVariantDialog]
    G --> H[useCreateVariant hook]
    H --> I[ProductService.createVariant]
    I --> J[Navigate to new variant]

    C --> K[Dropdown: Copy / Delete]

    subgraph PlanChangeDialog Steps
        S1[review: Preview changes]
        S2[strategy: Version choice]
        S3[scope: Variant selection]
        S4[migrate: Review & confirm]
        S1 -->|Next| S2
        S2 -->|Next| S3
        S3 -->|Next| S4
        S4 -->|Back via Stepper| S1
    end

    subgraph ProductList
        P1[ProductListTable] --> P2[ProductListColumns]
        P2 --> P3[ProductNameCell]
        P3 --> P4[LeadSlot: ExpandToggle or GitPullRequestIcon]
        P1 --> P5[getRowClassName: variant rows styled differently]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[EditPlanHeader] --> B[CreateVariantButton]
    A --> C[PlanToolbar]

    B --> D{isVariant OR hasVariants?}
    D -- Yes --> E[Hidden]
    D -- No --> F[IconButton: Create variant]
    F --> G[CreateVariantDialog]
    G --> H[useCreateVariant hook]
    H --> I[ProductService.createVariant]
    I --> J[Navigate to new variant]

    C --> K[Dropdown: Copy / Delete]

    subgraph PlanChangeDialog Steps
        S1[review: Preview changes]
        S2[strategy: Version choice]
        S3[scope: Variant selection]
        S4[migrate: Review & confirm]
        S1 -->|Next| S2
        S2 -->|Next| S3
        S3 -->|Next| S4
        S4 -->|Back via Stepper| S1
    end

    subgraph ProductList
        P1[ProductListTable] --> P2[ProductListColumns]
        P2 --> P3[ProductNameCell]
        P3 --> P4[LeadSlot: ExpandToggle or GitPullRequestIcon]
        P1 --> P5[getRowClassName: variant rows styled differently]
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/views/products/plan/versioning/PlanChangeDialog.tsx:510-543
**Dialog body no longer scrolls when content is tall**

The body container changed from `flex-1 overflow-y-auto` to a `motion.div` with `shrink-0` and `overflow: clip`. `shrink-0` means the body won't shrink inside the flex column, so if `bodyHeight` + header + footer + confirm input exceeds the dialog's `max-h-[85vh]` cap, `overflow-hidden` on `DialogContent` silently clips the footer and/or the bottom of the body — with no scroll escape. The "review" step (many item changes) and "scope" step (many variants) are the most likely to trigger this on shorter viewports.

The sibling `MigrateCustomersDialog` retains the old `overflow-y-auto min-h-0 flex-1` pattern for its body. Adding `overflow-y-auto` to the inner `div` (bodyRef) and capping its max height would let the measured-height animation still drive the step-transition tween while preserving scroll on overflow.

### Issue 2 of 2
vite/src/views/products/plan/components/CreateVariantButton.tsx:21
**Variant creation hidden once any variant exists**

The button hides when `hasVariants` is true, which prevents creating a second (or third) variant for a plan that already has at least one. The old `PlanToolbar` only checked `isVariant`, so multiple variants per base plan were previously creatable from this UI. Was the intent to limit the UI to one-variant-per-plan (with additional variants managed elsewhere), or is this an accidental regression?

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: cleanup variants ui"](https://github.com/useautumn/autumn/commit/5f1806386908a17916c4cf2137f8fca9972da560) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40551104)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->