### PR TITLE
Fix variant bugs: base rename overwriting variant names, false interval conflicts

### DIFF
--- a/server/src/internal/product/actions/common/planTransformUtils.ts
+++ b/server/src/internal/product/actions/common/planTransformUtils.ts
@@ -1,10 +1,10 @@
 import {
+	type ApiPlanV1,
 	apiPlan,
 	applyDiff,
 	composeMatchKey,
-	diffPlanV1,
-	type ApiPlanV1,
 	type DiffedCustomizePlanV1,
+	diffPlanV1,
 	type FullProduct,
 	type UpdatePlanParams,
 	type UpdateProductV2Params,
@@ -76,6 +76,13 @@ export const getVariantSettingsPatch = ({
 
 	return patch;
 };
+
+// Variants own their name; base→variant propagation must never overwrite it.
+// Same-plan version propagation still uses the full patch, name included.
+export const omitVariantOwnedSettings = ({
+	name: _name,
+	...rest
+}: VariantSettingsPatch): VariantSettingsPatch => rest;
 
 const hasVariantSettingsPatch = (patch: VariantSettingsPatch): boolean =>
 	Object.keys(patch).length > 0;

--- a/server/src/internal/product/actions/previewUpdatePlan/detectVariantConflicts.ts
+++ b/server/src/internal/product/actions/previewUpdatePlan/detectVariantConflicts.ts
@@ -4,10 +4,12 @@ import {
 	composeMatchKey,
 	type DiffedCustomizePlanV1,
 	type Feature,
+	findFeatureById,
 	itemsEqual,
 	type PlanItemFilter,
 	type PlanUpdatePreviewVariantConflict,
 } from "@autumn/shared";
+import { isConsumableFeature } from "@shared/utils/featureUtils/classifyFeature/isConsumableFeature";
 
 const intervalOf = (item: ApiPlanItemV1): string =>
 	item.price?.interval ?? item.reset?.interval ?? "none";
@@ -100,9 +102,6 @@ export const detectVariantConflicts = ({
 		if (!editedByMatchKey.has(key)) changedMatchKeys.add(key);
 	}
 
-	const featureName = (featureId: string) =>
-		features.find((f) => f.id === featureId)?.name;
-
 	const conflicts: PlanUpdatePreviewVariantConflict[] = [];
 
 	for (const featureId of changedFeatureIds) {
@@ -114,6 +113,8 @@ export const detectVariantConflicts = ({
 		const variantList = variantByFeature.get(featureId) ?? [];
 		if (variantList.length === 0) continue; // clean add into variant
 
+		const feature = findFeatureById({ features, featureId });
+
 		const editedIntervals = new Set(editedList.map(intervalOf));
 		const variantIntervals = new Set(variantList.map(intervalOf));
 		const sharesInterval = [...variantIntervals].some((iv) =>
@@ -121,11 +122,20 @@ export const detectVariantConflicts = ({
 		);
 
 		if (!sharesInterval) {
-			conflicts.push({
-				item_filter: filterForItem(variantList[0]),
-				feature_name: featureName(featureId),
-				reason: "different_interval",
-			});
+			// Unpriced non-consumables have no real interval, so propagation maps
+			// cleanly; a priced item propagates as a duplicate at the edit's interval.
+			const hasPricedItem =
+				editedList.some((item) => item.price != null) ||
+				variantList.some((item) => item.price != null);
+			const isCleanNonConsumableEntitlement =
+				feature != null && !isConsumableFeature(feature) && !hasPricedItem;
+			if (!isCleanNonConsumableEntitlement) {
+				conflicts.push({
+					item_filter: filterForItem(variantList[0]),
+					feature_name: feature?.name,
+					reason: "different_interval",
+				});
+			}
 			continue;
 		}
 
@@ -137,7 +147,7 @@ export const detectVariantConflicts = ({
 		if (divergentItem) {
 			conflicts.push({
 				item_filter: filterForItem(divergentItem),
-				feature_name: featureName(featureId),
+				feature_name: feature?.name,
 				reason: "value_divergence",
 			});
 		}

--- a/server/src/internal/product/actions/previewUpdatePlan/previewAffectedVariants.ts
+++ b/server/src/internal/product/actions/previewUpdatePlan/previewAffectedVariants.ts
@@ -1,4 +1,3 @@
-import { planUpdatePreviewHasDiff } from "@autumn/shared";
 import type {
 	ApiPlanV1,
 	DiffedCustomizePlanV1,
@@ -7,11 +6,13 @@ import type {
 	PreviewUpdatePlanParamsV2,
 	UpdateVariantParams,
 } from "@autumn/shared";
+import { planUpdatePreviewHasDiff } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 import { getPlanResponse } from "@/internal/products/productUtils/productResponseUtils/getPlanResponse.js";
 import {
 	applyDiffToVariantPlan,
+	omitVariantOwnedSettings,
 	type VariantSettingsPatch,
 } from "../common/planTransformUtils.js";
 import { resolveVariantUpdateSource } from "../common/variantUpdateSource.js";
@@ -45,6 +46,9 @@ export const previewAffectedVariants = async ({
 	variantUpdates?: UpdateVariantParams[];
 }): Promise<PlanUpdatePreviewVariant[]> => {
 	const { db, org, env, features } = ctx;
+	const variantSettingsPatch = settingsPatch
+		? omitVariantOwnedSettings(settingsPatch)
+		: undefined;
 	const variantUpdateById = new Map(
 		variantUpdates.map((variantUpdate) => [
 			variantUpdate.variant_plan_id,
@@ -79,11 +83,12 @@ export const previewAffectedVariants = async ({
 			Math.max(latestVersionById.get(variant.id) ?? 0, variant.version),
 		);
 	}
-	const previewVariants = data.include_versions || data.all_versions
-		? variants
-		: variants.filter(
-				(variant) => variant.version === latestVersionById.get(variant.id),
-			);
+	const previewVariants =
+		data.include_versions || data.all_versions
+			? variants
+			: variants.filter(
+					(variant) => variant.version === latestVersionById.get(variant.id),
+				);
 
 	return Promise.all(
 		previewVariants.map(async (variant) => {
@@ -107,7 +112,7 @@ export const previewAffectedVariants = async ({
 				: applyDiffToVariantPlan({
 						plan: currentPlan,
 						diff,
-						settingsPatch,
+						settingsPatch: variantSettingsPatch,
 					});
 			const { hasCustomers, customerCount } = await getPlanCustomerUsage({
 				ctx,
@@ -118,7 +123,8 @@ export const previewAffectedVariants = async ({
 				(variantUpdate
 					? diffHasVersionableChanges(variantUpdate.customize)
 					: false);
-			const forceVariantVersion = variantUpdate?.force_version ?? data.force_version;
+			const forceVariantVersion =
+				variantUpdate?.force_version ?? data.force_version;
 			const disableVariantVersion =
 				variantUpdate?.disable_version || data.disable_version;
 			const versionable =

--- a/server/src/internal/product/actions/updateProduct/shouldApplyVariantUpdates.ts
+++ b/server/src/internal/product/actions/updateProduct/shouldApplyVariantUpdates.ts
@@ -1,7 +1,6 @@
 import type { FullProduct, UpdateProductV2Params } from "@autumn/shared";
 
 const propagatedSettingFields = [
-	"name",
 	"description",
 	"group",
 	"is_add_on",

--- a/server/src/internal/product/actions/updateVariants/updateVariants.ts
+++ b/server/src/internal/product/actions/updateVariants/updateVariants.ts
@@ -1,22 +1,23 @@
 import {
 	type ApiPlanV1,
-	ErrCode,
-	RecaseError,
 	type DiffedCustomizePlanV1,
+	ErrCode,
 	type FullProduct,
 	products,
+	RecaseError,
 	type UpdateVariantParams,
 } from "@autumn/shared";
 import { inArray } from "drizzle-orm";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { createVariant } from "../createVariant/createVariant.js";
 import {
 	applyDiffToVariantPlan,
 	fullProductToApiPlanV1,
 	getApiPlanDiff,
 	getVariantSettingsPatch,
+	omitVariantOwnedSettings,
 	variantSettingsPatchHasValues,
 } from "../common/planTransformUtils.js";
+import { createVariant } from "../createVariant/createVariant.js";
 import { hasPlanCustomers } from "../previewUpdatePlan/hasPlanCustomers.js";
 import { getVariantPropagationTargets } from "./getVariantPropagationTargets.js";
 import { updateVariant } from "./updateVariant.js";
@@ -193,10 +194,12 @@ export const updateVariants = async ({
 		from: currentBasePlan,
 		to: incomingBasePlan,
 	});
-	const settingsPatch = getVariantSettingsPatch({
-		from: currentBasePlan,
-		to: incomingBasePlan,
-	});
+	const settingsPatch = omitVariantOwnedSettings(
+		getVariantSettingsPatch({
+			from: currentBasePlan,
+			to: incomingBasePlan,
+		}),
+	);
 	const hasSettingsPatch = variantSettingsPatchHasValues(settingsPatch);
 	const baseWasVersioned = oldBase.internal_id !== newBase.internal_id;
 	if (targetVariantIds.length === 0 && !hasSettingsPatch) {

--- a/server/tests/integration/crud/plans/variants/base-rename.test.ts
+++ b/server/tests/integration/crud/plans/variants/base-rename.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Plan variants — base rename must not clobber variant names.
+ *
+ * Variants own their name ("Pro Annual"); renaming the base ("Pro" → "Pro
+ * Plus") propagates settings but must leave every variant's name intact,
+ * in both the update and preview_update paths.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiPlanV1,
+	ApiVersion,
+	BillingInterval,
+	type PlanUpdatePreview,
+	ResetInterval,
+	type UpdatePlanParamsV2Input,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { AutumnRpcCli } from "@/external/autumn/autumnRpcCli.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { readableVariantTestId } from "./utils/readableVariantTestId.js";
+import { createVariantPlan } from "./utils/variantTestPlanUtils.js";
+
+type RpcUpdate = Omit<UpdatePlanParamsV2Input, "plan_id">;
+
+const getFull = (
+	ctx: { db: any; org: { id: string }; env: any },
+	planId: string,
+) =>
+	ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+
+const monthlyItem = (included: number) => ({
+	feature_id: TestFeature.Messages,
+	included,
+	reset: { interval: ResetInterval.Month },
+});
+
+const setupBaseWithAnnualVariant = async (label: string) => {
+	const cid = readableVariantTestId(label);
+	const base = products.pro({
+		id: `br_base_${cid}`,
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+
+	const { ctx } = await initScenario({
+		customerId: cid,
+		setup: [s.customer(), s.products({ list: [base] })],
+		actions: [],
+	});
+
+	const rpc = new AutumnRpcCli({
+		secretKey: ctx.orgSecretKey,
+		version: ApiVersion.V2_1,
+	});
+	const variantId = `br_var_${cid}`;
+
+	await createVariantPlan({
+		rpc,
+		basePlanId: base.id,
+		variantPlanId: variantId,
+		name: "Pro Annual",
+	});
+	await rpc.plans.update<ApiPlanV1, RpcUpdate>(variantId, {
+		price: { amount: 200, interval: BillingInterval.Year },
+		disable_version: true,
+	});
+
+	return { ctx, rpc, base, variantId };
+};
+
+test.concurrent(
+	`${chalk.yellowBright("variants base rename: variant keeps its own name")}`,
+	async () => {
+		const { ctx, rpc, base, variantId } =
+			await setupBaseWithAnnualVariant("br_only");
+
+		await rpc.plans.update<ApiPlanV1, RpcUpdate>(base.id, {
+			name: "Pro Plus",
+		});
+
+		const baseFull = await getFull(ctx, base.id);
+		const variantFull = await getFull(ctx, variantId);
+
+		expect(baseFull.name).toBe("Pro Plus");
+		expect(variantFull.name).toBe("Pro Annual");
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("variants base rename: propagated item update keeps variant name")}`,
+	async () => {
+		const { ctx, rpc, base, variantId } =
+			await setupBaseWithAnnualVariant("br_propagate");
+
+		await rpc.plans.update<ApiPlanV1, RpcUpdate>(base.id, {
+			name: "Pro Plus",
+			items: [monthlyItem(500)],
+			update_variant_ids: [variantId],
+		});
+
+		const baseFull = await getFull(ctx, base.id);
+		const variantFull = await getFull(ctx, variantId);
+
+		expect(baseFull.name).toBe("Pro Plus");
+		expect(variantFull.name).toBe("Pro Annual");
+		const variantMessages = variantFull.entitlements.find(
+			(entitlement) => entitlement.feature_id === TestFeature.Messages,
+		);
+		expect(variantMessages?.allowance).toBe(500);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("variants base rename: preview shows no variant name change")}`,
+	async () => {
+		const { rpc, base, variantId } =
+			await setupBaseWithAnnualVariant("br_preview");
+
+		const preview = (await rpc.post("/plans.preview_update", {
+			plan_id: base.id,
+			name: "Pro Plus",
+			include_variants: true,
+		})) as PlanUpdatePreview;
+
+		expect(preview.previous_attributes).toMatchObject({ name: base.name });
+
+		const variantPreview = preview.variants?.find(
+			(variant) => variant.plan_id === variantId,
+		);
+		expect(variantPreview).toBeDefined();
+		expect(variantPreview?.name).toBe("Pro Annual");
+		expect(variantPreview?.previous_attributes ?? null).toBeNull();
+	},
+);

--- a/server/tests/unit/products/detectVariantConflicts.test.ts
+++ b/server/tests/unit/products/detectVariantConflicts.test.ts
@@ -6,6 +6,8 @@ import {
 	BillingMethod,
 	type DiffedCustomizePlanV1,
 	type Feature,
+	FeatureType,
+	FeatureUsageType,
 	ResetInterval,
 } from "@autumn/shared";
 import { detectVariantConflicts } from "@/internal/product/actions/previewUpdatePlan/detectVariantConflicts";
@@ -49,7 +51,11 @@ const includedMonthly = (featureId: string, included: number): ApiPlanItemV1 =>
 		price: null,
 	}) as ApiPlanItemV1;
 
-const oneOffPrepaid = (featureId: string, amount: number): ApiPlanItemV1 =>
+const prepaid = (
+	featureId: string,
+	amount: number,
+	interval: BillingInterval,
+): ApiPlanItemV1 =>
 	({
 		feature_id: featureId,
 		included: 0,
@@ -57,11 +63,23 @@ const oneOffPrepaid = (featureId: string, amount: number): ApiPlanItemV1 =>
 		reset: null,
 		price: {
 			amount,
-			interval: BillingInterval.OneOff,
+			interval,
 			billing_units: 1,
 			billing_method: BillingMethod.Prepaid,
 			max_purchase: null,
 		},
+	}) as ApiPlanItemV1;
+
+const oneOffPrepaid = (featureId: string, amount: number): ApiPlanItemV1 =>
+	prepaid(featureId, amount, BillingInterval.OneOff);
+
+const includedNoReset = (featureId: string, included: number): ApiPlanItemV1 =>
+	({
+		feature_id: featureId,
+		included,
+		unlimited: false,
+		reset: null,
+		price: null,
 	}) as ApiPlanItemV1;
 
 const basePrice = (amount: number, interval: BillingInterval) =>
@@ -73,8 +91,19 @@ const plan = (
 ): ApiPlanV1 => ({ items, price }) as ApiPlanV1;
 
 const features = [
-	{ id: "messages", name: "Messages" },
-	{ id: "dashboard", name: "Dashboard" },
+	{
+		id: "messages",
+		name: "Messages",
+		type: FeatureType.Metered,
+		config: { usage_type: FeatureUsageType.Single },
+	},
+	{ id: "dashboard", name: "Dashboard", type: FeatureType.Boolean },
+	{
+		id: "seats",
+		name: "Seats",
+		type: FeatureType.Metered,
+		config: { usage_type: FeatureUsageType.Continuous },
+	},
 ] as Feature[];
 
 const MONTH = ResetInterval.Month as ResetInterval & BillingInterval;
@@ -85,7 +114,9 @@ describe("detectVariantConflicts", () => {
 		const conflicts = detectVariantConflicts({
 			currentBasePlan: plan([bool("dashboard"), usage("messages", MONTH)]),
 			editedBasePlan: plan([usage("messages", MONTH)]),
-			diff: { remove_items: [{ feature_id: "dashboard" }] } as DiffedCustomizePlanV1,
+			diff: {
+				remove_items: [{ feature_id: "dashboard" }],
+			} as DiffedCustomizePlanV1,
 			variantPlan: plan([bool("dashboard"), usage("messages", MONTH)]),
 			features,
 		});
@@ -97,7 +128,9 @@ describe("detectVariantConflicts", () => {
 		const conflicts = detectVariantConflicts({
 			currentBasePlan: plan([usage("messages", MONTH)]),
 			editedBasePlan: plan([usage("messages", MONTH), bool("dashboard")]),
-			diff: { add_items: [{ feature_id: "dashboard" }] } as DiffedCustomizePlanV1,
+			diff: {
+				add_items: [{ feature_id: "dashboard" }],
+			} as DiffedCustomizePlanV1,
 			variantPlan: plan([usage("messages", MONTH)]),
 			features,
 		});
@@ -125,7 +158,9 @@ describe("detectVariantConflicts", () => {
 		const conflicts = detectVariantConflicts({
 			currentBasePlan: plan([usage("messages", MONTH)]),
 			editedBasePlan: plan([usage("messages", MONTH)]),
-			diff: { add_items: [{ feature_id: "messages" }] } as DiffedCustomizePlanV1,
+			diff: {
+				add_items: [{ feature_id: "messages" }],
+			} as DiffedCustomizePlanV1,
 			variantPlan: plan([usage("messages", YEAR)]),
 			features,
 		});
@@ -136,6 +171,44 @@ describe("detectVariantConflicts", () => {
 			feature_name: "Messages",
 			item_filter: { feature_id: "messages" },
 		});
+	});
+
+	test("priced non-consumable on a different interval is a different_interval conflict", () => {
+		// Propagation would append the $12/month item next to the variant's
+		// $100/year item — a silent duplicate — so it must be flagged.
+		const conflicts = detectVariantConflicts({
+			currentBasePlan: plan([prepaid("seats", 10, BillingInterval.Month)]),
+			editedBasePlan: plan([prepaid("seats", 12, BillingInterval.Month)]),
+			diff: {
+				add_items: [{ feature_id: "seats" }],
+				remove_items: [{ feature_id: "seats", interval: MONTH }],
+			} as DiffedCustomizePlanV1,
+			variantPlan: plan([prepaid("seats", 100, BillingInterval.Year)]),
+			features,
+		});
+
+		expect(conflicts).toHaveLength(1);
+		expect(conflicts[0]).toMatchObject({
+			reason: "different_interval",
+			feature_name: "Seats",
+			item_filter: { feature_id: "seats" },
+		});
+	});
+
+	test("priced non-consumable edit against an unpriced variant entitlement is a different_interval conflict", () => {
+		const conflicts = detectVariantConflicts({
+			currentBasePlan: plan([prepaid("seats", 10, BillingInterval.Month)]),
+			editedBasePlan: plan([prepaid("seats", 12, BillingInterval.Month)]),
+			diff: {
+				add_items: [{ feature_id: "seats" }],
+				remove_items: [{ feature_id: "seats", interval: MONTH }],
+			} as DiffedCustomizePlanV1,
+			variantPlan: plan([includedNoReset("seats", 5)]),
+			features,
+		});
+
+		expect(conflicts).toHaveLength(1);
+		expect(conflicts[0]).toMatchObject({ reason: "different_interval" });
 	});
 
 	test("variant with a customized value (same interval) is a value_divergence conflict", () => {

--- a/server/tests/unit/products/variantSettingsPropagation.test.ts
+++ b/server/tests/unit/products/variantSettingsPropagation.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import type { ApiPlanV1 } from "@autumn/shared";
+import {
+	applyDiffToVariantPlan,
+	getVariantSettingsPatch,
+	omitVariantOwnedSettings,
+	variantSettingsPatchHasValues,
+} from "@/internal/product/actions/common/planTransformUtils";
+
+const plan = (overrides: Partial<ApiPlanV1>): ApiPlanV1 =>
+	({
+		id: "pro",
+		name: "Pro",
+		description: null,
+		group: null,
+		add_on: false,
+		items: [],
+		price: null,
+		free_trial: null,
+		...overrides,
+	}) as unknown as ApiPlanV1;
+
+describe("variant settings propagation on base rename", () => {
+	test("getVariantSettingsPatch includes name for same-plan version propagation", () => {
+		const patch = getVariantSettingsPatch({
+			from: plan({ name: "Pro" }),
+			to: plan({ name: "Pro Plus" }),
+		});
+
+		expect(patch).toEqual({ name: "Pro Plus" });
+	});
+
+	test("omitVariantOwnedSettings strips name but keeps other settings", () => {
+		const stripped = omitVariantOwnedSettings({
+			name: "Pro Plus",
+			description: "New description",
+		});
+
+		expect(stripped).toEqual({ description: "New description" });
+	});
+
+	test("base rename only produces an empty variant patch", () => {
+		const stripped = omitVariantOwnedSettings(
+			getVariantSettingsPatch({
+				from: plan({ name: "Pro" }),
+				to: plan({ name: "Pro Plus" }),
+			}),
+		);
+
+		expect(variantSettingsPatchHasValues(stripped)).toBe(false);
+	});
+
+	test("variant keeps its own name when base settings propagate", () => {
+		const settingsPatch = omitVariantOwnedSettings(
+			getVariantSettingsPatch({
+				from: plan({ name: "Pro", description: null }),
+				to: plan({ name: "Pro Plus", description: "Updated" }),
+			}),
+		);
+		const variantPlan = plan({ id: "pro_annual", name: "Pro Annual" });
+
+		const previewPlan = applyDiffToVariantPlan({
+			plan: variantPlan,
+			diff: {},
+			settingsPatch,
+		});
+
+		expect(previewPlan.name).toBe("Pro Annual");
+		expect(previewPlan.description).toBe("Updated");
+	});
+});

--- a/vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx
@@ -9,7 +9,9 @@ import {
 	type FullCustomer,
 	formatAmount,
 	fullCustomerToCustomerEntitlements,
-	isPrepaidCustomerEntitlement,
+	isOneOffPrice,
+	isPrepaidPrice,
+	isVolumeBasedCusEnt,
 	PurchaseLimitInterval,
 	type UsagePriceConfig,
 } from "@autumn/shared";
@@ -116,9 +118,25 @@ export function BillingAutoTopupSheet() {
 			featureId,
 		});
 
-		const prepaidCusEnt = cusEnts.find((cusEnt: FullCusEntWithFullCusProduct) =>
-			isPrepaidCustomerEntitlement(cusEnt),
-		);
+		const isOneOffPrepaid = (cusEnt: FullCusEntWithFullCusProduct) => {
+			const cusPrice = cusEntToCusPrice({ cusEnt });
+			return (
+				cusPrice &&
+				isOneOffPrice(cusPrice.price) &&
+				isPrepaidPrice(cusPrice.price) &&
+				!isVolumeBasedCusEnt(cusEnt)
+			);
+		};
+
+		// Mirror the backend's resolution for customer-level auto-topups: the
+		// most recently attached product's one-off prepaid price is charged.
+		const prepaidCusEnt = cusEnts
+			.filter(isOneOffPrepaid)
+			.sort(
+				(left, right) =>
+					(right.customer_product?.created_at ?? 0) -
+					(left.customer_product?.created_at ?? 0),
+			)[0];
 
 		if (!prepaidCusEnt) return { hasPrice: false as const };
 

--- a/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
+++ b/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
@@ -42,7 +42,6 @@ import {
 	useProductQueryState,
 } from "../../product/hooks/useProductQuery";
 import {
-	type AllVersionsUpdateMigrationTarget,
 	buildInPlaceUpdatePlanParams,
 	buildPreviewUpdatePlanParams,
 } from "./buildMigrationDraft";
@@ -96,56 +95,43 @@ function ConfirmInput({
 	);
 }
 
-const previewHasCustomersAcrossVersions = ({
-	preview,
-}: {
-	preview: Pick<PlanUpdatePreview, "has_customers" | "other_versions">;
-}) =>
-	preview.has_customers ||
-	(preview.other_versions ?? []).some((version) => version.has_customers);
-
-// Only item/price changes move existing customers; free-trial edits version
-// without a migration. Sourced from the backend preview.
-const entryHasMigratableDiff = (
-	entry: Pick<PlanUpdatePreview, "item_changes" | "price_change"> | undefined,
+// A version needs a migration only when it has customers to move AND a
+// migratable diff (item/price changes; free-trial edits version without one).
+const entryNeedsMigration = (
+	entry: Pick<
+		PlanUpdatePreview,
+		"item_changes" | "price_change" | "has_customers"
+	>,
 ) =>
-	(entry?.item_changes?.length ?? 0) > 0 || entry?.price_change !== undefined;
+	entry.has_customers &&
+	((entry.item_changes?.length ?? 0) > 0 || entry.price_change !== undefined);
 
-const collectAllVersionMigrationTargets = ({
+const hasMigrationTargets = ({
 	preview,
 	selectedVariantIds,
+	versionChoice,
 }: {
 	preview: PlanUpdatePreview | undefined;
 	selectedVariantIds: string[];
-}): AllVersionsUpdateMigrationTarget[] => {
-	if (!preview) return [];
+	versionChoice: VersionChoice;
+}): boolean => {
+	// New-version grandfathers everyone; update/all patch live versions.
+	if (!preview || versionChoice === "new") return false;
+	const includeHistorical = versionChoice === "all";
 
-	const targets: AllVersionsUpdateMigrationTarget[] = [];
-	if (
-		entryHasMigratableDiff(preview) &&
-		previewHasCustomersAcrossVersions({ preview })
-	) {
-		targets.push({ id: preview.plan_id, customize: preview.customize });
-	}
+	const baseEntries = [
+		preview,
+		...(includeHistorical ? (preview.other_versions ?? []) : []),
+	];
+	if (baseEntries.some(entryNeedsMigration)) return true;
 
-	for (const variantId of selectedVariantIds) {
-		const variantRows = preview.variants.filter(
-			(variant) => variant.plan_id === variantId,
-		);
-		const variantPreview = variantRows[0];
-		if (
-			variantPreview &&
-			entryHasMigratableDiff(variantPreview) &&
-			variantRows.some((row) => row.has_customers)
-		) {
-			targets.push({
-				id: variantPreview.plan_id,
-				customize: variantPreview.customize,
-			});
-		}
-	}
-
-	return targets;
+	return selectedVariantIds.some((variantId) => {
+		const entries = preview.variants
+			.filter((variant) => variant.plan_id === variantId)
+			.sort((a, b) => b.version - a.version);
+		const candidates = includeHistorical ? entries : entries.slice(0, 1);
+		return candidates.some(entryNeedsMigration);
+	});
 };
 
 export default function PlanChangeDialog({
@@ -245,21 +231,16 @@ export default function PlanChangeDialog({
 		[showScope, selectedVariantIds],
 	);
 
-	// Only item/price changes are migratable; free-trial edits version without
-	// ever moving existing customers.
-	const hasMigratableDiff = entryHasMigratableDiff(preview);
-	// Patch-in-place applies the change to the loaded version, so its existing
-	// customers need a migration. New-version intentionally grandfathers.
-	const baseNeedsMigration = versionChoice === "update" && hasMigratableDiff;
-	const allVersionsMigrationTargets = useMemo(
+	// Existing customers only need migrating when a patched version actually
+	// changes and has customers on it.
+	const migrateNeeded = useMemo(
 		() =>
-			versionChoice === "all"
-				? collectAllVersionMigrationTargets({
-						preview,
-						selectedVariantIds: effectiveVariantIds,
-					})
-				: [],
-		[versionChoice, preview, effectiveVariantIds],
+			hasMigrationTargets({
+				preview,
+				selectedVariantIds: effectiveVariantIds,
+				versionChoice,
+			}),
+		[preview, effectiveVariantIds, versionChoice],
 	);
 
 	const variantConflicts = useMemo<VariantConflictInfo[]>(
@@ -310,15 +291,6 @@ export default function PlanChangeDialog({
 			setVersionChoice("update");
 		}
 	}, [isMetadataOnly, isLatest, versionChoice]);
-
-	// New grandfathers everyone; update/all patch live versions, so their
-	// existing customers are migration targets. Variants only migrate when
-	// there's a migratable diff to push (not for billing-controls-only edits).
-	const migrateNeeded =
-		(versionChoice === "update" &&
-			(baseNeedsMigration ||
-				(effectiveVariantIds.length > 0 && hasMigratableDiff))) ||
-		allVersionsMigrationTargets.length > 0;
 
 	const migrateTargets = useMemo(() => {
 		if (!preview) return [];
@@ -648,7 +620,9 @@ export default function PlanChangeDialog({
 																</span>
 															</div>
 															<div className="rounded-lg bg-secondary/40 px-3 py-2.5">
-																<PlanSettingsChanges changes={settingsChanges} />
+																<PlanSettingsChanges
+																	changes={settingsChanges}
+																/>
 															</div>
 														</div>
 													)}


### PR DESCRIPTION
## Summary
- Variants own their `name`; renaming a base plan no longer overwrites variant names when settings propagate (added `omitVariantOwnedSettings`, removed `name` from `shouldApplyVariantUpdates` propagated fields).
- `detectVariantConflicts` no longer raises a false `different_interval` conflict for unpriced non-consumable entitlements — only flags it when a priced item is actually involved.
- Simplified `PlanChangeDialog.tsx` migration-target logic (`hasMigrationTargets`/`entryNeedsMigration`) to correctly check `has_customers` per version/variant for "update" and "all" version choices.

## Test plan
- [x] Added integration tests: base rename keeps variant name (update, propagated item update, and preview paths) in `server/tests/integration/crud/plans/variants/base-rename.test.ts`
- [x] Added unit tests for `omitVariantOwnedSettings`/settings propagation in `server/tests/unit/products/variantSettingsPropagation.test.ts`
- [x] Added unit tests for priced vs. unpriced non-consumable interval-conflict detection in `server/tests/unit/products/detectVariantConflicts.test.ts`

Cherry-picked from `729fd9093` on `fix/update-billing-controls-on-variant`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes variant name propagation and conflict detection so base renames don’t overwrite variant names, migration prompts only appear when customers would actually move, and the auto‑topup sheet charges the correct price.

- **Bug Fixes**
  - Variants now own their `name`; base plan renames no longer change variant names in preview or update paths (omit variant-owned settings; remove `name` from propagated fields).
  - Removed false `different_interval` conflicts for unpriced non-consumable entitlements; only flagged when a priced item is involved.
  - Simplified PlanChangeDialog migration logic to require migration only when the version has customers and item/price changes, honoring “update” vs “all” selections.
  - Fixed `BillingAutoTopupSheet` to pick the most recent one-off prepaid, non-volume price for auto-topups.

<sup>Written for commit 70f4af1f4b3aaafbd53901b6f58c9226aa9941f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two variant-related bugs and cleans up migration-target detection logic in the plan change dialog.

- **Bug fixes**: Renaming a base plan no longer overwrites variant names — `omitVariantOwnedSettings` strips `name` from the settings patch before propagation, and `name` is removed from `shouldApplyVariantUpdates`'s propagated fields so a name-only rename doesn't unnecessarily call `updateVariants` at all.
- **Bug fixes**: `detectVariantConflicts` no longer raises a false `different_interval` conflict for unpriced non-consumable entitlements; it now only flags the conflict when a priced item is actually involved on either side.
- **Improvements**: `hasMigrationTargets` in `PlanChangeDialog.tsx` replaces the previous dual-function approach with a single function that correctly gates on both `has_customers` and a migratable diff per version/variant, fixing a case where the migration prompt appeared even when no customers existed on the affected version.
</details>

<h3>Confidence Score: 5/5</h3>

All three fixes are narrowly scoped, each with corresponding unit and/or integration tests, and the changes are additive (new guard function, narrowed conflict condition, simplified boolean predicate).

The base-rename fix is applied consistently across all three call sites (update, preview, and the settings propagation gate). The interval-conflict narrowing is guarded behind both a feature-type check and a priced-item check, and both branches are tested. The `hasMigrationTargets` rewrite is simpler and more correct than the code it replaces — it no longer triggers a migration prompt when no customers exist on the affected version.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/product/actions/common/planTransformUtils.ts | Adds `omitVariantOwnedSettings` which destructures-away `name` from a `VariantSettingsPatch`; clean, minimal, and correct. |
| server/src/internal/product/actions/previewUpdatePlan/detectVariantConflicts.ts | Narrows `different_interval` conflict detection to only fire when a priced item is involved; replaces local `featureName` closure with shared `findFeatureById`. |
| server/src/internal/product/actions/previewUpdatePlan/previewAffectedVariants.ts | Applies `omitVariantOwnedSettings` to the settings patch before using it in variant previews; the `variantUpdate` branch already hard-codes `name: variant.name`, so both paths correctly preserve variant names. |
| server/src/internal/product/actions/updateProduct/shouldApplyVariantUpdates.ts | Removes `name` from `propagatedSettingFields` so a base rename alone no longer triggers the `updateVariants` path; correct complement to the `omitVariantOwnedSettings` fix. |
| server/src/internal/product/actions/updateVariants/updateVariants.ts | Wraps `getVariantSettingsPatch` with `omitVariantOwnedSettings` in the actual update path, ensuring names are never overwritten during propagation. |
| vite/src/views/products/plan/versioning/PlanChangeDialog.tsx | Replaces two-function migration-target approach with a single `hasMigrationTargets` that correctly requires both `has_customers` and a diff per version/variant, fixing spurious migration prompts. |
| server/tests/integration/crud/plans/variants/base-rename.test.ts | New integration tests covering update, propagated item update, and preview paths for base rename; concurrent tests with isolated scenario IDs. |
| server/tests/unit/products/detectVariantConflicts.test.ts | Extended tests with `FeatureType`/`FeatureUsageType` on the feature fixtures and new cases for priced vs unpriced non-consumable different-interval scenarios. |
| server/tests/unit/products/variantSettingsPropagation.test.ts | New unit tests validating that `omitVariantOwnedSettings` strips name, that a name-only patch becomes empty, and that variant names are preserved through `applyDiffToVariantPlan`. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Base plan rename / settings change] --> B{shouldApplyVariantUpdates?}
    B -- "name-only change" --> C[Skip updateVariants entirely]
    B -- "other settings changed OR variants selected" --> D[updateVariants called]

    D --> E[getVariantSettingsPatch\nfrom→to diff incl. name]
    E --> F[omitVariantOwnedSettings\nstrips 'name' from patch]
    F --> G{hasSettingsPatch?}
    G -- yes --> H[addSettingsPropagationJobs\nfor all variants]
    G -- no --> I[Only process selected variants]

    H --> J[updateVariant\nsettingsPatch applied\nvariant name preserved]
    I --> J

    subgraph Preview path
        P1[previewAffectedVariants] --> P2[omitVariantOwnedSettings\napplied to settingsPatch]
        P2 --> P3{variantUpdate?}
        P3 -- yes --> P4[name: variant.name\nexplicitly set]
        P3 -- no --> P5[applyDiffToVariantPlan\nwith stripped patch]
    end

    subgraph Conflict detection
        C1[detectVariantConflicts] --> C2{sharesInterval?}
        C2 -- no --> C3{hasPricedItem OR\nconsumable feature?}
        C3 -- yes --> C4[different_interval conflict]
        C3 -- no --> C5[No conflict\nunpriced non-consumable\npropagates cleanly]
        C2 -- yes --> C6{value divergence?}
        C6 -- yes --> C7[value_divergence conflict]
        C6 -- no --> C8[No conflict]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Base plan rename / settings change] --> B{shouldApplyVariantUpdates?}
    B -- "name-only change" --> C[Skip updateVariants entirely]
    B -- "other settings changed OR variants selected" --> D[updateVariants called]

    D --> E[getVariantSettingsPatch\nfrom→to diff incl. name]
    E --> F[omitVariantOwnedSettings\nstrips 'name' from patch]
    F --> G{hasSettingsPatch?}
    G -- yes --> H[addSettingsPropagationJobs\nfor all variants]
    G -- no --> I[Only process selected variants]

    H --> J[updateVariant\nsettingsPatch applied\nvariant name preserved]
    I --> J

    subgraph Preview path
        P1[previewAffectedVariants] --> P2[omitVariantOwnedSettings\napplied to settingsPatch]
        P2 --> P3{variantUpdate?}
        P3 -- yes --> P4[name: variant.name\nexplicitly set]
        P3 -- no --> P5[applyDiffToVariantPlan\nwith stripped patch]
    end

    subgraph Conflict detection
        C1[detectVariantConflicts] --> C2{sharesInterval?}
        C2 -- no --> C3{hasPricedItem OR\nconsumable feature?}
        C3 -- yes --> C4[different_interval conflict]
        C3 -- no --> C5[No conflict\nunpriced non-consumable\npropagates cleanly]
        C2 -- yes --> C6{value divergence?}
        C6 -- yes --> C7[value_divergence conflict]
        C6 -- no --> C8[No conflict]
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["bug fixes for variants"](https://github.com/useautumn/autumn/commit/db4ef3a75389e45e9445d461076cf6e880b3f9d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41423035)</sub>

<!-- /greptile_comment -->