### PR TITLE
Fix promo minimum validation across billing flows

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/errors/handleAttachV2Errors.ts
+++ b/server/src/internal/billing/v2/actions/attach/errors/handleAttachV2Errors.ts
@@ -19,6 +19,7 @@ import { handleProrationBehaviorErrors } from "@/internal/billing/v2/common/erro
 import { handleCustomLineItemsErrors } from "@/internal/billing/v2/common/errors/handleCustomLineItemsErrors";
 import { handleExternalPSPErrors } from "@/internal/billing/v2/common/errors/handleExternalPSPErrors";
 import { handleSubscriptionIdErrors } from "@/internal/billing/v2/common/errors/handleSubscriptionIdErrors";
+import { handleStripeBillingPlanErrors } from "@/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors";
 import { handleCustomPaymentMethodErrorsV2 } from "@/internal/customers/attach/attachUtils/handleAttachErrors";
 import { handleRevertTrialErrors } from "./handleRevertTrialErrors";
 
@@ -102,4 +103,6 @@ export const handleAttachV2Errors = async ({
 
 	// 13. Revert trial errors (card_required + revert, missing existing plan)
 	handleRevertTrialErrors({ billingContext });
+
+	handleStripeBillingPlanErrors({ ctx, billingContext, billingPlan });
 };

--- a/server/src/internal/billing/v2/actions/createSchedule/createSchedule.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/createSchedule.ts
@@ -13,7 +13,10 @@ import { evaluateStripeBillingPlan } from "@/internal/billing/v2/providers/strip
 import { billingResultToResponse } from "@/internal/billing/v2/utils/billingResult/billingResultToResponse";
 import { hashJson } from "@/utils/hash/hashJson";
 import { computeCreateSchedulePlan } from "./compute/computeCreateSchedulePlan";
-import { handleCreateScheduleErrors } from "./errors/handleCreateScheduleErrors";
+import {
+	handleCreateScheduleBillingPlanErrors,
+	handleCreateScheduleErrors,
+} from "./errors/handleCreateScheduleErrors";
 import { setupCreateScheduleBillingContext } from "./setup/setupCreateScheduleBillingContext";
 import { persistCreateSchedule } from "./utils/persistCreateSchedule";
 
@@ -78,6 +81,8 @@ export const createSchedule = async ({
 		autumn: autumnBillingPlan,
 		stripe: stripeBillingPlan,
 	};
+
+	handleCreateScheduleBillingPlanErrors({ ctx, billingContext, billingPlan });
 
 	if (!skipAutumnCheckout) {
 		const cachedResult = await checkCheckoutSessionLock({

--- a/server/src/internal/billing/v2/actions/createSchedule/errors/handleCreateScheduleErrors.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/errors/handleCreateScheduleErrors.ts
@@ -1,4 +1,5 @@
 import {
+	type BillingPlan,
 	type CreateScheduleBillingContext,
 	ErrCode,
 	isFreeProduct,
@@ -6,6 +7,8 @@ import {
 	RecaseError,
 } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { handleStripeBillingPlanErrors } from "@/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors";
 import { handleFirstPhaseStartDateErrors } from "./handleFirstPhaseStartDateErrors";
 
 export const handleCreateScheduleErrors = async ({
@@ -68,4 +71,16 @@ export const handleCreateScheduleErrors = async ({
 			});
 		}
 	}
+};
+
+export const handleCreateScheduleBillingPlanErrors = ({
+	ctx,
+	billingContext,
+	billingPlan,
+}: {
+	ctx: AutumnContext;
+	billingContext: CreateScheduleBillingContext;
+	billingPlan: BillingPlan;
+}) => {
+	handleStripeBillingPlanErrors({ ctx, billingContext, billingPlan });
 };

--- a/server/src/internal/billing/v2/actions/createSchedule/previewCreateSchedule.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/previewCreateSchedule.ts
@@ -8,7 +8,10 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { evaluateStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan";
 import { billingPlanToAttachPreview } from "@/internal/billing/v2/utils/billingPlan/billingPlanToAttachPreview";
 import { computeCreateSchedulePlan } from "./compute/computeCreateSchedulePlan";
-import { handleCreateScheduleErrors } from "./errors/handleCreateScheduleErrors";
+import {
+	handleCreateScheduleBillingPlanErrors,
+	handleCreateScheduleErrors,
+} from "./errors/handleCreateScheduleErrors";
 import { setupCreateScheduleBillingContext } from "./setup/setupCreateScheduleBillingContext";
 
 type PreviewCreateScheduleResult = {
@@ -48,6 +51,8 @@ export const previewCreateScheduleWithContext = async ({
 	});
 
 	const billingPlan = { autumn: autumnBillingPlan, stripe: stripeBillingPlan };
+
+	handleCreateScheduleBillingPlanErrors({ ctx, billingContext, billingPlan });
 
 	return {
 		billingContext,

--- a/server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachErrors.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachErrors.ts
@@ -1,6 +1,8 @@
-import type { MultiAttachBillingContext } from "@autumn/shared";
+import type { BillingPlan, MultiAttachBillingContext } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { handleSubscriptionIdErrors } from "@/internal/billing/v2/common/errors/handleSubscriptionIdErrors";
+import { handleStripeBillingPlanErrors } from "@/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors";
 import { handleMultiAttachCurrentProductErrors } from "./handleMultiAttachCurrentProductErrors";
 import { handleMultiAttachRedirectErrors } from "./handleMultiAttachRedirectErrors";
 
@@ -29,4 +31,16 @@ export const handleMultiAttachErrors = async ({
 		internalCustomerId: billingContext.fullCustomer.internal_id,
 		subscriptionIds: billingContext.productContexts.map((pc) => pc.externalId),
 	});
+};
+
+export const handleMultiAttachBillingPlanErrors = ({
+	ctx,
+	billingContext,
+	billingPlan,
+}: {
+	ctx: AutumnContext;
+	billingContext: MultiAttachBillingContext;
+	billingPlan: BillingPlan;
+}) => {
+	handleStripeBillingPlanErrors({ ctx, billingContext, billingPlan });
 };

--- a/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
@@ -11,7 +11,10 @@ import { logStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/log
 import { logStripeBillingResult } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingResult";
 import { logAutumnBillingPlan } from "@/internal/billing/v2/utils/logs/logAutumnBillingPlan";
 import { computeMultiAttachPlan } from "./compute/computeMultiAttachPlan";
-import { handleMultiAttachErrors } from "./errors/handleMultiAttachErrors";
+import {
+	handleMultiAttachBillingPlanErrors,
+	handleMultiAttachErrors,
+} from "./errors/handleMultiAttachErrors";
 import { logMultiAttachContext } from "./logs/logMultiAttachContext";
 import { setupMultiAttachBillingContext } from "./setup/setupMultiAttachBillingContext";
 
@@ -69,6 +72,8 @@ export async function multiAttach({
 		autumn: autumnBillingPlan,
 		stripe: stripeBillingPlan,
 	};
+
+	handleMultiAttachBillingPlanErrors({ ctx, billingContext, billingPlan });
 
 	if (preview) {
 		return {

--- a/server/src/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors.ts
+++ b/server/src/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors.ts
@@ -1,7 +1,4 @@
-import type {
-	BillingPlan,
-	UpdateSubscriptionBillingContext,
-} from "@autumn/shared";
+import type { BillingContext, BillingPlan } from "@autumn/shared";
 import { ErrCode, InternalError } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { validatePromotionCodeMinimums } from "@/internal/billing/v2/providers/stripe/errors/validatePromotionCodeMinimums";
@@ -16,7 +13,7 @@ export const handleStripeBillingPlanErrors = ({
 	billingPlan,
 }: {
 	ctx: AutumnContext;
-	billingContext: UpdateSubscriptionBillingContext;
+	billingContext: BillingContext;
 	billingPlan: BillingPlan;
 }) => {
 	const { stripeSubscriptionSchedule } = billingContext;

--- a/server/src/internal/billing/v2/providers/stripe/execute/executeStripeBillingPlan.ts
+++ b/server/src/internal/billing/v2/providers/stripe/execute/executeStripeBillingPlan.ts
@@ -13,6 +13,7 @@ import { executeStripeRefundAction } from "@/internal/billing/v2/providers/strip
 import { rollbackAfterSubscriptionFailure } from "@/internal/billing/v2/providers/stripe/execute/executeStripeBillingPlanRollback";
 import { executeStripeSubscriptionAction } from "@/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionAction";
 import { executeStripeSubscriptionScheduleAction } from "@/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionScheduleAction";
+import { validatePromotionCodeMinimums } from "@/internal/billing/v2/providers/stripe/errors/validatePromotionCodeMinimums";
 import { createStripeInvoiceItems } from "@/internal/billing/v2/providers/stripe/utils/invoices/stripeInvoiceOps";
 
 export const executeStripeBillingPlan = async ({
@@ -54,6 +55,10 @@ export const executeStripeBillingPlan = async ({
 
 	const resumeAfterSubscriptionAction =
 		resumeAfter === StripeBillingStage.SubscriptionAction;
+
+	if (!resumeAfterSubscriptionAction) {
+		validatePromotionCodeMinimums({ ctx, billingContext, billingPlan });
+	}
 
 	if (stripeInvoiceAction && !resumeAfterInvoiceAction) {
 		invoiceResult = await executeStripeInvoiceAction({

--- a/server/tests/integration/billing/attach/discounts/deferred-upgrade-minimum-promo.test.ts
+++ b/server/tests/integration/billing/attach/discounts/deferred-upgrade-minimum-promo.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression for deferred direct-billing upgrades with minimum-amount promo codes.
+ *
+ * Red-failure mode: attach accepts the promo, creates a payable invoice, then
+ * deferred replay later fails on the subscription update.
+ *
+ * Green-success criteria: preview and attach reject before any new invoice or
+ * plan transition side effect.
+ */
+
+import { type ApiCustomerV3, type AttachParamsV1Input } from "@autumn/shared";
+import { createPercentCoupon } from "@tests/integration/billing/utils/discounts/discountTestUtils";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import {
+	expectProductActive,
+	expectProductNotPresent,
+} from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import { expect, test } from "bun:test";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("attach deferred upgrade: rejects minimum-amount promo before invoicing")}`,
+	async () => {
+		const customerId = `attach-deferred-min-promo-${Date.now()}`;
+		const monthly = products.pro({
+			id: "monthly-min-promo",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+		const annual = products.proAnnual({
+			id: "annual-min-promo",
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+		});
+
+		const { autumnV1, autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [monthly, annual] }),
+			],
+			actions: [
+				s.billing.attach({ productId: monthly.id }),
+				s.attachPaymentMethod({ type: "authenticate" }),
+			],
+		});
+
+		const coupon = await createPercentCoupon({
+			stripeCli: ctx.stripeCli,
+			percentOff: 50,
+			duration: "once",
+		});
+		const promoCode = await ctx.stripeCli.promotionCodes.create({
+			promotion: { type: "coupon", coupon: coupon.id },
+			code: `MINPROMO${Date.now()}`,
+			restrictions: { minimum_amount: 1000, minimum_amount_currency: "usd" },
+		});
+		const params: AttachParamsV1Input = {
+			customer_id: customerId,
+			plan_id: annual.id,
+			redirect_mode: "if_required",
+			discounts: [{ promotion_code: promoCode.code }],
+		};
+
+		await expect(
+			autumnV2_2.billing.previewAttach<AttachParamsV1Input>(params),
+		).rejects.toThrow(/promotion code.*minimum/i);
+
+		await expect(
+			autumnV2_2.billing.attach<AttachParamsV1Input>(params),
+		).rejects.toThrow(/promotion code.*minimum/i);
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({
+			customer,
+			count: 1,
+		});
+		await expectProductActive({ customer, productId: monthly.id });
+		await expectProductNotPresent({ customer, productId: annual.id });
+	},
+);

--- a/server/tests/integration/billing/create-schedule/discounts/promotion-code-minimum-validation.test.ts
+++ b/server/tests/integration/billing/create-schedule/discounts/promotion-code-minimum-validation.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression for create_schedule immediate transitions with minimum-amount promo codes.
+ *
+ * Red-failure mode: create_schedule accepts the promo, invoices the customer,
+ * then Stripe rejects the subscription update.
+ *
+ * Green-success criteria: preview and create_schedule reject before any new
+ * invoice or plan transition side effect.
+ */
+
+import {
+	type ApiCustomerV3,
+	type AttachPreviewResponse,
+	type CreateScheduleParamsV0Input,
+} from "@autumn/shared";
+import { createPercentCoupon } from "@tests/integration/billing/utils/discounts/discountTestUtils";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import {
+	expectProductActive,
+	expectProductNotPresent,
+} from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import { expect, test } from "bun:test";
+import chalk from "chalk";
+
+const previewCreateSchedule = async ({
+	autumnV1,
+	params,
+}: {
+	autumnV1: Awaited<ReturnType<typeof initScenario>>["autumnV1"];
+	params: CreateScheduleParamsV0Input;
+}): Promise<AttachPreviewResponse> =>
+	await autumnV1.post("/billing.preview_create_schedule", params);
+
+test.concurrent(
+	`${chalk.yellowBright("create-schedule discounts: rejects minimum-amount promo before invoicing")}`,
+	async () => {
+		const customerId = `create-schedule-min-promo-${Date.now()}`;
+		const monthly = products.pro({
+			id: "cs-monthly-min-promo",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+		const annual = products.proAnnual({
+			id: "cs-annual-min-promo",
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+		});
+
+		const { autumnV1, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [monthly, annual] }),
+			],
+			actions: [s.billing.attach({ productId: monthly.id })],
+		});
+
+		const coupon = await createPercentCoupon({
+			stripeCli: ctx.stripeCli,
+			percentOff: 50,
+			duration: "once",
+		});
+		const promoCode = await ctx.stripeCli.promotionCodes.create({
+			promotion: { type: "coupon", coupon: coupon.id },
+			code: `CSMINPROMO${Date.now()}`,
+			restrictions: { minimum_amount: 1000, minimum_amount_currency: "usd" },
+		});
+		const params: CreateScheduleParamsV0Input = {
+			customer_id: customerId,
+			phases: [{ starts_at: "now", plans: [{ plan_id: annual.id }] }],
+			redirect_mode: "if_required",
+			discounts: [{ promotion_code: promoCode.code }],
+		};
+
+		await expect(previewCreateSchedule({ autumnV1, params })).rejects.toThrow(
+			/promotion code.*minimum/i,
+		);
+		await expect(autumnV1.billing.createSchedule(params)).rejects.toThrow(
+			/promotion code.*minimum/i,
+		);
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({ customer, count: 1 });
+		await expectProductActive({ customer, productId: monthly.id });
+		await expectProductNotPresent({ customer, productId: annual.id });
+	},
+);

--- a/server/tests/integration/billing/multi-attach/discounts/promotion-code-minimum-validation.test.ts
+++ b/server/tests/integration/billing/multi-attach/discounts/promotion-code-minimum-validation.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression for multi-attach transitions with minimum-amount promo codes.
+ *
+ * Red-failure mode: multi-attach accepts the promo, invoices the customer, then
+ * Stripe rejects the subscription update.
+ *
+ * Green-success criteria: preview and multi-attach reject before any new invoice
+ * or plan transition side effect.
+ */
+
+import {
+	type ApiCustomerV3,
+	type MultiAttachParamsV0Input,
+} from "@autumn/shared";
+import { createPercentCoupon } from "@tests/integration/billing/utils/discounts/discountTestUtils";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import {
+	expectProductActive,
+	expectProductNotPresent,
+} from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import { expect, test } from "bun:test";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("multi-attach discounts: rejects minimum-amount promo before invoicing")}`,
+	async () => {
+		const customerId = `multi-attach-min-promo-${Date.now()}`;
+		const monthly = products.pro({
+			id: "ma-monthly-min-promo",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+		const annual = products.proAnnual({
+			id: "ma-annual-min-promo",
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+		});
+
+		const { autumnV1, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [monthly, annual] }),
+			],
+			actions: [s.billing.attach({ productId: monthly.id })],
+		});
+
+		const coupon = await createPercentCoupon({
+			stripeCli: ctx.stripeCli,
+			percentOff: 50,
+			duration: "once",
+		});
+		const promoCode = await ctx.stripeCli.promotionCodes.create({
+			promotion: { type: "coupon", coupon: coupon.id },
+			code: `MAMINPROMO${Date.now()}`,
+			restrictions: { minimum_amount: 1000, minimum_amount_currency: "usd" },
+		});
+		const params: MultiAttachParamsV0Input = {
+			customer_id: customerId,
+			plans: [{ plan_id: annual.id }],
+			redirect_mode: "if_required",
+			discounts: [{ promotion_code: promoCode.code }],
+		};
+
+		await expect(autumnV1.billing.previewMultiAttach(params)).rejects.toThrow(
+			/promotion code.*minimum/i,
+		);
+		await expect(autumnV1.billing.multiAttach(params)).rejects.toThrow(
+			/promotion code.*minimum/i,
+		);
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({ customer, count: 1 });
+		await expectProductActive({ customer, productId: monthly.id });
+		await expectProductNotPresent({ customer, productId: annual.id });
+	},
+);


### PR DESCRIPTION
## Summary
- move promotion-code minimum validation into Stripe billing plan evaluation so attach, multi-attach, schedule, update, and previews share the same preflight
- keep a defensive execution preflight for stored/direct billing plans, including deferred replay
- add attach regression coverage for a deferred upgrade with a min-amount promo code

## Verification
- cd server && bunx tsgo --build --noEmit
- cd server && ./run.sh /Users/charlielamb/code/atmn/autumn-deferred-promo-repro/server/tests/integration/billing/attach/discounts/deferred-upgrade-minimum-promo.test.ts
- cd server && ./run.sh /Users/charlielamb/code/atmn/autumn-deferred-promo-repro/server/tests/integration/billing/update-subscription/discounts/promotion-code-minimum-amount-validation.test.ts
- cd server && ./run.sh /Users/charlielamb/code/atmn/autumn-deferred-promo-repro/server/tests/integration/billing/execute/stripe-billing-plan-atomicity.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies promotion-code minimum validation across Stripe billing flows. Invalid promos are rejected during plan evaluation and, when applicable, again at execution to prevent invoices and deferred replay failures.

- **Bug Fixes**
  - Validate promo minimums during plan evaluation and execution for attach, multi-attach, `createSchedule`, update, and previews.
  - Surface early errors via `handleStripeBillingPlanErrors` in attach, multi-attach, `createSchedule`, and previews; add `handleCreateScheduleBillingPlanErrors` and `handleMultiAttachBillingPlanErrors`; update to accept `BillingContext`.
  - Keep a defensive execution check with `validatePromotionCodeMinimums` for stored/direct plans; skip when resuming after the subscription stage to honor deferred replay resume points.
  - Add regression tests for attach deferred upgrade, `createSchedule`, and multi-attach with min-amount promos; previews and actions reject early with no invoice or plan switch.

<sup>Written for commit 6337c5c86592093c4c0f5c2b0c0666c618469fd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR centralizes Stripe promotion-code minimum validation across billing flows. The main changes are:

- **Bug fixes**: Validate promo minimums during Stripe billing plan evaluation.
- **Bug fixes**: Keep an execution-time promo minimum check for stored and direct plans.
- **Bug fixes**: Add a deferred upgrade test for minimum-amount promotion codes.
</details>

<h3>Confidence Score: 4/5</h3>

The changed validation timing can break preview and deferred replay billing paths.

- Preview evaluation can reject a promo before the previewed amount is considered.
- Deferred replay can fail before honoring the stored resume stage.
- The new test covers one attach path, but the broader timing changes still need fixes.

evaluateStripeBillingPlan.ts and executeStripeBillingPlan.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan.ts | Builds the Stripe billing plan into a local value and validates promo minimums before returning it. |
| server/src/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors.ts | Removes promo minimum validation from the Stripe plan error handler. |
| server/src/internal/billing/v2/providers/stripe/execute/executeStripeBillingPlan.ts | Adds a defensive promo minimum check at the start of Stripe plan execution. |
| server/tests/integration/billing/attach/discounts/deferred-upgrade-minimum-promo.test.ts | Adds a test that preview and attach reject a deferred upgrade before extra invoice or product side effects. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan.ts:144-151
**Preview Validation Rejects Valid Promos**

When an update preview includes a new promotion code with a Stripe minimum amount, this evaluation-time check can return 400 before the preview is built. The validator only checks that a minimum exists for the customer currency, so a promo that the evaluated invoice amount would satisfy can be blocked instead of returning the preview.

### Issue 2 of 2
server/src/internal/billing/v2/providers/stripe/execute/executeStripeBillingPlan.ts:30
**Deferred Replay Ignores Resume Stage**

Deferred execution passes `resumeAfter` so completed Stripe stages can be skipped, but this validation runs before that stage check. If a stored plan resumes after earlier side effects and the stored promo minimum context no longer passes, replay throws before reaching the recorded resume point and can leave the deferred billing plan stuck.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): validate promo minimums ac..."](https://github.com/useautumn/autumn/commit/007f74520c22c54c74e3b805793f5f35488519a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42327949)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->