### PR TITLE
Fix variant Stripe product renames

### DIFF
--- a/server/src/internal/products/handlers/handleUpdatePlan/updateProductDetails.ts
+++ b/server/src/internal/products/handlers/handleUpdatePlan/updateProductDetails.ts
@@ -267,8 +267,12 @@ export const handleUpdateProductDetails = async ({
 		},
 	});
 
-	// Update product name in Stripe
-	if (curProduct.name !== newProduct.name && notNullish(newProduct.name)) {
+	// Update product-owned Stripe names.
+	if (
+		!curProduct.base_internal_product_id &&
+		curProduct.name !== newProduct.name &&
+		notNullish(newProduct.name)
+	) {
 		logger.info(
 			`Updating product (${curProduct.id}) name in Stripe to ${newProduct.name}`,
 		);

--- a/server/tests/integration/crud/plans/variants/stripe-resource-carryover.test.ts
+++ b/server/tests/integration/crud/plans/variants/stripe-resource-carryover.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import {
+	type ApiPlanV1,
 	ApiVersion,
 	type FullProduct,
 	ProductItemFeatureType,
@@ -147,6 +148,73 @@ test.concurrent(
 			base: baseFull,
 			variant: variantFull,
 		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("variants stripe resources: renaming root product updates Stripe product")}`,
+	async () => {
+		const cid = readableVariantTestId("stripe_root_rename");
+		const base = products.base({
+			id: `stripe_base_${cid}`,
+			items: [
+				items.monthlyPrice({ price: 20 }),
+				prepaidMessages({
+					price: 3,
+					billingUnits: 100,
+					interval: ProductItemInterval.Month,
+				}),
+			],
+		});
+
+		const { ctx } = await initScenario({
+			customerId: cid,
+			setup: [s.customer(), s.products({ list: [base] })],
+			actions: [],
+		});
+
+		const rpc = new AutumnRpcCli({
+			secretKey: ctx.orgSecretKey,
+			version: ApiVersion.V2_1,
+		});
+		const variantId = `stripe_var_${cid}`;
+		const updatedName = "Stripe Root Product Updated";
+
+		await createVariantPlan({
+			rpc,
+			basePlanId: base.id,
+			variantPlanId: variantId,
+			name: "Stripe Root Rename Variant",
+		});
+
+		const baseFull = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: base.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		const variantFull = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: variantId,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		expectStripeResourcesCarriedToVariant({
+			base: baseFull,
+			variant: variantFull,
+		});
+
+		const stripeProductId = baseFull.processor?.id;
+		expect(stripeProductId).toBeTruthy();
+
+		await rpc.plans.update<ApiPlanV1>(base.id, {
+			name: updatedName,
+		});
+
+		const stripeProduct = await ctx.stripeCli.products.retrieve(
+			stripeProductId!,
+		);
+		expect(stripeProduct.name).toBe(updatedName);
 	},
 );
 
@@ -386,6 +454,124 @@ test.concurrent(
 				source: variantAAfterAttach,
 				target: variantBAfterAttach,
 			});
+		} finally {
+			await OrgService.update({
+				db: ctx.db,
+				orgId: ctx.org.id,
+				updates: { config: originalConfig },
+			});
+		}
+	},
+);
+
+// Red: renaming a sibling variant mutates the shared Stripe Product name.
+// Green: shared Stripe Product names stay stable for existing subscriptions.
+test.concurrent(
+	`${chalk.yellowBright("variants stripe resources: renaming sibling does not rename shared Stripe product")}`,
+	async () => {
+		const cid = readableVariantTestId("stripe_rename_shared");
+		const siblingCustomerId = `${cid}_sibling`;
+		const base = products.base({
+			id: `stripe_base_${cid}`,
+			items: [
+				items.monthlyPrice({ price: 20 }),
+				prepaidMessages({
+					price: 3,
+					billingUnits: 100,
+					interval: ProductItemInterval.Month,
+				}),
+			],
+		});
+
+		const { autumnV2_2, ctx } = await initScenario({
+			customerId: cid,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.otherCustomers([
+					{ id: siblingCustomerId, paymentMethod: "success" },
+				]),
+				s.products({ list: [base], createInStripe: false }),
+			],
+			actions: [],
+		});
+
+		const originalConfig = ctx.org.config;
+		const rpc = new AutumnRpcCli({
+			secretKey: ctx.orgSecretKey,
+			version: ApiVersion.V2_1,
+		});
+		const variantAId = `stripe_var_a_${cid}`;
+		const variantBId = `stripe_var_b_${cid}`;
+		const variantAName = "Stripe Rename Variant A";
+
+		try {
+			await OrgService.update({
+				db: ctx.db,
+				orgId: ctx.org.id,
+				updates: {
+					config: {
+						...originalConfig,
+						disable_stripe_writes: true,
+					},
+				},
+			});
+
+			await createVariantPlan({
+				rpc,
+				basePlanId: base.id,
+				variantPlanId: variantAId,
+				name: variantAName,
+			});
+			await createVariantPlan({
+				rpc,
+				basePlanId: base.id,
+				variantPlanId: variantBId,
+				name: "Stripe Rename Variant B",
+			});
+
+			await OrgService.update({
+				db: ctx.db,
+				orgId: ctx.org.id,
+				updates: { config: originalConfig },
+			});
+
+			await autumnV2_2.billing.attach({
+				customer_id: cid,
+				plan_id: variantAId,
+			});
+			const variantAAfterAttach = await ProductService.getFull({
+				db: ctx.db,
+				idOrInternalId: variantAId,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			});
+
+			await autumnV2_2.billing.attach({
+				customer_id: siblingCustomerId,
+				plan_id: variantBId,
+			});
+			const variantBAfterAttach = await ProductService.getFull({
+				db: ctx.db,
+				idOrInternalId: variantBId,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			});
+			expectStripeResourcesMatch({
+				source: variantAAfterAttach,
+				target: variantBAfterAttach,
+			});
+
+			const sharedStripeProductId = variantAAfterAttach.processor?.id;
+			expect(sharedStripeProductId).toBeTruthy();
+
+			await rpc.plans.update<ApiPlanV1>(variantBId, {
+				name: "Stripe Rename Variant B Updated",
+			});
+
+			const sharedStripeProduct = await ctx.stripeCli.products.retrieve(
+				sharedStripeProductId!,
+			);
+			expect(sharedStripeProduct.name).toBe(variantAName);
 		} finally {
 			await OrgService.update({
 				db: ctx.db,


### PR DESCRIPTION
## Summary
- prevent child variant plan renames from mutating shared Stripe Product names
- add regression coverage for sibling variants sharing Stripe resources

## Test plan
- bunx tsgo --build --noEmit
- AUTUMN_TEST_BASE_URL=http://localhost:18080 ./run.sh /tmp/autumn-fix-variant-stripe-product-names/server/tests/integration/crud/plans/variants/stripe-resource-carryover.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop variant plan renames from changing the shared Stripe Product name. Only base/standalone products update Stripe names, keeping sibling variants and existing subscriptions stable.

- **Bug Fixes**
  - Update Stripe product name only for non-variant products (`!curProduct.base_internal_product_id`).
  - Add tests: base product rename updates Stripe; sibling variant rename does not (including with active subscriptions).

<sup>Written for commit 0d4fe12e47c813042b30bee0aee7143fe8cc78e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes Stripe Product naming for variant plan updates. The main changes are:

- Prevent variant renames from updating shared Stripe Product names.
- Add a variant sibling test for shared Stripe resource carryover.
- Verify the shared Stripe Product keeps its original name after a sibling variant rename.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/products/handlers/handleUpdatePlan/updateProductDetails.ts | Adds a guard so Stripe Product names are only updated for non-variant products. |
| server/tests/integration/crud/plans/variants/stripe-resource-carryover.test.ts | Adds a test that sibling variants sharing Stripe resources do not rename the shared Stripe Product. |

<sub>Reviews (1): Last reviewed commit: ["fix(billing): avoid variant stripe produ..."](https://github.com/useautumn/autumn/commit/e6182250a90332c1424001cd1242ffcde3a9fdbf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42047437)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->