### PR TITLE
chore: variant ui cleanup

### DIFF
--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -152,7 +152,7 @@ const DialogDescription = React.forwardRef<
 	<DialogPrimitive.Description
 		ref={ref}
 		data-slot="dialog-description"
-		className={cn("text-muted-foreground text-sm", className)}
+		className={cn("text-tertiary-foreground text-sm", className)}
 		{...props}
 	/>
 ));

--- a/vite/src/views/products/plan/components/CreateVariantButton.tsx
+++ b/vite/src/views/products/plan/components/CreateVariantButton.tsx
@@ -11,12 +11,14 @@ export const CreateVariantButton = () => {
 	const { products } = useProductsQuery();
 	const createVariant = useCreateVariant(product);
 
-	const isVariant = !!product.base_internal_product_id;
-	// base_id is only populated on products-list entries, not the store product.
-	const hasVariants = useMemo(
-		() => products.some((p) => p.base_id === product.id),
-		[products, product.id],
-	);
+	// base_id lives on the products-list entry, not the store product.
+	const { isVariant, hasVariants } = useMemo(() => {
+		const current = products.find((p) => p.id === product.id);
+		return {
+			isVariant: !!current?.base_id && current.base_id !== product.id,
+			hasVariants: products.some((p) => p.base_id === product.id),
+		};
+	}, [products, product.id]);
 
 	if (isVariant || hasVariants) return null;
 

--- a/vite/src/views/products/plan/components/EditPlanHeader.tsx
+++ b/vite/src/views/products/plan/components/EditPlanHeader.tsx
@@ -18,6 +18,7 @@ import {
 	TriangleIcon,
 	UserIcon,
 } from "@phosphor-icons/react";
+import { PlusIcon } from "lucide-react";
 import { parseAsString, useQueryStates } from "nuqs";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
@@ -42,11 +43,13 @@ import {
 	useProductQuery,
 	useProductQueryState,
 } from "../../product/hooks/useProductQuery";
+import { useCreateVariant } from "../hooks/useCreateVariant";
 import {
 	MigrateCustomersDialog,
 	useMigratableVersions,
 } from "../versioning/MigrateCustomersDialog";
 import { CreateVariantButton } from "./CreateVariantButton";
+import { CreateVariantDialog } from "./CreateVariantDialog";
 import { PlanToolbar } from "./PlanToolbar.tsx";
 
 const MIGRATE_CUSTOMERS = "__migrate_customers__";
@@ -340,6 +343,7 @@ export const EditPlanHeader = () => {
 };
 
 const SHOW_ALL_VARIANTS = "__show_all_variants__";
+const CREATE_VARIANT = "__create_variant__";
 
 const VariantSelect = () => {
 	const product = useProductStore((s) => s.product);
@@ -363,10 +367,17 @@ const VariantSelect = () => {
 		return base ? [base, ...variants] : variants;
 	}, [products, baseId]);
 
+	const baseProduct = products.find((p) => p.id === baseId);
+	const createVariant = useCreateVariant(baseProduct ?? product);
+
 	const hasVariants = variantOptions.some((p) => p.id !== baseId);
 	if (!hasVariants) return null;
 
 	const handleChange = (id: string) => {
+		if (id === CREATE_VARIANT) {
+			createVariant.setOpen(true);
+			return;
+		}
 		if (id === SHOW_ALL_VARIANTS) {
 			setShowAllVariants(true);
 			// Variant cards only exist on the base, so focus it.
@@ -385,34 +396,46 @@ const VariantSelect = () => {
 	};
 
 	return (
-		<Select
-			value={showAllVariants ? SHOW_ALL_VARIANTS : product.id}
-			onValueChange={handleChange}
-			items={{
-				...Object.fromEntries(variantOptions.map((v) => [v.id, v.name])),
-				[SHOW_ALL_VARIANTS]: "All variants",
-			}}
-		>
-			<SelectTrigger className="w-fit min-w-28 max-w-48 !h-6" size="sm">
-				<SelectValue placeholder="Variant" className="min-w-0 truncate" />
-			</SelectTrigger>
-			<SelectContent>
-				{variantOptions.map((variant) => (
-					<SelectItem key={variant.id} value={variant.id}>
-						<div className="flex items-center justify-between w-full gap-3">
-							<span>{variant.name}</span>
-							{variant.id === baseId && (
-								<IconBadge variant="muted">Base</IconBadge>
-							)}
+		<>
+			<Select
+				value={showAllVariants ? SHOW_ALL_VARIANTS : product.id}
+				onValueChange={handleChange}
+				items={{
+					...Object.fromEntries(variantOptions.map((v) => [v.id, v.name])),
+					[SHOW_ALL_VARIANTS]: "All variants",
+				}}
+			>
+				<SelectTrigger className="w-fit min-w-28 max-w-48 !h-6" size="sm">
+					<SelectValue placeholder="Variant" className="min-w-0 truncate" />
+				</SelectTrigger>
+				<SelectContent>
+					{variantOptions.map((variant) => (
+						<SelectItem key={variant.id} value={variant.id}>
+							<div className="flex items-center justify-between w-full gap-3">
+								<span>{variant.name}</span>
+								{variant.id === baseId && (
+									<span className="text-tertiary-foreground text-xs">Base</span>
+								)}
+							</div>
+						</SelectItem>
+					))}
+					<SelectSeparator />
+					<SelectItem value={SHOW_ALL_VARIANTS}>
+						<span>Show all variants</span>
+					</SelectItem>
+					<SelectSeparator />
+					<SelectItem value={CREATE_VARIANT}>
+						<div className="flex items-center gap-2">
+							<PlusIcon size={12} className="text-tertiary-foreground" />
+							<span>Create variant</span>
 						</div>
 					</SelectItem>
-				))}
-				<SelectSeparator />
-				<SelectItem value={SHOW_ALL_VARIANTS}>
-					<span>Show all variants</span>
-				</SelectItem>
-			</SelectContent>
-		</Select>
+				</SelectContent>
+			</Select>
+			{createVariant.open && (
+				<CreateVariantDialog {...createVariant.dialogProps} />
+			)}
+		</>
 	);
 };
 

--- a/vite/src/views/products/plan/versioning/MigrateTargetsStep.tsx
+++ b/vite/src/views/products/plan/versioning/MigrateTargetsStep.tsx
@@ -3,7 +3,6 @@ import type {
 	PlanUpdatePreviewItemChange,
 	PlanUpdatePreviewVariantConflict,
 } from "@autumn/shared";
-import { Badge } from "@autumn/ui";
 import { UsersIcon, WarningIcon } from "@phosphor-icons/react";
 import { ItemChangeList } from "@/components/v2/ItemChangeList";
 import { conflictSentence } from "./variantConflicts";
@@ -110,72 +109,69 @@ export function buildMigrateTargets({
 	return targets;
 }
 
-function CustomerBadge({ count }: { count: number }) {
-	if (count <= 0) return null;
+function MetaBadge({ children }: { children: React.ReactNode }) {
 	return (
-		<Badge
-			className="gap-1 text-[11px] text-muted-foreground"
-			variant="secondary"
-		>
-			<UsersIcon size={11} />
-			{count} customer{count === 1 ? "" : "s"}
-		</Badge>
+		<span className="rounded-md bg-muted px-1.5 py-0.5 text-[11px] text-tertiary-foreground tabular-nums">
+			{children}
+		</span>
 	);
 }
 
-function VersionRow({
+function VersionStatusBadges({
 	row,
 	showCustomers,
 }: {
 	row: MigrateTargetRow;
 	showCustomers: boolean;
 }) {
-	const hasChanges = row.itemChanges.length > 0 || row.hasPriceChange;
-	let versionSuffix = "";
-	if (row.isNew) versionSuffix = " · new";
-	else if (row.isCurrent) versionSuffix = " · current";
+	let status = "";
+	if (row.isNew) status = "New";
+	else if (row.isCurrent) status = "Current";
 	return (
-		<div className="flex flex-col gap-1.5 rounded-md bg-muted/40 px-2.5 py-2">
-			<div className="flex flex-wrap items-center gap-2">
-				<span className="text-xs font-medium text-foreground">
-					v{row.version}
-					{versionSuffix}
+		<div className="flex shrink-0 items-center gap-1.5">
+			<MetaBadge>v{row.version}</MetaBadge>
+			{status && <MetaBadge>{status}</MetaBadge>}
+			{showCustomers && row.customerCount > 0 && (
+				<span className="flex items-center gap-1 text-[11px] text-tertiary-foreground">
+					<UsersIcon size={11} />
+					{row.customerCount}
 				</span>
-				{showCustomers && <CustomerBadge count={row.customerCount} />}
-				{row.conflicts.length > 0 && (
-					<Badge
-						className="gap-1 bg-amber-500/10 text-[11px] text-amber-600 dark:text-amber-500"
-						variant="secondary"
-					>
-						<WarningIcon size={11} weight="fill" />
-						{row.conflicts.length} conflict
-						{row.conflicts.length === 1 ? "" : "s"}
-					</Badge>
-				)}
-			</div>
+			)}
+			{row.conflicts.length > 0 && (
+				<span className="flex items-center gap-1 text-[11px] text-amber-600 dark:text-amber-500">
+					<WarningIcon size={11} weight="fill" />
+					{row.conflicts.length}
+				</span>
+			)}
+		</div>
+	);
+}
+
+function VersionBody({ row }: { row: MigrateTargetRow }) {
+	const hasChanges = row.itemChanges.length > 0 || row.hasPriceChange;
+	return (
+		<div className="flex flex-col gap-1.5">
 			{row.itemChanges.length > 0 && (
 				<ItemChangeList itemChanges={row.itemChanges} />
 			)}
 			{row.hasPriceChange && (
-				<span className="text-xs text-muted-foreground">Base price change</span>
+				<span className="text-tertiary-foreground text-xs">
+					Base price change
+				</span>
 			)}
 			{!hasChanges && (
-				<span className="text-xs text-muted-foreground/70 italic">
+				<span className="text-tertiary-foreground/70 text-xs italic">
 					No changes
 				</span>
 			)}
-			{row.conflicts.length > 0 && (
-				<div className="flex flex-col gap-0.5">
-					{row.conflicts.map((conflict, index) => (
-						<span
-							className="text-amber-600 text-xs dark:text-amber-500"
-							key={`${conflict.reason}-${index}`}
-						>
-							{conflictSentence(conflict)}
-						</span>
-					))}
-				</div>
-			)}
+			{row.conflicts.map((conflict, index) => (
+				<span
+					className="text-amber-600 text-xs dark:text-amber-500"
+					key={`${conflict.reason}-${index}`}
+				>
+					{conflictSentence(conflict)}
+				</span>
+			))}
 		</div>
 	);
 }
@@ -189,41 +185,51 @@ export function MigrateTargetsStep({
 }) {
 	if (targets.length === 0) {
 		return (
-			<p className="text-sm text-muted-foreground">No changes to apply.</p>
+			<p className="text-sm text-tertiary-foreground">No changes to apply.</p>
 		);
 	}
 
 	return (
-		<div className="flex flex-col gap-3">
-			{targets.map((target) => (
-				<div
-					className="flex flex-col gap-2 rounded-lg border border-border p-3"
-					key={target.id}
-				>
-					<div className="flex items-center justify-between gap-2">
-						<span className="text-sm font-medium text-foreground">
-							{target.name}
-						</span>
-						{target.isBase && (
-							<Badge
-								className="text-[11px] text-muted-foreground"
-								variant="secondary"
-							>
-								Base
-							</Badge>
+		<div className="flex flex-col gap-2">
+			{targets.map((target) => {
+				const singleRow = target.rows.length === 1;
+				return (
+					<div
+						className="flex flex-col gap-2.5 rounded-xl bg-secondary/40 px-3 py-2.5"
+						key={target.id}
+					>
+						<div className="flex items-center justify-between gap-2">
+							<span className="truncate text-sm font-medium text-foreground">
+								{target.name}
+							</span>
+							<div className="flex shrink-0 items-center gap-1.5">
+								{singleRow && (
+									<VersionStatusBadges
+										row={target.rows[0]}
+										showCustomers={showCustomers}
+									/>
+								)}
+								{target.isBase && <MetaBadge>Base</MetaBadge>}
+							</div>
+						</div>
+						{singleRow ? (
+							<VersionBody row={target.rows[0]} />
+						) : (
+							<div className="flex flex-col gap-2">
+								{target.rows.map((row) => (
+									<div className="flex flex-col gap-1.5" key={row.version}>
+										<VersionStatusBadges
+											row={row}
+											showCustomers={showCustomers}
+										/>
+										<VersionBody row={row} />
+									</div>
+								))}
+							</div>
 						)}
 					</div>
-					<div className="flex flex-col gap-2">
-						{target.rows.map((row) => (
-							<VersionRow
-								key={row.version}
-								row={row}
-								showCustomers={showCustomers}
-							/>
-						))}
-					</div>
-				</div>
-			))}
+				);
+			})}
 		</div>
 	);
 }

--- a/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
+++ b/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
@@ -541,7 +541,13 @@ export default function PlanChangeDialog({
 
 							{step === "scope" && (
 								<div className="flex flex-col gap-2.5">
-									<FieldLabel>Apply to variants</FieldLabel>
+									<div className="flex flex-col gap-0.5">
+										<FieldLabel>Apply to variants</FieldLabel>
+										<span className="text-tertiary-foreground text-xs">
+											Select which variants receive this change. Unselected
+											variants stay as they are.
+										</span>
+									</div>
 									<PropagateVariantsStep
 										variants={variantConflicts}
 										selectedIds={selectedVariantIds}
@@ -603,7 +609,7 @@ export default function PlanChangeDialog({
 									<div className="flex flex-col gap-2.5">
 										<div className="flex flex-col gap-0.5">
 											<FieldLabel>Review &amp; confirm</FieldLabel>
-											<span className="text-xs text-muted-foreground">
+											<span className="text-tertiary-foreground text-xs">
 												{migrateSubtitle}
 											</span>
 										</div>

--- a/vite/src/views/products/plan/versioning/PropagateVariantsStep.tsx
+++ b/vite/src/views/products/plan/versioning/PropagateVariantsStep.tsx
@@ -1,5 +1,4 @@
 import {
-	Badge,
 	Checkbox,
 	HoverCard,
 	HoverCardContent,
@@ -31,17 +30,7 @@ export function PropagateVariantsStep({
 	const hasConflicts = variants.some((v) => v.conflicts.length > 0);
 
 	return (
-		<div className="flex flex-col gap-3">
-			<div className="flex flex-col gap-1">
-				<span className="text-sm font-medium text-foreground">
-					Apply to variants
-				</span>
-				<span className="text-xs text-muted-foreground">
-					Select which variants receive this change. Unselected variants stay as
-					they are.
-				</span>
-			</div>
-
+		<div className="flex flex-col gap-2">
 			{hasConflicts && (
 				<InfoBox variant="warning">
 					This update conflicts with certain variants. We recommend handling
@@ -56,52 +45,46 @@ export function PropagateVariantsStep({
 					return (
 						<button
 							className={cn(
-								"flex items-center gap-3 rounded-lg border p-3 text-left transition-colors",
+								"flex items-center gap-3 rounded-xl bg-secondary/40 px-3 py-2.5 text-left ring-1 transition-colors",
 								checked
-									? "border-primary bg-primary/5"
-									: "border-border hover:bg-muted/50",
+									? "ring-primary"
+									: "ring-transparent hover:bg-secondary/60",
 							)}
 							key={variant.id}
 							onClick={() => onToggle(variant.id)}
 							type="button"
 						>
 							<Checkbox checked={checked} />
-							<div className="flex min-w-0 flex-1 flex-col gap-0.5">
+							<div className="flex min-w-0 flex-1 items-baseline gap-2">
 								<span className="text-sm font-medium text-foreground">
 									{variant.name}
 								</span>
-								<span className="truncate text-xs text-muted-foreground">
+								<span className="truncate font-mono text-tertiary-foreground text-xs">
 									{variant.id}
 								</span>
 							</div>
 							<HoverCard>
 								<HoverCardTrigger asChild closeDelay={0} delay={0}>
 									<span
-										className="cursor-help"
+										className="flex shrink-0 cursor-help items-center gap-1 text-xs"
 										onClick={(e) => e.stopPropagation()}
 									>
 										{hasConflict ? (
-											<Badge
-												className="shrink-0 gap-1 bg-amber-500/10 text-[11px] text-amber-600 dark:text-amber-500"
-												variant="secondary"
-											>
+											<span className="flex items-center gap-1 text-amber-600 dark:text-amber-500">
 												<WarningIcon size={11} weight="fill" />
 												{conflictBadgeLabel(conflicts)}
-											</Badge>
+											</span>
 										) : (
-											<Badge
-												className="shrink-0 gap-1 text-[11px] text-muted-foreground"
-												variant="secondary"
-											>
+											<span className="flex items-center gap-1 text-muted-foreground">
 												<EyeIcon size={11} />
-												Preview update
-											</Badge>
+												Preview
+											</span>
 										)}
 									</span>
 								</HoverCardTrigger>
 								<HoverCardContent
 									align="start"
-									className="w-80 p-3"
+									className="w-80 rounded-lg border-none bg-interactive-secondary p-3 shadow-md ring-1 ring-foreground/10"
 									side="right"
 								>
 									<div className="flex flex-col gap-2">


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Streamlined the variants UI and versioning flows. Adds a “Create variant” action to the variant selector and fixes variant detection for when to show the create button.

- **New Features**
  - Added “Create variant” option in the variant selector that opens `CreateVariantDialog`.

- **Refactors**
  - Unified badge/label styling and colors (use tertiary text), replaced `@autumn/ui` `Badge` with lightweight inline tokens, and simplified conflict/customer indicators.
  - Reworked migrate targets layout: clearer single-vs-multi version display with version/status badges; cleaner copy and “No changes” states.
  - Updated propagate variants cards (ring/hover, concise “Preview” hover, removed duplicate header) and added helper text in the scope step; `DialogDescription` uses tertiary text.
  - Fixed `CreateVariantButton` variant/base detection by reading `base_id` from the products list entry (correct `isVariant`/`hasVariants`).

<sup>Written for commit 218976549a9a941f23c47d04b679a1b548f2197c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR is a UI cleanup pass for the variant management surfaces in the product plan views, replacing `Badge` components with inline `span` elements, standardizing muted text to `text-tertiary-foreground`, and refactoring the variant conflict/migration UI into smaller composable pieces.

- **[Improvements]** `MigrateTargetsStep` splits the monolithic `VersionRow` into `VersionStatusBadges` + `VersionBody`, enabling a smarter single-row vs multi-row layout that promotes status metadata to the card header when there is only one version row.
- **[Improvements]** `VariantSelect` in `EditPlanHeader` gains a "Create variant" inline menu item that opens the `CreateVariantDialog`, keeping variant creation discoverable while already inside the selector.
- **[Bug fixes]** `CreateVariantButton` now resolves `isVariant` from the products-list entry (which carries `base_id`) instead of the store product (which does not), fixing a case where the button could incorrectly appear on a variant plan page.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — changes are scoped to UI layout, color tokens, and component decomposition with no mutations to data or business logic.

The functional change in CreateVariantButton correctly fixes the isVariant detection by reading from the products list rather than the store product. The VariantSelect dropdown addition is wired safely with an early-return guard. The MigrateTargetsStep refactor removes the "conflict(s)" word label from the count badge (now just an icon + number), which is a minor UX regression worth a quick visual check before shipping.

MigrateTargetsStep.tsx — confirm the conflict count display (icon + number only, no "conflict(s)" label) is intentional for the redesigned card layout.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/components/CreateVariantButton.tsx | Consolidates isVariant/hasVariants derivation into a single useMemo reading from the products list; fixes the bug where the store product lacked base_id. Logic looks correct. |
| vite/src/views/products/plan/components/EditPlanHeader.tsx | Adds "Create variant" item to VariantSelect dropdown and wires up CreateVariantDialog; SELECT value is never set to CREATE_VARIANT (intercepted early) so the Select state stays consistent. The items prop omits CREATE_VARIANT which is fine but slightly inconsistent. |
| vite/src/views/products/plan/versioning/MigrateTargetsStep.tsx | Major UI restructure: splits VersionRow into VersionStatusBadges + VersionBody, replaces Badge with MetaBadge span, and promotes single-row status to card header. Conflict count now shows only the number (no "conflict(s)" label) — intentional but worth confirming UX intent. |
| vite/src/views/products/plan/versioning/PropagateVariantsStep.tsx | Removes the inline title/description block (now owned by PlanChangeDialog), swaps Badge for inline spans, and refreshes ring/bg styling. Clean change. |
| vite/src/views/products/plan/versioning/PlanChangeDialog.tsx | Lifts "Apply to variants" header and description up from PropagateVariantsStep; standardizes text color to text-tertiary-foreground. Straightforward cleanup. |
| packages/ui/src/components/ui/dialog.tsx | Single-line color token swap on DialogDescription from text-muted-foreground to text-tertiary-foreground; consistent with the rest of this PR. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant VariantSelect
    participant handleChange
    participant CreateVariantDialog
    participant CreateVariantButton

    User->>VariantSelect: "Opens dropdown (hasVariants=true)"
    VariantSelect-->>User: Shows variant list + "Show all variants" + "Create variant"

    User->>VariantSelect: Selects "Create variant"
    VariantSelect->>handleChange: "id = CREATE_VARIANT"
    handleChange->>handleChange: Early return (no Select value change)
    handleChange->>CreateVariantDialog: setOpen(true)
    CreateVariantDialog-->>User: Dialog appears

    Note over User,CreateVariantButton: When no variants exist yet
    User->>CreateVariantButton: Clicks "Create variant" button
    CreateVariantButton->>CreateVariantDialog: setOpen(true)
    CreateVariantDialog-->>User: Dialog appears
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant VariantSelect
    participant handleChange
    participant CreateVariantDialog
    participant CreateVariantButton

    User->>VariantSelect: "Opens dropdown (hasVariants=true)"
    VariantSelect-->>User: Shows variant list + "Show all variants" + "Create variant"

    User->>VariantSelect: Selects "Create variant"
    VariantSelect->>handleChange: "id = CREATE_VARIANT"
    handleChange->>handleChange: Early return (no Select value change)
    handleChange->>CreateVariantDialog: setOpen(true)
    CreateVariantDialog-->>User: Dialog appears

    Note over User,CreateVariantButton: When no variants exist yet
    User->>CreateVariantButton: Clicks "Create variant" button
    CreateVariantButton->>CreateVariantDialog: setOpen(true)
    CreateVariantDialog-->>User: Dialog appears
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/views/products/plan/versioning/MigrateTargetsStep.tsx:148-153
**Conflict count loses its unit label**

Previously the badge read "2 conflicts" (or "1 conflict"), making the number immediately self-explanatory. After the refactor it displays only the `WarningIcon` + raw number (e.g. "⚠ 2"), which requires the user to infer the unit from context. If a card has both a customer-count and a conflict count side-by-side, the two bare numbers look identical in structure. Consider keeping at least a short label (e.g. "2 conflicts" or "2 ⚠") to preserve scannability.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: variant ui cleanup"](https://github.com/useautumn/autumn/commit/218976549a9a941f23c47d04b679a1b548f2197c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40564143)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->