### PR TITLE
fix: billing.import customer_data update + one-off/usage_based balance filters

### DIFF
--- a/server/src/internal/billing/v2/actions/dfu/compute/resolvers/balanceResolver.ts
+++ b/server/src/internal/billing/v2/actions/dfu/compute/resolvers/balanceResolver.ts
@@ -4,6 +4,7 @@ import {
 	type FlashBalance,
 	type FullCusProduct,
 	type FullCustomerEntitlement,
+	isPayPerUsePrice,
 	isPrepaidPrice,
 	type Price,
 	RecaseError,
@@ -11,9 +12,28 @@ import {
 } from "@autumn/shared";
 
 type FilterInterval = NonNullable<FlashBalance["filter"]>["interval"];
+type FilterBillingBehavior = NonNullable<
+	NonNullable<FlashBalance["filter"]>["billing_behavior"]
+>;
 
 const filterIntervalToReset = (interval: FilterInterval): ResetInterval =>
-	interval == null ? ResetInterval.OneOff : (interval as ResetInterval);
+	interval == null
+		? ResetInterval.OneOff
+		: entIntvToResetIntv({ entInterval: interval });
+
+const lineBillingBehavior = ({
+	customerEntitlement,
+	prices,
+}: {
+	customerEntitlement: FullCustomerEntitlement;
+	prices: Price[];
+}): FilterBillingBehavior => {
+	const price = entToPrice({ ent: customerEntitlement.entitlement, prices });
+	if (!price) return "included";
+	if (isPrepaidPrice(price)) return "prepaid";
+	if (isPayPerUsePrice({ price })) return "usage_based";
+	return "included";
+};
 
 const matchesFilter = ({
 	customerEntitlement,
@@ -36,13 +56,8 @@ const matchesFilter = ({
 	}
 
 	if (filter?.billing_behavior) {
-		const price = entToPrice({
-			ent: customerEntitlement.entitlement,
-			prices,
-		});
-		const isPrepaidLine = price ? isPrepaidPrice(price) : false;
-		const wantsPrepaid = filter.billing_behavior === "prepaid";
-		if (isPrepaidLine !== wantsPrepaid) return false;
+		const lineBehavior = lineBillingBehavior({ customerEntitlement, prices });
+		if (lineBehavior !== filter.billing_behavior) return false;
 	}
 
 	return true;
@@ -74,14 +89,14 @@ export const applyFlashBalances = ({
 
 		if (matches.length === 0) {
 			throw new RecaseError({
-				message: `dfu.flash: no entitlement line matched balance for feature '${balance.feature_id}'`,
+				message: `billing.import: no entitlement line matched balance for feature '${balance.feature_id}'`,
 				code: "flash_balance_no_match",
 				statusCode: 400,
 			});
 		}
 		if (matches.length > 1) {
 			throw new RecaseError({
-				message: `dfu.flash: balance filter for feature '${balance.feature_id}' matched multiple lines; add a filter to disambiguate`,
+				message: `billing.import: balance filter for feature '${balance.feature_id}' matched multiple lines; add a filter to disambiguate`,
 				code: "flash_balance_ambiguous",
 				statusCode: 400,
 			});

--- a/server/src/internal/billing/v2/actions/dfu/errors/handleFlashErrors.ts
+++ b/server/src/internal/billing/v2/actions/dfu/errors/handleFlashErrors.ts
@@ -3,7 +3,7 @@ import type { FlashContext } from "../setup/setupFlashContext";
 
 const rejectUnsupported = (message: string): never => {
 	throw new RecaseError({
-		message: `dfu.flash: ${message} is not yet supported`,
+		message: `billing.import: ${message} is not yet supported`,
 		code: "unsupported_field",
 		statusCode: 400,
 	});
@@ -49,7 +49,7 @@ export const handleFlashErrors = ({
 	if (hasStripeRecurringBase && hasRevenuecatRecurringBase) {
 		throw new RecaseError({
 			message:
-				"dfu.flash: a recurring Stripe base plan and a recurring RevenueCat base plan cannot be flashed together",
+				"billing.import: a recurring Stripe base plan and a recurring RevenueCat base plan cannot be flashed together",
 			code: "cross_processor_conflict",
 			statusCode: 400,
 		});

--- a/server/src/internal/billing/v2/actions/dfu/flash.ts
+++ b/server/src/internal/billing/v2/actions/dfu/flash.ts
@@ -43,13 +43,13 @@ export const flash = async ({
 	await deleteCachedFullCustomer({
 		ctx,
 		customerId,
-		source: "dfu.flash",
+		source: "billing.import",
 		skipGuard: true,
 	});
 	const customer = await getApiCustomerByRollout({
 		ctx,
 		customerId,
-		source: "dfu.flash",
+		source: "billing.import",
 	});
 
 	return {

--- a/server/src/internal/billing/v2/actions/dfu/setup/hydrate/hydrateStripeBillable.ts
+++ b/server/src/internal/billing/v2/actions/dfu/setup/hydrate/hydrateStripeBillable.ts
@@ -76,7 +76,7 @@ export const hydrateStripeBillables = async ({
 				);
 			} catch (error) {
 				ctx.logger.warn(
-					`dfu.flash: could not retrieve Stripe subscription ${subscriptionId} for hydration; using caller-supplied fields`,
+					`billing.import: could not retrieve Stripe subscription ${subscriptionId} for hydration; using caller-supplied fields`,
 					{ error },
 				);
 				hydrationBySubscription.set(subscriptionId, null);

--- a/server/src/internal/billing/v2/actions/dfu/setup/setupFlashContext.ts
+++ b/server/src/internal/billing/v2/actions/dfu/setup/setupFlashContext.ts
@@ -91,19 +91,38 @@ const upsertFullCustomer = async ({
 		allowNotFound: true,
 	});
 	if (existing) {
+		const update: Parameters<typeof CusService.update>[0]["update"] = {};
+
 		// Self-migration: seed the RC app_user_id so Phase 1 webhooks resolve this
 		// customer by it. Only-if-absent — never clobber an existing value.
 		if (revenueCatIdentity && !existing.processors?.revenuecat?.id) {
-			const processors = {
+			update.processors = {
 				...existing.processors,
 				revenuecat: { id: revenueCatIdentity.id, aliases: [] },
 			};
+		}
+
+		const customerData = params.customer_data;
+		if (customerData?.name !== undefined && customerData.name !== existing.name)
+			update.name = customerData.name;
+		if (
+			customerData?.email !== undefined &&
+			customerData.email !== existing.email
+		)
+			update.email = customerData.email;
+		if (
+			customerData?.fingerprint !== undefined &&
+			customerData.fingerprint !== existing.fingerprint
+		)
+			update.fingerprint = customerData.fingerprint;
+
+		if (Object.keys(update).length > 0) {
 			await CusService.update({
 				ctx,
 				idOrInternalId: existing.id ?? existing.internal_id,
-				update: { processors },
+				update,
 			});
-			existing.processors = processors;
+			Object.assign(existing, update);
 		}
 		return existing;
 	}

--- a/server/tests/integration/billing/dfu/billing-import/billing-import-balance-filter-predicates.test.ts
+++ b/server/tests/integration/billing/dfu/billing-import/billing-import-balance-filter-predicates.test.ts
@@ -1,0 +1,196 @@
+/**
+ * billing.import — balance filter predicates (GalaxyAI lifetime-plan repro).
+ *
+ * Red (pre-fix):
+ *  - `filter.interval` only accepted hour|day|week|month|year, so a one-off
+ *    line could not be targeted except via an explicit `interval: null`;
+ *    "lifetime" was rejected by the schema.
+ *  - `filter.billing_behavior` only accepted included|prepaid; "usage_based"
+ *    was rejected, so an included + pay-per-use pair was un-disambiguatable.
+ *  - Ambiguity errors said "dfu.flash" instead of "billing.import".
+ * Green: interval inherits EntInterval (lifetime = one-off line),
+ * billing_behavior accepts usage_based, and errors say "billing.import".
+ */
+
+import { expect, test } from "bun:test";
+import { type ApiCustomerV5, ResetInterval } from "@autumn/shared";
+import {
+	callFlash,
+	type FlashClient,
+} from "@tests/integration/billing/dfu/billing-import/utils/flashTestUtils.js";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect.js";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
+
+const lifetimeCreditsPlan = ({ id }: { id: string }) =>
+	products.base({
+		id,
+		isAddOn: true,
+		items: [
+			items.monthlyCredits({ includedUsage: 15 }),
+			constructFeatureItem({
+				featureId: TestFeature.Credits,
+				includedUsage: 100,
+				interval: null,
+			}),
+		],
+	});
+
+test.concurrent(
+	`${chalk.yellowBright("billing.import: interval 'lifetime' targets the one-off line")}`,
+	async () => {
+		const customerId = "dfu-flash-filter-lifetime";
+		const plan = lifetimeCreditsPlan({ id: "dfu-filter-lifetime" });
+
+		const { autumnV2_2, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+			actions: [],
+		});
+
+		const payload = {
+			customer_id: customerId,
+			billables: [
+				{
+					plan: {
+						plan_id: plan.id,
+						status: "active",
+						started_at: Date.now() - 1000 * 60 * 60 * 24 * 120,
+						balances: [
+							{
+								feature_id: TestFeature.Credits,
+								filter: { interval: "month", billing_behavior: "included" },
+								usage: 5,
+							},
+							{
+								feature_id: TestFeature.Credits,
+								filter: { interval: "lifetime", billing_behavior: "included" },
+								usage: 10,
+							},
+						],
+					},
+				},
+			],
+		};
+
+		const flashRes = await callFlash(autumnV2_2 as FlashClient, payload);
+		expect(flashRes.errorMessage).toBeNull();
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		await expectCustomerProducts({ customer, active: [plan.id] });
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Credits,
+			granted: 115,
+			remaining: 100,
+			usage: 15,
+			breakdown: {
+				[ResetInterval.Month]: { remaining: 10, usage: 5 },
+				[ResetInterval.OneOff]: { remaining: 90, usage: 10 },
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("billing.import: billing_behavior 'usage_based' targets the pay-per-use line")}`,
+	async () => {
+		const customerId = "dfu-flash-filter-usage-based";
+		const plan = products.base({
+			id: "dfu-filter-usage-based",
+			items: [
+				items.monthlyMessages({ includedUsage: 10 }),
+				items.consumableMessages({ includedUsage: 20, price: 0.1 }),
+			],
+		});
+
+		const { autumnV2_2, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+			actions: [],
+		});
+
+		const payload = {
+			customer_id: customerId,
+			billables: [
+				{
+					plan: {
+						plan_id: plan.id,
+						status: "active",
+						started_at: Date.now() - 1000 * 60 * 60 * 24 * 5,
+						balances: [
+							{
+								feature_id: TestFeature.Messages,
+								filter: { billing_behavior: "included" },
+								usage: 4,
+							},
+							{
+								feature_id: TestFeature.Messages,
+								filter: { billing_behavior: "usage_based" },
+								usage: 7,
+							},
+						],
+					},
+				},
+			],
+		};
+
+		const flashRes = await callFlash(autumnV2_2 as FlashClient, payload);
+		expect(flashRes.errorMessage).toBeNull();
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		await expectCustomerProducts({ customer, active: [plan.id] });
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			granted: 30,
+			remaining: 19,
+			usage: 11,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("billing.import: ambiguous-filter error says billing.import, not dfu.flash")}`,
+	async () => {
+		const customerId = "dfu-flash-filter-ambiguous";
+		const plan = lifetimeCreditsPlan({ id: "dfu-filter-ambiguous" });
+
+		const { autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+			actions: [],
+		});
+
+		const payload = {
+			customer_id: customerId,
+			billables: [
+				{
+					plan: {
+						plan_id: plan.id,
+						status: "active",
+						started_at: Date.now() - 1000 * 60 * 60 * 24 * 120,
+						balances: [
+							{
+								feature_id: TestFeature.Credits,
+								// Matches both the monthly and one-off included lines.
+								filter: { billing_behavior: "included" },
+								usage: 0,
+							},
+						],
+					},
+				},
+			],
+		};
+
+		const flashRes = await callFlash(autumnV2_2 as FlashClient, payload);
+		expect(flashRes.errorCode).toBe("flash_balance_ambiguous");
+		expect(flashRes.errorMessage).toContain("billing.import");
+		expect(flashRes.errorMessage).not.toContain("dfu.flash");
+	},
+);

--- a/server/tests/integration/billing/dfu/billing-import/billing-import-customer-data-update.test.ts
+++ b/server/tests/integration/billing/dfu/billing-import/billing-import-customer-data-update.test.ts
@@ -1,0 +1,66 @@
+/**
+ * billing.import — `customer_data` must update an EXISTING customer's identity
+ * fields, not just seed them at creation.
+ *
+ * Red (pre-fix): upsertFullCustomer only read customer_data on the create path,
+ * so name/email sent for an existing customer were silently dropped.
+ * Green: existing customer's name/email reflect the imported customer_data.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV5 } from "@autumn/shared";
+import {
+	callFlash,
+	type FlashClient,
+} from "@tests/integration/billing/dfu/billing-import/utils/flashTestUtils.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("billing.import: customer_data updates an existing customer")}`,
+	async () => {
+		const customerId = "dfu-flash-cusdata-update";
+		const free = products.base({
+			id: "dfu-cusdata-free",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV2_2, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({
+					testClock: false,
+					name: "Old Name",
+					email: "old-cusdata@example.com",
+				}),
+				s.products({ list: [free] }),
+			],
+			actions: [],
+		});
+
+		const payload = {
+			customer_id: customerId,
+			customer_data: { name: "Stripe Test", email: "stripetest@gmail.com" },
+			billables: [
+				{
+					plan: {
+						plan_id: free.id,
+						status: "active",
+						started_at: Date.now() - 1000 * 60 * 60 * 24 * 30,
+						balances: [{ feature_id: TestFeature.Messages, usage: 10 }],
+					},
+				},
+			],
+		};
+
+		const flashRes = await callFlash(autumnV2_2 as FlashClient, payload);
+		expect(flashRes.errorCode).toBeNull();
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		expect(customer.name).toBe("Stripe Test");
+		expect(customer.email).toBe("stripetest@gmail.com");
+	},
+);

--- a/shared/api/billing/dfu/dfuFlashParams.ts
+++ b/shared/api/billing/dfu/dfuFlashParams.ts
@@ -56,6 +56,7 @@ const FlashStartingAfterSchema = z
 	.meta({ internal: true });
 
 const FlashBalanceFilterSchema = z.object({
+	// Intentionally the full EntInterval set: filters match against the line's own interval.
 	interval: z.enum(EntInterval).nullable().optional().meta({
 		description:
 			"Reset interval selecting which entitlement line to target when a feature has several ('lifetime' or null = the non-resetting one-off line).",

--- a/shared/api/billing/dfu/dfuFlashParams.ts
+++ b/shared/api/billing/dfu/dfuFlashParams.ts
@@ -1,8 +1,9 @@
+import { EntInterval } from "@models/productModels/intervals/entitlementInterval";
 import { z } from "zod/v4";
 import { ApiCustomerV5Schema } from "../../customers/apiCustomerV5";
 
 /**
- * `POST /v1/dfu.flash` — image a customer INTO Autumn for live migration.
+ * `POST /v1/billing.import` — image a customer INTO Autumn for live migration.
  * Read-only against processors. v1 fields are public; deferred capabilities
  * are schema-defined but `.meta({ internal: true })` so docs hide them.
  */
@@ -55,18 +56,17 @@ const FlashStartingAfterSchema = z
 	.meta({ internal: true });
 
 const FlashBalanceFilterSchema = z.object({
-	interval: z
-		.enum(["hour", "day", "week", "month", "year"])
-		.nullable()
+	interval: z.enum(EntInterval).nullable().optional().meta({
+		description:
+			"Reset interval selecting which entitlement line to target when a feature has several ('lifetime' or null = the non-resetting one-off line).",
+	}),
+	billing_behavior: z
+		.enum(["included", "prepaid", "usage_based"])
 		.optional()
 		.meta({
 			description:
-				"Reset interval selecting which entitlement line to target when a feature has several (null = the non-resetting one-off line).",
+				"Selects the included vs prepaid vs usage-based (pay-per-use) entitlement line when a feature has several.",
 		}),
-	billing_behavior: z.enum(["included", "prepaid"]).optional().meta({
-		description:
-			"Selects the included vs prepaid entitlement line when a feature has both.",
-	}),
 });
 
 const FlashRolloverSchema = z
@@ -200,7 +200,8 @@ export const DfuFlashParamsSchema = z.object({
 		description: "Autumn customer to image into.",
 	}),
 	customer_data: FlashCustomerDataSchema.optional().meta({
-		description: "Optional identity fields to upsert if the customer is new.",
+		description:
+			"Optional identity fields upserted onto the customer (applied to existing customers too).",
 	}),
 	processors: z.array(FlashProcessorIdentitySchema).optional().meta({
 		description:


### PR DESCRIPTION
## What

Four fixes to `POST /v1/billing.import` (formerly `dfu.flash`), from the GalaxyAI migration:

1. **`customer_data` now updates existing customers.** Previously it was only read when creating the customer; name/email/fingerprint sent for an existing customer were silently dropped. `upsertFullCustomer` now diffs and applies them in the same `CusService.update` as the RevenueCat-id seeding.
2. **`balances[].filter.interval` inherits the full `EntInterval` enum.** `"lifetime"` (or `null`) targets the non-resetting one-off line. Fixes the `flash_balance_ambiguous` error when a plan has both a monthly and a one-off line for the same feature (e.g. Galaxy's Lifetime plan: 15M credits/month + 100M one-off) and the caller couldn't express the one-off filter.
3. **`balances[].filter.billing_behavior` accepts `included | prepaid | usage_based`.** Lines are classified three ways: no attached price → included, `UsageInAdvance` → prepaid, in-arrear → usage_based.
4. **User-facing strings say `billing.import`, not `dfu.flash`** (errors, log warning, internal source tags).

## Tests

4 new red-then-green regression tests in `server/tests/integration/billing/dfu/billing-import/`:
- `billing-import-customer-data-update.test.ts` — existing-customer identity update
- `billing-import-balance-filter-predicates.test.ts` — lifetime interval filter (GalaxyAI repro), usage_based behavior filter, and the renamed ambiguity error

Full billing-import suite run: 37/39 → the 2 failures are the pre-existing `billing-import-hydration-canceling` flake (webhook auto-sync racing the flash — fails ~50% on clean HEAD too; documented in `BILLING_IMPORT_HANDOFF.md`).

Greptile review: 4/5, safe to merge; its one P2 (full `EntInterval` set admitting minute/quarter/semi_annual) is intentional and now noted in the schema.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `POST /v1/billing.import` to update existing customer identity and let balance filters target one-off and usage-based lines. Standardizes all user-facing messages to `billing.import`.

- **Bug Fixes**
  - `customer_data` now upserts `name`, `email`, and `fingerprint` for existing customers.
  - `balances[].filter.interval` accepts full `EntInterval` (e.g., `'lifetime'` or `null` → one-off), resolving ambiguity when a feature has monthly + one-off lines.
  - `balances[].filter.billing_behavior` supports `'included' | 'prepaid' | 'usage_based'`; lines are classified accordingly to disambiguate balances.
  - Errors, logs, and source tags now say `billing.import` instead of `dfu.flash`.

<sup>Written for commit 65c78ca8b6d5b2cabc9d0c1a55b5f5b496c5cdc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates `billing.import` balance filtering and customer upserts. The main changes are:

- **[Bug fixes] [API changes]** Balance filters accept entitlement intervals, including `lifetime` for one-off lines.
- **[Bug fixes] [API changes]** Balance filters distinguish `included`, `prepaid`, and `usage_based` lines.
- **[Bug fixes]** Existing customers can receive `customer_data` updates during import.
- **[Improvements]** User-facing strings now say `billing.import` instead of `dfu.flash`.
- **[Bug fixes]** Tests cover lifetime filters, usage-based filters, renamed errors, and customer identity updates.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after considering the small schema hardening note.

- No blocking issues found in the changed code.
- The customer update path only writes explicitly provided fields.
- The renamed source strings affect logs and user-facing text, not cache behavior.
- The interval schema now relies on enum alignment between entitlement intervals and reset intervals.

shared/api/billing/dfu/dfuFlashParams.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/dfu/compute/resolvers/balanceResolver.ts | Maps filter intervals through entitlement-to-reset conversion and adds included/prepaid/usage-based line classification. |
| shared/api/billing/dfu/dfuFlashParams.ts | Expands the balance filter schema to the full entitlement interval set and documents the updated import fields. |
| server/src/internal/billing/v2/actions/dfu/setup/setupFlashContext.ts | Applies explicitly provided customer identity fields to existing customers during import. |
| server/src/internal/billing/v2/actions/dfu/flash.ts | Renames cache source labels from `dfu.flash` to `billing.import`. |
| server/src/internal/billing/v2/actions/dfu/errors/handleFlashErrors.ts | Renames unsupported and cross-processor error messages to `billing.import`. |
| server/src/internal/billing/v2/actions/dfu/setup/hydrate/hydrateStripeBillable.ts | Renames the Stripe hydration warning prefix to `billing.import`. |
| server/tests/integration/billing/dfu/billing-import/billing-import-balance-filter-predicates.test.ts | Adds tests for lifetime interval targeting, usage-based matching, and renamed ambiguity errors. |
| server/tests/integration/billing/dfu/billing-import/billing-import-customer-data-update.test.ts | Adds a test for updating existing customer identity fields through billing import. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
shared/api/billing/dfu/dfuFlashParams.ts:60
**Unbounded Interval Filter Values**

When a caller sends `interval: "minute"`, `"quarter"`, or `"semi_annual"`, this schema now accepts the request and the resolver casts the value through to a reset interval. That works only while the entitlement and reset interval enums stay string-identical, so future enum drift can turn a valid import request into a filter that silently targets no line or the wrong line instead of being rejected at the API boundary.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(atmn): ✏️ note intentional full Ent..."](https://github.com/useautumn/autumn/commit/65c78ca8b6d5b2cabc9d0c1a55b5f5b496c5cdc7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42086651)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->