### PR TITLE
Fix checkout email prefill for existing Stripe customers

### DIFF
--- a/server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts
+++ b/server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts
@@ -3,6 +3,7 @@ import {
 	orgDisableStripeWrites,
 	ProcessorType,
 } from "@autumn/shared";
+import { createStripeCli } from "@/external/connect/createStripeCli";
 import { createStripeCustomer } from "@/external/stripe/customers/operations/createStripeCustomer";
 import {
 	type ExpandedStripeCustomer,
@@ -35,7 +36,21 @@ export const getOrCreateStripeCustomer = async ({
 		expandTax: resolvedOptions.expandTax,
 	});
 
-	if (currentStripeCustomer) return currentStripeCustomer;
+	if (currentStripeCustomer) {
+		if (
+			customer.email &&
+			currentStripeCustomer.email !== customer.email &&
+			!orgDisableStripeWrites({ ctx })
+		) {
+			const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
+			await stripeCli.customers.update(currentStripeCustomer.id, {
+				email: customer.email,
+			});
+			return { ...currentStripeCustomer, email: customer.email };
+		}
+
+		return currentStripeCustomer;
+	}
 
 	if (orgDisableStripeWrites({ ctx })) return undefined;
 

--- a/server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-customer-email.test.ts
+++ b/server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-customer-email.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+
+const parseCheckoutSessionId = (url: string): string | null => {
+	const match = url.match(/\/c\/pay\/(cs_[^/?#]+)/);
+	return match?.[1] ?? null;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("stripe-checkout: syncs existing Stripe customer email before checkout")}`,
+	async () => {
+		const suffix = Math.random().toString(36).slice(2, 10);
+		const customerId = `stripe-checkout-email-${suffix}`;
+		const email = `${customerId}@example.com`;
+		const pro = products.pro({
+			id: `pro-checkout-email-${suffix}`,
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV1, ctx } = await initScenario({
+			setup: [s.deleteCustomer({ customerId }), s.products({ list: [pro] })],
+			actions: [],
+		});
+
+		const stripeCustomer = await ctx.stripeCli.customers.create({});
+		await autumnV1.customers.create({
+			id: customerId,
+			stripe_id: stripeCustomer.id,
+			internalOptions: { disable_defaults: true },
+		});
+
+		await autumnV1.post("/customers.get_or_create", {
+			customer_id: customerId,
+			email,
+		});
+		await autumnV1.customers.updateRpc(customerId, { email });
+
+		const result = await autumnV1.billing.attach(
+			{
+				customer_id: customerId,
+				product_id: pro.id,
+			},
+			{ timeout: 0 },
+		);
+		expect(result.payment_url).toContain("checkout.stripe.com");
+
+		const checkoutSessionId = parseCheckoutSessionId(result.payment_url);
+		expect(checkoutSessionId).toBeTruthy();
+
+		const checkoutSession = await ctx.stripeCli.checkout.sessions.retrieve(
+			checkoutSessionId!,
+		);
+		expect(checkoutSession.customer).toBe(stripeCustomer.id);
+
+		const updatedStripeCustomer = await ctx.stripeCli.customers.retrieve(
+			stripeCustomer.id,
+		);
+		expect(updatedStripeCustomer.deleted).toBeFalsy();
+		if (updatedStripeCustomer.deleted) return;
+		expect(updatedStripeCustomer.email).toBe(email);
+	},
+);


### PR DESCRIPTION
## Summary
- Reconcile an existing Stripe customer email from Autumn before returning it to billing/checkout.
- Add a regression for `get_or_create` + `customers.update` + `billing.attach` with a pre-existing email-less Stripe customer.

## Testing
- `cd server && bunx tsgo --build --noEmit`
- Commit hook ran `@autumn/server:ts` successfully.
- `cd server && ./run.sh /Users/charlielamb/code/atmn/autumn/server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-customer-email.test.ts` passed before extracting to the clean worktree.
- Clean `origin/dev` worktree rerun is blocked before the test body by a pre-existing dev DB schema mismatch: `features.stripe_meter` is missing although migration `0032_white_stone_men` appears marked applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync Autumn customer email to existing Stripe customers before checkout so Stripe Checkout pre-fills the correct email for returning customers.

- **Bug Fixes**
  - Reconcile email in `getOrCreateStripeCustomer`: if a Stripe customer exists and Autumn has an email, update via `customers.update` using `createStripeCli` (skips when writes are disabled) and return the customer with the new email.
  - Add integration test for the `get_or_create` → `customers.update` → `billing.attach` flow with an email-less Stripe customer.

<sup>Written for commit ca5f4480e23a5dc8dfffb361b396da2a950b9ba1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Syncs the Autumn customer email to an existing Stripe customer during `getOrCreateStripeCustomer` so that Stripe Checkout pre-fills the correct email for returning customers who were created in Stripe before an email was recorded.

- **Bug fixes** — When a Stripe customer already exists but its email differs from Autumn's record, `customers.update` is now called (via `createStripeCli`) before returning, and the patched object is returned in-memory. The update is skipped when Stripe writes are disabled, preserving existing org-level behaviour.
- **Improvements** — New integration test exercises the full `get_or_create` → `customers.updateRpc` → `billing.attach` path with an email-less Stripe customer, asserting the checkout session is bound to the right customer and the Stripe record carries the synced email.
</details>

<h3>Confidence Score: 5/5</h3>

The change is narrowly scoped to a single conditional block inside getOrCreateStripeCustomer and only fires when a Stripe customer already exists with a mismatched email; the writes-disabled guard is preserved, and the rest of the function is untouched.

Logic is correct and tightly guarded: the new branch checks all three conditions (email present, email mismatch, writes not disabled) before touching Stripe, the return value is a valid spread of the already-retrieved ExpandedStripeCustomer, and the integration test directly verifies the end-to-end email-sync scenario.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts | Adds email reconciliation: when a Stripe customer exists but its email differs from Autumn's record, the customer is updated in Stripe and the patched object is returned; writes-disabled orgs are skipped. |
| server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-customer-email.test.ts | New integration test covering the get_or_create → customers.update → billing.attach flow with an initially email-less Stripe customer; verifies the checkout session is linked to the correct customer and the Stripe customer's email is synced. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant billing.attach
    participant getOrCreateStripeCustomer
    participant getExpandedStripeCustomer
    participant Stripe

    Client->>billing.attach: "attach({ customer_id, product_id })"
    billing.attach->>getOrCreateStripeCustomer: "{ ctx, customer }"
    getOrCreateStripeCustomer->>getExpandedStripeCustomer: "{ stripeCustomerId }"
    getExpandedStripeCustomer->>Stripe: "customers.retrieve(id, { expand: [...] })"
    Stripe-->>getExpandedStripeCustomer: ExpandedStripeCustomer (email: null)
    getExpandedStripeCustomer-->>getOrCreateStripeCustomer: currentStripeCustomer

    alt "customer.email set AND currentStripeCustomer.email != customer.email AND writes enabled"
        getOrCreateStripeCustomer->>Stripe: "customers.update(id, { email })"
        Stripe-->>getOrCreateStripeCustomer: updated customer
        getOrCreateStripeCustomer-->>billing.attach: "{ ...currentStripeCustomer, email }"
    else no mismatch or writes disabled
        getOrCreateStripeCustomer-->>billing.attach: currentStripeCustomer
    end

    billing.attach->>Stripe: "checkout.sessions.create({ customer, customer_email })"
    Stripe-->>billing.attach: session (pre-filled email)
    billing.attach-->>Client: "{ payment_url }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant billing.attach
    participant getOrCreateStripeCustomer
    participant getExpandedStripeCustomer
    participant Stripe

    Client->>billing.attach: "attach({ customer_id, product_id })"
    billing.attach->>getOrCreateStripeCustomer: "{ ctx, customer }"
    getOrCreateStripeCustomer->>getExpandedStripeCustomer: "{ stripeCustomerId }"
    getExpandedStripeCustomer->>Stripe: "customers.retrieve(id, { expand: [...] })"
    Stripe-->>getExpandedStripeCustomer: ExpandedStripeCustomer (email: null)
    getExpandedStripeCustomer-->>getOrCreateStripeCustomer: currentStripeCustomer

    alt "customer.email set AND currentStripeCustomer.email != customer.email AND writes enabled"
        getOrCreateStripeCustomer->>Stripe: "customers.update(id, { email })"
        Stripe-->>getOrCreateStripeCustomer: updated customer
        getOrCreateStripeCustomer-->>billing.attach: "{ ...currentStripeCustomer, email }"
    else no mismatch or writes disabled
        getOrCreateStripeCustomer-->>billing.attach: currentStripeCustomer
    end

    billing.attach->>Stripe: "checkout.sessions.create({ customer, customer_email })"
    Stripe-->>billing.attach: session (pre-filled email)
    billing.attach-->>Client: "{ payment_url }"
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): prefill checkout customer ..."](https://github.com/useautumn/autumn/commit/ca5f4480e23a5dc8dfffb361b396da2a950b9ba1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41066646)</sub>

<!-- /greptile_comment -->