### PR TITLE
fix: leaf startup

### DIFF
--- a/apps/leaf/src/bot.ts
+++ b/apps/leaf/src/bot.ts
@@ -393,6 +393,9 @@ const runAndReply = async ({
 		});
 
 		if (output.finishReason === "stopped") {
+			// Stop before posting, or a pending tick re-renders the status after
+			// Slack's post-triggered clear and it sticks forever.
+			ticker.stop();
 			await finishLoading(target, loading, "Stopped.");
 			const stoppedBy = run.stop?.byUserId;
 			const notice =
@@ -507,6 +510,10 @@ const runAndReply = async ({
 		) {
 			decisionPlan = output.catalogDecision.plan as CatalogPlanPreview;
 		}
+
+		// Every branch below posts a terminal message/card — stop the status loop
+		// first so no pending tick re-renders after the post clears it.
+		ticker.stop();
 
 		if (decisionPlan) {
 			await finishLoading(target, loading, "Decision needed.");

--- a/apps/leaf/src/lib/env.ts
+++ b/apps/leaf/src/lib/env.ts
@@ -28,9 +28,12 @@ const envSchema = z
 		CLIENT_URL: z.string().min(1).default("http://localhost:3000"),
 		DATABASE_URL: z.string().min(1),
 		ENCRYPTION_PASSWORD: z.string().min(1),
-		// Binary file parts break at eve's workflow-world queue boundary (bytes
-		// deserialize as objects → provider rejects); flip on once fixed upstream.
-		EVE_ATTACHMENTS_ENABLED: z.coerce.boolean().default(false),
+		// Kill switch for eve file ingestion (falls back to an honest "can't view
+		// files" note) in case the upstream queue byte-corruption bug resurfaces.
+		EVE_ATTACHMENTS_ENABLED: z
+			.enum(["true", "false", "1", "0"])
+			.default("true")
+			.transform((value) => value === "true" || value === "1"),
 		EVE_INTERNAL_AUTH_TOKEN: optionalString,
 		EVE_SERVER_URL: z.string().url().default("http://127.0.0.1:3999"),
 		FIRECRAWL_API_KEY: z.string().min(1),

--- a/apps/leaf/src/ui/statusTicker.ts
+++ b/apps/leaf/src/ui/statusTicker.ts
@@ -109,6 +109,11 @@ export const createStatusTicker = (target: ReplyTarget): StatusTicker => {
 				clearInterval(timer);
 				timer = null;
 			}
+			// Explicitly clear the status: without this, a snippet rendered just
+			// before stop() outlives the run as a stuck "thinking" line.
+			if (lastRendered) {
+				target.startTyping("").catch(() => {});
+			}
 		},
 	};
 };

--- a/apps/leaf/tests/e2e/eveImage.e2e.ts
+++ b/apps/leaf/tests/e2e/eveImage.e2e.ts
@@ -1,0 +1,209 @@
+/**
+ * Image-attachment e2e for both chat surfaces against the local dev stack
+ * (eve :3999, main server :8080). Slack path drives runMessage in-process;
+ * web path drives streamWebChat with a data-URL file part.
+ *
+ * Run from apps/leaf:
+ *   EVE_INTERNAL_AUTH_TOKEN=local-eve-internal-token \
+ *     infisical run --env=dev --recursive -- bun tests/e2e/eveImage.e2e.ts
+ */
+import { DEFAULT_OAUTH_RESOURCE_SCOPES } from "@autumn/shared";
+import { runMessage } from "../../src/agent/runMessage/runMessage.js";
+import { db } from "../../src/lib/db.js";
+import { logger } from "../../src/lib/logger.js";
+import { createEveSlackPresenter } from "../../src/providers/slack/evePresenter.js";
+import { findInstallationWithOrg } from "../../src/providers/slack/installations.js";
+import { streamWebChat } from "../../src/providers/web/streamWebChat.js";
+import type { LeafChatInstallation } from "../../src/types.js";
+import { createStatusTicker } from "../../src/ui/statusTicker.js";
+
+const WORKSPACE_ID = process.env.E2E_SLACK_WORKSPACE ?? "T07NPTDCU69";
+const RUN_TAG = Date.now().toString(36);
+
+const RED_PIXEL_PNG = Buffer.from(
+	"iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAgElEQVR4nO3RwQkAMAwDMe+/dDtEH6Jw4AES3c729fwFPaAJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJK6AJKzCv+LILqdzw4i4ZAl4AAAAASUVORK5CYII=",
+	"base64",
+);
+const PROMPT =
+	"In sandbox (no tools needed): the attached image is a solid single-color swatch. What color is it? Answer with just the color name.";
+
+type CheckResult = { detail?: string; name: string; ok: boolean };
+const results: CheckResult[] = [];
+const check = (name: string, ok: boolean, detail?: string) => {
+	results.push({ detail, name, ok });
+	console.log(`${ok ? "✅" : "❌"} ${name}${detail ? ` — ${detail}` : ""}`);
+};
+
+const runSlackImageTurn = async ({
+	installation,
+}: {
+	installation: LeafChatInstallation;
+}) => {
+	const statuses: string[] = [];
+	const target = {
+		post: async () => undefined,
+		startTyping: async (text?: string) => {
+			statuses.push(text ?? "");
+		},
+	};
+	const ticker = createStatusTicker(target as never);
+	const presenter = createEveSlackPresenter({ ticker });
+	const threadId = `e2e-img-${RUN_TAG}-slack`;
+	const output = await runMessage({
+		attachments: [
+			{
+				data: RED_PIXEL_PNG,
+				mimeType: "image/png",
+				name: "pixel.png",
+				size: RED_PIXEL_PNG.byteLength,
+				type: "file" as const,
+			},
+		],
+		channelId: threadId,
+		installation,
+		logger,
+		onAction: (message) => presenter.onAction(message),
+		onActionKeyed: ({ message }) => presenter.onActionError(message),
+		onReasoning: presenter.onReasoning,
+		onThinking: ticker.thinking,
+		providerUserId: "U_E2E_ALICE",
+		text: PROMPT,
+		threadId,
+	});
+	ticker.stop();
+	return { output, statuses };
+};
+
+const runWebImageTurn = async ({
+	installation,
+}: {
+	installation: LeafChatInstallation;
+}) => {
+	const userId = installation.installed_by_user_id;
+	if (!userId) {
+		throw new Error(
+			"Slack installation has no installed_by_user_id to reuse for web auth",
+		);
+	}
+	if (process.env.E2E_DEBUG) {
+		const { ensureWebChatAuth } = await import(
+			"../../src/internal/installations/actions/ensureWebChatAuth.js"
+		);
+		const { getOrgInstallationToken } = await import(
+			"../../src/internal/installations/actions/getOrgInstallationToken.js"
+		);
+		await ensureWebChatAuth({
+			orgId: installation.org_id,
+			userId,
+			userScopes: [...DEFAULT_OAUTH_RESOURCE_SCOPES],
+		});
+		await getOrgInstallationToken({
+			env: "sandbox" as never,
+			orgId: installation.org_id,
+			provider: "web" as never,
+			userId,
+			workspaceId: installation.org_id,
+		});
+		console.log("  [web-debug] auth preflight ok");
+	}
+	const request = new Request("http://localhost/agent/chat", {
+		body: JSON.stringify({
+			id: crypto.randomUUID(),
+			messages: [
+				{
+					id: crypto.randomUUID(),
+					parts: [
+						{ text: PROMPT, type: "text" },
+						{
+							filename: "pixel.png",
+							mediaType: "image/png",
+							type: "file",
+							url: `data:image/png;base64,${RED_PIXEL_PNG.toString("base64")}`,
+						},
+					],
+					role: "user",
+				},
+			],
+		}),
+		headers: { app_env: "sandbox", "content-type": "application/json" },
+		method: "POST",
+	});
+	const response = await streamWebChat({
+		auth: {
+			orgId: installation.org_id,
+			scopes: [...DEFAULT_OAUTH_RESOURCE_SCOPES],
+			userId,
+		},
+		request,
+	});
+	if (!response.ok || !response.body) {
+		throw new Error(`web chat stream returned ${response.status}`);
+	}
+	let text = "";
+	let sse = "";
+	const decoder = new TextDecoder();
+	for await (const chunk of response.body) {
+		sse += decoder.decode(chunk as Uint8Array, { stream: true });
+		let index = sse.indexOf("\n");
+		while (index >= 0) {
+			const line = sse.slice(0, index).trim();
+			sse = sse.slice(index + 1);
+			if (line.startsWith("data: ") && line !== "data: [DONE]") {
+				const part = JSON.parse(line.slice(6)) as {
+					delta?: string;
+					type: string;
+				};
+				if (process.env.E2E_DEBUG) {
+					console.log("  [web-part]", JSON.stringify(part).slice(0, 200));
+				}
+				if (part.type === "text-delta" && part.delta) text += part.delta;
+			}
+			index = sse.indexOf("\n");
+		}
+	}
+	return { text };
+};
+
+const main = async () => {
+	console.log(`\n=== eve image e2e (tag ${RUN_TAG}) ===\n`);
+	const installation = (await findInstallationWithOrg(
+		"slack",
+		WORKSPACE_ID,
+	)) as LeafChatInstallation | null;
+	if (!installation) {
+		throw new Error(`No slack installation for workspace ${WORKSPACE_ID}`);
+	}
+	console.log(`Installation org=${installation.org_id}`);
+
+	if (process.env.E2E_ONLY !== "web") {
+		console.log("--- slack surface");
+		const slack = await runSlackImageTurn({ installation });
+		const slackText = slack.output.text ?? "";
+		check(
+			"slack: model saw the image",
+			/red/i.test(slackText),
+			slackText.slice(0, 140),
+		);
+		check(
+			"slack: status cleared after run (stuck-thinking fix)",
+			slack.statuses.at(-1) === "",
+			JSON.stringify(slack.statuses.slice(-3)),
+		);
+	}
+
+	console.log("--- web surface");
+	const web = await runWebImageTurn({ installation });
+	check(
+		"web: model saw the image",
+		/red/i.test(web.text),
+		web.text.slice(0, 140),
+	);
+
+	const failed = results.filter((result) => !result.ok);
+	console.log(
+		`\n${failed.length === 0 ? "ALL PASS" : `${failed.length} FAILED`} (${results.length} checks)`,
+	);
+	process.exit(failed.length === 0 ? 0 : 1);
+};
+
+await main().finally(() => db.$client.end?.());

--- a/packages/mcp/src/tools/utils/client.ts
+++ b/packages/mcp/src/tools/utils/client.ts
@@ -11,6 +11,26 @@ const parseBody = (text: string): unknown => {
 	}
 };
 
+// ~150k tokens; an unguarded page (e.g. listCustomers limit 1000) can exceed
+// the model's context outright, hard-failing the whole turn.
+const MAX_RESPONSE_CHARS = 600_000;
+
+const guardResponseSize = ({
+	body,
+	endpoint,
+	size,
+}: {
+	body: unknown;
+	endpoint: string;
+	size: number;
+}): unknown => {
+	if (size <= MAX_RESPONSE_CHARS) return body;
+	return {
+		error: true,
+		message: `Result from ${endpoint} is too large to process (${size} characters). Retry with a smaller limit, tighter filters, or paginate with start_cursor across multiple calls.`,
+	};
+};
+
 /** POSTs a request to an Autumn endpoint using the caller's resolved auth. */
 export const callAutumn = async ({
 	auth,
@@ -41,7 +61,7 @@ export const callAutumn = async ({
 			}`,
 		);
 	}
-	return body;
+	return guardResponseSize({ body, endpoint, size: text.length });
 };
 
 export const callAutumnGet = async ({
@@ -70,5 +90,5 @@ export const callAutumnGet = async ({
 			}`,
 		);
 	}
-	return body;
+	return guardResponseSize({ body, endpoint, size: text.length });
 };


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the stuck “thinking” status in Slack, re-enables Eve image/file ingestion by default, and caps oversized tool responses. Adds an e2e test covering image handling on Slack and web.

- **Bug Fixes**
  - Stop the status ticker before any terminal post and when runs are stopped; `stop()` now also clears typing to prevent a lingering status line.
  - Guard tool responses in `packages/mcp` by capping at 600k characters; return a clear error suggesting smaller limits or pagination.
  - Parse `EVE_ATTACHMENTS_ENABLED` as `"true"/"false"/"1"/"0"` and default to enabled; add an image e2e test that confirms the model sees the attachment and Slack status clears.

<sup>Written for commit 3ed01d37baccd7c9b6ee0411fe96ad1db5b7c79d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a Slack "stuck thinking" status bug caused by the status ticker's interval outliving a completed run, and enables EVE file attachments by default now that the upstream byte-corruption issue is resolved.

- **Bug fixes** — `statusTicker.stop()` now explicitly clears the Slack status via `target.startTyping("")`; `bot.ts` calls `ticker.stop()` before the stopped-run path and before all terminal message/card posts to prevent the ticker from re-rendering after Slack clears the status.
- **Bug fixes / Improvements** — `EVE_ATTACHMENTS_ENABLED` default flipped from `false` to `true`; the schema is rewritten with an explicit enum+transform to avoid `z.coerce.boolean()`'s surprising behavior (where `"false"` coerces to `true`).
- **Improvements** — `callAutumn`/`callAutumnGet` in the MCP client now guard against oversized responses (> 600 k chars) by returning a structured error message instead of crashing the model turn; a new e2e test validates image attachment on both Slack and web surfaces and asserts the stuck-thinking fix.
</details>


<h3>Confidence Score: 3/5</h3>

The core ticker fix works for the stopped and normal-completion paths, but the queued-message suppression path exits without stopping the ticker, leaving a leaked interval that conflicts with the next run's ticker.

Two of the three runAndReply exit paths now correctly stop the ticker, but the queued-message suppression return at line 467 is missing a ticker.stop() call. After that return, the old interval keeps calling target.startTyping while the next incoming message starts a fresh ticker, so two concurrent loops race to update the Slack status.

apps/leaf/src/bot.ts — the queued-message suppression block needs a ticker.stop() before its early return.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/bot.ts | Adds `ticker.stop()` before the stopped-run path and before all terminal message/card posts; the queued-message suppression early return at line 467 is missing a corresponding stop, leaving the interval active after function exit. |
| apps/leaf/src/lib/env.ts | Flips `EVE_ATTACHMENTS_ENABLED` default from `false` to `true` and replaces `z.coerce.boolean()` (which treated "false" as true) with a stricter enum transform; enum is case-sensitive, so uppercase values like "FALSE" would fail startup validation. |
| apps/leaf/src/ui/statusTicker.ts | Adds an explicit `target.startTyping("")` call on stop when any status was previously rendered, fixing the stuck "thinking" label; correctly bypasses `formatTypingStatus` (which converts "" to a default label) per existing comment. |
| packages/mcp/src/tools/utils/client.ts | Introduces a 600 k-character guard on `callAutumn` and `callAutumnGet` responses; oversized payloads return a structured error message instead of crashing the model turn outright. |
| apps/leaf/tests/e2e/eveImage.e2e.ts | New e2e script exercising image-attachment on both Slack and web surfaces; also validates the stuck-thinking fix by asserting the last captured status is an empty string after the run completes. |


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runAndReply starts\nticker created] --> B[runMessage executes\nticker.thinking fires]
    B --> C{output.finishReason}
    C -->|stopped| D["ticker.stop() NEW\nfinishLoading + post\nreturn"]
    C -->|completed| E{hasQueuedThreadMessage?}
    E -->|yes - evePresenter| F["return - ticker NOT stopped\n(leaked interval)"]
    E -->|no| G[build decisionPlan]
    G --> H["ticker.stop() NEW\npost terminal card/message"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[runAndReply starts\nticker created] --> B[runMessage executes\nticker.thinking fires]
    B --> C{output.finishReason}
    C -->|stopped| D["ticker.stop() NEW\nfinishLoading + post\nreturn"]
    C -->|completed| E{hasQueuedThreadMessage?}
    E -->|yes - evePresenter| F["return - ticker NOT stopped\n(leaked interval)"]
    E -->|no| G[build decisionPlan]
    G --> H["ticker.stop() NEW\npost terminal card/message"]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/leaf/src/bot.ts`, line 439-467 ([link](https://github.com/useautumn/autumn/blob/3ed01d37baccd7c9b6ee0411fe96ad1db5b7c79d/apps/leaf/src/bot.ts#L439-L467)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Missing `ticker.stop()` on queued-message suppression**

   This PR correctly calls `ticker.stop()` before the "stopped" return and before all terminal-message posts, but the queued-message suppression early return at line 467 exits without stopping the ticker. The interval keeps firing after this function returns, and the next incoming message creates a fresh ticker — so two concurrent `setInterval` loops both call `target.startTyping(...)` with conflicting values, producing a flickering or permanently stuck status label for the rest of that Slack thread.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/leaf/src/bot.ts
   Line: 439-467

   Comment:
   **Missing `ticker.stop()` on queued-message suppression**

   This PR correctly calls `ticker.stop()` before the "stopped" return and before all terminal-message posts, but the queued-message suppression early return at line 467 exits without stopping the ticker. The interval keeps firing after this function returns, and the next incoming message creates a fresh ticker — so two concurrent `setInterval` loops both call `target.startTyping(...)` with conflicting values, producing a flickering or permanently stuck status label for the rest of that Slack thread.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/leaf/src/bot.ts:439-467
**Missing `ticker.stop()` on queued-message suppression**

This PR correctly calls `ticker.stop()` before the "stopped" return and before all terminal-message posts, but the queued-message suppression early return at line 467 exits without stopping the ticker. The interval keeps firing after this function returns, and the next incoming message creates a fresh ticker — so two concurrent `setInterval` loops both call `target.startTyping(...)` with conflicting values, producing a flickering or permanently stuck status label for the rest of that Slack thread.

### Issue 2 of 2
apps/leaf/src/lib/env.ts:33-36
The new enum only accepts exact lowercase strings `"true"`, `"false"`, `"1"`, `"0"`. Any operator setting `EVE_ATTACHMENTS_ENABLED=FALSE` or `EVE_ATTACHMENTS_ENABLED=False` in an emergency would get a Zod parse failure at startup rather than the intended kill-switch behavior. A case-insensitive transform guards against this.

```suggestion
		EVE_ATTACHMENTS_ENABLED: z
			.string()
			.default("true")
			.transform((value) => ["true", "1"].includes(value.toLowerCase())),
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/leaf-startu..."](https://github.com/useautumn/autumn/commit/3ed01d37baccd7c9b6ee0411fe96ad1db5b7c79d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42966445)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->