### PR TITLE
Add allowNotFound: true to OrgService.getWithFeatures in invoice cron

### DIFF
--- a/server/src/cron/invoiceCron/runInvoiceCron.ts
+++ b/server/src/cron/invoiceCron/runInvoiceCron.ts
@@ -26,6 +26,7 @@ const getOrgAndCustomerFromMetadata = async ({
 			db,
 			orgId,
 			env,
+			allowNotFound: true,
 		});
 
 		return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR adds the `allowNotFound: true` parameter to the `OrgService.getWithFeatures` call in `runInvoiceCron.ts` on lines 27-29.

This change allows the invoice cron to handle cases where an org may not be found without throwing an error, which is appropriate for the cron job context where orgs may have been deleted or are otherwise unavailable.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1783595079774139?thread_ts=1783595079.774139&cid=C0BCAQQK0KS)

<div><a href="https://cursor.com/agents/bc-4bfb4a9a-ba7d-5202-99ea-17068efdbc55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4bfb4a9a-ba7d-5202-99ea-17068efdbc55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle missing orgs in the invoice cron without errors. Adds `allowNotFound: true` to `OrgService.getWithFeatures` in `server/src/cron/invoiceCron/runInvoiceCron.ts`, so the job skips deleted or unavailable orgs instead of failing.

<sup>Written for commit 87bc6bae13076bfafaa153cd6242909e2e0a5483. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `allowNotFound: true` to `OrgService.getWithFeatures` in the invoice cron so that deleted or unavailable orgs no longer throw an error and crash the batch. The change correctly prevents cron failures, but introduces a gap in cleanup for the deleted-org case.

- **Bug fix**: `OrgService.getWithFeatures` now returns `null` instead of throwing when an org is not found, preventing a single deleted org from aborting the entire cron batch via `Promise.all` rejection.
- **Improvements**: The `?.` optional-chain on `orgWithFeatures?.org` (line 33) already existed, so the null return is handled safely upstream — the `if (!org || !customer) return;` guard in `handleVoidInvoiceCron` prevents any further processing.
- **Bug introduced**: When the org is missing, `handleVoidInvoiceCron` exits early without calling `MetadataService.delete`, so the expired metadata row persists in the DB and is re-queried on every subsequent cron run.
</details>


<h3>Confidence Score: 3/5</h3>

The change fixes a real cron crash but leaves orphaned metadata rows for deleted orgs that will be re-fetched and silently skipped on every future run.

The early-return path in handleVoidInvoiceCron does not call MetadataService.delete when the org is missing, so expired metadata rows for deleted orgs accumulate in the database and are wastefully reprocessed on every cron invocation. This is a missing side-effect on the newly introduced code path.

server/src/cron/invoiceCron/runInvoiceCron.ts — the handleVoidInvoiceCron function needs a cleanup call when org lookup returns null.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/cron/invoiceCron/runInvoiceCron.ts | Adds allowNotFound: true to OrgService.getWithFeatures to prevent cron failures on deleted orgs, but the early-return path at line 54 skips MetadataService.delete, leaving orphaned metadata records that will be reprocessed indefinitely. |


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Cron as runInvoiceCron
    participant Handler as handleVoidInvoiceCron
    participant Helper as getOrgAndCustomerFromMetadata
    participant OrgSvc as OrgService.getWithFeatures
    participant MetaSvc as MetadataService.delete
    participant Stripe

    Cron->>Handler: handleVoidInvoiceCron(metadata)
    Handler->>Helper: getOrgAndCustomerFromMetadata(metadata)
    Helper->>OrgSvc: getWithFeatures(orgId, allowNotFound: true)
    alt Org exists
        OrgSvc-->>Helper: "{ org, features }"
        Helper-->>Handler: "{ org, customer }"
        Handler->>Stripe: invoices.retrieve()
        Stripe-->>Handler: invoice
        Handler->>Stripe: invoices.voidInvoice()
        Handler->>MetaSvc: delete(metadata.id)
    else Org not found (deleted)
        OrgSvc-->>Helper: null
        Helper-->>Handler: "{ org: undefined, customer }"
        Note over Handler: if (!org) return early — metadata NOT deleted
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Cron as runInvoiceCron
    participant Handler as handleVoidInvoiceCron
    participant Helper as getOrgAndCustomerFromMetadata
    participant OrgSvc as OrgService.getWithFeatures
    participant MetaSvc as MetadataService.delete
    participant Stripe

    Cron->>Handler: handleVoidInvoiceCron(metadata)
    Handler->>Helper: getOrgAndCustomerFromMetadata(metadata)
    Helper->>OrgSvc: getWithFeatures(orgId, allowNotFound: true)
    alt Org exists
        OrgSvc-->>Helper: "{ org, features }"
        Helper-->>Handler: "{ org, customer }"
        Handler->>Stripe: invoices.retrieve()
        Stripe-->>Handler: invoice
        Handler->>Stripe: invoices.voidInvoice()
        Handler->>MetaSvc: delete(metadata.id)
    else Org not found (deleted)
        OrgSvc-->>Helper: null
        Helper-->>Handler: "{ org: undefined, customer }"
        Note over Handler: if (!org) return early — metadata NOT deleted
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/cron/invoiceCron/runInvoiceCron.ts`, line 50-54 ([link](https://github.com/useautumn/autumn/blob/87bc6bae13076bfafaa153cd6242909e2e0a5483/server/src/cron/invoiceCron/runInvoiceCron.ts#L50-L54)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Orphaned metadata records never cleaned up for deleted orgs**

   When `allowNotFound: true` causes `getWithFeatures` to return `null`, `org` is `undefined` and `handleVoidInvoiceCron` exits early at line 54 — without calling `MetadataService.delete`. The expired metadata row remains in the DB, so `getExpiredInvoiceMetadata` keeps selecting it on every cron run indefinitely. Over time, a growing backlog of orphaned records for deleted orgs will be fetched and silently skipped on every invocation. The metadata entry should be deleted when the org cannot be found.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/cron/invoiceCron/runInvoiceCron.ts
   Line: 50-54

   Comment:
   **Orphaned metadata records never cleaned up for deleted orgs**

   When `allowNotFound: true` causes `getWithFeatures` to return `null`, `org` is `undefined` and `handleVoidInvoiceCron` exits early at line 54 — without calling `MetadataService.delete`. The expired metadata row remains in the DB, so `getExpiredInvoiceMetadata` keeps selecting it on every cron run indefinitely. Over time, a growing backlog of orphaned records for deleted orgs will be fetched and silently skipped on every invocation. The metadata entry should be deleted when the org cannot be found.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/cron/invoiceCron/runInvoiceCron.ts:50-54
**Orphaned metadata records never cleaned up for deleted orgs**

When `allowNotFound: true` causes `getWithFeatures` to return `null`, `org` is `undefined` and `handleVoidInvoiceCron` exits early at line 54 — without calling `MetadataService.delete`. The expired metadata row remains in the DB, so `getExpiredInvoiceMetadata` keeps selecting it on every cron run indefinitely. Over time, a growing backlog of orphaned records for deleted orgs will be fetched and silently skipped on every invocation. The metadata entry should be deleted when the org cannot be found.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add allowNotFound: true to OrgService.ge..."](https://github.com/useautumn/autumn/commit/87bc6bae13076bfafaa153cd6242909e2e0a5483) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42985537)</sub>

<!-- /greptile_comment -->