### PR TITLE
Add list rewards endpoint to docs sidebar

### DIFF
--- a/apps/docs/mintlify/api-reference/rewards/listRewards.mdx
+++ b/apps/docs/mintlify/api-reference/rewards/listRewards.mdx
@@ -1,0 +1,199 @@
+---
+title: "List Rewards"
+openapi: "openapi POST /v1/rewards.list"
+---
+
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
+
+Lists all rewards (coupons and feature grants) configured for your organization.
+
+### Common Use Cases
+
+<CodeGroup>
+
+```typescript List all rewards
+const rewards = await autumn.rewards.list();
+
+// Access coupons and feature grants
+const { coupons, featureGrants } = rewards;
+```
+
+</CodeGroup>
+
+### Response
+
+<DynamicResponseField name="coupons" type="object[]">
+  The list of coupons configured for the organization.
+  <Expandable title="properties">
+    <DynamicResponseField name="id" type="string">
+      The unique identifier for the coupon.
+    </DynamicResponseField>
+
+    <DynamicResponseField name="name" type="string | null">
+      A human-readable name for the coupon.
+    </DynamicResponseField>
+
+    <DynamicResponseField name="type" type="'percentage_discount' | 'fixed_discount' | 'invoice_credits'">
+      The type of discount: percentage_discount, fixed_discount, or invoice_credits.
+    </DynamicResponseField>
+
+    <DynamicResponseField name="value" type="number">
+      The discount value. A percentage for percentage_discount, or an amount for fixed_discount / invoice_credits.
+    </DynamicResponseField>
+
+    <DynamicResponseField name="duration" type="object">
+      How long the coupon applies once redeemed.
+      <Expandable title="properties">
+        <DynamicResponseField name="type" type="'once' | 'forever' | 'months'">
+          The duration type.
+        </DynamicResponseField>
+
+        <DynamicResponseField name="length" type="number">
+          The number of months (only for type 'months').
+        </DynamicResponseField>
+
+      </Expandable>
+    </DynamicResponseField>
+
+    <DynamicResponseField name="plan_ids" type="string[] | null">
+      The plan IDs the coupon applies to, or null when it applies to all plans.
+    </DynamicResponseField>
+
+    <DynamicResponseField name="promo_codes" type="object[]">
+      The promo codes customers can use to redeem the coupon.
+      <Expandable title="properties">
+        <DynamicResponseField name="code" type="string">
+          The promo code string.
+        </DynamicResponseField>
+
+        <DynamicResponseField name="global_max_redemption" type="number | null">
+          Maximum number of times this code can be redeemed across all customers, or null for unlimited.
+        </DynamicResponseField>
+
+        <DynamicResponseField name="first_time_transaction" type="boolean">
+          Whether the code can only be used by customers making their first transaction.
+        </DynamicResponseField>
+
+      </Expandable>
+    </DynamicResponseField>
+
+    <DynamicResponseField name="created_at" type="number">
+      The Unix timestamp (in milliseconds) when the coupon was created.
+    </DynamicResponseField>
+
+  </Expandable>
+</DynamicResponseField>
+
+<DynamicResponseField name="feature_grants" type="object[]">
+  The list of feature grants configured for the organization.
+  <Expandable title="properties">
+    <DynamicResponseField name="id" type="string">
+      The unique identifier for the feature grant.
+    </DynamicResponseField>
+
+    <DynamicResponseField name="name" type="string | null">
+      A human-readable name for the feature grant.
+    </DynamicResponseField>
+
+    <DynamicResponseField name="grants" type="object[]">
+      The feature grants awarded when the grant is redeemed.
+      <Expandable title="properties">
+        <DynamicResponseField name="feature_id" type="string">
+          The ID of the feature to grant.
+        </DynamicResponseField>
+
+        <DynamicResponseField name="included" type="number">
+          The amount of the feature to grant.
+        </DynamicResponseField>
+
+        <DynamicResponseField name="expiry" type="object | null">
+          When the granted balance expires.
+          <Expandable title="properties">
+            <DynamicResponseField name="type" type="'day' | 'month' | 'year'">
+              The expiry duration type.
+            </DynamicResponseField>
+
+            <DynamicResponseField name="length" type="number">
+              The number of duration units until expiry.
+            </DynamicResponseField>
+
+          </Expandable>
+        </DynamicResponseField>
+
+      </Expandable>
+    </DynamicResponseField>
+
+    <DynamicResponseField name="promo_codes" type="object[]">
+      The promo codes customers can use to redeem the feature grant.
+      <Expandable title="properties">
+        <DynamicResponseField name="code" type="string">
+          The promo code string.
+        </DynamicResponseField>
+
+        <DynamicResponseField name="max_uses" type="number | null">
+          Maximum number of times this code can be used, or null for unlimited.
+        </DynamicResponseField>
+
+      </Expandable>
+    </DynamicResponseField>
+
+    <DynamicResponseField name="created_at" type="number">
+      The Unix timestamp (in milliseconds) when the feature grant was created.
+    </DynamicResponseField>
+
+  </Expandable>
+</DynamicResponseField>
+
+
+<ResponseExample>
+```json 200
+{
+  "coupons": [
+    {
+      "id": "summer_sale",
+      "name": "Summer Sale",
+      "type": "percentage_discount",
+      "value": 20,
+      "duration": {
+        "type": "months",
+        "length": 3
+      },
+      "plan_ids": ["pro", "starter"],
+      "promo_codes": [
+        {
+          "code": "SUMMER20",
+          "global_max_redemption": 100,
+          "first_time_transaction": false
+        }
+      ],
+      "created_at": 1718000000000
+    }
+  ],
+  "feature_grants": [
+    {
+      "id": "beta_credits_grant",
+      "name": "Beta Tester Credits",
+      "promo_codes": [
+        {
+          "code": "BETA2024",
+          "max_uses": 500
+        }
+      ],
+      "grants": [
+        {
+          "feature_id": "credits",
+          "included": 1000,
+          "expiry": {
+            "type": "month",
+            "length": 1
+          }
+        }
+      ],
+      "created_at": 1718000000000
+    }
+  ]
+}
+```
+</ResponseExample>

--- a/apps/docs/mintlify/docs.json
+++ b/apps/docs/mintlify/docs.json
@@ -279,14 +279,15 @@
 							"api-reference/features/deleteFeature"
 						]
 					},
-					{
-						"group": "Rewards & Referrals",
-						"pages": [
-							"api-reference/referrals/createReferralCode",
-							"api-reference/referrals/redeemReferralCode",
-							"api-reference/rewards/redeemRewardCode"
-						]
-					},
+				{
+					"group": "Rewards & Referrals",
+					"pages": [
+						"api-reference/referrals/createReferralCode",
+						"api-reference/referrals/redeemReferralCode",
+						"api-reference/rewards/listRewards",
+						"api-reference/rewards/redeemRewardCode"
+					]
+				},
 					{
 						"group": "Webhook Events",
 						"pages": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Added the `listRewards` endpoint documentation to the Mintlify docs sidebar under the "Rewards & Referrals" section.

## Changes

- Created `/apps/docs/mintlify/api-reference/rewards/listRewards.mdx` with comprehensive documentation for the list rewards endpoint
- Updated `docs.json` to include the new endpoint in the sidebar navigation
- The endpoint returns both coupons and feature grants configured for the organization

## Note

The SDK doesn't currently have a `listRewards` method generated yet. The OpenAPI spec exists at `/rewards.list`, but the TypeScript SDK generation needs to be run to add this endpoint to `packages/sdk/src/sdk/rewards.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1782823254033039?thread_ts=1782823254.033039&cid=C0BCAQQK0KS)

<div><a href="https://cursor.com/agents/bc-d4e32c6f-1a41-40e1-956f-cb8be1a51f8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4e32c6f-1a41-40e1-956f-cb8be1a51f8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `listRewards` endpoint docs to the Mintlify API reference and the sidebar under Rewards & Referrals. Covers listing organization rewards (coupons and feature grants) with response fields and examples.

- **Migration**
  - The TypeScript SDK does not yet expose `listRewards`. Run SDK generation to add it to `packages/sdk/src/sdk/rewards.ts` (OpenAPI spec at `/v1/rewards.list`).

<sup>Written for commit ecb093f31b7b2b824a5039bdc0860f7727b1e944. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

