### PR TITLE
fix: leaf startup

### DIFF
--- a/apps/leaf/src/index.ts
+++ b/apps/leaf/src/index.ts
@@ -1,6 +1,9 @@
 import { initInfisical } from "@autumn/shared/utils/infisical";
 
 await initInfisical();
+// Bind leaf's port before eve's ~30s build/boot, or ALB health checks
+// (5s interval, 2-fail threshold, no grace period) kill the task first.
+await import("./main.js");
 // Local dev runs eve separately (scripts/dev.ts spawns `eve dev`); prod embeds it.
 const embedEve =
 	process.env.EVE_EMBEDDED ??
@@ -9,6 +12,8 @@ if (embedEve === "1") {
 	const { startEmbeddedEveServer } = await import(
 		"./harness/eve/embeddedServer.js"
 	);
-	await startEmbeddedEveServer();
+	startEmbeddedEveServer().catch((error) => {
+		console.error("Embedded eve server failed to start", error);
+		process.exit(1);
+	});
 }
-await import("./main.js");


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Leaf now binds its HTTP port before starting embedded Eve to keep ALB health checks passing during boot. It also fails fast with clear logs if embedded Eve fails to start.

- **Bug Fixes**
  - Moved `import("./main.js")` earlier to bind the port before Eve’s build/boot, preventing ALB (5s interval, 2-fail, no grace) from killing the task.
  - Wrapped `startEmbeddedEveServer()` with error handling to log the error and `process.exit(1)` on startup failure.

<sup>Written for commit 2b85c1445d0b60c8dfea6db03ed91cb77dded7a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a startup ordering issue in the `leaf` service where ALB health checks were killing the ECS task before the HTTP server had a chance to bind its port. It also updates the `ai` submodule pointer.

- **Bug fixes**: Moves `await import(\"./main.js\")` before the embedded Eve server launch so leaf's HTTP port is bound immediately, preventing ALB health-check failures during Eve's ~30-second build/boot.
- **Bug fixes / Improvements**: Replaces `await startEmbeddedEveServer()` with a fire-and-forget call plus `.catch()` handler so that the long Eve startup no longer blocks the event loop, while still calling `process.exit(1)` on failure.
- **Improvements**: Updates the `ai` submodule to a newer commit.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the reordering correctly fixes the ALB health-check race condition and the fire-and-forget pattern is well-guarded.

The startup order change is the right fix and the logic is sound. The only open question is the catch handler's error message, which is misleading for runtime failures but has no effect on behavior. The ai submodule bump is not reviewable here.

No files require special attention beyond confirming the ai submodule update is intentional.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/leaf/src/index.ts | Startup order fixed: main.js import moved before the embedded Eve server launch; Eve is now started fire-and-forget with a catch-and-exit handler. The error message in the catch handler is slightly misleading for runtime failures, but logic is sound. |
| ai | Submodule pointer bumped from bca809a to 7c63f31; submodule content is not reviewable here. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Proc as leaf process
    participant Main as main.js (HTTP server)
    participant Eve as embeddedServer.js (Eve)
    participant ALB as AWS ALB

    Note over Proc: Before this PR
    Proc->>Eve: await startEmbeddedEveServer() (~30s)
    ALB-->>Main: health check → 502 (port not bound)
    ALB->>Proc: 2 failures → task killed ❌

    Note over Proc: After this PR
    Proc->>Main: await import("./main.js") (binds port immediately)
    ALB-->>Main: health check → 200 ✅
    Proc->>Eve: startEmbeddedEveServer() [fire-and-forget]
    Eve-->>Proc: .catch() → console.error + process.exit(1) on failure
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Proc as leaf process
    participant Main as main.js (HTTP server)
    participant Eve as embeddedServer.js (Eve)
    participant ALB as AWS ALB

    Note over Proc: Before this PR
    Proc->>Eve: await startEmbeddedEveServer() (~30s)
    ALB-->>Main: health check → 502 (port not bound)
    ALB->>Proc: 2 failures → task killed ❌

    Note over Proc: After this PR
    Proc->>Main: await import("./main.js") (binds port immediately)
    ALB-->>Main: health check → 200 ✅
    Proc->>Eve: startEmbeddedEveServer() [fire-and-forget]
    Eve-->>Proc: .catch() → console.error + process.exit(1) on failure
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/leaf/src/index.ts:15-18
The error message `"Embedded eve server failed to start"` is only accurate during initial startup. Because `startEmbeddedEveServer()` is fire-and-forget and the catch handler fires for any rejection over the lifetime of the server, a runtime crash (e.g., Eve going down hours later) will log the same misleading "failed to start" message. A generic message like `"Embedded eve server error"` covers both cases accurately.

```suggestion
	startEmbeddedEveServer().catch((error) => {
		console.error("Embedded eve server error", error);
		process.exit(1);
	});
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: leaf startup"](https://github.com/useautumn/autumn/commit/2b85c1445d0b60c8dfea6db03ed91cb77dded7a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42824101)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->