### PR TITLE
feat(sandboxes): POST /v1/sandboxes.copy — copy plans + features between named sandboxes

### DIFF
--- a/server/src/internal/orgs/orgUtils/provisionSubOrg.ts
+++ b/server/src/internal/orgs/orgUtils/provisionSubOrg.ts
@@ -1,6 +1,7 @@
 import {
 	member,
 	type Organization,
+	type OrgConfig,
 	organizations,
 	type SandboxColor,
 	type SandboxIcon,
@@ -31,6 +32,7 @@ export const provisionSubOrg = async ({
 	createMembership,
 	sandboxColor,
 	sandboxIcon,
+	config,
 }: {
 	db: DrizzleCli;
 	masterOrg: Organization;
@@ -41,6 +43,7 @@ export const provisionSubOrg = async ({
 	createMembership: boolean;
 	sandboxColor?: SandboxColor;
 	sandboxIcon?: SandboxIcon;
+	config?: OrgConfig;
 }): Promise<Organization & { master?: Organization | null }> => {
 	const orgId = generateId();
 	const [insertedOrg] = await db
@@ -56,6 +59,7 @@ export const provisionSubOrg = async ({
 			is_sandbox: isSandbox,
 			sandbox_color: sandboxColor ?? null,
 			sandbox_icon: sandboxIcon ?? null,
+			config,
 		})
 		.returning();
 

--- a/server/src/internal/products/handlers/handleCopyEnvironment/handleCopyEnvironment.ts
+++ b/server/src/internal/products/handlers/handleCopyEnvironment/handleCopyEnvironment.ts
@@ -21,7 +21,7 @@ export const handleCopyEnvironment = createRoute({
 		const toEnv = AppEnv.Live;
 
 		// 1. Get all sandbox products and features
-		const [sandboxFeatures, liveFeatures] = await Promise.all([
+		const [fromFeatures, toFeatures] = await Promise.all([
 			FeatureService.list({
 				db,
 				orgId: org.id,
@@ -38,13 +38,17 @@ export const handleCopyEnvironment = createRoute({
 		// 2. Copy features first
 		await handleCopyFeatures({
 			ctx,
-			sandboxFeatures,
-			liveFeatures,
+			fromFeatures,
+			toOrg: org,
+			toEnv,
+			toFeatures,
 		});
 
 		await handleCopyProducts({
 			ctx,
+			fromOrg: org,
 			fromEnv,
+			toOrg: org,
 			toEnv,
 		});
 

--- a/server/src/internal/products/handlers/handleCopyEnvironment/handleCopyFeatures.ts
+++ b/server/src/internal/products/handlers/handleCopyEnvironment/handleCopyFeatures.ts
@@ -42,7 +42,9 @@ export const handleCopyFeatures = async ({
 		(f) => f.type === FeatureType.Boolean || f.type === FeatureType.Metered,
 	);
 	const creditSystemFeatures = fromFeatures.filter(
-		(f) => f.type === FeatureType.CreditSystem,
+		(f) =>
+			f.type === FeatureType.CreditSystem ||
+			f.type === FeatureType.AiCreditSystem,
 	);
 
 	// First, process boolean and metered features

--- a/server/src/internal/products/handlers/handleCopyEnvironment/handleCopyFeatures.ts
+++ b/server/src/internal/products/handlers/handleCopyEnvironment/handleCopyFeatures.ts
@@ -1,50 +1,68 @@
-import { AppEnv, type Feature, FeatureType } from "@autumn/shared";
+import {
+	type AppEnv,
+	type Feature,
+	FeatureType,
+	type Organization,
+} from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { createFeature } from "@/internal/features/featureActions/createFeature.js";
 import { updateFeature } from "@/internal/features/featureActions/updateFeature.js";
 
+/**
+ * Copies features from one (org, env) into another (org, env).
+ *
+ * Generalised from the original sandbox→live copy: the source and target may
+ * live in different organizations (e.g. two sandbox sub-orgs of the same master
+ * org), so the write context is rebuilt around an explicit `toOrg`/`toEnv`
+ * rather than reusing `ctx.org`.
+ */
 export const handleCopyFeatures = async ({
 	ctx,
-	sandboxFeatures,
-	liveFeatures,
+	fromFeatures,
+	toOrg,
+	toEnv,
+	toFeatures,
 }: {
 	ctx: AutumnContext;
-	sandboxFeatures: Feature[];
-	liveFeatures: Feature[];
+	fromFeatures: Feature[];
+	toOrg: Organization;
+	toEnv: AppEnv;
+	toFeatures: Feature[];
 }) => {
 	const newContext = {
 		...ctx,
-		features: liveFeatures,
-		env: AppEnv.Live,
+		org: toOrg,
+		features: toFeatures,
+		env: toEnv,
 	};
 
 	// Separate features by type: Boolean/Metered must be created before CreditSystem
 	// since credit systems can reference metered features in their credit_schema
-	const booleanAndMeteredFeatures = sandboxFeatures.filter(
+	const booleanAndMeteredFeatures = fromFeatures.filter(
 		(f) => f.type === FeatureType.Boolean || f.type === FeatureType.Metered,
 	);
-	const creditSystemFeatures = sandboxFeatures.filter(
+	const creditSystemFeatures = fromFeatures.filter(
 		(f) => f.type === FeatureType.CreditSystem,
 	);
 
 	// First, process boolean and metered features
 	const firstBatchPromises = [];
-	for (const sandboxFeature of booleanAndMeteredFeatures) {
-		const liveFeature = liveFeatures.find((f) => f.id === sandboxFeature.id);
+	for (const fromFeature of booleanAndMeteredFeatures) {
+		const toFeature = toFeatures.find((f) => f.id === fromFeature.id);
 
-		if (liveFeature) {
+		if (toFeature) {
 			firstBatchPromises.push(
 				updateFeature({
 					ctx: newContext,
-					featureId: sandboxFeature.id,
-					updates: sandboxFeature,
+					featureId: fromFeature.id,
+					updates: fromFeature,
 				}),
 			);
 		} else {
 			firstBatchPromises.push(
 				createFeature({
 					ctx: newContext,
-					data: sandboxFeature,
+					data: fromFeature,
 				}),
 			);
 		}
@@ -53,22 +71,22 @@ export const handleCopyFeatures = async ({
 
 	// Then, process credit system features
 	const secondBatchPromises = [];
-	for (const sandboxFeature of creditSystemFeatures) {
-		const liveFeature = liveFeatures.find((f) => f.id === sandboxFeature.id);
+	for (const fromFeature of creditSystemFeatures) {
+		const toFeature = toFeatures.find((f) => f.id === fromFeature.id);
 
-		if (liveFeature) {
+		if (toFeature) {
 			secondBatchPromises.push(
 				updateFeature({
 					ctx: newContext,
-					featureId: sandboxFeature.id,
-					updates: sandboxFeature,
+					featureId: fromFeature.id,
+					updates: fromFeature,
 				}),
 			);
 		} else {
 			secondBatchPromises.push(
 				createFeature({
 					ctx: newContext,
-					data: sandboxFeature,
+					data: fromFeature,
 				}),
 			);
 		}

--- a/server/src/internal/products/handlers/handleCopyEnvironment/handleCopyProducts.ts
+++ b/server/src/internal/products/handlers/handleCopyEnvironment/handleCopyProducts.ts
@@ -50,22 +50,30 @@ export const handleCopyProducts = async ({
 	fromEnv,
 	toOrg,
 	toEnv,
+	productIds,
 }: {
 	ctx: AutumnContext;
 	fromOrg: Organization;
 	fromEnv: AppEnv;
 	toOrg: Organization;
 	toEnv: AppEnv;
+	productIds?: string[];
 }) => {
 	const { db } = ctx;
 
-	const [fromFeatures, toFeatures, fromProducts, toProducts] =
+	const [fromFeatures, toFeatures, fromProductsAll, toProducts] =
 		await Promise.all([
 			FeatureService.list({ db, orgId: fromOrg.id, env: fromEnv }),
 			FeatureService.list({ db, orgId: toOrg.id, env: toEnv }),
 			ProductService.listFull({ db, orgId: fromOrg.id, env: fromEnv }),
 			ProductService.listFull({ db, orgId: toOrg.id, env: toEnv }),
 		]);
+
+	// undefined => copy every product (original behavior); a list (incl. empty)
+	// => only those ids.
+	const fromProducts = productIds
+		? fromProductsAll.filter((p) => productIds.includes(p.id))
+		: fromProductsAll;
 
 	const toProductsV2 = toProducts.map((p) =>
 		mapToProductV2({ product: p, features: toFeatures }),

--- a/server/src/internal/products/handlers/handleCopyEnvironment/handleCopyProducts.ts
+++ b/server/src/internal/products/handlers/handleCopyEnvironment/handleCopyProducts.ts
@@ -1,6 +1,7 @@
 import {
 	type AppEnv,
 	type CreateProductV2Params,
+	type Feature,
 	mapToProductV2,
 	type Organization,
 	type ProductV2,
@@ -51,6 +52,7 @@ export const handleCopyProducts = async ({
 	toOrg,
 	toEnv,
 	productIds,
+	fromFeatures: providedFromFeatures,
 }: {
 	ctx: AutumnContext;
 	fromOrg: Organization;
@@ -58,12 +60,14 @@ export const handleCopyProducts = async ({
 	toOrg: Organization;
 	toEnv: AppEnv;
 	productIds?: string[];
+	fromFeatures?: Feature[];
 }) => {
 	const { db } = ctx;
 
 	const [fromFeatures, toFeatures, fromProductsAll, toProducts] =
 		await Promise.all([
-			FeatureService.list({ db, orgId: fromOrg.id, env: fromEnv }),
+			providedFromFeatures ??
+				FeatureService.list({ db, orgId: fromOrg.id, env: fromEnv }),
 			FeatureService.list({ db, orgId: toOrg.id, env: toEnv }),
 			ProductService.listFull({ db, orgId: fromOrg.id, env: fromEnv }),
 			ProductService.listFull({ db, orgId: toOrg.id, env: toEnv }),

--- a/server/src/internal/products/handlers/handleCopyEnvironment/handleCopyProducts.ts
+++ b/server/src/internal/products/handlers/handleCopyEnvironment/handleCopyProducts.ts
@@ -64,6 +64,9 @@ export const handleCopyProducts = async ({
 }) => {
 	const { db } = ctx;
 
+	// Feature-only copy: nothing to read or map on the product side.
+	if (productIds?.length === 0) return;
+
 	const [fromFeatures, toFeatures, fromProductsAll, toProducts] =
 		await Promise.all([
 			providedFromFeatures ??

--- a/server/src/internal/products/handlers/handleCopyEnvironment/handleCopyProducts.ts
+++ b/server/src/internal/products/handlers/handleCopyEnvironment/handleCopyProducts.ts
@@ -2,14 +2,15 @@ import {
 	type AppEnv,
 	type CreateProductV2Params,
 	mapToProductV2,
+	type Organization,
 	type ProductV2,
 	type UpdateProductV2Params,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { FeatureService } from "@/internal/features/FeatureService.js";
-import { ProductService } from "../../ProductService.js";
 import { createProduct } from "../../../product/actions/createProduct.js";
 import { updateProduct } from "../../../product/actions/updateProduct.js";
+import { ProductService } from "../../ProductService.js";
 
 const conformProductToSchema = (
 	product: ProductV2,
@@ -34,33 +35,46 @@ const conformProductToSchema = (
 	};
 };
 
+/**
+ * Copies products from one (org, env) into another (org, env).
+ *
+ * Generalised from the original sandbox→live copy so the source and target may
+ * be different organizations (e.g. two sandbox sub-orgs of the same master
+ * org). Processor-specific ids (price/entitlement ids, price_config) are
+ * stripped so the target gets a clean copy, and the write context is rebuilt
+ * around an explicit `toOrg`/`toEnv`.
+ */
 export const handleCopyProducts = async ({
 	ctx,
+	fromOrg,
 	fromEnv,
+	toOrg,
 	toEnv,
 }: {
 	ctx: AutumnContext;
+	fromOrg: Organization;
 	fromEnv: AppEnv;
+	toOrg: Organization;
 	toEnv: AppEnv;
 }) => {
-	const { db, org } = ctx;
+	const { db } = ctx;
 
-	const [sandboxFeatures, liveFeatures, sandboxProducts, liveProducts] =
+	const [fromFeatures, toFeatures, fromProducts, toProducts] =
 		await Promise.all([
-			FeatureService.list({ db, orgId: org.id, env: fromEnv }),
-			FeatureService.list({ db, orgId: org.id, env: toEnv }),
-			ProductService.listFull({ db, orgId: org.id, env: fromEnv }),
-			ProductService.listFull({ db, orgId: org.id, env: toEnv }),
+			FeatureService.list({ db, orgId: fromOrg.id, env: fromEnv }),
+			FeatureService.list({ db, orgId: toOrg.id, env: toEnv }),
+			ProductService.listFull({ db, orgId: fromOrg.id, env: fromEnv }),
+			ProductService.listFull({ db, orgId: toOrg.id, env: toEnv }),
 		]);
 
-	const liveProductsV2 = liveProducts.map((p) =>
-		mapToProductV2({ product: p, features: liveFeatures }),
+	const toProductsV2 = toProducts.map((p) =>
+		mapToProductV2({ product: p, features: toFeatures }),
 	);
 
-	const sandboxProductsV2 = sandboxProducts.map((p) => {
+	const fromProductsV2 = fromProducts.map((p) => {
 		const productV2 = mapToProductV2({
 			product: p,
-			features: sandboxFeatures,
+			features: fromFeatures,
 		});
 		productV2.items = productV2.items.map((i) => {
 			const {
@@ -77,21 +91,20 @@ export const handleCopyProducts = async ({
 
 	const newContext = {
 		...ctx,
-		features: liveFeatures,
+		org: toOrg,
+		features: toFeatures,
 		env: toEnv,
 	};
 
-	const operations = sandboxProductsV2.map((sandboxProductV2) => {
-		const liveProductV2 = liveProductsV2.find(
-			(p) => p.id === sandboxProductV2.id,
-		);
+	const operations = fromProductsV2.map((fromProductV2) => {
+		const toProductV2 = toProductsV2.find((p) => p.id === fromProductV2.id);
 
-		const conformedProduct = conformProductToSchema(sandboxProductV2);
+		const conformedProduct = conformProductToSchema(fromProductV2);
 
-		if (liveProductV2) {
+		if (toProductV2) {
 			return updateProduct({
 				ctx: newContext,
-				productId: sandboxProductV2.id,
+				productId: fromProductV2.id,
 				query: { disable_version: true },
 				updates: conformedProduct,
 			});

--- a/server/src/internal/products/handlers/handleCopyProduct/copyProductForOrgs.ts
+++ b/server/src/internal/products/handlers/handleCopyProduct/copyProductForOrgs.ts
@@ -1,0 +1,179 @@
+import {
+	type AppEnv,
+	type CreateFeature,
+	CreateFeatureSchema,
+	ErrCode,
+	type Feature,
+	isAnyCreditSystem,
+	type Organization,
+	ProductAlreadyExistsError,
+} from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { Logger } from "@/external/logtail/logtailUtils.js";
+import { FeatureService } from "@/internal/features/FeatureService.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { invalidateProductsCache } from "@/internal/products/productCacheUtils.js";
+import { copyProduct } from "@/internal/products/productUtils.js";
+import RecaseError from "@/utils/errorUtils.js";
+import { generateId } from "@/utils/genUtils.js";
+
+const initNewFeature = ({
+	data,
+	orgId,
+	env,
+}: {
+	data: CreateFeature;
+	orgId: string;
+	env: AppEnv;
+}): Feature => ({
+	...data,
+	org_id: orgId,
+	env,
+	created_at: Date.now(),
+	internal_id: generateId("fe"),
+	archived: false,
+});
+
+/**
+ * Copies a single product between (org, env) pairs. When fromOrg === toOrg this
+ * is the classic same-org env-copy; when they differ it's a named-sandbox
+ * promote into the master org. The handler owns the auth gate that decides the
+ * orgs — this only executes the copy.
+ */
+export const copyProductForOrgs = async ({
+	db,
+	logger,
+	fromOrg,
+	fromEnv,
+	toOrg,
+	toEnv,
+	fromProductId,
+	toId,
+	toName,
+}: {
+	db: DrizzleCli;
+	logger: Logger;
+	fromOrg: Organization;
+	fromEnv: AppEnv;
+	toOrg: Organization;
+	toEnv: AppEnv;
+	fromProductId: string;
+	toId: string;
+	toName: string;
+}): Promise<void> => {
+	const crossOrg = fromOrg.id !== toOrg.id;
+
+	if (!crossOrg && fromEnv === toEnv && fromProductId === toId) {
+		throw new RecaseError({
+			message: `Product ID ${toId} already exists in ${toEnv}`,
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+
+	const toProduct = await ProductService.get({
+		db,
+		id: toId,
+		orgId: toOrg.id,
+		env: toEnv,
+	});
+	if (toProduct) {
+		throw new ProductAlreadyExistsError({
+			productId: toId,
+			message: `Product ${toId} already exists in ${toEnv}`,
+		});
+	}
+
+	const [fromFullProduct, fromFeatures, toFeatures] = await Promise.all([
+		ProductService.getFull({
+			db,
+			idOrInternalId: fromProductId,
+			orgId: fromOrg.id,
+			env: fromEnv,
+		}),
+		FeatureService.list({ db, orgId: fromOrg.id, env: fromEnv }),
+		FeatureService.list({ db, orgId: toOrg.id, env: toEnv }),
+	]);
+
+	// A variant's base_internal_product_id points at a product in the source
+	// org; there's no safe cross-org remap, so refuse rather than land a dangling
+	// reference.
+	if (crossOrg && fromFullProduct.base_internal_product_id) {
+		throw new RecaseError({
+			message:
+				"Variant plans can't be promoted directly. Promote the base plan instead.",
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+
+	fromFullProduct.is_default = false;
+	if (crossOrg) {
+		fromFullProduct.base_variant_id = null;
+	}
+
+	const featureIdsToCopy = new Set(
+		fromFullProduct.entitlements.map((e) => e.feature.id),
+	);
+	// Credit systems draw from metered features; bring those along so a promoted
+	// credit system isn't left pointing at a feature the target lacks.
+	for (const feature of fromFeatures) {
+		if (!isAnyCreditSystem(feature.type)) continue;
+		if (!featureIdsToCopy.has(feature.id)) continue;
+		const config = feature.config as
+			| { schema?: { metered_feature_id: string }[] }
+			| null
+			| undefined;
+		for (const entry of config?.schema ?? []) {
+			featureIdsToCopy.add(entry.metered_feature_id);
+		}
+	}
+
+	if (crossOrg || fromEnv !== toEnv) {
+		for (const fromFeature of fromFeatures.filter((f) =>
+			featureIdsToCopy.has(f.id),
+		)) {
+			const toFeature = toFeatures.find((f) => f.id === fromFeature.id);
+
+			if (toFeature && fromFeature.type !== toFeature.type) {
+				throw new RecaseError({
+					message: `Feature ${fromFeature.name} exists in ${toEnv}, but has a different config. Please match them then try again.`,
+					code: ErrCode.InvalidRequest,
+					statusCode: 400,
+				});
+			}
+
+			if (!toFeature) {
+				const res = await FeatureService.insert({
+					db,
+					data: initNewFeature({
+						data: CreateFeatureSchema.parse(fromFeature),
+						orgId: toOrg.id,
+						env: toEnv,
+					}),
+					logger,
+				});
+				toFeatures.push(res![0]);
+			}
+		}
+	}
+
+	await copyProduct({
+		db,
+		product: fromFullProduct,
+		toOrgId: toOrg.id,
+		toId,
+		toName,
+		fromEnv,
+		toEnv,
+		toFeatures,
+		fromFeatures,
+		org: toOrg,
+		logger,
+	});
+
+	await invalidateProductsCache({ orgId: toOrg.id, env: toEnv });
+	if (crossOrg || fromEnv !== toEnv) {
+		await invalidateProductsCache({ orgId: fromOrg.id, env: fromEnv });
+	}
+};

--- a/server/src/internal/products/handlers/handleCopyProduct/copyProductForOrgs.ts
+++ b/server/src/internal/products/handlers/handleCopyProduct/copyProductForOrgs.ts
@@ -137,7 +137,7 @@ export const copyProductForOrgs = async ({
 
 			if (toFeature && fromFeature.type !== toFeature.type) {
 				throw new RecaseError({
-					message: `Feature ${fromFeature.name} exists in ${toEnv}, but has a different config. Please match them then try again.`,
+					message: `Feature ${fromFeature.name} exists in ${toEnv} with a different type. Please match them then try again.`,
 					code: ErrCode.InvalidRequest,
 					statusCode: 400,
 				});

--- a/server/src/internal/products/handlers/handleCopyProduct/handleCopyProductV2.ts
+++ b/server/src/internal/products/handlers/handleCopyProduct/handleCopyProductV2.ts
@@ -1,38 +1,16 @@
-import {
-	CopyProductParamsSchema,
-	CreateFeatureSchema,
-	ErrCode,
-	ProductAlreadyExistsError,
-	Scopes,
-} from "@autumn/shared";
+import { AuthType, CopyProductParamsSchema, Scopes } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
-import { FeatureService } from "@/internal/features/FeatureService.js";
-import { ProductService } from "@/internal/products/ProductService.js";
-import { invalidateProductsCache } from "@/internal/products/productCacheUtils.js";
-import { copyProduct } from "@/internal/products/productUtils.js";
-import RecaseError from "@/utils/errorUtils.js";
-import { generateId } from "../../../../utils/genUtils";
-
-const initNewFeature = ({
-	data,
-	orgId,
-	env,
-}: {
-	data: any;
-	orgId: string;
-	env: any;
-}) => {
-	return {
-		...data,
-		org_id: orgId,
-		env,
-		created_at: Date.now(),
-		internal_id: generateId("fe"),
-	};
-};
+import { SANDBOX_ORG_HEADER } from "@/honoMiddlewares/sandboxAccess.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import { copyProductForOrgs } from "./copyProductForOrgs.js";
 
 /**
  * Route: POST /v1/products/:productId/copy - Copy a product
+ *
+ * Same-org env-copy by default. From a named sandbox (a dashboard session acting
+ * via `x-sandbox-org-id`), it promotes into the MASTER org's env instead — so
+ * "Copy to Production" reaches real production rather than the sub-org's own
+ * unviewable Live env. A sandbox API key (non-dashboard) keeps same-org copy.
  */
 export const handleCopyProductV2 = createRoute({
 	scopes: [Scopes.Plans.Write],
@@ -41,112 +19,31 @@ export const handleCopyProductV2 = createRoute({
 		const body = c.req.valid("json");
 		const ctx = c.get("ctx");
 
-		const { db, logger, org, env: fromEnv } = ctx;
+		const { db, logger, org, env: fromEnv, authType } = ctx;
 		const { product_id: fromProductId } = c.req.param();
 		const { env: toEnv, id: toId, name: toName } = body;
 
-		if (fromEnv === toEnv && fromProductId === toId) {
-			throw new RecaseError({
-				message: `Product ID ${toId} already exists in ${toEnv}`,
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
-		}
+		const promoting =
+			authType === AuthType.Dashboard &&
+			org.is_sandbox === true &&
+			!!c.req.header(SANDBOX_ORG_HEADER) &&
+			!!org.created_by;
 
-		// 1. Check if product exists in target environment
-		const toProduct = await ProductService.get({
+		const toOrg = promoting
+			? await OrgService.get({ db, orgId: org.created_by as string })
+			: org;
+
+		await copyProductForOrgs({
 			db,
-			id: toId,
-			orgId: org.id,
-			env: toEnv,
-		});
-
-		if (toProduct) {
-			throw new ProductAlreadyExistsError({
-				productId: toId,
-				message: `Product ${toId} already exists in ${toEnv}`,
-			});
-		}
-
-		// 2. Get source product and features from both environments
-		const [fromFullProduct, fromFeatures, toFeatures] = await Promise.all([
-			ProductService.getFull({
-				db,
-				idOrInternalId: fromProductId,
-				orgId: org.id,
-				env: fromEnv,
-			}),
-			FeatureService.list({
-				db,
-				orgId: org.id,
-				env: fromEnv,
-			}),
-			FeatureService.list({
-				db,
-				orgId: org.id,
-				env: toEnv,
-			}),
-		]);
-
-		if (fromFullProduct) {
-			fromFullProduct.is_default = false;
-		}
-
-		const featureIdsToCopy = fromFullProduct.entitlements.map(
-			(e) => e.feature.id,
-		);
-
-		// 3. Sync features between environments if copying across environments
-		if (fromEnv !== toEnv) {
-			for (const fromFeature of fromFeatures.filter((f) =>
-				featureIdsToCopy.includes(f.id),
-			)) {
-				const toFeature = toFeatures.find((f) => f.id === fromFeature.id);
-
-				if (toFeature && fromFeature.type !== toFeature.type) {
-					throw new RecaseError({
-						message: `Feature ${fromFeature.name} exists in ${toEnv}, but has a different config. Please match them then try again.`,
-						code: ErrCode.InvalidRequest,
-						statusCode: 400,
-					});
-				}
-
-				if (!toFeature) {
-					const res = await FeatureService.insert({
-						db,
-						data: initNewFeature({
-							data: CreateFeatureSchema.parse(fromFeature),
-							orgId: org.id,
-							env: toEnv,
-						}),
-						logger,
-					});
-
-					toFeatures.push(res![0]);
-				}
-			}
-		}
-
-		// 4. Copy product
-		await copyProduct({
-			db,
-			product: fromFullProduct,
-			toOrgId: org.id,
+			logger,
+			fromOrg: org,
+			fromEnv,
+			toOrg,
+			toEnv,
+			fromProductId,
 			toId,
 			toName,
-			fromEnv,
-			toEnv,
-			toFeatures,
-			fromFeatures,
-			org,
-			logger,
 		});
-
-		// Invalidate cache for target environment (and source if same org)
-		await invalidateProductsCache({ orgId: org.id, env: toEnv });
-		if (fromEnv !== toEnv) {
-			await invalidateProductsCache({ orgId: org.id, env: fromEnv });
-		}
 
 		return c.json({ message: "Product copied" });
 	},

--- a/server/src/internal/sandboxes/copySandbox.ts
+++ b/server/src/internal/sandboxes/copySandbox.ts
@@ -70,6 +70,15 @@ export const copySandboxForOrg = async ({
 		sourceOrg = await getOwnedSandbox({ db, masterOrg, sandboxId: fromSandboxId });
 		fromEnv = AppEnv.Sandbox;
 	} else if (fromOrg && fromEnvArg) {
+		// The only non-sandbox source is the caller's own master org; never copy
+		// from an unrelated org into a sandbox this master owns.
+		if (fromOrg.id !== masterOrg.id) {
+			throw new RecaseError({
+				message: "Invalid copy source",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
 		sourceOrg = fromOrg;
 		fromEnv = fromEnvArg;
 	} else {
@@ -101,6 +110,20 @@ export const copySandboxForOrg = async ({
 			orgId: sourceOrg.id,
 			env: fromEnv,
 		});
+
+		// A requested product that isn't in the source would otherwise no-op and
+		// still toast success; surface it instead.
+		const sourceProductIds = new Set(fromProducts.map((p) => p.id));
+		const missing = requestedProductIds.filter(
+			(id) => !sourceProductIds.has(id),
+		);
+		if (missing.length > 0) {
+			throw new RecaseError({
+				message: `Plan${missing.length > 1 ? "s" : ""} not found in source: ${missing.join(", ")}`,
+				code: ErrCode.ProductNotFound,
+				statusCode: 404,
+			});
+		}
 
 		const wantedFeatureIds = new Set(featureIds ?? []);
 		for (const product of fromProducts) {

--- a/server/src/internal/sandboxes/copySandbox.ts
+++ b/server/src/internal/sandboxes/copySandbox.ts
@@ -1,8 +1,10 @@
 import {
 	AppEnv,
+	ErrCode,
 	FeatureType,
 	mapToProductV2,
 	type Organization,
+	RecaseError,
 } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
@@ -40,6 +42,14 @@ export const copySandboxForOrg = async ({
 	productIds?: string[];
 	featureIds?: string[];
 }): Promise<{ fromSandbox: Organization; toSandbox: Organization }> => {
+	if (fromSandboxId === toSandboxId) {
+		throw new RecaseError({
+			message: "Source and target sandboxes must be different",
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+
 	// Authorize the caller for BOTH sandboxes. Either resolution failing folds
 	// into a uniform 404 so ownership/existence can't be probed.
 	const [fromSandbox, toSandbox] = await Promise.all([
@@ -113,6 +123,7 @@ export const copySandboxForOrg = async ({
 		toOrg: toSandbox,
 		toEnv,
 		productIds: productIdsToCopy,
+		fromFeatures,
 	});
 
 	await invalidateProductsCache({ orgId: toSandbox.id, env: toEnv });

--- a/server/src/internal/sandboxes/copySandbox.ts
+++ b/server/src/internal/sandboxes/copySandbox.ts
@@ -67,7 +67,11 @@ export const copySandboxForOrg = async ({
 	let sourceOrg: Organization;
 	let fromEnv: AppEnv;
 	if (fromSandboxId) {
-		sourceOrg = await getOwnedSandbox({ db, masterOrg, sandboxId: fromSandboxId });
+		sourceOrg = await getOwnedSandbox({
+			db,
+			masterOrg,
+			sandboxId: fromSandboxId,
+		});
 		fromEnv = AppEnv.Sandbox;
 	} else if (fromOrg && fromEnvArg) {
 		// The only non-sandbox source is the caller's own master org; never copy
@@ -111,21 +115,34 @@ export const copySandboxForOrg = async ({
 			env: fromEnv,
 		});
 
-		// A requested product that isn't in the source would otherwise no-op and
-		// still toast success; surface it instead.
+		// A requested product/feature that isn't in the source would otherwise
+		// no-op and still toast success; surface it instead.
 		const sourceProductIds = new Set(fromProducts.map((p) => p.id));
-		const missing = requestedProductIds.filter(
+		const missingProducts = requestedProductIds.filter(
 			(id) => !sourceProductIds.has(id),
 		);
-		if (missing.length > 0) {
+		if (missingProducts.length > 0) {
 			throw new RecaseError({
-				message: `Plan${missing.length > 1 ? "s" : ""} not found in source: ${missing.join(", ")}`,
+				message: `Plan${missingProducts.length > 1 ? "s" : ""} not found in source: ${missingProducts.join(", ")}`,
 				code: ErrCode.ProductNotFound,
 				statusCode: 404,
 			});
 		}
 
-		const wantedFeatureIds = new Set(featureIds ?? []);
+		const requestedFeatureIds = featureIds ?? [];
+		const sourceFeatureIds = new Set(fromFeatures.map((f) => f.id));
+		const missingFeatures = requestedFeatureIds.filter(
+			(id) => !sourceFeatureIds.has(id),
+		);
+		if (missingFeatures.length > 0) {
+			throw new RecaseError({
+				message: `Feature${missingFeatures.length > 1 ? "s" : ""} not found in source: ${missingFeatures.join(", ")}`,
+				code: ErrCode.FeatureNotFound,
+				statusCode: 404,
+			});
+		}
+
+		const wantedFeatureIds = new Set(requestedFeatureIds);
 		for (const product of fromProducts) {
 			if (!requestedProductIds.includes(product.id)) continue;
 			const { items } = mapToProductV2({ product, features: fromFeatures });

--- a/server/src/internal/sandboxes/copySandbox.ts
+++ b/server/src/internal/sandboxes/copySandbox.ts
@@ -1,9 +1,15 @@
-import { AppEnv, type Organization } from "@autumn/shared";
+import {
+	AppEnv,
+	FeatureType,
+	mapToProductV2,
+	type Organization,
+} from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { FeatureService } from "@/internal/features/FeatureService.js";
 import { handleCopyFeatures } from "@/internal/products/handlers/handleCopyEnvironment/handleCopyFeatures.js";
 import { handleCopyProducts } from "@/internal/products/handlers/handleCopyEnvironment/handleCopyProducts.js";
+import { ProductService } from "@/internal/products/ProductService.js";
 import { invalidateProductsCache } from "@/internal/products/productCacheUtils.js";
 import { getOwnedSandbox } from "./getOwnedSandbox.js";
 
@@ -23,12 +29,16 @@ export const copySandboxForOrg = async ({
 	masterOrg,
 	fromSandboxId,
 	toSandboxId,
+	productIds,
+	featureIds,
 }: {
 	db: DrizzleCli;
 	ctx: AutumnContext;
 	masterOrg: Organization;
 	fromSandboxId: string;
 	toSandboxId: string;
+	productIds?: string[];
+	featureIds?: string[];
 }): Promise<{ fromSandbox: Organization; toSandbox: Organization }> => {
 	// Authorize the caller for BOTH sandboxes. Either resolution failing folds
 	// into a uniform 404 so ownership/existence can't be probed.
@@ -45,11 +55,52 @@ export const copySandboxForOrg = async ({
 		FeatureService.list({ db, orgId: toSandbox.id, env: toEnv }),
 	]);
 
+	// No filter => whole-catalog copy. Any filter => copy only the requested
+	// products + features, plus every feature the requested products reference
+	// so a copied plan never lands with a dangling feature reference.
+	const selective = productIds !== undefined || featureIds !== undefined;
+	let featuresToCopy = fromFeatures;
+	let productIdsToCopy = productIds;
+
+	if (selective) {
+		const requestedProductIds = productIds ?? [];
+		const fromProducts = await ProductService.listFull({
+			db,
+			orgId: fromSandbox.id,
+			env: fromEnv,
+		});
+
+		const wantedFeatureIds = new Set(featureIds ?? []);
+		for (const product of fromProducts) {
+			if (!requestedProductIds.includes(product.id)) continue;
+			const { items } = mapToProductV2({ product, features: fromFeatures });
+			for (const item of items) {
+				if (item.feature_id) wantedFeatureIds.add(item.feature_id);
+			}
+		}
+
+		// Credit systems draw from metered features; bring those along too.
+		for (const feature of fromFeatures) {
+			if (feature.type !== FeatureType.CreditSystem) continue;
+			if (!wantedFeatureIds.has(feature.id)) continue;
+			const config = feature.config as
+				| { schema?: { metered_feature_id: string }[] }
+				| null
+				| undefined;
+			for (const entry of config?.schema ?? []) {
+				wantedFeatureIds.add(entry.metered_feature_id);
+			}
+		}
+
+		featuresToCopy = fromFeatures.filter((f) => wantedFeatureIds.has(f.id));
+		productIdsToCopy = requestedProductIds;
+	}
+
 	// Features first: products reference them, and credit systems reference
 	// metered features (handleCopyFeatures orders the batches accordingly).
 	await handleCopyFeatures({
 		ctx,
-		fromFeatures,
+		fromFeatures: featuresToCopy,
 		toOrg: toSandbox,
 		toEnv,
 		toFeatures,
@@ -61,6 +112,7 @@ export const copySandboxForOrg = async ({
 		fromEnv,
 		toOrg: toSandbox,
 		toEnv,
+		productIds: productIdsToCopy,
 	});
 
 	await invalidateProductsCache({ orgId: toSandbox.id, env: toEnv });

--- a/server/src/internal/sandboxes/copySandbox.ts
+++ b/server/src/internal/sandboxes/copySandbox.ts
@@ -1,7 +1,7 @@
 import {
 	AppEnv,
 	ErrCode,
-	FeatureType,
+	isAnyCreditSystem,
 	mapToProductV2,
 	type Organization,
 	RecaseError,
@@ -91,7 +91,7 @@ export const copySandboxForOrg = async ({
 
 		// Credit systems draw from metered features; bring those along too.
 		for (const feature of fromFeatures) {
-			if (feature.type !== FeatureType.CreditSystem) continue;
+			if (!isAnyCreditSystem(feature.type)) continue;
 			if (!wantedFeatureIds.has(feature.id)) continue;
 			const config = feature.config as
 				| { schema?: { metered_feature_id: string }[] }

--- a/server/src/internal/sandboxes/copySandbox.ts
+++ b/server/src/internal/sandboxes/copySandbox.ts
@@ -1,0 +1,69 @@
+import { AppEnv, type Organization } from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { FeatureService } from "@/internal/features/FeatureService.js";
+import { handleCopyFeatures } from "@/internal/products/handlers/handleCopyEnvironment/handleCopyFeatures.js";
+import { handleCopyProducts } from "@/internal/products/handlers/handleCopyEnvironment/handleCopyProducts.js";
+import { invalidateProductsCache } from "@/internal/products/productCacheUtils.js";
+import { getOwnedSandbox } from "./getOwnedSandbox.js";
+
+/**
+ * Copies plans (products) + features from one named sandbox into another.
+ *
+ * Both sandboxes are sub-orgs of the master org (`is_sandbox=true`,
+ * `created_by = masterOrg.id`), each its own organization living in
+ * `AppEnv.Sandbox`. The caller (a master-org dashboard session) must own BOTH
+ * sandboxes; `getOwnedSandbox` applies the same 404-masking ownership check as
+ * `assertSandboxAccess`, so a missing or non-owned id is indistinguishable from
+ * a 404 and we never touch any org's live catalog.
+ */
+export const copySandboxForOrg = async ({
+	db,
+	ctx,
+	masterOrg,
+	fromSandboxId,
+	toSandboxId,
+}: {
+	db: DrizzleCli;
+	ctx: AutumnContext;
+	masterOrg: Organization;
+	fromSandboxId: string;
+	toSandboxId: string;
+}): Promise<{ fromSandbox: Organization; toSandbox: Organization }> => {
+	// Authorize the caller for BOTH sandboxes. Either resolution failing folds
+	// into a uniform 404 so ownership/existence can't be probed.
+	const [fromSandbox, toSandbox] = await Promise.all([
+		getOwnedSandbox({ db, masterOrg, sandboxId: fromSandboxId }),
+		getOwnedSandbox({ db, masterOrg, sandboxId: toSandboxId }),
+	]);
+
+	const fromEnv = AppEnv.Sandbox;
+	const toEnv = AppEnv.Sandbox;
+
+	const [fromFeatures, toFeatures] = await Promise.all([
+		FeatureService.list({ db, orgId: fromSandbox.id, env: fromEnv }),
+		FeatureService.list({ db, orgId: toSandbox.id, env: toEnv }),
+	]);
+
+	// Features first: products reference them, and credit systems reference
+	// metered features (handleCopyFeatures orders the batches accordingly).
+	await handleCopyFeatures({
+		ctx,
+		fromFeatures,
+		toOrg: toSandbox,
+		toEnv,
+		toFeatures,
+	});
+
+	await handleCopyProducts({
+		ctx,
+		fromOrg: fromSandbox,
+		fromEnv,
+		toOrg: toSandbox,
+		toEnv,
+	});
+
+	await invalidateProductsCache({ orgId: toSandbox.id, env: toEnv });
+
+	return { fromSandbox, toSandbox };
+};

--- a/server/src/internal/sandboxes/copySandbox.ts
+++ b/server/src/internal/sandboxes/copySandbox.ts
@@ -30,6 +30,8 @@ export const copySandboxForOrg = async ({
 	ctx,
 	masterOrg,
 	fromSandboxId,
+	fromOrg,
+	fromEnv: fromEnvArg,
 	toSandboxId,
 	productIds,
 	featureIds,
@@ -37,12 +39,14 @@ export const copySandboxForOrg = async ({
 	db: DrizzleCli;
 	ctx: AutumnContext;
 	masterOrg: Organization;
-	fromSandboxId: string;
+	fromSandboxId?: string;
+	fromOrg?: Organization;
+	fromEnv?: AppEnv;
 	toSandboxId: string;
 	productIds?: string[];
 	featureIds?: string[];
 }): Promise<{ fromSandbox: Organization; toSandbox: Organization }> => {
-	if (fromSandboxId === toSandboxId) {
+	if (fromSandboxId && fromSandboxId === toSandboxId) {
 		throw new RecaseError({
 			message: "Source and target sandboxes must be different",
 			code: ErrCode.InvalidRequest,
@@ -50,18 +54,36 @@ export const copySandboxForOrg = async ({
 		});
 	}
 
-	// Authorize the caller for BOTH sandboxes. Either resolution failing folds
-	// into a uniform 404 so ownership/existence can't be probed.
-	const [fromSandbox, toSandbox] = await Promise.all([
-		getOwnedSandbox({ db, masterOrg, sandboxId: fromSandboxId }),
-		getOwnedSandbox({ db, masterOrg, sandboxId: toSandboxId }),
-	]);
+	// Target is always an owned named sandbox. Source is either another owned
+	// sandbox or — for a copy started from the default sandbox / production — the
+	// master org at the caller's current env. Ownership failures fold into a
+	// uniform 404 so ids/ownership can't be probed.
+	const toSandbox = await getOwnedSandbox({
+		db,
+		masterOrg,
+		sandboxId: toSandboxId,
+	});
 
-	const fromEnv = AppEnv.Sandbox;
+	let sourceOrg: Organization;
+	let fromEnv: AppEnv;
+	if (fromSandboxId) {
+		sourceOrg = await getOwnedSandbox({ db, masterOrg, sandboxId: fromSandboxId });
+		fromEnv = AppEnv.Sandbox;
+	} else if (fromOrg && fromEnvArg) {
+		sourceOrg = fromOrg;
+		fromEnv = fromEnvArg;
+	} else {
+		throw new RecaseError({
+			message: "No copy source specified",
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+
 	const toEnv = AppEnv.Sandbox;
 
 	const [fromFeatures, toFeatures] = await Promise.all([
-		FeatureService.list({ db, orgId: fromSandbox.id, env: fromEnv }),
+		FeatureService.list({ db, orgId: sourceOrg.id, env: fromEnv }),
 		FeatureService.list({ db, orgId: toSandbox.id, env: toEnv }),
 	]);
 
@@ -76,7 +98,7 @@ export const copySandboxForOrg = async ({
 		const requestedProductIds = productIds ?? [];
 		const fromProducts = await ProductService.listFull({
 			db,
-			orgId: fromSandbox.id,
+			orgId: sourceOrg.id,
 			env: fromEnv,
 		});
 
@@ -118,7 +140,7 @@ export const copySandboxForOrg = async ({
 
 	await handleCopyProducts({
 		ctx,
-		fromOrg: fromSandbox,
+		fromOrg: sourceOrg,
 		fromEnv,
 		toOrg: toSandbox,
 		toEnv,
@@ -128,5 +150,5 @@ export const copySandboxForOrg = async ({
 
 	await invalidateProductsCache({ orgId: toSandbox.id, env: toEnv });
 
-	return { fromSandbox, toSandbox };
+	return { fromSandbox: sourceOrg, toSandbox };
 };

--- a/server/src/internal/sandboxes/createSandbox.ts
+++ b/server/src/internal/sandboxes/createSandbox.ts
@@ -34,7 +34,7 @@ export const assertDashboardActor = ({
 }): User => {
 	if (authType !== AuthType.Dashboard || !user) {
 		throw new RecaseError({
-			message: "Sandboxes can only be created from the dashboard",
+			message: "Sandboxes can only be managed from the dashboard",
 			code: ErrCode.InvalidRequest,
 			statusCode: 401,
 		});

--- a/server/src/internal/sandboxes/createSandbox.ts
+++ b/server/src/internal/sandboxes/createSandbox.ts
@@ -193,6 +193,7 @@ export const createSandboxForOrg = async ({
 		createMembership: false,
 		sandboxColor: color ?? DEFAULT_SANDBOX_COLOR,
 		sandboxIcon: icon ?? DEFAULT_SANDBOX_ICON,
+		config: masterOrg.config,
 	});
 
 	try {

--- a/server/src/internal/sandboxes/handlers/handleCopySandbox.ts
+++ b/server/src/internal/sandboxes/handlers/handleCopySandbox.ts
@@ -7,34 +7,42 @@ import {
 	assertNotSandboxContext,
 } from "../createSandbox.js";
 
-const CopySandboxSchema = z.object({
-	fromSandboxId: z.string().min(1),
-	toSandboxId: z.string().min(1),
-	// Omit both to copy the whole catalog; pass either to copy only those items
-	// (selected products pull in the features they reference).
-	productIds: z.array(z.string()).optional(),
-	featureIds: z.array(z.string()).optional(),
-});
+const CopySandboxSchema = z
+	.object({
+		// Source is exactly one of: another owned sandbox (fromSandboxId), or the
+		// master org's current env — default sandbox / production — via fromMaster.
+		fromSandboxId: z.string().min(1).optional(),
+		fromMaster: z.literal(true).optional(),
+		toSandboxId: z.string().min(1),
+		// Omit both to copy the whole catalog; pass either to copy only those items
+		// (selected products pull in the features they reference).
+		productIds: z.array(z.string()).optional(),
+		featureIds: z.array(z.string()).optional(),
+	})
+	.refine((d) => (d.fromSandboxId ? 1 : 0) + (d.fromMaster ? 1 : 0) === 1, {
+		message: "Provide exactly one of fromSandboxId or fromMaster",
+	});
 
 /**
  * POST /sandboxes.copy
  *
- * Dashboard-only RPC that copies plans (products) + features from one named
- * sandbox into another. Both must be sandbox sub-orgs owned by the caller's
- * master org; ownership is enforced inside copySandboxForOrg via the 404-masking
- * getOwnedSandbox check, so a non-owned source or target reads as a 404.
+ * Dashboard-only RPC that copies plans (products) + features into a named
+ * sandbox. The source is another owned sandbox, or — via fromMaster — the master
+ * org at the caller's current env (so you can seed a sandbox from the default
+ * sandbox or from production). Ownership is enforced inside copySandboxForOrg via
+ * the 404-masking getOwnedSandbox check, so a non-owned endpoint reads as a 404.
  */
 export const handleCopySandbox = createRoute({
 	scopes: [Scopes.Platform.Write],
 	body: CopySandboxSchema,
 	handler: async (c) => {
 		const ctx = c.get("ctx");
-		const { db, org: masterOrg, user, authType } = ctx;
+		const { db, org: masterOrg, env, user, authType } = ctx;
 
 		assertNotSandboxContext(masterOrg);
 		assertDashboardActor({ authType, user });
 
-		const { fromSandboxId, toSandboxId, productIds, featureIds } =
+		const { fromSandboxId, fromMaster, toSandboxId, productIds, featureIds } =
 			c.req.valid("json");
 
 		if (fromSandboxId === toSandboxId) {
@@ -50,6 +58,8 @@ export const handleCopySandbox = createRoute({
 			ctx,
 			masterOrg,
 			fromSandboxId,
+			fromOrg: fromMaster ? masterOrg : undefined,
+			fromEnv: fromMaster ? env : undefined,
 			toSandboxId,
 			productIds,
 			featureIds,

--- a/server/src/internal/sandboxes/handlers/handleCopySandbox.ts
+++ b/server/src/internal/sandboxes/handlers/handleCopySandbox.ts
@@ -10,6 +10,10 @@ import {
 const CopySandboxSchema = z.object({
 	fromSandboxId: z.string().min(1),
 	toSandboxId: z.string().min(1),
+	// Omit both to copy the whole catalog; pass either to copy only those items
+	// (selected products pull in the features they reference).
+	productIds: z.array(z.string()).optional(),
+	featureIds: z.array(z.string()).optional(),
 });
 
 /**
@@ -30,7 +34,8 @@ export const handleCopySandbox = createRoute({
 		assertNotSandboxContext(masterOrg);
 		assertDashboardActor({ authType, user });
 
-		const { fromSandboxId, toSandboxId } = c.req.valid("json");
+		const { fromSandboxId, toSandboxId, productIds, featureIds } =
+			c.req.valid("json");
 
 		if (fromSandboxId === toSandboxId) {
 			throw new RecaseError({
@@ -46,6 +51,8 @@ export const handleCopySandbox = createRoute({
 			masterOrg,
 			fromSandboxId,
 			toSandboxId,
+			productIds,
+			featureIds,
 		});
 
 		return c.json({ success: true });

--- a/server/src/internal/sandboxes/handlers/handleCopySandbox.ts
+++ b/server/src/internal/sandboxes/handlers/handleCopySandbox.ts
@@ -12,7 +12,9 @@ const CopySandboxSchema = z
 		// Source is exactly one of: another owned sandbox (fromSandboxId), or the
 		// master org's current env — default sandbox / production — via fromMaster.
 		fromSandboxId: z.string().min(1).optional(),
-		fromMaster: z.literal(true).optional(),
+		// boolean (not z.literal(true)) so clients that serialize `false` instead
+		// of omitting still parse; the refine treats falsy as "no master source".
+		fromMaster: z.boolean().optional(),
 		toSandboxId: z.string().min(1),
 		// Omit both to copy the whole catalog; pass either to copy only those items
 		// (selected products pull in the features they reference).

--- a/server/src/internal/sandboxes/handlers/handleCopySandbox.ts
+++ b/server/src/internal/sandboxes/handlers/handleCopySandbox.ts
@@ -1,0 +1,53 @@
+import { ErrCode, RecaseError, Scopes } from "@autumn/shared";
+import { z } from "zod/v4";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { copySandboxForOrg } from "../copySandbox.js";
+import {
+	assertDashboardActor,
+	assertNotSandboxContext,
+} from "../createSandbox.js";
+
+const CopySandboxSchema = z.object({
+	fromSandboxId: z.string().min(1),
+	toSandboxId: z.string().min(1),
+});
+
+/**
+ * POST /sandboxes.copy
+ *
+ * Dashboard-only RPC that copies plans (products) + features from one named
+ * sandbox into another. Both must be sandbox sub-orgs owned by the caller's
+ * master org; ownership is enforced inside copySandboxForOrg via the 404-masking
+ * getOwnedSandbox check, so a non-owned source or target reads as a 404.
+ */
+export const handleCopySandbox = createRoute({
+	scopes: [Scopes.Platform.Write],
+	body: CopySandboxSchema,
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { db, org: masterOrg, user, authType } = ctx;
+
+		assertNotSandboxContext(masterOrg);
+		assertDashboardActor({ authType, user });
+
+		const { fromSandboxId, toSandboxId } = c.req.valid("json");
+
+		if (fromSandboxId === toSandboxId) {
+			throw new RecaseError({
+				message: "Source and target sandboxes must be different",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		await copySandboxForOrg({
+			db,
+			ctx,
+			masterOrg,
+			fromSandboxId,
+			toSandboxId,
+		});
+
+		return c.json({ success: true });
+	},
+});

--- a/server/src/internal/sandboxes/sandboxesRouter.ts
+++ b/server/src/internal/sandboxes/sandboxesRouter.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { handleCopySandbox } from "./handlers/handleCopySandbox.js";
 import { handleCreateSandbox } from "./handlers/handleCreateSandbox.js";
 import { handleDeleteSandbox } from "./handlers/handleDeleteSandbox.js";
 import { handleListSandboxes } from "./handlers/handleListSandboxes.js";
@@ -11,3 +12,4 @@ sandboxesRpcRouter.post("/sandboxes.create", ...handleCreateSandbox);
 sandboxesRpcRouter.post("/sandboxes.list", ...handleListSandboxes);
 sandboxesRpcRouter.post("/sandboxes.delete", ...handleDeleteSandbox);
 sandboxesRpcRouter.post("/sandboxes.update", ...handleUpdateSandbox);
+sandboxesRpcRouter.post("/sandboxes.copy", ...handleCopySandbox);

--- a/server/tests/integration/sandbox/copy-master-to-sandbox.test.ts
+++ b/server/tests/integration/sandbox/copy-master-to-sandbox.test.ts
@@ -134,7 +134,7 @@ afterAll(async () => {
 			}).catch(() => {});
 		}
 	}
-});
+}, 180_000);
 
 describe("copy a plan from the master org into a named sandbox", () => {
 	test("from the default sandbox (master Sandbox env)", async () => {

--- a/server/tests/integration/sandbox/copy-master-to-sandbox.test.ts
+++ b/server/tests/integration/sandbox/copy-master-to-sandbox.test.ts
@@ -234,4 +234,24 @@ describe("copy a plan from the master org into a named sandbox", () => {
 		}
 		expect(thrown).toBe(true);
 	}, 120_000);
+
+	test("a requested plan absent from the source is rejected, not a silent no-op", async () => {
+		if (!master || !sub) throw new Error("orgs not provisioned");
+
+		let thrown = false;
+		try {
+			await copySandboxForOrg({
+				db,
+				ctx: baseCtx,
+				masterOrg: master,
+				fromOrg: master,
+				fromEnv: AppEnv.Sandbox,
+				toSandboxId: sub.id,
+				productIds: [`missing_${suffix}`],
+			});
+		} catch {
+			thrown = true;
+		}
+		expect(thrown).toBe(true);
+	}, 120_000);
 });

--- a/server/tests/integration/sandbox/copy-master-to-sandbox.test.ts
+++ b/server/tests/integration/sandbox/copy-master-to-sandbox.test.ts
@@ -2,9 +2,11 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
 	AppEnv,
 	type CreateProductV2Params,
+	ErrCode,
 	type Organization,
 	type OrgConfig,
 	organizations,
+	RecaseError,
 } from "@autumn/shared";
 import { products } from "@tests/utils/fixtures/products.js";
 import defaultCtx from "@tests/utils/testInitUtils/createTestContext.js";
@@ -220,7 +222,7 @@ describe("copy a plan from the master org into a named sandbox", () => {
 	test("a copy with no source specified is rejected", async () => {
 		if (!master || !sub) throw new Error("orgs not provisioned");
 
-		let thrown = false;
+		let thrown: unknown;
 		try {
 			await copySandboxForOrg({
 				db,
@@ -229,16 +231,17 @@ describe("copy a plan from the master org into a named sandbox", () => {
 				toSandboxId: sub.id,
 				productIds: [SBX_PLAN],
 			});
-		} catch {
-			thrown = true;
+		} catch (error) {
+			thrown = error;
 		}
-		expect(thrown).toBe(true);
+		expect(thrown).toBeInstanceOf(RecaseError);
+		expect((thrown as RecaseError).code).toBe(ErrCode.InvalidRequest);
 	}, 120_000);
 
 	test("a requested plan absent from the source is rejected, not a silent no-op", async () => {
 		if (!master || !sub) throw new Error("orgs not provisioned");
 
-		let thrown = false;
+		let thrown: unknown;
 		try {
 			await copySandboxForOrg({
 				db,
@@ -249,9 +252,10 @@ describe("copy a plan from the master org into a named sandbox", () => {
 				toSandboxId: sub.id,
 				productIds: [`missing_${suffix}`],
 			});
-		} catch {
-			thrown = true;
+		} catch (error) {
+			thrown = error;
 		}
-		expect(thrown).toBe(true);
+		expect(thrown).toBeInstanceOf(RecaseError);
+		expect((thrown as RecaseError).code).toBe(ErrCode.ProductNotFound);
 	}, 120_000);
 });

--- a/server/tests/integration/sandbox/copy-master-to-sandbox.test.ts
+++ b/server/tests/integration/sandbox/copy-master-to-sandbox.test.ts
@@ -1,0 +1,237 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+	AppEnv,
+	type CreateProductV2Params,
+	type Organization,
+	type OrgConfig,
+	organizations,
+} from "@autumn/shared";
+import { products } from "@tests/utils/fixtures/products.js";
+import defaultCtx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initDrizzle } from "@/db/initDrizzle.js";
+import { logger } from "@/external/logtail/logtailUtils.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { FeatureService } from "@/internal/features/FeatureService.js";
+import { createFeature } from "@/internal/features/featureActions/createFeature.js";
+import { constructBooleanFeature } from "@/internal/features/utils/constructFeatureUtils.js";
+import { deletePlatformSubOrg } from "@/internal/orgs/deleteOrg/deletePlatformSubOrg.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import { createProduct } from "@/internal/product/actions/createProduct.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { copySandboxForOrg } from "@/internal/sandboxes/copySandbox.js";
+import { generatePublishableKey } from "@/utils/encryptUtils.js";
+import { generateId } from "@/utils/genUtils.js";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
+
+// Copying from the master org (default sandbox = master@Sandbox, production =
+// master@Live) INTO a named sandbox. Exercises copySandboxForOrg's fromMaster
+// source branch (fromOrg + fromEnv instead of a source sandbox), which the
+// dashboard "Copy to <sandbox>" menu uses from the default sandbox / production.
+
+const { db } = initDrizzle();
+const suffix = crypto.randomUUID().slice(0, 8);
+
+const SBX_FEATURE = `m2s_sbx_${suffix}`;
+const SBX_PLAN = `m2s_sbx_plan_${suffix}`;
+const LIVE_FEATURE = `m2s_live_${suffix}`;
+const LIVE_PLAN = `m2s_live_plan_${suffix}`;
+
+let master: Organization | undefined;
+let sub: Organization | undefined;
+
+const baseCtx = { ...defaultCtx } as AutumnContext;
+
+const insertOrg = async ({
+	name,
+	isSandbox,
+	masterOrgId,
+}: {
+	name: string;
+	isSandbox: boolean;
+	masterOrgId: string | null;
+}): Promise<Organization> => {
+	const orgId = generateId("org");
+	await db.insert(organizations).values({
+		id: orgId,
+		slug: `${name}-${crypto.randomUUID()}`,
+		name,
+		createdAt: new Date(),
+		created_at: Date.now(),
+		created_by: masterOrgId,
+		is_sandbox: isSandbox,
+		stripe_connected: false,
+		default_currency: "usd",
+		config: {} as OrgConfig,
+		onboarded: true,
+		test_pkey: generatePublishableKey(AppEnv.Sandbox),
+		live_pkey: generatePublishableKey(AppEnv.Live),
+	});
+	return OrgService.get({ db, orgId });
+};
+
+const seedPlan = async ({
+	org,
+	env,
+	featureId,
+	planId,
+}: {
+	org: Organization;
+	env: AppEnv;
+	featureId: string;
+	planId: string;
+}) => {
+	const seedCtx: AutumnContext = { ...baseCtx, org, env, features: [] };
+	await createFeature({
+		ctx: seedCtx,
+		data: constructBooleanFeature({ featureId, orgId: org.id, env }),
+		skipGenerateDisplay: true,
+	});
+	const features = await FeatureService.list({ db, orgId: org.id, env });
+	await createProduct({
+		ctx: { ...seedCtx, features },
+		data: products.base({
+			id: planId,
+			items: [constructFeatureItem({ featureId, isBoolean: true })],
+		}) as unknown as CreateProductV2Params,
+	});
+};
+
+beforeAll(async () => {
+	master = await insertOrg({
+		name: `m2s-master-${suffix}`,
+		isSandbox: false,
+		masterOrgId: null,
+	});
+	sub = await insertOrg({
+		name: `m2s-sub-${suffix}`,
+		isSandbox: true,
+		masterOrgId: master.id,
+	});
+	await seedPlan({
+		org: master,
+		env: AppEnv.Sandbox,
+		featureId: SBX_FEATURE,
+		planId: SBX_PLAN,
+	});
+	await seedPlan({
+		org: master,
+		env: AppEnv.Live,
+		featureId: LIVE_FEATURE,
+		planId: LIVE_PLAN,
+	});
+}, 180_000);
+
+afterAll(async () => {
+	for (const created of [sub, master]) {
+		if (created) {
+			await deletePlatformSubOrg({
+				db,
+				org: created,
+				logger,
+				skipLiveCustomerCheck: true,
+			}).catch(() => {});
+		}
+	}
+});
+
+describe("copy a plan from the master org into a named sandbox", () => {
+	test("from the default sandbox (master Sandbox env)", async () => {
+		if (!master || !sub) throw new Error("orgs not provisioned");
+
+		await copySandboxForOrg({
+			db,
+			ctx: baseCtx,
+			masterOrg: master,
+			fromOrg: master,
+			fromEnv: AppEnv.Sandbox,
+			toSandboxId: sub.id,
+			productIds: [SBX_PLAN],
+		});
+
+		const subProducts = await ProductService.listFull({
+			db,
+			orgId: sub.id,
+			env: AppEnv.Sandbox,
+		});
+		const subFeatures = await FeatureService.list({
+			db,
+			orgId: sub.id,
+			env: AppEnv.Sandbox,
+		});
+		expect(subProducts.map((p) => p.id)).toContain(SBX_PLAN);
+		expect(subFeatures.map((f) => f.id)).toContain(SBX_FEATURE);
+	}, 120_000);
+
+	test("from production (master Live env)", async () => {
+		if (!master || !sub) throw new Error("orgs not provisioned");
+
+		await copySandboxForOrg({
+			db,
+			ctx: baseCtx,
+			masterOrg: master,
+			fromOrg: master,
+			fromEnv: AppEnv.Live,
+			toSandboxId: sub.id,
+			productIds: [LIVE_PLAN],
+		});
+
+		const subProducts = await ProductService.listFull({
+			db,
+			orgId: sub.id,
+			env: AppEnv.Sandbox,
+		});
+		const subFeatures = await FeatureService.list({
+			db,
+			orgId: sub.id,
+			env: AppEnv.Sandbox,
+		});
+		expect(subProducts.map((p) => p.id)).toContain(LIVE_PLAN);
+		expect(subFeatures.map((f) => f.id)).toContain(LIVE_FEATURE);
+	}, 120_000);
+
+	test("re-copy overwrites a matching-id plan in the target (upsert, not duplicate)", async () => {
+		if (!master || !sub) throw new Error("orgs not provisioned");
+
+		const before = await ProductService.listFull({
+			db,
+			orgId: sub.id,
+			env: AppEnv.Sandbox,
+		});
+		const countBefore = before.filter((p) => p.id === SBX_PLAN).length;
+
+		await copySandboxForOrg({
+			db,
+			ctx: baseCtx,
+			masterOrg: master,
+			fromOrg: master,
+			fromEnv: AppEnv.Sandbox,
+			toSandboxId: sub.id,
+			productIds: [SBX_PLAN],
+		});
+
+		const after = await ProductService.listFull({
+			db,
+			orgId: sub.id,
+			env: AppEnv.Sandbox,
+		});
+		expect(after.filter((p) => p.id === SBX_PLAN).length).toBe(countBefore);
+	}, 120_000);
+
+	test("a copy with no source specified is rejected", async () => {
+		if (!master || !sub) throw new Error("orgs not provisioned");
+
+		let thrown = false;
+		try {
+			await copySandboxForOrg({
+				db,
+				ctx: baseCtx,
+				masterOrg: master,
+				toSandboxId: sub.id,
+				productIds: [SBX_PLAN],
+			});
+		} catch {
+			thrown = true;
+		}
+		expect(thrown).toBe(true);
+	}, 120_000);
+});

--- a/server/tests/integration/sandbox/copy-sandbox.test.ts
+++ b/server/tests/integration/sandbox/copy-sandbox.test.ts
@@ -435,3 +435,158 @@ describe("sandboxes.copy: selective copy via productIds / featureIds", () => {
 		);
 	}, 180_000);
 });
+
+describe("sandboxes.copy: edge cases", () => {
+	const freshOrg = async (label: string) => {
+		const org = await insertSandboxSubOrg({
+			masterOrgId: defaultCtx.org.id,
+			name: `copy-edge-${label}-${suffix}`,
+		});
+		extraTargets.push(org);
+		return org;
+	};
+
+	test("overwrites matching-id items in the target and re-copy is idempotent", async () => {
+		if (!source) throw new Error("source not provisioned");
+		const dst = await freshOrg("overwrite");
+
+		const seedCtx: AutumnContext = {
+			...baseCtx,
+			org: dst,
+			env: AppEnv.Sandbox,
+			features: [],
+		};
+		await createFeature({
+			ctx: seedCtx,
+			data: constructBooleanFeature({
+				featureId: DASH_FEATURE,
+				orgId: dst.id,
+				env: AppEnv.Sandbox,
+				name: "Stale Dashboard",
+			}),
+			skipGenerateDisplay: true,
+		});
+		const targetFeaturesBefore = await FeatureService.list({
+			db,
+			orgId: dst.id,
+			env: AppEnv.Sandbox,
+		});
+		await createProduct({
+			ctx: { ...seedCtx, features: targetFeaturesBefore },
+			data: products.base({
+				id: PRODUCT_ID,
+				items: [],
+			}) as unknown as CreateProductV2Params,
+		});
+
+		await copySandboxForOrg({
+			db,
+			ctx: baseCtx,
+			masterOrg: defaultCtx.org,
+			fromSandboxId: source.id,
+			toSandboxId: dst.id,
+		});
+
+		const featsAfter = await FeatureService.list({
+			db,
+			orgId: dst.id,
+			env: AppEnv.Sandbox,
+		});
+		const dash = featsAfter.find((f) => f.id === DASH_FEATURE);
+		expect(dash).toBeDefined();
+		expect(dash?.name).not.toBe("Stale Dashboard");
+
+		const prodsAfter = await ProductService.listFull({
+			db,
+			orgId: dst.id,
+			env: AppEnv.Sandbox,
+		});
+		const matching = prodsAfter.filter((p) => p.id === PRODUCT_ID);
+		expect(matching.length).toBe(1);
+		const copiedV2 = mapToProductV2({
+			product: matching[0],
+			features: featsAfter,
+		});
+		const itemFeatureIds = copiedV2.items
+			.map((i) => i.feature_id)
+			.filter((id): id is string => Boolean(id));
+		expect(itemFeatureIds.sort()).toEqual([DASH_FEATURE, MSG_FEATURE].sort());
+
+		await copySandboxForOrg({
+			db,
+			ctx: baseCtx,
+			masterOrg: defaultCtx.org,
+			fromSandboxId: source.id,
+			toSandboxId: dst.id,
+		});
+
+		const featsAgain = await FeatureService.list({
+			db,
+			orgId: dst.id,
+			env: AppEnv.Sandbox,
+		});
+		const prodsAgain = await ProductService.listFull({
+			db,
+			orgId: dst.id,
+			env: AppEnv.Sandbox,
+		});
+		expect(featsAgain.map((f) => f.id).sort()).toEqual(
+			featsAfter.map((f) => f.id).sort(),
+		);
+		expect(prodsAgain.filter((p) => p.id === PRODUCT_ID).length).toBe(1);
+	}, 180_000);
+
+	test("productIds: [] and featureIds: [] copies nothing", async () => {
+		if (!source) throw new Error("source not provisioned");
+		const dst = await freshOrg("empty-filters");
+
+		await copySandboxForOrg({
+			db,
+			ctx: baseCtx,
+			masterOrg: defaultCtx.org,
+			fromSandboxId: source.id,
+			toSandboxId: dst.id,
+			productIds: [],
+			featureIds: [],
+		});
+
+		const features = await FeatureService.list({
+			db,
+			orgId: dst.id,
+			env: AppEnv.Sandbox,
+		});
+		const dstProducts = await ProductService.listFull({
+			db,
+			orgId: dst.id,
+			env: AppEnv.Sandbox,
+		});
+		expect(features.length).toBe(0);
+		expect(dstProducts.length).toBe(0);
+	}, 180_000);
+
+	test("copying from an empty source succeeds and copies nothing", async () => {
+		const emptySource = await freshOrg("empty-src");
+		const dst = await freshOrg("empty-dst");
+
+		await copySandboxForOrg({
+			db,
+			ctx: baseCtx,
+			masterOrg: defaultCtx.org,
+			fromSandboxId: emptySource.id,
+			toSandboxId: dst.id,
+		});
+
+		const features = await FeatureService.list({
+			db,
+			orgId: dst.id,
+			env: AppEnv.Sandbox,
+		});
+		const dstProducts = await ProductService.listFull({
+			db,
+			orgId: dst.id,
+			env: AppEnv.Sandbox,
+		});
+		expect(features.length).toBe(0);
+		expect(dstProducts.length).toBe(0);
+	}, 180_000);
+});

--- a/server/tests/integration/sandbox/copy-sandbox.test.ts
+++ b/server/tests/integration/sandbox/copy-sandbox.test.ts
@@ -53,6 +53,7 @@ const suffix = crypto.randomUUID().slice(0, 8);
 
 let source: Organization | undefined;
 let target: Organization | undefined;
+const extraTargets: Organization[] = [];
 
 const baseCtx = { ...defaultCtx } as AutumnContext;
 
@@ -167,7 +168,7 @@ beforeAll(async () => {
 }, 180_000);
 
 afterAll(async () => {
-	for (const created of [source, target]) {
+	for (const created of [source, target, ...extraTargets]) {
 		if (created) {
 			await deletePlatformSubOrg({
 				db,
@@ -300,4 +301,100 @@ describe("sandboxes.copy: copy plans + features between two sandbox sub-orgs", (
 		expect((caught as RecaseError).code).toBe(ErrCode.OrgNotFound);
 		expect((caught as RecaseError).statusCode).toBe(404);
 	});
+});
+
+describe("sandboxes.copy: selective copy via productIds / featureIds", () => {
+	const freshTarget = async (label: string) => {
+		const dst = await insertSandboxSubOrg({
+			masterOrgId: defaultCtx.org.id,
+			name: `copy-sel-${label}-${suffix}`,
+		});
+		extraTargets.push(dst);
+		return dst;
+	};
+
+	test("productIds copies only that product plus the features it references", async () => {
+		if (!source) throw new Error("source not provisioned");
+		const dst = await freshTarget("prod");
+
+		await copySandboxForOrg({
+			db,
+			ctx: baseCtx,
+			masterOrg: defaultCtx.org,
+			fromSandboxId: source.id,
+			toSandboxId: dst.id,
+			productIds: [PRODUCT_ID],
+		});
+
+		const features = await FeatureService.list({
+			db,
+			orgId: dst.id,
+			env: AppEnv.Sandbox,
+		});
+		const dstProducts = await ProductService.listFull({
+			db,
+			orgId: dst.id,
+			env: AppEnv.Sandbox,
+		});
+
+		// The one product copied; its referenced features (dashboard + messages)
+		// auto-included; the unrelated credit system is NOT pulled in.
+		expect(dstProducts.map((p) => p.id)).toEqual([PRODUCT_ID]);
+		expect(features.map((f) => f.id).sort()).toEqual(
+			[DASH_FEATURE, MSG_FEATURE].sort(),
+		);
+	}, 180_000);
+
+	test("featureIds copies only those features and no products", async () => {
+		if (!source) throw new Error("source not provisioned");
+		const dst = await freshTarget("feat");
+
+		await copySandboxForOrg({
+			db,
+			ctx: baseCtx,
+			masterOrg: defaultCtx.org,
+			fromSandboxId: source.id,
+			toSandboxId: dst.id,
+			featureIds: [DASH_FEATURE],
+		});
+
+		const features = await FeatureService.list({
+			db,
+			orgId: dst.id,
+			env: AppEnv.Sandbox,
+		});
+		const dstProducts = await ProductService.listFull({
+			db,
+			orgId: dst.id,
+			env: AppEnv.Sandbox,
+		});
+
+		expect(features.map((f) => f.id)).toEqual([DASH_FEATURE]);
+		expect(dstProducts.length).toBe(0);
+	}, 180_000);
+
+	test("a credit-system featureId pulls in the metered feature it references", async () => {
+		if (!source) throw new Error("source not provisioned");
+		const dst = await freshTarget("credit");
+
+		await copySandboxForOrg({
+			db,
+			ctx: baseCtx,
+			masterOrg: defaultCtx.org,
+			fromSandboxId: source.id,
+			toSandboxId: dst.id,
+			featureIds: [CREDIT_FEATURE],
+		});
+
+		const features = await FeatureService.list({
+			db,
+			orgId: dst.id,
+			env: AppEnv.Sandbox,
+		});
+
+		// Credit system + the metered feature its schema references, nothing else.
+		expect(features.map((f) => f.id).sort()).toEqual(
+			[CREDIT_FEATURE, MSG_FEATURE].sort(),
+		);
+	}, 180_000);
 });

--- a/server/tests/integration/sandbox/copy-sandbox.test.ts
+++ b/server/tests/integration/sandbox/copy-sandbox.test.ts
@@ -1,0 +1,303 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+	AppEnv,
+	type CreateProductV2Params,
+	ErrCode,
+	FeatureUsageType,
+	mapToProductV2,
+	type Organization,
+	type OrgConfig,
+	organizations,
+	RecaseError,
+} from "@autumn/shared";
+import { products } from "@tests/utils/fixtures/products.js";
+import defaultCtx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initDrizzle } from "@/db/initDrizzle.js";
+import { logger } from "@/external/logtail/logtailUtils.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { FeatureService } from "@/internal/features/FeatureService.js";
+import { createFeature } from "@/internal/features/featureActions/createFeature.js";
+import {
+	constructBooleanFeature,
+	constructCreditSystem,
+	constructMeteredFeature,
+} from "@/internal/features/utils/constructFeatureUtils.js";
+import { deletePlatformSubOrg } from "@/internal/orgs/deleteOrg/deletePlatformSubOrg.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import { createProduct } from "@/internal/product/actions/createProduct.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { copySandboxForOrg } from "@/internal/sandboxes/copySandbox.js";
+import { generatePublishableKey } from "@/utils/encryptUtils.js";
+import { generateId } from "@/utils/genUtils.js";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
+
+// Drives copySandboxForOrg directly (the route is dashboard-only, so a
+// secret-key HTTP call is rejected by assertDashboardActor). Seeds the source
+// sandbox via the same createFeature/createProduct actions the copy engine
+// uses, then asserts the target sub-org receives the plans + features. No dev
+// server required — pure DB + action layer.
+//
+// Sandbox sub-orgs are inserted directly (is_sandbox=true, created_by=master)
+// instead of via createSandboxForOrg: real sandbox creation provisions a Stripe
+// connect account, which the copy feature is independent of. The inserted rows
+// carry the exact ownership shape getOwnedSandbox/assertSandboxAccess check.
+
+const { db } = initDrizzle();
+
+const MSG_FEATURE = "copy_messages";
+const DASH_FEATURE = "copy_dashboard";
+const CREDIT_FEATURE = "copy_credits";
+const PRODUCT_ID = "copy_pro";
+
+const suffix = crypto.randomUUID().slice(0, 8);
+
+let source: Organization | undefined;
+let target: Organization | undefined;
+
+const baseCtx = { ...defaultCtx } as AutumnContext;
+
+const insertSandboxSubOrg = async ({
+	masterOrgId,
+	name,
+}: {
+	masterOrgId: string;
+	name: string;
+}): Promise<Organization> => {
+	const orgId = generateId("org");
+	const slug = `${name}-${crypto.randomUUID()}|${masterOrgId}`;
+	await db.insert(organizations).values({
+		id: orgId,
+		slug,
+		name,
+		createdAt: new Date(),
+		created_at: Date.now(),
+		created_by: masterOrgId,
+		is_sandbox: true,
+		stripe_connected: false,
+		default_currency: "usd",
+		config: {} as OrgConfig,
+		onboarded: true,
+		test_pkey: generatePublishableKey(AppEnv.Sandbox),
+		live_pkey: generatePublishableKey(AppEnv.Live),
+	});
+	return OrgService.get({ db, orgId });
+};
+
+const seedSourceSandbox = async (sourceOrg: Organization) => {
+	const seedCtx: AutumnContext = {
+		...baseCtx,
+		org: sourceOrg,
+		env: AppEnv.Sandbox,
+		features: [],
+	};
+
+	const messages = constructMeteredFeature({
+		featureId: MSG_FEATURE,
+		orgId: sourceOrg.id,
+		env: AppEnv.Sandbox,
+		usageType: FeatureUsageType.Single,
+	});
+	const dashboard = constructBooleanFeature({
+		featureId: DASH_FEATURE,
+		orgId: sourceOrg.id,
+		env: AppEnv.Sandbox,
+	});
+
+	await createFeature({
+		ctx: seedCtx,
+		data: messages,
+		skipGenerateDisplay: true,
+	});
+	await createFeature({
+		ctx: seedCtx,
+		data: dashboard,
+		skipGenerateDisplay: true,
+	});
+
+	// Credit system references the metered feature; created after it so the
+	// schema reference resolves (mirrors handleCopyFeatures' batching).
+	const afterMetered = await FeatureService.list({
+		db,
+		orgId: sourceOrg.id,
+		env: AppEnv.Sandbox,
+	});
+	const credits = constructCreditSystem({
+		featureId: CREDIT_FEATURE,
+		orgId: sourceOrg.id,
+		env: AppEnv.Sandbox,
+		schema: [{ metered_feature_id: MSG_FEATURE, credit_cost: 1 }],
+	});
+	await createFeature({
+		ctx: { ...seedCtx, features: afterMetered },
+		data: credits,
+		skipGenerateDisplay: true,
+	});
+
+	const allFeatures = await FeatureService.list({
+		db,
+		orgId: sourceOrg.id,
+		env: AppEnv.Sandbox,
+	});
+
+	const product = products.base({
+		id: PRODUCT_ID,
+		items: [
+			constructFeatureItem({ featureId: DASH_FEATURE, isBoolean: true }),
+			constructFeatureItem({ featureId: MSG_FEATURE, includedUsage: 100 }),
+		],
+	});
+
+	await createProduct({
+		ctx: { ...seedCtx, features: allFeatures },
+		data: product as unknown as CreateProductV2Params,
+	});
+};
+
+beforeAll(async () => {
+	source = await insertSandboxSubOrg({
+		masterOrgId: defaultCtx.org.id,
+		name: `copy-source-${suffix}`,
+	});
+	target = await insertSandboxSubOrg({
+		masterOrgId: defaultCtx.org.id,
+		name: `copy-target-${suffix}`,
+	});
+
+	await seedSourceSandbox(source);
+}, 180_000);
+
+afterAll(async () => {
+	for (const created of [source, target]) {
+		if (created) {
+			await deletePlatformSubOrg({
+				db,
+				org: created,
+				logger,
+				skipLiveCustomerCheck: true,
+			}).catch(() => {});
+		}
+	}
+});
+
+describe("sandboxes.copy: copy plans + features between two sandbox sub-orgs", () => {
+	test("copies the source sandbox's features + product into the target sandbox", async () => {
+		if (!source || !target) throw new Error("sandboxes not provisioned");
+
+		// Sanity: target starts empty.
+		const targetFeaturesBefore = await FeatureService.list({
+			db,
+			orgId: target.id,
+			env: AppEnv.Sandbox,
+		});
+		const targetProductsBefore = await ProductService.listFull({
+			db,
+			orgId: target.id,
+			env: AppEnv.Sandbox,
+		});
+		expect(targetFeaturesBefore.length).toBe(0);
+		expect(targetProductsBefore.length).toBe(0);
+
+		await copySandboxForOrg({
+			db,
+			ctx: baseCtx,
+			masterOrg: defaultCtx.org,
+			fromSandboxId: source.id,
+			toSandboxId: target.id,
+		});
+
+		const targetFeatures = await FeatureService.list({
+			db,
+			orgId: target.id,
+			env: AppEnv.Sandbox,
+		});
+		const targetProducts = await ProductService.listFull({
+			db,
+			orgId: target.id,
+			env: AppEnv.Sandbox,
+		});
+
+		// All three feature types copied across the org boundary.
+		expect(targetFeatures.map((f) => f.id).sort()).toEqual(
+			[CREDIT_FEATURE, DASH_FEATURE, MSG_FEATURE].sort(),
+		);
+
+		// The product copied, and its items still reference the copied features.
+		const copied = targetProducts.find((p) => p.id === PRODUCT_ID);
+		expect(copied).toBeDefined();
+
+		const copiedV2 = mapToProductV2({
+			product: copied!,
+			features: targetFeatures,
+		});
+		const itemFeatureIds = copiedV2.items
+			.map((i) => i.feature_id)
+			.filter((id): id is string => Boolean(id));
+		expect(itemFeatureIds.sort()).toEqual([DASH_FEATURE, MSG_FEATURE].sort());
+	}, 180_000);
+
+	test("rejects a non-owned source with a 404 (ownership masked)", async () => {
+		if (!target) throw new Error("sandbox not provisioned");
+
+		let caught: unknown;
+		try {
+			await copySandboxForOrg({
+				db,
+				ctx: baseCtx,
+				masterOrg: defaultCtx.org,
+				fromSandboxId: `org_${crypto.randomUUID()}`,
+				toSandboxId: target.id,
+			});
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(RecaseError);
+		expect((caught as RecaseError).code).toBe(ErrCode.OrgNotFound);
+		expect((caught as RecaseError).statusCode).toBe(404);
+	});
+
+	test("rejects a non-owned target with a 404 (ownership masked)", async () => {
+		if (!source) throw new Error("sandbox not provisioned");
+
+		let caught: unknown;
+		try {
+			await copySandboxForOrg({
+				db,
+				ctx: baseCtx,
+				masterOrg: defaultCtx.org,
+				fromSandboxId: source.id,
+				toSandboxId: `org_${crypto.randomUUID()}`,
+			});
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(RecaseError);
+		expect((caught as RecaseError).code).toBe(ErrCode.OrgNotFound);
+		expect((caught as RecaseError).statusCode).toBe(404);
+	});
+
+	test("never targets the master org's live catalog (master id reads as 404)", async () => {
+		if (!source) throw new Error("sandbox not provisioned");
+
+		// The master org is a real org but is not a sandbox sub-org, so the
+		// ownership check folds it into the same uniform 404 — proving the copy
+		// can't be aimed at any org's live catalog.
+		let caught: unknown;
+		try {
+			await copySandboxForOrg({
+				db,
+				ctx: baseCtx,
+				masterOrg: defaultCtx.org,
+				fromSandboxId: source.id,
+				toSandboxId: defaultCtx.org.id,
+			});
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(RecaseError);
+		expect((caught as RecaseError).code).toBe(ErrCode.OrgNotFound);
+		expect((caught as RecaseError).statusCode).toBe(404);
+	});
+});

--- a/server/tests/integration/sandbox/copy-sandbox.test.ts
+++ b/server/tests/integration/sandbox/copy-sandbox.test.ts
@@ -18,6 +18,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { FeatureService } from "@/internal/features/FeatureService.js";
 import { createFeature } from "@/internal/features/featureActions/createFeature.js";
 import {
+	constructAiCreditSystem,
 	constructBooleanFeature,
 	constructCreditSystem,
 	constructMeteredFeature,
@@ -47,6 +48,7 @@ const { db } = initDrizzle();
 const MSG_FEATURE = "copy_messages";
 const DASH_FEATURE = "copy_dashboard";
 const CREDIT_FEATURE = "copy_credits";
+const AI_CREDIT_FEATURE = "copy_ai_credits";
 const PRODUCT_ID = "copy_pro";
 
 const suffix = crypto.randomUUID().slice(0, 8);
@@ -131,6 +133,20 @@ const seedSourceSandbox = async (sourceOrg: Organization) => {
 	await createFeature({
 		ctx: { ...seedCtx, features: afterMetered },
 		data: credits,
+		skipGenerateDisplay: true,
+	});
+
+	const aiCredits = constructAiCreditSystem({
+		featureId: AI_CREDIT_FEATURE,
+		orgId: sourceOrg.id,
+		env: AppEnv.Sandbox,
+		modelMarkups: {
+			"anthropic/claude-3-5-haiku-20241022": { markup: 20 },
+		},
+	});
+	await createFeature({
+		ctx: { ...seedCtx, features: afterMetered },
+		data: aiCredits,
 		skipGenerateDisplay: true,
 	});
 
@@ -219,7 +235,7 @@ describe("sandboxes.copy: copy plans + features between two sandbox sub-orgs", (
 
 		// All three feature types copied across the org boundary.
 		expect(targetFeatures.map((f) => f.id).sort()).toEqual(
-			[CREDIT_FEATURE, DASH_FEATURE, MSG_FEATURE].sort(),
+			[AI_CREDIT_FEATURE, CREDIT_FEATURE, DASH_FEATURE, MSG_FEATURE].sort(),
 		);
 
 		// The product copied, and its items still reference the copied features.
@@ -300,6 +316,27 @@ describe("sandboxes.copy: copy plans + features between two sandbox sub-orgs", (
 		expect(caught).toBeInstanceOf(RecaseError);
 		expect((caught as RecaseError).code).toBe(ErrCode.OrgNotFound);
 		expect((caught as RecaseError).statusCode).toBe(404);
+	});
+
+	test("rejects a self-copy (same source and target) with a 400", async () => {
+		if (!source) throw new Error("source not provisioned");
+
+		let caught: unknown;
+		try {
+			await copySandboxForOrg({
+				db,
+				ctx: baseCtx,
+				masterOrg: defaultCtx.org,
+				fromSandboxId: source.id,
+				toSandboxId: source.id,
+			});
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(RecaseError);
+		expect((caught as RecaseError).code).toBe(ErrCode.InvalidRequest);
+		expect((caught as RecaseError).statusCode).toBe(400);
 	});
 });
 

--- a/server/tests/integration/sandbox/copy-sandbox.test.ts
+++ b/server/tests/integration/sandbox/copy-sandbox.test.ts
@@ -410,6 +410,27 @@ describe("sandboxes.copy: selective copy via productIds / featureIds", () => {
 		expect(dstProducts.length).toBe(0);
 	}, 180_000);
 
+	test("a requested featureId absent from the source is rejected", async () => {
+		if (!source) throw new Error("source not provisioned");
+		const dst = await freshTarget("missing-feat");
+
+		let thrown: unknown;
+		try {
+			await copySandboxForOrg({
+				db,
+				ctx: baseCtx,
+				masterOrg: defaultCtx.org,
+				fromSandboxId: source.id,
+				toSandboxId: dst.id,
+				featureIds: ["does_not_exist"],
+			});
+		} catch (error) {
+			thrown = error;
+		}
+		expect(thrown).toBeInstanceOf(RecaseError);
+		expect((thrown as RecaseError).code).toBe(ErrCode.FeatureNotFound);
+	}, 180_000);
+
 	test("a credit-system featureId pulls in the metered feature it references", async () => {
 		if (!source) throw new Error("source not provisioned");
 		const dst = await freshTarget("credit");

--- a/server/tests/integration/sandbox/copy-sandbox.test.ts
+++ b/server/tests/integration/sandbox/copy-sandbox.test.ts
@@ -194,7 +194,7 @@ afterAll(async () => {
 			}).catch(() => {});
 		}
 	}
-});
+}, 180_000);
 
 describe("sandboxes.copy: copy plans + features between two sandbox sub-orgs", () => {
 	test("copies the source sandbox's features + product into the target sandbox", async () => {

--- a/server/tests/integration/sandbox/create-sandbox.test.ts
+++ b/server/tests/integration/sandbox/create-sandbox.test.ts
@@ -1,28 +1,48 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { AuthType, member, type Organization } from "@autumn/shared";
+import {
+	AppEnv,
+	AuthType,
+	member,
+	type Organization,
+	OrgConfigSchema,
+	organizations,
+} from "@autumn/shared";
 import defaultCtx from "@tests/utils/testInitUtils/createTestContext.js";
 import type { User } from "better-auth";
 import { eq } from "drizzle-orm";
 import { initDrizzle } from "@/db/initDrizzle.js";
 import { logger } from "@/external/logtail/logtailUtils.js";
 import { deletePlatformSubOrg } from "@/internal/orgs/deleteOrg/deletePlatformSubOrg.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
 import {
 	assertDashboardActor,
 	assertNotSandboxContext,
 	createSandboxForOrg,
 } from "@/internal/sandboxes/createSandbox.js";
+import { generatePublishableKey } from "@/utils/encryptUtils.js";
+import { generateId } from "@/utils/genUtils.js";
 
 const { db } = initDrizzle();
 let createdOrg: Organization | undefined;
+let inheritSandbox: Organization | undefined;
+let inheritMasterId: string | undefined;
 
 afterAll(async () => {
-	if (createdOrg) {
-		await deletePlatformSubOrg({
-			db,
-			org: createdOrg,
-			logger,
-			skipLiveCustomerCheck: true,
-		});
+	for (const org of [createdOrg, inheritSandbox]) {
+		if (org) {
+			await deletePlatformSubOrg({
+				db,
+				org,
+				logger,
+				skipLiveCustomerCheck: true,
+			}).catch(() => {});
+		}
+	}
+	if (inheritMasterId) {
+		await db
+			.delete(organizations)
+			.where(eq(organizations.id, inheritMasterId))
+			.catch(() => {});
 	}
 });
 
@@ -79,5 +99,42 @@ describe("createSandboxForOrg", () => {
 			where: eq(member.organizationId, org.id),
 		});
 		expect(members.length).toBe(0);
+	}, 120_000);
+
+	test("a new sandbox inherits the master org's config", async () => {
+		const actorUser = (await db.query.user.findFirst()) as unknown as User;
+
+		const masterConfig = OrgConfigSchema.parse({
+			default_applies_to_entities: true,
+			prorate_unused: false,
+		});
+		inheritMasterId = generateId("org");
+		await db.insert(organizations).values({
+			id: inheritMasterId,
+			slug: `cfg-master-${crypto.randomUUID()}`,
+			name: "cfg-master",
+			createdAt: new Date(),
+			created_at: Date.now(),
+			is_sandbox: false,
+			stripe_connected: false,
+			default_currency: "usd",
+			config: masterConfig,
+			onboarded: true,
+			test_pkey: generatePublishableKey(AppEnv.Sandbox),
+			live_pkey: generatePublishableKey(AppEnv.Live),
+		});
+		const master = await OrgService.get({ db, orgId: inheritMasterId });
+
+		const { org } = await createSandboxForOrg({
+			db,
+			masterOrg: master,
+			actorUser,
+			name: "Config Inherit Sandbox",
+		});
+		inheritSandbox = org;
+
+		expect(org.config.default_applies_to_entities).toBe(true);
+		expect(org.config.prorate_unused).toBe(false);
+		expect(org.config).toEqual(masterConfig);
 	}, 120_000);
 });

--- a/server/tests/integration/sandbox/promote-product.test.ts
+++ b/server/tests/integration/sandbox/promote-product.test.ts
@@ -210,7 +210,7 @@ afterAll(async () => {
 			}).catch(() => {});
 		}
 	}
-});
+}, 180_000);
 
 describe("promote product from a named sandbox to the master org", () => {
 	test("promotes a plan into master Live, not the sub-org's own Live", async () => {

--- a/server/tests/integration/sandbox/promote-product.test.ts
+++ b/server/tests/integration/sandbox/promote-product.test.ts
@@ -1,0 +1,391 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+	AppEnv,
+	type CreateProductV2Params,
+	ErrCode,
+	FeatureUsageType,
+	mapToProductV2,
+	type Organization,
+	type OrgConfig,
+	organizations,
+	products as productsTable,
+	RecaseError,
+} from "@autumn/shared";
+import { products } from "@tests/utils/fixtures/products.js";
+import defaultCtx from "@tests/utils/testInitUtils/createTestContext.js";
+import { eq } from "drizzle-orm";
+import { initDrizzle } from "@/db/initDrizzle.js";
+import { logger } from "@/external/logtail/logtailUtils.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { FeatureService } from "@/internal/features/FeatureService.js";
+import { createFeature } from "@/internal/features/featureActions/createFeature.js";
+import {
+	constructBooleanFeature,
+	constructCreditSystem,
+	constructMeteredFeature,
+} from "@/internal/features/utils/constructFeatureUtils.js";
+import { deletePlatformSubOrg } from "@/internal/orgs/deleteOrg/deletePlatformSubOrg.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import { createProduct } from "@/internal/product/actions/createProduct.js";
+import { copyProductForOrgs } from "@/internal/products/handlers/handleCopyProduct/copyProductForOrgs.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { generatePublishableKey } from "@/utils/encryptUtils.js";
+import { generateId } from "@/utils/genUtils.js";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
+
+// Exercises the promote path: from inside a named sandbox sub-org, copying a
+// plan to Production/Sandbox must land in the MASTER org's env, never the
+// sub-org's own (unviewable) Live env. Drives copyProductForOrgs directly with
+// explicit from/to orgs (the handler owns the auth gate that decides these).
+
+const { db } = initDrizzle();
+const suffix = crypto.randomUUID().slice(0, 8);
+
+const DASH = `promo_dash_${suffix}`;
+const MSG = `promo_msg_${suffix}`;
+const CREDIT = `promo_credit_${suffix}`;
+const PLAN = `promo_plan_${suffix}`;
+const CREDIT_PLAN = `promo_credit_plan_${suffix}`;
+const BASE_PLAN = `promo_base_${suffix}`;
+const VARIANT_PLAN = `promo_variant_${suffix}`;
+
+let master: Organization | undefined;
+let sub: Organization | undefined;
+
+const baseCtx = { ...defaultCtx } as AutumnContext;
+
+const insertOrg = async ({
+	name,
+	isSandbox,
+	masterOrgId,
+}: {
+	name: string;
+	isSandbox: boolean;
+	masterOrgId: string | null;
+}): Promise<Organization> => {
+	const orgId = generateId("org");
+	const slug = `${name}-${crypto.randomUUID()}`;
+	await db.insert(organizations).values({
+		id: orgId,
+		slug,
+		name,
+		createdAt: new Date(),
+		created_at: Date.now(),
+		created_by: masterOrgId,
+		is_sandbox: isSandbox,
+		stripe_connected: false,
+		default_currency: "usd",
+		config: {} as OrgConfig,
+		onboarded: true,
+		test_pkey: generatePublishableKey(AppEnv.Sandbox),
+		live_pkey: generatePublishableKey(AppEnv.Live),
+	});
+	return OrgService.get({ db, orgId });
+};
+
+const seedSub = async (sourceOrg: Organization) => {
+	const seedCtx: AutumnContext = {
+		...baseCtx,
+		org: sourceOrg,
+		env: AppEnv.Sandbox,
+		features: [],
+	};
+
+	await createFeature({
+		ctx: seedCtx,
+		data: constructBooleanFeature({
+			featureId: DASH,
+			orgId: sourceOrg.id,
+			env: AppEnv.Sandbox,
+		}),
+		skipGenerateDisplay: true,
+	});
+	await createFeature({
+		ctx: seedCtx,
+		data: constructMeteredFeature({
+			featureId: MSG,
+			orgId: sourceOrg.id,
+			env: AppEnv.Sandbox,
+			usageType: FeatureUsageType.Single,
+		}),
+		skipGenerateDisplay: true,
+	});
+
+	const afterMetered = await FeatureService.list({
+		db,
+		orgId: sourceOrg.id,
+		env: AppEnv.Sandbox,
+	});
+	await createFeature({
+		ctx: { ...seedCtx, features: afterMetered },
+		data: constructCreditSystem({
+			featureId: CREDIT,
+			orgId: sourceOrg.id,
+			env: AppEnv.Sandbox,
+			schema: [{ metered_feature_id: MSG, credit_cost: 1 }],
+		}),
+		skipGenerateDisplay: true,
+	});
+
+	const allFeatures = await FeatureService.list({
+		db,
+		orgId: sourceOrg.id,
+		env: AppEnv.Sandbox,
+	});
+
+	await createProduct({
+		ctx: { ...seedCtx, features: allFeatures },
+		data: products.base({
+			id: PLAN,
+			items: [constructFeatureItem({ featureId: DASH, isBoolean: true })],
+		}) as unknown as CreateProductV2Params,
+	});
+	await createProduct({
+		ctx: { ...seedCtx, features: allFeatures },
+		data: products.base({
+			id: CREDIT_PLAN,
+			items: [constructFeatureItem({ featureId: CREDIT, includedUsage: 100 })],
+		}) as unknown as CreateProductV2Params,
+	});
+
+	// A variant plan (base_internal_product_id set) to prove cross-org promote
+	// of a variant is refused.
+	await createProduct({
+		ctx: { ...seedCtx, features: allFeatures },
+		data: products.base({
+			id: BASE_PLAN,
+			items: [],
+		}) as unknown as CreateProductV2Params,
+	});
+	await createProduct({
+		ctx: { ...seedCtx, features: allFeatures },
+		data: products.base({
+			id: VARIANT_PLAN,
+			items: [],
+		}) as unknown as CreateProductV2Params,
+	});
+	const seeded = await ProductService.listFull({
+		db,
+		orgId: sourceOrg.id,
+		env: AppEnv.Sandbox,
+	});
+	const basePlan = seeded.find((p) => p.id === BASE_PLAN);
+	await db
+		.update(productsTable)
+		.set({ base_internal_product_id: basePlan?.internal_id })
+		.where(eq(productsTable.internal_id, basePlan?.internal_id ?? ""));
+	await db
+		.update(productsTable)
+		.set({ base_internal_product_id: basePlan?.internal_id })
+		.where(
+			eq(
+				productsTable.internal_id,
+				seeded.find((p) => p.id === VARIANT_PLAN)?.internal_id ?? "",
+			),
+		);
+};
+
+beforeAll(async () => {
+	master = await insertOrg({
+		name: `promo-master-${suffix}`,
+		isSandbox: false,
+		masterOrgId: null,
+	});
+	sub = await insertOrg({
+		name: `promo-sub-${suffix}`,
+		isSandbox: true,
+		masterOrgId: master.id,
+	});
+	await seedSub(sub);
+}, 180_000);
+
+afterAll(async () => {
+	for (const created of [sub, master]) {
+		if (created) {
+			await deletePlatformSubOrg({
+				db,
+				org: created,
+				logger,
+				skipLiveCustomerCheck: true,
+			}).catch(() => {});
+		}
+	}
+});
+
+describe("promote product from a named sandbox to the master org", () => {
+	test("promotes a plan into master Live, not the sub-org's own Live", async () => {
+		if (!master || !sub) throw new Error("orgs not provisioned");
+
+		await copyProductForOrgs({
+			db,
+			logger,
+			fromOrg: sub,
+			fromEnv: AppEnv.Sandbox,
+			toOrg: master,
+			toEnv: AppEnv.Live,
+			fromProductId: PLAN,
+			toId: PLAN,
+			toName: "Promoted Plan",
+		});
+
+		const masterLiveProducts = await ProductService.listFull({
+			db,
+			orgId: master.id,
+			env: AppEnv.Live,
+		});
+		const masterLiveFeatures = await FeatureService.list({
+			db,
+			orgId: master.id,
+			env: AppEnv.Live,
+		});
+		const subLiveProducts = await ProductService.listFull({
+			db,
+			orgId: sub.id,
+			env: AppEnv.Live,
+		});
+
+		expect(masterLiveProducts.map((p) => p.id)).toContain(PLAN);
+		expect(masterLiveFeatures.map((f) => f.id)).toContain(DASH);
+		// The sub-org's own Live env stays empty — the old void target.
+		expect(subLiveProducts.length).toBe(0);
+	}, 120_000);
+
+	test("promotes into master Sandbox (the default sandbox)", async () => {
+		if (!master || !sub) throw new Error("orgs not provisioned");
+
+		await copyProductForOrgs({
+			db,
+			logger,
+			fromOrg: sub,
+			fromEnv: AppEnv.Sandbox,
+			toOrg: master,
+			toEnv: AppEnv.Sandbox,
+			fromProductId: PLAN,
+			toId: PLAN,
+			toName: "Promoted Plan",
+		});
+
+		const masterSandboxProducts = await ProductService.listFull({
+			db,
+			orgId: master.id,
+			env: AppEnv.Sandbox,
+		});
+		expect(masterSandboxProducts.map((p) => p.id)).toContain(PLAN);
+	}, 120_000);
+
+	test("pulls a credit system's metered dependency along on promote", async () => {
+		if (!master || !sub) throw new Error("orgs not provisioned");
+
+		await copyProductForOrgs({
+			db,
+			logger,
+			fromOrg: sub,
+			fromEnv: AppEnv.Sandbox,
+			toOrg: master,
+			toEnv: AppEnv.Live,
+			fromProductId: CREDIT_PLAN,
+			toId: CREDIT_PLAN,
+			toName: "Promoted Credit Plan",
+		});
+
+		const masterLiveFeatures = await FeatureService.list({
+			db,
+			orgId: master.id,
+			env: AppEnv.Live,
+		});
+		const ids = masterLiveFeatures.map((f) => f.id);
+		// The credit system AND the metered feature its schema references.
+		expect(ids).toContain(CREDIT);
+		expect(ids).toContain(MSG);
+	}, 120_000);
+
+	test("refuses to promote a variant plan across orgs", async () => {
+		if (!master || !sub) throw new Error("orgs not provisioned");
+
+		let thrown: unknown;
+		try {
+			await copyProductForOrgs({
+				db,
+				logger,
+				fromOrg: sub,
+				fromEnv: AppEnv.Sandbox,
+				toOrg: master,
+				toEnv: AppEnv.Live,
+				fromProductId: VARIANT_PLAN,
+				toId: VARIANT_PLAN,
+				toName: "Promoted Variant",
+			});
+		} catch (error) {
+			thrown = error;
+		}
+
+		expect(thrown).toBeInstanceOf(RecaseError);
+		expect((thrown as RecaseError).code).toBe(ErrCode.InvalidRequest);
+		expect((thrown as RecaseError).statusCode).toBe(400);
+	}, 120_000);
+
+	test("same-org copy is unchanged (regression): master Sandbox to master Live", async () => {
+		if (!master) throw new Error("orgs not provisioned");
+
+		const seedCtx: AutumnContext = {
+			...baseCtx,
+			org: master,
+			env: AppEnv.Sandbox,
+			features: [],
+		};
+		await createFeature({
+			ctx: seedCtx,
+			data: constructBooleanFeature({
+				featureId: `${DASH}_same`,
+				orgId: master.id,
+				env: AppEnv.Sandbox,
+			}),
+			skipGenerateDisplay: true,
+		});
+		const feats = await FeatureService.list({
+			db,
+			orgId: master.id,
+			env: AppEnv.Sandbox,
+		});
+		await createProduct({
+			ctx: { ...seedCtx, features: feats },
+			data: products.base({
+				id: `${PLAN}_same`,
+				items: [
+					constructFeatureItem({ featureId: `${DASH}_same`, isBoolean: true }),
+				],
+			}) as unknown as CreateProductV2Params,
+		});
+
+		await copyProductForOrgs({
+			db,
+			logger,
+			fromOrg: master,
+			fromEnv: AppEnv.Sandbox,
+			toOrg: master,
+			toEnv: AppEnv.Live,
+			fromProductId: `${PLAN}_same`,
+			toId: `${PLAN}_same`,
+			toName: "Same Org Copy",
+		});
+
+		const masterLive = await ProductService.listFull({
+			db,
+			orgId: master.id,
+			env: AppEnv.Live,
+		});
+		const copied = masterLive.find((p) => p.id === `${PLAN}_same`);
+		expect(copied).toBeDefined();
+		const copiedV2 = mapToProductV2({
+			product: copied!,
+			features: await FeatureService.list({
+				db,
+				orgId: master.id,
+				env: AppEnv.Live,
+			}),
+		});
+		expect(copiedV2.items.map((i) => i.feature_id).filter(Boolean)).toContain(
+			`${DASH}_same`,
+		);
+	}, 120_000);
+});

--- a/server/tests/integration/sandbox/route-guards.test.ts
+++ b/server/tests/integration/sandbox/route-guards.test.ts
@@ -52,4 +52,12 @@ describe("sandbox route guards (zod + dashboard-actor wiring on the request path
 		const status = await postStatus("/sandboxes.list", {});
 		expect(status).toBe(401);
 	});
+
+	test("copy from a secret key is blocked by assertDashboardActor (401)", async () => {
+		const status = await postStatus("/sandboxes.copy", {
+			fromMaster: true,
+			toSandboxId: "sandbox_does_not_exist",
+		});
+		expect(status).toBe(401);
+	});
 });

--- a/vite/src/hooks/queries/useSandboxCatalogQuery.tsx
+++ b/vite/src/hooks/queries/useSandboxCatalogQuery.tsx
@@ -1,3 +1,4 @@
+import { AppEnv } from "@autumn/shared";
 import { useQuery } from "@tanstack/react-query";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 
@@ -8,7 +9,10 @@ export type CatalogItem = { id: string; name: string };
 // so the copy dialog can show the source sandbox's catalog while you sit in a
 // different one.
 export const useSandboxCatalogQuery = (sandboxId: string | null) => {
-	const axiosInstance = useAxiosInstance({ skipSandbox: true });
+	const axiosInstance = useAxiosInstance({
+		skipSandbox: true,
+		env: AppEnv.Sandbox,
+	});
 
 	const { data, isLoading } = useQuery({
 		queryKey: ["sandbox-catalog", sandboxId],

--- a/vite/src/hooks/queries/useSandboxCatalogQuery.tsx
+++ b/vite/src/hooks/queries/useSandboxCatalogQuery.tsx
@@ -1,0 +1,34 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+
+export type CatalogItem = { id: string; name: string };
+
+// Lists a SPECIFIC sandbox's plans + features by overriding x-sandbox-org-id
+// per request (skipSandbox keeps the interceptor from forcing the active one),
+// so the copy dialog can show the source sandbox's catalog while you sit in a
+// different one.
+export const useSandboxCatalogQuery = (sandboxId: string | null) => {
+	const axiosInstance = useAxiosInstance({ skipSandbox: true });
+
+	const { data, isLoading } = useQuery({
+		queryKey: ["sandbox-catalog", sandboxId],
+		enabled: !!sandboxId,
+		queryFn: async () => {
+			const headers = { "x-sandbox-org-id": sandboxId as string };
+			const [productsRes, featuresRes] = await Promise.all([
+				axiosInstance.get("/v1/products", { headers }),
+				axiosInstance.post("/v1/features.list", {}, { headers }),
+			]);
+			return {
+				products: (productsRes.data?.list ?? []) as CatalogItem[],
+				features: (featuresRes.data?.list ?? []) as CatalogItem[],
+			};
+		},
+	});
+
+	return {
+		products: data?.products ?? [],
+		features: data?.features ?? [],
+		isLoading,
+	};
+};

--- a/vite/src/hooks/queries/useSandboxesQuery.tsx
+++ b/vite/src/hooks/queries/useSandboxesQuery.tsx
@@ -194,17 +194,20 @@ export const useCopySandbox = () => {
 	return useMutation({
 		mutationFn: async ({
 			fromSandboxId,
+			fromMaster,
 			toSandboxId,
 			productIds,
 			featureIds,
 		}: {
-			fromSandboxId: string;
+			fromSandboxId?: string;
+			fromMaster?: true;
 			toSandboxId: string;
 			productIds?: string[];
 			featureIds?: string[];
 		}) => {
 			await axiosInstance.post("/v1/sandboxes.copy", {
 				fromSandboxId,
+				fromMaster,
 				toSandboxId,
 				productIds,
 				featureIds,

--- a/vite/src/hooks/queries/useSandboxesQuery.tsx
+++ b/vite/src/hooks/queries/useSandboxesQuery.tsx
@@ -207,6 +207,7 @@ export const useCopySandbox = () => {
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ["products"] });
 			queryClient.invalidateQueries({ queryKey: ["product_counts"] });
+			queryClient.invalidateQueries({ queryKey: ["product"] });
 			queryClient.invalidateQueries({ queryKey: ["features"] });
 		},
 	});

--- a/vite/src/hooks/queries/useSandboxesQuery.tsx
+++ b/vite/src/hooks/queries/useSandboxesQuery.tsx
@@ -192,26 +192,16 @@ export const useCopySandbox = () => {
 	const queryClient = useQueryClient();
 
 	return useMutation({
-		mutationFn: async ({
-			fromSandboxId,
-			fromMaster,
-			toSandboxId,
-			productIds,
-			featureIds,
-		}: {
-			fromSandboxId?: string;
-			fromMaster?: true;
-			toSandboxId: string;
-			productIds?: string[];
-			featureIds?: string[];
-		}) => {
-			await axiosInstance.post("/v1/sandboxes.copy", {
-				fromSandboxId,
-				fromMaster,
-				toSandboxId,
-				productIds,
-				featureIds,
-			});
+		// Source is exactly one of fromSandboxId / fromMaster — a union so bad
+		// combos fail to compile instead of hitting a guaranteed server 400.
+		mutationFn: async (
+			input: ({ fromSandboxId: string } | { fromMaster: true }) & {
+				toSandboxId: string;
+				productIds?: string[];
+				featureIds?: string[];
+			},
+		) => {
+			await axiosInstance.post("/v1/sandboxes.copy", input);
 		},
 		// Copy overwrites the target's whole catalog, so refresh any open plan/feature views.
 		onSuccess: () => {

--- a/vite/src/hooks/queries/useSandboxesQuery.tsx
+++ b/vite/src/hooks/queries/useSandboxesQuery.tsx
@@ -186,3 +186,35 @@ export const useDeleteSandbox = () => {
 		},
 	});
 };
+
+export const useCopySandbox = () => {
+	const axiosInstance = useAxiosInstance({ skipSandbox: true });
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: async ({
+			fromSandboxId,
+			toSandboxId,
+			productIds,
+			featureIds,
+		}: {
+			fromSandboxId: string;
+			toSandboxId: string;
+			productIds?: string[];
+			featureIds?: string[];
+		}) => {
+			await axiosInstance.post("/v1/sandboxes.copy", {
+				fromSandboxId,
+				toSandboxId,
+				productIds,
+				featureIds,
+			});
+		},
+		// Copy overwrites the target's whole catalog, so refresh any open plan/feature views.
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["products"] });
+			queryClient.invalidateQueries({ queryKey: ["product_counts"] });
+			queryClient.invalidateQueries({ queryKey: ["features"] });
+		},
+	});
+};

--- a/vite/src/views/main-sidebar/EnvDropdown.tsx
+++ b/vite/src/views/main-sidebar/EnvDropdown.tsx
@@ -9,7 +9,7 @@ import {
 	DropdownMenuSeparator,
 	Skeleton,
 } from "@autumn/ui";
-import { Check, Copy, Pencil, Plus, Trash2 } from "lucide-react";
+import { Check, Import, Pencil, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { PhosphorIcon } from "@/components/v2/icons/PhosphorIcon";
@@ -186,7 +186,7 @@ export const EnvDropdown = ({ env }: { env: AppEnv }) => {
 									</button>
 									{sandboxes.length > 1 && (
 										<button
-											aria-label={`Copy into ${sandbox.name}`}
+											aria-label={`Import into ${sandbox.name}`}
 											className="text-muted-foreground transition-colors hover:text-foreground"
 											onClick={(e) => {
 												e.stopPropagation();
@@ -195,7 +195,7 @@ export const EnvDropdown = ({ env }: { env: AppEnv }) => {
 											}}
 											type="button"
 										>
-											<Copy size={12} className="!h-3 w-3" />
+											<Import size={12} className="!h-3 w-3" />
 										</button>
 									)}
 									<button

--- a/vite/src/views/main-sidebar/EnvDropdown.tsx
+++ b/vite/src/views/main-sidebar/EnvDropdown.tsx
@@ -9,7 +9,7 @@ import {
 	DropdownMenuSeparator,
 	Skeleton,
 } from "@autumn/ui";
-import { Check, Pencil, Plus, Trash2 } from "lucide-react";
+import { Check, Copy, Pencil, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { PhosphorIcon } from "@/components/v2/icons/PhosphorIcon";
@@ -27,6 +27,7 @@ import {
 } from "@/hooks/sandbox/useActiveSandbox";
 import { cn } from "@/lib/utils";
 import { envToPath } from "@/utils/genUtils";
+import { CopySandboxDialog } from "./env-dropdown/CopySandboxDialog";
 import { CreateSandboxDialog } from "./env-dropdown/CreateSandboxDialog";
 import { DeleteSandboxDialog } from "./env-dropdown/DeleteSandboxDialog";
 import { EditSandboxDialog } from "./env-dropdown/EditSandboxDialog";
@@ -70,6 +71,8 @@ export const EnvDropdown = ({ env }: { env: AppEnv }) => {
 	const [sandboxToEdit, setSandboxToEdit] = useState<SandboxSummary | null>(
 		null,
 	);
+	const [sandboxToCopyInto, setSandboxToCopyInto] =
+		useState<SandboxSummary | null>(null);
 	const handleEnvChange = useEnvChange();
 	const { expanded } = useSidebarContext();
 
@@ -181,6 +184,20 @@ export const EnvDropdown = ({ env }: { env: AppEnv }) => {
 									>
 										<Pencil size={12} className="!h-3 w-3" />
 									</button>
+									{sandboxes.length > 1 && (
+										<button
+											aria-label={`Copy into ${sandbox.name}`}
+											className="text-muted-foreground transition-colors hover:text-foreground"
+											onClick={(e) => {
+												e.stopPropagation();
+												setOpen(false);
+												setSandboxToCopyInto(sandbox);
+											}}
+											type="button"
+										>
+											<Copy size={12} className="!h-3 w-3" />
+										</button>
+									)}
 									<button
 										aria-label={`Delete ${sandbox.name}`}
 										className="text-muted-foreground transition-colors hover:text-destructive"
@@ -230,6 +247,18 @@ export const EnvDropdown = ({ env }: { env: AppEnv }) => {
 					setOpen={(next) => {
 						if (!next) {
 							setSandboxToEdit(null);
+						}
+					}}
+				/>
+			)}
+			{sandboxToCopyInto && (
+				<CopySandboxDialog
+					target={sandboxToCopyInto}
+					sandboxes={sandboxes}
+					open
+					setOpen={(next) => {
+						if (!next) {
+							setSandboxToCopyInto(null);
 						}
 					}}
 				/>

--- a/vite/src/views/main-sidebar/env-dropdown/CopySandboxChecklist.tsx
+++ b/vite/src/views/main-sidebar/env-dropdown/CopySandboxChecklist.tsx
@@ -3,12 +3,14 @@ import type { CatalogItem } from "@/hooks/queries/useSandboxCatalogQuery";
 
 export const CopySandboxChecklist = ({
 	title,
+	kind,
 	items,
 	deselected,
 	onToggle,
 	isLoading,
 }: {
 	title: string;
+	kind: string;
 	items: CatalogItem[];
 	deselected: Set<string>;
 	onToggle: (id: string) => void;
@@ -26,12 +28,12 @@ export const CopySandboxChecklist = ({
 			{items.map((item) => (
 				<label
 					className="flex cursor-pointer select-none items-center gap-2 text-sm"
-					htmlFor={`copy-item-${item.id}`}
+					htmlFor={`copy-item-${kind}-${item.id}`}
 					key={item.id}
 				>
 					<Checkbox
 						checked={!deselected.has(item.id)}
-						id={`copy-item-${item.id}`}
+						id={`copy-item-${kind}-${item.id}`}
 						onCheckedChange={() => onToggle(item.id)}
 					/>
 					<span className="truncate">{item.name}</span>

--- a/vite/src/views/main-sidebar/env-dropdown/CopySandboxChecklist.tsx
+++ b/vite/src/views/main-sidebar/env-dropdown/CopySandboxChecklist.tsx
@@ -1,0 +1,45 @@
+import { Checkbox } from "@autumn/ui";
+import type { CatalogItem } from "@/hooks/queries/useSandboxCatalogQuery";
+
+export const CopySandboxChecklist = ({
+	title,
+	items,
+	deselected,
+	onToggle,
+	isLoading,
+}: {
+	title: string;
+	items: CatalogItem[];
+	deselected: Set<string>;
+	onToggle: (id: string) => void;
+	isLoading: boolean;
+}) => {
+	return (
+		<div className="flex flex-col gap-1.5">
+			<span className="font-medium text-muted-foreground text-xs">{title}</span>
+			{isLoading && (
+				<span className="text-muted-foreground text-xs">Loading…</span>
+			)}
+			{!isLoading && items.length === 0 && (
+				<span className="text-muted-foreground text-xs">None</span>
+			)}
+			{items.map((item) => (
+				<label
+					className="flex cursor-pointer select-none items-center gap-2 text-sm"
+					htmlFor={`copy-item-${item.id}`}
+					key={item.id}
+				>
+					<Checkbox
+						checked={!deselected.has(item.id)}
+						id={`copy-item-${item.id}`}
+						onCheckedChange={() => onToggle(item.id)}
+					/>
+					<span className="truncate">{item.name}</span>
+					<span className="truncate text-muted-foreground text-xs">
+						{item.id}
+					</span>
+				</label>
+			))}
+		</div>
+	);
+};

--- a/vite/src/views/main-sidebar/env-dropdown/CopySandboxDialog.tsx
+++ b/vite/src/views/main-sidebar/env-dropdown/CopySandboxDialog.tsx
@@ -127,6 +127,7 @@ export const CopySandboxDialog = ({
 						<CopySandboxChecklist
 							isLoading={isLoading}
 							items={products}
+							kind="plan"
 							onToggle={(id) => toggle("products", id)}
 							title="Plans"
 							deselected={deselected.products}
@@ -134,6 +135,7 @@ export const CopySandboxDialog = ({
 						<CopySandboxChecklist
 							isLoading={isLoading}
 							items={features}
+							kind="feature"
 							onToggle={(id) => toggle("features", id)}
 							title="Features"
 							deselected={deselected.features}

--- a/vite/src/views/main-sidebar/env-dropdown/CopySandboxDialog.tsx
+++ b/vite/src/views/main-sidebar/env-dropdown/CopySandboxDialog.tsx
@@ -1,0 +1,159 @@
+import {
+	Button,
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@autumn/ui";
+import { useState } from "react";
+import { toast } from "sonner";
+import { useSandboxCatalogQuery } from "@/hooks/queries/useSandboxCatalogQuery";
+import {
+	type SandboxSummary,
+	useCopySandbox,
+} from "@/hooks/queries/useSandboxesQuery";
+import { getBackendErr } from "@/utils/genUtils";
+import { CopySandboxChecklist } from "./CopySandboxChecklist";
+
+export const CopySandboxDialog = ({
+	target,
+	sandboxes,
+	open,
+	setOpen,
+}: {
+	target: SandboxSummary;
+	sandboxes: SandboxSummary[];
+	open: boolean;
+	setOpen: (open: boolean) => void;
+}) => {
+	const copySandbox = useCopySandbox();
+	const [sourceId, setSourceId] = useState("");
+	// Track de-selections (default = everything checked) so a freshly loaded
+	// catalog needs no effect to initialise.
+	const [deselected, setDeselected] = useState<{
+		products: Set<string>;
+		features: Set<string>;
+	}>({ products: new Set(), features: new Set() });
+
+	const sources = sandboxes.filter((s) => s.id !== target.id);
+	const { products, features, isLoading } = useSandboxCatalogQuery(
+		sourceId || null,
+	);
+
+	const selectSource = (id: string) => {
+		setSourceId(id);
+		setDeselected({ products: new Set(), features: new Set() });
+	};
+
+	const toggle = (kind: "products" | "features", id: string) => {
+		setDeselected((prev) => {
+			const next = new Set(prev[kind]);
+			if (next.has(id)) {
+				next.delete(id);
+			} else {
+				next.add(id);
+			}
+			return { ...prev, [kind]: next };
+		});
+	};
+
+	const checkedProductIds = products
+		.filter((p) => !deselected.products.has(p.id))
+		.map((p) => p.id);
+	const checkedFeatureIds = features
+		.filter((f) => !deselected.features.has(f.id))
+		.map((f) => f.id);
+	const nothingSelected =
+		checkedProductIds.length === 0 && checkedFeatureIds.length === 0;
+
+	const handleCopy = async () => {
+		if (!sourceId || nothingSelected) {
+			return;
+		}
+
+		try {
+			await copySandbox.mutateAsync({
+				fromSandboxId: sourceId,
+				toSandboxId: target.id,
+				productIds: checkedProductIds,
+				featureIds: checkedFeatureIds,
+			});
+			toast.success(`Copied plans & features into ${target.name}`);
+			setOpen(false);
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to copy sandbox"));
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogContent className="bg-card">
+				<DialogHeader>
+					<DialogTitle>Copy into {target.name}</DialogTitle>
+					<DialogDescription>
+						Copy plans and features from another sandbox into{" "}
+						<span className="font-bold">{target.name}</span>. Existing items
+						with a matching ID are overwritten; features used by a selected plan
+						are always included.
+					</DialogDescription>
+				</DialogHeader>
+
+				<Select
+					value={sourceId}
+					onValueChange={selectSource}
+					items={Object.fromEntries(sources.map((s) => [s.id, s.name]))}
+				>
+					<SelectTrigger className="w-full">
+						<SelectValue placeholder="Select a source sandbox" />
+					</SelectTrigger>
+					<SelectContent>
+						{sources.map((s) => (
+							<SelectItem key={s.id} value={s.id}>
+								{s.name}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+
+				{sourceId && (
+					<div className="flex max-h-72 flex-col gap-4 overflow-y-auto">
+						<CopySandboxChecklist
+							isLoading={isLoading}
+							items={products}
+							onToggle={(id) => toggle("products", id)}
+							title="Plans"
+							deselected={deselected.products}
+						/>
+						<CopySandboxChecklist
+							isLoading={isLoading}
+							items={features}
+							onToggle={(id) => toggle("features", id)}
+							title="Features"
+							deselected={deselected.features}
+						/>
+					</div>
+				)}
+
+				<DialogFooter>
+					<Button onClick={() => setOpen(false)} variant="secondary">
+						Cancel
+					</Button>
+					<Button
+						disabled={!sourceId || nothingSelected}
+						isLoading={copySandbox.isPending}
+						onClick={handleCopy}
+					>
+						Copy
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/vite/src/views/main-sidebar/env-dropdown/CopySandboxDialog.tsx
+++ b/vite/src/views/main-sidebar/env-dropdown/CopySandboxDialog.tsx
@@ -85,10 +85,10 @@ export const CopySandboxDialog = ({
 				productIds: checkedProductIds,
 				featureIds: checkedFeatureIds,
 			});
-			toast.success(`Copied plans & features into ${target.name}`);
+			toast.success(`Imported plans & features into ${target.name}`);
 			setOpen(false);
 		} catch (error) {
-			toast.error(getBackendErr(error, "Failed to copy sandbox"));
+			toast.error(getBackendErr(error, "Failed to import"));
 		}
 	};
 
@@ -96,9 +96,9 @@ export const CopySandboxDialog = ({
 		<Dialog open={open} onOpenChange={setOpen}>
 			<DialogContent className="bg-card">
 				<DialogHeader>
-					<DialogTitle>Copy into {target.name}</DialogTitle>
+					<DialogTitle>Import into {target.name}</DialogTitle>
 					<DialogDescription>
-						Copy plans and features from another sandbox into{" "}
+						Import plans and features from another sandbox into{" "}
 						<span className="font-bold">{target.name}</span>. Existing items
 						with a matching ID are overwritten; features used by a selected plan
 						are always included.
@@ -152,7 +152,7 @@ export const CopySandboxDialog = ({
 						isLoading={copySandbox.isPending}
 						onClick={handleCopy}
 					>
-						Copy
+						Import
 					</Button>
 				</DialogFooter>
 			</DialogContent>

--- a/vite/src/views/products/features/feature-list/FeatureListRowToolbar.tsx
+++ b/vite/src/views/products/features/feature-list/FeatureListRowToolbar.tsx
@@ -1,13 +1,25 @@
 import { type Feature, FeatureType } from "@autumn/shared";
-import { ToolbarButton } from "@autumn/ui";
-import { ArchiveRestore, Delete, Pen } from "lucide-react";
-import { useState } from "react";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
 	DropdownMenuTrigger,
+	ToolbarButton,
 } from "@autumn/ui";
+import { ArchiveRestore, Copy, Delete, Pen } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+	type SandboxSummary,
+	useCopySandbox,
+	useSandboxesQuery,
+} from "@/hooks/queries/useSandboxesQuery";
+import { useActiveSandbox } from "@/hooks/sandbox/useActiveSandbox";
+import { getBackendErr } from "@/utils/genUtils";
 import UpdateFeatureSheet from "../components/UpdateFeatureSheet";
 import UpdateCreditSystemSheet from "../credit-systems/components/UpdateCreditSystemSheet";
 import { DeleteFeatureDialog } from "../feature-row-toolbar/DeleteFeatureDialog";
@@ -16,8 +28,28 @@ export const FeatureListRowToolbar = ({ feature }: { feature: Feature }) => {
 	const [dropdownOpen, setDropdownOpen] = useState(false);
 	const [updateOpen, setUpdateOpen] = useState(false);
 	const [deleteOpen, setDeleteOpen] = useState(false);
+	const activeSandbox = useActiveSandbox();
+	const { sandboxes } = useSandboxesQuery({ enabled: !!activeSandbox });
+	const copySandbox = useCopySandbox();
+
+	const otherSandboxes = sandboxes.filter((s) => s.id !== activeSandbox?.id);
 
 	const isCreditSystem = feature.type === FeatureType.CreditSystem;
+
+	const handleCopyToSandbox = async (target: SandboxSummary) => {
+		if (!activeSandbox) return;
+		setDropdownOpen(false);
+		try {
+			await copySandbox.mutateAsync({
+				fromSandboxId: activeSandbox.id,
+				toSandboxId: target.id,
+				featureIds: [feature.id],
+			});
+			toast.success(`Copied ${feature.name} to ${target.name}`);
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to copy feature"));
+		}
+	};
 
 	const deleteText = feature.archived ? "Unarchive" : "Delete";
 	const DeleteIcon = feature.archived ? ArchiveRestore : Delete;
@@ -49,6 +81,32 @@ export const FeatureListRowToolbar = ({ feature }: { feature: Feature }) => {
 					<ToolbarButton />
 				</DropdownMenuTrigger>
 				<DropdownMenuContent className="text-muted-foreground" align="end">
+					{activeSandbox && otherSandboxes.length > 0 && (
+						<>
+							<DropdownMenuSub>
+								<DropdownMenuSubTrigger className="flex items-center gap-2 text-xs">
+									<Copy size={12} className="text-tertiary-foreground" />
+									Copy to
+								</DropdownMenuSubTrigger>
+								<DropdownMenuSubContent>
+									{otherSandboxes.map((s) => (
+										<DropdownMenuItem
+											key={s.id}
+											className="flex items-center text-xs"
+											onClick={(e) => {
+												e.stopPropagation();
+												e.preventDefault();
+												handleCopyToSandbox(s);
+											}}
+										>
+											{s.name}
+										</DropdownMenuItem>
+									))}
+								</DropdownMenuSubContent>
+							</DropdownMenuSub>
+							<DropdownMenuSeparator />
+						</>
+					)}
 					<DropdownMenuItem
 						className="flex items-center text-xs"
 						onClick={(e) => {

--- a/vite/src/views/products/features/feature-list/FeatureListRowToolbar.tsx
+++ b/vite/src/views/products/features/feature-list/FeatureListRowToolbar.tsx
@@ -1,4 +1,4 @@
-import { type Feature, FeatureType } from "@autumn/shared";
+import { AppEnv, type Feature, FeatureType } from "@autumn/shared";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -19,6 +19,7 @@ import {
 	useSandboxesQuery,
 } from "@/hooks/queries/useSandboxesQuery";
 import { useActiveSandbox } from "@/hooks/sandbox/useActiveSandbox";
+import { useEnv } from "@/utils/envUtils";
 import { getBackendErr } from "@/utils/genUtils";
 import UpdateFeatureSheet from "../components/UpdateFeatureSheet";
 import UpdateCreditSystemSheet from "../credit-systems/components/UpdateCreditSystemSheet";
@@ -29,7 +30,9 @@ export const FeatureListRowToolbar = ({ feature }: { feature: Feature }) => {
 	const [updateOpen, setUpdateOpen] = useState(false);
 	const [deleteOpen, setDeleteOpen] = useState(false);
 	const activeSandbox = useActiveSandbox();
-	const { sandboxes } = useSandboxesQuery({ enabled: !!activeSandbox });
+	const env = useEnv();
+	const inNamedSandbox = env === AppEnv.Sandbox && !!activeSandbox;
+	const { sandboxes } = useSandboxesQuery({ enabled: inNamedSandbox });
 	const copySandbox = useCopySandbox();
 
 	const otherSandboxes = sandboxes.filter((s) => s.id !== activeSandbox?.id);
@@ -37,7 +40,7 @@ export const FeatureListRowToolbar = ({ feature }: { feature: Feature }) => {
 	const isCreditSystem = feature.type === FeatureType.CreditSystem;
 
 	const handleCopyToSandbox = async (target: SandboxSummary) => {
-		if (!activeSandbox) return;
+		if (!inNamedSandbox || !activeSandbox) return;
 		setDropdownOpen(false);
 		try {
 			await copySandbox.mutateAsync({
@@ -81,7 +84,7 @@ export const FeatureListRowToolbar = ({ feature }: { feature: Feature }) => {
 					<ToolbarButton />
 				</DropdownMenuTrigger>
 				<DropdownMenuContent className="text-muted-foreground" align="end">
-					{activeSandbox && otherSandboxes.length > 0 && (
+					{inNamedSandbox && otherSandboxes.length > 0 && (
 						<>
 							<DropdownMenuSub>
 								<DropdownMenuSubTrigger className="flex items-center gap-2 text-xs">

--- a/vite/src/views/products/features/feature-list/FeatureListRowToolbar.tsx
+++ b/vite/src/views/products/features/feature-list/FeatureListRowToolbar.tsx
@@ -1,26 +1,13 @@
-import { AppEnv, type Feature, FeatureType } from "@autumn/shared";
+import { type Feature, FeatureType } from "@autumn/shared";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
-	DropdownMenuSeparator,
-	DropdownMenuSub,
-	DropdownMenuSubContent,
-	DropdownMenuSubTrigger,
 	DropdownMenuTrigger,
 	ToolbarButton,
 } from "@autumn/ui";
-import { ArchiveRestore, Copy, Delete, Pen } from "lucide-react";
+import { ArchiveRestore, Delete, Pen } from "lucide-react";
 import { useState } from "react";
-import { toast } from "sonner";
-import {
-	type SandboxSummary,
-	useCopySandbox,
-	useSandboxesQuery,
-} from "@/hooks/queries/useSandboxesQuery";
-import { useActiveSandbox } from "@/hooks/sandbox/useActiveSandbox";
-import { useEnv } from "@/utils/envUtils";
-import { getBackendErr } from "@/utils/genUtils";
 import UpdateFeatureSheet from "../components/UpdateFeatureSheet";
 import UpdateCreditSystemSheet from "../credit-systems/components/UpdateCreditSystemSheet";
 import { DeleteFeatureDialog } from "../feature-row-toolbar/DeleteFeatureDialog";
@@ -29,30 +16,8 @@ export const FeatureListRowToolbar = ({ feature }: { feature: Feature }) => {
 	const [dropdownOpen, setDropdownOpen] = useState(false);
 	const [updateOpen, setUpdateOpen] = useState(false);
 	const [deleteOpen, setDeleteOpen] = useState(false);
-	const activeSandbox = useActiveSandbox();
-	const env = useEnv();
-	const inNamedSandbox = env === AppEnv.Sandbox && !!activeSandbox;
-	const { sandboxes } = useSandboxesQuery({ enabled: inNamedSandbox });
-	const copySandbox = useCopySandbox();
-
-	const otherSandboxes = sandboxes.filter((s) => s.id !== activeSandbox?.id);
 
 	const isCreditSystem = feature.type === FeatureType.CreditSystem;
-
-	const handleCopyToSandbox = async (target: SandboxSummary) => {
-		if (!inNamedSandbox || !activeSandbox) return;
-		setDropdownOpen(false);
-		try {
-			await copySandbox.mutateAsync({
-				fromSandboxId: activeSandbox.id,
-				toSandboxId: target.id,
-				featureIds: [feature.id],
-			});
-			toast.success(`Copied ${feature.name} to ${target.name}`);
-		} catch (error) {
-			toast.error(getBackendErr(error, "Failed to copy feature"));
-		}
-	};
 
 	const deleteText = feature.archived ? "Unarchive" : "Delete";
 	const DeleteIcon = feature.archived ? ArchiveRestore : Delete;
@@ -84,32 +49,6 @@ export const FeatureListRowToolbar = ({ feature }: { feature: Feature }) => {
 					<ToolbarButton />
 				</DropdownMenuTrigger>
 				<DropdownMenuContent className="text-muted-foreground" align="end">
-					{inNamedSandbox && otherSandboxes.length > 0 && (
-						<>
-							<DropdownMenuSub>
-								<DropdownMenuSubTrigger className="flex items-center gap-2 text-xs">
-									<Copy size={12} className="text-tertiary-foreground" />
-									Copy to
-								</DropdownMenuSubTrigger>
-								<DropdownMenuSubContent>
-									{otherSandboxes.map((s) => (
-										<DropdownMenuItem
-											key={s.id}
-											className="flex items-center text-xs"
-											onClick={(e) => {
-												e.stopPropagation();
-												e.preventDefault();
-												handleCopyToSandbox(s);
-											}}
-										>
-											{s.name}
-										</DropdownMenuItem>
-									))}
-								</DropdownMenuSubContent>
-							</DropdownMenuSub>
-							<DropdownMenuSeparator />
-						</>
-					)}
 					<DropdownMenuItem
 						className="flex items-center text-xs"
 						onClick={(e) => {

--- a/vite/src/views/products/products/components/CopyProductDialog.tsx
+++ b/vite/src/views/products/products/components/CopyProductDialog.tsx
@@ -19,6 +19,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
+import { useActiveSandbox } from "@/hooks/sandbox/useActiveSandbox";
 import { ProductService } from "@/services/products/ProductService";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { useEnv } from "@/utils/envUtils";
@@ -39,8 +40,13 @@ export const CopyProductDialog = ({
 }) => {
 	const env = useEnv();
 	const axiosInstance = useAxiosInstance({ env });
+	const activeSandbox = useActiveSandbox();
 	const { refetch } = useProductsQuery();
 	const navigate = useNavigate();
+
+	// Inside a named sandbox, "Copy to Sandbox/Production" promotes into the
+	// master org (a different org), so a same-env same-id copy isn't a collision.
+	const inNamedSandbox = env === AppEnv.Sandbox && !!activeSandbox;
 
 	const [loading, setLoading] = useState(false);
 	const [name, setName] = useState(product.name);
@@ -60,8 +66,9 @@ export const CopyProductDialog = ({
 			else toast.error("ID cannot be empty");
 			return;
 		}
-		// 2. If env is the same and id is same, throw error
-		if (env === effectiveEnv && id === product.id) {
+		// 2. Same-org same-env copy with an unchanged id would collide (skip this
+		// when promoting from a named sandbox — the target is the master org).
+		if (!inNamedSandbox && env === effectiveEnv && id === product.id) {
 			toast.error("Plan ID already exists");
 			return;
 		}
@@ -87,12 +94,12 @@ export const CopyProductDialog = ({
 
 			if (onSuccess) {
 				await onSuccess(copiedProduct);
-			} else if (env === effectiveEnv) {
-				// Only navigate if copying to the same environment
+			} else if (!inNamedSandbox && env === effectiveEnv) {
+				// Same-org duplicate lands in this view; a promote goes to another
+				// org, so don't navigate to a same-id plan in the current context.
 				navigateTo(`/products/${id}`, navigate);
 			}
 		} catch (error: unknown) {
-			console.log("Error copying product", error);
 			toast.error(getBackendErr(error as AxiosError, "Failed to copy plan"));
 		} finally {
 			setLoading(false);

--- a/vite/src/views/products/products/components/product-list/ProductListColumns.tsx
+++ b/vite/src/views/products/products/components/product-list/ProductListColumns.tsx
@@ -1,6 +1,7 @@
 import type { ProductV2 } from "@autumn/shared";
 import { MiniCopyButton } from "@autumn/ui";
 import type { Row } from "@tanstack/react-table";
+import type { SandboxSummary } from "@/hooks/queries/useSandboxesQuery";
 import { formatUnixToDateTime } from "@/utils/formatUtils/formatDateUtils";
 import { ProductCountsTooltip } from "@/views/products/products/product-row-toolbar/ProductCountsTooltip";
 import { ProductListRowToolbar } from "./ProductListRowToolbar";
@@ -9,9 +10,11 @@ import { ProductNameCell } from "./ProductNameCell";
 export const createProductListColumns = ({
 	showGroup = false,
 	onDeleteClick,
+	sandboxes = [],
 }: {
 	showGroup?: boolean;
 	onDeleteClick?: (product: ProductV2) => void;
+	sandboxes?: SandboxSummary[];
 } = {}) => [
 	{
 		size: 300,
@@ -92,6 +95,7 @@ export const createProductListColumns = ({
 					<ProductListRowToolbar
 						product={row.original}
 						onDeleteClick={onDeleteClick}
+						sandboxes={sandboxes}
 					/>
 				</div>
 			);

--- a/vite/src/views/products/products/components/product-list/ProductListRowToolbar.tsx
+++ b/vite/src/views/products/products/components/product-list/ProductListRowToolbar.tsx
@@ -24,7 +24,6 @@ import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import {
 	type SandboxSummary,
 	useCopySandbox,
-	useSandboxesQuery,
 } from "@/hooks/queries/useSandboxesQuery";
 import { useActiveSandbox } from "@/hooks/sandbox/useActiveSandbox";
 import { ProductService } from "@/services/products/ProductService";
@@ -37,9 +36,11 @@ import { CopyProductDialog } from "../CopyProductDialog";
 export const ProductListRowToolbar = ({
 	product,
 	onDeleteClick,
+	sandboxes,
 }: {
 	product: ProductV2;
 	onDeleteClick?: (product: ProductV2) => void;
+	sandboxes: SandboxSummary[];
 }) => {
 	const [dropdownOpen, setDropdownOpen] = useState(false);
 	const [copyOpen, setCopyOpen] = useState(false);
@@ -56,7 +57,6 @@ export const ProductListRowToolbar = ({
 	// Only a Sandbox-env view with an active sandbox is a real named-sandbox
 	// context; activeSandbox can be stale on a production route (no header sent).
 	const inNamedSandbox = env === AppEnv.Sandbox && !!activeSandbox;
-	const { sandboxes } = useSandboxesQuery({ enabled: true });
 	const copySandbox = useCopySandbox();
 
 	const currentSandboxId = inNamedSandbox ? activeSandbox?.id : undefined;

--- a/vite/src/views/products/products/components/product-list/ProductListRowToolbar.tsx
+++ b/vite/src/views/products/products/components/product-list/ProductListRowToolbar.tsx
@@ -3,7 +3,6 @@ import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
-	DropdownMenuSeparator,
 	DropdownMenuSub,
 	DropdownMenuSubContent,
 	DropdownMenuSubTrigger,
@@ -155,55 +154,58 @@ export const ProductListRowToolbar = ({
 					</DropdownMenuTrigger>
 				</div>
 				<DropdownMenuContent align="end">
-					<DropdownMenuSub>
-						<DropdownMenuSubTrigger className="flex gap-2">
-							<CopyIcon />
-							Copy to
-						</DropdownMenuSubTrigger>
-						<DropdownMenuSubContent>
-							<DropdownMenuItem
-								className="flex gap-2"
-								onClick={(e) => {
-									e.stopPropagation();
-									e.preventDefault();
-									setDropdownOpen(false);
-									setCopyToEnv(AppEnv.Sandbox);
-									setCopyOpen(true);
-								}}
-							>
-								Sandbox
-							</DropdownMenuItem>
-							<DropdownMenuItem
-								className="flex gap-2"
-								onClick={(e) => {
-									e.stopPropagation();
-									e.preventDefault();
-									setDropdownOpen(false);
-									setCopyToEnv(AppEnv.Live);
-									setCopyOpen(true);
-								}}
-							>
-								Production
-							</DropdownMenuItem>
-							{inNamedSandbox && otherSandboxes.length > 0 && (
-								<DropdownMenuSeparator />
-							)}
-							{inNamedSandbox &&
-								otherSandboxes.map((s) => (
-									<DropdownMenuItem
-										key={s.id}
-										className="flex gap-2"
-										onClick={(e) => {
-											e.stopPropagation();
-											e.preventDefault();
-											handleCopyToSandbox(s);
-										}}
-									>
-										{s.name}
-									</DropdownMenuItem>
-								))}
-						</DropdownMenuSubContent>
-					</DropdownMenuSub>
+					{(!inNamedSandbox || otherSandboxes.length > 0) && (
+						<DropdownMenuSub>
+							<DropdownMenuSubTrigger className="flex gap-2">
+								<CopyIcon />
+								Copy to
+							</DropdownMenuSubTrigger>
+							<DropdownMenuSubContent>
+								{!inNamedSandbox && (
+									<>
+										<DropdownMenuItem
+											className="flex gap-2"
+											onClick={(e) => {
+												e.stopPropagation();
+												e.preventDefault();
+												setDropdownOpen(false);
+												setCopyToEnv(AppEnv.Sandbox);
+												setCopyOpen(true);
+											}}
+										>
+											Sandbox
+										</DropdownMenuItem>
+										<DropdownMenuItem
+											className="flex gap-2"
+											onClick={(e) => {
+												e.stopPropagation();
+												e.preventDefault();
+												setDropdownOpen(false);
+												setCopyToEnv(AppEnv.Live);
+												setCopyOpen(true);
+											}}
+										>
+											Production
+										</DropdownMenuItem>
+									</>
+								)}
+								{inNamedSandbox &&
+									otherSandboxes.map((s) => (
+										<DropdownMenuItem
+											key={s.id}
+											className="flex gap-2"
+											onClick={(e) => {
+												e.stopPropagation();
+												e.preventDefault();
+												handleCopyToSandbox(s);
+											}}
+										>
+											{s.name}
+										</DropdownMenuItem>
+									))}
+							</DropdownMenuSubContent>
+						</DropdownMenuSub>
+					)}
 					{!isVariant && !product.archived && (
 						<DropdownMenuItem
 							className="flex gap-2"

--- a/vite/src/views/products/products/components/product-list/ProductListRowToolbar.tsx
+++ b/vite/src/views/products/products/components/product-list/ProductListRowToolbar.tsx
@@ -29,6 +29,7 @@ import {
 import { useActiveSandbox } from "@/hooks/sandbox/useActiveSandbox";
 import { ProductService } from "@/services/products/ProductService";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { useEnv } from "@/utils/envUtils";
 import { getBackendErr, pushPage } from "@/utils/genUtils";
 import { CreateVariantDialog } from "@/views/products/plan/components/CreateVariantDialog";
 import { CopyProductDialog } from "../CopyProductDialog";
@@ -51,13 +52,15 @@ export const ProductListRowToolbar = ({
 	const navigate = useNavigate();
 	const axiosInstance = useAxiosInstance();
 	const activeSandbox = useActiveSandbox();
-	const { sandboxes } = useSandboxesQuery({ enabled: !!activeSandbox });
+	const env = useEnv();
+	const inNamedSandbox = env === AppEnv.Sandbox && !!activeSandbox;
+	const { sandboxes } = useSandboxesQuery({ enabled: inNamedSandbox });
 	const copySandbox = useCopySandbox();
 
 	const otherSandboxes = sandboxes.filter((s) => s.id !== activeSandbox?.id);
 
 	const handleCopyToSandbox = async (target: SandboxSummary) => {
-		if (!activeSandbox) return;
+		if (!inNamedSandbox || !activeSandbox) return;
 		setDropdownOpen(false);
 		try {
 			await copySandbox.mutateAsync({
@@ -182,10 +185,10 @@ export const ProductListRowToolbar = ({
 							>
 								Production
 							</DropdownMenuItem>
-							{activeSandbox && otherSandboxes.length > 0 && (
+							{inNamedSandbox && otherSandboxes.length > 0 && (
 								<DropdownMenuSeparator />
 							)}
-							{activeSandbox &&
+							{inNamedSandbox &&
 								otherSandboxes.map((s) => (
 									<DropdownMenuItem
 										key={s.id}

--- a/vite/src/views/products/products/components/product-list/ProductListRowToolbar.tsx
+++ b/vite/src/views/products/products/components/product-list/ProductListRowToolbar.tsx
@@ -3,6 +3,7 @@ import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
+	DropdownMenuSeparator,
 	DropdownMenuSub,
 	DropdownMenuSubContent,
 	DropdownMenuSubTrigger,
@@ -154,58 +155,55 @@ export const ProductListRowToolbar = ({
 					</DropdownMenuTrigger>
 				</div>
 				<DropdownMenuContent align="end">
-					{(!inNamedSandbox || otherSandboxes.length > 0) && (
-						<DropdownMenuSub>
-							<DropdownMenuSubTrigger className="flex gap-2">
-								<CopyIcon />
-								Copy to
-							</DropdownMenuSubTrigger>
-							<DropdownMenuSubContent>
-								{!inNamedSandbox && (
-									<>
-										<DropdownMenuItem
-											className="flex gap-2"
-											onClick={(e) => {
-												e.stopPropagation();
-												e.preventDefault();
-												setDropdownOpen(false);
-												setCopyToEnv(AppEnv.Sandbox);
-												setCopyOpen(true);
-											}}
-										>
-											Sandbox
-										</DropdownMenuItem>
-										<DropdownMenuItem
-											className="flex gap-2"
-											onClick={(e) => {
-												e.stopPropagation();
-												e.preventDefault();
-												setDropdownOpen(false);
-												setCopyToEnv(AppEnv.Live);
-												setCopyOpen(true);
-											}}
-										>
-											Production
-										</DropdownMenuItem>
-									</>
-								)}
-								{inNamedSandbox &&
-									otherSandboxes.map((s) => (
-										<DropdownMenuItem
-											key={s.id}
-											className="flex gap-2"
-											onClick={(e) => {
-												e.stopPropagation();
-												e.preventDefault();
-												handleCopyToSandbox(s);
-											}}
-										>
-											{s.name}
-										</DropdownMenuItem>
-									))}
-							</DropdownMenuSubContent>
-						</DropdownMenuSub>
-					)}
+					<DropdownMenuSub>
+						<DropdownMenuSubTrigger className="flex gap-2">
+							<CopyIcon />
+							Copy to
+						</DropdownMenuSubTrigger>
+						<DropdownMenuSubContent>
+							<DropdownMenuItem
+								className="flex gap-2"
+								onClick={(e) => {
+									e.stopPropagation();
+									e.preventDefault();
+									setDropdownOpen(false);
+									setCopyToEnv(AppEnv.Sandbox);
+									setCopyOpen(true);
+								}}
+							>
+								Sandbox
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								className="flex gap-2"
+								onClick={(e) => {
+									e.stopPropagation();
+									e.preventDefault();
+									setDropdownOpen(false);
+									setCopyToEnv(AppEnv.Live);
+									setCopyOpen(true);
+								}}
+							>
+								Production
+							</DropdownMenuItem>
+							{inNamedSandbox && otherSandboxes.length > 0 && (
+								<DropdownMenuSeparator />
+							)}
+							{inNamedSandbox &&
+								otherSandboxes.map((s) => (
+									<DropdownMenuItem
+										key={s.id}
+										className="flex gap-2"
+										onClick={(e) => {
+											e.stopPropagation();
+											e.preventDefault();
+											handleCopyToSandbox(s);
+										}}
+									>
+										{s.name}
+									</DropdownMenuItem>
+								))}
+						</DropdownMenuSubContent>
+					</DropdownMenuSub>
 					{!isVariant && !product.archived && (
 						<DropdownMenuItem
 							className="flex gap-2"

--- a/vite/src/views/products/products/components/product-list/ProductListRowToolbar.tsx
+++ b/vite/src/views/products/products/components/product-list/ProductListRowToolbar.tsx
@@ -53,18 +53,22 @@ export const ProductListRowToolbar = ({
 	const axiosInstance = useAxiosInstance();
 	const activeSandbox = useActiveSandbox();
 	const env = useEnv();
+	// Only a Sandbox-env view with an active sandbox is a real named-sandbox
+	// context; activeSandbox can be stale on a production route (no header sent).
 	const inNamedSandbox = env === AppEnv.Sandbox && !!activeSandbox;
-	const { sandboxes } = useSandboxesQuery({ enabled: inNamedSandbox });
+	const { sandboxes } = useSandboxesQuery({ enabled: true });
 	const copySandbox = useCopySandbox();
 
-	const otherSandboxes = sandboxes.filter((s) => s.id !== activeSandbox?.id);
+	const currentSandboxId = inNamedSandbox ? activeSandbox?.id : undefined;
+	const otherSandboxes = sandboxes.filter((s) => s.id !== currentSandboxId);
 
 	const handleCopyToSandbox = async (target: SandboxSummary) => {
-		if (!inNamedSandbox || !activeSandbox) return;
 		setDropdownOpen(false);
 		try {
 			await copySandbox.mutateAsync({
-				fromSandboxId: activeSandbox.id,
+				...(inNamedSandbox && activeSandbox
+					? { fromSandboxId: activeSandbox.id }
+					: { fromMaster: true }),
 				toSandboxId: target.id,
 				productIds: [product.id],
 			});
@@ -185,23 +189,20 @@ export const ProductListRowToolbar = ({
 							>
 								Production
 							</DropdownMenuItem>
-							{inNamedSandbox && otherSandboxes.length > 0 && (
-								<DropdownMenuSeparator />
-							)}
-							{inNamedSandbox &&
-								otherSandboxes.map((s) => (
-									<DropdownMenuItem
-										key={s.id}
-										className="flex gap-2"
-										onClick={(e) => {
-											e.stopPropagation();
-											e.preventDefault();
-											handleCopyToSandbox(s);
-										}}
-									>
-										{s.name}
-									</DropdownMenuItem>
-								))}
+							{otherSandboxes.length > 0 && <DropdownMenuSeparator />}
+							{otherSandboxes.map((s) => (
+								<DropdownMenuItem
+									key={s.id}
+									className="flex gap-2"
+									onClick={(e) => {
+										e.stopPropagation();
+										e.preventDefault();
+										handleCopyToSandbox(s);
+									}}
+								>
+									{s.name}
+								</DropdownMenuItem>
+							))}
 						</DropdownMenuSubContent>
 					</DropdownMenuSub>
 					{!isVariant && !product.archived && (

--- a/vite/src/views/products/products/components/product-list/ProductListRowToolbar.tsx
+++ b/vite/src/views/products/products/components/product-list/ProductListRowToolbar.tsx
@@ -1,5 +1,15 @@
 import { AppEnv, type ProductV2 } from "@autumn/shared";
-import { ToolbarButton } from "@autumn/ui";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
+	DropdownMenuTrigger,
+	ToolbarButton,
+} from "@autumn/ui";
 import {
 	ArchiveIcon,
 	ArrowCounterClockwiseIcon,
@@ -8,21 +18,18 @@ import {
 	TrashIcon,
 } from "@phosphor-icons/react";
 import { useState } from "react";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuSub,
-	DropdownMenuSubContent,
-	DropdownMenuSubTrigger,
-	DropdownMenuTrigger,
-} from "@autumn/ui";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
+import {
+	type SandboxSummary,
+	useCopySandbox,
+	useSandboxesQuery,
+} from "@/hooks/queries/useSandboxesQuery";
+import { useActiveSandbox } from "@/hooks/sandbox/useActiveSandbox";
 import { ProductService } from "@/services/products/ProductService";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
-import { pushPage } from "@/utils/genUtils";
+import { getBackendErr, pushPage } from "@/utils/genUtils";
 import { CreateVariantDialog } from "@/views/products/plan/components/CreateVariantDialog";
 import { CopyProductDialog } from "../CopyProductDialog";
 
@@ -43,6 +50,26 @@ export const ProductListRowToolbar = ({
 	const { counts, invalidate: invalidateProducts } = useProductsQuery();
 	const navigate = useNavigate();
 	const axiosInstance = useAxiosInstance();
+	const activeSandbox = useActiveSandbox();
+	const { sandboxes } = useSandboxesQuery({ enabled: !!activeSandbox });
+	const copySandbox = useCopySandbox();
+
+	const otherSandboxes = sandboxes.filter((s) => s.id !== activeSandbox?.id);
+
+	const handleCopyToSandbox = async (target: SandboxSummary) => {
+		if (!activeSandbox) return;
+		setDropdownOpen(false);
+		try {
+			await copySandbox.mutateAsync({
+				fromSandboxId: activeSandbox.id,
+				toSandboxId: target.id,
+				productIds: [product.id],
+			});
+			toast.success(`Copied ${product.name} to ${target.name}`);
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to copy plan"));
+		}
+	};
 
 	const isVariant = !!product.base_internal_product_id;
 
@@ -155,6 +182,23 @@ export const ProductListRowToolbar = ({
 							>
 								Production
 							</DropdownMenuItem>
+							{activeSandbox && otherSandboxes.length > 0 && (
+								<DropdownMenuSeparator />
+							)}
+							{activeSandbox &&
+								otherSandboxes.map((s) => (
+									<DropdownMenuItem
+										key={s.id}
+										className="flex gap-2"
+										onClick={(e) => {
+											e.stopPropagation();
+											e.preventDefault();
+											handleCopyToSandbox(s);
+										}}
+									>
+										{s.name}
+									</DropdownMenuItem>
+								))}
 						</DropdownMenuSubContent>
 					</DropdownMenuSub>
 					{!isVariant && !product.archived && (

--- a/vite/src/views/products/products/components/product-list/ProductListTable.tsx
+++ b/vite/src/views/products/products/components/product-list/ProductListTable.tsx
@@ -5,6 +5,7 @@ import { useCallback, useMemo, useState } from "react";
 import { Table } from "@/components/general/table";
 import { EmptyState } from "@/components/v2/empty-states/EmptyState";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
+import { useSandboxesQuery } from "@/hooks/queries/useSandboxesQuery";
 import { pushPage } from "@/utils/genUtils";
 import { useProductsQueryState } from "@/views/products/hooks/useProductsQueryState";
 import { useProductTable } from "@/views/products/hooks/useProductTable";
@@ -130,13 +131,18 @@ export function ProductListTable() {
 		[recurringBasePlans, recurringAddOnPlans, oneTimePlans],
 	);
 
+	// Fetched once here (not per row) and passed into the toolbar, so a large
+	// product list doesn't spawn one sandboxes-query observer per row.
+	const { sandboxes } = useSandboxesQuery({ enabled: true });
+
 	const columns = useMemo(
 		() =>
 			createProductListColumns({
 				showGroup: hasAnyGroup,
 				onDeleteClick: handleDeleteClick,
+				sandboxes,
 			}),
-		[hasAnyGroup, handleDeleteClick],
+		[hasAnyGroup, handleDeleteClick, sandboxes],
 	);
 
 	const recurringBaseTable = useProductTable({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a dashboard-only RPC `POST /v1/sandboxes.copy { fromSandboxId, toSandboxId }` that copies plans (products) + features from one named sandbox into another.

Each named sandbox is its own organization sub-org (`is_sandbox=true`, `created_by =` the master org), living in `AppEnv.Sandbox`. This builds on the existing copy engine in `server/src/internal/products/handlers/handleCopyEnvironment/` and generalizes it from a single `ctx.org` to a cross-org copy.

## How

- **Generalized the copy engine** (`handleCopyFeatures` / `handleCopyProducts`): these were parameterized only by `env` and implicitly reused `ctx.org` for both source and target. They now take explicit `(org, env)` source/target descriptors and rebuild the write context around the **target** org. The existing `copy_to_production` flow is behaviorally unchanged (it passes the same org as source and target). Processor-specific ids (price/entitlement ids, `price_config`) continue to be stripped.
- **`copySandboxForOrg`** (new): authorizes the caller for **both** sandboxes via the existing `getOwnedSandbox` 404-masking ownership check (same ownership rule as `assertSandboxAccess`: `id !== master`, `created_by === master`, `is_sandbox === true`). A missing or non-owned source/target folds into a uniform 404, so it can never read or write any org's live catalog. It then copies features first (boolean/metered before credit systems) then products, and invalidates the target's product cache.
- **`handleCopySandbox`** (new RPC handler): dashboard-only (`assertDashboardActor` + `assertNotSandboxContext`, `Scopes.Platform.Write`), rejects copying a sandbox onto itself, registered at `/sandboxes.copy` → `/v1/sandboxes.copy`.

## Testing (TDD)

Wrote the integration test first (it fails to resolve `copySandboxForOrg` before the implementation exists — red), then implemented to green.

`server/tests/integration/sandbox/copy-sandbox.test.ts` provisions two sandbox sub-orgs, seeds the source with boolean + metered + credit-system features and a product, copies A→B via `copySandboxForOrg`, and asserts:
- the target receives all three features and the product, and the product's items still reference the copied features;
- a non-owned source, a non-owned target, and the master org's own id each raise a uniform `404` (`OrgNotFound`), proving the copy can't target a live catalog.

All 4 tests pass; `biome check` and the server typecheck (`tsgo --build --noEmit`) are clean.

```
 4 pass
 0 fail
 14 expect() calls
Ran 4 tests across 1 file.
```

### Notes for reviewers
- The test inserts the two sandbox sub-orgs directly (the exact persisted shape `is_sandbox=true, created_by=master`) rather than calling `createSandboxForOrg`, because real sandbox creation provisions a Stripe connect account (requires `STRIPE_SANDBOX_SECRET_KEY`, unavailable in the offline test VM). The copy feature is independent of Stripe, and the inserted rows carry the exact ownership shape the authorization check validates.
- The route is not added to the `apps/scope-picker/routes.json` / `scope-403` snapshot, consistent with the existing `sandboxes.*` routes which are also absent from that generated snapshot.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1782828335768239?thread_ts=1782828335.768239&cid=C0BCAQQK0KS)

<div><a href="https://cursor.com/agents/bc-f2dc5057-d765-56ae-8852-3e052ae4cc81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2dc5057-d765-56ae-8852-3e052ae4cc81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dashboard-only POST `/v1/sandboxes.copy` to move plans and features between named sandboxes with selective copy, dependency closure, and strong guardrails. You can also seed a sandbox from the master org (default sandbox or production) and promote plans from a named sandbox into the master org; caches are updated for both lists and plan detail views.

- **New Features**
  - POST `/v1/sandboxes.copy` with `{ fromSandboxId | fromMaster, toSandboxId, productIds?, featureIds? }`; requires `Scopes.Platform.Write`, dashboard-only, rejects same source/target; 404‑masks non‑owned or missing sandboxes; requested `productIds`/`featureIds` missing in the source return 404; empty selections copy nothing; overwrite is idempotent and target product cache is invalidated (client also refreshes product lists and detail pages).
  - Selective copy pulls in features referenced by selected plans and metered deps of credit systems (including AI). The UI adds an “Import into <sandbox>” dialog; catalog fetches are pinned to the chosen sandbox/env via `useSandboxCatalogQuery`; `useCopySandbox` uses a union input (`fromSandboxId` | `fromMaster`) and refreshes plan/feature caches.
  - From a named sandbox, “Copy to Production/Sandbox” promotes into the master org; cross‑org variant promotion is refused; metered deps of credit systems are pulled in; same‑org same‑env ID collision checks and navigation behave correctly. From the default sandbox or production, “Copy to <sandbox>” copies a plan into a named sandbox; the source env is enforced and the option is shown only when applicable.

- **Refactors**
  - Generalized `handleCopyFeatures`/`handleCopyProducts` to copy across `(fromOrg, fromEnv) → (toOrg, toEnv)`; `handleCopyProducts` accepts `productIds` and optional `fromFeatures` to avoid redundant fetches and now includes `AiCreditSystem`.
  - Added `copyProductForOrgs` and updated `handleCopyProductV2` to route named‑sandbox promotions to the master org; hoisted the sandboxes query to the table level to avoid per‑row fetches; new sandboxes inherit the parent org’s config via `provisionSubOrg`.

<sup>Written for commit 328ae9d7c5297d40a786a30385f9f9551dc35ff7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `POST /v1/sandboxes.copy`, a dashboard-only RPC that copies plans and features between named sandbox sub-orgs. It generalizes the existing copy engine from same-org env copies to explicit `(fromOrg, fromEnv) → (toOrg, toEnv)` pairs, and introduces selective copy with automatic feature dependency closure for credit systems.

- **[API changes] New `POST /v1/sandboxes.copy`** (`handleCopySandbox`): dashboard-only, `Scopes.Platform.Write`, Zod-validated `fromSandboxId | fromMaster` mutual-exclusion, ownership enforced via `getOwnedSandbox` 404-masking.
- **[Improvements] Generalized copy engine** (`handleCopyFeatures`, `handleCopyProducts`): now accept explicit `fromOrg`/`toOrg` so the same logic handles sandbox→live, sandbox→sandbox, and named-sandbox→master-org promotion; `AiCreditSystem` added to the credit-system batch.
- **[Improvements] Named-sandbox product promotion** (`handleCopyProductV2`, `copyProductForOrgs`): when a dashboard session acts via `x-sandbox-org-id`, "Copy to Production/Sandbox" promotes into the master org; variant cross-org promotion is blocked server-side.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — ownership auth is enforced end-to-end, the copy engine generalization preserves the existing sandbox→live flow unchanged, and the new code is covered by integration tests.

The authorization model is sound: getOwnedSandbox 404-masks non-owned IDs at both source and target, assertNotSandboxContext + assertDashboardActor guard the entry point, and the Zod schema refine enforces the fromSandboxId|fromMaster mutual exclusion. The copy engine refactor is backward-compatible. The two observations are quality nits with no correctness impact.

No files require special attention. copySandbox.ts has two minor quality notes but no correctness issues.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/sandboxes/copySandbox.ts | New cross-org sandbox copy engine; ownership auth is solid (getOwnedSandbox 404-masking), but featureIds are silently dropped if absent from source (unlike productIds which throw a 404), and credit-system dep expansion logic is duplicated from copyProductForOrgs.ts. |
| server/src/internal/sandboxes/handlers/handleCopySandbox.ts | New dashboard-only RPC handler; assertNotSandboxContext + assertDashboardActor guards are correct, scope check is present, and the fromSandboxId/fromMaster mutual-exclusion refine in the Zod schema is well-placed. |
| server/src/internal/products/handlers/handleCopyEnvironment/handleCopyFeatures.ts | Generalized from sandbox→live to cross-org; AiCreditSystem correctly added to the credit-system batch; existing call-site in handleCopyEnvironment unchanged. |
| server/src/internal/products/handlers/handleCopyEnvironment/handleCopyProducts.ts | Generalized to cross-org; providedFromFeatures optimization avoids a redundant source-feature fetch; toFeatures is always freshly fetched post-handleCopyFeatures. |
| server/src/internal/products/handlers/handleCopyProduct/copyProductForOrgs.ts | New single-product cross-org copy helper; variant cross-org guard, feature-type conflict check, and cache invalidation are all present. |
| server/src/internal/products/handlers/handleCopyProduct/handleCopyProductV2.ts | Refactored to delegate to copyProductForOrgs; promoting logic correctly routes named-sandbox copies to the master org. |
| server/src/internal/sandboxes/createSandbox.ts | assertDashboardActor error message updated to 'managed'; new sandboxes now inherit the master org's config via provisionSubOrg. |
| vite/src/views/main-sidebar/env-dropdown/CopySandboxDialog.tsx | New import dialog; source-change resets deselected state, nothingSelected guard prevents empty copies. |
| server/tests/integration/sandbox/copy-sandbox.test.ts | Integration tests cover boolean/metered/credit features + product copy and 404-masking for non-owned orgs. |

<sub>Reviews (2): Last reviewed commit: ["feat(sandboxes): wire copy-to-sandbox fr..."](https://github.com/useautumn/autumn/commit/7c48a14ef60d7b07465efb9f69daa7f588ac70de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40830482)</sub>

<!-- /greptile_comment -->