### PR TITLE
log SQS queue dwell time on worker spans

### DIFF
--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -197,6 +197,7 @@ export const startPollingLoop = async ({
 			MaxNumberOfMessages: 10,
 			WaitTimeSeconds: 20,
 			VisibilityTimeout: 30,
+			MessageSystemAttributeNames: ["SentTimestamp", "ApproximateReceiveCount"],
 			...(isFifo && { ReceiveRequestAttemptId: generateId("receive") }),
 		});
 

--- a/server/src/queue/processMessage.ts
+++ b/server/src/queue/processMessage.ts
@@ -325,6 +325,10 @@ export const processMessage = async ({
 		}
 	};
 
+	// Queue dwell = SQS SentTimestamp → processing start; surfaces backlog per job type.
+	const sentAtMs = Number(message.Attributes?.SentTimestamp);
+	const receiveCount = Number(message.Attributes?.ApproximateReceiveCount);
+
 	try {
 		await withWorkerSpan({
 			workflowName: job.name,
@@ -333,6 +337,14 @@ export const processMessage = async ({
 				org_id: job.data?.orgId,
 				env: job.data?.env,
 				customer_id: job.data?.customerId,
+			},
+			attributes: {
+				...(Number.isFinite(sentAtMs) && {
+					"queue.dwell_ms": Date.now() - sentAtMs,
+				}),
+				...(Number.isFinite(receiveCount) && {
+					"queue.receive_count": receiveCount,
+				}),
 			},
 			fn: executeJob,
 		});

--- a/server/src/utils/otel/withWorkerSpan.ts
+++ b/server/src/utils/otel/withWorkerSpan.ts
@@ -14,11 +14,13 @@ export const withWorkerSpan = async <T>({
 	workflowName,
 	workflowId,
 	tenantAttrs,
+	attributes,
 	fn,
 }: {
 	workflowName: string;
 	workflowId: string;
 	tenantAttrs?: TenantAttrs;
+	attributes?: Record<string, string | number>;
 	fn: () => Promise<T>;
 }): Promise<T> => {
 	return tracer.startActiveSpan(
@@ -28,6 +30,7 @@ export const withWorkerSpan = async <T>({
 			span.setAttributes({
 				workflow_id: workflowId,
 				workflow_name: workflowName,
+				...attributes,
 			});
 
 			const aws = getAwsTaskIdentity();


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Log SQS queue dwell time and receive count on worker spans to surface backlogs and retries. Adds span attributes for clearer visibility into processing delays.

- **New Features**
  - Request SQS system attributes (`SentTimestamp`, `ApproximateReceiveCount`) and compute dwell time from `SentTimestamp`.
  - Add `queue.dwell_ms` and `queue.receive_count` to worker spans via a new `attributes` option in `withWorkerSpan`.

<sup>Written for commit 1d88f8e269c348b5be900e43edb2d1bfe7af06c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds SQS queue dwell-time observability by requesting `SentTimestamp` and `ApproximateReceiveCount` system attributes on each `ReceiveMessageCommand` and stamping them onto worker OTel spans as `queue.dwell_ms` and `queue.receive_count`. The `withWorkerSpan` helper is extended with an optional `attributes` bag to support this and future ad-hoc span attributes.

- **[Improvements]** `initWorkers.ts`: adds `MessageSystemAttributeNames` to the SQS receive call so the two system attributes are returned without fetching all attributes.
- **[Improvements]** `processMessage.ts`: computes `queue.dwell_ms` (milliseconds from send to processing start) and `queue.receive_count` with `Number.isFinite` guards so spans degrade gracefully when attributes are absent.
- **[Improvements]** `withWorkerSpan.ts`: exposes an optional `attributes?: Record<string, string | number>` parameter that is spread into `span.setAttributes()`, keeping the extension backward-compatible.
</details>

<h3>Confidence Score: 4/5</h3>

Observability-only change with no effect on job execution or SQS ack semantics; safe to merge.

All three files touch only telemetry paths. The attribute guards correctly handle missing SQS attributes. The one thing worth watching is that `queue.dwell_ms` reflects total message age from original enqueue time, so for retried messages it will include prior processing attempts — operators setting latency alerts should account for this.

processMessage.ts — the `dwell_ms` semantics for retried messages deserve a look if alerting thresholds are planned.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/queue/initWorkers.ts | Adds `MessageSystemAttributeNames` to the SQS ReceiveMessageCommand to fetch `SentTimestamp` and `ApproximateReceiveCount` — a purely additive, non-breaking change. |
| server/src/queue/processMessage.ts | Extracts `SentTimestamp` and `ApproximateReceiveCount` from message system attributes and passes them as OTel span attributes. Guards against missing/non-numeric values with `Number.isFinite`. For retried messages `dwell_ms` measures total age from original send time, not just the most-recent queue wait — operationally fine but worth noting for alerting. |
| server/src/utils/otel/withWorkerSpan.ts | Adds an optional `attributes?: Record<string, string | number>` parameter that is spread into `span.setAttributes()` before the existing workflow and tenant attrs. Clean, backward-compatible extension. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant SQS
    participant initWorkers as initWorkers (polling loop)
    participant processMessage
    participant withWorkerSpan
    participant OTel as OTel Span

    initWorkers->>SQS: ReceiveMessageCommand (MessageSystemAttributeNames: [SentTimestamp, ApproximateReceiveCount])
    SQS-->>initWorkers: "Message + Attributes{SentTimestamp, ApproximateReceiveCount}"
    initWorkers->>processMessage: "processMessage({ message, ... })"
    processMessage->>processMessage: "sentAtMs = Number(Attributes.SentTimestamp)<br/>receiveCount = Number(Attributes.ApproximateReceiveCount)"
    processMessage->>withWorkerSpan: "withWorkerSpan({ attributes: { queue.dwell_ms, queue.receive_count }, fn })"
    withWorkerSpan->>OTel: "span.setAttributes({ workflow_id, workflow_name, queue.dwell_ms, queue.receive_count, ... })"
    withWorkerSpan->>withWorkerSpan: fn() — execute job
    withWorkerSpan-->>OTel: span.end()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant SQS
    participant initWorkers as initWorkers (polling loop)
    participant processMessage
    participant withWorkerSpan
    participant OTel as OTel Span

    initWorkers->>SQS: ReceiveMessageCommand (MessageSystemAttributeNames: [SentTimestamp, ApproximateReceiveCount])
    SQS-->>initWorkers: "Message + Attributes{SentTimestamp, ApproximateReceiveCount}"
    initWorkers->>processMessage: "processMessage({ message, ... })"
    processMessage->>processMessage: "sentAtMs = Number(Attributes.SentTimestamp)<br/>receiveCount = Number(Attributes.ApproximateReceiveCount)"
    processMessage->>withWorkerSpan: "withWorkerSpan({ attributes: { queue.dwell_ms, queue.receive_count }, fn })"
    withWorkerSpan->>OTel: "span.setAttributes({ workflow_id, workflow_name, queue.dwell_ms, queue.receive_count, ... })"
    withWorkerSpan->>withWorkerSpan: fn() — execute job
    withWorkerSpan-->>OTel: span.end()
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/queue/processMessage.ts:342-344
**`dwell_ms` accumulates across retries** — `SentTimestamp` is the moment the message was first enqueued and never changes on re-delivery. For a message that has been retried several times, `Date.now() - sentAtMs` captures total age (including prior processing attempts and visibility-timeout gaps), not just the wait time since the last visibility-timeout expiry. An alert threshold tuned to healthy single-delivery latency could fire spuriously on long-running retry cycles. The co-logged `queue.receive_count` helps distinguish the two cases, but it may be worth documenting this semantic in the comment or metric name (e.g. `queue.age_ms`).

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["log SQS queue dwell time on worker spans"](https://github.com/useautumn/autumn/commit/1d88f8e269c348b5be900e43edb2d1bfe7af06c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41345565)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->