### PR TITLE
fix(atmn): emit archived flag when pulling archived plans

### DIFF
--- a/packages/atmn/src/lib/transforms/sdkToCode/plan.ts
+++ b/packages/atmn/src/lib/transforms/sdkToCode/plan.ts
@@ -48,6 +48,11 @@ export function buildPlanCode(
 		lines.push(`\tautoEnable: ${plan.autoEnable},`);
 	}
 
+	// Add archived flag only when explicitly true
+	if (plan.archived === true) {
+		lines.push(`\tarchived: true,`);
+	}
+
 	// Add price
 	if (plan.price) {
 		lines.push(`\tprice: {`);


### PR DESCRIPTION
## Problem

Pulling an already-archived plan from the Remote did not generate `archived: true` in the resulting `autumn.config.ts`.

The `archived` flag survives the whole pull pipeline — `listPlans` fetches with `include_archived: true`, `planTransformer` copies it into the SDK `Plan`, and the compose model supports it — but `buildPlanCode` (the SDK→code generator) never emitted it. The sibling feature generator already handles this correctly.

## Fix

`buildPlanCode` now emits `archived: true,` when `plan.archived === true`, matching the feature generator exactly. The field is omitted entirely for non-archived plans, so existing configs produce zero diff.

Both pull write paths (`buildConfigFile` fresh generation and `updateConfigInPlace`) delegate to this function, so one fix covers both.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing `archived: true` when pulling archived plans so the generated `autumn.config.ts` correctly reflects archive status. `buildPlanCode` in `atmn` now emits `archived: true` only when `plan.archived === true`, omitting it otherwise across both fresh generation and in-place updates.

<sup>Written for commit 7b0c7c26bf80d56b78271b084066014bdf99bd5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR preserves archived plan state in generated config code. The main changes are:

- **[Bug fixes]** Emit `archived: true` for plans that are explicitly archived.
- **[Bug fixes]** Keep non-archived plans unchanged by omitting the field.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/atmn/src/lib/transforms/sdkToCode/plan.ts | Adds conditional `archived: true` emission for archived plans in generated config output. |

<sub>Reviews (1): Last reviewed commit: ["fix(atmn): 🐛 emit archived flag when pu..."](https://github.com/useautumn/autumn/commit/7b0c7c26bf80d56b78271b084066014bdf99bd5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42064717)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->