### PR TITLE
chore: disable expiry cron

### DIFF
--- a/server/src/cron/cronInit.ts
+++ b/server/src/cron/cronInit.ts
@@ -16,7 +16,6 @@ import { runInvoiceCron } from "./invoiceCron/runInvoiceCron.js";
 import { runOneOffCleanup } from "./oneoffCron/runOneOffCleanup.js";
 import { runOneOffExpiry } from "./oneoffCron/runOneOffExpiry.js";
 import { runProductCron } from "./productCron/runProductCron.js";
-import { runClearExpiredResetCron } from "./resetCron/runClearExpiredResetCron.js";
 import { runResetCron } from "./resetCron/runResetCron.js";
 import type { CronContext } from "./utils/CronContext.js";
 
@@ -66,7 +65,7 @@ const main = async () => {
 		runInvoiceCron({ ctx }),
 		runOneOffCleanup({ ctx }),
 		runOneOffExpiry({ ctx }),
-		runClearExpiredResetCron({ ctx }),
+		// runClearExpiredResetCron({ ctx }),
 	]);
 };
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disabled the expired reset cleanup cron so it no longer runs with the main cron jobs. This pauses `runClearExpiredResetCron` execution until we re-enable it.

<sup>Written for commit d78a42e946a88324176624b25684a857502bb1e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR disables the expired reset cleanup cron. The main changes are:

- Removed the `runClearExpiredResetCron` import.
- Commented out the expired reset cleanup job in cron startup.
</details>

<h3>Confidence Score: 5/5</h3>

The changed flow looks mergeable after a small cleanup decision for expired entitlement indexing.

- The removed import has no build or module-load issue.
- Current reset paths still filter expired customer products before resetting balances.
- Disabling the cleanup job can leave expired entitlement rows in the reset partial index over time.

server/src/cron/cronInit.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/cron/cronInit.ts | Disables the expired reset cleanup cron from startup; the import removal is build-safe, but expired entitlement rows can remain in the reset partial index. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/cron/cronInit.ts:68
**Expired Entitlements Stay Indexed**

When this cron is disabled, product-backed entitlements whose customer products are expired keep `expired = NULL`. Those rows still satisfy `expired IS NOT TRUE`, so they remain in the reset partial index indefinitely and can cause avoidable index growth as expired products accumulate.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: disable expiry cron"](https://github.com/useautumn/autumn/commit/d78a42e946a88324176624b25684a857502bb1e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40965526)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->