### PR TITLE
fix: trigger redeploy

### DIFF
--- a/server/src/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook.ts
+++ b/server/src/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook.ts
@@ -46,6 +46,7 @@ export const sendBillingUpdatedWebhook = async ({
 
 		// console.log("response", response);
 		// console.log("response", response);
+		// console.log("response", response);
 
 		if (!billingChangeResponseHasContent(response)) return;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Trigger a redeploy of the billing webhook workflow by adding another commented debug line in `sendBillingUpdatedWebhook`. No functional or runtime behavior changes.

<sup>Written for commit 6db5e1e6668585b31d2f142268f8d511fbaa2a92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a commented debug line in the billing webhook workflow. The main changes are:

- Added a commented-out `response` log near the webhook response handling.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook.ts | Adds a commented-out debug line with no executable behavior change. |

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/trigger-red..."](https://github.com/useautumn/autumn/commit/6db5e1e6668585b31d2f142268f8d511fbaa2a92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40960351)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->