### PR TITLE
fix: clamp queue dwell + protect reserved span attrs

### DIFF
--- a/server/src/queue/processMessage.ts
+++ b/server/src/queue/processMessage.ts
@@ -325,7 +325,8 @@ export const processMessage = async ({
 		}
 	};
 
-	// Queue dwell = SQS SentTimestamp → processing start; surfaces backlog per job type.
+	// Queue dwell = SQS SentTimestamp → processing start. Total message age:
+	// includes prior delivery attempts on retry (SentTimestamp never resets).
 	const sentAtMs = Number(message.Attributes?.SentTimestamp);
 	const receiveCount = Number(message.Attributes?.ApproximateReceiveCount);
 
@@ -340,7 +341,7 @@ export const processMessage = async ({
 			},
 			attributes: {
 				...(Number.isFinite(sentAtMs) && {
-					"queue.dwell_ms": Date.now() - sentAtMs,
+					"queue.dwell_ms": Math.max(0, Date.now() - sentAtMs),
 				}),
 				...(Number.isFinite(receiveCount) && {
 					"queue.receive_count": receiveCount,

--- a/server/src/utils/otel/withWorkerSpan.ts
+++ b/server/src/utils/otel/withWorkerSpan.ts
@@ -28,9 +28,9 @@ export const withWorkerSpan = async <T>({
 		{ kind: SpanKind.CONSUMER },
 		async (span) => {
 			span.setAttributes({
+				...attributes,
 				workflow_id: workflowId,
 				workflow_name: workflowName,
-				...attributes,
 			});
 
 			const aws = getAwsTaskIdentity();


### PR DESCRIPTION
- **log SQS queue dwell time on worker spans**
- **clamp queue dwell + protect reserved span attrs**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp SQS queue dwell time on worker spans to prevent negative values and ensure dwell reflects total message age across retries. Also protect reserved span attributes by ensuring workflow_id and workflow_name can’t be overridden by user-provided attributes.

<sup>Written for commit 0cbe3f8349e12f30181a5fee7fd2c393c0c90374. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes two small defensive fixes to the worker span instrumentation: it clamps `queue.dwell_ms` to a minimum of zero (guarding against negative values from clock skew between the SQS service and the worker host), and it reorders the `setAttributes` call so that `workflow_id` and `workflow_name` always win over any caller-supplied `attributes` spread.

- **[Bug fixes]** `Math.max(0, Date.now() - sentAtMs)` prevents negative dwell-time metrics that could appear when the worker clock lags behind the SQS clock; comment now also notes that `SentTimestamp` is frozen at first enqueue, so the value accumulates across delivery attempts.
- **[Bug fixes]** Spreading `attributes` before the hardcoded `workflow_id`/`workflow_name` keys in `withWorkerSpan` ensures callers cannot accidentally (or intentionally) overwrite those reserved span attributes.
</details>

<h3>Confidence Score: 5/5</h3>

Both changes are small, targeted, and move in a safer direction — no existing correct behavior is altered.

The dwell-time clamp and attribute ordering fix are each one-line changes with clear, correct intent. The clamp cannot introduce incorrect metric values (zero is the worst it can emit), and the reorder only tightens which values win in a spread — it cannot break any currently working caller. No new error paths or data mutations are introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/queue/processMessage.ts | Clamps `queue.dwell_ms` to ≥ 0 with `Math.max` and updates the comment to clarify `SentTimestamp` freeze semantics — defensive and correct. |
| server/src/utils/otel/withWorkerSpan.ts | Reorders `setAttributes` spread so `workflow_id`/`workflow_name` are always applied last, preventing caller attributes from overwriting reserved keys. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant SQS
    participant processMessage
    participant withWorkerSpan
    participant OTel Span

    SQS->>processMessage: message (SentTimestamp, ApproximateReceiveCount)
    processMessage->>processMessage: "sentAtMs = Number(SentTimestamp)"
    processMessage->>processMessage: "dwell_ms = Math.max(0, Date.now() - sentAtMs)"
    processMessage->>withWorkerSpan: "{ workflowName, workflowId, attributes: { queue.dwell_ms, queue.receive_count } }"
    withWorkerSpan->>OTel Span: setAttributes({ ...attributes, workflow_id, workflow_name })
    Note over OTel Span: workflow_id / workflow_name always win over spread attrs
    withWorkerSpan->>OTel Span: setAttribute(aws.service_arn, aws.image_sha)
    withWorkerSpan->>OTel Span: setAttribute(tenantAttrs)
    withWorkerSpan->>processMessage: executeJob()
    withWorkerSpan->>OTel Span: span.end()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant SQS
    participant processMessage
    participant withWorkerSpan
    participant OTel Span

    SQS->>processMessage: message (SentTimestamp, ApproximateReceiveCount)
    processMessage->>processMessage: "sentAtMs = Number(SentTimestamp)"
    processMessage->>processMessage: "dwell_ms = Math.max(0, Date.now() - sentAtMs)"
    processMessage->>withWorkerSpan: "{ workflowName, workflowId, attributes: { queue.dwell_ms, queue.receive_count } }"
    withWorkerSpan->>OTel Span: setAttributes({ ...attributes, workflow_id, workflow_name })
    Note over OTel Span: workflow_id / workflow_name always win over spread attrs
    withWorkerSpan->>OTel Span: setAttribute(aws.service_arn, aws.image_sha)
    withWorkerSpan->>OTel Span: setAttribute(tenantAttrs)
    withWorkerSpan->>processMessage: executeJob()
    withWorkerSpan->>OTel Span: span.end()
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["clamp queue dwell + protect reserved spa..."](https://github.com/useautumn/autumn/commit/0cbe3f8349e12f30181a5fee7fd2c393c0c90374) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41349741)</sub>

<!-- /greptile_comment -->