### PR TITLE
fire balances.limit_reached for plan-level & percentage spend/usage limits

### DIFF
--- a/server/src/internal/balances/check/buildEvaluationSubject.ts
+++ b/server/src/internal/balances/check/buildEvaluationSubject.ts
@@ -1,0 +1,108 @@
+import {
+	type ApiCustomerV5,
+	type ApiEntityV2,
+	type DbSpendLimit,
+	DEFAULT_PLAN_CONTROL_STATUSES,
+	type FullSubject,
+	fullSubjectToCustomerEntitlements,
+	mergeCustomerBillingControlsForCheck,
+	mergePlanBillingControlsForCheck,
+	resolveSpendLimitOverageLimit,
+} from "@autumn/shared";
+import type { RequestContext } from "@/honoUtils/HonoEnv.js";
+import { getApiCustomerBaseV2 } from "@/internal/customers/cusUtils/getApiCustomerV2/getApiCustomerBaseV2.js";
+import { getApiSubject } from "@/internal/customers/cusUtils/getApiCustomerV2/getApiSubject.js";
+import { resolveCheckSpendLimits } from "./resolveCheckSpendLimits.js";
+
+/**
+ * Build the api subject used to evaluate `allowed` (via apiBalanceToAllowed),
+ * with plan-level and (for entities) customer-level billing controls merged in
+ * and percentage spend limits resolved to absolute.
+ *
+ * This is the single source of truth for "what limits gate this subject",
+ * shared by the /v1/check path (getCheckDataV2) and the track webhooks
+ * (checkLimitReached). Both must see identical billing controls, or a plan-level
+ * / percentage cap that blocks a track would fail to fire balances.limit_reached.
+ *
+ * Pure with respect to inputs (returns a new subject); does no aggregation
+ * (evaluation subject only), matching getApiSubject includeAggregations: false.
+ */
+export const buildEvaluationSubject = async ({
+	ctx,
+	fullSubject,
+	entityId,
+}: {
+	ctx: RequestContext;
+	fullSubject: FullSubject;
+	entityId?: string;
+}): Promise<ApiCustomerV5 | ApiEntityV2> => {
+	let evaluationApiSubject = await getApiSubject({
+		ctx,
+		fullSubject,
+		includeAggregations: false,
+	});
+
+	const cusEntsForFeature = (featureId: string) =>
+		fullSubjectToCustomerEntitlements({
+			fullSubject,
+			featureIds: [featureId],
+			inStatuses: DEFAULT_PLAN_CONTROL_STATUSES,
+		});
+	const additionalAllowanceForFeature = (featureId: string) =>
+		fullSubject.aggregated_customer_entitlements?.find(
+			(entitlement) => entitlement.feature_id === featureId,
+		)?.allowance_total ?? 0;
+	const normalizeSpendLimitForCompare = (
+		control: DbSpendLimit,
+	): DbSpendLimit => {
+		if (control.limit_type !== "usage_percentage" || !control.feature_id) {
+			return control;
+		}
+		return {
+			...control,
+			overage_limit: resolveSpendLimitOverageLimit({
+				spendLimit: control,
+				cusEnts: cusEntsForFeature(control.feature_id),
+				entityId,
+				additionalAllowance: additionalAllowanceForFeature(control.feature_id),
+			}),
+			limit_type: "absolute",
+		};
+	};
+
+	if (fullSubject.subjectType === "entity") {
+		const { apiCustomer } = await getApiCustomerBaseV2({
+			ctx,
+			fullSubject: {
+				...fullSubject,
+				aggregated_customer_products: undefined,
+				aggregated_customer_entitlements: undefined,
+				aggregated_subject_flags: undefined,
+			},
+			withAutumnId: true,
+		});
+		evaluationApiSubject = mergeCustomerBillingControlsForCheck({
+			entityApiSubject: evaluationApiSubject as ApiEntityV2,
+			customerApiSubject: apiCustomer,
+			planCustomerProducts: fullSubject.customer_products,
+			normalizeSpendLimitForCompare,
+			fullSubject,
+			features: ctx.features,
+		});
+	} else {
+		evaluationApiSubject = mergePlanBillingControlsForCheck({
+			customerApiSubject: evaluationApiSubject as ApiCustomerV5,
+			planCustomerProducts: fullSubject.customer_products,
+			normalizeSpendLimitForCompare,
+			fullSubject,
+			features: ctx.features,
+		});
+	}
+
+	return resolveCheckSpendLimits({
+		subject: evaluationApiSubject,
+		cusEntsForFeature,
+		entityId,
+		additionalAllowanceForFeature,
+	});
+};

--- a/server/src/internal/balances/check/buildEvaluationSubject.ts
+++ b/server/src/internal/balances/check/buildEvaluationSubject.ts
@@ -15,17 +15,10 @@ import { getApiSubject } from "@/internal/customers/cusUtils/getApiCustomerV2/ge
 import { resolveCheckSpendLimits } from "./resolveCheckSpendLimits.js";
 
 /**
- * Build the api subject used to evaluate `allowed` (via apiBalanceToAllowed),
- * with plan-level and (for entities) customer-level billing controls merged in
- * and percentage spend limits resolved to absolute.
- *
- * This is the single source of truth for "what limits gate this subject",
- * shared by the /v1/check path (getCheckDataV2) and the track webhooks
- * (checkLimitReached). Both must see identical billing controls, or a plan-level
- * / percentage cap that blocks a track would fail to fire balances.limit_reached.
- *
- * Pure with respect to inputs (returns a new subject); does no aggregation
- * (evaluation subject only), matching getApiSubject includeAggregations: false.
+ * Evaluation subject for apiBalanceToAllowed, with plan-level (and, for
+ * entities, customer-level) billing controls merged in and percentage spend
+ * limits resolved to absolute. Shared by /v1/check and the track webhooks so
+ * both gate on identical limits.
  */
 export const buildEvaluationSubject = async ({
 	ctx,

--- a/server/src/internal/balances/check/getCheckDataV2.ts
+++ b/server/src/internal/balances/check/getCheckDataV2.ts
@@ -1,31 +1,22 @@
 import {
-	type ApiCustomerV5,
-	type ApiEntityV2,
 	ApiVersion,
 	type CheckParams,
-	type DbSpendLimit,
-	DEFAULT_PLAN_CONTROL_STATUSES,
 	type Feature,
 	FeatureNotFoundError,
 	findFeatureById,
-	fullSubjectToCustomerEntitlements,
 	fullSubjectToFullCustomer,
 	getFeatureToUseForCheck,
-	mergeCustomerBillingControlsForCheck,
-	mergePlanBillingControlsForCheck,
-	resolveSpendLimitOverageLimit,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import {
 	getOrCreateCachedPartialFullSubject,
 	getOrSetCachedPartialFullSubject,
 } from "@/internal/customers/cache/fullSubject/index.js";
-import { getApiCustomerBaseV2 } from "@/internal/customers/cusUtils/getApiCustomerV2/getApiCustomerBaseV2.js";
 import { getApiSubject } from "@/internal/customers/cusUtils/getApiCustomerV2/getApiSubject.js";
 import { getCreditSystemsFromFeature } from "@/internal/features/creditSystemUtils.js";
 import { triggerAutoTopUp } from "../autoTopUp/triggerAutoTopUp.js";
+import { buildEvaluationSubject } from "./buildEvaluationSubject.js";
 import type { CheckDataV2 } from "./checkTypes/CheckDataV2.js";
-import { resolveCheckSpendLimits } from "./resolveCheckSpendLimits.js";
 
 const getFeatureAndCreditSystems = ({
 	features,
@@ -90,79 +81,10 @@ export const getCheckDataV2 = async ({
 		fullSubject,
 		includeAggregations: true,
 	});
-	let evaluationApiSubject = await getApiSubject({
+	const evaluationApiSubject = await buildEvaluationSubject({
 		ctx,
 		fullSubject,
-		includeAggregations: false,
-	});
-
-	const cusEntsForFeature = (featureId: string) =>
-		fullSubjectToCustomerEntitlements({
-			fullSubject,
-			featureIds: [featureId],
-			inStatuses: DEFAULT_PLAN_CONTROL_STATUSES,
-		});
-	const additionalAllowanceForFeature = (featureId: string) =>
-		fullSubject.aggregated_customer_entitlements?.find(
-			(entitlement) => entitlement.feature_id === featureId,
-		)?.allowance_total ?? 0;
-	const normalizeSpendLimitForCompare = (
-		control: DbSpendLimit,
-	): DbSpendLimit => {
-		if (control.limit_type !== "usage_percentage" || !control.feature_id) {
-			return control;
-		}
-		return {
-			...control,
-			overage_limit: resolveSpendLimitOverageLimit({
-				spendLimit: control,
-				cusEnts: cusEntsForFeature(control.feature_id),
-				entityId: entity_id,
-				additionalAllowance: additionalAllowanceForFeature(control.feature_id),
-			}),
-			limit_type: "absolute",
-		};
-	};
-
-	if (fullSubject.subjectType === "entity") {
-		const { apiCustomer } = await getApiCustomerBaseV2({
-			ctx,
-			fullSubject: {
-				...fullSubject,
-				aggregated_customer_products: undefined,
-				aggregated_customer_entitlements: undefined,
-				aggregated_subject_flags: undefined,
-			},
-			withAutumnId: true,
-		});
-		evaluationApiSubject = mergeCustomerBillingControlsForCheck({
-			entityApiSubject: evaluationApiSubject as ApiEntityV2,
-			customerApiSubject: apiCustomer,
-			planCustomerProducts: fullSubject.customer_products,
-			normalizeSpendLimitForCompare,
-			fullSubject,
-			features: ctx.features,
-		});
-	} else {
-		evaluationApiSubject = mergePlanBillingControlsForCheck({
-			customerApiSubject: evaluationApiSubject as ApiCustomerV5,
-			planCustomerProducts: fullSubject.customer_products,
-			normalizeSpendLimitForCompare,
-			fullSubject,
-			features: ctx.features,
-		});
-	}
-
-	evaluationApiSubject = resolveCheckSpendLimits({
-		subject: evaluationApiSubject,
-		cusEntsForFeature: (featureId) =>
-			fullSubjectToCustomerEntitlements({
-				fullSubject,
-				featureIds: [featureId],
-				inStatuses: DEFAULT_PLAN_CONTROL_STATUSES,
-			}),
 		entityId: entity_id,
-		additionalAllowanceForFeature,
 	});
 
 	const featureToUseMin = getFeatureToUseForCheck({

--- a/server/src/internal/balances/trackWebhooks/checkLimitReached.ts
+++ b/server/src/internal/balances/trackWebhooks/checkLimitReached.ts
@@ -9,117 +9,70 @@ import {
 } from "@autumn/shared";
 import { sendSvixEvent } from "@/external/svix/svixHelpers.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { getApiCustomerBase } from "@/internal/customers/cusUtils/apiCusUtils/getApiCustomerBase.js";
-import { getApiEntityBase } from "@/internal/entities/entityUtils/apiEntityUtils/getApiEntityBase.js";
 
-const checkLimitForSubject = async ({
-	ctx,
-	oldFullCus,
-	newFullCus,
-	feature,
-	entityId,
-}: {
-	ctx: AutumnContext;
-	oldFullCus: FullCustomer;
-	newFullCus: FullCustomer;
-	feature: Feature;
-	entityId?: string;
-}) => {
-	const entity = entityId
-		? newFullCus.entities?.find((e) => e.id === entityId)
-		: undefined;
-
-	let oldSubject: ApiCustomerV5 | ApiEntityV2 | undefined;
-	let newSubject: ApiCustomerV5 | ApiEntityV2 | undefined;
-
-	if (entity) {
-		const { apiEntity: oldApiEntity } = await getApiEntityBase({
-			ctx,
-			entity,
-			fullCus: oldFullCus,
-		});
-		const { apiEntity: newApiEntity } = await getApiEntityBase({
-			ctx,
-			entity,
-			fullCus: newFullCus,
-		});
-		oldSubject = oldApiEntity;
-		newSubject = newApiEntity;
-	} else {
-		const { apiCustomer: oldApiCustomer } = await getApiCustomerBase({
-			ctx,
-			fullCus: oldFullCus,
-		});
-		const { apiCustomer: newApiCustomer } = await getApiCustomerBase({
-			ctx,
-			fullCus: newFullCus,
-		});
-		oldSubject = oldApiCustomer;
-		newSubject = newApiCustomer;
-	}
-
-	const oldBalance = oldSubject.balances?.[feature.id];
-	const newBalance = newSubject.balances?.[feature.id];
-
-	if (!oldBalance || !newBalance) return;
-
-	const oldResult = apiBalanceToAllowed({
-		apiBalance: oldBalance,
-		apiSubject: oldSubject,
-		feature,
-		requiredBalance: 0.0000001,
-	});
-
-	const newResult = apiBalanceToAllowed({
-		apiBalance: newBalance,
-		apiSubject: newSubject,
-		feature,
-		requiredBalance: 0.0000001,
-	});
-
-	if (!oldResult.allowed || newResult.allowed) return;
-
-	const customerId = newFullCus.id || newFullCus.internal_id;
-	const tags = fullCustomerToTags({ fullCustomer: newFullCus });
-
-	await sendSvixEvent({
-		ctx,
-		eventType: WebhookEventType.BalancesLimitReached,
-		data: {
-			customer_id: customerId,
-			feature_id: feature.id,
-			limit_type: newResult.limitType ?? "included",
-			...(entityId && { entity_id: entityId }),
-		},
-		tags,
-	});
-
-	ctx.logger.info(
-		`Limit reached for customer ${customerId}, feature ${feature.id}, type ${newResult.limitType ?? "included"}${entityId ? `, entity ${entityId}` : ""}`,
-	);
-};
-
+/**
+ * Fires balances.limit_reached when a feature crosses from allowed -> blocked.
+ *
+ * The old/new subjects must already carry plan-level + percentage-resolved
+ * billing controls (built via buildEvaluationSubject, the same pipeline the
+ * /v1/check path uses). Building them off the raw customer-level controls would
+ * miss plan-level spend/usage caps, so the transition would never be seen.
+ */
 export const checkLimitReached = async ({
 	ctx,
-	oldFullCus,
+	oldEvalSubject,
+	newEvalSubject,
 	newFullCus,
 	feature,
 	entityId,
 }: {
 	ctx: AutumnContext;
-	oldFullCus: FullCustomer;
+	oldEvalSubject: ApiCustomerV5 | ApiEntityV2;
+	newEvalSubject: ApiCustomerV5 | ApiEntityV2;
 	newFullCus: FullCustomer;
 	feature: Feature;
 	entityId?: string;
 }) => {
 	try {
-		await checkLimitForSubject({
-			ctx,
-			oldFullCus,
-			newFullCus,
+		const oldBalance = oldEvalSubject.balances?.[feature.id];
+		const newBalance = newEvalSubject.balances?.[feature.id];
+
+		if (!oldBalance || !newBalance) return;
+
+		const oldResult = apiBalanceToAllowed({
+			apiBalance: oldBalance,
+			apiSubject: oldEvalSubject,
 			feature,
-			entityId,
+			requiredBalance: 0.0000001,
 		});
+
+		const newResult = apiBalanceToAllowed({
+			apiBalance: newBalance,
+			apiSubject: newEvalSubject,
+			feature,
+			requiredBalance: 0.0000001,
+		});
+
+		if (!oldResult.allowed || newResult.allowed) return;
+
+		const customerId = newFullCus.id || newFullCus.internal_id;
+		const tags = fullCustomerToTags({ fullCustomer: newFullCus });
+
+		await sendSvixEvent({
+			ctx,
+			eventType: WebhookEventType.BalancesLimitReached,
+			data: {
+				customer_id: customerId,
+				feature_id: feature.id,
+				limit_type: newResult.limitType ?? "included",
+				...(entityId && { entity_id: entityId }),
+			},
+			tags,
+		});
+
+		ctx.logger.info(
+			`Limit reached for customer ${customerId}, feature ${feature.id}, type ${newResult.limitType ?? "included"}${entityId ? `, entity ${entityId}` : ""}`,
+		);
 	} catch (error) {
 		ctx.logger.error(`[checkLimitReached] error: ${error}`, { error });
 	}

--- a/server/src/internal/balances/trackWebhooks/checkLimitReached.ts
+++ b/server/src/internal/balances/trackWebhooks/checkLimitReached.ts
@@ -10,14 +10,8 @@ import {
 import { sendSvixEvent } from "@/external/svix/svixHelpers.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 
-/**
- * Fires balances.limit_reached when a feature crosses from allowed -> blocked.
- *
- * The old/new subjects must already carry plan-level + percentage-resolved
- * billing controls (built via buildEvaluationSubject, the same pipeline the
- * /v1/check path uses). Building them off the raw customer-level controls would
- * miss plan-level spend/usage caps, so the transition would never be seen.
- */
+// Subjects must be built via buildEvaluationSubject, or plan-level / percentage
+// caps are invisible here and the allowed -> blocked transition never fires.
 export const checkLimitReached = async ({
 	ctx,
 	oldEvalSubject,

--- a/server/src/internal/balances/trackWebhooks/fireTrackWebhooks.ts
+++ b/server/src/internal/balances/trackWebhooks/fireTrackWebhooks.ts
@@ -53,9 +53,6 @@ export const fireTrackWebhooks = ({
 		});
 	}
 
-	// Build the old/new evaluation subjects once (plan-level + percentage-resolved
-	// billing controls, matching the /v1/check path), then detect the
-	// allowed -> blocked transition per affected feature.
 	(async () => {
 		const [oldEvalSubject, newEvalSubject] = await Promise.all([
 			buildEvaluationSubject({ ctx, fullSubject: oldFullSubject, entityId }),

--- a/server/src/internal/balances/trackWebhooks/fireTrackWebhooks.ts
+++ b/server/src/internal/balances/trackWebhooks/fireTrackWebhooks.ts
@@ -1,24 +1,32 @@
-import type { Feature, FullCustomer } from "@autumn/shared";
+import {
+	type Feature,
+	type FullSubject,
+	fullSubjectToFullCustomer,
+} from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { buildEvaluationSubject } from "@/internal/balances/check/buildEvaluationSubject.js";
 import { checkLimitReached } from "./checkLimitReached.js";
 import { checkUsageAlerts } from "./checkUsageAlerts.js";
 import { handleThresholdReached } from "./handleThresholdReached.js";
 
 export const fireTrackWebhooks = ({
 	ctx,
-	oldFullCus,
-	newFullCus,
+	oldFullSubject,
+	newFullSubject,
 	feature,
 	entityId,
 	featuresFromMutationLogs,
 }: {
 	ctx: AutumnContext;
-	oldFullCus: FullCustomer;
-	newFullCus: FullCustomer;
+	oldFullSubject: FullSubject;
+	newFullSubject: FullSubject;
 	feature: Feature;
 	entityId?: string;
 	featuresFromMutationLogs?: Feature[];
 }) => {
+	const oldFullCus = fullSubjectToFullCustomer({ fullSubject: oldFullSubject });
+	const newFullCus = fullSubjectToFullCustomer({ fullSubject: newFullSubject });
+
 	handleThresholdReached({
 		ctx,
 		oldFullCus,
@@ -43,15 +51,28 @@ export const fireTrackWebhooks = ({
 		}).catch((error) => {
 			ctx.logger.error(`[fireTrackWebhooks] checkUsageAlerts: ${error}`);
 		});
-
-		checkLimitReached({
-			ctx,
-			oldFullCus,
-			newFullCus,
-			feature: affectedFeature,
-			entityId,
-		}).catch((error) => {
-			ctx.logger.error(`[fireTrackWebhooks] checkLimitReached: ${error}`);
-		});
 	}
+
+	// Build the old/new evaluation subjects once (plan-level + percentage-resolved
+	// billing controls, matching the /v1/check path), then detect the
+	// allowed -> blocked transition per affected feature.
+	(async () => {
+		const [oldEvalSubject, newEvalSubject] = await Promise.all([
+			buildEvaluationSubject({ ctx, fullSubject: oldFullSubject, entityId }),
+			buildEvaluationSubject({ ctx, fullSubject: newFullSubject, entityId }),
+		]);
+
+		for (const affectedFeature of featuresForUsageAlertsAndLimit) {
+			await checkLimitReached({
+				ctx,
+				oldEvalSubject,
+				newEvalSubject,
+				newFullCus,
+				feature: affectedFeature,
+				entityId,
+			});
+		}
+	})().catch((error) => {
+		ctx.logger.error(`[fireTrackWebhooks] checkLimitReached: ${error}`);
+	});
 };

--- a/server/src/internal/balances/utils/deduction/executePostgresDeduction.ts
+++ b/server/src/internal/balances/utils/deduction/executePostgresDeduction.ts
@@ -1,6 +1,7 @@
 import {
 	ACTIVE_STATUSES,
 	type FullCustomer,
+	fullCustomerToFullSubject,
 	InternalError,
 } from "@autumn/shared";
 import { sql } from "drizzle-orm";
@@ -248,8 +249,8 @@ export const executePostgresDeduction = async ({
 
 			fireTrackWebhooks({
 				ctx,
-				oldFullCus,
-				newFullCus: fullCustomer,
+				oldFullSubject: fullCustomerToFullSubject({ fullCustomer: oldFullCus }),
+				newFullSubject: fullCustomerToFullSubject({ fullCustomer }),
 				feature: deduction.feature,
 				entityId,
 				featuresFromMutationLogs,

--- a/server/src/internal/balances/utils/deduction/executeRedisDeduction.ts
+++ b/server/src/internal/balances/utils/deduction/executeRedisDeduction.ts
@@ -1,6 +1,7 @@
-import type {
-	FullCusEntWithFullCusProduct,
-	FullCustomer,
+import {
+	type FullCusEntWithFullCusProduct,
+	type FullCustomer,
+	fullCustomerToFullSubject,
 } from "@autumn/shared";
 import type { Redis } from "ioredis";
 import { currentRegion, redis } from "@/external/redis/initRedis.js";
@@ -258,8 +259,8 @@ export const executeRedisDeduction = async ({
 
 		fireTrackWebhooks({
 			ctx,
-			oldFullCus,
-			newFullCus: fullCustomer,
+			oldFullSubject: fullCustomerToFullSubject({ fullCustomer: oldFullCus }),
+			newFullSubject: fullCustomerToFullSubject({ fullCustomer }),
 			feature: deduction.feature,
 			entityId,
 			featuresFromMutationLogs,

--- a/server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts
@@ -288,8 +288,8 @@ export const executePostgresDeductionV2 = async ({
 
 			fireTrackWebhooks({
 				ctx,
-				oldFullCus: oldFullCustomer,
-				newFullCus: newFullCustomer,
+				oldFullSubject,
+				newFullSubject: fullSubject,
 				feature: deduction.feature,
 				entityId,
 				featuresFromMutationLogs,

--- a/server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts
@@ -390,8 +390,8 @@ export const executeRedisDeductionV2 = async ({
 
 		fireTrackWebhooks({
 			ctx,
-			oldFullCus: oldFullCustomer,
-			newFullCus: newFullCustomer,
+			oldFullSubject,
+			newFullSubject: fullSubject,
 			feature: deduction.feature,
 			entityId,
 			featuresFromMutationLogs,

--- a/server/tests/integration/balances/track/limit-reached/limit-reached-plan.test.ts
+++ b/server/tests/integration/balances/track/limit-reached/limit-reached-plan.test.ts
@@ -1,13 +1,6 @@
 /**
- * Integration tests for the `balances.limit_reached` webhook when the limit is
- * configured at the PLAN level (billing controls on the attached product),
- * rather than on the customer.
- *
- * Reproduces Resend's setup: their spend limits live on the plan
- * ("Transactional Pro" > billing controls), e.g. an absolute overage cap and a
- * `usage_percentage` overage cap. Enforcement blocks the track correctly, but
- * the webhook must also fire — the check path merges plan-level billing
- * controls into the evaluated subject, so the track-webhook path must too.
+ * balances.limit_reached for PLAN-level billing controls (Resend's setup:
+ * spend/usage limits live on the plan, not the customer).
  */
 
 import { afterAll, beforeAll, expect, test } from "bun:test";
@@ -86,7 +79,6 @@ test.concurrent(
 			actions: [s.attach({ productId: planProd.id })],
 		});
 
-		// included 50 + overage cap 10 → allowed up to 60; 60 lands exactly on the cap.
 		await autumnV2_1.track({
 			customer_id: customerId,
 			feature_id: TestFeature.Messages,
@@ -121,7 +113,7 @@ test.concurrent(
 			includedUsage: 50,
 			price: 1,
 		});
-		// 120% of the 50-unit allowance = 60 units of overage → total allowed 110.
+		// 120% of 50 allowance = 60 overage → total allowed 110.
 		const planProd = products.base({
 			id: "lr-plan-pct-spend-1",
 			items: [consumableMsg],
@@ -176,9 +168,8 @@ test.concurrent(
 test.concurrent(
 	`${chalk.yellowBright("limit-reached-plan3: plan-level usage_limit fires webhook (usage_limit)")}`,
 	async () => {
-		// Cap of 5/day on the plan, well under the 1000 included allowance — the
-		// windowed usage_limit is the gate. Its live window `usage` only survives if
-		// the webhook path evaluates the real fullSubject (not a FullCustomer).
+		// Windowed cap (5/day) under the 1000 allowance; its live window `usage`
+		// only survives if the webhook evaluates the real fullSubject.
 		const planProd = products.base({
 			id: "lr-plan-usage-limit-1",
 			items: [items.monthlyMessages({ includedUsage: 1000 })],

--- a/server/tests/integration/balances/track/limit-reached/limit-reached-plan.test.ts
+++ b/server/tests/integration/balances/track/limit-reached/limit-reached-plan.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Integration tests for the `balances.limit_reached` webhook when the limit is
+ * configured at the PLAN level (billing controls on the attached product),
+ * rather than on the customer.
+ *
+ * Reproduces Resend's setup: their spend limits live on the plan
+ * ("Transactional Pro" > billing controls), e.g. an absolute overage cap and a
+ * `usage_percentage` overage cap. Enforcement blocks the track correctly, but
+ * the webhook must also fire — the check path merges plan-level billing
+ * controls into the evaluated subject, so the track-webhook path must too.
+ */
+
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { ResetInterval } from "@autumn/shared";
+import {
+	getTestSvixAppId,
+	setupWebhookTest,
+	type WebhookTestSetup,
+	waitForWebhook,
+} from "@tests/integration/utils/svixWebhookTestUtils.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+type BalancesLimitReachedPayload = {
+	type: string;
+	data: {
+		customer_id: string;
+		feature_id: string;
+		limit_type: string;
+		entity_id?: string;
+	};
+};
+
+let webhook: WebhookTestSetup;
+let playToken: string;
+
+beforeAll(async () => {
+	const appId = getTestSvixAppId({ svixConfig: ctx.org.svix_config });
+	webhook = await setupWebhookTest({
+		appId,
+		filterTypes: ["balances.limit_reached"],
+	});
+	playToken = webhook.playToken;
+});
+
+afterAll(async () => {
+	await webhook?.cleanup();
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 1: plan-level absolute spend limit reached fires webhook
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("limit-reached-plan1: plan-level absolute spend_limit fires webhook")}`,
+	async () => {
+		const consumableMsg = items.consumableMessages({
+			includedUsage: 50,
+			price: 1,
+		});
+		const planProd = products.base({
+			id: "lr-plan-abs-spend-1",
+			items: [consumableMsg],
+			billingControls: {
+				spend_limits: [
+					{
+						feature_id: TestFeature.Messages,
+						enabled: true,
+						limit_type: "absolute",
+						overage_limit: 10,
+					},
+				],
+			},
+		});
+
+		const { customerId, autumnV2_1 } = await initScenario({
+			customerId: "lr-plan-abs-spend-cus-1",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [planProd] }),
+			],
+			actions: [s.attach({ productId: planProd.id })],
+		});
+
+		// included 50 + overage cap 10 → allowed up to 60; 60 lands exactly on the cap.
+		await autumnV2_1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 60,
+		});
+
+		const result = await waitForWebhook<BalancesLimitReachedPayload>({
+			token: playToken,
+			predicate: (payload) =>
+				payload.type === "balances.limit_reached" &&
+				payload.data?.customer_id === customerId &&
+				payload.data?.limit_type === "spend_limit",
+			timeoutMs: 15000,
+		});
+
+		expect(result).not.toBeNull();
+		const { data } = result!.payload;
+		expect(data.customer_id).toBe(customerId);
+		expect(data.feature_id).toBe(TestFeature.Messages);
+		expect(data.limit_type).toBe("spend_limit");
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 2: plan-level usage_percentage spend limit reached fires webhook
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("limit-reached-plan2: plan-level usage_percentage spend_limit fires webhook")}`,
+	async () => {
+		const consumableMsg = items.consumableMessages({
+			includedUsage: 50,
+			price: 1,
+		});
+		// 120% of the 50-unit allowance = 60 units of overage → total allowed 110.
+		const planProd = products.base({
+			id: "lr-plan-pct-spend-1",
+			items: [consumableMsg],
+			billingControls: {
+				spend_limits: [
+					{
+						feature_id: TestFeature.Messages,
+						enabled: true,
+						limit_type: "usage_percentage",
+						overage_limit: 120,
+					},
+				],
+			},
+		});
+
+		const { customerId, autumnV2_1 } = await initScenario({
+			customerId: "lr-plan-pct-spend-cus-1",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [planProd] }),
+			],
+			actions: [s.attach({ productId: planProd.id })],
+		});
+
+		await autumnV2_1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 120,
+		});
+
+		const result = await waitForWebhook<BalancesLimitReachedPayload>({
+			token: playToken,
+			predicate: (payload) =>
+				payload.type === "balances.limit_reached" &&
+				payload.data?.customer_id === customerId &&
+				payload.data?.limit_type === "spend_limit",
+			timeoutMs: 15000,
+		});
+
+		expect(result).not.toBeNull();
+		const { data } = result!.payload;
+		expect(data.customer_id).toBe(customerId);
+		expect(data.feature_id).toBe(TestFeature.Messages);
+		expect(data.limit_type).toBe("spend_limit");
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 3: plan-level windowed usage_limit reached fires webhook (type usage_limit)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("limit-reached-plan3: plan-level usage_limit fires webhook (usage_limit)")}`,
+	async () => {
+		// Cap of 5/day on the plan, well under the 1000 included allowance — the
+		// windowed usage_limit is the gate. Its live window `usage` only survives if
+		// the webhook path evaluates the real fullSubject (not a FullCustomer).
+		const planProd = products.base({
+			id: "lr-plan-usage-limit-1",
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+			billingControls: {
+				usage_limits: [
+					{
+						feature_id: TestFeature.Messages,
+						enabled: true,
+						limit: 5,
+						interval: ResetInterval.Day,
+					},
+				],
+			},
+		});
+
+		const { customerId, autumnV2_1 } = await initScenario({
+			customerId: "lr-plan-usage-limit-cus-1",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [planProd] }),
+			],
+			actions: [s.attach({ productId: planProd.id })],
+		});
+
+		await autumnV2_1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 6,
+		});
+
+		const result = await waitForWebhook<BalancesLimitReachedPayload>({
+			token: playToken,
+			predicate: (payload) =>
+				payload.type === "balances.limit_reached" &&
+				payload.data?.customer_id === customerId &&
+				payload.data?.limit_type === "usage_limit",
+			timeoutMs: 15000,
+		});
+
+		expect(result).not.toBeNull();
+		const { data } = result!.payload;
+		expect(data.customer_id).toBe(customerId);
+		expect(data.feature_id).toBe(TestFeature.Messages);
+		expect(data.limit_type).toBe("usage_limit");
+	},
+);


### PR DESCRIPTION
…e spend/usage limits

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `balances.limit_reached` fires for plan-level usage limits and percentage-based spend caps by using the same limit evaluation as checks. Also prevent multi-deduction races and run per-feature checks so one failure doesn’t block others.

- **Bug Fixes**
  - Added shared `buildEvaluationSubject` to merge plan/customer controls and resolve percentage spend caps; used by checks and webhooks.
  - `fireTrackWebhooks` now accepts `FullSubject`, builds old/new evaluation subjects once, and runs per-feature limit checks; `checkLimitReached` compares allowed → blocked and emits the webhook.
  - All deduction paths pass `FullSubject` into webhooks; V2 paths snapshot `newFullSubject` to avoid multi-deduction races.
  - New integration tests for plan-level absolute/percentage spend limits and windowed usage limits.

<sup>Written for commit 9493fed1e7a358f387e0ea720b0e9c08f466187f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes `balances.limit_reached` use the same limit evaluation path as checks. The main changes are:

- Shared evaluation-subject building for check and webhook flows.
- Plan-level billing controls included in webhook limit checks.
- Percentage spend limits resolved before comparing old and new balances.
- Deduction paths updated to pass full subject data into webhook evaluation.
- Integration tests added for plan-level spend and usage limits.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/check/buildEvaluationSubject.ts | Adds shared evaluation-subject construction for plan-level controls and percentage spend-limit handling. |
| server/src/internal/balances/check/getCheckDataV2.ts | Switches check data preparation to the shared evaluation-subject helper. |
| server/src/internal/balances/trackWebhooks/checkLimitReached.ts | Compares old and new evaluation subjects to fire the limit-reached webhook on allowed-to-blocked transitions. |
| server/src/internal/balances/trackWebhooks/fireTrackWebhooks.ts | Builds evaluation subjects once and checks all affected features for limit transitions. |
| server/src/internal/balances/utils/deduction/executePostgresDeduction.ts | Passes converted full subjects from the V1 Postgres deduction path into webhook processing. |
| server/src/internal/balances/utils/deduction/executeRedisDeduction.ts | Passes converted full subjects from the V1 Redis deduction path into webhook processing. |
| server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts | Passes V2 full subject snapshots directly into webhook processing. |
| server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts | Passes V2 full subject snapshots directly into webhook processing. |
| server/tests/integration/balances/track/limit-reached/limit-reached-plan.test.ts | Adds webhook coverage for plan-level absolute spend, percentage spend, and windowed usage limits. |

<sub>Reviews (4): Last reviewed commit: ["chore(webhooks): trim comments on limit\_..."](https://github.com/useautumn/autumn/commit/9493fed1e7a358f387e0ea720b0e9c08f466187f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42101764)</sub>

<!-- /greptile_comment -->