### PR TITLE
show inherited org members in sandbox settings

### DIFF
--- a/vite/src/hooks/sandbox/useInNamedSandbox.ts
+++ b/vite/src/hooks/sandbox/useInNamedSandbox.ts
@@ -1,0 +1,9 @@
+import { AppEnv } from "@autumn/shared";
+import { useActiveSandbox } from "@/hooks/sandbox/useActiveSandbox";
+import { useEnv } from "@/utils/envUtils";
+
+export const useInNamedSandbox = () => {
+	const env = useEnv();
+	const activeSandbox = useActiveSandbox();
+	return env === AppEnv.Sandbox && Boolean(activeSandbox);
+};

--- a/vite/src/views/main-sidebar/org-dropdown/hooks/useMemberships.tsx
+++ b/vite/src/views/main-sidebar/org-dropdown/hooks/useMemberships.tsx
@@ -1,13 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
-import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
+import { useOrg } from "@/hooks/common/useOrg";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 
 export const useMemberships = () => {
-	const axiosInstance = useAxiosInstance();
-	const buildKey = useQueryKeyFactory();
+	const { org } = useOrg();
+	const axiosInstance = useAxiosInstance({ skipSandbox: true });
 
 	const { data, error, isLoading, refetch } = useQuery({
-		queryKey: buildKey(["organization-members"]),
+		queryKey: ["organization-members", org?.id],
 		queryFn: async () => {
 			const { data } = await axiosInstance.get("/organization/members");
 			return data;

--- a/vite/src/views/main-sidebar/org-dropdown/manage-org/OrgInvitesList.tsx
+++ b/vite/src/views/main-sidebar/org-dropdown/manage-org/OrgInvitesList.tsx
@@ -2,6 +2,7 @@ import type { Invite, Role } from "@autumn/shared";
 import { Badge, TableCell, TableRow } from "@autumn/ui";
 import { isFuture } from "date-fns";
 import { ROLE_META } from "@/components/v2/selects/RoleSelect";
+import { useInNamedSandbox } from "@/hooks/sandbox/useInNamedSandbox";
 import { formatDateStr } from "@/utils/formatUtils/formatDateUtils";
 import {
 	SETTINGS_ROW_CLASS,
@@ -21,6 +22,7 @@ const COLUMNS = [
 export const OrgInvitesList = () => {
 	const { invites, isLoading } = useMemberships();
 	const { isAdmin } = useCurrentMembership();
+	const inNamedSandbox = useInNamedSandbox();
 
 	if (isLoading) return null;
 
@@ -60,7 +62,9 @@ export const OrgInvitesList = () => {
 						</TableCell>
 						<TableCell className="pr-2">
 							<div className="flex justify-end">
-								{isAdmin && <MemberRowToolbar invite={invite} />}
+								{isAdmin && !inNamedSandbox && (
+									<MemberRowToolbar invite={invite} />
+								)}
 							</div>
 						</TableCell>
 					</TableRow>

--- a/vite/src/views/main-sidebar/org-dropdown/manage-org/OrgMembersList.tsx
+++ b/vite/src/views/main-sidebar/org-dropdown/manage-org/OrgMembersList.tsx
@@ -3,7 +3,8 @@ import { TableCell, TableRow } from "@autumn/ui";
 import { useState } from "react";
 import { toast } from "sonner";
 import { RoleSelect } from "@/components/v2/selects/RoleSelect";
-import { authClient, useSession } from "@/lib/auth-client";
+import { useInNamedSandbox } from "@/hooks/sandbox/useInNamedSandbox";
+import { authClient } from "@/lib/auth-client";
 import { formatDateStr } from "@/utils/formatUtils/formatDateUtils";
 import {
 	SETTINGS_ROW_CLASS,
@@ -74,6 +75,7 @@ const MemberRoleSelect = ({
 export const OrgMembersList = () => {
 	const { memberships, isLoading, refetch } = useMemberships();
 	const { currentRole, isAdmin, userId } = useCurrentMembership();
+	const inNamedSandbox = useInNamedSandbox();
 
 	if (isLoading) return null;
 
@@ -85,7 +87,8 @@ export const OrgMembersList = () => {
 				const memberRole = member.role as Role;
 				const isSelf = user.id === userId;
 				const isOwnerUser = currentRole === "owner";
-				const canEdit = memberRole !== "owner" && (isAdmin || isSelf);
+				const canEdit =
+					memberRole !== "owner" && (isAdmin || isSelf) && !inNamedSandbox;
 				const canPromoteToOwner =
 					isOwnerUser && memberRole !== "owner" && canEdit;
 
@@ -108,9 +111,12 @@ export const OrgMembersList = () => {
 						</TableCell>
 						<TableCell className="pr-2">
 							<div className="flex justify-end">
-								{isAdmin && memberRole !== "owner" && !isSelf && (
-									<MemberRowToolbar membership={membership} />
-								)}
+								{isAdmin &&
+									memberRole !== "owner" &&
+									!isSelf &&
+									!inNamedSandbox && (
+										<MemberRowToolbar membership={membership} />
+									)}
 							</div>
 						</TableCell>
 					</TableRow>

--- a/vite/src/views/settings/sections/MembersSection.tsx
+++ b/vite/src/views/settings/sections/MembersSection.tsx
@@ -1,15 +1,22 @@
 import { Separator } from "@autumn/ui";
+import { useInNamedSandbox } from "@/hooks/sandbox/useInNamedSandbox";
 import { InvitePopover } from "@/views/main-sidebar/org-dropdown/manage-org/InvitePopover";
 import { OrgInvitesList } from "@/views/main-sidebar/org-dropdown/manage-org/OrgInvitesList";
 import { OrgMembersList } from "@/views/main-sidebar/org-dropdown/manage-org/OrgMembersList";
 import { SettingsSection } from "../SettingsSection";
 
 export const MembersSection = () => {
+	const inNamedSandbox = useInNamedSandbox();
+
 	return (
 		<SettingsSection
 			title="Members"
-			description="Manage team members and invitations"
-			actions={<InvitePopover />}
+			description={
+				inNamedSandbox
+					? "Members are inherited from your organization and managed there"
+					: "Manage team members and invitations"
+			}
+			actions={inNamedSandbox ? undefined : <InvitePopover />}
 		>
 			<OrgMembersList />
 			<Separator />


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show organization-inherited members in sandbox settings and make the list read-only. Disables invites and member edits in sandboxes while still displaying current members and pending invites.

- New Features
  - Added `useInNamedSandbox` hook to detect named sandboxes and gate UI.
  - Members and Invites lists are read-only in sandboxes (no role changes, removals, or invite actions; Invite button hidden; description clarifies inheritance).
  - Memberships/Invites fetch now uses `skipSandbox: true` and query key includes `org.id` to scope data correctly.

<sup>Written for commit cb6ea79fc59efb44d8ae9de0761045d7d77573f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes the Members settings page accessible and read-only when viewing a named sandbox, showing inherited org members instead of blocking access. It also fixes the member-list query to always fetch from the parent org (`skipSandbox: true`) and scopes the React Query cache key to the org ID.

- **[Improvements]** Adds `useInNamedSandbox` hook and threads it through `MembersSection`, `OrgMembersList`, and `OrgInvitesList` to hide all management controls (invite, remove, role change) when inside a named sandbox environment.
- **[Bug fixes]** `useMemberships` now uses `skipSandbox: true` on the axios instance so the `/organization/members` request always resolves against the parent org rather than the sandbox sub-org, and updates the query key to include `org?.id` for correct cache invalidation on org switches.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive UI guards with no mutations to data access patterns beyond the intended parent-org scoping.

The changes are well-scoped: a new read-only hook, conditional rendering in three view components, and a focused fix to the memberships query (skipSandbox + org-scoped cache key). The useOrg() default already applies skipSandbox: true, so org?.id in the query key consistently represents the parent org across sandbox switches. No management actions are exposed in sandbox mode.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/hooks/sandbox/useInNamedSandbox.ts | New hook combining env check and active sandbox presence — clean and focused. |
| vite/src/views/main-sidebar/org-dropdown/hooks/useMemberships.tsx | Switches to skipSandbox axios instance and scopes query key to org ID; removes dependency on useQueryKeyFactory which included env/sandbox IDs that are no longer needed since members are always parent-org-scoped. |
| vite/src/views/settings/sections/MembersSection.tsx | Hides InvitePopover and updates description in named-sandbox context; straightforward conditional rendering. |
| vite/src/views/main-sidebar/org-dropdown/manage-org/OrgMembersList.tsx | Guards canEdit and MemberRowToolbar behind !inNamedSandbox; also cleans up the unused useSession import. |
| vite/src/views/main-sidebar/org-dropdown/manage-org/OrgInvitesList.tsx | Hides invite management toolbar in named-sandbox view; invites remain visible read-only, consistent with the inherited-members UX. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MembersSection renders] --> B{useInNamedSandbox?}
    B -->|false - live or base sandbox| C[Show InvitePopover
Manage team members]
    B -->|true - named sandbox| D[Hide InvitePopover
Inherited from org message]

    C --> E[OrgMembersList]
    D --> E

    E --> F{inNamedSandbox?}
    F -->|false| G[canEdit = role check
MemberRoleSelect enabled
MemberRowToolbar visible]
    F -->|true| H[canEdit = false
MemberRoleSelect disabled
MemberRowToolbar hidden]

    C --> I[OrgInvitesList]
    D --> I

    I --> J{isAdmin and not inNamedSandbox?}
    J -->|true| K[Show MemberRowToolbar]
    J -->|false| L[Read-only invite rows]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[MembersSection renders] --> B{useInNamedSandbox?}
    B -->|false - live or base sandbox| C[Show InvitePopover
Manage team members]
    B -->|true - named sandbox| D[Hide InvitePopover
Inherited from org message]

    C --> E[OrgMembersList]
    D --> E

    E --> F{inNamedSandbox?}
    F -->|false| G[canEdit = role check
MemberRoleSelect enabled
MemberRowToolbar visible]
    F -->|true| H[canEdit = false
MemberRoleSelect disabled
MemberRowToolbar hidden]

    C --> I[OrgInvitesList]
    D --> I

    I --> J{isAdmin and not inNamedSandbox?}
    J -->|true| K[Show MemberRowToolbar]
    J -->|false| L[Read-only invite rows]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["show inherited org members in sandbox se..."](https://github.com/useautumn/autumn/commit/cb6ea79fc59efb44d8ae9de0761045d7d77573f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40830503)</sub>

<!-- /greptile_comment -->