### PR TITLE
fix(billing): clamp stripe anchor reset day

### DIFF
--- a/server/src/cron/resetCron/getStripeSubscriptionAnchor.ts
+++ b/server/src/cron/resetCron/getStripeSubscriptionAnchor.ts
@@ -5,7 +5,7 @@ import {
 	type ResetCusEnt,
 } from "@autumn/shared";
 import { UTCDate } from "@date-fns/utc";
-import { format, getDate, getMonth, setDate } from "date-fns";
+import { format, getDate, getDaysInMonth, getMonth, setDate } from "date-fns";
 import type { DrizzleCli } from "@/db/initDrizzle";
 import { createStripeCli } from "@/external/connect/createStripeCli";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
@@ -74,7 +74,10 @@ export const getStripeSubscriptionAnchor = async ({
 	const billingCycleDay = getDate(new UTCDate(billingCycleAnchor));
 	const nextResetDay = getDate(nextResetAtDate);
 
-	if (billingCycleDay > nextResetDay) {
+	if (
+		billingCycleDay > nextResetDay &&
+		billingCycleDay <= getDaysInMonth(nextResetAtDate)
+	) {
 		nextResetAtDate = setDate(nextResetAtDate, billingCycleDay);
 		return nextResetAtDate.getTime();
 	} else {

--- a/server/src/cron/resetCron/getStripeSubscriptionAnchor.ts
+++ b/server/src/cron/resetCron/getStripeSubscriptionAnchor.ts
@@ -1,11 +1,12 @@
 import {
 	type AppEnv,
 	EntInterval,
+	getCycleEnd,
 	type Organization,
 	type ResetCusEnt,
 } from "@autumn/shared";
 import { UTCDate } from "@date-fns/utc";
-import { format, getDate, getDaysInMonth, getMonth, setDate } from "date-fns";
+import { format, getDate, getMonth } from "date-fns";
 import type { DrizzleCli } from "@/db/initDrizzle";
 import { createStripeCli } from "@/external/connect/createStripeCli";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
@@ -19,16 +20,19 @@ const shortDurations: string[] = [
 export const getStripeSubscriptionAnchor = async ({
 	db,
 	cusEnt,
+	curResetAt,
 	nextResetAt,
 }: {
 	db: DrizzleCli;
 	cusEnt: ResetCusEnt;
+	curResetAt: number;
 	nextResetAt: number;
 }) => {
 	const entInterval = cusEnt.entitlement?.interval;
+	if (!entInterval) return nextResetAt;
 	if (entInterval && shortDurations.includes(entInterval)) return nextResetAt;
 
-	let nextResetAtDate = new UTCDate(nextResetAt);
+	const nextResetAtDate = new UTCDate(nextResetAt);
 
 	// Only check Stripe anchor on edge dates (28th Feb, 30th of month)
 	const nextResetAtDay = getDate(nextResetAtDate);
@@ -63,6 +67,10 @@ export const getStripeSubscriptionAnchor = async ({
 	const billingCycleAnchor = sub.billing_cycle_anchor * 1000;
 	console.log("Checking billing cycle anchor");
 	console.log(
+		"Current reset at    ",
+		format(new UTCDate(curResetAt), "dd MMM yyyy HH:mm:ss"),
+	);
+	console.log(
 		"Next reset at       ",
 		format(new UTCDate(nextResetAt), "dd MMM yyyy HH:mm:ss"),
 	);
@@ -71,16 +79,11 @@ export const getStripeSubscriptionAnchor = async ({
 		format(new UTCDate(billingCycleAnchor), "dd MMM yyyy HH:mm:ss"),
 	);
 
-	const billingCycleDay = getDate(new UTCDate(billingCycleAnchor));
-	const nextResetDay = getDate(nextResetAtDate);
-
-	if (
-		billingCycleDay > nextResetDay &&
-		billingCycleDay <= getDaysInMonth(nextResetAtDate)
-	) {
-		nextResetAtDate = setDate(nextResetAtDate, billingCycleDay);
-		return nextResetAtDate.getTime();
-	} else {
-		return nextResetAt;
-	}
+	const stripeAlignedResetAt = getCycleEnd({
+		anchor: billingCycleAnchor,
+		interval: entInterval,
+		intervalCount: cusEnt.entitlement.interval_count ?? 1,
+		now: curResetAt,
+	});
+	return Math.max(nextResetAt, stripeAlignedResetAt);
 };

--- a/server/src/cron/resetCron/resetCustomerEntitlement.ts
+++ b/server/src/cron/resetCron/resetCustomerEntitlement.ts
@@ -173,6 +173,7 @@ const resetCustomerEntitlementInDb = async ({
 				nextResetAt = await getStripeSubscriptionAnchor({
 					db: ctx.db,
 					cusEnt,
+					curResetAt: cusEnt.next_reset_at,
 					nextResetAt,
 				});
 			} catch (error) {

--- a/server/src/internal/customers/actions/resetCustomerEntitlements/getResetAtUpdate.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlements/getResetAtUpdate.ts
@@ -6,7 +6,7 @@ import {
 	type Organization,
 } from "@autumn/shared";
 import { UTCDate } from "@date-fns/utc";
-import { getDate, getMonth, setDate } from "date-fns";
+import { getDate, getDaysInMonth, getMonth, setDate } from "date-fns";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
 import { getNextResetAt } from "@/utils/timeUtils.js";
 
@@ -66,7 +66,10 @@ export const getResetAtUpdate = async ({
 		const billingCycleAnchor = sub.billing_cycle_anchor * 1000;
 		const billingCycleDay = getDate(new UTCDate(billingCycleAnchor));
 
-		if (billingCycleDay > nextResetAtDay) {
+		if (
+			billingCycleDay > nextResetAtDay &&
+			billingCycleDay <= getDaysInMonth(nextResetAtDate)
+		) {
 			return setDate(nextResetAtDate, billingCycleDay).getTime();
 		}
 	} catch (error) {

--- a/server/src/internal/customers/actions/resetCustomerEntitlements/getResetAtUpdate.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlements/getResetAtUpdate.ts
@@ -3,10 +3,11 @@ import {
 	type EntInterval,
 	EntInterval as EntIntervalEnum,
 	type FullCusProduct,
+	getCycleEnd,
 	type Organization,
 } from "@autumn/shared";
 import { UTCDate } from "@date-fns/utc";
-import { getDate, getDaysInMonth, getMonth, setDate } from "date-fns";
+import { getDate, getMonth } from "date-fns";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
 import { getNextResetAt } from "@/utils/timeUtils.js";
 
@@ -64,14 +65,13 @@ export const getResetAtUpdate = async ({
 		const sub = await stripeCli.subscriptions.retrieve(subId);
 
 		const billingCycleAnchor = sub.billing_cycle_anchor * 1000;
-		const billingCycleDay = getDate(new UTCDate(billingCycleAnchor));
-
-		if (
-			billingCycleDay > nextResetAtDay &&
-			billingCycleDay <= getDaysInMonth(nextResetAtDate)
-		) {
-			return setDate(nextResetAtDate, billingCycleDay).getTime();
-		}
+		const stripeAlignedResetAt = getCycleEnd({
+			anchor: billingCycleAnchor,
+			interval,
+			intervalCount,
+			now: curResetAt,
+		});
+		return Math.max(nextResetAt, stripeAlignedResetAt);
 	} catch (error) {
 		console.log(`[Lazy Reset] WARNING: Failed to check sub anchor: ${error}`);
 	}

--- a/server/tests/integration/balances/reset/month-end-stripe-anchor-reset.test.ts
+++ b/server/tests/integration/balances/reset/month-end-stripe-anchor-reset.test.ts
@@ -1,5 +1,10 @@
 import { afterAll, expect, mock, test } from "bun:test";
-import { AppEnv, EntInterval, type FullCusProduct } from "@autumn/shared";
+import {
+	AppEnv,
+	EntInterval,
+	type FullCusProduct,
+	type ResetCusEnt,
+} from "@autumn/shared";
 import chalk from "chalk";
 
 // A day-31 Stripe anchor must not push a shorter-month reset into the next month.
@@ -9,6 +14,7 @@ const MAY_31_2026 = Date.UTC(2026, 4, 31, 15, 13, 9);
 const MAY_15_2026 = Date.UTC(2026, 4, 15, 15, 13, 9);
 const JUST_AFTER_MAY_31_RESET = MAY_31_2026 + 60_000;
 const JUNE_30_2026 = Date.UTC(2026, 5, 30, 15, 13, 9);
+const JULY_30_2026 = Date.UTC(2026, 6, 30, 15, 13, 9);
 const JULY_31_2026 = Date.UTC(2026, 6, 31, 15, 13, 9);
 
 const realDateNow = Date.now;
@@ -24,9 +30,32 @@ mock.module("@/external/connect/createStripeCli.js", () => ({
 	}),
 }));
 
+mock.module("@/internal/customers/cusProducts/CusProductService", () => ({
+	CusProductService: {
+		getByIdForReset: async () => ({
+			subscription_ids: ["sub_month_end"],
+			product: {
+				env: AppEnv.Sandbox,
+				org: { id: "org_month_end" },
+			},
+		}),
+	},
+}));
+
 const { getResetAtUpdate } = await import(
 	"@/internal/customers/actions/resetCustomerEntitlements/getResetAtUpdate.js"
 );
+const { getStripeSubscriptionAnchor } = await import(
+	"@/cron/resetCron/getStripeSubscriptionAnchor.js"
+);
+
+const monthEndCusEnt = {
+	customer_product_id: "cus_prod_month_end",
+	entitlement: {
+		interval: EntInterval.Month,
+		interval_count: 1,
+	},
+} as ResetCusEnt;
 
 afterAll(() => {
 	Date.now = realDateNow;
@@ -47,6 +76,22 @@ test(
 			} as FullCusProduct,
 			org: { id: "org_month_end" } as never,
 			env: AppEnv.Sandbox,
+		});
+
+		expect(nextResetAt).toBe(JUNE_30_2026);
+	},
+);
+
+test(
+	`${chalk.yellowBright("month-end reset cron: Stripe anchor day 31 clamps to June 30")}`,
+	async () => {
+		stripeBillingCycleAnchor = MAY_31_2026;
+
+		const nextResetAt = await getStripeSubscriptionAnchor({
+			db: null as never,
+			cusEnt: monthEndCusEnt,
+			curResetAt: MAY_31_2026,
+			nextResetAt: JUNE_30_2026,
 		});
 
 		expect(nextResetAt).toBe(JUNE_30_2026);
@@ -75,6 +120,22 @@ test(
 );
 
 test(
+	`${chalk.yellowBright("month-end reset cron: following reset realigns to July 31")}`,
+	async () => {
+		stripeBillingCycleAnchor = MAY_31_2026;
+
+		const nextResetAt = await getStripeSubscriptionAnchor({
+			db: null as never,
+			cusEnt: monthEndCusEnt,
+			curResetAt: JUNE_30_2026,
+			nextResetAt: JULY_30_2026,
+		});
+
+		expect(nextResetAt).toBe(JULY_31_2026);
+	},
+);
+
+test(
 	`${chalk.yellowBright("month-end reset: Stripe anchor never shortens existing reset")}`,
 	async () => {
 		stripeBillingCycleAnchor = MAY_15_2026;
@@ -89,6 +150,22 @@ test(
 			} as FullCusProduct,
 			org: { id: "org_month_end" } as never,
 			env: AppEnv.Sandbox,
+		});
+
+		expect(nextResetAt).toBe(JUNE_30_2026);
+	},
+);
+
+test(
+	`${chalk.yellowBright("month-end reset cron: Stripe anchor never shortens existing reset")}`,
+	async () => {
+		stripeBillingCycleAnchor = MAY_15_2026;
+
+		const nextResetAt = await getStripeSubscriptionAnchor({
+			db: null as never,
+			cusEnt: monthEndCusEnt,
+			curResetAt: MAY_31_2026,
+			nextResetAt: JUNE_30_2026,
 		});
 
 		expect(nextResetAt).toBe(JUNE_30_2026);

--- a/server/tests/integration/balances/reset/month-end-stripe-anchor-reset.test.ts
+++ b/server/tests/integration/balances/reset/month-end-stripe-anchor-reset.test.ts
@@ -6,16 +6,19 @@ import chalk from "chalk";
 // Expected failure without clamping: June 30 becomes July 1.
 
 const MAY_31_2026 = Date.UTC(2026, 4, 31, 15, 13, 9);
+const MAY_15_2026 = Date.UTC(2026, 4, 15, 15, 13, 9);
 const JUST_AFTER_MAY_31_RESET = MAY_31_2026 + 60_000;
 const JUNE_30_2026 = Date.UTC(2026, 5, 30, 15, 13, 9);
+const JULY_31_2026 = Date.UTC(2026, 6, 31, 15, 13, 9);
 
 const realDateNow = Date.now;
+let stripeBillingCycleAnchor = MAY_31_2026;
 
 mock.module("@/external/connect/createStripeCli.js", () => ({
 	createStripeCli: () => ({
 		subscriptions: {
 			retrieve: async () => ({
-				billing_cycle_anchor: Math.floor(MAY_31_2026 / 1000),
+				billing_cycle_anchor: Math.floor(stripeBillingCycleAnchor / 1000),
 			}),
 		},
 	}),
@@ -32,6 +35,49 @@ afterAll(() => {
 test(
 	`${chalk.yellowBright("month-end reset: Stripe anchor day 31 clamps to June 30")}`,
 	async () => {
+		stripeBillingCycleAnchor = MAY_31_2026;
+		Date.now = () => JUST_AFTER_MAY_31_RESET;
+
+		const nextResetAt = await getResetAtUpdate({
+			curResetAt: MAY_31_2026,
+			interval: EntInterval.Month,
+			intervalCount: 1,
+			cusProduct: {
+				subscription_ids: ["sub_month_end"],
+			} as FullCusProduct,
+			org: { id: "org_month_end" } as never,
+			env: AppEnv.Sandbox,
+		});
+
+		expect(nextResetAt).toBe(JUNE_30_2026);
+	},
+);
+
+test(
+	`${chalk.yellowBright("month-end reset: following reset realigns to July 31")}`,
+	async () => {
+		stripeBillingCycleAnchor = MAY_31_2026;
+		Date.now = () => JUNE_30_2026 + 60_000;
+
+		const nextResetAt = await getResetAtUpdate({
+			curResetAt: JUNE_30_2026,
+			interval: EntInterval.Month,
+			intervalCount: 1,
+			cusProduct: {
+				subscription_ids: ["sub_month_end"],
+			} as FullCusProduct,
+			org: { id: "org_month_end" } as never,
+			env: AppEnv.Sandbox,
+		});
+
+		expect(nextResetAt).toBe(JULY_31_2026);
+	},
+);
+
+test(
+	`${chalk.yellowBright("month-end reset: Stripe anchor never shortens existing reset")}`,
+	async () => {
+		stripeBillingCycleAnchor = MAY_15_2026;
 		Date.now = () => JUST_AFTER_MAY_31_RESET;
 
 		const nextResetAt = await getResetAtUpdate({

--- a/server/tests/integration/balances/reset/month-end-stripe-anchor-reset.test.ts
+++ b/server/tests/integration/balances/reset/month-end-stripe-anchor-reset.test.ts
@@ -1,0 +1,50 @@
+import { afterAll, expect, mock, test } from "bun:test";
+import { AppEnv, EntInterval, type FullCusProduct } from "@autumn/shared";
+import chalk from "chalk";
+
+// A day-31 Stripe anchor must not push a shorter-month reset into the next month.
+// Expected failure without clamping: June 30 becomes July 1.
+
+const MAY_31_2026 = Date.UTC(2026, 4, 31, 15, 13, 9);
+const JUST_AFTER_MAY_31_RESET = MAY_31_2026 + 60_000;
+const JUNE_30_2026 = Date.UTC(2026, 5, 30, 15, 13, 9);
+
+const realDateNow = Date.now;
+
+mock.module("@/external/connect/createStripeCli.js", () => ({
+	createStripeCli: () => ({
+		subscriptions: {
+			retrieve: async () => ({
+				billing_cycle_anchor: Math.floor(MAY_31_2026 / 1000),
+			}),
+		},
+	}),
+}));
+
+const { getResetAtUpdate } = await import(
+	"@/internal/customers/actions/resetCustomerEntitlements/getResetAtUpdate.js"
+);
+
+afterAll(() => {
+	Date.now = realDateNow;
+});
+
+test(
+	`${chalk.yellowBright("month-end reset: Stripe anchor day 31 clamps to June 30")}`,
+	async () => {
+		Date.now = () => JUST_AFTER_MAY_31_RESET;
+
+		const nextResetAt = await getResetAtUpdate({
+			curResetAt: MAY_31_2026,
+			interval: EntInterval.Month,
+			intervalCount: 1,
+			cusProduct: {
+				subscription_ids: ["sub_month_end"],
+			} as FullCusProduct,
+			org: { id: "org_month_end" } as never,
+			env: AppEnv.Sandbox,
+		});
+
+		expect(nextResetAt).toBe(JUNE_30_2026);
+	},
+);


### PR DESCRIPTION
## Summary
- Prevent day-31 Stripe billing anchors from overflowing shorter-month entitlement resets into the next month
- Apply the same guard to the lazy reset path and legacy reset cron helper
- Add a repro for May 31 -> June 30 monthly resets

## Verification
- Red: with the fix temporarily reversed, `NODE_ENV=test bun test --timeout 0 /Users/charlielamb/.codex/worktrees/reset-anchor-alignment/autumn/server/tests/integration/balances/reset/month-end-stripe-anchor-reset.test.ts` failed with expected `1782832389000` and received `1782918789000`
- Green: same command passes after the fix
- `bunx tsgo --build --noEmit`

Note: `./run.sh` for this focused test currently fails before the test body on this machine because the local integration bootstrap hits Postgres schema error `column "stripe_meter" does not exist`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp Stripe billing anchor day to the last valid day of the next month to prevent monthly entitlement resets from spilling into the following month (e.g., May 31 now resets on June 30 instead of July 1). Reuses `getCycleEnd` and never shortens an existing `nextResetAt`, applied in both cron and lazy reset paths.

- **Bug Fixes**
  - Replace manual day logic with `getCycleEnd` and `Math.max(nextResetAt, stripeAlignedResetAt)` in `getStripeSubscriptionAnchor` and `getResetAtUpdate` (passes `curResetAt`; skips short or missing intervals).
  - Added `month-end-stripe-anchor-reset.test.ts` covering both lazy and cron paths: May 31 → June 30 clamp, realignment to July 31, and no-shortening behavior.

<sup>Written for commit e1bc77f5a5eeaa257d606f952a4b96132db60f84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

