### PR TITLE
fix: nongroup backsync

### DIFF
--- a/server/src/internal/billing/v2/actions/sync/scope/targetGroupLinks.ts
+++ b/server/src/internal/billing/v2/actions/sync/scope/targetGroupLinks.ts
@@ -17,14 +17,16 @@ const targetGroupKey = ({
 	group: string;
 }) => `${internalEntityId ?? "customer"}:${group}`;
 
+/**
+ * Missing/blank group is itself a valid group key (the implicit "default"
+ * group most catalogs use) -- it is NOT ambiguous on its own. Ambiguity only
+ * exists when two non-add-on products collide on the same entity+group key.
+ */
 const normalizeProductGroup = ({
 	group,
 }: {
 	group?: string | null;
-}): string | null => {
-	if (group == null || group === "") return null;
-	return group;
-};
+}): string => group ?? "";
 
 export const matchedPlanToTargetGroupLink = ({
 	matchedPlan,
@@ -35,7 +37,6 @@ export const matchedPlanToTargetGroupLink = ({
 }): TargetGroupLink | null => {
 	if (matchedPlan.product.is_add_on === true) return null;
 	const group = normalizeProductGroup({ group: matchedPlan.product.group });
-	if (!group) return null;
 
 	return {
 		key: targetGroupKey({ internalEntityId: syncPlan.entity_id, group }),
@@ -56,8 +57,6 @@ export const linkedCustomerProductsToTargetGroupMap = ({
 		if (linkedProduct.product.is_add_on === true) continue;
 
 		const group = normalizeProductGroup({ group: linkedProduct.product.group });
-		if (!group) return { ok: false };
-
 		const key = targetGroupKey({
 			internalEntityId: linkedProduct.internal_entity_id,
 			group,

--- a/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-auto-sync-ungrouped-downgrade.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-auto-sync-ungrouped-downgrade.test.ts
@@ -1,0 +1,95 @@
+/** TDD contract: subscription-updated auto-sync must not treat a single
+ * ungrouped (no product.group configured) base plan as "ambiguous". Most
+ * catalogs never set product.group, so a customer with exactly one
+ * non-add-on product linked to a subscription must still auto-sync a
+ * Stripe-portal downgrade to another ungrouped plan with a custom price. */
+
+import { test } from "bun:test";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import chalk from "chalk";
+import {
+	createCustomBasePriceForProduct,
+	createExternalStripeSubscription,
+	expectActiveLinkedCustomerProducts,
+	expectStripeSubscriptionCreated,
+	getFullProduct,
+	updateBaseSubscriptionItemToVariant,
+	waitForCustomerProducts,
+} from "@tests/integration/billing/stripe-webhooks/utils/sharedStripeProductAutoSyncUtils";
+import testCtx from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+
+test(`${chalk.yellowBright("customer.subscription.updated auto-sync: ungrouped base plan downgrade with custom price")}`, async () => {
+	const customerId = "sub-updated-ungrouped-downgrade";
+	const ultraId = "ungrouped_downgrade_ultra";
+	const proId = "ungrouped_downgrade_pro";
+
+	const ultra = products.base({
+		id: ultraId,
+		items: [items.monthlyPrice({ price: 30 })],
+	});
+	const pro = products.base({
+		id: proId,
+		items: [items.monthlyPrice({ price: 19 })],
+	});
+
+	const { autumnV1, ctx } = await initScenario({
+		customerId,
+		ctx: testCtx,
+		setup: [
+			s.deleteCustomer({ customerId }),
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [ultra, pro], prefix: "" }),
+		],
+		actions: [],
+	});
+
+	const ultraFull = await getFullProduct({ ctx, productId: ultraId });
+	const proFull = await getFullProduct({ ctx, productId: proId });
+
+	const ultraCustomPrice = await createCustomBasePriceForProduct({
+		ctx,
+		fullProduct: ultraFull,
+		amount: 30,
+	});
+
+	const createdSubscription = await createExternalStripeSubscription({
+		ctx,
+		customerId,
+		items: [{ price: ultraCustomPrice.id }],
+	});
+	expectStripeSubscriptionCreated({ subscription: createdSubscription });
+
+	await waitForCustomerProducts({
+		autumnV1,
+		customerId,
+		active: [ultraId],
+		notPresent: [proId],
+	});
+	await expectActiveLinkedCustomerProducts({
+		ctx,
+		stripeSubscriptionId: createdSubscription.id,
+		productIds: [ultraId],
+	});
+
+	await updateBaseSubscriptionItemToVariant({
+		ctx,
+		subscription: createdSubscription,
+		fromFullProduct: ultraFull,
+		toFullProduct: proFull,
+		toAmount: 19,
+	});
+
+	await waitForCustomerProducts({
+		autumnV1,
+		customerId,
+		active: [proId],
+		notPresent: [ultraId],
+	});
+	await expectActiveLinkedCustomerProducts({
+		ctx,
+		stripeSubscriptionId: createdSubscription.id,
+		productIds: [proId],
+	});
+});

--- a/server/tests/unit/billing/sync/build-incremental-sync-params.spec.ts
+++ b/server/tests/unit/billing/sync/build-incremental-sync-params.spec.ts
@@ -1,3 +1,12 @@
+/**
+ * Pre-fix: a non-add-on linked product with no `product.group` set made
+ * `linkedCustomerProductsToTargetGroupMap` bail with `{ ok: false }` even when
+ * it was the only linked product -- blocking Stripe-portal downgrades from
+ * auto-syncing for any catalog that doesn't configure product groups (the
+ * common case). Post-fix: missing/blank group is itself a valid group key;
+ * ambiguity now only fires on an actual collision between two non-add-on
+ * products sharing the same entity+group key.
+ */
 import { describe, expect, test } from "bun:test";
 import type {
 	FeatureOptions,
@@ -252,7 +261,7 @@ describe("buildIncrementalSyncParams", () => {
 		});
 	});
 
-	test("rejects unsupported targets with no product group", () => {
+	test("syncs a single ungrouped product with no linked customer product", () => {
 		const noGroup = product({ id: "no_group", group: null });
 		const blankGroup = product({ id: "blank_group", group: "" });
 
@@ -267,11 +276,52 @@ describe("buildIncrementalSyncParams", () => {
 				linkedCustomerProducts: [],
 			});
 
-			expect(result).toMatchObject({
-				shouldSync: false,
-				reason: "unsupported_target",
-			});
+			expect(result.shouldSync).toBe(true);
+			if (!result.shouldSync) throw new Error(result.reason);
+			expect(result.params.phases?.[0]?.plans.map((plan) => plan.plan_id)).toEqual([
+				unsupported.id,
+			]);
 		}
+	});
+
+	test("syncs a downgrade between two ungrouped products with a single linked target (production regression)", () => {
+		const ultra = product({ id: "poke_ultra", group: "" });
+		const pro = product({ id: "poke_pro", group: "" });
+		const { match, params } = draft({ matchedPlans: [matchedPlan({ product: pro })] });
+
+		const result = buildIncrementalSyncParams({
+			match,
+			params,
+			linkedCustomerProducts: [linkedCustomerProduct({ product: ultra })],
+		});
+
+		expect(result.shouldSync).toBe(true);
+		if (!result.shouldSync) throw new Error(result.reason);
+		expect(result.params.phases?.[0]?.plans.map((plan) => plan.plan_id)).toEqual([
+			"poke_pro",
+		]);
+	});
+
+	test("rejects genuinely ambiguous ungrouped linked targets", () => {
+		const ultra = product({ id: "poke_ultra", group: null });
+		const credits = product({ id: "poke_credits", group: "" });
+		const { match, params } = draft({
+			matchedPlans: [matchedPlan({ product: ultra })],
+		});
+
+		const result = buildIncrementalSyncParams({
+			match,
+			params,
+			linkedCustomerProducts: [
+				linkedCustomerProduct({ product: ultra, id: "cp_ultra" }),
+				linkedCustomerProduct({ product: credits, id: "cp_credits" }),
+			],
+		});
+
+		expect(result).toMatchObject({
+			shouldSync: false,
+			reason: "ambiguous_linked_targets",
+		});
 	});
 
 	test("keeps add-ons when linked quantity is below desired quantity", () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes auto-sync for subscriptions with ungrouped base plans by treating missing/blank `product.group` as the default group. Restores Stripe portal downgrade sync for catalogs that don’t set groups, and only flags ambiguity on actual collisions.

- **Bug Fixes**
  - Normalize `product.group` to `""` and include it in the target key; remove early returns on empty groups in `matchedPlanToTargetGroupLink` and `linkedCustomerProductsToTargetGroupMap`.
  - Tests: added integration test for ungrouped downgrade with custom price; updated unit tests to ensure a single ungrouped product syncs and multiple ungrouped targets are correctly rejected.

<sup>Written for commit 84caca7c4c00a2a00edc90bda03950345bd3a83b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes a production regression where any catalog using ungrouped products (no `product.group` configured — the common case) was permanently blocked from Stripe-portal downgrades auto-syncing. The root cause was `normalizeProductGroup` returning `null` for blank/absent groups, which caused both `matchedPlanToTargetGroupLink` and `linkedCustomerProductsToTargetGroupMap` to bail out before comparing products.

- **Bug fixes**: `normalizeProductGroup` now normalises `null`/`""` to `""` (empty string) so ungrouped products share a valid implicit group key; collision detection still fires correctly when two non-add-on products share that same key.
- **Bug fixes / Improvements**: Removed the two early-return guards that treated an absent group as an error, enabling single-ungrouped-product catalogs to auto-sync as expected.
- **Improvements**: New unit tests (regression case, genuinely-ambiguous case, blank-vs-null equivalence) and a new integration test covering the full Stripe webhook → customer-product update path for ungrouped downgrades.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a tightly scoped fix to a single normalization function, backed by three new unit tests and an integration test covering the exact production regression.

The fix correctly treats an absent/blank product group as the implicit default group key rather than an error, restoring auto-sync for the common case of ungrouped catalogs. Collision detection is preserved: two non-add-on ungrouped products sharing the same entity still produce an ambiguous result. The integration test exercises the full Stripe webhook path end-to-end.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/sync/scope/targetGroupLinks.ts | Core fix: normalizeProductGroup changed from returning null (causing premature bail-out) to returning "" for absent/blank groups; two early-exit guards removed; logic is correct and well-commented. |
| server/tests/unit/billing/sync/build-incremental-sync-params.spec.ts | Existing negative test flipped to positive (ungrouped → should sync), plus two new tests covering the downgrade regression and the genuinely-ambiguous case; all three scenarios are correct. |
| server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-auto-sync-ungrouped-downgrade.test.ts | New integration test validating the full Stripe webhook → customer-product update path for two ungrouped plans; setup and assertions look correct. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Stripe subscription.updated webhook] --> B[buildIncrementalSyncParams]
    B --> C[linkedCustomerProductsToTargetGroupMap]
    C --> D{Non-add-on product has group?}
    D -- "null or empty (BEFORE: bail → ok:false)" --> E_old["❌ return { ok: false } → ambiguous_linked_targets"]
    D -- "null or empty (AFTER: normalize to '')" --> F["key = 'customer:'"]
    D -- "has group value" --> G["key = 'customer:groupValue'"]
    F --> H{Collision on key?}
    G --> H
    H -- Yes --> I["return { ok: false } → ambiguous_linked_targets"]
    H -- No --> J["Add to targets map"]
    J --> K[matchedPlanToTargetGroupLink]
    K --> L{is_add_on?}
    L -- Yes --> M[return null → skip]
    L -- No --> N["Compute target key (same normalization)"]
    N --> O{Linked product matches target?}
    O -- Same product --> P[Prune from changedPlans]
    O -- Different / absent --> Q[Keep in changedPlans]
    Q --> R{changedPlans empty?}
    P --> R
    R -- Yes --> S["no_changed_targets"]
    R -- No --> T["shouldSync: true → apply sync"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Stripe subscription.updated webhook] --> B[buildIncrementalSyncParams]
    B --> C[linkedCustomerProductsToTargetGroupMap]
    C --> D{Non-add-on product has group?}
    D -- "null or empty (BEFORE: bail → ok:false)" --> E_old["❌ return { ok: false } → ambiguous_linked_targets"]
    D -- "null or empty (AFTER: normalize to '')" --> F["key = 'customer:'"]
    D -- "has group value" --> G["key = 'customer:groupValue'"]
    F --> H{Collision on key?}
    G --> H
    H -- Yes --> I["return { ok: false } → ambiguous_linked_targets"]
    H -- No --> J["Add to targets map"]
    J --> K[matchedPlanToTargetGroupLink]
    K --> L{is_add_on?}
    L -- Yes --> M[return null → skip]
    L -- No --> N["Compute target key (same normalization)"]
    N --> O{Linked product matches target?}
    O -- Same product --> P[Prune from changedPlans]
    O -- Different / absent --> Q[Keep in changedPlans]
    Q --> R{changedPlans empty?}
    P --> R
    R -- Yes --> S["no_changed_targets"]
    R -- No --> T["shouldSync: true → apply sync"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: nongroup backsync"](https://github.com/useautumn/autumn/commit/8bff26baa59c9d3e63cabc6662b199f8a3f796b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41224276)</sub>

<!-- /greptile_comment -->