### PR TITLE
sanitize customer/entity ids in webhook tags to Svix charset

### DIFF
--- a/server/src/external/svix/svixHelpers.ts
+++ b/server/src/external/svix/svixHelpers.ts
@@ -62,7 +62,12 @@ export const sendSvixEvent = async ({
 
 		const svix = createSvixCli();
 		const appId = getSvixAppId({ org, env });
-		if (!appId) return null;
+		if (!appId) {
+			ctx.logger.warn(
+				`[svix] No app id for org ${org.id} (${env}); skipping ${eventType}`,
+			);
+			return null;
+		}
 
 		return await svix.message.create(
 			appId,
@@ -78,7 +83,12 @@ export const sendSvixEvent = async ({
 			idempotencyKey ? { idempotencyKey } : undefined,
 		);
 	} catch (error) {
-		ctx.logger.error(`[svix] Failed to send ${eventType}: ${error}`);
+		// Svix's ApiException carries the 422 reason on `.body`; log it plus the
+		// tags so tag-validation rejections aren't invisible.
+		const svixBody = (error as { body?: unknown }).body;
+		ctx.logger.error(
+			`[svix] Failed to send ${eventType}: ${error} | body=${JSON.stringify(svixBody)} | tags=${JSON.stringify(tags ?? [])}`,
+		);
 		Sentry.captureException(error, {
 			tags: getSentryTags({ ctx }),
 		});

--- a/shared/utils/cusUtils/fullCusUtils/fullCustomerToTags.test.ts
+++ b/shared/utils/cusUtils/fullCusUtils/fullCustomerToTags.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, test } from "bun:test";
 import type { FullCustomer } from "@models/cusModels/fullCusModel.js";
 import { fullCustomerToTags } from "./fullCustomerToTags";
 
-// Svix rejects any message tag outside this set (or >128 chars) with HTTP 422,
-// dropping the whole webhook. See shared/.../fullCustomerToTags.ts.
-const SVIX_TAG_PATTERN = /^[a-zA-Z0-9\-_./\\#]+$/;
+// The set fullCustomerToTags guarantees its output stays within (a subset of
+// what Svix accepts); tags outside it, or >128 chars, are rejected with HTTP 422.
+const SVIX_TAG_PATTERN = /^[a-zA-Z0-9\-_./#]+$/;
 const SVIX_TAG_MAX_LENGTH = 128;
 
 const cus = (id: string, entityId?: string): FullCustomer =>
@@ -61,6 +61,17 @@ describe("fullCustomerToTags", () => {
 	test("emits only customer_id when there is no entity", () => {
 		expect(fullCustomerToTags({ fullCustomer: cus("cus_plain") })).toEqual([
 			"customer_id.cus_plain",
+		]);
+	});
+
+	test("falls back to internal_id (still sanitized) when id is nullish", () => {
+		const fullCustomer = {
+			id: undefined,
+			internal_id: "int:01hxyz",
+			entity: undefined,
+		} as unknown as FullCustomer;
+		expect(fullCustomerToTags({ fullCustomer })).toEqual([
+			"customer_id.int_01hxyz",
 		]);
 	});
 });

--- a/shared/utils/cusUtils/fullCusUtils/fullCustomerToTags.test.ts
+++ b/shared/utils/cusUtils/fullCusUtils/fullCustomerToTags.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import type { FullCustomer } from "@models/cusModels/fullCusModel.js";
+import { fullCustomerToTags } from "./fullCustomerToTags";
+
+// Svix rejects any message tag outside this set (or >128 chars) with HTTP 422,
+// dropping the whole webhook. See shared/.../fullCustomerToTags.ts.
+const SVIX_TAG_PATTERN = /^[a-zA-Z0-9\-_./\\#]+$/;
+const SVIX_TAG_MAX_LENGTH = 128;
+
+const cus = (id: string, entityId?: string): FullCustomer =>
+	({
+		id,
+		internal_id: `internal_${id}`,
+		entity: entityId ? { id: entityId } : undefined,
+	}) as unknown as FullCustomer;
+
+const expectSvixSafe = (tags: string[]) => {
+	for (const tag of tags) {
+		expect(tag).toMatch(SVIX_TAG_PATTERN);
+		expect(tag.length).toBeLessThanOrEqual(SVIX_TAG_MAX_LENGTH);
+	}
+};
+
+describe("fullCustomerToTags", () => {
+	test("colon-delimited ids (e.g. tana:org:...) produce Svix-valid tags", () => {
+		const tags = fullCustomerToTags({
+			fullCustomer: cus(
+				"tana:org:01kt19mvwrfhekvvdjejmnhgpa",
+				"tana:user-profile:01kj7w67nbcbn7hvh5jyaq0aan",
+			),
+		});
+		expectSvixSafe(tags);
+	});
+
+	test("email ids (contain @) produce Svix-valid tags", () => {
+		expectSvixSafe(
+			fullCustomerToTags({ fullCustomer: cus("someone@gmail.com") }),
+		);
+	});
+
+	test("ids longer than 128 chars are clamped", () => {
+		expectSvixSafe(
+			fullCustomerToTags({ fullCustomer: cus(`x:${"a".repeat(200)}`) }),
+		);
+	});
+
+	test("svix-allowed special chars (/ # - _ .) are preserved", () => {
+		const tags = fullCustomerToTags({
+			fullCustomer: cus("org/team#1.2-3_x"),
+		});
+		expect(tags).toEqual(["customer_id.org/team#1.2-3_x"]);
+	});
+
+	test("clean ids are preserved unchanged", () => {
+		const tags = fullCustomerToTags({
+			fullCustomer: cus("cus_3Fq123", "ent_abc"),
+		});
+		expect(tags).toEqual(["customer_id.cus_3Fq123", "entity_id.ent_abc"]);
+	});
+
+	test("emits only customer_id when there is no entity", () => {
+		expect(fullCustomerToTags({ fullCustomer: cus("cus_plain") })).toEqual([
+			"customer_id.cus_plain",
+		]);
+	});
+});

--- a/shared/utils/cusUtils/fullCusUtils/fullCustomerToTags.ts
+++ b/shared/utils/cusUtils/fullCusUtils/fullCustomerToTags.ts
@@ -1,15 +1,24 @@
 import type { FullCustomer } from "@models/cusModels/fullCusModel.js";
 
-// Svix tag chars must match [a-zA-Z0-9\-_.], so we separate key/value with `.`
-// instead of `:` (rejected with HTTP 422 at message creation).
+// Svix rejects any tag outside ^[a-zA-Z0-9\-_./#]+$ (or >128 chars) with HTTP
+// 422; customer/entity ids carry ':' or '@', so scrub the value before tagging.
+const SVIX_TAG_MAX_LENGTH = 128;
+const SVIX_TAG_DISALLOWED = /[^a-zA-Z0-9._#/-]/g;
+
+const toSvixTag = (key: string, value: string): string =>
+	`${key}.${value.replace(SVIX_TAG_DISALLOWED, "_")}`.slice(
+		0,
+		SVIX_TAG_MAX_LENGTH,
+	);
+
 export const fullCustomerToTags = ({
 	fullCustomer,
 }: {
 	fullCustomer: FullCustomer;
 }): string[] => {
 	const customerId = fullCustomer.id ?? fullCustomer.internal_id;
-	const tags = [`customer_id.${customerId}`];
+	const tags = [toSvixTag("customer_id", customerId)];
 	const entityId = fullCustomer.entity?.id;
-	if (entityId) tags.push(`entity_id.${entityId}`);
+	if (entityId) tags.push(toSvixTag("entity_id", entityId));
 	return tags;
 };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes customer and entity IDs in webhook tags to meet `svix` character and length rules, preventing 422 errors that drop messages. Adds clearer logs for missing app IDs and tag validation failures.

- **Bug Fixes**
  - Sanitize `customer_id`/`entity_id` tags: replace disallowed chars with `_`, keep `/ # - _ .`, clamp to 128; fallback to `internal_id` when `id` is missing; tests cover colon/email/long IDs and stricter tag pattern.
  - Skip sending when missing app ID and warn with org/env and event type.
  - On send errors, log `svix` error body and the tags to aid debugging.

<sup>Written for commit a0e270a5107f2645b3ae5edfb25171ecf8ac11f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes Svix webhook tags valid for customer and entity IDs. The main changes are:

- **Bug fixes**: Scrubs unsupported characters from customer and entity tag values.
- **Bug fixes**: Clamps Svix tags to the documented 128-character limit.
- **Improvements**: Adds Bun tests for colon IDs, email IDs, long IDs, allowed characters, and missing entity IDs.
- **Improvements**: Adds more context to Svix skip and failure logs.
</details>

<h3>Confidence Score: 5/5</h3>

The changed flow looks mergeable after a small cleanup to tag identity handling.

- Webhook delivery should improve because invalid Svix tags are now scrubbed.
- The remaining issue affects Svix filtering/debugging accuracy when different IDs sanitize or truncate to the same tag.
- The new tests cover validity, but not uniqueness after sanitization.

shared/utils/cusUtils/fullCusUtils/fullCustomerToTags.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/cusUtils/fullCusUtils/fullCustomerToTags.ts | Adds Svix-safe tag formatting for customer and entity IDs, with lossy replacement and truncation that can make distinct IDs share a tag. |
| shared/utils/cusUtils/fullCusUtils/fullCustomerToTags.test.ts | Adds focused tests for valid Svix tag output across special characters, long IDs, and entity/no-entity cases. |
| server/src/external/svix/svixHelpers.ts | Adds warning/error log context for skipped Svix sends and rejected Svix messages. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
shared/utils/cusUtils/fullCusUtils/fullCustomerToTags.ts:9-12
**Sanitized Tags Can Collide**

When two IDs differ only by unsupported characters, such as `user:alpha`, `user@alpha`, and `user_alpha`, they all produce the same Svix tag `customer_id.user_alpha`. Svix tag filtering is exact-match, so webhook searches by customer or entity tag can return messages for the wrong record even though the payload IDs are distinct.

### Issue 2 of 2
shared/utils/cusUtils/fullCusUtils/fullCustomerToTags.ts:10-12
**Long Tag Suffixes Disappear**

The length clamp slices the whole `key.value` tag, so `customer_id.` leaves only 116 characters of the customer ID and `entity_id.` leaves 118 characters of the entity ID. Two long IDs with the same prefix and different suffixes become the same tag, which makes Svix filtering/debugging return a combined result set for different customers or entities.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(svix): sanitize customer/entity ids ..."](https://github.com/useautumn/autumn/commit/85ac2e2684e52671fd55c557b57e65fb39e3f8f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42054312)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->