### PR TITLE
skip overage billing

### DIFF
--- a/apps/docs/mintlify/documentation/modelling-pricing/spend-limits.mdx
+++ b/apps/docs/mintlify/documentation/modelling-pricing/spend-limits.mdx
@@ -126,11 +126,68 @@ curl -X POST "https://api.useautumn.com/v1/customers/update" \
 |-------|------|-------------|
 | `feature_id` | string | The feature to apply the spend limit to |
 | `enabled` | boolean | Whether the spend limit is active |
-| `overage_limit` | number | Maximum overage units allowed beyond the included amount |
+| `overage_limit` | number (optional) | Maximum overage units allowed beyond the included amount |
+| `skip_overage_billing` | boolean (optional) | When `true`, overage on this feature is never billed — usage beyond the included amount is not added to the customer's invoice. Usage tracking and balance resets are unaffected. |
 
 <Note>
 The `overage_limit` is measured in the same units as the feature's balance — not in dollars. For example, if your feature is "API calls", an `overage_limit` of 5,000 means 5,000 additional API calls beyond the included amount.
 </Note>
+
+## Skipping overage billing
+
+Set `skip_overage_billing` to `true` on a spend limit to let a customer use overage without being charged for it. Usage tracking, `check` responses, and end-of-cycle balance resets all behave as normal — the overage line items are simply never added to the customer's invoice.
+
+<CodeGroup>
+
+```typescript TypeScript
+await autumn.customers.update({
+  customerId: "user_123",
+  billingControls: {
+    spendLimits: [{
+      featureId: "api_calls",
+      enabled: true,
+      skipOverageBilling: true,
+    }],
+  },
+});
+```
+
+```python Python
+await autumn.customers.update(
+    customer_id="user_123",
+    billing_controls={
+        "spend_limits": [{
+            "feature_id": "api_calls",
+            "enabled": True,
+            "skip_overage_billing": True,
+        }],
+    },
+)
+```
+
+```bash cURL
+curl -X POST "https://api.useautumn.com/v1/customers/update" \
+  -H "Authorization: Bearer am_sk_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "customer_id": "user_123",
+    "billing_controls": {
+      "spend_limits": [{
+        "feature_id": "api_calls",
+        "enabled": true,
+        "skip_overage_billing": true
+      }]
+    }
+  }'
+```
+
+</CodeGroup>
+
+The spend limit must be `enabled` and have a `feature_id`. It can also be set on an [entity](/documentation/customers/feature-entities) — resolution is per-feature, and the nearest configuration wins: entity-level spend limit, then customer-level, then plan-level billing controls.
+
+<Tip>
+Combine `skip_overage_billing` with an `overage_limit` to allow a bounded amount of free overage: the customer is blocked once they hit the cap, and the overage they did use is never billed.
+</Tip>
 
 ## How it works
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add docs for `skip_overage_billing` on spend limits so teams can allow overage without billing. Also mark `overage_limit` as optional and include setup examples.

- **New Features**
  - Documented `skip_overage_billing` behavior: usage is tracked but not invoiced; requires `enabled` and `feature_id`.
  - Added TypeScript, Python, and cURL examples for `customers.update`.
  - Clarified resolution order (entity → customer → plan) and how to cap free overage by pairing with `overage_limit`.

<sup>Written for commit a6f6c66a62b5813607444459d1b7460d261da7cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds documentation for the new `skip_overage_billing` feature on spend limits, which lets customers consume overage without being charged for it while keeping usage tracking and balance resets intact.

- **[Improvements]** Marks `overage_limit` as optional in the spend limit fields table and adds the new `skip_overage_billing` boolean parameter with a description covering invoice suppression semantics.
- **[API changes]** Adds a \"Skipping overage billing\" section with TypeScript, Python, and cURL code examples, plus a `<Tip>` on combining `skip_overage_billing` with `overage_limit` for bounded free overage.
</details>


<h3>Confidence Score: 4/5</h3>

Documentation-only change with no runtime impact; safe to merge, but a couple of gaps in the new section could mislead API consumers.

The change is purely additive documentation. The two gaps — the "How it works" section not being updated, and the unbounded-free-overage scenario being undocumented — are clarity issues rather than correctness bugs, but they concern a billing feature where misunderstanding the behavior could lead to unexpected revenue loss for the operator.

apps/docs/mintlify/documentation/modelling-pricing/spend-limits.mdx — the new "Skipping overage billing" section and the unchanged "How it works" section.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/docs/mintlify/documentation/modelling-pricing/spend-limits.mdx | Documentation-only change: adds `skip_overage_billing` optional boolean to the spend limit fields table and a new "Skipping overage billing" section with TypeScript, Python, and cURL code examples. The "How it works" section and the standalone (no `overage_limit`) behaviour are not addressed. |


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Customer track/check call] --> B{Spend limit enabled?}
    B -- No --> C[Normal overage billing]
    B -- Yes --> D{overage_limit set?}
    D -- Yes --> E{Usage > overage_limit?}
    E -- Yes --> F[Block: check returns allowed: false]
    E -- No --> G{skip_overage_billing?}
    D -- No --> G
    G -- false --> H[Add overage line item to invoice]
    G -- true --> I[Suppress overage line item — not billed]
    H --> J[Usage tracked & balance reset normally]
    I --> J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Customer track/check call] --> B{Spend limit enabled?}
    B -- No --> C[Normal overage billing]
    B -- Yes --> D{overage_limit set?}
    D -- Yes --> E{Usage > overage_limit?}
    E -- Yes --> F[Block: check returns allowed: false]
    E -- No --> G{skip_overage_billing?}
    D -- No --> G
    G -- false --> H[Add overage line item to invoice]
    G -- true --> I[Suppress overage line item — not billed]
    H --> J[Usage tracked & balance reset normally]
    I --> J
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/docs/mintlify/documentation/modelling-pricing/spend-limits.mdx`, line 192-200 ([link](https://github.com/useautumn/autumn/blob/a6f6c66a62b5813607444459d1b7460d261da7cb/apps/docs/mintlify/documentation/modelling-pricing/spend-limits.mdx#L192-L200)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **"How it works" section not updated for `skip_overage_billing`**

   The three-step "How it works" section below was not updated to mention the new `skip_overage_billing` flag. Step 3 currently only describes the `overage_limit` blocking behaviour. A reader setting `skip_overage_billing: true` (with or without an `overage_limit`) would have no guidance here on how those steps change — specifically that overage usage is still tracked and may still trigger blocking at the cap, but invoice line items for that overage are suppressed.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/docs/mintlify/documentation/modelling-pricing/spend-limits.mdx
   Line: 192-200

   Comment:
   **"How it works" section not updated for `skip_overage_billing`**

   The three-step "How it works" section below was not updated to mention the new `skip_overage_billing` flag. Step 3 currently only describes the `overage_limit` blocking behaviour. A reader setting `skip_overage_billing: true` (with or without an `overage_limit`) would have no guidance here on how those steps change — specifically that overage usage is still tracked and may still trigger blocking at the cap, but invoice line items for that overage are suppressed.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/docs/mintlify/documentation/modelling-pricing/spend-limits.mdx:192-200
**"How it works" section not updated for `skip_overage_billing`**

The three-step "How it works" section below was not updated to mention the new `skip_overage_billing` flag. Step 3 currently only describes the `overage_limit` blocking behaviour. A reader setting `skip_overage_billing: true` (with or without an `overage_limit`) would have no guidance here on how those steps change — specifically that overage usage is still tracked and may still trigger blocking at the cap, but invoice line items for that overage are suppressed.

### Issue 2 of 2
apps/docs/mintlify/documentation/modelling-pricing/spend-limits.mdx:136-190
**Unbounded free overage behaviour not documented**

The new section explains combining `skip_overage_billing` with `overage_limit` (bounded free overage), but doesn't clarify what happens when `skip_overage_billing: true` is used *without* an `overage_limit`. In that configuration, does the customer get unlimited free overage — i.e. `check` always returns `allowed: true` and nothing is ever invoiced? If so, this is a significant footgun worth calling out explicitly, since forgetting to set `overage_limit` would silently give the customer unlimited usage at no charge.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["added docs on skip overage billing"](https://github.com/useautumn/autumn/commit/a6f6c66a62b5813607444459d1b7460d261da7cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42965887)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->