### PR TITLE
Fix card preview showing USD instead of org currency

### DIFF
--- a/vite/src/views/onboarding4/PricingPreview.tsx
+++ b/vite/src/views/onboarding4/PricingPreview.tsx
@@ -1,5 +1,6 @@
 import type { AgentPricingConfig } from "@autumn/shared";
 import type { ReactNode } from "react";
+import { useOrg } from "@/hooks/common/useOrg";
 import { GroupedPlanCards } from "./preview/GroupedPlanCards";
 import { PreviewCreditSchemaCard } from "./preview/PreviewCreditSchemaCard";
 import {
@@ -29,12 +30,15 @@ export function PricingPreview({
 	isSyncing,
 	headerActions,
 }: PricingPreviewProps) {
+	const { org } = useOrg();
+	const currency = org?.default_currency ?? "USD";
 	const hasProducts = config && config.products.length > 0;
 
 	const previewProducts = hasProducts
 		? transformToPreviewProducts({
 				products: config.products,
 				features: config.features,
+				currency,
 			})
 		: [];
 

--- a/vite/src/views/onboarding4/preview/previewTypes.ts
+++ b/vite/src/views/onboarding4/preview/previewTypes.ts
@@ -55,9 +55,11 @@ export interface PreviewProductItem {
 export function transformToPreviewProducts({
 	products,
 	features,
+	currency = "USD",
 }: {
 	products: AgentProduct[];
 	features: AgentFeature[];
+	currency?: string;
 }): PreviewProduct[] {
 	// Convert agent features to shared Feature type for display function
 	const sharedFeatures = features.map(agentFeatureToFeature);
@@ -66,7 +68,7 @@ export function transformToPreviewProducts({
 		// Convert to ProductV2 → FrontendProduct to use existing getBasePriceDisplay
 		const productV2 = agentProductToProductV2(product);
 		const frontendProduct = productV2ToFrontendProduct({ product: productV2 });
-		const basePrice = getBasePriceDisplay({ product: frontendProduct });
+		const basePrice = getBasePriceDisplay({ product: frontendProduct, currency });
 
 		// Normalize items for isOneOffProductV2 check (undefined → null for interval)
 		// This is needed because agentItemToProductItem may leave interval as undefined,
@@ -81,7 +83,7 @@ export function transformToPreviewProducts({
 		const featureItems = (product.items ?? [])
 			.filter((item) => item.feature_id)
 			.map((item) =>
-				transformToPreviewItem({ item, features, sharedFeatures }),
+				transformToPreviewItem({ item, features, sharedFeatures, currency }),
 			);
 
 		return {
@@ -106,10 +108,12 @@ function transformToPreviewItem({
 	item,
 	features,
 	sharedFeatures,
+	currency,
 }: {
 	item: AgentProductItem;
 	features: AgentFeature[];
 	sharedFeatures: Feature[];
+	currency: string;
 }): PreviewProductItem {
 	const agentFeature = features.find((f) => f.id === item.feature_id);
 	const featureName =
@@ -124,7 +128,7 @@ function transformToPreviewItem({
 	const displayResult = getProductItemDisplay({
 		item: productItem,
 		features: sharedFeatures,
-		currency: "USD",
+		currency,
 		fullDisplay: true,
 		amountFormatOptions: { currencyDisplay: "narrowSymbol" },
 	});

--- a/vite/tests/views/onboarding4/preview/previewTypes-currency.test.ts
+++ b/vite/tests/views/onboarding4/preview/previewTypes-currency.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentFeature, AgentProduct } from "@autumn/shared";
+import { transformToPreviewProducts } from "@/views/onboarding4/preview/previewTypes";
+
+const euroFeature: AgentFeature = {
+	id: "euros",
+	name: "Euros",
+	type: "single_use",
+};
+
+const starterPlan: AgentProduct = {
+	id: "org_starter",
+	name: "Organisation Starter",
+	items: [
+		{
+			feature_id: null,
+			price: 10,
+			interval: "month",
+		},
+		{
+			feature_id: "euros",
+			included_usage: 5,
+			price: 1,
+			usage_model: "prepaid",
+			billing_units: 1,
+			interval: "month",
+		},
+	],
+};
+
+describe("transformToPreviewProducts currency", () => {
+	test("before fix: EUR org saw USD symbols because currency defaulted to USD", () => {
+		const preview = transformToPreviewProducts({
+			products: [starterPlan],
+			features: [euroFeature],
+			currency: "USD",
+		});
+
+		expect(preview[0]?.basePrice.formattedAmount).toBe("$10");
+		expect(preview[0]?.items[0]?.display.secondaryText).toContain("$1");
+	});
+
+	test("after fix: EUR org sees euro symbols when currency is threaded through", () => {
+		const preview = transformToPreviewProducts({
+			products: [starterPlan],
+			features: [euroFeature],
+			currency: "EUR",
+		});
+
+		expect(preview[0]?.basePrice.formattedAmount).toBe("€10");
+		expect(preview[0]?.items[0]?.display.secondaryText).toContain("€1");
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Products overview card mode (AI preview) was always formatting prices in USD, even for orgs configured with EUR or other currencies. The individual product page already used `org.default_currency` correctly.

## Fix
- Read `org.default_currency` in `PricingPreview` via `useOrg()`
- Pass currency through `transformToPreviewProducts` into both `getBasePriceDisplay` and `getProductItemDisplay`

## Test
Added `previewTypes-currency.test.ts` demonstrating before/after formatting for an Organisation Starter-style plan:
- **Before:** `$10` base price, `$1 per euro` feature line
- **After:** `€10` base price, `€1 per euro` feature line

## Test plan
- [x] `bun test tests/views/onboarding4/preview/previewTypes-currency.test.ts`
- [ ] Manual: open Products → card mode with a EUR org and confirm € symbols on plan cards
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1782814971448259?thread_ts=1782814971.448259&cid=C0BCAQQK0KS)

<div><a href="https://cursor.com/agents/bc-498d0c5f-8972-57f8-9466-8b4b2e98af9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-498d0c5f-8972-57f8-9466-8b4b2e98af9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Products card preview to use the org’s default currency instead of USD. Card mode prices and feature lines now match the product detail page.

- **Bug Fixes**
  - Read `org.default_currency` via `useOrg()` in `PricingPreview` and pass `currency` into `transformToPreviewProducts`.
  - Thread `currency` to `getBasePriceDisplay` and `getProductItemDisplay` for consistent formatting.
  - Added `previewTypes-currency.test.ts`; manual check: Products → card mode with a EUR org shows € symbols.

<sup>Written for commit 643d07cc883e4bb2a7b8738719836ba495a7eb2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes the Products card-mode preview always rendering prices in USD regardless of the org's configured currency. The individual product page already used `org.default_currency` correctly; this PR brings the card preview into parity.

- **Bug fixes**: `PricingPreview` now reads `org.default_currency` via `useOrg()` and passes the value into `transformToPreviewProducts`, which threads it through to both `getBasePriceDisplay` and `getProductItemDisplay`.
- **Bug fixes**: Removes the hard-coded `"USD"` string in `transformToPreviewItem` in favour of the caller-supplied currency, with `"USD"` kept only as a default for callers that don't specify one.
- **Improvements**: Adds `previewTypes-currency.test.ts` with before/after assertions to guard against the regression.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is minimal and well-scoped, replacing a single hard-coded USD string with a caller-supplied currency that defaults back to USD, with no impact on non-EUR orgs.

Three files changed: a one-liner hook read in the component, the currency threading in the transform function, and a new test. The fallback to USD when org is still loading preserves the previous behaviour. The only concern is a slightly misleading test description, which does not affect correctness.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/onboarding4/PricingPreview.tsx | Reads org.default_currency via useOrg() and threads it into transformToPreviewProducts; falls back to "USD" during loading with safe optional chaining. |
| vite/src/views/onboarding4/preview/previewTypes.ts | Adds optional currency param (default "USD") to transformToPreviewProducts and threads it to both getBasePriceDisplay and getProductItemDisplay, replacing the previous hard-coded "USD" string. |
| vite/tests/views/onboarding4/preview/previewTypes-currency.test.ts | New unit tests for currency threading. The "before fix" test description is slightly misleading — it passes explicit USD rather than omitting the arg to exercise the true default-fallback path. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant PP as PricingPreview
    participant UO as useOrg()
    participant TTP as transformToPreviewProducts
    participant GBPD as getBasePriceDisplay
    participant GPID as getProductItemDisplay

    PP->>UO: org.default_currency
    UO-->>PP: "EUR" (or fallback "USD")
    PP->>TTP: "{ products, features, currency }"
    TTP->>GBPD: "{ product, currency }"
    GBPD-->>TTP: BasePriceDisplayResult (€10)
    TTP->>GPID: "{ item, features, currency, ... }"
    GPID-->>TTP: DisplayResult (€1 per euro)
    TTP-->>PP: PreviewProduct[]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant PP as PricingPreview
    participant UO as useOrg()
    participant TTP as transformToPreviewProducts
    participant GBPD as getBasePriceDisplay
    participant GPID as getProductItemDisplay

    PP->>UO: org.default_currency
    UO-->>PP: "EUR" (or fallback "USD")
    PP->>TTP: "{ products, features, currency }"
    TTP->>GBPD: "{ product, currency }"
    GBPD-->>TTP: BasePriceDisplayResult (€10)
    TTP->>GPID: "{ item, features, currency, ... }"
    GPID-->>TTP: DisplayResult (€1 per euro)
    TTP-->>PP: PreviewProduct[]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/tests/views/onboarding4/preview/previewTypes-currency.test.ts:32-37
The "before fix" test name implies it reproduces the pre-fix code path, but it achieves that by passing `currency: "USD"` explicitly — which is valid input both before and after the fix. The actual regression would be omitting the `currency` arg entirely (exercising the default `"USD"` fallback), which is the code path that was broken before the fix. The test still validates the right thing, but the description can create confusion for future readers.

```suggestion
	test("default currency (USD) produces dollar symbols", () => {
		const preview = transformToPreviewProducts({
			products: [starterPlan],
			features: [euroFeature],
			// no currency arg — exercises the "USD" default
		});
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix card preview showing USD instead of ..."](https://github.com/useautumn/autumn/commit/643d07cc883e4bb2a7b8738719836ba495a7eb2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40783260)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->