### PR TITLE
Allow customer JWTs to call events.list and events.aggregate (customer-scoped)

### DIFF
--- a/server/src/honoMiddlewares/customerJwtMiddleware.ts
+++ b/server/src/honoMiddlewares/customerJwtMiddleware.ts
@@ -17,9 +17,14 @@ import {
 import RecaseError from "@/utils/errorUtils.js";
 
 /**
- * Default-deny allowlists keyed by token audience. Access tokens reach the 6
- * data routes; refresh tokens reach ONLY keys.refresh. Anything else is 403 by
- * virtue of not being listed — bidirectional aud isolation.
+ * Default-deny allowlists keyed by token audience. Access tokens reach the
+ * allowlisted data + analytics routes; refresh tokens reach ONLY keys.refresh.
+ * Anything else is 403 by virtue of not being listed — bidirectional aud
+ * isolation.
+ *
+ * The analytics routes (events.list / events.aggregate) are read-only and stay
+ * scoped to the token's own customer: `customer_id` is force-set below so a
+ * caller can ONLY query their own events, never another customer's.
  */
 const ACCESS_ROUTES = new Set([
 	"POST /v1/check",
@@ -28,6 +33,8 @@ const ACCESS_ROUTES = new Set([
 	"POST /v1/balances.track",
 	"POST /v1/customers.get",
 	"POST /v1/entities.get",
+	"POST /v1/events.list",
+	"POST /v1/events.aggregate",
 ]);
 const REFRESH_ROUTES = new Set(["POST /v1/keys.refresh"]);
 
@@ -37,6 +44,7 @@ const TOKEN_SCOPES: string[] = [
 	Scopes.Customers.Read,
 	Scopes.Balances.Read,
 	Scopes.Balances.Write,
+	Scopes.Analytics.Read,
 ];
 
 export const customerJwtMiddleware = async (

--- a/server/src/honoMiddlewares/customerJwtMiddleware.ts
+++ b/server/src/honoMiddlewares/customerJwtMiddleware.ts
@@ -21,10 +21,6 @@ import RecaseError from "@/utils/errorUtils.js";
  * allowlisted data + analytics routes; refresh tokens reach ONLY keys.refresh.
  * Anything else is 403 by virtue of not being listed — bidirectional aud
  * isolation.
- *
- * The analytics routes (events.list / events.aggregate) are read-only and stay
- * scoped to the token's own customer: `customer_id` is force-set below so a
- * caller can ONLY query their own events, never another customer's.
  */
 const ACCESS_ROUTES = new Set([
 	"POST /v1/check",

--- a/server/tests/integration/others/customer-jwt/customer-jwt-contract.test.ts
+++ b/server/tests/integration/others/customer-jwt/customer-jwt-contract.test.ts
@@ -13,7 +13,8 @@
  *     - access  token: `am_cjwt_` prefix, aud=autumn-api,     exp +1h
  *     - refresh token: `am_cjwt_` prefix, aud=autumn-refresh, exp +24h
  *   New behaviors:
- *     - access token authorized on the 6 allowlisted routes (check×2, track×2, customers.get, entities.get)
+ *     - access token authorized on the allowlisted routes (check×2, track×2, customers.get, entities.get, events.list, events.aggregate)
+ *     - analytics routes (events.list / events.aggregate) are read-only and scoped: a caller can ONLY query their own customer's events
  *     - body.customer_id is FORCE-SET to the token's customer (passing another id is ignored)
  *     - non-allowlisted route (customers.list) with an access token -> 403
  *     - x-api-version < 2.3 with an access token -> 400
@@ -35,6 +36,7 @@ import { expect, test } from "bun:test";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 
@@ -176,6 +178,49 @@ test(`${chalk.yellowBright("customer-jwt: mint/scope/allowlist/refresh/revoke co
 		body: { entity_id: mainEntity.id },
 	});
 	expect([400, 404]).toContain(crossEntity.status);
+
+	// ── 9: analytics routes — authorized, read-only, and customer-scoped ──
+	// Seed a few events for THIS customer so the analytical queries have data.
+	for (let i = 0; i < 3; i++) {
+		await raw({
+			path: "/balances.track",
+			token: accessToken,
+			body: { feature_id: TestFeature.Messages, value: 1 },
+		});
+	}
+	// Tinybird ingest is async — give it a moment before querying.
+	await timeout(3000);
+
+	// 9a: events.list authorized with an access token (previously 403).
+	//     Pass a SPOOFED customer_id — force-set must override it so every
+	//     returned row belongs to the token's own customer, never `otherId`.
+	const listEvents = await raw({
+		path: "/events.list",
+		token: accessToken,
+		body: { customer_id: otherId, limit: 100 },
+	});
+	expect(listEvents.status).toBe(200);
+	expect(Array.isArray(listEvents.json?.list)).toBe(true);
+	expect(listEvents.json.list.length).toBeGreaterThan(0);
+	for (const event of listEvents.json.list) {
+		expect(event.customer_id).toBe(customerId);
+	}
+
+	// 9b: events.aggregate authorized with an access token (previously 403).
+	const aggregateEvents = await raw({
+		path: "/events.aggregate",
+		token: accessToken,
+		body: { feature_id: TestFeature.Messages, range: "7d" },
+	});
+	expect(aggregateEvents.status).toBe(200);
+
+	// 9c: aud isolation — a refresh token cannot reach analytics routes.
+	const refreshOnEvents = await raw({
+		path: "/events.list",
+		token: refreshToken,
+		body: { limit: 100 },
+	});
+	expect(refreshOnEvents.status).toBe(403);
 
 	// ── 10: refresh rotates — new access AND refresh; new access works ───
 	const refresh = await raw({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Updates the hard-coded allowlist ("block list") in the customer JWT middleware (`customerJwtMiddleware.ts`) so access tokens can call the two analytics RPC routes:

- `POST /v1/events.list`
- `POST /v1/events.aggregate`

## Why / scoping guarantee

These are read-only analytical queries. The middleware already force-sets `body.customer_id` to the token's own customer via `forceJsonBodyField` for every access token, and that value propagates through Hono's body cache to every downstream reader (validators + handlers). As a result a caller can **only** run analytical queries on their own `customer_id` — passing another customer's id is silently overridden.

Both handlers require `Scopes.Analytics.Read`, which `scopeCheckMiddleware` enforces per-route. Since the JWT middleware hard-codes `TOKEN_SCOPES` (so an empty `ctx.scopes` can't fail open), `Scopes.Analytics.Read` is added there too; otherwise the routes would 403 on the scope check.

## Changes

- `server/src/honoMiddlewares/customerJwtMiddleware.ts`
  - Add `events.list` + `events.aggregate` to `ACCESS_ROUTES`
  - Add `Scopes.Analytics.Read` to `TOKEN_SCOPES`
- `server/tests/integration/others/customer-jwt/customer-jwt-contract.test.ts`
  - New coverage: access token authorized on both analytics routes; spoofed `customer_id` is overridden so every returned event belongs to the token's customer; refresh token on `events.list` is rejected (403 aud isolation).

## Testing

Not run in this environment per the repo's testing convention (dev server / tests are run manually, and analytics endpoints depend on Tinybird). Please run:

```
bun test server/tests/integration/others/customer-jwt/customer-jwt-contract.test.ts --timeout 60000
```

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1782991311239849?thread_ts=1782991311.239849&cid=C0BCAQQK0KS)

<div><a href="https://cursor.com/agents/bc-fc40119f-b347-546c-9f34-22341a656cff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc40119f-b347-546c-9f34-22341a656cff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow customer JWT access tokens to call `POST /v1/events.list` and `POST /v1/events.aggregate`. These analytics queries are read-only and always scoped to the token’s `customer_id`.

- **New Features**
  - Allowlisted both analytics routes in `customerJwtMiddleware.ts` and added `Scopes.Analytics.Read` to `TOKEN_SCOPES`.
  - Force-set `customer_id` from the token so callers can only query their own data.
  - Added integration tests for authorized access, spoofed `customer_id` override, and aud isolation (refresh tokens get 403).

<sup>Written for commit 731ba41b37fec78bfabf55ad8c19fe20f7c2d6c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR allowlists `POST /v1/events.list` and `POST /v1/events.aggregate` for customer JWT access tokens and adds `Scopes.Analytics.Read` to the hard-coded scope set so both routes pass the scope gate. The existing `forceJsonBodyField` mechanism correctly locks `customer_id` to the token's own customer on every call, and both handlers already filter Tinybird queries by that field.

- **API changes**: Two analytics RPC routes added to `ACCESS_ROUTES` in `customerJwtMiddleware.ts`; `Scopes.Analytics.Read` added to `TOKEN_SCOPES` so the scope check doesn't 403 before the handler runs.
- **Improvements**: Integration test step 9 covers `events.list` authorization, spoofed-`customer_id` override, and refresh-token aud isolation; the `balances.track` seed + `timeout(3000)` ensures Tinybird has data before the list assertion.
</details>

<h3>Confidence Score: 4/5</h3>

The middleware change is minimal and follows the established pattern; the scoping guarantee for events.list is well-tested, but events.aggregate test coverage is thinner.

The middleware change itself is straightforward and low-risk — two route strings added to a set and one scope constant added to an array, using the same force-set mechanism already validated by the existing six routes. The events.aggregate test only asserts a 200 status and does not attempt a spoofed customer_id or verify that returned data is scoped to the token's customer.

server/tests/integration/others/customer-jwt/customer-jwt-contract.test.ts — the events.aggregate test block (step 9b) needs a spoofed-customer assertion and a refresh-token aud-isolation check to match the coverage level of events.list.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/honoMiddlewares/customerJwtMiddleware.ts | Adds events.list and events.aggregate to ACCESS_ROUTES and Scopes.Analytics.Read to TOKEN_SCOPES; the existing force-set mechanism correctly scopes both routes to the token's customer |
| server/tests/integration/others/customer-jwt/customer-jwt-contract.test.ts | Adds integration tests for steps 9a/9b/9c covering events.list spoofed-id override and aud isolation, but test 9b only asserts HTTP 200 for events.aggregate without verifying customer scoping of returned data |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Client (Customer JWT)
    participant M as customerJwtMiddleware
    participant F as forceJsonBodyField
    participant S as scopeCheckMiddleware
    participant H as events.list / events.aggregate handler
    participant T as Tinybird

    C->>M: POST /v1/events.list or /v1/events.aggregate
    M->>M: verifyCustomerJwt() decode and verify sig
    M->>M: routeKey in ACCESS_ROUTES?
    M->>M: "set ctx.scopes = TOKEN_SCOPES incl Analytics.Read"
    M->>F: forceJsonBodyField(c, customer_id, claims.customerId)
    F-->>M: "body.customer_id = tokens own customerId spoof overridden"
    M->>S: next scopeCheckMiddleware
    S->>S: Scopes.Analytics.Read in ctx.scopes?
    S->>H: next handler
    H->>H: "c.req.valid json customer_id = tokens customerId"
    H->>T: "query customer_id = tokens customerId"
    T-->>H: events scoped to that customer only
    H-->>C: 200 OK
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Client (Customer JWT)
    participant M as customerJwtMiddleware
    participant F as forceJsonBodyField
    participant S as scopeCheckMiddleware
    participant H as events.list / events.aggregate handler
    participant T as Tinybird

    C->>M: POST /v1/events.list or /v1/events.aggregate
    M->>M: verifyCustomerJwt() decode and verify sig
    M->>M: routeKey in ACCESS_ROUTES?
    M->>M: "set ctx.scopes = TOKEN_SCOPES incl Analytics.Read"
    M->>F: forceJsonBodyField(c, customer_id, claims.customerId)
    F-->>M: "body.customer_id = tokens own customerId spoof overridden"
    M->>S: next scopeCheckMiddleware
    S->>S: Scopes.Analytics.Read in ctx.scopes?
    S->>H: next handler
    H->>H: "c.req.valid json customer_id = tokens customerId"
    H->>T: "query customer_id = tokens customerId"
    T-->>H: events scoped to that customer only
    H-->>C: 200 OK
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/tests/integration/others/customer-jwt/customer-jwt-contract.test.ts:209-215
Test 9b only asserts an HTTP 200 but never checks that the aggregate results are scoped to the token's own customer. The PR description's key guarantee — "a caller can ONLY query their own customer's events" — is verified for `events.list` (every event row is checked against `customerId`) but left completely untested for `events.aggregate`. If the force-set ever fails to apply on that route, this test would still pass.

```suggestion
	// 9b: events.aggregate authorized with an access token (previously 403).
	//     Pass a SPOOFED customer_id — force-set must override it so the
	//     aggregate is computed only for the token's own customer.
	const aggregateEvents = await raw({
		path: "/events.aggregate",
		token: accessToken,
		body: { customer_id: otherId, feature_id: TestFeature.Messages, range: "7d" },
	});
	expect(aggregateEvents.status).toBe(200);
	// Verify the response customer_id reflects the token owner, not the spoofed id.
	expect(aggregateEvents.json?.customer_id).not.toBe(otherId);
```

### Issue 2 of 2
server/tests/integration/others/customer-jwt/customer-jwt-contract.test.ts:217-223
Aud isolation is only tested for `events.list` (step 9c), but `events.aggregate` is equally new and equally accessible to access tokens. A parallel check — calling `events.aggregate` with `refreshToken` and asserting 403 — would give the same bidirectional isolation guarantee that the PR description claims for both routes.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Apply suggestion from @SirTenzin"](https://github.com/useautumn/autumn/commit/731ba41b37fec78bfabf55ad8c19fe20f7c2d6c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41348407)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->