### PR TITLE
DB health probe framework + long-txn/xmin probe

### DIFF
--- a/server/src/cron/cronInit.ts
+++ b/server/src/cron/cronInit.ts
@@ -21,6 +21,11 @@ import { runResetCron } from "./resetCron/runResetCron.js";
 import type { CronContext } from "./utils/CronContext.js";
 
 const { db, client } = initDrizzle({ name: "cron", maxConnections: 40 });
+const { db: probeDb, client: probeClient } = initDrizzle({
+	name: "db-probe",
+	maxConnections: 2,
+	connectTimeout: 5,
+});
 startPgPoolMonitor();
 startBlueGreenHeartbeat({ db, logger, serviceName: "cron" });
 
@@ -94,7 +99,7 @@ const oneOffCleanupTick = async () => {
 // billing cron can't delay detection. Slot-gated like the other jobs.
 const dbProbesTick = async () => {
 	if (!shouldRunTick()) return;
-	await runDbProbes({ db });
+	await runDbProbes({ db: probeDb });
 };
 
 new CronJob(
@@ -131,6 +136,7 @@ process.on("SIGTERM", async () => {
 	stopBlueGreenHeartbeat({ serviceName: "cron" });
 	stopBlueGreenSlotStorePolling({ serviceName: "cron" });
 	await client.end();
+	await probeClient.end();
 	process.exit(0);
 });
 
@@ -140,5 +146,6 @@ process.on("SIGINT", async () => {
 	stopBlueGreenHeartbeat({ serviceName: "cron" });
 	stopBlueGreenSlotStorePolling({ serviceName: "cron" });
 	await client.end();
+	await probeClient.end();
 	process.exit(0);
 });

--- a/server/src/cron/cronInit.ts
+++ b/server/src/cron/cronInit.ts
@@ -2,6 +2,7 @@ import "../sentry.ts";
 import { CronJob } from "cron";
 import { initDrizzle } from "../db/initDrizzle.js";
 import { startPgPoolMonitor, stopPgPoolMonitor } from "../db/pgPoolMonitor.js";
+import { runDbProbes } from "../db/probes/runDbProbes.js";
 import { logger } from "../external/logtail/logtailUtils.js";
 import {
 	describeSlotGate,
@@ -89,6 +90,13 @@ const oneOffCleanupTick = async () => {
 	await runOneOffCleanup({ ctx });
 };
 
+// DB health probes (long-txn / xmin pin, ...) — a separate tick so a heavy
+// billing cron can't delay detection. Slot-gated like the other jobs.
+const dbProbesTick = async () => {
+	if (!shouldRunTick()) return;
+	await runDbProbes({ db });
+};
+
 new CronJob(
 	"* * * * *", // Run every minute
 	main,
@@ -105,8 +113,17 @@ new CronJob(
 	"UTC", // timezone (adjust as needed)
 );
 
+new CronJob(
+	"* * * * *", // Run every minute
+	dbProbesTick,
+	null, // onComplete
+	true, // start immediately
+	"UTC", // timezone (adjust as needed)
+);
+
 main();
 oneOffCleanupTick();
+dbProbesTick();
 
 process.on("SIGTERM", async () => {
 	console.log("Received SIGTERM signal, closing database connection...");

--- a/server/src/db/probes/longTxnProbe.ts
+++ b/server/src/db/probes/longTxnProbe.ts
@@ -4,7 +4,7 @@ import type { DbProbe } from "./types.js";
 
 type LongTxnRow = {
 	longest_txn_seconds: number | null;
-	max_xmin_lag: number | null;
+	xmin_lag: number | null;
 	pid: number | null;
 	wait_event: string | null;
 	query_kind: string | null;
@@ -15,10 +15,11 @@ export const longTxnProbe: DbProbe = {
 	name: "db_long_txn",
 	run: async ({ db }) => {
 		const [row] = await db.execute<LongTxnRow>(sql`
-			WITH oldest AS (
+			WITH top_txn AS (
 				SELECT
-					round(extract(epoch FROM (now() - xact_start)))::int AS longest_txn_seconds,
 					pid,
+					round(extract(epoch FROM (now() - xact_start)))::int AS longest_txn_seconds,
+					age(backend_xmin) AS xmin_lag,
 					coalesce(wait_event_type || '/' || wait_event, 'on_cpu') AS wait_event,
 					CASE WHEN upper(substring(query FROM '[a-zA-Z]+')) IN (
 							'SELECT','INSERT','UPDATE','DELETE','WITH','MERGE','CALL','VACUUM',
@@ -32,12 +33,11 @@ export const longTxnProbe: DbProbe = {
 				LIMIT 1
 			)
 			SELECT
-				coalesce((SELECT longest_txn_seconds FROM oldest), 0) AS longest_txn_seconds,
-				coalesce((SELECT max(age(backend_xmin))
-					FROM pg_stat_activity WHERE backend_xmin IS NOT NULL), 0) AS max_xmin_lag,
-				(SELECT pid FROM oldest) AS pid,
-				(SELECT wait_event FROM oldest) AS wait_event,
-				(SELECT query_kind FROM oldest) AS query_kind,
+				coalesce((SELECT longest_txn_seconds FROM top_txn), 0) AS longest_txn_seconds,
+				coalesce((SELECT xmin_lag FROM top_txn), 0) AS xmin_lag,
+				(SELECT pid FROM top_txn) AS pid,
+				(SELECT wait_event FROM top_txn) AS wait_event,
+				(SELECT query_kind FROM top_txn) AS query_kind,
 				(SELECT count(*)::int FROM pg_stat_activity) AS visible_backends
 		`);
 
@@ -55,7 +55,7 @@ export const longTxnProbe: DbProbe = {
 				type: "db_long_txn",
 				blind,
 				longest_txn_seconds: blind ? null : (row?.longest_txn_seconds ?? 0),
-				max_xmin_lag: blind ? null : (row?.max_xmin_lag ?? 0),
+				xmin_lag: blind ? null : (row?.xmin_lag ?? 0),
 				pid: blind ? null : (row?.pid ?? null),
 				wait_event: blind ? null : (row?.wait_event ?? null),
 				query_kind: blind ? null : (row?.query_kind ?? null),

--- a/server/src/db/probes/longTxnProbe.ts
+++ b/server/src/db/probes/longTxnProbe.ts
@@ -38,7 +38,7 @@ export const longTxnProbe: DbProbe = {
 				(SELECT pid FROM top_txn) AS pid,
 				(SELECT wait_event FROM top_txn) AS wait_event,
 				(SELECT query_kind FROM top_txn) AS query_kind,
-				(SELECT count(*)::int FROM pg_stat_activity) AS visible_backends
+				(SELECT count(state)::int FROM pg_stat_activity) AS visible_backends
 		`);
 
 		const visibleBackends = row?.visible_backends ?? 0;

--- a/server/src/db/probes/longTxnProbe.ts
+++ b/server/src/db/probes/longTxnProbe.ts
@@ -1,0 +1,52 @@
+import { sql } from "drizzle-orm";
+import { logger } from "../../external/logtail/logtailUtils.js";
+import type { DbProbe } from "./types.js";
+
+type LongTxnRow = {
+	longest_txn_seconds: number | null;
+	max_xmin_lag: number | null;
+	pid: number | null;
+	wait_event: string | null;
+	query: string | null;
+};
+
+// Longest-running client transaction + how far any backend holds the xmin
+// horizon back. Leading signal for the xmin-pin / sync-convoy failure mode: a
+// long client txn pins xmin, blocks HOT-prune/VACUUM, and stalls the primary.
+export const longTxnProbe: DbProbe = {
+	name: "db_long_txn",
+	run: async ({ db }) => {
+		const [row] = await db.execute<LongTxnRow>(sql`
+			SELECT
+				coalesce((SELECT round(extract(epoch FROM (now() - min(xact_start))))::int
+					FROM pg_stat_activity
+					WHERE state <> 'idle' AND xact_start IS NOT NULL
+						AND backend_type = 'client backend'), 0) AS longest_txn_seconds,
+				coalesce((SELECT max(age(backend_xmin))
+					FROM pg_stat_activity WHERE backend_xmin IS NOT NULL), 0) AS max_xmin_lag,
+				(SELECT pid FROM pg_stat_activity
+					WHERE state <> 'idle' AND xact_start IS NOT NULL AND backend_type = 'client backend'
+					ORDER BY xact_start ASC LIMIT 1) AS pid,
+				(SELECT coalesce(wait_event_type || '/' || wait_event, 'on_cpu')
+					FROM pg_stat_activity
+					WHERE state <> 'idle' AND xact_start IS NOT NULL AND backend_type = 'client backend'
+					ORDER BY xact_start ASC LIMIT 1) AS wait_event,
+				(SELECT left(regexp_replace(query, '[[:space:]]+', ' ', 'g'), 300)
+					FROM pg_stat_activity
+					WHERE state <> 'idle' AND xact_start IS NOT NULL AND backend_type = 'client backend'
+					ORDER BY xact_start ASC LIMIT 1) AS query
+		`);
+
+		logger.info(
+			{
+				type: "db_long_txn",
+				longest_txn_seconds: row?.longest_txn_seconds ?? 0,
+				max_xmin_lag: row?.max_xmin_lag ?? 0,
+				pid: row?.pid ?? null,
+				wait_event: row?.wait_event ?? null,
+				query: row?.query ?? null,
+			},
+			"DB long-txn probe",
+		);
+	},
+};

--- a/server/src/db/probes/longTxnProbe.ts
+++ b/server/src/db/probes/longTxnProbe.ts
@@ -29,7 +29,12 @@ export const longTxnProbe: DbProbe = {
 					FROM pg_stat_activity
 					WHERE state <> 'idle' AND xact_start IS NOT NULL AND backend_type = 'client backend'
 					ORDER BY xact_start ASC LIMIT 1) AS wait_event,
-				(SELECT upper(substring(query FROM '[a-zA-Z]+'))
+				(SELECT CASE WHEN upper(substring(query FROM '[a-zA-Z]+')) IN (
+						'SELECT','INSERT','UPDATE','DELETE','WITH','MERGE','CALL','VACUUM',
+						'ANALYZE','COPY','TRUNCATE','CREATE','ALTER','DROP','BEGIN','COMMIT',
+						'ROLLBACK','SAVEPOINT','SET','SHOW','EXPLAIN','REFRESH','GRANT',
+						'REVOKE','LOCK','FETCH','DECLARE','PREPARE','EXECUTE')
+					THEN upper(substring(query FROM '[a-zA-Z]+')) END
 					FROM pg_stat_activity
 					WHERE state <> 'idle' AND xact_start IS NOT NULL AND backend_type = 'client backend'
 					ORDER BY xact_start ASC LIMIT 1) AS query_kind,

--- a/server/src/db/probes/longTxnProbe.ts
+++ b/server/src/db/probes/longTxnProbe.ts
@@ -7,7 +7,7 @@ type LongTxnRow = {
 	max_xmin_lag: number | null;
 	pid: number | null;
 	wait_event: string | null;
-	query: string | null;
+	visible_backends: number | null;
 };
 
 // Longest-running client transaction + how far any backend holds the xmin
@@ -31,12 +31,21 @@ export const longTxnProbe: DbProbe = {
 					FROM pg_stat_activity
 					WHERE state <> 'idle' AND xact_start IS NOT NULL AND backend_type = 'client backend'
 					ORDER BY xact_start ASC LIMIT 1) AS wait_event,
-				(SELECT left(regexp_replace(query, '[[:space:]]+', ' ', 'g'), 300)
-					FROM pg_stat_activity
-					WHERE state <> 'idle' AND xact_start IS NOT NULL AND backend_type = 'client backend'
-					ORDER BY xact_start ASC LIMIT 1) AS query
+				(SELECT count(*)::int FROM pg_stat_activity) AS visible_backends
 		`);
 
+		const visibleBackends = row?.visible_backends ?? 0;
+		// Without pg_monitor visibility the role sees only its own session, so
+		// every metric reads 0 — surface that instead of giving false confidence.
+		if (visibleBackends <= 1) {
+			logger.warn(
+				{ type: "db_long_txn_blind", visible_backends: visibleBackends },
+				"DB long-txn probe sees <=1 backend — missing pg_monitor visibility?",
+			);
+		}
+
+		// The offending query text is intentionally NOT logged (it can contain
+		// customer literals). Triage the pinner by pid via `ops db-long`.
 		logger.info(
 			{
 				type: "db_long_txn",
@@ -44,7 +53,7 @@ export const longTxnProbe: DbProbe = {
 				max_xmin_lag: row?.max_xmin_lag ?? 0,
 				pid: row?.pid ?? null,
 				wait_event: row?.wait_event ?? null,
-				query: row?.query ?? null,
+				visible_backends: visibleBackends,
 			},
 			"DB long-txn probe",
 		);

--- a/server/src/db/probes/longTxnProbe.ts
+++ b/server/src/db/probes/longTxnProbe.ts
@@ -7,12 +7,10 @@ type LongTxnRow = {
 	max_xmin_lag: number | null;
 	pid: number | null;
 	wait_event: string | null;
+	query_kind: string | null;
 	visible_backends: number | null;
 };
 
-// Longest-running client transaction + how far any backend holds the xmin
-// horizon back. Leading signal for the xmin-pin / sync-convoy failure mode: a
-// long client txn pins xmin, blocks HOT-prune/VACUUM, and stalls the primary.
 export const longTxnProbe: DbProbe = {
 	name: "db_long_txn",
 	run: async ({ db }) => {
@@ -31,28 +29,31 @@ export const longTxnProbe: DbProbe = {
 					FROM pg_stat_activity
 					WHERE state <> 'idle' AND xact_start IS NOT NULL AND backend_type = 'client backend'
 					ORDER BY xact_start ASC LIMIT 1) AS wait_event,
+				(SELECT upper(substring(query FROM '[a-zA-Z]+'))
+					FROM pg_stat_activity
+					WHERE state <> 'idle' AND xact_start IS NOT NULL AND backend_type = 'client backend'
+					ORDER BY xact_start ASC LIMIT 1) AS query_kind,
 				(SELECT count(*)::int FROM pg_stat_activity) AS visible_backends
 		`);
 
 		const visibleBackends = row?.visible_backends ?? 0;
-		// Without pg_monitor visibility the role sees only its own session, so
-		// every metric reads 0 — surface that instead of giving false confidence.
-		if (visibleBackends <= 1) {
+		const blind = visibleBackends <= 1;
+		if (blind) {
 			logger.warn(
 				{ type: "db_long_txn_blind", visible_backends: visibleBackends },
 				"DB long-txn probe sees <=1 backend — missing pg_monitor visibility?",
 			);
 		}
 
-		// The offending query text is intentionally NOT logged (it can contain
-		// customer literals). Triage the pinner by pid via `ops db-long`.
 		logger.info(
 			{
 				type: "db_long_txn",
-				longest_txn_seconds: row?.longest_txn_seconds ?? 0,
-				max_xmin_lag: row?.max_xmin_lag ?? 0,
-				pid: row?.pid ?? null,
-				wait_event: row?.wait_event ?? null,
+				blind,
+				longest_txn_seconds: blind ? null : (row?.longest_txn_seconds ?? 0),
+				max_xmin_lag: blind ? null : (row?.max_xmin_lag ?? 0),
+				pid: blind ? null : (row?.pid ?? null),
+				wait_event: blind ? null : (row?.wait_event ?? null),
+				query_kind: blind ? null : (row?.query_kind ?? null),
 				visible_backends: visibleBackends,
 			},
 			"DB long-txn probe",

--- a/server/src/db/probes/longTxnProbe.ts
+++ b/server/src/db/probes/longTxnProbe.ts
@@ -15,29 +15,29 @@ export const longTxnProbe: DbProbe = {
 	name: "db_long_txn",
 	run: async ({ db }) => {
 		const [row] = await db.execute<LongTxnRow>(sql`
+			WITH oldest AS (
+				SELECT
+					round(extract(epoch FROM (now() - xact_start)))::int AS longest_txn_seconds,
+					pid,
+					coalesce(wait_event_type || '/' || wait_event, 'on_cpu') AS wait_event,
+					CASE WHEN upper(substring(query FROM '[a-zA-Z]+')) IN (
+							'SELECT','INSERT','UPDATE','DELETE','WITH','MERGE','CALL','VACUUM',
+							'ANALYZE','COPY','TRUNCATE','CREATE','ALTER','DROP','BEGIN','COMMIT',
+							'ROLLBACK','SAVEPOINT','SET','SHOW','EXPLAIN','REFRESH','GRANT',
+							'REVOKE','LOCK','FETCH','DECLARE','PREPARE','EXECUTE')
+						THEN upper(substring(query FROM '[a-zA-Z]+')) END AS query_kind
+				FROM pg_stat_activity
+				WHERE state <> 'idle' AND xact_start IS NOT NULL AND backend_type = 'client backend'
+				ORDER BY xact_start ASC, pid ASC
+				LIMIT 1
+			)
 			SELECT
-				coalesce((SELECT round(extract(epoch FROM (now() - min(xact_start))))::int
-					FROM pg_stat_activity
-					WHERE state <> 'idle' AND xact_start IS NOT NULL
-						AND backend_type = 'client backend'), 0) AS longest_txn_seconds,
+				coalesce((SELECT longest_txn_seconds FROM oldest), 0) AS longest_txn_seconds,
 				coalesce((SELECT max(age(backend_xmin))
 					FROM pg_stat_activity WHERE backend_xmin IS NOT NULL), 0) AS max_xmin_lag,
-				(SELECT pid FROM pg_stat_activity
-					WHERE state <> 'idle' AND xact_start IS NOT NULL AND backend_type = 'client backend'
-					ORDER BY xact_start ASC LIMIT 1) AS pid,
-				(SELECT coalesce(wait_event_type || '/' || wait_event, 'on_cpu')
-					FROM pg_stat_activity
-					WHERE state <> 'idle' AND xact_start IS NOT NULL AND backend_type = 'client backend'
-					ORDER BY xact_start ASC LIMIT 1) AS wait_event,
-				(SELECT CASE WHEN upper(substring(query FROM '[a-zA-Z]+')) IN (
-						'SELECT','INSERT','UPDATE','DELETE','WITH','MERGE','CALL','VACUUM',
-						'ANALYZE','COPY','TRUNCATE','CREATE','ALTER','DROP','BEGIN','COMMIT',
-						'ROLLBACK','SAVEPOINT','SET','SHOW','EXPLAIN','REFRESH','GRANT',
-						'REVOKE','LOCK','FETCH','DECLARE','PREPARE','EXECUTE')
-					THEN upper(substring(query FROM '[a-zA-Z]+')) END
-					FROM pg_stat_activity
-					WHERE state <> 'idle' AND xact_start IS NOT NULL AND backend_type = 'client backend'
-					ORDER BY xact_start ASC LIMIT 1) AS query_kind,
+				(SELECT pid FROM oldest) AS pid,
+				(SELECT wait_event FROM oldest) AS wait_event,
+				(SELECT query_kind FROM oldest) AS query_kind,
 				(SELECT count(*)::int FROM pg_stat_activity) AS visible_backends
 		`);
 

--- a/server/src/db/probes/registry.ts
+++ b/server/src/db/probes/registry.ts
@@ -1,8 +1,4 @@
 import { longTxnProbe } from "./longTxnProbe.js";
 import type { DbProbe } from "./types.js";
 
-/**
- * Every DB health probe run on the cron tick. Add a new check by importing its
- * DbProbe here — it is scheduled and error-isolated automatically.
- */
-export const dbProbes: DbProbe[] = [longTxnProbe];
+export const dbProbes: readonly DbProbe[] = [longTxnProbe];

--- a/server/src/db/probes/registry.ts
+++ b/server/src/db/probes/registry.ts
@@ -1,0 +1,8 @@
+import { longTxnProbe } from "./longTxnProbe.js";
+import type { DbProbe } from "./types.js";
+
+/**
+ * Every DB health probe run on the cron tick. Add a new check by importing its
+ * DbProbe here — it is scheduled and error-isolated automatically.
+ */
+export const dbProbes: DbProbe[] = [longTxnProbe];

--- a/server/src/db/probes/runDbProbes.ts
+++ b/server/src/db/probes/runDbProbes.ts
@@ -3,23 +3,66 @@ import type { DrizzleCli } from "../initDrizzle.js";
 import { dbProbes } from "./registry.js";
 import type { DbProbe } from "./types.js";
 
-const runProbe = async (probe: DbProbe, db: DrizzleCli): Promise<void> => {
+const PROBE_TIMEOUT_MS = 10_000;
+
+// Single-flight: skip a tick while the previous run is still in flight, so a
+// slow probe (exactly when the DB is under pressure) can't stack up ticks and
+// pile connections onto the cron pool.
+let running = false;
+
+const withTimeout = <T>(
+	promise: Promise<T>,
+	ms: number,
+	label: string,
+): Promise<T> => {
+	let timer: ReturnType<typeof setTimeout>;
+	const timeout = new Promise<never>((_, reject) => {
+		timer = setTimeout(
+			() => reject(new Error(`${label} timed out after ${ms}ms`)),
+			ms,
+		);
+	});
+	return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+};
+
+const runProbe = async (
+	probe: DbProbe,
+	db: DrizzleCli,
+	timeoutMs: number,
+): Promise<void> => {
 	try {
-		await probe.run({ db });
+		await withTimeout(probe.run({ db }), timeoutMs, `db probe ${probe.name}`);
 	} catch (error) {
-		// A probe must never break the cron tick or the other probes.
+		// A probe must never break the cron tick or the other probes. Pass the
+		// raw Error so the structured logger keeps the stack/cause.
 		logger.warn(
-			{ type: "db_probe_error", probe: probe.name, error: String(error) },
+			{ type: "db_probe_error", probe: probe.name, err: error },
 			"DB probe failed",
 		);
 	}
 };
 
-/** Runs every registered DB health probe once, each isolated from the others. */
+/** Runs every registered DB health probe once — each isolated and time-bounded. */
 export const runDbProbes = async ({
 	db,
+	probes = dbProbes,
+	timeoutMs = PROBE_TIMEOUT_MS,
 }: {
 	db: DrizzleCli;
+	probes?: DbProbe[];
+	timeoutMs?: number;
 }): Promise<void> => {
-	await Promise.all(dbProbes.map((probe) => runProbe(probe, db)));
+	if (running) {
+		logger.info(
+			{ type: "db_probes_skipped" },
+			"DB probes still in flight, skipping tick",
+		);
+		return;
+	}
+	running = true;
+	try {
+		await Promise.all(probes.map((probe) => runProbe(probe, db, timeoutMs)));
+	} finally {
+		running = false;
+	}
 };

--- a/server/src/db/probes/runDbProbes.ts
+++ b/server/src/db/probes/runDbProbes.ts
@@ -43,7 +43,7 @@ export const runDbProbes = async ({
 	timeoutMs = PROBE_TIMEOUT_MS,
 }: {
 	db: DrizzleCli;
-	probes?: DbProbe[];
+	probes?: readonly DbProbe[];
 	timeoutMs?: number;
 }): Promise<void> => {
 	if (running) {

--- a/server/src/db/probes/runDbProbes.ts
+++ b/server/src/db/probes/runDbProbes.ts
@@ -1,0 +1,25 @@
+import { logger } from "../../external/logtail/logtailUtils.js";
+import type { DrizzleCli } from "../initDrizzle.js";
+import { dbProbes } from "./registry.js";
+import type { DbProbe } from "./types.js";
+
+const runProbe = async (probe: DbProbe, db: DrizzleCli): Promise<void> => {
+	try {
+		await probe.run({ db });
+	} catch (error) {
+		// A probe must never break the cron tick or the other probes.
+		logger.warn(
+			{ type: "db_probe_error", probe: probe.name, error: String(error) },
+			"DB probe failed",
+		);
+	}
+};
+
+/** Runs every registered DB health probe once, each isolated from the others. */
+export const runDbProbes = async ({
+	db,
+}: {
+	db: DrizzleCli;
+}): Promise<void> => {
+	await Promise.all(dbProbes.map((probe) => runProbe(probe, db)));
+};

--- a/server/src/db/probes/runDbProbes.ts
+++ b/server/src/db/probes/runDbProbes.ts
@@ -5,9 +5,6 @@ import type { DbProbe } from "./types.js";
 
 const PROBE_TIMEOUT_MS = 10_000;
 
-// Single-flight: skip a tick while the previous run is still in flight, so a
-// slow probe (exactly when the DB is under pressure) can't stack up ticks and
-// pile connections onto the cron pool.
 let running = false;
 
 const withTimeout = <T>(
@@ -33,8 +30,6 @@ const runProbe = async (
 	try {
 		await withTimeout(probe.run({ db }), timeoutMs, `db probe ${probe.name}`);
 	} catch (error) {
-		// A probe must never break the cron tick or the other probes. Pass the
-		// raw Error so the structured logger keeps the stack/cause.
 		logger.warn(
 			{ type: "db_probe_error", probe: probe.name, err: error },
 			"DB probe failed",
@@ -42,7 +37,6 @@ const runProbe = async (
 	}
 };
 
-/** Runs every registered DB health probe once — each isolated and time-bounded. */
 export const runDbProbes = async ({
 	db,
 	probes = dbProbes,

--- a/server/src/db/probes/types.ts
+++ b/server/src/db/probes/types.ts
@@ -1,0 +1,13 @@
+import type { DrizzleCli } from "../initDrizzle.js";
+
+/**
+ * A DB health probe: reads pg_stat_* (or similar) and emits one tagged
+ * telemetry line per run for an Axiom monitor to alert on. Add a probe by
+ * creating a file that exports a DbProbe and registering it in registry.ts.
+ */
+export type DbProbe = {
+	/** Stable slug — also the `type` tag on the emitted log + the Axiom monitor key. */
+	name: string;
+	/** Reads the DB and emits its telemetry line. Runs on every cron tick. */
+	run: (args: { db: DrizzleCli }) => Promise<void>;
+};

--- a/server/src/db/probes/types.ts
+++ b/server/src/db/probes/types.ts
@@ -1,13 +1,6 @@
 import type { DrizzleCli } from "../initDrizzle.js";
 
-/**
- * A DB health probe: reads pg_stat_* (or similar) and emits one tagged
- * telemetry line per run for an Axiom monitor to alert on. Add a probe by
- * creating a file that exports a DbProbe and registering it in registry.ts.
- */
 export type DbProbe = {
-	/** Stable slug — also the `type` tag on the emitted log + the Axiom monitor key. */
 	name: string;
-	/** Reads the DB and emits its telemetry line. Runs on every cron tick. */
 	run: (args: { db: DrizzleCli }) => Promise<void>;
 };

--- a/server/tests/unit/db/probes.test.ts
+++ b/server/tests/unit/db/probes.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import type { DbProbe } from "@/db/probes/types.js";
 
-// Mock the logger before importing the SUT so probe emits are captured, not shipped.
 const info = mock((..._args: unknown[]) => {});
 const warn = mock((..._args: unknown[]) => {});
 mock.module("@/external/logtail/logtailUtils.js", () => ({
@@ -92,7 +91,7 @@ describe("runDbProbes", () => {
 });
 
 describe("longTxnProbe", () => {
-	it("emits db_long_txn and never logs raw query text", async () => {
+	it("emits db_long_txn with query_kind and never logs raw query text", async () => {
 		const db = {
 			execute: async () => [
 				{
@@ -100,6 +99,7 @@ describe("longTxnProbe", () => {
 					max_xmin_lag: 123,
 					pid: 999,
 					wait_event: "on_cpu",
+					query_kind: "UPDATE",
 					visible_backends: 60,
 				},
 			],
@@ -112,30 +112,17 @@ describe("longTxnProbe", () => {
 		const [fields] = info.mock.calls[0];
 		expect(fields).toMatchObject({
 			type: "db_long_txn",
+			blind: false,
 			longest_txn_seconds: 42,
 			max_xmin_lag: 123,
 			pid: 999,
 			wait_event: "on_cpu",
+			query_kind: "UPDATE",
 		});
 		expect(fields).not.toHaveProperty("query");
 	});
 
-	it("defaults to zeros on an empty result", async () => {
-		// biome-ignore lint/suspicious/noExplicitAny: minimal db stub
-		const db = { execute: async () => [] } as any;
-
-		await longTxnProbe.run({ db });
-
-		const [fields] = info.mock.calls[0];
-		expect(fields).toMatchObject({
-			type: "db_long_txn",
-			longest_txn_seconds: 0,
-			max_xmin_lag: 0,
-			pid: null,
-		});
-	});
-
-	it("warns when it can see <=1 backend (missing pg_monitor visibility)", async () => {
+	it("marks blind readings with null metrics so they can't look healthy", async () => {
 		const db = {
 			execute: async () => [
 				{
@@ -143,6 +130,7 @@ describe("longTxnProbe", () => {
 					max_xmin_lag: 0,
 					pid: null,
 					wait_event: null,
+					query_kind: null,
 					visible_backends: 1,
 				},
 			],
@@ -155,6 +143,29 @@ describe("longTxnProbe", () => {
 		expect(warn.mock.calls[0][0]).toMatchObject({
 			type: "db_long_txn_blind",
 			visible_backends: 1,
+		});
+		const [fields] = info.mock.calls[0];
+		expect(fields).toMatchObject({
+			type: "db_long_txn",
+			blind: true,
+			longest_txn_seconds: null,
+			max_xmin_lag: null,
+		});
+	});
+
+	it("treats an empty result as blind (no fake-healthy zero)", async () => {
+		// biome-ignore lint/suspicious/noExplicitAny: minimal db stub
+		const db = { execute: async () => [] } as any;
+
+		await longTxnProbe.run({ db });
+
+		expect(warn).toHaveBeenCalledTimes(1);
+		const [fields] = info.mock.calls[0];
+		expect(fields).toMatchObject({
+			type: "db_long_txn",
+			blind: true,
+			longest_txn_seconds: null,
+			max_xmin_lag: null,
 		});
 	});
 });

--- a/server/tests/unit/db/probes.test.ts
+++ b/server/tests/unit/db/probes.test.ts
@@ -96,7 +96,7 @@ describe("longTxnProbe", () => {
 			execute: async () => [
 				{
 					longest_txn_seconds: 42,
-					max_xmin_lag: 123,
+					xmin_lag: 123,
 					pid: 999,
 					wait_event: "on_cpu",
 					query_kind: "UPDATE",
@@ -114,7 +114,7 @@ describe("longTxnProbe", () => {
 			type: "db_long_txn",
 			blind: false,
 			longest_txn_seconds: 42,
-			max_xmin_lag: 123,
+			xmin_lag: 123,
 			pid: 999,
 			wait_event: "on_cpu",
 			query_kind: "UPDATE",
@@ -127,7 +127,7 @@ describe("longTxnProbe", () => {
 			execute: async () => [
 				{
 					longest_txn_seconds: 0,
-					max_xmin_lag: 0,
+					xmin_lag: 0,
 					pid: null,
 					wait_event: null,
 					query_kind: null,
@@ -149,7 +149,7 @@ describe("longTxnProbe", () => {
 			type: "db_long_txn",
 			blind: true,
 			longest_txn_seconds: null,
-			max_xmin_lag: null,
+			xmin_lag: null,
 		});
 	});
 
@@ -160,12 +160,16 @@ describe("longTxnProbe", () => {
 		await longTxnProbe.run({ db });
 
 		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0][0]).toMatchObject({
+			type: "db_long_txn_blind",
+			visible_backends: 0,
+		});
 		const [fields] = info.mock.calls[0];
 		expect(fields).toMatchObject({
 			type: "db_long_txn",
 			blind: true,
 			longest_txn_seconds: null,
-			max_xmin_lag: null,
+			xmin_lag: null,
 		});
 	});
 });

--- a/server/tests/unit/db/probes.test.ts
+++ b/server/tests/unit/db/probes.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { DbProbe } from "@/db/probes/types.js";
+
+// Mock the logger before importing the SUT so probe emits are captured, not shipped.
+const info = mock((..._args: unknown[]) => {});
+const warn = mock((..._args: unknown[]) => {});
+mock.module("@/external/logtail/logtailUtils.js", () => ({
+	logger: {
+		info,
+		warn,
+		error: mock(() => {}),
+		debug: mock(() => {}),
+		child: () => ({}),
+	},
+}));
+
+const { runDbProbes } = await import("@/db/probes/runDbProbes.js");
+const { longTxnProbe } = await import("@/db/probes/longTxnProbe.js");
+
+// biome-ignore lint/suspicious/noExplicitAny: probes ignore the db in these tests
+const fakeDb = {} as any;
+
+beforeEach(() => {
+	info.mockClear();
+	warn.mockClear();
+});
+
+describe("runDbProbes", () => {
+	it("isolates a throwing probe: others still run, error is logged", async () => {
+		const ran: string[] = [];
+		const good: DbProbe = {
+			name: "good",
+			run: async () => {
+				ran.push("good");
+			},
+		};
+		const bad: DbProbe = {
+			name: "bad",
+			run: async () => {
+				throw new Error("boom");
+			},
+		};
+
+		await runDbProbes({ db: fakeDb, probes: [bad, good] });
+
+		expect(ran).toEqual(["good"]);
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0][0]).toMatchObject({
+			type: "db_probe_error",
+			probe: "bad",
+		});
+	});
+
+	it("bounds a hung probe with a timeout instead of hanging forever", async () => {
+		const hung: DbProbe = {
+			name: "hung",
+			run: () => new Promise<void>(() => {}),
+		};
+
+		const start = Date.now();
+		await runDbProbes({ db: fakeDb, probes: [hung], timeoutMs: 30 });
+
+		expect(Date.now() - start).toBeLessThan(2000);
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0][0]).toMatchObject({
+			type: "db_probe_error",
+			probe: "hung",
+		});
+	});
+
+	it("single-flights: a concurrent tick is skipped while one is in flight", async () => {
+		let runs = 0;
+		const slow: DbProbe = {
+			name: "slow",
+			run: async () => {
+				runs++;
+				await new Promise((r) => setTimeout(r, 40));
+			},
+		};
+
+		await Promise.all([
+			runDbProbes({ db: fakeDb, probes: [slow] }),
+			runDbProbes({ db: fakeDb, probes: [slow] }),
+		]);
+
+		expect(runs).toBe(1);
+		expect(info).toHaveBeenCalledWith(
+			{ type: "db_probes_skipped" },
+			expect.any(String),
+		);
+	});
+});
+
+describe("longTxnProbe", () => {
+	it("emits db_long_txn and never logs raw query text", async () => {
+		const db = {
+			execute: async () => [
+				{
+					longest_txn_seconds: 42,
+					max_xmin_lag: 123,
+					pid: 999,
+					wait_event: "on_cpu",
+					visible_backends: 60,
+				},
+			],
+			// biome-ignore lint/suspicious/noExplicitAny: minimal db stub
+		} as any;
+
+		await longTxnProbe.run({ db });
+
+		expect(info).toHaveBeenCalledTimes(1);
+		const [fields] = info.mock.calls[0];
+		expect(fields).toMatchObject({
+			type: "db_long_txn",
+			longest_txn_seconds: 42,
+			max_xmin_lag: 123,
+			pid: 999,
+			wait_event: "on_cpu",
+		});
+		expect(fields).not.toHaveProperty("query");
+	});
+
+	it("defaults to zeros on an empty result", async () => {
+		// biome-ignore lint/suspicious/noExplicitAny: minimal db stub
+		const db = { execute: async () => [] } as any;
+
+		await longTxnProbe.run({ db });
+
+		const [fields] = info.mock.calls[0];
+		expect(fields).toMatchObject({
+			type: "db_long_txn",
+			longest_txn_seconds: 0,
+			max_xmin_lag: 0,
+			pid: null,
+		});
+	});
+
+	it("warns when it can see <=1 backend (missing pg_monitor visibility)", async () => {
+		const db = {
+			execute: async () => [
+				{
+					longest_txn_seconds: 0,
+					max_xmin_lag: 0,
+					pid: null,
+					wait_event: null,
+					visible_backends: 1,
+				},
+			],
+			// biome-ignore lint/suspicious/noExplicitAny: minimal db stub
+		} as any;
+
+		await longTxnProbe.run({ db });
+
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0][0]).toMatchObject({
+			type: "db_long_txn_blind",
+			visible_backends: 1,
+		});
+	});
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a DB health probe framework and a long-transaction/xmin probe on its own per-minute cron with a dedicated low-connection pool. Probes run concurrently with isolation, single-flight, and 10s timeouts; logs record only allowlisted query_kind and never SQL text.

- **New Features**
  - Runner and readonly registry execute probes concurrently with per-probe isolation, single-flight, and a 10s timeout.
  - db_long_txn logs longest_txn_seconds, xmin_lag, pid, wait_event, query_kind (allowlisted), and visible_backends (via count(state)); never logs query text; when visibility is limited (<=1), emits db_long_txn_blind with blind: true and null metrics.
  - Dedicated, slot-gated per-minute cron for DB probes using a separate `initDrizzle` pool (2 max connections, 5s connect timeout) so heavy jobs can’t delay detection or starve connections.

- **Refactors**
  - Long-txn probe selects the oldest backend once for consistent metrics.

<sup>Written for commit 857c55d670cac5915251f47bf605bfe42658e46d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a database health probe framework and a long-transaction/xmin probe. The main changes are:

- Dedicated per-minute cron execution for DB probes.
- Probe registry and runner with timeout, isolation, and single-flight behavior.
- Long-transaction logging with visibility checks and null metrics when the probe is blind.
- Query kind logging limited to an allowlisted SQL verb instead of raw query text.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/db/probes/longTxnProbe.ts | Adds the long-transaction/xmin probe with blind-mode metrics and allowlisted query kind logging. |
| server/src/db/probes/runDbProbes.ts | Adds the probe runner with per-probe timeout handling, error isolation, and single-flight execution. |
| server/src/cron/cronInit.ts | Adds a separate slot-gated cron tick for DB probes. |

<sub>Reviews (4): Last reviewed commit: ["fix(probes): allowlist query\_kind so no ..."](https://github.com/useautumn/autumn/commit/8a83677b43d5364c1c3833164f6a688c055953be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42391643)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->