### PR TITLE
Fix filter button visibility for customers with only expired products

### DIFF
--- a/vite/src/views/customers2/components/table/customer-products/CustomerProductsTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-products/CustomerProductsTable.tsx
@@ -92,7 +92,8 @@ export function CustomerProductsTable() {
 	const showFooter = totalCount >= CUSTOMER_PRODUCTS_PAGE_SIZES[0];
 
 	const hasActiveFilters = kind !== "all" || showExpired;
-	const showFilter = totalCount > 0 || hasActiveFilters;
+	const hasAnyProducts = customer.customer_products.length > 0;
+	const showFilter = hasAnyProducts || hasActiveFilters;
 
 	const [transferOpen, setTransferOpen] = useState(false);
 	const [selectedProduct, setSelectedProduct] = useState<FullCusProduct | null>(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The "Filter" button on the CustomerView page was hidden when a customer only had expired products. This gave users the impression that the customer had never purchased anything before.

**Root Cause:**
The filter button visibility was determined by checking if `totalCount > 0`, where `totalCount` comes from the paginated query that respects the `showExpired` filter. Since `showExpired` defaults to `false`, customers with only expired products would have `totalCount = 0`, causing the filter button to be hidden.

## Solution

Updated the filter button visibility logic to check if the customer has ANY products (expired or active) by checking `customer.customer_products.length > 0` instead of relying solely on the filtered `totalCount`.

**Changes:**
- Added `hasAnyProducts` variable that checks `customer.customer_products.length > 0`
- Updated `showFilter` logic to use `hasAnyProducts || hasActiveFilters`

This ensures the filter button is always visible when a customer has products, allowing users to toggle the "Show expired" filter to view expired products.

## Testing

The fix uses data that's already available in the frontend state (`customer.customer_products`), so no new API calls are made. The filter button will now be visible for customers with only expired products, allowing users to toggle the expired filter to view them.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1783416706675349?thread_ts=1783416706.675349&cid=C0BCAQQK0KS)

<div><a href="https://cursor.com/agents/bc-6e996091-4e9a-5954-8e2a-0f36926f5291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e996091-4e9a-5954-8e2a-0f36926f5291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always show the Filter button on the customer products table when the customer has any products, including expired ones. Visibility now uses customer.customer_products.length (any > 0) or active filters, instead of the filtered totalCount that hid the button for customers with only expired products.

<sup>Written for commit b3fd503b75fb2a5ff0747596a34fe76c036068b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes when the customer products filter button is shown. The main changes are:

- Adds a `hasAnyProducts` check from `customer.customer_products.length`.
- Shows the filter button when the customer has products or active filters.
- Keeps the existing active-filter visibility behavior.
</details>

<h3>Confidence Score: 4/5</h3>

The changed filter visibility path can still hide the control for expired-only customers when the customer detail projection omits expired products.

- The new condition depends on `customer.customer_products` being a complete product-existence signal.
- The table data and the customer detail product list can come from different projections.
- An expired-only customer can still be unable to toggle “Show expired”.

vite/src/views/customers2/components/table/customer-products/CustomerProductsTable.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/table/customer-products/CustomerProductsTable.tsx | Updates filter-button visibility to use `customer.customer_products.length`, which can still be wrong if that field is not a complete product-existence signal. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/views/customers2/components/table/customer-products/CustomerProductsTable.tsx:95-96
**Incomplete Product Projection**

When the customer detail response omits expired products from `customer.customer_products`, an expired-only customer still gets `hasAnyProducts = false` while the default table count is also zero. The filter button stays hidden, so the user cannot enable “Show expired” to reveal the products this change is meant to expose.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix filter button visibility for custome..."](https://github.com/useautumn/autumn/commit/b3fd503b75fb2a5ff0747596a34fe76c036068b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42317350)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/autumn-org-2/github/useautumn/autumn/-/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))
- Context used - server/CLAUDE.md ([source](https://app.greptile.com/autumn-org-2/github/useautumn/autumn/-/custom-context?memory=7866843d-5d47-47cf-8270-b04b4f695fd8))
- Context used - AGENTS.md ([source](https://app.greptile.com/autumn-org-2/github/useautumn/autumn/-/custom-context?memory=e38717a3-e8ad-4054-9219-102b893d3b3c))
- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
</details>

<!-- /greptile_comment -->