### PR TITLE
feat: add expires_at to balances.update endpoint

### DIFF
--- a/server/src/honoMiddlewares/refreshCacheConfigs.ts
+++ b/server/src/honoMiddlewares/refreshCacheConfigs.ts
@@ -86,6 +86,15 @@ export const REFRESH_CACHE_ROUTE_CONFIGS: RefreshCacheRouteConfig[] = [
 		url: "/balances/create",
 	}),
 
+	route({
+		method: "POST",
+		url: "/balances/update",
+		// balances.update mutates balances cache-first (Postgres lags until the
+		// async flush), so flush cached balances to Postgres before invalidating
+		// — otherwise the rebuilt-from-Postgres view loses the just-written value.
+		flushBalances: true,
+	}),
+
 	// RPC ROUTES
 	route({
 		method: "POST",
@@ -122,6 +131,12 @@ export const REFRESH_CACHE_ROUTE_CONFIGS: RefreshCacheRouteConfig[] = [
 	route({
 		method: "POST",
 		url: "/balances.create",
+	}),
+
+	route({
+		method: "POST",
+		url: "/balances.update",
+		flushBalances: true,
 	}),
 
 	route({

--- a/server/src/honoMiddlewares/refreshCacheConfigs.ts
+++ b/server/src/honoMiddlewares/refreshCacheConfigs.ts
@@ -89,9 +89,6 @@ export const REFRESH_CACHE_ROUTE_CONFIGS: RefreshCacheRouteConfig[] = [
 	route({
 		method: "POST",
 		url: "/balances/update",
-		// balances.update mutates balances cache-first (Postgres lags until the
-		// async flush), so flush cached balances to Postgres before invalidating
-		// — otherwise the rebuilt-from-Postgres view loses the just-written value.
 		flushBalances: true,
 	}),
 

--- a/server/src/internal/balances/handlers/handleUpdateBalance.ts
+++ b/server/src/internal/balances/handlers/handleUpdateBalance.ts
@@ -26,10 +26,6 @@ export const handleUpdateBalance = createRoute({
 			});
 		}
 
-		// A non-future expiry immediately filters the balance out of the
-		// customer's active entitlements (see fullCustomerToCustomerEntitlements'
-		// `expires_at > now` guard) — and once filtered it can no longer be
-		// targeted to undo. Reject it, mirroring create's next_reset_at rule.
 		if (notNullish(params.expires_at) && params.expires_at <= Date.now()) {
 			throw new RecaseError({
 				message: "expires_at must be in the future",

--- a/server/src/internal/balances/handlers/handleUpdateBalance.ts
+++ b/server/src/internal/balances/handlers/handleUpdateBalance.ts
@@ -1,4 +1,10 @@
-import { findFeatureById, UpdateBalanceParamsV0Schema, Scopes } from "@autumn/shared";
+import {
+	findFeatureById,
+	notNullish,
+	RecaseError,
+	Scopes,
+	UpdateBalanceParamsV0Schema,
+} from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler";
 import { updateBalanceV1 } from "@/internal/balances/updateBalance/updateBalanceV1.js";
 import { updateBalanceV2 } from "@/internal/balances/updateBalance/v2/updateBalanceV2.js";
@@ -17,6 +23,17 @@ export const handleUpdateBalance = createRoute({
 				features: ctx.features,
 				featureId: params.feature_id,
 				errorOnNotFound: true,
+			});
+		}
+
+		// A non-future expiry immediately filters the balance out of the
+		// customer's active entitlements (see fullCustomerToCustomerEntitlements'
+		// `expires_at > now` guard) — and once filtered it can no longer be
+		// targeted to undo. Reject it, mirroring create's next_reset_at rule.
+		if (notNullish(params.expires_at) && params.expires_at <= Date.now()) {
+			throw new RecaseError({
+				message: "expires_at must be in the future",
+				statusCode: 400,
 			});
 		}
 

--- a/server/src/internal/balances/updateBalance/updateBalanceV1.ts
+++ b/server/src/internal/balances/updateBalance/updateBalanceV1.ts
@@ -3,6 +3,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getOrSetCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/getOrSetCachedFullCustomer.js";
 import { buildCustomerEntitlementFilters } from "../utils/buildCustomerEntitlementFilters.js";
 import { runUpdateUsage } from "./runUpdateUsage.js";
+import { updateExpiresAt } from "./updateExpiresAt.js";
 import { updateGrantedBalance } from "./updateGrantedBalance.js";
 import { updateNextResetAt } from "./updateNextResetAt.js";
 import { updateRemainingV1 } from "./updateRemainingV1.js";
@@ -61,6 +62,20 @@ export const updateBalanceV1 = async ({
 			fullCustomer,
 			featureId: params.feature_id,
 			nextResetAt: params.next_reset_at,
+			customerEntitlementFilters,
+		});
+	}
+
+	if (notNullish(params.expires_at)) {
+		const customerEntitlementFilters = buildCustomerEntitlementFilters({
+			params,
+		});
+
+		await updateExpiresAt({
+			ctx,
+			fullCustomer,
+			featureId: params.feature_id,
+			expiresAt: params.expires_at,
 			customerEntitlementFilters,
 		});
 	}

--- a/server/src/internal/balances/updateBalance/updateExpiresAt.ts
+++ b/server/src/internal/balances/updateBalance/updateExpiresAt.ts
@@ -1,0 +1,78 @@
+import {
+	type CustomerEntitlementFilters,
+	EntInterval,
+	type FullCustomer,
+	fullCustomerToCustomerEntitlements,
+	notNullish,
+	orgToInStatuses,
+	RecaseError,
+} from "@autumn/shared";
+import type { AutumnContext } from "../../../honoUtils/HonoEnv.js";
+import { CusEntService } from "../../customers/cusProducts/cusEnts/CusEntitlementService.js";
+
+/**
+ * Set `expires_at` on the targeted balance (customer_entitlement).
+ *
+ * Cache coherence is handled by refreshCacheMiddleware (both /balances/update
+ * and /balances.update are registered in REFRESH_CACHE_ROUTE_CONFIGS), so this
+ * only needs to persist to Postgres.
+ */
+export const updateExpiresAt = async ({
+	ctx,
+	fullCustomer,
+	featureId,
+	expiresAt,
+	customerEntitlementFilters,
+}: {
+	ctx: AutumnContext;
+	fullCustomer: FullCustomer;
+	featureId: string | undefined;
+	expiresAt: number;
+	customerEntitlementFilters?: CustomerEntitlementFilters;
+}) => {
+	const cusEnts = fullCustomerToCustomerEntitlements({
+		fullCustomer,
+		featureIds: featureId ? [featureId] : undefined,
+		entity: fullCustomer.entity,
+		inStatuses: orgToInStatuses({ org: ctx.org }),
+		customerEntitlementFilters,
+	});
+
+	if (cusEnts.length === 0) {
+		throw new RecaseError({
+			message: `No balances found for feature ${featureId}, customer ${fullCustomer.id}`,
+			statusCode: 404,
+		});
+	}
+
+	// When multiple balances match, target the one that expires earliest
+	// (nulls last) for a deterministic choice; callers narrow to a single
+	// balance via balance_id / interval.
+	const sorted = [...cusEnts].sort((a, b) => {
+		const aExpires = a.expires_at ?? Number.POSITIVE_INFINITY;
+		const bExpires = b.expires_at ?? Number.POSITIVE_INFINITY;
+		return aExpires - bExpires;
+	});
+
+	const targetCusEnt = sorted[0];
+
+	// expires_at only makes sense on one-off balances (loose grants and one-off
+	// prepaid top-ups). Recurring balances reset each cycle — expiry belongs at
+	// the plan level (trial / ends_at) — and usage-based/arrear balances are
+	// recurring, so this guard covers them too. A null interval is treated as
+	// one-off (loose).
+	const interval = targetCusEnt.entitlement.interval;
+	if (notNullish(interval) && interval !== EntInterval.Lifetime) {
+		throw new RecaseError({
+			message: `expires_at can only be set on one-off balances, not recurring balances (feature ${targetCusEnt.entitlement.feature.id})`,
+			statusCode: 400,
+		});
+	}
+
+	await CusEntService.update({
+		ctx,
+		id: targetCusEnt.id,
+		updates: { expires_at: expiresAt },
+		incrementCacheVersion: false,
+	});
+};

--- a/server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts
+++ b/server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts
@@ -2,6 +2,7 @@ import { notNullish, type UpdateBalanceParamsV0 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.js";
 import { buildCustomerEntitlementFilters } from "../../utils/buildCustomerEntitlementFilters.js";
+import { updateExpiresAtV2 } from "./updateExpiresAtV2.js";
 import { updateIncludedGrantV2 } from "./updateIncludedGrantV2.js";
 import { updateNextResetAtV2 } from "./updateNextResetAtV2.js";
 import { updateRemainingV2 } from "./updateRemainingV2.js";
@@ -60,6 +61,20 @@ export const updateBalanceV2 = async ({
 			fullSubject,
 			featureId: params.feature_id,
 			nextResetAt: params.next_reset_at,
+			customerEntitlementFilters,
+		});
+	}
+
+	if (notNullish(params.expires_at)) {
+		const customerEntitlementFilters = buildCustomerEntitlementFilters({
+			params,
+		});
+
+		await updateExpiresAtV2({
+			ctx,
+			fullSubject,
+			featureId: params.feature_id,
+			expiresAt: params.expires_at,
 			customerEntitlementFilters,
 		});
 	}

--- a/server/src/internal/balances/updateBalance/v2/updateExpiresAtV2.ts
+++ b/server/src/internal/balances/updateBalance/v2/updateExpiresAtV2.ts
@@ -1,0 +1,74 @@
+import {
+	type CustomerEntitlementFilters,
+	EntInterval,
+	type FullSubject,
+	fullSubjectToCustomerEntitlements,
+	notNullish,
+	orgToInStatuses,
+	RecaseError,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
+
+/**
+ * Set `expires_at` on the targeted balance via the FullSubject cache path.
+ *
+ * Cache coherence is handled by refreshCacheMiddleware (both /balances/update
+ * and /balances.update are registered in REFRESH_CACHE_ROUTE_CONFIGS), so this
+ * only needs to persist to Postgres.
+ */
+export const updateExpiresAtV2 = async ({
+	ctx,
+	fullSubject,
+	featureId,
+	expiresAt,
+	customerEntitlementFilters,
+}: {
+	ctx: AutumnContext;
+	fullSubject: FullSubject;
+	featureId: string | undefined;
+	expiresAt: number;
+	customerEntitlementFilters?: CustomerEntitlementFilters;
+}) => {
+	const cusEnts = fullSubjectToCustomerEntitlements({
+		fullSubject,
+		featureIds: featureId ? [featureId] : undefined,
+		inStatuses: orgToInStatuses({ org: ctx.org }),
+		customerEntitlementFilters,
+	});
+
+	if (cusEnts.length === 0) {
+		throw new RecaseError({
+			message: `No balances found for feature ${featureId}, customer ${fullSubject.customerId}`,
+			statusCode: 404,
+		});
+	}
+
+	const sorted = [...cusEnts].sort((a, b) => {
+		const aExpires = a.expires_at ?? Number.POSITIVE_INFINITY;
+		const bExpires = b.expires_at ?? Number.POSITIVE_INFINITY;
+		return aExpires - bExpires;
+	});
+
+	const targetCusEnt = sorted[0];
+
+	// expires_at only makes sense on one-off balances (loose grants and one-off
+	// prepaid top-ups). Recurring balances reset each cycle — expiry belongs at
+	// the plan level (trial / ends_at) — and usage-based/arrear balances are
+	// recurring, so this guard covers them too. A null interval is treated as
+	// one-off (loose).
+	const interval = targetCusEnt.entitlement.interval;
+	if (notNullish(interval) && interval !== EntInterval.Lifetime) {
+		throw new RecaseError({
+			message: `expires_at can only be set on one-off balances, not recurring balances (feature ${targetCusEnt.entitlement.feature.id})`,
+			statusCode: 400,
+		});
+	}
+
+	await CusEntService.update({
+		ctx,
+		id: targetCusEnt.id,
+		updates: { expires_at: expiresAt },
+		incrementCacheVersion: false,
+	});
+};

--- a/server/tests/integration/balances/update/expires-at/update-expires-at.test.ts
+++ b/server/tests/integration/balances/update/expires-at/update-expires-at.test.ts
@@ -1,0 +1,325 @@
+/**
+ * TDD test for `expires_at` on the `balances.update` endpoint
+ * (POST /v1/balances/update and /v1/balances.update -> handleUpdateBalance).
+ *
+ * Contract under test:
+ *   New types/fields:
+ *     - expires_at?: number on UpdateBalanceParamsV0Schema — Unix ms timestamp
+ *       when the targeted balance expires.
+ *   New behaviors:
+ *     - balances.update({ balance_id: <raw cus_ent_ id>, expires_at }) sets
+ *       expires_at on the cusEnt addressed by its internal id (balance_id
+ *       fallback: external_id ?? cusEnt.id).
+ *     - balances.update({ balance_id: <external id from create>, expires_at })
+ *       sets expires_at on the cusEnt addressed by the caller-chosen external id.
+ *   Validation:
+ *     - a non-future expires_at (<= now) is rejected, since it would instantly
+ *       filter the balance out of the customer's active entitlements.
+ *     - expires_at is only allowed on one-off balances; setting it on a
+ *       recurring (resetting) balance is rejected.
+ *   Side effects:
+ *     - customer_entitlements.expires_at updated for the targeted row; the
+ *       change is visible via check.balance.breakdown[n].expires_at on both the
+ *       cached and skip_cache read paths.
+ *
+ * Pre-impl red: every assertion fails because the schema has no expires_at
+ * field, so the update is a no-op and breakdown.expires_at stays null.
+ * Post-impl green: expires_at is persisted and surfaced on the breakdown.
+ */
+
+import { expect, test } from "bun:test";
+import { type CheckResponseV2, ms, ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+// ═══════════════════════════════════════════════════════════════════
+// UPDATE-EXPIRES-AT-1: target a loose balance by its raw cus_ent_ id
+// A balance created without a balance_id is addressable by its internal
+// cusEnt id (breakdown[n].id = cus_ent_... when no external_id is set).
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("update-expires-at-1: set expires_at via raw cus_ent_ id")}`,
+	async () => {
+		const customerId = "update-expires-at-1";
+		const { autumnV2 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		// Loose balance, no balance_id → breakdown id is the raw cusEnt id.
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 100,
+		});
+
+		const initialCheck = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(initialCheck.balance?.breakdown).toHaveLength(1);
+		const cusEntId = initialCheck.balance?.breakdown?.[0].id ?? "";
+		// Raw internal id (no external_id was set at create time).
+		expect(cusEntId.startsWith("cus_ent")).toBe(true);
+		expect(initialCheck.balance?.breakdown?.[0].expires_at ?? null).toBeNull();
+
+		const expiresAt = Date.now() + ms.days(30);
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			balance_id: cusEntId,
+			expires_at: expiresAt,
+		});
+
+		// Cached read reflects the new expiry.
+		const check = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(check.balance?.breakdown?.[0].expires_at).toBeCloseTo(expiresAt, -3);
+
+		// Balance itself is untouched.
+		expect(check.balance?.breakdown?.[0].current_balance).toBe(100);
+
+		// DB sync (skip_cache) agrees.
+		const checkFromDb = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(checkFromDb.balance?.breakdown?.[0].expires_at).toBeCloseTo(
+			expiresAt,
+			-3,
+		);
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// UPDATE-EXPIRES-AT-2: target a balance by its external id (set on create)
+// balances.create({ balance_id }) stores the caller-chosen id as external_id;
+// balances.update({ balance_id }) addresses that same balance to set expiry.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("update-expires-at-2: set expires_at via external balance_id from create")}`,
+	async () => {
+		const customerId = "update-expires-at-2";
+		const externalBalanceId = "invite-credits";
+
+		const { autumnV2 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 250,
+			balance_id: externalBalanceId,
+		});
+
+		const initialCheck = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		const created = initialCheck.balance?.breakdown?.find(
+			(b) => b.id === externalBalanceId,
+		);
+		expect(created).toBeTruthy();
+		expect(created?.expires_at ?? null).toBeNull();
+
+		const expiresAt = Date.now() + ms.days(7);
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			balance_id: externalBalanceId,
+			expires_at: expiresAt,
+		});
+
+		const check = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		const updated = check.balance?.breakdown?.find(
+			(b) => b.id === externalBalanceId,
+		);
+		expect(updated?.expires_at).toBeCloseTo(expiresAt, -3);
+		expect(updated?.current_balance).toBe(250);
+
+		// DB sync (skip_cache) agrees.
+		const checkFromDb = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		const updatedDb = checkFromDb.balance?.breakdown?.find(
+			(b) => b.id === externalBalanceId,
+		);
+		expect(updatedDb?.expires_at).toBeCloseTo(expiresAt, -3);
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// UPDATE-EXPIRES-AT-3: a past expires_at is rejected
+// A non-future expiry would immediately filter the balance out of the
+// customer's active entitlements, so it is refused.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("update-expires-at-3: past expires_at is rejected")}`,
+	async () => {
+		const customerId = "update-expires-at-3";
+		const { autumnV2 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 100,
+			balance_id: "past-expiry",
+		});
+
+		await expectAutumnError({
+			func: async () => {
+				await autumnV2.balances.update({
+					customer_id: customerId,
+					feature_id: TestFeature.Messages,
+					balance_id: "past-expiry",
+					expires_at: Date.now() - ms.days(1),
+				});
+			},
+		});
+
+		// Balance is untouched and still visible (not expired).
+		const check = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		const balance = check.balance?.breakdown?.find(
+			(b) => b.id === "past-expiry",
+		);
+		expect(balance?.current_balance).toBe(100);
+		expect(balance?.expires_at ?? null).toBeNull();
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// UPDATE-EXPIRES-AT-4: expires_at is rejected on a recurring balance
+// Only one-off balances (loose grants / one-off top-ups) may expire;
+// a resetting monthly balance's expiry belongs at the plan level.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("update-expires-at-4: expires_at rejected on recurring balance")}`,
+	async () => {
+		const customerId = "update-expires-at-4";
+		const monthlyProd = products.base({
+			id: "free-monthly",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [monthlyProd] }),
+			],
+			actions: [s.attach({ productId: monthlyProd.id })],
+		});
+
+		await expectAutumnError({
+			func: async () => {
+				await autumnV2.balances.update({
+					customer_id: customerId,
+					feature_id: TestFeature.Messages,
+					expires_at: Date.now() + ms.days(30),
+				});
+			},
+		});
+
+		// Balance still present and unexpired.
+		const check = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(check.balance?.breakdown?.[0].expires_at ?? null).toBeNull();
+		expect(check.balance?.current_balance).toBe(100);
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// UPDATE-EXPIRES-AT-5: expire a one-off top-up while a recurring plan grant
+// on the SAME feature stays untouched.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("update-expires-at-5: expire a one-off top-up alongside a recurring grant")}`,
+	async () => {
+		const customerId = "update-expires-at-5";
+		const plan = products.base({
+			id: "recurring-plan",
+			items: [items.monthlyMessages({ includedUsage: 800 })],
+		});
+
+		const { autumnV2 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+			actions: [s.attach({ productId: plan.id })],
+		});
+
+		const topUpBalanceId = "topup";
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 5000,
+			balance_id: topUpBalanceId,
+		});
+
+		const initialCheck = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(initialCheck.balance?.breakdown?.length).toBeGreaterThanOrEqual(2);
+
+		const oneOffBreakdown = initialCheck.balance?.breakdown?.find(
+			(b) => b.id === topUpBalanceId,
+		);
+		expect(oneOffBreakdown).toBeTruthy();
+		expect(oneOffBreakdown?.reset?.interval ?? ResetInterval.OneOff).toBe(
+			ResetInterval.OneOff,
+		);
+
+		const expiresAt = Date.now() + ms.days(30);
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			balance_id: topUpBalanceId,
+			expires_at: expiresAt,
+		});
+
+		const check = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		const topUpAfter = check.balance?.breakdown?.find(
+			(b) => b.id === topUpBalanceId,
+		);
+		expect(topUpAfter?.expires_at).toBeCloseTo(expiresAt, -3);
+
+		// The recurring grant is unaffected and cannot itself be expired.
+		const monthlyBreakdown = check.balance?.breakdown?.find(
+			(b) => b.reset?.interval === ResetInterval.Month,
+		);
+		expect(monthlyBreakdown?.expires_at ?? null).toBeNull();
+	},
+);

--- a/shared/api/balances/update/updateBalanceParams.ts
+++ b/shared/api/balances/update/updateBalanceParams.ts
@@ -38,6 +38,11 @@ export const ExtUpdateBalanceParamsV0Schema = BalanceParamsBaseSchema.extend({
 		description:
 			"The next reset time for the balance. If there are multiple breakdowns, this will update the breakdown with the next reset time.",
 	}),
+
+	expires_at: z.number().optional().meta({
+		description:
+			"Unix timestamp (milliseconds) when the balance expires. Targets a specific balance via balance_id / interval when the customer has multiple balances for the same feature.",
+	}),
 });
 
 export const UpdateBalanceParamsV0Schema =

--- a/vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
@@ -1,11 +1,13 @@
 import {
 	computeGrantedBalanceInput,
 	customerEntitlementToBillingCycleEnd,
+	EntInterval,
 	type Entity,
 	type FullCusProduct,
 	type FullCustomerEntitlement,
 	type FullCustomerPrice,
 	getRolloverFields,
+	isPayPerUsePrice,
 	isUnlimitedCusEnt,
 	numberWithCommas,
 } from "@autumn/shared";
@@ -414,6 +416,18 @@ function SetBalanceFields({
 	const balance = useStore(form.store, (s) => s.values.balance);
 	const gpb = useStore(form.store, (s) => s.values.grantedAndPurchasedBalance);
 
+	// Mirror the backend guard (updateExpiresAt): expires_at is only valid on
+	// one-off balances (loose grants / one-off top-ups). Recurring balances
+	// reset each cycle — expiry belongs at the plan level (trial / ends_at) —
+	// and usage-based (pay-per-use) meters shouldn't expire.
+	const interval = selectedCusEnt.entitlement.interval;
+	const isRecurringBalance =
+		notNullish(interval) && interval !== EntInterval.Lifetime;
+	const isUsageBasedBalance = cusPrice
+		? isPayPerUsePrice({ price: cusPrice.price })
+		: false;
+	const expiresAtDisabled = isRecurringBalance || isUsageBasedBalance;
+
 	return (
 		<div className="flex flex-col gap-3">
 			<div className="flex items-end gap-2 w-full">
@@ -475,6 +489,28 @@ function SetBalanceFields({
 						/>
 					)}
 				</form.Field>
+			</div>
+
+			<div className="flex flex-col shrink-0 w-full">
+				<div className="text-form-label block mb-1">Expires At</div>
+				<form.Field name="expiresAt">
+					{(field) => (
+						<DateInputUnix
+							disabled={expiresAtDisabled}
+							unixDate={field.state.value}
+							setUnixDate={(v) => field.handleChange(v)}
+							withTime
+							use24Hour
+						/>
+					)}
+				</form.Field>
+				{expiresAtDisabled && (
+					<div className="text-subtle text-xs mt-1">
+						{isUsageBasedBalance
+							? "Usage-based balances can't be set to expire."
+							: "Only one-off balances can be set to expire."}
+					</div>
+				)}
 			</div>
 
 			<BalanceEditPreviews
@@ -607,6 +643,7 @@ function SubmitButton({
 							customer_entitlement_id: selectedCusEnt.id,
 							entity_id: entityId ?? undefined,
 							next_reset_at: values.nextResetAt ?? undefined,
+							expires_at: values.expiresAt ?? undefined,
 						}),
 					);
 				} else {
@@ -675,6 +712,7 @@ function hasBalanceChanges({
 	return (
 		meta.balance?.isDirty ||
 		meta.nextResetAt?.isDirty ||
+		meta.expiresAt?.isDirty ||
 		meta.grantedAndPurchasedBalance?.isDirty ||
 		false
 	);

--- a/vite/src/views/customers2/components/sheets/balanceEditFormSchema.ts
+++ b/vite/src/views/customers2/components/sheets/balanceEditFormSchema.ts
@@ -6,6 +6,7 @@ export const BalanceEditFormSchema = z
 		balance: z.number().nullable(),
 		grantedAndPurchasedBalance: z.number().nullable(),
 		nextResetAt: z.number().nullable(),
+		expiresAt: z.number().nullable(),
 		addValue: z.number().nullable(),
 		updateGrantedBalance: z.boolean(),
 	})

--- a/vite/src/views/customers2/components/sheets/useBalanceEditForm.ts
+++ b/vite/src/views/customers2/components/sheets/useBalanceEditForm.ts
@@ -49,6 +49,7 @@ export function useBalanceEditForm({
 			balance: balance ?? null,
 			grantedAndPurchasedBalance: grantedAndPurchasedBalance ?? null,
 			nextResetAt: selectedCusEnt.next_reset_at ?? null,
+			expiresAt: selectedCusEnt.expires_at ?? null,
 			addValue: null,
 			updateGrantedBalance: true,
 		} as BalanceEditForm,


### PR DESCRIPTION
## What

Adds an \`expires_at\` field to the \`balances.update\` endpoint (\`POST /v1/balances/update\` and \`/v1/balances.update\`), so an expiry timestamp can be set on a one-off balance after it's created (e.g. a top-up).

## Behavior

- Set \`expires_at\` on a balance targeted by its raw \`cus_ent_\` id or by an external \`balance_id\` (set at create time).
- Surfaces on \`check.balance.breakdown[n].expires_at\`; cached and \`skip_cache\` reads agree.
- Both route forms registered in \`REFRESH_CACHE_ROUTE_CONFIGS\` with \`flushBalances: true\` so the cache-authoritative balance is flushed to Postgres before invalidation (fixes an otherwise-lost update).

## Validation (enforced backend + reflected in the dashboard)

- **Past/now timestamps rejected** — a non-future expiry would instantly filter the balance out of the customer's active entitlements.
- **Only one-off balances** — rejected on recurring balances (they reset each cycle; plan-level \`ends_at\`/trial is the right tool) and on usage-based/arrear balances.
- Dashboard edit sheet exposes an **Expires At** field, disabled for balances that can't take one.

## Tests

\`server/tests/integration/balances/update/expires-at/update-expires-at.test.ts\` (5, all green): target by raw \`cus_ent_\` id, target by external id, past-date rejected, recurring rejected, and a one-off top-up expiring alongside an untouched recurring grant.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an expires_at field to balances.update so you can set a future expiry on a one-off balance (e.g., a top‑up). Target by raw `cus_ent_` id or external `balance_id`; the expiry appears in `check.balance.breakdown` and is editable in the dashboard.

- **New Features**
  - Add `expires_at` to `POST /v1/balances/update` and `/v1/balances.update` to set an expiry on a one-off balance; target via `balance_id` (external or raw `cus_ent_` id).
  - Exposes `check.balance.breakdown[n].expires_at`; cached and `skip_cache` reads match.
  - Dashboard Balance Edit adds an Expires At field; disabled for recurring or usage-based balances.
  - Validation: `expires_at` must be in the future; only allowed on one-off balances.

- **Bug Fixes**
  - Register both update routes in `REFRESH_CACHE_ROUTE_CONFIGS` with `flushBalances: true` to persist before invalidation and prevent lost updates.

<sup>Written for commit 82941fb46303d3396730150bfa1f25d4dcc4df0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an `expires_at` field to the `balances.update` endpoint (`POST /v1/balances/update` and `/v1/balances.update`), allowing callers to set a future expiry timestamp on one-off balance grants. Both REST and RPC route forms are registered in `REFRESH_CACHE_ROUTE_CONFIGS` with `flushBalances: true`, fixing a pre-existing cache-coherence gap where updates could be lost before invalidation.

- **API changes / Improvements**: Adds `expires_at?: number` to `UpdateBalanceParamsV0Schema`; validation rejects past timestamps and recurring-balance targets; expiry is addressable via `balance_id` (external id or raw `cus_ent_` id) or `interval`, and is surfaced on `check.balance.breakdown[n].expires_at` for both cached and `skip_cache` reads.
- **Bug fixes**: Both `/balances/update` and `/balances.update` are now registered in `REFRESH_CACHE_ROUTE_CONFIGS` with `flushBalances: true`, preventing a previously-silent lost-update when the cache was invalidated before the Postgres write completed.
- **Improvements**: Dashboard Balance Edit sheet gains an Expires At date/time picker, automatically disabled for recurring and usage-based balances with an explanatory hint; 5 integration tests cover raw-id targeting, external-id targeting, past-date rejection, recurring rejection, and a mixed one-off + recurring scenario.
</details>

<h3>Confidence Score: 4/5</h3>

The core update path is well-structured and the cache-flush registration is a genuine correctness fix. The main gaps are a one-way-door in the API (no way to remove an expiry once set) and an ambiguous balance-selection fallback when `balance_id` is omitted with multiple one-off balances.

The feature is well-tested, the backend guard logic is consistent between V1 and V2 paths, and the cache-coherence fix is correct. Two concerns prevent a higher score: `expires_at` cannot be cleared once set (the schema only accepts a positive number, not null), and the earliest-expiry sort for multi-balance disambiguation is non-deterministic for ties on null — callers are expected to supply `balance_id` but the schema does not enforce this when `expires_at` is present.

Both `updateExpiresAt.ts` and `updateExpiresAtV2.ts` for the tie-breaking sort, and `updateBalanceParams.ts` for the missing nullable path. The dashboard `BalanceEditSheet.tsx` unconditionally re-submits `expiresAt` on every save, which could surface a confusing error if the expiry crosses into the past while the sheet is open.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/updateBalance/updateExpiresAt.ts | New file implementing expires_at update for V1 path; sorting heuristic for multi-balance disambiguation is documented but relies on non-deterministic JS sort for equal keys. |
| server/src/internal/balances/updateBalance/v2/updateExpiresAtV2.ts | V2 equivalent of updateExpiresAt for FullSubject cache path; same sorting concern as V1 counterpart. |
| server/src/internal/balances/handlers/handleUpdateBalance.ts | Adds future-timestamp validation for expires_at before delegating to V1/V2 update paths; guard is correct and consistent. |
| shared/api/balances/update/updateBalanceParams.ts | Adds optional expires_at number field to the schema; lacks a nullable path to clear an existing expiry. |
| server/src/honoMiddlewares/refreshCacheConfigs.ts | Registers both /balances/update and /balances.update with flushBalances: true to prevent cache-coherence loss on expires_at writes. |
| vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx | Adds Expires At date field, correctly disabled for recurring/usage-based balances; unconditional re-submission of unchanged expiresAt is a minor edge-case concern. |
| server/tests/integration/balances/update/expires-at/update-expires-at.test.ts | 5 integration tests covering raw cus_ent_ targeting, external balance_id, past-date rejection, recurring rejection, and mixed one-off + recurring scenario. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant handleUpdateBalance
    participant refreshCacheMiddleware
    participant updateExpiresAt
    participant CusEntService
    participant Postgres
    participant Cache

    Client->>handleUpdateBalance: "POST /v1/balances/update { expires_at, balance_id }"
    handleUpdateBalance->>handleUpdateBalance: "Validate expires_at > Date.now()"
    handleUpdateBalance->>updateExpiresAt: "{ fullCustomer, featureId, expiresAt, filters }"
    updateExpiresAt->>updateExpiresAt: fullCustomerToCustomerEntitlements (filtered by balance_id/interval)
    updateExpiresAt->>updateExpiresAt: Sort by expires_at (nulls last), pick first
    updateExpiresAt->>updateExpiresAt: Guard: reject recurring interval
    updateExpiresAt->>CusEntService: "update({ id, expires_at, incrementCacheVersion: false })"
    CusEntService->>Postgres: "UPDATE customer_entitlements SET expires_at = ?"
    Postgres-->>CusEntService: OK
    handleUpdateBalance-->>refreshCacheMiddleware: "Response { success: true }"
    refreshCacheMiddleware->>refreshCacheMiddleware: flushBalances: true → persist cache to Postgres
    refreshCacheMiddleware->>Cache: Invalidate customer balance cache
    refreshCacheMiddleware-->>Client: 200 OK
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant handleUpdateBalance
    participant refreshCacheMiddleware
    participant updateExpiresAt
    participant CusEntService
    participant Postgres
    participant Cache

    Client->>handleUpdateBalance: "POST /v1/balances/update { expires_at, balance_id }"
    handleUpdateBalance->>handleUpdateBalance: "Validate expires_at > Date.now()"
    handleUpdateBalance->>updateExpiresAt: "{ fullCustomer, featureId, expiresAt, filters }"
    updateExpiresAt->>updateExpiresAt: fullCustomerToCustomerEntitlements (filtered by balance_id/interval)
    updateExpiresAt->>updateExpiresAt: Sort by expires_at (nulls last), pick first
    updateExpiresAt->>updateExpiresAt: Guard: reject recurring interval
    updateExpiresAt->>CusEntService: "update({ id, expires_at, incrementCacheVersion: false })"
    CusEntService->>Postgres: "UPDATE customer_entitlements SET expires_at = ?"
    Postgres-->>CusEntService: OK
    handleUpdateBalance-->>refreshCacheMiddleware: "Response { success: true }"
    refreshCacheMiddleware->>refreshCacheMiddleware: flushBalances: true → persist cache to Postgres
    refreshCacheMiddleware->>Cache: Invalidate customer balance cache
    refreshCacheMiddleware-->>Client: 200 OK
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
shared/api/balances/update/updateBalanceParams.ts:42-45
**No mechanism to clear `expires_at` once set**

`expires_at` is typed as `z.number().optional()`, meaning a caller can only omit the field (no-op) or provide a future timestamp — there is no way to pass `null` to clear an existing expiry. In the dashboard, the edit sheet initialises the field from `selectedCusEnt.expires_at` and always submits the current form value; if a user wants to remove an expiry and extends the balance indefinitely, neither the API nor the UI offer a path to do so. Consider adding `z.number().nullable().optional()` and handling `null` as a clear operation in `updateExpiresAt`/`updateExpiresAtV2`.

### Issue 2 of 3
server/src/internal/balances/updateBalance/updateExpiresAt.ts:47-57
**Ambiguous balance selection when `balance_id` is omitted with multiple one-off balances**

When a customer holds more than one one-off balance for the same feature and no `balance_id` is supplied, the sort by `expires_at` (nulls → `+Infinity`) can produce a non-deterministic ordering among balances that all have `expires_at = null` — JavaScript's `Array.prototype.sort` is not stable-across-all-runtimes for equal keys. The wrong balance could silently receive the expiry. The same logic exists in `updateExpiresAtV2.ts`. While the comment documents that callers should narrow via `balance_id`, the schema does not enforce it when `expires_at` is provided, so this silent mismatch is reachable in practice.

### Issue 3 of 3
vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx:643-644
**`expires_at` is always re-submitted even when unchanged**

`expires_at: values.expiresAt ?? undefined` is evaluated unconditionally on every submit. If the user edits only the balance amount while an existing `expiresAt` is loaded in the form, the current timestamp is re-sent to the server. This is harmless for valid future timestamps, but if the expiry crosses from future to past while the dialog is open (e.g., the edit sheet was left open overnight and the balance expired), the unchanged `expiresAt` value now fails the `<= Date.now()` guard and the entire save is rejected with a confusing error unrelated to what the user was trying to change. Checking `meta.expiresAt?.isDirty` before including the field (matching the guard already used in `hasBalanceChanges`) would prevent this.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;dev&#39; into feat/expires-at-..."](https://github.com/useautumn/autumn/commit/82941fb46303d3396730150bfa1f25d4dcc4df0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43003340)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->