### PR TITLE
fix: subscription sheet tooltips, coupon error handling, plan id chip in mappings

### DIFF
--- a/server/src/external/stripe/stripeCouponUtils/stripeCouponUtils.ts
+++ b/server/src/external/stripe/stripeCouponUtils/stripeCouponUtils.ts
@@ -143,6 +143,23 @@ const getStripeProductIdForCoupon = ({
 	return stripeProductId;
 };
 
+/** Throws product_not_in_stripe for any plan missing in Stripe. Run before deleting an existing coupon. */
+export const resolveCouponStripeProductIds = ({
+	reward,
+	prices,
+}: {
+	reward: Reward;
+	prices: (Price & { product: Product })[];
+}) => {
+	const appliesToSpecificProducts =
+		reward.type !== RewardType.FreeProduct &&
+		!reward.discount_config!.apply_to_all;
+
+	return appliesToSpecificProducts
+		? prices.map((price) => getStripeProductIdForCoupon({ price }))
+		: [];
+};
+
 const getPromoCouponId = (promo: Stripe.PromotionCode): string | null => {
 	const coupon =
 		promo.promotion?.coupon ??
@@ -173,9 +190,7 @@ export const createStripeCoupon = async ({
 
 	// Resolve Stripe product ids before any Stripe writes so a missing
 	// plan fails cleanly instead of after the existing coupon is deleted.
-	const stripeProdIds = appliesToSpecificProducts
-		? prices.map((price) => getStripeProductIdForCoupon({ price }))
-		: [];
+	const stripeProdIds = resolveCouponStripeProductIds({ reward, prices });
 
 	const stripeCli = createStripeCli({
 		org,

--- a/server/src/external/stripe/stripeCouponUtils/stripeCouponUtils.ts
+++ b/server/src/external/stripe/stripeCouponUtils/stripeCouponUtils.ts
@@ -122,6 +122,27 @@ const couponToStripeValue = ({
 	}
 };
 
+const getStripeProductIdForCoupon = ({
+	price,
+}: {
+	price: Price & { product: Product };
+}) => {
+	const stripeProductId =
+		price.config.type === PriceType.Fixed
+			? price.product.processor?.id
+			: (price.config as UsagePriceConfig).stripe_product_id;
+
+	if (!stripeProductId) {
+		throw new RecaseError({
+			message: `Plan ${price.product.id} doesn't exist in Stripe yet. Call attach to generate a checkout URL and it will be created in Stripe automatically.`,
+			code: ErrCode.ProductNotInStripe,
+			statusCode: 400,
+		});
+	}
+
+	return stripeProductId;
+};
+
 const getPromoCouponId = (promo: Stripe.PromotionCode): string | null => {
 	const coupon =
 		promo.promotion?.coupon ??
@@ -146,6 +167,15 @@ export const createStripeCoupon = async ({
 	legacyVersion?: boolean;
 }) => {
 	const discountConfig = reward.discount_config;
+
+	const appliesToSpecificProducts =
+		reward.type !== RewardType.FreeProduct && !discountConfig!.apply_to_all;
+
+	// Resolve Stripe product ids before any Stripe writes so a missing
+	// plan fails cleanly instead of after the existing coupon is deleted.
+	const stripeProdIds = appliesToSpecificProducts
+		? prices.map((price) => getStripeProductIdForCoupon({ price }))
+		: [];
 
 	const stripeCli = createStripeCli({
 		org,
@@ -177,28 +207,7 @@ export const createStripeCoupon = async ({
 		await stripeCli.coupons.del(reward.id);
 	} catch (_) {}
 
-	const stripeProdIds = prices.map((price) => {
-		if (price.config!.type === PriceType.Fixed) {
-			return price.product.processor?.id;
-		} else {
-			const config = price.config as UsagePriceConfig;
-			if (!config.stripe_product_id) {
-				logger.warn("No stripe product id for price", { price });
-				logger.warn("Config", { config });
-				throw new RecaseError({
-					message: `No stripe product id for price ${price.id}`,
-					code: ErrCode.InternalError,
-				});
-			}
-
-			return config.stripe_product_id;
-		}
-	});
-
 	// Collect Autumn product IDs for metadata when coupon applies to specific products
-	const appliesToSpecificProducts =
-		reward.type !== RewardType.FreeProduct && !discountConfig!.apply_to_all;
-
 	const autumnProductIds = appliesToSpecificProducts
 		? [...new Set(prices.map((price) => price.product.id))]
 		: [];

--- a/server/src/internal/api/rewards/handlers/rewards/handleUpdateCoupon.ts
+++ b/server/src/internal/api/rewards/handlers/rewards/handleUpdateCoupon.ts
@@ -10,7 +10,10 @@ import {
 } from "@autumn/shared";
 import { z } from "zod/v4";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
-import { createStripeCoupon } from "@/external/stripe/stripeCouponUtils/stripeCouponUtils.js";
+import {
+	createStripeCoupon,
+	resolveCouponStripeProductIds,
+} from "@/external/stripe/stripeCouponUtils/stripeCouponUtils.js";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 import { PriceService } from "@/internal/products/prices/PriceService.js";
@@ -92,16 +95,23 @@ export const handleUpdateCoupon = createRoute({
 			}
 		}
 
+		const willRecreateStripeCoupon =
+			rewardCat === RewardCategory.Discount ||
+			(rewardCat === RewardCategory.FreeProduct && prices.length > 0);
+
+		// Preflight before deleting the old Stripe coupon, so a plan missing
+		// in Stripe fails the update while the existing coupon is still intact.
+		if (willRecreateStripeCoupon) {
+			resolveCouponStripeProductIds({ reward: rewardBody, prices });
+		}
+
 		// Delete old prices from stripe
 		try {
 			await stripeCli.coupons.del(reward.id);
 			await stripeCli.coupons.del(reward.internal_id);
 		} catch (_) {}
 
-		if (
-			rewardCat === RewardCategory.Discount ||
-			(rewardCat === RewardCategory.FreeProduct && prices.length > 0)
-		) {
+		if (willRecreateStripeCoupon) {
 			await createStripeCoupon({
 				reward: rewardBody,
 				org,

--- a/shared/enums/ErrCode.ts
+++ b/shared/enums/ErrCode.ts
@@ -127,6 +127,7 @@ export const ErrCode = {
 
 	// Rewards
 	InvalidReward: "invalid_reward",
+	ProductNotInStripe: "product_not_in_stripe",
 	DuplicateRewardId: "duplicate_reward_id",
 	DuplicatePromoCode: "duplicate_promo_code",
 	PromoCodeAlreadyExistsInStripe: "promo_code_already_exists_in_stripe",

--- a/vite/src/components/v2/PlanItemLabel.tsx
+++ b/vite/src/components/v2/PlanItemLabel.tsx
@@ -40,6 +40,16 @@ const PRICE_CHIP_CLASS =
 const isTieredPrice = (item: ProductItem): boolean =>
 	(item.tiers?.length ?? 0) > 1;
 
+/** A rollover config can sit on any item of a feature; only items with a
+ * resetting included/prepaid balance actually roll anything over. */
+const itemCanRollOver = (item: ProductItem): boolean => {
+	if (!item.feature_id) return false;
+	if (intervalIsNone(item.interval)) return false;
+	const includedUsage =
+		typeof item.included_usage === "number" ? item.included_usage : 0;
+	return includedUsage > 0 || item.usage_model === UsageModel.Prepaid;
+};
+
 /** Volume-based tiers priced as a flat amount per band — the real price lives in
  * `flat_amount`, matching getFeaturePriceItemDisplay's formatting. */
 const isVolumeFlatAmountItem = (item: ProductItem): boolean =>
@@ -167,7 +177,13 @@ function TierBreakdownChip({
 	return (
 		<Tooltip>
 			<TooltipTrigger asChild>
-				<span className={cn(PRICE_CHIP_CLASS, "cursor-help")}>{priceStr}</span>
+				{/* pointer-events-auto: read-only rows disable pointer events, which
+				 * would otherwise swallow the hover that opens this tooltip. */}
+				<span
+					className={cn(PRICE_CHIP_CLASS, "cursor-help pointer-events-auto")}
+				>
+					{priceStr}
+				</span>
 			</TooltipTrigger>
 			<TooltipContent className="max-w-xs" side="top">
 				<div className="flex flex-col gap-2">
@@ -261,7 +277,7 @@ export function PlanItemLabel({
 	const feature = features.find((f) => f.id === item.feature_id);
 	const hasFeatureName = feature?.name && feature.name.trim() !== "";
 	const displayText = hasFeatureName ? display.primary_text : unnamedText;
-	const rollover = item.config?.rollover;
+	const rollover = itemCanRollOver(item) ? item.config?.rollover : undefined;
 
 	const icons = <FeatureIconCluster item={item} />;
 

--- a/vite/src/components/v2/RolloverIndicator.tsx
+++ b/vite/src/components/v2/RolloverIndicator.tsx
@@ -29,8 +29,10 @@ export function RolloverIndicator({ rollover }: { rollover: RolloverConfig }) {
 	return (
 		<Tooltip>
 			<TooltipTrigger asChild>
+				{/* pointer-events-auto: read-only rows disable pointer events, which
+				 * would otherwise swallow the hover that opens this tooltip. */}
 				<CircleHalfTiltIcon
-					className="size-3.5 shrink-0 text-tertiary-foreground"
+					className="size-3.5 shrink-0 text-tertiary-foreground pointer-events-auto"
 					aria-label="Rolls over"
 				/>
 			</TooltipTrigger>

--- a/vite/src/views/developer/configure-stripe/mappings/CatalogMappingsTable.tsx
+++ b/vite/src/views/developer/configure-stripe/mappings/CatalogMappingsTable.tsx
@@ -1,5 +1,5 @@
 import type { CatalogGetMappingsResponse, ProductV2 } from "@autumn/shared";
-import { Skeleton } from "@autumn/ui";
+import { CopyButton, Skeleton } from "@autumn/ui";
 import { CaretRightIcon } from "@phosphor-icons/react";
 import { useStripeProductsResolveQuery } from "@/hooks/queries/useStripeProductsResolveQuery";
 import {
@@ -58,16 +58,30 @@ export const CatalogMappingsTable = ({
 					});
 
 					return (
-						<button
-							className="group -mx-2 flex w-[calc(100%+1rem)] items-center gap-3 rounded-md px-2 py-2.5 text-left hover:bg-accent"
+						// biome-ignore lint/a11y/useSemanticElements: row can't be a <button> — the copy chip inside is a button and buttons can't nest
+						<div
+							className="group -mx-2 flex w-[calc(100%+1rem)] cursor-pointer items-center gap-3 rounded-md px-2 py-2.5 text-left hover:bg-accent"
 							key={group.base.id}
 							onClick={() => onSelectPlan(group.base.id)}
-							type="button"
+							onKeyDown={(event) => {
+								if (event.key === "Enter" || event.key === " ") {
+									event.preventDefault();
+									onSelectPlan(group.base.id);
+								}
+							}}
+							role="button"
+							tabIndex={0}
 						>
 							<span className="flex min-w-0 flex-1 items-center gap-2">
 								<span className="truncate font-medium text-sm">
 									{group.base.name}
 								</span>
+								<CopyButton
+									className="shrink-0 text-tertiary-foreground"
+									innerClassName="max-w-30 text-tiny-id truncate"
+									size="mini"
+									text={group.base.id}
+								/>
 								{group.variants.length > 0 && (
 									<span className="shrink-0 text-tertiary-foreground text-xs">
 										{group.variants.length} variant
@@ -97,7 +111,7 @@ export const CatalogMappingsTable = ({
 								className="size-4 shrink-0 text-tertiary-foreground group-hover:text-foreground"
 								size={14}
 							/>
-						</button>
+						</div>
 					);
 				})}
 			</div>

--- a/vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx
+++ b/vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx
@@ -177,9 +177,9 @@ export const PlanFeatureRow = ({
 
 				<div
 					className={cn(
-						"flex items-center max-w-0 opacity-0 overflow-hidden group-hover:max-w-[200px] shrink-0",
+						"flex items-center max-w-0 opacity-0 overflow-hidden shrink-0",
 						isSelected && "max-w-[200px] opacity-100",
-						!readOnly && " group-hover:opacity-100",
+						!readOnly && "group-hover:max-w-[200px] group-hover:opacity-100",
 					)}
 				>
 					<IconButton


### PR DESCRIPTION
## Summary
- **Subscription detail sheet**: show tooltips and correct rollover icon
- **Stripe coupon creation**: resolve Stripe product ids before any Stripe writes, so a plan that doesn't exist in Stripe yet fails cleanly with a new `product_not_in_stripe` error code instead of failing after the existing coupon has already been deleted
- **Stripe product mappings**: add a mini copy chip with the plan id next to the plan name in the mappings table (row converted from `<button>` to accessible `div[role=button]` since the chip is itself a button)
- Bump `ai` submodule

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes subscription sheet tooltips and only shows the rollover icon when an item actually rolls over. Coupon create/update now preflights Stripe product IDs and returns `product_not_in_stripe` if missing; also adds a mini plan‑id copy chip in the Stripe mappings table and bumps `ai`.

- **Bug Fixes**
  - Subscription sheet: enable hover on tier‑price and rollover tooltip triggers; gate the rollover icon to items with included/prepaid balance; prevent hidden delete container from expanding on hover in read‑only rows.
  - Stripe coupons: resolve Stripe product IDs before any writes and before deleting on update; return `product_not_in_stripe` (400) when missing.

- **New Features**
  - Stripe product mappings: add a mini copy chip with the plan ID next to the plan name; row changed to `div[role=button]` with Enter/Space handling to support the chip button.

<sup>Written for commit 02eb26c4610dea1fce885730feffb794f45d741e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates Stripe coupon handling and several subscription UI details. The main changes are:

- Stripe coupon creation resolves Stripe product ids before helper-level coupon writes.
- A new `product_not_in_stripe` error code was added.
- Subscription item rollover and tier tooltip behavior was adjusted.
- Stripe mapping rows now include a copyable plan-id chip.
- Read-only plan rows no longer reveal the delete affordance on hover.
- The `ai` submodule was bumped.
</details>

<h3>Confidence Score: 4/5</h3>

The coupon update flow and two UI interaction paths need fixes before merging.

- Coupon updates can still remove the existing Stripe coupon before the missing-product guard runs.
- Keyboard activation on the mapping copy chip can also select the row.
- Infinite included-usage items can lose their rollover indicator.

server/src/external/stripe/stripeCouponUtils/stripeCouponUtils.ts, vite/src/views/developer/configure-stripe/mappings/CatalogMappingsTable.tsx, vite/src/components/v2/PlanItemLabel.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/stripeCouponUtils/stripeCouponUtils.ts | Adds Stripe product-id preflight before helper-level coupon writes, but update callers can still delete before this guard runs. |
| shared/enums/ErrCode.ts | Adds the new `product_not_in_stripe` error code. |
| vite/src/components/v2/PlanItemLabel.tsx | Adds tooltip pointer-event handling and a rollover eligibility check that can hide infinite-usage rollover indicators. |
| vite/src/components/v2/RolloverIndicator.tsx | Adds pointer-event handling to the rollover tooltip trigger. |
| vite/src/views/developer/configure-stripe/mappings/CatalogMappingsTable.tsx | Adds a copyable plan-id chip and converts rows to `div[role=button]`, with a keyboard bubbling issue on the nested copy control. |
| vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx | Restricts hover expansion of row actions to editable rows. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
server/src/external/stripe/stripeCouponUtils/stripeCouponUtils.ts:174-178
**Update Path Deletes First**

This preflight runs before the delete inside `createStripeCoupon`, but `handleUpdateCoupon` deletes `reward.id` and `reward.internal_id` before it calls this helper. When an update references a plan that is not in Stripe, `getStripeProductIdForCoupon` throws `product_not_in_stripe` after the old Stripe coupon has already been removed, leaving the database pointing at a missing coupon.

### Issue 2 of 3
vite/src/views/developer/configure-stripe/mappings/CatalogMappingsTable.tsx:66-71
**Copy Key Selects Row**

The wrapping row now handles Enter and Space, but the nested `CopyButton` is also focusable. When keyboard focus is on the copy chip, pressing Enter or Space bubbles the keydown event to this handler, so the same action copies the plan id and also selects the plan row.

### Issue 3 of 3
vite/src/components/v2/PlanItemLabel.tsx:48-50
**Infinite Usage Hides Rollover**

`included_usage` can be the infinite sentinel string, but this check treats every non-number as zero. A recurring item with `included_usage: "inf"` and `config.rollover` now fails `itemCanRollOver` unless its usage model is explicitly prepaid, so the rollover icon disappears even though the item has unlimited included usage and a rollover config.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ai): 🤖 bump ai submodule"](https://github.com/useautumn/autumn/commit/208bc4ac3ae47dd9f47d09a8a462937ace94ee70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42100781)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->