### PR TITLE
fix(billing): bake fresh discounts into manual invoices

### DIFF
--- a/server/src/internal/billing/v2/compute/finalize/finalizeLineItems.ts
+++ b/server/src/internal/billing/v2/compute/finalize/finalizeLineItems.ts
@@ -74,7 +74,7 @@ export const finalizeLineItems = ({
 			lineItems: finalizedLineItems,
 			discounts: billingContext.stripeDiscounts,
 			options: {
-				disableDiscountableForRecurringDiscounts: true,
+				disableDiscountableForFreshDiscounts: true,
 			},
 		});
 	}

--- a/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeInvoiceAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeInvoiceAction.ts
@@ -2,10 +2,24 @@ import {
 	atmnToStripeAmount,
 	type CustomLineItem,
 	type LineItem,
+	type LineItemDiscount,
+	type StripeDiscountWithCoupon,
 	type StripeInvoiceAction,
 } from "@autumn/shared";
 
+import { customLineItemsToLineItems } from "@/internal/billing/v2/utils/lineItems/customLineItemsToLineItems";
 import { lineItemsToInvoiceAddLinesParams } from "../utils/invoiceLines/lineItemsToInvoiceAddLinesParams";
+
+const discountsToMetadata = (
+	discounts: LineItemDiscount[],
+): { coupon_ids?: string } | undefined => {
+	const couponIds = discounts
+		.map((discount) => discount.stripeCouponId)
+		.filter(Boolean)
+		.join(",");
+
+	return couponIds ? { coupon_ids: couponIds } : undefined;
+};
 
 /**
  * Builds a StripeInvoiceAction for immediate charges.
@@ -16,17 +30,33 @@ export const buildStripeInvoiceAction = ({
 	lineItems,
 	customLineItems,
 	currency,
+	stripeDiscounts,
 }: {
 	lineItems?: LineItem[];
 	customLineItems?: CustomLineItem[];
 	currency?: string;
+	stripeDiscounts?: StripeDiscountWithCoupon[];
 }): StripeInvoiceAction | undefined => {
 	// Custom line items bypass the normal LineItem → Stripe conversion
 	if (customLineItems?.length && currency) {
-		const lines = customLineItems.map((item) => ({
-			amount: atmnToStripeAmount({ amount: item.amount, currency }),
-			description: item.description,
-		}));
+		const customLineItemsWithDiscounts = customLineItemsToLineItems({
+			customLineItems,
+			currency,
+			stripeDiscounts,
+		});
+		const lines = customLineItemsWithDiscounts
+			.filter((item) => item.amountAfterDiscounts !== 0)
+			.map((item) => ({
+				amount: atmnToStripeAmount({
+					amount: item.amountAfterDiscounts,
+					currency,
+				}),
+				description: item.description,
+				discountable: false,
+				metadata: discountsToMetadata(item.discounts),
+			}));
+
+		if (lines.length === 0) return undefined;
 
 		return { addLineParams: { lines } };
 	}

--- a/server/src/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan.ts
+++ b/server/src/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan.ts
@@ -115,6 +115,7 @@ export const evaluateStripeBillingPlan = async ({
 			lineItems: autumnBillingPlan.lineItems ?? undefined,
 			customLineItems,
 			currency,
+			stripeDiscounts: billingContext.stripeDiscounts ?? [],
 		});
 
 		// Invoice items only apply when using normal line items (not custom)

--- a/server/src/internal/billing/v2/providers/stripe/utils/discounts/applyStripeDiscountsToLineItems.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/discounts/applyStripeDiscountsToLineItems.ts
@@ -2,18 +2,15 @@ import type { LineItem, StripeDiscountWithCoupon } from "@autumn/shared";
 import { applyAmountOffDiscountToLineItems } from "./applyAmountOffDiscountToLineItems";
 import { applyPercentOffDiscountToLineItems } from "./applyPercentOffDiscountToLineItems";
 
-const hasFreshRecurringDiscount = ({
+const hasFreshDiscount = ({
 	discounts,
 }: {
 	discounts: StripeDiscountWithCoupon[];
 }) => {
-	return discounts.some(
-		(discount) =>
-			!discount.id && discount.source.coupon.duration === "repeating",
-	);
+	return discounts.some((discount) => !discount.id);
 };
 
-const disableDiscountableForRecurringDiscounts = ({
+const disableDiscountableForFreshDiscounts = ({
 	lineItems,
 }: {
 	lineItems: LineItem[];
@@ -40,14 +37,14 @@ export const applyStripeDiscountsToLineItems = ({
 	discounts: StripeDiscountWithCoupon[];
 	options?: {
 		skipDescriptionTag?: boolean;
-		disableDiscountableForRecurringDiscounts?: boolean;
+		disableDiscountableForFreshDiscounts?: boolean;
 	};
 }): LineItem[] => {
 	if (
-		options.disableDiscountableForRecurringDiscounts &&
-		hasFreshRecurringDiscount({ discounts })
+		options.disableDiscountableForFreshDiscounts &&
+		hasFreshDiscount({ discounts })
 	) {
-		lineItems = disableDiscountableForRecurringDiscounts({ lineItems });
+		lineItems = disableDiscountableForFreshDiscounts({ lineItems });
 	}
 
 	const percentOffDiscounts = discounts.filter(

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
@@ -24,25 +24,19 @@ const stripeDiscountsToInvoiceParams = ({
 }: {
 	stripeDiscounts: StripeDiscountWithCoupon[];
 }): Stripe.InvoiceCreateParams["discounts"] => {
-	return stripeDiscounts.map((discount) => {
-		if (discount.id) return { discount: discount.id };
-		if (discount.promotionCodeId)
-			return { promotion_code: discount.promotionCodeId };
-		return { coupon: discount.source.coupon.id };
-	});
+	return stripeDiscounts
+		.filter(
+			(discount): discount is StripeDiscountWithCoupon & { id: string } =>
+				Boolean(discount.id),
+		)
+		.map((discount) => ({ discount: discount.id }));
 };
 
-const getInvoiceEligibleStripeDiscounts = ({
-	stripeDiscounts,
+const invoiceLinesAllowStripeDiscounts = ({
+	lines,
 }: {
-	stripeDiscounts: StripeDiscountWithCoupon[];
-}) => {
-	return stripeDiscounts.filter((discount) => {
-		if (discount.id) return true;
-
-		return discount.source.coupon.duration !== "repeating";
-	});
-};
+	lines: StripeInvoiceAction["addLineParams"]["lines"];
+}) => lines.some((line) => line.discountable !== false);
 
 export const createInvoiceForBilling = async ({
 	ctx,
@@ -88,14 +82,17 @@ export const createInvoiceForBilling = async ({
 		},
 	});
 
-	const invoiceEligibleStripeDiscounts = getInvoiceEligibleStripeDiscounts({
-		stripeDiscounts: billingContext.stripeDiscounts ?? [],
-	});
-
 	const wantsAutoTax = shouldEnableStripeAutomaticTax({ ctx, billingContext });
 	const stripeSubId = options.skipSubscriptionLink
 		? undefined
 		: billingContext.stripeSubscription?.id;
+	const invoiceDiscounts = invoiceLinesAllowStripeDiscounts({
+		lines: addLineParams.lines,
+	})
+		? stripeDiscountsToInvoiceParams({
+				stripeDiscounts: billingContext.stripeDiscounts ?? [],
+			})
+		: undefined;
 
 	const draftInvoice = await createStripeInvoice({
 		stripeCli,
@@ -109,9 +106,7 @@ export const createInvoiceForBilling = async ({
 		footer: invoiceMode?.footer,
 		description: invoiceMode?.memo,
 		metadata: invoiceMetadata,
-		discounts: stripeDiscountsToInvoiceParams({
-			stripeDiscounts: invoiceEligibleStripeDiscounts,
-		}),
+		discounts: invoiceDiscounts,
 		automaticTax: wantsAutoTax,
 	});
 

--- a/server/src/internal/billing/v2/utils/billingPlan/toImmediatePreview/billingPlanToImmediatePreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/toImmediatePreview/billingPlanToImmediatePreview.ts
@@ -1,16 +1,26 @@
-import type { BillingPlan, LineItem, PreviewLineItem } from "@autumn/shared";
+import type {
+	BillingContext,
+	BillingPlan,
+	LineItem,
+	PreviewLineItem,
+} from "@autumn/shared";
 import { sumValues } from "@autumn/shared";
 import { Decimal } from "decimal.js";
 import { customLineItemToPreviewLineItem } from "../../lineItems/customLineItemToPreviewLineItem";
+import { customLineItemsToLineItems } from "../../lineItems/customLineItemsToLineItems";
 import { lineItemToPreviewLineItem } from "../../lineItems/lineItemToPreviewLineItem";
 
 const roundAmount = ({ amount }: { amount: number }) =>
 	new Decimal(amount).toDP(2).toNumber();
 
 export const billingPlanToImmediatePreview = ({
+	billingContext,
 	billingPlan,
+	currency,
 }: {
+	billingContext: BillingContext;
 	billingPlan: BillingPlan;
+	currency: string;
 }): {
 	immediateLineItems: LineItem[];
 	previewLineItems: PreviewLineItem[];
@@ -25,8 +35,16 @@ export const billingPlanToImmediatePreview = ({
 	);
 
 	if (customLineItems?.length) {
-		const previewLineItems = customLineItems.map(
-			customLineItemToPreviewLineItem,
+		const customLineItemsWithDiscounts = customLineItemsToLineItems({
+			customLineItems,
+			currency,
+			stripeDiscounts: billingContext.stripeDiscounts ?? [],
+		});
+		const previewLineItems = customLineItems.map((item, index) =>
+			customLineItemToPreviewLineItem(
+				item,
+				customLineItemsWithDiscounts[index],
+			),
 		);
 		const subtotal = roundAmount({
 			amount: sumValues(customLineItems.map((item) => item.amount)),
@@ -36,7 +54,9 @@ export const billingPlanToImmediatePreview = ({
 			immediateLineItems,
 			previewLineItems,
 			subtotal,
-			total: subtotal,
+			total: roundAmount({
+				amount: sumValues(previewLineItems.map((line) => line.total)),
+			}),
 		};
 	}
 

--- a/server/src/internal/billing/v2/utils/billingPlanToPreviewResponse.ts
+++ b/server/src/internal/billing/v2/utils/billingPlanToPreviewResponse.ts
@@ -81,21 +81,24 @@ export const billingPlanToPreviewResponse = async ({
 
 	const autumnBillingPlan = billingPlan.autumn;
 	const allLineItems = autumnBillingPlan.lineItems ?? [];
+	const currency = orgToCurrency({ org: ctx.org });
 
 	const {
 		immediateLineItems,
 		previewLineItems,
 		subtotal,
 		total: lineItemsTotal,
-	} = billingPlanToImmediatePreview({ billingPlan });
+	} = billingPlanToImmediatePreview({
+		billingContext,
+		billingPlan,
+		currency,
+	});
 
 	const total = applyPreviewAdjustmentsToTotal({
 		subtotal,
 		total: lineItemsTotal,
 		billingPlan,
 	});
-
-	const currency = orgToCurrency({ org: ctx.org });
 
 	// Get next cycle object
 	const { nextCycle: rawNextCycle, debug: nextCycleDebug } =

--- a/server/src/internal/billing/v2/utils/lineItems/customLineItemToPreviewLineItem.ts
+++ b/server/src/internal/billing/v2/utils/lineItems/customLineItemToPreviewLineItem.ts
@@ -1,16 +1,23 @@
-import type { CustomLineItem, PreviewLineItem } from "@autumn/shared";
+import type { CustomLineItem, LineItem, PreviewLineItem } from "@autumn/shared";
 
 /** Transforms a CustomLineItem to a PreviewLineItem for API responses. */
 export const customLineItemToPreviewLineItem = (
 	item: CustomLineItem,
+	lineItem?: LineItem,
 ): PreviewLineItem => {
 	return {
 		object: "billing_preview_line_item" as const,
 		display_name: item.description,
 		description: item.description,
 		subtotal: item.amount,
-		total: item.amount,
-		discounts: [],
+		total: lineItem?.amountAfterDiscounts ?? item.amount,
+		discounts:
+			lineItem?.discounts.map((discount) => ({
+				amount_off: discount.amountOff,
+				percent_off: discount.percentOff,
+				reward_id: discount.stripeCouponId,
+				reward_name: discount.couponName,
+			})) ?? [],
 		plan_id: "",
 		feature_id: null,
 		custom: true,

--- a/server/src/internal/billing/v2/utils/lineItems/customLineItemsToLineItems.ts
+++ b/server/src/internal/billing/v2/utils/lineItems/customLineItemsToLineItems.ts
@@ -1,0 +1,44 @@
+import { generateKsuid } from "@autumn/ksuid";
+import type {
+	CustomLineItem,
+	LineItem,
+	StripeDiscountWithCoupon,
+} from "@autumn/shared";
+import { applyStripeDiscountsToLineItems } from "@/internal/billing/v2/providers/stripe/utils/discounts/applyStripeDiscountsToLineItems";
+
+export const customLineItemsToLineItems = ({
+	customLineItems,
+	currency,
+	stripeDiscounts = [],
+}: {
+	customLineItems: CustomLineItem[];
+	currency: string;
+	stripeDiscounts?: StripeDiscountWithCoupon[];
+}): LineItem[] => {
+	const lineItems = customLineItems.map((item) => ({
+		id: generateKsuid({ prefix: "invoice_li_" }),
+		amount: item.amount,
+		amountAfterDiscounts: item.amount,
+		description: item.description,
+		discounts: [],
+		chargeImmediately: true,
+		prorated: false,
+		context: {
+			price: {} as LineItem["context"]["price"],
+			product: { id: "", name: item.description } as LineItem["context"]["product"],
+			currency,
+			direction: item.amount >= 0 ? "charge" : "refund",
+			now: Date.now(),
+			billingTiming: "in_advance",
+			discountable: false,
+		},
+	})) satisfies LineItem[];
+
+	if (!stripeDiscounts.length) return lineItems;
+
+	return applyStripeDiscountsToLineItems({
+		lineItems,
+		discounts: stripeDiscounts,
+		options: { disableDiscountableForFreshDiscounts: true },
+	});
+};

--- a/server/tests/integration/billing/attach/discounts/attach-once-promo-manual-invoice.test.ts
+++ b/server/tests/integration/billing/attach/discounts/attach-once-promo-manual-invoice.test.ts
@@ -1,0 +1,77 @@
+import {
+	type AttachParamsV1Input,
+	type AttachPreviewResponse,
+	atmnToStripeAmount,
+} from "@autumn/shared";
+import {
+	createPercentCoupon,
+	createPromotionCode,
+} from "@tests/integration/billing/utils/discounts/discountTestUtils";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import { expect, test } from "bun:test";
+import chalk from "chalk";
+
+test.concurrent(`${chalk.yellowBright("attach once promo: manual upgrade invoice total matches preview")}`, async () => {
+	const customerId = "attach-once-promo-manual-invoice";
+	const monthly = products.pro({
+		id: "monthly-once-promo",
+		items: [items.monthlyMessages({ includedUsage: 500 })],
+	});
+	const annual = products.proAnnual({
+		id: "annual-once-promo",
+		items: [items.monthlyMessages({ includedUsage: 1000 })],
+	});
+
+	const { autumnV2_2, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [monthly, annual] }),
+		],
+		actions: [
+			s.billing.attach({ productId: monthly.id }),
+			s.removePaymentMethod(),
+			s.attachPaymentMethod({ type: "fail" }),
+		],
+	});
+
+	const coupon = await createPercentCoupon({
+		stripeCli: ctx.stripeCli,
+		percentOff: 25,
+		duration: "once",
+	});
+	const promoCode = await createPromotionCode({
+		stripeCli: ctx.stripeCli,
+		coupon,
+		code: "ONCEPROMO",
+	});
+	const params: AttachParamsV1Input = {
+		customer_id: customerId,
+		plan_id: annual.id,
+		redirect_mode: "if_required",
+		discounts: [{ promotion_code: promoCode.code }],
+	};
+
+	const preview =
+		(await autumnV2_2.billing.previewAttach<AttachParamsV1Input>(
+			params,
+		)) as AttachPreviewResponse;
+	expect(preview.total).toBeLessThan(preview.subtotal);
+	expect(preview.line_items.some((item) => item.discounts.length > 0)).toBe(
+		true,
+	);
+
+	const result = await autumnV2_2.billing.attach<AttachParamsV1Input>(params);
+
+	expect(result.invoice?.stripe_id).toBeDefined();
+	expect(result.invoice?.total).toBeCloseTo(preview.total, 2);
+
+	const stripeInvoice = await ctx.stripeCli.invoices.retrieve(
+		result.invoice!.stripe_id,
+	);
+	expect(stripeInvoice.total).toBe(
+		atmnToStripeAmount({ amount: preview.total, currency: "usd" }),
+	);
+});

--- a/server/tests/integration/billing/attach/params/custom-line-items/custom-line-items.test.ts
+++ b/server/tests/integration/billing/attach/params/custom-line-items/custom-line-items.test.ts
@@ -15,6 +15,7 @@ import { type ApiCustomerV3, atmnToStripeAmount } from "@autumn/shared";
 import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
 import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
 import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect";
+import { createPercentCoupon } from "@tests/integration/billing/utils/discounts/discountTestUtils";
 import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
 import ctx from "@tests/utils/testInitUtils/createTestContext";
@@ -190,6 +191,60 @@ test.concurrent(`${chalk.yellowBright("custom-line-items 2: preview with custom 
 	expect(subtotals).toContain(3.5);
 	expect(totals).toContain(10);
 	expect(totals).toContain(3.5);
+});
+
+test.concurrent(`${chalk.yellowBright("custom-line-items 2b: fresh discount applies to custom line items")}`, async () => {
+	const customerId = "cli-discounted-custom-lines";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 500 });
+	const pro = products.pro({
+		id: "pro",
+		items: [messagesItem],
+	});
+
+	const premiumMessagesItem = items.monthlyMessages({ includedUsage: 1000 });
+	const premium = products.premium({
+		id: "premium",
+		items: [premiumMessagesItem],
+	});
+
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro, premium] }),
+		],
+		actions: [s.billing.attach({ productId: pro.id })],
+	});
+
+	const coupon = await createPercentCoupon({
+		stripeCli: ctx.stripeCli,
+		percentOff: 25,
+	});
+	const customLineItems = [{ amount: 20, description: "Custom upgrade charge" }];
+	const params = {
+		customer_id: customerId,
+		product_id: premium.id,
+		redirect_mode: "if_required" as const,
+		custom_line_items: customLineItems,
+		discounts: [{ reward_id: coupon.id }],
+	};
+
+	const preview = await autumnV1.billing.previewAttach(params);
+
+	expect(preview.subtotal).toBe(20);
+	expect(preview.total).toBe(15);
+	expect(preview.line_items[0].discounts[0].amount_off).toBe(5);
+
+	const result = await autumnV1.billing.attach(params);
+	expect(result.invoice?.stripe_id).toBeDefined();
+
+	const stripeInvoice = await ctx.stripeCli.invoices.retrieve(
+		result.invoice!.stripe_id,
+	);
+	expect(stripeInvoice.total).toBe(
+		atmnToStripeAmount({ amount: 15, currency: "usd" }),
+	);
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/server/tests/unit/billing/stripe/discounts/apply-stripe-discounts-to-line-items.spec.ts
+++ b/server/tests/unit/billing/stripe/discounts/apply-stripe-discounts-to-line-items.spec.ts
@@ -112,6 +112,34 @@ describe(chalk.yellowBright("applyStripeDiscountsToLineItems"), () => {
 			expect(result[0].discounts[0].percentOff).toBe(25);
 		});
 
+		test("fresh one-time percent_off discount disables Stripe discounting when requested", () => {
+			const lineItem = lineItemFixtures.charge({ amount: 100 });
+			const lineItems = [
+				{
+					...lineItem,
+					context: {
+						...lineItem.context,
+						discountable: true,
+					},
+				},
+			];
+			const discountList = [
+				withDuration({
+					discount: discounts.percentOff({ percentOff: 25 }),
+					duration: "once",
+				}),
+			];
+
+			const result = applyStripeDiscountsToLineItems({
+				lineItems,
+				discounts: discountList,
+				options: { disableDiscountableForFreshDiscounts: true },
+			});
+
+			expect(result[0].amountAfterDiscounts).toBe(75);
+			expect(result[0].context.discountable).toBe(false);
+		});
+
 		test("single amount_off discount applied correctly", () => {
 			const lineItems = [lineItemFixtures.charge({ amount: 100 })];
 			const discountList = [discounts.amountOff({ amountOffCents: 1500 })]; // $15


### PR DESCRIPTION
## Summary
- bake fresh Stripe discounts into immediate manual invoice line amounts for all fresh discounts, not only repeating coupons
- bake discounts into custom manual invoice lines too, so preview and final invoice both reflect discounts on `custom_line_items`
- only pass existing Stripe invoice-level discounts when added invoice lines can actually be discounted by Stripe
- add focused unit/integration regressions for one-time promotion codes and custom line items

## Verification
- `bun test tests/unit/billing/stripe/discounts/apply-stripe-discounts-to-line-items.spec.ts`
- `./run.sh /Users/charlielamb/code/atmn/autumn/server/tests/integration/billing/attach/discounts/attach-once-promo-manual-invoice.test.ts` against the local main checkout server with the patch temporarily applied
- `AUTUMN_TEST_BASE_URL=http://localhost:8081 ./run.sh /Users/charlielamb/code/atmn/autumn-manual-invoice-discount/server/tests/integration/billing/attach/params/custom-line-items/custom-line-items.test.ts`
- `bunx tsgo --build --noEmit`
- commit hook: `knip` and `@autumn/server:ts`

## Notes
The focused unit test failed before the fix: a fresh `once` discount produced the discounted `amountAfterDiscounts` but left the line `discountable`, allowing Stripe manual invoice creation to ignore the already-computed discount.

The custom-line-items review issue was valid because `custom_line_items` bypassed normal line-item discount baking while fresh invoice-level discounts were filtered out; the fix now uses the same discounted line representation for custom preview and invoice execution.