### PR TITLE
release: bug fixes for billing.import

### DIFF
--- a/apps/docs/mintlify/api-reference/billing/import.mdx
+++ b/apps/docs/mintlify/api-reference/billing/import.mdx
@@ -14,7 +14,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 </DynamicParamField>
 
 <DynamicParamField body="customer_data" type="object">
-  Optional identity fields to upsert if the customer is new.
+  Optional identity fields upserted onto the customer (applied to existing customers too).
   <Expandable title="properties">
     <DynamicParamField body="name" type="string">
       Display name for the customer.
@@ -117,12 +117,12 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
             <DynamicParamField body="filter" type="object">
               Disambiguates which entitlement line to target when the feature has multiple.
               <Expandable title="properties">
-                <DynamicParamField body="interval" type="'hour' | 'day' | 'week' | 'month' | 'year'">
-                  Reset interval selecting which entitlement line to target when a feature has several (null = the non-resetting one-off line).
+                <DynamicParamField body="interval" type="'lifetime' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'semi_annual' | 'year'">
+                  Reset interval selecting which entitlement line to target when a feature has several ('lifetime' or null = the non-resetting one-off line).
                 </DynamicParamField>
 
-                <DynamicParamField body="billing_behavior" type="'included' | 'prepaid'">
-                  Selects the included vs prepaid entitlement line when a feature has both.
+                <DynamicParamField body="billing_behavior" type="'included' | 'prepaid' | 'usage_based'">
+                  Selects the included vs prepaid vs usage-based (pay-per-use) entitlement line when a feature has several.
                 </DynamicParamField>
 
               </Expandable>

--- a/apps/docs/mintlify/api/openapi.yml
+++ b/apps/docs/mintlify/api/openapi.yml
@@ -21343,7 +21343,8 @@ paths:
                     fingerprint:
                       type: string
                       description: Anti-fraud fingerprint for the customer.
-                  description: Optional identity fields to upsert if the customer is new.
+                  description: Optional identity fields upserted onto the customer (applied to
+                    existing customers too).
                 processors:
                   type: array
                   items:
@@ -21448,23 +21449,29 @@ paths:
                                     interval:
                                       anyOf:
                                         - enum:
+                                            - lifetime
+                                            - minute
                                             - hour
                                             - day
                                             - week
                                             - month
+                                            - quarter
+                                            - semi_annual
                                             - year
                                           type: string
                                         - type: "null"
                                       description: Reset interval selecting which entitlement line to target when a
-                                        feature has several (null = the
-                                        non-resetting one-off line).
+                                        feature has several ('lifetime' or null
+                                        = the non-resetting one-off line).
                                     billing_behavior:
                                       enum:
                                         - included
                                         - prepaid
+                                        - usage_based
                                       type: string
-                                      description: Selects the included vs prepaid entitlement line when a feature has
-                                        both.
+                                      description: Selects the included vs prepaid vs usage-based (pay-per-use)
+                                        entitlement line when a feature has
+                                        several.
                                   description: Disambiguates which entitlement line to target when the feature has
                                     multiple.
                                 usage:

--- a/others/python-sdk/.speakeasy/gen.lock
+++ b/others/python-sdk/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: 05940b80-1ef8-40f4-9878-822fb2792070
 management:
-  docChecksum: 279f02ac42abe5516a849850597b951d
+  docChecksum: ae20e074f63569c8c7b786ceb8cac549
   docVersion: 2.3.0
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
   releaseVersion: 0.4.18
   configChecksum: 2263d20254e354a1792248274002f650
 persistentEdits:
-  generation_id: 146164fc-88da-4c2d-82bd-67aedf954ba1
-  pristine_commit_hash: a7a5704bdf70186542f5faad28c2cf2d9cf33e51
-  pristine_tree_hash: 184715a7c481c262e3ab1cd5c84953676ef304c2
+  generation_id: 408cb1b7-f480-4d50-8064-86cd5a516a4a
+  pristine_commit_hash: 3989ade5209a466793ac73d6a8378fe10dd2270c
+  pristine_tree_hash: 14fb2244641247f6757111ca6556ac06a3d355f8
 features:
   python:
     additionalDependencies: 1.0.0
@@ -2078,8 +2078,8 @@ trackedFiles:
     pristine_git_object: 613f5798f6c2590b44c3920b508ca00e5517585a
   docs/models/dfuflashparams.md:
     id: e021be4cec77
-    last_write_checksum: sha1:8b353ca6b35dd7faf51d8f2512954e0eb589385d
-    pristine_git_object: f80bdec72b3b03b7990ce2517033e64ee9002f49
+    last_write_checksum: sha1:ea4399914a3ec8b5f11a8999f8e3d3036061e881
+    pristine_git_object: f169f1ddd36e24b7f4550963f7919c6ddecd7892
   docs/models/dfuflashresult.md:
     id: 3384fc2b3e47
     last_write_checksum: sha1:fa67a32ff06fdc4773c9c64a3fc3d609f05f3046
@@ -2134,8 +2134,8 @@ trackedFiles:
     pristine_git_object: 9c0128850f8805a81bf4f631c12b19c31fc893f7
   docs/models/filter_.md:
     id: 5c3da70f78a7
-    last_write_checksum: sha1:d98f1257d8c25567941893e700ef2abf8569af31
-    pristine_git_object: 4e402fd364874622fb570a68f8379cbadec8afa7
+    last_write_checksum: sha1:1ffc9fdb28be846a1f3ce800f545aecfa1c9018e
+    pristine_git_object: cf5d654b78f5be4fbf80235752ab86c1c3c70fbc
   docs/models/finalizebalanceparams.md:
     id: 610af9b4049c
     last_write_checksum: sha1:2c966f16004e08e546d2c04b408c8c7a59299796
@@ -2190,8 +2190,8 @@ trackedFiles:
     pristine_git_object: 27e647d2b9a83f32913c07d76fa297a040bfa300
   docs/models/flashed.md:
     id: b8a959a77a54
-    last_write_checksum: sha1:18c184e13091d61aa727db2eca57447d26e6c3ca
-    pristine_git_object: 4e6340346d6fb5862ef547309421e7a2e5b0ef1f
+    last_write_checksum: sha1:13bee4bc8092dbb9562e312ac17da30fecda651b
+    pristine_git_object: b55faa95f1a0c3b28368f20a6769ec19e23cdbfb
   docs/models/freetrial.md:
     id: dc73eb37daef
     last_write_checksum: sha1:91215dab3a818bef14ec2d97d2f9fe332f29817e
@@ -2930,12 +2930,12 @@ trackedFiles:
     pristine_git_object: 4e8c45976b35ecbbdd875131512bfea72ec103db
   docs/models/importbillingbehavior.md:
     id: cb2c02cb98cd
-    last_write_checksum: sha1:d4263ef3f6a452b801fbb9392edf28bcb12374d4
-    pristine_git_object: f62b6082e8253e721490c2eee3204cd8f8dcc7bf
+    last_write_checksum: sha1:fcb50d561e9fb579f876cfabccd0f6d544ec2ea2
+    pristine_git_object: d7b3e86a26913bf8676bedde14cff0e41c553d22
   docs/models/importcustomerdata.md:
     id: 7a48403d1119
-    last_write_checksum: sha1:33a870a4a2aa853b66366667597396b8a218f737
-    pristine_git_object: a8b1c047c2a4c2dcd32b7475ce9c4b8bd4b11285
+    last_write_checksum: sha1:c58e4498d4532f3ae111e3e7a11322cd8ad52e2c
+    pristine_git_object: bd4a7217cfe3ec36ad036859bc533d8e948fa522
   docs/models/importfeaturequantity.md:
     id: 411549a5e0e8
     last_write_checksum: sha1:45a31b3a8b4053ddb7707942de65367b49952be1
@@ -2946,8 +2946,8 @@ trackedFiles:
     pristine_git_object: efa8e4ac7d43248cbaac6638470eb4a79e1d29e5
   docs/models/importinterval.md:
     id: 26f21ac740dd
-    last_write_checksum: sha1:9142d2c3bb5206985ce5757065698b1a2b43d474
-    pristine_git_object: 5f10ff80191dd6a4a7951e633f33b9b12894ec42
+    last_write_checksum: sha1:c73dc8424244bddb366e7814f7c1b43e9fb95104
+    pristine_git_object: ee3db3b4423aded53d0d9b4fa7e01291e8c81910
   docs/models/importplan.md:
     id: 1191da7092e4
     last_write_checksum: sha1:3c416773ad05f5f97161501e838534a374866ccf
@@ -6558,8 +6558,8 @@ trackedFiles:
     pristine_git_object: 68895ca0eccaf28eb5632028010026ae347f57a6
   docs/sdks/billing/README.md:
     id: dc915331dd9d
-    last_write_checksum: sha1:68e9cee2baf44fc59cd8ea106d3b035a65874bad
-    pristine_git_object: b78a1fd3fd8752a12c1c9499c1471572e06308ed
+    last_write_checksum: sha1:b9b4a74d2a2e526e204907c5e7ab2098a35576fa
+    pristine_git_object: 4470044ceaab5cbdc0f587b31539acb5d1d26088
   docs/sdks/customers/README.md:
     id: 9332759cffc2
     last_write_checksum: sha1:3ba96b62f6a62480122a03a7f8c27c119eefade6
@@ -6642,8 +6642,8 @@ trackedFiles:
     pristine_git_object: 4db96641966f6337a1a1613ea731050ed25a1fb9
   src/autumn_sdk/billing.py:
     id: e6cffdbf2221
-    last_write_checksum: sha1:d0b6ad2163bff4c22e09f4b07b4bcda47ff35b7a
-    pristine_git_object: 75b85759972bcbe58e2200958c7c04bcf6e06443
+    last_write_checksum: sha1:83b3b25a8b6c9e5cec1bfdcddbe5477448632014
+    pristine_git_object: 0983535f6d4b860de07cec418f0c64a0e4dbebd5
   src/autumn_sdk/customers.py:
     id: 5c5a0a07a433
     last_write_checksum: sha1:bbdd432fc314a94a6ac5bd6335c8cf9474e02b66
@@ -6802,8 +6802,8 @@ trackedFiles:
     pristine_git_object: a51f5d26227a36d16cce914b32e92363eb5a95ff
   src/autumn_sdk/models/importop.py:
     id: bd28bf9634d8
-    last_write_checksum: sha1:184df6393c8fb01d0d0425d06f6f2c1ac6ed010c
-    pristine_git_object: cb94e197da913320baa45e0e41e6825a8799d524
+    last_write_checksum: sha1:64b13e57f5653936aaeed3484c15b71706102d77
+    pristine_git_object: f50bd3d4d20b9433049e6b6f444487ad92172ab6
   src/autumn_sdk/models/internal/__init__.py:
     id: 2906fe7f2cde
     last_write_checksum: sha1:1905b58b74ecc52346d8f5c24ded2b6d6e1dad4a

--- a/others/python-sdk/src/autumn_sdk/billing.py
+++ b/others/python-sdk/src/autumn_sdk/billing.py
@@ -3044,7 +3044,7 @@ class Billing(BaseSDK):
 
         :param customer_id: Autumn customer to image into.
         :param billables: The billing objects (subscriptions, one-offs) to image, each carrying its plan.
-        :param customer_data: Optional identity fields to upsert if the customer is new.
+        :param customer_data: Optional identity fields upserted onto the customer (applied to existing customers too).
         :param processors: The customer's processor identities (e.g. Stripe customer id, RevenueCat app_user_id). Omit for customers with no processor, e.g. those only ever on a free plan.
         :param dry_run: If true, validate and compute without persisting; returns what would be flashed.
         :param retries: Override the default retry configuration for this method
@@ -3156,7 +3156,7 @@ class Billing(BaseSDK):
 
         :param customer_id: Autumn customer to image into.
         :param billables: The billing objects (subscriptions, one-offs) to image, each carrying its plan.
-        :param customer_data: Optional identity fields to upsert if the customer is new.
+        :param customer_data: Optional identity fields upserted onto the customer (applied to existing customers too).
         :param processors: The customer's processor identities (e.g. Stripe customer id, RevenueCat app_user_id). Omit for customers with no processor, e.g. those only ever on a free plan.
         :param dry_run: If true, validate and compute without persisting; returns what would be flashed.
         :param retries: Override the default retry configuration for this method

--- a/others/python-sdk/src/autumn_sdk/models/importop.py
+++ b/others/python-sdk/src/autumn_sdk/models/importop.py
@@ -45,7 +45,7 @@ class ImportGlobals(BaseModel):
 
 
 class ImportCustomerDataTypedDict(TypedDict):
-    r"""Optional identity fields to upsert if the customer is new."""
+    r"""Optional identity fields upserted onto the customer (applied to existing customers too)."""
 
     name: NotRequired[str]
     r"""Display name for the customer."""
@@ -56,7 +56,7 @@ class ImportCustomerDataTypedDict(TypedDict):
 
 
 class ImportCustomerData(BaseModel):
-    r"""Optional identity fields to upsert if the customer is new."""
+    r"""Optional identity fields upserted onto the customer (applied to existing customers too)."""
 
     name: Optional[str] = None
     r"""Display name for the customer."""
@@ -174,10 +174,14 @@ class ImportFeatureQuantity(BaseModel):
 
 
 ImportInterval = Literal[
+    "lifetime",
+    "minute",
     "hour",
     "day",
     "week",
     "month",
+    "quarter",
+    "semi_annual",
     "year",
 ]
 
@@ -185,27 +189,28 @@ ImportInterval = Literal[
 ImportBillingBehavior = Literal[
     "included",
     "prepaid",
+    "usage_based",
 ]
-r"""Selects the included vs prepaid entitlement line when a feature has both."""
+r"""Selects the included vs prepaid vs usage-based (pay-per-use) entitlement line when a feature has several."""
 
 
 class FilterTypedDict(TypedDict):
     r"""Disambiguates which entitlement line to target when the feature has multiple."""
 
     interval: NotRequired[Nullable[ImportInterval]]
-    r"""Reset interval selecting which entitlement line to target when a feature has several (null = the non-resetting one-off line)."""
+    r"""Reset interval selecting which entitlement line to target when a feature has several ('lifetime' or null = the non-resetting one-off line)."""
     billing_behavior: NotRequired[ImportBillingBehavior]
-    r"""Selects the included vs prepaid entitlement line when a feature has both."""
+    r"""Selects the included vs prepaid vs usage-based (pay-per-use) entitlement line when a feature has several."""
 
 
 class Filter(BaseModel):
     r"""Disambiguates which entitlement line to target when the feature has multiple."""
 
     interval: OptionalNullable[ImportInterval] = UNSET
-    r"""Reset interval selecting which entitlement line to target when a feature has several (null = the non-resetting one-off line)."""
+    r"""Reset interval selecting which entitlement line to target when a feature has several ('lifetime' or null = the non-resetting one-off line)."""
 
     billing_behavior: Optional[ImportBillingBehavior] = None
-    r"""Selects the included vs prepaid entitlement line when a feature has both."""
+    r"""Selects the included vs prepaid vs usage-based (pay-per-use) entitlement line when a feature has several."""
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
@@ -395,7 +400,7 @@ class DfuFlashParamsTypedDict(TypedDict):
     billables: List[BillableTypedDict]
     r"""The billing objects (subscriptions, one-offs) to image, each carrying its plan."""
     customer_data: NotRequired[ImportCustomerDataTypedDict]
-    r"""Optional identity fields to upsert if the customer is new."""
+    r"""Optional identity fields upserted onto the customer (applied to existing customers too)."""
     processors: NotRequired[List[ImportProcessorTypedDict]]
     r"""The customer's processor identities (e.g. Stripe customer id, RevenueCat app_user_id). Omit for customers with no processor, e.g. those only ever on a free plan."""
     dry_run: NotRequired[bool]
@@ -410,7 +415,7 @@ class DfuFlashParams(BaseModel):
     r"""The billing objects (subscriptions, one-offs) to image, each carrying its plan."""
 
     customer_data: Optional[ImportCustomerData] = None
-    r"""Optional identity fields to upsert if the customer is new."""
+    r"""Optional identity fields upserted onto the customer (applied to existing customers too)."""
 
     processors: Optional[List[ImportProcessor]] = None
     r"""The customer's processor identities (e.g. Stripe customer id, RevenueCat app_user_id). Omit for customers with no processor, e.g. those only ever on a free plan."""
@@ -449,7 +454,7 @@ class FlashedTypedDict(TypedDict):
     expired: NotRequired[bool]
     r"""True if this was an existing active plan expired because it was absent from the imaged desired state."""
     mismatch: NotRequired[bool]
-    r"""True when the imaged state may be wrong — e.g. a resetting plan with no resolvable billing anchor, so its cycle defaulted to the import time. The plan is still imaged; fix by supplying started_at or a resolvable subscription."""
+    r"""True when the imaged state may be wrong — e.g. a resetting plan with no resolvable billing anchor, or a paid recurring plan with no linked subscription for Autumn to manage. The plan is still imaged; see `reason` and fix by supplying started_at or a subscription_id."""
     reason: NotRequired[str]
     r"""Why the plan was skipped, expired, or flagged as a mismatch, when applicable."""
 
@@ -474,7 +479,7 @@ class Flashed(BaseModel):
     r"""True if this was an existing active plan expired because it was absent from the imaged desired state."""
 
     mismatch: Optional[bool] = None
-    r"""True when the imaged state may be wrong — e.g. a resetting plan with no resolvable billing anchor, so its cycle defaulted to the import time. The plan is still imaged; fix by supplying started_at or a resolvable subscription."""
+    r"""True when the imaged state may be wrong — e.g. a resetting plan with no resolvable billing anchor, or a paid recurring plan with no linked subscription for Autumn to manage. The plan is still imaged; see `reason` and fix by supplying started_at or a subscription_id."""
 
     reason: Optional[str] = None
     r"""Why the plan was skipped, expired, or flagged as a mismatch, when applicable."""

--- a/packages/openapi/openapi-stripped.yml
+++ b/packages/openapi/openapi-stripped.yml
@@ -20657,7 +20657,8 @@ paths:
                     fingerprint:
                       type: string
                       description: Anti-fraud fingerprint for the customer.
-                  description: Optional identity fields to upsert if the customer is new.
+                  description: Optional identity fields upserted onto the customer (applied to
+                    existing customers too).
                 processors:
                   type: array
                   items:
@@ -20762,23 +20763,29 @@ paths:
                                     interval:
                                       anyOf:
                                         - enum:
+                                            - lifetime
+                                            - minute
                                             - hour
                                             - day
                                             - week
                                             - month
+                                            - quarter
+                                            - semi_annual
                                             - year
                                           type: string
                                         - type: "null"
                                       description: Reset interval selecting which entitlement line to target when a
-                                        feature has several (null = the
-                                        non-resetting one-off line).
+                                        feature has several ('lifetime' or null
+                                        = the non-resetting one-off line).
                                     billing_behavior:
                                       enum:
                                         - included
                                         - prepaid
+                                        - usage_based
                                       type: string
-                                      description: Selects the included vs prepaid entitlement line when a feature has
-                                        both.
+                                      description: Selects the included vs prepaid vs usage-based (pay-per-use)
+                                        entitlement line when a feature has
+                                        several.
                                   description: Disambiguates which entitlement line to target when the feature has
                                     multiple.
                                 usage:
@@ -20867,10 +20874,11 @@ paths:
                         mismatch:
                           type: boolean
                           description: True when the imaged state may be wrong — e.g. a resetting plan
-                            with no resolvable billing anchor, so its cycle
-                            defaulted to the import time. The plan is still
-                            imaged; fix by supplying started_at or a resolvable
-                            subscription.
+                            with no resolvable billing anchor, or a paid
+                            recurring plan with no linked subscription for
+                            Autumn to manage. The plan is still imaged; see
+                            `reason` and fix by supplying started_at or a
+                            subscription_id.
                         reason:
                           type: string
                           description: Why the plan was skipped, expired, or flagged as a mismatch, when

--- a/packages/openapi/openapi.yml
+++ b/packages/openapi/openapi.yml
@@ -13871,7 +13871,7 @@ paths:
         @example
         ```typescript
         // Schedule a transition from a trial plan to a paid plan
-        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783259673472,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784469273472,"plans":[{"planId":"pro_plan"}]}] });
+        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783348981363,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784558581363,"plans":[{"planId":"pro_plan"}]}] });
         ```
 
         @param customerId - The ID of the customer to create the schedule for.
@@ -21473,7 +21473,8 @@ paths:
                     fingerprint:
                       type: string
                       description: Anti-fraud fingerprint for the customer.
-                  description: Optional identity fields to upsert if the customer is new.
+                  description: Optional identity fields upserted onto the customer (applied to
+                    existing customers too).
                 processors:
                   type: array
                   items:
@@ -21578,23 +21579,29 @@ paths:
                                     interval:
                                       anyOf:
                                         - enum:
+                                            - lifetime
+                                            - minute
                                             - hour
                                             - day
                                             - week
                                             - month
+                                            - quarter
+                                            - semi_annual
                                             - year
                                           type: string
                                         - type: "null"
                                       description: Reset interval selecting which entitlement line to target when a
-                                        feature has several (null = the
-                                        non-resetting one-off line).
+                                        feature has several ('lifetime' or null
+                                        = the non-resetting one-off line).
                                     billing_behavior:
                                       enum:
                                         - included
                                         - prepaid
+                                        - usage_based
                                       type: string
-                                      description: Selects the included vs prepaid entitlement line when a feature has
-                                        both.
+                                      description: Selects the included vs prepaid vs usage-based (pay-per-use)
+                                        entitlement line when a feature has
+                                        several.
                                   description: Disambiguates which entitlement line to target when the feature has
                                     multiple.
                                 usage:
@@ -21681,10 +21688,11 @@ paths:
                         mismatch:
                           type: boolean
                           description: True when the imaged state may be wrong — e.g. a resetting plan
-                            with no resolvable billing anchor, so its cycle
-                            defaulted to the import time. The plan is still
-                            imaged; fix by supplying started_at or a resolvable
-                            subscription.
+                            with no resolvable billing anchor, or a paid
+                            recurring plan with no linked subscription for
+                            Autumn to manage. The plan is still imaged; see
+                            `reason` and fix by supplying started_at or a
+                            subscription_id.
                         reason:
                           type: string
                           description: Why the plan was skipped, expired, or flagged as a mismatch, when

--- a/packages/sdk/.speakeasy/gen.lock
+++ b/packages/sdk/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: 7b300647-cd76-49e9-bf77-7d1bf5446d66
 management:
-  docChecksum: 42bce4767c63e544011f4d1b6cb89635
+  docChecksum: f798e2b3ecce7790b5ece613997d34a6
   docVersion: 2.3.0
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
   releaseVersion: 0.10.17
   configChecksum: 4722f16a8dee67ebd4038caf3c345296
 persistentEdits:
-  generation_id: 16e3eece-4b9b-4263-b0ff-887926dd7293
-  pristine_commit_hash: 7907dfbbb84ef1528b1b4b476d71478c7a5a6fbf
-  pristine_tree_hash: 06d3b58bcf0d5a3cff75d778f2c4b2418e6c0969
+  generation_id: 6fbe2f5d-4751-49ce-a7cb-7173319308fa
+  pristine_commit_hash: 3aa8feb1fc3bda7e4830fa2798ec6427cfc16b2e
+  pristine_tree_hash: 6907d3c6c8a644a4d13de7b5c3b7d25f0e150399
 features:
   typescript:
     additionalDependencies: 0.1.0
@@ -2101,8 +2101,8 @@ trackedFiles:
     pristine_git_object: 279d06d9980c7356b8767be081fedc85360650c4
   docs/models/dfu-flash-params.md:
     id: c002a39df56d
-    last_write_checksum: sha1:664b3375df79bf6ad83758a0450774826657ef70
-    pristine_git_object: 77baa8aa00593280b76a30ad3de2f83abd783f5a
+    last_write_checksum: sha1:d61ca85fe2180118debd962abdad3c3bdd8537e6
+    pristine_git_object: 8d018d01d4d0fec30161ac1a88d12a5cb2848dfe
   docs/models/dfu-flash-result.md:
     id: 2464162c6425
     last_write_checksum: sha1:6673cecf7b1917ab1bb4499da8edc97b8d03bd4a
@@ -2157,8 +2157,8 @@ trackedFiles:
     pristine_git_object: 22cb0f95afca20abd0512ff1b879945666ae942e
   docs/models/filter.md:
     id: b5c476e3dfbc
-    last_write_checksum: sha1:5b52f105062ab9179b8cb7a2291824f0db87aff5
-    pristine_git_object: c6ac592969b187e67b36dd382cfea86489914a68
+    last_write_checksum: sha1:228680c9872b17e07697c5580fd55ed8e76a5288
+    pristine_git_object: 8946c3a02b7dc035ec4827d5e9d62019a601e658
   docs/models/finalize-balance-params.md:
     id: d27a9dc54b34
     last_write_checksum: sha1:27a372d01debd8a28cf612df6857f84ae2a9576d
@@ -2213,8 +2213,8 @@ trackedFiles:
     pristine_git_object: 31ef9d606867dca40dea4bc8c751118acfb7077f
   docs/models/flashed.md:
     id: b8a959a77a54
-    last_write_checksum: sha1:220e47695ef8ffffc47cc9d5ff23beeec4cf7126
-    pristine_git_object: b3f14a91dd479987b3df61aff4e7ddd9772fbccf
+    last_write_checksum: sha1:71af9e7e17fcc664d1674123806c58f8afad9e23
+    pristine_git_object: f532f07b2b9211b136111ca11e2edb5247cadf72
   docs/models/free-trial-duration1.md:
     id: 489b02917323
     last_write_checksum: sha1:c8eeda3fd04248398afb5d63fa625a63ad4b3433
@@ -2953,12 +2953,12 @@ trackedFiles:
     pristine_git_object: 7458fc9984e1d664f7a3e141d27a2cfc3d929b4d
   docs/models/import-billing-behavior.md:
     id: caaa3259fd3f
-    last_write_checksum: sha1:5a0cb7f20222bdd021e346320290df5d2ab49b76
-    pristine_git_object: 579d3570253146fab0355d55f6d400a9f1d7926f
+    last_write_checksum: sha1:573952d4067ea603c437ce7903383fe5e5823c79
+    pristine_git_object: f3530cf9d8182a67d19dc47b4ea711c145543af0
   docs/models/import-customer-data.md:
     id: 0593dcec1afe
-    last_write_checksum: sha1:1f9ab2d3f5705ab9351d42b14da385da1f8bffe4
-    pristine_git_object: 65661d7077bd6979c296c5c27171fab5d99c665a
+    last_write_checksum: sha1:73d4ed0be1efa7a3aa9b8773d5368ed64bb0f426
+    pristine_git_object: 06850a71103b2f76c823c1d5ca8ef09ac26a40c6
   docs/models/import-feature-quantity.md:
     id: 76c79e8b9b30
     last_write_checksum: sha1:93c3da851b2011c8f05f4663aebbc60d5c04f2bd
@@ -2969,8 +2969,8 @@ trackedFiles:
     pristine_git_object: 34f2ff72e3b53b459730297e1d01835f4f825657
   docs/models/import-interval.md:
     id: a65acbd131d5
-    last_write_checksum: sha1:13e100056ec97a97946c0c9653d402151a27bd31
-    pristine_git_object: b0bade2e28e7927b9f6593638dc5574329cc2da6
+    last_write_checksum: sha1:0aa5367369428b95268a817835cdb183a676cf92
+    pristine_git_object: 989180146f5405cafb5e467fbe5385ef84089409
   docs/models/import-plan.md:
     id: 0e6a0acc0e27
     last_write_checksum: sha1:c3781d0da88242f3b06c42145f96193b80c297b5
@@ -6573,8 +6573,8 @@ trackedFiles:
     pristine_git_object: 0ebe5146cd24c153cb9b7655e4f502c09f7d4abd
   docs/sdks/billing/README.md:
     id: dc915331dd9d
-    last_write_checksum: sha1:3a6416ced86220ffbdada56e2f41d4d0cceab73b
-    pristine_git_object: cb6bf13261d3da0029d4f6dcfb871bd3364d2d84
+    last_write_checksum: sha1:075d0881bb5af849396bd4ba8400666e53e28a3b
+    pristine_git_object: d33ea15a9e47ba78541498aa69c9861b62134771
   docs/sdks/customers/README.md:
     id: 9332759cffc2
     last_write_checksum: sha1:74cd5f6cf800e1d86b2c332fed3c3cd53f3eeb6b
@@ -6669,8 +6669,8 @@ trackedFiles:
     pristine_git_object: 7991653fe7a7302891a242026bedf4fb0d2394f9
   src/funcs/billing-create-schedule.ts:
     id: fd662bfcdc10
-    last_write_checksum: sha1:4c6e31c54a53bc762bd15ac6e1a2c879d406b0af
-    pristine_git_object: 89e31f5a7bb465fc1884373fba2728d5a3bf1f42
+    last_write_checksum: sha1:2f836882e51aea0f831e31890aa2daf4631833ae
+    pristine_git_object: 648771f2b91195987dd04d486f9e212181c251c9
   src/funcs/billing-import.ts:
     id: ff582ad4629f
     last_write_checksum: sha1:673851739184e659789772519b9bc01485a21d79
@@ -7045,8 +7045,8 @@ trackedFiles:
     pristine_git_object: b34f612124c797c2a1106b9735708f679a90b74f
   src/models/import-op.ts:
     id: 6a79acb4432b
-    last_write_checksum: sha1:18804e3dbdb4ca0eadb0bc7d74af3823533341ea
-    pristine_git_object: 9210af8354b46670982689d7312b9772095db5f7
+    last_write_checksum: sha1:a03a34de327cd024e6ed06c263b33c21def0cc3c
+    pristine_git_object: 368134e0088e39a04ba992f6a8920907675130d3
   src/models/index.ts:
     id: f93644b0f37e
     last_write_checksum: sha1:2d4c1acde8eab2ce05bff932d20af11c357f9b2d
@@ -7177,8 +7177,8 @@ trackedFiles:
     pristine_git_object: 571de419ea3321d79acec4bddbb46b1580007115
   src/sdk/billing.ts:
     id: 10905058c4ad
-    last_write_checksum: sha1:0f3248015e5e6a4beda6aa052d4daf7a3e5b2174
-    pristine_git_object: 41ecb002c0d6dab6fa2aa5e9461819fc3ad5ce6d
+    last_write_checksum: sha1:ac4b1d6661c42eb57dc0459e039ca669d04a92c9
+    pristine_git_object: 1b5922ac43c7bc766f86e6e31f14345c79c03d60
   src/sdk/customers.ts:
     id: d33e193e0c00
     last_write_checksum: sha1:8d64f03efa17b4ef45a6d67a44d23e2943f1cd8b

--- a/packages/sdk/.speakeasy/out.openapi.yaml
+++ b/packages/sdk/.speakeasy/out.openapi.yaml
@@ -12751,7 +12751,7 @@ paths:
         @example
         ```typescript
         // Schedule a transition from a trial plan to a paid plan
-        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783259673472,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784469273472,"plans":[{"planId":"pro_plan"}]}] });
+        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783348981363,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784558581363,"plans":[{"planId":"pro_plan"}]}] });
         ```
 
         @param customerId - The ID of the customer to create the schedule for.
@@ -19602,7 +19602,7 @@ paths:
                     fingerprint:
                       type: string
                       description: Anti-fraud fingerprint for the customer.
-                  description: Optional identity fields to upsert if the customer is new.
+                  description: Optional identity fields upserted onto the customer (applied to existing customers too).
                 processors:
                   type: array
                   items:
@@ -19698,20 +19698,25 @@ paths:
                                     interval:
                                       anyOf:
                                         - enum:
+                                            - lifetime
+                                            - minute
                                             - hour
                                             - day
                                             - week
                                             - month
+                                            - quarter
+                                            - semi_annual
                                             - year
                                           type: string
                                         - type: "null"
-                                      description: Reset interval selecting which entitlement line to target when a feature has several (null = the non-resetting one-off line).
+                                      description: Reset interval selecting which entitlement line to target when a feature has several ('lifetime' or null = the non-resetting one-off line).
                                     billing_behavior:
                                       enum:
                                         - included
                                         - prepaid
+                                        - usage_based
                                       type: string
-                                      description: Selects the included vs prepaid entitlement line when a feature has both.
+                                      description: Selects the included vs prepaid vs usage-based (pay-per-use) entitlement line when a feature has several.
                                   description: Disambiguates which entitlement line to target when the feature has multiple.
                                 usage:
                                   type: number
@@ -19789,7 +19794,7 @@ paths:
                           description: True if this was an existing active plan expired because it was absent from the imaged desired state.
                         mismatch:
                           type: boolean
-                          description: True when the imaged state may be wrong — e.g. a resetting plan with no resolvable billing anchor, so its cycle defaulted to the import time. The plan is still imaged; fix by supplying started_at or a resolvable subscription.
+                          description: True when the imaged state may be wrong — e.g. a resetting plan with no resolvable billing anchor, or a paid recurring plan with no linked subscription for Autumn to manage. The plan is still imaged; see `reason` and fix by supplying started_at or a subscription_id.
                         reason:
                           type: string
                           description: Why the plan was skipped, expired, or flagged as a mismatch, when applicable.

--- a/packages/sdk/.speakeasy/workflow.lock
+++ b/packages/sdk/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.762.0
 sources:
     Autumn API:
         sourceNamespace: autumn-api
-        sourceRevisionDigest: sha256:372c49f2aac4325edc0577f1d3ad7ec568e7a2730391d20d7e65667c9e41c8d5
-        sourceBlobDigest: sha256:2a1fab7b35906586aaf51bb81af13888c0c6463d78c9d9c2e56ed2d84f5a6a87
+        sourceRevisionDigest: sha256:da5ed5eb5a4497d260ad740aa99590f838c831e5f30309a8492806ccb535ac8b
+        sourceBlobDigest: sha256:4b64237977d51849025452acafeec4fe7cc99af3b55ac8c073acafa29ac735b8
         tags:
             - latest
             - 2.3.0
@@ -18,10 +18,10 @@ targets:
     autumn:
         source: Autumn API
         sourceNamespace: autumn-api
-        sourceRevisionDigest: sha256:372c49f2aac4325edc0577f1d3ad7ec568e7a2730391d20d7e65667c9e41c8d5
-        sourceBlobDigest: sha256:2a1fab7b35906586aaf51bb81af13888c0c6463d78c9d9c2e56ed2d84f5a6a87
+        sourceRevisionDigest: sha256:da5ed5eb5a4497d260ad740aa99590f838c831e5f30309a8492806ccb535ac8b
+        sourceBlobDigest: sha256:4b64237977d51849025452acafeec4fe7cc99af3b55ac8c073acafa29ac735b8
         codeSamplesNamespace: autumn-api-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:9c945406c53c61c8ffe030047097fda680ed7ad01795e502e991420e29e67d72
+        codeSamplesRevisionDigest: sha256:3e80560b6103cfdd4dbd00ee274a432f93e8ec100e1f3bb9699139138b54cfc9
     autumn-python:
         source: Autumn API Stripped
         sourceNamespace: autumn-api-stripped

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -309,7 +309,7 @@ Use this endpoint to schedule future plan changes (e.g. switch from a trial plan
 @example
 ```typescript
 // Schedule a transition from a trial plan to a paid plan
-const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783259673472,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784469273472,"plans":[{"planId":"pro_plan"}]}] });
+const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783348981363,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784558581363,"plans":[{"planId":"pro_plan"}]}] });
 ```
 
 @param customerId - The ID of the customer to create the schedule for.
@@ -853,7 +853,7 @@ Use this endpoint to schedule future plan changes (e.g. switch from a trial plan
 @example
 ```typescript
 // Schedule a transition from a trial plan to a paid plan
-const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783259673472,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784469273472,"plans":[{"planId":"pro_plan"}]}] });
+const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783348981363,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784558581363,"plans":[{"planId":"pro_plan"}]}] });
 ```
 
 @param customerId - The ID of the customer to create the schedule for.

--- a/packages/sdk/src/funcs/billing-create-schedule.ts
+++ b/packages/sdk/src/funcs/billing-create-schedule.ts
@@ -34,7 +34,7 @@ import { Result } from "../types/fp.js";
  * @example
  * ```typescript
  * // Schedule a transition from a trial plan to a paid plan
- * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783259673472,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784469273472,"plans":[{"planId":"pro_plan"}]}] });
+ * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783348981363,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784558581363,"plans":[{"planId":"pro_plan"}]}] });
  * ```
  *
  * @param customerId - The ID of the customer to create the schedule for.

--- a/packages/sdk/src/models/import-op.ts
+++ b/packages/sdk/src/models/import-op.ts
@@ -16,7 +16,7 @@ export type ImportGlobals = {
 };
 
 /**
- * Optional identity fields to upsert if the customer is new.
+ * Optional identity fields upserted onto the customer (applied to existing customers too).
  */
 export type ImportCustomerData = {
   /**
@@ -109,23 +109,28 @@ export type ImportFeatureQuantity = {
 };
 
 export const ImportInterval = {
+  Lifetime: "lifetime",
+  Minute: "minute",
   Hour: "hour",
   Day: "day",
   Week: "week",
   Month: "month",
+  Quarter: "quarter",
+  SemiAnnual: "semi_annual",
   Year: "year",
 } as const;
 export type ImportInterval = ClosedEnum<typeof ImportInterval>;
 
 /**
- * Selects the included vs prepaid entitlement line when a feature has both.
+ * Selects the included vs prepaid vs usage-based (pay-per-use) entitlement line when a feature has several.
  */
 export const ImportBillingBehavior = {
   Included: "included",
   Prepaid: "prepaid",
+  UsageBased: "usage_based",
 } as const;
 /**
- * Selects the included vs prepaid entitlement line when a feature has both.
+ * Selects the included vs prepaid vs usage-based (pay-per-use) entitlement line when a feature has several.
  */
 export type ImportBillingBehavior = ClosedEnum<typeof ImportBillingBehavior>;
 
@@ -134,11 +139,11 @@ export type ImportBillingBehavior = ClosedEnum<typeof ImportBillingBehavior>;
  */
 export type Filter = {
   /**
-   * Reset interval selecting which entitlement line to target when a feature has several (null = the non-resetting one-off line).
+   * Reset interval selecting which entitlement line to target when a feature has several ('lifetime' or null = the non-resetting one-off line).
    */
   interval?: ImportInterval | null | undefined;
   /**
-   * Selects the included vs prepaid entitlement line when a feature has both.
+   * Selects the included vs prepaid vs usage-based (pay-per-use) entitlement line when a feature has several.
    */
   billingBehavior?: ImportBillingBehavior | undefined;
 };
@@ -225,7 +230,7 @@ export type DfuFlashParams = {
    */
   customerId: string;
   /**
-   * Optional identity fields to upsert if the customer is new.
+   * Optional identity fields upserted onto the customer (applied to existing customers too).
    */
   customerData?: ImportCustomerData | undefined;
   /**
@@ -268,7 +273,7 @@ export type Flashed = {
    */
   expired?: boolean | undefined;
   /**
-   * True when the imaged state may be wrong — e.g. a resetting plan with no resolvable billing anchor, so its cycle defaulted to the import time. The plan is still imaged; fix by supplying started_at or a resolvable subscription.
+   * True when the imaged state may be wrong — e.g. a resetting plan with no resolvable billing anchor, or a paid recurring plan with no linked subscription for Autumn to manage. The plan is still imaged; see `reason` and fix by supplying started_at or a subscription_id.
    */
   mismatch?: boolean | undefined;
   /**

--- a/packages/sdk/src/sdk/billing.ts
+++ b/packages/sdk/src/sdk/billing.ts
@@ -89,7 +89,7 @@ export class Billing extends ClientSDK {
    * @example
    * ```typescript
    * // Schedule a transition from a trial plan to a paid plan
-   * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783259673472,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784469273472,"plans":[{"planId":"pro_plan"}]}] });
+   * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783348981363,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784558581363,"plans":[{"planId":"pro_plan"}]}] });
    * ```
    *
    * @param customerId - The ID of the customer to create the schedule for.

--- a/server/src/cron/cronInit.ts
+++ b/server/src/cron/cronInit.ts
@@ -23,13 +23,14 @@ const { db, client } = initDrizzle({ name: "cron", maxConnections: 40 });
 startPgPoolMonitor();
 startBlueGreenHeartbeat({ db, logger, serviceName: "cron" });
 
-const logCronHeartbeat = () => {
+const logCronHeartbeat = (job = "main") => {
 	logger.info(
 		{
 			type: "cron_heartbeat",
 			cron: {
 				pid: process.pid,
 				timezone: "UTC",
+				job,
 			},
 		},
 		"Cron heartbeat",
@@ -78,6 +79,8 @@ const main = async () => {
 // column to seek on), so it runs on a slower cadence than the other jobs.
 const oneOffCleanupTick = async () => {
 	if (!shouldRunTick()) return;
+
+	logCronHeartbeat("one_off_cleanup");
 
 	const ctx: CronContext = {
 		db,

--- a/server/src/cron/cronInit.ts
+++ b/server/src/cron/cronInit.ts
@@ -36,10 +36,10 @@ const logCronHeartbeat = () => {
 	);
 };
 
-const main = async () => {
+const shouldRunTick = () => {
 	if (process.env.DISABLE_CRON === "true") {
 		console.log(`Cron disabled!`);
-		return;
+		return false;
 	}
 
 	// Blue-green gate: skip the tick on the idle task set so a swap doesn't
@@ -50,8 +50,14 @@ const main = async () => {
 			type: "cron_skipped_idle",
 			gate: reason,
 		});
-		return;
+		return false;
 	}
+
+	return true;
+};
+
+const main = async () => {
+	if (!shouldRunTick()) return;
 
 	logCronHeartbeat();
 
@@ -63,10 +69,21 @@ const main = async () => {
 		runProductCron({ ctx }),
 		runResetCron({ ctx }),
 		runInvoiceCron({ ctx }),
-		runOneOffCleanup({ ctx }),
 		runOneOffExpiry({ ctx }),
 		// runClearExpiredResetCron({ ctx }),
 	]);
+};
+
+// Cleanup re-derives "depleted one-off" candidates from scratch (no time
+// column to seek on), so it runs on a slower cadence than the other jobs.
+const oneOffCleanupTick = async () => {
+	if (!shouldRunTick()) return;
+
+	const ctx: CronContext = {
+		db,
+		logger,
+	};
+	await runOneOffCleanup({ ctx });
 };
 
 new CronJob(
@@ -77,7 +94,16 @@ new CronJob(
 	"UTC", // timezone (adjust as needed)
 );
 
+new CronJob(
+	"*/10 * * * *", // Run every 10 minutes
+	oneOffCleanupTick,
+	null, // onComplete
+	true, // start immediately
+	"UTC", // timezone (adjust as needed)
+);
+
 main();
+oneOffCleanupTick();
 
 process.on("SIGTERM", async () => {
 	console.log("Received SIGTERM signal, closing database connection...");

--- a/server/src/internal/billing/v2/actions/dfu/compute/resolvers/balanceResolver.ts
+++ b/server/src/internal/billing/v2/actions/dfu/compute/resolvers/balanceResolver.ts
@@ -4,6 +4,7 @@ import {
 	type FlashBalance,
 	type FullCusProduct,
 	type FullCustomerEntitlement,
+	isPayPerUsePrice,
 	isPrepaidPrice,
 	type Price,
 	RecaseError,
@@ -11,9 +12,28 @@ import {
 } from "@autumn/shared";
 
 type FilterInterval = NonNullable<FlashBalance["filter"]>["interval"];
+type FilterBillingBehavior = NonNullable<
+	NonNullable<FlashBalance["filter"]>["billing_behavior"]
+>;
 
 const filterIntervalToReset = (interval: FilterInterval): ResetInterval =>
-	interval == null ? ResetInterval.OneOff : (interval as ResetInterval);
+	interval == null
+		? ResetInterval.OneOff
+		: entIntvToResetIntv({ entInterval: interval });
+
+const lineBillingBehavior = ({
+	customerEntitlement,
+	prices,
+}: {
+	customerEntitlement: FullCustomerEntitlement;
+	prices: Price[];
+}): FilterBillingBehavior => {
+	const price = entToPrice({ ent: customerEntitlement.entitlement, prices });
+	if (!price) return "included";
+	if (isPrepaidPrice(price)) return "prepaid";
+	if (isPayPerUsePrice({ price })) return "usage_based";
+	return "included";
+};
 
 const matchesFilter = ({
 	customerEntitlement,
@@ -36,13 +56,8 @@ const matchesFilter = ({
 	}
 
 	if (filter?.billing_behavior) {
-		const price = entToPrice({
-			ent: customerEntitlement.entitlement,
-			prices,
-		});
-		const isPrepaidLine = price ? isPrepaidPrice(price) : false;
-		const wantsPrepaid = filter.billing_behavior === "prepaid";
-		if (isPrepaidLine !== wantsPrepaid) return false;
+		const lineBehavior = lineBillingBehavior({ customerEntitlement, prices });
+		if (lineBehavior !== filter.billing_behavior) return false;
 	}
 
 	return true;
@@ -74,14 +89,14 @@ export const applyFlashBalances = ({
 
 		if (matches.length === 0) {
 			throw new RecaseError({
-				message: `dfu.flash: no entitlement line matched balance for feature '${balance.feature_id}'`,
+				message: `billing.import: no entitlement line matched balance for feature '${balance.feature_id}'`,
 				code: "flash_balance_no_match",
 				statusCode: 400,
 			});
 		}
 		if (matches.length > 1) {
 			throw new RecaseError({
-				message: `dfu.flash: balance filter for feature '${balance.feature_id}' matched multiple lines; add a filter to disambiguate`,
+				message: `billing.import: balance filter for feature '${balance.feature_id}' matched multiple lines; add a filter to disambiguate`,
 				code: "flash_balance_ambiguous",
 				statusCode: 400,
 			});

--- a/server/src/internal/billing/v2/actions/dfu/errors/handleFlashErrors.ts
+++ b/server/src/internal/billing/v2/actions/dfu/errors/handleFlashErrors.ts
@@ -3,7 +3,7 @@ import type { FlashContext } from "../setup/setupFlashContext";
 
 const rejectUnsupported = (message: string): never => {
 	throw new RecaseError({
-		message: `dfu.flash: ${message} is not yet supported`,
+		message: `billing.import: ${message} is not yet supported`,
 		code: "unsupported_field",
 		statusCode: 400,
 	});
@@ -49,7 +49,7 @@ export const handleFlashErrors = ({
 	if (hasStripeRecurringBase && hasRevenuecatRecurringBase) {
 		throw new RecaseError({
 			message:
-				"dfu.flash: a recurring Stripe base plan and a recurring RevenueCat base plan cannot be flashed together",
+				"billing.import: a recurring Stripe base plan and a recurring RevenueCat base plan cannot be flashed together",
 			code: "cross_processor_conflict",
 			statusCode: 400,
 		});

--- a/server/src/internal/billing/v2/actions/dfu/flash.ts
+++ b/server/src/internal/billing/v2/actions/dfu/flash.ts
@@ -43,13 +43,13 @@ export const flash = async ({
 	await deleteCachedFullCustomer({
 		ctx,
 		customerId,
-		source: "dfu.flash",
+		source: "billing.import",
 		skipGuard: true,
 	});
 	const customer = await getApiCustomerByRollout({
 		ctx,
 		customerId,
-		source: "dfu.flash",
+		source: "billing.import",
 	});
 
 	return {

--- a/server/src/internal/billing/v2/actions/dfu/setup/hydrate/hydrateStripeBillable.ts
+++ b/server/src/internal/billing/v2/actions/dfu/setup/hydrate/hydrateStripeBillable.ts
@@ -76,7 +76,7 @@ export const hydrateStripeBillables = async ({
 				);
 			} catch (error) {
 				ctx.logger.warn(
-					`dfu.flash: could not retrieve Stripe subscription ${subscriptionId} for hydration; using caller-supplied fields`,
+					`billing.import: could not retrieve Stripe subscription ${subscriptionId} for hydration; using caller-supplied fields`,
 					{ error },
 				);
 				hydrationBySubscription.set(subscriptionId, null);

--- a/server/src/internal/billing/v2/actions/dfu/setup/setupFlashContext.ts
+++ b/server/src/internal/billing/v2/actions/dfu/setup/setupFlashContext.ts
@@ -91,19 +91,38 @@ const upsertFullCustomer = async ({
 		allowNotFound: true,
 	});
 	if (existing) {
+		const update: Parameters<typeof CusService.update>[0]["update"] = {};
+
 		// Self-migration: seed the RC app_user_id so Phase 1 webhooks resolve this
 		// customer by it. Only-if-absent — never clobber an existing value.
 		if (revenueCatIdentity && !existing.processors?.revenuecat?.id) {
-			const processors = {
+			update.processors = {
 				...existing.processors,
 				revenuecat: { id: revenueCatIdentity.id, aliases: [] },
 			};
+		}
+
+		const customerData = params.customer_data;
+		if (customerData?.name !== undefined && customerData.name !== existing.name)
+			update.name = customerData.name;
+		if (
+			customerData?.email !== undefined &&
+			customerData.email !== existing.email
+		)
+			update.email = customerData.email;
+		if (
+			customerData?.fingerprint !== undefined &&
+			customerData.fingerprint !== existing.fingerprint
+		)
+			update.fingerprint = customerData.fingerprint;
+
+		if (Object.keys(update).length > 0) {
 			await CusService.update({
 				ctx,
 				idOrInternalId: existing.id ?? existing.internal_id,
-				update: { processors },
+				update,
 			});
-			existing.processors = processors;
+			Object.assign(existing, update);
 		}
 		return existing;
 	}

--- a/server/src/internal/customers/cusProducts/actions/cleanupOneOff/getOneOffToCleanup.ts
+++ b/server/src/internal/customers/cusProducts/actions/cleanupOneOff/getOneOffToCleanup.ts
@@ -26,11 +26,18 @@ export const getOneOffCustomerProductsToCleanup = async ({
 }): Promise<OneOffCustomerProductResult[]> => {
 	const result = await ctx.db.execute<OneOffCustomerProductResult>(`
 		WITH 
-		-- CTE 1: Active customer products with at least one price
+		-- CTE 1: Active customer products (with at least one price) on products that
+		-- have a one_off price. Driving from the catalog side keeps this off the
+		-- full customer_products table.
 		active_cus_products_with_prices AS (
 			SELECT DISTINCT cp.id
 			FROM customer_products cp
 			WHERE cp.status IN ('${CusProductStatus.Active}', '${CusProductStatus.PastDue}')
+			  AND cp.internal_product_id IN (
+				SELECT DISTINCT p.internal_product_id
+				FROM prices p
+				WHERE COALESCE(p.config->>'interval', '') = '${BillingInterval.OneOff}'
+			)
 			  AND EXISTS (
 				SELECT 1 FROM customer_prices cpr WHERE cpr.customer_product_id = cp.id
 			)

--- a/server/tests/integration/billing/dfu/billing-import/billing-import-balance-filter-predicates.test.ts
+++ b/server/tests/integration/billing/dfu/billing-import/billing-import-balance-filter-predicates.test.ts
@@ -1,0 +1,196 @@
+/**
+ * billing.import — balance filter predicates (GalaxyAI lifetime-plan repro).
+ *
+ * Red (pre-fix):
+ *  - `filter.interval` only accepted hour|day|week|month|year, so a one-off
+ *    line could not be targeted except via an explicit `interval: null`;
+ *    "lifetime" was rejected by the schema.
+ *  - `filter.billing_behavior` only accepted included|prepaid; "usage_based"
+ *    was rejected, so an included + pay-per-use pair was un-disambiguatable.
+ *  - Ambiguity errors said "dfu.flash" instead of "billing.import".
+ * Green: interval inherits EntInterval (lifetime = one-off line),
+ * billing_behavior accepts usage_based, and errors say "billing.import".
+ */
+
+import { expect, test } from "bun:test";
+import { type ApiCustomerV5, ResetInterval } from "@autumn/shared";
+import {
+	callFlash,
+	type FlashClient,
+} from "@tests/integration/billing/dfu/billing-import/utils/flashTestUtils.js";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect.js";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
+
+const lifetimeCreditsPlan = ({ id }: { id: string }) =>
+	products.base({
+		id,
+		isAddOn: true,
+		items: [
+			items.monthlyCredits({ includedUsage: 15 }),
+			constructFeatureItem({
+				featureId: TestFeature.Credits,
+				includedUsage: 100,
+				interval: null,
+			}),
+		],
+	});
+
+test.concurrent(
+	`${chalk.yellowBright("billing.import: interval 'lifetime' targets the one-off line")}`,
+	async () => {
+		const customerId = "dfu-flash-filter-lifetime";
+		const plan = lifetimeCreditsPlan({ id: "dfu-filter-lifetime" });
+
+		const { autumnV2_2, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+			actions: [],
+		});
+
+		const payload = {
+			customer_id: customerId,
+			billables: [
+				{
+					plan: {
+						plan_id: plan.id,
+						status: "active",
+						started_at: Date.now() - 1000 * 60 * 60 * 24 * 120,
+						balances: [
+							{
+								feature_id: TestFeature.Credits,
+								filter: { interval: "month", billing_behavior: "included" },
+								usage: 5,
+							},
+							{
+								feature_id: TestFeature.Credits,
+								filter: { interval: "lifetime", billing_behavior: "included" },
+								usage: 10,
+							},
+						],
+					},
+				},
+			],
+		};
+
+		const flashRes = await callFlash(autumnV2_2 as FlashClient, payload);
+		expect(flashRes.errorMessage).toBeNull();
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		await expectCustomerProducts({ customer, active: [plan.id] });
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Credits,
+			granted: 115,
+			remaining: 100,
+			usage: 15,
+			breakdown: {
+				[ResetInterval.Month]: { remaining: 10, usage: 5 },
+				[ResetInterval.OneOff]: { remaining: 90, usage: 10 },
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("billing.import: billing_behavior 'usage_based' targets the pay-per-use line")}`,
+	async () => {
+		const customerId = "dfu-flash-filter-usage-based";
+		const plan = products.base({
+			id: "dfu-filter-usage-based",
+			items: [
+				items.monthlyMessages({ includedUsage: 10 }),
+				items.consumableMessages({ includedUsage: 20, price: 0.1 }),
+			],
+		});
+
+		const { autumnV2_2, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+			actions: [],
+		});
+
+		const payload = {
+			customer_id: customerId,
+			billables: [
+				{
+					plan: {
+						plan_id: plan.id,
+						status: "active",
+						started_at: Date.now() - 1000 * 60 * 60 * 24 * 5,
+						balances: [
+							{
+								feature_id: TestFeature.Messages,
+								filter: { billing_behavior: "included" },
+								usage: 4,
+							},
+							{
+								feature_id: TestFeature.Messages,
+								filter: { billing_behavior: "usage_based" },
+								usage: 7,
+							},
+						],
+					},
+				},
+			],
+		};
+
+		const flashRes = await callFlash(autumnV2_2 as FlashClient, payload);
+		expect(flashRes.errorMessage).toBeNull();
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		await expectCustomerProducts({ customer, active: [plan.id] });
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			granted: 30,
+			remaining: 19,
+			usage: 11,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("billing.import: ambiguous-filter error says billing.import, not dfu.flash")}`,
+	async () => {
+		const customerId = "dfu-flash-filter-ambiguous";
+		const plan = lifetimeCreditsPlan({ id: "dfu-filter-ambiguous" });
+
+		const { autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+			actions: [],
+		});
+
+		const payload = {
+			customer_id: customerId,
+			billables: [
+				{
+					plan: {
+						plan_id: plan.id,
+						status: "active",
+						started_at: Date.now() - 1000 * 60 * 60 * 24 * 120,
+						balances: [
+							{
+								feature_id: TestFeature.Credits,
+								// Matches both the monthly and one-off included lines.
+								filter: { billing_behavior: "included" },
+								usage: 0,
+							},
+						],
+					},
+				},
+			],
+		};
+
+		const flashRes = await callFlash(autumnV2_2 as FlashClient, payload);
+		expect(flashRes.errorCode).toBe("flash_balance_ambiguous");
+		expect(flashRes.errorMessage).toContain("billing.import");
+		expect(flashRes.errorMessage).not.toContain("dfu.flash");
+	},
+);

--- a/server/tests/integration/billing/dfu/billing-import/billing-import-customer-data-update.test.ts
+++ b/server/tests/integration/billing/dfu/billing-import/billing-import-customer-data-update.test.ts
@@ -1,0 +1,66 @@
+/**
+ * billing.import — `customer_data` must update an EXISTING customer's identity
+ * fields, not just seed them at creation.
+ *
+ * Red (pre-fix): upsertFullCustomer only read customer_data on the create path,
+ * so name/email sent for an existing customer were silently dropped.
+ * Green: existing customer's name/email reflect the imported customer_data.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV5 } from "@autumn/shared";
+import {
+	callFlash,
+	type FlashClient,
+} from "@tests/integration/billing/dfu/billing-import/utils/flashTestUtils.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("billing.import: customer_data updates an existing customer")}`,
+	async () => {
+		const customerId = "dfu-flash-cusdata-update";
+		const free = products.base({
+			id: "dfu-cusdata-free",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV2_2, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({
+					testClock: false,
+					name: "Old Name",
+					email: "old-cusdata@example.com",
+				}),
+				s.products({ list: [free] }),
+			],
+			actions: [],
+		});
+
+		const payload = {
+			customer_id: customerId,
+			customer_data: { name: "Stripe Test", email: "stripetest@gmail.com" },
+			billables: [
+				{
+					plan: {
+						plan_id: free.id,
+						status: "active",
+						started_at: Date.now() - 1000 * 60 * 60 * 24 * 30,
+						balances: [{ feature_id: TestFeature.Messages, usage: 10 }],
+					},
+				},
+			],
+		};
+
+		const flashRes = await callFlash(autumnV2_2 as FlashClient, payload);
+		expect(flashRes.errorCode).toBeNull();
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		expect(customer.name).toBe("Stripe Test");
+		expect(customer.email).toBe("stripetest@gmail.com");
+	},
+);

--- a/shared/api/billing/dfu/dfuFlashParams.ts
+++ b/shared/api/billing/dfu/dfuFlashParams.ts
@@ -56,6 +56,7 @@ const FlashStartingAfterSchema = z
 	.meta({ internal: true });
 
 const FlashBalanceFilterSchema = z.object({
+	// Intentionally the full EntInterval set: filters match against the line's own interval.
 	interval: z.enum(EntInterval).nullable().optional().meta({
 		description:
 			"Reset interval selecting which entitlement line to target when a feature has several ('lifetime' or null = the non-resetting one-off line).",

--- a/shared/api/billing/dfu/dfuFlashParams.ts
+++ b/shared/api/billing/dfu/dfuFlashParams.ts
@@ -1,8 +1,9 @@
+import { EntInterval } from "@models/productModels/intervals/entitlementInterval";
 import { z } from "zod/v4";
 import { ApiCustomerV5Schema } from "../../customers/apiCustomerV5";
 
 /**
- * `POST /v1/dfu.flash` — image a customer INTO Autumn for live migration.
+ * `POST /v1/billing.import` — image a customer INTO Autumn for live migration.
  * Read-only against processors. v1 fields are public; deferred capabilities
  * are schema-defined but `.meta({ internal: true })` so docs hide them.
  */
@@ -55,18 +56,17 @@ const FlashStartingAfterSchema = z
 	.meta({ internal: true });
 
 const FlashBalanceFilterSchema = z.object({
-	interval: z
-		.enum(["hour", "day", "week", "month", "year"])
-		.nullable()
+	interval: z.enum(EntInterval).nullable().optional().meta({
+		description:
+			"Reset interval selecting which entitlement line to target when a feature has several ('lifetime' or null = the non-resetting one-off line).",
+	}),
+	billing_behavior: z
+		.enum(["included", "prepaid", "usage_based"])
 		.optional()
 		.meta({
 			description:
-				"Reset interval selecting which entitlement line to target when a feature has several (null = the non-resetting one-off line).",
+				"Selects the included vs prepaid vs usage-based (pay-per-use) entitlement line when a feature has several.",
 		}),
-	billing_behavior: z.enum(["included", "prepaid"]).optional().meta({
-		description:
-			"Selects the included vs prepaid entitlement line when a feature has both.",
-	}),
 });
 
 const FlashRolloverSchema = z
@@ -200,7 +200,8 @@ export const DfuFlashParamsSchema = z.object({
 		description: "Autumn customer to image into.",
 	}),
 	customer_data: FlashCustomerDataSchema.optional().meta({
-		description: "Optional identity fields to upsert if the customer is new.",
+		description:
+			"Optional identity fields upserted onto the customer (applied to existing customers too).",
 	}),
 	processors: z.array(FlashProcessorIdentitySchema).optional().meta({
 		description:


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes `billing.import` to correctly target one-off/lifetime and usage-based lines and to apply `customer_data` updates to existing customers. Also regenerates OpenAPI, docs, and SDKs (`packages/sdk`, Python) to surface the new filter options, and reduces cron load by scoping one-off cleanup and running it less often.

- **Bug Fixes**
  - Balance filters: `filter.interval` now accepts full entitlement intervals (e.g., `lifetime` targets the one-off line); `filter.billing_behavior` supports `usage_based`.
  - Disambiguation uses actual line billing behavior (included/prepaid/usage_based) and returns clear errors that reference `billing.import`.
  - `customer_data` now upserts onto existing customers (name/email/fingerprint). Adds regression tests.

- **Performance**
  - One-off cleanup runs as a separate cron every 10 minutes with a job-tagged heartbeat.
  - Cleanup query only scans products that have a one-off price, reducing load.

<sup>Written for commit cc6b98c72e87c458958fe7beb402d5544f6a7a62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes several billing.import paths and adjusts one-off cleanup. The main changes are:

- **Bug fixes:** Balance filters now accept lifetime intervals and usage-based billing behavior.
- **Bug fixes:** Existing customers can receive `customer_data` updates during billing.import.
- **Bug fixes:** User-facing dfu.flash strings were renamed to billing.import.
- **Improvements:** One-off cleanup now runs on a separate slower cron cadence.
- **Improvements:** One-off cleanup now prefilters products with catalog one-off prices.
- **Bug fixes:** Integration tests cover the new balance filters and customer-data update behavior.
</details>

<h3>Confidence Score: 4/5</h3>

The changed billing.import and cleanup paths need fixes before merging.

- Existing customer emails can be overwritten with invalid strings.
- One-off cleanup can skip customer products whose catalog price rows no longer match their persisted customer prices.
- The balance-filter changes look consistent with the new schema and tests.

setupFlashContext.ts and getOneOffToCleanup.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/api/billing/dfu/dfuFlashParams.ts | Expands billing.import filter schema and updates customer_data documentation. |
| server/src/internal/billing/v2/actions/dfu/compute/resolvers/balanceResolver.ts | Canonicalizes balance filter intervals and distinguishes included, prepaid, and usage-based lines. |
| server/src/internal/billing/v2/actions/dfu/setup/setupFlashContext.ts | Updates existing customer identity fields from billing.import customer_data, with an email validation gap. |
| server/src/internal/customers/cusProducts/actions/cleanupOneOff/getOneOffToCleanup.ts | Narrows one-off cleanup candidates with a catalog-price prefilter that can skip legacy customer products. |
| server/src/cron/cronInit.ts | Moves one-off cleanup into its own ten-minute cron tick. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/billing/v2/actions/dfu/setup/setupFlashContext.ts:111-114
**Invalid Email Is Persisted**

When billing.import sends `customer_data.email` for an existing customer, this path writes any string directly through `CusService.update`. A payload such as `not-an-email` can replace a valid stored email, while the normal customer update path validates email format before writing.

### Issue 2 of 2
server/src/internal/customers/cusProducts/actions/cleanupOneOff/getOneOffToCleanup.ts:36-40
**Catalog Filter Skips Cleanup**

This prefilter decides whether to scan a customer product from the product's current catalog `prices` rows instead of the persisted customer prices being cleaned up. If the catalog one-off price was removed or changed after customers bought it, depleted one-off customer products no longer enter the cleanup CTEs and can stay active indefinitely.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: 🤖 regen sdks and docs"](https://github.com/useautumn/autumn/commit/cc6b98c72e87c458958fe7beb402d5544f6a7a62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42092249)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->