### PR TITLE
General-pool statement_timeout backstop

### DIFF
--- a/server/src/db/initDrizzle.ts
+++ b/server/src/db/initDrizzle.ts
@@ -133,6 +133,12 @@ const replicaPoolMax = poolMaxFromEnv({
 	fallback: PROD_POOL_MAX.replica,
 });
 
+// Backstop so one slow query can't pin the xmin horizon; tune via env without a redeploy.
+const generalStatementTimeoutMs = (() => {
+	const parsed = Number(process.env.GENERAL_DB_STATEMENT_TIMEOUT_MS);
+	return Number.isInteger(parsed) && parsed > 0 ? parsed : 300_000;
+})();
+
 const budgetedFleetConnections =
 	BUDGETED_FLEET_PROCESSES *
 		(criticalPoolMax + generalPoolMax + replicaPoolMax) +
@@ -165,6 +171,10 @@ export const { db: dbGeneral, client: clientGeneral } = initDrizzle({
 	name: "general",
 	maxConnections: generalPoolMax,
 	connectTimeout: isProd ? 5 : 30,
+	poolConfig: {
+		application_name: "autumn-general",
+		statement_timeout: isProd ? generalStatementTimeoutMs : undefined,
+	},
 });
 
 // -- Replica pool: used as fallback when primary is degraded --

--- a/server/src/db/initDrizzle.ts
+++ b/server/src/db/initDrizzle.ts
@@ -173,7 +173,7 @@ export const { db: dbGeneral, client: clientGeneral } = initDrizzle({
 	connectTimeout: isProd ? 5 : 30,
 	poolConfig: {
 		application_name: "autumn-general",
-		statement_timeout: isProd ? generalStatementTimeoutMs : undefined,
+		...(isProd ? { statement_timeout: generalStatementTimeoutMs } : {}),
 	},
 });
 

--- a/server/src/db/initDrizzle.ts
+++ b/server/src/db/initDrizzle.ts
@@ -136,7 +136,7 @@ const replicaPoolMax = poolMaxFromEnv({
 // Backstop so one slow query can't pin the xmin horizon; tune via env without a redeploy.
 const generalStatementTimeoutMs = (() => {
 	const parsed = Number(process.env.GENERAL_DB_STATEMENT_TIMEOUT_MS);
-	return Number.isInteger(parsed) && parsed > 0 ? parsed : 300_000;
+	return Number.isInteger(parsed) && parsed > 0 ? parsed : 600_000;
 })();
 
 const budgetedFleetConnections =


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a production-only statement_timeout on the general DB pool to stop long-running queries from pinning the xmin horizon. Default is 10 minutes (override with `GENERAL_DB_STATEMENT_TIMEOUT_MS`); omitted outside production, and sets the pool `application_name` to "autumn-general".

<sup>Written for commit 196630bd2ed81664256773e7e1e22aaab41f2c78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a database timeout backstop for the general pool. The main changes are:

- Production-only `statement_timeout` for the general pool.
- `GENERAL_DB_STATEMENT_TIMEOUT_MS` override with a five-minute default.
- `application_name` tagging for the general pool.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/db/initDrizzle.ts | Adds the general pool timeout backstop and omits the timeout setting outside production. |

<sub>Reviews (2): Last reviewed commit: ["refactor(db): omit statement\_timeout key..."](https://github.com/useautumn/autumn/commit/5cb5853458fa02ccf9fd464ce63853af05ff7e53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42329289)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->