### PR TITLE
fix: cache race condition

### DIFF
--- a/server/src/_luaScriptsV2/fullSubject/getDelSharedBalanceFields.lua
+++ b/server/src/_luaScriptsV2/fullSubject/getDelSharedBalanceFields.lua
@@ -1,0 +1,52 @@
+--[[
+  Lua Script: Destructive-read shared balance fields (GETDEL semantics)
+
+  Atomically reads customer-entitlement balance fields and deletes them, so an
+  invalidation cannot race a deduction between the read and the delete. The
+  returned values are flushed to Postgres by the caller before the subject
+  view is unlinked.
+
+  KEYS = shared balance hash keys (one per feature, same {customerId} slot)
+
+  ARGV[1] = JSON array aligned with KEYS: per-key array of cusEnt field names
+  ARGV[2] = JSON array of field names to delete from every key without
+            returning (derived fields, e.g. _aggregated / _usage_windows)
+
+  Returns JSON: array aligned with KEYS of per-key value arrays
+  (null where the field was missing)
+]]
+
+local cus_ent_fields_by_key = cjson.decode(ARGV[1])
+local delete_only_fields = cjson.decode(ARGV[2])
+
+local values_by_key = {}
+
+for key_index, balance_key in ipairs(KEYS) do
+  local cus_ent_fields = cus_ent_fields_by_key[key_index]
+  if type(cus_ent_fields) ~= "table" then
+    cus_ent_fields = {}
+  end
+
+  local values = {}
+  if #cus_ent_fields > 0 then
+    local raw_values = redis.call("HMGET", balance_key, unpack(cus_ent_fields))
+    for value_index = 1, #cus_ent_fields do
+      values[value_index] = raw_values[value_index] or cjson.null
+    end
+  end
+
+  local fields_to_delete = {}
+  for _, field_name in ipairs(cus_ent_fields) do
+    table.insert(fields_to_delete, field_name)
+  end
+  for _, field_name in ipairs(delete_only_fields) do
+    table.insert(fields_to_delete, field_name)
+  end
+  if #fields_to_delete > 0 then
+    redis.call("HDEL", balance_key, unpack(fields_to_delete))
+  end
+
+  values_by_key[key_index] = values
+end
+
+return cjson.encode(values_by_key)

--- a/server/src/_luaScriptsV2/luaScriptsV2.ts
+++ b/server/src/_luaScriptsV2/luaScriptsV2.ts
@@ -25,6 +25,7 @@ import LUA_UTILS from "./luaUtils.lua";
 // ============================================================================
 
 import adjustSubjectBalanceMainScript from "./fullSubject/adjustSubjectBalance.lua";
+import getDelSharedBalanceFieldsScript from "./fullSubject/getDelSharedBalanceFields.lua";
 import setCachedFullSubjectScript from "./fullSubject/setCachedFullSubject.lua";
 import updateCachedInvoiceV2Script from "./fullSubject/updateCachedInvoice.lua";
 import updateCustomerDataV2Script from "./fullSubject/updateCustomerDataV2.lua";
@@ -121,6 +122,9 @@ export const SET_CACHED_FULL_SUBJECT_SCRIPT = `${setCachedFullSubjectScript}`;
 
 /** Atomically update top-level customer fields in the cached FullSubject. */
 export const UPDATE_CUSTOMER_DATA_V2_SCRIPT = `${updateCustomerDataV2Script}`;
+
+/** Atomically read + delete shared balance hash fields (GETDEL semantics). */
+export const GETDEL_SHARED_BALANCE_FIELDS_SCRIPT = `${getDelSharedBalanceFieldsScript}`;
 
 /** Atomically update top-level entity fields in the cached FullSubject. */
 export const UPDATE_ENTITY_DATA_V2_SCRIPT = `${updateEntityDataV2Script}`;

--- a/server/src/external/redis/initUtils/redisTypes.ts
+++ b/server/src/external/redis/initUtils/redisTypes.ts
@@ -145,6 +145,10 @@ declare module "ioredis" {
 			cacheTtlSeconds: string,
 			nowMs: string,
 		): Promise<string>;
+		getDelFullSubjectBalanceFields(
+			numKeys: number,
+			...args: string[]
+		): Promise<string>;
 		updateFullSubjectCustomerProductV2(
 			subjectKey: string,
 			paramsJson: string,

--- a/server/src/external/redis/initUtils/registerRedisCommands.ts
+++ b/server/src/external/redis/initUtils/registerRedisCommands.ts
@@ -21,6 +21,7 @@ import {
 	DEDUCT_FROM_CUSTOMER_ENTITLEMENTS_SCRIPT,
 	DEDUCT_FROM_SUBJECT_BALANCES_SCRIPT,
 	DELETE_FULL_CUSTOMER_CACHE_SCRIPT,
+	GETDEL_SHARED_BALANCE_FIELDS_SCRIPT,
 	RESET_CUSTOMER_ENTITLEMENTS_SCRIPT,
 	ROLL_USAGE_WINDOWS_SCRIPT,
 	SET_CACHED_FULL_SUBJECT_SCRIPT,
@@ -203,6 +204,10 @@ export const registerRedisCommands = ({
 	redisInstance.defineCommand("updateFullSubjectEntityDataV2", {
 		numberOfKeys: 1,
 		lua: prepareScript(UPDATE_ENTITY_DATA_V2_SCRIPT),
+	});
+
+	redisInstance.defineCommand("getDelFullSubjectBalanceFields", {
+		lua: prepareScript(GETDEL_SHARED_BALANCE_FIELDS_SCRIPT),
 	});
 
 	redisInstance.defineCommand("updateFullSubjectCustomerProductV2", {

--- a/server/src/external/redis/otel/redisSlowlogConfig.ts
+++ b/server/src/external/redis/otel/redisSlowlogConfig.ts
@@ -93,6 +93,11 @@ export const REDIS_THRESHOLDS: RedisThresholdConfig[] = [
 		severeMs: 300,
 	}),
 	threshold({
+		operation: "getDelFullSubjectBalanceFields",
+		slowMs: 50,
+		severeMs: 300,
+	}),
+	threshold({
 		operation: "updateFullSubjectCustomerProductV2",
 		slowMs: 50,
 		severeMs: 300,

--- a/server/src/honoMiddlewares/refreshCacheConfigs.ts
+++ b/server/src/honoMiddlewares/refreshCacheConfigs.ts
@@ -3,14 +3,20 @@ import { matchRoute } from "./middlewareUtils.js";
 export type RefreshCacheRouteConfig = {
 	method: string;
 	url: string;
+	/** Flush cached balances to Postgres before invalidating. Only safe on
+	 *  balance-neutral routes — everywhere else Postgres was just written
+	 *  directly and the cached balances are stale. */
+	flushBalances?: boolean;
 };
 
 const route = ({
 	method,
 	url,
+	flushBalances,
 }: RefreshCacheRouteConfig): RefreshCacheRouteConfig => ({
 	method,
 	url,
+	flushBalances,
 });
 
 export const REFRESH_CACHE_ROUTE_CONFIGS: RefreshCacheRouteConfig[] = [
@@ -22,10 +28,12 @@ export const REFRESH_CACHE_ROUTE_CONFIGS: RefreshCacheRouteConfig[] = [
 	route({
 		method: "POST",
 		url: "/customers/:customer_id",
+		flushBalances: true,
 	}),
 	route({
 		method: "PATCH",
 		url: "/customers/:customer_id",
+		flushBalances: true,
 	}),
 
 	route({
@@ -92,6 +100,7 @@ export const REFRESH_CACHE_ROUTE_CONFIGS: RefreshCacheRouteConfig[] = [
 	route({
 		method: "POST",
 		url: "/billing.setup_payment",
+		flushBalances: true,
 	}),
 
 	route({
@@ -107,6 +116,7 @@ export const REFRESH_CACHE_ROUTE_CONFIGS: RefreshCacheRouteConfig[] = [
 	route({
 		method: "POST",
 		url: "/billing.open_customer_portal",
+		flushBalances: true,
 	}),
 
 	route({
@@ -142,6 +152,7 @@ export const REFRESH_CACHE_ROUTE_CONFIGS: RefreshCacheRouteConfig[] = [
 	route({
 		method: "POST",
 		url: "/customers.update",
+		flushBalances: true,
 	}),
 
 	route({

--- a/server/src/honoMiddlewares/refreshCacheConfigs.ts
+++ b/server/src/honoMiddlewares/refreshCacheConfigs.ts
@@ -148,6 +148,16 @@ export const REFRESH_CACHE_ROUTE_CONFIGS: RefreshCacheRouteConfig[] = [
 		method: "POST",
 		url: "/billing.import",
 	}),
+
+	route({
+		method: "POST",
+		url: "/billing.sync",
+	}),
+
+	route({
+		method: "POST",
+		url: "/billing.sync_v2",
+	}),
 ];
 
 export const getRefreshCacheRouteConfig = ({

--- a/server/src/honoMiddlewares/refreshCacheMiddleware.ts
+++ b/server/src/honoMiddlewares/refreshCacheMiddleware.ts
@@ -36,6 +36,7 @@ export const refreshCacheMiddleware = async (
 		entityId: ctx.entityId,
 		ctx,
 		source: "refreshCacheMiddleware",
+		flushBalances: routeConfig.flushBalances,
 	});
 
 	warmFullSubjectCache({

--- a/server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts
+++ b/server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts
@@ -1,0 +1,128 @@
+import type {
+	EntityBalance,
+	EntityRolloverBalance,
+	SubjectBalance,
+} from "@autumn/shared";
+import { tryCatch } from "@autumn/shared";
+import { sql } from "drizzle-orm";
+import { planetScaleTag } from "@/db/dbUtils.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+export const SYNC_CONFLICT_CODES = {
+	ResetAtMismatch: "RESET_AT_MISMATCH",
+	EntityCountMismatch: "ENTITY_COUNT_MISMATCH",
+	CacheVersionMismatch: "CACHE_VERSION_MISMATCH",
+} as const;
+
+export const isSyncConflictError = (error: Error): boolean => {
+	const message = error.message || "";
+	return Object.values(SYNC_CONFLICT_CODES).some((code) =>
+		message.includes(code),
+	);
+};
+
+export interface SyncEntry {
+	customer_entitlement_id: string;
+	feature_id: string;
+	balance: number;
+	adjustment: number;
+	entities: Record<string, EntityBalance> | null;
+	next_reset_at: number | null;
+	entity_count: number;
+	cache_version: number | null;
+}
+
+export interface RolloverSyncEntry {
+	rollover_id: string;
+	balance: number;
+	usage: number;
+	entities: Record<string, EntityRolloverBalance> | null;
+}
+
+export const subjectBalanceToSyncEntry = ({
+	subjectBalance,
+}: {
+	subjectBalance: SubjectBalance;
+}): SyncEntry => ({
+	customer_entitlement_id: subjectBalance.id,
+	feature_id: subjectBalance.feature_id,
+	balance: subjectBalance.balance ?? 0,
+	adjustment: subjectBalance.adjustment ?? 0,
+	entities: subjectBalance.entities ?? null,
+	next_reset_at: subjectBalance.next_reset_at ?? null,
+	entity_count: subjectBalance.entities
+		? Object.keys(subjectBalance.entities).length
+		: 0,
+	cache_version: subjectBalance.cache_version ?? 0,
+});
+
+const subjectBalancesToRolloverEntries = ({
+	subjectBalances,
+}: {
+	subjectBalances: SubjectBalance[];
+}): RolloverSyncEntry[] =>
+	subjectBalances.flatMap((subjectBalance) =>
+		// cjson-written values can carry {} for empty arrays; never trust shape.
+		(Array.isArray(subjectBalance.rollovers)
+			? subjectBalance.rollovers
+			: []
+		).map((rollover) => ({
+			rollover_id: rollover.id,
+			balance: rollover.balance ?? 0,
+			usage: rollover.usage ?? 0,
+			entities: rollover.entities ?? null,
+		})),
+	);
+
+/**
+ * Best-effort flush of cached subject balances to Postgres. Never throws:
+ * conflicts mean Postgres is ahead (the rebuild wins), other failures are
+ * logged — the caller is invalidating and must proceed either way.
+ */
+export const flushSubjectBalancesToDb = async ({
+	ctx,
+	customerId,
+	subjectBalances,
+	source,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	subjectBalances: SubjectBalance[];
+	source: string;
+}): Promise<void> => {
+	if (subjectBalances.length === 0) return;
+
+	const { db, logger } = ctx;
+	const entries = subjectBalances.map((subjectBalance) =>
+		subjectBalanceToSyncEntry({ subjectBalance }),
+	);
+	const rolloverEntries = subjectBalancesToRolloverEntries({ subjectBalances });
+
+	const { error } = await tryCatch(
+		db.execute(
+			sql`SELECT * FROM sync_balances_v2(${JSON.stringify({
+				customer_entitlement_updates: entries,
+				rollover_updates: rolloverEntries,
+				usage_window_updates: [],
+			})}::jsonb) ${planetScaleTag({ query: "flushSubjectBalancesToDb" })}`,
+		),
+	);
+
+	if (!error) {
+		logger.info(
+			`[flushSubjectBalancesToDb] ${customerId}: flushed ${entries.length} balances, source: ${source}`,
+		);
+		return;
+	}
+
+	if (isSyncConflictError(error)) {
+		logger.warn(
+			`[flushSubjectBalancesToDb] ${customerId}: sync conflict during flush (Postgres ahead), source: ${source}, error: ${error.message}`,
+		);
+		return;
+	}
+
+	logger.error(
+		`[flushSubjectBalancesToDb] ${customerId}: flush failed, unsynced balances lost, source: ${source}, error: ${error}`,
+	);
+};

--- a/server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts
+++ b/server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts
@@ -7,6 +7,7 @@ import { tryCatch } from "@autumn/shared";
 import { sql } from "drizzle-orm";
 import { planetScaleTag } from "@/db/dbUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type { UsageWindowUpdate } from "../types/usageWindowUpdate.js";
 
 export const SYNC_CONFLICT_CODES = {
 	ResetAtMismatch: "RESET_AT_MISMATCH",
@@ -83,14 +84,16 @@ export const flushSubjectBalancesToDb = async ({
 	ctx,
 	customerId,
 	subjectBalances,
+	usageWindowUpdates = [],
 	source,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	subjectBalances: SubjectBalance[];
+	usageWindowUpdates?: UsageWindowUpdate[];
 	source: string;
 }): Promise<void> => {
-	if (subjectBalances.length === 0) return;
+	if (subjectBalances.length === 0 && usageWindowUpdates.length === 0) return;
 
 	const { db, logger } = ctx;
 	const entries = subjectBalances.map((subjectBalance) =>
@@ -103,14 +106,14 @@ export const flushSubjectBalancesToDb = async ({
 			sql`SELECT * FROM sync_balances_v2(${JSON.stringify({
 				customer_entitlement_updates: entries,
 				rollover_updates: rolloverEntries,
-				usage_window_updates: [],
+				usage_window_updates: usageWindowUpdates,
 			})}::jsonb) ${planetScaleTag({ query: "flushSubjectBalancesToDb" })}`,
 		),
 	);
 
 	if (!error) {
 		logger.info(
-			`[flushSubjectBalancesToDb] ${customerId}: flushed ${entries.length} balances, source: ${source}`,
+			`[flushSubjectBalancesToDb] ${customerId}: flushed ${entries.length} balances, ${usageWindowUpdates.length} usage windows, source: ${source}`,
 		);
 		return;
 	}

--- a/server/src/internal/balances/utils/sync/syncItemV4.ts
+++ b/server/src/internal/balances/utils/sync/syncItemV4.ts
@@ -1,10 +1,4 @@
-import {
-	type AppEnv,
-	type EntityBalance,
-	type EntityRolloverBalance,
-	type SubjectBalance,
-	tryCatch,
-} from "@autumn/shared";
+import { type AppEnv, type SubjectBalance, tryCatch } from "@autumn/shared";
 import { sql } from "drizzle-orm";
 import { planetScaleTag } from "@/db/dbUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
@@ -12,13 +6,18 @@ import { getCachedFeatureBalance } from "@/internal/customers/cache/fullSubject/
 import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
 import { globalRefreshEntityAggregateBatchingManager } from "../refreshEntityAggregate/RefreshEntityAggregateBatchingManager";
 import type { UsageWindowUpdate } from "../types/usageWindowUpdate.js";
+import {
+	type RolloverSyncEntry,
+	SYNC_CONFLICT_CODES,
+	type SyncEntry,
+	subjectBalanceToSyncEntry,
+} from "./flushSubjectBalancesToDb.js";
 import { logSyncItem } from "./logs/logSyncItem";
 
-const SYNC_CONFLICT_CODES = {
-	ResetAtMismatch: "RESET_AT_MISMATCH",
-	EntityCountMismatch: "ENTITY_COUNT_MISMATCH",
-	CacheVersionMismatch: "CACHE_VERSION_MISMATCH",
-} as const;
+export type {
+	RolloverSyncEntry,
+	SyncEntry,
+} from "./flushSubjectBalancesToDb.js";
 
 const handleSyncPostgresError = async ({
 	error,
@@ -75,41 +74,6 @@ interface SyncItemV4 {
 	 *  via full-replace per (customer, feature). */
 	usageWindowUpdates?: UsageWindowUpdate[];
 }
-
-export interface SyncEntry {
-	customer_entitlement_id: string;
-	feature_id: string;
-	balance: number;
-	adjustment: number;
-	entities: Record<string, EntityBalance> | null;
-	next_reset_at: number | null;
-	entity_count: number;
-	cache_version: number | null;
-}
-
-export interface RolloverSyncEntry {
-	rollover_id: string;
-	balance: number;
-	usage: number;
-	entities: Record<string, EntityRolloverBalance> | null;
-}
-
-const subjectBalanceToSyncEntry = ({
-	subjectBalance,
-}: {
-	subjectBalance: SubjectBalance;
-}): SyncEntry => ({
-	customer_entitlement_id: subjectBalance.id,
-	feature_id: subjectBalance.feature_id,
-	balance: subjectBalance.balance ?? 0,
-	adjustment: subjectBalance.adjustment ?? 0,
-	entities: subjectBalance.entities ?? null,
-	next_reset_at: subjectBalance.next_reset_at ?? null,
-	entity_count: subjectBalance.entities
-		? Object.keys(subjectBalance.entities).length
-		: 0,
-	cache_version: subjectBalance.cache_version ?? 0,
-});
 
 /** Sync cached subject balances to Postgres using targeted hash reads. */
 export const syncItemV4 = async ({

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateFullSubject.ts
@@ -13,12 +13,14 @@ const invalidateCachedFullSubjectOnRedis = async ({
 	ctx,
 	source,
 	redisV2,
+	flushBalances,
 }: {
 	customerId: string;
 	entityId?: string;
 	ctx: AutumnContext;
 	source?: string;
 	redisV2: Redis;
+	flushBalances?: boolean;
 }): Promise<void> => {
 	if (redisV2.status !== "ready") {
 		const subjectLabel = entityId ? `${customerId}:${entityId}` : customerId;
@@ -32,6 +34,7 @@ const invalidateCachedFullSubjectOnRedis = async ({
 		ctx,
 		customerId,
 		redisV2,
+		flushBalances,
 	});
 
 	const { org, env, logger } = ctx;
@@ -80,11 +83,16 @@ export const invalidateCachedFullSubject = async ({
 	entityId,
 	ctx,
 	source,
+	flushBalances,
 }: {
 	customerId: string;
 	entityId?: string;
 	ctx: AutumnContext;
 	source?: string;
+	/** Flush cached balances to Postgres before deleting them. Only safe when
+	 *  the caller has NOT just written balances to Postgres directly — the
+	 *  cached balances must still be the source of truth. */
+	flushBalances?: boolean;
 }): Promise<void> => {
 	if (!customerId) return;
 
@@ -99,6 +107,7 @@ export const invalidateCachedFullSubject = async ({
 				ctx,
 				source,
 				redisV2,
+				flushBalances,
 			}),
 		),
 	);

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts
@@ -1,5 +1,7 @@
+import type { SubjectBalance } from "@autumn/shared";
 import type { Redis } from "ioredis";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { flushSubjectBalancesToDb } from "@/internal/balances/utils/sync/flushSubjectBalancesToDb.js";
 import { tryRedisRead, tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
 import { buildFullSubjectKey } from "../../builders/buildFullSubjectKey.js";
 import { buildSharedFullSubjectBalanceKey } from "../../builders/buildSharedFullSubjectBalanceKey.js";
@@ -8,13 +10,20 @@ import {
 	USAGE_WINDOWS_FIELD,
 } from "../../config/fullSubjectCacheConfig.js";
 import type { CachedFullSubject } from "../../fullSubjectCacheModel.js";
+import { roundSubjectBalance } from "../../roundCacheBalance.js";
+import { sanitizeCachedSubjectBalance } from "../../sanitize/index.js";
+
+// Kill switch: set to false to revert to the legacy blind-HDEL path (drops
+// unsynced deductions racing the invalidation).
+const FLUSH_BALANCES_ON_INVALIDATION = true;
 
 /**
- * Deletes shared balance hash fields for a customer during structural
- * invalidation. Reads the subject view manifest to target specific cusEnt
- * fields + _aggregated per feature hash. No-op when the subject view is
- * already gone — paired with HSET-on-write semantics in setCachedFullSubject,
- * stale fields are overwritten on the next populate.
+ * Destructively reads (atomic read + HDEL) the shared balance hash fields for
+ * a customer during structural invalidation, then flushes the values to
+ * Postgres — an invalidation racing an un-synced deduction must not lose it.
+ * No-op when the subject view is already gone — paired with HSET-on-write
+ * semantics in setCachedFullSubject, stale fields are overwritten on the next
+ * populate.
  *
  * Must be called BEFORE the subject view key is deleted.
  */
@@ -35,20 +44,28 @@ export const invalidateSharedBalanceFields = async ({
 	const cachedRaw = await tryRedisRead(() => redisV2.get(subjectKey), redisV2);
 	if (!cachedRaw) return;
 
-	await deleteFieldsFromManifest({ ctx, customerId, cachedRaw, redisV2 });
+	if (!FLUSH_BALANCES_ON_INVALIDATION) {
+		await deleteFieldsFromManifest({ ctx, customerId, cachedRaw, redisV2 });
+		return;
+	}
+
+	await getDelFieldsFromManifest({ ctx, customerId, cachedRaw, redisV2 });
 };
 
-async function deleteFieldsFromManifest({
+type BalanceFieldTargets = {
+	balanceKeys: string[];
+	customerEntitlementIdsByKey: string[][];
+};
+
+const manifestToBalanceFieldTargets = ({
 	ctx,
 	customerId,
 	cachedRaw,
-	redisV2,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	cachedRaw: string;
-	redisV2: Redis;
-}) {
+}): BalanceFieldTargets | null => {
 	const { org, env, logger } = ctx;
 
 	let manifest: CachedFullSubject;
@@ -58,11 +75,11 @@ async function deleteFieldsFromManifest({
 		logger.warn(
 			`[invalidateSharedBalanceFields] Failed to parse subject view for ${customerId}, skipping field deletion`,
 		);
-		return;
+		return null;
 	}
 
 	const { customerEntitlementIdsByFeatureId } = manifest;
-	if (!customerEntitlementIdsByFeatureId) return;
+	if (!customerEntitlementIdsByFeatureId) return null;
 
 	// Capped features may have no entitlements, so their hashes only appear in
 	// usageWindowFeatureIds; union both so `_usage_windows` is cleared too.
@@ -77,25 +94,109 @@ async function deleteFieldsFromManifest({
 		...Object.keys(customerEntitlementIdsByFeatureId),
 		...usageWindowFeatureIds,
 	]);
+	if (featureIds.size === 0) return null;
+
+	const balanceKeys: string[] = [];
+	const customerEntitlementIdsByKey: string[][] = [];
+	for (const featureId of featureIds) {
+		const rawCusEntIds = customerEntitlementIdsByFeatureId[featureId];
+		balanceKeys.push(
+			buildSharedFullSubjectBalanceKey({
+				orgId: org.id,
+				env,
+				customerId,
+				featureId,
+			}),
+		);
+		customerEntitlementIdsByKey.push(
+			Array.isArray(rawCusEntIds) ? rawCusEntIds : [],
+		);
+	}
+
+	return { balanceKeys, customerEntitlementIdsByKey };
+};
+
+async function getDelFieldsFromManifest({
+	ctx,
+	customerId,
+	cachedRaw,
+	redisV2,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	cachedRaw: string;
+	redisV2: Redis;
+}) {
+	const { logger } = ctx;
+
+	const targets = manifestToBalanceFieldTargets({ ctx, customerId, cachedRaw });
+	if (!targets) return;
+	const { balanceKeys, customerEntitlementIdsByKey } = targets;
+
+	const resultRaw = await tryRedisWrite(
+		() =>
+			redisV2.getDelFullSubjectBalanceFields(
+				balanceKeys.length,
+				...balanceKeys,
+				JSON.stringify(customerEntitlementIdsByKey),
+				JSON.stringify([AGGREGATED_BALANCE_FIELD, USAGE_WINDOWS_FIELD]),
+			),
+		redisV2,
+	);
+
+	if (resultRaw === null) {
+		logger.warn(
+			`[invalidateSharedBalanceFields] ${customerId}: GETDEL failed, skipping flush`,
+		);
+		return;
+	}
+
+	const subjectBalances = parseSubjectBalances({
+		ctx,
+		customerId,
+		resultRaw,
+	});
+
+	logger.info(
+		`[invalidateSharedBalanceFields] ${customerId}: GETDEL ${balanceKeys.length} balance keys, flushing ${subjectBalances.length} balances`,
+	);
+
+	await flushSubjectBalancesToDb({
+		ctx,
+		customerId,
+		subjectBalances,
+		source: "invalidateSharedBalanceFields",
+	});
+}
+
+/** Legacy blind HDEL, kept as the DISABLE_INVALIDATION_BALANCE_FLUSH path. */
+async function deleteFieldsFromManifest({
+	ctx,
+	customerId,
+	cachedRaw,
+	redisV2,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	cachedRaw: string;
+	redisV2: Redis;
+}) {
+	const { logger } = ctx;
+
+	const targets = manifestToBalanceFieldTargets({ ctx, customerId, cachedRaw });
+	if (!targets) return;
+	const { balanceKeys, customerEntitlementIdsByKey } = targets;
 
 	const pipeline = redisV2.pipeline();
 	let fieldCount = 0;
 
-	for (const featureId of featureIds) {
-		const rawCusEntIds = customerEntitlementIdsByFeatureId[featureId];
-		const cusEntIds = Array.isArray(rawCusEntIds) ? rawCusEntIds : [];
-		const balanceKey = buildSharedFullSubjectBalanceKey({
-			orgId: org.id,
-			env,
-			customerId,
-			featureId,
-		});
+	for (let index = 0; index < balanceKeys.length; index++) {
 		const fieldsToDelete = [
-			...cusEntIds,
+			...customerEntitlementIdsByKey[index],
 			AGGREGATED_BALANCE_FIELD,
 			USAGE_WINDOWS_FIELD,
 		];
-		pipeline.hdel(balanceKey, ...fieldsToDelete);
+		pipeline.hdel(balanceKeys[index], ...fieldsToDelete);
 		fieldCount += fieldsToDelete.length;
 	}
 
@@ -105,4 +206,52 @@ async function deleteFieldsFromManifest({
 			`[invalidateSharedBalanceFields] ${customerId}: HDEL ${fieldCount} fields from manifest`,
 		);
 	}
+}
+
+function parseSubjectBalances({
+	ctx,
+	customerId,
+	resultRaw,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	resultRaw: string;
+}): SubjectBalance[] {
+	let valuesByKey: unknown[];
+	try {
+		valuesByKey = JSON.parse(resultRaw) as unknown[];
+	} catch (error) {
+		ctx.logger.warn(
+			`[invalidateSharedBalanceFields] ${customerId}: failed to parse GETDEL result, skipping flush, error: ${error}`,
+		);
+		return [];
+	}
+
+	// cjson encodes empty Lua tables as {}, so each per-key entry must be
+	// Array.isArray-guarded.
+	const allValues = (Array.isArray(valuesByKey) ? valuesByKey : []).flatMap(
+		(values) => (Array.isArray(values) ? values : []),
+	);
+
+	const subjectBalances: SubjectBalance[] = [];
+	for (const value of allValues) {
+		if (typeof value !== "string") continue;
+		try {
+			// Same parse path as getCachedFeatureBalances: cjson-written values
+			// need sanitizing (e.g. empty arrays re-encoded as {}).
+			const parsedBalance = JSON.parse(value) as SubjectBalance;
+			subjectBalances.push(
+				roundSubjectBalance({
+					subjectBalance: sanitizeCachedSubjectBalance({
+						subjectBalance: parsedBalance,
+					}),
+				}),
+			);
+		} catch {
+			ctx.logger.warn(
+				`[invalidateSharedBalanceFields] ${customerId}: unparseable balance field, dropping it from flush`,
+			);
+		}
+	}
+	return subjectBalances;
 }

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts
@@ -1,7 +1,8 @@
-import type { SubjectBalance } from "@autumn/shared";
+import type { SubjectBalance, UsageWindow } from "@autumn/shared";
 import type { Redis } from "ioredis";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { flushSubjectBalancesToDb } from "@/internal/balances/utils/sync/flushSubjectBalancesToDb.js";
+import type { UsageWindowUpdate } from "@/internal/balances/utils/types/usageWindowUpdate.js";
 import { tryRedisRead, tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
 import { buildFullSubjectKey } from "../../builders/buildFullSubjectKey.js";
 import { buildSharedFullSubjectBalanceKey } from "../../builders/buildSharedFullSubjectBalanceKey.js";
@@ -53,6 +54,8 @@ export const invalidateSharedBalanceFields = async ({
 };
 
 type BalanceFieldTargets = {
+	internalCustomerId: string;
+	featureIds: string[];
 	balanceKeys: string[];
 	customerEntitlementIdsByKey: string[][];
 };
@@ -82,24 +85,24 @@ const manifestToBalanceFieldTargets = ({
 	if (!customerEntitlementIdsByFeatureId) return null;
 
 	// Capped features may have no entitlements, so their hashes only appear in
-	// usageWindowFeatureIds; union both so `_usage_windows` is cleared too.
-	// Safe to delete counters: capped tracks write through to PG synchronously,
-	// and the rebuild re-seeds the field from PG.
+	// usageWindowFeatureIds; union both so `_usage_windows` is covered too.
 	// Raw blob, no sanitize walker: cjson re-encodes empty arrays as {}, so
 	// array fields must be Array.isArray-guarded before spreading.
 	const usageWindowFeatureIds = Array.isArray(manifest.usageWindowFeatureIds)
 		? manifest.usageWindowFeatureIds
 		: [];
-	const featureIds = new Set([
+	const featureIdSet = new Set([
 		...Object.keys(customerEntitlementIdsByFeatureId),
 		...usageWindowFeatureIds,
 	]);
-	if (featureIds.size === 0) return null;
+	if (featureIdSet.size === 0) return null;
 
+	const featureIds: string[] = [];
 	const balanceKeys: string[] = [];
 	const customerEntitlementIdsByKey: string[][] = [];
-	for (const featureId of featureIds) {
+	for (const featureId of featureIdSet) {
 		const rawCusEntIds = customerEntitlementIdsByFeatureId[featureId];
+		featureIds.push(featureId);
 		balanceKeys.push(
 			buildSharedFullSubjectBalanceKey({
 				orgId: org.id,
@@ -113,7 +116,12 @@ const manifestToBalanceFieldTargets = ({
 		);
 	}
 
-	return { balanceKeys, customerEntitlementIdsByKey };
+	return {
+		internalCustomerId: manifest.internalCustomerId,
+		featureIds,
+		balanceKeys,
+		customerEntitlementIdsByKey,
+	};
 };
 
 async function getDelFieldsFromManifest({
@@ -133,13 +141,20 @@ async function getDelFieldsFromManifest({
 	if (!targets) return;
 	const { balanceKeys, customerEntitlementIdsByKey } = targets;
 
+	// `_usage_windows` is read+deleted alongside the cusEnt fields (last field
+	// per key) so window counters are flushed too, not just deleted.
+	const fieldsByKey = customerEntitlementIdsByKey.map((cusEntIds) => [
+		...cusEntIds,
+		USAGE_WINDOWS_FIELD,
+	]);
+
 	const resultRaw = await tryRedisWrite(
 		() =>
 			redisV2.getDelFullSubjectBalanceFields(
 				balanceKeys.length,
 				...balanceKeys,
-				JSON.stringify(customerEntitlementIdsByKey),
-				JSON.stringify([AGGREGATED_BALANCE_FIELD, USAGE_WINDOWS_FIELD]),
+				JSON.stringify(fieldsByKey),
+				JSON.stringify([AGGREGATED_BALANCE_FIELD]),
 			),
 		redisV2,
 	);
@@ -151,25 +166,30 @@ async function getDelFieldsFromManifest({
 		return;
 	}
 
-	const subjectBalances = parseSubjectBalances({
+	const parsed = parseGetDelResult({
 		ctx,
 		customerId,
 		resultRaw,
+		targets,
+		fieldsByKey,
 	});
+	if (!parsed) return;
+	const { subjectBalances, usageWindowUpdates } = parsed;
 
 	logger.info(
-		`[invalidateSharedBalanceFields] ${customerId}: GETDEL ${balanceKeys.length} balance keys, flushing ${subjectBalances.length} balances`,
+		`[invalidateSharedBalanceFields] ${customerId}: GETDEL ${balanceKeys.length} balance keys, flushing ${subjectBalances.length} balances, ${usageWindowUpdates.length} usage windows`,
 	);
 
 	await flushSubjectBalancesToDb({
 		ctx,
 		customerId,
 		subjectBalances,
+		usageWindowUpdates,
 		source: "invalidateSharedBalanceFields",
 	});
 }
 
-/** Legacy blind HDEL, kept as the DISABLE_INVALIDATION_BALANCE_FLUSH path. */
+/** Legacy blind HDEL, kept as the FLUSH_BALANCES_ON_INVALIDATION=false path. */
 async function deleteFieldsFromManifest({
 	ctx,
 	customerId,
@@ -208,50 +228,79 @@ async function deleteFieldsFromManifest({
 	}
 }
 
-function parseSubjectBalances({
+function parseGetDelResult({
 	ctx,
 	customerId,
 	resultRaw,
+	targets,
+	fieldsByKey,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	resultRaw: string;
-}): SubjectBalance[] {
+	targets: BalanceFieldTargets;
+	fieldsByKey: string[][];
+}): {
+	subjectBalances: SubjectBalance[];
+	usageWindowUpdates: UsageWindowUpdate[];
+} | null {
+	const { logger } = ctx;
+
 	let valuesByKey: unknown[];
 	try {
 		valuesByKey = JSON.parse(resultRaw) as unknown[];
 	} catch (error) {
-		ctx.logger.warn(
+		logger.warn(
 			`[invalidateSharedBalanceFields] ${customerId}: failed to parse GETDEL result, skipping flush, error: ${error}`,
 		);
-		return [];
+		return null;
 	}
-
-	// cjson encodes empty Lua tables as {}, so each per-key entry must be
-	// Array.isArray-guarded.
-	const allValues = (Array.isArray(valuesByKey) ? valuesByKey : []).flatMap(
-		(values) => (Array.isArray(values) ? values : []),
-	);
+	if (!Array.isArray(valuesByKey)) return null;
 
 	const subjectBalances: SubjectBalance[] = [];
-	for (const value of allValues) {
-		if (typeof value !== "string") continue;
-		try {
-			// Same parse path as getCachedFeatureBalances: cjson-written values
-			// need sanitizing (e.g. empty arrays re-encoded as {}).
-			const parsedBalance = JSON.parse(value) as SubjectBalance;
-			subjectBalances.push(
-				roundSubjectBalance({
-					subjectBalance: sanitizeCachedSubjectBalance({
-						subjectBalance: parsedBalance,
-					}),
-				}),
-			);
-		} catch {
-			ctx.logger.warn(
-				`[invalidateSharedBalanceFields] ${customerId}: unparseable balance field, dropping it from flush`,
-			);
+	const usageWindowUpdates: UsageWindowUpdate[] = [];
+
+	for (let keyIndex = 0; keyIndex < fieldsByKey.length; keyIndex++) {
+		const rawValues = valuesByKey[keyIndex];
+		// cjson encodes empty Lua tables as {}, so each per-key entry must be
+		// Array.isArray-guarded.
+		const values = Array.isArray(rawValues) ? (rawValues as unknown[]) : [];
+		const fields = fieldsByKey[keyIndex];
+
+		for (let fieldIndex = 0; fieldIndex < fields.length; fieldIndex++) {
+			const value = values[fieldIndex];
+			if (typeof value !== "string") continue;
+
+			const isUsageWindowsField = fieldIndex === fields.length - 1;
+			try {
+				if (isUsageWindowsField) {
+					// Same fail-open semantics as getCachedFeatureBalances: a non-array
+					// blob reads as an empty counter set (still full-replaces).
+					const parsedWindows = JSON.parse(value) as UsageWindow[];
+					usageWindowUpdates.push({
+						internal_customer_id: targets.internalCustomerId,
+						feature_id: targets.featureIds[keyIndex],
+						usage_windows: Array.isArray(parsedWindows) ? parsedWindows : [],
+					});
+				} else {
+					// Same parse path as getCachedFeatureBalances: cjson-written values
+					// need sanitizing (e.g. empty arrays re-encoded as {}).
+					const parsedBalance = JSON.parse(value) as SubjectBalance;
+					subjectBalances.push(
+						roundSubjectBalance({
+							subjectBalance: sanitizeCachedSubjectBalance({
+								subjectBalance: parsedBalance,
+							}),
+						}),
+					);
+				}
+			} catch {
+				logger.warn(
+					`[invalidateSharedBalanceFields] ${customerId}: unparseable balance field ${fields[fieldIndex]}, dropping it from flush`,
+				);
+			}
 		}
 	}
-	return subjectBalances;
+
+	return { subjectBalances, usageWindowUpdates };
 }

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts
@@ -14,8 +14,8 @@ import type { CachedFullSubject } from "../../fullSubjectCacheModel.js";
 import { roundSubjectBalance } from "../../roundCacheBalance.js";
 import { sanitizeCachedSubjectBalance } from "../../sanitize/index.js";
 
-// Kill switch: set to false to revert to the legacy blind-HDEL path (drops
-// unsynced deductions racing the invalidation).
+// Kill switch: set to false to force the legacy blind-HDEL path everywhere,
+// ignoring callers' flushBalances opt-in.
 const FLUSH_BALANCES_ON_INVALIDATION = true;
 
 /**
@@ -32,10 +32,15 @@ export const invalidateSharedBalanceFields = async ({
 	ctx,
 	customerId,
 	redisV2 = ctx.redisV2,
+	flushBalances = false,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	redisV2?: Redis;
+	/** Flush cached balances to Postgres before deleting them. Opt-in: only
+	 *  safe when the caller has NOT just written balances to Postgres directly
+	 *  (the cached balances must still be the source of truth). */
+	flushBalances?: boolean;
 }): Promise<void> => {
 	const { org, env } = ctx;
 	if (!customerId || redisV2.status !== "ready") return;
@@ -45,7 +50,7 @@ export const invalidateSharedBalanceFields = async ({
 	const cachedRaw = await tryRedisRead(() => redisV2.get(subjectKey), redisV2);
 	if (!cachedRaw) return;
 
-	if (!FLUSH_BALANCES_ON_INVALIDATION) {
+	if (!FLUSH_BALANCES_ON_INVALIDATION || !flushBalances) {
 		await deleteFieldsFromManifest({ ctx, customerId, cachedRaw, redisV2 });
 		return;
 	}

--- a/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.ts
+++ b/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.ts
@@ -23,12 +23,14 @@ export const deleteCachedFullCustomer = async ({
 	entityId,
 	source,
 	skipGuard = false,
+	flushBalances = false,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	entityId?: string;
 	source?: string;
 	skipGuard?: boolean;
+	flushBalances?: boolean;
 }): Promise<void> => {
 	const { org, env, logger } = ctx;
 
@@ -49,6 +51,7 @@ export const deleteCachedFullCustomer = async ({
 			customerId,
 			entityId,
 			source,
+			flushBalances,
 		}),
 	];
 

--- a/server/tests/balances/track/race-condition/invalidation-flush-unsynced-balances.test.ts
+++ b/server/tests/balances/track/race-condition/invalidation-flush-unsynced-balances.test.ts
@@ -1,0 +1,136 @@
+/**
+ * TDD test: full-subject invalidation must not lose un-synced Redis deductions.
+ *
+ * Contract under test:
+ *   New behaviors:
+ *     - (unsynced Redis deduction) + (invalidateCachedFullSubject) -> deduction
+ *       is flushed to Postgres via sync_balances_v2 before the cache is wiped.
+ *   Side effects:
+ *     - Balance hash cusEnt fields are still deleted (invalidation semantics kept).
+ *     - Post-invalidation reads (skip_cache and rebuilt cache) both reflect the
+ *       deduction instead of reverting to the pre-track balance.
+ *
+ * Pre-impl red: invalidateSharedBalanceFields blindly HDELs the balance hash
+ * fields, so the unsynced deduction never reaches Postgres and both reads
+ * show 100. Post-impl green: the fields are destructively read (atomic Lua)
+ * and flushed, so both reads show 95.
+ */
+
+import { beforeAll, describe, expect, test } from "bun:test";
+import { type ApiCustomer, ApiVersion } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { waitForRedisReady } from "@/external/redis/initRedis.js";
+import { executeRedisDeductionV2 } from "@/internal/balances/utils/deductionV2/executeRedisDeductionV2.js";
+import { buildSharedFullSubjectBalanceKey } from "@/internal/customers/cache/fullSubject/builders/buildSharedFullSubjectBalanceKey.js";
+import {
+	getOrSetCachedFullSubject,
+	invalidateCachedFullSubject,
+} from "@/internal/customers/cache/fullSubject/index.js";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
+import { constructProduct } from "@/utils/scriptUtils/createTestProducts.js";
+import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
+import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
+
+const pro = constructProduct({
+	type: "pro",
+	items: [
+		constructFeatureItem({
+			featureId: TestFeature.Messages,
+			includedUsage: 100,
+		}),
+	],
+});
+
+const testCase = "invalidation-flush-unsynced-balances";
+
+const getMessagesRemaining = (customer: ApiCustomer) => {
+	const balance = customer.balances[TestFeature.Messages] as {
+		current_balance?: number;
+		remaining?: number;
+	};
+	return balance.remaining ?? balance.current_balance;
+};
+
+describe(`${chalk.yellowBright("invalidation-flush: invalidation must not lose unsynced deductions")}`, () => {
+	const customerId = testCase;
+	const autumnV2 = new AutumnInt({ version: ApiVersion.V2_1 });
+
+	beforeAll(async () => {
+		await waitForRedisReady(ctx.redisV2, "customer-redis", 5000);
+
+		await initCustomerV3({
+			ctx,
+			customerId,
+			withTestClock: true,
+			attachPm: "success",
+		});
+
+		await initProductsV0({
+			ctx,
+			products: [pro],
+			prefix: testCase,
+		});
+
+		await autumnV2.attach({
+			customer_id: customerId,
+			product_id: pro.id,
+		});
+	});
+
+	test("flushes unsynced Redis balances to Postgres during invalidation", async () => {
+		const fullSubject = await getOrSetCachedFullSubject({
+			ctx,
+			customerId,
+			source: "test-setup",
+		});
+
+		const messagesFeature = ctx.features.find(
+			(feature) => feature.id === TestFeature.Messages,
+		)!;
+
+		// Deduct 5 in Redis WITHOUT queuing sync — stands in for a /track whose
+		// async syncItemV4 has not landed yet.
+		await executeRedisDeductionV2({
+			ctx,
+			deductions: [{ feature: messagesFeature, deduction: 5 }],
+			fullSubject,
+			deductionOptions: { overageBehaviour: "cap" },
+		});
+
+		const cachedBeforeInvalidation =
+			await autumnV2.customers.get<ApiCustomer>(customerId);
+		expect(getMessagesRemaining(cachedBeforeInvalidation)).toBe(95);
+
+		await invalidateCachedFullSubject({
+			ctx,
+			customerId,
+			source: "test-invalidation",
+		});
+
+		// ── Contract: invalidation semantics preserved ───────────────────────
+		// The balance hash fields must still be deleted.
+		const balanceKey = buildSharedFullSubjectBalanceKey({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+		expect(await ctx.redisV2.hlen(balanceKey)).toBe(0);
+
+		// ── Contract: deduction flushed to Postgres ──────────────────────────
+		// Pre-fix: HDEL wiped the unsynced deduction, DB shows 100.
+		// Post-fix: destructive read + sync_balances_v2 flush, DB shows 95.
+		const dbCustomer = await autumnV2.customers.get<ApiCustomer>(customerId, {
+			skip_cache: "true",
+		});
+		expect(getMessagesRemaining(dbCustomer)).toBe(95);
+
+		// ── Contract: rebuilt cache reflects the flushed balance ─────────────
+		const rebuiltCustomer =
+			await autumnV2.customers.get<ApiCustomer>(customerId);
+		expect(getMessagesRemaining(rebuiltCustomer)).toBe(95);
+	});
+});

--- a/server/tests/balances/track/race-condition/invalidation-flush-unsynced-balances.test.ts
+++ b/server/tests/balances/track/race-condition/invalidation-flush-unsynced-balances.test.ts
@@ -104,10 +104,13 @@ describe(`${chalk.yellowBright("invalidation-flush: invalidation must not lose u
 			await autumnV2.customers.get<ApiCustomer>(customerId);
 		expect(getMessagesRemaining(cachedBeforeInvalidation)).toBe(95);
 
+		// flushBalances opt-in mirrors the customers.update route config — the
+		// only invalidation source where cached balances are the source of truth.
 		await invalidateCachedFullSubject({
 			ctx,
 			customerId,
 			source: "test-invalidation",
+			flushBalances: true,
 		});
 
 		// ── Contract: invalidation semantics preserved ───────────────────────

--- a/server/tests/unit/redis/register-redis-commands.spec.ts
+++ b/server/tests/unit/redis/register-redis-commands.spec.ts
@@ -17,6 +17,7 @@ const upstashLockedCommands = new Set([
 	"upsertInvoiceInFullSubjectV2",
 	"adjustSubjectBalance",
 	"rollUsageWindows",
+	"getDelFullSubjectBalanceFields",
 ]);
 
 const registerCommands = (supportsUpstashShebang: boolean) => {

--- a/server/tests/utils/setup/ensureOrgSvixApps.ts
+++ b/server/tests/utils/setup/ensureOrgSvixApps.ts
@@ -1,0 +1,67 @@
+import { AppEnv, type Organization } from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle";
+import { createSvixApp } from "@/external/svix/svixHelpers.js";
+import { createSvixCli } from "@/external/svix/svixUtils.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+
+const svixAppExists = async (appId: string | undefined): Promise<boolean> => {
+	if (!appId) return false;
+	try {
+		await createSvixCli().application.get(appId);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+/**
+ * Recreates the org's Svix apps when svix_config points at apps that no
+ * longer exist in Svix (they are only ever created at org signup, so a
+ * deleted app otherwise 404s webhook tests forever).
+ */
+export const ensureOrgSvixApps = async ({
+	db,
+	org,
+}: {
+	db: DrizzleCli;
+	org: Organization;
+}): Promise<void> => {
+	if (!process.env.SVIX_API_KEY) return;
+
+	const svixConfig = org.svix_config ?? {
+		sandbox_app_id: "",
+		live_app_id: "",
+	};
+	const [sandboxExists, liveExists] = await Promise.all([
+		svixAppExists(svixConfig.sandbox_app_id),
+		svixAppExists(svixConfig.live_app_id),
+	]);
+	if (sandboxExists && liveExists) return;
+
+	const createApp = (env: AppEnv) =>
+		createSvixApp({
+			name: `${org.slug}_${env}`,
+			orgId: org.id,
+			env,
+		});
+
+	const [sandboxApp, liveApp] = await Promise.all([
+		sandboxExists ? null : createApp(AppEnv.Sandbox),
+		liveExists ? null : createApp(AppEnv.Live),
+	]);
+
+	const updatedSvixConfig = {
+		sandbox_app_id: sandboxApp?.id ?? svixConfig.sandbox_app_id ?? "",
+		live_app_id: liveApp?.id ?? svixConfig.live_app_id ?? "",
+	};
+
+	await OrgService.update({
+		db,
+		orgId: org.id,
+		updates: { svix_config: updatedSvixConfig },
+	});
+
+	console.log(
+		`✅ Repaired svix apps: sandbox=${updatedSvixConfig.sandbox_app_id}, live=${updatedSvixConfig.live_app_id}`,
+	);
+};

--- a/server/tests/utils/setup/setupOrg.ts
+++ b/server/tests/utils/setup/setupOrg.ts
@@ -1,5 +1,6 @@
 import type { AppEnv } from "@autumn/shared";
 import { getFeatures } from "@tests/setup/v2Features.js";
+import { ensureOrgSvixApps } from "@tests/utils/setup/ensureOrgSvixApps.js";
 import axios from "axios";
 import { initDrizzle } from "@/db/initDrizzle";
 import { FeatureService } from "@/internal/features/FeatureService.js";
@@ -61,4 +62,5 @@ export const setupOrg = async ({
 		},
 	});
 
+	await ensureOrgSvixApps({ db, org });
 };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where invalidating a customer's cache could drop unsynced Redis deductions. We now atomically read-and-delete balance fields and `_usage_windows`, flush them to Postgres, and only do this flush on balance‑neutral routes.

- **Bug Fixes**
  - Added Lua command to GETDEL shared balance fields (including `_usage_windows`); registered `getDelFullSubjectBalanceFields` and added slowlog thresholds; updated Redis typings.
  - Updated `invalidateSharedBalanceFields` to destructively read balances and `_usage_windows`, sanitize/round, then flush via `sync_balances_v2` before unlinking; legacy blind HDEL remains behind `FLUSH_BALANCES_ON_INVALIDATION`.
  - Made flushing opt-in via `flushBalances` from route configs; enabled for `POST/PATCH /customers/:customer_id`, `/customers.update`, `/billing.setup_payment`, and `/billing.open_customer_portal`; wired through `refreshCacheMiddleware`, `invalidateFullSubject`, and `deleteCachedFullCustomer`; added refresh coverage for `/billing.sync` and `/billing.sync_v2`.
  - Added race test ensuring unsynced deductions and window counters survive invalidation and are reflected in DB and rebuilt cache; updated unit tests for command registration.

<sup>Written for commit bdc9b8dcdb6f552238119070c68e76163824244a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes full-subject invalidation so unsynced cached balances are flushed before the cache is removed. The main changes are:

- **[Bug fixes]** New Lua command for atomic read-and-delete of shared balance fields.
- **[Bug fixes]** New invalidation path that flushes destructively read balances to Postgres.
- **[Improvements]** Shared sync-entry helpers used by both normal sync and invalidation flushes.
- **[Improvements]** Redis slowlog coverage for the new command.
- **[API changes]** Refresh-cache coverage for `/billing.sync` and `/billing.sync_v2`.
- **[Bug fixes]** Race-condition test for preserving an unsynced balance deduction during invalidation.
</details>

<h3>Confidence Score: 4/5</h3>

The invalidation flush path can still lose Redis-only balance state.

- Usage-window counters are deleted without being flushed.
- Database errors after the Redis delete can drop unsynced deductions.
- Sync conflicts are treated as safe even when the deleted Redis value may contain newer cache state.

server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts; server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/_luaScriptsV2/fullSubject/getDelSharedBalanceFields.lua | Adds the atomic Redis script that reads entitlement balance fields and deletes entitlement plus derived fields. |
| server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts | Switches invalidation to destructive balance reads followed by a DB flush, but deletes usage-window state without flushing it. |
| server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts | Adds the invalidation flush helper, but some failure and conflict paths can drop Redis-only balance changes. |
| server/src/internal/balances/utils/sync/syncItemV4.ts | Moves shared sync-entry types and conversion helpers into the new flush module. |
| server/src/external/redis/initUtils/registerRedisCommands.ts | Registers the new dynamic-key Redis command. |
| server/tests/balances/track/race-condition/invalidation-flush-unsynced-balances.test.ts | Adds coverage for the basic unsynced deduction invalidation race. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Inv as Invalidation
  participant Redis as Redis balance hash
  participant Flush as Flush helper
  participant DB as sync_balances_v2

  Inv->>Redis: HMGET cusEnt fields and HDEL balance fields
  Redis-->>Inv: SubjectBalance values
  Inv->>Flush: Parsed balances
  Flush->>DB: Balance and rollover updates
  DB-->>Flush: Success, conflict, or error
  Inv->>Redis: Unlink subject view
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Inv as Invalidation
  participant Redis as Redis balance hash
  participant Flush as Flush helper
  participant DB as sync_balances_v2

  Inv->>Redis: HMGET cusEnt fields and HDEL balance fields
  Redis-->>Inv: SubjectBalance values
  Inv->>Flush: Parsed balances
  Flush->>DB: Balance and rollover updates
  DB-->>Flush: Success, conflict, or error
  Inv->>Redis: Unlink subject view
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts:142
**Usage Window State Is Deleted**

When an invalidation races an unsynced deduction on a windowed feature, this passes `_usage_windows` as a delete-only field. The Lua script deletes that Redis value without returning it, while the flush sends `usage_window_updates: []`, so the rebuilt cache can come back from stale Postgres window counters and restore usage that was already consumed.

### Issue 2 of 3
server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts:125-127
**Failed Flush Drops Deductions**

A non-conflict database error is swallowed after the Redis fields have already been read and deleted by the invalidation Lua script. A transient Postgres failure during this call leaves the unsynced deduction in neither Redis nor Postgres, so the next cache rebuild can restore the old balance.

### Issue 3 of 3
server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts:118-123
**Conflicts Delete Newer Cache State**

This conflict path treats every reset, entity-count, or cache-version mismatch as Postgres being ahead, but in the invalidation flow the Redis value has already been deleted. If the cached balance includes an unsynced deduction and a concurrent entity/cache-version change makes `sync_balances_v2` raise one of these conflicts, the flush is skipped and that newer Redis deduction is lost rather than retried against the rebuilt state.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: flush then clear cache"](https://github.com/useautumn/autumn/commit/c0e0d52afab8e3a4f728102e3f3359a1a1dc6676) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42075835)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->