### PR TITLE
Add PlanetScale query tags for database performance monitoring

### DIFF
--- a/server/src/internal/balances/utils/deduction/executePostgresDeduction.ts
+++ b/server/src/internal/balances/utils/deduction/executePostgresDeduction.ts
@@ -4,6 +4,7 @@ import {
 	InternalError,
 } from "@autumn/shared";
 import { sql } from "drizzle-orm";
+import { planetScaleTag } from "@/db/dbUtils.js";
 import { withLock } from "@/external/redis/redisUtils.js";
 import { triggerAutoTopUp } from "@/internal/balances/autoTopUp/triggerAutoTopUp.js";
 import { rollbackDeduction } from "@/internal/balances/utils/paidAllocatedFeature/rollbackDeduction.js";
@@ -132,28 +133,28 @@ export const executePostgresDeduction = async ({
 				continue;
 			}
 
-			// Call the stored function to deduct from entitlements with credit costs
-			const result = await db.execute(
-				sql`SELECT * FROM deduct_from_cus_ents(
-				${JSON.stringify({
-					sorted_entitlements: customerEntitlementDeductions,
-					spend_limit_by_feature_id: spendLimitByFeatureId ?? null,
-					usage_based_cus_ent_ids_by_feature_id:
-						usageBasedCusEntIdsByFeatureId ?? null,
-					amount_to_deduct: toDeduct ?? null,
-					target_balance: targetBalance ?? null,
-					lock_receipt: lockReceipt ?? null,
-					unwind_value: unwindValue ?? null,
-					target_entity_id: entityId || null,
-					rollovers: rollovers.length > 0 ? rollovers : null,
-					cus_ent_ids: customerEntitlements.map((ce) => ce.id),
-					skip_additional_balance: resolvedOptions.skipAdditionalBalance,
-					alter_granted_balance: resolvedOptions.alterGrantedBalance,
-					overage_behaviour: resolvedOptions.overageBehaviour,
-					feature_id: feature.id,
-				})}::jsonb
-			)`,
-			);
+		// Call the stored function to deduct from entitlements with credit costs
+		const result = await db.execute(
+			sql`SELECT * FROM deduct_from_cus_ents(
+			${JSON.stringify({
+				sorted_entitlements: customerEntitlementDeductions,
+				spend_limit_by_feature_id: spendLimitByFeatureId ?? null,
+				usage_based_cus_ent_ids_by_feature_id:
+					usageBasedCusEntIdsByFeatureId ?? null,
+				amount_to_deduct: toDeduct ?? null,
+				target_balance: targetBalance ?? null,
+				lock_receipt: lockReceipt ?? null,
+				unwind_value: unwindValue ?? null,
+				target_entity_id: entityId || null,
+				rollovers: rollovers.length > 0 ? rollovers : null,
+				cus_ent_ids: customerEntitlements.map((ce) => ce.id),
+				skip_additional_balance: resolvedOptions.skipAdditionalBalance,
+				alter_granted_balance: resolvedOptions.alterGrantedBalance,
+				overage_behaviour: resolvedOptions.overageBehaviour,
+				feature_id: feature.id,
+			})}::jsonb
+		) ${planetScaleTag({ query: "deductFromCusEnts" })}`,
+		);
 
 			// Parse the JSONB result
 			const resultJson = result[0]?.deduct_from_cus_ents as {

--- a/server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts
@@ -7,6 +7,7 @@ import {
 	isUsageBasedAllocatedCustomerEntitlement,
 } from "@autumn/shared";
 import { sql } from "drizzle-orm";
+import { planetScaleTag } from "@/db/dbUtils.js";
 import { withLock } from "@/external/redis/redisUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { triggerAutoTopUp } from "@/internal/balances/autoTopUp/triggerAutoTopUp.js";
@@ -145,30 +146,30 @@ export const executePostgresDeductionV2 = async ({
 				continue;
 			}
 
-			const result = await db.execute(
-				sql`SELECT * FROM deduct_from_cus_ents(
-				${JSON.stringify({
-					sorted_entitlements: customerEntitlementDeductions,
-					// No usage_window_limits here: the hard usage cap is enforced only on the
-					// Redis/Lua path, so this Postgres fallback intentionally fails open
-					// (availability over strict cap enforcement during a Redis outage).
-					spend_limit_by_feature_id: spendLimitByFeatureId ?? null,
-					usage_based_cus_ent_ids_by_feature_id:
-						usageBasedCusEntIdsByFeatureId ?? null,
-					amount_to_deduct: toDeduct ?? null,
-					target_balance: targetBalance ?? null,
-					lock_receipt: lockReceipt ?? null,
-					unwind_value: unwindValue ?? null,
-					target_entity_id: entityId || null,
-					rollovers: rollovers.length > 0 ? rollovers : null,
-					cus_ent_ids: customerEntitlements.map((ce) => ce.id),
-					skip_additional_balance: resolvedOptions.skipAdditionalBalance,
-					alter_granted_balance: resolvedOptions.alterGrantedBalance,
-					overage_behaviour: resolvedOptions.overageBehaviour,
-					feature_id: feature.id,
-				})}::jsonb
-			)`,
-			);
+		const result = await db.execute(
+			sql`SELECT * FROM deduct_from_cus_ents(
+			${JSON.stringify({
+				sorted_entitlements: customerEntitlementDeductions,
+				// No usage_window_limits here: the hard usage cap is enforced only on the
+				// Redis/Lua path, so this Postgres fallback intentionally fails open
+				// (availability over strict cap enforcement during a Redis outage).
+				spend_limit_by_feature_id: spendLimitByFeatureId ?? null,
+				usage_based_cus_ent_ids_by_feature_id:
+					usageBasedCusEntIdsByFeatureId ?? null,
+				amount_to_deduct: toDeduct ?? null,
+				target_balance: targetBalance ?? null,
+				lock_receipt: lockReceipt ?? null,
+				unwind_value: unwindValue ?? null,
+				target_entity_id: entityId || null,
+				rollovers: rollovers.length > 0 ? rollovers : null,
+				cus_ent_ids: customerEntitlements.map((ce) => ce.id),
+				skip_additional_balance: resolvedOptions.skipAdditionalBalance,
+				alter_granted_balance: resolvedOptions.alterGrantedBalance,
+				overage_behaviour: resolvedOptions.overageBehaviour,
+				feature_id: feature.id,
+			})}::jsonb
+		) ${planetScaleTag({ query: "deductFromCusEnts" })}`,
+		);
 
 			const resultJson = result[0]?.deduct_from_cus_ents as {
 				updates: Record<string, DeductionUpdate>;

--- a/server/src/internal/balances/utils/sql/client.ts
+++ b/server/src/internal/balances/utils/sql/client.ts
@@ -1,5 +1,6 @@
 import type { EntityBalance, Rollover } from "@autumn/shared";
 import { sql } from "drizzle-orm";
+import { planetScaleTag } from "@/db/dbUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 
 export type ResetCusEntParam = {
@@ -49,7 +50,7 @@ export const resetCusEnts = async ({
 	const result = await db.execute(
 		sql`SELECT * FROM reset_customer_entitlements(${JSON.stringify({
 			resets,
-		})}::jsonb)`,
+		})}::jsonb) ${planetScaleTag({ query: "resetCustomerEntitlements" })}`,
 	);
 
 	const raw = result[0]?.reset_customer_entitlements as

--- a/server/src/internal/balances/utils/sync/syncItemV3.ts
+++ b/server/src/internal/balances/utils/sync/syncItemV3.ts
@@ -7,6 +7,7 @@ import {
 	tryCatch,
 } from "@autumn/shared";
 import { sql } from "drizzle-orm";
+import { planetScaleTag } from "@/db/dbUtils.js";
 import { getRegionalRedis } from "@/external/redis/initRedis.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
@@ -239,7 +240,7 @@ export const syncItemV3 = async ({
 			sql`SELECT * FROM sync_balances_v2(${JSON.stringify({
 				customer_entitlement_updates: entries,
 				rollover_updates: rolloverEntries,
-			})}::jsonb)`,
+			})}::jsonb) ${planetScaleTag({ query: "syncBalancesV3" })}`,
 		),
 	);
 

--- a/server/src/internal/balances/utils/sync/syncItemV4.ts
+++ b/server/src/internal/balances/utils/sync/syncItemV4.ts
@@ -6,6 +6,7 @@ import {
 	tryCatch,
 } from "@autumn/shared";
 import { sql } from "drizzle-orm";
+import { planetScaleTag } from "@/db/dbUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getCachedFeatureBalance } from "@/internal/customers/cache/fullSubject/balances/getCachedFeatureBalances.js";
 import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
@@ -206,7 +207,7 @@ export const syncItemV4 = async ({
 				customer_entitlement_updates: entries,
 				rollover_updates: rolloverEntries,
 				usage_window_updates: usageWindowEntries,
-			})}::jsonb)`,
+			})}::jsonb) ${planetScaleTag({ query: "syncBalancesV4" })}`,
 		),
 	);
 

--- a/server/src/internal/customers/CusSearchService.ts
+++ b/server/src/internal/customers/CusSearchService.ts
@@ -22,6 +22,7 @@ import {
 	sql,
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
+import { planetScaleTag } from "@/db/dbUtils.js";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { getOrgCusProductLimit } from "../misc/edgeConfig/orgLimitsStore.js";
 import type { CustomerListFilters } from "./customerListFilters.js";
@@ -855,6 +856,7 @@ export class CusSearchService {
 				${cursorClause}
 				ORDER BY ${customers.created_at} DESC, ${customers.id} DESC
 				LIMIT ${fetchLimit}
+				${planetScaleTag({ query: "searchCustomersByProductMode" })}
 			`)) as unknown as Array<{
 				internal_id: string;
 				created_at: number;
@@ -872,6 +874,7 @@ export class CusSearchService {
 			${cursorClause}
 			ORDER BY ${customers.created_at} DESC, ${customers.id} DESC
 			LIMIT ${fetchLimit}
+			${planetScaleTag({ query: "searchCustomersByProduct" })}
 		`)) as unknown as Array<{
 			internal_id: string;
 			created_at: number;

--- a/server/src/internal/customers/repos/getFullSubject/getEntityAggregateForSync.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getEntityAggregateForSync.ts
@@ -5,6 +5,7 @@ import {
 	type CusProductStatus,
 } from "@autumn/shared";
 import { sql } from "drizzle-orm";
+import { planetScaleTag } from "@/db/dbUtils.js";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { RELEVANT_STATUSES } from "@/internal/customers/cusProducts/CusProductService.js";
 import { getEntityAggregateFragments } from "@/internal/customers/repos/getFullSubject/getEntityAggregateFragments.js";
@@ -58,6 +59,7 @@ export const getEntityAggregateForSync = async ({
 
 		SELECT *
 		FROM entity_aggregated_cus_entitlements
+		${planetScaleTag({ query: "getEntityAggregateForSync" })}
 	`;
 
 	const result = await db.execute(query);

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts
@@ -53,6 +53,7 @@ export const getFullSubjectRowsQuery = ({
 	includeInvoices,
 	includeEntityAggregations,
 	entityScopedOnly = false,
+	queryTag = "getFullSubject",
 }: {
 	leadingCtes: SQL;
 	inStatuses: CusProductStatus[];
@@ -60,6 +61,7 @@ export const getFullSubjectRowsQuery = ({
 	includeEntityAggregations: boolean;
 	/** Only hydrate rows scoped to the subject's entity (requires non-null internal_entity_id on every subject). Customer-level rows must be merged back in separately. */
 	entityScopedOnly?: boolean;
+	queryTag?: string;
 }) => {
 	const statusFilter =
 		inStatuses.length > 0
@@ -522,6 +524,6 @@ export const getFullSubjectRowsQuery = ({
 		LEFT JOIN entities er
 			ON er.internal_id = sr.internal_entity_id
 		ORDER BY sr.subject_order
-		${planetScaleTag({ query: "getFullSubject" })}
+		${planetScaleTag({ query: queryTag })}
 	`;
 };

--- a/server/src/internal/entities/repos/cursorListEntitiesQuery.ts
+++ b/server/src/internal/entities/repos/cursorListEntitiesQuery.ts
@@ -152,5 +152,6 @@ export const getCursorPaginatedEntitySubjectsQuery = ({
 		includeInvoices: false,
 		includeEntityAggregations: false,
 		entityScopedOnly: true,
+		queryTag: "getCursorPaginatedEntitySubjects",
 	});
 };

--- a/server/src/internal/entities/repos/customerLevelSubjectsQuery.ts
+++ b/server/src/internal/entities/repos/customerLevelSubjectsQuery.ts
@@ -38,5 +38,6 @@ export const getCustomerLevelSubjectRowsQuery = ({
 		inStatuses,
 		includeInvoices: false,
 		includeEntityAggregations: false,
+		queryTag: "getCustomerLevelSubjectRows",
 	});
 };

--- a/server/src/internal/entities/repos/listEntitiesQuery.ts
+++ b/server/src/internal/entities/repos/listEntitiesQuery.ts
@@ -4,6 +4,7 @@ import type {
 	ListEntitiesParams,
 } from "@autumn/shared";
 import { type SQL, sql } from "drizzle-orm";
+import { planetScaleTag } from "@/db/dbUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getFullSubjectRowsQuery } from "@/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.js";
 
@@ -175,6 +176,7 @@ export const getPaginatedEntitySubjectsQuery = ({
 		includeInvoices: false,
 		includeEntityAggregations: false,
 		entityScopedOnly: true,
+		queryTag: "getPaginatedEntitySubjects",
 	});
 };
 
@@ -192,6 +194,7 @@ const countEntities = async ({
 			env: ctx.env,
 			filterSql,
 		})}
+		${planetScaleTag({ query: "countEntities" })}
 	`);
 	const rawCount = (rows[0] as { total_count?: string | number } | undefined)
 		?.total_count;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds PlanetScale query tags to 11 critical database queries for performance monitoring.

**Tagged queries:**
- Balance/sync: getEntityAggregateForSync, syncBalancesV4/V3, deductFromCusEnts, resetCustomerEntitlements  
- Entity queries: countEntities, getPaginatedEntitySubjects, getCursorPaginatedEntitySubjects, getCustomerLevelSubjectRows
- Search: searchCustomersByProductMode, searchCustomersByProduct

**Implementation:** Added `planetScaleTag({ query: "..." })` using SQLCommenter format. Extended getFullSubjectRowsQuery with optional queryTag parameter.

**Usage in PlanetScale:** `tag:query:syncBalancesV4` or `tag:query:deductFromCusEnts`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1782754548019929?thread_ts=1782754548.019929&cid=C0BCAQQK0KS)

<div><a href="https://cursor.com/agents/bc-6801a980-7159-59d5-851b-b80c41b3afab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6801a980-7159-59d5-851b-b80c41b3afab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add SQLCommenter query tags to 11 high-traffic PlanetScale queries to improve Insights visibility and speed up performance investigations. Also adds a `queryTag` to `getFullSubjectRowsQuery` and wires it through entity and search queries.

- **New Features**
  - Applied `planetScaleTag({ query: "..." })` to: `deductFromCusEnts`, `resetCustomerEntitlements`, `syncBalancesV3`, `syncBalancesV4`, `getEntityAggregateForSync`, `countEntities`, `getPaginatedEntitySubjects`, `getCursorPaginatedEntitySubjects`, `getCustomerLevelSubjectRows`, `searchCustomersByProductMode`, `searchCustomersByProduct`.
  - `getFullSubjectRowsQuery` now accepts `queryTag` (default: `getFullSubject`) and uses it; passed from `getPaginatedEntitySubjects`, `getCursorPaginatedEntitySubjects`, and `getCustomerLevelSubjectRows`.
  - In PlanetScale, filter with `tag:query:<name>`, e.g. `tag:query:syncBalancesV4` or `tag:query:deductFromCusEnts`.

<sup>Written for commit be86e95926b0493deb16dad75a340a5c5038b2cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds SQLCommenter query tags for database monitoring. The main changes are:

- **[Improvements]** Balance deduction, reset, sync, and aggregate queries now append `planetScaleTag` comments.
- **[API changes] [Improvements]** `getFullSubjectRowsQuery` now accepts an optional `queryTag` parameter.
- **[Improvements]** Entity and customer search modules start wiring query-tag support.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after small observability fixes.

- The appended SQL comments are inert for the changed stored-function and select queries.
- Some advertised monitoring tags are not emitted because parameters or imports are unused.
- No security or runtime correctness issue was found in the changed code.

getFullSubjectRowsQuery.ts, listEntitiesQuery.ts, CusSearchService.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/utils/deduction/executePostgresDeduction.ts | Adds a SQL comment tag to the `deduct_from_cus_ents` stored-function call. |
| server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts | Adds the same deduction query tag to the V2 Postgres deduction path. |
| server/src/internal/balances/utils/sql/client.ts | Adds a query tag to the customer entitlement reset stored-function call. |
| server/src/internal/balances/utils/sync/syncItemV3.ts | Adds a `syncItemV3` query tag to the balance sync call. |
| server/src/internal/balances/utils/sync/syncItemV4.ts | Adds a `syncItemV4` query tag to the balance sync call. |
| server/src/internal/customers/CusSearchService.ts | Adds a query-tag import, but the search queries do not use it. |
| server/src/internal/customers/repos/getFullSubject/getEntityAggregateForSync.ts | Adds a query tag to the entity aggregate sync query. |
| server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts | Adds a `queryTag` parameter, but the emitted tag remains hardcoded. |
| server/src/internal/entities/repos/cursorListEntitiesQuery.ts | Passes a cursor pagination query tag into `getFullSubjectRowsQuery`. |
| server/src/internal/entities/repos/customerLevelSubjectsQuery.ts | Passes a customer-level subject query tag into `getFullSubjectRowsQuery`. |
| server/src/internal/entities/repos/listEntitiesQuery.ts | Adds a query-tag import, but the list and count queries do not use it. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts:56
**Custom Query Tag Ignored**

When `getCursorPaginatedEntitySubjectsQuery` or `getCustomerLevelSubjectRowsQuery` passes a distinct `queryTag`, this function still emits the hardcoded `getFullSubject` tag in the final SQL. Those queries will be grouped under the wrong tag in PlanetScale Insights, so the new per-query monitoring split does not work for these callers.

### Issue 2 of 3
server/src/internal/entities/repos/listEntitiesQuery.ts:7
**Entity Queries Stay Untagged**

This new import is never used, and the entity list/count SQL paths still do not append a query tag. Calls to `countEntities` and `getPaginatedEntitySubjectsQuery` therefore keep running without the advertised `countEntities` and `getPaginatedEntitySubjects` monitoring tags.

### Issue 3 of 3
server/src/internal/customers/CusSearchService.ts:25
**Search Queries Stay Untagged**

This new import is never used, so the customer search SQL built in this service does not include the advertised search query tags. Traffic from the product-mode and product search paths will remain invisible to `tag:query:searchCustomersByProductMode` and `tag:query:searchCustomersByProduct` filters.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Apply suggestion from @SirTenzin"](https://github.com/useautumn/autumn/commit/842b08f4b81ecba4cb2f662a4152cedd84bdb12f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41058457)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->