### PR TITLE
fix: trigger redeploy

### DIFF
--- a/server/src/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook.ts
+++ b/server/src/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook.ts
@@ -44,6 +44,8 @@ export const sendBillingUpdatedWebhook = async ({
 			tags,
 		});
 
+		// console.log("response", response);
+
 		if (!billingChangeResponseHasContent(response)) return;
 
 		// Svix message tags (separate from the payload `tags` field) — used


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Trigger redeploy by adding a commented-out debug log in `server/src/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook.ts`. No functional changes or behavior changes.

<sup>Written for commit 7ac28e210c3a1546429d576ba66b0202a4711d35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes a no-op redeploy change in the billing webhook workflow.

- Adds a commented-out debug log near the billing update response handling.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook.ts | Adds only a commented-out debug line, with no runtime behavior change. |

<sub>Reviews (1): Last reviewed commit: ["chore: trigger redeploy"](https://github.com/useautumn/autumn/commit/7ac28e210c3a1546429d576ba66b0202a4711d35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40956080)</sub>

<!-- /greptile_comment -->