### PR TITLE
fix: 🐛 bugs

### DIFF
--- a/server/src/internal/analytics/actions/aggregate.ts
+++ b/server/src/internal/analytics/actions/aggregate.ts
@@ -25,6 +25,7 @@ import {
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { validatePropertyPathForJSON } from "@/internal/analytics/actions/eventValidationUtils.js";
 import { getBillingCycleStartDate } from "../analyticsUtils.js";
+import { getCountAndSum } from "./getCountAndSum.js";
 
 /** Flattens filter_by into indexed filter_key_N / filter_value_N params for Tinybird pipes */
 const buildFilterParams = ({
@@ -394,50 +395,27 @@ const formatGroupableResults = ({
 };
 
 /**
- * Decides whether the groupable pipe must bypass events_property_mv.
+ * Ducttape fallback for the property-rollup cardinality gate.
  *
- * The property rollup's insert-time value-shape gate drops high-entropy values
- * (UUIDs, long hex, opaque strings), so a key whose values are all gate-dropped
- * has zero rows in the rollup even though the raw events exist — querying it
- * silently returns an empty result. Probe the rollup for the key and force the
- * ungated events_hourly_mv path when it is absent. Probe failures fall back to
- * the rollup (current behavior) rather than failing the whole query.
+ * Unfiltered property group-bys read events_property_mv, whose insert-time gate
+ * drops high-entropy values (UUIDs, long hex, opaque strings) to keep the rollup
+ * bounded. A group-by over such a key therefore returns an EMPTY grouped result
+ * even though the events exist — the gate can't tell a genuinely explosive key
+ * (per-request trace ids) from a low-cardinality-but-UUID-shaped one (a customer
+ * with 21 project ids).
+ *
+ * When the grouped result is empty BUT the authoritative totals (getCountAndSum,
+ * read from the ungated rollups) show real events, we know the gate ate the
+ * values, so we retry the same query against the ungated events_hourly_mv. When
+ * the totals are also empty, the customer simply has no events — no retry.
+ *
+ * This does NOT cover the partial case (a key with a mix of gate-surviving and
+ * gate-dropped values), which needs cardinality-aware routing (topKWeighted).
  */
-const shouldSkipPropertyRollup = async ({
-	pipes,
-	orgId,
-	env,
-	groupColumn,
-	propertyKey,
-	hasPropertyFilters,
-}: {
-	pipes: ReturnType<typeof getTinybirdPipes>;
-	orgId: string;
-	env: string;
-	groupColumn: string;
-	propertyKey: string;
-	hasPropertyFilters: boolean;
-}): Promise<boolean> => {
-	// The pipe only reads the rollup for unfiltered property group-bys
-	if (groupColumn !== "property" || hasPropertyFilters || !propertyKey) {
-		return false;
-	}
-
-	try {
-		const probe = await pipes.propertyKeyExists({
-			org_id: orgId,
-			env,
-			property_key: propertyKey,
-		});
-		return probe.data.length === 0;
-	} catch (error) {
-		console.warn(
-			`[aggregate] property_key_exists probe failed for key "${propertyKey}", using property rollup`,
-			error,
-		);
-		return false;
-	}
-};
+const totalsHaveEvents = (
+	totals: Record<string, { count: number; sum: number }>,
+): boolean =>
+	Object.values(totals).some((t) => t.count > 0 && t.sum > 0);
 
 /** Aggregates events into time-bucketed timeseries data */
 export const aggregate = async ({
@@ -492,14 +470,6 @@ export const aggregate = async ({
 		}
 
 		const filterParams = buildFilterParams({ filter_by: params.filter_by });
-		const skipPropertyRollup = await shouldSkipPropertyRollup({
-			pipes,
-			orgId: org.id,
-			env,
-			groupColumn,
-			propertyKey,
-			hasPropertyFilters: Object.keys(filterParams).length > 0,
-		});
 
 		const pipeParams = {
 			org_id: org.id,
@@ -515,10 +485,28 @@ export const aggregate = async ({
 			property_key: propertyKey,
 			...filterParams,
 			max_groups: params.max_groups,
-			skip_property_rollup: skipPropertyRollup ? ("1" as const) : undefined,
 		};
 
-		const result = await pipes.aggregateGroupable(pipeParams);
+		let result = await pipes.aggregateGroupable(pipeParams);
+
+		// The gated property rollup only serves unfiltered property group-bys. If it
+		// returns nothing, check whether real events exist (ungated totals); if so,
+		// the value-shape gate dropped the group values — retry against the ungated
+		// events_hourly_mv. See totalsHaveEvents for the full rationale.
+		const usedGatedRollup =
+			groupColumn === "property" &&
+			Object.keys(filterParams).length === 0 &&
+			result.data.length === 0;
+
+		if (usedGatedRollup) {
+			const totals = await getCountAndSum({ ctx, params });
+			if (totalsHaveEvents(totals)) {
+				result = await pipes.aggregateGroupable({
+					...pipeParams,
+					skip_property_rollup: "1",
+				});
+			}
+		}
 
 		// For external API (enforceGroupLimit), truncated is always false
 		// For internal API, return the actual truncation status from the pipe

--- a/server/tests/integration/analytics/aggregate/uuid-group-by-fallback.test.ts
+++ b/server/tests/integration/analytics/aggregate/uuid-group-by-fallback.test.ts
@@ -7,14 +7,15 @@
  * values — so the key has zero rows in the rollup and the query silently returns
  * nothing, while totals (served from an ungated pipe) look correct.
  *
- * Red-failure mode (current behavior):
+ * Red-failure mode (pre-fix):
  *  - list is [] even though the tracked events exist and totals report them.
  *
- * Green-success criteria (after fix — requires the property_key_exists probe pipe
- * and the skip_property_rollup param to be deployed to Tinybird):
- *  - The server probes events_property_mv for the key, finds it absent, and routes
- *    to the ungated events_hourly_mv — the list contains per-period grouped_values
- *    keyed by the UUID project ids with the tracked sums.
+ * Green-success criteria (after fix — requires the skip_property_rollup param
+ * deployed to Tinybird):
+ *  - The grouped query comes back empty, but getCountAndSum (ungated totals) shows
+ *    real events, so the server retries with skip_property_rollup=1 against the
+ *    ungated events_hourly_mv — the list contains per-period grouped_values keyed
+ *    by the UUID project ids with the tracked sums.
  */
 
 import { expect, test } from "bun:test";


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes false-empty results for unfiltered property group-bys with UUID-shaped values by retrying against the ungated rollup when totals show real events. Users now see grouped values that match totals instead of an empty list.

- **Bug Fixes**
  - Added totals-based fallback: if an unfiltered `groupColumn=property` query returns no rows, call `getCountAndSum`; when totals > 0, re-run `aggregateGroupable` with `skip_property_rollup=1` to use `events_hourly_mv` instead of the gated `events_property_mv`.
  - Removed the `property_key_exists` probe and related routing logic to simplify behavior and reduce failures.
  - Updated the integration test to assert the retry path and `skip_property_rollup` behavior.

<sup>Written for commit 22752edadfbe0cf6cdfadbcc5a4a9b194d359078. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the upfront `property_key_exists` Tinybird probe (which required an additional pipe deployment) with a post-hoc retry strategy for UUID-valued property group-bys: run the gated rollup query first, and if it returns nothing, call `getCountAndSum` against the ungated rollups to check whether real events exist before retrying with `skip_property_rollup=1`.

- **Bug fixes**: Removes dependency on the `property_key_exists` probe pipe; the fallback is now self-contained in the server layer using `getCountAndSum` as the authoritative existence check.
- **Improvements**: The integration test comments are updated to accurately describe the new retry-on-empty flow and its success criteria.
- **Bug fixes**: `totalsHaveEvents` gates the retry with `count > 0 && sum > 0`, which silently skips the fallback for events tracked with `value: 0` — those events have a non-zero count but zero sum, so the UUID fix does not apply to count-only tracking.
</details>

<h3>Confidence Score: 3/5</h3>

The retry logic itself is sound, but the existence check incorrectly requires sum > 0, meaning the fix does not apply to count-only events and will silently return empty grouped data for them.

The `totalsHaveEvents` guard uses `count > 0 && sum > 0`. Any event tracked with an explicit `value: 0` will have sum = 0 in both rollup paths, so the condition evaluates false even though real events are present. The fallback to `events_hourly_mv` is skipped and the caller receives the same empty list the bug fix was meant to prevent — making the fix incomplete for a common tracking pattern.

server/src/internal/analytics/actions/aggregate.ts — specifically the `totalsHaveEvents` predicate on lines 415–418.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/analytics/actions/aggregate.ts | Replaces the upfront `property_key_exists` probe (requires a Tinybird pipe deployment) with a post-hoc retry driven by `getCountAndSum`. The `totalsHaveEvents` guard uses `count > 0 && sum > 0`, which incorrectly skips the fallback for zero-value (count-only) events. |
| server/tests/integration/analytics/aggregate/uuid-group-by-fallback.test.ts | Integration test updated to reflect the new retry-on-empty strategy; test comments and success criteria are accurate and clear. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[aggregate called with group_by] --> B{groupColumn === property?}
    B -- No --> C[aggregateGroupable\ngated rollup]
    B -- Yes --> D[aggregateGroupable\ngated rollup]
    D --> E{result.data.length === 0\nAND no filterParams?}
    E -- No --> F[Use result as-is]
    E -- Yes --> G[getCountAndSum\nungated rollups]
    G --> H{totalsHaveEvents?\ncount > 0 AND sum > 0}
    H -- No / zero-sum events --> I[Return empty result\n⚠️ false negative for value=0 events]
    H -- Yes --> J[aggregateGroupable\nskip_property_rollup=1\nungated events_hourly_mv]
    J --> K[Return grouped data]
    C --> F
    F --> L[formatGroupableResults]
    K --> L
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[aggregate called with group_by] --> B{groupColumn === property?}
    B -- No --> C[aggregateGroupable\ngated rollup]
    B -- Yes --> D[aggregateGroupable\ngated rollup]
    D --> E{result.data.length === 0\nAND no filterParams?}
    E -- No --> F[Use result as-is]
    E -- Yes --> G[getCountAndSum\nungated rollups]
    G --> H{totalsHaveEvents?\ncount > 0 AND sum > 0}
    H -- No / zero-sum events --> I[Return empty result\n⚠️ false negative for value=0 events]
    H -- Yes --> J[aggregateGroupable\nskip_property_rollup=1\nungated events_hourly_mv]
    J --> K[Return grouped data]
    C --> F
    F --> L[formatGroupableResults]
    K --> L
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/analytics/actions/aggregate.ts:415-418
The `totalsHaveEvents` guard requires **both** `count > 0` and `sum > 0`. This means the UUID-fallback is silently skipped for count-only events — events tracked with an explicit `value: 0` will have `sum === 0` in both rollups and raw storage, so `totalsHaveEvents` returns `false` even though real events exist. The grouped query stays empty and the retry never fires, reproducing the original bug for this entire class of events.

```suggestion
const totalsHaveEvents = (
	totals: Record<string, { count: number; sum: number }>,
): boolean =>
	Object.values(totals).some((t) => t.count > 0);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 bugs"](https://github.com/useautumn/autumn/commit/22752edadfbe0cf6cdfadbcc5a4a9b194d359078) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42796544)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->