### PR TITLE
Copying sandboxes

### DIFF
--- a/server/src/internal/products/handlers/handleCopyProduct/copyProductForOrgs.ts
+++ b/server/src/internal/products/handlers/handleCopyProduct/copyProductForOrgs.ts
@@ -98,10 +98,10 @@ export const copyProductForOrgs = async ({
 	// A variant's base_internal_product_id points at a product in the source
 	// org; there's no safe cross-org remap, so refuse rather than land a dangling
 	// reference.
-	if (crossOrg && fromFullProduct.base_internal_product_id) {
+	if (fromFullProduct.base_internal_product_id) {
 		throw new RecaseError({
 			message:
-				"Variant plans can't be promoted directly. Promote the base plan instead.",
+				"Variant plans can't be copied on their own. Copy the base plan instead.",
 			code: ErrCode.InvalidRequest,
 			statusCode: 400,
 		});

--- a/server/tests/integration/sandbox/promote-product.test.ts
+++ b/server/tests/integration/sandbox/promote-product.test.ts
@@ -173,10 +173,6 @@ const seedSub = async (sourceOrg: Organization) => {
 	await db
 		.update(productsTable)
 		.set({ base_internal_product_id: basePlan?.internal_id })
-		.where(eq(productsTable.internal_id, basePlan?.internal_id ?? ""));
-	await db
-		.update(productsTable)
-		.set({ base_internal_product_id: basePlan?.internal_id })
 		.where(
 			eq(
 				productsTable.internal_id,

--- a/vite/src/hooks/queries/useSandboxCatalogQuery.tsx
+++ b/vite/src/hooks/queries/useSandboxCatalogQuery.tsx
@@ -3,6 +3,13 @@ import { useQuery } from "@tanstack/react-query";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 
 export type CatalogItem = { id: string; name: string };
+export type CatalogProduct = CatalogItem & { featureIds: string[] };
+
+type RawProduct = {
+	id: string;
+	name: string;
+	items?: { feature_id?: string | null }[];
+};
 
 // Lists a SPECIFIC sandbox's plans + features by overriding x-sandbox-org-id
 // per request (skipSandbox keeps the interceptor from forcing the active one),
@@ -23,8 +30,15 @@ export const useSandboxCatalogQuery = (sandboxId: string | null) => {
 				axiosInstance.get("/v1/products", { headers }),
 				axiosInstance.post("/v1/features.list", {}, { headers }),
 			]);
+			const rawProducts = (productsRes.data?.list ?? []) as RawProduct[];
 			return {
-				products: (productsRes.data?.list ?? []) as CatalogItem[],
+				products: rawProducts.map((p) => ({
+					id: p.id,
+					name: p.name,
+					featureIds: (p.items ?? [])
+						.map((i) => i.feature_id)
+						.filter((id): id is string => Boolean(id)),
+				})) as CatalogProduct[],
 				features: (featuresRes.data?.list ?? []) as CatalogItem[],
 			};
 		},

--- a/vite/src/hooks/queries/useSandboxesQuery.tsx
+++ b/vite/src/hooks/queries/useSandboxesQuery.tsx
@@ -195,7 +195,10 @@ export const useCopySandbox = () => {
 		// Source is exactly one of fromSandboxId / fromMaster — a union so bad
 		// combos fail to compile instead of hitting a guaranteed server 400.
 		mutationFn: async (
-			input: ({ fromSandboxId: string } | { fromMaster: true }) & {
+			input: (
+				| { fromSandboxId: string; fromMaster?: never }
+				| { fromMaster: true; fromSandboxId?: never }
+			) & {
 				toSandboxId: string;
 				productIds?: string[];
 				featureIds?: string[];

--- a/vite/src/views/main-sidebar/env-dropdown/CopySandboxChecklist.tsx
+++ b/vite/src/views/main-sidebar/env-dropdown/CopySandboxChecklist.tsx
@@ -1,11 +1,13 @@
 import { Checkbox } from "@autumn/ui";
 import type { CatalogItem } from "@/hooks/queries/useSandboxCatalogQuery";
+import { cn } from "@/lib/utils";
 
 export const CopySandboxChecklist = ({
 	title,
 	kind,
 	items,
 	deselected,
+	forced,
 	onToggle,
 	isLoading,
 }: {
@@ -13,6 +15,7 @@ export const CopySandboxChecklist = ({
 	kind: string;
 	items: CatalogItem[];
 	deselected: Set<string>;
+	forced?: Set<string>;
 	onToggle: (id: string) => void;
 	isLoading: boolean;
 }) => {
@@ -25,23 +28,35 @@ export const CopySandboxChecklist = ({
 			{!isLoading && items.length === 0 && (
 				<span className="text-muted-foreground text-xs">None</span>
 			)}
-			{items.map((item) => (
-				<label
-					className="flex cursor-pointer select-none items-center gap-2 text-sm"
-					htmlFor={`copy-item-${kind}-${item.id}`}
-					key={item.id}
-				>
-					<Checkbox
-						checked={!deselected.has(item.id)}
-						id={`copy-item-${kind}-${item.id}`}
-						onCheckedChange={() => onToggle(item.id)}
-					/>
-					<span className="truncate">{item.name}</span>
-					<span className="truncate text-muted-foreground text-xs">
-						{item.id}
-					</span>
-				</label>
-			))}
+			{items.map((item) => {
+				const isForced = forced?.has(item.id) ?? false;
+				return (
+					<label
+						className={cn(
+							"flex select-none items-center gap-2 text-sm",
+							isForced ? "cursor-default" : "cursor-pointer",
+						)}
+						htmlFor={`copy-item-${kind}-${item.id}`}
+						key={item.id}
+					>
+						<Checkbox
+							checked={isForced || !deselected.has(item.id)}
+							disabled={isForced}
+							id={`copy-item-${kind}-${item.id}`}
+							onCheckedChange={() => onToggle(item.id)}
+						/>
+						<span className="truncate">{item.name}</span>
+						<span className="truncate text-muted-foreground text-xs">
+							{item.id}
+						</span>
+						{isForced && (
+							<span className="ml-auto shrink-0 text-muted-foreground text-xs">
+								required by a plan
+							</span>
+						)}
+					</label>
+				);
+			})}
 		</div>
 	);
 };

--- a/vite/src/views/main-sidebar/env-dropdown/CopySandboxChecklist.tsx
+++ b/vite/src/views/main-sidebar/env-dropdown/CopySandboxChecklist.tsx
@@ -7,7 +7,7 @@ export const CopySandboxChecklist = ({
 	kind,
 	items,
 	deselected,
-	forced,
+	forcedBy,
 	onToggle,
 	isLoading,
 }: {
@@ -15,7 +15,7 @@ export const CopySandboxChecklist = ({
 	kind: string;
 	items: CatalogItem[];
 	deselected: Set<string>;
-	forced?: Set<string>;
+	forcedBy?: Map<string, string[]>;
 	onToggle: (id: string) => void;
 	isLoading: boolean;
 }) => {
@@ -29,7 +29,8 @@ export const CopySandboxChecklist = ({
 				<span className="text-muted-foreground text-xs">None</span>
 			)}
 			{items.map((item) => {
-				const isForced = forced?.has(item.id) ?? false;
+				const requiredBy = forcedBy?.get(item.id) ?? [];
+				const isForced = requiredBy.length > 0;
 				return (
 					<label
 						className={cn(
@@ -41,17 +42,22 @@ export const CopySandboxChecklist = ({
 					>
 						<Checkbox
 							checked={isForced || !deselected.has(item.id)}
+							className={cn(isForced && "opacity-40")}
 							disabled={isForced}
 							id={`copy-item-${kind}-${item.id}`}
 							onCheckedChange={() => onToggle(item.id)}
 						/>
-						<span className="truncate">{item.name}</span>
+						<span
+							className={cn("truncate", isForced && "text-muted-foreground")}
+						>
+							{item.name}
+						</span>
 						<span className="truncate text-muted-foreground text-xs">
 							{item.id}
 						</span>
 						{isForced && (
 							<span className="ml-auto shrink-0 text-muted-foreground text-xs">
-								required by a plan
+								required by {requiredBy.join(", ")}
 							</span>
 						)}
 					</label>

--- a/vite/src/views/main-sidebar/env-dropdown/CopySandboxDialog.tsx
+++ b/vite/src/views/main-sidebar/env-dropdown/CopySandboxDialog.tsx
@@ -64,11 +64,15 @@ export const CopySandboxDialog = ({
 		});
 	};
 
-	const checkedProductIds = products
-		.filter((p) => !deselected.products.has(p.id))
-		.map((p) => p.id);
+	const checkedProducts = products.filter(
+		(p) => !deselected.products.has(p.id),
+	);
+	const checkedProductIds = checkedProducts.map((p) => p.id);
+	const forcedFeatureIds = new Set(
+		checkedProducts.flatMap((p) => p.featureIds),
+	);
 	const checkedFeatureIds = features
-		.filter((f) => !deselected.features.has(f.id))
+		.filter((f) => forcedFeatureIds.has(f.id) || !deselected.features.has(f.id))
 		.map((f) => f.id);
 	const nothingSelected =
 		checkedProductIds.length === 0 && checkedFeatureIds.length === 0;
@@ -139,6 +143,7 @@ export const CopySandboxDialog = ({
 							onToggle={(id) => toggle("features", id)}
 							title="Features"
 							deselected={deselected.features}
+							forced={forcedFeatureIds}
 						/>
 					</div>
 				)}

--- a/vite/src/views/main-sidebar/env-dropdown/CopySandboxDialog.tsx
+++ b/vite/src/views/main-sidebar/env-dropdown/CopySandboxDialog.tsx
@@ -68,11 +68,18 @@ export const CopySandboxDialog = ({
 		(p) => !deselected.products.has(p.id),
 	);
 	const checkedProductIds = checkedProducts.map((p) => p.id);
-	const forcedFeatureIds = new Set(
-		checkedProducts.flatMap((p) => p.featureIds),
-	);
+	const forcedBy = new Map<string, string[]>();
+	for (const p of checkedProducts) {
+		for (const fid of p.featureIds) {
+			const names = forcedBy.get(fid) ?? [];
+			if (!names.includes(p.name)) {
+				names.push(p.name);
+			}
+			forcedBy.set(fid, names);
+		}
+	}
 	const checkedFeatureIds = features
-		.filter((f) => forcedFeatureIds.has(f.id) || !deselected.features.has(f.id))
+		.filter((f) => forcedBy.has(f.id) || !deselected.features.has(f.id))
 		.map((f) => f.id);
 	const nothingSelected =
 		checkedProductIds.length === 0 && checkedFeatureIds.length === 0;
@@ -143,7 +150,7 @@ export const CopySandboxDialog = ({
 							onToggle={(id) => toggle("features", id)}
 							title="Features"
 							deselected={deselected.features}
-							forced={forcedFeatureIds}
+							forcedBy={forcedBy}
 						/>
 					</div>
 				)}

--- a/vite/src/views/products/products/components/product-list/ProductListRowToolbar.tsx
+++ b/vite/src/views/products/products/components/product-list/ProductListRowToolbar.tsx
@@ -159,52 +159,54 @@ export const ProductListRowToolbar = ({
 					</DropdownMenuTrigger>
 				</div>
 				<DropdownMenuContent align="end">
-					<DropdownMenuSub>
-						<DropdownMenuSubTrigger className="flex gap-2">
-							<CopyIcon />
-							Copy to
-						</DropdownMenuSubTrigger>
-						<DropdownMenuSubContent>
-							<DropdownMenuItem
-								className="flex gap-2"
-								onClick={(e) => {
-									e.stopPropagation();
-									e.preventDefault();
-									setDropdownOpen(false);
-									setCopyToEnv(AppEnv.Sandbox);
-									setCopyOpen(true);
-								}}
-							>
-								Sandbox
-							</DropdownMenuItem>
-							<DropdownMenuItem
-								className="flex gap-2"
-								onClick={(e) => {
-									e.stopPropagation();
-									e.preventDefault();
-									setDropdownOpen(false);
-									setCopyToEnv(AppEnv.Live);
-									setCopyOpen(true);
-								}}
-							>
-								Production
-							</DropdownMenuItem>
-							{otherSandboxes.length > 0 && <DropdownMenuSeparator />}
-							{otherSandboxes.map((s) => (
+					{!isVariant && (
+						<DropdownMenuSub>
+							<DropdownMenuSubTrigger className="flex gap-2">
+								<CopyIcon />
+								Copy to
+							</DropdownMenuSubTrigger>
+							<DropdownMenuSubContent>
 								<DropdownMenuItem
-									key={s.id}
 									className="flex gap-2"
 									onClick={(e) => {
 										e.stopPropagation();
 										e.preventDefault();
-										handleCopyToSandbox(s);
+										setDropdownOpen(false);
+										setCopyToEnv(AppEnv.Sandbox);
+										setCopyOpen(true);
 									}}
 								>
-									{s.name}
+									Sandbox
 								</DropdownMenuItem>
-							))}
-						</DropdownMenuSubContent>
-					</DropdownMenuSub>
+								<DropdownMenuItem
+									className="flex gap-2"
+									onClick={(e) => {
+										e.stopPropagation();
+										e.preventDefault();
+										setDropdownOpen(false);
+										setCopyToEnv(AppEnv.Live);
+										setCopyOpen(true);
+									}}
+								>
+									Production
+								</DropdownMenuItem>
+								{otherSandboxes.length > 0 && <DropdownMenuSeparator />}
+								{otherSandboxes.map((s) => (
+									<DropdownMenuItem
+										key={s.id}
+										className="flex gap-2"
+										onClick={(e) => {
+											e.stopPropagation();
+											e.preventDefault();
+											handleCopyToSandbox(s);
+										}}
+									>
+										{s.name}
+									</DropdownMenuItem>
+								))}
+							</DropdownMenuSubContent>
+						</DropdownMenuSub>
+					)}
 					{!isVariant && !product.archived && (
 						<DropdownMenuItem
 							className="flex gap-2"


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Blocks copying variant plans and makes the copy dialog auto-include and lock features required by selected plans, showing which plan requires them. Also tightens copy-source typing and fixes a sandbox test fixture.

- **New Features**
  - Copy Sandbox dialog auto-checks and disables required features, labeled “required by <plan names>”.

- **Bug Fixes**
  - Server rejects copying a variant plan with a clearer error.
  - UI hides “Copy to” actions for variant plans.
  - Stricter union for `useCopySandbox` input to prevent invalid sources.
  - Fixed sandbox test fixture setup.

<sup>Written for commit aa638dbe0293af8044434be7d068ead7476f0d38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds the ability to copy plans and features from one named sandbox into another, with automatic dependency enforcement — features required by a selected plan are locked and always included in the copy operation.

- **Improvements**: The sandbox copy dialog now builds a `forcedBy` map from checked products' `featureIds`, rendering dependent features as disabled checkboxes labelled "required by \<product\>" so users understand why they can't be deselected; the server already enforced this dependency but the UI was silent about it.
- **Bug fixes**: A long-standing test seed bug is fixed where `BASE_PLAN` was inadvertently setting its own `base_internal_product_id` to itself (making it look like a variant), which silently prevented it from being promoted in tests.
- **Improvements**: The variant-copy guard in `copyProductForOrgs` is widened from cross-org only to all copy contexts, and the "Copy to" submenu is now hidden entirely for variant products in the per-product toolbar, preventing a guaranteed server 400.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge; the logic is well-structured and the server-side path for sandbox copies is independent of the variant guard change.

All behavioral changes are intentional and consistent: the variant guard widening in copyProductForOrgs is paired with the UI change hiding 'Copy to' for variants, the test seed fix corrects a self-referential product setup that was masking promotion failures, and the forcedBy UI logic mirrors server-side behavior that was already enforced. The only gap is a comment in copyProductForOrgs that still says 'cross-org' despite the guard now covering same-org cross-env copies too.

The explanatory comment on lines 98–100 of copyProductForOrgs.ts should be updated to cover same-org cross-env copies, not just cross-org ones.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/products/handlers/handleCopyProduct/copyProductForOrgs.ts | Widens variant-copy block from cross-org only to all copy operations; comment still says 'cross-org' but guard now fires for same-org cross-env copies too. |
| server/tests/integration/sandbox/promote-product.test.ts | Removes an erroneous SQL update that set BASE_PLAN's base_internal_product_id to itself (self-referential variant), leaving only the correct update that marks VARIANT_PLAN as a variant of BASE_PLAN. |
| vite/src/hooks/queries/useSandboxCatalogQuery.tsx | Adds CatalogProduct type with featureIds extracted from product items; used downstream to build the forcedBy map for the feature checklist. |
| vite/src/views/main-sidebar/env-dropdown/CopySandboxChecklist.tsx | Adds forcedBy prop to render features as disabled/locked with a 'required by <product names>' label when a checked product depends on them. |
| vite/src/views/main-sidebar/env-dropdown/CopySandboxDialog.tsx | Builds a forcedBy map from checked products' featureIds and passes it to the feature checklist; forced features are always included in checkedFeatureIds regardless of the deselected set. |
| vite/src/views/products/products/components/product-list/ProductListRowToolbar.tsx | Wraps the entire 'Copy to' submenu in !isVariant to hide it for variant products, consistent with the server-side block in copyProductForOrgs. |


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens Copy Sandbox Dialog] --> B[Select source sandbox]
    B --> C[useSandboxCatalogQuery fetches products + features]
    C --> D[Products rendered in checklist\nAll checked by default]
    D --> E{User toggles product}
    E -->|deselect| F[Product added to deselected.products]
    E -->|select| G[Product stays in checkedProducts]
    G --> H[Build forcedBy map\nproduct.featureIds → product.name]
    H --> I{Feature in forcedBy?}
    I -->|yes| J[Feature checkbox disabled\nlabelled 'required by P']
    I -->|no| K[Feature checkbox toggleable]
    J --> L[Feature always in checkedFeatureIds]
    K --> M{Feature in deselected.features?}
    M -->|yes| N[Feature excluded from checkedFeatureIds]
    M -->|no| L
    L --> O[POST /v1/sandboxes.copy\nproductIds + featureIds]
    O --> P[copySandboxForOrg\nhandleCopyProducts + handleCopyFeatures]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User opens Copy Sandbox Dialog] --> B[Select source sandbox]
    B --> C[useSandboxCatalogQuery fetches products + features]
    C --> D[Products rendered in checklist\nAll checked by default]
    D --> E{User toggles product}
    E -->|deselect| F[Product added to deselected.products]
    E -->|select| G[Product stays in checkedProducts]
    G --> H[Build forcedBy map\nproduct.featureIds → product.name]
    H --> I{Feature in forcedBy?}
    I -->|yes| J[Feature checkbox disabled\nlabelled 'required by P']
    I -->|no| K[Feature checkbox toggleable]
    J --> L[Feature always in checkedFeatureIds]
    K --> M{Feature in deselected.features?}
    M -->|yes| N[Feature excluded from checkedFeatureIds]
    M -->|no| L
    L --> O[POST /v1/sandboxes.copy\nproductIds + featureIds]
    O --> P[copySandboxForOrg\nhandleCopyProducts + handleCopyFeatures]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/products/handlers/handleCopyProduct/copyProductForOrgs.ts`, line 98-108 ([link](https://github.com/useautumn/autumn/blob/aa638dbe0293af8044434be7d068ead7476f0d38/server/src/internal/products/handlers/handleCopyProduct/copyProductForOrgs.ts#L98-L108)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Comment no longer matches the widened guard**

   The prose still says "there's no safe *cross-org* remap" as the only reason to block variant copies, but the `crossOrg &&` condition was intentionally dropped — meaning the guard now fires for same-org sandbox→live copies too. That's correct: `base_internal_product_id` stores an `internal_id` that is unique to its `(org, env)` pair, so copying a variant to a different env (even within the same org) would create a dangling reference regardless of whether the orgs differ. The comment should be updated to cover this wider case so future readers don't re-introduce the `crossOrg` guard thinking the same-env path is safe.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/products/handlers/handleCopyProduct/copyProductForOrgs.ts
   Line: 98-108

   Comment:
   **Comment no longer matches the widened guard**

   The prose still says "there's no safe *cross-org* remap" as the only reason to block variant copies, but the `crossOrg &&` condition was intentionally dropped — meaning the guard now fires for same-org sandbox→live copies too. That's correct: `base_internal_product_id` stores an `internal_id` that is unique to its `(org, env)` pair, so copying a variant to a different env (even within the same org) would create a dangling reference regardless of whether the orgs differ. The comment should be updated to cover this wider case so future readers don't re-introduce the `crossOrg` guard thinking the same-env path is safe.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/products/handlers/handleCopyProduct/copyProductForOrgs.ts:98-108
**Comment no longer matches the widened guard**

The prose still says "there's no safe *cross-org* remap" as the only reason to block variant copies, but the `crossOrg &&` condition was intentionally dropped — meaning the guard now fires for same-org sandbox→live copies too. That's correct: `base_internal_product_id` stores an `internal_id` that is unique to its `(org, env)` pair, so copying a variant to a different env (even within the same org) would create a dangling reference regardless of whether the orgs differ. The comment should be updated to cover this wider case so future readers don't re-introduce the `crossOrg` guard thinking the same-env path is safe.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sandboxes): grey out plan-required f..."](https://github.com/useautumn/autumn/commit/aa638dbe0293af8044434be7d068ead7476f0d38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41464555)</sub>

<!-- /greptile_comment -->