### PR TITLE
fix(mcp): match getCurrentOrganization schema to organization/me response

### DIFF
--- a/apps/leaf/tests/evals/harness/context/createAutumnApiMock.ts
+++ b/apps/leaf/tests/evals/harness/context/createAutumnApiMock.ts
@@ -205,6 +205,7 @@ const defaultHandlers = {
 	},
 	getAgentRules: ({ setup }) => setup.agentRules,
 	getCurrentOrganization: () => ({
+		id: "org_acme_knowledge_systems",
 		env: "sandbox",
 		name: "Acme Knowledge Systems",
 		slug: "acme-knowledge-systems",

--- a/packages/mcp/src/tools/org.ts
+++ b/packages/mcp/src/tools/org.ts
@@ -4,13 +4,19 @@ import { getAutumnAuth } from "../server/auth/auth.js";
 import { mcpAnnotations } from "./utils/annotations.js";
 import { callAutumnGet } from "./utils/client.js";
 
-const organizationMeSchema = z
-	.object({
-		name: z.string(),
-		slug: z.string(),
-		env: z.string(),
-	})
-	.strict();
+const organizationMeSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	slug: z.string(),
+	env: z.string(),
+	user: z
+		.object({
+			id: z.string(),
+			email: z.string(),
+			name: z.string(),
+		})
+		.optional(),
+});
 
 const signalOf = (context: { mcp?: { extra?: { signal?: AbortSignal } } }) =>
 	context?.mcp?.extra?.signal;

--- a/packages/mcp/src/tools/org.ts
+++ b/packages/mcp/src/tools/org.ts
@@ -15,7 +15,7 @@ const organizationMeSchema = z.object({
 			email: z.string(),
 			name: z.string(),
 		})
-		.optional(),
+		.nullish(),
 });
 
 const signalOf = (context: { mcp?: { extra?: { signal?: AbortSignal } } }) =>

--- a/packages/mcp/tests/unit/mcp-server/agent/tools.test.ts
+++ b/packages/mcp/tests/unit/mcp-server/agent/tools.test.ts
@@ -557,9 +557,15 @@ describe("Autumn operation tools", () => {
 			expect(init?.method).toBe("GET");
 			expect(init?.body).toBeUndefined();
 			return Response.json({
+				id: "org_unit_tests",
 				name: "Unit Tests",
 				slug: "unit-tests",
 				env: "sandbox",
+				user: {
+					id: "user_unit_tests",
+					email: "unit@tests.dev",
+					name: "Unit Tester",
+				},
 			});
 		}) as typeof fetch;
 
@@ -575,9 +581,15 @@ describe("Autumn operation tools", () => {
 					{ mcp: { extra: { authInfo: auth } } } as never,
 				),
 			).resolves.toEqual({
+				id: "org_unit_tests",
 				name: "Unit Tests",
 				slug: "unit-tests",
 				env: "sandbox",
+				user: {
+					id: "user_unit_tests",
+					email: "unit@tests.dev",
+					name: "Unit Tester",
+				},
 			});
 		} finally {
 			globalThis.fetch = originalFetch;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the MCP organization tool schema to match the `organization/me` API and prevent validation errors. Adds org `id` and supports `user` being missing or null; updates tests and mocks.

- **Bug Fixes**
  - Added `id` and `user { id, email, name }` to `getCurrentOrganization` schema; `user` can be null or undefined.
  - Removed `.strict()` to tolerate extra fields from the API.
  - Updated test fixtures and the Autumn API mock with `id` and sample `user`.

<sup>Written for commit 70a1f94ed3a8cb96442a50ec2b8d8a3931ae0d06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

