### PR TITLE
feat(slack-unfurl): add Slack customer-card link unfurler

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -579,6 +579,7 @@
         "@puzzmo/revenue-cat-webhook-types": "^1.1.0",
         "@react-email/components": "0.0.42",
         "@sentry/bun": "catalog:",
+        "@slack/web-api": "^7.8.0",
         "@supabase/supabase-js": "^2.46.2",
         "@tinybirdco/sdk": "^0.0.69",
         "@trigger.dev/build": "4.4.6",
@@ -642,6 +643,7 @@
         "semver": "^7.7.2",
         "stripe": "catalog:",
         "svix": "^1.45.1",
+        "takumi-js": "rc",
         "tsc-alias": "^1.8.16",
         "ws": "^8.18.0",
         "zod": "^3.25.23",
@@ -2577,6 +2579,28 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.1", "", { "dependencies": { "@tailwindcss/node": "4.2.1", "@tailwindcss/oxide": "4.2.1", "tailwindcss": "4.2.1" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7" } }, "sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w=="],
 
+    "@takumi-rs/core": ["@takumi-rs/core@1.0.0-rc.17", "", { "dependencies": { "@takumi-rs/helpers": "1.0.0-rc.17" }, "optionalDependencies": { "@takumi-rs/core-darwin-arm64": "1.0.0-rc.17", "@takumi-rs/core-darwin-x64": "1.0.0-rc.17", "@takumi-rs/core-linux-arm64-gnu": "1.0.0-rc.17", "@takumi-rs/core-linux-arm64-musl": "1.0.0-rc.17", "@takumi-rs/core-linux-x64-gnu": "1.0.0-rc.17", "@takumi-rs/core-linux-x64-musl": "1.0.0-rc.17", "@takumi-rs/core-win32-arm64-msvc": "1.0.0-rc.17", "@takumi-rs/core-win32-x64-msvc": "1.0.0-rc.17" } }, "sha512-UDDOkvoy73USHRd+gF2LQ2BfeOugOThdDY8X09FRgvMlmXS9ZdUc7YvPzpL85PWKFEFnmqoJqJZaffQqFD9MFg=="],
+
+    "@takumi-rs/core-darwin-arm64": ["@takumi-rs/core-darwin-arm64@1.0.0-rc.17", "", { "os": "darwin", "cpu": "arm64" }, "sha512-EGiw9hEReHyDxQvRTN+OSmGUCuDfQir53vqfnBjJIGVJUyQym3BaZTFOKxBIYOomEIj5DFbyJwbhUm/JU6sHjQ=="],
+
+    "@takumi-rs/core-darwin-x64": ["@takumi-rs/core-darwin-x64@1.0.0-rc.17", "", { "os": "darwin", "cpu": "x64" }, "sha512-uaEpzZfWiPAa2UzBxVoGO9v4pD+3QsYePvgkMXXzm5vOtW1xobkAwGIjS7YPQRpJy9WcrAKvOL6WpVymAZTPyw=="],
+
+    "@takumi-rs/core-linux-arm64-gnu": ["@takumi-rs/core-linux-arm64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-FtBFkmn4qVYplL2n1fwxVRx7dY15YCEJp1qJ6LSTFIMpr1gcnBUw3bJPdexLyRQnyv/9sOnNo1F9KoxGjzg2iA=="],
+
+    "@takumi-rs/core-linux-arm64-musl": ["@takumi-rs/core-linux-arm64-musl@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-A0lwZp3iVrAd1p9cxq39V6ywKTgFc3xHZYYmxtaaK9HN/2An7rNMrWEE3UY3GW/Ox1XXpoha8gkFGH2E8XYW8g=="],
+
+    "@takumi-rs/core-linux-x64-gnu": ["@takumi-rs/core-linux-x64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "x64" }, "sha512-r8Ntuk2EPe2FNV0Pp5V2XaPhKp9UdfWCgmgI0WFtpiCc0NBiBjUTgPhMg0KQsCg9UuurGSWmu8RA9RRPtspB/g=="],
+
+    "@takumi-rs/core-linux-x64-musl": ["@takumi-rs/core-linux-x64-musl@1.0.0-rc.17", "", { "os": "linux", "cpu": "x64" }, "sha512-Ag0Jny19gTbHX85rboHPgp5JHlawotqNeYxQM25PrpC9w5ODMDBbrvo0w3a7ESyqO0lATdcMSm2dQGaJfGmaWA=="],
+
+    "@takumi-rs/core-win32-arm64-msvc": ["@takumi-rs/core-win32-arm64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "arm64" }, "sha512-xSW7/jcxapVwqbsXq5Q/3r4SDTbBOWpVqDTnY+q1rokZaxvmzkXTccN9b+X69MhX7pPvwRJNr8HitHDrfDxqcQ=="],
+
+    "@takumi-rs/core-win32-x64-msvc": ["@takumi-rs/core-win32-x64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "x64" }, "sha512-fVPb8xoQBh7LzvvgZX+qjJb05ysNpOSVjrEYBBEGoyAnmX2/pdqq10Qaz3HTDdjg1BQSIm7FpsthSZ6ooI1iFQ=="],
+
+    "@takumi-rs/helpers": ["@takumi-rs/helpers@1.0.0-rc.17", "", { "peerDependencies": { "react": "^19.2.5", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react-dom"] }, "sha512-ZOhGLdxs4QLOhfoYq2zuusPKFNrwvyqqYePn6xTxfQhk4IT/R7doB6nMUa9P+At/Ynb2kJseOJmMjeUb6ESqHw=="],
+
+    "@takumi-rs/wasm": ["@takumi-rs/wasm@1.0.0-rc.17", "", { "dependencies": { "@takumi-rs/helpers": "1.0.0-rc.17" } }, "sha512-R9gaDD38dT7uQlsF56OyMWcUd+z1WQM6vqaNuAJj44fIVuwI9TNXqcAWXJh1pV8nXnxjaZb4t4LLJlvF0Bgx/w=="],
+
     "@tanstack/devtools-event-client": ["@tanstack/devtools-event-client@0.4.4", "", { "bin": { "intent": "./bin/intent.js" } }, "sha512-6T5Yop/793YI+H+5J8Hsyj4kCih9sl4t3ElLgKioW5hk3ocn+ZdSJ94tT7vL7uabxSugWYBZlOTMPzEw2puvQw=="],
 
     "@tanstack/form-core": ["@tanstack/form-core@1.33.0", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1", "@tanstack/pacer-lite": "^0.1.1", "@tanstack/store": "^0.11.0" } }, "sha512-AV4Pw9Dk4orFsuPBcDssfWMJFs+yMYBae7zZ4oTqrCf4ftNGQKxvrQRZeqKHG6A4TkiLeSvf2kzIjcVkrW7E6w=="],
@@ -2827,7 +2851,7 @@
 
     "@types/responselike": ["@types/responselike@1.0.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw=="],
 
-    "@types/retry": ["@types/retry@0.12.2", "", {}, "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow=="],
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 
     "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
@@ -5177,7 +5201,7 @@
 
     "p-some": ["p-some@6.0.0", "", { "dependencies": { "aggregate-error": "^4.0.0", "p-cancelable": "^3.0.0" } }, "sha512-CJbQCKdfSX3fIh8/QKgS+9rjm7OBNUTmwWswAFQAhc8j1NR1dsEDETUEuVUtQHZpV+J03LqWBEwvu0g1Yn+TYg=="],
 
-    "p-timeout": ["p-timeout@5.1.0", "", {}, "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="],
+    "p-timeout": ["p-timeout@3.2.0", "", { "dependencies": { "p-finally": "^1.0.0" } }, "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg=="],
 
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
@@ -5888,6 +5912,8 @@
     "tailwindcss": ["tailwindcss@4.3.1", "", {}, "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q=="],
 
     "tailwindcss-animate": ["tailwindcss-animate@1.0.7", "", { "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders" } }, "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA=="],
+
+    "takumi-js": ["takumi-js@1.0.0-rc.17", "", { "dependencies": { "@takumi-rs/core": "1.0.0-rc.17", "@takumi-rs/helpers": "1.0.0-rc.17", "@takumi-rs/wasm": "1.0.0-rc.17" } }, "sha512-WMNs2Cjiqa/RoQfBe4+pGp+wwu1XBnj36JAb3AUkNi+mRcpqdCsekVhIP1cE7lif11Ff3FOyq35kGm8NOgTzxA=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
@@ -7073,8 +7099,6 @@
 
     "@slack/web-api/@types/node": ["@types/node@25.9.4", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g=="],
 
-    "@slack/web-api/@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
-
     "@slack/web-api/p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
 
     "@smithy/abort-controller/@smithy/types": ["@smithy/types@3.7.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg=="],
@@ -7661,6 +7685,8 @@
 
     "is-online/got": ["got@12.6.1", "", { "dependencies": { "@sindresorhus/is": "^5.2.0", "@szmarczak/http-timer": "^5.0.1", "cacheable-lookup": "^7.0.0", "cacheable-request": "^10.2.8", "decompress-response": "^6.0.0", "form-data-encoder": "^2.1.2", "get-stream": "^6.0.1", "http2-wrapper": "^2.1.10", "lowercase-keys": "^3.0.0", "p-cancelable": "^3.0.0", "responselike": "^3.0.0" } }, "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ=="],
 
+    "is-online/p-timeout": ["p-timeout@5.1.0", "", {}, "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="],
+
     "is-proto-prop/lowercase-keys": ["lowercase-keys@1.0.1", "", {}, "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="],
 
     "jake/async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
@@ -7775,11 +7801,13 @@
 
     "p-any/p-cancelable": ["p-cancelable@3.0.0", "", {}, "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw=="],
 
+    "p-event/p-timeout": ["p-timeout@5.1.0", "", {}, "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="],
+
     "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
-    "p-queue/p-timeout": ["p-timeout@3.2.0", "", { "dependencies": { "p-finally": "^1.0.0" } }, "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg=="],
+    "p-retry/@types/retry": ["@types/retry@0.12.2", "", {}, "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow=="],
 
     "p-some/p-cancelable": ["p-cancelable@3.0.0", "", {}, "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw=="],
 
@@ -8288,8 +8316,6 @@
     "@eslint/eslintrc/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "@eslint/eslintrc/minimatch/brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
-
-    "@google/genai/p-retry/@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 
     "@grpc/proto-loader/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 

--- a/server/package.json
+++ b/server/package.json
@@ -152,7 +152,9 @@
 		"svix": "^1.45.1",
 		"tsc-alias": "^1.8.16",
 		"ws": "^8.18.0",
-		"zod": "^3.25.23"
+		"zod": "^3.25.23",
+		"@slack/web-api": "^7.8.0",
+		"takumi-js": "rc"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.3.1",

--- a/server/src/initHono.ts
+++ b/server/src/initHono.ts
@@ -17,6 +17,7 @@ import { oauthRouter } from "./internal/auth/oauth/oauthRouter.js";
 import { cliRouter } from "./internal/dev/cli/cliRouter.js";
 import { handleRevenueCatOAuthCallback } from "./internal/orgs/handlers/revenueCatHandlers/handleRevenueCatOAuthCallback.js";
 import { handleOAuthCallback } from "./internal/orgs/handlers/stripeHandlers/handleOAuthCallback.js";
+import { slackUnfurlRouter } from "./internal/slackUnfurl/slackUnfurlRouter.js";
 import { apiRouter } from "./routers/apiRouter.js";
 import { createChatProxyRouter } from "./routers/chatProxyRouter.js";
 import { internalRouter } from "./routers/internalRouter.js";
@@ -83,6 +84,11 @@ export const createHonoApp = () => {
 	app.get("/revenuecat/oauth_callback", handleRevenueCatOAuthCallback);
 	app.get("/ready/:token", handleReadyCheck);
 	app.get("/", handleHealthCheck);
+
+	// Slack-unfurl (/slack-unfurl/*) — own prefix so it doesn't collide with the
+	// chat proxy's /slack/* (-> leaf). Slack-facing, auths via request signature,
+	// so mounted ahead of the org/auth middleware.
+	app.route("/slack-unfurl", slackUnfurlRouter);
 
 	// Step 1: OTel HTTP span + base middleware + span enrichment
 	app.use(

--- a/server/src/internal/slackUnfurl/data/getCardData.ts
+++ b/server/src/internal/slackUnfurl/data/getCardData.ts
@@ -1,0 +1,414 @@
+import {
+	type ApiCustomerV5,
+	ApiVersionClass,
+	type AppEnv,
+	CustomerExpand,
+	type FullCustomer,
+	type FullSubject,
+	LATEST_VERSION,
+	type RangeEnum,
+} from "@autumn/shared";
+import { db } from "@/db/initDrizzle.js";
+import { createDualLogger } from "@/external/logtail/logtailUtils.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { eventActions } from "@/internal/analytics/actions/eventActions.js";
+import { CusService } from "@/internal/customers/CusService.js";
+import { getCachedFullSubject } from "@/internal/customers/cache/fullSubject/actions/getCachedFullSubject.js";
+import { getApiCustomerV2 } from "@/internal/customers/cusUtils/getApiCustomerV2/index.js";
+import { getFullSubject } from "@/internal/customers/repos/getFullSubject/index.js";
+import { createWorkerContext } from "@/queue/createWorkerContext.js";
+import type {
+	BalanceBar,
+	CustomerCardData,
+	GroupedPlan,
+	PlanStatus,
+	UsageSeries,
+} from "./types.js";
+
+/**
+ * Real data layer — runs in-process in the server:
+ *   createWorkerContext (org+env ctx, pinned to latest API version)
+ *     -> getFullSubject / getCachedFullSubject (aggregated subject)
+ *     -> getApiCustomerV2 (plans/balances/flags/invoices)
+ *   CusService.getFull (entity count) + eventActions (usage, via Tinybird).
+ */
+type Subscription = ApiCustomerV5["subscriptions"][number];
+type Balance = ApiCustomerV5["balances"][string];
+type Invoice = NonNullable<ApiCustomerV5["invoices"]>[number];
+
+/**
+ * Subject load: Redis cache first (fast), DB fallback on miss. Both paths still
+ * run the subject's lazy resets, so this is a speed win, not a reset-skip.
+ */
+async function loadSubject(
+	ctx: AutumnContext,
+	customerId: string,
+	entityId?: string,
+): Promise<FullSubject | undefined> {
+	try {
+		const cached = await getCachedFullSubject({
+			ctx,
+			customerId,
+			entityId,
+			source: "slack-unfurl",
+		});
+		if (cached.fullSubject) return cached.fullSubject;
+	} catch (error) {
+		console.warn(
+			`[slack-unfurl] cache read failed, using DB: ${String(error)}`,
+		);
+	}
+	return getFullSubject({ ctx, customerId, entityId });
+}
+
+export async function getCardDataLive(
+	orgId: string,
+	customerId: string,
+	env: AppEnv,
+): Promise<CustomerCardData | null> {
+	// env comes from the URL path (/sandbox/... = sandbox, else live), so we
+	// resolve exactly that env. Every query is org+env-scoped → tenant-safe.
+	let ctx: AutumnContext | undefined;
+	try {
+		ctx = await createWorkerContext({
+			db,
+			payload: { orgId, env, customerId },
+			logger: createDualLogger(),
+		});
+	} catch (error) {
+		console.warn(
+			`[slack-unfurl] createWorkerContext(${env}) failed for org=${orgId}: ${String(error)}`,
+		);
+		return null;
+	}
+	if (!ctx) return null;
+
+	// Pin to the latest API version — otherwise getApiCustomerV2 emits this org's
+	// legacy response shape (e.g. v1.2) with no subscriptions/balances/flags keys.
+	ctx.apiVersion = new ApiVersionClass(LATEST_VERSION);
+
+	// Invoices + expand each subscription's plan so we get real prices.
+	ctx.expand = [CustomerExpand.Invoices, CustomerExpand.SubscriptionsPlan];
+
+	// Aggregated subject (rolls entity-scoped products/entitlements/flags up to
+	// the customer) — this is what getApiCustomerV2 is built to consume.
+	let fullSubject: FullSubject | undefined;
+	try {
+		fullSubject = await loadSubject(ctx, customerId);
+	} catch (error) {
+		console.warn(
+			`[slack-unfurl] loadSubject(${env}) failed for ${customerId}: ${String(error)}`,
+		);
+		return null;
+	}
+	if (!fullSubject) {
+		console.info(
+			`[slack-unfurl] no subject ${customerId} in org=${orgId} env=${env}`,
+		);
+		return null;
+	}
+
+	const apiCustomer = await getApiCustomerV2({ ctx, fullSubject });
+
+	// Entity count comes from the full customer (getFullSubject doesn't carry it).
+	let fullCustomer: FullCustomer | undefined;
+	try {
+		fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			withSubs: false,
+			withEntities: true,
+			allowNotFound: true,
+		});
+	} catch {
+		fullCustomer = undefined;
+	}
+	const entityCount = fullCustomer?.entities?.length ?? 0;
+
+	const featureIds = Object.keys(apiCustomer.balances ?? {});
+	const usage = await fetchUsage(ctx, customerId, fullCustomer, featureIds);
+
+	// Prices live at entity level for entity-scoped plans, so the customer view
+	// flattens them. Collect each entity's plan prices to widen the range.
+	const entityPrices = await fetchEntityPlanPrices(
+		ctx,
+		customerId,
+		fullCustomer?.entities ?? [],
+	);
+
+	console.info(
+		`[slack-unfurl] resolved ${customerId} (org=${orgId} env=${env}): ` +
+			`entities=${entityCount} subs=${apiCustomer.subscriptions?.length ?? 0} ` +
+			`balances=${featureIds.length} flags=${Object.keys(apiCustomer.flags ?? {}).length} ` +
+			`invoices=${apiCustomer.invoices?.length ?? 0} usagePoints=${usage?.points.length ?? 0}`,
+	);
+	return mapToCard(orgId, apiCustomer, entityCount, usage, entityPrices);
+}
+
+async function fetchUsage(
+	ctx: AutumnContext,
+	customerId: string,
+	fullCustomer: FullCustomer | undefined,
+	featureIds: string[],
+): Promise<UsageSeries | null> {
+	if (featureIds.length === 0 || !fullCustomer) return null;
+	const params = {
+		customer_id: customerId,
+		interval: "7d" as RangeEnum,
+		event_names: featureIds, // event_name === feature id
+		bin_size: "day" as const,
+		aggregateAll: false,
+		customer: fullCustomer,
+	};
+	try {
+		const [{ formatted }, totals] = await Promise.all([
+			eventActions.aggregate({ ctx, params }),
+			eventActions.getCountAndSum({ ctx, params }),
+		]);
+
+		const points = (formatted.data ?? []).map((row) => ({
+			label: formatPeriod(row.period),
+			value: sumNumericExcept(row, "period"),
+		}));
+		const total = featureIds.reduce(
+			(acc, id) => acc + (totals[id]?.sum ?? totals[id]?.count ?? 0),
+			0,
+		);
+		if (points.every((point) => point.value === 0) && total === 0) return null;
+
+		return {
+			featureLabel: featureIds.length === 1 ? featureIds[0] : "Usage",
+			total,
+			points,
+		};
+	} catch (error) {
+		console.warn(`[slack-unfurl] usage fetch failed: ${String(error)}`);
+		return null;
+	}
+}
+
+const sumNumericExcept = (
+	row: Record<string, unknown>,
+	exclude: string,
+): number => {
+	let total = 0;
+	for (const [key, value] of Object.entries(row)) {
+		if (key === exclude) continue;
+		if (typeof value === "number") total += value;
+		else if (
+			typeof value === "string" &&
+			value !== "" &&
+			!Number.isNaN(Number(value))
+		)
+			total += Number(value);
+	}
+	return total;
+};
+
+const formatPeriod = (period: unknown): string => {
+	const date = new Date(String(period));
+	if (Number.isNaN(date.getTime())) return String(period);
+	return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+};
+
+const formatNumber = (value: number): string =>
+	Number.isFinite(value) ? value.toLocaleString("en-US") : String(value);
+
+const prettify = (id: string): string =>
+	id.replace(/[_-]+/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+
+const planStatus = (sub: Subscription): PlanStatus => {
+	if (sub.past_due) return "past_due";
+	if (sub.canceled_at != null) return "canceled";
+	if (sub.trial_ends_at != null) return "trialing";
+	return "active";
+};
+
+const formatCurrency = (total: number, currency: string | null): string => {
+	const code = (currency ?? "usd").toUpperCase();
+	try {
+		return new Intl.NumberFormat("en-US", {
+			style: "currency",
+			currency: code,
+		}).format(total);
+	} catch {
+		return `${formatNumber(total)} ${code}`;
+	}
+};
+
+const planPriceLabel = (sub: Subscription): string => {
+	const price = sub.plan?.price;
+	if (!price) return sub.add_on ? "Add-on" : "Free";
+	if (price.display?.primary_text) {
+		return [price.display.primary_text, price.display.secondary_text]
+			.filter(Boolean)
+			.join(" ");
+	}
+	return `${formatCurrency(price.amount, null)}/${price.interval}`;
+};
+
+type PriceEntry = { amount: number; label: string };
+
+const subPriceEntry = (sub: Subscription): PriceEntry => ({
+	amount: sub.plan?.price?.amount ?? 0,
+	label: planPriceLabel(sub),
+});
+
+/** Single price if every plan in the group prices the same, else "low – high". */
+const priceRangeLabel = (entries: PriceEntry[]): string => {
+	const uniqueLabels = [...new Set(entries.map((entry) => entry.label))];
+	if (uniqueLabels.length <= 1) return uniqueLabels[0] ?? "—";
+	const sorted = [...entries].sort((a, b) => a.amount - b.amount);
+	const low = sorted[0];
+	const high = sorted[sorted.length - 1];
+	return low.label === high.label ? low.label : `${low.label} – ${high.label}`;
+};
+
+/**
+ * Per-entity plan prices keyed by plan name. Entity-scoped plans price at the
+ * entity level, so the customer view flattens them — we query each entity's
+ * subject to recover the real prices and widen the range. Sequential to avoid
+ * racing on the shared ctx.
+ */
+async function fetchEntityPlanPrices(
+	ctx: AutumnContext,
+	customerId: string,
+	entities: Array<{ id?: string | null }>,
+): Promise<Map<string, PriceEntry[]>> {
+	const byName = new Map<string, PriceEntry[]>();
+	for (const entity of entities) {
+		const entityId = entity?.id;
+		if (!entityId) continue;
+		try {
+			const subject = await loadSubject(ctx, customerId, entityId);
+			if (!subject) continue;
+			const entityApi = await getApiCustomerV2({ ctx, fullSubject: subject });
+			for (const sub of entityApi.subscriptions ?? []) {
+				const name = sub.plan?.name ?? sub.plan_id;
+				const list = byName.get(name) ?? [];
+				list.push(subPriceEntry(sub));
+				byName.set(name, list);
+			}
+		} catch (error) {
+			console.warn(
+				`[slack-unfurl] entity ${entityId} price fetch failed: ${String(error)}`,
+			);
+		}
+	}
+	return byName;
+}
+
+function groupPlans(
+	subscriptions: Subscription[],
+	entityPrices: Map<string, PriceEntry[]>,
+): GroupedPlan[] {
+	// Collapse by plan name. Count comes from the customer view; the price range
+	// spans both customer- and entity-level prices (lowest to highest).
+	const groups = new Map<
+		string,
+		{ name: string; count: number; status: PlanStatus; prices: PriceEntry[] }
+	>();
+	for (const sub of subscriptions) {
+		const name = sub.plan?.name ?? sub.plan_id;
+		const existing = groups.get(name);
+		if (existing) {
+			existing.count += 1;
+			existing.prices.push(subPriceEntry(sub));
+		} else {
+			groups.set(name, {
+				name,
+				count: 1,
+				status: planStatus(sub),
+				prices: [subPriceEntry(sub)],
+			});
+		}
+	}
+	return [...groups.values()].map((group) => {
+		// Entity-scoped plans price at the entity level; the customer-level price
+		// is flattened (often a phantom "Free"). So when this plan has entity
+		// prices, those are authoritative — don't mix in the flattened price.
+		const entityList = entityPrices.get(group.name);
+		const prices =
+			entityList && entityList.length > 0 ? entityList : group.prices;
+		return {
+			name: group.name,
+			count: group.count,
+			status: group.status,
+			priceLabel: priceRangeLabel(prices),
+		};
+	});
+}
+
+function mapBalances(balances: Record<string, Balance>): BalanceBar[] {
+	return Object.entries(balances).map(([featureId, balance]) => {
+		if (balance.unlimited) {
+			return {
+				feature: prettify(balance.feature_id ?? featureId),
+				unlimited: true,
+				fraction: 1,
+				label: "Unlimited",
+				over: false,
+				overageLabel: null,
+			};
+		}
+		// Overage is derived at read time (not stored): negative remaining, else
+		// usage past the grant. Display remaining clamps at 0.
+		const granted = balance.granted;
+		const rawRemaining = balance.remaining;
+		const overage =
+			rawRemaining < 0
+				? -rawRemaining
+				: Math.max(0, (balance.usage ?? 0) - granted);
+		const remaining = Math.max(0, rawRemaining);
+		const fraction = granted > 0 ? remaining / granted : 0;
+		return {
+			feature: prettify(balance.feature_id ?? featureId),
+			unlimited: false,
+			fraction: Math.max(0, Math.min(1, fraction)),
+			label: `${formatNumber(remaining)} / ${formatNumber(granted)}`,
+			over: overage > 0,
+			overageLabel: overage > 0 ? `+${formatNumber(overage)} over` : null,
+		};
+	});
+}
+
+function mapToCard(
+	orgId: string,
+	apiCustomer: ApiCustomerV5,
+	entityCount: number,
+	usage: UsageSeries | null,
+	entityPrices: Map<string, PriceEntry[]>,
+): CustomerCardData {
+	// plan_id -> display name, from the (expanded) subscriptions.
+	const planNameById = new Map<string, string>();
+	for (const sub of apiCustomer.subscriptions ?? []) {
+		planNameById.set(sub.plan_id, sub.plan?.name ?? prettify(sub.plan_id));
+	}
+
+	const invoices = [...(apiCustomer.invoices ?? [])]
+		.sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0))
+		.slice(0, 3)
+		.map((invoice: Invoice) => ({
+			products:
+				(invoice.plan_ids ?? [])
+					.map((id) => planNameById.get(id) ?? prettify(id))
+					.join(", ") || "—",
+			status: invoice.status ?? null,
+			totalLabel: formatCurrency(invoice.total, invoice.currency),
+			createdAt: new Date(invoice.created_at).toISOString(),
+		}));
+
+	return {
+		orgId,
+		customerId: apiCustomer.id ?? "",
+		name: apiCustomer.name ?? apiCustomer.id ?? "Customer",
+		email: apiCustomer.email ?? null,
+		createdAt: new Date(apiCustomer.created_at).toISOString(),
+		entityCount,
+		plans: groupPlans(apiCustomer.subscriptions ?? [], entityPrices),
+		balances: mapBalances(apiCustomer.balances ?? {}),
+		featureFlags: Object.keys(apiCustomer.flags ?? {}).map(prettify),
+		usage,
+		invoices,
+	};
+}

--- a/server/src/internal/slackUnfurl/data/types.ts
+++ b/server/src/internal/slackUnfurl/data/types.ts
@@ -1,0 +1,65 @@
+/**
+ * The shape the renderer consumes. Decoupled from Autumn's internal models: a
+ * data-access module maps Autumn store / ClickHouse rows into this, and the
+ * takumi components only ever see this.
+ *
+ * Every fetch that produces a `CustomerCardData` MUST be scoped to `orgId`.
+ */
+export type PlanStatus = "active" | "trialing" | "canceled" | "past_due";
+
+/** Plans collapsed by name: "Enterprise ×5" rather than one row per entity. */
+export type GroupedPlan = {
+	name: string;
+	count: number;
+	status: PlanStatus;
+	priceLabel: string; // preformatted, e.g. "$200,000/yr" or "Free"
+};
+
+/** A feature balance rendered as a progress bar. */
+export type BalanceBar = {
+	feature: string;
+	unlimited: boolean;
+	/** Fraction of the bar to fill, 0..1 (ignored when unlimited). */
+	fraction: number;
+	/** Right-aligned label, e.g. "500 / 500" or "Unlimited". */
+	label: string;
+	/** True when usage exceeded the grant — renders as an over-limit bar. */
+	over: boolean;
+	/** e.g. "+7,519 over", or null when not in overage. */
+	overageLabel: string | null;
+};
+
+/** One column of the usage bar chart. */
+export type UsagePoint = { label: string; value: number };
+
+export type UsageSeries = {
+	featureLabel: string; // e.g. "AI_CREDITS"
+	total: number;
+	points: UsagePoint[];
+};
+
+/** One invoice, with its real status — never collapsed to a single bucket. */
+export type InvoiceLine = {
+	/** Product names this invoice is for, e.g. "Enterprise, Add On Pro". */
+	products: string;
+	/** draft | open | void | paid | uncollectible | null — verbatim from source. */
+	status: string | null;
+	totalLabel: string; // currency-formatted, e.g. "$200,000.00"
+	createdAt: string; // ISO
+};
+
+export type CustomerCardData = {
+	orgId: string;
+	customerId: string;
+	name: string;
+	email: string | null;
+	createdAt: string; // ISO
+
+	entityCount: number;
+	plans: GroupedPlan[];
+	balances: BalanceBar[];
+	featureFlags: string[];
+	usage: UsageSeries | null;
+
+	invoices: InvoiceLine[];
+};

--- a/server/src/internal/slackUnfurl/env.ts
+++ b/server/src/internal/slackUnfurl/env.ts
@@ -1,0 +1,44 @@
+/**
+ * Slack-unfurl config, read from the server's env. NON-throwing on purpose:
+ * this module is imported by the main server, so a missing Slack secret must
+ * NOT crash boot — handlers fail closed (401 / no-op) instead.
+ *
+ * `ALU_`-prefixed names win so they don't collide with any `SLACK_*` the server
+ * vault already defines (e.g. leaf's app).
+ */
+const firstOf = (names: string[], fallback = ""): string => {
+	for (const name of names) {
+		const value = process.env[name];
+		if (value) return value;
+	}
+	return fallback;
+};
+
+export const env = {
+	SLACK_SIGNING_SECRET: firstOf([
+		"ALU_SLACK_SIGNING_SECRET",
+		"SLACK_SIGNING_SECRET",
+	]),
+	SLACK_BOT_TOKEN: firstOf(["ALU_SLACK_BOT_TOKEN", "SLACK_BOT_TOKEN"]),
+	/** JSON map: { "<channel_id>": "<org_id>" }. The tenancy key. */
+	SLACK_CHANNEL_ORG_MAP: firstOf(
+		["ALU_SLACK_CHANNEL_ORG_MAP", "SLACK_CHANNEL_ORG_MAP"],
+		"{}",
+	),
+	/** Host whose /customers/<id> links we unfurl. */
+	APP_HOST: process.env.APP_HOST ?? "app.useautumn.com",
+	/**
+	 * Publicly reachable base url of the server (used to build the card image_url).
+	 * Falls back to NGROK_URL — the server's existing dev-tunnel convention (also
+	 * used by stripe/revenuecat) — so local testing needs no extra var.
+	 */
+	PUBLIC_BASE_URL: firstOf([
+		"ALU_PUBLIC_BASE_URL",
+		"PUBLIC_BASE_URL",
+		"NGROK_URL",
+	]),
+};
+
+/** True only when the Slack creds are present — handlers no-op otherwise. */
+export const isSlackUnfurlConfigured = (): boolean =>
+	env.SLACK_SIGNING_SECRET !== "" && env.SLACK_BOT_TOKEN !== "";

--- a/server/src/internal/slackUnfurl/render/CustomerCard.tsx
+++ b/server/src/internal/slackUnfurl/render/CustomerCard.tsx
@@ -1,0 +1,397 @@
+import type { CSSProperties } from "react";
+import type {
+	BalanceBar,
+	CustomerCardData,
+	GroupedPlan,
+	InvoiceLine,
+	UsageSeries,
+} from "../data/types.js";
+import { statusColor, theme } from "./theme.js";
+import { usageChartSvgDataUri } from "./usageChartSvg.js";
+
+/**
+ * Pure presentational component for the unfurl card. takumi paints a flex/grid
+ * tree (no DOM, no hooks, no recharts) — bespoke static JSX styled with the
+ * shared brand tokens. Width is fixed; height grows with content.
+ */
+
+export const CARD_WIDTH = 1100;
+const CHART_HEIGHT = 90;
+const MAX_FLAGS = 40;
+
+const col = (style?: CSSProperties): CSSProperties => ({
+	display: "flex",
+	flexDirection: "column",
+	...style,
+});
+const row = (style?: CSSProperties): CSSProperties => ({
+	display: "flex",
+	flexDirection: "row",
+	...style,
+});
+
+const invoiceStatusColor: Record<string, string> = {
+	paid: theme.positive,
+	open: theme.warning,
+	draft: theme.subtle,
+	void: theme.subtle,
+	uncollectible: theme.danger,
+};
+
+function Pill({ text, color }: { text: string; color: string }) {
+	return (
+		<div
+			style={{
+				display: "flex",
+				color,
+				border: `1px solid ${color}`,
+				borderRadius: 999,
+				padding: "2px 12px",
+				fontSize: 18,
+				fontWeight: 600,
+			}}
+		>
+			{text}
+		</div>
+	);
+}
+
+function SectionLabel({ text }: { text: string }) {
+	return (
+		<span style={{ color: theme.muted, fontSize: 20, fontWeight: 600 }}>
+			{text}
+		</span>
+	);
+}
+
+function PlanRow({ plan }: { plan: GroupedPlan }) {
+	return (
+		<div
+			style={row({
+				justifyContent: "space-between",
+				alignItems: "center",
+				padding: "14px 18px",
+				backgroundColor: theme.surface,
+				border: `1px solid ${theme.border}`,
+				borderRadius: 12,
+			})}
+		>
+			<div style={row({ alignItems: "center", gap: 10 })}>
+				<span style={{ fontSize: 26, fontWeight: 700 }}>{plan.name}</span>
+				{plan.count > 1 ? (
+					<span
+						style={{
+							fontSize: 20,
+							fontWeight: 700,
+							color: theme.purple,
+							backgroundColor: theme.purpleSoft,
+							borderRadius: 8,
+							padding: "2px 10px",
+						}}
+					>
+						×{plan.count}
+					</span>
+				) : null}
+			</div>
+			<div style={row({ alignItems: "center", gap: 16 })}>
+				<span style={{ fontSize: 22, color: theme.muted }}>
+					{plan.priceLabel}
+				</span>
+				<Pill
+					text={plan.status.toUpperCase()}
+					color={statusColor[plan.status] ?? theme.muted}
+				/>
+			</div>
+		</div>
+	);
+}
+
+function BalanceRow({ balance }: { balance: BalanceBar }) {
+	// Over-limit: fill the whole bar in the danger colour to signal maxed + over.
+	const fillPct = balance.over
+		? 100
+		: balance.unlimited
+			? 100
+			: Math.round(balance.fraction * 100);
+	const fillColor = balance.over ? theme.danger : theme.purple;
+	return (
+		<div style={col({ gap: 8 })}>
+			<div style={row({ justifyContent: "space-between", alignItems: "center" })}>
+				<span style={{ fontSize: 22, fontWeight: 600 }}>{balance.feature}</span>
+				<div style={row({ alignItems: "center", gap: 10 })}>
+					<span style={{ fontSize: 20, color: theme.muted }}>{balance.label}</span>
+					{balance.overageLabel ? (
+						<span
+							style={{ fontSize: 20, fontWeight: 600, color: theme.danger }}
+						>
+							{balance.overageLabel}
+						</span>
+					) : null}
+				</div>
+			</div>
+			<div
+				style={{
+					display: "flex",
+					width: "100%",
+					height: 12,
+					backgroundColor: theme.track,
+					borderRadius: 999,
+				}}
+			>
+				<div
+					style={{
+						display: "flex",
+						width: `${fillPct}%`,
+						height: "100%",
+						backgroundColor: fillColor,
+						borderRadius: 999,
+					}}
+				/>
+			</div>
+		</div>
+	);
+}
+
+function UsageChart({ usage }: { usage: UsageSeries }) {
+	const first = usage.points[0]?.label;
+	const last = usage.points[usage.points.length - 1]?.label;
+	return (
+		<div style={col({ gap: 8 })}>
+			<div style={row({ justifyContent: "space-between", alignItems: "center" })}>
+				<SectionLabel text="Usage (7d)" />
+				<div style={row({ alignItems: "center", gap: 10 })}>
+					<span style={{ fontSize: 20, color: theme.muted }}>
+						{usage.featureLabel}
+					</span>
+					<span style={{ fontSize: 24, fontWeight: 700, color: theme.purple }}>
+						{formatCompact(usage.total)}
+					</span>
+				</div>
+			</div>
+			<img
+				src={usageChartSvgDataUri(usage.points, { height: CHART_HEIGHT })}
+				alt="usage"
+				style={{ display: "flex", width: "100%", height: CHART_HEIGHT }}
+			/>
+			<div style={row({ justifyContent: "space-between" })}>
+				<span style={{ fontSize: 15, color: theme.subtle }}>{first}</span>
+				<span style={{ fontSize: 15, color: theme.subtle }}>{last}</span>
+			</div>
+		</div>
+	);
+}
+
+function FlagChips({ flags }: { flags: string[] }) {
+	const shown = flags.slice(0, MAX_FLAGS);
+	const overflow = flags.length - shown.length;
+	return (
+		<div style={col({ gap: 12 })}>
+			<SectionLabel text={`Flags (${flags.length})`} />
+			<div style={row({ gap: 8, flexWrap: "wrap" })}>
+				{shown.map((flag) => (
+					<div
+						key={flag}
+						style={{
+							display: "flex",
+							fontSize: 16,
+							color: theme.foreground,
+							backgroundColor: theme.surface,
+							border: `1px solid ${theme.border}`,
+							borderRadius: 8,
+							padding: "5px 12px",
+						}}
+					>
+						{flag}
+					</div>
+				))}
+				{overflow > 0 ? (
+					<div
+						style={{
+							display: "flex",
+							fontSize: 16,
+							color: theme.muted,
+							padding: "5px 12px",
+						}}
+					>
+						+{overflow} more
+					</div>
+				) : null}
+			</div>
+		</div>
+	);
+}
+
+const INVOICE_TOTAL_COL = 200;
+const INVOICE_DATE_COL = 170;
+
+function InvoiceHeader() {
+	const cell: CSSProperties = {
+		fontSize: 16,
+		color: theme.subtle,
+		textTransform: "uppercase",
+	};
+	return (
+		<div
+			style={row({
+				alignItems: "center",
+				paddingBottom: 8,
+				borderBottom: `1px solid ${theme.border}`,
+			})}
+		>
+			<span style={{ ...cell, flex: 1 }}>Products</span>
+			<span style={{ ...cell, width: INVOICE_TOTAL_COL, textAlign: "right" }}>
+				Total
+			</span>
+			<span style={{ ...cell, width: INVOICE_DATE_COL, textAlign: "right" }}>
+				Created
+			</span>
+		</div>
+	);
+}
+
+function InvoiceRow({ invoice }: { invoice: InvoiceLine }) {
+	const status = invoice.status ?? "unknown";
+	const statusColr = invoiceStatusColor[status] ?? theme.subtle;
+	return (
+		<div
+			style={row({
+				alignItems: "center",
+				padding: "12px 0",
+				borderBottom: `1px solid ${theme.border}`,
+			})}
+		>
+			<div style={row({ flex: 1, alignItems: "center", gap: 12 })}>
+				<span style={{ fontSize: 21, fontWeight: 700 }}>{invoice.products}</span>
+				<span
+					style={{
+						fontSize: 17,
+						fontWeight: 400,
+						color: statusColr,
+						textTransform: "capitalize",
+					}}
+				>
+					{status}
+				</span>
+			</div>
+			<span
+				style={{
+					width: INVOICE_TOTAL_COL,
+					textAlign: "right",
+					fontSize: 20,
+					fontWeight: 600,
+				}}
+			>
+				{invoice.totalLabel}
+			</span>
+			<span
+				style={{
+					width: INVOICE_DATE_COL,
+					textAlign: "right",
+					fontSize: 18,
+					color: theme.subtle,
+				}}
+			>
+				{formatDate(invoice.createdAt)}
+			</span>
+		</div>
+	);
+}
+
+export function CustomerCard({ data }: { data: CustomerCardData }) {
+	const primaryStatus = data.plans[0]?.status;
+	return (
+		<div
+			style={col({
+				width: CARD_WIDTH,
+				backgroundColor: theme.bg,
+				padding: 44,
+				gap: 30,
+				fontFamily: "sans-serif",
+				color: theme.foreground,
+			})}
+		>
+			{/* Header */}
+			<div style={row({ justifyContent: "space-between", alignItems: "flex-start" })}>
+				<div style={col({ gap: 6 })}>
+					<span style={{ fontSize: 46, fontWeight: 800 }}>{data.name}</span>
+					<span style={{ color: theme.muted, fontSize: 20 }}>
+						{data.email ?? data.customerId}
+					</span>
+				</div>
+				<div style={col({ alignItems: "flex-end", gap: 10 })}>
+					{primaryStatus ? (
+						<Pill
+							text={primaryStatus.toUpperCase()}
+							color={statusColor[primaryStatus] ?? theme.muted}
+						/>
+					) : null}
+					<span style={{ fontSize: 20, color: theme.muted }}>
+						{data.entityCount} {data.entityCount === 1 ? "entity" : "entities"}
+					</span>
+				</div>
+			</div>
+
+			{/* Plans */}
+			{data.plans.length > 0 ? (
+				<div style={col({ gap: 12 })}>
+					<SectionLabel text="Plans" />
+					{data.plans.map((plan) => (
+						<PlanRow key={plan.name} plan={plan} />
+					))}
+				</div>
+			) : null}
+
+			{/* Balances */}
+			{data.balances.length > 0 ? (
+				<div style={col({ gap: 16 })}>
+					<SectionLabel text="Balances" />
+					{data.balances.map((balance) => (
+						<BalanceRow key={balance.feature} balance={balance} />
+					))}
+				</div>
+			) : null}
+
+			{/* Usage */}
+			{data.usage && data.usage.points.length > 0 ? (
+				<UsageChart usage={data.usage} />
+			) : null}
+
+			{/* Flags */}
+			{data.featureFlags.length > 0 ? (
+				<FlagChips flags={data.featureFlags} />
+			) : null}
+
+			{/* Invoices */}
+			{data.invoices.length > 0 ? (
+				<div style={col({ gap: 4 })}>
+					<SectionLabel text="Invoices" />
+					<InvoiceHeader />
+					{data.invoices.map((invoice, index) => (
+						<InvoiceRow key={`${invoice.createdAt}-${index}`} invoice={invoice} />
+					))}
+				</div>
+			) : null}
+
+			{/* Footer */}
+			<span style={{ color: theme.subtle, fontSize: 15 }}>
+				{data.orgId} · {data.customerId}
+			</span>
+		</div>
+	);
+}
+
+const formatCompact = (value: number): string => {
+	if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(2)}M`;
+	if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+	return String(Math.round(value));
+};
+
+const formatDate = (iso: string): string => {
+	const date = new Date(iso);
+	if (Number.isNaN(date.getTime())) return "";
+	return date.toLocaleDateString("en-US", {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+	});
+};

--- a/server/src/internal/slackUnfurl/render/cardToken.ts
+++ b/server/src/internal/slackUnfurl/render/cardToken.ts
@@ -1,0 +1,61 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { AppEnv } from "@autumn/shared";
+import { env } from "../env.js";
+
+/**
+ * The card PNG is served from a PUBLIC url (Slack fetches it), so the token in
+ * that url is HMAC-signed: only urls we minted resolve, and the tenant identity
+ * (orgId + env) is baked in and signed — it can't be tampered to probe another
+ * org/env. The route still re-runs ownership validation on every fetch.
+ *
+ * One token can carry up to 3 customers (one composite image, cards side-by-side).
+ */
+const MAX_ITEMS = 3;
+
+type CardItem = { customerId: string; env: AppEnv };
+type CardClaims = { orgId: string; items: CardItem[] };
+
+const b64url = (input: string): string =>
+	Buffer.from(input).toString("base64url");
+
+const sign = (payload: string): string =>
+	createHmac("sha256", env.SLACK_SIGNING_SECRET)
+		.update(payload)
+		.digest("base64url")
+		.slice(0, 24);
+
+export function signCardToken(claims: CardClaims): string {
+	const payload = b64url(JSON.stringify(claims));
+	return `${payload}.${sign(payload)}`;
+}
+
+export function verifyCardToken(token: string): CardClaims | null {
+	const [payload, sig] = token.split(".");
+	if (!(payload && sig)) return null;
+
+	const expected = sign(payload);
+	const a = Buffer.from(expected);
+	const b = Buffer.from(sig);
+	if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
+
+	try {
+		const parsed = JSON.parse(Buffer.from(payload, "base64url").toString());
+		if (typeof parsed?.orgId !== "string" || !Array.isArray(parsed?.items)) {
+			return null;
+		}
+		const items: CardItem[] = [];
+		for (const item of parsed.items.slice(0, MAX_ITEMS)) {
+			if (
+				typeof item?.customerId === "string" &&
+				(item?.env === AppEnv.Live || item?.env === AppEnv.Sandbox)
+			) {
+				items.push({ customerId: item.customerId, env: item.env });
+			}
+		}
+		if (items.length === 0) return null;
+		return { orgId: parsed.orgId, items };
+	} catch {
+		// fall through
+	}
+	return null;
+}

--- a/server/src/internal/slackUnfurl/render/renderCard.tsx
+++ b/server/src/internal/slackUnfurl/render/renderCard.tsx
@@ -1,0 +1,52 @@
+import { render } from "takumi-js";
+import type { CustomerCardData } from "../data/types.js";
+import { CARD_WIDTH, CustomerCard } from "./CustomerCard.js";
+import { theme } from "./theme.js";
+
+const CARD_WIDTH_PX = 1100;
+
+/**
+ * data -> PNG. Width is fixed for a predictable aspect; height is content-driven.
+ */
+export async function renderCustomerCardPng(
+	data: CustomerCardData,
+): Promise<Uint8Array> {
+	const result = await render(<CustomerCard data={data} />, {
+		width: CARD_WIDTH_PX,
+		loadDefaultFonts: true,
+	});
+	return result instanceof Uint8Array ? result : new Uint8Array(result);
+}
+
+const GAP = 24;
+const PAD = 24;
+
+/**
+ * Up to N cards composited into ONE PNG, side-by-side. A single card renders
+ * exactly as before (no wrapper); multiple cards sit in a padded flex row.
+ */
+export async function renderCustomerCardsPng(
+	datas: CustomerCardData[],
+): Promise<Uint8Array> {
+	if (datas.length <= 1) return renderCustomerCardPng(datas[0]);
+
+	const width = datas.length * CARD_WIDTH + (datas.length - 1) * GAP + PAD * 2;
+	const result = await render(
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "row",
+				alignItems: "flex-start",
+				gap: GAP,
+				padding: PAD,
+				backgroundColor: theme.bg,
+			}}
+		>
+			{datas.map((data) => (
+				<CustomerCard key={data.customerId} data={data} />
+			))}
+		</div>,
+		{ width, loadDefaultFonts: true },
+	);
+	return result instanceof Uint8Array ? result : new Uint8Array(result);
+}

--- a/server/src/internal/slackUnfurl/render/theme.ts
+++ b/server/src/internal/slackUnfurl/render/theme.ts
@@ -1,0 +1,29 @@
+/**
+ * Brand tokens mirrored from @autumn/ui (packages/ui/src/styles/index.css).
+ * Kept as plain constants so takumi's Tailwind engine can interpolate them via
+ * arbitrary values (e.g. tw={`bg-[${theme.bg}]`}) without pulling the runtime
+ * Tailwind config. When we bundle Inter, set fontFamily here too.
+ */
+export const theme = {
+	bg: "#fafaf9",
+	surface: "#ffffff",
+	foreground: "#121212",
+	muted: "#6b6b6b",
+	subtle: "#9a9a9a",
+	border: "#e7e5e4",
+	track: "#ececea",
+	accent: "#1a1a1a",
+	// Autumn brand purple — used for usage bars and balance progress fills.
+	purple: "#7c5cff",
+	purpleSoft: "#efeaff",
+	positive: "#15803d",
+	warning: "#b45309",
+	danger: "#b91c1c",
+} as const;
+
+export const statusColor: Record<string, string> = {
+	active: theme.positive,
+	trialing: theme.accent,
+	canceled: theme.muted,
+	past_due: theme.danger,
+};

--- a/server/src/internal/slackUnfurl/render/usageChartSvg.ts
+++ b/server/src/internal/slackUnfurl/render/usageChartSvg.ts
@@ -1,0 +1,41 @@
+import type { UsagePoint } from "../data/types.js";
+import { theme } from "./theme.js";
+
+/**
+ * Build a compact area/line chart as an inline SVG data URI. takumi rasterises
+ * SVG images, so this gives a real smooth area chart (line + gradient fill)
+ * rather than chunky bars.
+ */
+export function usageChartSvgDataUri(
+	points: UsagePoint[],
+	{ width = 1000, height = 90 }: { width?: number; height?: number } = {},
+): string {
+	const values = points.map((point) => point.value);
+	const max = Math.max(...values, 1);
+	const top = 6;
+	const bottom = height - 4;
+	const usableHeight = bottom - top;
+
+	const coords = points.map((point, index) => {
+		const x =
+			points.length === 1 ? width / 2 : (index / (points.length - 1)) * width;
+		const y = bottom - (point.value / max) * usableHeight;
+		return { x: round(x), y: round(y) };
+	});
+
+	const line = coords.map(({ x, y }) => `${x},${y}`).join(" ");
+	const area = `${coords[0].x},${bottom} ${line} ${coords[coords.length - 1].x},${bottom}`;
+
+	const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none">
+<defs><linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+<stop offset="0" stop-color="${theme.purple}" stop-opacity="0.28"/>
+<stop offset="1" stop-color="${theme.purple}" stop-opacity="0"/>
+</linearGradient></defs>
+<polygon points="${area}" fill="url(#g)"/>
+<polyline points="${line}" fill="none" stroke="${theme.purple}" stroke-width="3" stroke-linejoin="round" stroke-linecap="round"/>
+</svg>`;
+
+	return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}
+
+const round = (value: number): number => Math.round(value * 10) / 10;

--- a/server/src/internal/slackUnfurl/slack-manifest.example.json
+++ b/server/src/internal/slackUnfurl/slack-manifest.example.json
@@ -1,0 +1,30 @@
+{
+	"display_information": {
+		"name": "ALU"
+	},
+	"features": {
+		"bot_user": {
+			"display_name": "Autumn's Link Unfurler",
+			"always_online": false
+		},
+		"unfurl_domains": ["app.useautumn.com"]
+	},
+	"oauth_config": {
+		"scopes": {
+			"bot": ["links:read", "links:write", "chat:write", "files:write"]
+		}
+	},
+	"settings": {
+		"event_subscriptions": {
+			"request_url": "https://api.useautumn.com/slack-unfurl/events",
+			"bot_events": ["link_shared"]
+		},
+		"interactivity": {
+			"is_enabled": true,
+			"request_url": "https://api.useautumn.com/slack-unfurl/interactions"
+		},
+		"org_deploy_enabled": false,
+		"socket_mode_enabled": false,
+		"is_hosted": false
+	}
+}

--- a/server/src/internal/slackUnfurl/slack/client.ts
+++ b/server/src/internal/slackUnfurl/slack/client.ts
@@ -1,0 +1,34 @@
+import { type LinkUnfurls, WebClient } from "@slack/web-api";
+import { env } from "../env.js";
+
+export const slack = new WebClient(env.SLACK_BOT_TOKEN);
+
+export type UnfurlCard = { url: string; imageUrl: string; altText: string };
+
+/**
+ * Post one or more rendered cards as link unfurls in a single call — works
+ * WITHOUT the bot being a member of the channel (unlike chat.postMessage /
+ * files.uploadV2). Uses the membership-free `unfurl_id` + `source` from the
+ * link_shared event. Each image block points at our own server-served PNG, since
+ * unfurl image blocks need a public image_url.
+ */
+export async function unfurlCards({
+	unfurlId,
+	source,
+	cards,
+}: {
+	unfurlId: string;
+	source: "composer" | "conversations_history";
+	cards: UnfurlCard[];
+}): Promise<void> {
+	if (cards.length === 0) return;
+	const unfurls: LinkUnfurls = {};
+	for (const card of cards) {
+		unfurls[card.url] = {
+			blocks: [
+				{ type: "image", image_url: card.imageUrl, alt_text: card.altText },
+			],
+		};
+	}
+	await slack.chat.unfurl({ unfurl_id: unfurlId, source, unfurls });
+}

--- a/server/src/internal/slackUnfurl/slack/events.ts
+++ b/server/src/internal/slackUnfurl/slack/events.ts
@@ -1,0 +1,118 @@
+import { env } from "../env.js";
+import { signCardToken } from "../render/cardToken.js";
+import { resolveChannelToOrg } from "../tenancy/channelOrgMap.js";
+import {
+	type ParsedCustomerLink,
+	parseCustomerLink,
+	resolveCustomer,
+} from "../tenancy/resolveCustomer.js";
+import { type UnfurlCard, unfurlCards } from "./client.js";
+
+type LinkSharedEvent = {
+	type: "link_shared";
+	channel: string;
+	message_ts: string;
+	unfurl_id: string;
+	source: "composer" | "conversations_history";
+	links: Array<{ url: string; domain: string }>;
+};
+
+export type SlackEventEnvelope = {
+	type: "url_verification" | "event_callback";
+	challenge?: string;
+	event?: { type?: string } & Partial<LinkSharedEvent>;
+};
+
+const isLinkShared = (
+	event: SlackEventEnvelope["event"],
+): event is LinkSharedEvent =>
+	event?.type === "link_shared" &&
+	Array.isArray(event.links) &&
+	typeof event.channel === "string" &&
+	typeof event.unfurl_id === "string" &&
+	(event.source === "composer" || event.source === "conversations_history");
+
+/**
+ * Runs AFTER the 3s ack, asynchronously. Resolves tenancy strictly by channel,
+ * validates customer ownership, renders, and unfurls. Unfurling needs no channel
+ * membership. Any failure is swallowed with a log — a probed/typo'd link simply
+ * produces no card.
+ */
+export async function handleLinkShared(
+	event: SlackEventEnvelope["event"],
+): Promise<void> {
+	if (!isLinkShared(event)) return;
+
+	const orgId = resolveChannelToOrg(event.channel);
+	if (!orgId) {
+		// Unmapped channel: decline to render. Never guess a tenant.
+		console.info(`[slack-unfurl] unmapped channel ${event.channel}, skipping`);
+		return;
+	}
+
+	// Parse + dedupe customer links, cap at MAX_CARDS — they render side-by-side
+	// into ONE composite image, so beyond a few they'd be unreadable anyway.
+	const seen = new Set<string>();
+	const links: Array<{ url: string } & ParsedCustomerLink> = [];
+	for (const link of event.links) {
+		const parsed = parseCustomerLink(link.url);
+		if (!parsed || seen.has(link.url)) continue;
+		seen.add(link.url);
+		links.push({ url: link.url, ...parsed });
+		if (links.length >= MAX_CARDS) break;
+	}
+	if (links.length === 0) return;
+
+	// Resolve every link concurrently; each runs on its own org+env-scoped ctx.
+	// We resolve here only to decide what to include + name the alt text; the
+	// /cards route re-resolves and renders.
+	const resolved = (
+		await Promise.all(
+			links.map(async (link) => {
+				try {
+					const data = await resolveCustomer(orgId, link.customerId, link.env);
+					if (data) return { ...link, name: data.name };
+					console.info(
+						`[slack-unfurl] ${link.customerId} not in ${orgId} (${link.env}), skipping`,
+					);
+				} catch (error) {
+					console.warn(
+						`[slack-unfurl] resolve failed for ${link.url}: ${String(error)}`,
+					);
+				}
+				return null;
+			}),
+		)
+	).filter(
+		(link): link is { url: string; name: string } & ParsedCustomerLink =>
+			link !== null,
+	);
+
+	if (resolved.length === 0) return;
+
+	// ONE token carries all resolved customers -> ONE composite image, attached to
+	// the first resolved link. `?v` is pinned to the top of the current UTC hour
+	// so the url is stable for an hour (Slack/CDN reuse the render).
+	const HOUR_MS = 3_600_000;
+	const hourBucket = Math.floor(Date.now() / HOUR_MS) * HOUR_MS;
+	const token = signCardToken({
+		orgId,
+		items: resolved.map((link) => ({
+			customerId: link.customerId,
+			env: link.env,
+		})),
+	});
+	const card: UnfurlCard = {
+		url: resolved[0].url,
+		imageUrl: `${env.PUBLIC_BASE_URL}/slack-unfurl/cards/${token}.png?v=${hourBucket}`,
+		altText: resolved.map((link) => link.name).join(", "),
+	};
+
+	await unfurlCards({
+		unfurlId: event.unfurl_id,
+		source: event.source,
+		cards: [card],
+	});
+}
+
+const MAX_CARDS = 3;

--- a/server/src/internal/slackUnfurl/slack/verify.ts
+++ b/server/src/internal/slackUnfurl/slack/verify.ts
@@ -1,0 +1,52 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { env } from "../env.js";
+
+const FIVE_MINUTES_SECONDS = 60 * 5;
+
+/**
+ * Slack request signing: v0 HMAC-SHA256 over `v0:{timestamp}:{rawBody}`,
+ * with a 5-minute replay window. MUST run over the raw, unparsed body — so
+ * callers pass the exact string they read off the request.
+ */
+export function verifySlackSignature({
+	rawBody,
+	timestamp,
+	signature,
+	nowSeconds,
+}: {
+	rawBody: string;
+	timestamp: string | null;
+	signature: string | null;
+	nowSeconds: number;
+}): boolean {
+	if (!(timestamp && signature)) {
+		console.warn("[slack-unfurl] verify: missing timestamp/signature header");
+		return false;
+	}
+
+	const ts = Number(timestamp);
+	if (!Number.isFinite(ts)) {
+		console.warn("[slack-unfurl] verify: non-numeric timestamp");
+		return false;
+	}
+	if (Math.abs(nowSeconds - ts) > FIVE_MINUTES_SECONDS) {
+		console.warn(
+			`[slack-unfurl] verify: stale timestamp (delta=${nowSeconds - ts}s) — check clock`,
+		);
+		return false;
+	}
+
+	const expected = `v0=${createHmac("sha256", env.SLACK_SIGNING_SECRET)
+		.update(`v0:${timestamp}:${rawBody}`)
+		.digest("hex")}`;
+
+	const a = Buffer.from(expected);
+	const b = Buffer.from(signature);
+	const ok = a.length === b.length && timingSafeEqual(a, b);
+	if (!ok) {
+		console.warn(
+			`[slack-unfurl] verify: digest mismatch — SLACK_SIGNING_SECRET likely wrong (secret loaded, len=${env.SLACK_SIGNING_SECRET.length})`,
+		);
+	}
+	return ok;
+}

--- a/server/src/internal/slackUnfurl/slackUnfurlRouter.ts
+++ b/server/src/internal/slackUnfurl/slackUnfurlRouter.ts
@@ -1,0 +1,98 @@
+import { Hono } from "hono";
+import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
+import type { CustomerCardData } from "./data/types.js";
+import { verifyCardToken } from "./render/cardToken.js";
+import { renderCustomerCardsPng } from "./render/renderCard.js";
+import { handleLinkShared, type SlackEventEnvelope } from "./slack/events.js";
+import { verifySlackSignature } from "./slack/verify.js";
+import { resolveCustomer } from "./tenancy/resolveCustomer.js";
+
+/**
+ * Slack-unfurl routes, mounted at `/slack-unfurl` on the main server (initHono).
+ * Its own prefix avoids the chat proxy, which already owns `/slack/*` (-> leaf).
+ * Slack-facing: auths via the Slack request signature, mounted ahead of the
+ * org/auth middleware.
+ */
+export const slackUnfurlRouter = new Hono<HonoEnv>();
+
+// Public PNG endpoint Slack fetches for the unfurl image block. Token is
+// HMAC-signed (only urls we minted resolve) and we re-resolve the customer in
+// the signed org+env on every fetch — defence in depth. Cached an hour to match
+// the hourly `?v=` bucket on the image url.
+slackUnfurlRouter.get("/cards/:file", async (c) => {
+	const token = c.req.param("file").replace(/\.png$/, "");
+	const claims = verifyCardToken(token);
+	if (!claims) return c.text("not found", 404);
+
+	// Resolve every customer in the token (org+env-scoped) concurrently; render
+	// whatever resolves as one side-by-side composite.
+	const datas = (
+		await Promise.all(
+			claims.items.map((item) =>
+				resolveCustomer(claims.orgId, item.customerId, item.env),
+			),
+		)
+	).filter((data): data is CustomerCardData => data !== null);
+	if (datas.length === 0) return c.text("not found", 404);
+
+	const png = await renderCustomerCardsPng(datas);
+	const body = new Uint8Array(png.byteLength);
+	body.set(png);
+	return new Response(body, {
+		status: 200,
+		headers: {
+			"content-type": "image/png",
+			"cache-control": "public, max-age=3600",
+		},
+	});
+});
+
+slackUnfurlRouter.post("/events", async (c) => {
+	// Read the RAW body first — signature verification depends on the exact bytes.
+	const rawBody = await c.req.text();
+
+	let body: SlackEventEnvelope;
+	try {
+		body = JSON.parse(rawBody);
+	} catch {
+		return c.text("bad request", 400);
+	}
+
+	// URL-verification handshake: echo the challenge BEFORE signature checking.
+	// It only reflects Slack's own value (no data, no action), so this is safe —
+	// and it lets the request URL verify independent of secret wiring.
+	if (body.type === "url_verification") {
+		return c.json({ challenge: body.challenge });
+	}
+
+	// Real events must be signature-verified.
+	const verified = verifySlackSignature({
+		rawBody,
+		timestamp: c.req.header("x-slack-request-timestamp") ?? null,
+		signature: c.req.header("x-slack-signature") ?? null,
+		nowSeconds: Math.floor(Date.now() / 1000),
+	});
+	if (!verified) return c.text("invalid signature", 401);
+
+	// Ack within 3s, then do all fetching/rendering asynchronously.
+	if (body.type === "event_callback") {
+		void handleLinkShared(body.event).catch((error) => {
+			console.error("[slack-unfurl] handleLinkShared failed", error);
+		});
+	}
+	return c.body(null, 200);
+});
+
+// Block actions / view submissions land here. Stubbed (no interactive surface
+// on the unfurl) — ack so Slack doesn't show an error.
+slackUnfurlRouter.post("/interactions", async (c) => {
+	const rawBody = await c.req.text();
+	const verified = verifySlackSignature({
+		rawBody,
+		timestamp: c.req.header("x-slack-request-timestamp") ?? null,
+		signature: c.req.header("x-slack-signature") ?? null,
+		nowSeconds: Math.floor(Date.now() / 1000),
+	});
+	if (!verified) return c.text("invalid signature", 401);
+	return c.body(null, 200);
+});

--- a/server/src/internal/slackUnfurl/tenancy/channelOrgMap.ts
+++ b/server/src/internal/slackUnfurl/tenancy/channelOrgMap.ts
@@ -1,0 +1,28 @@
+import { env } from "../env.js";
+
+/**
+ * THE tenancy key is channel_id, not team_id (single-install model — every
+ * event arrives in our workspace). Each channel maps to exactly one org.
+ * Prototype source is an env JSON blob; swap for a DB table later.
+ */
+let cache: Record<string, string> | null = null;
+
+const load = (): Record<string, string> => {
+	if (cache) return cache;
+	let map: Record<string, string> = {};
+	try {
+		const parsed = JSON.parse(env.SLACK_CHANNEL_ORG_MAP);
+		if (parsed && typeof parsed === "object") map = parsed;
+	} catch {
+		// fall through to empty map
+	}
+	cache = map;
+	return map;
+};
+
+/**
+ * Resolve a channel to its org. Returns `null` for unmapped channels — the
+ * caller MUST decline to render rather than guess a tenant.
+ */
+export const resolveChannelToOrg = (channelId: string): string | null =>
+	load()[channelId] ?? null;

--- a/server/src/internal/slackUnfurl/tenancy/resolveCustomer.ts
+++ b/server/src/internal/slackUnfurl/tenancy/resolveCustomer.ts
@@ -1,0 +1,41 @@
+import { AppEnv } from "@autumn/shared";
+import { getCardDataLive } from "../data/getCardData.js";
+import type { CustomerCardData } from "../data/types.js";
+import { env } from "../env.js";
+
+export type ParsedCustomerLink = { customerId: string; env: AppEnv };
+
+/**
+ * Pull the customerId + env out of an Autumn customer-page URL, scoped to our
+ * host. `/sandbox/customers/<id>` is sandbox; `/customers/<id>` is live.
+ * Returns null for anything else.
+ */
+export function parseCustomerLink(rawUrl: string): ParsedCustomerLink | null {
+	let url: URL;
+	try {
+		url = new URL(rawUrl);
+	} catch {
+		return null;
+	}
+	if (url.hostname !== env.APP_HOST) return null;
+	const match = url.pathname.match(/^(\/sandbox)?\/customers\/([^/]+)\/?$/);
+	if (!match) return null;
+	return {
+		customerId: decodeURIComponent(match[2]),
+		env: match[1] ? AppEnv.Sandbox : AppEnv.Live,
+	};
+}
+
+/**
+ * Resolve a customerId WITHIN an org + env. The org comes from the channel
+ * mapping (never the URL/poster); the env comes from the URL path. So a typo'd /
+ * probed id can only ever resolve inside the channel's own org. Backed by the
+ * live Autumn store + Tinybird.
+ */
+export async function resolveCustomer(
+	orgId: string,
+	customerId: string,
+	customerEnv: AppEnv,
+): Promise<CustomerCardData | null> {
+	return getCardDataLive(orgId, customerId, customerEnv);
+}


### PR DESCRIPTION
Mounts a Slack link-unfurler at \`/slack-unfurl/*\` on the main server. Sharing an \`app.useautumn.com/customers/<id>\` link in a mapped Slack Connect channel posts a rendered customer card (plans, balances, usage, flags, invoices) as the unfurl image. Up to 3 links → one side-by-side composite.

Tenancy keys on \`channel_id → org_id\` (env: \`ALU_SLACK_CHANNEL_ORG_MAP\`); each customer resolves org+env-scoped, no cross-tenant fallback.

Deploy prerequisites (env): \`ALU_SLACK_SIGNING_SECRET\`, \`ALU_SLACK_BOT_TOKEN\`, \`ALU_PUBLIC_BASE_URL\`, \`ALU_SLACK_CHANNEL_ORG_MAP\`. Slack app request URLs → \`https://api.useautumn.com/slack-unfurl/events\` + \`/interactions\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Slack link unfurler that posts a customer card image when an `app.useautumn.com/customers/<id>` link is shared in a mapped Slack channel. Supports up to 3 links per message and enforces per-channel tenancy.

- **New Features**
  - New router at `/slack-unfurl/*` (`/events`, `/interactions`, `/cards/:token.png`) mounted ahead of org/auth.
  - Tenancy via `channel_id → org_id` map (`ALU_SLACK_CHANNEL_ORG_MAP`); env from URL (`/sandbox/...` → sandbox).
  - Secure: Slack signature verification, HMAC-signed image URLs, and per-request ownership checks.
  - Card shows grouped plans (with price range), balances with overage, 7d usage, flags, and recent invoices; rendered with `takumi-js`.
  - Unfurls via `chat.unfurl` (no channel membership needed) using `@slack/web-api`; image cached for 1h.

- **Migration**
  - Set env: `ALU_SLACK_SIGNING_SECRET`, `ALU_SLACK_BOT_TOKEN`, `ALU_PUBLIC_BASE_URL`, `ALU_SLACK_CHANNEL_ORG_MAP` (JSON), optional `APP_HOST`.
  - Slack app: add `unfurl_domains: ["app.useautumn.com"]`; set events URL to `/slack-unfurl/events`; interactivity URL to `/slack-unfurl/interactions`.

<sup>Written for commit cf9fb254e0c772ee5d1088c8aad0da7d5f159d04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a self-contained Slack link-unfurler mounted at `/slack-unfurl/*` on the main server. When an `app.useautumn.com/customers/<id>` link is shared in a mapped Slack Connect channel, the server renders a customer card (plans, balances, usage, flags, invoices) as a PNG and posts it as an unfurl image — up to three links compose side-by-side into one image.

- **[Improvements]** New `slackUnfurlRouter` handling `/events`, `/interactions`, and `/cards/:file` endpoints — tenancy is strictly channel-scoped via an env-configured JSON map, with no cross-tenant fallback; `handleLinkShared` acks within 3s and defers all rendering asynchronously.
- **[Improvements]** HMAC-signed card image tokens (`cardToken.ts`) bake `orgId`/`env`/`customerId` into a public URL and the route re-validates customer ownership on every fetch for defence-in-depth.
- **[API changes]** Two new dependencies added: `@slack/web-api` for `chat.unfurl` calls and `takumi-js` (RC) for server-side JSX-to-PNG rendering.
</details>

<h3>Confidence Score: 3/5</h3>

The new Slack routes are safe for most deployments, but the signature-verification logic has a gap that could be exploited on servers where the signing secret is not yet configured.

The `verifySlackSignature` function computes an HMAC with whatever string `SLACK_SIGNING_SECRET` holds, including an empty string — there is no early-return for a missing secret. A server with a configured channel map but no signing secret would accept forged events. Additionally, `renderCustomerCardsPng` passes `undefined` to `renderCustomerCardPng` when called with an empty array due to the overly broad `<= 1` guard.

`server/src/internal/slackUnfurl/slack/verify.ts` (empty-secret gap) and `server/src/internal/slackUnfurl/render/renderCard.tsx` (unsafe empty-array branch) deserve a second look before deploying to production.

<details open><summary><h3>Security Review</h3></summary>

- **Empty signing secret → forgeable HMAC** (`verify.ts`): `createHmac("sha256", "")` succeeds, so if `ALU_SLACK_SIGNING_SECRET` is unset, any caller can compute a matching digest and pass signature verification. The channel-org map provides a secondary gate, but a deployment with a configured map and no signing secret would allow forged `link_shared` events to trigger customer-data lookups.
- **Shared HMAC key for two purposes** (`cardToken.ts`): Card image tokens are signed with `SLACK_SIGNING_SECRET`, the same key used to verify incoming Slack webhooks. A compromised or leaked signing secret lets an attacker mint valid card-token URLs for arbitrary org/customer combinations. The route re-validates ownership on fetch, limiting exposure, but a dedicated secret would allow independent rotation.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/slackUnfurl/slack/verify.ts | Slack request signature verification — missing guard for empty signing secret allows trivially forgeable signatures when the secret is unconfigured |
| server/src/internal/slackUnfurl/render/renderCard.tsx | PNG composition — `datas.length <= 1` check includes length 0, passing `undefined` to renderCustomerCardPng; also duplicates the CARD_WIDTH constant |
| server/src/internal/slackUnfurl/render/cardToken.ts | HMAC-signed card image token — reuses SLACK_SIGNING_SECRET for two distinct purposes; token structure, timing-safe comparison, and MAX_ITEMS cap look correct |
| server/src/internal/slackUnfurl/slackUnfurlRouter.ts | Main router for Slack-facing endpoints — url_verification echoes challenge without origin validation; otherwise correctly acks within 3s and defers rendering async |
| server/src/internal/slackUnfurl/slack/events.ts | link_shared event handler — tenancy is correctly resolved from channel only, URL deduplication and MAX_CARDS cap are in place, errors are swallowed cleanly |
| server/src/internal/slackUnfurl/data/getCardData.ts | Real data layer — uses Redis cache with DB fallback, pins API version, fetches usage/entity prices correctly; sequential entity loop is intentional to avoid shared-ctx racing |
| server/src/internal/slackUnfurl/tenancy/channelOrgMap.ts | Channel-to-org tenancy map — single-parse module-level cache is simple and correct; prototype design (env JSON blob) is noted as temporary |
| server/src/internal/slackUnfurl/tenancy/resolveCustomer.ts | Customer resolution — thin wrapper delegating to getCardDataLive with correct org+env scoping; parseCustomerLink regex is well-scoped to the app host |
| server/src/internal/slackUnfurl/env.ts | Non-throwing env config with ALU_* prefix fallbacks — isSlackUnfurlConfigured is exported but never consulted by the router, leaving unconfigured deployments without an early-exit path |
| server/src/initHono.ts | Router mounting — slackUnfurlRouter correctly placed before org/auth middleware and uses a distinct /slack-unfurl prefix to avoid colliding with the chat proxy's /slack/* routes |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant S as Slack
    participant R as /slack-unfurl/events
    participant H as handleLinkShared
    participant CM as channelOrgMap
    participant RC as resolveCustomer
    participant CT as signCardToken
    participant SL as slack.chat.unfurl

    S->>R: POST link_shared event
    R->>R: verify HMAC signature
    R-->>S: 200 ACK (within 3s)
    R->>H: void handleLinkShared(event)
    H->>CM: resolveChannelToOrg(channel_id)
    CM-->>H: orgId (or null skip)
    H->>RC: resolveCustomer(orgId, customerId, env)
    RC-->>H: CustomerCardData (or null skip)
    H->>CT: "signCardToken({orgId, items})"
    CT-->>H: signed token
    H->>SL: "chat.unfurl(imageUrl=/cards/token.png)"

    S->>R: GET /cards/token.png
    R->>R: verifyCardToken(token)
    R->>RC: resolveCustomer(orgId, customerId, env)
    RC-->>R: CustomerCardData
    R->>R: renderCustomerCardsPng(datas)
    R-->>S: PNG (cache-control: 1h)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant S as Slack
    participant R as /slack-unfurl/events
    participant H as handleLinkShared
    participant CM as channelOrgMap
    participant RC as resolveCustomer
    participant CT as signCardToken
    participant SL as slack.chat.unfurl

    S->>R: POST link_shared event
    R->>R: verify HMAC signature
    R-->>S: 200 ACK (within 3s)
    R->>H: void handleLinkShared(event)
    H->>CM: resolveChannelToOrg(channel_id)
    CM-->>H: orgId (or null skip)
    H->>RC: resolveCustomer(orgId, customerId, env)
    RC-->>H: CustomerCardData (or null skip)
    H->>CT: "signCardToken({orgId, items})"
    CT-->>H: signed token
    H->>SL: "chat.unfurl(imageUrl=/cards/token.png)"

    S->>R: GET /cards/token.png
    R->>R: verifyCardToken(token)
    R->>RC: resolveCustomer(orgId, customerId, env)
    RC-->>R: CustomerCardData
    R->>R: renderCustomerCardsPng(datas)
    R-->>S: PNG (cache-control: 1h)
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 5 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 5
server/src/internal/slackUnfurl/slack/verify.ts:39-51
**Empty signing secret bypasses HMAC verification**

When `ALU_SLACK_SIGNING_SECRET` / `SLACK_SIGNING_SECRET` is not set, `env.SLACK_SIGNING_SECRET` is `""`. `createHmac("sha256", "")` still succeeds and produces a deterministic HMAC for any payload. An attacker who knows the key is empty can compute a matching digest and pass signature verification. Combined with a populated `SLACK_CHANNEL_ORG_MAP`, this lets forged `link_shared` events trigger customer data lookups for any customer ID in a mapped org. Adding `if (!env.SLACK_SIGNING_SECRET) return false;` at the top of `verifySlackSignature` would close this gap without breaking the "non-throwing boot" contract in `env.ts`.

### Issue 2 of 5
server/src/internal/slackUnfurl/render/renderCard.tsx:31
`renderCustomerCardsPng` crashes when called with an empty array because `datas.length <= 1` includes length 0, and `datas[0]` is `undefined` for an empty array — passing `undefined` to `renderCustomerCardPng` will cause `CustomerCard` to crash accessing its props. The current route-level guard (`datas.length === 0 → 404`) prevents this today, but the exported function is not self-protecting.

```suggestion
	if (datas.length === 0) throw new Error("renderCustomerCardsPng: datas must not be empty");
	if (datas.length === 1) return renderCustomerCardPng(datas[0]);
```

### Issue 3 of 5
server/src/internal/slackUnfurl/render/cardToken.ts:21-25
The card token MAC reuses `SLACK_SIGNING_SECRET`, the same key used to verify incoming Slack webhook signatures. If that secret is rotated or becomes known, an attacker can forge card-image tokens for arbitrary `orgId`/`customerId`/`env` combinations. The route does re-validate ownership via `resolveCustomer`, which limits the blast radius, but using a dedicated signing secret for card tokens would give independent rotation capability and follow least-privilege key usage.

```suggestion
const CARD_SIGNING_SECRET =
	process.env.ALU_CARD_SIGNING_SECRET ?? env.SLACK_SIGNING_SECRET;

const sign = (payload: string): string =>
	createHmac("sha256", CARD_SIGNING_SECRET)
		.update(payload)
		.digest("base64url")
		.slice(0, 24);
```

### Issue 4 of 5
server/src/internal/slackUnfurl/slackUnfurlRouter.ts:64-66
`body.challenge` is reflected to any caller without any signature or origin check. Though no sensitive data is returned, the endpoint becomes a generic open-reflection surface: any actor (not only Slack) can POST `{"type":"url_verification","challenge":"<any-value>"}` and get a successful 200 containing their own value. At minimum the challenge value should be validated to be a non-empty string before echoing it.

```suggestion
	if (body.type === "url_verification") {
		if (typeof body.challenge !== "string" || body.challenge.length === 0) {
			return c.text("bad request", 400);
		}
		return c.json({ challenge: body.challenge });
	}
```

### Issue 5 of 5
server/src/internal/slackUnfurl/render/renderCard.tsx:6-15
`CARD_WIDTH_PX` duplicates the `CARD_WIDTH` constant imported from `CustomerCard.tsx` — both are 1100. Using the imported constant for the single-card path removes the silent divergence risk if one value is ever changed independently.

```suggestion
/**
 * data -> PNG. Width is fixed for a predictable aspect; height is content-driven.
 */
export async function renderCustomerCardPng(
	data: CustomerCardData,
): Promise<Uint8Array> {
	const result = await render(<CustomerCard data={data} />, {
		width: CARD_WIDTH,
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(slack-unfurl): 🎸 add Slack custome..."](https://github.com/useautumn/autumn/commit/cf9fb254e0c772ee5d1088c8aad0da7d5f159d04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40809144)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->