### PR TITLE
Allow free first schedule phase

### DIFF
--- a/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
@@ -110,12 +110,14 @@ export const setupImmediateMultiProductBillingContext = async ({
 	preview = false,
 	billingStartsAt,
 	billingStartsAtToleranceMs,
+	fetchScheduledCustomerProductSchedule,
 }: {
 	ctx: AutumnContext;
 	params: MultiAttachParamsV0;
 	preview?: boolean;
 	billingStartsAt?: number;
 	billingStartsAtToleranceMs?: number;
+	fetchScheduledCustomerProductSchedule?: boolean;
 }): Promise<MultiAttachBillingContext> => {
 	const fullCustomer = await setupFullCustomerContext({
 		ctx,
@@ -188,6 +190,7 @@ export const setupImmediateMultiProductBillingContext = async ({
 		params,
 		skipSubscriptionFetching: fullProducts.every(isOneOffProduct),
 		newBillingSubscription: params.new_billing_subscription || undefined,
+		fetchScheduledCustomerProductSchedule,
 		createStripeCustomerIfMissing: !preview,
 	});
 

--- a/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
@@ -110,14 +110,14 @@ export const setupImmediateMultiProductBillingContext = async ({
 	preview = false,
 	billingStartsAt,
 	billingStartsAtToleranceMs,
-	fetchScheduledCustomerProductSchedule,
+	includeScheduledProductsForScheduleLookup,
 }: {
 	ctx: AutumnContext;
 	params: MultiAttachParamsV0;
 	preview?: boolean;
 	billingStartsAt?: number;
 	billingStartsAtToleranceMs?: number;
-	fetchScheduledCustomerProductSchedule?: boolean;
+	includeScheduledProductsForScheduleLookup?: boolean;
 }): Promise<MultiAttachBillingContext> => {
 	const fullCustomer = await setupFullCustomerContext({
 		ctx,
@@ -190,7 +190,7 @@ export const setupImmediateMultiProductBillingContext = async ({
 		params,
 		skipSubscriptionFetching: fullProducts.every(isOneOffProduct),
 		newBillingSubscription: params.new_billing_subscription || undefined,
-		fetchScheduledCustomerProductSchedule,
+		includeScheduledProductsForScheduleLookup,
 		createStripeCustomerIfMissing: !preview,
 	});
 

--- a/server/src/internal/billing/v2/actions/createSchedule/errors/handleCreateScheduleErrors.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/errors/handleCreateScheduleErrors.ts
@@ -2,6 +2,7 @@ import {
 	type CreateScheduleBillingContext,
 	ErrCode,
 	isFreeProduct,
+	isProductPaidAndRecurring,
 	RecaseError,
 } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle";
@@ -51,8 +52,14 @@ export const handleCreateScheduleErrors = async ({
 		const subscriptionWillBeCanceled =
 			productsOnSub.length > 0 &&
 			productsOnSub.every((cp) => transitioningOutIds.has(cp.id));
+		const hasFuturePaidRecurringPhase =
+			billingContext.scheduledPhaseContexts.some((phase) =>
+				phase.productContexts.some((ctx) =>
+					isProductPaidAndRecurring(ctx.fullProduct),
+				),
+			);
 
-		if (subscriptionWillBeCanceled) {
+		if (subscriptionWillBeCanceled && !hasFuturePaidRecurringPhase) {
 			throw new RecaseError({
 				message:
 					"Cannot create a schedule with a free first phase while the customer has an active subscription. Please cancel the existing subscription first.",

--- a/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
@@ -117,6 +117,15 @@ const getCurrentPhaseIndex = ({
 	return currentPhaseIndex;
 };
 
+const hasScheduledCustomerProducts = ({
+	billingContext,
+}: {
+	billingContext: Pick<CreateScheduleBillingContext, "fullCustomer">;
+}) =>
+	billingContext.fullCustomer.customer_products.some(
+		(customerProduct) => (customerProduct.scheduled_ids?.length ?? 0) > 0,
+	);
+
 /** Build billing context for the immediate phase. */
 export const setupCreateScheduleBillingContext = async ({
 	ctx,
@@ -160,7 +169,10 @@ export const setupCreateScheduleBillingContext = async ({
 		currentEpochMs: billingContext.currentEpochMs,
 		cycleBoundaryMs,
 	});
-	const immediatePhaseIndex = billingContext.stripeSubscriptionSchedule
+	const isExistingScheduleUpdate =
+		billingContext.stripeSubscriptionSchedule ||
+		hasScheduledCustomerProducts({ billingContext });
+	const immediatePhaseIndex = isExistingScheduleUpdate
 		? getCurrentPhaseIndex({
 				phases: normalizedPhases,
 				currentEpochMs: billingContext.currentEpochMs,

--- a/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
@@ -73,6 +73,50 @@ const setupCreateScheduleCheckoutMode = ({
 	return null;
 };
 
+const phaseToImmediateParams = ({
+	params,
+	phase,
+}: {
+	params: CreateScheduleParamsV0;
+	phase: CreateScheduleParamsV0["phases"][number];
+}): MultiAttachParamsV0 => ({
+	customer_id: params.customer_id,
+	entity_id: params.entity_id,
+	plans: phase.plans.map((plan) => ({
+		plan_id: plan.plan_id,
+		customize: plan.customize,
+		feature_quantities: plan.feature_quantities,
+		version: plan.version,
+		subscription_id: plan.subscription_id,
+	})),
+	invoice_mode: params.invoice_mode,
+	discounts: params.discounts,
+	success_url: params.success_url,
+	checkout_session_params: params.checkout_session_params,
+	redirect_mode: params.redirect_mode ?? "if_required",
+	enable_plan_immediately: params.enable_plan_immediately,
+});
+
+const getCurrentPhaseIndex = ({
+	phases,
+	currentEpochMs,
+}: {
+	phases: ReturnType<typeof normalizeCreateSchedulePhases>;
+	currentEpochMs: number;
+}) => {
+	let currentPhaseIndex = 0;
+
+	for (let index = 0; index < phases.length; index++) {
+		const phase = phases[index];
+		if (!phase || phase.starts_at > currentEpochMs + FIRST_PHASE_TOLERANCE_MS) {
+			break;
+		}
+		currentPhaseIndex = index;
+	}
+
+	return currentPhaseIndex;
+};
+
 /** Build billing context for the immediate phase. */
 export const setupCreateScheduleBillingContext = async ({
 	ctx,
@@ -87,27 +131,9 @@ export const setupCreateScheduleBillingContext = async ({
 		phases: params.phases,
 	});
 
-	const immediateParams = {
-		customer_id: params.customer_id,
-		entity_id: params.entity_id,
-		plans: initialPhase.plans.map((plan) => ({
-			plan_id: plan.plan_id,
-			customize: plan.customize,
-			feature_quantities: plan.feature_quantities,
-			version: plan.version,
-			subscription_id: plan.subscription_id,
-		})),
-		invoice_mode: params.invoice_mode,
-		discounts: params.discounts,
-		success_url: params.success_url,
-		checkout_session_params: params.checkout_session_params,
-		redirect_mode: params.redirect_mode ?? "if_required",
-		enable_plan_immediately: params.enable_plan_immediately,
-	} satisfies MultiAttachParamsV0;
-
-	const billingContext = await setupImmediateMultiProductBillingContext({
+	let billingContext = await setupImmediateMultiProductBillingContext({
 		ctx,
-		params: immediateParams,
+		params: phaseToImmediateParams({ params, phase: initialPhase }),
 		preview,
 		billingStartsAt: phaseHasNumericStart(initialPhase)
 			? initialPhase.starts_at
@@ -134,7 +160,25 @@ export const setupCreateScheduleBillingContext = async ({
 		currentEpochMs: billingContext.currentEpochMs,
 		cycleBoundaryMs,
 	});
-	const [immediatePhase, ...futurePhases] = normalizedPhases;
+	const immediatePhaseIndex = billingContext.stripeSubscriptionSchedule
+		? getCurrentPhaseIndex({
+				phases: normalizedPhases,
+				currentEpochMs: billingContext.currentEpochMs,
+			})
+		: 0;
+	const immediatePhase = normalizedPhases[immediatePhaseIndex]!;
+
+	if (immediatePhaseIndex > 0) {
+		billingContext = await setupImmediateMultiProductBillingContext({
+			ctx,
+			params: phaseToImmediateParams({ params, phase: immediatePhase }),
+			preview,
+			billingStartsAt: immediatePhase.starts_at,
+			billingStartsAtToleranceMs: FIRST_PHASE_TOLERANCE_MS,
+		});
+	}
+
+	const futurePhases = normalizedPhases.slice(immediatePhaseIndex + 1);
 
 	const scheduledPhaseContexts = await setupScheduledProductsContext({
 		ctx,

--- a/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
@@ -5,6 +5,7 @@ import {
 	isOneOffProduct,
 	isPastStartDate,
 	isProductPaidAndRecurring,
+	type MultiAttachBillingContext,
 	type MultiAttachParamsV0,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
@@ -120,11 +121,57 @@ const getCurrentPhaseIndex = ({
 const hasScheduledCustomerProducts = ({
 	billingContext,
 }: {
-	billingContext: Pick<CreateScheduleBillingContext, "fullCustomer">;
+	billingContext: Pick<MultiAttachBillingContext, "fullCustomer">;
 }) =>
 	billingContext.fullCustomer.customer_products.some(
 		(customerProduct) => (customerProduct.scheduled_ids?.length ?? 0) > 0,
 	);
+
+const setupCreateScheduleImmediatePhase = async ({
+	ctx,
+	params,
+	preview,
+	billingContext,
+	normalizedPhases,
+}: {
+	ctx: AutumnContext;
+	params: CreateScheduleParamsV0;
+	preview: boolean;
+	billingContext: MultiAttachBillingContext;
+	normalizedPhases: ReturnType<typeof normalizeCreateSchedulePhases>;
+}) => {
+	const isExistingScheduleUpdate =
+		billingContext.stripeSubscriptionSchedule ||
+		hasScheduledCustomerProducts({ billingContext });
+	const immediatePhaseIndex = isExistingScheduleUpdate
+		? getCurrentPhaseIndex({
+				phases: normalizedPhases,
+				currentEpochMs: billingContext.currentEpochMs,
+			})
+		: 0;
+	const immediatePhase = normalizedPhases[immediatePhaseIndex]!;
+
+	if (immediatePhaseIndex === 0) {
+		return {
+			billingContext,
+			immediatePhase,
+			futurePhases: normalizedPhases.slice(1),
+		};
+	}
+
+	return {
+		billingContext: await setupImmediateMultiProductBillingContext({
+			ctx,
+			params: phaseToImmediateParams({ params, phase: immediatePhase }),
+			preview,
+			billingStartsAt: immediatePhase.starts_at,
+			billingStartsAtToleranceMs: FIRST_PHASE_TOLERANCE_MS,
+			includeScheduledProductsForScheduleLookup: true,
+		}),
+		immediatePhase,
+		futurePhases: normalizedPhases.slice(immediatePhaseIndex + 1),
+	};
+};
 
 /** Build billing context for the immediate phase. */
 export const setupCreateScheduleBillingContext = async ({
@@ -170,29 +217,15 @@ export const setupCreateScheduleBillingContext = async ({
 		currentEpochMs: billingContext.currentEpochMs,
 		cycleBoundaryMs,
 	});
-	const isExistingScheduleUpdate =
-		billingContext.stripeSubscriptionSchedule ||
-		hasScheduledCustomerProducts({ billingContext });
-	const immediatePhaseIndex = isExistingScheduleUpdate
-		? getCurrentPhaseIndex({
-				phases: normalizedPhases,
-				currentEpochMs: billingContext.currentEpochMs,
-			})
-		: 0;
-	const immediatePhase = normalizedPhases[immediatePhaseIndex]!;
-
-	if (immediatePhaseIndex > 0) {
-		billingContext = await setupImmediateMultiProductBillingContext({
-			ctx,
-			params: phaseToImmediateParams({ params, phase: immediatePhase }),
-			preview,
-			billingStartsAt: immediatePhase.starts_at,
-			billingStartsAtToleranceMs: FIRST_PHASE_TOLERANCE_MS,
-			includeScheduledProductsForScheduleLookup: true,
-		});
-	}
-
-	const futurePhases = normalizedPhases.slice(immediatePhaseIndex + 1);
+	const immediatePhaseContext = await setupCreateScheduleImmediatePhase({
+		ctx,
+		params,
+		preview,
+		billingContext,
+		normalizedPhases,
+	});
+	billingContext = immediatePhaseContext.billingContext;
+	const { immediatePhase, futurePhases } = immediatePhaseContext;
 
 	const scheduledPhaseContexts = await setupScheduledProductsContext({
 		ctx,

--- a/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
@@ -148,6 +148,7 @@ export const setupCreateScheduleBillingContext = async ({
 			? initialPhase.starts_at
 			: undefined,
 		billingStartsAtToleranceMs: FIRST_PHASE_TOLERANCE_MS,
+		fetchScheduledCustomerProductSchedule: true,
 	});
 
 	validateCreateSchedulePhasePlans({
@@ -187,6 +188,7 @@ export const setupCreateScheduleBillingContext = async ({
 			preview,
 			billingStartsAt: immediatePhase.starts_at,
 			billingStartsAtToleranceMs: FIRST_PHASE_TOLERANCE_MS,
+			fetchScheduledCustomerProductSchedule: true,
 		});
 	}
 

--- a/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
@@ -148,7 +148,7 @@ export const setupCreateScheduleBillingContext = async ({
 			? initialPhase.starts_at
 			: undefined,
 		billingStartsAtToleranceMs: FIRST_PHASE_TOLERANCE_MS,
-		fetchScheduledCustomerProductSchedule: true,
+		includeScheduledProductsForScheduleLookup: true,
 	});
 
 	validateCreateSchedulePhasePlans({
@@ -188,7 +188,7 @@ export const setupCreateScheduleBillingContext = async ({
 			preview,
 			billingStartsAt: immediatePhase.starts_at,
 			billingStartsAtToleranceMs: FIRST_PHASE_TOLERANCE_MS,
-			fetchScheduledCustomerProductSchedule: true,
+			includeScheduledProductsForScheduleLookup: true,
 		});
 	}
 
@@ -221,11 +221,11 @@ export const setupCreateScheduleBillingContext = async ({
 		customPrices: [
 			...(billingContext.customPrices ?? []),
 			...scheduledCustomPrices,
-		], // combine custom prices from immediate and scheduled phases
+		],
 		customEnts: [
 			...(billingContext.customEnts ?? []),
 			...scheduledCustomEntitlements,
-		], // combine custom prices and entitlements from immediate and scheduled phases
+		],
 		isCustom:
 			billingContext.isCustom ||
 			scheduledCustomPrices.length > 0 ||

--- a/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeSubscriptionAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeSubscriptionAction.ts
@@ -7,10 +7,12 @@ import type {
 } from "@autumn/shared";
 import { stripePhaseStartsInFuture } from "@autumn/shared";
 import type { AutumnContext } from "@server/honoUtils/HonoEnv";
+import type Stripe from "stripe";
 import { buildStripeSubscriptionItemsUpdate } from "@server/internal/billing/v2/providers/stripe/utils/subscriptionItems/buildStripeSubscriptionItemsUpdate";
 import { buildStripeSubscriptionCreateAction } from "@server/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionCreateAction";
 import { buildStripeSubscriptionUpdateAction } from "@server/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionUpdateAction";
 import { billingPlanToOneOffStripeItemSpecs } from "@/internal/billing/v2/providers/stripe/utils/stripeItemSpec/billingPlanToOneOffStripeItemSpecs";
+import { buildFreeRecurringPlaceholderItem } from "../utils/subscriptionSchedules/buildStripePhasesUpdate";
 
 const subscriptionStartsInFuture = ({
 	billingContext,
@@ -93,11 +95,33 @@ export const buildStripeSubscriptionAction = ({
 	}
 
 	// Case 4: Cancel subscription
-	if (
+	const deletesAllSubscriptionItems =
 		stripeSubscription &&
 		subItemsUpdate.length === stripeSubscription.items.data.length &&
-		subItemsUpdate.every((item) => item.deleted)
+		subItemsUpdate.every((item) => item.deleted);
+
+	if (
+		deletesAllSubscriptionItems &&
+		(stripeSubscriptionScheduleAction?.type === "create" ||
+			stripeSubscriptionScheduleAction?.type === "update")
 	) {
+		const placeholderItem = buildFreeRecurringPlaceholderItem({
+			ctx,
+			customerProducts: finalCustomerProducts,
+		}) as Stripe.SubscriptionUpdateParams.Item | undefined;
+		if (placeholderItem) {
+			return buildStripeSubscriptionUpdateAction({
+				ctx,
+				billingContext,
+				autumnBillingPlan,
+				subItemsUpdate: [placeholderItem, ...subItemsUpdate],
+				stripeSubscriptionScheduleAction,
+				subscriptionCancelAt,
+			});
+		}
+	}
+
+	if (deletesAllSubscriptionItems) {
 		return {
 			type: "cancel" as const,
 			stripeSubscriptionId: stripeSubscription.id,

--- a/server/src/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext.ts
+++ b/server/src/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext.ts
@@ -36,6 +36,7 @@ export const setupStripeBillingContext = async ({
 	newBillingSubscription,
 	skipBillingFetching,
 	skipSubscriptionFetching,
+	fetchScheduledCustomerProductSchedule = false,
 	createStripeCustomerIfMissing = true,
 	fetchTaxRate = false,
 }: {
@@ -48,6 +49,7 @@ export const setupStripeBillingContext = async ({
 	newBillingSubscription?: boolean;
 	skipBillingFetching?: boolean;
 	skipSubscriptionFetching?: boolean;
+	fetchScheduledCustomerProductSchedule?: boolean;
 	createStripeCustomerIfMissing?: boolean;
 	fetchTaxRate?: boolean;
 }) => {
@@ -106,7 +108,9 @@ export const setupStripeBillingContext = async ({
 		async stripeSubscriptionSchedule() {
 			const localStripeSubscription = await this.$.stripeSubscription;
 
-			return targetCustomerProduct || notNullish(localStripeSubscription)
+			return targetCustomerProduct ||
+				notNullish(localStripeSubscription) ||
+				fetchScheduledCustomerProductSchedule
 				? fetchStripeSubscriptionScheduleForBilling({
 						ctx,
 						fullCus: fullCustomer,

--- a/server/src/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext.ts
+++ b/server/src/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext.ts
@@ -36,7 +36,7 @@ export const setupStripeBillingContext = async ({
 	newBillingSubscription,
 	skipBillingFetching,
 	skipSubscriptionFetching,
-	fetchScheduledCustomerProductSchedule = false,
+	includeScheduledProductsForScheduleLookup = false,
 	createStripeCustomerIfMissing = true,
 	fetchTaxRate = false,
 }: {
@@ -49,7 +49,7 @@ export const setupStripeBillingContext = async ({
 	newBillingSubscription?: boolean;
 	skipBillingFetching?: boolean;
 	skipSubscriptionFetching?: boolean;
-	fetchScheduledCustomerProductSchedule?: boolean;
+	includeScheduledProductsForScheduleLookup?: boolean;
 	createStripeCustomerIfMissing?: boolean;
 	fetchTaxRate?: boolean;
 }) => {
@@ -110,7 +110,7 @@ export const setupStripeBillingContext = async ({
 
 			return targetCustomerProduct ||
 				notNullish(localStripeSubscription) ||
-				fetchScheduledCustomerProductSchedule
+				includeScheduledProductsForScheduleLookup
 				? fetchStripeSubscriptionScheduleForBilling({
 						ctx,
 						fullCus: fullCustomer,

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/buildStripePhasesUpdate.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/buildStripePhasesUpdate.ts
@@ -148,14 +148,14 @@ const stripeDiscountsToPhaseDiscounts = ({
 	);
 };
 
-export const getBillingCycleAnchorResetAt = ({
+export const getBillingCycleAnchorResetAts = ({
 	customerProducts,
 	nowMs,
 }: {
 	customerProducts: FullCusProduct[];
 	nowMs: number;
 }) => {
-	const futureResetTimestamps = Array.from(
+	return Array.from(
 		new Set(
 			customerProducts
 				.map(
@@ -167,12 +167,21 @@ export const getBillingCycleAnchorResetAt = ({
 				),
 		),
 	).sort((a, b) => a - b);
+};
 
-	if (futureResetTimestamps.length === 0) {
-		return undefined;
-	}
+export const getBillingCycleAnchorResetAt = ({
+	customerProducts,
+	nowMs,
+}: {
+	customerProducts: FullCusProduct[];
+	nowMs: number;
+}) => {
+	const resetTimestamps = getBillingCycleAnchorResetAts({
+		customerProducts,
+		nowMs,
+	});
 
-	return futureResetTimestamps[0];
+	return resetTimestamps[0];
 };
 
 /**
@@ -201,7 +210,7 @@ export const buildStripePhasesUpdate = ({
 	const normalizedCustomerProducts = customerProducts.map(
 		normalizeCustomerProductTimestamps,
 	);
-	const billingCycleAnchorResetAt = getBillingCycleAnchorResetAt({
+	const billingCycleAnchorResetAts = getBillingCycleAnchorResetAts({
 		customerProducts: normalizedCustomerProducts,
 		nowMs,
 	});
@@ -211,7 +220,7 @@ export const buildStripePhasesUpdate = ({
 		customerProducts: normalizedCustomerProducts,
 		nowMs,
 		trialEndsAt: normalizedTrialEndsAt,
-		newBillingCycleAnchorMs: billingCycleAnchorResetAt,
+		newBillingCycleAnchorMs: billingCycleAnchorResetAts,
 	});
 
 	const debugLogs = false;
@@ -297,7 +306,7 @@ export const buildStripePhasesUpdate = ({
 
 		const phaseStartDateSeconds = msToSeconds(startMs);
 		const isBillingCycleAnchorResetPhase =
-			billingCycleAnchorResetAt === startMs;
+			billingCycleAnchorResetAts.includes(startMs);
 		const hasOneOffInvoiceItems = phaseAddInvoiceItems.length > 0;
 		const shouldInvoicePhaseTransition =
 			phaseIndex > 0 && phaseItems.length > 0;

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/buildStripePhasesUpdate.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/buildStripePhasesUpdate.ts
@@ -79,7 +79,7 @@ const customerProductsToPhaseItems = ({
 	return [...storedItems, ...inlineItems];
 };
 
-const buildFreePhasePlaceholderItem = ({
+export const buildFreeRecurringPlaceholderItem = ({
 	ctx,
 	customerProducts,
 }: {
@@ -257,15 +257,20 @@ export const buildStripePhasesUpdate = ({
 			phaseStartMs: startMs,
 			phaseEndMs: endMs,
 		});
+		const needsFreePhasePlaceholder =
+			endMs &&
+			(activeCustomerProducts.length > 0 ||
+				(normalizedCustomerProducts.some(
+					(product) => product.starts_at < startMs,
+				) &&
+					normalizedCustomerProducts.some(
+						(product) => product.starts_at >= endMs,
+					)));
 		if (
 			phaseItems.length === 0 &&
-			endMs &&
-			normalizedCustomerProducts.some(
-				(product) => product.starts_at < startMs,
-			) &&
-			normalizedCustomerProducts.some((product) => product.starts_at >= endMs)
+			needsFreePhasePlaceholder
 		) {
-			const placeholderItem = buildFreePhasePlaceholderItem({
+			const placeholderItem = buildFreeRecurringPlaceholderItem({
 				ctx,
 				customerProducts: normalizedCustomerProducts,
 			});

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/buildStripePhasesUpdate.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/buildStripePhasesUpdate.ts
@@ -148,7 +148,7 @@ const stripeDiscountsToPhaseDiscounts = ({
 	);
 };
 
-const getBillingCycleAnchorResetAt = ({
+export const getBillingCycleAnchorResetAt = ({
 	customerProducts,
 	nowMs,
 }: {
@@ -163,7 +163,7 @@ const getBillingCycleAnchorResetAt = ({
 				)
 				.filter(
 					(resetAt): resetAt is number =>
-						typeof resetAt === "number" && resetAt > nowMs,
+						typeof resetAt === "number" && resetAt >= nowMs,
 				),
 		),
 	).sort((a, b) => a - b);

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/buildTransitionPoints.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/buildTransitionPoints.ts
@@ -19,13 +19,18 @@ export const buildTransitionPoints = ({
 	customerProducts: FullCusProduct[];
 	nowMs?: number;
 	trialEndsAt?: number;
-	newBillingCycleAnchorMs?: number;
+	newBillingCycleAnchorMs?: number | number[];
 }): (number | undefined)[] => {
 	const timestamps = new Set<number>();
 
 	// Add new billing cycle anchor as a transition point
-	if (newBillingCycleAnchorMs && newBillingCycleAnchorMs > nowMs) {
-		timestamps.add(newBillingCycleAnchorMs);
+	const billingCycleAnchorMs = Array.isArray(newBillingCycleAnchorMs)
+		? newBillingCycleAnchorMs
+		: [newBillingCycleAnchorMs];
+	for (const anchorMs of billingCycleAnchorMs) {
+		if (anchorMs && anchorMs > nowMs) {
+			timestamps.add(anchorMs);
+		}
 	}
 
 	for (const customerProduct of customerProducts) {

--- a/server/tests/integration/billing/create-schedule/params/create-schedule-free-first-phase.test.ts
+++ b/server/tests/integration/billing/create-schedule/params/create-schedule-free-first-phase.test.ts
@@ -3,7 +3,9 @@
 
 import { expect, test } from "bun:test";
 import {
+	type AttachPreviewResponse,
 	BillingInterval,
+	type CreateScheduleParamsV0Input,
 	CusProductStatus,
 	customerProducts,
 	ms,
@@ -54,6 +56,15 @@ const newInvoices = ({
 	beforeIds: Set<string>;
 	invoices: Stripe.Invoice[];
 }) => invoices.filter((invoice) => !beforeIds.has(invoice.id));
+
+const previewCreateSchedule = async ({
+	autumnV1,
+	params,
+}: {
+	autumnV1: Awaited<ReturnType<typeof initScenario>>["autumnV1"];
+	params: CreateScheduleParamsV0Input;
+}): Promise<AttachPreviewResponse> =>
+	await autumnV1.post("/billing.preview_create_schedule", params);
 
 test.concurrent(
 	`${chalk.yellowBright("create-schedule free first phase: active subscription resumes paid future phase")}`,
@@ -250,6 +261,7 @@ test.concurrent(
 		const clockStart = Date.UTC(2027, 4, 2, 16, 49);
 		const scheduleStartsAt = Date.UTC(2027, 5, 30, 13, 11);
 		const badQuarterlyStartsAt = Date.UTC(2027, 6, 2, 16, 49);
+		const postCorrectionPreviewAt = Date.UTC(2027, 6, 6, 12, 0);
 		const noChargeCheckAt = Date.UTC(2027, 7, 2, 17, 0);
 		const paidStartsAt = Date.UTC(2027, 9, 2, 12, 0);
 		const freeStartsAt = Date.UTC(2028, 3, 2, 12, 0);
@@ -281,10 +293,6 @@ test.concurrent(
 				}),
 			],
 		});
-		const commercialFree = products.base({
-			id: "commercial-free-access",
-			items: [items.monthlyMessages({ includedUsage: 500 })],
-		});
 
 		const { autumnV1, customer, ctx } = await initScenario({
 			customerId,
@@ -295,16 +303,15 @@ test.concurrent(
 					stripeCustomerOverrides: { test_clock: testClock.id },
 				}),
 				s.products({
-					list: [
-						agencyMonthly,
-						rpsAddOn,
-						commercialQuarterly,
-						commercialFree,
-					],
+					list: [agencyMonthly, rpsAddOn, commercialQuarterly],
 				}),
 			],
 			actions: [s.billing.attach({ productId: agencyMonthly.id })],
 		});
+		const freeCommercialPlan = {
+			plan_id: commercialQuarterly.id,
+			customize: { price: null },
+		};
 
 		await advanceTestClock({
 			stripeCli: ctx.stripeCli,
@@ -326,7 +333,7 @@ test.concurrent(
 				},
 				{
 					starts_at: freeStartsAt,
-					plans: [{ plan_id: commercialFree.id }],
+					plans: [freeCommercialPlan],
 				},
 				{
 					starts_at: paidResumesAt,
@@ -352,7 +359,7 @@ test.concurrent(
 			invoicesAfterBadCharge.data.some((invoice) => invoice.total === 67391),
 		).toBe(true);
 
-		await autumnV1.billing.createSchedule({
+		const correctedScheduleParams = {
 			customer_id: customerId,
 			billing_behavior: "none",
 			phases: [
@@ -362,7 +369,7 @@ test.concurrent(
 				},
 				{
 					starts_at: badQuarterlyStartsAt,
-					plans: [{ plan_id: commercialFree.id }],
+					plans: [freeCommercialPlan],
 				},
 				{
 					starts_at: paidStartsAt,
@@ -371,7 +378,7 @@ test.concurrent(
 				},
 				{
 					starts_at: freeStartsAt,
-					plans: [{ plan_id: commercialFree.id }],
+					plans: [freeCommercialPlan],
 				},
 				{
 					starts_at: paidResumesAt,
@@ -379,6 +386,20 @@ test.concurrent(
 					plans: [{ plan_id: commercialQuarterly.id }],
 				},
 			],
+		} satisfies CreateScheduleParamsV0Input;
+
+		await autumnV1.billing.createSchedule(correctedScheduleParams);
+
+		await advanceTestClock({
+			stripeCli: ctx.stripeCli,
+			testClockId: testClock.id,
+			advanceTo: postCorrectionPreviewAt,
+			waitForSeconds: 30,
+		});
+
+		await previewCreateSchedule({
+			autumnV1,
+			params: correctedScheduleParams,
 		});
 
 		const subscriptions = await ctx.stripeCli.subscriptions.list({

--- a/server/tests/integration/billing/create-schedule/params/create-schedule-free-first-phase.test.ts
+++ b/server/tests/integration/billing/create-schedule/params/create-schedule-free-first-phase.test.ts
@@ -11,6 +11,8 @@ import {
 import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import globalCtx from "@tests/utils/testInitUtils/createTestContext";
+import { advanceTestClock } from "@tests/utils/stripeUtils";
 import { addMonths } from "date-fns";
 import { and, eq } from "drizzle-orm";
 import type Stripe from "stripe";
@@ -28,9 +30,30 @@ const findSchedulePhase = ({
 		(phase) => Math.abs(phase.start_date * 1000 - startsAt) < ms.minutes(1),
 	);
 
+const findSchedulePhaseAt = ({
+	schedule,
+	timestamp,
+}: {
+	schedule: Stripe.SubscriptionSchedule;
+	timestamp: number;
+}) =>
+	schedule.phases.find(
+		(phase) =>
+			phase.start_date * 1000 <= timestamp &&
+			(!phase.end_date || phase.end_date * 1000 > timestamp),
+	);
+
 const expandedStripePrice = (
 	price: Stripe.SubscriptionSchedule.Phase.Item["price"] | undefined,
 ) => (price && typeof price !== "string" && !("deleted" in price) ? price : undefined);
+
+const newInvoices = ({
+	beforeIds,
+	invoices,
+}: {
+	beforeIds: Set<string>;
+	invoices: Stripe.Invoice[];
+}) => invoices.filter((invoice) => !beforeIds.has(invoice.id));
 
 test.concurrent(
 	`${chalk.yellowBright("create-schedule free first phase: active subscription resumes paid future phase")}`,
@@ -128,5 +151,253 @@ test.concurrent(
 		const paidPrice = expandedStripePrice(paidStripePhase?.items[0]?.price);
 		expect(paidPrice?.recurring?.interval).toBe("month");
 		expect(paidPrice?.recurring?.interval_count).toBe(3);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("create-schedule free current phase: resumes quarterly billing in October with reset anchor")}`,
+	async () => {
+		const customerId = "create-schedule-free-current-october-reset";
+		const clockStart = Date.UTC(2027, 4, 2, 16, 49);
+		const scheduleStartsAt = Date.UTC(2027, 5, 30, 13, 11);
+		const badQuarterlyStartsAt = Date.UTC(2027, 6, 2, 16, 49);
+		const noChargeCheckAt = Date.UTC(2027, 7, 2, 17, 0);
+		const paidStartsAt = Date.UTC(2027, 9, 2, 12, 0);
+		const freeStartsAt = Date.UTC(2028, 3, 2, 12, 0);
+		const paidResumesAt = Date.UTC(2028, 6, 2, 12, 0);
+
+		const testClock = await globalCtx.stripeCli.testHelpers.testClocks.create({
+			frozen_time: Math.floor(clockStart / 1000),
+		});
+
+		const agencyMonthly = products.base({
+			id: "agency-premium",
+			items: [
+				items.monthlyMessages({ includedUsage: 500 }),
+				items.monthlyPrice({ price: 499 }),
+			],
+		});
+		const rpsAddOn = products.base({
+			id: "plus-5-rps",
+			isAddOn: true,
+			items: [items.monthlyMessages({ includedUsage: 5 })],
+		});
+		const commercialQuarterly = products.base({
+			id: "commercial-quarterly",
+			items: [
+				items.monthlyMessages({ includedUsage: 500 }),
+				constructPriceItem({
+					price: 2000,
+					interval: BillingInterval.Quarter,
+				}),
+			],
+		});
+		const commercialFree = products.base({
+			id: "commercial-free-access",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		const { autumnV1, customer, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({
+					testClock: false,
+					paymentMethod: "success",
+					stripeCustomerOverrides: { test_clock: testClock.id },
+				}),
+				s.products({
+					list: [
+						agencyMonthly,
+						rpsAddOn,
+						commercialQuarterly,
+						commercialFree,
+					],
+				}),
+			],
+			actions: [s.billing.attach({ productId: agencyMonthly.id })],
+		});
+
+		await advanceTestClock({
+			stripeCli: ctx.stripeCli,
+			testClockId: testClock.id,
+			advanceTo: scheduleStartsAt,
+			waitForSeconds: 30,
+		});
+
+		await autumnV1.billing.createSchedule({
+			customer_id: customerId,
+			phases: [
+				{
+					starts_at: scheduleStartsAt,
+					plans: [{ plan_id: agencyMonthly.id }, { plan_id: rpsAddOn.id }],
+				},
+				{
+					starts_at: badQuarterlyStartsAt,
+					plans: [{ plan_id: commercialQuarterly.id }],
+				},
+				{
+					starts_at: freeStartsAt,
+					plans: [{ plan_id: commercialFree.id }],
+				},
+				{
+					starts_at: paidResumesAt,
+					plans: [{ plan_id: commercialQuarterly.id }],
+				},
+			],
+		});
+
+		await advanceTestClock({
+			stripeCli: ctx.stripeCli,
+			testClockId: testClock.id,
+			advanceTo: badQuarterlyStartsAt,
+			waitForSeconds: 30,
+		});
+
+		const stripeCustomerId = customer.processor?.id;
+		expect(stripeCustomerId).toBeDefined();
+		const invoicesAfterBadCharge = await ctx.stripeCli.invoices.list({
+			customer: stripeCustomerId!,
+			limit: 20,
+		});
+		expect(
+			invoicesAfterBadCharge.data.some((invoice) => invoice.total === 67391),
+		).toBe(true);
+
+		await autumnV1.billing.createSchedule({
+			customer_id: customerId,
+			billing_behavior: "none",
+			phases: [
+				{
+					starts_at: scheduleStartsAt,
+					plans: [{ plan_id: agencyMonthly.id }, { plan_id: rpsAddOn.id }],
+				},
+				{
+					starts_at: badQuarterlyStartsAt,
+					plans: [{ plan_id: commercialFree.id }],
+				},
+				{
+					starts_at: paidStartsAt,
+					billing_cycle_anchor: "phase_start",
+					plans: [{ plan_id: commercialQuarterly.id }],
+				},
+				{
+					starts_at: freeStartsAt,
+					plans: [{ plan_id: commercialFree.id }],
+				},
+				{
+					starts_at: paidResumesAt,
+					billing_cycle_anchor: "phase_start",
+					plans: [{ plan_id: commercialQuarterly.id }],
+				},
+			],
+		});
+
+		const subscriptions = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCustomerId!,
+			status: "all",
+			limit: 10,
+			expand: ["data.schedule"],
+		});
+		const subscription = subscriptions.data.find((sub) => sub.schedule);
+		expect(subscription).toBeDefined();
+		const stripeScheduleId =
+			typeof subscription?.schedule === "string"
+				? subscription.schedule
+				: subscription?.schedule?.id;
+		expect(stripeScheduleId).toBeDefined();
+
+		const schedule = await ctx.stripeCli.subscriptionSchedules.retrieve(
+			stripeScheduleId!,
+			{ expand: ["phases.items.price"] },
+		);
+		const currentFreePhase = findSchedulePhaseAt({
+			schedule,
+			timestamp: badQuarterlyStartsAt,
+		});
+		expect(currentFreePhase).toBeDefined();
+		const hasPaidCurrentItem = currentFreePhase!.items.some(
+			(item) => (expandedStripePrice(item.price)?.unit_amount ?? 0) > 0,
+		);
+		expect(hasPaidCurrentItem).toBe(false);
+
+		const currentSubscription = await ctx.stripeCli.subscriptions.retrieve(
+			subscription!.id,
+			{ expand: ["items.data.price"] },
+		);
+		expect(
+			currentSubscription.items.data.every(
+				(item) => item.price.unit_amount === 0,
+			),
+		).toBe(true);
+
+		const octoberPaidPhase = findSchedulePhase({
+			schedule,
+			startsAt: paidStartsAt,
+		});
+		expect(octoberPaidPhase?.billing_cycle_anchor).toBe("phase_start");
+		const julyPaidPhase = findSchedulePhase({
+			schedule,
+			startsAt: paidResumesAt,
+		});
+		expect(julyPaidPhase?.billing_cycle_anchor).toBe("phase_start");
+
+		const invoiceIdsBeforeAugust = new Set(
+			invoicesAfterBadCharge.data.map((invoice) => invoice.id),
+		);
+		await advanceTestClock({
+			stripeCli: ctx.stripeCli,
+			testClockId: testClock.id,
+			advanceTo: noChargeCheckAt,
+			waitForSeconds: 30,
+		});
+		const invoicesAfterAugust = await ctx.stripeCli.invoices.list({
+			customer: stripeCustomerId!,
+			limit: 20,
+		});
+		const augustInvoices = newInvoices({
+			beforeIds: invoiceIdsBeforeAugust,
+			invoices: invoicesAfterAugust.data,
+		});
+		expect(augustInvoices.every((invoice) => invoice.total === 0)).toBe(true);
+
+		const invoiceIdsBeforeOctober = new Set(
+			invoicesAfterAugust.data.map((invoice) => invoice.id),
+		);
+		await advanceTestClock({
+			stripeCli: ctx.stripeCli,
+			testClockId: testClock.id,
+			advanceTo: paidStartsAt,
+			waitForSeconds: 30,
+		});
+		const invoicesAfterOctober = await ctx.stripeCli.invoices.list({
+			customer: stripeCustomerId!,
+			limit: 20,
+		});
+		const octoberPaidInvoices = newInvoices({
+			beforeIds: invoiceIdsBeforeOctober,
+			invoices: invoicesAfterOctober.data,
+		}).filter((invoice) => invoice.total > 0);
+		expect(octoberPaidInvoices.map((invoice) => invoice.total)).toEqual([
+			200000,
+		]);
+
+		const paidSubscription = await ctx.stripeCli.subscriptions.retrieve(
+			subscription!.id,
+			{ expand: ["items.data.price"] },
+		);
+		const subscriptionItem = paidSubscription.items.data[0];
+		expect(subscriptionItem).toBeDefined();
+		expect(
+			Math.abs(subscriptionItem!.current_period_start * 1000 - paidStartsAt),
+		).toBeLessThan(ms.minutes(1));
+		expect(
+			Math.abs(
+				subscriptionItem!.current_period_end * 1000 -
+					Date.UTC(2028, 0, 2, 12, 0),
+			),
+		).toBeLessThan(ms.minutes(1));
+		const stripePrice = subscriptionItem?.price;
+		expect(stripePrice?.recurring?.interval).toBe("month");
+		expect(stripePrice?.recurring?.interval_count).toBe(3);
 	},
 );

--- a/server/tests/integration/billing/create-schedule/params/create-schedule-free-first-phase.test.ts
+++ b/server/tests/integration/billing/create-schedule/params/create-schedule-free-first-phase.test.ts
@@ -155,6 +155,95 @@ test.concurrent(
 );
 
 test.concurrent(
+	`${chalk.yellowBright("create-schedule free historical first phase: reset current paid phase")}`,
+	async () => {
+		const customerId = "create-schedule-reset-historical-free";
+		const clockStart = Date.UTC(2027, 0, 1, 12, 0);
+		const paidStartsAt = clockStart + ms.days(1);
+		const nextPaidStartsAt = paidStartsAt + ms.days(30);
+		const editAt = paidStartsAt + ms.hours(1);
+
+		const testClock = await globalCtx.stripeCli.testHelpers.testClocks.create({
+			frozen_time: Math.floor(clockStart / 1000),
+		});
+
+		const paid = products.pro({
+			id: "paid-after-historical-free",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+		const nextPaid = products.pro({
+			id: "next-paid-after-historical-free",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+		const free = products.base({
+			id: "historical-free-access",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		const { autumnV1, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({
+					testClock: false,
+					paymentMethod: "success",
+					stripeCustomerOverrides: { test_clock: testClock.id },
+				}),
+				s.products({ list: [paid, nextPaid, free] }),
+			],
+			actions: [s.billing.attach({ productId: paid.id })],
+		});
+
+		await autumnV1.billing.createSchedule({
+			customer_id: customerId,
+			billing_behavior: "none",
+			phases: [
+				{ starts_at: clockStart, plans: [{ plan_id: free.id }] },
+				{ starts_at: paidStartsAt, plans: [{ plan_id: paid.id }] },
+				{ starts_at: nextPaidStartsAt, plans: [{ plan_id: nextPaid.id }] },
+			],
+		});
+
+		await advanceTestClock({
+			stripeCli: ctx.stripeCli,
+			testClockId: testClock.id,
+			advanceTo: editAt,
+			waitForSeconds: 30,
+		});
+
+		const response = await autumnV1.billing.createSchedule({
+			customer_id: customerId,
+			billing_behavior: "none",
+			phases: [
+				{ starts_at: clockStart, plans: [{ plan_id: free.id }] },
+				{
+					starts_at: paidStartsAt,
+					billing_cycle_anchor: "phase_start",
+					plans: [{ plan_id: paid.id }],
+				},
+				{
+					starts_at: nextPaidStartsAt,
+					billing_cycle_anchor: "phase_start",
+					plans: [{ plan_id: nextPaid.id }],
+				},
+			],
+		});
+
+		const nextPaidPhase = response.phases.find(
+			(phase) => Math.abs(phase.starts_at - nextPaidStartsAt) < ms.minutes(1),
+		);
+		expect(nextPaidPhase).toBeDefined();
+		const [nextPaidCustomerProduct] = await ctx.db
+			.select()
+			.from(customerProducts)
+			.where(eq(customerProducts.id, nextPaidPhase!.customer_product_ids[0]!));
+
+		expect(nextPaidCustomerProduct?.billing_cycle_anchor_resets_at).toBe(
+			nextPaidPhase!.starts_at,
+		);
+	},
+);
+
+test.concurrent(
 	`${chalk.yellowBright("create-schedule free current phase: resumes quarterly billing in October with reset anchor")}`,
 	async () => {
 		const customerId = "create-schedule-free-current-october-reset";

--- a/server/tests/integration/billing/create-schedule/params/create-schedule-free-first-phase.test.ts
+++ b/server/tests/integration/billing/create-schedule/params/create-schedule-free-first-phase.test.ts
@@ -1,0 +1,132 @@
+// Regression: active subscriptions can be corrected with a prepaid/free first
+// phase, then resume paid billing on a future phase.
+
+import { expect, test } from "bun:test";
+import {
+	BillingInterval,
+	CusProductStatus,
+	customerProducts,
+	ms,
+} from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import { addMonths } from "date-fns";
+import { and, eq } from "drizzle-orm";
+import type Stripe from "stripe";
+import { constructPriceItem } from "@/internal/products/product-items/productItemUtils";
+import chalk from "chalk";
+
+const findSchedulePhase = ({
+	schedule,
+	startsAt,
+}: {
+	schedule: Stripe.SubscriptionSchedule;
+	startsAt: number;
+}) =>
+	schedule.phases.find(
+		(phase) => Math.abs(phase.start_date * 1000 - startsAt) < ms.minutes(1),
+	);
+
+const expandedStripePrice = (
+	price: Stripe.SubscriptionSchedule.Phase.Item["price"] | undefined,
+) => (price && typeof price !== "string" && !("deleted" in price) ? price : undefined);
+
+test.concurrent(
+	`${chalk.yellowBright("create-schedule free first phase: active subscription resumes paid future phase")}`,
+	async () => {
+		const customerId = "create-schedule-free-first-active-sub";
+		const paid = products.base({
+			id: "commercial-quarterly",
+			items: [
+				items.monthlyMessages({ includedUsage: 500 }),
+				constructPriceItem({
+					price: 2000,
+					interval: BillingInterval.Quarter,
+				}),
+			],
+		});
+		const free = products.base({
+			id: "commercial-free-access",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		const { autumnV1, ctx, advancedTo } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [paid, free] }),
+			],
+			actions: [s.billing.attach({ productId: paid.id })],
+		});
+
+		const [paidBefore] = await ctx.db
+			.select()
+			.from(customerProducts)
+			.where(
+				and(
+					eq(customerProducts.customer_id, customerId),
+					eq(customerProducts.product_id, paid.id),
+					eq(customerProducts.status, CusProductStatus.Active),
+				),
+			);
+		const stripeSubscriptionId = paidBefore?.subscription_ids?.[0];
+		expect(stripeSubscriptionId).toBeDefined();
+
+		const paidPhaseStartsAt = addMonths(advancedTo, 3).getTime();
+		const response = await autumnV1.billing.createSchedule({
+			customer_id: customerId,
+			billing_behavior: "none",
+			phases: [
+				{
+					starts_at: advancedTo,
+					plans: [{ plan_id: free.id }],
+				},
+				{
+					starts_at: paidPhaseStartsAt,
+					billing_cycle_anchor: "phase_start",
+					plans: [{ plan_id: paid.id }],
+				},
+			],
+		});
+
+		const freeCustomerProductId = response.phases[0]?.customer_product_ids[0];
+		expect(freeCustomerProductId).toBeDefined();
+		const [freeCustomerProduct] = await ctx.db
+			.select()
+			.from(customerProducts)
+			.where(eq(customerProducts.id, freeCustomerProductId!));
+		expect(freeCustomerProduct?.status).toBe(CusProductStatus.Active);
+		expect(freeCustomerProduct?.ended_at).toBe(response.phases[1]?.starts_at);
+
+		const subscription = await ctx.stripeCli.subscriptions.retrieve(
+			stripeSubscriptionId!,
+		);
+		const stripeScheduleId =
+			typeof subscription.schedule === "string"
+				? subscription.schedule
+				: subscription.schedule?.id;
+		expect(stripeScheduleId).toBeDefined();
+
+		const schedule = await ctx.stripeCli.subscriptionSchedules.retrieve(
+			stripeScheduleId!,
+			{ expand: ["phases.items.price"] },
+		);
+		const freeStripePhase = findSchedulePhase({
+			schedule,
+			startsAt: response.phases[0]!.starts_at,
+		});
+		expect(freeStripePhase).toBeDefined();
+		const freePrice = expandedStripePrice(freeStripePhase?.items[0]?.price);
+		expect(freePrice?.unit_amount).toBe(0);
+
+		const paidStripePhase = findSchedulePhase({
+			schedule,
+			startsAt: response.phases[1]!.starts_at,
+		});
+		expect(paidStripePhase?.billing_cycle_anchor).toBe("phase_start");
+		const paidPrice = expandedStripePrice(paidStripePhase?.items[0]?.price);
+		expect(paidPrice?.recurring?.interval).toBe("month");
+		expect(paidPrice?.recurring?.interval_count).toBe(3);
+	},
+);

--- a/server/tests/unit/billing/subscription-schedules/billing-cycle-anchor-reset-at.test.ts
+++ b/server/tests/unit/billing/subscription-schedules/billing-cycle-anchor-reset-at.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import type { FullCusProduct } from "@autumn/shared";
-import { getBillingCycleAnchorResetAt } from "@/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/buildStripePhasesUpdate";
+import {
+	getBillingCycleAnchorResetAt,
+	getBillingCycleAnchorResetAts,
+} from "@/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/buildStripePhasesUpdate";
 
 const customerProductWithResetAt = (
 	billingCycleAnchorResetsAt: number | null,
@@ -30,5 +33,22 @@ describe("getBillingCycleAnchorResetAt", () => {
 				nowMs: now,
 			}),
 		).toBeUndefined();
+	});
+
+	test("keeps every reset timestamp from current and future phases", () => {
+		const now = Date.UTC(2026, 6, 21, 11);
+		const october = Date.UTC(2026, 9, 3, 15, 52, 33);
+		const january = Date.UTC(2027, 0, 3, 15, 52, 35);
+
+		expect(
+			getBillingCycleAnchorResetAts({
+				customerProducts: [
+					customerProductWithResetAt(now),
+					customerProductWithResetAt(october),
+					customerProductWithResetAt(january),
+				],
+				nowMs: now,
+			}),
+		).toEqual([now, october, january]);
 	});
 });

--- a/server/tests/unit/billing/subscription-schedules/billing-cycle-anchor-reset-at.test.ts
+++ b/server/tests/unit/billing/subscription-schedules/billing-cycle-anchor-reset-at.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import type { FullCusProduct } from "@autumn/shared";
+import { getBillingCycleAnchorResetAt } from "@/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/buildStripePhasesUpdate";
+
+const customerProductWithResetAt = (
+	billingCycleAnchorResetsAt: number | null,
+) =>
+	({
+		billing_cycle_anchor_resets_at: billingCycleAnchorResetsAt,
+	}) as FullCusProduct;
+
+describe("getBillingCycleAnchorResetAt", () => {
+	test("keeps a reset timestamp that starts at the current phase", () => {
+		const now = Date.UTC(2026, 6, 22, 11);
+
+		expect(
+			getBillingCycleAnchorResetAt({
+				customerProducts: [customerProductWithResetAt(now)],
+				nowMs: now,
+			}),
+		).toBe(now);
+	});
+
+	test("ignores reset timestamps before the current phase", () => {
+		const now = Date.UTC(2026, 6, 22, 11);
+
+		expect(
+			getBillingCycleAnchorResetAt({
+				customerProducts: [customerProductWithResetAt(now - 1000)],
+				nowMs: now,
+			}),
+		).toBeUndefined();
+	});
+});

--- a/vite/src/components/forms/create-schedule/components/CreateScheduleAdvancedSection.tsx
+++ b/vite/src/components/forms/create-schedule/components/CreateScheduleAdvancedSection.tsx
@@ -4,6 +4,10 @@ import {
 	AdvancedSection,
 	ConfigRow,
 } from "@/components/forms/shared/advanced-section";
+import {
+	canResetScheduleBillingCycle,
+	hasMultipleImmediateSchedulePlans,
+} from "../createScheduleFormSchema";
 import { useCreateScheduleFormContext } from "../context/CreateScheduleFormProvider";
 
 export function CreateScheduleAdvancedSection() {
@@ -22,17 +26,23 @@ export function CreateScheduleAdvancedSection() {
 	}, [isCheckoutRedirect, enablePlanImmediately, form]);
 
 	const isProrate = billingBehavior !== "none";
-	const hasMultipleImmediatePlans = (phases[0]?.plans.length ?? 0) > 1;
-	const disabledReason = hasMultipleImmediatePlans
+	const hasMultipleImmediatePlans = hasMultipleImmediateSchedulePlans({ phases });
+	const prorateDisabledReason = hasMultipleImmediatePlans
 		? "Not yet supported for multi attach"
 		: null;
+	const resetDisabledReason =
+		hasMultipleImmediatePlans && !canResetScheduleBillingCycle({ phases })
+			? "Not yet supported for multi attach"
+			: null;
 
 	const renderToggle = ({
 		checked,
 		onCheckedChange,
+		disabledReason,
 	}: {
 		checked: boolean;
 		onCheckedChange: (checked: boolean) => void;
+		disabledReason: string | null;
 	}): ReactNode => (
 		<Tooltip>
 			<TooltipTrigger asChild>
@@ -57,6 +67,7 @@ export function CreateScheduleAdvancedSection() {
 					checked: isProrate,
 					onCheckedChange: (checked) =>
 						form.setFieldValue("billingBehavior", checked ? null : "none"),
+					disabledReason: prorateDisabledReason,
 				})}
 			/>
 			<ConfigRow
@@ -66,6 +77,7 @@ export function CreateScheduleAdvancedSection() {
 					checked: resetBillingCycle,
 					onCheckedChange: (checked) =>
 						form.setFieldValue("resetBillingCycle", !!checked),
+					disabledReason: resetDisabledReason,
 				})}
 			/>
 			{isCheckoutRedirect && (

--- a/vite/src/components/forms/create-schedule/createScheduleFormSchema.ts
+++ b/vite/src/components/forms/create-schedule/createScheduleFormSchema.ts
@@ -35,6 +35,25 @@ export function hasPersistedCreateSchedule({
 	return phases[0]?.persistedStartsAt != null;
 }
 
+export function hasMultipleImmediateSchedulePlans({
+	phases,
+}: {
+	phases: SchedulePhase[];
+}) {
+	return (phases[0]?.plans.filter((plan) => plan.productId).length ?? 0) > 1;
+}
+
+export function canResetScheduleBillingCycle({
+	phases,
+}: {
+	phases: SchedulePhase[];
+}) {
+	return (
+		!hasMultipleImmediateSchedulePlans({ phases }) ||
+		hasPersistedCreateSchedule({ phases })
+	);
+}
+
 export function getCurrentCreateSchedulePhaseIndex({
 	phases,
 	nowMs = Date.now(),

--- a/vite/src/components/forms/create-schedule/createScheduleFormSchema.ts
+++ b/vite/src/components/forms/create-schedule/createScheduleFormSchema.ts
@@ -40,7 +40,12 @@ export function hasMultipleImmediateSchedulePlans({
 }: {
 	phases: SchedulePhase[];
 }) {
-	return (phases[0]?.plans.filter((plan) => plan.productId).length ?? 0) > 1;
+	const immediatePhase = phases.find((phase) =>
+		phase.plans.some((plan) => plan.productId),
+	);
+	return (
+		(immediatePhase?.plans.filter((plan) => plan.productId).length ?? 0) > 1
+	);
 }
 
 export function canResetScheduleBillingCycle({

--- a/vite/src/components/forms/create-schedule/hooks/useCreateScheduleRequestBody.ts
+++ b/vite/src/components/forms/create-schedule/hooks/useCreateScheduleRequestBody.ts
@@ -20,10 +20,8 @@ type CreatePlanItemParams = Omit<
 };
 
 import {
-	canResetScheduleBillingCycle,
 	getCreateSchedulePhaseTimingError,
 	hasPersistedCreateSchedule,
-	hasMultipleImmediateSchedulePlans,
 	type SchedulePhase,
 } from "../createScheduleFormSchema";
 
@@ -135,9 +133,6 @@ export function buildCreateScheduleRequestBody({
 	if (!customerId || phases.length === 0) return null;
 	if (getCreateSchedulePhaseTimingError({ phases, nowMs: now })) return null;
 	const hasPersistedSchedule = hasPersistedCreateSchedule({ phases });
-	const hasMultipleImmediatePlans = hasMultipleImmediateSchedulePlans({ phases });
-	const canResetFuturePhases =
-		resetBillingCycle && canResetScheduleBillingCycle({ phases });
 
 	const apiPhases = phases.map((phase, index) => {
 		// The first phase starts immediately (now) unless backdating is allowed —
@@ -177,9 +172,6 @@ export function buildCreateScheduleRequestBody({
 		return {
 			starts_at: startsAt,
 			plans,
-			...(index > 0 && canResetFuturePhases
-				? { billing_cycle_anchor: "phase_start" as const }
-				: {}),
 		};
 	});
 
@@ -188,9 +180,19 @@ export function buildCreateScheduleRequestBody({
 	);
 	if (validPhases.length === 0) return null;
 
+	const hasMultipleImmediatePlans = (validPhases[0]?.plans.length ?? 0) > 1;
+	const canResetFuturePhases =
+		resetBillingCycle && (!hasMultipleImmediatePlans || hasPersistedSchedule);
+	const phasesWithBillingAnchors = validPhases.map((phase, index) => ({
+		...phase,
+		...(index > 0 && canResetFuturePhases
+			? { billing_cycle_anchor: "phase_start" as const }
+			: {}),
+	}));
+
 	const body: Record<string, unknown> = {
 		customer_id: customerId,
-		phases: validPhases,
+		phases: phasesWithBillingAnchors,
 	};
 	if (entityId) body.entity_id = entityId;
 

--- a/vite/src/components/forms/create-schedule/hooks/useCreateScheduleRequestBody.ts
+++ b/vite/src/components/forms/create-schedule/hooks/useCreateScheduleRequestBody.ts
@@ -20,8 +20,10 @@ type CreatePlanItemParams = Omit<
 };
 
 import {
+	canResetScheduleBillingCycle,
 	getCreateSchedulePhaseTimingError,
 	hasPersistedCreateSchedule,
+	hasMultipleImmediateSchedulePlans,
 	type SchedulePhase,
 } from "../createScheduleFormSchema";
 
@@ -133,6 +135,9 @@ export function buildCreateScheduleRequestBody({
 	if (!customerId || phases.length === 0) return null;
 	if (getCreateSchedulePhaseTimingError({ phases, nowMs: now })) return null;
 	const hasPersistedSchedule = hasPersistedCreateSchedule({ phases });
+	const hasMultipleImmediatePlans = hasMultipleImmediateSchedulePlans({ phases });
+	const canResetFuturePhases =
+		resetBillingCycle && canResetScheduleBillingCycle({ phases });
 
 	const apiPhases = phases.map((phase, index) => {
 		// The first phase starts immediately (now) unless backdating is allowed —
@@ -172,7 +177,7 @@ export function buildCreateScheduleRequestBody({
 		return {
 			starts_at: startsAt,
 			plans,
-			...(index > 0 && resetBillingCycle
+			...(index > 0 && canResetFuturePhases
 				? { billing_cycle_anchor: "phase_start" as const }
 				: {}),
 		};
@@ -189,12 +194,9 @@ export function buildCreateScheduleRequestBody({
 	};
 	if (entityId) body.entity_id = entityId;
 
-	// `billing_behavior` / `billing_cycle_anchor` aren't supported when the
-	// immediate phase is a multi-attach. The review UI disables the toggles in
-	// that case; mirror the same guard here so stale values don't leak into the
-	// request if the user flips from single-plan to multi-plan after toggling.
-	const immediatePlanCount = validPhases[0]?.plans.length ?? 0;
-	const supportsBillingFlags = immediatePlanCount === 1;
+	// Top-level billing flags aren't supported when the immediate phase is a
+	// multi-attach; future phase anchor resets are allowed for persisted schedules.
+	const supportsBillingFlags = !hasMultipleImmediatePlans;
 	if (supportsBillingFlags) {
 		if (billingBehavior) body.billing_behavior = billingBehavior;
 		if (resetBillingCycle && !hasPersistedSchedule) {

--- a/vite/src/components/forms/create-schedule/hooks/useCreateScheduleRequestBody.ts
+++ b/vite/src/components/forms/create-schedule/hooks/useCreateScheduleRequestBody.ts
@@ -135,14 +135,11 @@ export function buildCreateScheduleRequestBody({
 	const hasPersistedSchedule = hasPersistedCreateSchedule({ phases });
 
 	const apiPhases = phases.map((phase, index) => {
-		// The first phase starts immediately (now) unless backdating is allowed —
-		// only when a brand-new Stripe subscription will be created — in which case
-		// a past starts_at flows through to backdate that subscription.
 		const startsAt =
 			index === 0
 				? allowFirstPhaseBackdate
 					? (phase.startsAt ?? now)
-					: now
+					: (phase.persistedStartsAt ?? now)
 				: phase.startsAt;
 		if (startsAt === null) return null;
 

--- a/vite/tests/components/forms/create-schedule/hooks/build-create-schedule-request-body.test.ts
+++ b/vite/tests/components/forms/create-schedule/hooks/build-create-schedule-request-body.test.ts
@@ -301,6 +301,17 @@ describe("canResetScheduleBillingCycle", () => {
 			}),
 		).toBe(false);
 	});
+
+	test("blocks new schedules whose first non-empty phase has multiple plans", () => {
+		expect(
+			canResetScheduleBillingCycle({
+				phases: [
+					schedulePhase({ productIds: [""] }),
+					schedulePhase({ productIds: ["prod_1", "prod_2"] }),
+				],
+			}),
+		).toBe(false);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -652,6 +663,37 @@ describe("buildCreateScheduleRequestBody", () => {
 
 		expect(result).not.toBeNull();
 		expect(result).not.toHaveProperty("billing_cycle_anchor");
+		expect(result!.phases[1]).not.toHaveProperty("billing_cycle_anchor");
+	});
+
+	test("does not send billing flags when the first valid phase is multi-plan", () => {
+		const now = Date.now();
+		const future = now + 1000 * 60 * 60 * 24 * 30;
+		const later = now + 1000 * 60 * 60 * 24 * 60;
+		const result = buildCreateScheduleRequestBody({
+			customerId: "cus_1",
+			entityId: undefined,
+			phases: [
+				schedulePhase({ startsAt: now, productIds: [""] }),
+				schedulePhase({
+					startsAt: future,
+					productIds: ["prod_1", "prod_2"],
+				}),
+				schedulePhase({ startsAt: later }),
+			],
+			products: defaultProducts,
+			features,
+			nowMs: now,
+			billingBehavior: "none",
+			resetBillingCycle: true,
+		});
+
+		expect(result).not.toBeNull();
+		expect(result).not.toHaveProperty("billing_behavior");
+		expect(result).not.toHaveProperty("billing_cycle_anchor");
+		expect(result!.phases).toHaveLength(2);
+		expect(result!.phases[0].plans).toHaveLength(2);
+		expect(result!.phases[0]).not.toHaveProperty("billing_cycle_anchor");
 		expect(result!.phases[1]).not.toHaveProperty("billing_cycle_anchor");
 	});
 });

--- a/vite/tests/components/forms/create-schedule/hooks/build-create-schedule-request-body.test.ts
+++ b/vite/tests/components/forms/create-schedule/hooks/build-create-schedule-request-body.test.ts
@@ -7,7 +7,11 @@ import {
 	buildCustomizeItems,
 	buildCreateScheduleRequestBody,
 } from "@/components/forms/create-schedule/hooks/useCreateScheduleRequestBody";
-import { EMPTY_SCHEDULE_PLAN } from "@/components/forms/create-schedule/createScheduleFormSchema";
+import {
+	canResetScheduleBillingCycle,
+	EMPTY_SCHEDULE_PLAN,
+	type SchedulePhase,
+} from "@/components/forms/create-schedule/createScheduleFormSchema";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -75,6 +79,25 @@ const features: Feature[] = [
 	{ id: "storage", name: "Storage", internal_id: "int_storage", type: "usage" } as Feature,
 	{ id: "support", name: "Support", internal_id: "int_support", type: "boolean" } as Feature,
 ];
+
+const schedulePlan = (productId: string) => ({
+	...EMPTY_SCHEDULE_PLAN,
+	productId,
+});
+
+const schedulePhase = ({
+	startsAt = 1000,
+	persistedStartsAt,
+	productIds = ["prod_1"],
+}: {
+	startsAt?: number;
+	persistedStartsAt?: number;
+	productIds?: string[];
+}): SchedulePhase => ({
+	startsAt,
+	persistedStartsAt,
+	plans: productIds.map(schedulePlan),
+});
 
 // ---------------------------------------------------------------------------
 // buildCustomizeBasePrice
@@ -250,6 +273,33 @@ describe("buildCustomize", () => {
 		expect(result).toBeDefined();
 		expect(result!.price).toBeDefined();
 		expect(result!.items).toBeDefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// canResetScheduleBillingCycle
+// ---------------------------------------------------------------------------
+
+describe("canResetScheduleBillingCycle", () => {
+	test("allows existing schedules with multiple current plans", () => {
+		expect(
+			canResetScheduleBillingCycle({
+				phases: [
+					schedulePhase({
+						persistedStartsAt: 1000,
+						productIds: ["prod_1", "prod_2"],
+					}),
+				],
+			}),
+		).toBe(true);
+	});
+
+	test("blocks new schedules with multiple current plans", () => {
+		expect(
+			canResetScheduleBillingCycle({
+				phases: [schedulePhase({ productIds: ["prod_1", "prod_2"] })],
+			}),
+		).toBe(false);
 	});
 });
 
@@ -549,5 +599,59 @@ describe("buildCreateScheduleRequestBody", () => {
 		expect(result).not.toBeNull();
 		expect(result).not.toHaveProperty("billing_cycle_anchor");
 		expect(result!.phases[1].billing_cycle_anchor).toBe("phase_start");
+	});
+
+	test("sets future phase anchors for existing schedules with multiple current plans", () => {
+		const now = Date.now();
+		const persistedStart = now - 1000 * 60 * 60 * 24;
+		const future = now + 1000 * 60 * 60 * 24 * 30;
+		const result = buildCreateScheduleRequestBody({
+			customerId: "cus_1",
+			entityId: undefined,
+			phases: [
+				schedulePhase({
+					startsAt: persistedStart,
+					persistedStartsAt: persistedStart,
+					productIds: ["prod_1", "prod_2"],
+				}),
+				schedulePhase({
+					startsAt: future,
+				}),
+			],
+			products: defaultProducts,
+			features,
+			nowMs: now,
+			resetBillingCycle: true,
+		});
+
+		expect(result).not.toBeNull();
+		expect(result).not.toHaveProperty("billing_cycle_anchor");
+		expect(result!.phases[1].billing_cycle_anchor).toBe("phase_start");
+	});
+
+	test("does not send stale billing anchors for new schedules with multiple current plans", () => {
+		const now = Date.now();
+		const future = now + 1000 * 60 * 60 * 24 * 30;
+		const result = buildCreateScheduleRequestBody({
+			customerId: "cus_1",
+			entityId: undefined,
+			phases: [
+				schedulePhase({
+					startsAt: now,
+					productIds: ["prod_1", "prod_2"],
+				}),
+				schedulePhase({
+					startsAt: future,
+				}),
+			],
+			products: defaultProducts,
+			features,
+			nowMs: now,
+			resetBillingCycle: true,
+		});
+
+		expect(result).not.toBeNull();
+		expect(result).not.toHaveProperty("billing_cycle_anchor");
+		expect(result!.phases[1]).not.toHaveProperty("billing_cycle_anchor");
 	});
 });

--- a/vite/tests/components/forms/create-schedule/hooks/build-create-schedule-request-body.test.ts
+++ b/vite/tests/components/forms/create-schedule/hooks/build-create-schedule-request-body.test.ts
@@ -553,6 +553,43 @@ describe("buildCreateScheduleRequestBody", () => {
 		expect(result!.phases[0].starts_at).toBe(now);
 	});
 
+	test("preserves persisted first phase start when editing an existing schedule", () => {
+		const persistedStart = Date.UTC(2027, 5, 30, 13, 11);
+		const now = Date.UTC(2027, 6, 2, 16, 49);
+		const paidStart = Date.UTC(2027, 9, 2, 12, 0);
+		const result = buildCreateScheduleRequestBody({
+			customerId: "cus_1",
+			entityId: undefined,
+			phases: [
+				schedulePhase({
+					startsAt: persistedStart,
+					persistedStartsAt: persistedStart,
+					productIds: ["prod_1", "prod_2"],
+				}),
+				schedulePhase({
+					startsAt: now,
+					persistedStartsAt: now,
+					productIds: ["prod_1"],
+				}),
+				schedulePhase({
+					startsAt: paidStart,
+					productIds: ["prod_1"],
+				}),
+			],
+			products: defaultProducts,
+			features,
+			nowMs: now,
+			resetBillingCycle: true,
+		});
+
+		expect(result).not.toBeNull();
+		expect(result!.phases.map((phase) => phase.starts_at)).toEqual([
+			persistedStart,
+			now,
+			paidStart,
+		]);
+	});
+
 	test("sets phase billing anchor for future phases when billing cycle reset is enabled", () => {
 		const now = Date.now();
 		const future = now + 1000 * 60 * 60 * 24 * 30;


### PR DESCRIPTION
## Summary
- allow create_schedule to use a free/access-only first phase over an active subscription when a future paid recurring phase exists
- use a zero-dollar recurring placeholder so Stripe can migrate the active subscription into a schedule
- add integration coverage for active subscription -> free first phase -> paid quarterly future phase

## Tests
- bunx tsgo --build --noEmit
- AUTUMN_TEST_BASE_URL=http://localhost:18083 ENV_FILE=.env infisical run --env=dev --recursive -- bun test --timeout 0 --preload ./tests/setup-integration-tests.ts tests/integration/billing/create-schedule/params/create-schedule-free-first-phase.test.ts tests/integration/billing/create-schedule/params/create-schedule-phase-billing-anchor.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow creating a subscription schedule with a free first phase over an active subscription when a future paid recurring phase exists. We keep the subscription alive with a $0 recurring placeholder, pick the correct immediate phase (including existing schedules), hydrate Stripe during free‑phase edits, and safely reset billing anchors across phases; the dashboard constrains billing flags and enables safe anchor edits.

- **Bug Fixes**
  - Allow a free first phase only when a future paid recurring phase exists; otherwise return a safety error.
  - Keep the subscription alive during schedule create/update by injecting a $0 recurring placeholder when all items would be deleted; also fill empty free phases and handle active/free products that start “now” or overlap.
  - Billing anchors: collect current/future reset timestamps (including those equal to the current phase start), accept multiple anchors in transition points, and reset every scheduled phase’s anchor.
  - Immediate phase: include scheduled customer products when looking up the Stripe schedule to choose the correct immediate phase; preserve a persisted first‑phase start when editing and tolerate historical/current free phases.
  - Dashboard/form: allow future‑phase anchor resets on existing schedules with multiple current plans; block top‑level `billing_behavior`/`billing_cycle_anchor` when the first valid phase is multi‑plan; send only safe phase‑level anchors and show clear disabled reasons.
  - Tests: integration for active subscription → free current/historical phase → paid with anchor resets; unit tests for multiple reset timestamps and request payload guards.

<sup>Written for commit a56a45d3fd2f0c9b1ca15ae9dcf6b0768c7e53fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR enables `create_schedule` to accept a free/access-only first phase when the customer already has an active paid subscription, provided a future paid recurring phase exists. Previously this combination was rejected outright; now the subscription is kept alive via a `$0` recurring placeholder item so Stripe can migrate it into a subscription schedule.

- **[Improvements]** `handleCreateScheduleErrors.ts`: relax the \"free first phase over active subscription\" guard to only throw when there is no future paid recurring phase in the schedule.
- **[Improvements]** `buildStripeSubscriptionAction.ts`: when all subscription items would be deleted and a schedule is being created/updated, inject a `$0` recurring placeholder item (via `buildFreeRecurringPlaceholderItem`) instead of canceling the subscription, keeping it alive for schedule attachment.
- **[Improvements]** `buildStripePhasesUpdate.ts`: expand `needsFreePhasePlaceholder` to fire when active free products occupy a bounded phase (previously required a product starting *before* `startMs`, which was false when the free product starts exactly at `nowMs`).
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core logic is correct and backed by an integration test. The main rough edge is a silent fallback path in the subscription action builder that could produce a confusing Stripe error in an edge case.

The `buildFreeRecurringPlaceholderItem` call in `buildStripeSubscriptionAction` falls through silently to subscription cancellation when no placeholder can be built, which would make the subsequent schedule create/update operate against a canceled subscription. The type cast bridging the two incompatible Stripe SDK item types also bypasses compiler checks. Neither issue affects the primary happy path covered by the integration test, but the silent fallback could surface as an opaque Stripe error in edge cases.

server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeSubscriptionAction.ts — the placeholder injection block and its silent fallback warrant a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeSubscriptionAction.ts | Adds placeholder-item injection to keep a subscription alive for schedule attachment; uses a cross-type cast (Phase.Item → SubscriptionUpdateParams.Item) and has a silent fallback to subscription cancellation if the placeholder cannot be built. |
| server/src/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/buildStripePhasesUpdate.ts | Broadens the `needsFreePhasePlaceholder` condition to include phases with active (free) products; refactors inline condition into a named variable for readability. |
| server/src/internal/billing/v2/actions/createSchedule/errors/handleCreateScheduleErrors.ts | Relaxes the free-first-phase error guard to allow the combination when a future paid recurring phase exists; logic is clear and correctly scoped. |
| server/tests/integration/billing/create-schedule/params/create-schedule-free-first-phase.test.ts | New integration test covering the active-subscription → free first phase → future paid quarterly phase scenario; validates the Stripe schedule phases, placeholder price, and customer product status. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildStripeSubscriptionAction] --> B{stripeSubscription exists?}
    B -- No --> C[Case 1/2/3: no-op, future-only, or create]
    B -- Yes --> D{deletesAllSubscriptionItems?}
    D -- No --> E[Case 5: Update subscription normally]
    D -- Yes --> F{scheduleAction = create or update?}
    F -- No --> G[Case 4: Cancel subscription]
    F -- Yes --> H[buildFreeRecurringPlaceholderItem from finalCustomerProducts]
    H --> I{placeholder found?}
    I -- Yes --> J[Return UpdateAction with placeholder + delete all items - Subscription stays alive for schedule]
    I -- No --> G
    J --> K[Schedule create/update executed against still-active subscription]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[buildStripeSubscriptionAction] --> B{stripeSubscription exists?}
    B -- No --> C[Case 1/2/3: no-op, future-only, or create]
    B -- Yes --> D{deletesAllSubscriptionItems?}
    D -- No --> E[Case 5: Update subscription normally]
    D -- Yes --> F{scheduleAction = create or update?}
    F -- No --> G[Case 4: Cancel subscription]
    F -- Yes --> H[buildFreeRecurringPlaceholderItem from finalCustomerProducts]
    H --> I{placeholder found?}
    I -- Yes --> J[Return UpdateAction with placeholder + delete all items - Subscription stays alive for schedule]
    I -- No --> G
    J --> K[Schedule create/update executed against still-active subscription]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeSubscriptionAction.ts:108-111
The `buildFreeRecurringPlaceholderItem` return type is `Stripe.SubscriptionScheduleUpdateParams.Phase.Item | undefined`, but here it is cast to `Stripe.SubscriptionUpdateParams.Item | undefined`. These are distinct Stripe SDK types with non-overlapping `price_data` sub-types, so the cast bypasses compiler checks. If a future Stripe SDK version diverges their shapes this will fail silently at runtime. A narrower cast or a local adapter would keep the types sound.

```suggestion
		const placeholderItemRaw = buildFreeRecurringPlaceholderItem({
			ctx,
			customerProducts: finalCustomerProducts,
		});
		const placeholderItem = placeholderItemRaw as
			| Stripe.SubscriptionUpdateParams.Item
			| undefined;
```

### Issue 2 of 2
server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeSubscriptionAction.ts:103-122
**Silent fallback to cancellation when placeholder is unavailable**

If `buildFreeRecurringPlaceholderItem` returns `undefined` — e.g., none of the `finalCustomerProducts` carry a Stripe product ID or a recurring price — the block exits without returning and falls through to the `cancel` branch below. This cancels the subscription even though a schedule create/update was expected, which would cause the subsequent schedule action to fail (Stripe can't attach a schedule to a canceled subscription). Adding a warning log or an explicit guard here would surface the failure earlier rather than as a cryptic downstream Stripe error.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): allow free first schedule ..."](https://github.com/useautumn/autumn/commit/42f7d408e7648e3c081795e59a1f2a759182f3d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41654479)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->