### PR TITLE
skip overage billing

### DIFF
--- a/server/src/external/stripe/webhookHandlers/common/eventContextToArrearLineItems.ts
+++ b/server/src/external/stripe/webhookHandlers/common/eventContextToArrearLineItems.ts
@@ -12,6 +12,7 @@ import {
 	type BaseWebhookEventContext,
 	buildBillingContextForArrearInvoice,
 } from "./buildBillingContextFromWebhook";
+import { partitionSkippedOverageLineItems } from "./filterSkippedOverageLineItems";
 import { logWebhookArrearLineItems } from "./logs/logWebhookArrearLineItems";
 
 /**
@@ -90,12 +91,24 @@ export const eventContextToArrearLineItems = async ({
 		});
 	}
 
+	// Per-feature skip_overage_billing spend limits exclude items from billing
+	const { billableLineItems, skippedLineItems } =
+		partitionSkippedOverageLineItems({
+			fullCustomer: billingContext.fullCustomer,
+			lineItems,
+		});
+
 	// Log the arrear line items and customer entitlement updates
 	logWebhookArrearLineItems({
 		ctx,
-		lineItems,
+		lineItems: billableLineItems,
+		skippedLineItems,
 		updateCustomerEntitlements,
 	});
 
-	return { lineItems, updateCustomerEntitlements, billingContext };
+	return {
+		lineItems: billableLineItems,
+		updateCustomerEntitlements,
+		billingContext,
+	};
 };

--- a/server/src/external/stripe/webhookHandlers/common/filterSkippedOverageLineItems.ts
+++ b/server/src/external/stripe/webhookHandlers/common/filterSkippedOverageLineItems.ts
@@ -1,0 +1,41 @@
+import {
+	type FullCustomer,
+	fullCustomerToSkipOverageBilling,
+	type LineItem,
+} from "@autumn/shared";
+
+/**
+ * Partition arrear line items by whether their feature resolves to an enabled
+ * spend_limit with skip_overage_billing (entity > customer > plan). Skipped
+ * items are never posted to Stripe; balance resets are unaffected.
+ */
+export const partitionSkippedOverageLineItems = ({
+	fullCustomer,
+	lineItems,
+}: {
+	fullCustomer: FullCustomer;
+	lineItems: LineItem[];
+}): { billableLineItems: LineItem[]; skippedLineItems: LineItem[] } => {
+	const billableLineItems: LineItem[] = [];
+	const skippedLineItems: LineItem[] = [];
+
+	for (const lineItem of lineItems) {
+		const featureId = lineItem.context.feature?.id;
+
+		const skipOverageBilling = featureId
+			? fullCustomerToSkipOverageBilling({
+					fullCustomer,
+					featureId,
+					internalEntityId: lineItem.context.entity?.internal_id,
+				})
+			: false;
+
+		if (skipOverageBilling) {
+			skippedLineItems.push(lineItem);
+		} else {
+			billableLineItems.push(lineItem);
+		}
+	}
+
+	return { billableLineItems, skippedLineItems };
+};

--- a/server/src/external/stripe/webhookHandlers/common/logs/logWebhookArrearLineItems.ts
+++ b/server/src/external/stripe/webhookHandlers/common/logs/logWebhookArrearLineItems.ts
@@ -3,25 +3,35 @@ import { formatMs, type LineItem } from "@autumn/shared";
 import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
 import { addToExtraLogs } from "@/utils/logging/addToExtraLogs";
 
+const toLineItemLog = (item: LineItem) => ({
+	featureId: item.context.feature?.id,
+	entityId: item.context.entity?.id,
+	description: item.description,
+	amount: item.amount,
+	amountAfterDiscounts: item.amountAfterDiscounts,
+	discountable: item.context.discountable ?? false,
+});
+
 export const logWebhookArrearLineItems = ({
 	ctx,
 	lineItems,
+	skippedLineItems = [],
 	updateCustomerEntitlements,
 }: {
 	ctx: StripeWebhookContext;
 	lineItems: LineItem[];
+	/** Excluded from billing by a skip_overage_billing spend limit. */
+	skippedLineItems?: LineItem[];
 	updateCustomerEntitlements: UpdateCustomerEntitlement[];
 }) => {
 	addToExtraLogs({
 		ctx,
 		extras: {
 			arrearLineItems: {
-				lineItems: lineItems.map((item) => ({
-					description: item.description,
-					amount: item.amount,
-					amountAfterDiscounts: item.amountAfterDiscounts,
-					discountable: item.context.discountable ?? false,
-				})),
+				lineItems: lineItems.map(toLineItemLog),
+				...(skippedLineItems.length > 0 && {
+					skippedOverageLineItems: skippedLineItems.map(toLineItemLog),
+				}),
 				updateCustomerEntitlements: updateCustomerEntitlements.map(
 					(update) => ({
 						featureId: update.customerEntitlement.entitlement.feature?.id,

--- a/server/src/external/stripe/webhookHandlers/handleStripeInvoiceCreated/tasks/processConsumablePricesForInvoiceCreated.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeInvoiceCreated/tasks/processConsumablePricesForInvoiceCreated.ts
@@ -13,6 +13,7 @@ import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntit
 import { RolloverService } from "@/internal/customers/cusProducts/cusEnts/cusRollovers/RolloverService";
 import { getRolloverUpdates } from "@/internal/customers/cusProducts/cusEnts/cusRollovers/rolloverUtils";
 import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
+import { addToExtraLogs } from "@/utils/logging/addToExtraLogs";
 import type { StripeWebhookContext } from "../../../webhookMiddlewares/stripeWebhookContext";
 import type { InvoiceCreatedContext } from "../setupInvoiceCreatedContext";
 
@@ -94,6 +95,9 @@ export const processConsumablePricesForInvoiceCreated = async ({
 		customerId: eventContext.fullCustomer.id,
 		customerConfig: eventContext.fullCustomer.config,
 	});
+	if (disableOverageBilling && lineItems.length > 0) {
+		addToExtraLogs({ ctx, extras: { overageBillingDisabledByConfig: true } });
+	}
 	if (lineItems.length > 0 && !disableOverageBilling) {
 		await createStripeInvoiceItems({
 			ctx,

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionDeleted/tasks/processConsumablePricesForSubscriptionDeleted.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionDeleted/tasks/processConsumablePricesForSubscriptionDeleted.ts
@@ -11,6 +11,7 @@ import { createInvoiceForBilling } from "@/internal/billing/v2/providers/stripe/
 import { upsertInvoiceFromBilling } from "@/internal/billing/v2/utils/upsertFromStripe/upsertInvoiceFromBilling";
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService";
 import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
+import { addToExtraLogs } from "@/utils/logging/addToExtraLogs";
 import type { StripeSubscriptionDeletedContext } from "../setupStripeSubscriptionDeletedContext";
 
 /**
@@ -88,6 +89,9 @@ export const processConsumablePricesForSubscriptionDeleted = async ({
 		org: ctx.org,
 		customerId: eventContext.fullCustomer.id,
 	});
+	if (disableOverageBilling && lineItems.length > 0) {
+		addToExtraLogs({ ctx, extras: { overageBillingDisabledByConfig: true } });
+	}
 	if (lineItems.length > 0 && !disableOverageBilling) {
 		// 2. Create, finalize, and pay a single invoice with all line items
 		const invoiceLines = lineItemsToInvoiceAddLinesParams({ lineItems });

--- a/server/src/internal/products/handlers/handleUpdatePlan/updateProductDetails.ts
+++ b/server/src/internal/products/handlers/handleUpdatePlan/updateProductDetails.ts
@@ -5,6 +5,7 @@ import {
 	type FreeTrial,
 	type FullProduct,
 	isFreeProductV2,
+	normalizeBillingControlsForCompare,
 	type Organization,
 	type Product,
 	type ProductItem,
@@ -60,8 +61,10 @@ const productDetailsSame = (prod1: Product, prod2: UpdateProduct) => {
 
 	if (
 		notNullish(prod2.billing_controls) &&
-		JSON.stringify(billingControlsFromColumns(prod1)) !==
-			JSON.stringify(prod2.billing_controls)
+		JSON.stringify(
+			normalizeBillingControlsForCompare(billingControlsFromColumns(prod1)),
+		) !==
+			JSON.stringify(normalizeBillingControlsForCompare(prod2.billing_controls))
 	) {
 		return false;
 	}
@@ -291,5 +294,8 @@ export const handleUpdateProductDetails = async ({
 	curProduct.is_default = newProduct.is_default ?? curProduct.is_default;
 	curProduct.archived = newProduct.archived ?? curProduct.archived;
 	curProduct.config = mergedConfig ?? curProduct.config;
-	Object.assign(curProduct, pickBillingControlColumns(newProduct.billing_controls));
+	Object.assign(
+		curProduct,
+		pickBillingControlColumns(newProduct.billing_controls),
+	);
 };

--- a/server/tests/integration/billing/stripe-webhooks/invoice-created/invoice-created-skip-overage-billing.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/invoice-created/invoice-created-skip-overage-billing.test.ts
@@ -1,0 +1,418 @@
+/**
+ * TDD test for per-feature `skip_overage_billing` on spend_limit billing controls.
+ *
+ * Contract under test:
+ *   New types/fields:
+ *     - DbSpendLimit.skip_overage_billing?: boolean — settable on plan
+ *       billing_controls (create/update plan), customer billing_controls
+ *       (customers.update), and entity billing_controls.
+ *   New behaviors (invoice.created renewal invoices):
+ *     - Feature whose resolved spend_limit entry (entity > customer > plan)
+ *       has skip_overage_billing: true → consumable overage line item is NOT
+ *       posted to Stripe. Features without it are billed normally.
+ *     - Balances still reset on the billing cycle for skipped features.
+ *     - Plan-level control acts as a default; a customer-level entry for the
+ *       same feature OVERRIDES it entirely (e.g. flips skip back to billed).
+ *     - Works when the included allowance lives on the main plan and the
+ *       consumable overage price lives on an add-on, with each plan carrying
+ *       billing controls for different features.
+ *   Side effects:
+ *     - Skipped line items are excluded from the Stripe invoice total (and
+ *       therefore from the stored Autumn invoice total).
+ *
+ * Pre-impl red: skip_overage_billing is stripped by zod on plan create /
+ * customer update, so overage is billed everywhere → latestTotal mismatches.
+ * Post-impl green: schema field + hierarchy resolution + line-item filter in
+ * processConsumablePricesForInvoiceCreated.
+ */
+
+import { expect, test } from "bun:test";
+import { type ApiCustomerV3, ErrCode } from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { timeout } from "@tests/utils/genUtils";
+import { advanceToNextInvoice } from "@tests/utils/testAttachUtils/testAttachUtils";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 1: Customer-level controls — two overage features, one skips billing
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Scenario:
+ * - Pro ($20/mo) with consumable messages (100 included, $0.10/u) and
+ *   consumable words (100 included, $0.05/u)
+ * - Customer spend_limits: messages { overage_limit: 500, skip: true },
+ *   words { overage_limit: 500, skip: false }
+ * - Track messages 150 (50 overage), words 180 (80 overage) → advance cycle
+ *
+ * Expected:
+ * - Renewal invoice = $20 base + $4 words overage (80 × $0.05); the $5
+ *   messages overage (50 × $0.10) is NOT billed
+ * - BOTH balances reset to 100
+ */
+test.concurrent(
+	`${chalk.yellowBright("invoice.created skip-overage-billing 1: customer-level — one feature skips, one bills, both reset")}`,
+	async () => {
+		const customerId = "inv-skip-ovg-customer-level";
+
+		const pro = products.pro({
+			id: "pro",
+			items: [
+				items.consumableMessages({ includedUsage: 100 }),
+				items.consumableWords({ includedUsage: 100 }),
+			],
+		});
+
+		const { autumnV1, autumnV2_1, testClockId, advancedTo, ctx } =
+			await initScenario({
+				customerId,
+				setup: [
+					s.customer({ paymentMethod: "success" }),
+					s.products({ list: [pro] }),
+				],
+				actions: [s.attach({ productId: pro.id, timeout: 2000 })],
+			});
+
+		await autumnV2_1.customers.update(customerId, {
+			billing_controls: {
+				spend_limits: [
+					{
+						feature_id: TestFeature.Messages,
+						enabled: true,
+						overage_limit: 500,
+						skip_overage_billing: true,
+					},
+					{
+						feature_id: TestFeature.Words,
+						enabled: true,
+						overage_limit: 500,
+						skip_overage_billing: false,
+					},
+				],
+			},
+		});
+		await timeout(3000);
+
+		await autumnV2_1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 150,
+		});
+		await autumnV2_1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Words,
+			value: 180,
+		});
+		await timeout(4000);
+
+		await advanceToNextInvoice({
+			stripeCli: ctx.stripeCli,
+			testClockId: testClockId!,
+			currentEpochMs: advancedTo,
+			withPause: true,
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+		// ── Contract: only words overage billed (messages skipped) ──────────
+		await expectCustomerInvoiceCorrect({
+			customer,
+			count: 2,
+			latestTotal: 20 + 80 * 0.05, // $24 — no $5 messages overage
+			latestInvoiceProductId: pro.id,
+		});
+
+		// ── Contract: BOTH features reset on the cycle ───────────────────────
+		expect(customer.features[TestFeature.Messages].balance).toBe(100);
+		expect(customer.features[TestFeature.Words].balance).toBe(100);
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 2: Plan-level default (percent cap + skip) → customer override re-bills
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Scenario:
+ * - Pro ($20/mo) with consumable messages (100 included, $0.10/u); plan
+ *   billing_controls: { usage_percentage, overage_limit: 20, skip: true }
+ *   → usable up to 120% of included allowance, overage never posted to Stripe
+ * - Track to the 120 cap; a further track is rejected (cap enforced)
+ * - Advance cycle → renewal is base-only, balance resets
+ * - Customer override: { usage_percentage, overage_limit: 400, skip: false }
+ * - Track 150 (50 overage) → advance cycle → overage IS billed
+ */
+test.concurrent(
+	`${chalk.yellowBright("invoice.created skip-overage-billing 2: plan-level default, customer override re-enables billing")}`,
+	async () => {
+		const customerId = "inv-skip-ovg-plan-override";
+
+		const pro = products.pro({
+			id: "pro",
+			items: [items.consumableMessages({ includedUsage: 100 })],
+			billingControls: {
+				spend_limits: [
+					{
+						feature_id: TestFeature.Messages,
+						enabled: true,
+						limit_type: "usage_percentage",
+						overage_limit: 20,
+						skip_overage_billing: true,
+					},
+				],
+			},
+		});
+
+		const { autumnV1, autumnV2_1, testClockId, advancedTo, ctx } =
+			await initScenario({
+				customerId,
+				setup: [
+					s.customer({ paymentMethod: "success" }),
+					s.products({ list: [pro] }),
+				],
+				actions: [s.attach({ productId: pro.id, timeout: 2000 })],
+			});
+
+		// ── Contract: plan-level cap enforced at 120% of included ────────────
+		await autumnV2_1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 120,
+		});
+		await timeout(4000);
+
+		await expectAutumnError({
+			errCode: ErrCode.InsufficientBalance,
+			func: async () =>
+				await autumnV2_1.track({
+					customer_id: customerId,
+					feature_id: TestFeature.Messages,
+					value: 1,
+					overage_behavior: "reject",
+				}),
+		});
+
+		const renewedAt = await advanceToNextInvoice({
+			stripeCli: ctx.stripeCli,
+			testClockId: testClockId!,
+			currentEpochMs: advancedTo,
+			withPause: true,
+		});
+
+		const customerAfterFirstCycle =
+			await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+		// ── Contract: plan-level skip → renewal is base-only ─────────────────
+		await expectCustomerInvoiceCorrect({
+			customer: customerAfterFirstCycle,
+			count: 2,
+			latestTotal: 20, // 20 units of overage NOT billed
+			latestInvoiceProductId: pro.id,
+		});
+
+		// ── Contract: balance still resets for the skipped feature ───────────
+		expect(customerAfterFirstCycle.features[TestFeature.Messages].balance).toBe(
+			100,
+		);
+
+		// ── Contract: customer-level entry overrides the plan default ────────
+		await autumnV2_1.customers.update(customerId, {
+			billing_controls: {
+				spend_limits: [
+					{
+						feature_id: TestFeature.Messages,
+						enabled: true,
+						limit_type: "usage_percentage",
+						overage_limit: 400,
+						skip_overage_billing: false,
+					},
+				],
+			},
+		});
+		await timeout(3000);
+
+		await autumnV2_1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 150,
+		});
+		await timeout(4000);
+
+		await advanceToNextInvoice({
+			stripeCli: ctx.stripeCli,
+			testClockId: testClockId!,
+			currentEpochMs: renewedAt,
+			withPause: true,
+		});
+
+		const customerAfterSecondCycle =
+			await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+		// ── Contract: overage now posted to Stripe ───────────────────────────
+		await expectCustomerInvoiceCorrect({
+			customer: customerAfterSecondCycle,
+			count: 3,
+			latestTotal: 20 + 50 * 0.1, // $25 — 50 overage × $0.10
+			latestInvoiceProductId: pro.id,
+		});
+
+		expect(
+			customerAfterSecondCycle.features[TestFeature.Messages].balance,
+		).toBe(100);
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 3: Main plan + add-on — included on main, overage price on add-on,
+//         different billing controls per plan for different features
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Scenario:
+ * - Main pro ($20/mo): words INCLUDED allowance (100, no price) + consumable
+ *   messages (100 included, $0.10/u); plan controls: messages { skip: false }
+ * - Recurring add-on ($20/mo): consumable words price ($0.05/u, 0 included);
+ *   plan controls: words { skip: true }
+ * - Track words 150 (50 overage, priced by the add-on), messages 130 (30 overage)
+ * - Advance cycle → words overage skipped, messages overage billed, both reset
+ * - Customer override: words { skip: false } → track words 140 → advance →
+ *   words overage billed
+ */
+test.concurrent(
+	`${chalk.yellowBright("invoice.created skip-overage-billing 3: main plan + add-on with split allowance/price and per-plan controls")}`,
+	async () => {
+		const customerId = "inv-skip-ovg-addon-split";
+
+		const mainPlan = products.pro({
+			id: "main-pro",
+			items: [
+				items.monthlyWords({ includedUsage: 100 }),
+				items.consumableMessages({ includedUsage: 100 }),
+			],
+			billingControls: {
+				spend_limits: [
+					{
+						feature_id: TestFeature.Messages,
+						enabled: true,
+						overage_limit: 1000,
+						skip_overage_billing: false,
+					},
+				],
+			},
+		});
+
+		const wordsAddOn = products.recurringAddOn({
+			id: "words-addon",
+			items: [items.consumableWords({ includedUsage: 0 })],
+			billingControls: {
+				spend_limits: [
+					{
+						feature_id: TestFeature.Words,
+						enabled: true,
+						overage_limit: 1000,
+						skip_overage_billing: true,
+					},
+				],
+			},
+		});
+
+		const { autumnV1, autumnV2_1, testClockId, advancedTo, ctx } =
+			await initScenario({
+				customerId,
+				setup: [
+					s.customer({ paymentMethod: "success" }),
+					s.products({ list: [mainPlan, wordsAddOn] }),
+				],
+				actions: [
+					s.attach({ productId: mainPlan.id, timeout: 2000 }),
+					s.attach({ productId: wordsAddOn.id, timeout: 2000 }),
+				],
+			});
+
+		await autumnV2_1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Words,
+			value: 150,
+		});
+		await autumnV2_1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 130,
+		});
+		await timeout(4000);
+
+		const renewedAt = await advanceToNextInvoice({
+			stripeCli: ctx.stripeCli,
+			testClockId: testClockId!,
+			currentEpochMs: advancedTo,
+			withPause: true,
+		});
+
+		const customerAfterFirstCycle =
+			await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+		// ── Contract: words overage (add-on control, skip) NOT billed;
+		//    messages overage (main-plan control) billed ──────────────────────
+		await expectCustomerInvoiceCorrect({
+			customer: customerAfterFirstCycle,
+			count: 3, // main attach + add-on attach + renewal
+			latestTotal: 20 + 20 + 30 * 0.1, // $43 — no words overage ($2.50)
+		});
+
+		// ── Contract: both features reset ────────────────────────────────────
+		expect(customerAfterFirstCycle.features[TestFeature.Words].balance).toBe(
+			100,
+		);
+		expect(customerAfterFirstCycle.features[TestFeature.Messages].balance).toBe(
+			100,
+		);
+
+		// ── Contract: customer-level entry overrides the add-on's plan control ─
+		await autumnV2_1.customers.update(customerId, {
+			billing_controls: {
+				spend_limits: [
+					{
+						feature_id: TestFeature.Words,
+						enabled: true,
+						overage_limit: 1000,
+						skip_overage_billing: false,
+					},
+				],
+			},
+		});
+		await timeout(3000);
+
+		await autumnV2_1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Words,
+			value: 140,
+		});
+		await timeout(4000);
+
+		await advanceToNextInvoice({
+			stripeCli: ctx.stripeCli,
+			testClockId: testClockId!,
+			currentEpochMs: renewedAt,
+			withPause: true,
+		});
+
+		const customerAfterSecondCycle =
+			await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+		// ── Contract: words overage now billed ───────────────────────────────
+		await expectCustomerInvoiceCorrect({
+			customer: customerAfterSecondCycle,
+			count: 4,
+			latestTotal: 20 + 20 + 40 * 0.05, // $42 — 40 words overage × $0.05
+		});
+
+		expect(customerAfterSecondCycle.features[TestFeature.Words].balance).toBe(
+			100,
+		);
+	},
+);

--- a/server/tests/unit/billing/skip-overage-billing-resolution.test.ts
+++ b/server/tests/unit/billing/skip-overage-billing-resolution.test.ts
@@ -105,14 +105,26 @@ describe("skip_overage_billing resolution — undefined is always billed", () =>
 		expect(resolve(fullCustomer)).toBe(false);
 	});
 
-	test("customer cap-only entry does NOT shadow plan skip true → skipped", () => {
+	test("customer cap-only entry takes over wholesale (undefined = billed) → billed", () => {
 		const fullCustomer = buildFullCustomer({
 			customer: [{ feature_id: FEATURE, enabled: true, overage_limit: 500 }],
 			plan: [
 				{ feature_id: FEATURE, enabled: true, skip_overage_billing: true },
 			],
 		});
-		expect(resolve(fullCustomer)).toBe(true);
+		expect(resolve(fullCustomer)).toBe(false);
+	});
+
+	test("disabled customer entry shadows plan skip true → billed", () => {
+		const fullCustomer = buildFullCustomer({
+			customer: [
+				{ feature_id: FEATURE, enabled: false, skip_overage_billing: true },
+			],
+			plan: [
+				{ feature_id: FEATURE, enabled: true, skip_overage_billing: true },
+			],
+		});
+		expect(resolve(fullCustomer)).toBe(false);
 	});
 
 	test("entity skip false overrides customer skip true → billed", () => {

--- a/server/tests/unit/billing/skip-overage-billing-resolution.test.ts
+++ b/server/tests/unit/billing/skip-overage-billing-resolution.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Pins the backward-compatibility contract of fullCustomerToSkipOverageBilling:
+ * undefined skip_overage_billing ALWAYS resolves to billed (false). Existing
+ * customers with cap-only spend limits must never have overage posting skipped.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	CusProductStatus,
+	type DbSpendLimit,
+	type FullCustomer,
+	fullCustomerToSkipOverageBilling,
+} from "@autumn/shared";
+
+const FEATURE = "messages";
+const NOW = Date.UTC(2026, 6, 8, 12, 0, 0);
+
+const buildFullCustomer = ({
+	customer,
+	entity,
+	plan,
+}: {
+	customer?: DbSpendLimit[];
+	entity?: DbSpendLimit[];
+	plan?: DbSpendLimit[];
+}): FullCustomer =>
+	({
+		spend_limits: customer ?? null,
+		entity: entity ? { spend_limits: entity } : undefined,
+		entities: [],
+		customer_products: plan
+			? [
+					{
+						id: "cus_prod_1",
+						status: CusProductStatus.Active,
+						starts_at: NOW - 1000,
+						access_starts_at: NOW - 1000,
+						ended_at: null,
+						created_at: NOW - 1000,
+						customer_entitlements: [],
+						product: { spend_limits: plan },
+					},
+				]
+			: [],
+	}) as unknown as FullCustomer;
+
+const resolve = (fullCustomer: FullCustomer) =>
+	fullCustomerToSkipOverageBilling({ fullCustomer, featureId: FEATURE });
+
+describe("skip_overage_billing resolution — undefined is always billed", () => {
+	test("no spend limits anywhere → billed", () => {
+		expect(resolve(buildFullCustomer({}))).toBe(false);
+	});
+
+	test("existing-user shape: customer cap without skip field → billed", () => {
+		const fullCustomer = buildFullCustomer({
+			customer: [{ feature_id: FEATURE, enabled: true, overage_limit: 500 }],
+		});
+		expect(resolve(fullCustomer)).toBe(false);
+	});
+
+	test("existing-user shape: plan cap without skip field → billed", () => {
+		const fullCustomer = buildFullCustomer({
+			plan: [{ feature_id: FEATURE, enabled: true, overage_limit: 500 }],
+		});
+		expect(resolve(fullCustomer)).toBe(false);
+	});
+
+	test("skip true on a disabled entry → billed", () => {
+		const fullCustomer = buildFullCustomer({
+			customer: [
+				{ feature_id: FEATURE, enabled: false, skip_overage_billing: true },
+			],
+		});
+		expect(resolve(fullCustomer)).toBe(false);
+	});
+
+	test("skip true on another feature's entry → billed", () => {
+		const fullCustomer = buildFullCustomer({
+			customer: [
+				{ feature_id: "words", enabled: true, skip_overage_billing: true },
+			],
+		});
+		expect(resolve(fullCustomer)).toBe(false);
+	});
+
+	test("plan skip true + enabled → skipped (the only opt-in path)", () => {
+		const fullCustomer = buildFullCustomer({
+			plan: [
+				{ feature_id: FEATURE, enabled: true, skip_overage_billing: true },
+			],
+		});
+		expect(resolve(fullCustomer)).toBe(true);
+	});
+
+	test("customer skip false overrides plan skip true → billed", () => {
+		const fullCustomer = buildFullCustomer({
+			customer: [
+				{ feature_id: FEATURE, enabled: true, skip_overage_billing: false },
+			],
+			plan: [
+				{ feature_id: FEATURE, enabled: true, skip_overage_billing: true },
+			],
+		});
+		expect(resolve(fullCustomer)).toBe(false);
+	});
+
+	test("customer cap-only entry does NOT shadow plan skip true → skipped", () => {
+		const fullCustomer = buildFullCustomer({
+			customer: [{ feature_id: FEATURE, enabled: true, overage_limit: 500 }],
+			plan: [
+				{ feature_id: FEATURE, enabled: true, skip_overage_billing: true },
+			],
+		});
+		expect(resolve(fullCustomer)).toBe(true);
+	});
+
+	test("entity skip false overrides customer skip true → billed", () => {
+		const fullCustomer = buildFullCustomer({
+			entity: [
+				{ feature_id: FEATURE, enabled: true, skip_overage_billing: false },
+			],
+			customer: [
+				{ feature_id: FEATURE, enabled: true, skip_overage_billing: true },
+			],
+		});
+		expect(resolve(fullCustomer)).toBe(false);
+	});
+});

--- a/server/tests/unit/shared/compareBillingControls.test.ts
+++ b/server/tests/unit/shared/compareBillingControls.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Pins skip_overage_billing false ≡ unset for billing-control change detection
+ * (UI save-button dirty checks and backend plan-change decisioning).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	type CustomerBillingControls,
+	compareBillingControls,
+} from "@autumn/shared";
+
+const capOnly: CustomerBillingControls = {
+	spend_limits: [{ feature_id: "messages", enabled: true, overage_limit: 100 }],
+};
+
+const withSkip = (skipOverageBilling: boolean): CustomerBillingControls => ({
+	spend_limits: [
+		{
+			feature_id: "messages",
+			enabled: true,
+			overage_limit: 100,
+			skip_overage_billing: skipOverageBilling,
+		},
+	],
+});
+
+describe("compareBillingControls — skip_overage_billing normalization", () => {
+	test("explicit false vs unset → same", () => {
+		expect(
+			compareBillingControls({
+				newBillingControls: withSkip(false),
+				curBillingControls: capOnly,
+			}),
+		).toBe(true);
+	});
+
+	test("explicit true vs unset → different", () => {
+		expect(
+			compareBillingControls({
+				newBillingControls: withSkip(true),
+				curBillingControls: capOnly,
+			}),
+		).toBe(false);
+	});
+
+	test("true vs false → different", () => {
+		expect(
+			compareBillingControls({
+				newBillingControls: withSkip(true),
+				curBillingControls: withSkip(false),
+			}),
+		).toBe(false);
+	});
+});

--- a/server/tests/unit/shared/diffPlanV1PreviewFields.test.ts
+++ b/server/tests/unit/shared/diffPlanV1PreviewFields.test.ts
@@ -142,3 +142,57 @@ test("diffPlanV1PreviewFields ignores joined item feature fields", () => {
 	expect(diff.previous_attributes).toBeNull();
 	expect(diff.item_changes).toEqual([]);
 });
+
+test("billing_controls: skip_overage_billing false vs unset is not a change", () => {
+	const from = plan({
+		billing_controls: {
+			spend_limits: [
+				{ feature_id: "messages", enabled: true, overage_limit: 100 },
+			],
+		},
+	});
+	const to = plan({
+		billing_controls: {
+			spend_limits: [
+				{
+					feature_id: "messages",
+					enabled: true,
+					overage_limit: 100,
+					skip_overage_billing: false,
+				},
+			],
+		},
+	});
+
+	const diff = diffPlanV1PreviewFields({ from, to });
+
+	expect(diff.previous_attributes).toBeNull();
+});
+
+test("billing_controls: skip_overage_billing true vs unset is a change", () => {
+	const from = plan({
+		billing_controls: {
+			spend_limits: [
+				{ feature_id: "messages", enabled: true, overage_limit: 100 },
+			],
+		},
+	});
+	const to = plan({
+		billing_controls: {
+			spend_limits: [
+				{
+					feature_id: "messages",
+					enabled: true,
+					overage_limit: 100,
+					skip_overage_billing: true,
+				},
+			],
+		},
+	});
+
+	const diff = diffPlanV1PreviewFields({ from, to });
+
+	expect(diff.previous_attributes).toMatchObject({
+		billing_controls: from.billing_controls,
+	});
+});

--- a/server/tests/utils/fixtures/products.ts
+++ b/server/tests/utils/fixtures/products.ts
@@ -80,18 +80,24 @@ const pro = ({
 	items,
 	id = "pro",
 	group,
+	billingControls,
 }: {
 	items: ProductItem[];
 	id?: string;
 	group?: string;
-}): ProductV2 =>
-	constructProduct({
+	billingControls?: CustomerBillingControlsParams;
+}): ProductV2 => ({
+	...constructProduct({
 		id,
 		items: [...items],
 		type: "pro",
 		isDefault: false,
 		group,
-	});
+	}),
+	...(billingControls
+		? { billing_controls: billingControls as CustomerBillingControls }
+		: {}),
+});
 
 /**
  * Pro annual product - $200/year base price
@@ -331,17 +337,23 @@ const oneOff = ({
 const recurringAddOn = ({
 	items,
 	id = "addon",
+	billingControls,
 }: {
 	items: ProductItem[];
 	id?: string;
-}): ProductV2 =>
-	constructProduct({
+	billingControls?: CustomerBillingControlsParams;
+}): ProductV2 => ({
+	...constructProduct({
 		id,
 		items: [...items],
 		type: "pro",
 		isDefault: false,
 		isAddOn: true,
-	});
+	}),
+	...(billingControls
+		? { billing_controls: billingControls as CustomerBillingControls }
+		: {}),
+});
 
 /**
  * One-off add-on product - $10 base price (one-time), is_add_on: true

--- a/shared/models/cusModels/billingControls/customerBillingControls.ts
+++ b/shared/models/cusModels/billingControls/customerBillingControls.ts
@@ -56,6 +56,22 @@ export const billingControlsFromColumns = (
 	) as CustomerBillingControls;
 };
 
+/** Canonical form for change detection: skip_overage_billing false ≡ unset. */
+export const normalizeBillingControlsForCompare = (
+	billingControls: CustomerBillingControls | null | undefined,
+): CustomerBillingControls | undefined => {
+	if (!billingControls?.spend_limits) return billingControls ?? undefined;
+
+	return {
+		...billingControls,
+		spend_limits: billingControls.spend_limits.map((spendLimit) => {
+			if (spendLimit.skip_overage_billing === true) return spendLimit;
+			const { skip_overage_billing: _dropped, ...rest } = spendLimit;
+			return rest;
+		}),
+	};
+};
+
 export const mergeBillingControls = (
 	current: CustomerBillingControls | null | undefined,
 	patch: CustomerBillingControls | null | undefined,

--- a/shared/models/cusModels/billingControls/spendLimit.ts
+++ b/shared/models/cusModels/billingControls/spendLimit.ts
@@ -19,11 +19,19 @@ export const DbSpendLimitSchema = z
 			description:
 				"Overage cap for the feature: absolute units, or a percent (e.g. 120) when limit_type is usage_percentage.",
 		}),
+		skip_overage_billing: z.boolean().optional().meta({
+			description:
+				"When true, overage for this feature is not posted to Stripe. Usage tracking and balance resets still behave normally.",
+		}),
 	})
 	.refine(
-		(data) => data.overage_limit === undefined || data.feature_id !== undefined,
+		(data) =>
+			(data.overage_limit === undefined &&
+				data.skip_overage_billing === undefined) ||
+			data.feature_id !== undefined,
 		{
-			message: "feature_id is required when overage_limit is provided",
+			message:
+				"feature_id is required when overage_limit or skip_overage_billing is provided",
 			path: ["feature_id"],
 		},
 	);

--- a/shared/utils/cusUtils/fullCusUtils/fullCustomerToSkipOverageBilling.ts
+++ b/shared/utils/cusUtils/fullCusUtils/fullCustomerToSkipOverageBilling.ts
@@ -7,8 +7,8 @@ import {
 
 /**
  * Resolve whether overage billing is skipped for a feature (entity > customer > plan).
- * Only spend_limit entries that define skip_overage_billing participate, so a
- * customer entry that only sets an overage cap doesn't shadow a plan-level skip.
+ * The nearest entry for the feature wins wholesale; undefined skip_overage_billing
+ * means billed, so only an enabled entry with an explicit true skips.
  */
 export const fullCustomerToSkipOverageBilling = ({
 	fullCustomer,
@@ -29,12 +29,10 @@ export const fullCustomerToSkipOverageBilling = ({
 		controlLists: [entity?.spend_limits ?? [], fullCustomer.spend_limits ?? []],
 		customerProducts: fullCustomerToPlanProducts({ fullCustomer }),
 		controlKey: "spend_limits",
-		matches: (candidate) =>
-			candidate.feature_id === featureId &&
-			candidate.skip_overage_billing !== undefined,
+		matches: (candidate) => candidate.feature_id === featureId,
 	});
 
-	if (!spendLimit?.enabled) return false;
-
-	return spendLimit.skip_overage_billing === true;
+	return (
+		spendLimit?.enabled === true && spendLimit.skip_overage_billing === true
+	);
 };

--- a/shared/utils/cusUtils/fullCusUtils/fullCustomerToSkipOverageBilling.ts
+++ b/shared/utils/cusUtils/fullCusUtils/fullCustomerToSkipOverageBilling.ts
@@ -1,0 +1,40 @@
+import type { DbSpendLimit } from "@models/cusModels/billingControls/spendLimit.js";
+import type { FullCustomer } from "@models/cusModels/fullCusModel.js";
+import {
+	fullCustomerToPlanProducts,
+	resolveBillingControl,
+} from "../../fullSubjectUtils/planBillingControlUtils.js";
+
+/**
+ * Resolve whether overage billing is skipped for a feature (entity > customer > plan).
+ * Only spend_limit entries that define skip_overage_billing participate, so a
+ * customer entry that only sets an overage cap doesn't shadow a plan-level skip.
+ */
+export const fullCustomerToSkipOverageBilling = ({
+	fullCustomer,
+	featureId,
+	internalEntityId,
+}: {
+	fullCustomer: FullCustomer;
+	featureId: string;
+	internalEntityId?: string;
+}): boolean => {
+	const entity = internalEntityId
+		? fullCustomer.entities?.find(
+				(candidate) => candidate.internal_id === internalEntityId,
+			)
+		: fullCustomer.entity;
+
+	const spendLimit = resolveBillingControl<DbSpendLimit, "spend_limits">({
+		controlLists: [entity?.spend_limits ?? [], fullCustomer.spend_limits ?? []],
+		customerProducts: fullCustomerToPlanProducts({ fullCustomer }),
+		controlKey: "spend_limits",
+		matches: (candidate) =>
+			candidate.feature_id === featureId &&
+			candidate.skip_overage_billing !== undefined,
+	});
+
+	if (!spendLimit?.enabled) return false;
+
+	return spendLimit.skip_overage_billing === true;
+};

--- a/shared/utils/cusUtils/index.ts
+++ b/shared/utils/cusUtils/index.ts
@@ -6,6 +6,7 @@ export * from "./fullCusUtils/enrichFullCustomer";
 
 export * from "./fullCusUtils/fullCustomerToCustomerEntitlements";
 export * from "./fullCusUtils/fullCustomerToOverageAllowed";
+export * from "./fullCusUtils/fullCustomerToSkipOverageBilling";
 export * from "./fullCusUtils/fullCustomerToSpendLimit";
 export * from "./fullCusUtils/fullCustomerToTags";
 export * from "./fullCusUtils/getCusStripeSubCount";

--- a/shared/utils/planV1Utils/diff/diffPlanV1PreviewFields.ts
+++ b/shared/utils/planV1Utils/diff/diffPlanV1PreviewFields.ts
@@ -1,6 +1,7 @@
 import type { ApiPlanV1 } from "@api/products/apiPlanV1.js";
 import type { CorePlanUpdatePreview } from "@api/products/previewUpdatePlan/components/corePlanUpdatePreview.js";
 import type { PlanUpdatePreviewItemChange } from "@api/products/previewUpdatePlan/components/planUpdatePreviewChanges.js";
+import { normalizeBillingControlsForCompare } from "@models/cusModels/billingControls/customerBillingControls.js";
 import {
 	composeMatchKey,
 	diffPlanV1,
@@ -43,6 +44,7 @@ const valuesEqual = (left: unknown, right: unknown): boolean => {
 		if (leftKeys.length !== rightKeys.length) return false;
 		return leftKeys.every(
 			(key) =>
+				// biome-ignore lint/suspicious/noPrototypeBuiltins: Object.hasOwn needs lib ES2022; shared targets ES2020.
 				Object.prototype.hasOwnProperty.call(rightRecord, key) &&
 				valuesEqual(leftRecord[key], rightRecord[key]),
 		);
@@ -61,10 +63,7 @@ export const planUpdatePreviewHasDiff = ({
 	"customize" | "previous_attributes" | "price_change" | "item_changes"
 >): boolean =>
 	Boolean(
-		customize ||
-			previous_attributes ||
-			price_change ||
-			item_changes.length > 0,
+		customize || previous_attributes || price_change || item_changes.length > 0,
 	);
 
 export const diffPlanV1PreviousAttributes = ({
@@ -76,8 +75,17 @@ export const diffPlanV1PreviousAttributes = ({
 }): CorePlanUpdatePreview["previous_attributes"] => {
 	const previous: Record<string, unknown> = {};
 
+	// skip_overage_billing false ≡ unset — don't report it as a change.
+	const comparable = (
+		plan: ApiPlanV1,
+		key: (typeof previousAttributeKeys)[number],
+	) =>
+		key === "billing_controls"
+			? normalizeBillingControlsForCompare(plan.billing_controls)
+			: plan[key];
+
 	for (const key of previousAttributeKeys) {
-		if (!valuesEqual(from[key], to[key])) {
+		if (!valuesEqual(comparable(from, key), comparable(to, key))) {
 			// Use null (not undefined) for added fields so the key survives JSON
 			// serialization and clients can still tell the field changed.
 			previous[key] = from[key] === undefined ? null : from[key];

--- a/shared/utils/productV2Utils/compareProductUtils/compareProductUtils.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/compareProductUtils.ts
@@ -3,6 +3,7 @@
 import {
 	BILLING_CONTROL_KEYS,
 	billingControlsFromColumns,
+	normalizeBillingControlsForCompare,
 } from "../../../models/cusModels/billingControls/customerBillingControls.js";
 import type { Feature } from "../../../models/featureModels/featureModels.js";
 import type { FullProduct } from "../../../models/productModels/productModels.js";
@@ -130,13 +131,15 @@ const sortControls = (items: Array<{ feature_id?: string }>) =>
 
 const normalizeBillingControls = (
 	billingControls?: ProductV2["billing_controls"],
-) =>
-	JSON.stringify(
+) => {
+	const canonical = normalizeBillingControlsForCompare(billingControls);
+	return JSON.stringify(
 		BILLING_CONTROL_KEYS.flatMap((key) => {
-			const items = billingControls?.[key];
+			const items = canonical?.[key];
 			return items?.length ? [[key, sortControls(items)]] : [];
 		}),
 	);
+};
 
 export const compareBillingControls = ({
 	newBillingControls,

--- a/vite/src/components/billing-controls/BillingControlsDisplay.tsx
+++ b/vite/src/components/billing-controls/BillingControlsDisplay.tsx
@@ -20,6 +20,7 @@ import { motion } from "motion/react";
 import { createContext, Fragment, type ReactNode, useContext } from "react";
 import { cn } from "@/lib/utils";
 import { EmptyState } from "@/views/customers2/components/table/EmptyState";
+import { skipOverageBillingLabel } from "./overageBillingOptions";
 
 const ROW_SWAP_TRANSITION = {
 	duration: 0.2,
@@ -269,6 +270,10 @@ export const SpendLimitRow = ({
 				entries={[
 					{ label: "Type", value: isPercent ? "Usage %" : "Absolute" },
 					{ label: "Overage limit", value: overageLimitValue },
+					{
+						label: "Overage billing",
+						value: skipOverageBillingLabel(spendLimit.skip_overage_billing),
+					},
 				]}
 			/>
 		</RowButton>

--- a/vite/src/components/billing-controls/overageBillingOptions.ts
+++ b/vite/src/components/billing-controls/overageBillingOptions.ts
@@ -1,0 +1,29 @@
+/**
+ * UI mapping for DbSpendLimit.skip_overage_billing. The UI is binary (Billed
+ * writes false, Skipped writes true); unset entries (API-created) display as
+ * Billed and are rewritten to explicit false on save.
+ */
+export type OverageBillingOption = "skipped" | "billed";
+
+export const OVERAGE_BILLING_OPTIONS: {
+	value: OverageBillingOption;
+	label: string;
+}[] = [
+	{ value: "billed", label: "Billed" },
+	{ value: "skipped", label: "Skipped" },
+];
+
+export const skipOverageBillingToOption = (
+	skipOverageBilling?: boolean,
+): OverageBillingOption => (skipOverageBilling ? "skipped" : "billed");
+
+export const optionToSkipOverageBilling = (
+	option: OverageBillingOption,
+): boolean => option === "skipped";
+
+export const skipOverageBillingLabel = (
+	skipOverageBilling?: boolean,
+): string | null => {
+	if (skipOverageBilling === undefined) return null;
+	return skipOverageBilling ? "Skipped" : "Billed";
+};

--- a/vite/src/views/customers2/components/sheets/BillingSpendLimitSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingSpendLimitSheet.tsx
@@ -18,6 +18,12 @@ import {
 } from "@autumn/ui";
 import { type ChangeEvent, useState } from "react";
 import { toast } from "sonner";
+import {
+	OVERAGE_BILLING_OPTIONS,
+	type OverageBillingOption,
+	optionToSkipOverageBilling,
+	skipOverageBillingToOption,
+} from "@/components/billing-controls/overageBillingOptions";
 import { FeatureSearchDropdown } from "@/components/v2/dropdowns/FeatureSearchDropdown";
 import {
 	LayoutGroup,
@@ -66,6 +72,9 @@ export function BillingSpendLimitSheet() {
 	);
 	const [limitType, setLimitType] = useState<SpendLimitType>(
 		existingItem?.limit_type ?? "absolute",
+	);
+	const [overageBilling, setOverageBilling] = useState<OverageBillingOption>(
+		skipOverageBillingToOption(existingItem?.skip_overage_billing),
 	);
 
 	const isUsagePercentage = limitType === "usage_percentage";
@@ -132,6 +141,7 @@ export function BillingSpendLimitSheet() {
 			enabled,
 			overage_limit: parsedOverageLimit,
 			limit_type: limitType,
+			skip_overage_billing: optionToSkipOverageBilling(overageBilling),
 		} satisfies DbSpendLimit;
 
 		const currentSpendLimits = getCurrentSpendLimits();
@@ -249,6 +259,31 @@ export function BillingSpendLimitSheet() {
 									setOverageLimit(e.target.value)
 								}
 							/>
+						</div>
+
+						<div>
+							<FormLabel>Overage billing</FormLabel>
+							<Select
+								value={overageBilling}
+								onValueChange={(value: string) =>
+									setOverageBilling(value as OverageBillingOption)
+								}
+								items={OVERAGE_BILLING_OPTIONS}
+							>
+								<SelectTrigger className="w-full">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{OVERAGE_BILLING_OPTIONS.map((option) => (
+										<SelectItem key={option.value} value={option.value}>
+											{option.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+							<div className="mt-1 text-xs text-tertiary-foreground">
+								Skipped usage still resets each cycle but is never invoiced.
+							</div>
 						</div>
 					</div>
 				</SheetSection>

--- a/vite/src/views/products/plan/components/edit-plan-details/PlanBillingControlsSection.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-details/PlanBillingControlsSection.tsx
@@ -31,6 +31,7 @@ import {
 	BillingControlsList,
 	hasBillingControls,
 } from "@/components/billing-controls/BillingControlsDisplay";
+import { OVERAGE_BILLING_OPTIONS } from "@/components/billing-controls/overageBillingOptions";
 import { FieldInfo } from "@/components/general/form/field-info";
 import { FeatureSearchDropdown } from "@/components/v2/dropdowns/FeatureSearchDropdown";
 import { useProduct } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
@@ -219,7 +220,11 @@ function SelectFieldRow({
 	options,
 }: {
 	form: UsePlanBillingControlForm;
-	name: "purchase_limit_interval" | "usage_interval" | "threshold_type";
+	name:
+		| "purchase_limit_interval"
+		| "usage_interval"
+		| "threshold_type"
+		| "overage_billing";
 	label: string;
 	placeholder: string;
 	options: SelectOption[];
@@ -382,6 +387,13 @@ function SpendLimitFields({ form }: { form: UsePlanBillingControlForm }) {
 					/>
 				)}
 			</form.Subscribe>
+			<SelectFieldRow
+				form={form}
+				name="overage_billing"
+				label="Overage billing"
+				placeholder="Default"
+				options={OVERAGE_BILLING_OPTIONS}
+			/>
 		</div>
 	);
 }

--- a/vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts
+++ b/vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts
@@ -11,6 +11,11 @@ import {
 } from "@autumn/shared";
 import { useRef } from "react";
 import { z } from "zod/v4";
+import {
+	type OverageBillingOption,
+	optionToSkipOverageBilling,
+	skipOverageBillingToOption,
+} from "@/components/billing-controls/overageBillingOptions";
 import { useAppForm } from "@/hooks/form/form";
 
 export type ControlItem =
@@ -32,6 +37,7 @@ export type PlanBillingControlFormValues = {
 	invoice_mode: boolean;
 	limit_type: SpendLimitType;
 	overage_limit: number | null;
+	overage_billing: OverageBillingOption;
 	usage_limit: number | null;
 	usage_interval: ResetInterval;
 	alert_name: string;
@@ -160,6 +166,7 @@ export function buildControlItem(
 			enabled: values.enabled,
 			limit_type: values.limit_type,
 			overage_limit: values.overage_limit ?? undefined,
+			skip_overage_billing: optionToSkipOverageBilling(values.overage_billing),
 		} satisfies DbSpendLimit;
 	}
 
@@ -228,6 +235,9 @@ function toDefaultValues(
 		invoice_mode: autoTopup?.invoice_mode ?? false,
 		limit_type: spendLimit?.limit_type ?? "absolute",
 		overage_limit: spendLimit?.overage_limit ?? null,
+		overage_billing: skipOverageBillingToOption(
+			spendLimit?.skip_overage_billing,
+		),
 		usage_limit: usageLimit?.limit ?? null,
 		usage_interval: usageLimit?.interval ?? ResetInterval.Month,
 		alert_name: usageAlert?.name ?? "",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-feature “skip overage billing” spend-limit to skip invoicing while keeping usage tracking and cycle resets. Skipped overage is filtered out before posting to Stripe and is surfaced in webhook logs.

- **New Features**
  - Added `skip_overage_billing?: boolean` to spend limits; requires `feature_id` when set.
  - Resolves via entity > customer > plan; partitions arrear line items and posts only billable items; Stripe/Autumn totals exclude skipped.
  - Webhook logs include `skippedOverageLineItems` and `overageBillingDisabledByConfig`.
  - UI: plan and customer forms add an “Overage billing” selector (Billed/Skipped) and show the value in rows.
  - Change detection: treats `skip_overage_billing: false` as unset for dirty checks and plan-update previews to avoid no-op updates.
  - Tests: integration and unit coverage for hierarchy resolution, add-on split allowance/price, and backward-compat (undefined resolves to billed).

- **Migration**
  - No action required. Existing limits continue billing by default. Opt-in by setting `skip_overage_billing: true` at the plan, customer, or entity level for a feature.

<sup>Written for commit 0e05b383ecd39a02ccde2b1baef8b619ded252f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds per-feature skip overage billing for spend-limit controls. The main changes are:

- **[Improvements]** New `skip_overage_billing` field on spend limits.
- **[Improvements]** Arrear invoice line items are filtered before Stripe invoice item creation.
- **[Improvements]** Skipped overage line items are logged separately.
- **[Improvements]** Customer and plan billing-control UIs expose overage billing options.
- **[Bug fixes]** New tests cover skip-overage resolution and invoice-created behavior.
</details>

<h3>Confidence Score: 4/5</h3>

The overage billing UI save paths need a fix before merging.

- Backend filtering and resolution match the main invoice-created flow.
- The UI can rewrite an inherited unset value into explicit billed state.
- That can change which spend-limit control wins and can produce unexpected Stripe overage charges.

BillingSpendLimitSheet.tsx and usePlanBillingControlForm.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/common/eventContextToArrearLineItems.ts | Adds skip-overage partitioning before logging and returning billable line items. |
| server/src/external/stripe/webhookHandlers/common/filterSkippedOverageLineItems.ts | Adds the helper that splits arrear line items into billable and skipped groups. |
| shared/utils/cusUtils/fullCusUtils/fullCustomerToSkipOverageBilling.ts | Adds hierarchy-based resolution for skip-overage billing. |
| shared/models/cusModels/billingControls/spendLimit.ts | Adds optional schema support for `skip_overage_billing`. |
| vite/src/views/customers2/components/sheets/BillingSpendLimitSheet.tsx | Adds customer/entity UI for overage billing, with an unset-to-false save issue. |
| vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts | Adds plan form state and serialization for overage billing, with an unset-to-false save issue. |
| vite/src/components/billing-controls/overageBillingOptions.ts | Adds shared UI mappings for billed versus skipped overage billing. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Arrear line items] --> B[Resolve skip_overage_billing]
  B -->|true| C[Skip Stripe invoice item]
  B -->|false| D[Create Stripe invoice item]
  A --> E[Entitlement updates]
  E --> F[Balances reset]
  G[Billing-control UI save] --> H{Preserve unset value?}
  H -->|yes| I[Inheritance stays intact]
  H -->|no| J[Explicit billed override can shadow skip]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[Arrear line items] --> B[Resolve skip_overage_billing]
  B -->|true| C[Skip Stripe invoice item]
  B -->|false| D[Create Stripe invoice item]
  A --> E[Entitlement updates]
  E --> F[Balances reset]
  G[Billing-control UI save] --> H{Preserve unset value?}
  H -->|yes| I[Inheritance stays intact]
  H -->|no| J[Explicit billed override can shadow skip]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/views/customers2/components/sheets/BillingSpendLimitSheet.tsx:141-145
**Unset Override Becomes Billed**

When an existing customer or entity spend limit has only an `overage_limit`, this save path writes `skip_overage_billing: false` even if the user only edits another field. The resolver treats absent and explicit `false` differently, so this turns a cap-only override that can inherit a plan-level skip into an explicit billed override; the next invoice can charge overage that was previously skipped.

### Issue 2 of 2
vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts:166-170
**Plan Default Becomes Explicit**

Saving a plan spend limit with an unset `skip_overage_billing` now serializes it as `false`. Because the resolver only skips entries where this field is absent, editing a legacy or cap-only plan control can make that product's billed setting participate and win before another active product's `skip_overage_billing: true` for the same feature, so overage can be posted to Stripe instead of skipped.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["skip overage billing"](https://github.com/useautumn/autumn/commit/116efce34f46715c2f6737c0f68c849913179673) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42767877)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->