### PR TITLE
Fix duplicate manual invoice past due sync

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/stripeSubscriptionUpdatedContext.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/stripeSubscriptionUpdatedContext.ts
@@ -12,6 +12,7 @@ import type { ExpandedStripeSubscription } from "@/external/stripe/subscriptions
  */
 export interface SubscriptionPreviousAttributes {
 	status?: Stripe.Subscription.Status;
+	latest_invoice?: string | Stripe.Invoice | null;
 	cancel_at_period_end?: boolean;
 	cancel_at?: number | null;
 	canceled_at?: number | null;

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/syncCustomerProductStatus/syncCustomerProductStatus.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/syncCustomerProductStatus/syncCustomerProductStatus.ts
@@ -3,6 +3,7 @@ import {
 	type CollectionMethod,
 	CusProductStatus,
 	cp,
+	type FullCusProduct,
 	type InsertCustomerProduct,
 } from "@autumn/shared";
 import { getStripeInvoice } from "@/external/stripe/invoices/operations/getStripeInvoice";
@@ -22,30 +23,44 @@ import type {
 } from "../../stripeSubscriptionUpdatedContext";
 import { fixUnexpectedStatuses } from "./fixUnexpectedStatuses";
 
-/**
- * In cases where a manual invoice was created due to an upgrade, we don't want to treat it as a past due.
- * Only applies when the subscription just transitioned to past_due from a healthy state.
- * If the sub was already past_due before this event, it's a real past_due.
- */
+const isManualBillingUpdateInvoice = (
+	invoice: { metadata?: Record<string, string> | null },
+) =>
+	invoice.metadata?.autumn_billing_update &&
+	invoice.metadata?.autumn_invoice_mode !== "true";
+
+const getInvoiceId = (invoice: string | { id?: string } | null | undefined) =>
+	typeof invoice === "string" ? invoice : invoice?.id;
+
+/** Manual billing-update invoices should not make an otherwise-active subscription past_due. */
 const handleFalsePositivePastDue = async ({
 	ctx,
 	stripeSubscription,
 	autumnStatus,
 	previousAttributes,
+	customerProducts,
 }: {
 	ctx: StripeWebhookContext;
 	stripeSubscription: ExpandedStripeSubscription;
 	autumnStatus: CusProductStatus;
 	previousAttributes: SubscriptionPreviousAttributes;
+	customerProducts: FullCusProduct[];
 }): Promise<CusProductStatus> => {
 	if (!isStripeSubscriptionPastDue(stripeSubscription)) return autumnStatus;
 
-	// If the status didn't change in this event or was already past_due,
-	// the subscription was genuinely past_due — don't override.
-	const wasAlreadyPastDue =
-		previousAttributes.status === undefined ||
-		previousAttributes.status === "past_due";
-	if (wasAlreadyPastDue) return autumnStatus;
+	if (previousAttributes.status === "past_due") return autumnStatus;
+
+	const statusChanged = previousAttributes.status !== undefined;
+	const latestInvoiceChanged = previousAttributes.latest_invoice !== undefined;
+	if (!statusChanged && !latestInvoiceChanged) return autumnStatus;
+
+	const hasActiveCustomerProduct = customerProducts.some((customerProduct) => {
+		const { valid } = cp(customerProduct)
+			.recurring()
+			.onStripeSubscription({ stripeSubscriptionId: stripeSubscription.id });
+		return valid && customerProduct.status === CusProductStatus.Active;
+	});
+	if (!hasActiveCustomerProduct) return autumnStatus;
 
 	const latestInvoice = await getStripeInvoice({
 		stripeClient: ctx.stripeCli,
@@ -53,16 +68,21 @@ const handleFalsePositivePastDue = async ({
 		expand: [],
 	});
 
-	const metadata = latestInvoice?.metadata;
+	if (!isManualBillingUpdateInvoice(latestInvoice)) return autumnStatus;
 
-	if (
-		metadata?.autumn_billing_update &&
-		metadata?.autumn_invoice_mode !== "true"
-	) {
-		return CusProductStatus.Active;
+	if (!statusChanged) {
+		const previousInvoiceId = getInvoiceId(previousAttributes.latest_invoice);
+		if (!previousInvoiceId) return autumnStatus;
+
+		const previousInvoice = await getStripeInvoice({
+			stripeClient: ctx.stripeCli,
+			invoiceId: previousInvoiceId,
+			expand: [],
+		});
+		if (!isManualBillingUpdateInvoice(previousInvoice)) return autumnStatus;
 	}
 
-	return autumnStatus;
+	return CusProductStatus.Active;
 };
 
 /**
@@ -100,9 +120,8 @@ export const syncCustomerProductStatus = async ({
 		stripeSubscription,
 		autumnStatus,
 		previousAttributes,
+		customerProducts,
 	});
-
-	// Don't transition autumn status to past_due if the stripe invoice has metadata: autumn_billing_update, and invoice_mode is false.
 
 	// Get trial_ends_at and collection_method from Stripe
 	const trialEndsAt = stripeSubscriptionToTrialEndsAtMs({ stripeSubscription });

--- a/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-past-due.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-past-due.test.ts
@@ -19,12 +19,22 @@ import {
 	CusProductStatus,
 	customerProducts,
 } from "@autumn/shared";
+import type Stripe from "stripe";
+import {
+	getExpandedStripeSubscription,
+	type ExpandedStripeSubscription,
+} from "@/external/stripe/subscriptions";
+import type { StripeSubscriptionUpdatedContext } from "@/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/stripeSubscriptionUpdatedContext";
+import { syncCustomerProductStatus } from "@/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/syncCustomerProductStatus/syncCustomerProductStatus";
+import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
 import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
 import {
 	expectCustomerProducts,
+	expectProductActive,
 	expectProductPastDue,
 } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
 import { driveProductPastDue } from "@tests/integration/billing/utils/driveProductPastDue";
+import { getSubscriptionId } from "@tests/integration/billing/utils/stripe/getSubscriptionId";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
@@ -32,6 +42,91 @@ import { eq } from "drizzle-orm";
 import chalk from "chalk";
 import { CusService } from "@/internal/customers/CusService";
 import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
+
+type ScenarioCtx = Awaited<ReturnType<typeof initScenario>>["ctx"];
+
+const createManualBillingUpdateInvoice = async ({
+	ctx,
+	stripeCustomerId,
+	manualBillingUpdate = true,
+}: {
+	ctx: ScenarioCtx;
+	stripeCustomerId: string;
+	manualBillingUpdate?: boolean;
+}) => {
+	const invoice = await ctx.stripeCli.invoices.create({
+		customer: stripeCustomerId,
+		auto_advance: false,
+		metadata: manualBillingUpdate
+			? {
+					autumn_billing_update: "true",
+					autumn_invoice_mode: "false",
+				}
+			: undefined,
+	});
+
+	return invoice.id;
+};
+
+const syncManualPastDue = async ({
+	ctx,
+	customerId,
+	subscriptionId,
+	latestInvoiceId,
+	previousAttributes,
+}: {
+	ctx: ScenarioCtx;
+	customerId: string;
+	subscriptionId: string;
+	latestInvoiceId: string;
+	previousAttributes: StripeSubscriptionUpdatedContext["previousAttributes"];
+}) => {
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	const stripeSubscription = await getExpandedStripeSubscription({
+		ctx,
+		subscriptionId,
+	});
+	const pastDueSubscription = {
+		...stripeSubscription,
+		status: "past_due",
+		latest_invoice: latestInvoiceId,
+	} as ExpandedStripeSubscription;
+
+	await syncCustomerProductStatus({
+		ctx: {
+			...ctx,
+			fullCustomer,
+			stripeEvent: {
+				id: `evt_${latestInvoiceId}`,
+				object: "event",
+				api_version: null,
+				created: Math.floor(Date.now() / 1000),
+				data: { object: pastDueSubscription },
+				livemode: false,
+				pending_webhooks: 0,
+				request: null,
+				type: "customer.subscription.updated",
+			} as Stripe.Event,
+		} satisfies StripeWebhookContext,
+		subscriptionUpdatedContext: {
+			stripeSubscription: pastDueSubscription,
+			previousAttributes,
+			fullCustomer,
+			customerProducts: [...fullCustomer.customer_products],
+			nowMs: Date.now(),
+			updatedCustomerProducts: [],
+			deletedCustomerProducts: [],
+			insertedCustomerProducts: [],
+			oneOffPrepaidCarryOvers: [],
+			billingChangeTags: new Set<string>(),
+		},
+	});
+
+	await deleteCachedFullCustomer({ ctx, customerId });
+};
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // TEST 1: Subscription enters past_due after failed payment at renewal
@@ -88,6 +183,141 @@ test.concurrent(`${chalk.yellowBright("sub.updated: product enters past_due afte
 		latestTotal: 20,
 		latestStatus: "open",
 		latestInvoiceProductId: pro.id,
+	});
+});
+
+/** TDD: duplicate manual upgrade invoices can emit past_due with only latest_invoice changed.
+ * Red flips the active plan to past_due; green ignores manual billing-update invoices. */
+test.concurrent(`${chalk.yellowBright("sub.updated: duplicate manual upgrade invoice does not mark active plan past_due")}`, async () => {
+	const customerId = "sub-updated-manual-duplicate-invoice";
+	const pro = products.pro({
+		id: "pro",
+		items: [items.monthlyMessages({ includedUsage: 10 })],
+	});
+
+	const { autumnV1, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	const subscriptionId = await getSubscriptionId({
+		ctx,
+		customerId,
+		productId: pro.id,
+	});
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	const stripeCustomerId = fullCustomer.processor?.id;
+	expect(stripeCustomerId).toBeDefined();
+
+	const firstInvoiceId = await createManualBillingUpdateInvoice({
+		ctx,
+		stripeCustomerId: stripeCustomerId!,
+	});
+	await syncManualPastDue({
+		ctx,
+		customerId,
+		subscriptionId,
+		latestInvoiceId: firstInvoiceId,
+		previousAttributes: { status: "active" },
+	});
+
+	const customerAfterFirst =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductActive({
+		customer: customerAfterFirst,
+		productId: pro.id,
+	});
+
+	const secondInvoiceId = await createManualBillingUpdateInvoice({
+		ctx,
+		stripeCustomerId: stripeCustomerId!,
+	});
+	await syncManualPastDue({
+		ctx,
+		customerId,
+		subscriptionId,
+		latestInvoiceId: secondInvoiceId,
+		previousAttributes: {
+			latest_invoice: firstInvoiceId,
+		},
+	});
+
+	const customerAfterSecond =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductActive({
+		customer: customerAfterSecond,
+		productId: pro.id,
+	});
+});
+
+test.concurrent(`${chalk.yellowBright("sub.updated: duplicate manual invoice keeps past_due plan past_due")}`, async () => {
+	const customerId = "sub-updated-manual-duplicate-past-due";
+	const pro = products.pro({
+		id: "pro",
+		items: [items.monthlyMessages({ includedUsage: 10 })],
+	});
+
+	const { autumnV1, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	const subscriptionId = await getSubscriptionId({
+		ctx,
+		customerId,
+		productId: pro.id,
+	});
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	const stripeCustomerId = fullCustomer.processor?.id;
+	expect(stripeCustomerId).toBeDefined();
+	const cusProduct = fullCustomer.customer_products.find(
+		(cp) => cp.product.id === pro.id,
+	);
+	expect(cusProduct).toBeDefined();
+	await ctx.db
+		.update(customerProducts)
+		.set({ status: CusProductStatus.PastDue })
+		.where(eq(customerProducts.id, cusProduct!.id));
+	await deleteCachedFullCustomer({ ctx, customerId });
+
+	const firstManualInvoiceId = await createManualBillingUpdateInvoice({
+		ctx,
+		stripeCustomerId: stripeCustomerId!,
+	});
+	const secondManualInvoiceId = await createManualBillingUpdateInvoice({
+		ctx,
+		stripeCustomerId: stripeCustomerId!,
+	});
+
+	await syncManualPastDue({
+		ctx,
+		customerId,
+		subscriptionId,
+		latestInvoiceId: secondManualInvoiceId,
+		previousAttributes: {
+			latest_invoice: firstManualInvoiceId,
+		},
+	});
+
+	const customerAfterSync =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductPastDue({
+		customer: customerAfterSync,
+		productId: pro.id,
 	});
 });
 


### PR DESCRIPTION
## Summary
- suppress false past_due syncs for duplicate manual billing-update invoices when Stripe only reports latest_invoice changing
- keep real past_due subscriptions untouched by requiring an active Autumn customer product before suppressing
- add a regression test for the duplicate manual upgrade invoice event shape

## Tests
- bunx tsgo --build --noEmit
- NODE_ENV=development infisical run --env=dev --recursive -- bun test --timeout 0 /Users/charlielamb/code/atmn/autumn-manual-invoice-past-due/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-past-due.test.ts -t "sub.updated: duplicate manual upgrade invoice does not mark active plan past_due"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false past_due syncs from duplicate manual billing-update invoices that only update latest_invoice. Active plans stay active; real past_due transitions remain intact.

- **Bug Fixes**
  - Added `latest_invoice` to `SubscriptionPreviousAttributes` and detect duplicates when either `status` or `latest_invoice` changed.
  - Suppress past_due only if both the current and previous invoices are manual billing updates (`autumn_billing_update=true`, `autumn_invoice_mode=false`) and the customer has an active product on this subscription.
  - Added integration tests for both paths: active plan stays active on duplicate manual upgrade; already past_due plan stays past_due.

<sup>Written for commit cfdc6b14bf14d436882dda3a9905629105aaa491. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a false-positive past_due sync triggered when Stripe fires a duplicate `subscription.updated` event where only `latest_invoice` changes (not `status`). The old guard treated a missing `previousAttributes.status` as "was already past_due" and skipped suppression, which silently flipped active customer products to past_due. The new logic expands the detection to also catch `latest_invoice`-only changes and adds an active-customer-product guard to avoid interfering with subscriptions that are genuinely past_due.

- **Bug fixes** — `handleFalsePositivePastDue` now enters the invoice-metadata check when either `status` or `latest_invoice` changed in the event, fixing the duplicate-manual-invoice false positive while preserving real past_due transitions.
- **Improvements** — A `hasActiveCustomerProduct` guard is added so that subscriptions Autumn has already synced to past_due (no active customer product) are never falsely suppressed.
- **Improvements** — A regression test is added that directly calls `syncCustomerProductStatus` with the exact event shape (only `latest_invoice` changed) to lock in the fixed behaviour.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge for the targeted regression; the active-customer-product guard works correctly in the common case and the new test locks in the fix.

The fix correctly handles all three cases the PR targets: status-only transitions, latest_invoice-only transitions, and already-past_due subscriptions. The one gap is that the hasActiveCustomerProduct guard can be fooled when Autumn's customer-product status has drifted back to Active while Stripe already considers the subscription past_due — a narrow window where a concurrent billing-update invoice would suppress a real past_due. The fixUnexpectedStatuses safety net provides a downstream backstop, but the guard's assumption is not documented inline.

syncCustomerProductStatus.ts deserves a second look around the hasActiveCustomerProduct guard and how it interacts with the data-drift scenario from test 4.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/syncCustomerProductStatus/syncCustomerProductStatus.ts | Core logic change: expands suppression trigger from status-only to status-or-latest_invoice and adds active-customer-product guard; logic is correct for the main cases but has a subtle edge case with data-drifted active products on genuinely past_due subscriptions. |
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/stripeSubscriptionUpdatedContext.ts | Adds latest_invoice to SubscriptionPreviousAttributes to match the Stripe field the fix depends on; type mirrors the Stripe SDK type correctly. |
| server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-past-due.test.ts | New regression test directly exercises both the status-transition case and the latest_invoice-only case; the manual invoice is created without a subscription link, which is fine for the metadata-check logic but means the test does not exercise the real Stripe event path that sets latest_invoice on the subscription. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[subscription.updated webhook arrives
stripe status = past_due] --> B{isStripeSubscriptionPastDue?}
    B -- No --> C[Return autumnStatus as-is]
    B -- Yes --> D{previousAttributes.status
=== 'past_due'?}
    D -- Yes --> E[Real past_due — return
autumnStatus unchanged]
    D -- No --> F{status !== undefined
OR latest_invoice !== undefined?}
    F -- No --> G[Nothing relevant changed —
return autumnStatus unchanged]
    F -- Yes --> H{hasActiveCustomerProduct
on this subscription?}
    H -- No --> I[No active plan to protect —
return autumnStatus unchanged]
    H -- Yes --> J[Fetch latest invoice
from Stripe]
    J --> K{autumn_billing_update set
AND autumn_invoice_mode ≠ 'true'?}
    K -- No --> L[Real past_due — return
autumnStatus unchanged]
    K -- Yes --> M[Suppress false positive —
return CusProductStatus.Active]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[subscription.updated webhook arrives
stripe status = past_due] --> B{isStripeSubscriptionPastDue?}
    B -- No --> C[Return autumnStatus as-is]
    B -- Yes --> D{previousAttributes.status
=== 'past_due'?}
    D -- Yes --> E[Real past_due — return
autumnStatus unchanged]
    D -- No --> F{status !== undefined
OR latest_invoice !== undefined?}
    F -- No --> G[Nothing relevant changed —
return autumnStatus unchanged]
    F -- Yes --> H{hasActiveCustomerProduct
on this subscription?}
    H -- No --> I[No active plan to protect —
return autumnStatus unchanged]
    H -- Yes --> J[Fetch latest invoice
from Stripe]
    J --> K{autumn_billing_update set
AND autumn_invoice_mode ≠ 'true'?}
    K -- No --> L[Real past_due — return
autumnStatus unchanged]
    K -- Yes --> M[Suppress false positive —
return CusProductStatus.Active]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/syncCustomerProductStatus/syncCustomerProductStatus.ts:49-56
**Active-product guard can suppress a real past_due during data drift**

The `hasActiveCustomerProduct` check is the key safety net, but it can fire on a subscription that is genuinely past_due if Autumn's customer-product status has drifted back to `Active` — exactly the scenario recreated in test 4 (`driveProductPastDue` → manual `set({ status: Active })`). In that window, if a billing-update invoice happens to be the `latest_invoice` on the subscription and the event fires with only `latest_invoice` in `previousAttributes`, the check would suppress the real past_due and return `CusProductStatus.Active`. The `fixUnexpectedStatuses` safety net at the end of `syncCustomerProductStatus` may or may not catch this depending on its own conditions. Worth adding a comment here that this guard is deliberately relying on Autumn's status being already synced to past_due before a second duplicate event can arrive, and that the data-drift scenario is accepted as a known gap.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): ignore duplicate manual in..."](https://github.com/useautumn/autumn/commit/9ffcea942ca1af9de7664778a95d2edba32784cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41394904)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->