### PR TITLE
fix: leaf startup

### DIFF
--- a/apps/leaf/src/harness/eve/embeddedServer.ts
+++ b/apps/leaf/src/harness/eve/embeddedServer.ts
@@ -1,6 +1,8 @@
 import { $ } from "bun";
 
 const EVE_PORT = process.env.EVE_PORT ?? "3999";
+// Leaf's own listen port — eve's MCP connection dials leaf back on loopback.
+const CHAT_PORT = process.env.CHAT_PORT ?? process.env.PORT ?? "3099";
 
 /** Runs eve inside the leaf task: leaf reaches it over loopback, matching
  * EVE_SERVER_URL's default, so prod needs no extra service or domain. */
@@ -10,7 +12,9 @@ export const startEmbeddedEveServer = async () => {
 	// redeploys; unset both vars and sessions fall back to ephemeral local files.
 	const workflowPostgresUrl =
 		process.env.WORKFLOW_POSTGRES_URL ?? process.env.CHAT_DATABASE_URL;
-	await $`bunx eve build`.cwd(leafRoot);
+	// eve build bakes the connection URL into the manifest, so CHAT_PORT must
+	// be set here — setting it only on the runtime spawn below is too late.
+	await $`bunx eve build`.cwd(leafRoot).env({ ...process.env, CHAT_PORT });
 	if (workflowPostgresUrl) {
 		await $`bunx workflow-postgres-setup`
 			.cwd(leafRoot)
@@ -24,9 +28,7 @@ export const startEmbeddedEveServer = async () => {
 			...(workflowPostgresUrl
 				? { WORKFLOW_POSTGRES_URL: workflowPostgresUrl }
 				: {}),
-			// Eve's MCP connection dials leaf back via CHAT_PORT, which must be
-			// leaf's own listen port — not the PORT override eve binds below.
-			CHAT_PORT: process.env.CHAT_PORT ?? process.env.PORT ?? "3099",
+			CHAT_PORT,
 			NITRO_HOST: process.env.EVE_HOST ?? "127.0.0.1",
 			NITRO_PORT: EVE_PORT,
 			PORT: EVE_PORT,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Leaf startup by making Eve’s MCP callback use Leaf’s actual listen port. This prevents mis-baked manifests and loopback connection failures.

- **Bug Fixes**
  - Set `CHAT_PORT` during `bunx eve build` so the manifest contains the correct callback URL.
  - Centralized `CHAT_PORT` resolution to `process.env.CHAT_PORT ?? process.env.PORT ?? "3099"` and reuse the same value at runtime.

<sup>Written for commit cb49a517075a6322a03ff9b5ba9dd3f3796cea2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a startup regression in the `leaf` embedded Eve server where `CHAT_PORT` was missing from the `bunx eve build` step. The build step bakes the MCP callback URL into the compiled manifest, so the port must be available at build time — not only at runtime spawn.

- **[Bug fixes]** Extracts `CHAT_PORT` to module-level so its value (resolved from `CHAT_PORT → PORT → "3099"`) is available early, and passes it via `.env()` to `bunx eve build` before the runtime spawn.
- **[Improvements]** Eliminates the duplicated inline `CHAT_PORT` derivation at the spawn site, replacing it with the single module-level constant.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted one-file fix that ensures the build step receives the same port value already passed to the runtime spawn.

The fix is minimal and correct: CHAT_PORT is resolved once at module load from the same env-var chain used before, then injected into both the build and runtime steps. There are no new code paths, no changed fallback logic, and no risk of the two uses diverging since they now share a single constant.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/leaf/src/harness/eve/embeddedServer.ts | Moves CHAT_PORT resolution to module level and injects it into the eve build step so the compiled manifest has the correct callback port; also removes the duplicated inline port derivation at the spawn site. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Leaf as Leaf Process
    participant Build as bunx eve build
    participant Setup as workflow-postgres-setup
    participant Eve as Eve Server (.output/server)

    Leaf->>Build: spawn with CHAT_PORT (new) + full env
    Build-->>Leaf: manifest written (CHAT_PORT baked in)
    alt workflowPostgresUrl set
        Leaf->>Setup: spawn with WORKFLOW_POSTGRES_URL
        Setup-->>Leaf: DB schemas ready
    end
    Leaf->>Eve: "Bun.spawn with CHAT_PORT, NITRO_PORT=EVE_PORT, PORT=EVE_PORT"
    Eve-->>Leaf: MCP dials back on CHAT_PORT (loopback)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Leaf as Leaf Process
    participant Build as bunx eve build
    participant Setup as workflow-postgres-setup
    participant Eve as Eve Server (.output/server)

    Leaf->>Build: spawn with CHAT_PORT (new) + full env
    Build-->>Leaf: manifest written (CHAT_PORT baked in)
    alt workflowPostgresUrl set
        Leaf->>Setup: spawn with WORKFLOW_POSTGRES_URL
        Setup-->>Leaf: DB schemas ready
    end
    Leaf->>Eve: "Bun.spawn with CHAT_PORT, NITRO_PORT=EVE_PORT, PORT=EVE_PORT"
    Eve-->>Leaf: MCP dials back on CHAT_PORT (loopback)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/leaf-startu..."](https://github.com/useautumn/autumn/commit/cb49a517075a6322a03ff9b5ba9dd3f3796cea2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42838298)</sub>

<!-- /greptile_comment -->