### PR TITLE
fix: update billing controls on variant plan

### DIFF
--- a/server/src/internal/product/actions/updateProduct/validateVariantSettingsUpdate.ts
+++ b/server/src/internal/product/actions/updateProduct/validateVariantSettingsUpdate.ts
@@ -16,6 +16,39 @@ const variantSettingsFields = [
 	"metadata",
 ] as const satisfies readonly (keyof UpdateProductV2Params)[];
 
+// Order-insensitive canonical form: DB stores billing_controls in one key/array
+// order while the editor re-serializes it in another, so a plain JSON.stringify
+// falsely reports a change when nothing meaningful differs.
+const sortDeep = (value: unknown): unknown => {
+	if (Array.isArray(value)) return value.map(sortDeep);
+	if (value && typeof value === "object") {
+		return Object.fromEntries(
+			Object.keys(value as Record<string, unknown>)
+				.sort()
+				.map((key) => [key, sortDeep((value as Record<string, unknown>)[key])]),
+		);
+	}
+	return value;
+};
+
+const canonicalizeBillingControls = (value: unknown): string => {
+	const source = (value ?? {}) as Record<string, unknown>;
+	const normalized: Record<string, unknown> = {};
+	for (const key of Object.keys(source)) {
+		const entries = source[key];
+		// Treat an absent key and an empty array as the same "no controls" state.
+		if (Array.isArray(entries) && entries.length === 0) continue;
+		normalized[key] = Array.isArray(entries)
+			? [...entries].sort((a, b) =>
+					String((a as { feature_id?: string })?.feature_id ?? "").localeCompare(
+						String((b as { feature_id?: string })?.feature_id ?? ""),
+					),
+				)
+			: entries;
+	}
+	return JSON.stringify(sortDeep(normalized));
+};
+
 const normalizeVariantSettingValue = ({
 	field,
 	value,
@@ -27,7 +60,8 @@ const normalizeVariantSettingValue = ({
 	// Treat "" and null/undefined as the same empty description; the editor sends
 	// "" while a description-less plan stores null, which isn't a real change.
 	if (field === "description") return value || null;
-	if (["config", "billing_controls", "metadata"].includes(field)) {
+	if (field === "billing_controls") return canonicalizeBillingControls(value);
+	if (["config", "metadata"].includes(field)) {
 		return JSON.stringify(value ?? {});
 	}
 	return value;


### PR DESCRIPTION
## Problem

Updating a variant plan by **removing an item** failed with:

> Cannot update billing_controls directly on a variant plan.

`validateVariantSettingsUpdate` compared `billing_controls` with a raw `JSON.stringify`. `currentProduct.billing_controls` is derived from DB columns (canonical `BILLING_CONTROL_KEYS` order, empty keys omitted), while the editor sends its own serialization. Removing an item makes the editor re-serialize the plan, producing a differently-ordered `billing_controls` that no longer byte-matches the DB form — so the guard falsely treated it as a direct `billing_controls` edit and blocked the update, even when nothing meaningful changed.

## Fix

Compare `billing_controls` via a canonical form (`canonicalizeBillingControls`) that:
- drops empty arrays (treats an absent key and `[]` as the same "no controls" state),
- sorts each control array by `feature_id`,
- recursively sorts object keys.

Cosmetic ordering/empty differences no longer trip the guard, while a genuine change to a still-present control's values is still detected and blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false “Cannot update billing_controls directly” errors when removing items from variant plans. We now compare `billing_controls` in a canonical form so cosmetic differences don’t block updates.

- **Bug Fixes**
  - Added `canonicalizeBillingControls` to drop empty arrays, sort entries by `feature_id`, and deep-sort object keys.
  - Updated `validateVariantSettingsUpdate` to use the canonical form for `billing_controls`; `config` and `metadata` keep JSON normalization.

<sup>Written for commit 56bc2ec0dbc20e65e7aca0295fe33117d48f3717. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a false-positive guard error in `validateVariantSettingsUpdate` that blocked item removal on variant plans. The root cause was a raw `JSON.stringify` comparison between the DB form and the editor's re-serialization of `billing_controls`, which diverged in key order when items were removed.

- **Bug fixes** — Replaces the `JSON.stringify` comparison for `billing_controls` with `canonicalizeBillingControls`, which drops empty arrays, sorts control-array entries by `feature_id`, and recursively sorts object keys before stringifying, so cosmetic ordering differences no longer trigger the variant guard.
- **Improvements** — The fix is surgical: `config` and `metadata` keep their existing `JSON.stringify` treatment; only `billing_controls` gets the new canonical form.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is confined to a single comparison helper and cannot widen or loosen the variant guard beyond cosmetic normalization.

The canonical form handles the described failure mode correctly. The only gap is that nested arrays within control entries are not order-normalized, which could cause a false positive if the schema evolves to include them — but that is not the case today.

validateVariantSettingsUpdate.ts deserves a second look if the billing_controls schema ever gains nested arrays; otherwise no files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/product/actions/updateProduct/validateVariantSettingsUpdate.ts | Introduces `canonicalizeBillingControls` to replace raw `JSON.stringify` comparison for `billing_controls`, fixing false-positive variant guard errors when removing items. Logic is sound for the current schema; nested arrays in control entries are not order-normalized but this is unlikely in practice. |
| ai | Submodule pointer bump — no application logic changed here. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[updateProduct on variant plan] --> B{allowVariantSettingsUpdate?}
    B -- yes --> C[Allow update]
    B -- no --> D[validateVariantSettingsUpdate]
    D --> E[For each field in updates]
    E --> F[normalizeVariantSettingValue for update]
    E --> G[normalizeVariantSettingValue for DB value]
    F --> H{field type?}
    G --> H
    H -- billing_controls --> I[canonicalizeBillingControls]
    H -- config or metadata --> K[JSON.stringify value]
    H -- other --> L[return value as-is]
    I --> M[Drop empty arrays]
    M --> N[Sort entries by feature_id]
    N --> O[Sort object keys recursively]
    O --> P{Normalized strings equal?}
    K --> P
    L --> P
    P -- yes --> Q[No change, continue]
    P -- no --> R[Throw RecaseError 400]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[updateProduct on variant plan] --> B{allowVariantSettingsUpdate?}
    B -- yes --> C[Allow update]
    B -- no --> D[validateVariantSettingsUpdate]
    D --> E[For each field in updates]
    E --> F[normalizeVariantSettingValue for update]
    E --> G[normalizeVariantSettingValue for DB value]
    F --> H{field type?}
    G --> H
    H -- billing_controls --> I[canonicalizeBillingControls]
    H -- config or metadata --> K[JSON.stringify value]
    H -- other --> L[return value as-is]
    I --> M[Drop empty arrays]
    M --> N[Sort entries by feature_id]
    N --> O[Sort object keys recursively]
    O --> P{Normalized strings equal?}
    K --> P
    L --> P
    P -- yes --> Q[No change, continue]
    P -- no --> R[Throw RecaseError 400]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/product/actions/updateProduct/validateVariantSettingsUpdate.ts:41-47
**Nested arrays inside control entries are not order-normalized**

`canonicalizeBillingControls` sorts the top-level array of each control key by `feature_id`, and `sortDeep` recursively sorts object keys — but `sortDeep` only maps over arrays (preserving order) rather than sorting them. If any control entry ever contains a nested array whose element order can differ between the DB form and the editor form, the comparison will still produce a false positive. This isn't a problem with the current `billing_controls` shape, but worth keeping in mind if the schema evolves.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix update billing controls on variant"](https://github.com/useautumn/autumn/commit/56bc2ec0dbc20e65e7aca0295fe33117d48f3717) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41191845)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->