### PR TITLE
fix: resync scheduled cusProduct starts_at on subscription_schedule.updated

### DIFF
--- a/server/src/external/stripe/handleStripeWebhookEvent.ts
+++ b/server/src/external/stripe/handleStripeWebhookEvent.ts
@@ -18,6 +18,7 @@ import { handleStripeSubscriptionDeleted } from "./webhookHandlers/handleStripeS
 import { handleStripeSubscriptionCreated } from "./webhookHandlers/handleStripeSubscriptionCreated/handleStripeSubscriptionCreated.js";
 import { handleStripeTestClockReady } from "./webhookHandlers/handleStripeTestClockReady.js";
 import { handleSubscriptionScheduleCanceled } from "./webhookHandlers/handleSubScheduleCanceled.js";
+import { handleSubscriptionScheduleUpdated } from "./webhookHandlers/handleSubScheduleUpdated.js";
 import type {
 	StripeWebhookContext,
 	StripeWebhookHonoEnv,
@@ -69,6 +70,14 @@ export const handleStripeWebhookEvent = async (
 
 			case "invoice.finalized": {
 				await handleStripeInvoiceFinalized({ ctx, event });
+				break;
+			}
+
+			case "subscription_schedule.updated": {
+				await handleSubscriptionScheduleUpdated({
+					ctx,
+					schedule: event.data.object,
+				});
 				break;
 			}
 

--- a/server/src/external/stripe/handleStripeWebhookEvent.ts
+++ b/server/src/external/stripe/handleStripeWebhookEvent.ts
@@ -74,10 +74,7 @@ export const handleStripeWebhookEvent = async (
 			}
 
 			case "subscription_schedule.updated": {
-				await handleStripeSubscriptionScheduleUpdated({
-					ctx,
-					schedule: event.data.object,
-				});
+				await handleStripeSubscriptionScheduleUpdated({ ctx, event });
 				break;
 			}
 

--- a/server/src/external/stripe/handleStripeWebhookEvent.ts
+++ b/server/src/external/stripe/handleStripeWebhookEvent.ts
@@ -18,7 +18,7 @@ import { handleStripeSubscriptionDeleted } from "./webhookHandlers/handleStripeS
 import { handleStripeSubscriptionCreated } from "./webhookHandlers/handleStripeSubscriptionCreated/handleStripeSubscriptionCreated.js";
 import { handleStripeTestClockReady } from "./webhookHandlers/handleStripeTestClockReady.js";
 import { handleSubscriptionScheduleCanceled } from "./webhookHandlers/handleSubScheduleCanceled.js";
-import { handleSubscriptionScheduleUpdated } from "./webhookHandlers/handleSubScheduleUpdated.js";
+import { handleStripeSubscriptionScheduleUpdated } from "./webhookHandlers/handleStripeSubscriptionScheduleUpdated/handleStripeSubscriptionScheduleUpdated.js";
 import type {
 	StripeWebhookContext,
 	StripeWebhookHonoEnv,
@@ -74,7 +74,7 @@ export const handleStripeWebhookEvent = async (
 			}
 
 			case "subscription_schedule.updated": {
-				await handleSubscriptionScheduleUpdated({
+				await handleStripeSubscriptionScheduleUpdated({
 					ctx,
 					schedule: event.data.object,
 				});

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionScheduleUpdated/getSchedulePhaseMoves.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionScheduleUpdated/getSchedulePhaseMoves.ts
@@ -1,0 +1,27 @@
+import type Stripe from "stripe";
+
+// Stripe stores phase starts at second precision; Autumn stores ms. Ignore
+// sub-second drift so Autumn's own schedule writes don't echo back as updates.
+export const STRIPE_SECOND_PRECISION_MS = 1000;
+
+export type SchedulePhaseMove = { oldStartMs: number; newStartMs: number };
+
+/** Pairs previous/current phases by index and returns the ones whose start moved. */
+export const getSchedulePhaseMoves = ({
+	previousPhases,
+	currentPhases,
+}: {
+	previousPhases: Stripe.SubscriptionSchedule.Phase[];
+	currentPhases: Stripe.SubscriptionSchedule.Phase[];
+}): SchedulePhaseMove[] => {
+	const moves: SchedulePhaseMove[] = [];
+	for (const [index, previousPhase] of previousPhases.entries()) {
+		const oldStartMs = (previousPhase.start_date ?? 0) * 1000;
+		const newStartMs = (currentPhases[index]?.start_date ?? 0) * 1000;
+		if (!(oldStartMs && newStartMs)) continue;
+		if (Math.abs(oldStartMs - newStartMs) < STRIPE_SECOND_PRECISION_MS)
+			continue;
+		moves.push({ oldStartMs, newStartMs });
+	}
+	return moves;
+};

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionScheduleUpdated/handleStripeSubscriptionScheduleUpdated.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionScheduleUpdated/handleStripeSubscriptionScheduleUpdated.ts
@@ -1,4 +1,5 @@
-import { CusProductStatus } from "@autumn/shared";
+import { CusProductStatus, schedulePhases } from "@autumn/shared";
+import { and, arrayOverlaps, gte, lt } from "drizzle-orm";
 import type Stripe from "stripe";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService.js";
 import type { StripeWebhookContext } from "../../webhookMiddlewares/stripeWebhookContext.js";
@@ -7,25 +8,54 @@ import type { StripeWebhookContext } from "../../webhookMiddlewares/stripeWebhoo
 // sub-second drift so Autumn's own schedule writes don't echo back as updates.
 const STRIPE_SECOND_PRECISION_MS = 1000;
 
+type PhaseMove = { oldStartMs: number; newStartMs: number };
+
+const getPhaseMoves = ({
+	previousPhases,
+	currentPhases,
+}: {
+	previousPhases: Stripe.SubscriptionSchedule.Phase[];
+	currentPhases: Stripe.SubscriptionSchedule.Phase[];
+}): PhaseMove[] => {
+	const moves: PhaseMove[] = [];
+	for (const [index, previousPhase] of previousPhases.entries()) {
+		const oldStartMs = (previousPhase.start_date ?? 0) * 1000;
+		const newStartMs = (currentPhases[index]?.start_date ?? 0) * 1000;
+		if (!(oldStartMs && newStartMs)) continue;
+		if (Math.abs(oldStartMs - newStartMs) < STRIPE_SECOND_PRECISION_MS)
+			continue;
+		moves.push({ oldStartMs, newStartMs });
+	}
+	return moves;
+};
+
 /**
- * Re-syncs scheduled customerProduct starts_at when a not-yet-started schedule
- * is rescheduled outside Autumn (e.g. Stripe dashboard). Started schedules and
- * multi-phase schedules are intentionally left alone.
+ * Re-syncs scheduled customerProduct (and Autumn phase) starts_at when a
+ * not-yet-started schedule is rescheduled outside Autumn (e.g. Stripe
+ * dashboard). Each moved phase only touches the products anchored to its OLD
+ * start; started schedules and phase add/remove are intentionally left alone.
  */
 export const handleStripeSubscriptionScheduleUpdated = async ({
 	ctx,
-	schedule,
+	event,
 }: {
 	ctx: StripeWebhookContext;
-	schedule: Stripe.SubscriptionSchedule;
+	event: Stripe.SubscriptionScheduleUpdatedEvent;
 }) => {
 	const { db, org, env, logger } = ctx;
 
-	if (schedule.status !== "not_started") return;
-	if (schedule.phases.length !== 1) return;
+	const schedule = event.data.object;
+	const previousPhases = event.data.previous_attributes?.phases;
 
-	const phaseStartMs = (schedule.phases[0]?.start_date ?? 0) * 1000;
-	if (!phaseStartMs) return;
+	if (schedule.status !== "not_started") return;
+	if (!previousPhases) return;
+	if (previousPhases.length !== schedule.phases.length) return;
+
+	const moves = getPhaseMoves({
+		previousPhases,
+		currentPhases: schedule.phases,
+	});
+	if (moves.length === 0) return;
 
 	const customerProductsOnSchedule = await CusProductService.getByScheduleId({
 		db,
@@ -33,21 +63,41 @@ export const handleStripeSubscriptionScheduleUpdated = async ({
 		orgId: org.id,
 		env,
 	});
+	const scheduledProducts = customerProductsOnSchedule.filter(
+		(customerProduct) => customerProduct.status === CusProductStatus.Scheduled,
+	);
 
-	for (const customerProduct of customerProductsOnSchedule) {
-		if (customerProduct.status !== CusProductStatus.Scheduled) continue;
-
-		const driftMs = Math.abs((customerProduct.starts_at ?? 0) - phaseStartMs);
-		if (driftMs < STRIPE_SECOND_PRECISION_MS) continue;
-
-		await CusProductService.update({
-			ctx,
-			cusProductId: customerProduct.id,
-			updates: { starts_at: phaseStartMs },
-		});
-
-		logger.info(
-			`[handleStripeSubscriptionScheduleUpdated] resynced starts_at ${customerProduct.starts_at} -> ${phaseStartMs} for customerProduct ${customerProduct.id} (schedule ${schedule.id})`,
+	for (const { oldStartMs, newStartMs } of moves) {
+		const matchedProducts = scheduledProducts.filter(
+			(customerProduct) =>
+				Math.abs((customerProduct.starts_at ?? 0) - oldStartMs) <
+				STRIPE_SECOND_PRECISION_MS,
 		);
+		if (matchedProducts.length === 0) continue;
+
+		for (const customerProduct of matchedProducts) {
+			await CusProductService.update({
+				ctx,
+				cusProductId: customerProduct.id,
+				updates: { starts_at: newStartMs },
+			});
+			logger.info(
+				`[handleStripeSubscriptionScheduleUpdated] resynced starts_at ${customerProduct.starts_at} -> ${newStartMs} for customerProduct ${customerProduct.id} (schedule ${schedule.id})`,
+			);
+		}
+
+		await db
+			.update(schedulePhases)
+			.set({ starts_at: newStartMs })
+			.where(
+				and(
+					gte(schedulePhases.starts_at, oldStartMs),
+					lt(schedulePhases.starts_at, oldStartMs + STRIPE_SECOND_PRECISION_MS),
+					arrayOverlaps(
+						schedulePhases.customer_product_ids,
+						matchedProducts.map((customerProduct) => customerProduct.id),
+					),
+				),
+			);
 	}
 };

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionScheduleUpdated/handleStripeSubscriptionScheduleUpdated.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionScheduleUpdated/handleStripeSubscriptionScheduleUpdated.ts
@@ -20,7 +20,12 @@ export const handleStripeSubscriptionScheduleUpdated = async ({
 
 	if (schedule.status !== "not_started") return;
 	if (!previousPhases) return;
-	if (previousPhases.length !== schedule.phases.length) return;
+	if (previousPhases.length !== schedule.phases.length) {
+		ctx.logger.warn(
+			`[handleStripeSubscriptionScheduleUpdated] skipping structural phase change (${previousPhases.length} -> ${schedule.phases.length} phases) on schedule ${schedule.id}`,
+		);
+		return;
+	}
 
 	const moves = getSchedulePhaseMoves({
 		previousPhases,

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionScheduleUpdated/handleStripeSubscriptionScheduleUpdated.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionScheduleUpdated/handleStripeSubscriptionScheduleUpdated.ts
@@ -1,7 +1,7 @@
 import { CusProductStatus } from "@autumn/shared";
 import type Stripe from "stripe";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService.js";
-import type { StripeWebhookContext } from "../webhookMiddlewares/stripeWebhookContext.js";
+import type { StripeWebhookContext } from "../../webhookMiddlewares/stripeWebhookContext.js";
 
 // Stripe stores phase starts at second precision; Autumn stores ms. Ignore
 // sub-second drift so Autumn's own schedule writes don't echo back as updates.
@@ -12,7 +12,7 @@ const STRIPE_SECOND_PRECISION_MS = 1000;
  * is rescheduled outside Autumn (e.g. Stripe dashboard). Started schedules and
  * multi-phase schedules are intentionally left alone.
  */
-export const handleSubscriptionScheduleUpdated = async ({
+export const handleStripeSubscriptionScheduleUpdated = async ({
 	ctx,
 	schedule,
 }: {
@@ -47,7 +47,7 @@ export const handleSubscriptionScheduleUpdated = async ({
 		});
 
 		logger.info(
-			`[handleSubScheduleUpdated] resynced starts_at ${customerProduct.starts_at} -> ${phaseStartMs} for customerProduct ${customerProduct.id} (schedule ${schedule.id})`,
+			`[handleStripeSubscriptionScheduleUpdated] resynced starts_at ${customerProduct.starts_at} -> ${phaseStartMs} for customerProduct ${customerProduct.id} (schedule ${schedule.id})`,
 		);
 	}
 };

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionScheduleUpdated/handleStripeSubscriptionScheduleUpdated.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionScheduleUpdated/handleStripeSubscriptionScheduleUpdated.ts
@@ -1,39 +1,12 @@
-import { CusProductStatus, schedulePhases } from "@autumn/shared";
-import { and, arrayOverlaps, gte, lt } from "drizzle-orm";
 import type Stripe from "stripe";
-import { CusProductService } from "@/internal/customers/cusProducts/CusProductService.js";
 import type { StripeWebhookContext } from "../../webhookMiddlewares/stripeWebhookContext.js";
-
-// Stripe stores phase starts at second precision; Autumn stores ms. Ignore
-// sub-second drift so Autumn's own schedule writes don't echo back as updates.
-const STRIPE_SECOND_PRECISION_MS = 1000;
-
-type PhaseMove = { oldStartMs: number; newStartMs: number };
-
-const getPhaseMoves = ({
-	previousPhases,
-	currentPhases,
-}: {
-	previousPhases: Stripe.SubscriptionSchedule.Phase[];
-	currentPhases: Stripe.SubscriptionSchedule.Phase[];
-}): PhaseMove[] => {
-	const moves: PhaseMove[] = [];
-	for (const [index, previousPhase] of previousPhases.entries()) {
-		const oldStartMs = (previousPhase.start_date ?? 0) * 1000;
-		const newStartMs = (currentPhases[index]?.start_date ?? 0) * 1000;
-		if (!(oldStartMs && newStartMs)) continue;
-		if (Math.abs(oldStartMs - newStartMs) < STRIPE_SECOND_PRECISION_MS)
-			continue;
-		moves.push({ oldStartMs, newStartMs });
-	}
-	return moves;
-};
+import { getSchedulePhaseMoves } from "./getSchedulePhaseMoves.js";
+import { resyncScheduledCustomerProductStartsAt } from "./tasks/resyncScheduledCustomerProductStartsAt.js";
 
 /**
- * Re-syncs scheduled customerProduct (and Autumn phase) starts_at when a
- * not-yet-started schedule is rescheduled outside Autumn (e.g. Stripe
- * dashboard). Each moved phase only touches the products anchored to its OLD
- * start; started schedules and phase add/remove are intentionally left alone.
+ * Re-syncs scheduled customerProduct starts_at when a not-yet-started schedule
+ * is rescheduled outside Autumn (e.g. Stripe dashboard). Started schedules and
+ * phase add/remove are intentionally left alone.
  */
 export const handleStripeSubscriptionScheduleUpdated = async ({
 	ctx,
@@ -42,8 +15,6 @@ export const handleStripeSubscriptionScheduleUpdated = async ({
 	ctx: StripeWebhookContext;
 	event: Stripe.SubscriptionScheduleUpdatedEvent;
 }) => {
-	const { db, org, env, logger } = ctx;
-
 	const schedule = event.data.object;
 	const previousPhases = event.data.previous_attributes?.phases;
 
@@ -51,53 +22,11 @@ export const handleStripeSubscriptionScheduleUpdated = async ({
 	if (!previousPhases) return;
 	if (previousPhases.length !== schedule.phases.length) return;
 
-	const moves = getPhaseMoves({
+	const moves = getSchedulePhaseMoves({
 		previousPhases,
 		currentPhases: schedule.phases,
 	});
 	if (moves.length === 0) return;
 
-	const customerProductsOnSchedule = await CusProductService.getByScheduleId({
-		db,
-		scheduleId: schedule.id,
-		orgId: org.id,
-		env,
-	});
-	const scheduledProducts = customerProductsOnSchedule.filter(
-		(customerProduct) => customerProduct.status === CusProductStatus.Scheduled,
-	);
-
-	for (const { oldStartMs, newStartMs } of moves) {
-		const matchedProducts = scheduledProducts.filter(
-			(customerProduct) =>
-				Math.abs((customerProduct.starts_at ?? 0) - oldStartMs) <
-				STRIPE_SECOND_PRECISION_MS,
-		);
-		if (matchedProducts.length === 0) continue;
-
-		for (const customerProduct of matchedProducts) {
-			await CusProductService.update({
-				ctx,
-				cusProductId: customerProduct.id,
-				updates: { starts_at: newStartMs },
-			});
-			logger.info(
-				`[handleStripeSubscriptionScheduleUpdated] resynced starts_at ${customerProduct.starts_at} -> ${newStartMs} for customerProduct ${customerProduct.id} (schedule ${schedule.id})`,
-			);
-		}
-
-		await db
-			.update(schedulePhases)
-			.set({ starts_at: newStartMs })
-			.where(
-				and(
-					gte(schedulePhases.starts_at, oldStartMs),
-					lt(schedulePhases.starts_at, oldStartMs + STRIPE_SECOND_PRECISION_MS),
-					arrayOverlaps(
-						schedulePhases.customer_product_ids,
-						matchedProducts.map((customerProduct) => customerProduct.id),
-					),
-				),
-			);
-	}
+	await resyncScheduledCustomerProductStartsAt({ ctx, schedule, moves });
 };

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionScheduleUpdated/tasks/resyncScheduledCustomerProductStartsAt.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionScheduleUpdated/tasks/resyncScheduledCustomerProductStartsAt.ts
@@ -58,7 +58,7 @@ export const resyncScheduledCustomerProductStartsAt = async ({
 			);
 		}
 
-		await db
+		const updatedPhaseRows = await db
 			.update(schedulePhases)
 			.set({ starts_at: newStartMs })
 			.where(
@@ -70,6 +70,12 @@ export const resyncScheduledCustomerProductStartsAt = async ({
 						matchedProducts.map((customerProduct) => customerProduct.id),
 					),
 				),
-			);
+			)
+			.returning({ id: schedulePhases.id });
+
+		// 0 rows is normal for attach-origin schedules (no Autumn phase rows)
+		logger.info(
+			`[handleStripeSubscriptionScheduleUpdated] moved ${updatedPhaseRows.length} autumn phase row(s) ${oldStartMs} -> ${newStartMs} (schedule ${schedule.id})`,
+		);
 	}
 };

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionScheduleUpdated/tasks/resyncScheduledCustomerProductStartsAt.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionScheduleUpdated/tasks/resyncScheduledCustomerProductStartsAt.ts
@@ -1,0 +1,70 @@
+import { CusProductStatus, schedulePhases } from "@autumn/shared";
+import { and, arrayOverlaps, gte, lt } from "drizzle-orm";
+import type Stripe from "stripe";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService.js";
+import type { StripeWebhookContext } from "../../../webhookMiddlewares/stripeWebhookContext.js";
+import {
+	STRIPE_SECOND_PRECISION_MS,
+	type SchedulePhaseMove,
+} from "../getSchedulePhaseMoves.js";
+
+/**
+ * Applies phase-start moves to Autumn: for each moved phase, only the scheduled
+ * customerProducts (and Autumn phase rows) anchored to its OLD start are
+ * retargeted to the new start.
+ */
+export const resyncScheduledCustomerProductStartsAt = async ({
+	ctx,
+	schedule,
+	moves,
+}: {
+	ctx: StripeWebhookContext;
+	schedule: Stripe.SubscriptionSchedule;
+	moves: SchedulePhaseMove[];
+}) => {
+	const { db, org, env, logger } = ctx;
+
+	const customerProductsOnSchedule = await CusProductService.getByScheduleId({
+		db,
+		scheduleId: schedule.id,
+		orgId: org.id,
+		env,
+	});
+	const scheduledProducts = customerProductsOnSchedule.filter(
+		(customerProduct) => customerProduct.status === CusProductStatus.Scheduled,
+	);
+
+	for (const { oldStartMs, newStartMs } of moves) {
+		const matchedProducts = scheduledProducts.filter(
+			(customerProduct) =>
+				Math.abs((customerProduct.starts_at ?? 0) - oldStartMs) <
+				STRIPE_SECOND_PRECISION_MS,
+		);
+		if (matchedProducts.length === 0) continue;
+
+		for (const customerProduct of matchedProducts) {
+			await CusProductService.update({
+				ctx,
+				cusProductId: customerProduct.id,
+				updates: { starts_at: newStartMs },
+			});
+			logger.info(
+				`[handleStripeSubscriptionScheduleUpdated] resynced starts_at ${customerProduct.starts_at} -> ${newStartMs} for customerProduct ${customerProduct.id} (schedule ${schedule.id})`,
+			);
+		}
+
+		await db
+			.update(schedulePhases)
+			.set({ starts_at: newStartMs })
+			.where(
+				and(
+					gte(schedulePhases.starts_at, oldStartMs),
+					lt(schedulePhases.starts_at, oldStartMs + STRIPE_SECOND_PRECISION_MS),
+					arrayOverlaps(
+						schedulePhases.customer_product_ids,
+						matchedProducts.map((customerProduct) => customerProduct.id),
+					),
+				),
+			);
+	}
+};

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionScheduleUpdated/tasks/resyncScheduledCustomerProductStartsAt.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionScheduleUpdated/tasks/resyncScheduledCustomerProductStartsAt.ts
@@ -40,7 +40,12 @@ export const resyncScheduledCustomerProductStartsAt = async ({
 				Math.abs((customerProduct.starts_at ?? 0) - oldStartMs) <
 				STRIPE_SECOND_PRECISION_MS,
 		);
-		if (matchedProducts.length === 0) continue;
+		if (matchedProducts.length === 0) {
+			logger.warn(
+				`[handleStripeSubscriptionScheduleUpdated] no scheduled customerProduct anchored to moved phase start ${oldStartMs} on schedule ${schedule.id} — skipping`,
+			);
+			continue;
+		}
 
 		for (const customerProduct of matchedProducts) {
 			await CusProductService.update({

--- a/server/src/external/stripe/webhookHandlers/handleSubScheduleUpdated.ts
+++ b/server/src/external/stripe/webhookHandlers/handleSubScheduleUpdated.ts
@@ -1,0 +1,53 @@
+import { CusProductStatus } from "@autumn/shared";
+import type Stripe from "stripe";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService.js";
+import type { StripeWebhookContext } from "../webhookMiddlewares/stripeWebhookContext.js";
+
+// Stripe stores phase starts at second precision; Autumn stores ms. Ignore
+// sub-second drift so Autumn's own schedule writes don't echo back as updates.
+const STRIPE_SECOND_PRECISION_MS = 1000;
+
+/**
+ * Re-syncs scheduled customerProduct starts_at when a not-yet-started schedule
+ * is rescheduled outside Autumn (e.g. Stripe dashboard). Started schedules and
+ * multi-phase schedules are intentionally left alone.
+ */
+export const handleSubscriptionScheduleUpdated = async ({
+	ctx,
+	schedule,
+}: {
+	ctx: StripeWebhookContext;
+	schedule: Stripe.SubscriptionSchedule;
+}) => {
+	const { db, org, env, logger } = ctx;
+
+	if (schedule.status !== "not_started") return;
+	if (schedule.phases.length !== 1) return;
+
+	const phaseStartMs = (schedule.phases[0]?.start_date ?? 0) * 1000;
+	if (!phaseStartMs) return;
+
+	const customerProductsOnSchedule = await CusProductService.getByScheduleId({
+		db,
+		scheduleId: schedule.id,
+		orgId: org.id,
+		env,
+	});
+
+	for (const customerProduct of customerProductsOnSchedule) {
+		if (customerProduct.status !== CusProductStatus.Scheduled) continue;
+
+		const driftMs = Math.abs((customerProduct.starts_at ?? 0) - phaseStartMs);
+		if (driftMs < STRIPE_SECOND_PRECISION_MS) continue;
+
+		await CusProductService.update({
+			ctx,
+			cusProductId: customerProduct.id,
+			updates: { starts_at: phaseStartMs },
+		});
+
+		logger.info(
+			`[handleSubScheduleUpdated] resynced starts_at ${customerProduct.starts_at} -> ${phaseStartMs} for customerProduct ${customerProduct.id} (schedule ${schedule.id})`,
+		);
+	}
+};

--- a/server/src/external/stripe/webhookMiddlewares/stripeToAutumnCustomerMiddleware.ts
+++ b/server/src/external/stripe/webhookMiddlewares/stripeToAutumnCustomerMiddleware.ts
@@ -24,6 +24,7 @@ const getAutumnCustomerId = async ({ ctx }: { ctx: StripeWebhookContext }) => {
 			case "invoice.created":
 			case "invoice.finalized":
 			case "subscription_schedule.canceled":
+			case "subscription_schedule.updated":
 				return stripeEvent.data.object.customer;
 
 			case "customer.updated":

--- a/server/src/external/stripe/webhookMiddlewares/stripeWebhookRefreshMiddleware.ts
+++ b/server/src/external/stripe/webhookMiddlewares/stripeWebhookRefreshMiddleware.ts
@@ -10,6 +10,7 @@ const updateProductEvents = ["customer.subscription.updated"];
 const coreEvents = [
 	"customer.subscription.deleted",
 	"subscription_schedule.canceled",
+	"subscription_schedule.updated",
 	"checkout.session.completed",
 ];
 

--- a/server/tests/integration/billing/attach/params/start-date/starts-at-external-schedule-move.test.ts
+++ b/server/tests/integration/billing/attach/params/start-date/starts-at-external-schedule-move.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Regression test for scheduled attaches whose Stripe schedule is rescheduled
+ * outside Autumn (e.g. Stripe dashboard) before it starts. Fully webhook-driven:
+ * no handlers are invoked in-process — assertions poll for the effects of real
+ * stripe-listen deliveries.
+ *
+ * Pre-fix: Autumn ignored subscription_schedule.updated, so the scheduled
+ * customerProduct kept its stale starts_at; when the phase started earlier than
+ * that, activation was skipped and the product stayed `scheduled` forever.
+ */
+
+import { expect, test } from "bun:test";
+import { type AttachParamsV1Input, CusProductStatus, ms } from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { advanceTestClock } from "@tests/utils/stripeUtils";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import { CusService } from "@/internal/customers/CusService";
+import { getCustomerProduct } from "./utils";
+
+const pollUntil = async <T>({
+	fetch,
+	until,
+	timeoutMs = 60_000,
+	intervalMs = 1000,
+	label,
+}: {
+	fetch: () => Promise<T>;
+	until: (value: T) => boolean;
+	timeoutMs?: number;
+	intervalMs?: number;
+	label: string;
+}): Promise<T> => {
+	const deadline = Date.now() + timeoutMs;
+	let last: T = await fetch();
+	while (!until(last)) {
+		if (Date.now() > deadline)
+			throw new Error(`Timed out waiting for: ${label}`);
+		await new Promise((resolve) => setTimeout(resolve, intervalMs));
+		last = await fetch();
+	}
+	return last;
+};
+
+test.concurrent(`${chalk.yellowBright("starts_at: external schedule move resyncs via webhook and activates on phase start")}`, async () => {
+	const customerId = "attach-external-schedule-move";
+	const pro = products.pro({
+		id: "pro",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+
+	const { autumnV2_2, ctx, advancedTo, testClockId } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [],
+	});
+	expect(testClockId).toBeDefined();
+
+	const requestedStart = advancedTo + ms.days(2);
+	await autumnV2_2.billing.attach<AttachParamsV1Input>({
+		customer_id: customerId,
+		plan_id: pro.id,
+		starts_at: requestedStart,
+	});
+
+	const cusProduct = await getCustomerProduct({
+		ctx,
+		customerId,
+		productId: pro.id,
+	});
+	expect(cusProduct.status).toBe(CusProductStatus.Scheduled);
+	const scheduleId = cusProduct.scheduled_ids?.[0];
+	if (!scheduleId) throw new Error("Expected schedule id");
+
+	const schedule = (await ctx.stripeCli.subscriptionSchedules.retrieve(
+		scheduleId,
+	)) as Stripe.SubscriptionSchedule;
+
+	// External edit (dashboard-style): move the phase start 8h earlier
+	const editedStartSec = Math.floor((requestedStart - ms.hours(8)) / 1000);
+	await ctx.stripeCli.subscriptionSchedules.update(scheduleId, {
+		phases: schedule.phases.map((phase) => ({
+			items: phase.items.map((item) => ({
+				price: typeof item.price === "string" ? item.price : item.price?.id,
+				quantity: item.quantity,
+			})),
+			start_date: editedStartSec,
+			end_date: phase.end_date ?? undefined,
+			proration_behavior: phase.proration_behavior ?? undefined,
+		})),
+	});
+
+	// Real subscription_schedule.updated webhook resyncs starts_at
+	const resyncedProduct = await pollUntil({
+		fetch: () => getCustomerProduct({ ctx, customerId, productId: pro.id }),
+		until: (cp) => cp.starts_at === editedStartSec * 1000,
+		label: `starts_at resync to ${editedStartSec * 1000} via subscription_schedule.updated webhook`,
+	});
+	expect(resyncedProduct.status).toBe(CusProductStatus.Scheduled);
+
+	// Phase starts at the EDITED (earlier) time; the real
+	// customer.subscription.created webhook must activate the scheduled product
+	await advanceTestClock({
+		stripeCli: ctx.stripeCli,
+		testClockId: testClockId!,
+		advanceTo: editedStartSec * 1000 + ms.hours(1),
+		waitForSeconds: 30,
+	});
+
+	const activatedProduct = await pollUntil({
+		fetch: () => getCustomerProduct({ ctx, customerId, productId: pro.id }),
+		until: (cp) => cp.status === CusProductStatus.Active,
+		label: "scheduled product activation via customer.subscription.created webhook",
+	});
+	expect(activatedProduct.subscription_ids?.length).toBe(1);
+
+	// The phase-start subscription_schedule.updated (status -> active) must NOT
+	// touch starts_at anymore — started schedules are ignored
+	expect(activatedProduct.starts_at).toBe(editedStartSec * 1000);
+
+	// No stranded duplicate
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	const proProducts = fullCustomer.customer_products.filter(
+		(cp) => cp.product_id === pro.id,
+	);
+	expect(proProducts).toHaveLength(1);
+});

--- a/server/tests/integration/billing/attach/params/start-date/starts-at-external-schedule-move.test.ts
+++ b/server/tests/integration/billing/attach/params/start-date/starts-at-external-schedule-move.test.ts
@@ -10,7 +10,13 @@
  */
 
 import { expect, test } from "bun:test";
-import { type AttachParamsV1Input, CusProductStatus, ms } from "@autumn/shared";
+import {
+	type ApiCustomerV5,
+	type AttachParamsV1Input,
+	CusProductStatus,
+	ms,
+} from "@autumn/shared";
+import { expectProductScheduled } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
 import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
 import { advanceTestClock } from "@tests/utils/stripeUtils";
@@ -81,6 +87,10 @@ test.concurrent(`${chalk.yellowBright("starts_at: external schedule move resyncs
 		scheduleId,
 	)) as Stripe.SubscriptionSchedule;
 
+	// Warm the customer cache so a missed webhook invalidation would surface
+	// as a stale API read below
+	await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+
 	// External edit (dashboard-style): move the phase start 8h earlier
 	const editedStartSec = Math.floor((requestedStart - ms.hours(8)) / 1000);
 	await ctx.stripeCli.subscriptionSchedules.update(scheduleId, {
@@ -102,6 +112,16 @@ test.concurrent(`${chalk.yellowBright("starts_at: external schedule move resyncs
 		label: `starts_at resync to ${editedStartSec * 1000} via subscription_schedule.updated webhook`,
 	});
 	expect(resyncedProduct.status).toBe(CusProductStatus.Scheduled);
+
+	// The webhook must also evict the warmed cache: the API (cached read path)
+	// has to serve the NEW start, not the pre-edit snapshot
+	const cachedCustomer =
+		await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+	await expectProductScheduled({
+		customer: cachedCustomer,
+		productId: pro.id,
+		startsAt: editedStartSec * 1000,
+	});
 
 	// Phase starts at the EDITED (earlier) time; the real
 	// customer.subscription.created webhook must activate the scheduled product

--- a/server/tests/integration/billing/attach/params/start-date/starts-at-external-schedule-move.test.ts
+++ b/server/tests/integration/billing/attach/params/start-date/starts-at-external-schedule-move.test.ts
@@ -133,3 +133,96 @@ test.concurrent(`${chalk.yellowBright("starts_at: external schedule move resyncs
 	);
 	expect(proProducts).toHaveLength(1);
 });
+
+
+test.concurrent(`${chalk.yellowBright("starts_at: moving one phase of a multi-phase schedule only touches that phase's product")}`, async () => {
+	const customerId = "external-schedule-move-multi-phase";
+	const pro = products.pro({
+		id: "pro",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+
+	const { autumnV2_2, ctx, advancedTo } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [],
+	});
+
+	const phase1Start = advancedTo + ms.days(10);
+	await autumnV2_2.billing.attach<AttachParamsV1Input>({
+		customer_id: customerId,
+		plan_id: pro.id,
+		starts_at: phase1Start,
+	});
+
+	const cusProduct = await getCustomerProduct({
+		ctx,
+		customerId,
+		productId: pro.id,
+	});
+	const scheduleId = cusProduct.scheduled_ids?.[0];
+	if (!scheduleId) throw new Error("Expected schedule id");
+	const schedule = (await ctx.stripeCli.subscriptionSchedules.retrieve(
+		scheduleId,
+	)) as Stripe.SubscriptionSchedule;
+	const phaseItems = schedule.phases[0]!.items.map((item) => ({
+		price: typeof item.price === "string" ? item.price : item.price?.id,
+		quantity: item.quantity,
+	}));
+	const phase1StartSec = schedule.phases[0]!.start_date;
+	const phase2StartSec = Math.floor((advancedTo + ms.days(40)) / 1000);
+	const phase3StartSec = Math.floor((advancedTo + ms.days(70)) / 1000);
+
+	// External edit #1: expand to 3 phases (structural change — Autumn must not react)
+	await ctx.stripeCli.subscriptionSchedules.update(scheduleId, {
+		phases: [
+			{ items: phaseItems, start_date: phase1StartSec, end_date: phase2StartSec },
+			{ items: phaseItems, start_date: phase2StartSec, end_date: phase3StartSec },
+			{ items: phaseItems, start_date: phase3StartSec },
+		],
+	});
+
+	// External edit #2: move ONLY phase 1 (+4 days); phases 2 and 3 untouched
+	const editedPhase1StartSec = phase1StartSec + Math.floor(ms.days(4) / 1000);
+	await ctx.stripeCli.subscriptionSchedules.update(scheduleId, {
+		phases: [
+			{ items: phaseItems, start_date: editedPhase1StartSec, end_date: phase2StartSec },
+			{ items: phaseItems, start_date: phase2StartSec, end_date: phase3StartSec },
+			{ items: phaseItems, start_date: phase3StartSec },
+		],
+	});
+
+	// The real webhook must retarget the product anchored to phase 1 — and to
+	// phase 1's NEW start specifically, not any other phase's
+	const resyncedProduct = await pollUntil({
+		fetch: () => getCustomerProduct({ ctx, customerId, productId: pro.id }),
+		until: (cp) => cp.starts_at !== phase1Start,
+		label: "phase-1 starts_at resync via subscription_schedule.updated webhook",
+	});
+	expect(resyncedProduct.starts_at).toBe(editedPhase1StartSec * 1000);
+	expect(resyncedProduct.status).toBe(CusProductStatus.Scheduled);
+
+	// External edit #3: move ONLY phase 2 — nothing in Autumn is anchored to it,
+	// so the product must stay exactly where it is
+	const editedPhase2StartSec = phase2StartSec + Math.floor(ms.days(5) / 1000);
+	await ctx.stripeCli.subscriptionSchedules.update(scheduleId, {
+		phases: [
+			{ items: phaseItems, start_date: editedPhase1StartSec, end_date: editedPhase2StartSec },
+			{ items: phaseItems, start_date: editedPhase2StartSec, end_date: phase3StartSec },
+			{ items: phaseItems, start_date: phase3StartSec },
+		],
+	});
+
+	// Give the webhook time to arrive, then assert nothing moved
+	await new Promise((resolve) => setTimeout(resolve, 8000));
+	const untouchedProduct = await getCustomerProduct({
+		ctx,
+		customerId,
+		productId: pro.id,
+	});
+	expect(untouchedProduct.starts_at).toBe(editedPhase1StartSec * 1000);
+	expect(untouchedProduct.status).toBe(CusProductStatus.Scheduled);
+});

--- a/server/tests/integration/billing/attach/params/start-date/starts-at-external-schedule-move.test.ts
+++ b/server/tests/integration/billing/attach/params/start-date/starts-at-external-schedule-move.test.ts
@@ -225,24 +225,26 @@ test.concurrent(`${chalk.yellowBright("starts_at: moving one phase of a multi-ph
 	expect(resyncedProduct.starts_at).toBe(editedPhase1StartSec * 1000);
 	expect(resyncedProduct.status).toBe(CusProductStatus.Scheduled);
 
-	// External edit #3: move ONLY phase 2 — nothing in Autumn is anchored to it,
-	// so the product must stay exactly where it is
+	// External edit #3: move phase 1 AND phase 2 in one update. The product must
+	// follow phase 1's new start — if moves were applied indiscriminately, it
+	// would land on phase 2's start instead. Deterministic: the phase-1 move is
+	// the pollable proof this webhook was fully processed.
+	const finalPhase1StartSec = editedPhase1StartSec + Math.floor(ms.days(2) / 1000);
 	const editedPhase2StartSec = phase2StartSec + Math.floor(ms.days(5) / 1000);
 	await ctx.stripeCli.subscriptionSchedules.update(scheduleId, {
 		phases: [
-			{ items: phaseItems, start_date: editedPhase1StartSec, end_date: editedPhase2StartSec },
+			{ items: phaseItems, start_date: finalPhase1StartSec, end_date: editedPhase2StartSec },
 			{ items: phaseItems, start_date: editedPhase2StartSec, end_date: phase3StartSec },
 			{ items: phaseItems, start_date: phase3StartSec },
 		],
 	});
 
-	// Give the webhook time to arrive, then assert nothing moved
-	await new Promise((resolve) => setTimeout(resolve, 8000));
-	const untouchedProduct = await getCustomerProduct({
-		ctx,
-		customerId,
-		productId: pro.id,
+	const finalProduct = await pollUntil({
+		fetch: () => getCustomerProduct({ ctx, customerId, productId: pro.id }),
+		until: (cp) => cp.starts_at !== editedPhase1StartSec * 1000,
+		label: "phase-1 second move processed via subscription_schedule.updated webhook",
 	});
-	expect(untouchedProduct.starts_at).toBe(editedPhase1StartSec * 1000);
-	expect(untouchedProduct.status).toBe(CusProductStatus.Scheduled);
+	expect(finalProduct.starts_at).toBe(finalPhase1StartSec * 1000);
+	expect(finalProduct.starts_at).not.toBe(editedPhase2StartSec * 1000);
+	expect(finalProduct.status).toBe(CusProductStatus.Scheduled);
 });


### PR DESCRIPTION
## Problem

When a not-yet-started Stripe subscription schedule is edited **outside Autumn** (e.g. Stripe dashboard), Autumn never learns the phase start moved: the scheduled `customer_product` keeps its stale `starts_at`. If the schedule was moved earlier, the `customer.subscription.created` activation guard (`hasCustomerProductStarted`) fails at phase start — the product is stranded in `scheduled` forever while auto-sync inserts a duplicate active product with default (wrong) entitlements.

Hit in prod by athenahq customer `848f6094-2355-4dbe-b5da-1b008a8d7e10` (schedule `sub_sched_1ThXuuRxQ9e3oL7udnKt5NdJ`): dashboard edit moved the phase start 8h earlier ~80s after `billing.attach`; live state was repaired manually on 2026-07-08.

## Fix (deliberately minimal)

Handle `subscription_schedule.updated` for **not-yet-started (`not_started`) schedules only**, resyncing **`starts_at` only**, per phase:

- `handleStripeSubscriptionScheduleUpdated/` (new handler, folder convention): diffs `previous_attributes.phases` against current phases by index and builds per-phase moves. For each moved phase, only the scheduled customer_products (and Autumn `phases` rows) anchored to that phase's **old** start are updated to its new start — editing one phase of a multi-phase schedule never touches the others. Sub-second drift is ignored so Autumn's own ms-precision schedule writes don't echo back (Stripe stores seconds).
- Out of scope by design: started/in-phase schedules, phase add/remove (structural changes), and any other schedule fields.
- `handleStripeWebhookEvent.ts`: new switch case.
- `stripeWebhookRefreshMiddleware.ts`: added event to `coreEvents` so the customer cache invalidates.

`subscription_schedule.updated` was already in `MAIN_STRIPE_EVENT_TYPES` / `WEBHOOK_EVENTS` (register.ts derives from those). **Deploy note:** prod webhook endpoints created before that constant included the event may need their enabled_events refreshed in Stripe.

## Tests

`starts-at-external-schedule-move.test.ts` — fully webhook-driven (no in-process handler calls; assertions poll for real stripe-listen deliveries):

1. **Incident replay:** attach with future `starts_at` → edit the schedule start 8h earlier directly in Stripe → real `subscription_schedule.updated` resyncs `starts_at` → advance test clock past the new start → real `customer.subscription.created` activates the product → no duplicate, and the phase-start schedule event leaves `starts_at` alone (started-schedule guard).
2. **Multi-phase targeting:** attach → externally expand the schedule to 3 phases (structural change: Autumn correctly ignores) → move ONLY phase 1: the product anchored to phase 1 follows it (to phase 1's new start specifically) → move ONLY phase 2: the product stays untouched.

Note: `billing.createSchedule` requires the first phase to start immediately, so a not-yet-started multi-phase schedule can only arise via external Stripe edits — which is exactly how the test builds it.

Neighboring suites (`starts-at-scheduling`, `starts-at-webhook`, `create-schedule-phases-schedules`) pass: 13/13.