### PR TITLE
scope one-off cleanup scan to one-off priced products, run every 10m

### DIFF
--- a/server/src/cron/cronInit.ts
+++ b/server/src/cron/cronInit.ts
@@ -23,13 +23,14 @@ const { db, client } = initDrizzle({ name: "cron", maxConnections: 40 });
 startPgPoolMonitor();
 startBlueGreenHeartbeat({ db, logger, serviceName: "cron" });
 
-const logCronHeartbeat = () => {
+const logCronHeartbeat = (job = "main") => {
 	logger.info(
 		{
 			type: "cron_heartbeat",
 			cron: {
 				pid: process.pid,
 				timezone: "UTC",
+				job,
 			},
 		},
 		"Cron heartbeat",
@@ -78,6 +79,8 @@ const main = async () => {
 // column to seek on), so it runs on a slower cadence than the other jobs.
 const oneOffCleanupTick = async () => {
 	if (!shouldRunTick()) return;
+
+	logCronHeartbeat("one_off_cleanup");
 
 	const ctx: CronContext = {
 		db,

--- a/server/src/cron/cronInit.ts
+++ b/server/src/cron/cronInit.ts
@@ -36,10 +36,10 @@ const logCronHeartbeat = () => {
 	);
 };
 
-const main = async () => {
+const shouldRunTick = () => {
 	if (process.env.DISABLE_CRON === "true") {
 		console.log(`Cron disabled!`);
-		return;
+		return false;
 	}
 
 	// Blue-green gate: skip the tick on the idle task set so a swap doesn't
@@ -50,8 +50,14 @@ const main = async () => {
 			type: "cron_skipped_idle",
 			gate: reason,
 		});
-		return;
+		return false;
 	}
+
+	return true;
+};
+
+const main = async () => {
+	if (!shouldRunTick()) return;
 
 	logCronHeartbeat();
 
@@ -63,10 +69,21 @@ const main = async () => {
 		runProductCron({ ctx }),
 		runResetCron({ ctx }),
 		runInvoiceCron({ ctx }),
-		runOneOffCleanup({ ctx }),
 		runOneOffExpiry({ ctx }),
 		// runClearExpiredResetCron({ ctx }),
 	]);
+};
+
+// Cleanup re-derives "depleted one-off" candidates from scratch (no time
+// column to seek on), so it runs on a slower cadence than the other jobs.
+const oneOffCleanupTick = async () => {
+	if (!shouldRunTick()) return;
+
+	const ctx: CronContext = {
+		db,
+		logger,
+	};
+	await runOneOffCleanup({ ctx });
 };
 
 new CronJob(
@@ -77,7 +94,16 @@ new CronJob(
 	"UTC", // timezone (adjust as needed)
 );
 
+new CronJob(
+	"*/10 * * * *", // Run every 10 minutes
+	oneOffCleanupTick,
+	null, // onComplete
+	true, // start immediately
+	"UTC", // timezone (adjust as needed)
+);
+
 main();
+oneOffCleanupTick();
 
 process.on("SIGTERM", async () => {
 	console.log("Received SIGTERM signal, closing database connection...");

--- a/server/src/internal/customers/cusProducts/actions/cleanupOneOff/getOneOffToCleanup.ts
+++ b/server/src/internal/customers/cusProducts/actions/cleanupOneOff/getOneOffToCleanup.ts
@@ -26,11 +26,18 @@ export const getOneOffCustomerProductsToCleanup = async ({
 }): Promise<OneOffCustomerProductResult[]> => {
 	const result = await ctx.db.execute<OneOffCustomerProductResult>(`
 		WITH 
-		-- CTE 1: Active customer products with at least one price
+		-- CTE 1: Active customer products (with at least one price) on products that
+		-- have a one_off price. Driving from the catalog side keeps this off the
+		-- full customer_products table.
 		active_cus_products_with_prices AS (
 			SELECT DISTINCT cp.id
 			FROM customer_products cp
 			WHERE cp.status IN ('${CusProductStatus.Active}', '${CusProductStatus.PastDue}')
+			  AND cp.internal_product_id IN (
+				SELECT DISTINCT p.internal_product_id
+				FROM prices p
+				WHERE COALESCE(p.config->>'interval', '') = '${BillingInterval.OneOff}'
+			)
 			  AND EXISTS (
 				SELECT 1 FROM customer_prices cpr WHERE cpr.customer_product_id = cp.id
 			)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped the one-off cleanup to products with a one‑off price and moved it to a dedicated cron every 10 minutes (runs once on startup). This reduces full-table scans and lowers DB load while the main cron continues every minute.

- **Refactors**
  - Extracted shared `shouldRunTick()` for `DISABLE_CRON` and blue‑green gate checks.
  - Tagged cron heartbeat by job and emit it from the one‑off cleanup tick for observability.

<sup>Written for commit da2902f9f2dd21edbbd861e9333775bd42864c02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves `runOneOffCleanup` from the 1-minute main cron into a dedicated 10-minute cron, and scopes the cleanup query to customer products whose catalog product has at least one `one_off`-interval price, reducing the scan surface.

- **[Improvements]** Extracts `shouldRunTick()` as a reusable guard and gives the one-off cleanup job its own `CronJob` on a `*/10 * * * *` schedule instead of running every minute with the main tick.
- **[Improvements]** Adds an early `internal_product_id IN (...)` filter in CTE 1 of the cleanup query that pre-filters from the `prices` catalog, keeping the query off the full `customer_products` table on every cleanup run.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the cron restructuring and SQL pre-filter are both correct, with one minor observability gap in the new cleanup tick.

The `oneOffCleanupTick` omits the `logCronHeartbeat()` call that the main cron emits, leaving no structured log to confirm the 10-minute job is actually firing in production. Everything else — the `shouldRunTick()` extraction, the new `CronJob` schedule, and the CTE 1 catalog pre-filter — looks correct and well-reasoned.

server/src/cron/cronInit.ts — missing heartbeat log in oneOffCleanupTick.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/cron/cronInit.ts | Refactors main cron into a reusable shouldRunTick() guard and moves runOneOffCleanup to a new 10-minute CronJob; oneOffCleanupTick omits the logCronHeartbeat call present in main, reducing observability for the cleanup schedule. |
| server/src/internal/customers/cusProducts/actions/cleanupOneOff/getOneOffToCleanup.ts | Adds an internal_product_id IN (...) pre-filter in CTE 1 to scope cleanup candidates to products with a one_off catalog price; logic is sound and reduces unnecessary scanning of the full customer_products table. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Process as cronInit startup
    participant Gate as shouldRunTick()
    participant MainJob as main() [every 1m]
    participant CleanupJob as oneOffCleanupTick() [every 10m]
    participant DB as Database

    Process->>Gate: shouldRunTick()
    Gate-->>MainJob: true
    MainJob->>DB: runProductCron, runResetCron, runInvoiceCron, runOneOffExpiry

    Process->>Gate: shouldRunTick()
    Gate-->>CleanupJob: true
    CleanupJob->>DB: runOneOffCleanup (getOneOffCustomerProductsToCleanup)
    Note over DB: CTE 1 pre-filters on prices.internal_product_id WHERE interval = 'one_off'

    Note over MainJob,CleanupJob: Both jobs share the same shouldRunTick() guard
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Process as cronInit startup
    participant Gate as shouldRunTick()
    participant MainJob as main() [every 1m]
    participant CleanupJob as oneOffCleanupTick() [every 10m]
    participant DB as Database

    Process->>Gate: shouldRunTick()
    Gate-->>MainJob: true
    MainJob->>DB: runProductCron, runResetCron, runInvoiceCron, runOneOffExpiry

    Process->>Gate: shouldRunTick()
    Gate-->>CleanupJob: true
    CleanupJob->>DB: runOneOffCleanup (getOneOffCustomerProductsToCleanup)
    Note over DB: CTE 1 pre-filters on prices.internal_product_id WHERE interval = 'one_off'

    Note over MainJob,CleanupJob: Both jobs share the same shouldRunTick() guard
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/cron/cronInit.ts:79-85
The `oneOffCleanupTick` skips the `logCronHeartbeat()` call that `main()` emits. Without it, there's no structured log entry to confirm the 10-minute cleanup cron is firing, making it harder to detect if the job silently stops running (e.g. after a blue-green swap that keeps skipping it).

```suggestion
const oneOffCleanupTick = async () => {
	if (!shouldRunTick()) return;

	logCronHeartbeat();

	const ctx: CronContext = {
		db,
		logger,
	};
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["scope one-off cleanup scan to one-off pr..."](https://github.com/useautumn/autumn/commit/0a0834a99dcb6cecee76dd9155d42e99fcba0d2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41680962)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->