### PR TITLE
feat(billing): make billing.import processors and billable.processor …

### DIFF
--- a/apps/docs/mintlify/api-reference/billing/import.mdx
+++ b/apps/docs/mintlify/api-reference/billing/import.mdx
@@ -31,8 +31,8 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
   </Expandable>
 </DynamicParamField>
 
-<DynamicParamField body="processors" type="object[]" required>
-  The customer's processor identities (e.g. Stripe customer id, RevenueCat app_user_id).
+<DynamicParamField body="processors" type="object[]">
+  The customer's processor identities (e.g. Stripe customer id, RevenueCat app_user_id). Omit for customers with no processor, e.g. those only ever on a free plan.
   <Expandable title="properties">
     <DynamicParamField body="type" type="'stripe' | 'revenuecat'" required>
       The processor this identity belongs to.
@@ -48,8 +48,8 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 <DynamicParamField body="billables" type="object[]" required>
   The billing objects (subscriptions, one-offs) to image, each carrying its plan.
   <Expandable title="properties">
-    <DynamicParamField body="processor" type="'stripe' | 'revenuecat' | 'none'" required>
-      The processor that owns this billable (stripe, revenuecat, or none).
+    <DynamicParamField body="processor" type="'stripe' | 'revenuecat'">
+      The processor that owns this billable (stripe or revenuecat). Omit for plans with no processor, e.g. a free plan.
     </DynamicParamField>
 
     <DynamicParamField body="link" type="object">

--- a/apps/docs/mintlify/api/openapi.yml
+++ b/apps/docs/mintlify/api/openapi.yml
@@ -21363,7 +21363,8 @@ paths:
                       - type
                       - id
                   description: The customer's processor identities (e.g. Stripe customer id,
-                    RevenueCat app_user_id).
+                    RevenueCat app_user_id). Omit for customers with no
+                    processor, e.g. those only ever on a free plan.
                 billables:
                   type: array
                   items:
@@ -21373,10 +21374,9 @@ paths:
                         enum:
                           - stripe
                           - revenuecat
-                          - none
                         type: string
-                        description: The processor that owns this billable (stripe, revenuecat, or
-                          none).
+                        description: The processor that owns this billable (stripe or revenuecat). Omit
+                          for plans with no processor, e.g. a free plan.
                       link:
                         type: object
                         properties:
@@ -21485,8 +21485,6 @@ paths:
                           - plan_id
                         description: The single plan on this billable (provide either plan or phases,
                           not both).
-                    required:
-                      - processor
                   description: The billing objects (subscriptions, one-offs) to image, each
                     carrying its plan.
                 dry_run:
@@ -21495,7 +21493,6 @@ paths:
                     would be flashed.
               required:
                 - customer_id
-                - processors
                 - billables
               title: DfuFlashParams
               examples:
@@ -21694,12 +21691,6 @@ paths:
 
             res = autumn.billing.import_(
                 customer_id="cus_123",
-                processors=[
-                    {
-                        "type": "stripe",
-                        "id": "cus_stripe_123",
-                    },
-                ],
                 billables=[
                     {
                         "processor": "stripe",
@@ -21716,6 +21707,12 @@ paths:
                                 },
                             ],
                         },
+                    },
+                ],
+                processors=[
+                    {
+                        "type": "stripe",
+                        "id": "cus_stripe_123",
                     },
                 ],
             )

--- a/others/python-sdk/.speakeasy/code-samples.overlay.yaml
+++ b/others/python-sdk/.speakeasy/code-samples.overlay.yaml
@@ -227,12 +227,7 @@ actions:
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
-                res = autumn.billing.import_(customer_id="cus_123", processors=[
-                    {
-                        "type": "stripe",
-                        "id": "cus_stripe_123",
-                    },
-                ], billables=[
+                res = autumn.billing.import_(customer_id="cus_123", billables=[
                     {
                         "processor": "stripe",
                         "link": {
@@ -248,6 +243,11 @@ actions:
                                 },
                             ],
                         },
+                    },
+                ], processors=[
+                    {
+                        "type": "stripe",
+                        "id": "cus_stripe_123",
                     },
                 ])
 

--- a/others/python-sdk/.speakeasy/gen.lock
+++ b/others/python-sdk/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: 05940b80-1ef8-40f4-9878-822fb2792070
 management:
-  docChecksum: 3c57ddb4d698ca3635c73c1f4ba2b947
+  docChecksum: 279f02ac42abe5516a849850597b951d
   docVersion: 2.3.0
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
   releaseVersion: 0.4.18
   configChecksum: 2263d20254e354a1792248274002f650
 persistentEdits:
-  generation_id: bfaf750b-4ad0-4e09-8fa9-9ce926ca5c2b
-  pristine_commit_hash: 32b850a9b5abbe2cb0dd7046e8d5dfda1498ee93
-  pristine_tree_hash: 259b45ab12b2b205e89297dcff5a2f6ed0d8efb9
+  generation_id: 146164fc-88da-4c2d-82bd-67aedf954ba1
+  pristine_commit_hash: a7a5704bdf70186542f5faad28c2cf2d9cf33e51
+  pristine_tree_hash: 184715a7c481c262e3ab1cd5c84953676ef304c2
 features:
   python:
     additionalDependencies: 1.0.0
@@ -418,12 +418,12 @@ trackedFiles:
     pristine_git_object: 20dbbdc41bde67e521b8d043106d0767107dc55d
   docs/models/billable.md:
     id: dc4a2c472aeb
-    last_write_checksum: sha1:2b9a345d67b2868a1d0071418e848f71e0ec566e
-    pristine_git_object: f7331f66a0b4a6051a8cce06d4fd1eb07743cd63
+    last_write_checksum: sha1:4e5ca37e9a9ebbd57e42847aff83860785b3d55c
+    pristine_git_object: 4d33f748039ca17bebb7a13c630920802c9eb988
   docs/models/billableprocessor.md:
     id: 819d301a4e63
-    last_write_checksum: sha1:6ba01b1c447f78210f53ca6ca3ba746be53988fc
-    pristine_git_object: 83147f7354cc84194c82d911d952c71074741ac8
+    last_write_checksum: sha1:00d242b2cad4f844b54cf737a77522797569fae7
+    pristine_git_object: a45b817adda31222a839f0b8f440e13bce0277ce
   docs/models/billingcycleanchor2.md:
     id: 831a89ece2a7
     last_write_checksum: sha1:7c423a6cd31b35cc69ef2057dbace3a5ec1eebd8
@@ -2078,8 +2078,8 @@ trackedFiles:
     pristine_git_object: 613f5798f6c2590b44c3920b508ca00e5517585a
   docs/models/dfuflashparams.md:
     id: e021be4cec77
-    last_write_checksum: sha1:313ca2d208847ac1f8a2793ed8e289de2f3e16af
-    pristine_git_object: a1fe7d01ca19da0e9a83c48110dea400d0405cb8
+    last_write_checksum: sha1:8b353ca6b35dd7faf51d8f2512954e0eb589385d
+    pristine_git_object: f80bdec72b3b03b7990ce2517033e64ee9002f49
   docs/models/dfuflashresult.md:
     id: 3384fc2b3e47
     last_write_checksum: sha1:fa67a32ff06fdc4773c9c64a3fc3d609f05f3046
@@ -6558,8 +6558,8 @@ trackedFiles:
     pristine_git_object: 68895ca0eccaf28eb5632028010026ae347f57a6
   docs/sdks/billing/README.md:
     id: dc915331dd9d
-    last_write_checksum: sha1:5da3af5580fc17261c9414f32f71c99322475c03
-    pristine_git_object: 2cbb0fe400ed04e1ad91fa11b9bcf7673168d1d3
+    last_write_checksum: sha1:68e9cee2baf44fc59cd8ea106d3b035a65874bad
+    pristine_git_object: b78a1fd3fd8752a12c1c9499c1471572e06308ed
   docs/sdks/customers/README.md:
     id: 9332759cffc2
     last_write_checksum: sha1:3ba96b62f6a62480122a03a7f8c27c119eefade6
@@ -6642,8 +6642,8 @@ trackedFiles:
     pristine_git_object: 4db96641966f6337a1a1613ea731050ed25a1fb9
   src/autumn_sdk/billing.py:
     id: e6cffdbf2221
-    last_write_checksum: sha1:a8f5300d65e025a6276d9dfa7ba55c206de86f2c
-    pristine_git_object: b3ee6d58a9a4659ef95499fa6ea26e140bc14d02
+    last_write_checksum: sha1:d0b6ad2163bff4c22e09f4b07b4bcda47ff35b7a
+    pristine_git_object: 75b85759972bcbe58e2200958c7c04bcf6e06443
   src/autumn_sdk/customers.py:
     id: 5c5a0a07a433
     last_write_checksum: sha1:bbdd432fc314a94a6ac5bd6335c8cf9474e02b66
@@ -6802,8 +6802,8 @@ trackedFiles:
     pristine_git_object: a51f5d26227a36d16cce914b32e92363eb5a95ff
   src/autumn_sdk/models/importop.py:
     id: bd28bf9634d8
-    last_write_checksum: sha1:c210946f6d989a3327969da28ba6042edd00507a
-    pristine_git_object: e5654e4d3b297278b44f85bd5e4cb0051be7ae05
+    last_write_checksum: sha1:184df6393c8fb01d0d0425d06f6f2c1ac6ed010c
+    pristine_git_object: cb94e197da913320baa45e0e41e6825a8799d524
   src/autumn_sdk/models/internal/__init__.py:
     id: 2906fe7f2cde
     last_write_checksum: sha1:1905b58b74ecc52346d8f5c24ded2b6d6e1dad4a

--- a/others/python-sdk/src/autumn_sdk/billing.py
+++ b/others/python-sdk/src/autumn_sdk/billing.py
@@ -3025,12 +3025,12 @@ class Billing(BaseSDK):
         self,
         *,
         customer_id: str,
-        processors: Union[
-            List[models.ImportProcessor], List[models.ImportProcessorTypedDict]
-        ],
         billables: Union[List[models.Billable], List[models.BillableTypedDict]],
         customer_data: Optional[
             Union[models.ImportCustomerData, models.ImportCustomerDataTypedDict]
+        ] = None,
+        processors: Optional[
+            Union[List[models.ImportProcessor], List[models.ImportProcessorTypedDict]]
         ] = None,
         dry_run: Optional[bool] = None,
         retries: OptionalNullable[utils.RetryConfig] = UNSET,
@@ -3043,9 +3043,9 @@ class Billing(BaseSDK):
         Image a customer into Autumn for live migration. Read-only against processors.
 
         :param customer_id: Autumn customer to image into.
-        :param processors: The customer's processor identities (e.g. Stripe customer id, RevenueCat app_user_id).
         :param billables: The billing objects (subscriptions, one-offs) to image, each carrying its plan.
         :param customer_data: Optional identity fields to upsert if the customer is new.
+        :param processors: The customer's processor identities (e.g. Stripe customer id, RevenueCat app_user_id). Omit for customers with no processor, e.g. those only ever on a free plan.
         :param dry_run: If true, validate and compute without persisting; returns what would be flashed.
         :param retries: Override the default retry configuration for this method
         :param server_url: Override the default server URL for this method
@@ -3068,7 +3068,7 @@ class Billing(BaseSDK):
                 customer_data, Optional[models.ImportCustomerData]
             ),
             processors=utils.get_pydantic_model(
-                processors, List[models.ImportProcessor]
+                processors, Optional[List[models.ImportProcessor]]
             ),
             billables=utils.get_pydantic_model(billables, List[models.Billable]),
             dry_run=dry_run,
@@ -3137,12 +3137,12 @@ class Billing(BaseSDK):
         self,
         *,
         customer_id: str,
-        processors: Union[
-            List[models.ImportProcessor], List[models.ImportProcessorTypedDict]
-        ],
         billables: Union[List[models.Billable], List[models.BillableTypedDict]],
         customer_data: Optional[
             Union[models.ImportCustomerData, models.ImportCustomerDataTypedDict]
+        ] = None,
+        processors: Optional[
+            Union[List[models.ImportProcessor], List[models.ImportProcessorTypedDict]]
         ] = None,
         dry_run: Optional[bool] = None,
         retries: OptionalNullable[utils.RetryConfig] = UNSET,
@@ -3155,9 +3155,9 @@ class Billing(BaseSDK):
         Image a customer into Autumn for live migration. Read-only against processors.
 
         :param customer_id: Autumn customer to image into.
-        :param processors: The customer's processor identities (e.g. Stripe customer id, RevenueCat app_user_id).
         :param billables: The billing objects (subscriptions, one-offs) to image, each carrying its plan.
         :param customer_data: Optional identity fields to upsert if the customer is new.
+        :param processors: The customer's processor identities (e.g. Stripe customer id, RevenueCat app_user_id). Omit for customers with no processor, e.g. those only ever on a free plan.
         :param dry_run: If true, validate and compute without persisting; returns what would be flashed.
         :param retries: Override the default retry configuration for this method
         :param server_url: Override the default server URL for this method
@@ -3180,7 +3180,7 @@ class Billing(BaseSDK):
                 customer_data, Optional[models.ImportCustomerData]
             ),
             processors=utils.get_pydantic_model(
-                processors, List[models.ImportProcessor]
+                processors, Optional[List[models.ImportProcessor]]
             ),
             billables=utils.get_pydantic_model(billables, List[models.Billable]),
             dry_run=dry_run,

--- a/others/python-sdk/src/autumn_sdk/models/importop.py
+++ b/others/python-sdk/src/autumn_sdk/models/importop.py
@@ -109,9 +109,8 @@ class ImportProcessor(BaseModel):
 BillableProcessor = Literal[
     "stripe",
     "revenuecat",
-    "none",
 ]
-r"""The processor that owns this billable (stripe, revenuecat, or none)."""
+r"""The processor that owns this billable (stripe or revenuecat). Omit for plans with no processor, e.g. a free plan."""
 
 
 class LinkTypedDict(TypedDict):
@@ -350,8 +349,8 @@ class ImportPlan(BaseModel):
 
 
 class BillableTypedDict(TypedDict):
-    processor: BillableProcessor
-    r"""The processor that owns this billable (stripe, revenuecat, or none)."""
+    processor: NotRequired[BillableProcessor]
+    r"""The processor that owns this billable (stripe or revenuecat). Omit for plans with no processor, e.g. a free plan."""
     link: NotRequired[LinkTypedDict]
     r"""Existing processor billing object this billable is adopted from; omit for paid one-offs."""
     billing_cycle_anchor: NotRequired[float]
@@ -361,8 +360,8 @@ class BillableTypedDict(TypedDict):
 
 
 class Billable(BaseModel):
-    processor: BillableProcessor
-    r"""The processor that owns this billable (stripe, revenuecat, or none)."""
+    processor: Optional[BillableProcessor] = None
+    r"""The processor that owns this billable (stripe or revenuecat). Omit for plans with no processor, e.g. a free plan."""
 
     link: Optional[Link] = None
     r"""Existing processor billing object this billable is adopted from; omit for paid one-offs."""
@@ -375,7 +374,7 @@ class Billable(BaseModel):
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["link", "billing_cycle_anchor", "plan"])
+        optional_fields = set(["processor", "link", "billing_cycle_anchor", "plan"])
         serialized = handler(self)
         m = {}
 
@@ -393,12 +392,12 @@ class Billable(BaseModel):
 class DfuFlashParamsTypedDict(TypedDict):
     customer_id: str
     r"""Autumn customer to image into."""
-    processors: List[ImportProcessorTypedDict]
-    r"""The customer's processor identities (e.g. Stripe customer id, RevenueCat app_user_id)."""
     billables: List[BillableTypedDict]
     r"""The billing objects (subscriptions, one-offs) to image, each carrying its plan."""
     customer_data: NotRequired[ImportCustomerDataTypedDict]
     r"""Optional identity fields to upsert if the customer is new."""
+    processors: NotRequired[List[ImportProcessorTypedDict]]
+    r"""The customer's processor identities (e.g. Stripe customer id, RevenueCat app_user_id). Omit for customers with no processor, e.g. those only ever on a free plan."""
     dry_run: NotRequired[bool]
     r"""If true, validate and compute without persisting; returns what would be flashed."""
 
@@ -407,21 +406,21 @@ class DfuFlashParams(BaseModel):
     customer_id: str
     r"""Autumn customer to image into."""
 
-    processors: List[ImportProcessor]
-    r"""The customer's processor identities (e.g. Stripe customer id, RevenueCat app_user_id)."""
-
     billables: List[Billable]
     r"""The billing objects (subscriptions, one-offs) to image, each carrying its plan."""
 
     customer_data: Optional[ImportCustomerData] = None
     r"""Optional identity fields to upsert if the customer is new."""
 
+    processors: Optional[List[ImportProcessor]] = None
+    r"""The customer's processor identities (e.g. Stripe customer id, RevenueCat app_user_id). Omit for customers with no processor, e.g. those only ever on a free plan."""
+
     dry_run: Optional[bool] = None
     r"""If true, validate and compute without persisting; returns what would be flashed."""
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["customer_data", "dry_run"])
+        optional_fields = set(["customer_data", "processors", "dry_run"])
         serialized = handler(self)
         m = {}
 

--- a/packages/openapi/openapi-stripped.yml
+++ b/packages/openapi/openapi-stripped.yml
@@ -20677,7 +20677,8 @@ paths:
                       - type
                       - id
                   description: The customer's processor identities (e.g. Stripe customer id,
-                    RevenueCat app_user_id).
+                    RevenueCat app_user_id). Omit for customers with no
+                    processor, e.g. those only ever on a free plan.
                 billables:
                   type: array
                   items:
@@ -20687,10 +20688,9 @@ paths:
                         enum:
                           - stripe
                           - revenuecat
-                          - none
                         type: string
-                        description: The processor that owns this billable (stripe, revenuecat, or
-                          none).
+                        description: The processor that owns this billable (stripe or revenuecat). Omit
+                          for plans with no processor, e.g. a free plan.
                       link:
                         type: object
                         properties:
@@ -20799,8 +20799,6 @@ paths:
                           - plan_id
                         description: The single plan on this billable (provide either plan or phases,
                           not both).
-                    required:
-                      - processor
                   description: The billing objects (subscriptions, one-offs) to image, each
                     carrying its plan.
                 dry_run:
@@ -20809,7 +20807,6 @@ paths:
                     would be flashed.
               required:
                 - customer_id
-                - processors
                 - billables
               title: DfuFlashParams
               examples:

--- a/packages/openapi/openapi.yml
+++ b/packages/openapi/openapi.yml
@@ -13871,7 +13871,7 @@ paths:
         @example
         ```typescript
         // Schedule a transition from a trial plan to a paid plan
-        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783204252278,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784413852278,"plans":[{"planId":"pro_plan"}]}] });
+        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783259673472,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784469273472,"plans":[{"planId":"pro_plan"}]}] });
         ```
 
         @param customerId - The ID of the customer to create the schedule for.
@@ -21493,7 +21493,8 @@ paths:
                       - type
                       - id
                   description: The customer's processor identities (e.g. Stripe customer id,
-                    RevenueCat app_user_id).
+                    RevenueCat app_user_id). Omit for customers with no
+                    processor, e.g. those only ever on a free plan.
                 billables:
                   type: array
                   items:
@@ -21503,10 +21504,9 @@ paths:
                         enum:
                           - stripe
                           - revenuecat
-                          - none
                         type: string
-                        description: The processor that owns this billable (stripe, revenuecat, or
-                          none).
+                        description: The processor that owns this billable (stripe or revenuecat). Omit
+                          for plans with no processor, e.g. a free plan.
                       link:
                         type: object
                         properties:
@@ -21615,8 +21615,6 @@ paths:
                           - plan_id
                         description: The single plan on this billable (provide either plan or phases,
                           not both).
-                    required:
-                      - processor
                   description: The billing objects (subscriptions, one-offs) to image, each
                     carrying its plan.
                 dry_run:
@@ -21625,7 +21623,6 @@ paths:
                     would be flashed.
               required:
                 - customer_id
-                - processors
                 - billables
               title: DfuFlashParams
               examples:

--- a/packages/sdk/.speakeasy/gen.lock
+++ b/packages/sdk/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: 7b300647-cd76-49e9-bf77-7d1bf5446d66
 management:
-  docChecksum: a4063c69cefc3c754fd81bb9e9d51eef
+  docChecksum: 42bce4767c63e544011f4d1b6cb89635
   docVersion: 2.3.0
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
   releaseVersion: 0.10.17
   configChecksum: 4722f16a8dee67ebd4038caf3c345296
 persistentEdits:
-  generation_id: 58d3f456-43b8-4e74-9f34-1ba6fab63765
-  pristine_commit_hash: 8bb8bb556c8aae13618c21039572c8d8f4d2578a
-  pristine_tree_hash: d853599963e7d8c0f52c16ab07eacdd83dbf50a7
+  generation_id: 16e3eece-4b9b-4263-b0ff-887926dd7293
+  pristine_commit_hash: 7907dfbbb84ef1528b1b4b476d71478c7a5a6fbf
+  pristine_tree_hash: 06d3b58bcf0d5a3cff75d778f2c4b2418e6c0969
 features:
   typescript:
     additionalDependencies: 0.1.0
@@ -441,12 +441,12 @@ trackedFiles:
     pristine_git_object: b713fe163c80ce5fe148c68fcf038b2ca718e573
   docs/models/billable-processor.md:
     id: 6da764b15517
-    last_write_checksum: sha1:5d7bda04d0c0b6d7d792881238745e551bb0395b
-    pristine_git_object: cf623bc9d274b138b90ae89f8dd3a160db0c7097
+    last_write_checksum: sha1:80776118a6b38eaf6dd5fbc799097872b57eb486
+    pristine_git_object: a616f23b8b141c0da8974ffd3f5c78f020735e97
   docs/models/billable.md:
     id: dc4a2c472aeb
-    last_write_checksum: sha1:ec7d9822e54f0e5668ad593d543d66c973b3fce6
-    pristine_git_object: 1fde8de74c3d0607f2a57626745b368fe742c025
+    last_write_checksum: sha1:7b1815a3297f6a4ebbb25b85f6d948eb122ce489
+    pristine_git_object: f3beda0934f72c52be4e13ce8faeb27807acf299
   docs/models/billing-cycle-anchor2.md:
     id: 41ad5f3529dd
     last_write_checksum: sha1:35d0557bfbafe9fce52efff13ab0861b231d0da8
@@ -2101,8 +2101,8 @@ trackedFiles:
     pristine_git_object: 279d06d9980c7356b8767be081fedc85360650c4
   docs/models/dfu-flash-params.md:
     id: c002a39df56d
-    last_write_checksum: sha1:388ab247e4209a8aecae75a581281d0051a6a4a1
-    pristine_git_object: 2ab6260ca69e533f5eb483683fd65f46ab76be4d
+    last_write_checksum: sha1:664b3375df79bf6ad83758a0450774826657ef70
+    pristine_git_object: 77baa8aa00593280b76a30ad3de2f83abd783f5a
   docs/models/dfu-flash-result.md:
     id: 2464162c6425
     last_write_checksum: sha1:6673cecf7b1917ab1bb4499da8edc97b8d03bd4a
@@ -6573,8 +6573,8 @@ trackedFiles:
     pristine_git_object: 0ebe5146cd24c153cb9b7655e4f502c09f7d4abd
   docs/sdks/billing/README.md:
     id: dc915331dd9d
-    last_write_checksum: sha1:22b5f4011c25e0b8c1e4d7e21b9dffcfee057602
-    pristine_git_object: 694f3ca1717cba0bf1eb4ef404aa6bd7e6e5d668
+    last_write_checksum: sha1:3a6416ced86220ffbdada56e2f41d4d0cceab73b
+    pristine_git_object: cb6bf13261d3da0029d4f6dcfb871bd3364d2d84
   docs/sdks/customers/README.md:
     id: 9332759cffc2
     last_write_checksum: sha1:74cd5f6cf800e1d86b2c332fed3c3cd53f3eeb6b
@@ -6669,8 +6669,8 @@ trackedFiles:
     pristine_git_object: 7991653fe7a7302891a242026bedf4fb0d2394f9
   src/funcs/billing-create-schedule.ts:
     id: fd662bfcdc10
-    last_write_checksum: sha1:b62dbd208d30103d91de53bc5cdb2beaa3c14235
-    pristine_git_object: 04f549fea6aa7d7fd0738a258020d57b057a3648
+    last_write_checksum: sha1:4c6e31c54a53bc762bd15ac6e1a2c879d406b0af
+    pristine_git_object: 89e31f5a7bb465fc1884373fba2728d5a3bf1f42
   src/funcs/billing-import.ts:
     id: ff582ad4629f
     last_write_checksum: sha1:673851739184e659789772519b9bc01485a21d79
@@ -7045,8 +7045,8 @@ trackedFiles:
     pristine_git_object: b34f612124c797c2a1106b9735708f679a90b74f
   src/models/import-op.ts:
     id: 6a79acb4432b
-    last_write_checksum: sha1:17dcd8d6774718776921ac00bfa20814104810e9
-    pristine_git_object: c5e98ed1e0405efd75e9bc77045191354ce501d3
+    last_write_checksum: sha1:18804e3dbdb4ca0eadb0bc7d74af3823533341ea
+    pristine_git_object: 9210af8354b46670982689d7312b9772095db5f7
   src/models/index.ts:
     id: f93644b0f37e
     last_write_checksum: sha1:2d4c1acde8eab2ce05bff932d20af11c357f9b2d
@@ -7177,8 +7177,8 @@ trackedFiles:
     pristine_git_object: 571de419ea3321d79acec4bddbb46b1580007115
   src/sdk/billing.ts:
     id: 10905058c4ad
-    last_write_checksum: sha1:f4c738a27b97b66644e0d16244197d361181b3b6
-    pristine_git_object: eef6f71b106522aa9759c278042f78e962fa95e6
+    last_write_checksum: sha1:0f3248015e5e6a4beda6aa052d4daf7a3e5b2174
+    pristine_git_object: 41ecb002c0d6dab6fa2aa5e9461819fc3ad5ce6d
   src/sdk/customers.ts:
     id: d33e193e0c00
     last_write_checksum: sha1:8d64f03efa17b4ef45a6d67a44d23e2943f1cd8b

--- a/packages/sdk/.speakeasy/out.openapi.yaml
+++ b/packages/sdk/.speakeasy/out.openapi.yaml
@@ -12751,7 +12751,7 @@ paths:
         @example
         ```typescript
         // Schedule a transition from a trial plan to a paid plan
-        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783204252278,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784413852278,"plans":[{"planId":"pro_plan"}]}] });
+        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783259673472,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784469273472,"plans":[{"planId":"pro_plan"}]}] });
         ```
 
         @param customerId - The ID of the customer to create the schedule for.
@@ -19620,7 +19620,7 @@ paths:
                     required:
                       - type
                       - id
-                  description: The customer's processor identities (e.g. Stripe customer id, RevenueCat app_user_id).
+                  description: The customer's processor identities (e.g. Stripe customer id, RevenueCat app_user_id). Omit for customers with no processor, e.g. those only ever on a free plan.
                 billables:
                   type: array
                   items:
@@ -19630,9 +19630,8 @@ paths:
                         enum:
                           - stripe
                           - revenuecat
-                          - none
                         type: string
-                        description: The processor that owns this billable (stripe, revenuecat, or none).
+                        description: The processor that owns this billable (stripe or revenuecat). Omit for plans with no processor, e.g. a free plan.
                       link:
                         type: object
                         properties:
@@ -19729,15 +19728,12 @@ paths:
                         required:
                           - plan_id
                         description: The single plan on this billable (provide either plan or phases, not both).
-                    required:
-                      - processor
                   description: The billing objects (subscriptions, one-offs) to image, each carrying its plan.
                 dry_run:
                   type: boolean
                   description: If true, validate and compute without persisting; returns what would be flashed.
               required:
                 - customer_id
-                - processors
                 - billables
               title: DfuFlashParams
               examples:

--- a/packages/sdk/.speakeasy/workflow.lock
+++ b/packages/sdk/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.762.0
 sources:
     Autumn API:
         sourceNamespace: autumn-api
-        sourceRevisionDigest: sha256:8e4ebc48d1f130e9f785a51749e7f1e3c58be32407346f494419ceec8928c181
-        sourceBlobDigest: sha256:e95d2c5edfcebddf1894f15b6f46309fcf6b3bdd5073167b6d8988d0c3e906ff
+        sourceRevisionDigest: sha256:372c49f2aac4325edc0577f1d3ad7ec568e7a2730391d20d7e65667c9e41c8d5
+        sourceBlobDigest: sha256:2a1fab7b35906586aaf51bb81af13888c0c6463d78c9d9c2e56ed2d84f5a6a87
         tags:
             - latest
             - 2.3.0
@@ -18,10 +18,10 @@ targets:
     autumn:
         source: Autumn API
         sourceNamespace: autumn-api
-        sourceRevisionDigest: sha256:8e4ebc48d1f130e9f785a51749e7f1e3c58be32407346f494419ceec8928c181
-        sourceBlobDigest: sha256:e95d2c5edfcebddf1894f15b6f46309fcf6b3bdd5073167b6d8988d0c3e906ff
+        sourceRevisionDigest: sha256:372c49f2aac4325edc0577f1d3ad7ec568e7a2730391d20d7e65667c9e41c8d5
+        sourceBlobDigest: sha256:2a1fab7b35906586aaf51bb81af13888c0c6463d78c9d9c2e56ed2d84f5a6a87
         codeSamplesNamespace: autumn-api-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:1d816f988255c149d85f2939cdcf47b7a01ff0f2330a1ed92e97b8bb46340427
+        codeSamplesRevisionDigest: sha256:9c945406c53c61c8ffe030047097fda680ed7ad01795e502e991420e29e67d72
     autumn-python:
         source: Autumn API Stripped
         sourceNamespace: autumn-api-stripped

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -309,7 +309,7 @@ Use this endpoint to schedule future plan changes (e.g. switch from a trial plan
 @example
 ```typescript
 // Schedule a transition from a trial plan to a paid plan
-const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783204252278,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784413852278,"plans":[{"planId":"pro_plan"}]}] });
+const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783259673472,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784469273472,"plans":[{"planId":"pro_plan"}]}] });
 ```
 
 @param customerId - The ID of the customer to create the schedule for.
@@ -853,7 +853,7 @@ Use this endpoint to schedule future plan changes (e.g. switch from a trial plan
 @example
 ```typescript
 // Schedule a transition from a trial plan to a paid plan
-const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783204252278,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784413852278,"plans":[{"planId":"pro_plan"}]}] });
+const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783259673472,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784469273472,"plans":[{"planId":"pro_plan"}]}] });
 ```
 
 @param customerId - The ID of the customer to create the schedule for.

--- a/packages/sdk/src/funcs/billing-create-schedule.ts
+++ b/packages/sdk/src/funcs/billing-create-schedule.ts
@@ -34,7 +34,7 @@ import { Result } from "../types/fp.js";
  * @example
  * ```typescript
  * // Schedule a transition from a trial plan to a paid plan
- * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783204252278,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784413852278,"plans":[{"planId":"pro_plan"}]}] });
+ * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783259673472,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784469273472,"plans":[{"planId":"pro_plan"}]}] });
  * ```
  *
  * @param customerId - The ID of the customer to create the schedule for.

--- a/packages/sdk/src/models/import-op.ts
+++ b/packages/sdk/src/models/import-op.ts
@@ -57,15 +57,14 @@ export type ImportProcessor = {
 };
 
 /**
- * The processor that owns this billable (stripe, revenuecat, or none).
+ * The processor that owns this billable (stripe or revenuecat). Omit for plans with no processor, e.g. a free plan.
  */
 export const BillableProcessor = {
   Stripe: "stripe",
   Revenuecat: "revenuecat",
-  None: "none",
 } as const;
 /**
- * The processor that owns this billable (stripe, revenuecat, or none).
+ * The processor that owns this billable (stripe or revenuecat). Omit for plans with no processor, e.g. a free plan.
  */
 export type BillableProcessor = ClosedEnum<typeof BillableProcessor>;
 
@@ -203,9 +202,9 @@ export type ImportPlan = {
 
 export type Billable = {
   /**
-   * The processor that owns this billable (stripe, revenuecat, or none).
+   * The processor that owns this billable (stripe or revenuecat). Omit for plans with no processor, e.g. a free plan.
    */
-  processor: BillableProcessor;
+  processor?: BillableProcessor | undefined;
   /**
    * Existing processor billing object this billable is adopted from; omit for paid one-offs.
    */
@@ -230,9 +229,9 @@ export type DfuFlashParams = {
    */
   customerData?: ImportCustomerData | undefined;
   /**
-   * The customer's processor identities (e.g. Stripe customer id, RevenueCat app_user_id).
+   * The customer's processor identities (e.g. Stripe customer id, RevenueCat app_user_id). Omit for customers with no processor, e.g. those only ever on a free plan.
    */
-  processors: Array<ImportProcessor>;
+  processors?: Array<ImportProcessor> | undefined;
   /**
    * The billing objects (subscriptions, one-offs) to image, each carrying its plan.
    */
@@ -518,7 +517,7 @@ export function importPlanToJSON(importPlan: ImportPlan): string {
 
 /** @internal */
 export type Billable$Outbound = {
-  processor: string;
+  processor?: string | undefined;
   link?: Link$Outbound | undefined;
   billing_cycle_anchor?: number | undefined;
   plan?: ImportPlan$Outbound | undefined;
@@ -530,7 +529,7 @@ export const Billable$outboundSchema: z.ZodMiniType<
   Billable
 > = z.pipe(
   z.object({
-    processor: BillableProcessor$outboundSchema,
+    processor: z.optional(BillableProcessor$outboundSchema),
     link: z.optional(z.lazy(() => Link$outboundSchema)),
     billingCycleAnchor: z.optional(z.number()),
     plan: z.optional(z.lazy(() => ImportPlan$outboundSchema)),
@@ -550,7 +549,7 @@ export function billableToJSON(billable: Billable): string {
 export type DfuFlashParams$Outbound = {
   customer_id: string;
   customer_data?: ImportCustomerData$Outbound | undefined;
-  processors: Array<ImportProcessor$Outbound>;
+  processors?: Array<ImportProcessor$Outbound> | undefined;
   billables: Array<Billable$Outbound>;
   dry_run?: boolean | undefined;
 };
@@ -563,7 +562,9 @@ export const DfuFlashParams$outboundSchema: z.ZodMiniType<
   z.object({
     customerId: z.string(),
     customerData: z.optional(z.lazy(() => ImportCustomerData$outboundSchema)),
-    processors: z.array(z.lazy(() => ImportProcessor$outboundSchema)),
+    processors: z.optional(
+      z.array(z.lazy(() => ImportProcessor$outboundSchema)),
+    ),
     billables: z.array(z.lazy(() => Billable$outboundSchema)),
     dryRun: z.optional(z.boolean()),
   }),

--- a/packages/sdk/src/sdk/billing.ts
+++ b/packages/sdk/src/sdk/billing.ts
@@ -89,7 +89,7 @@ export class Billing extends ClientSDK {
    * @example
    * ```typescript
    * // Schedule a transition from a trial plan to a paid plan
-   * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783204252278,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784413852278,"plans":[{"planId":"pro_plan"}]}] });
+   * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783259673472,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784469273472,"plans":[{"planId":"pro_plan"}]}] });
    * ```
    *
    * @param customerId - The ID of the customer to create the schedule for.

--- a/server/src/internal/billing/v2/actions/dfu/compute/computeFlashPlan.ts
+++ b/server/src/internal/billing/v2/actions/dfu/compute/computeFlashPlan.ts
@@ -172,7 +172,7 @@ export const computeFlashPlan = ({
 		if (existing) {
 			flashed.push({
 				plan_id: planContext.plan.plan_id,
-				processor: planContext.processor,
+				processor: planContext.processor ?? "stripe",
 				customer_product_id: existing.id,
 				status: existing.status,
 				skipped: true,
@@ -191,7 +191,7 @@ export const computeFlashPlan = ({
 
 		flashed.push({
 			plan_id: planContext.plan.plan_id,
-			processor: planContext.processor,
+			processor: planContext.processor ?? "stripe",
 			customer_product_id: customerProduct.id,
 			status: reportStatus,
 			skipped: false,

--- a/server/src/internal/billing/v2/actions/dfu/compute/computeFlashPlan.ts
+++ b/server/src/internal/billing/v2/actions/dfu/compute/computeFlashPlan.ts
@@ -6,6 +6,7 @@ import {
 	cusProductToProcessorType,
 	type DfuFlashedPlan,
 	type FullCusProduct,
+	isProductPaidAndRecurring,
 	isResettingEntitlement,
 	nullish,
 	ProcessorType,
@@ -34,7 +35,7 @@ const buildCustomerProduct = ({
 }): {
 	customerProduct: FullCusProduct;
 	reportStatus: string;
-	anchorMismatch: boolean;
+	mismatchReason: string | undefined;
 } => {
 	const { fullCustomer, currentEpochMs } = flashContext;
 	const {
@@ -66,8 +67,8 @@ const buildCustomerProduct = ({
 		resolvedStartsAt ??
 		currentEpochMs;
 
-	// Flag (don't block): a resetting plan whose anchor fell through to the import
-	// time — its cycle is likely wrong and the caller should supply started_at.
+	// Flags (don't block) surfaced to the caller as `mismatch` — the plan images
+	// anyway, but its billing state is likely wrong and needs attention.
 	const anchorResolved =
 		billingCycleAnchor != null ||
 		hydration?.periodEndMs != null ||
@@ -77,6 +78,16 @@ const buildCustomerProduct = ({
 		fullProduct.entitlements.some((entitlement) =>
 			isResettingEntitlement({ entitlement }),
 		);
+	// A paid recurring plan with no linked subscription can't be billed/managed —
+	// Autumn has no processor object to run renewals against.
+	const paidPlanUnlinked =
+		isProductPaidAndRecurring(fullProduct) && subscriptionIds.length === 0;
+
+	const mismatchReason = paidPlanUnlinked
+		? "paid_plan_without_subscription"
+		: anchorMismatch
+			? "no_resolvable_billing_anchor"
+			: undefined;
 
 	const customerProduct = initFullCustomerProduct({
 		ctx,
@@ -124,7 +135,7 @@ const buildCustomerProduct = ({
 	return {
 		customerProduct,
 		reportStatus: statusInfo.reportStatus,
-		anchorMismatch,
+		mismatchReason,
 	};
 };
 
@@ -181,7 +192,7 @@ export const computeFlashPlan = ({
 			continue;
 		}
 
-		const { customerProduct, reportStatus, anchorMismatch } =
+		const { customerProduct, reportStatus, mismatchReason } =
 			buildCustomerProduct({
 				ctx,
 				flashContext,
@@ -195,10 +206,7 @@ export const computeFlashPlan = ({
 			customer_product_id: customerProduct.id,
 			status: reportStatus,
 			skipped: false,
-			...(anchorMismatch && {
-				mismatch: true,
-				reason: "no_resolvable_billing_anchor",
-			}),
+			...(mismatchReason && { mismatch: true, reason: mismatchReason }),
 		});
 	}
 

--- a/server/src/internal/billing/v2/actions/dfu/setup/setupFlashContext.ts
+++ b/server/src/internal/billing/v2/actions/dfu/setup/setupFlashContext.ts
@@ -78,7 +78,7 @@ const upsertFullCustomer = async ({
 	ctx: AutumnContext;
 	params: DfuFlashParams;
 }): Promise<FullCustomer> => {
-	const revenueCatIdentity = params.processors.find(
+	const revenueCatIdentity = params.processors?.find(
 		(p) => p.type === "revenuecat",
 	);
 
@@ -108,7 +108,7 @@ const upsertFullCustomer = async ({
 		return existing;
 	}
 
-	const stripeIdentity = params.processors.find((p) => p.type === "stripe");
+	const stripeIdentity = params.processors?.find((p) => p.type === "stripe");
 	await createNewCustomer({
 		ctx,
 		customer: {
@@ -257,7 +257,7 @@ export const setupFlashContext = async ({
 	}
 
 	// Fill omitted fields from processors BEFORE status/balance resolution.
-	const revenueCatAppUserId = params.processors.find(
+	const revenueCatAppUserId = params.processors?.find(
 		(p) => p.type === "revenuecat",
 	)?.id;
 	await Promise.all([

--- a/server/tests/integration/billing/dfu/billing-import/billing-import-free-plan.test.ts
+++ b/server/tests/integration/billing/dfu/billing-import/billing-import-free-plan.test.ts
@@ -1,0 +1,61 @@
+/**
+ * dfu.flash — a free-plan customer (never created in any processor) imports with
+ * no top-level `processors` and no `billable.processor`.
+ */
+
+import { expect, test } from "bun:test";
+import { type ApiCustomerV5 } from "@autumn/shared";
+import {
+	type FlashClient,
+	callFlash,
+} from "@tests/integration/billing/dfu/billing-import/utils/flashTestUtils.js";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("dfu.flash: free-plan customer imports with no processors and no billable processor")}`,
+	async () => {
+		const customerId = "dfu-flash-free-plan";
+		const free = products.pro({
+			id: "dfu-free-plan",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV2_2, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [free] })],
+			actions: [],
+		});
+
+		const payload = {
+			customer_id: customerId,
+			customer_data: { email: `${customerId}@example.com` },
+			// No `processors` and no `billable.processor` — the customer was only
+			// ever on a free plan, so it exists in no processor.
+			billables: [
+				{
+					plan: {
+						plan_id: free.id,
+						status: "active",
+						started_at: Date.now() - 1000 * 60 * 60 * 24 * 30,
+						balances: [{ feature_id: TestFeature.Messages, usage: 10 }],
+					},
+				},
+			],
+		};
+
+		const flashRes = await callFlash(autumnV2_2 as FlashClient, payload);
+		expect(flashRes.errorCode).not.toBe("invalid_inputs");
+		expect(flashRes.errorCode).not.toBe("invalid_request");
+		const flashed = flashRes.result?.flashed?.find((f) => f.plan_id === free.id);
+		expect(flashed?.customer_product_id).toBeTruthy();
+		expect(flashed?.status).toBe("active");
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		await expectCustomerProducts({ customer, active: [free.id] });
+	},
+);

--- a/server/tests/integration/billing/dfu/billing-import/billing-import-free-plan.test.ts
+++ b/server/tests/integration/billing/dfu/billing-import/billing-import-free-plan.test.ts
@@ -20,7 +20,8 @@ test.concurrent(
 	`${chalk.yellowBright("dfu.flash: free-plan customer imports with no processors and no billable processor")}`,
 	async () => {
 		const customerId = "dfu-flash-free-plan";
-		const free = products.pro({
+		// `base` has no base price — a genuinely free plan (no processor needed).
+		const free = products.base({
 			id: "dfu-free-plan",
 			items: [items.monthlyMessages({ includedUsage: 100 })],
 		});

--- a/server/tests/integration/billing/dfu/billing-import/billing-import-paid-plan-unlinked.test.ts
+++ b/server/tests/integration/billing/dfu/billing-import/billing-import-paid-plan-unlinked.test.ts
@@ -1,0 +1,61 @@
+/**
+ * dfu.flash — a paid recurring plan imported with no linked subscription can't be
+ * billed/managed, so it images but comes back flagged (mismatch), not blocked.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type FlashClient,
+	callFlash,
+	createRealStripeCustomer,
+} from "@tests/integration/billing/dfu/billing-import/utils/flashTestUtils.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("dfu.flash: paid recurring plan with no subscription is flagged as mismatch")}`,
+	async () => {
+		const customerId = "dfu-flash-paid-unlinked";
+		// `pro` has a $20/mo base price — a paid recurring plan.
+		const pro = products.pro({
+			id: "dfu-paid-unlinked",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [pro] })],
+			actions: [],
+		});
+
+		const stripeCustomerId = await createRealStripeCustomer(ctx, {
+			email: `${customerId}@example.com`,
+		});
+
+		const payload = {
+			customer_id: customerId,
+			processors: [{ type: "stripe", id: stripeCustomerId }],
+			// Paid recurring plan, but NO link.subscription_id → Autumn can't manage it.
+			billables: [
+				{
+					processor: "stripe",
+					plan: {
+						plan_id: pro.id,
+						status: "active",
+						started_at: Date.now() - 1000 * 60 * 60 * 24 * 30,
+						balances: [{ feature_id: TestFeature.Messages, usage: 10 }],
+					},
+				},
+			],
+		};
+
+		const flashRes = await callFlash(autumnV2_2 as FlashClient, payload);
+		const flashed = flashRes.result?.flashed?.find((f) => f.plan_id === pro.id);
+		expect(flashed?.customer_product_id).toBeTruthy();
+		expect(flashed?.mismatch).toBe(true);
+		expect(flashed?.reason).toBe("paid_plan_without_subscription");
+	},
+);

--- a/server/tests/integration/billing/dfu/billing-import/billing-import-started-at.test.ts
+++ b/server/tests/integration/billing/dfu/billing-import/billing-import-started-at.test.ts
@@ -21,7 +21,7 @@ test.concurrent(
 	`${chalk.yellowBright("dfu.flash: plan.started_at sets the imported one-off start date")}`,
 	async () => {
 		const customerId = "dfu-flash-starts-at";
-		const pro = products.pro({
+		const pro = products.oneOff({
 			id: "dfu-starts-at-pro",
 			items: [items.monthlyMessages({ includedUsage: 100 })],
 		});
@@ -71,10 +71,12 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("dfu.flash: one-off with resetting credits and no started_at is flagged, not blocked")}`,
+	`${chalk.yellowBright("dfu.flash: resetting plan with no started_at is flagged, not blocked")}`,
 	async () => {
 		const customerId = "dfu-flash-started-at-required";
-		const pro = products.pro({
+		// Free (no base price) so this isolates the anchor mismatch, not the
+		// paid-plan-without-subscription one.
+		const pro = products.base({
 			id: "dfu-started-at-required-pro",
 			items: [items.monthlyMessages({ includedUsage: 100 })],
 		});

--- a/shared/api/billing/dfu/dfuFlashParams.ts
+++ b/shared/api/billing/dfu/dfuFlashParams.ts
@@ -240,7 +240,7 @@ export const DfuFlashedPlanSchema = z.object({
 	}),
 	mismatch: z.boolean().optional().meta({
 		description:
-			"True when the imaged state may be wrong — e.g. a resetting plan with no resolvable billing anchor, so its cycle defaulted to the import time. The plan is still imaged; fix by supplying started_at or a resolvable subscription.",
+			"True when the imaged state may be wrong — e.g. a resetting plan with no resolvable billing anchor, or a paid recurring plan with no linked subscription for Autumn to manage. The plan is still imaged; see `reason` and fix by supplying started_at or a subscription_id.",
 	}),
 	reason: z.string().optional().meta({
 		description:

--- a/shared/api/billing/dfu/dfuFlashParams.ts
+++ b/shared/api/billing/dfu/dfuFlashParams.ts
@@ -11,8 +11,6 @@ import { ApiCustomerV5Schema } from "../../customers/apiCustomerV5";
 // supported and is intentionally omitted so `type` renders as a clean enum.)
 const ProcessorTypeSchema = z.enum(["stripe", "revenuecat"]);
 
-const BillableProcessorSchema = z.enum(["stripe", "revenuecat", "none"]);
-
 const FlashCustomerDataSchema = z.object({
 	name: z
 		.string()
@@ -153,9 +151,9 @@ const FlashPhaseSchema = z.object({
 
 const FlashBillableSchema = z
 	.object({
-		processor: BillableProcessorSchema.meta({
+		processor: ProcessorTypeSchema.optional().meta({
 			description:
-				"The processor that owns this billable (stripe, revenuecat, or none).",
+				"The processor that owns this billable (stripe or revenuecat). Omit for plans with no processor, e.g. a free plan.",
 		}),
 		link: FlashLinkSchema.optional().meta({
 			description:
@@ -204,9 +202,9 @@ export const DfuFlashParamsSchema = z.object({
 	customer_data: FlashCustomerDataSchema.optional().meta({
 		description: "Optional identity fields to upsert if the customer is new.",
 	}),
-	processors: z.array(FlashProcessorIdentitySchema).meta({
+	processors: z.array(FlashProcessorIdentitySchema).optional().meta({
 		description:
-			"The customer's processor identities (e.g. Stripe customer id, RevenueCat app_user_id).",
+			"The customer's processor identities (e.g. Stripe customer id, RevenueCat app_user_id). Omit for customers with no processor, e.g. those only ever on a free plan.",
 	}),
 	billables: z.array(FlashBillableSchema).meta({
 		description:


### PR DESCRIPTION
…optional for processor-less free-plan customers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow `dfu.flash` imports for free‑plan customers with no processors, and flag paid recurring plans imported without a subscription as mismatches. OpenAPI/docs and SDKs updated to match.

- **New Features**
  - `DfuFlashParams.processors` and `billable.processor` are optional; omit both for processor‑less free plans. Server defaults flashed `processor` to `"stripe"` when absent.
  - Flashed responses include `mismatch` with `reason` for edge cases, including `"paid_plan_without_subscription"` and `"no_resolvable_billing_anchor"`. Tests cover both paths.
  - OpenAPI/docs and SDKs remove `"none"` from processor enums and mark these fields optional.

- **Migration**
  - If you previously sent `"none"` for `billable.processor`, omit the field instead.

<sup>Written for commit 234725417a8ddaa29c63dabf4bee3114efd64222. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR lets DFU flash import processor-less free-plan customers. The main changes are:

- Makes top-level processor identities optional.
- Makes each billable processor optional for no-processor plans.
- Updates setup lookups to tolerate omitted processor arrays.
- Adds an integration test for a free-plan import without processor data.
</details>

<h3>Confidence Score: 4/5</h3>

The processor-less import path returns incorrect processor labels and rejects the old no-processor encoding.

- `processor: "none"` requests now fail validation instead of importing as no-processor billables.
- Free-plan flash results can report `"stripe"` while the stored customer product has no processor.
- The setup changes for omitted processor identities look consistent with the intended free-plan path.

shared/api/billing/dfu/dfuFlashParams.ts and server/src/internal/billing/v2/actions/dfu/compute/computeFlashPlan.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/api/billing/dfu/dfuFlashParams.ts | Makes processor metadata optional, but no longer accepts the old `processor: "none"` representation. |
| server/src/internal/billing/v2/actions/dfu/setup/setupFlashContext.ts | Uses optional processor identity lookups so processor-less imports can enter setup. |
| server/src/internal/billing/v2/actions/dfu/compute/computeFlashPlan.ts | Adds response fallbacks for omitted processors, but reports processor-less flashed plans as Stripe-owned. |
| server/tests/integration/billing/dfu/billing-import/billing-import-free-plan.test.ts | Adds coverage for importing a fresh free-plan customer without processor data. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
shared/api/billing/dfu/dfuFlashParams.ts:153
**None Sentinel Rejected**

Existing import clients that send `processor: "none"` for free or processor-less plans now fail validation because this schema only accepts `"stripe"` or `"revenuecat"`. That is the old explicit representation of the same state this PR now represents by omission, so those callers cannot import the customers this change is meant to support.

### Issue 2 of 3
server/src/internal/billing/v2/actions/dfu/compute/computeFlashPlan.ts:175
**Processor-Less Plans Report Stripe**

When a processor-less billable is already active, `planContext.processor` is `undefined`, but this fallback reports the flashed row as `"stripe"`. The customer product itself remains processor-less, so callers can receive a flash result that says a free plan is Stripe-owned and route audit or follow-up work to the wrong processor.

### Issue 3 of 3
server/src/internal/billing/v2/actions/dfu/compute/computeFlashPlan.ts:195
**Created Free Plans Report Stripe**

For a new free-plan import with omitted `billable.processor`, the inserted customer product is created without a processor, but the flash response returns `processor: "stripe"`. This makes the created response disagree with persisted ownership and can make clients treat a processor-less plan as Stripe-backed.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(billing): make billing.import proce..."](https://github.com/useautumn/autumn/commit/f75d11ca4a87d8923ecb639acd157e2c4ac427ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41909375)</sub>

> Greptile also left **3 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/autumn-org-2/github/useautumn/autumn/-/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))
- Context used - server/CLAUDE.md ([source](https://app.greptile.com/autumn-org-2/github/useautumn/autumn/-/custom-context?memory=7866843d-5d47-47cf-8270-b04b4f695fd8))
- Context used - AGENTS.md ([source](https://app.greptile.com/autumn-org-2/github/useautumn/autumn/-/custom-context?memory=e38717a3-e8ad-4054-9219-102b893d3b3c))
</details>

<!-- /greptile_comment -->