### PR TITLE
release: sync back on flush, usage windows, coupon bug fixes

### DIFF
--- a/server/src/_luaScriptsV2/fullSubject/getDelSharedBalanceFields.lua
+++ b/server/src/_luaScriptsV2/fullSubject/getDelSharedBalanceFields.lua
@@ -1,0 +1,52 @@
+--[[
+  Lua Script: Destructive-read shared balance fields (GETDEL semantics)
+
+  Atomically reads customer-entitlement balance fields and deletes them, so an
+  invalidation cannot race a deduction between the read and the delete. The
+  returned values are flushed to Postgres by the caller before the subject
+  view is unlinked.
+
+  KEYS = shared balance hash keys (one per feature, same {customerId} slot)
+
+  ARGV[1] = JSON array aligned with KEYS: per-key array of cusEnt field names
+  ARGV[2] = JSON array of field names to delete from every key without
+            returning (derived fields, e.g. _aggregated / _usage_windows)
+
+  Returns JSON: array aligned with KEYS of per-key value arrays
+  (null where the field was missing)
+]]
+
+local cus_ent_fields_by_key = cjson.decode(ARGV[1])
+local delete_only_fields = cjson.decode(ARGV[2])
+
+local values_by_key = {}
+
+for key_index, balance_key in ipairs(KEYS) do
+  local cus_ent_fields = cus_ent_fields_by_key[key_index]
+  if type(cus_ent_fields) ~= "table" then
+    cus_ent_fields = {}
+  end
+
+  local values = {}
+  if #cus_ent_fields > 0 then
+    local raw_values = redis.call("HMGET", balance_key, unpack(cus_ent_fields))
+    for value_index = 1, #cus_ent_fields do
+      values[value_index] = raw_values[value_index] or cjson.null
+    end
+  end
+
+  local fields_to_delete = {}
+  for _, field_name in ipairs(cus_ent_fields) do
+    table.insert(fields_to_delete, field_name)
+  end
+  for _, field_name in ipairs(delete_only_fields) do
+    table.insert(fields_to_delete, field_name)
+  end
+  if #fields_to_delete > 0 then
+    redis.call("HDEL", balance_key, unpack(fields_to_delete))
+  end
+
+  values_by_key[key_index] = values
+end
+
+return cjson.encode(values_by_key)

--- a/server/src/_luaScriptsV2/luaScriptsV2.ts
+++ b/server/src/_luaScriptsV2/luaScriptsV2.ts
@@ -25,6 +25,7 @@ import LUA_UTILS from "./luaUtils.lua";
 // ============================================================================
 
 import adjustSubjectBalanceMainScript from "./fullSubject/adjustSubjectBalance.lua";
+import getDelSharedBalanceFieldsScript from "./fullSubject/getDelSharedBalanceFields.lua";
 import setCachedFullSubjectScript from "./fullSubject/setCachedFullSubject.lua";
 import updateCachedInvoiceV2Script from "./fullSubject/updateCachedInvoice.lua";
 import updateCustomerDataV2Script from "./fullSubject/updateCustomerDataV2.lua";
@@ -121,6 +122,9 @@ export const SET_CACHED_FULL_SUBJECT_SCRIPT = `${setCachedFullSubjectScript}`;
 
 /** Atomically update top-level customer fields in the cached FullSubject. */
 export const UPDATE_CUSTOMER_DATA_V2_SCRIPT = `${updateCustomerDataV2Script}`;
+
+/** Atomically read + delete shared balance hash fields (GETDEL semantics). */
+export const GETDEL_SHARED_BALANCE_FIELDS_SCRIPT = `${getDelSharedBalanceFieldsScript}`;
 
 /** Atomically update top-level entity fields in the cached FullSubject. */
 export const UPDATE_ENTITY_DATA_V2_SCRIPT = `${updateEntityDataV2Script}`;

--- a/server/src/external/redis/initUtils/redisTypes.ts
+++ b/server/src/external/redis/initUtils/redisTypes.ts
@@ -145,6 +145,10 @@ declare module "ioredis" {
 			cacheTtlSeconds: string,
 			nowMs: string,
 		): Promise<string>;
+		getDelFullSubjectBalanceFields(
+			numKeys: number,
+			...args: string[]
+		): Promise<string>;
 		updateFullSubjectCustomerProductV2(
 			subjectKey: string,
 			paramsJson: string,

--- a/server/src/external/redis/initUtils/registerRedisCommands.ts
+++ b/server/src/external/redis/initUtils/registerRedisCommands.ts
@@ -21,6 +21,7 @@ import {
 	DEDUCT_FROM_CUSTOMER_ENTITLEMENTS_SCRIPT,
 	DEDUCT_FROM_SUBJECT_BALANCES_SCRIPT,
 	DELETE_FULL_CUSTOMER_CACHE_SCRIPT,
+	GETDEL_SHARED_BALANCE_FIELDS_SCRIPT,
 	RESET_CUSTOMER_ENTITLEMENTS_SCRIPT,
 	ROLL_USAGE_WINDOWS_SCRIPT,
 	SET_CACHED_FULL_SUBJECT_SCRIPT,
@@ -203,6 +204,10 @@ export const registerRedisCommands = ({
 	redisInstance.defineCommand("updateFullSubjectEntityDataV2", {
 		numberOfKeys: 1,
 		lua: prepareScript(UPDATE_ENTITY_DATA_V2_SCRIPT),
+	});
+
+	redisInstance.defineCommand("getDelFullSubjectBalanceFields", {
+		lua: prepareScript(GETDEL_SHARED_BALANCE_FIELDS_SCRIPT),
 	});
 
 	redisInstance.defineCommand("updateFullSubjectCustomerProductV2", {

--- a/server/src/external/redis/otel/redisSlowlogConfig.ts
+++ b/server/src/external/redis/otel/redisSlowlogConfig.ts
@@ -93,6 +93,11 @@ export const REDIS_THRESHOLDS: RedisThresholdConfig[] = [
 		severeMs: 300,
 	}),
 	threshold({
+		operation: "getDelFullSubjectBalanceFields",
+		slowMs: 50,
+		severeMs: 300,
+	}),
+	threshold({
 		operation: "updateFullSubjectCustomerProductV2",
 		slowMs: 50,
 		severeMs: 300,

--- a/server/src/external/stripe/stripeCouponUtils/stripeCouponUtils.ts
+++ b/server/src/external/stripe/stripeCouponUtils/stripeCouponUtils.ts
@@ -143,6 +143,23 @@ const getStripeProductIdForCoupon = ({
 	return stripeProductId;
 };
 
+/** Throws product_not_in_stripe for any plan missing in Stripe. Run before deleting an existing coupon. */
+export const resolveCouponStripeProductIds = ({
+	reward,
+	prices,
+}: {
+	reward: Reward;
+	prices: (Price & { product: Product })[];
+}) => {
+	const appliesToSpecificProducts =
+		reward.type !== RewardType.FreeProduct &&
+		!reward.discount_config!.apply_to_all;
+
+	return appliesToSpecificProducts
+		? prices.map((price) => getStripeProductIdForCoupon({ price }))
+		: [];
+};
+
 const getPromoCouponId = (promo: Stripe.PromotionCode): string | null => {
 	const coupon =
 		promo.promotion?.coupon ??
@@ -173,9 +190,7 @@ export const createStripeCoupon = async ({
 
 	// Resolve Stripe product ids before any Stripe writes so a missing
 	// plan fails cleanly instead of after the existing coupon is deleted.
-	const stripeProdIds = appliesToSpecificProducts
-		? prices.map((price) => getStripeProductIdForCoupon({ price }))
-		: [];
+	const stripeProdIds = resolveCouponStripeProductIds({ reward, prices });
 
 	const stripeCli = createStripeCli({
 		org,

--- a/server/src/external/stripe/stripeCouponUtils/stripeCouponUtils.ts
+++ b/server/src/external/stripe/stripeCouponUtils/stripeCouponUtils.ts
@@ -122,6 +122,27 @@ const couponToStripeValue = ({
 	}
 };
 
+const getStripeProductIdForCoupon = ({
+	price,
+}: {
+	price: Price & { product: Product };
+}) => {
+	const stripeProductId =
+		price.config.type === PriceType.Fixed
+			? price.product.processor?.id
+			: (price.config as UsagePriceConfig).stripe_product_id;
+
+	if (!stripeProductId) {
+		throw new RecaseError({
+			message: `Plan ${price.product.id} doesn't exist in Stripe yet. Call attach to generate a checkout URL and it will be created in Stripe automatically.`,
+			code: ErrCode.ProductNotInStripe,
+			statusCode: 400,
+		});
+	}
+
+	return stripeProductId;
+};
+
 const getPromoCouponId = (promo: Stripe.PromotionCode): string | null => {
 	const coupon =
 		promo.promotion?.coupon ??
@@ -146,6 +167,15 @@ export const createStripeCoupon = async ({
 	legacyVersion?: boolean;
 }) => {
 	const discountConfig = reward.discount_config;
+
+	const appliesToSpecificProducts =
+		reward.type !== RewardType.FreeProduct && !discountConfig!.apply_to_all;
+
+	// Resolve Stripe product ids before any Stripe writes so a missing
+	// plan fails cleanly instead of after the existing coupon is deleted.
+	const stripeProdIds = appliesToSpecificProducts
+		? prices.map((price) => getStripeProductIdForCoupon({ price }))
+		: [];
 
 	const stripeCli = createStripeCli({
 		org,
@@ -177,28 +207,7 @@ export const createStripeCoupon = async ({
 		await stripeCli.coupons.del(reward.id);
 	} catch (_) {}
 
-	const stripeProdIds = prices.map((price) => {
-		if (price.config!.type === PriceType.Fixed) {
-			return price.product.processor?.id;
-		} else {
-			const config = price.config as UsagePriceConfig;
-			if (!config.stripe_product_id) {
-				logger.warn("No stripe product id for price", { price });
-				logger.warn("Config", { config });
-				throw new RecaseError({
-					message: `No stripe product id for price ${price.id}`,
-					code: ErrCode.InternalError,
-				});
-			}
-
-			return config.stripe_product_id;
-		}
-	});
-
 	// Collect Autumn product IDs for metadata when coupon applies to specific products
-	const appliesToSpecificProducts =
-		reward.type !== RewardType.FreeProduct && !discountConfig!.apply_to_all;
-
 	const autumnProductIds = appliesToSpecificProducts
 		? [...new Set(prices.map((price) => price.product.id))]
 		: [];

--- a/server/src/honoMiddlewares/refreshCacheConfigs.ts
+++ b/server/src/honoMiddlewares/refreshCacheConfigs.ts
@@ -3,14 +3,20 @@ import { matchRoute } from "./middlewareUtils.js";
 export type RefreshCacheRouteConfig = {
 	method: string;
 	url: string;
+	/** Flush cached balances to Postgres before invalidating. Only safe on
+	 *  balance-neutral routes — everywhere else Postgres was just written
+	 *  directly and the cached balances are stale. */
+	flushBalances?: boolean;
 };
 
 const route = ({
 	method,
 	url,
+	flushBalances,
 }: RefreshCacheRouteConfig): RefreshCacheRouteConfig => ({
 	method,
 	url,
+	flushBalances,
 });
 
 export const REFRESH_CACHE_ROUTE_CONFIGS: RefreshCacheRouteConfig[] = [
@@ -22,10 +28,12 @@ export const REFRESH_CACHE_ROUTE_CONFIGS: RefreshCacheRouteConfig[] = [
 	route({
 		method: "POST",
 		url: "/customers/:customer_id",
+		flushBalances: true,
 	}),
 	route({
 		method: "PATCH",
 		url: "/customers/:customer_id",
+		flushBalances: true,
 	}),
 
 	route({
@@ -92,6 +100,7 @@ export const REFRESH_CACHE_ROUTE_CONFIGS: RefreshCacheRouteConfig[] = [
 	route({
 		method: "POST",
 		url: "/billing.setup_payment",
+		flushBalances: true,
 	}),
 
 	route({
@@ -107,6 +116,7 @@ export const REFRESH_CACHE_ROUTE_CONFIGS: RefreshCacheRouteConfig[] = [
 	route({
 		method: "POST",
 		url: "/billing.open_customer_portal",
+		flushBalances: true,
 	}),
 
 	route({
@@ -142,6 +152,7 @@ export const REFRESH_CACHE_ROUTE_CONFIGS: RefreshCacheRouteConfig[] = [
 	route({
 		method: "POST",
 		url: "/customers.update",
+		flushBalances: true,
 	}),
 
 	route({

--- a/server/src/honoMiddlewares/refreshCacheConfigs.ts
+++ b/server/src/honoMiddlewares/refreshCacheConfigs.ts
@@ -148,6 +148,16 @@ export const REFRESH_CACHE_ROUTE_CONFIGS: RefreshCacheRouteConfig[] = [
 		method: "POST",
 		url: "/billing.import",
 	}),
+
+	route({
+		method: "POST",
+		url: "/billing.sync",
+	}),
+
+	route({
+		method: "POST",
+		url: "/billing.sync_v2",
+	}),
 ];
 
 export const getRefreshCacheRouteConfig = ({

--- a/server/src/honoMiddlewares/refreshCacheMiddleware.ts
+++ b/server/src/honoMiddlewares/refreshCacheMiddleware.ts
@@ -36,6 +36,7 @@ export const refreshCacheMiddleware = async (
 		entityId: ctx.entityId,
 		ctx,
 		source: "refreshCacheMiddleware",
+		flushBalances: routeConfig.flushBalances,
 	});
 
 	warmFullSubjectCache({

--- a/server/src/internal/api/rewards/handlers/rewards/handleUpdateCoupon.ts
+++ b/server/src/internal/api/rewards/handlers/rewards/handleUpdateCoupon.ts
@@ -10,7 +10,10 @@ import {
 } from "@autumn/shared";
 import { z } from "zod/v4";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
-import { createStripeCoupon } from "@/external/stripe/stripeCouponUtils/stripeCouponUtils.js";
+import {
+	createStripeCoupon,
+	resolveCouponStripeProductIds,
+} from "@/external/stripe/stripeCouponUtils/stripeCouponUtils.js";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 import { PriceService } from "@/internal/products/prices/PriceService.js";
@@ -92,16 +95,23 @@ export const handleUpdateCoupon = createRoute({
 			}
 		}
 
+		const willRecreateStripeCoupon =
+			rewardCat === RewardCategory.Discount ||
+			(rewardCat === RewardCategory.FreeProduct && prices.length > 0);
+
+		// Preflight before deleting the old Stripe coupon, so a plan missing
+		// in Stripe fails the update while the existing coupon is still intact.
+		if (willRecreateStripeCoupon) {
+			resolveCouponStripeProductIds({ reward: rewardBody, prices });
+		}
+
 		// Delete old prices from stripe
 		try {
 			await stripeCli.coupons.del(reward.id);
 			await stripeCli.coupons.del(reward.internal_id);
 		} catch (_) {}
 
-		if (
-			rewardCat === RewardCategory.Discount ||
-			(rewardCat === RewardCategory.FreeProduct && prices.length > 0)
-		) {
+		if (willRecreateStripeCoupon) {
 			await createStripeCoupon({
 				reward: rewardBody,
 				org,

--- a/server/src/internal/balances/utils/sql/syncBalancesV2.sql
+++ b/server/src/internal/balances/utils/sql/syncBalancesV2.sql
@@ -17,9 +17,8 @@
 --   usage_window_updates: array of objects with:
 --     - internal_customer_id: string
 --     - feature_id: string
---     - usage_windows: jsonb array of DbUsageWindow rows (the COMPLETE set for
---       that customer+feature; Redis is authoritative and prunes closed
---       windows, so rows are full-replaced per customer+feature)
+--     - usage_windows: jsonb array of DbUsageWindow rows to upsert; empty arrays
+--       mean no Redis rows to flush, not a delete/prune signal
 --
 -- Returns JSONB with:
 --   updates: object mapping customer_entitlement_id -> { balance, adjustment, entities }

--- a/server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts
+++ b/server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts
@@ -1,0 +1,128 @@
+import type {
+	EntityBalance,
+	EntityRolloverBalance,
+	SubjectBalance,
+} from "@autumn/shared";
+import { tryCatch } from "@autumn/shared";
+import { sql } from "drizzle-orm";
+import { planetScaleTag } from "@/db/dbUtils.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+export const SYNC_CONFLICT_CODES = {
+	ResetAtMismatch: "RESET_AT_MISMATCH",
+	EntityCountMismatch: "ENTITY_COUNT_MISMATCH",
+	CacheVersionMismatch: "CACHE_VERSION_MISMATCH",
+} as const;
+
+export const isSyncConflictError = (error: Error): boolean => {
+	const message = error.message || "";
+	return Object.values(SYNC_CONFLICT_CODES).some((code) =>
+		message.includes(code),
+	);
+};
+
+export interface SyncEntry {
+	customer_entitlement_id: string;
+	feature_id: string;
+	balance: number;
+	adjustment: number;
+	entities: Record<string, EntityBalance> | null;
+	next_reset_at: number | null;
+	entity_count: number;
+	cache_version: number | null;
+}
+
+export interface RolloverSyncEntry {
+	rollover_id: string;
+	balance: number;
+	usage: number;
+	entities: Record<string, EntityRolloverBalance> | null;
+}
+
+export const subjectBalanceToSyncEntry = ({
+	subjectBalance,
+}: {
+	subjectBalance: SubjectBalance;
+}): SyncEntry => ({
+	customer_entitlement_id: subjectBalance.id,
+	feature_id: subjectBalance.feature_id,
+	balance: subjectBalance.balance ?? 0,
+	adjustment: subjectBalance.adjustment ?? 0,
+	entities: subjectBalance.entities ?? null,
+	next_reset_at: subjectBalance.next_reset_at ?? null,
+	entity_count: subjectBalance.entities
+		? Object.keys(subjectBalance.entities).length
+		: 0,
+	cache_version: subjectBalance.cache_version ?? 0,
+});
+
+const subjectBalancesToRolloverEntries = ({
+	subjectBalances,
+}: {
+	subjectBalances: SubjectBalance[];
+}): RolloverSyncEntry[] =>
+	subjectBalances.flatMap((subjectBalance) =>
+		// cjson-written values can carry {} for empty arrays; never trust shape.
+		(Array.isArray(subjectBalance.rollovers)
+			? subjectBalance.rollovers
+			: []
+		).map((rollover) => ({
+			rollover_id: rollover.id,
+			balance: rollover.balance ?? 0,
+			usage: rollover.usage ?? 0,
+			entities: rollover.entities ?? null,
+		})),
+	);
+
+/**
+ * Best-effort flush of cached subject balances to Postgres. Never throws:
+ * conflicts mean Postgres is ahead (the rebuild wins), other failures are
+ * logged — the caller is invalidating and must proceed either way.
+ */
+export const flushSubjectBalancesToDb = async ({
+	ctx,
+	customerId,
+	subjectBalances,
+	source,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	subjectBalances: SubjectBalance[];
+	source: string;
+}): Promise<void> => {
+	if (subjectBalances.length === 0) return;
+
+	const { db, logger } = ctx;
+	const entries = subjectBalances.map((subjectBalance) =>
+		subjectBalanceToSyncEntry({ subjectBalance }),
+	);
+	const rolloverEntries = subjectBalancesToRolloverEntries({ subjectBalances });
+
+	const { error } = await tryCatch(
+		db.execute(
+			sql`SELECT * FROM sync_balances_v2(${JSON.stringify({
+				customer_entitlement_updates: entries,
+				rollover_updates: rolloverEntries,
+				usage_window_updates: [],
+			})}::jsonb) ${planetScaleTag({ query: "flushSubjectBalancesToDb" })}`,
+		),
+	);
+
+	if (!error) {
+		logger.info(
+			`[flushSubjectBalancesToDb] ${customerId}: flushed ${entries.length} balances, source: ${source}`,
+		);
+		return;
+	}
+
+	if (isSyncConflictError(error)) {
+		logger.warn(
+			`[flushSubjectBalancesToDb] ${customerId}: sync conflict during flush (Postgres ahead), source: ${source}, error: ${error.message}`,
+		);
+		return;
+	}
+
+	logger.error(
+		`[flushSubjectBalancesToDb] ${customerId}: flush failed, unsynced balances lost, source: ${source}, error: ${error}`,
+	);
+};

--- a/server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts
+++ b/server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts
@@ -7,6 +7,7 @@ import { tryCatch } from "@autumn/shared";
 import { sql } from "drizzle-orm";
 import { planetScaleTag } from "@/db/dbUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type { UsageWindowUpdate } from "../types/usageWindowUpdate.js";
 
 export const SYNC_CONFLICT_CODES = {
 	ResetAtMismatch: "RESET_AT_MISMATCH",
@@ -83,14 +84,16 @@ export const flushSubjectBalancesToDb = async ({
 	ctx,
 	customerId,
 	subjectBalances,
+	usageWindowUpdates = [],
 	source,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	subjectBalances: SubjectBalance[];
+	usageWindowUpdates?: UsageWindowUpdate[];
 	source: string;
 }): Promise<void> => {
-	if (subjectBalances.length === 0) return;
+	if (subjectBalances.length === 0 && usageWindowUpdates.length === 0) return;
 
 	const { db, logger } = ctx;
 	const entries = subjectBalances.map((subjectBalance) =>
@@ -103,14 +106,14 @@ export const flushSubjectBalancesToDb = async ({
 			sql`SELECT * FROM sync_balances_v2(${JSON.stringify({
 				customer_entitlement_updates: entries,
 				rollover_updates: rolloverEntries,
-				usage_window_updates: [],
+				usage_window_updates: usageWindowUpdates,
 			})}::jsonb) ${planetScaleTag({ query: "flushSubjectBalancesToDb" })}`,
 		),
 	);
 
 	if (!error) {
 		logger.info(
-			`[flushSubjectBalancesToDb] ${customerId}: flushed ${entries.length} balances, source: ${source}`,
+			`[flushSubjectBalancesToDb] ${customerId}: flushed ${entries.length} balances, ${usageWindowUpdates.length} usage windows, source: ${source}`,
 		);
 		return;
 	}

--- a/server/src/internal/balances/utils/sync/syncItemV4.ts
+++ b/server/src/internal/balances/utils/sync/syncItemV4.ts
@@ -1,10 +1,4 @@
-import {
-	type AppEnv,
-	type EntityBalance,
-	type EntityRolloverBalance,
-	type SubjectBalance,
-	tryCatch,
-} from "@autumn/shared";
+import { type AppEnv, type SubjectBalance, tryCatch } from "@autumn/shared";
 import { sql } from "drizzle-orm";
 import { planetScaleTag } from "@/db/dbUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
@@ -12,13 +6,18 @@ import { getCachedFeatureBalance } from "@/internal/customers/cache/fullSubject/
 import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
 import { globalRefreshEntityAggregateBatchingManager } from "../refreshEntityAggregate/RefreshEntityAggregateBatchingManager";
 import type { UsageWindowUpdate } from "../types/usageWindowUpdate.js";
+import {
+	type RolloverSyncEntry,
+	SYNC_CONFLICT_CODES,
+	type SyncEntry,
+	subjectBalanceToSyncEntry,
+} from "./flushSubjectBalancesToDb.js";
 import { logSyncItem } from "./logs/logSyncItem";
 
-const SYNC_CONFLICT_CODES = {
-	ResetAtMismatch: "RESET_AT_MISMATCH",
-	EntityCountMismatch: "ENTITY_COUNT_MISMATCH",
-	CacheVersionMismatch: "CACHE_VERSION_MISMATCH",
-} as const;
+export type {
+	RolloverSyncEntry,
+	SyncEntry,
+} from "./flushSubjectBalancesToDb.js";
 
 const handleSyncPostgresError = async ({
 	error,
@@ -75,41 +74,6 @@ interface SyncItemV4 {
 	 *  via full-replace per (customer, feature). */
 	usageWindowUpdates?: UsageWindowUpdate[];
 }
-
-export interface SyncEntry {
-	customer_entitlement_id: string;
-	feature_id: string;
-	balance: number;
-	adjustment: number;
-	entities: Record<string, EntityBalance> | null;
-	next_reset_at: number | null;
-	entity_count: number;
-	cache_version: number | null;
-}
-
-export interface RolloverSyncEntry {
-	rollover_id: string;
-	balance: number;
-	usage: number;
-	entities: Record<string, EntityRolloverBalance> | null;
-}
-
-const subjectBalanceToSyncEntry = ({
-	subjectBalance,
-}: {
-	subjectBalance: SubjectBalance;
-}): SyncEntry => ({
-	customer_entitlement_id: subjectBalance.id,
-	feature_id: subjectBalance.feature_id,
-	balance: subjectBalance.balance ?? 0,
-	adjustment: subjectBalance.adjustment ?? 0,
-	entities: subjectBalance.entities ?? null,
-	next_reset_at: subjectBalance.next_reset_at ?? null,
-	entity_count: subjectBalance.entities
-		? Object.keys(subjectBalance.entities).length
-		: 0,
-	cache_version: subjectBalance.cache_version ?? 0,
-});
 
 /** Sync cached subject balances to Postgres using targeted hash reads. */
 export const syncItemV4 = async ({

--- a/server/src/internal/balances/utils/types/usageWindowUpdate.ts
+++ b/server/src/internal/balances/utils/types/usageWindowUpdate.ts
@@ -1,16 +1,7 @@
 import type { UsageWindow } from "@autumn/shared";
 
-/**
- * Post-deduction usage-window counter state for one capped feature, handed
- * down from the Lua result through the deduction flow to syncItemV4 (sibling
- * of DeductionUpdate / RolloverUpdate).
- *
- * Deliberately a SNAPSHOT, not a MutationLog-style delta: the deduction
- * script is atomic and the Postgres sync full-replaces rows per (customer,
- * feature), so the complete `usage_windows` array IS the update. An empty
- * array is meaningful (all windows pruned/closed) and still full-replaces.
- * Matches the `usage_window_updates` jsonb param of sync_balances_v2 1:1.
- */
+/** Usage-window rows to upsert into Postgres.
+ * Empty arrays mean no Redis rows to flush; rolling/expiry lives elsewhere. */
 export interface UsageWindowUpdate {
 	internal_customer_id: string;
 	feature_id: string;

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateFullSubject.ts
@@ -13,12 +13,14 @@ const invalidateCachedFullSubjectOnRedis = async ({
 	ctx,
 	source,
 	redisV2,
+	flushBalances,
 }: {
 	customerId: string;
 	entityId?: string;
 	ctx: AutumnContext;
 	source?: string;
 	redisV2: Redis;
+	flushBalances?: boolean;
 }): Promise<void> => {
 	if (redisV2.status !== "ready") {
 		const subjectLabel = entityId ? `${customerId}:${entityId}` : customerId;
@@ -32,6 +34,7 @@ const invalidateCachedFullSubjectOnRedis = async ({
 		ctx,
 		customerId,
 		redisV2,
+		flushBalances,
 	});
 
 	const { org, env, logger } = ctx;
@@ -80,11 +83,16 @@ export const invalidateCachedFullSubject = async ({
 	entityId,
 	ctx,
 	source,
+	flushBalances,
 }: {
 	customerId: string;
 	entityId?: string;
 	ctx: AutumnContext;
 	source?: string;
+	/** Flush cached balances to Postgres before deleting them. Only safe when
+	 *  the caller has NOT just written balances to Postgres directly — the
+	 *  cached balances must still be the source of truth. */
+	flushBalances?: boolean;
 }): Promise<void> => {
 	if (!customerId) return;
 
@@ -99,6 +107,7 @@ export const invalidateCachedFullSubject = async ({
 				ctx,
 				source,
 				redisV2,
+				flushBalances,
 			}),
 		),
 	);

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts
@@ -1,5 +1,7 @@
+import type { SubjectBalance } from "@autumn/shared";
 import type { Redis } from "ioredis";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { flushSubjectBalancesToDb } from "@/internal/balances/utils/sync/flushSubjectBalancesToDb.js";
 import { tryRedisRead, tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
 import { buildFullSubjectKey } from "../../builders/buildFullSubjectKey.js";
 import { buildSharedFullSubjectBalanceKey } from "../../builders/buildSharedFullSubjectBalanceKey.js";
@@ -8,13 +10,20 @@ import {
 	USAGE_WINDOWS_FIELD,
 } from "../../config/fullSubjectCacheConfig.js";
 import type { CachedFullSubject } from "../../fullSubjectCacheModel.js";
+import { roundSubjectBalance } from "../../roundCacheBalance.js";
+import { sanitizeCachedSubjectBalance } from "../../sanitize/index.js";
+
+// Kill switch: set to false to revert to the legacy blind-HDEL path (drops
+// unsynced deductions racing the invalidation).
+const FLUSH_BALANCES_ON_INVALIDATION = true;
 
 /**
- * Deletes shared balance hash fields for a customer during structural
- * invalidation. Reads the subject view manifest to target specific cusEnt
- * fields + _aggregated per feature hash. No-op when the subject view is
- * already gone — paired with HSET-on-write semantics in setCachedFullSubject,
- * stale fields are overwritten on the next populate.
+ * Destructively reads (atomic read + HDEL) the shared balance hash fields for
+ * a customer during structural invalidation, then flushes the values to
+ * Postgres — an invalidation racing an un-synced deduction must not lose it.
+ * No-op when the subject view is already gone — paired with HSET-on-write
+ * semantics in setCachedFullSubject, stale fields are overwritten on the next
+ * populate.
  *
  * Must be called BEFORE the subject view key is deleted.
  */
@@ -35,20 +44,28 @@ export const invalidateSharedBalanceFields = async ({
 	const cachedRaw = await tryRedisRead(() => redisV2.get(subjectKey), redisV2);
 	if (!cachedRaw) return;
 
-	await deleteFieldsFromManifest({ ctx, customerId, cachedRaw, redisV2 });
+	if (!FLUSH_BALANCES_ON_INVALIDATION) {
+		await deleteFieldsFromManifest({ ctx, customerId, cachedRaw, redisV2 });
+		return;
+	}
+
+	await getDelFieldsFromManifest({ ctx, customerId, cachedRaw, redisV2 });
 };
 
-async function deleteFieldsFromManifest({
+type BalanceFieldTargets = {
+	balanceKeys: string[];
+	customerEntitlementIdsByKey: string[][];
+};
+
+const manifestToBalanceFieldTargets = ({
 	ctx,
 	customerId,
 	cachedRaw,
-	redisV2,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	cachedRaw: string;
-	redisV2: Redis;
-}) {
+}): BalanceFieldTargets | null => {
 	const { org, env, logger } = ctx;
 
 	let manifest: CachedFullSubject;
@@ -58,11 +75,11 @@ async function deleteFieldsFromManifest({
 		logger.warn(
 			`[invalidateSharedBalanceFields] Failed to parse subject view for ${customerId}, skipping field deletion`,
 		);
-		return;
+		return null;
 	}
 
 	const { customerEntitlementIdsByFeatureId } = manifest;
-	if (!customerEntitlementIdsByFeatureId) return;
+	if (!customerEntitlementIdsByFeatureId) return null;
 
 	// Capped features may have no entitlements, so their hashes only appear in
 	// usageWindowFeatureIds; union both so `_usage_windows` is cleared too.
@@ -77,25 +94,109 @@ async function deleteFieldsFromManifest({
 		...Object.keys(customerEntitlementIdsByFeatureId),
 		...usageWindowFeatureIds,
 	]);
+	if (featureIds.size === 0) return null;
+
+	const balanceKeys: string[] = [];
+	const customerEntitlementIdsByKey: string[][] = [];
+	for (const featureId of featureIds) {
+		const rawCusEntIds = customerEntitlementIdsByFeatureId[featureId];
+		balanceKeys.push(
+			buildSharedFullSubjectBalanceKey({
+				orgId: org.id,
+				env,
+				customerId,
+				featureId,
+			}),
+		);
+		customerEntitlementIdsByKey.push(
+			Array.isArray(rawCusEntIds) ? rawCusEntIds : [],
+		);
+	}
+
+	return { balanceKeys, customerEntitlementIdsByKey };
+};
+
+async function getDelFieldsFromManifest({
+	ctx,
+	customerId,
+	cachedRaw,
+	redisV2,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	cachedRaw: string;
+	redisV2: Redis;
+}) {
+	const { logger } = ctx;
+
+	const targets = manifestToBalanceFieldTargets({ ctx, customerId, cachedRaw });
+	if (!targets) return;
+	const { balanceKeys, customerEntitlementIdsByKey } = targets;
+
+	const resultRaw = await tryRedisWrite(
+		() =>
+			redisV2.getDelFullSubjectBalanceFields(
+				balanceKeys.length,
+				...balanceKeys,
+				JSON.stringify(customerEntitlementIdsByKey),
+				JSON.stringify([AGGREGATED_BALANCE_FIELD, USAGE_WINDOWS_FIELD]),
+			),
+		redisV2,
+	);
+
+	if (resultRaw === null) {
+		logger.warn(
+			`[invalidateSharedBalanceFields] ${customerId}: GETDEL failed, skipping flush`,
+		);
+		return;
+	}
+
+	const subjectBalances = parseSubjectBalances({
+		ctx,
+		customerId,
+		resultRaw,
+	});
+
+	logger.info(
+		`[invalidateSharedBalanceFields] ${customerId}: GETDEL ${balanceKeys.length} balance keys, flushing ${subjectBalances.length} balances`,
+	);
+
+	await flushSubjectBalancesToDb({
+		ctx,
+		customerId,
+		subjectBalances,
+		source: "invalidateSharedBalanceFields",
+	});
+}
+
+/** Legacy blind HDEL, kept as the DISABLE_INVALIDATION_BALANCE_FLUSH path. */
+async function deleteFieldsFromManifest({
+	ctx,
+	customerId,
+	cachedRaw,
+	redisV2,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	cachedRaw: string;
+	redisV2: Redis;
+}) {
+	const { logger } = ctx;
+
+	const targets = manifestToBalanceFieldTargets({ ctx, customerId, cachedRaw });
+	if (!targets) return;
+	const { balanceKeys, customerEntitlementIdsByKey } = targets;
 
 	const pipeline = redisV2.pipeline();
 	let fieldCount = 0;
 
-	for (const featureId of featureIds) {
-		const rawCusEntIds = customerEntitlementIdsByFeatureId[featureId];
-		const cusEntIds = Array.isArray(rawCusEntIds) ? rawCusEntIds : [];
-		const balanceKey = buildSharedFullSubjectBalanceKey({
-			orgId: org.id,
-			env,
-			customerId,
-			featureId,
-		});
+	for (let index = 0; index < balanceKeys.length; index++) {
 		const fieldsToDelete = [
-			...cusEntIds,
+			...customerEntitlementIdsByKey[index],
 			AGGREGATED_BALANCE_FIELD,
 			USAGE_WINDOWS_FIELD,
 		];
-		pipeline.hdel(balanceKey, ...fieldsToDelete);
+		pipeline.hdel(balanceKeys[index], ...fieldsToDelete);
 		fieldCount += fieldsToDelete.length;
 	}
 
@@ -105,4 +206,52 @@ async function deleteFieldsFromManifest({
 			`[invalidateSharedBalanceFields] ${customerId}: HDEL ${fieldCount} fields from manifest`,
 		);
 	}
+}
+
+function parseSubjectBalances({
+	ctx,
+	customerId,
+	resultRaw,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	resultRaw: string;
+}): SubjectBalance[] {
+	let valuesByKey: unknown[];
+	try {
+		valuesByKey = JSON.parse(resultRaw) as unknown[];
+	} catch (error) {
+		ctx.logger.warn(
+			`[invalidateSharedBalanceFields] ${customerId}: failed to parse GETDEL result, skipping flush, error: ${error}`,
+		);
+		return [];
+	}
+
+	// cjson encodes empty Lua tables as {}, so each per-key entry must be
+	// Array.isArray-guarded.
+	const allValues = (Array.isArray(valuesByKey) ? valuesByKey : []).flatMap(
+		(values) => (Array.isArray(values) ? values : []),
+	);
+
+	const subjectBalances: SubjectBalance[] = [];
+	for (const value of allValues) {
+		if (typeof value !== "string") continue;
+		try {
+			// Same parse path as getCachedFeatureBalances: cjson-written values
+			// need sanitizing (e.g. empty arrays re-encoded as {}).
+			const parsedBalance = JSON.parse(value) as SubjectBalance;
+			subjectBalances.push(
+				roundSubjectBalance({
+					subjectBalance: sanitizeCachedSubjectBalance({
+						subjectBalance: parsedBalance,
+					}),
+				}),
+			);
+		} catch {
+			ctx.logger.warn(
+				`[invalidateSharedBalanceFields] ${customerId}: unparseable balance field, dropping it from flush`,
+			);
+		}
+	}
+	return subjectBalances;
 }

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts
@@ -1,7 +1,8 @@
-import type { SubjectBalance } from "@autumn/shared";
+import type { SubjectBalance, UsageWindow } from "@autumn/shared";
 import type { Redis } from "ioredis";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { flushSubjectBalancesToDb } from "@/internal/balances/utils/sync/flushSubjectBalancesToDb.js";
+import type { UsageWindowUpdate } from "@/internal/balances/utils/types/usageWindowUpdate.js";
 import { tryRedisRead, tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
 import { buildFullSubjectKey } from "../../builders/buildFullSubjectKey.js";
 import { buildSharedFullSubjectBalanceKey } from "../../builders/buildSharedFullSubjectBalanceKey.js";
@@ -53,6 +54,8 @@ export const invalidateSharedBalanceFields = async ({
 };
 
 type BalanceFieldTargets = {
+	internalCustomerId: string;
+	featureIds: string[];
 	balanceKeys: string[];
 	customerEntitlementIdsByKey: string[][];
 };
@@ -82,24 +85,24 @@ const manifestToBalanceFieldTargets = ({
 	if (!customerEntitlementIdsByFeatureId) return null;
 
 	// Capped features may have no entitlements, so their hashes only appear in
-	// usageWindowFeatureIds; union both so `_usage_windows` is cleared too.
-	// Safe to delete counters: capped tracks write through to PG synchronously,
-	// and the rebuild re-seeds the field from PG.
+	// usageWindowFeatureIds; union both so `_usage_windows` is covered too.
 	// Raw blob, no sanitize walker: cjson re-encodes empty arrays as {}, so
 	// array fields must be Array.isArray-guarded before spreading.
 	const usageWindowFeatureIds = Array.isArray(manifest.usageWindowFeatureIds)
 		? manifest.usageWindowFeatureIds
 		: [];
-	const featureIds = new Set([
+	const featureIdSet = new Set([
 		...Object.keys(customerEntitlementIdsByFeatureId),
 		...usageWindowFeatureIds,
 	]);
-	if (featureIds.size === 0) return null;
+	if (featureIdSet.size === 0) return null;
 
+	const featureIds: string[] = [];
 	const balanceKeys: string[] = [];
 	const customerEntitlementIdsByKey: string[][] = [];
-	for (const featureId of featureIds) {
+	for (const featureId of featureIdSet) {
 		const rawCusEntIds = customerEntitlementIdsByFeatureId[featureId];
+		featureIds.push(featureId);
 		balanceKeys.push(
 			buildSharedFullSubjectBalanceKey({
 				orgId: org.id,
@@ -113,7 +116,12 @@ const manifestToBalanceFieldTargets = ({
 		);
 	}
 
-	return { balanceKeys, customerEntitlementIdsByKey };
+	return {
+		internalCustomerId: manifest.internalCustomerId,
+		featureIds,
+		balanceKeys,
+		customerEntitlementIdsByKey,
+	};
 };
 
 async function getDelFieldsFromManifest({
@@ -133,13 +141,20 @@ async function getDelFieldsFromManifest({
 	if (!targets) return;
 	const { balanceKeys, customerEntitlementIdsByKey } = targets;
 
+	// `_usage_windows` is read+deleted alongside the cusEnt fields (last field
+	// per key) so window counters are flushed too, not just deleted.
+	const fieldsByKey = customerEntitlementIdsByKey.map((cusEntIds) => [
+		...cusEntIds,
+		USAGE_WINDOWS_FIELD,
+	]);
+
 	const resultRaw = await tryRedisWrite(
 		() =>
 			redisV2.getDelFullSubjectBalanceFields(
 				balanceKeys.length,
 				...balanceKeys,
-				JSON.stringify(customerEntitlementIdsByKey),
-				JSON.stringify([AGGREGATED_BALANCE_FIELD, USAGE_WINDOWS_FIELD]),
+				JSON.stringify(fieldsByKey),
+				JSON.stringify([AGGREGATED_BALANCE_FIELD]),
 			),
 		redisV2,
 	);
@@ -151,25 +166,30 @@ async function getDelFieldsFromManifest({
 		return;
 	}
 
-	const subjectBalances = parseSubjectBalances({
+	const parsed = parseGetDelResult({
 		ctx,
 		customerId,
 		resultRaw,
+		targets,
+		fieldsByKey,
 	});
+	if (!parsed) return;
+	const { subjectBalances, usageWindowUpdates } = parsed;
 
 	logger.info(
-		`[invalidateSharedBalanceFields] ${customerId}: GETDEL ${balanceKeys.length} balance keys, flushing ${subjectBalances.length} balances`,
+		`[invalidateSharedBalanceFields] ${customerId}: GETDEL ${balanceKeys.length} balance keys, flushing ${subjectBalances.length} balances, ${usageWindowUpdates.length} usage windows`,
 	);
 
 	await flushSubjectBalancesToDb({
 		ctx,
 		customerId,
 		subjectBalances,
+		usageWindowUpdates,
 		source: "invalidateSharedBalanceFields",
 	});
 }
 
-/** Legacy blind HDEL, kept as the DISABLE_INVALIDATION_BALANCE_FLUSH path. */
+/** Legacy blind HDEL, kept as the FLUSH_BALANCES_ON_INVALIDATION=false path. */
 async function deleteFieldsFromManifest({
 	ctx,
 	customerId,
@@ -208,50 +228,79 @@ async function deleteFieldsFromManifest({
 	}
 }
 
-function parseSubjectBalances({
+function parseGetDelResult({
 	ctx,
 	customerId,
 	resultRaw,
+	targets,
+	fieldsByKey,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	resultRaw: string;
-}): SubjectBalance[] {
+	targets: BalanceFieldTargets;
+	fieldsByKey: string[][];
+}): {
+	subjectBalances: SubjectBalance[];
+	usageWindowUpdates: UsageWindowUpdate[];
+} | null {
+	const { logger } = ctx;
+
 	let valuesByKey: unknown[];
 	try {
 		valuesByKey = JSON.parse(resultRaw) as unknown[];
 	} catch (error) {
-		ctx.logger.warn(
+		logger.warn(
 			`[invalidateSharedBalanceFields] ${customerId}: failed to parse GETDEL result, skipping flush, error: ${error}`,
 		);
-		return [];
+		return null;
 	}
-
-	// cjson encodes empty Lua tables as {}, so each per-key entry must be
-	// Array.isArray-guarded.
-	const allValues = (Array.isArray(valuesByKey) ? valuesByKey : []).flatMap(
-		(values) => (Array.isArray(values) ? values : []),
-	);
+	if (!Array.isArray(valuesByKey)) return null;
 
 	const subjectBalances: SubjectBalance[] = [];
-	for (const value of allValues) {
-		if (typeof value !== "string") continue;
-		try {
-			// Same parse path as getCachedFeatureBalances: cjson-written values
-			// need sanitizing (e.g. empty arrays re-encoded as {}).
-			const parsedBalance = JSON.parse(value) as SubjectBalance;
-			subjectBalances.push(
-				roundSubjectBalance({
-					subjectBalance: sanitizeCachedSubjectBalance({
-						subjectBalance: parsedBalance,
-					}),
-				}),
-			);
-		} catch {
-			ctx.logger.warn(
-				`[invalidateSharedBalanceFields] ${customerId}: unparseable balance field, dropping it from flush`,
-			);
+	const usageWindowUpdates: UsageWindowUpdate[] = [];
+
+	for (let keyIndex = 0; keyIndex < fieldsByKey.length; keyIndex++) {
+		const rawValues = valuesByKey[keyIndex];
+		// cjson encodes empty Lua tables as {}, so each per-key entry must be
+		// Array.isArray-guarded.
+		const values = Array.isArray(rawValues) ? (rawValues as unknown[]) : [];
+		const fields = fieldsByKey[keyIndex];
+
+		for (let fieldIndex = 0; fieldIndex < fields.length; fieldIndex++) {
+			const value = values[fieldIndex];
+			if (typeof value !== "string") continue;
+
+			const isUsageWindowsField = fieldIndex === fields.length - 1;
+			try {
+				if (isUsageWindowsField) {
+					// Same fail-open semantics as getCachedFeatureBalances: a non-array
+					// blob reads as an empty counter set (still full-replaces).
+					const parsedWindows = JSON.parse(value) as UsageWindow[];
+					usageWindowUpdates.push({
+						internal_customer_id: targets.internalCustomerId,
+						feature_id: targets.featureIds[keyIndex],
+						usage_windows: Array.isArray(parsedWindows) ? parsedWindows : [],
+					});
+				} else {
+					// Same parse path as getCachedFeatureBalances: cjson-written values
+					// need sanitizing (e.g. empty arrays re-encoded as {}).
+					const parsedBalance = JSON.parse(value) as SubjectBalance;
+					subjectBalances.push(
+						roundSubjectBalance({
+							subjectBalance: sanitizeCachedSubjectBalance({
+								subjectBalance: parsedBalance,
+							}),
+						}),
+					);
+				}
+			} catch {
+				logger.warn(
+					`[invalidateSharedBalanceFields] ${customerId}: unparseable balance field ${fields[fieldIndex]}, dropping it from flush`,
+				);
+			}
 		}
 	}
-	return subjectBalances;
+
+	return { subjectBalances, usageWindowUpdates };
 }

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts
@@ -279,8 +279,8 @@ function parseGetDelResult({
 			const isUsageWindowsField = fieldIndex === fields.length - 1;
 			try {
 				if (isUsageWindowsField) {
-					// Same fail-open semantics as getCachedFeatureBalances: a non-array
-					// blob reads as an empty counter set (still full-replaces).
+					// Empty/non-array snapshots mean no Redis rows to upsert; usage-window
+					// expiry and rolling are handled outside sync-back.
 					const parsedWindows = JSON.parse(value) as UsageWindow[];
 					usageWindowUpdates.push({
 						internal_customer_id: targets.internalCustomerId,

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts
@@ -14,8 +14,8 @@ import type { CachedFullSubject } from "../../fullSubjectCacheModel.js";
 import { roundSubjectBalance } from "../../roundCacheBalance.js";
 import { sanitizeCachedSubjectBalance } from "../../sanitize/index.js";
 
-// Kill switch: set to false to revert to the legacy blind-HDEL path (drops
-// unsynced deductions racing the invalidation).
+// Kill switch: set to false to force the legacy blind-HDEL path everywhere,
+// ignoring callers' flushBalances opt-in.
 const FLUSH_BALANCES_ON_INVALIDATION = true;
 
 /**
@@ -32,10 +32,15 @@ export const invalidateSharedBalanceFields = async ({
 	ctx,
 	customerId,
 	redisV2 = ctx.redisV2,
+	flushBalances = false,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	redisV2?: Redis;
+	/** Flush cached balances to Postgres before deleting them. Opt-in: only
+	 *  safe when the caller has NOT just written balances to Postgres directly
+	 *  (the cached balances must still be the source of truth). */
+	flushBalances?: boolean;
 }): Promise<void> => {
 	const { org, env } = ctx;
 	if (!customerId || redisV2.status !== "ready") return;
@@ -45,7 +50,7 @@ export const invalidateSharedBalanceFields = async ({
 	const cachedRaw = await tryRedisRead(() => redisV2.get(subjectKey), redisV2);
 	if (!cachedRaw) return;
 
-	if (!FLUSH_BALANCES_ON_INVALIDATION) {
+	if (!FLUSH_BALANCES_ON_INVALIDATION || !flushBalances) {
 		await deleteFieldsFromManifest({ ctx, customerId, cachedRaw, redisV2 });
 		return;
 	}

--- a/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.ts
+++ b/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.ts
@@ -23,12 +23,14 @@ export const deleteCachedFullCustomer = async ({
 	entityId,
 	source,
 	skipGuard = false,
+	flushBalances = false,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	entityId?: string;
 	source?: string;
 	skipGuard?: boolean;
+	flushBalances?: boolean;
 }): Promise<void> => {
 	const { org, env, logger } = ctx;
 
@@ -49,6 +51,7 @@ export const deleteCachedFullCustomer = async ({
 			customerId,
 			entityId,
 			source,
+			flushBalances,
 		}),
 	];
 

--- a/server/tests/balances/track/race-condition/invalidation-flush-unsynced-balances.test.ts
+++ b/server/tests/balances/track/race-condition/invalidation-flush-unsynced-balances.test.ts
@@ -1,0 +1,136 @@
+/**
+ * TDD test: full-subject invalidation must not lose un-synced Redis deductions.
+ *
+ * Contract under test:
+ *   New behaviors:
+ *     - (unsynced Redis deduction) + (invalidateCachedFullSubject) -> deduction
+ *       is flushed to Postgres via sync_balances_v2 before the cache is wiped.
+ *   Side effects:
+ *     - Balance hash cusEnt fields are still deleted (invalidation semantics kept).
+ *     - Post-invalidation reads (skip_cache and rebuilt cache) both reflect the
+ *       deduction instead of reverting to the pre-track balance.
+ *
+ * Pre-impl red: invalidateSharedBalanceFields blindly HDELs the balance hash
+ * fields, so the unsynced deduction never reaches Postgres and both reads
+ * show 100. Post-impl green: the fields are destructively read (atomic Lua)
+ * and flushed, so both reads show 95.
+ */
+
+import { beforeAll, describe, expect, test } from "bun:test";
+import { type ApiCustomer, ApiVersion } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { waitForRedisReady } from "@/external/redis/initRedis.js";
+import { executeRedisDeductionV2 } from "@/internal/balances/utils/deductionV2/executeRedisDeductionV2.js";
+import { buildSharedFullSubjectBalanceKey } from "@/internal/customers/cache/fullSubject/builders/buildSharedFullSubjectBalanceKey.js";
+import {
+	getOrSetCachedFullSubject,
+	invalidateCachedFullSubject,
+} from "@/internal/customers/cache/fullSubject/index.js";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
+import { constructProduct } from "@/utils/scriptUtils/createTestProducts.js";
+import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
+import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
+
+const pro = constructProduct({
+	type: "pro",
+	items: [
+		constructFeatureItem({
+			featureId: TestFeature.Messages,
+			includedUsage: 100,
+		}),
+	],
+});
+
+const testCase = "invalidation-flush-unsynced-balances";
+
+const getMessagesRemaining = (customer: ApiCustomer) => {
+	const balance = customer.balances[TestFeature.Messages] as {
+		current_balance?: number;
+		remaining?: number;
+	};
+	return balance.remaining ?? balance.current_balance;
+};
+
+describe(`${chalk.yellowBright("invalidation-flush: invalidation must not lose unsynced deductions")}`, () => {
+	const customerId = testCase;
+	const autumnV2 = new AutumnInt({ version: ApiVersion.V2_1 });
+
+	beforeAll(async () => {
+		await waitForRedisReady(ctx.redisV2, "customer-redis", 5000);
+
+		await initCustomerV3({
+			ctx,
+			customerId,
+			withTestClock: true,
+			attachPm: "success",
+		});
+
+		await initProductsV0({
+			ctx,
+			products: [pro],
+			prefix: testCase,
+		});
+
+		await autumnV2.attach({
+			customer_id: customerId,
+			product_id: pro.id,
+		});
+	});
+
+	test("flushes unsynced Redis balances to Postgres during invalidation", async () => {
+		const fullSubject = await getOrSetCachedFullSubject({
+			ctx,
+			customerId,
+			source: "test-setup",
+		});
+
+		const messagesFeature = ctx.features.find(
+			(feature) => feature.id === TestFeature.Messages,
+		)!;
+
+		// Deduct 5 in Redis WITHOUT queuing sync — stands in for a /track whose
+		// async syncItemV4 has not landed yet.
+		await executeRedisDeductionV2({
+			ctx,
+			deductions: [{ feature: messagesFeature, deduction: 5 }],
+			fullSubject,
+			deductionOptions: { overageBehaviour: "cap" },
+		});
+
+		const cachedBeforeInvalidation =
+			await autumnV2.customers.get<ApiCustomer>(customerId);
+		expect(getMessagesRemaining(cachedBeforeInvalidation)).toBe(95);
+
+		await invalidateCachedFullSubject({
+			ctx,
+			customerId,
+			source: "test-invalidation",
+		});
+
+		// ── Contract: invalidation semantics preserved ───────────────────────
+		// The balance hash fields must still be deleted.
+		const balanceKey = buildSharedFullSubjectBalanceKey({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+		expect(await ctx.redisV2.hlen(balanceKey)).toBe(0);
+
+		// ── Contract: deduction flushed to Postgres ──────────────────────────
+		// Pre-fix: HDEL wiped the unsynced deduction, DB shows 100.
+		// Post-fix: destructive read + sync_balances_v2 flush, DB shows 95.
+		const dbCustomer = await autumnV2.customers.get<ApiCustomer>(customerId, {
+			skip_cache: "true",
+		});
+		expect(getMessagesRemaining(dbCustomer)).toBe(95);
+
+		// ── Contract: rebuilt cache reflects the flushed balance ─────────────
+		const rebuiltCustomer =
+			await autumnV2.customers.get<ApiCustomer>(customerId);
+		expect(getMessagesRemaining(rebuiltCustomer)).toBe(95);
+	});
+});

--- a/server/tests/balances/track/race-condition/invalidation-flush-unsynced-balances.test.ts
+++ b/server/tests/balances/track/race-condition/invalidation-flush-unsynced-balances.test.ts
@@ -104,10 +104,13 @@ describe(`${chalk.yellowBright("invalidation-flush: invalidation must not lose u
 			await autumnV2.customers.get<ApiCustomer>(customerId);
 		expect(getMessagesRemaining(cachedBeforeInvalidation)).toBe(95);
 
+		// flushBalances opt-in mirrors the customers.update route config — the
+		// only invalidation source where cached balances are the source of truth.
 		await invalidateCachedFullSubject({
 			ctx,
 			customerId,
 			source: "test-invalidation",
+			flushBalances: true,
 		});
 
 		// ── Contract: invalidation semantics preserved ───────────────────────

--- a/server/tests/unit/redis/register-redis-commands.spec.ts
+++ b/server/tests/unit/redis/register-redis-commands.spec.ts
@@ -17,6 +17,7 @@ const upstashLockedCommands = new Set([
 	"upsertInvoiceInFullSubjectV2",
 	"adjustSubjectBalance",
 	"rollUsageWindows",
+	"getDelFullSubjectBalanceFields",
 ]);
 
 const registerCommands = (supportsUpstashShebang: boolean) => {

--- a/server/tests/utils/setup/ensureOrgSvixApps.ts
+++ b/server/tests/utils/setup/ensureOrgSvixApps.ts
@@ -1,0 +1,67 @@
+import { AppEnv, type Organization } from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle";
+import { createSvixApp } from "@/external/svix/svixHelpers.js";
+import { createSvixCli } from "@/external/svix/svixUtils.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+
+const svixAppExists = async (appId: string | undefined): Promise<boolean> => {
+	if (!appId) return false;
+	try {
+		await createSvixCli().application.get(appId);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+/**
+ * Recreates the org's Svix apps when svix_config points at apps that no
+ * longer exist in Svix (they are only ever created at org signup, so a
+ * deleted app otherwise 404s webhook tests forever).
+ */
+export const ensureOrgSvixApps = async ({
+	db,
+	org,
+}: {
+	db: DrizzleCli;
+	org: Organization;
+}): Promise<void> => {
+	if (!process.env.SVIX_API_KEY) return;
+
+	const svixConfig = org.svix_config ?? {
+		sandbox_app_id: "",
+		live_app_id: "",
+	};
+	const [sandboxExists, liveExists] = await Promise.all([
+		svixAppExists(svixConfig.sandbox_app_id),
+		svixAppExists(svixConfig.live_app_id),
+	]);
+	if (sandboxExists && liveExists) return;
+
+	const createApp = (env: AppEnv) =>
+		createSvixApp({
+			name: `${org.slug}_${env}`,
+			orgId: org.id,
+			env,
+		});
+
+	const [sandboxApp, liveApp] = await Promise.all([
+		sandboxExists ? null : createApp(AppEnv.Sandbox),
+		liveExists ? null : createApp(AppEnv.Live),
+	]);
+
+	const updatedSvixConfig = {
+		sandbox_app_id: sandboxApp?.id ?? svixConfig.sandbox_app_id ?? "",
+		live_app_id: liveApp?.id ?? svixConfig.live_app_id ?? "",
+	};
+
+	await OrgService.update({
+		db,
+		orgId: org.id,
+		updates: { svix_config: updatedSvixConfig },
+	});
+
+	console.log(
+		`✅ Repaired svix apps: sandbox=${updatedSvixConfig.sandbox_app_id}, live=${updatedSvixConfig.live_app_id}`,
+	);
+};

--- a/server/tests/utils/setup/setupOrg.ts
+++ b/server/tests/utils/setup/setupOrg.ts
@@ -1,5 +1,6 @@
 import type { AppEnv } from "@autumn/shared";
 import { getFeatures } from "@tests/setup/v2Features.js";
+import { ensureOrgSvixApps } from "@tests/utils/setup/ensureOrgSvixApps.js";
 import axios from "axios";
 import { initDrizzle } from "@/db/initDrizzle";
 import { FeatureService } from "@/internal/features/FeatureService.js";
@@ -61,4 +62,5 @@ export const setupOrg = async ({
 		},
 	});
 
+	await ensureOrgSvixApps({ db, org });
 };

--- a/shared/enums/ErrCode.ts
+++ b/shared/enums/ErrCode.ts
@@ -127,6 +127,7 @@ export const ErrCode = {
 
 	// Rewards
 	InvalidReward: "invalid_reward",
+	ProductNotInStripe: "product_not_in_stripe",
 	DuplicateRewardId: "duplicate_reward_id",
 	DuplicatePromoCode: "duplicate_promo_code",
 	PromoCodeAlreadyExistsInStripe: "promo_code_already_exists_in_stripe",

--- a/vite/src/components/v2/PlanItemLabel.tsx
+++ b/vite/src/components/v2/PlanItemLabel.tsx
@@ -40,6 +40,16 @@ const PRICE_CHIP_CLASS =
 const isTieredPrice = (item: ProductItem): boolean =>
 	(item.tiers?.length ?? 0) > 1;
 
+/** A rollover config can sit on any item of a feature; only items with a
+ * resetting included/prepaid balance actually roll anything over. */
+const itemCanRollOver = (item: ProductItem): boolean => {
+	if (!item.feature_id) return false;
+	if (intervalIsNone(item.interval)) return false;
+	const includedUsage =
+		typeof item.included_usage === "number" ? item.included_usage : 0;
+	return includedUsage > 0 || item.usage_model === UsageModel.Prepaid;
+};
+
 /** Volume-based tiers priced as a flat amount per band — the real price lives in
  * `flat_amount`, matching getFeaturePriceItemDisplay's formatting. */
 const isVolumeFlatAmountItem = (item: ProductItem): boolean =>
@@ -167,7 +177,13 @@ function TierBreakdownChip({
 	return (
 		<Tooltip>
 			<TooltipTrigger asChild>
-				<span className={cn(PRICE_CHIP_CLASS, "cursor-help")}>{priceStr}</span>
+				{/* pointer-events-auto: read-only rows disable pointer events, which
+				 * would otherwise swallow the hover that opens this tooltip. */}
+				<span
+					className={cn(PRICE_CHIP_CLASS, "cursor-help pointer-events-auto")}
+				>
+					{priceStr}
+				</span>
 			</TooltipTrigger>
 			<TooltipContent className="max-w-xs" side="top">
 				<div className="flex flex-col gap-2">
@@ -261,7 +277,7 @@ export function PlanItemLabel({
 	const feature = features.find((f) => f.id === item.feature_id);
 	const hasFeatureName = feature?.name && feature.name.trim() !== "";
 	const displayText = hasFeatureName ? display.primary_text : unnamedText;
-	const rollover = item.config?.rollover;
+	const rollover = itemCanRollOver(item) ? item.config?.rollover : undefined;
 
 	const icons = <FeatureIconCluster item={item} />;
 

--- a/vite/src/components/v2/RolloverIndicator.tsx
+++ b/vite/src/components/v2/RolloverIndicator.tsx
@@ -29,8 +29,10 @@ export function RolloverIndicator({ rollover }: { rollover: RolloverConfig }) {
 	return (
 		<Tooltip>
 			<TooltipTrigger asChild>
+				{/* pointer-events-auto: read-only rows disable pointer events, which
+				 * would otherwise swallow the hover that opens this tooltip. */}
 				<CircleHalfTiltIcon
-					className="size-3.5 shrink-0 text-tertiary-foreground"
+					className="size-3.5 shrink-0 text-tertiary-foreground pointer-events-auto"
 					aria-label="Rolls over"
 				/>
 			</TooltipTrigger>

--- a/vite/src/views/developer/configure-stripe/mappings/CatalogMappingsTable.tsx
+++ b/vite/src/views/developer/configure-stripe/mappings/CatalogMappingsTable.tsx
@@ -1,5 +1,5 @@
 import type { CatalogGetMappingsResponse, ProductV2 } from "@autumn/shared";
-import { Skeleton } from "@autumn/ui";
+import { CopyButton, Skeleton } from "@autumn/ui";
 import { CaretRightIcon } from "@phosphor-icons/react";
 import { useStripeProductsResolveQuery } from "@/hooks/queries/useStripeProductsResolveQuery";
 import {
@@ -58,16 +58,30 @@ export const CatalogMappingsTable = ({
 					});
 
 					return (
-						<button
-							className="group -mx-2 flex w-[calc(100%+1rem)] items-center gap-3 rounded-md px-2 py-2.5 text-left hover:bg-accent"
+						// biome-ignore lint/a11y/useSemanticElements: row can't be a <button> — the copy chip inside is a button and buttons can't nest
+						<div
+							className="group -mx-2 flex w-[calc(100%+1rem)] cursor-pointer items-center gap-3 rounded-md px-2 py-2.5 text-left hover:bg-accent"
 							key={group.base.id}
 							onClick={() => onSelectPlan(group.base.id)}
-							type="button"
+							onKeyDown={(event) => {
+								if (event.key === "Enter" || event.key === " ") {
+									event.preventDefault();
+									onSelectPlan(group.base.id);
+								}
+							}}
+							role="button"
+							tabIndex={0}
 						>
 							<span className="flex min-w-0 flex-1 items-center gap-2">
 								<span className="truncate font-medium text-sm">
 									{group.base.name}
 								</span>
+								<CopyButton
+									className="shrink-0 text-tertiary-foreground"
+									innerClassName="max-w-30 text-tiny-id truncate"
+									size="mini"
+									text={group.base.id}
+								/>
 								{group.variants.length > 0 && (
 									<span className="shrink-0 text-tertiary-foreground text-xs">
 										{group.variants.length} variant
@@ -97,7 +111,7 @@ export const CatalogMappingsTable = ({
 								className="size-4 shrink-0 text-tertiary-foreground group-hover:text-foreground"
 								size={14}
 							/>
-						</button>
+						</div>
 					);
 				})}
 			</div>

--- a/vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx
+++ b/vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx
@@ -177,9 +177,9 @@ export const PlanFeatureRow = ({
 
 				<div
 					className={cn(
-						"flex items-center max-w-0 opacity-0 overflow-hidden group-hover:max-w-[200px] shrink-0",
+						"flex items-center max-w-0 opacity-0 overflow-hidden shrink-0",
 						isSelected && "max-w-[200px] opacity-100",
-						!readOnly && " group-hover:opacity-100",
+						!readOnly && "group-hover:max-w-[200px] group-hover:opacity-100",
 					)}
 				>
 					<IconButton


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents data loss during cache invalidation by atomically GETDEL-ing shared Redis balance fields (including `_usage_windows`) and syncing them to Postgres before the cache is cleared. Also hardens Stripe coupon updates and cleans up subscription sheet UX.

- **New Features**
  - Added `getDelFullSubjectBalanceFields` (Lua/Redis) and a parse+flush path via `flushSubjectBalancesToDb` to `sync_balances_v2` (covers rollovers and usage windows).
  - Route-level `flushBalances` opt-in in `refreshCacheMiddleware` (enabled for safe routes like customer create/update and billing setup/portal); legacy blind HDEL remains elsewhere.
  - Added a race-condition test to ensure unsynced deductions are preserved on invalidation.

- **Bug Fixes**
  - Stripe coupons: preflight and resolve Stripe product IDs before any writes; fail early with `product_not_in_stripe`; `handleUpdateCoupon` now validates before deleting existing coupons.
  - UI: re-enable tooltips in read-only rows; show rollover icon only when the item can roll over; add plan ID copy chip in Stripe mappings with keyboard support; prevent hidden actions expanding on read-only rows.

<sup>Written for commit 310753ed1b084a97a89a1d906fb0098eab52d957. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds safer balance invalidation and coupon update handling. The main changes are:

- **[Bug fixes]** Flushes selected cached balances during invalidation before removing shared Redis fields.
- **[Bug fixes]** Adds a Redis script and command registration for atomic balance-field read and delete.
- **[Bug fixes]** Preflights Stripe coupon product IDs before recreating coupons.
- **[Improvements]** Adds route-level `flushBalances` controls for cache refresh paths.
- **[Improvements]** Updates plan-row, rollover, and catalog-mapping UI behavior.
</details>

<h3>Confidence Score: 4/5</h3>

The changed balance invalidation path needs fixes before merging.

- The new Redis read/delete call removes cached balances before the database flush is durable.
- Empty usage-window flushes can leave stale database rows behind.
- The Stripe coupon and UI changes look contained from the reviewed diff.

server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts | Adds the new destructive Redis read/delete path and parsing before Postgres flush; this is where the remaining data-loss risks sit. |
| server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts | Adds a best-effort wrapper around `sync_balances_v2` for invalidation-time balance and usage-window flushes. |
| server/src/external/stripe/stripeCouponUtils/stripeCouponUtils.ts | Centralizes Stripe product ID resolution before coupon writes. |
| server/src/internal/api/rewards/handlers/rewards/handleUpdateCoupon.ts | Runs coupon product validation before deleting old Stripe coupons. |
| vite/src/views/developer/configure-stripe/mappings/CatalogMappingsTable.tsx | Allows a copy button inside selectable mapping rows by switching the row to an ARIA button div. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts:158-164
**Deleted Balances Lose Crash Recovery**

When this Redis script returns, the balance fields have already been removed from Redis, but `flushSubjectBalancesToDb` has not committed them to Postgres yet. If the process exits, is killed, or loses the DB connection after this call and before the flush finishes, the invalidation permanently drops the only copy of the unsynced deduction or usage-window counters.

### Issue 2 of 2
server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts:284-288
**Empty Windows Leave Stale Rows**

When `_usage_windows` parses to an empty array, this enqueues a usage-window update with `usage_windows: []`, but the sync path only upserts rows produced from the array. A balance invalidation that clears the Redis window field can therefore leave older Postgres usage-window rows in place, so rebuilt cache reads can resurrect stale counters.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into dev"](https://github.com/useautumn/autumn/commit/0229bbfbca015df0199b7d99cbd4b2aface51258) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42112226)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->