### PR TITLE
Replace atmn custom .env parser with dotenv

### DIFF
--- a/packages/atmn/src/lib/env/dotenv.ts
+++ b/packages/atmn/src/lib/env/dotenv.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { parse } from "dotenv";
 
 /**
  * Low-level .env file reading/writing utilities
@@ -11,32 +12,10 @@ export interface DotenvEntry {
 }
 
 /**
- * Parse .env file content into key-value pairs
+ * Parse .env file content into key-value pairs (delegates to dotenv)
  */
 export function parseDotenv(content: string): Map<string, string> {
-	const entries = new Map<string, string>();
-
-	for (const line of content.split("\n")) {
-		const trimmed = line.trim();
-
-		// Skip comments and empty lines
-		if (!trimmed || trimmed.startsWith("#")) {
-			continue;
-		}
-
-		// Parse KEY=VALUE
-		const match = trimmed.match(/^([^=]+)=(.*)$/);
-		if (match) {
-			const [, key, value] = match;
-			if (key && value !== undefined) {
-				// Remove quotes if present
-				const cleanValue = value.replace(/^["']|["']$/g, "");
-				entries.set(key.trim(), cleanValue);
-			}
-		}
-	}
-
-	return entries;
+	return new Map(Object.entries(parse(content)));
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the hand-rolled `.env`/`.env.local` line parser in `packages/atmn/src/lib/env/dotenv.ts` with the `dotenv` package's `parse()` function. `dotenv` (v17) was already a dependency of the package, so no dependency changes were needed.

`parseDotenv()` now delegates to `dotenv.parse()` and returns the same `Map<string, string>` shape, so all callers (`readDotenvFile`, `getDotenvValue`, `setDotenvValue`, `readApiKeys`, etc.) are unchanged. The precedence order (`process.env` → `.env.local` → `.env`) and the line-preserving write/remove helpers (`writeDotenvFile`, `removeKeysFromEnv`) are untouched.

Side benefit: the parser now correctly handles `export KEY=...` prefixes, multiline quoted values, inline comments (`KEY=value # comment`), and `#` inside quoted values, which the old regex-based parser did not.

## Testing

- Ran a verification script with `bun` against the modified module covering: basic keys, single/double quotes, empty values, whitespace trimming, `export` prefixes, multiline values, inline comments, `#` inside quotes, `.env.local` > `.env` precedence, `process.env` precedence, `setDotenvValue` round-trip, and `removeKeysFromEnv` comment preservation — all passed.
- `bunx tsgo --build --noEmit` (package typecheck) passes.
- `bunx biome check` on the modified file passes.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1783446703259029?thread_ts=1783446703.259029&cid=C0BCAQQK0KS)

<div><a href="https://cursor.com/agents/bc-0d67c0ee-db8f-5ee4-9ae4-6051ee5b5f32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d67c0ee-db8f-5ee4-9ae4-6051ee5b5f32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the custom `.env` parser in `packages/atmn/src/lib/env/dotenv.ts` with `dotenv.parse()` to improve correctness. This keeps `parseDotenv`’s Map return type, all callers, and precedence (`process.env` → `.env.local` → `.env`) unchanged.

- **Bug Fixes**
  - Correctly parses `export`-prefixed keys, multiline quoted values, inline comments, and `#` inside quotes.

<sup>Written for commit 22c28c3e1013fc8abef81bccd13675fdc4121149. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the custom environment-file parser with `dotenv.parse()`. The main changes are:

- **[Improvements] [Bug fixes]** Support standard dotenv quoting, comments, exports, and multiline values.
- **[API changes]** Preserve the existing `Map<string, string>` return shape for callers.
</details>

<h3>Confidence Score: 5/5</h3>

The parser change is mostly safe, with a non-blocking compatibility issue in read-modify-write flows.

- Standard dotenv files gain the intended parsing behavior.
- Updating one key can truncate an existing unquoted value containing `#`.

packages/atmn/src/lib/env/dotenv.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/atmn/src/lib/env/dotenv.ts | Delegates environment parsing to dotenv while retaining the existing Map interface; read-modify-write operations can now truncate legacy unquoted values containing `#`. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/atmn/src/lib/env/dotenv.ts:18
**Read-Modify-Write Truncates Values**

When `setDotenvValue` reads a file containing an unquoted value such as `TOKEN=abc#def`, `dotenv.parse()` treats `#def` as a comment. The unchanged writer then persists only `TOKEN=abc`, so updating another key can silently corrupt an existing value that the previous parser preserved.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Replace atmn custom .env parser with dot..."](https://github.com/useautumn/autumn/commit/22c28c3e1013fc8abef81bccd13675fdc4121149) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43859465)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->