### PR TITLE
fix: trigger redeploy

### DIFF
--- a/server/src/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook.ts
+++ b/server/src/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook.ts
@@ -45,6 +45,7 @@ export const sendBillingUpdatedWebhook = async ({
 		});
 
 		// console.log("response", response);
+		// console.log("response", response);
 
 		if (!billingChangeResponseHasContent(response)) return;
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Trigger a redeploy by adding a commented debug log in `sendBillingUpdatedWebhook` and syncing with `main`; no runtime or functional changes.

<sup>Written for commit 97a355c2bc9da349ab92c0f9821427ed3d88e2d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes a comment-only redeploy trigger in the billing webhook workflow. The main change is:

- Added a duplicate commented-out response log line in `sendBillingUpdatedWebhook.ts`.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook.ts | Comment-only change; no runtime behavior changed. |

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/trigger-red..."](https://github.com/useautumn/autumn/commit/97a355c2bc9da349ab92c0f9821427ed3d88e2d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40958461)</sub>

<!-- /greptile_comment -->