### PR TITLE
fix: check usage limit

### DIFF
--- a/server/src/internal/balances/check/getCheckDataV2.ts
+++ b/server/src/internal/balances/check/getCheckDataV2.ts
@@ -140,12 +140,16 @@ export const getCheckDataV2 = async ({
 			customerApiSubject: apiCustomer,
 			planCustomerProducts: fullSubject.customer_products,
 			normalizeSpendLimitForCompare,
+			fullSubject,
+			features: ctx.features,
 		});
 	} else {
 		evaluationApiSubject = mergePlanBillingControlsForCheck({
 			customerApiSubject: evaluationApiSubject as ApiCustomerV5,
 			planCustomerProducts: fullSubject.customer_products,
 			normalizeSpendLimitForCompare,
+			fullSubject,
+			features: ctx.features,
 		});
 	}
 

--- a/server/tests/integration/balances/usage-windows/plan-only-usage-limit-check.test.ts
+++ b/server/tests/integration/balances/usage-windows/plan-only-usage-limit-check.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Bug: a usage_limits cap configured ONLY on the plan (product.billing_controls,
+ * no customer/entity-level override) is enforced correctly by `track` (clamps
+ * to 0 once exhausted) but NOT by `check` (`allowed` stays `true` forever).
+ *
+ * Root cause: mergePlanBillingControlsForCheck's mergeControlsByFeature()
+ * resolves the plan-level usage_limits entry but never decorates it with the
+ * current window's `usage` (unlike fullSubjectToApiUsageLimits, which uses
+ * getCurrentUsageWindowUsage for customer/entity-level entries). With `usage`
+ * missing, apiSubjectToUsageLimitHeadroom defaults it to 0, so headroom is
+ * always the full `limit` and the cap never gates `check`.
+ *
+ * Red (pre-fix): after exhausting the cap via track, `check` still returns
+ * `allowed: true`.
+ * Green (post-fix): `check` returns `allowed: false` once the plan-level cap
+ * is exhausted, matching what `track` already enforces.
+ */
+
+import { expect, test } from "bun:test";
+import { ApiVersion, ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+
+// initScenario only exposes clients up to V2_2; build the latest-version client
+// directly (same pattern as other usage-window tests).
+const autumnV2_3 = new AutumnInt({ version: ApiVersion.V2_3 });
+
+test.concurrent(
+	`${chalk.yellowBright("plan-only-usage-limit-check1: check reflects a PLAN-level usage cap once exhausted (no customer-level override)")}`,
+	async () => {
+		const customerProduct = products.base({
+			id: "plan-only-uw-check",
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+			billingControls: {
+				usage_limits: [
+					{
+						feature_id: TestFeature.Messages,
+						enabled: true,
+						limit: 5,
+						interval: ResetInterval.Day,
+					},
+				],
+			},
+		});
+
+		const customerId = "plan-only-uw-check-1";
+		await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [customerProduct] }),
+			],
+			actions: [s.billing.attach({ productId: customerProduct.id })],
+		});
+
+		// Exhaust the plan-level 5/day cap.
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 5,
+		});
+
+		// track already enforces the cap correctly: a further unit clamps to 0
+		// instead of deducting (proven via the unaffected 1000-included balance).
+		const overCapTrack = await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 1,
+		});
+		expect(overCapTrack.balance?.usage).toBe(5);
+
+		// The cap is exhausted (0 headroom); check must reflect that.
+		const check = await autumnV2_3.check({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			required_balance: 1,
+		});
+		expect(check.allowed).toBe(false);
+	},
+);

--- a/shared/utils/fullSubjectUtils/mergeCustomerBillingControlsForCheck.ts
+++ b/shared/utils/fullSubjectUtils/mergeCustomerBillingControlsForCheck.ts
@@ -6,7 +6,11 @@ import type {
 	DbSpendLimit,
 	DbUsageLimit,
 } from "../../models/cusModels/billingControls/customerBillingControls.js";
+import type { FullSubject } from "../../models/cusModels/fullSubject/fullSubjectModel.js";
 import type { FullCusProduct } from "../../models/cusProductModels/cusProductModels.js";
+import type { Feature } from "../../models/featureModels/featureModels.js";
+import { getCurrentUsageWindowUsage } from "../usageWindowUtils/getCurrentUsageWindowUsage.js";
+import { fullSubjectToUsageWindowLimits } from "./fullSubjectToUsageWindowLimits.js";
 import { resolveBillingControl } from "./planBillingControlUtils.js";
 
 const mergeControlsByFeature = <
@@ -70,6 +74,53 @@ const mergeControlsByFeature = <
 };
 
 /**
+ * A plan-derived usage_limits entry (from mergeControlsByFeature's
+ * planControls) is raw product config with no `usage` -- unlike
+ * entity/customer-owned entries, which fullSubjectToApiUsageLimits already
+ * decorated upstream. Fill in just the missing ones from the live
+ * usage-window counters, so a plan-only cap can gate `check`.
+ */
+const decorateInheritedPlanUsageLimits = ({
+	usageLimits,
+	fullSubject,
+	features,
+}: {
+	usageLimits: DbUsageLimit[];
+	fullSubject?: FullSubject;
+	features?: Feature[];
+}): DbUsageLimit[] => {
+	const undecorated = usageLimits.filter(
+		(usageLimit) => !("usage" in usageLimit),
+	);
+	if (!fullSubject || !features || undecorated.length === 0) {
+		return usageLimits;
+	}
+
+	const now = Date.now();
+	const resolvedLimits = fullSubjectToUsageWindowLimits({
+		fullSubject,
+		featureIds: undecorated.map((usageLimit) => usageLimit.feature_id),
+		features,
+		now,
+	});
+	const usageWindows = fullSubject.usage_windows ?? [];
+
+	return usageLimits.map((usageLimit) => {
+		if ("usage" in usageLimit) return usageLimit;
+
+		const resolved = resolvedLimits.find(
+			(limit) => limit.feature_id === usageLimit.feature_id,
+		);
+		if (!resolved) return usageLimit;
+
+		return {
+			...usageLimit,
+			usage: getCurrentUsageWindowUsage({ usageWindows, limit: resolved, now }),
+		};
+	});
+};
+
+/**
  * Build a new entity apiSubject whose billing_controls inherit customer and
  * plan spend_limits, usage_limits and overage_allowed entries per feature_id.
  * Entity's own entry always wins per feature; customer, then plan fill gaps.
@@ -85,12 +136,18 @@ export const mergeCustomerBillingControlsForCheck = ({
 	customerApiSubject,
 	planCustomerProducts = [],
 	normalizeSpendLimitForCompare,
+	fullSubject,
+	features,
 }: {
 	entityApiSubject: ApiEntityV2;
 	customerApiSubject: ApiCustomerV5;
 	planCustomerProducts?: FullCusProduct[];
 	/** Normalizes spend limits only for most-restrictive plan comparisons. */
 	normalizeSpendLimitForCompare?: (control: DbSpendLimit) => DbSpendLimit;
+	/** When provided (with `features`), a plan-inherited usage_limits entry is
+	 *  decorated with its current window `usage`. */
+	fullSubject?: FullSubject;
+	features?: Feature[];
 }): ApiEntityV2 => {
 	const entitySpendLimits =
 		entityApiSubject.billing_controls?.spend_limits ?? [];
@@ -111,11 +168,15 @@ export const mergeCustomerBillingControlsForCheck = ({
 		controlKey: "spend_limits",
 		normalizeForCompare: normalizeSpendLimitForCompare,
 	});
-	const usageLimits = mergeControlsByFeature<DbUsageLimit, "usage_limits">({
-		entityControls: entityUsageLimits,
-		customerControls: customerUsageLimits,
-		planCustomerProducts,
-		controlKey: "usage_limits",
+	const usageLimits = decorateInheritedPlanUsageLimits({
+		usageLimits: mergeControlsByFeature<DbUsageLimit, "usage_limits">({
+			entityControls: entityUsageLimits,
+			customerControls: customerUsageLimits,
+			planCustomerProducts,
+			controlKey: "usage_limits",
+		}),
+		fullSubject,
+		features,
 	});
 	const overageAllowed = mergeControlsByFeature<
 		DbOverageAllowed,
@@ -150,11 +211,17 @@ export const mergePlanBillingControlsForCheck = ({
 	customerApiSubject,
 	planCustomerProducts = [],
 	normalizeSpendLimitForCompare,
+	fullSubject,
+	features,
 }: {
 	customerApiSubject: ApiCustomerV5;
 	planCustomerProducts?: FullCusProduct[];
 	/** Normalizes spend limits only for most-restrictive plan comparisons. */
 	normalizeSpendLimitForCompare?: (control: DbSpendLimit) => DbSpendLimit;
+	/** When provided (with `features`), a plan-inherited usage_limits entry is
+	 *  decorated with its current window `usage`. */
+	fullSubject?: FullSubject;
+	features?: Feature[];
 }): ApiCustomerV5 => {
 	const customerSpendLimits =
 		customerApiSubject.billing_controls?.spend_limits ?? [];
@@ -169,11 +236,15 @@ export const mergePlanBillingControlsForCheck = ({
 		controlKey: "spend_limits",
 		normalizeForCompare: normalizeSpendLimitForCompare,
 	});
-	const usageLimits = mergeControlsByFeature<DbUsageLimit, "usage_limits">({
-		entityControls: customerUsageLimits,
-		customerControls: [],
-		planCustomerProducts,
-		controlKey: "usage_limits",
+	const usageLimits = decorateInheritedPlanUsageLimits({
+		usageLimits: mergeControlsByFeature<DbUsageLimit, "usage_limits">({
+			entityControls: customerUsageLimits,
+			customerControls: [],
+			planCustomerProducts,
+			controlKey: "usage_limits",
+		}),
+		fullSubject,
+		features,
 	});
 	const overageAllowed = mergeControlsByFeature<
 		DbOverageAllowed,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes check to enforce plan-only usage limits. We now compute current window usage for plan-inherited caps so headroom is correct and exhausted caps block check.

- **Bug Fixes**
  - Decorates plan-inherited usage_limits with current window usage using existing usage window data.
  - Applies the fix in mergeCustomerBillingControlsForCheck and mergePlanBillingControlsForCheck.
  - Passes fullSubject and features into getCheckDataV2 to enable decoration.
  - Adds an integration test that exhausts a plan-level cap and verifies check returns allowed: false.

<sup>Written for commit 95f56b2f7e0094f913bdf09e8def9790bc7ecb34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes a bug where a `usage_limits` cap configured exclusively at the plan level was never enforced by `check` — `check` always returned `allowed: true` because the merged `DbUsageLimit` entry lacked a `usage` field, so headroom defaulted to the full `limit`. The fix adds a `decorateInheritedPlanUsageLimits` step that fills in live window usage for plan-inherited entries only.

- **Bug fixes**: `decorateInheritedPlanUsageLimits` is injected into both `mergeCustomerBillingControlsForCheck` and `mergePlanBillingControlsForCheck`; it targets only undecorated (plan-level) entries via an `\"usage\" in usageLimit` guard, leaving entity/customer-level entries untouched.
- **Bug fixes / Improvements**: `getCheckDataV2` now forwards `fullSubject` and `ctx.features` to both merge helpers so the decoration step has the data it needs to resolve window counters.
- **Improvements**: A new integration test (`plan-only-usage-limit-check.test.ts`) documents the pre-fix red path and verifies the green path end-to-end.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the fix is targeted and the new test exercises the corrected path end-to-end.

The core decoration logic is correct for the primary case (plan controls from customer_products). There is a narrow edge case where the decoration step resolves plan controls from a wider set (aggregated_customer_products via fullSubjectToUsageWindowLimits) than the merge step used to build usageLimits, which could produce a mismatched interval and return usage: 0 when a window exists for a different interval. This requires conflicting usage_limits across product sets for the same feature and is unlikely in common configurations.

shared/utils/fullSubjectUtils/mergeCustomerBillingControlsForCheck.ts — the decorateInheritedPlanUsageLimits function resolves plan controls via fullSubjectToUsageWindowLimits (which includes aggregated_customer_products) while the upstream merge step only uses customer_products.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/fullSubjectUtils/mergeCustomerBillingControlsForCheck.ts | Adds decorateInheritedPlanUsageLimits to fill `usage` on plan-level usage_limits entries; logic is sound but resolves plan controls from a wider product set than mergeControlsByFeature in an edge case involving aggregated_customer_products. |
| server/src/internal/balances/check/getCheckDataV2.ts | Passes fullSubject and ctx.features into both merge helpers so the new decoration step has the data it needs; change is minimal and correct. |
| server/tests/integration/balances/usage-windows/plan-only-usage-limit-check.test.ts | New integration test clearly documents the pre-fix bug (check returning allowed:true after exhausting a plan-level daily cap) and verifies the post-fix behavior. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as check endpoint
    participant GCD as getCheckDataV2
    participant MB as mergePlanBillingControlsForCheck
    participant DL as decorateInheritedPlanUsageLimits
    participant FW as fullSubjectToUsageWindowLimits
    participant GU as getCurrentUsageWindowUsage

    C->>GCD: check(customer_id, feature_id)
    GCD->>GCD: getApiSubject (evaluationApiSubject, no aggregations)
    GCD->>MB: merge(customerApiSubject, planCustomerProducts, fullSubject, features)
    MB->>MB: mergeControlsByFeature → planControls (raw, no usage)
    MB->>DL: decorateInheritedPlanUsageLimits(usageLimits, fullSubject, features)
    DL->>DL: filter undecorated entries (!("usage" in limit))
    DL->>FW: fullSubjectToUsageWindowLimits(featureIds, fullSubject, features, now)
    FW-->>DL: resolvedLimits[]
    DL->>GU: getCurrentUsageWindowUsage(usageWindows, resolved, now)
    GU-->>DL: usage (live window counter)
    DL-->>MB: decorated DbUsageLimit[] (with usage field)
    MB-->>GCD: merged ApiCustomerV5
    GCD->>GCD: "apiSubjectToUsageLimitHeadroom → headroom = limit - usage"
    GCD-->>C: "allowed = headroom >= required_balance"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as check endpoint
    participant GCD as getCheckDataV2
    participant MB as mergePlanBillingControlsForCheck
    participant DL as decorateInheritedPlanUsageLimits
    participant FW as fullSubjectToUsageWindowLimits
    participant GU as getCurrentUsageWindowUsage

    C->>GCD: check(customer_id, feature_id)
    GCD->>GCD: getApiSubject (evaluationApiSubject, no aggregations)
    GCD->>MB: merge(customerApiSubject, planCustomerProducts, fullSubject, features)
    MB->>MB: mergeControlsByFeature → planControls (raw, no usage)
    MB->>DL: decorateInheritedPlanUsageLimits(usageLimits, fullSubject, features)
    DL->>DL: filter undecorated entries (!("usage" in limit))
    DL->>FW: fullSubjectToUsageWindowLimits(featureIds, fullSubject, features, now)
    FW-->>DL: resolvedLimits[]
    DL->>GU: getCurrentUsageWindowUsage(usageWindows, resolved, now)
    GU-->>DL: usage (live window counter)
    DL-->>MB: decorated DbUsageLimit[] (with usage field)
    MB-->>GCD: merged ApiCustomerV5
    GCD->>GCD: "apiSubjectToUsageLimitHeadroom → headroom = limit - usage"
    GCD-->>C: "allowed = headroom >= required_balance"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
shared/utils/fullSubjectUtils/mergeCustomerBillingControlsForCheck.ts:100-105
**Resolution source mismatch between merge and decoration steps**

`mergeControlsByFeature` resolves plan controls exclusively from `planCustomerProducts` (i.e. `fullSubject.customer_products`), but `fullSubjectToUsageWindowLimits` here uses `fullSubjectToPlanProducts` which adds `aggregated_customer_products`. If the strictest control for a feature lives in `aggregated_customer_products` (e.g. `limit: 5/month`) while `customer_products` has a looser one (`limit: 10/day`), the two steps resolve different controls: `mergeControlsByFeature` writes the 10/day limit into `usageLimits`, but the `resolved` returned here has `interval: month`. `getCurrentUsageWindowUsage` then looks up a month-scoped window, finds nothing (tracking was against the day window), and decorates `usage: 0` — so check never gates even after the 10/day cap is exhausted.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: check usage limit"](https://github.com/useautumn/autumn/commit/95f56b2f7e0094f913bdf09e8def9790bc7ecb34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41166073)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->