### PR TITLE
Fix ACH processing invoice handling

### DIFF
--- a/apps/checkout/src/components/checkout/states/checkoutActionRequiredCopy.ts
+++ b/apps/checkout/src/components/checkout/states/checkoutActionRequiredCopy.ts
@@ -20,6 +20,13 @@ export const getCheckoutActionRequiredCopy = ({
 					"This payment needs extra verification before it can go through.",
 				ctaLabel: "Complete payment",
 			};
+		case "payment_processing":
+			return {
+				title: "Payment processing",
+				description:
+					"Your payment is still settling. We'll update this checkout once it completes.",
+				ctaLabel: "View invoice",
+			};
 		case "payment_failed":
 		default:
 			return {

--- a/apps/docs/mintlify/api-reference/billing/attach.mdx
+++ b/apps/docs/mintlify/api-reference/billing/attach.mdx
@@ -726,7 +726,7 @@ This is useful for attaching custom metadata to the Stripe subscription created 
 <DynamicResponseField name="required_action" type="object">
   Details about any action required to complete the payment. Present when the payment could not be processed automatically.
   <Expandable title="properties">
-    <DynamicResponseField name="code" type="'3ds_required' | 'payment_method_required' | 'payment_failed'">
+    <DynamicResponseField name="code" type="'3ds_required' | 'payment_method_required' | 'payment_failed' | 'payment_processing'">
       The type of action required to complete the payment.
     </DynamicResponseField>
 

--- a/apps/docs/mintlify/api-reference/billing/billingUpdate.mdx
+++ b/apps/docs/mintlify/api-reference/billing/billingUpdate.mdx
@@ -635,7 +635,7 @@ const response = await autumn.billing.update({
 <DynamicResponseField name="required_action" type="object">
   Details about any action required to complete the payment. Present when the payment could not be processed automatically.
   <Expandable title="properties">
-    <DynamicResponseField name="code" type="'3ds_required' | 'payment_method_required' | 'payment_failed'">
+    <DynamicResponseField name="code" type="'3ds_required' | 'payment_method_required' | 'payment_failed' | 'payment_processing'">
       The type of action required to complete the payment.
     </DynamicResponseField>
 

--- a/apps/docs/mintlify/api-reference/billing/createSchedule.mdx
+++ b/apps/docs/mintlify/api-reference/billing/createSchedule.mdx
@@ -618,7 +618,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 <DynamicResponseField name="required_action" type="object">
   <Expandable title="properties">
-    <DynamicResponseField name="code" type="'3ds_required' | 'payment_method_required' | 'payment_failed'">
+    <DynamicResponseField name="code" type="'3ds_required' | 'payment_method_required' | 'payment_failed' | 'payment_processing'">
       The type of action required to complete the payment.
     </DynamicResponseField>
 

--- a/apps/docs/mintlify/api-reference/billing/multiAttach.mdx
+++ b/apps/docs/mintlify/api-reference/billing/multiAttach.mdx
@@ -604,7 +604,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 <DynamicResponseField name="required_action" type="object">
   Details about any action required to complete the payment. Present when the payment could not be processed automatically.
   <Expandable title="properties">
-    <DynamicResponseField name="code" type="'3ds_required' | 'payment_method_required' | 'payment_failed'">
+    <DynamicResponseField name="code" type="'3ds_required' | 'payment_method_required' | 'payment_failed' | 'payment_processing'">
       The type of action required to complete the payment.
     </DynamicResponseField>
 

--- a/apps/docs/mintlify/api/openapi.yml
+++ b/apps/docs/mintlify/api/openapi.yml
@@ -13693,6 +13693,7 @@ paths:
                           - 3ds_required
                           - payment_method_required
                           - payment_failed
+                          - payment_processing
                         type: string
                         description: The type of action required to complete the payment.
                       reason:
@@ -15250,6 +15251,7 @@ paths:
                           - 3ds_required
                           - payment_method_required
                           - payment_failed
+                          - payment_processing
                         type: string
                         description: The type of action required to complete the payment.
                       reason:
@@ -15915,6 +15917,7 @@ paths:
                           - 3ds_required
                           - payment_method_required
                           - payment_failed
+                          - payment_processing
                         type: string
                         description: The type of action required to complete the payment.
                       reason:
@@ -19098,6 +19101,7 @@ paths:
                           - 3ds_required
                           - payment_method_required
                           - payment_failed
+                          - payment_processing
                         type: string
                         description: The type of action required to complete the payment.
                       reason:

--- a/others/python-sdk/.speakeasy/gen.lock
+++ b/others/python-sdk/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: 05940b80-1ef8-40f4-9878-822fb2792070
 management:
-  docChecksum: ae20e074f63569c8c7b786ceb8cac549
+  docChecksum: 6d3d2a12c03ecc0457b441c7e9d689df
   docVersion: 2.3.0
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
   releaseVersion: 0.4.18
   configChecksum: 2263d20254e354a1792248274002f650
 persistentEdits:
-  generation_id: 408cb1b7-f480-4d50-8064-86cd5a516a4a
-  pristine_commit_hash: 3989ade5209a466793ac73d6a8378fe10dd2270c
-  pristine_tree_hash: 14fb2244641247f6757111ca6556ac06a3d355f8
+  generation_id: b3ce069d-ae0b-4f99-9c7a-4f643f46d44a
+  pristine_commit_hash: 8489a232ff08419ed5f97ebdda187803c4f9c917
+  pristine_tree_hash: 14b9190ffd5ccb297e82f6984eee0b5841278992
 features:
   python:
     additionalDependencies: 1.0.0
@@ -158,8 +158,8 @@ trackedFiles:
     pristine_git_object: ad5200ea1d15b517606e8f16bb2af11982b62f5b
   docs/models/attachcode.md:
     id: 1d55f798a682
-    last_write_checksum: sha1:fccfcfb5a4d6ca2d6e54086340042de8e6ec0897
-    pristine_git_object: 278b7f044f6b8e69ba9eb7ebc9d584425b0b758c
+    last_write_checksum: sha1:c73fa087abfa0d21373796b9d65071f33345bdb1
+    pristine_git_object: 19ce35f121a02d03e1a0db4cbe2ff4ea2dc65e3b
   docs/models/attachcustomize.md:
     id: 46261b03538b
     last_write_checksum: sha1:eb13b579fee4cda80f2cb8d4cbb47ae5e6fdb393
@@ -510,8 +510,8 @@ trackedFiles:
     pristine_git_object: 90008265d8b54177bcd9576f9f05ac9ba42ac633
   docs/models/billingupdatecode.md:
     id: 9b4598eb634b
-    last_write_checksum: sha1:ab83e37b31683591f116c230145ba361bd2aba67
-    pristine_git_object: b84d2bb18ea93dcf6314b5d3193dc413e94e897a
+    last_write_checksum: sha1:424aec14315cc03e1df131c0f3d3b5abcdd4c758
+    pristine_git_object: 161a441d9dd0293d504442c7fecec0e57634b506
   docs/models/billingupdatecustomize.md:
     id: 72b14fed6d26
     last_write_checksum: sha1:3f3155892b1b38e3ec74da6498500adcf58db7d0
@@ -1674,8 +1674,8 @@ trackedFiles:
     pristine_git_object: 278e8d8eb601837f6b6b80c28ca70611c62a4900
   docs/models/createschedulecode.md:
     id: ae8797299cb3
-    last_write_checksum: sha1:5e22eb9e2ef88e6b4d0956b452f000add08ca68b
-    pristine_git_object: de1afe7be3a3b8e8f31d8ef15bde78b740a6935a
+    last_write_checksum: sha1:4f4240a06aba52b02404a2cd3b4dc85f009b771e
+    pristine_git_object: adc85e797726a17e4bce2c36a337bfa9569e3769
   docs/models/createschedulecustomize2.md:
     id: 2d3dbf831687
     last_write_checksum: sha1:1cfef3bbd404022c0e384fb7d94d7b46582a8fac
@@ -3722,8 +3722,8 @@ trackedFiles:
     pristine_git_object: f77600fa9e3c31833d7e0070240eedeefca91039
   docs/models/multiattachcode.md:
     id: f423dbc408f7
-    last_write_checksum: sha1:2f92a6cc4f83c35e4b26d376dc24494f9a717d57
-    pristine_git_object: bbd3919960c0184383fbb4bda321f931fa81c0ba
+    last_write_checksum: sha1:d321997fafbce89e0a32363e6d58b5073278bcb3
+    pristine_git_object: 85e6102671be61324f6f470452ca2ffefdb5c3df
   docs/models/multiattachcustomize.md:
     id: 5f3ca0c4e8cd
     last_write_checksum: sha1:45fd9bec1e1233c2c7ae11ccc4fae5619dd06ec1
@@ -6698,8 +6698,8 @@ trackedFiles:
     pristine_git_object: c504f21bd1266d19d3859fd6bdab9c4fbec9dcc6
   src/autumn_sdk/models/attachop.py:
     id: ebb59e06476c
-    last_write_checksum: sha1:11d1bb58ef03af8c3cc4ce6f3f42e7a4b91fec96
-    pristine_git_object: 50f65d08bbee0baa54b6567d21e53d6ed8a5d53e
+    last_write_checksum: sha1:9bd2e615fea9fab61938e490975141a06d4c7bb4
+    pristine_git_object: ed508107fc82f696b4663bcd065ef75a69a39553
   src/autumn_sdk/models/balance.py:
     id: a6354d7c4b97
     last_write_checksum: sha1:b5ce91bd9a42de2332529dd64e83aa1154fd3d0e
@@ -6710,8 +6710,8 @@ trackedFiles:
     pristine_git_object: 1104fa7da9a719ed9f4978b2e71061cbfe7800c9
   src/autumn_sdk/models/billingupdateop.py:
     id: a2f17c75cfd3
-    last_write_checksum: sha1:c7ecb229426c67439b2b20853ea07a193d1fb475
-    pristine_git_object: 4643e4fc841589f55f78a4f75e84731b50047e10
+    last_write_checksum: sha1:a1394384795f44e3178f7758262372f07a08427e
+    pristine_git_object: 7399f00baeee8e7679c124a04c5663fc34cf9141
   src/autumn_sdk/models/checkop.py:
     id: 31c2f84723c6
     last_write_checksum: sha1:8717d236976ffbbd554184d1b65f89c3d4df42da
@@ -6738,8 +6738,8 @@ trackedFiles:
     pristine_git_object: fea4d1bb3875848e66502705e4cb818233ec3f5a
   src/autumn_sdk/models/createscheduleop.py:
     id: afb0cf1cf7f2
-    last_write_checksum: sha1:6bc98d0537b484c7359155cef2692d330b0fada9
-    pristine_git_object: e714ce9d26267325f5cc9180b6a56dacd07725e5
+    last_write_checksum: sha1:051149a9c0b4730f622e9bc9872228816c85c777
+    pristine_git_object: ca789e6191d44f66bfea57194529debd096fea02
   src/autumn_sdk/models/customer.py:
     id: 8ed0174f7272
     last_write_checksum: sha1:c3eca71e597019d6c5e00c6b86e39a195ee7d42a
@@ -6846,8 +6846,8 @@ trackedFiles:
     pristine_git_object: b89b298f7d345a25837a556d97f522487932f817
   src/autumn_sdk/models/multiattachop.py:
     id: dfdf7952c870
-    last_write_checksum: sha1:7e219f7c15a4e141a08279d61d7f0b47c13f4975
-    pristine_git_object: 456107f57544c9a45176820d017bc6385d932d99
+    last_write_checksum: sha1:cdd5bf834fbb8583a5f948ac394bfc49899ad907
+    pristine_git_object: af95e279b52b228bcf301990c731051b5c466d73
   src/autumn_sdk/models/opencustomerportalop.py:
     id: 004cc9a6466f
     last_write_checksum: sha1:e32037dcfea1c4bd953f749f74775b3d7d1d83c3

--- a/others/python-sdk/src/autumn_sdk/models/attachop.py
+++ b/others/python-sdk/src/autumn_sdk/models/attachop.py
@@ -1825,6 +1825,7 @@ AttachCode = Union[
         "3ds_required",
         "payment_method_required",
         "payment_failed",
+        "payment_processing",
     ],
     UnrecognizedStr,
 ]

--- a/others/python-sdk/src/autumn_sdk/models/billingupdateop.py
+++ b/others/python-sdk/src/autumn_sdk/models/billingupdateop.py
@@ -1729,6 +1729,7 @@ BillingUpdateCode = Union[
         "3ds_required",
         "payment_method_required",
         "payment_failed",
+        "payment_processing",
     ],
     UnrecognizedStr,
 ]

--- a/others/python-sdk/src/autumn_sdk/models/createscheduleop.py
+++ b/others/python-sdk/src/autumn_sdk/models/createscheduleop.py
@@ -1716,6 +1716,7 @@ CreateScheduleCode = Union[
         "3ds_required",
         "payment_method_required",
         "payment_failed",
+        "payment_processing",
     ],
     UnrecognizedStr,
 ]

--- a/others/python-sdk/src/autumn_sdk/models/multiattachop.py
+++ b/others/python-sdk/src/autumn_sdk/models/multiattachop.py
@@ -1157,6 +1157,7 @@ MultiAttachCode = Union[
         "3ds_required",
         "payment_method_required",
         "payment_failed",
+        "payment_processing",
     ],
     UnrecognizedStr,
 ]

--- a/packages/openapi/openapi-stripped.yml
+++ b/packages/openapi/openapi-stripped.yml
@@ -13331,6 +13331,7 @@ paths:
                           - 3ds_required
                           - payment_method_required
                           - payment_failed
+                          - payment_processing
                         type: string
                         description: The type of action required to complete the payment.
                       reason:
@@ -14864,6 +14865,7 @@ paths:
                           - 3ds_required
                           - payment_method_required
                           - payment_failed
+                          - payment_processing
                         type: string
                         description: The type of action required to complete the payment.
                       reason:
@@ -15471,6 +15473,7 @@ paths:
                           - 3ds_required
                           - payment_method_required
                           - payment_failed
+                          - payment_processing
                         type: string
                         description: The type of action required to complete the payment.
                       reason:
@@ -18530,6 +18533,7 @@ paths:
                           - 3ds_required
                           - payment_method_required
                           - payment_failed
+                          - payment_processing
                         type: string
                         description: The type of action required to complete the payment.
                       reason:

--- a/packages/openapi/openapi.yml
+++ b/packages/openapi/openapi.yml
@@ -13841,6 +13841,7 @@ paths:
                           - 3ds_required
                           - payment_method_required
                           - payment_failed
+                          - payment_processing
                         type: string
                         description: The type of action required to complete the payment.
                       reason:
@@ -13871,7 +13872,7 @@ paths:
         @example
         ```typescript
         // Schedule a transition from a trial plan to a paid plan
-        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783348981363,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784558581363,"plans":[{"planId":"pro_plan"}]}] });
+        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783420959314,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784630559314,"plans":[{"planId":"pro_plan"}]}] });
         ```
 
         @param customerId - The ID of the customer to create the schedule for.
@@ -15385,6 +15386,7 @@ paths:
                           - 3ds_required
                           - payment_method_required
                           - payment_failed
+                          - payment_processing
                         type: string
                         description: The type of action required to complete the payment.
                       reason:
@@ -16016,6 +16018,7 @@ paths:
                           - 3ds_required
                           - payment_method_required
                           - payment_failed
+                          - payment_processing
                         type: string
                         description: The type of action required to complete the payment.
                       reason:
@@ -19288,6 +19291,7 @@ paths:
                           - 3ds_required
                           - payment_method_required
                           - payment_failed
+                          - payment_processing
                         type: string
                         description: The type of action required to complete the payment.
                       reason:

--- a/packages/sdk/.speakeasy/gen.lock
+++ b/packages/sdk/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: 7b300647-cd76-49e9-bf77-7d1bf5446d66
 management:
-  docChecksum: f798e2b3ecce7790b5ece613997d34a6
+  docChecksum: 52364ef14ea54c4235702c5731933332
   docVersion: 2.3.0
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
   releaseVersion: 0.10.17
   configChecksum: 4722f16a8dee67ebd4038caf3c345296
 persistentEdits:
-  generation_id: 6fbe2f5d-4751-49ce-a7cb-7173319308fa
-  pristine_commit_hash: 3aa8feb1fc3bda7e4830fa2798ec6427cfc16b2e
-  pristine_tree_hash: 6907d3c6c8a644a4d13de7b5c3b7d25f0e150399
+  generation_id: 9c1809a1-ba4f-40c5-8280-dff67d5859a6
+  pristine_commit_hash: eb1bb9b18286f1bcbe1e0a0183938222aa963015
+  pristine_tree_hash: b75654364a64ac7e05e138b1076f076fefd2f5e1
 features:
   typescript:
     additionalDependencies: 0.1.0
@@ -181,8 +181,8 @@ trackedFiles:
     pristine_git_object: 376a0838c9e0cfdfe6ecfbfd2508353db485a627
   docs/models/attach-code.md:
     id: 14b09292cbbc
-    last_write_checksum: sha1:3e916de85430e347c1a3594a8b68da273b5ad036
-    pristine_git_object: fd60d9f2ea9203a756954cb671eb4931662820b8
+    last_write_checksum: sha1:1fbae6ce0ab1e55593774ce71c86e577492952c1
+    pristine_git_object: 561adefaaa5ff78a7c1f6b9780dca82768d33375
   docs/models/attach-custom-line-item.md:
     id: 0968ebbf76e1
     last_write_checksum: sha1:4c493a8fba5e774a59206c47f63bef7ea4f9d613
@@ -533,8 +533,8 @@ trackedFiles:
     pristine_git_object: ba307f7810c7b0afb8dc080a2bb18e281364113c
   docs/models/billing-update-code.md:
     id: b84ac28f1591
-    last_write_checksum: sha1:42971aa6160a71ae958639a336f749df58147eb2
-    pristine_git_object: 7c5c0d332961e51e90e875930bc57fc5769f66dc
+    last_write_checksum: sha1:7fc22bd7ce1c8d111b0b7a2e0c750ee856794cd8
+    pristine_git_object: 25d5ee32820d7650fce5c486f81f08bb6be4e860
   docs/models/billing-update-customize.md:
     id: 533e2ca5e4bd
     last_write_checksum: sha1:d3edc75a6b7174fb3fa8bdfa23e0f01bf2b97479
@@ -1697,8 +1697,8 @@ trackedFiles:
     pristine_git_object: 1274ad12d5b3a2f428f86c33273547388275fabd
   docs/models/create-schedule-code.md:
     id: 4c18cfab5c24
-    last_write_checksum: sha1:bb168ff66d793854b4af4f553eb3c87e68e7c444
-    pristine_git_object: 7f13ed77e162527db1c4c9ef65f253da50cc8826
+    last_write_checksum: sha1:ee45eb207f5a8fc6382a622b90ee1f7fb5ec7bc9
+    pristine_git_object: 81b343a6e521c9abe87d534c10724ce06a42abe5
   docs/models/create-schedule-customize2.md:
     id: bffe7e3c5eab
     last_write_checksum: sha1:1a9a09c05a3c609bb1f9ab343e1dcc6fe5d065e7
@@ -3741,8 +3741,8 @@ trackedFiles:
     pristine_git_object: 9f2a0075d180395846c3983ea3d08951a26c1b1f
   docs/models/multi-attach-code.md:
     id: 09921b9ac8e1
-    last_write_checksum: sha1:671b0456d6419384e67921a9f9a732ffc09a5b97
-    pristine_git_object: 8a4eaa5b71c739b2f9ae755205fec9401fb1a70f
+    last_write_checksum: sha1:f6a338d82fadcc4d8db9484aca08afd35ec789a9
+    pristine_git_object: 67c157e5f55f6cddaaffaff668183dcf2b73b33a
   docs/models/multi-attach-customize.md:
     id: aedf94cc14eb
     last_write_checksum: sha1:e691f0270d87b69a45e6e7422bbf55802f798479
@@ -3837,8 +3837,8 @@ trackedFiles:
     pristine_git_object: 771c5bc1c6efbcf8e33e06fd6b92779f6f3f4e6a
   docs/models/multi-attach-required-action.md:
     id: 65606b4924cb
-    last_write_checksum: sha1:6813fc8b13f549c2b5f5476b8668c4a1be4aeb9b
-    pristine_git_object: c45c50f16a9ec5562f1fda65a65f626f7fbd0e49
+    last_write_checksum: sha1:94cf8490856265bdcf54d701b121a8215b382117
+    pristine_git_object: e457d090eb0d1633615a665dcab8bd11c123f8a0
   docs/models/multi-attach-reset-interval.md:
     id: a4ab17316d9c
     last_write_checksum: sha1:8737611244dd67a2a2ac605882931f1cab4c155f
@@ -6573,8 +6573,8 @@ trackedFiles:
     pristine_git_object: 0ebe5146cd24c153cb9b7655e4f502c09f7d4abd
   docs/sdks/billing/README.md:
     id: dc915331dd9d
-    last_write_checksum: sha1:075d0881bb5af849396bd4ba8400666e53e28a3b
-    pristine_git_object: d33ea15a9e47ba78541498aa69c9861b62134771
+    last_write_checksum: sha1:08ba67b67677b1f4599b1d4a7a5ad0fb4b0bb00c
+    pristine_git_object: d5c61057af94845783fce84294c61e8f5e825a7c
   docs/sdks/customers/README.md:
     id: 9332759cffc2
     last_write_checksum: sha1:74cd5f6cf800e1d86b2c332fed3c3cd53f3eeb6b
@@ -6669,8 +6669,8 @@ trackedFiles:
     pristine_git_object: 7991653fe7a7302891a242026bedf4fb0d2394f9
   src/funcs/billing-create-schedule.ts:
     id: fd662bfcdc10
-    last_write_checksum: sha1:2f836882e51aea0f831e31890aa2daf4631833ae
-    pristine_git_object: 648771f2b91195987dd04d486f9e212181c251c9
+    last_write_checksum: sha1:c58ef84598eb5eca0026284827a8d82411048b0c
+    pristine_git_object: cd32669aa075f1bba3f67f55eada179ebd73f2ec
   src/funcs/billing-import.ts:
     id: ff582ad4629f
     last_write_checksum: sha1:673851739184e659789772519b9bc01485a21d79
@@ -6929,8 +6929,8 @@ trackedFiles:
     pristine_git_object: 466d8b6a58b3c58209f6a3525107a23863bf6144
   src/models/attach-op.ts:
     id: 83ed65c26ab4
-    last_write_checksum: sha1:9bba3e4d91c83a75b9a4dfb5fba4876d5003e66b
-    pristine_git_object: 3d1797024955e1f5d7e1b71668a45265b314d77f
+    last_write_checksum: sha1:1cd3205cdaa837f15d4e212c77f50e7c675b0a85
+    pristine_git_object: 025605f117f5fc8a3d4e45d8b3c8993980f5b521
   src/models/autumn-default-error.ts:
     id: 2528aa7886eb
     last_write_checksum: sha1:4cce18f91be3262ada7d11dcd6326544e2341b58
@@ -6949,8 +6949,8 @@ trackedFiles:
     pristine_git_object: 63a63e9346140804c185712686d6b58308fe5cdc
   src/models/billing-update-op.ts:
     id: e7371769c7ca
-    last_write_checksum: sha1:148a876bc2e4ebddf40f18b69696da7c31243cf8
-    pristine_git_object: 3083e67da6def8c93ab73d1c59f6cd540cc51234
+    last_write_checksum: sha1:7b3549402e8415e99550f8c24de761674f74bed0
+    pristine_git_object: adc8452de26328353cb9892d564df0ed65a95a5c
   src/models/check-op.ts:
     id: 42085bda016a
     last_write_checksum: sha1:4d27f8123827408ad245de0fd7078099c6b809fa
@@ -6977,8 +6977,8 @@ trackedFiles:
     pristine_git_object: d979198ac227f8e5731e5ca5e2e34b55d88da348
   src/models/create-schedule-op.ts:
     id: 68442c0abd75
-    last_write_checksum: sha1:979f39aac0d93d3e479715abddaac292e73c5d1b
-    pristine_git_object: 35d034dd3a4c83ff43a7a652c5320046cf0a99b5
+    last_write_checksum: sha1:ac683739b83382b290cedc0564cb8fa7d0d40d86
+    pristine_git_object: 66c40b9d0b030f61f2a20eb5497a3866355c7103
   src/models/customer-data.ts:
     id: 04dac7ee392e
     last_write_checksum: sha1:bbb8b02f9753e4b39f62567a64b082a9cd04a5b0
@@ -7085,8 +7085,8 @@ trackedFiles:
     pristine_git_object: 031fa8ce421f669533a83f4993e79db0b1e3772a
   src/models/multi-attach-op.ts:
     id: 99a2b77c1afc
-    last_write_checksum: sha1:8e257afbfee77978bde1d3291a3c29926e4a1340
-    pristine_git_object: 6f2601b3bc08dafcfbbd9ccb891d76beb51ea7fc
+    last_write_checksum: sha1:d3b465dc8018eb59aa5dc9153b1f395e76f51391
+    pristine_git_object: be4c691501ac3b067cb3fbbe6053ea53e4fa06ea
   src/models/open-customer-portal-op.ts:
     id: a003eb4172a9
     last_write_checksum: sha1:5e672fc975a0336c963181042a770c2a43cbc0e3
@@ -7177,8 +7177,8 @@ trackedFiles:
     pristine_git_object: 571de419ea3321d79acec4bddbb46b1580007115
   src/sdk/billing.ts:
     id: 10905058c4ad
-    last_write_checksum: sha1:ac4b1d6661c42eb57dc0459e039ca669d04a92c9
-    pristine_git_object: 1b5922ac43c7bc766f86e6e31f14345c79c03d60
+    last_write_checksum: sha1:c4bb315c770218c93d91e5e85e0ebc6f563779fe
+    pristine_git_object: 3057199c71e4b560488175e6a599d7007ebf3ca1
   src/sdk/customers.ts:
     id: d33e193e0c00
     last_write_checksum: sha1:8d64f03efa17b4ef45a6d67a44d23e2943f1cd8b

--- a/packages/sdk/.speakeasy/out.openapi.yaml
+++ b/packages/sdk/.speakeasy/out.openapi.yaml
@@ -12722,6 +12722,7 @@ paths:
                           - 3ds_required
                           - payment_method_required
                           - payment_failed
+                          - payment_processing
                         type: string
                         description: The type of action required to complete the payment.
                       reason:
@@ -12751,7 +12752,7 @@ paths:
         @example
         ```typescript
         // Schedule a transition from a trial plan to a paid plan
-        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783348981363,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784558581363,"plans":[{"planId":"pro_plan"}]}] });
+        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1783420959314,"plans":[{"planId":"trial_plan"}]},{"startsAt":1784630559314,"plans":[{"planId":"pro_plan"}]}] });
         ```
 
         @param customerId - The ID of the customer to create the schedule for.
@@ -14119,6 +14120,7 @@ paths:
                           - 3ds_required
                           - payment_method_required
                           - payment_failed
+                          - payment_processing
                         type: string
                         description: The type of action required to complete the payment.
                       reason:
@@ -14700,6 +14702,7 @@ paths:
                           - 3ds_required
                           - payment_method_required
                           - payment_failed
+                          - payment_processing
                         type: string
                         description: The type of action required to complete the payment.
                       reason:
@@ -17628,6 +17631,7 @@ paths:
                           - 3ds_required
                           - payment_method_required
                           - payment_failed
+                          - payment_processing
                         type: string
                         description: The type of action required to complete the payment.
                       reason:

--- a/packages/sdk/.speakeasy/workflow.lock
+++ b/packages/sdk/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.762.0
 sources:
     Autumn API:
         sourceNamespace: autumn-api
-        sourceRevisionDigest: sha256:da5ed5eb5a4497d260ad740aa99590f838c831e5f30309a8492806ccb535ac8b
-        sourceBlobDigest: sha256:4b64237977d51849025452acafeec4fe7cc99af3b55ac8c073acafa29ac735b8
+        sourceRevisionDigest: sha256:136e6e69377ed5ec3dc69550b48e670008b085ce12fc9fc251b3a0b7204a340c
+        sourceBlobDigest: sha256:21f2fc7ce08a96e93ea050683a01f038d68064dbd9ce87c4148c3f18123c49f3
         tags:
             - latest
             - 2.3.0
@@ -18,10 +18,10 @@ targets:
     autumn:
         source: Autumn API
         sourceNamespace: autumn-api
-        sourceRevisionDigest: sha256:da5ed5eb5a4497d260ad740aa99590f838c831e5f30309a8492806ccb535ac8b
-        sourceBlobDigest: sha256:4b64237977d51849025452acafeec4fe7cc99af3b55ac8c073acafa29ac735b8
+        sourceRevisionDigest: sha256:136e6e69377ed5ec3dc69550b48e670008b085ce12fc9fc251b3a0b7204a340c
+        sourceBlobDigest: sha256:21f2fc7ce08a96e93ea050683a01f038d68064dbd9ce87c4148c3f18123c49f3
         codeSamplesNamespace: autumn-api-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:3e80560b6103cfdd4dbd00ee274a432f93e8ec100e1f3bb9699139138b54cfc9
+        codeSamplesRevisionDigest: sha256:7491ad8dae3a37a922414577bfed73ec992205847b25f96c4128912408ab22c9
     autumn-python:
         source: Autumn API Stripped
         sourceNamespace: autumn-api-stripped

--- a/packages/sdk/src/models/attach-op.ts
+++ b/packages/sdk/src/models/attach-op.ts
@@ -1145,6 +1145,7 @@ export const AttachCode = {
   ThreedsRequired: "3ds_required",
   PaymentMethodRequired: "payment_method_required",
   PaymentFailed: "payment_failed",
+  PaymentProcessing: "payment_processing",
 } as const;
 /**
  * The type of action required to complete the payment.

--- a/packages/sdk/src/models/billing-update-op.ts
+++ b/packages/sdk/src/models/billing-update-op.ts
@@ -1103,6 +1103,7 @@ export const BillingUpdateCode = {
   ThreedsRequired: "3ds_required",
   PaymentMethodRequired: "payment_method_required",
   PaymentFailed: "payment_failed",
+  PaymentProcessing: "payment_processing",
 } as const;
 /**
  * The type of action required to complete the payment.

--- a/packages/sdk/src/models/create-schedule-op.ts
+++ b/packages/sdk/src/models/create-schedule-op.ts
@@ -1104,6 +1104,7 @@ export const CreateScheduleCode = {
   ThreedsRequired: "3ds_required",
   PaymentMethodRequired: "payment_method_required",
   PaymentFailed: "payment_failed",
+  PaymentProcessing: "payment_processing",
 } as const;
 /**
  * The type of action required to complete the payment.

--- a/packages/sdk/src/models/multi-attach-op.ts
+++ b/packages/sdk/src/models/multi-attach-op.ts
@@ -685,6 +685,7 @@ export const MultiAttachCode = {
   ThreedsRequired: "3ds_required",
   PaymentMethodRequired: "payment_method_required",
   PaymentFailed: "payment_failed",
+  PaymentProcessing: "payment_processing",
 } as const;
 /**
  * The type of action required to complete the payment.

--- a/server/src/external/stripe/stripeInvoiceUtils.ts
+++ b/server/src/external/stripe/stripeInvoiceUtils.ts
@@ -84,26 +84,11 @@ export const payForInvoice = async ({
 		};
 	}
 
+	let paidInvoice: Stripe.Response<Stripe.Invoice>;
 	try {
-		const invoice = await stripeCli.invoices.pay(invoiceId, {
+		paidInvoice = await stripeCli.invoices.pay(invoiceId, {
 			payment_method: paymentMethod?.id,
 		});
-		const paid = invoice.status === "paid";
-		const error = paid
-			? null
-			: new RecaseError({
-					message: `Invoice ${invoiceId} is ${invoice.status ?? "not paid"}`,
-					code: ErrCode.PayInvoiceFailed,
-					data: invoice,
-				});
-
-		if (!paid && errorOnFail) throw error;
-
-		return {
-			paid,
-			error,
-			invoice,
-		};
 	} catch (error: any) {
 		logger.error(
 			`❌ Stripe error: Failed to pay invoice: ${error?.message || error}`,
@@ -134,6 +119,23 @@ export const payForInvoice = async ({
 			};
 		}
 	}
+
+	const paid = paidInvoice.status === "paid";
+	const error = paid
+		? null
+		: new RecaseError({
+				message: `Invoice ${invoiceId} is ${paidInvoice.status ?? "not paid"}`,
+				code: ErrCode.PayInvoiceFailed,
+				data: paidInvoice,
+			});
+
+	if (!paid && errorOnFail) throw error;
+
+	return {
+		paid,
+		error,
+		invoice: paidInvoice,
+	};
 };
 
 export const getInvoiceDiscounts = ({

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/payStripeInvoice.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/payStripeInvoice.ts
@@ -70,11 +70,12 @@ export const payStripeInvoice = async ({
 	}
 
 	if (paidInvoice.status !== "paid") {
+		const isProcessing = paidInvoice.status === "open";
 		return {
 			paid: false,
 			invoice: paidInvoice,
 			requiredAction: {
-				code: "payment_failed",
+				code: isProcessing ? "payment_processing" : "payment_failed",
 				reason: `Invoice is ${paidInvoice.status ?? "not paid"}`,
 			},
 		};

--- a/server/tests/unit/billing/payForInvoice.test.ts
+++ b/server/tests/unit/billing/payForInvoice.test.ts
@@ -1,0 +1,32 @@
+// Red: open invoice.pay result flowed through Stripe failure cleanup and voided.
+// Green: open invoice result throws without voiding an in-flight ACH invoice.
+import { describe, expect, test } from "bun:test";
+import { payForInvoice } from "@/external/stripe/stripeInvoiceUtils";
+
+describe("payForInvoice", () => {
+	test("does not void an open invoice returned by invoice.pay", async () => {
+		const invoice = { id: "in_123", status: "open" };
+		let voidCalls = 0;
+
+		await expect(
+			payForInvoice({
+				stripeCli: {
+					invoices: {
+						retrieve: async () => invoice,
+						pay: async () => invoice,
+						voidInvoice: async () => {
+							voidCalls += 1;
+						},
+					},
+				} as never,
+				paymentMethod: { id: "pm_123" } as never,
+				invoiceId: invoice.id,
+				logger: { info: () => {}, error: () => {} },
+				errorOnFail: true,
+				voidIfFailed: true,
+			}),
+		).rejects.toThrow("Invoice in_123 is open");
+
+		expect(voidCalls).toBe(0);
+	});
+});

--- a/server/tests/unit/billing/payStripeInvoice.test.ts
+++ b/server/tests/unit/billing/payStripeInvoice.test.ts
@@ -1,3 +1,5 @@
+// Red: open invoice.pay result returned payment_failed.
+// Green: it returns payment_processing because ACH is still settling.
 import { describe, expect, test } from "bun:test";
 import { payStripeInvoice } from "@/internal/billing/v2/providers/stripe/utils/invoices/payStripeInvoice";
 
@@ -15,7 +17,10 @@ describe("payStripeInvoice", () => {
 						retrieveCalls += 1;
 						throw new Error("invoice retrieve should not be called");
 					},
-					pay: async (invoiceId: string, params: { payment_method: string }) => {
+					pay: async (
+						invoiceId: string,
+						params: { payment_method: string },
+					) => {
 						payCalls += 1;
 						expect(invoiceId).toBe(invoice.id);
 						expect(params.payment_method).toBe(paymentMethod.id);
@@ -32,5 +37,43 @@ describe("payStripeInvoice", () => {
 		expect(result.invoice.status).toBe("paid");
 		expect(retrieveCalls).toBe(0);
 		expect(payCalls).toBe(1);
+	});
+
+	test("returns payment_processing when invoice pay leaves invoice open", async () => {
+		const invoice = { id: "in_processing", status: "open" };
+		const paymentMethod = { id: "pm_123" };
+
+		const result = await payStripeInvoice({
+			stripeCli: {
+				invoices: {
+					pay: async () => ({ ...invoice, status: "open" }),
+				},
+			} as never,
+			invoice: invoice as never,
+			paymentMethod: paymentMethod as never,
+		});
+
+		expect(result.paid).toBe(false);
+		expect(result.requiredAction?.code).toBe("payment_processing");
+		expect(result.invoice.status).toBe("open");
+	});
+
+	test("returns payment_failed when invoice pay returns a terminal status", async () => {
+		const invoice = { id: "in_terminal", status: "open" };
+		const paymentMethod = { id: "pm_123" };
+
+		const result = await payStripeInvoice({
+			stripeCli: {
+				invoices: {
+					pay: async () => ({ ...invoice, status: "void" }),
+				},
+			} as never,
+			invoice: invoice as never,
+			paymentMethod: paymentMethod as never,
+		});
+
+		expect(result.paid).toBe(false);
+		expect(result.requiredAction?.code).toBe("payment_failed");
+		expect(result.invoice.status).toBe("void");
 	});
 });

--- a/shared/api/billing/common/billingResponse.ts
+++ b/shared/api/billing/common/billingResponse.ts
@@ -1,10 +1,15 @@
 import { z } from "zod/v4";
 
 export const PaymentFailureCodeEnum = z
-	.enum(["3ds_required", "payment_method_required", "payment_failed"])
+	.enum([
+		"3ds_required",
+		"payment_method_required",
+		"payment_failed",
+		"payment_processing",
+	])
 	.meta({
 		description:
-			"The type of payment failure. '3ds_required' means 3D Secure authentication is needed, 'payment_method_required' means the customer needs to add a payment method, 'payment_failed' means the payment was declined.",
+			"The type of payment action. '3ds_required' means 3D Secure authentication is needed, 'payment_method_required' means the customer needs to add a payment method, 'payment_failed' means the payment was declined, 'payment_processing' means payment is still settling.",
 	});
 
 export type PaymentFailureCode = z.infer<typeof PaymentFailureCodeEnum>;


### PR DESCRIPTION
## Summary
- keep open ACH invoice.pay results out of Stripe failure cleanup so processing invoices are not voided
- return `payment_processing` instead of `payment_failed` for invoices that remain open after payment
- add regression unit coverage for both helper paths

## Tests
- `bunx tsgo --build --noEmit`
- `./run.sh /Users/charlielamb/code/atmn/autumn-ach-processing-invoices/server/tests/unit/billing/payForInvoice.test.ts`
- `./run.sh /Users/charlielamb/code/atmn/autumn-ach-processing-invoices/server/tests/unit/billing/payStripeInvoice.test.ts`
- `./run.sh /Users/charlielamb/code/atmn/autumn-ach-processing-invoices/server/tests/integration/billing/legacy/attach/new/legacy-new-oneoff-open-invoice.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ACH invoice handling by treating `invoice.pay` results that leave the invoice `open` as processing instead of failed, preventing in-flight ACH invoices from being voided. Also updates OpenAPI, SDKs, and checkout copy to support the new `payment_processing` state.

- **Bug Fixes**
  - Skip Stripe failure cleanup for `invoice.pay` results that are `open` to avoid voiding ACH payments.
  - Return `payment_processing` only when the invoice remains `open`; terminal statuses still return `payment_failed`.
  - Added unit tests covering `payForInvoice` and `payStripeInvoice`; updated checkout copy to display a processing state.

- **Migration**
  - `PaymentFailureCodeEnum` now includes `payment_processing`. OpenAPI and SDKs (TypeScript and Python) are updated—regenerate clients and handle this state (show processing and poll) instead of treating it as an error.

<sup>Written for commit b7f0eef97223ac60f8e912a98e44c2af386fb6a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates ACH invoice payment handling. The main changes are:

- **[Bug fixes]** Open ACH invoice payment results are no longer sent through Stripe failure cleanup.
- **[Bug fixes] [API changes]** Open invoice payment results now return `payment_processing`.
- **[API changes]** The shared billing response enum includes `payment_processing`.
- **[Improvements]** Unit tests cover the open-invoice helper paths.
</details>

<h3>Confidence Score: 4/5</h3>

The ACH flow is close, but the new response code needs to match the public API contract before merging.

- The invoice cleanup change preserves the intended open-invoice behavior.
- `payment_processing` can now reach clients that still validate against the old response enum.
- The unpaid invoice branch may also label terminal invoice states as processing.

shared/api/billing/common/billingResponse.ts and the generated/public API response models

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/stripeInvoiceUtils.ts | Moves successful-but-unpaid invoice handling outside Stripe error cleanup while keeping thrown payment errors on the cleanup path. |
| server/src/internal/billing/v2/providers/stripe/utils/invoices/payStripeInvoice.ts | Returns `payment_processing` for unpaid invoice payment results, but currently applies that code to every unpaid status. |
| shared/api/billing/common/billingResponse.ts | Adds `payment_processing` to the shared Zod enum without the matching public contract updates visible in this change. |
| server/tests/unit/billing/payForInvoice.test.ts | Adds coverage that open invoice payment results are not voided. |
| server/tests/unit/billing/payStripeInvoice.test.ts | Adds coverage for paid and open invoice payment results. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/billing/v2/providers/stripe/utils/invoices/payStripeInvoice.ts:77
**Terminal Invoices Become Processing**

When `invoices.pay` returns any unpaid status, this branch now reports `payment_processing`. If Stripe returns a terminal status such as `void` or `uncollectible`, callers receive a processing action instead of a payment failure, so the checkout flow can wait on an invoice that will never settle.

### Issue 2 of 2
shared/api/billing/common/billingResponse.ts:7
**Response Enum Contract Mismatch**

The server can now return `payment_processing`, but the public OpenAPI and generated SDK response models still use the old closed set. Clients generated from those contracts can reject a valid ACH-processing response even though this schema accepts it.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): handle processing ach invo..."](https://github.com/useautumn/autumn/commit/d4136ecf861fd944fc2136242102c1364795799b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42327841)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->