### PR TITLE
fix(leaf): stabilize Claude Managed Sessions and MCP permissions

### DIFF
--- a/apps/leaf/src/agent/runMessage/engines/claudeManagedEngine.ts
+++ b/apps/leaf/src/agent/runMessage/engines/claudeManagedEngine.ts
@@ -227,7 +227,7 @@ export const claudeManagedEngine: AgentEngine = {
 						],
 					})
 					.then(() => undefined),
-			runTurn: ({ onTurnEnd, span }) =>
+			runTurn: ({ onTurnEnd, onTurnStarted, span }) =>
 				runClaudeManagedTurn({
 					client,
 					content,
@@ -236,6 +236,7 @@ export const claudeManagedEngine: AgentEngine = {
 					onAction,
 					onActionKeyed,
 					onThinking,
+					onTurnStarted,
 					onTurnEnd,
 					orgId: org.id,
 					sessionId: activeSessionId,

--- a/apps/leaf/src/agent/runMessage/engines/claudeManagedEngine.ts
+++ b/apps/leaf/src/agent/runMessage/engines/claudeManagedEngine.ts
@@ -1,6 +1,9 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { all } from "better-all";
-import { ensureLeafResources } from "../../../harness/claudeManaged/ensureLeafResources.js";
+import {
+	ensureLeafResources,
+	syncClaudeManagedSessionAgentConfig,
+} from "../../../harness/claudeManaged/ensureLeafResources.js";
 import { ensureMemoryStore } from "../../../harness/claudeManaged/memory/ensureMemoryStore.js";
 import { cmaRepo } from "../../../harness/claudeManaged/repos/claudeManagedRepo.js";
 import {
@@ -55,6 +58,16 @@ export const claudeManagedEngine: AgentEngine = {
 		} = ctx;
 
 		const perf = createPhaseTimer(logger);
+		const surface = thread.provider === "web" ? "dashboard" : "slack";
+		const resourcesPromise = perf.time("ensure_resources", () =>
+			ensureLeafResources({
+				client,
+				env,
+				logger,
+				surface,
+				token,
+			}),
+		);
 		const existingSession =
 			claudeManagedSession ??
 			(await perf.time("lookup_session", () =>
@@ -66,6 +79,7 @@ export const claudeManagedEngine: AgentEngine = {
 					userId: autumnUserId,
 				}),
 			));
+		const resources = await resourcesPromise;
 
 		let sessionRef = existingSession;
 		let orgContext: Awaited<ReturnType<typeof autumnOrgContextService.load>>;
@@ -73,20 +87,8 @@ export const claudeManagedEngine: AgentEngine = {
 			const {
 				memoryStoreId,
 				orgContext: loadedOrgContext,
-				resources: { agentId, environmentId },
 				vaultId,
 			} = await all({
-				async resources() {
-					return perf.time("ensure_resources", () =>
-						ensureLeafResources({
-							client,
-							env,
-							logger,
-							surface: thread.provider === "web" ? "dashboard" : "slack",
-							token,
-						}),
-					);
-				},
 				async vaultId() {
 					return perf.time("ensure_vault", () =>
 						ensureAutumnVault({
@@ -113,11 +115,11 @@ export const claudeManagedEngine: AgentEngine = {
 			orgContext = loadedOrgContext;
 			sessionRef = await perf.time("session_create", () =>
 				createClaudeManagedSession({
-					agentId,
+					agentId: resources.agentId,
 					client,
 					db,
 					env,
-					environmentId,
+					environmentId: resources.environmentId,
 					memoryStoreId,
 					orgId: org.id,
 					thread,
@@ -136,6 +138,15 @@ export const claudeManagedEngine: AgentEngine = {
 		ctx.run?.resolveSessionId(activeSessionId);
 
 		if (!newSession) {
+			await syncClaudeManagedSessionAgentConfig({
+				client,
+				env,
+				logger,
+				orgId: org.id,
+				resources,
+				sessionId: activeSessionId,
+			});
+
 			// Re-sync the vault: it's seeded only at session creation, but leaf
 			// rotates the shared OAuth refresh token each turn, so a stale vault 401s.
 			await ensureAutumnVault({

--- a/apps/leaf/src/agent/runMessage/engines/claudeManagedEngine.ts
+++ b/apps/leaf/src/agent/runMessage/engines/claudeManagedEngine.ts
@@ -208,6 +208,14 @@ export const claudeManagedEngine: AgentEngine = {
 					.then(() => undefined),
 			newSession,
 			params,
+			sendFollowUp: ({ text }) =>
+				client.beta.sessions.events
+					.send(activeSessionId, {
+						events: [
+							{ content: [{ text, type: "text" }], type: "user.message" },
+						],
+					})
+					.then(() => undefined),
 			runTurn: ({ onTurnEnd, span }) =>
 				runClaudeManagedTurn({
 					client,

--- a/apps/leaf/src/harness/claudeManaged/ensureLeafResources.ts
+++ b/apps/leaf/src/harness/claudeManaged/ensureLeafResources.ts
@@ -13,7 +13,10 @@ import {
 import {
 	buildDesiredTools,
 	builtinSignatureFromToolset,
+	type ClaudeManagedToolset,
 	desiredBuiltinSignature,
+	mcpSignatureFromToolset,
+	type McpToolsetLike,
 } from "./toolset.js";
 
 const isLoopback = (hostname: string) =>
@@ -63,6 +66,77 @@ const agentNameForSurface = (surface: LeafSurface) =>
 		? claudeManagedConfig.agentName
 		: `${claudeManagedConfig.agentName} Dashboard`;
 
+const buildAutumnMcpServers = (mcpUrl: string) => [
+	{
+		name: claudeManagedConfig.autumnMcpServerName,
+		type: "url" as const,
+		url: mcpUrl,
+	},
+];
+
+type AutumnMcpServer = ReturnType<typeof buildAutumnMcpServers>[number];
+
+type LeafManagedResources = {
+	agentId: string;
+	environmentId: string;
+	mcpServers: AutumnMcpServer[];
+	tools: ClaudeManagedToolset[];
+};
+
+const isBuiltinToolset = (tool: { type: string }) =>
+	tool.type === "agent_toolset_20260401";
+
+const isAutumnMcpToolset = (
+	tool: { mcp_server_name?: string; type: string },
+): tool is McpToolsetLike =>
+	tool.type === "mcp_toolset" &&
+	tool.mcp_server_name === claudeManagedConfig.autumnMcpServerName;
+
+const findAutumnMcpUrl = (servers?: Array<{ name: string; url: string }>) =>
+	servers?.find(
+		(server) => server.name === claudeManagedConfig.autumnMcpServerName,
+	)?.url;
+
+const toolConfigDiff = ({
+	currentMcpServers,
+	currentTools,
+	expectedMcpServers,
+	expectedTools,
+}: {
+	currentMcpServers?: Array<{ name: string; url: string }>;
+	currentTools?: Array<{ mcp_server_name?: string; type: string }>;
+	expectedMcpServers: AutumnMcpServer[];
+	expectedTools: ClaudeManagedToolset[];
+}) => {
+	const currentBuiltinToolset = currentTools?.find(isBuiltinToolset) as
+		| Parameters<typeof builtinSignatureFromToolset>[0]
+		| undefined;
+	const currentMcpToolset = currentTools?.find(isAutumnMcpToolset);
+	const expectedMcpToolset = expectedTools.find(isAutumnMcpToolset) as
+		| McpToolsetLike
+		| undefined;
+	const currentBuiltinSig = currentBuiltinToolset
+		? builtinSignatureFromToolset(currentBuiltinToolset)
+		: "";
+	const expectedBuiltinSig = desiredBuiltinSignature();
+	const currentMcpSig = mcpSignatureFromToolset(currentMcpToolset);
+	const expectedMcpSig = mcpSignatureFromToolset(expectedMcpToolset);
+	const currentMcpUrl = findAutumnMcpUrl(currentMcpServers);
+	const expectedMcpUrl = findAutumnMcpUrl(expectedMcpServers);
+
+	return {
+		builtinChanged: currentBuiltinSig !== expectedBuiltinSig,
+		currentBuiltinSig,
+		currentMcpSig,
+		currentMcpUrl,
+		expectedBuiltinSig,
+		expectedMcpSig,
+		expectedMcpUrl,
+		mcpPermissionsChanged: currentMcpSig !== expectedMcpSig,
+		mcpUrlChanged: currentMcpUrl !== expectedMcpUrl,
+	};
+};
+
 // Keep the shared agent config in sync with local code/tunnel changes.
 // Dev re-syncs every turn; prod syncs once per process.
 const alwaysResync = process.env.NODE_ENV !== "production";
@@ -70,16 +144,16 @@ const syncedSurfaces = new Set<LeafSurface>();
 const syncAgentConfig = async ({
 	agentId,
 	client,
-	destructiveTools,
-	expectedUrl,
+	expectedMcpServers,
+	expectedTools,
 	logger,
 	skills,
 	surface,
 }: {
 	agentId: string;
 	client: Anthropic;
-	destructiveTools: Iterable<string>;
-	expectedUrl: string;
+	expectedMcpServers: AutumnMcpServer[];
+	expectedTools: ClaudeManagedToolset[];
 	logger: AutumnLogger;
 	skills: LeafSkillRef[];
 	surface: LeafSurface;
@@ -87,44 +161,33 @@ const syncAgentConfig = async ({
 	if (syncedSurfaces.has(surface) && !alwaysResync) return;
 	const agent = await client.beta.agents.retrieve(agentId);
 	const expectedSystem = buildAgentSystem({ surface });
-	const currentUrl = agent.mcp_servers?.find(
-		(server) => server.name === claudeManagedConfig.autumnMcpServerName,
-	)?.url;
-	const currentToolset = agent.tools?.find(
-		(tool): tool is Extract<typeof tool, { type: "agent_toolset_20260401" }> =>
-			tool.type === "agent_toolset_20260401",
-	);
-	const currentBuiltinSig = currentToolset
-		? builtinSignatureFromToolset(currentToolset)
-		: "";
-	const mcpUrlChanged = currentUrl !== expectedUrl;
+	const diff = toolConfigDiff({
+		currentMcpServers: agent.mcp_servers,
+		currentTools: agent.tools,
+		expectedMcpServers,
+		expectedTools,
+	});
 	const systemChanged = agent.system !== expectedSystem;
 	const modelChanged = agent.model.id !== claudeManagedConfig.model;
-	const toolsChanged = currentBuiltinSig !== desiredBuiltinSignature();
+	const toolsChanged = diff.builtinChanged || diff.mcpPermissionsChanged;
 	const skillsChanged = !skillsMatch(agent.skills, skills);
 	if (
-		mcpUrlChanged ||
+		diff.mcpUrlChanged ||
 		systemChanged ||
 		modelChanged ||
 		toolsChanged ||
 		skillsChanged
 	) {
 		await client.beta.agents.update(agentId, {
-			...(mcpUrlChanged
+			...(diff.mcpUrlChanged
 				? {
-						mcp_servers: [
-							{
-								name: claudeManagedConfig.autumnMcpServerName,
-								type: "url" as const,
-								url: expectedUrl,
-							},
-						],
+						mcp_servers: expectedMcpServers,
 					}
 				: {}),
 			...(systemChanged ? { system: expectedSystem } : {}),
 			...(modelChanged ? { model: claudeManagedConfig.model } : {}),
 			...(toolsChanged
-				? { tools: buildDesiredTools({ destructiveTools }) }
+				? { tools: expectedTools }
 				: {}),
 			...(skillsChanged ? { skills } : {}),
 			version: agent.version,
@@ -133,26 +196,71 @@ const syncAgentConfig = async ({
 			event: "leaf.claude_managed_agent_config_refreshed",
 			data: {
 				agent_id: agentId,
-				mcp_url_changed: mcpUrlChanged,
-				mcp_url_from: currentUrl,
-				mcp_url_to: expectedUrl,
+				mcp_url_changed: diff.mcpUrlChanged,
+				mcp_url_from: diff.currentMcpUrl,
+				mcp_url_to: diff.expectedMcpUrl,
 				system_changed: systemChanged,
 				model_changed: modelChanged,
 				model_from: agent.model.id,
 				model_to: claudeManagedConfig.model,
 				tools_changed: toolsChanged,
-				builtin_tools_from: currentBuiltinSig,
-				builtin_tools_to: desiredBuiltinSignature(),
+				builtin_tools_changed: diff.builtinChanged,
+				builtin_tools_from: diff.currentBuiltinSig,
+				builtin_tools_to: diff.expectedBuiltinSig,
+				mcp_permissions_changed: diff.mcpPermissionsChanged,
 			},
 		});
 	}
 	syncedSurfaces.add(surface);
 };
 
-const cachedResources = new Map<
-	LeafSurface,
-	{ agentId: string; environmentId: string }
->();
+export const syncClaudeManagedSessionAgentConfig = async ({
+	client,
+	env,
+	logger,
+	orgId,
+	resources,
+	sessionId,
+}: {
+	client: Anthropic;
+	env: AppEnv;
+	logger: AutumnLogger;
+	orgId: string;
+	resources: LeafManagedResources;
+	sessionId: string;
+}) => {
+	const session = await client.beta.sessions.retrieve(sessionId);
+	const diff = toolConfigDiff({
+		currentMcpServers: session.agent.mcp_servers,
+		currentTools: session.agent.tools,
+		expectedMcpServers: resources.mcpServers,
+		expectedTools: resources.tools,
+	});
+	const toolsChanged = diff.builtinChanged || diff.mcpPermissionsChanged;
+	if (!diff.mcpUrlChanged && !toolsChanged) return;
+
+	await client.beta.sessions.update(sessionId, {
+		agent: {
+			...(diff.mcpUrlChanged ? { mcp_servers: resources.mcpServers } : {}),
+			...(toolsChanged ? { tools: resources.tools } : {}),
+		},
+	});
+	logger.info("Refreshed Claude Managed session agent config", {
+		event: "leaf.claude_managed_session_agent_config_refreshed",
+		context: { env, org_id: orgId },
+		data: {
+			session_id: sessionId,
+			mcp_url_changed: diff.mcpUrlChanged,
+			mcp_url_from: diff.currentMcpUrl,
+			mcp_url_to: diff.expectedMcpUrl,
+			tools_changed: toolsChanged,
+			builtin_tools_changed: diff.builtinChanged,
+			mcp_permissions_changed: diff.mcpPermissionsChanged,
+		},
+	});
+};
+
+const cachedResources = new Map<LeafSurface, LeafManagedResources>();
 export const ensureLeafResources = async ({
 	client,
 	env,
@@ -165,8 +273,9 @@ export const ensureLeafResources = async ({
 	logger: AutumnLogger;
 	surface: LeafSurface;
 	token: string;
-}): Promise<{ agentId: string; environmentId: string }> => {
+}): Promise<LeafManagedResources> => {
 	const mcpUrl = autumnMcpUrl();
+	const mcpServers = buildAutumnMcpServers(mcpUrl);
 	const cached = cachedResources.get(surface);
 	if (cached && syncedSurfaces.has(surface) && !alwaysResync) {
 		return cached;
@@ -176,18 +285,21 @@ export const ensureLeafResources = async ({
 		setupAgentToolContext({ env, logger, token }),
 		ensureLeafSkills(client),
 	]);
+	const tools = buildDesiredTools({ destructiveTools });
 
 	if (cached) {
 		await syncAgentConfig({
 			agentId: cached.agentId,
 			client,
-			destructiveTools,
-			expectedUrl: mcpUrl,
+			expectedMcpServers: mcpServers,
+			expectedTools: tools,
 			logger,
 			skills,
 			surface,
 		});
-		return cached;
+		const resources = { ...cached, mcpServers, tools };
+		cachedResources.set(surface, resources);
+		return resources;
 	}
 
 	const environmentId =
@@ -208,8 +320,8 @@ export const ensureLeafResources = async ({
 		await syncAgentConfig({
 			agentId,
 			client,
-			destructiveTools,
-			expectedUrl: mcpUrl,
+			expectedMcpServers: mcpServers,
+			expectedTools: tools,
 			logger,
 			skills,
 			surface,
@@ -219,15 +331,9 @@ export const ensureLeafResources = async ({
 			model: claudeManagedConfig.model,
 			name: agentName,
 			system: buildAgentSystem({ surface }),
-			mcp_servers: [
-				{
-					name: claudeManagedConfig.autumnMcpServerName,
-					type: "url",
-					url: mcpUrl,
-				},
-			],
+			mcp_servers: mcpServers,
 			skills,
-			tools: buildDesiredTools({ destructiveTools }),
+			tools,
 		});
 		agentId = agent.id;
 		syncedSurfaces.add(surface);
@@ -237,7 +343,7 @@ export const ensureLeafResources = async ({
 		});
 	}
 
-	const resources = { agentId, environmentId };
+	const resources = { agentId, environmentId, mcpServers, tools };
 	cachedResources.set(surface, resources);
 	return resources;
 };

--- a/apps/leaf/src/harness/claudeManaged/ensureLeafResources.ts
+++ b/apps/leaf/src/harness/claudeManaged/ensureLeafResources.ts
@@ -138,12 +138,45 @@ const toolConfigDiff = ({
 };
 
 // Keep the shared agent config in sync with local code/tunnel changes.
-// Dev re-syncs every turn; prod syncs once per process.
+// Dev re-syncs every turn; prod re-syncs when the active token-derived tool
+// policy changes for a surface.
 const alwaysResync = process.env.NODE_ENV !== "production";
-const syncedSurfaces = new Set<LeafSurface>();
+const syncedResourceKeysBySurface = new Map<LeafSurface, string>();
+
+const toolSignatureFromTools = (tools: ClaudeManagedToolset[]) => {
+	const builtinToolset = tools.find(isBuiltinToolset) as
+		| Parameters<typeof builtinSignatureFromToolset>[0]
+		| undefined;
+	const mcpToolset = tools.find(isAutumnMcpToolset) as
+		| McpToolsetLike
+		| undefined;
+
+	return JSON.stringify({
+		builtin: builtinToolset ? builtinSignatureFromToolset(builtinToolset) : "",
+		mcp: mcpSignatureFromToolset(mcpToolset),
+	});
+};
+
+const resourceCacheKey = ({
+	surface,
+	tools,
+}: {
+	surface: LeafSurface;
+	tools: ClaudeManagedToolset[];
+}) => JSON.stringify({ surface, tools: toolSignatureFromTools(tools) });
+
+const isResourceSynced = ({
+	cacheKey,
+	surface,
+}: {
+	cacheKey: string;
+	surface: LeafSurface;
+}) => syncedResourceKeysBySurface.get(surface) === cacheKey;
+
 const syncAgentConfig = async ({
 	agentId,
 	client,
+	cacheKey,
 	expectedMcpServers,
 	expectedTools,
 	logger,
@@ -152,13 +185,14 @@ const syncAgentConfig = async ({
 }: {
 	agentId: string;
 	client: Anthropic;
+	cacheKey: string;
 	expectedMcpServers: AutumnMcpServer[];
 	expectedTools: ClaudeManagedToolset[];
 	logger: AutumnLogger;
 	skills: LeafSkillRef[];
 	surface: LeafSurface;
 }) => {
-	if (syncedSurfaces.has(surface) && !alwaysResync) return;
+	if (isResourceSynced({ cacheKey, surface }) && !alwaysResync) return;
 	const agent = await client.beta.agents.retrieve(agentId);
 	const expectedSystem = buildAgentSystem({ surface });
 	const diff = toolConfigDiff({
@@ -211,7 +245,7 @@ const syncAgentConfig = async ({
 			},
 		});
 	}
-	syncedSurfaces.add(surface);
+	syncedResourceKeysBySurface.set(surface, cacheKey);
 };
 
 export const syncClaudeManagedSessionAgentConfig = async ({
@@ -260,7 +294,7 @@ export const syncClaudeManagedSessionAgentConfig = async ({
 	});
 };
 
-const cachedResources = new Map<LeafSurface, LeafManagedResources>();
+const cachedResources = new Map<string, LeafManagedResources>();
 export const ensureLeafResources = async ({
 	client,
 	env,
@@ -276,20 +310,25 @@ export const ensureLeafResources = async ({
 }): Promise<LeafManagedResources> => {
 	const mcpUrl = autumnMcpUrl();
 	const mcpServers = buildAutumnMcpServers(mcpUrl);
-	const cached = cachedResources.get(surface);
-	if (cached && syncedSurfaces.has(surface) && !alwaysResync) {
+
+	const { destructiveTools } = await setupAgentToolContext({
+		env,
+		logger,
+		token,
+	});
+	const tools = buildDesiredTools({ destructiveTools });
+	const cacheKey = resourceCacheKey({ surface, tools });
+	const cached = cachedResources.get(cacheKey);
+	if (cached && isResourceSynced({ cacheKey, surface }) && !alwaysResync) {
 		return cached;
 	}
 
-	const [{ destructiveTools }, skills] = await Promise.all([
-		setupAgentToolContext({ env, logger, token }),
-		ensureLeafSkills(client),
-	]);
-	const tools = buildDesiredTools({ destructiveTools });
+	const skills = await ensureLeafSkills(client);
 
 	if (cached) {
 		await syncAgentConfig({
 			agentId: cached.agentId,
+			cacheKey,
 			client,
 			expectedMcpServers: mcpServers,
 			expectedTools: tools,
@@ -298,7 +337,7 @@ export const ensureLeafResources = async ({
 			surface,
 		});
 		const resources = { ...cached, mcpServers, tools };
-		cachedResources.set(surface, resources);
+		cachedResources.set(cacheKey, resources);
 		return resources;
 	}
 
@@ -319,6 +358,7 @@ export const ensureLeafResources = async ({
 	if (agentId) {
 		await syncAgentConfig({
 			agentId,
+			cacheKey,
 			client,
 			expectedMcpServers: mcpServers,
 			expectedTools: tools,
@@ -336,7 +376,7 @@ export const ensureLeafResources = async ({
 			tools,
 		});
 		agentId = agent.id;
-		syncedSurfaces.add(surface);
+		syncedResourceKeysBySurface.set(surface, cacheKey);
 		logger.info("Created shared Claude Managed agent", {
 			event: "leaf.claude_managed_agent_created",
 			data: { agent_id: agentId, environment_id: environmentId, surface },
@@ -344,6 +384,6 @@ export const ensureLeafResources = async ({
 	}
 
 	const resources = { agentId, environmentId, mcpServers, tools };
-	cachedResources.set(surface, resources);
+	cachedResources.set(cacheKey, resources);
 	return resources;
 };

--- a/apps/leaf/src/harness/claudeManaged/ensureLeafResources.ts
+++ b/apps/leaf/src/harness/claudeManaged/ensureLeafResources.ts
@@ -1,22 +1,19 @@
 import type Anthropic from "@anthropic-ai/sdk";
+import { type LeafSurface, leafSystemPrompt } from "@autumn/agent-docs/agent";
 import type { AutumnLogger } from "@autumn/logging";
 import type { AppEnv } from "@autumn/shared";
 import { setupAgentToolContext } from "../../agent/runMessage/setup/setupAgentToolContext.js";
 import { env as chatEnv } from "../../lib/env.js";
-import { leafSystemPrompt, type LeafSurface } from "@autumn/agent-docs/agent";
 import { claudeManagedConfig } from "./config.js";
+import { ensureLeafSkills, type LeafSkillRef, skillsMatch } from "./skills.js";
 import {
-	ensureLeafSkills,
-	type LeafSkillRef,
-	skillsMatch,
-} from "./skills.js";
-import {
+	type BuiltinToolsetLike,
 	buildDesiredTools,
 	builtinSignatureFromToolset,
 	type ClaudeManagedToolset,
 	desiredBuiltinSignature,
-	mcpSignatureFromToolset,
 	type McpToolsetLike,
+	mcpSignatureFromToolset,
 } from "./toolset.js";
 
 const isLoopback = (hostname: string) =>
@@ -83,14 +80,22 @@ type LeafManagedResources = {
 	tools: ClaudeManagedToolset[];
 };
 
-const isBuiltinToolset = (tool: { type: string }) =>
+const isBuiltinToolset = (tool: { type: string }): tool is BuiltinToolsetLike =>
 	tool.type === "agent_toolset_20260401";
 
-const isAutumnMcpToolset = (
-	tool: { mcp_server_name?: string; type: string },
-): tool is McpToolsetLike =>
+const isAutumnMcpToolset = (tool: {
+	mcp_server_name?: string;
+	type: string;
+}): tool is McpToolsetLike =>
 	tool.type === "mcp_toolset" &&
 	tool.mcp_server_name === claudeManagedConfig.autumnMcpServerName;
+
+const findToolsets = (
+	tools?: Array<{ mcp_server_name?: string; type: string }>,
+) => ({
+	builtinToolset: tools?.find(isBuiltinToolset),
+	mcpToolset: tools?.find(isAutumnMcpToolset),
+});
 
 const findAutumnMcpUrl = (servers?: Array<{ name: string; url: string }>) =>
 	servers?.find(
@@ -108,13 +113,11 @@ const toolConfigDiff = ({
 	expectedMcpServers: AutumnMcpServer[];
 	expectedTools: ClaudeManagedToolset[];
 }) => {
-	const currentBuiltinToolset = currentTools?.find(isBuiltinToolset) as
-		| Parameters<typeof builtinSignatureFromToolset>[0]
-		| undefined;
-	const currentMcpToolset = currentTools?.find(isAutumnMcpToolset);
-	const expectedMcpToolset = expectedTools.find(isAutumnMcpToolset) as
-		| McpToolsetLike
-		| undefined;
+	const {
+		builtinToolset: currentBuiltinToolset,
+		mcpToolset: currentMcpToolset,
+	} = findToolsets(currentTools);
+	const { mcpToolset: expectedMcpToolset } = findToolsets(expectedTools);
 	const currentBuiltinSig = currentBuiltinToolset
 		? builtinSignatureFromToolset(currentBuiltinToolset)
 		: "";
@@ -127,34 +130,63 @@ const toolConfigDiff = ({
 	return {
 		builtinChanged: currentBuiltinSig !== expectedBuiltinSig,
 		currentBuiltinSig,
-		currentMcpSig,
 		currentMcpUrl,
 		expectedBuiltinSig,
-		expectedMcpSig,
 		expectedMcpUrl,
 		mcpPermissionsChanged: currentMcpSig !== expectedMcpSig,
 		mcpUrlChanged: currentMcpUrl !== expectedMcpUrl,
 	};
 };
 
-// Keep the shared agent config in sync with local code/tunnel changes.
-// Dev re-syncs every turn; prod re-syncs when the active token-derived tool
-// policy changes for a surface.
+// Dev re-syncs every turn; prod re-syncs only when the token-derived tool policy changes.
 const alwaysResync = process.env.NODE_ENV !== "production";
 const syncedResourceKeysBySurface = new Map<LeafSurface, string>();
 
-const toolSignatureFromTools = (tools: ClaudeManagedToolset[]) => {
-	const builtinToolset = tools.find(isBuiltinToolset) as
-		| Parameters<typeof builtinSignatureFromToolset>[0]
-		| undefined;
-	const mcpToolset = tools.find(isAutumnMcpToolset) as
-		| McpToolsetLike
-		| undefined;
+// Caches the setupAgentToolContext round trip briefly; dev always fetches fresh
+// so tool-policy edits take effect.
+const TOOL_CONTEXT_TTL_MS = 60_000;
+const destructiveToolsByToken = new Map<
+	string,
+	{ destructiveTools: Set<string>; expiresAt: number }
+>();
 
-	return JSON.stringify({
+const resolveDestructiveTools = async ({
+	env,
+	logger,
+	token,
+}: {
+	env: AppEnv;
+	logger: AutumnLogger;
+	token: string;
+}) => {
+	if (alwaysResync) {
+		return (await setupAgentToolContext({ env, logger, token }))
+			.destructiveTools;
+	}
+	const now = Date.now();
+	const cached = destructiveToolsByToken.get(token);
+	if (cached && cached.expiresAt > now) return cached.destructiveTools;
+	for (const [key, entry] of destructiveToolsByToken) {
+		if (entry.expiresAt <= now) destructiveToolsByToken.delete(key);
+	}
+	const { destructiveTools } = await setupAgentToolContext({
+		env,
+		logger,
+		token,
+	});
+	destructiveToolsByToken.set(token, {
+		destructiveTools,
+		expiresAt: now + TOOL_CONTEXT_TTL_MS,
+	});
+	return destructiveTools;
+};
+
+const toolSignatureFromTools = (tools: ClaudeManagedToolset[]) => {
+	const { builtinToolset, mcpToolset } = findToolsets(tools);
+	return {
 		builtin: builtinToolset ? builtinSignatureFromToolset(builtinToolset) : "",
 		mcp: mcpSignatureFromToolset(mcpToolset),
-	});
+	};
 };
 
 const resourceCacheKey = ({
@@ -220,9 +252,7 @@ const syncAgentConfig = async ({
 				: {}),
 			...(systemChanged ? { system: expectedSystem } : {}),
 			...(modelChanged ? { model: claudeManagedConfig.model } : {}),
-			...(toolsChanged
-				? { tools: expectedTools }
-				: {}),
+			...(toolsChanged ? { tools: expectedTools } : {}),
 			...(skillsChanged ? { skills } : {}),
 			version: agent.version,
 		});
@@ -248,6 +278,24 @@ const syncAgentConfig = async ({
 	syncedResourceKeysBySurface.set(surface, cacheKey);
 };
 
+// Skips the session retrieve when the desired tools/MCP URL haven't changed
+// since the last sync.
+const MAX_SESSION_SIGNATURE_CACHE = 500;
+const lastSyncedSessionSignatures = new Map<string, string>();
+
+const sessionSyncSignature = (resources: LeafManagedResources) =>
+	JSON.stringify({
+		mcpUrl: findAutumnMcpUrl(resources.mcpServers),
+		tools: toolSignatureFromTools(resources.tools),
+	});
+
+const rememberSessionSignature = (sessionId: string, signature: string) => {
+	if (lastSyncedSessionSignatures.size >= MAX_SESSION_SIGNATURE_CACHE) {
+		lastSyncedSessionSignatures.clear();
+	}
+	lastSyncedSessionSignatures.set(sessionId, signature);
+};
+
 export const syncClaudeManagedSessionAgentConfig = async ({
 	client,
 	env,
@@ -263,6 +311,9 @@ export const syncClaudeManagedSessionAgentConfig = async ({
 	resources: LeafManagedResources;
 	sessionId: string;
 }) => {
+	const signature = sessionSyncSignature(resources);
+	if (lastSyncedSessionSignatures.get(sessionId) === signature) return;
+
 	const session = await client.beta.sessions.retrieve(sessionId);
 	const diff = toolConfigDiff({
 		currentMcpServers: session.agent.mcp_servers,
@@ -271,7 +322,10 @@ export const syncClaudeManagedSessionAgentConfig = async ({
 		expectedTools: resources.tools,
 	});
 	const toolsChanged = diff.builtinChanged || diff.mcpPermissionsChanged;
-	if (!diff.mcpUrlChanged && !toolsChanged) return;
+	if (!diff.mcpUrlChanged && !toolsChanged) {
+		rememberSessionSignature(sessionId, signature);
+		return;
+	}
 
 	await client.beta.sessions.update(sessionId, {
 		agent: {
@@ -292,6 +346,7 @@ export const syncClaudeManagedSessionAgentConfig = async ({
 			mcp_permissions_changed: diff.mcpPermissionsChanged,
 		},
 	});
+	rememberSessionSignature(sessionId, signature);
 };
 
 const cachedResources = new Map<string, LeafManagedResources>();
@@ -311,7 +366,7 @@ export const ensureLeafResources = async ({
 	const mcpUrl = autumnMcpUrl();
 	const mcpServers = buildAutumnMcpServers(mcpUrl);
 
-	const { destructiveTools } = await setupAgentToolContext({
+	const destructiveTools = await resolveDestructiveTools({
 		env,
 		logger,
 		token,

--- a/apps/leaf/src/harness/claudeManaged/session/driveSessionTurn.ts
+++ b/apps/leaf/src/harness/claudeManaged/session/driveSessionTurn.ts
@@ -21,6 +21,7 @@ export const driveSessionTurn = async ({
 	onSessionRetry,
 	onThinking,
 	onToolError,
+	onTurnStarted,
 	onTurnEnd,
 	perfLabel,
 	sessionId,
@@ -54,6 +55,8 @@ export const driveSessionTurn = async ({
 		name: string;
 		output: unknown;
 	}) => Promise<void> | void;
+	/** Fires once for each turn after the session emits active agent work. */
+	onTurnStarted?: () => void;
 	/** Multi-turn pump: on "continue", the drained turn is emitted and the stream keeps being consumed. */
 	onTurnEnd?: (
 		turn: SessionTurnOutcome,
@@ -99,6 +102,12 @@ export const driveSessionTurn = async ({
 	let sandboxReadCount = 0;
 	let inferenceMs = 0;
 	let inferenceStart = 0;
+	let turnStarted = false;
+	const markTurnStarted = () => {
+		if (turnStarted) return;
+		turnStarted = true;
+		onTurnStarted?.();
+	};
 
 	const stream = await client.beta.sessions.events.stream(sessionId);
 	mark("stream_open");
@@ -118,6 +127,16 @@ export const driveSessionTurn = async ({
 			lastEventAt = now;
 		}
 		mark("first_event");
+		if (
+			event.type === "agent.message" ||
+			event.type === "agent.mcp_tool_use" ||
+			event.type === "agent.mcp_tool_result" ||
+			event.type === "agent.tool_use" ||
+			event.type === "agent.thinking" ||
+			event.type === "span.model_request_start"
+		) {
+			markTurnStarted();
+		}
 		if (
 			event.type === "agent.message" &&
 			event.content.some((b) => b.type === "text" && b.text)
@@ -241,6 +260,7 @@ export const driveSessionTurn = async ({
 				if (decision === "continue") {
 					outcome.textParts = [];
 					outcome.toolResults = [];
+					turnStarted = false;
 					continue;
 				}
 			}

--- a/apps/leaf/src/harness/claudeManaged/session/driveSessionTurn.ts
+++ b/apps/leaf/src/harness/claudeManaged/session/driveSessionTurn.ts
@@ -8,6 +8,10 @@ export type {
 	SuspendedToolCall,
 } from "../../common/types.js";
 
+// The SDK has no idle `agent.*` event, so any one means active work.
+const isActiveAgentWork = (type: string) =>
+	type.startsWith("agent.") || type === "span.model_request_start";
+
 // Streams one CMA turn to completion after `kickoff`, preserving text, tool
 // results, usage, and pending destructive tool confirmations.
 export const driveSessionTurn = async ({
@@ -127,14 +131,7 @@ export const driveSessionTurn = async ({
 			lastEventAt = now;
 		}
 		mark("first_event");
-		if (
-			event.type === "agent.message" ||
-			event.type === "agent.mcp_tool_use" ||
-			event.type === "agent.mcp_tool_result" ||
-			event.type === "agent.tool_use" ||
-			event.type === "agent.thinking" ||
-			event.type === "span.model_request_start"
-		) {
+		if (isActiveAgentWork(event.type)) {
 			markTurnStarted();
 		}
 		if (

--- a/apps/leaf/src/harness/claudeManaged/session/runManagedTurn.ts
+++ b/apps/leaf/src/harness/claudeManaged/session/runManagedTurn.ts
@@ -63,6 +63,7 @@ export const runClaudeManagedTurn = async ({
 	onAction,
 	onActionKeyed,
 	onThinking,
+	onTurnStarted,
 	onTurnEnd,
 	orgId,
 	sessionId,
@@ -75,6 +76,7 @@ export const runClaudeManagedTurn = async ({
 	onAction?: (message: string) => Promise<void> | void;
 	onActionKeyed?: KeyedActionLogger;
 	onThinking?: () => void;
+	onTurnStarted?: () => void;
 	onTurnEnd?: (
 		turn: SessionTurnOutcome,
 	) => Promise<"continue" | "stop"> | "continue" | "stop";
@@ -167,6 +169,7 @@ export const runClaudeManagedTurn = async ({
 					message: `⚠️ ${toolLabel(name)} failed: ${message}`,
 				});
 			},
+			onTurnStarted,
 			onTurnEnd,
 			sessionId,
 		});

--- a/apps/leaf/src/harness/claudeManaged/toolset.ts
+++ b/apps/leaf/src/harness/claudeManaged/toolset.ts
@@ -61,12 +61,13 @@ export type McpToolsetLike = {
 const policyType = (policy: PermissionPolicyLike, fallback: string) =>
 	policy?.type || fallback;
 
-const buildMcpToolset = ({
+export const buildDesiredTools = ({
 	destructiveTools,
 }: {
 	destructiveTools: Iterable<string>;
-}) =>
-	({
+}) => {
+	const toolset = buildAgentToolset();
+	const mcpToolset = {
 		configs: [...destructiveTools].map((name) => ({
 			name,
 			permission_policy: { type: "always_ask" as const },
@@ -74,15 +75,7 @@ const buildMcpToolset = ({
 		default_config: { permission_policy: { type: "always_allow" as const } },
 		mcp_server_name: claudeManagedConfig.autumnMcpServerName,
 		type: "mcp_toolset" as const,
-	}) satisfies McpToolsetLike;
-
-export const buildDesiredTools = ({
-	destructiveTools,
-}: {
-	destructiveTools: Iterable<string>;
-}) => {
-	const toolset = buildAgentToolset();
-	const mcpToolset = buildMcpToolset({ destructiveTools });
+	} satisfies McpToolsetLike;
 	return toolset ? [toolset, mcpToolset] : [mcpToolset];
 };
 
@@ -91,10 +84,13 @@ export type ClaudeManagedToolset = ReturnType<typeof buildDesiredTools>[number];
 export const desiredBuiltinSignature = () =>
 	[...claudeManagedBuiltinTools].sort().join(",");
 
-export const builtinSignatureFromToolset = (toolset: {
+export type BuiltinToolsetLike = {
 	configs?: { enabled: boolean; name: string }[];
 	default_config?: { enabled: boolean } | null;
-}) => {
+	type: string;
+};
+
+export const builtinSignatureFromToolset = (toolset: BuiltinToolsetLike) => {
 	const enabled = new Set<string>(
 		toolset.default_config?.enabled === false ? [] : ALL_BUILTIN_TOOLS,
 	);

--- a/apps/leaf/src/harness/claudeManaged/toolset.ts
+++ b/apps/leaf/src/harness/claudeManaged/toolset.ts
@@ -42,6 +42,7 @@ const buildAgentToolset = () =>
 			};
 
 type PermissionPolicyLike = { type?: string } | null | undefined;
+const DEFAULT_MCP_PERMISSION_POLICY = "always_allow";
 
 export type McpToolsetLike = {
 	configs?: Array<{
@@ -57,7 +58,8 @@ export type McpToolsetLike = {
 	type: "mcp_toolset";
 };
 
-const policyType = (policy: PermissionPolicyLike) => policy?.type ?? "unset";
+const policyType = (policy: PermissionPolicyLike, fallback: string) =>
+	policy?.type || fallback;
 
 const buildMcpToolset = ({
 	destructiveTools,
@@ -109,14 +111,15 @@ export const builtinSignatureFromToolset = (toolset: {
 export const mcpSignatureFromToolset = (toolset?: McpToolsetLike | null) => {
 	if (!toolset) return "";
 	const defaultEnabled = toolset.default_config?.enabled ?? true;
-	const defaultPolicy = policyType(toolset.default_config?.permission_policy);
+	const defaultPolicy = policyType(
+		toolset.default_config?.permission_policy,
+		DEFAULT_MCP_PERMISSION_POLICY,
+	);
 	const configs = (toolset.configs ?? [])
 		.map((config) => ({
 			enabled: config.enabled ?? defaultEnabled,
 			name: config.name,
-			permission: config.permission_policy
-				? policyType(config.permission_policy)
-				: defaultPolicy,
+			permission: policyType(config.permission_policy, defaultPolicy),
 		}))
 		.sort((a, b) => a.name.localeCompare(b.name));
 

--- a/apps/leaf/src/harness/claudeManaged/toolset.ts
+++ b/apps/leaf/src/harness/claudeManaged/toolset.ts
@@ -41,13 +41,30 @@ const buildAgentToolset = () =>
 				})),
 			};
 
-export const buildDesiredTools = ({
+type PermissionPolicyLike = { type?: string } | null | undefined;
+
+export type McpToolsetLike = {
+	configs?: Array<{
+		enabled?: boolean | null;
+		name: string;
+		permission_policy?: PermissionPolicyLike;
+	}>;
+	default_config?: {
+		enabled?: boolean | null;
+		permission_policy?: PermissionPolicyLike;
+	} | null;
+	mcp_server_name: string;
+	type: "mcp_toolset";
+};
+
+const policyType = (policy: PermissionPolicyLike) => policy?.type ?? "unset";
+
+const buildMcpToolset = ({
 	destructiveTools,
 }: {
 	destructiveTools: Iterable<string>;
-}) => {
-	const toolset = buildAgentToolset();
-	const mcpToolset = {
+}) =>
+	({
 		configs: [...destructiveTools].map((name) => ({
 			name,
 			permission_policy: { type: "always_ask" as const },
@@ -55,9 +72,19 @@ export const buildDesiredTools = ({
 		default_config: { permission_policy: { type: "always_allow" as const } },
 		mcp_server_name: claudeManagedConfig.autumnMcpServerName,
 		type: "mcp_toolset" as const,
-	};
+	}) satisfies McpToolsetLike;
+
+export const buildDesiredTools = ({
+	destructiveTools,
+}: {
+	destructiveTools: Iterable<string>;
+}) => {
+	const toolset = buildAgentToolset();
+	const mcpToolset = buildMcpToolset({ destructiveTools });
 	return toolset ? [toolset, mcpToolset] : [mcpToolset];
 };
+
+export type ClaudeManagedToolset = ReturnType<typeof buildDesiredTools>[number];
 
 export const desiredBuiltinSignature = () =>
 	[...claudeManagedBuiltinTools].sort().join(",");
@@ -77,4 +104,25 @@ export const builtinSignatureFromToolset = (toolset: {
 		}
 	}
 	return [...enabled].sort().join(",");
+};
+
+export const mcpSignatureFromToolset = (toolset?: McpToolsetLike | null) => {
+	if (!toolset) return "";
+	const defaultEnabled = toolset.default_config?.enabled ?? true;
+	const defaultPolicy = policyType(toolset.default_config?.permission_policy);
+	const configs = (toolset.configs ?? [])
+		.map((config) => ({
+			enabled: config.enabled ?? defaultEnabled,
+			name: config.name,
+			permission: config.permission_policy
+				? policyType(config.permission_policy)
+				: defaultPolicy,
+		}))
+		.sort((a, b) => a.name.localeCompare(b.name));
+
+	return JSON.stringify({
+		configs,
+		default: { enabled: defaultEnabled, permission: defaultPolicy },
+		server: toolset.mcp_server_name,
+	});
 };

--- a/apps/leaf/src/harness/common/runEngineLoop.ts
+++ b/apps/leaf/src/harness/common/runEngineLoop.ts
@@ -17,6 +17,7 @@ export const runEngineLoop = async ({
 	newSession,
 	params,
 	runTurn,
+	sendFollowUp,
 	sessionId,
 }: {
 	braintrust?: {
@@ -35,6 +36,8 @@ export const runEngineLoop = async ({
 		onTurnEnd: (turn: SessionTurnOutcome) => Promise<"continue" | "stop">;
 		span?: Span;
 	}) => Promise<SessionTurnOutcome>;
+	/** Deliver queued follow-up text to the session as the next user message. */
+	sendFollowUp: (input: { text: string }) => Promise<void>;
 	sessionId: string;
 }): Promise<AgentOutput> => {
 	const {
@@ -73,26 +76,49 @@ export const runEngineLoop = async ({
 		);
 	};
 
-	// Pump gate: keep consuming while injected follow-ups are pending, posting
-	// each drained turn's text as its own reply.
+	// The pump is the session's only writer of user messages: follow-ups queue
+	// locally on the run and are flushed here, at an idle the pump observed. A
+	// flush into an idle session starts exactly one turn ending in exactly one
+	// idle, so the pump can never wait on a turn the server won't run.
+	let turnInFlight = false;
+	if (run) {
+		run.notifyFollowUpQueued = () => {
+			// Interrupt only a live turn, so the queued text becomes the very next
+			// turn (the user chose immediate pivot over queue-behind-the-turn). At
+			// idle there is nothing to interrupt — the flush below delivers it.
+			if (turnInFlight && !isCancelled()) {
+				void Promise.resolve(interrupt()).catch(() => {});
+			}
+		};
+	}
+
 	const onTurnEnd = async (turn: SessionTurnOutcome) => {
-		if (!isCancelled() && run && run.pendingTurns > 0) {
-			run.pendingTurns -= 1;
-			const rawTurnText = turn.textParts.join("\n\n");
-			assertPostableText(rawTurnText);
-			const turnText = redactAgentOutput({
-				logger,
-				text: rawTurnText,
-			});
-			if (turnText.trim()) await onTurnComplete?.(turnText);
-			return "continue" as const;
+		turnInFlight = false;
+		// The drain and the empty-queue close stay synchronous so they are atomic
+		// against injectFollowUp's closed-check-then-push on the same event loop.
+		const queued = run && !isCancelled() ? run.drainFollowUps() : [];
+		if (queued.length === 0) {
+			if (run) run.closed = true;
+			return "stop" as const;
 		}
-		if (run) run.closed = true;
-		return "stop" as const;
+		const rawTurnText = turn.textParts.join("\n\n");
+		assertPostableText(rawTurnText);
+		const turnText = redactAgentOutput({
+			logger,
+			text: rawTurnText,
+		});
+		if (turnText.trim()) await onTurnComplete?.(turnText);
+		// One message per flush: several queued texts become one turn, and the
+		// pump expects exactly the one idle that turn ends with.
+		await sendFollowUp({ text: queued.join("\n\n") });
+		turnInFlight = true;
+		return "continue" as const;
 	};
 
-	const drive = ({ span }: { span?: Span }) =>
-		runTurn({ isCancelled, onTurnEnd, span });
+	const drive = ({ span }: { span?: Span }) => {
+		turnInFlight = true;
+		return runTurn({ isCancelled, onTurnEnd, span });
+	};
 
 	const deadlineDelayMs = deadlineAt ? deadlineAt - Date.now() : 0;
 	const deadlineWatchdog =
@@ -128,6 +154,9 @@ export const runEngineLoop = async ({
 			: await drive({});
 	} finally {
 		if (deadlineWatchdog) clearTimeout(deadlineWatchdog);
+		// A late inject must not interrupt a suspended or finished session; its
+		// queued text is surfaced as dropped when the run closes.
+		if (run) run.notifyFollowUpQueued = undefined;
 	}
 
 	const rawFinalText = outcome.textParts.join("\n\n");

--- a/apps/leaf/src/harness/common/runEngineLoop.ts
+++ b/apps/leaf/src/harness/common/runEngineLoop.ts
@@ -36,6 +36,7 @@ export const runEngineLoop = async ({
 	/** Run a single turn to completion, wiring the shared pump + cancel. */
 	runTurn: (input: {
 		isCancelled: () => boolean;
+		onTurnStarted: () => void;
 		onTurnEnd: (turn: SessionTurnOutcome) => Promise<"continue" | "stop">;
 		span?: Span;
 	}) => Promise<SessionTurnOutcome>;
@@ -79,7 +80,42 @@ export const runEngineLoop = async ({
 		);
 	};
 
+	let turnInterruptible = false;
+	let followUpInterruptRequested = false;
+	let followUpInterrupt: Promise<void> | undefined;
+	const requestFollowUpInterrupt = () => {
+		if (
+			!run ||
+			!turnInterruptible ||
+			followUpInterruptRequested ||
+			isCancelled() ||
+			run.followUps.size === 0
+		) {
+			return;
+		}
+		followUpInterruptRequested = true;
+		turnInterruptible = false;
+		followUpInterrupt = Promise.resolve(interrupt()).catch((error) => {
+			logger.warn("Could not interrupt session for follow-up", {
+				event: "leaf.run_follow_up_interrupt_failed",
+				context: { env, org_id: org.id },
+				data: { session_id: sessionId },
+				error,
+			});
+		});
+	};
+	if (run) run.followUps.onPush = requestFollowUpInterrupt;
+
+	const onTurnStarted = () => {
+		turnInterruptible = true;
+		requestFollowUpInterrupt();
+	};
+
 	const onTurnEnd = async (turn: SessionTurnOutcome) => {
+		turnInterruptible = false;
+		const interruptBeforeFlush = followUpInterrupt;
+		followUpInterrupt = undefined;
+		followUpInterruptRequested = false;
 		if (!run || isCancelled() || run.followUps.size === 0) {
 			run?.followUps.close();
 			return "stop" as const;
@@ -91,6 +127,9 @@ export const runEngineLoop = async ({
 			text: rawTurnText,
 		});
 		if (turnText.trim()) await onTurnComplete?.(turnText);
+		// If a follow-up interrupt raced with this turn ending, make it land
+		// before the queued user message so it cannot cancel that message later.
+		await interruptBeforeFlush;
 		// Drain only after the post succeeds so a failed turn keeps the queue.
 		const singleTurnBatch = run.followUps.drain().join("\n\n");
 		await sendFollowUp({ text: singleTurnBatch });
@@ -98,7 +137,7 @@ export const runEngineLoop = async ({
 	};
 
 	const drive = ({ span }: { span?: Span }) =>
-		runTurn({ isCancelled, onTurnEnd, span });
+		runTurn({ isCancelled, onTurnEnd, onTurnStarted, span });
 
 	const deadlineDelayMs = deadlineAt ? deadlineAt - Date.now() : 0;
 	const deadlineWatchdog =
@@ -135,7 +174,11 @@ export const runEngineLoop = async ({
 	} finally {
 		if (deadlineWatchdog) clearTimeout(deadlineWatchdog);
 		// Close on every exit (incl. suspension) so late injects start a new run.
-		if (run) run.followUps.close();
+		turnInterruptible = false;
+		if (run) {
+			run.followUps.close();
+			run.followUps.onPush = undefined;
+		}
 	}
 
 	const rawFinalText = outcome.textParts.join("\n\n");

--- a/apps/leaf/src/harness/common/runEngineLoop.ts
+++ b/apps/leaf/src/harness/common/runEngineLoop.ts
@@ -9,10 +9,7 @@ import { containsInternalToolCall, redactAgentOutput } from "./output.js";
 import type { SessionTurnOutcome } from "./types.js";
 
 /** Drives one engine turn through the shared pump gate, deadline watchdog, and
- * output assembly. The pump is the session's only writer of user messages:
- * queued follow-ups are flushed at an idle it observed, so a "continue" always
- * has a real next turn behind it. Engines supply only the harness-specific
- * `runTurn`, `interrupt`, and `sendFollowUp`. */
+ * output assembly. */
 export const runEngineLoop = async ({
 	braintrust,
 	ctx,
@@ -81,19 +78,17 @@ export const runEngineLoop = async ({
 	};
 
 	let turnInterruptible = false;
-	let followUpInterruptRequested = false;
 	let followUpInterrupt: Promise<void> | undefined;
 	const requestFollowUpInterrupt = () => {
 		if (
 			!run ||
 			!turnInterruptible ||
-			followUpInterruptRequested ||
+			followUpInterrupt !== undefined ||
 			isCancelled() ||
 			run.followUps.size === 0
 		) {
 			return;
 		}
-		followUpInterruptRequested = true;
 		turnInterruptible = false;
 		followUpInterrupt = Promise.resolve(interrupt()).catch((error) => {
 			logger.warn("Could not interrupt session for follow-up", {
@@ -115,7 +110,6 @@ export const runEngineLoop = async ({
 		turnInterruptible = false;
 		const interruptBeforeFlush = followUpInterrupt;
 		followUpInterrupt = undefined;
-		followUpInterruptRequested = false;
 		if (!run || isCancelled() || run.followUps.size === 0) {
 			run?.followUps.close();
 			return "stop" as const;
@@ -127,12 +121,16 @@ export const runEngineLoop = async ({
 			text: rawTurnText,
 		});
 		if (turnText.trim()) await onTurnComplete?.(turnText);
-		// If a follow-up interrupt raced with this turn ending, make it land
-		// before the queued user message so it cannot cancel that message later.
+		// A racing follow-up interrupt must land before the queued user message, or it could cancel that message.
 		await interruptBeforeFlush;
-		// Drain only after the post succeeds so a failed turn keeps the queue.
-		const singleTurnBatch = run.followUps.drain().join("\n\n");
-		await sendFollowUp({ text: singleTurnBatch });
+		// Drain after the post succeeds so a failed turn keeps the queue; restore on a failed send.
+		const singleTurnBatch = run.followUps.drain();
+		try {
+			await sendFollowUp({ text: singleTurnBatch.join("\n\n") });
+		} catch (error) {
+			run.followUps.restore(singleTurnBatch);
+			throw error;
+		}
 		return "continue" as const;
 	};
 

--- a/apps/leaf/src/harness/common/runEngineLoop.ts
+++ b/apps/leaf/src/harness/common/runEngineLoop.ts
@@ -81,7 +81,7 @@ export const runEngineLoop = async ({
 
 	let turnInFlight = false;
 	if (run) {
-		run.notifyFollowUpQueued = () => {
+		run.followUps.onPush = () => {
 			if (turnInFlight && !isCancelled()) {
 				void Promise.resolve(interrupt()).catch(() => {});
 			}
@@ -90,9 +90,8 @@ export const runEngineLoop = async ({
 
 	const onTurnEnd = async (turn: SessionTurnOutcome) => {
 		turnInFlight = false;
-		const queued = run && !isCancelled() ? run.drainFollowUps() : [];
-		if (queued.length === 0) {
-			if (run) run.closed = true;
+		if (!run || isCancelled() || run.followUps.size === 0) {
+			run?.followUps.close();
 			return "stop" as const;
 		}
 		const rawTurnText = turn.textParts.join("\n\n");
@@ -102,7 +101,8 @@ export const runEngineLoop = async ({
 			text: rawTurnText,
 		});
 		if (turnText.trim()) await onTurnComplete?.(turnText);
-		const singleTurnBatch = queued.join("\n\n");
+		// Drain only after the post succeeds so a failed turn keeps the queue.
+		const singleTurnBatch = run.followUps.drain().join("\n\n");
 		await sendFollowUp({ text: singleTurnBatch });
 		turnInFlight = true;
 		return "continue" as const;
@@ -147,7 +147,11 @@ export const runEngineLoop = async ({
 			: await drive({});
 	} finally {
 		if (deadlineWatchdog) clearTimeout(deadlineWatchdog);
-		if (run) run.notifyFollowUpQueued = undefined;
+		// Close on every exit (incl. suspension) so late injects start a new run.
+		if (run) {
+			run.followUps.close();
+			run.followUps.onPush = undefined;
+		}
 	}
 
 	const rawFinalText = outcome.textParts.join("\n\n");

--- a/apps/leaf/src/harness/common/runEngineLoop.ts
+++ b/apps/leaf/src/harness/common/runEngineLoop.ts
@@ -9,7 +9,10 @@ import { containsInternalToolCall, redactAgentOutput } from "./output.js";
 import type { SessionTurnOutcome } from "./types.js";
 
 /** Drives one engine turn through the shared pump gate, deadline watchdog, and
- * output assembly. Engines supply only the harness-specific `runTurn` + `interrupt`. */
+ * output assembly. The pump is the session's only writer of user messages:
+ * queued follow-ups are flushed at an idle it observed, so a "continue" always
+ * has a real next turn behind it. Engines supply only the harness-specific
+ * `runTurn`, `interrupt`, and `sendFollowUp`. */
 export const runEngineLoop = async ({
 	braintrust,
 	ctx,
@@ -76,16 +79,9 @@ export const runEngineLoop = async ({
 		);
 	};
 
-	// The pump is the session's only writer of user messages: follow-ups queue
-	// locally on the run and are flushed here, at an idle the pump observed. A
-	// flush into an idle session starts exactly one turn ending in exactly one
-	// idle, so the pump can never wait on a turn the server won't run.
 	let turnInFlight = false;
 	if (run) {
 		run.notifyFollowUpQueued = () => {
-			// Interrupt only a live turn, so the queued text becomes the very next
-			// turn (the user chose immediate pivot over queue-behind-the-turn). At
-			// idle there is nothing to interrupt — the flush below delivers it.
 			if (turnInFlight && !isCancelled()) {
 				void Promise.resolve(interrupt()).catch(() => {});
 			}
@@ -94,8 +90,6 @@ export const runEngineLoop = async ({
 
 	const onTurnEnd = async (turn: SessionTurnOutcome) => {
 		turnInFlight = false;
-		// The drain and the empty-queue close stay synchronous so they are atomic
-		// against injectFollowUp's closed-check-then-push on the same event loop.
 		const queued = run && !isCancelled() ? run.drainFollowUps() : [];
 		if (queued.length === 0) {
 			if (run) run.closed = true;
@@ -108,9 +102,8 @@ export const runEngineLoop = async ({
 			text: rawTurnText,
 		});
 		if (turnText.trim()) await onTurnComplete?.(turnText);
-		// One message per flush: several queued texts become one turn, and the
-		// pump expects exactly the one idle that turn ends with.
-		await sendFollowUp({ text: queued.join("\n\n") });
+		const singleTurnBatch = queued.join("\n\n");
+		await sendFollowUp({ text: singleTurnBatch });
 		turnInFlight = true;
 		return "continue" as const;
 	};
@@ -154,8 +147,6 @@ export const runEngineLoop = async ({
 			: await drive({});
 	} finally {
 		if (deadlineWatchdog) clearTimeout(deadlineWatchdog);
-		// A late inject must not interrupt a suspended or finished session; its
-		// queued text is surfaced as dropped when the run closes.
 		if (run) run.notifyFollowUpQueued = undefined;
 	}
 

--- a/apps/leaf/src/harness/common/runEngineLoop.ts
+++ b/apps/leaf/src/harness/common/runEngineLoop.ts
@@ -79,17 +79,7 @@ export const runEngineLoop = async ({
 		);
 	};
 
-	let turnInFlight = false;
-	if (run) {
-		run.followUps.onPush = () => {
-			if (turnInFlight && !isCancelled()) {
-				void Promise.resolve(interrupt()).catch(() => {});
-			}
-		};
-	}
-
 	const onTurnEnd = async (turn: SessionTurnOutcome) => {
-		turnInFlight = false;
 		if (!run || isCancelled() || run.followUps.size === 0) {
 			run?.followUps.close();
 			return "stop" as const;
@@ -104,14 +94,11 @@ export const runEngineLoop = async ({
 		// Drain only after the post succeeds so a failed turn keeps the queue.
 		const singleTurnBatch = run.followUps.drain().join("\n\n");
 		await sendFollowUp({ text: singleTurnBatch });
-		turnInFlight = true;
 		return "continue" as const;
 	};
 
-	const drive = ({ span }: { span?: Span }) => {
-		turnInFlight = true;
-		return runTurn({ isCancelled, onTurnEnd, span });
-	};
+	const drive = ({ span }: { span?: Span }) =>
+		runTurn({ isCancelled, onTurnEnd, span });
 
 	const deadlineDelayMs = deadlineAt ? deadlineAt - Date.now() : 0;
 	const deadlineWatchdog =
@@ -148,10 +135,7 @@ export const runEngineLoop = async ({
 	} finally {
 		if (deadlineWatchdog) clearTimeout(deadlineWatchdog);
 		// Close on every exit (incl. suspension) so late injects start a new run.
-		if (run) {
-			run.followUps.close();
-			run.followUps.onPush = undefined;
-		}
+		if (run) run.followUps.close();
 	}
 
 	const rawFinalText = outcome.textParts.join("\n\n");

--- a/apps/leaf/src/internal/runs/followUpQueue.ts
+++ b/apps/leaf/src/internal/runs/followUpQueue.ts
@@ -5,6 +5,8 @@
  * ordering is settled by the event loop.
  */
 export class FollowUpQueue {
+	/** Installed by the pump to request an interrupt when a live turn should pivot. */
+	onPush?: () => void;
 	private items: string[] = [];
 	private closedFlag = false;
 
@@ -27,5 +29,6 @@ export class FollowUpQueue {
 	push(text: string) {
 		if (this.closedFlag) throw new Error("Run is closing");
 		this.items.push(text);
+		this.onPush?.();
 	}
 }

--- a/apps/leaf/src/internal/runs/followUpQueue.ts
+++ b/apps/leaf/src/internal/runs/followUpQueue.ts
@@ -1,9 +1,4 @@
-/**
- * Follow-up texts queued on one run. The engine pump is the only consumer:
- * it drains at turn boundaries it observed, so delivery can't desync from
- * session behavior. All methods are synchronous — push vs drain/close
- * ordering is settled by the event loop.
- */
+// Queued follow-up texts for one run; the engine pump drains this at turn boundaries.
 export class FollowUpQueue {
 	/** Installed by the pump to request an interrupt when a live turn should pivot. */
 	onPush?: () => void;
@@ -24,6 +19,11 @@ export class FollowUpQueue {
 
 	drain() {
 		return this.items.splice(0);
+	}
+
+	/** Ignores the closed flag: a failed send is the one caller and must not lose items. */
+	restore(items: string[]) {
+		this.items.unshift(...items);
 	}
 
 	push(text: string) {

--- a/apps/leaf/src/internal/runs/followUpQueue.ts
+++ b/apps/leaf/src/internal/runs/followUpQueue.ts
@@ -1,0 +1,34 @@
+/**
+ * Follow-up texts queued on one run. The engine pump is the only consumer:
+ * it drains at turn boundaries it observed, so delivery can't desync from
+ * session behavior. All methods are synchronous — push vs drain/close
+ * ordering is settled by the event loop.
+ */
+export class FollowUpQueue {
+	/** Installed by the pump to interrupt a turn in flight on push. */
+	onPush?: () => void;
+	private items: string[] = [];
+	private closedFlag = false;
+
+	get closed() {
+		return this.closedFlag;
+	}
+
+	get size() {
+		return this.items.length;
+	}
+
+	close() {
+		this.closedFlag = true;
+	}
+
+	drain() {
+		return this.items.splice(0);
+	}
+
+	push(text: string) {
+		if (this.closedFlag) throw new Error("Run is closing");
+		this.items.push(text);
+		this.onPush?.();
+	}
+}

--- a/apps/leaf/src/internal/runs/followUpQueue.ts
+++ b/apps/leaf/src/internal/runs/followUpQueue.ts
@@ -5,8 +5,6 @@
  * ordering is settled by the event loop.
  */
 export class FollowUpQueue {
-	/** Installed by the pump to interrupt a turn in flight on push. */
-	onPush?: () => void;
 	private items: string[] = [];
 	private closedFlag = false;
 
@@ -29,6 +27,5 @@ export class FollowUpQueue {
 	push(text: string) {
 		if (this.closedFlag) throw new Error("Run is closing");
 		this.items.push(text);
-		this.onPush?.();
 	}
 }

--- a/apps/leaf/src/internal/runs/runCoordinator.ts
+++ b/apps/leaf/src/internal/runs/runCoordinator.ts
@@ -10,7 +10,7 @@ const STOP_KEYWORDS = new Set([
 	"stop please",
 ]);
 
-const MAX_PENDING_TURNS = 5;
+const MAX_QUEUED_FOLLOW_UPS = 5;
 
 export const isStopMessage = (text: string) =>
 	STOP_KEYWORDS.has(
@@ -41,7 +41,7 @@ export const dispatchThreadMessage = async ({
 	text: string;
 }) => {
 	const active = getRun(runKey);
-	if (active && !(active.closed || active.stop)) {
+	if (active && !(active.followUps.closed || active.stop)) {
 		if (isStopMessage(text)) {
 			logger.info("Stop keyword received for active run", {
 				event: "leaf.run_stop_keyword",
@@ -56,14 +56,14 @@ export const dispatchThreadMessage = async ({
 			active.kind === "message" &&
 			active.ownerProviderUserId === providerUserId &&
 			!hasAttachments &&
-			active.pendingTurns < MAX_PENDING_TURNS;
+			active.followUps.size < MAX_QUEUED_FOLLOW_UPS;
 
 		if (injectable) {
 			try {
-				active.injectFollowUp({ text });
+				active.followUps.push(text);
 				logger.info("Injected follow-up into active run", {
 					event: "leaf.run_follow_up_injected",
-					data: { pending_turns: active.pendingTurns, run_key: runKey },
+					data: { pending_follow_ups: active.followUps.size, run_key: runKey },
 				});
 				await onFollowUpInjected?.();
 				return;

--- a/apps/leaf/src/internal/runs/runCoordinator.ts
+++ b/apps/leaf/src/internal/runs/runCoordinator.ts
@@ -60,7 +60,7 @@ export const dispatchThreadMessage = async ({
 
 		if (injectable) {
 			try {
-				await active.injectFollowUp({ text });
+				active.injectFollowUp({ text });
 				logger.info("Injected follow-up into active run", {
 					event: "leaf.run_follow_up_injected",
 					data: { pending_turns: active.pendingTurns, run_key: runKey },

--- a/apps/leaf/src/internal/runs/runCoordinator.ts
+++ b/apps/leaf/src/internal/runs/runCoordinator.ts
@@ -41,17 +41,17 @@ export const dispatchThreadMessage = async ({
 	text: string;
 }) => {
 	const active = getRun(runKey);
-	if (active && !(active.followUps.closed || active.stop)) {
-		if (isStopMessage(text)) {
-			logger.info("Stop keyword received for active run", {
-				event: "leaf.run_stop_keyword",
-				data: { run_key: runKey },
-			});
-			await active.logAction?.(`Stopping — requested by <@${providerUserId}>…`);
-			await active.requestStop({ byUserId: providerUserId, reason: "user" });
-			return;
-		}
+	if (active && !active.stop && isStopMessage(text)) {
+		logger.info("Stop keyword received for active run", {
+			event: "leaf.run_stop_keyword",
+			data: { run_key: runKey },
+		});
+		await active.logAction?.(`Stopping — requested by <@${providerUserId}>…`);
+		await active.requestStop({ byUserId: providerUserId, reason: "user" });
+		return;
+	}
 
+	if (active && !(active.followUps.closed || active.stop)) {
 		const injectable =
 			active.kind === "message" &&
 			active.ownerProviderUserId === providerUserId &&

--- a/apps/leaf/src/internal/runs/runRegistry.ts
+++ b/apps/leaf/src/internal/runs/runRegistry.ts
@@ -1,5 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { logger } from "../../lib/logger.js";
+import { FollowUpQueue } from "./followUpQueue.js";
 
 const client = new Anthropic();
 
@@ -8,18 +9,11 @@ const SESSION_RESOLVE_TIMEOUT_MS = 15_000;
 export type RunStopReason = "timeout" | "user";
 
 export type ActiveRun = {
-	/** Set by the pump once it stops consuming turns — no more injections. */
-	closed?: boolean;
-	drainFollowUps: () => string[];
-	/** Queues text as an upcoming turn for the engine pump; throws once the run is closing. */
-	injectFollowUp: (input: { text: string }) => void;
+	followUps: FollowUpQueue;
 	key: string;
 	kind: "approval" | "message";
 	logAction?: (message: string) => Promise<void> | void;
-	/** Set by the engine pump to interrupt a turn in flight when a follow-up queues. */
-	notifyFollowUpQueued?: () => void;
 	ownerProviderUserId: string;
-	readonly pendingTurns: number;
 	requestStop: (input: {
 		byUserId: string;
 		reason: RunStopReason;
@@ -68,7 +62,6 @@ export const registerRun = ({
 		resolveSessionId = resolve;
 	});
 	let interruptSent = false;
-	const followUpQueue: string[] = [];
 
 	const resolveSessionIdOrNull = () =>
 		Promise.race([
@@ -79,24 +72,17 @@ export const registerRun = ({
 		]);
 
 	const run: ActiveRun = {
+		followUps: new FollowUpQueue(),
 		key,
 		kind,
 		ownerProviderUserId,
-		get pendingTurns() {
-			return followUpQueue.length;
-		},
 		resolveSessionId,
 		sessionId,
 		startedAt: Date.now(),
-		drainFollowUps: () => followUpQueue.splice(0),
-		injectFollowUp: ({ text }) => {
-			if (run.closed || run.stop) throw new Error("Run is closing");
-			followUpQueue.push(text);
-			run.notifyFollowUpQueued?.();
-		},
 		requestStop: async ({ byUserId, reason }) => {
 			if (run.stop) return;
 			run.stop = { byUserId, reason };
+			run.followUps.close();
 			if (interruptSent) return;
 			interruptSent = true;
 			// The session id may never resolve if the run failed during setup.
@@ -121,11 +107,11 @@ export const getRun = (key: string) => runs.get(key);
 
 /** Marks the run inactive and removes the entry only if it still belongs to this run. */
 export const closeRun = ({ key, run }: { key: string; run: ActiveRun }) => {
-	run.closed = true;
-	if (run.pendingTurns > 0) {
+	run.followUps.close();
+	if (run.followUps.size > 0) {
 		logger.warn("Closing run with undelivered follow-ups", {
 			event: "leaf.run_closed_with_pending_follow_ups",
-			data: { pending_turns: run.pendingTurns, run_key: key },
+			data: { pending_follow_ups: run.followUps.size, run_key: key },
 		});
 	}
 	if (runs.get(key) === run) runs.delete(key);

--- a/apps/leaf/src/internal/runs/runRegistry.ts
+++ b/apps/leaf/src/internal/runs/runRegistry.ts
@@ -10,22 +10,15 @@ export type RunStopReason = "timeout" | "user";
 export type ActiveRun = {
 	/** Set by the pump once it stops consuming turns — no more injections. */
 	closed?: boolean;
-	/** Pump-side: takes every queued follow-up text, emptying the queue. */
 	drainFollowUps: () => string[];
-	/**
-	 * Queues text to run as an upcoming turn. The engine pump is the only
-	 * writer of user messages to the session, so it delivers the queue itself
-	 * at a turn boundary it observed — the turn count can never desync from
-	 * server behavior. Throws once the run is closing.
-	 */
+	/** Queues text as an upcoming turn for the engine pump; throws once the run is closing. */
 	injectFollowUp: (input: { text: string }) => void;
 	key: string;
 	kind: "approval" | "message";
 	logAction?: (message: string) => Promise<void> | void;
-	/** Set by the engine pump; fires after a follow-up is queued so a turn in flight can be interrupted. */
+	/** Set by the engine pump to interrupt a turn in flight when a follow-up queues. */
 	notifyFollowUpQueued?: () => void;
 	ownerProviderUserId: string;
-	/** Queued follow-up turns not yet delivered to the session. */
 	readonly pendingTurns: number;
 	requestStop: (input: {
 		byUserId: string;
@@ -97,8 +90,6 @@ export const registerRun = ({
 		startedAt: Date.now(),
 		drainFollowUps: () => followUpQueue.splice(0),
 		injectFollowUp: ({ text }) => {
-			// The closed check and the push stay synchronous so they are atomic
-			// against the pump's drain-then-close decision on the same event loop.
 			if (run.closed || run.stop) throw new Error("Run is closing");
 			followUpQueue.push(text);
 			run.notifyFollowUpQueued?.();

--- a/apps/leaf/src/internal/runs/runRegistry.ts
+++ b/apps/leaf/src/internal/runs/runRegistry.ts
@@ -10,13 +10,23 @@ export type RunStopReason = "timeout" | "user";
 export type ActiveRun = {
 	/** Set by the pump once it stops consuming turns — no more injections. */
 	closed?: boolean;
-	/** Interrupts the current turn and delivers the text as the next turn. */
-	injectFollowUp: (input: { text: string }) => Promise<void>;
+	/** Pump-side: takes every queued follow-up text, emptying the queue. */
+	drainFollowUps: () => string[];
+	/**
+	 * Queues text to run as an upcoming turn. The engine pump is the only
+	 * writer of user messages to the session, so it delivers the queue itself
+	 * at a turn boundary it observed — the turn count can never desync from
+	 * server behavior. Throws once the run is closing.
+	 */
+	injectFollowUp: (input: { text: string }) => void;
 	key: string;
 	kind: "approval" | "message";
 	logAction?: (message: string) => Promise<void> | void;
+	/** Set by the engine pump; fires after a follow-up is queued so a turn in flight can be interrupted. */
+	notifyFollowUpQueued?: () => void;
 	ownerProviderUserId: string;
-	pendingTurns: number;
+	/** Queued follow-up turns not yet delivered to the session. */
+	readonly pendingTurns: number;
 	requestStop: (input: {
 		byUserId: string;
 		reason: RunStopReason;
@@ -49,39 +59,23 @@ const defaultSendInterrupt = async (sessionId: string) => {
 	});
 };
 
-const defaultSendUserMessage = async ({
-	sessionId,
-	text,
-}: {
-	sessionId: string;
-	text: string;
-}) => {
-	await client.beta.sessions.events.send(sessionId, {
-		events: [{ content: [{ text, type: "text" }], type: "user.message" }],
-	});
-};
-
 export const registerRun = ({
 	key,
 	kind,
 	ownerProviderUserId,
 	sendInterrupt = defaultSendInterrupt,
-	sendUserMessage = defaultSendUserMessage,
 }: {
 	key: string;
 	kind: ActiveRun["kind"];
 	ownerProviderUserId: string;
 	sendInterrupt?: (sessionId: string) => Promise<void>;
-	sendUserMessage?: (input: {
-		sessionId: string;
-		text: string;
-	}) => Promise<void>;
 }): ActiveRun => {
 	let resolveSessionId!: (sessionId: string) => void;
 	const sessionId = new Promise<string>((resolve) => {
 		resolveSessionId = resolve;
 	});
 	let interruptSent = false;
+	const followUpQueue: string[] = [];
 
 	const resolveSessionIdOrNull = () =>
 		Promise.race([
@@ -95,25 +89,19 @@ export const registerRun = ({
 		key,
 		kind,
 		ownerProviderUserId,
-		pendingTurns: 0,
+		get pendingTurns() {
+			return followUpQueue.length;
+		},
 		resolveSessionId,
 		sessionId,
 		startedAt: Date.now(),
-		injectFollowUp: async ({ text }) => {
+		drainFollowUps: () => followUpQueue.splice(0),
+		injectFollowUp: ({ text }) => {
+			// The closed check and the push stay synchronous so they are atomic
+			// against the pump's drain-then-close decision on the same event loop.
 			if (run.closed || run.stop) throw new Error("Run is closing");
-			const resolved = await resolveSessionIdOrNull();
-			if (!resolved) throw new Error("Session is not ready yet");
-			if (run.closed || run.stop) throw new Error("Run is closing");
-			run.pendingTurns += 1;
-			try {
-				// Interrupt first so the message becomes the very next turn —
-				// the user chose immediate pivot over queue-behind-the-turn.
-				if (run.kind === "message") await sendInterrupt(resolved);
-				await sendUserMessage({ sessionId: resolved, text });
-			} catch (error) {
-				run.pendingTurns -= 1;
-				throw error;
-			}
+			followUpQueue.push(text);
+			run.notifyFollowUpQueued?.();
 		},
 		requestStop: async ({ byUserId, reason }) => {
 			if (run.stop) return;
@@ -143,5 +131,11 @@ export const getRun = (key: string) => runs.get(key);
 /** Marks the run inactive and removes the entry only if it still belongs to this run. */
 export const closeRun = ({ key, run }: { key: string; run: ActiveRun }) => {
 	run.closed = true;
+	if (run.pendingTurns > 0) {
+		logger.warn("Closing run with undelivered follow-ups", {
+			event: "leaf.run_closed_with_pending_follow_ups",
+			data: { pending_turns: run.pendingTurns, run_key: key },
+		});
+	}
 	if (runs.get(key) === run) runs.delete(key);
 };

--- a/apps/leaf/tests/unit/agent/agent.test.ts
+++ b/apps/leaf/tests/unit/agent/agent.test.ts
@@ -30,8 +30,11 @@ const { createFirecrawlTools } = await import(
 const { isCmaVaultStale } = await import(
 	"../../../src/harness/claudeManaged/vaults/ensureAutumnVault.js"
 );
-const { buildAgentSystem } = await import(
+const { buildAgentSystem, syncClaudeManagedSessionAgentConfig } = await import(
 	"../../../src/harness/claudeManaged/ensureLeafResources.js"
+);
+const { buildDesiredTools } = await import(
+	"../../../src/harness/claudeManaged/toolset.js"
 );
 const { containsInternalToolCall } = await import(
 	"../../../src/harness/common/output.js"
@@ -336,6 +339,58 @@ describe("Claude Managed vault sync", () => {
 		expect(system).toContain("Preview before every write.");
 		// The slack surface points at the billing knowledge.
 		expect(system).toContain("autumn-billing");
+	});
+
+	test("refreshes stale session MCP permissions", async () => {
+		const mcpServers = [
+			{
+				name: "autumn" as const,
+				type: "url" as const,
+				url: "https://j.dev.useautumn.com/mcp",
+			},
+		];
+		const tools = buildDesiredTools({ destructiveTools: ["attach"] });
+		const staleTools = tools.map((tool) =>
+			tool.type === "mcp_toolset"
+				? {
+						...tool,
+						default_config: {
+							enabled: false,
+							permission_policy: { type: "always_allow" as const },
+						},
+					}
+				: tool,
+		);
+		const updates: unknown[] = [];
+		const client = {
+			beta: {
+				sessions: {
+					retrieve: async () => ({
+						agent: { mcp_servers: mcpServers, tools: staleTools },
+					}),
+					update: async (_sessionId: string, params: unknown) => {
+						updates.push(params);
+						return {};
+					},
+				},
+			},
+		} as never;
+
+		await syncClaudeManagedSessionAgentConfig({
+			client,
+			env: AppEnv.Sandbox,
+			logger: { info: () => {} } as never,
+			orgId: "org_1",
+			resources: {
+				agentId: "agent_1",
+				environmentId: "env_1",
+				mcpServers,
+				tools,
+			},
+			sessionId: "session_1",
+		});
+
+		expect(updates).toEqual([{ agent: { tools } }]);
 	});
 
 	test("treats the vault as stale when local OAuth credentials are newer", () => {

--- a/apps/leaf/tests/unit/agent/agent.test.ts
+++ b/apps/leaf/tests/unit/agent/agent.test.ts
@@ -393,6 +393,47 @@ describe("Claude Managed vault sync", () => {
 		expect(updates).toEqual([{ agent: { tools } }]);
 	});
 
+	test("skips the session retrieve when resources are unchanged", async () => {
+		const mcpServers = [
+			{
+				name: "autumn" as const,
+				type: "url" as const,
+				url: "https://j.dev.useautumn.com/mcp",
+			},
+		];
+		const tools = buildDesiredTools({ destructiveTools: ["attach"] });
+		let retrieves = 0;
+		const client = {
+			beta: {
+				sessions: {
+					retrieve: async () => {
+						retrieves += 1;
+						return { agent: { mcp_servers: mcpServers, tools } };
+					},
+					update: async () => ({}),
+				},
+			},
+		} as never;
+		const args = {
+			client,
+			env: AppEnv.Sandbox,
+			logger: { info: () => {} } as never,
+			orgId: "org_1",
+			resources: {
+				agentId: "agent_2",
+				environmentId: "env_2",
+				mcpServers,
+				tools,
+			},
+			sessionId: "session_unchanged",
+		};
+
+		await syncClaudeManagedSessionAgentConfig(args);
+		await syncClaudeManagedSessionAgentConfig(args);
+
+		expect(retrieves).toBe(1);
+	});
+
 	test("treats the vault as stale when local OAuth credentials are newer", () => {
 		expect(
 			isCmaVaultStale({

--- a/apps/leaf/tests/unit/harness/claudeManagedToolset.test.ts
+++ b/apps/leaf/tests/unit/harness/claudeManagedToolset.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import {
+	mcpSignatureFromToolset,
+	type McpToolsetLike,
+} from "../../../src/harness/claudeManaged/toolset.js";
+
+const explicitAlwaysAllowToolset = {
+	configs: [],
+	default_config: { permission_policy: { type: "always_allow" } },
+	mcp_server_name: "autumn",
+	type: "mcp_toolset" as const,
+} satisfies McpToolsetLike;
+
+describe("mcpSignatureFromToolset", () => {
+	test("normalizes omitted default permission policies to always_allow", () => {
+		const omittedDefaultPolicy = {
+			configs: [],
+			default_config: {},
+			mcp_server_name: "autumn",
+			type: "mcp_toolset" as const,
+		} satisfies McpToolsetLike;
+		const emptyDefaultPolicy = {
+			configs: [],
+			default_config: { permission_policy: {} },
+			mcp_server_name: "autumn",
+			type: "mcp_toolset" as const,
+		} satisfies McpToolsetLike;
+
+		expect(mcpSignatureFromToolset(omittedDefaultPolicy)).toBe(
+			mcpSignatureFromToolset(explicitAlwaysAllowToolset),
+		);
+		expect(mcpSignatureFromToolset(emptyDefaultPolicy)).toBe(
+			mcpSignatureFromToolset(explicitAlwaysAllowToolset),
+		);
+	});
+
+	test("normalizes empty permission policy objects to the effective default", () => {
+		const explicitInheritedPolicy = {
+			...explicitAlwaysAllowToolset,
+			configs: [
+				{
+					name: "listCustomers",
+					permission_policy: { type: "always_allow" },
+				},
+			],
+		} satisfies McpToolsetLike;
+		const emptyPolicyObject = {
+			...explicitAlwaysAllowToolset,
+			configs: [
+				{
+					name: "listCustomers",
+					permission_policy: {},
+				},
+			],
+		} satisfies McpToolsetLike;
+
+		expect(mcpSignatureFromToolset(emptyPolicyObject)).toBe(
+			mcpSignatureFromToolset(explicitInheritedPolicy),
+		);
+	});
+});

--- a/apps/leaf/tests/unit/harness/driveSessionTurn.test.ts
+++ b/apps/leaf/tests/unit/harness/driveSessionTurn.test.ts
@@ -110,6 +110,7 @@ describe("driveSessionTurn", () => {
 
 	test("pumps multiple turns while onTurnEnd continues", async () => {
 		const drainedTurns: string[][] = [];
+		let turnStarts = 0;
 		let continuesLeft = 1;
 		const outcome = await driveSessionTurn({
 			autumnMcpServerName: "autumn",
@@ -126,6 +127,9 @@ describe("driveSessionTurn", () => {
 				idleEndTurn,
 			]),
 			kickoff: async () => {},
+			onTurnStarted: () => {
+				turnStarts += 1;
+			},
 			onTurnEnd: (turn) => {
 				drainedTurns.push([...turn.textParts]);
 				if (continuesLeft > 0) {
@@ -138,6 +142,7 @@ describe("driveSessionTurn", () => {
 		});
 
 		expect(drainedTurns).toEqual([["first turn"], ["second turn"]]);
+		expect(turnStarts).toBe(2);
 		expect(outcome.textParts).toEqual(["second turn"]);
 	});
 

--- a/apps/leaf/tests/unit/harness/ensureLeafResources.test.ts
+++ b/apps/leaf/tests/unit/harness/ensureLeafResources.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
+
+const originalNodeEnv = process.env.NODE_ENV;
+
+afterEach(() => {
+	if (originalNodeEnv === undefined) {
+		delete process.env.NODE_ENV;
+	} else {
+		process.env.NODE_ENV = originalNodeEnv;
+	}
+});
+
+const destructiveToolNames = (
+	tools: Array<{ configs?: Array<{ name: string }>; type: string }>,
+) =>
+	(
+		tools.find((tool) => tool.type === "mcp_toolset")?.configs ?? []
+	)
+		.map((config) => config.name)
+		.sort();
+
+describe("ensureLeafResources", () => {
+	test("partitions production resources by token-derived MCP permissions", async () => {
+		process.env.NODE_ENV = "production";
+
+		const setupAgentToolContext = mock(
+			async ({ token }: { token: string }) => ({
+				destructiveTools: new Set(
+					token === "token-a" ? ["attach"] : ["delete_customer"],
+				),
+			}),
+		);
+		const skills = [
+			{ type: "custom" as const, skill_id: "skill_1", version: "latest" as const },
+		];
+		const ensureLeafSkills = mock(async () => skills);
+
+		mock.module("../../../src/lib/env.js", () => ({
+			env: { MCP_SERVER_URL: "https://j.dev.useautumn.com" },
+		}));
+		mock.module(
+			"../../../src/agent/runMessage/setup/setupAgentToolContext.js",
+			() => ({ setupAgentToolContext }),
+		);
+		mock.module("../../../src/harness/claudeManaged/skills.js", () => ({
+			ensureLeafSkills,
+			skillsMatch: (
+				current: Array<{ skill_id?: string | null }> | undefined,
+				desired: typeof skills,
+			) => {
+				const currentIds = new Set(
+					(current ?? [])
+						.map((skill) => skill.skill_id)
+						.filter((id): id is string => Boolean(id)),
+				);
+				return (
+					desired.length === currentIds.size &&
+					desired.every((ref) => currentIds.has(ref.skill_id))
+				);
+			},
+		}));
+
+		const { ensureLeafResources } = await import(
+			`../../../src/harness/claudeManaged/ensureLeafResources.js?cache-test=${Date.now()}`
+		);
+
+		let storedAgent:
+			| {
+					id: string;
+					mcp_servers: unknown;
+					model: { id: string };
+					name: string;
+					skills: typeof skills;
+					system: string;
+					tools: Array<{ configs?: Array<{ name: string }>; type: string }>;
+					version: number;
+			  }
+			| undefined;
+		const updates: unknown[] = [];
+		const client = {
+			beta: {
+				agents: {
+					create: async (params: {
+						mcp_servers: unknown;
+						model: string;
+						name: string;
+						skills: typeof skills;
+						system: string;
+						tools: Array<{
+							configs?: Array<{ name: string }>;
+							type: string;
+						}>;
+					}) => {
+						storedAgent = {
+							...params,
+							id: "agent_1",
+							model: { id: params.model },
+							version: 1,
+						};
+						return { id: storedAgent.id };
+					},
+					list: async function* () {
+						if (storedAgent) yield storedAgent;
+					},
+					retrieve: async () => {
+						if (!storedAgent) throw new Error("Agent was not created");
+						return storedAgent;
+					},
+					update: async (
+						_id: string,
+						params: {
+							mcp_servers?: unknown;
+							model?: string;
+							skills?: typeof skills;
+							system?: string;
+							tools?: Array<{
+								configs?: Array<{ name: string }>;
+								type: string;
+							}>;
+							version: number;
+						},
+					) => {
+						if (!storedAgent) throw new Error("Agent was not created");
+						updates.push(params);
+						storedAgent = {
+							...storedAgent,
+							...params,
+							mcp_servers: params.mcp_servers ?? storedAgent.mcp_servers,
+							model: { id: params.model ?? storedAgent.model.id },
+							skills: params.skills ?? storedAgent.skills,
+							system: params.system ?? storedAgent.system,
+							tools: params.tools ?? storedAgent.tools,
+							version: storedAgent.version + 1,
+						};
+						return storedAgent;
+					},
+				},
+				environments: {
+					create: async () => ({ id: "env_1" }),
+					list: async function* () {},
+				},
+			},
+		};
+
+		const logger = { info: () => {} };
+		const first = await ensureLeafResources({
+			client: client as never,
+			env: AppEnv.Sandbox,
+			logger: logger as never,
+			surface: "slack",
+			token: "token-a",
+		});
+		const second = await ensureLeafResources({
+			client: client as never,
+			env: AppEnv.Sandbox,
+			logger: logger as never,
+			surface: "slack",
+			token: "token-b",
+		});
+		const firstAgain = await ensureLeafResources({
+			client: client as never,
+			env: AppEnv.Sandbox,
+			logger: logger as never,
+			surface: "slack",
+			token: "token-a",
+		});
+
+		expect(setupAgentToolContext).toHaveBeenCalledTimes(3);
+		expect(destructiveToolNames(first.tools)).toEqual(["attach"]);
+		expect(destructiveToolNames(second.tools)).toEqual(["delete_customer"]);
+		expect(destructiveToolNames(firstAgain.tools)).toEqual(["attach"]);
+		expect(updates).toHaveLength(2);
+		expect(
+			destructiveToolNames(
+				(updates[0] as { tools: typeof second.tools }).tools,
+			),
+		).toEqual(["delete_customer"]);
+		expect(
+			destructiveToolNames(
+				(updates[1] as { tools: typeof first.tools }).tools,
+			),
+		).toEqual(["attach"]);
+		expect(ensureLeafSkills).toHaveBeenCalledTimes(3);
+	});
+});

--- a/apps/leaf/tests/unit/harness/ensureLeafResources.test.ts
+++ b/apps/leaf/tests/unit/harness/ensureLeafResources.test.ts
@@ -14,9 +14,7 @@ afterEach(() => {
 const destructiveToolNames = (
 	tools: Array<{ configs?: Array<{ name: string }>; type: string }>,
 ) =>
-	(
-		tools.find((tool) => tool.type === "mcp_toolset")?.configs ?? []
-	)
+	(tools.find((tool) => tool.type === "mcp_toolset")?.configs ?? [])
 		.map((config) => config.name)
 		.sort();
 
@@ -32,7 +30,11 @@ describe("ensureLeafResources", () => {
 			}),
 		);
 		const skills = [
-			{ type: "custom" as const, skill_id: "skill_1", version: "latest" as const },
+			{
+				type: "custom" as const,
+				skill_id: "skill_1",
+				version: "latest" as const,
+			},
 		];
 		const ensureLeafSkills = mock(async () => skills);
 
@@ -166,7 +168,9 @@ describe("ensureLeafResources", () => {
 			token: "token-a",
 		});
 
-		expect(setupAgentToolContext).toHaveBeenCalledTimes(3);
+		// token-a is fetched once and served from the short-TTL cache on the
+		// third call, so only the two distinct tokens hit the round trip.
+		expect(setupAgentToolContext).toHaveBeenCalledTimes(2);
 		expect(destructiveToolNames(first.tools)).toEqual(["attach"]);
 		expect(destructiveToolNames(second.tools)).toEqual(["delete_customer"]);
 		expect(destructiveToolNames(firstAgain.tools)).toEqual(["attach"]);
@@ -177,9 +181,7 @@ describe("ensureLeafResources", () => {
 			),
 		).toEqual(["delete_customer"]);
 		expect(
-			destructiveToolNames(
-				(updates[1] as { tools: typeof first.tools }).tools,
-			),
+			destructiveToolNames((updates[1] as { tools: typeof first.tools }).tools),
 		).toEqual(["attach"]);
 		expect(ensureLeafSkills).toHaveBeenCalledTimes(3);
 	});

--- a/apps/leaf/tests/unit/harness/runEngineLoop.test.ts
+++ b/apps/leaf/tests/unit/harness/runEngineLoop.test.ts
@@ -83,7 +83,7 @@ describe("runEngineLoop follow-up pump", () => {
 		closeRun({ key: "el1", run });
 	});
 
-	test("interrupts only a turn in flight and rejects injects after close", async () => {
+	test("never interrupts the session for queued follow-ups", async () => {
 		const run = registerRun({
 			key: "el2",
 			kind: "message",
@@ -101,8 +101,7 @@ describe("runEngineLoop follow-up pump", () => {
 			params: { text: "question" },
 			runTurn: async ({ onTurnEnd }) => {
 				run.followUps.push("pivot");
-				expect(interrupts).toBe(1);
-				expect(await onTurnEnd(turnOutcome("aborted answer"))).toBe("continue");
+				expect(await onTurnEnd(turnOutcome("first answer"))).toBe("continue");
 				const second = turnOutcome("pivot answer");
 				expect(await onTurnEnd(second)).toBe("stop");
 				return second;
@@ -111,7 +110,7 @@ describe("runEngineLoop follow-up pump", () => {
 			sessionId: "sesn_2",
 		});
 
-		expect(interrupts).toBe(1);
+		expect(interrupts).toBe(0);
 		expect(() => run.followUps.push("late")).toThrow("Run is closing");
 		closeRun({ key: "el2", run });
 	});

--- a/apps/leaf/tests/unit/harness/runEngineLoop.test.ts
+++ b/apps/leaf/tests/unit/harness/runEngineLoop.test.ts
@@ -231,4 +231,43 @@ describe("runEngineLoop follow-up pump", () => {
 		expect(run.followUps.closed).toBe(true);
 		closeRun({ key: "el5", run });
 	});
+
+	test("a failed follow-up send restores the queue instead of losing it", async () => {
+		const run = registerRun({
+			key: "el6",
+			kind: "message",
+			ownerProviderUserId: "U1",
+		});
+		run.resolveSessionId("sesn_6");
+		const posted: string[] = [];
+
+		await expect(
+			runEngineLoop({
+				ctx: makeContext({
+					onTurnComplete: (text) => {
+						posted.push(text);
+					},
+					run,
+				}),
+				interrupt: () => {},
+				newSession: true,
+				params: { text: "question" },
+				runTurn: async ({ onTurnEnd }) => {
+					run.followUps.push("follow-up");
+					const outcome = turnOutcome("answer");
+					await onTurnEnd(outcome);
+					return outcome;
+				},
+				sendFollowUp: async () => {
+					throw new Error("send failed");
+				},
+				sessionId: "sesn_6",
+			}),
+		).rejects.toThrow("send failed");
+
+		expect(posted).toEqual(["answer"]);
+		expect(run.followUps.size).toBe(1);
+		expect(run.followUps.closed).toBe(true);
+		closeRun({ key: "el6", run });
+	});
 });

--- a/apps/leaf/tests/unit/harness/runEngineLoop.test.ts
+++ b/apps/leaf/tests/unit/harness/runEngineLoop.test.ts
@@ -47,8 +47,8 @@ describe("runEngineLoop follow-up pump", () => {
 		});
 		run.resolveSessionId("sesn_1");
 		// The hang repro: two queued follow-ups answered by a single turn.
-		run.injectFollowUp({ text: "second question" });
-		run.injectFollowUp({ text: "third question" });
+		run.followUps.push("second question");
+		run.followUps.push("third question");
 		const flushed: string[] = [];
 		const posted: string[] = [];
 
@@ -79,7 +79,7 @@ describe("runEngineLoop follow-up pump", () => {
 		expect(posted).toEqual(["answer one"]);
 		expect(output.text).toBe("answer two");
 		expect(output.finishReason).toBe("stop");
-		expect(run.closed).toBe(true);
+		expect(run.followUps.closed).toBe(true);
 		closeRun({ key: "el1", run });
 	});
 
@@ -100,7 +100,7 @@ describe("runEngineLoop follow-up pump", () => {
 			newSession: true,
 			params: { text: "question" },
 			runTurn: async ({ onTurnEnd }) => {
-				run.injectFollowUp({ text: "pivot" });
+				run.followUps.push("pivot");
 				expect(interrupts).toBe(1);
 				expect(await onTurnEnd(turnOutcome("aborted answer"))).toBe("continue");
 				const second = turnOutcome("pivot answer");
@@ -112,9 +112,7 @@ describe("runEngineLoop follow-up pump", () => {
 		});
 
 		expect(interrupts).toBe(1);
-		expect(() => run.injectFollowUp({ text: "late" })).toThrow(
-			"Run is closing",
-		);
+		expect(() => run.followUps.push("late")).toThrow("Run is closing");
 		closeRun({ key: "el2", run });
 	});
 
@@ -134,7 +132,7 @@ describe("runEngineLoop follow-up pump", () => {
 			newSession: true,
 			params: { text: "question" },
 			runTurn: async ({ onTurnEnd }) => {
-				run.injectFollowUp({ text: "follow-up" });
+				run.followUps.push("follow-up");
 				await run.requestStop({ byUserId: "U9", reason: "user" });
 				const outcome = turnOutcome("partial");
 				expect(await onTurnEnd(outcome)).toBe("stop");
@@ -149,5 +147,71 @@ describe("runEngineLoop follow-up pump", () => {
 		expect(flushed).toEqual([]);
 		expect(output.finishReason).toBe("stopped");
 		closeRun({ key: "el3", run });
+	});
+
+	test("closes the queue when a turn suspends so late injects start a new run", async () => {
+		const run = registerRun({
+			key: "el4",
+			kind: "message",
+			ownerProviderUserId: "U1",
+		});
+		run.resolveSessionId("sesn_4");
+
+		const output = await runEngineLoop({
+			ctx: makeContext({ run }),
+			interrupt: () => {},
+			newSession: true,
+			params: { text: "attach the pro plan" },
+			runTurn: async () => ({
+				...turnOutcome("needs approval"),
+				suspendedQueue: [{ args: {}, toolCallId: "t1", toolName: "attach" }],
+			}),
+			sendFollowUp: async () => {},
+			sessionId: "sesn_4",
+		});
+
+		expect(output.finishReason).toBe("suspended");
+		expect(run.followUps.closed).toBe(true);
+		expect(() => run.followUps.push("late")).toThrow("Run is closing");
+		closeRun({ key: "el4", run });
+	});
+
+	test("a failed turn post keeps the queue instead of losing it", async () => {
+		const run = registerRun({
+			key: "el5",
+			kind: "message",
+			ownerProviderUserId: "U1",
+		});
+		run.resolveSessionId("sesn_5");
+		const flushed: string[] = [];
+
+		await expect(
+			runEngineLoop({
+				ctx: makeContext({
+					onTurnComplete: () => {
+						throw new Error("slack down");
+					},
+					run,
+				}),
+				interrupt: () => {},
+				newSession: true,
+				params: { text: "question" },
+				runTurn: async ({ onTurnEnd }) => {
+					run.followUps.push("follow-up");
+					const outcome = turnOutcome("answer");
+					await onTurnEnd(outcome);
+					return outcome;
+				},
+				sendFollowUp: async ({ text }) => {
+					flushed.push(text);
+				},
+				sessionId: "sesn_5",
+			}),
+		).rejects.toThrow("slack down");
+
+		expect(flushed).toEqual([]);
+		expect(run.followUps.size).toBe(1);
+		expect(run.followUps.closed).toBe(true);
+		closeRun({ key: "el5", run });
 	});
 });

--- a/apps/leaf/tests/unit/harness/runEngineLoop.test.ts
+++ b/apps/leaf/tests/unit/harness/runEngineLoop.test.ts
@@ -46,8 +46,7 @@ describe("runEngineLoop follow-up pump", () => {
 			ownerProviderUserId: "U1",
 		});
 		run.resolveSessionId("sesn_1");
-		// Two quick follow-ups queued before the turn ends — the old counting
-		// pump expected two extra turns and hung when the session ran only one.
+		// The hang repro: two queued follow-ups answered by a single turn.
 		run.injectFollowUp({ text: "second question" });
 		run.injectFollowUp({ text: "third question" });
 		const flushed: string[] = [];

--- a/apps/leaf/tests/unit/harness/runEngineLoop.test.ts
+++ b/apps/leaf/tests/unit/harness/runEngineLoop.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import type { AppEnv } from "@autumn/shared";
+import type { MessageContext } from "../../../src/agent/runMessage/types.js";
+import { runEngineLoop } from "../../../src/harness/common/runEngineLoop.js";
+import type { SessionTurnOutcome } from "../../../src/harness/common/types.js";
+import {
+	closeRun,
+	registerRun,
+} from "../../../src/internal/runs/runRegistry.js";
+import { logger } from "../../../src/lib/logger.js";
+
+const turnOutcome = (text: string): SessionTurnOutcome => ({
+	textParts: [text],
+	toolResults: [],
+	usage: {
+		cacheCreationInputTokens: 0,
+		cacheReadInputTokens: 0,
+		inputTokens: 0,
+		outputTokens: 0,
+	},
+});
+
+const makeContext = (overrides: Partial<MessageContext>): MessageContext => ({
+	agentTools: { destructiveTools: new Set<string>() },
+	env: "sandbox" as AppEnv,
+	id: "run-1",
+	logger,
+	org: { id: "org_1" },
+	providerUserId: "U1",
+	thread: {
+		channelId: "C1",
+		provider: "slack",
+		threadId: "171.001",
+		workspaceId: "T1",
+	},
+	timestamp: Date.now(),
+	token: "token",
+	...overrides,
+});
+
+describe("runEngineLoop follow-up pump", () => {
+	test("flushes queued follow-ups as one message and stops when the queue empties", async () => {
+		const run = registerRun({
+			key: "el1",
+			kind: "message",
+			ownerProviderUserId: "U1",
+		});
+		run.resolveSessionId("sesn_1");
+		// Two quick follow-ups queued before the turn ends — the old counting
+		// pump expected two extra turns and hung when the session ran only one.
+		run.injectFollowUp({ text: "second question" });
+		run.injectFollowUp({ text: "third question" });
+		const flushed: string[] = [];
+		const posted: string[] = [];
+
+		const output = await runEngineLoop({
+			ctx: makeContext({
+				onTurnComplete: (text) => {
+					posted.push(text);
+				},
+				run,
+			}),
+			interrupt: () => {},
+			newSession: true,
+			params: { text: "first question" },
+			runTurn: async ({ onTurnEnd }) => {
+				let outcome = turnOutcome("answer one");
+				while ((await onTurnEnd(outcome)) === "continue") {
+					outcome = turnOutcome("answer two");
+				}
+				return outcome;
+			},
+			sendFollowUp: async ({ text }) => {
+				flushed.push(text);
+			},
+			sessionId: "sesn_1",
+		});
+
+		expect(flushed).toEqual(["second question\n\nthird question"]);
+		expect(posted).toEqual(["answer one"]);
+		expect(output.text).toBe("answer two");
+		expect(output.finishReason).toBe("stop");
+		expect(run.closed).toBe(true);
+		closeRun({ key: "el1", run });
+	});
+
+	test("interrupts only a turn in flight and rejects injects after close", async () => {
+		const run = registerRun({
+			key: "el2",
+			kind: "message",
+			ownerProviderUserId: "U1",
+		});
+		run.resolveSessionId("sesn_2");
+		let interrupts = 0;
+
+		await runEngineLoop({
+			ctx: makeContext({ run }),
+			interrupt: () => {
+				interrupts += 1;
+			},
+			newSession: true,
+			params: { text: "question" },
+			runTurn: async ({ onTurnEnd }) => {
+				run.injectFollowUp({ text: "pivot" });
+				expect(interrupts).toBe(1);
+				expect(await onTurnEnd(turnOutcome("aborted answer"))).toBe("continue");
+				const second = turnOutcome("pivot answer");
+				expect(await onTurnEnd(second)).toBe("stop");
+				return second;
+			},
+			sendFollowUp: async () => {},
+			sessionId: "sesn_2",
+		});
+
+		expect(interrupts).toBe(1);
+		expect(() => run.injectFollowUp({ text: "late" })).toThrow(
+			"Run is closing",
+		);
+		closeRun({ key: "el2", run });
+	});
+
+	test("a stopped run drops queued follow-ups instead of flushing them", async () => {
+		const run = registerRun({
+			key: "el3",
+			kind: "message",
+			ownerProviderUserId: "U1",
+			sendInterrupt: async () => {},
+		});
+		run.resolveSessionId("sesn_3");
+		const flushed: string[] = [];
+
+		const output = await runEngineLoop({
+			ctx: makeContext({ run }),
+			interrupt: () => {},
+			newSession: true,
+			params: { text: "question" },
+			runTurn: async ({ onTurnEnd }) => {
+				run.injectFollowUp({ text: "follow-up" });
+				await run.requestStop({ byUserId: "U9", reason: "user" });
+				const outcome = turnOutcome("partial");
+				expect(await onTurnEnd(outcome)).toBe("stop");
+				return outcome;
+			},
+			sendFollowUp: async ({ text }) => {
+				flushed.push(text);
+			},
+			sessionId: "sesn_3",
+		});
+
+		expect(flushed).toEqual([]);
+		expect(output.finishReason).toBe("stopped");
+		closeRun({ key: "el3", run });
+	});
+});

--- a/apps/leaf/tests/unit/harness/runEngineLoop.test.ts
+++ b/apps/leaf/tests/unit/harness/runEngineLoop.test.ts
@@ -83,7 +83,7 @@ describe("runEngineLoop follow-up pump", () => {
 		closeRun({ key: "el1", run });
 	});
 
-	test("never interrupts the session for queued follow-ups", async () => {
+	test("interrupts an active turn for queued follow-ups before pump delivery", async () => {
 		const run = registerRun({
 			key: "el2",
 			kind: "message",
@@ -91,26 +91,44 @@ describe("runEngineLoop follow-up pump", () => {
 		});
 		run.resolveSessionId("sesn_2");
 		let interrupts = 0;
+		let resolveInterrupt: (() => void) | undefined;
+		const flushed: string[] = [];
 
 		await runEngineLoop({
 			ctx: makeContext({ run }),
 			interrupt: () => {
 				interrupts += 1;
+				return new Promise<void>((resolve) => {
+					resolveInterrupt = resolve;
+				});
 			},
 			newSession: true,
 			params: { text: "question" },
-			runTurn: async ({ onTurnEnd }) => {
+			runTurn: async ({ onTurnEnd, onTurnStarted }) => {
+				onTurnStarted();
 				run.followUps.push("pivot");
-				expect(await onTurnEnd(turnOutcome("first answer"))).toBe("continue");
+				run.followUps.push("clarification");
+				expect(interrupts).toBe(1);
+
+				const firstTurnEnd = onTurnEnd(turnOutcome("aborted answer"));
+				await Promise.resolve();
+				expect(flushed).toEqual([]);
+				expect(resolveInterrupt).toBeDefined();
+				resolveInterrupt?.();
+				expect(await firstTurnEnd).toBe("continue");
+
 				const second = turnOutcome("pivot answer");
 				expect(await onTurnEnd(second)).toBe("stop");
 				return second;
 			},
-			sendFollowUp: async () => {},
+			sendFollowUp: async ({ text }) => {
+				flushed.push(text);
+			},
 			sessionId: "sesn_2",
 		});
 
-		expect(interrupts).toBe(0);
+		expect(interrupts).toBe(1);
+		expect(flushed).toEqual(["pivot\n\nclarification"]);
 		expect(() => run.followUps.push("late")).toThrow("Run is closing");
 		closeRun({ key: "el2", run });
 	});

--- a/apps/leaf/tests/unit/runs/runCoordinator.test.ts
+++ b/apps/leaf/tests/unit/runs/runCoordinator.test.ts
@@ -56,7 +56,7 @@ describe("dispatchThreadMessage", () => {
 		});
 		run.resolveSessionId("sesn_1");
 		let notified = 0;
-		run.notifyFollowUpQueued = () => {
+		run.followUps.onPush = () => {
 			notified += 1;
 		};
 		let acked = 0;
@@ -75,9 +75,9 @@ describe("dispatchThreadMessage", () => {
 			text: "also, what's the MRR?",
 		});
 
-		expect(run.pendingTurns).toBe(1);
+		expect(run.followUps.size).toBe(1);
 		expect(notified).toBe(1);
-		expect(run.drainFollowUps()).toEqual(["also, what's the MRR?"]);
+		expect(run.followUps.drain()).toEqual(["also, what's the MRR?"]);
 		expect(acked).toBe(1);
 		expect(newRuns).toBe(0);
 		closeRun({ key: "co2", run });
@@ -117,8 +117,8 @@ describe("dispatchThreadMessage", () => {
 			ownerProviderUserId: "U1",
 		});
 		run.resolveSessionId("sesn_1");
-		// The pump closed the run between the coordinator's check and the inject.
-		run.injectFollowUp = () => {
+		// The pump closed the run between the coordinator's check and the push.
+		run.followUps.push = () => {
 			throw new Error("Run is closing");
 		};
 		let newRuns = 0;
@@ -134,7 +134,7 @@ describe("dispatchThreadMessage", () => {
 		});
 
 		expect(newRuns).toBe(1);
-		expect(run.pendingTurns).toBe(0);
+		expect(run.followUps.size).toBe(0);
 		closeRun({ key: "co4", run });
 	});
 
@@ -182,7 +182,7 @@ describe("dispatchThreadMessage", () => {
 			text: "attach the enterprise plan to cus_1",
 		});
 
-		expect(run.pendingTurns).toBe(0);
+		expect(run.followUps.size).toBe(0);
 		expect(newRuns).toBe(1);
 		closeRun({ key: "co6", run });
 	});

--- a/apps/leaf/tests/unit/runs/runCoordinator.test.ts
+++ b/apps/leaf/tests/unit/runs/runCoordinator.test.ts
@@ -48,20 +48,17 @@ describe("dispatchThreadMessage", () => {
 		closeRun({ key: "co1", run });
 	});
 
-	test("injects follow-ups into the active run with an interrupt first", async () => {
-		const sent: string[] = [];
+	test("queues follow-ups on the active run and notifies the pump", async () => {
 		const run = registerRun({
 			key: "co2",
 			kind: "message",
 			ownerProviderUserId: "U1",
-			sendInterrupt: async () => {
-				sent.push("interrupt");
-			},
-			sendUserMessage: async ({ text }) => {
-				sent.push(`message:${text}`);
-			},
 		});
 		run.resolveSessionId("sesn_1");
+		let notified = 0;
+		run.notifyFollowUpQueued = () => {
+			notified += 1;
+		};
 		let acked = 0;
 		let newRuns = 0;
 
@@ -78,8 +75,9 @@ describe("dispatchThreadMessage", () => {
 			text: "also, what's the MRR?",
 		});
 
-		expect(sent).toEqual(["interrupt", "message:also, what's the MRR?"]);
 		expect(run.pendingTurns).toBe(1);
+		expect(notified).toBe(1);
+		expect(run.drainFollowUps()).toEqual(["also, what's the MRR?"]);
 		expect(acked).toBe(1);
 		expect(newRuns).toBe(0);
 		closeRun({ key: "co2", run });
@@ -117,11 +115,13 @@ describe("dispatchThreadMessage", () => {
 			key: "co4",
 			kind: "message",
 			ownerProviderUserId: "U1",
-			sendInterrupt: async () => {
-				throw new Error("session busy");
-			},
 		});
 		run.resolveSessionId("sesn_1");
+		// Emulate the close race: the pump closes the run between the
+		// coordinator's active check and the inject.
+		run.injectFollowUp = () => {
+			throw new Error("Run is closing");
+		};
 		let newRuns = 0;
 
 		await dispatchThreadMessage({
@@ -163,17 +163,10 @@ describe("dispatchThreadMessage", () => {
 	});
 
 	test("does not inject a different sender's message into the owner's run", async () => {
-		const sent: string[] = [];
 		const run = registerRun({
 			key: "co6",
 			kind: "message",
 			ownerProviderUserId: "U1",
-			sendInterrupt: async () => {
-				sent.push("interrupt");
-			},
-			sendUserMessage: async ({ text }) => {
-				sent.push(`message:${text}`);
-			},
 		});
 		run.resolveSessionId("sesn_1");
 		let newRuns = 0;
@@ -190,7 +183,6 @@ describe("dispatchThreadMessage", () => {
 			text: "attach the enterprise plan to cus_1",
 		});
 
-		expect(sent).toEqual([]);
 		expect(run.pendingTurns).toBe(0);
 		expect(newRuns).toBe(1);
 		closeRun({ key: "co6", run });

--- a/apps/leaf/tests/unit/runs/runCoordinator.test.ts
+++ b/apps/leaf/tests/unit/runs/runCoordinator.test.ts
@@ -117,8 +117,7 @@ describe("dispatchThreadMessage", () => {
 			ownerProviderUserId: "U1",
 		});
 		run.resolveSessionId("sesn_1");
-		// Emulate the close race: the pump closes the run between the
-		// coordinator's active check and the inject.
+		// The pump closed the run between the coordinator's check and the inject.
 		run.injectFollowUp = () => {
 			throw new Error("Run is closing");
 		};

--- a/apps/leaf/tests/unit/runs/runCoordinator.test.ts
+++ b/apps/leaf/tests/unit/runs/runCoordinator.test.ts
@@ -48,6 +48,36 @@ describe("dispatchThreadMessage", () => {
 		closeRun({ key: "co1", run });
 	});
 
+	test("routes stop keywords even after the follow-up queue closes", async () => {
+		const interrupts: string[] = [];
+		const run = registerRun({
+			key: "co1b",
+			kind: "message",
+			ownerProviderUserId: "U1",
+			sendInterrupt: async (sessionId) => {
+				interrupts.push(sessionId);
+			},
+		});
+		run.resolveSessionId("sesn_1");
+		run.followUps.close();
+		let newRuns = 0;
+
+		await dispatchThreadMessage({
+			hasAttachments: false,
+			providerUserId: "U1",
+			runKey: "co1b",
+			runNewMessage: async () => {
+				newRuns += 1;
+			},
+			text: "stop",
+		});
+
+		expect(run.stop).toEqual({ byUserId: "U1", reason: "user" });
+		expect(interrupts).toEqual(["sesn_1"]);
+		expect(newRuns).toBe(0);
+		closeRun({ key: "co1b", run });
+	});
+
 	test("queues follow-ups on the active run", async () => {
 		const run = registerRun({
 			key: "co2",
@@ -76,6 +106,36 @@ describe("dispatchThreadMessage", () => {
 		expect(acked).toBe(1);
 		expect(newRuns).toBe(0);
 		closeRun({ key: "co2", run });
+	});
+
+	test("queues a new run for follow-ups after the follow-up queue closes", async () => {
+		const run = registerRun({
+			key: "co2b",
+			kind: "message",
+			ownerProviderUserId: "U1",
+		});
+		run.resolveSessionId("sesn_1");
+		run.followUps.close();
+		let acked = 0;
+		let newRuns = 0;
+
+		await dispatchThreadMessage({
+			hasAttachments: false,
+			onFollowUpInjected: () => {
+				acked += 1;
+			},
+			providerUserId: "U1",
+			runKey: "co2b",
+			runNewMessage: async () => {
+				newRuns += 1;
+			},
+			text: "also, what's the MRR?",
+		});
+
+		expect(run.followUps.size).toBe(0);
+		expect(acked).toBe(0);
+		expect(newRuns).toBe(1);
+		closeRun({ key: "co2b", run });
 	});
 
 	test("serializes new runs per thread when nothing is active", async () => {

--- a/apps/leaf/tests/unit/runs/runCoordinator.test.ts
+++ b/apps/leaf/tests/unit/runs/runCoordinator.test.ts
@@ -48,17 +48,13 @@ describe("dispatchThreadMessage", () => {
 		closeRun({ key: "co1", run });
 	});
 
-	test("queues follow-ups on the active run and notifies the pump", async () => {
+	test("queues follow-ups on the active run", async () => {
 		const run = registerRun({
 			key: "co2",
 			kind: "message",
 			ownerProviderUserId: "U1",
 		});
 		run.resolveSessionId("sesn_1");
-		let notified = 0;
-		run.followUps.onPush = () => {
-			notified += 1;
-		};
 		let acked = 0;
 		let newRuns = 0;
 
@@ -76,7 +72,6 @@ describe("dispatchThreadMessage", () => {
 		});
 
 		expect(run.followUps.size).toBe(1);
-		expect(notified).toBe(1);
 		expect(run.followUps.drain()).toEqual(["also, what's the MRR?"]);
 		expect(acked).toBe(1);
 		expect(newRuns).toBe(0);

--- a/apps/leaf/tests/unit/runs/runRegistry.test.ts
+++ b/apps/leaf/tests/unit/runs/runRegistry.test.ts
@@ -31,7 +31,7 @@ describe("runRegistry", () => {
 		expect(run.closed).toBe(true);
 	});
 
-	test("injection is rejected once a run is closed", async () => {
+	test("injection is rejected once a run is closed", () => {
 		const run = registerRun({
 			key: "k1b",
 			kind: "message",
@@ -40,9 +40,31 @@ describe("runRegistry", () => {
 		run.resolveSessionId("sesn_1");
 		closeRun({ key: "k1b", run });
 
-		expect(run.injectFollowUp({ text: "late" })).rejects.toThrow(
+		expect(() => run.injectFollowUp({ text: "late" })).toThrow(
 			"Run is closing",
 		);
+	});
+
+	test("queues follow-ups locally and drains them in order", () => {
+		const run = registerRun({
+			key: "k1c",
+			kind: "message",
+			ownerProviderUserId: "U1",
+		});
+		const notifiedAtCounts: number[] = [];
+		run.notifyFollowUpQueued = () => {
+			notifiedAtCounts.push(run.pendingTurns);
+		};
+
+		run.injectFollowUp({ text: "one" });
+		run.injectFollowUp({ text: "two" });
+
+		expect(run.pendingTurns).toBe(2);
+		expect(notifiedAtCounts).toEqual([1, 2]);
+		expect(run.drainFollowUps()).toEqual(["one", "two"]);
+		expect(run.pendingTurns).toBe(0);
+		expect(run.drainFollowUps()).toEqual([]);
+		closeRun({ key: "k1c", run });
 	});
 
 	test("close ignores entries replaced by a newer run", () => {

--- a/apps/leaf/tests/unit/runs/runRegistry.test.ts
+++ b/apps/leaf/tests/unit/runs/runRegistry.test.ts
@@ -28,7 +28,7 @@ describe("runRegistry", () => {
 
 		closeRun({ key: "k1", run });
 		expect(getRun("k1")).toBeUndefined();
-		expect(run.closed).toBe(true);
+		expect(run.followUps.closed).toBe(true);
 	});
 
 	test("injection is rejected once a run is closed", () => {
@@ -40,9 +40,7 @@ describe("runRegistry", () => {
 		run.resolveSessionId("sesn_1");
 		closeRun({ key: "k1b", run });
 
-		expect(() => run.injectFollowUp({ text: "late" })).toThrow(
-			"Run is closing",
-		);
+		expect(() => run.followUps.push("late")).toThrow("Run is closing");
 	});
 
 	test("queues follow-ups locally and drains them in order", () => {
@@ -51,20 +49,35 @@ describe("runRegistry", () => {
 			kind: "message",
 			ownerProviderUserId: "U1",
 		});
-		const notifiedAtCounts: number[] = [];
-		run.notifyFollowUpQueued = () => {
-			notifiedAtCounts.push(run.pendingTurns);
+		const notifiedAtSizes: number[] = [];
+		run.followUps.onPush = () => {
+			notifiedAtSizes.push(run.followUps.size);
 		};
 
-		run.injectFollowUp({ text: "one" });
-		run.injectFollowUp({ text: "two" });
+		run.followUps.push("one");
+		run.followUps.push("two");
 
-		expect(run.pendingTurns).toBe(2);
-		expect(notifiedAtCounts).toEqual([1, 2]);
-		expect(run.drainFollowUps()).toEqual(["one", "two"]);
-		expect(run.pendingTurns).toBe(0);
-		expect(run.drainFollowUps()).toEqual([]);
+		expect(run.followUps.size).toBe(2);
+		expect(notifiedAtSizes).toEqual([1, 2]);
+		expect(run.followUps.drain()).toEqual(["one", "two"]);
+		expect(run.followUps.size).toBe(0);
+		expect(run.followUps.drain()).toEqual([]);
 		closeRun({ key: "k1c", run });
+	});
+
+	test("a stop request closes the queue", async () => {
+		const run = registerRun({
+			key: "k1d",
+			kind: "message",
+			ownerProviderUserId: "U1",
+			sendInterrupt: async () => {},
+		});
+		run.resolveSessionId("sesn_1");
+
+		await run.requestStop({ byUserId: "U1", reason: "user" });
+
+		expect(() => run.followUps.push("late")).toThrow("Run is closing");
+		closeRun({ key: "k1d", run });
 	});
 
 	test("close ignores entries replaced by a newer run", () => {

--- a/apps/leaf/tests/unit/runs/runRegistry.test.ts
+++ b/apps/leaf/tests/unit/runs/runRegistry.test.ts
@@ -49,16 +49,10 @@ describe("runRegistry", () => {
 			kind: "message",
 			ownerProviderUserId: "U1",
 		});
-		const notifiedAtSizes: number[] = [];
-		run.followUps.onPush = () => {
-			notifiedAtSizes.push(run.followUps.size);
-		};
-
 		run.followUps.push("one");
 		run.followUps.push("two");
 
 		expect(run.followUps.size).toBe(2);
-		expect(notifiedAtSizes).toEqual([1, 2]);
 		expect(run.followUps.drain()).toEqual(["one", "two"]);
 		expect(run.followUps.size).toBe(0);
 		expect(run.followUps.drain()).toEqual([]);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilizes Claude Managed sessions by making the pump the only writer of follow-ups and syncing MCP permissions at agent and session levels with less overhead. Restores run coordination guards and fixes hangs from desynced follow-ups.

- **Bug Fixes**
  - Queue follow-ups locally and flush them at an observed idle as one user message; no direct session writes outside the pump.
  - Interrupt only while a turn is active; detect turn start from any `agent.*` event to avoid canceling queued messages.
  - Restore coordinator guards: route stop keywords even after the queue closes; cap at 5 queued follow-ups; start a new run when the queue is closed, sender differs, or there are attachments.
  - Close the follow-up queue on stop/exit/suspend so late messages start a new run; restore drained follow-ups if send fails so none are lost.
  - Sync MCP URL and tool permissions for the active session via `syncClaudeManagedSessionAgentConfig`; skip session retrieve when the desired config is unchanged.

- **Refactors**
  - Introduced `FollowUpQueue`; removed `injectFollowUp` and `pendingTurns`. `runEngineLoop` now accepts `sendFollowUp` and emits `onTurnStarted`; `claudeManagedEngine` wires both to the CMA client and turn driver.
  - `ensureLeafResources` now returns `mcpServers` and `tools`, caches per surface + token-derived tool policy with a short TTL, and diffs builtin and MCP signatures to decide updates; deduped toolset extraction and signatures. Added unit tests for the pump, coordinator, session sync, and toolset signatures.

<sup>Written for commit 048090630ccb77d99c246ee15ff21ba8d70356e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

