### PR TITLE
Fix product cron trial expiry pagination

### DIFF
--- a/server/src/cron/productCron/processExpiredTrialRow.ts
+++ b/server/src/cron/productCron/processExpiredTrialRow.ts
@@ -45,10 +45,27 @@ export const processExpiredTrialRow = async ({
 		withSubs: true,
 	});
 
-	const trialFullCusProduct = fullCustomer.customer_products.find(
+	const customerPageTrialCusProduct = fullCustomer.customer_products.find(
 		(cp) => cp.id === customerProduct.id,
 	);
+	const trialFullCusProduct =
+		customerPageTrialCusProduct ??
+		(await CusProductService.getFull({
+			db: ctx.db,
+			id: customerProduct.id,
+			inStatuses: [CusProductStatus.Active, CusProductStatus.PastDue],
+		}));
 	if (!trialFullCusProduct) return;
+
+	const originalFullCustomer = customerPageTrialCusProduct
+		? fullCustomer
+		: {
+				...fullCustomer,
+				customer_products: [
+					...fullCustomer.customer_products,
+					trialFullCusProduct,
+				],
+			};
 
 	const defaultProduct = customerProductToDefaultProduct({
 		ctx,
@@ -61,7 +78,7 @@ export const processExpiredTrialRow = async ({
 		activatedDefault = await activateFreeDefaultProduct({
 			ctx,
 			customerProduct: trialFullCusProduct,
-			fullCustomer,
+			fullCustomer: originalFullCustomer,
 			defaultProduct,
 		});
 	}
@@ -82,7 +99,7 @@ export const processExpiredTrialRow = async ({
 	void sendBillingUpdatedWebhook({
 		ctx,
 		autumnBillingPlan: {
-			customerId: fullCustomer.id ?? fullCustomer.internal_id,
+			customerId: originalFullCustomer.id ?? originalFullCustomer.internal_id,
 			insertCustomerProducts: activatedDefault ? [activatedDefault] : [],
 			updateCustomerProducts: [
 				{
@@ -91,7 +108,7 @@ export const processExpiredTrialRow = async ({
 				},
 			],
 		},
-		originalFullCustomer: fullCustomer,
+		originalFullCustomer,
 		tags: ["trial_ended"],
 	});
 };

--- a/server/tests/integration/cron/product-cron/expired-trial-full-customer-limit.test.ts
+++ b/server/tests/integration/cron/product-cron/expired-trial-full-customer-limit.test.ts
@@ -1,0 +1,108 @@
+/** Regression: product cron must expire selected trial rows even when full-customer product pagination omits them.
+ * Red: row stays active; green: row becomes expired. */
+
+import { expect, test } from "bun:test";
+import {
+	CusProductStatus,
+	FreeTrialDuration,
+	customerProducts,
+	customers,
+} from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { and, eq } from "drizzle-orm";
+import { runProductCron } from "@/cron/productCron/runProductCron";
+import { logger } from "@/external/logtail/logtailUtils";
+import { CusService } from "@/internal/customers/CusService";
+
+const trialConfig = {
+	length: 7,
+	duration: FreeTrialDuration.Day,
+	cardRequired: false,
+};
+
+test(
+	`${chalk.yellowBright("product-cron: expires trial row omitted from full customer product page")}`,
+	async () => {
+		const customerId = "expired-trial-full-customer-limit";
+		const oldTrial = products.base({
+			id: "old-trial",
+			group: "old-trial",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+			freeTrial: trialConfig,
+		});
+		const newerProducts = Array.from({ length: 16 }, (_, index) => {
+			const id = `newer-trial-${index + 1}`;
+			return products.base({
+				id,
+				group: id,
+				items: [items.monthlyMessages({ includedUsage: 200 + index })],
+				freeTrial: trialConfig,
+			});
+		});
+
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [oldTrial, ...newerProducts] }),
+			],
+			actions: [
+				s.billing.attach({ productId: "old-trial" }),
+				...newerProducts.map((product) =>
+					s.billing.attach({ productId: product.id }),
+				),
+			],
+		});
+
+		const [customer] = await ctx.db
+			.select({ internalId: customers.internal_id })
+			.from(customers)
+			.where(
+				and(
+					eq(customers.id, customerId),
+					eq(customers.org_id, ctx.org.id),
+					eq(customers.env, ctx.env),
+				),
+			);
+		expect(customer).toBeDefined();
+
+		const [trialCusProduct] = await ctx.db
+			.select()
+			.from(customerProducts)
+			.where(
+				and(
+					eq(customerProducts.internal_customer_id, customer!.internalId),
+					eq(customerProducts.product_id, oldTrial.id),
+				),
+			);
+		expect(trialCusProduct).toBeDefined();
+
+		const pastTrialEnd = Date.now() - 60_000;
+		await ctx.db
+			.update(customerProducts)
+			.set({ created_at: 0, trial_ends_at: pastTrialEnd })
+			.where(eq(customerProducts.id, trialCusProduct!.id));
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			withEntities: true,
+			withSubs: true,
+		});
+		expect(
+			fullCustomer.customer_products.some((cp) => cp.id === trialCusProduct!.id),
+		).toBe(false);
+
+		await runProductCron({ ctx: { db: ctx.db, logger } });
+
+		const [expiredCusProduct] = await ctx.db
+			.select({ status: customerProducts.status })
+			.from(customerProducts)
+			.where(eq(customerProducts.id, trialCusProduct!.id));
+
+		expect(expiredCusProduct?.status).toBe(CusProductStatus.Expired);
+	},
+);


### PR DESCRIPTION
## Summary
- expire selected trial customer products even when full customer hydration omits them from the paginated product list
- preserve the selected trial product in the webhook/default-activation snapshot
- add a regression test for an expired trial outside the customer product page

## Tests
- `cd server && bunx tsgo --build --noEmit`
- `cd server && ./run.sh /Users/charlielamb/code/atmn/autumn/server/tests/integration/cron/product-cron/expired-trial-full-customer-limit.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes product cron so expired trials are processed even when the trial product is missing from the paginated customer product list. Also ensures the webhook/default-activation snapshot includes the selected trial product.

- **Bug Fixes**
  - If the trial product isn’t in `fullCustomer.customer_products`, fetch it via `CusProductService.getFull` and merge it so expiry and default activation run correctly.
  - Include the selected trial product in the webhook/default-activation snapshot.
  - Add a regression test that covers an expired trial omitted by pagination.

<sup>Written for commit 58e989e5adff71c03daac5bb55d59d899cf7d5f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes expired-trial cron handling when full-customer hydration is paginated. The main changes are:

- **Bug fixes**: Fetch the selected trial product directly when it is missing from the hydrated product page.
- **Bug fixes**: Include the selected trial product in the activation and webhook snapshot.
- **Bug fixes**: Add a regression test for an expired trial outside the hydrated product page.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after making the regression test independent of org-limit config.

- The cron fallback uses the same active and past-due status set as the expired-trial selector.
- The fetched product has the hydrated fields needed by downstream activation logic.
- The only issue found is test brittleness around the configured customer-product page size.

server/tests/integration/cron/product-cron/expired-trial-full-customer-limit.test.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/cron/productCron/processExpiredTrialRow.ts | Adds a direct fallback fetch for trial products omitted by full-customer pagination and uses the rebuilt snapshot in activation and webhook paths. |
| server/tests/integration/cron/product-cron/expired-trial-full-customer-limit.test.ts | Adds regression coverage for the pagination case, but the setup relies on the default customer-product limit being below the number of attached products. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/tests/integration/cron/product-cron/expired-trial-full-customer-limit.test.ts:37
**Limit Override Breaks Regression**

When the test org has a `maxCusProducts` override above 17, `CusService.getFull` can return all attached products, so the old trial is not omitted and the assertion expecting `false` fails before the cron path runs. This makes the regression test depend on external org-limit config instead of forcing the pagination condition it is meant to cover.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cron): expire paginated trial produc..."](https://github.com/useautumn/autumn/commit/58e989e5adff71c03daac5bb55d59d899cf7d5f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41813210)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/autumn-org-2/github/useautumn/autumn/-/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))
- Context used - server/CLAUDE.md ([source](https://app.greptile.com/autumn-org-2/github/useautumn/autumn/-/custom-context?memory=7866843d-5d47-47cf-8270-b04b4f695fd8))
- Context used - AGENTS.md ([source](https://app.greptile.com/autumn-org-2/github/useautumn/autumn/-/custom-context?memory=e38717a3-e8ad-4054-9219-102b893d3b3c))
</details>

<!-- /greptile_comment -->