### PR TITLE
feat: Support autumn_customer_email and autumn_customer_fingerprint in RevenueCat webhooks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -242,7 +242,7 @@
     },
     "packages/atmn": {
       "name": "atmn",
-      "version": "1.1.12",
+      "version": "1.1.14",
       "bin": {
         "atmn": "dist/cli.js",
       },

--- a/server/src/external/revenueCat/misc/getRevenueCatOverrideCustomerId.ts
+++ b/server/src/external/revenueCat/misc/getRevenueCatOverrideCustomerId.ts
@@ -1,4 +1,6 @@
 const OVERRIDE_ATTRIBUTE_KEY = "autumn_customer_id";
+const EMAIL_ATTRIBUTE_KEY = "autumn_customer_email";
+const FINGERPRINT_ATTRIBUTE_KEY = "autumn_customer_fingerprint";
 
 type WithSubscriberAttributes = {
 	subscriber_attributes?: Record<string, { value: string } | undefined>;
@@ -10,5 +12,23 @@ export const getRevenueCatOverrideCustomerId = (
 ): string | undefined => {
 	const value =
 		event.subscriber_attributes?.[OVERRIDE_ATTRIBUTE_KEY]?.value?.trim();
+	return value ? value : undefined;
+};
+
+/** Canonical Autumn customer email the client declares via the `autumn_customer_email` RC subscriber attribute. */
+export const getRevenueCatCustomerEmail = (
+	event: WithSubscriberAttributes,
+): string | undefined => {
+	const value =
+		event.subscriber_attributes?.[EMAIL_ATTRIBUTE_KEY]?.value?.trim();
+	return value ? value : undefined;
+};
+
+/** Canonical Autumn customer fingerprint the client declares via the `autumn_customer_fingerprint` RC subscriber attribute. */
+export const getRevenueCatCustomerFingerprint = (
+	event: WithSubscriberAttributes,
+): string | undefined => {
+	const value =
+		event.subscriber_attributes?.[FINGERPRINT_ATTRIBUTE_KEY]?.value?.trim();
 	return value ? value : undefined;
 };

--- a/server/src/external/revenueCat/misc/resolveRevenuecatResources.ts
+++ b/server/src/external/revenueCat/misc/resolveRevenuecatResources.ts
@@ -422,7 +422,7 @@ const resolveRevenueCatCustomer = async ({
 		customerId: idIsValid ? appUserId : null,
 		withEntities: true,
 		customerData: {
-			email: idIsValid ? customerEmail : (appUserId || customerEmail),
+			email: idIsValid ? customerEmail : (customerEmail || appUserId),
 			fingerprint: customerFingerprint,
 			processors: {
 				revenuecat: {

--- a/server/src/external/revenueCat/misc/resolveRevenuecatResources.ts
+++ b/server/src/external/revenueCat/misc/resolveRevenuecatResources.ts
@@ -91,6 +91,71 @@ const accumulateRevenueCatAliases = ({
 	});
 };
 
+/**
+ * Update customer email and fingerprint from RevenueCat subscriber attributes.
+ * Updates if provided values differ from current values.
+ * Fire-and-forget: must never block or throw the webhook.
+ */
+const updateRevenueCatCustomerDetails = ({
+	ctx,
+	customer,
+	customerEmail,
+	customerFingerprint,
+}: {
+	ctx: RevenueCatWebhookContext;
+	customer: FullCustomer;
+	customerEmail?: string;
+	customerFingerprint?: string;
+}) => {
+	const resolvedCustomerId = customer.id ?? customer.internal_id;
+	const updates: { email?: string; fingerprint?: string } = {};
+
+	// Update email if provided and different
+	if (customerEmail && customer.email !== customerEmail) {
+		updates.email = customerEmail;
+	}
+
+	// Update fingerprint if provided and different
+	if (customerFingerprint && customer.fingerprint !== customerFingerprint) {
+		updates.fingerprint = customerFingerprint;
+	}
+
+	if (Object.keys(updates).length === 0) return;
+
+	void (async () => {
+		try {
+			await CusService.update({
+				ctx,
+				idOrInternalId: customer.internal_id,
+				update: updates,
+			});
+			ctx.logger
+				.child({
+					context: {
+						extras: {
+							rc_customer_details_updated: true,
+							resolved_customer_id: resolvedCustomerId,
+							updated_fields: Object.keys(updates),
+						},
+					},
+				})
+				.info("Updated RevenueCat customer details");
+		} catch (error) {
+			ctx.logger
+				.child({
+					context: {
+						extras: {
+							rc_customer_details_update_failed: true,
+							resolved_customer_id: resolvedCustomerId,
+							error: error instanceof Error ? error.message : String(error),
+						},
+					},
+				})
+				.error("Failed to update RevenueCat customer details");
+		}
+	})();
+};
+
 const writeRevenueCatIdentity = async ({
 	ctx,
 	customer,
@@ -142,12 +207,16 @@ const resolveRevenueCatCustomer = async ({
 	appUserId,
 	originalAppUserId,
 	overrideCustomerId,
+	customerEmail,
+	customerFingerprint,
 	autoCreateCustomer,
 }: {
 	ctx: RevenueCatWebhookContext;
 	appUserId: string;
 	originalAppUserId?: string;
 	overrideCustomerId?: string;
+	customerEmail?: string;
+	customerFingerprint?: string;
 	autoCreateCustomer: boolean;
 }): Promise<FullCustomer> => {
 	const hasOriginal = Boolean(
@@ -173,6 +242,8 @@ const resolveRevenueCatCustomer = async ({
 				withEntities: true,
 				customerData: {
 					processors: { revenuecat: { id: appUserId, aliases: [] } },
+					email: customerEmail,
+					fingerprint: customerFingerprint,
 				},
 			}));
 
@@ -198,6 +269,12 @@ const resolveRevenueCatCustomer = async ({
 			customer: overrideCustomer,
 			appUserId,
 			originalAppUserId,
+		});
+		updateRevenueCatCustomerDetails({
+			ctx,
+			customer: overrideCustomer,
+			customerEmail,
+			customerFingerprint,
 		});
 		return overrideCustomer;
 	}
@@ -296,6 +373,12 @@ const resolveRevenueCatCustomer = async ({
 			appUserId,
 			originalAppUserId,
 		});
+		updateRevenueCatCustomerDetails({
+			ctx,
+			customer: processorMatch,
+			customerEmail,
+			customerFingerprint,
+		});
 		return processorMatch;
 	}
 
@@ -318,6 +401,12 @@ const resolveRevenueCatCustomer = async ({
 			appUserId,
 			originalAppUserId,
 		});
+		updateRevenueCatCustomerDetails({
+			ctx,
+			customer: customerIdMatch,
+			customerEmail,
+			customerFingerprint,
+		});
 		return customerIdMatch;
 	}
 
@@ -333,7 +422,8 @@ const resolveRevenueCatCustomer = async ({
 		customerId: idIsValid ? appUserId : null,
 		withEntities: true,
 		customerData: {
-			email: idIsValid ? undefined : appUserId,
+			email: idIsValid ? customerEmail : (appUserId || customerEmail),
+			fingerprint: customerFingerprint,
 			processors: {
 				revenuecat: {
 					id: appUserId,
@@ -371,6 +461,8 @@ export const resolveRevenuecatResources = async ({
 	customerId,
 	originalAppUserId,
 	overrideCustomerId,
+	customerEmail,
+	customerFingerprint,
 	autoCreateCustomer = false,
 }: {
 	ctx: RevenueCatWebhookContext;
@@ -378,6 +470,8 @@ export const resolveRevenuecatResources = async ({
 	customerId: string;
 	originalAppUserId?: string;
 	overrideCustomerId?: string;
+	customerEmail?: string;
+	customerFingerprint?: string;
 	autoCreateCustomer?: boolean;
 }): Promise<{
 	ctx: RevenueCatWebhookContext;
@@ -419,6 +513,8 @@ export const resolveRevenuecatResources = async ({
 			appUserId: customerId,
 			originalAppUserId,
 			overrideCustomerId,
+			customerEmail,
+			customerFingerprint,
 			autoCreateCustomer,
 		}),
 	]);

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenucatRenewal.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenucatRenewal.ts
@@ -4,7 +4,11 @@ import {
 	AttachScenario,
 	CusProductStatus,
 } from "@shared/index";
-import { getRevenueCatOverrideCustomerId } from "@/external/revenueCat/misc/getRevenueCatOverrideCustomerId";
+import {
+	getRevenueCatCustomerEmail,
+	getRevenueCatCustomerFingerprint,
+	getRevenueCatOverrideCustomerId,
+} from "@/external/revenueCat/misc/getRevenueCatOverrideCustomerId";
 import { provisionRevenueCatCusProduct } from "@/external/revenueCat/misc/provisionRevenueCatCusProduct";
 import { resolveRevenuecatResources } from "@/external/revenueCat/misc/resolveRevenuecatResources";
 import { recordRevenueCatInvoice } from "@/external/revenueCat/utils/recordRevenueCatInvoice";
@@ -34,6 +38,8 @@ export const handleRenewal = async ({
 		customerId: app_user_id,
 		originalAppUserId: original_app_user_id,
 		overrideCustomerId: getRevenueCatOverrideCustomerId(event),
+		customerEmail: getRevenueCatCustomerEmail(event),
+		customerFingerprint: getRevenueCatCustomerFingerprint(event),
 	});
 
 	const { curSameProduct } = getExistingCusProducts({

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenuecatBillingIssue.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenuecatBillingIssue.ts
@@ -6,7 +6,11 @@ import type { RevenueCatWebhookContext } from "@/external/revenueCat/webhookMidd
 import { customerProductActions } from "@/internal/customers/cusProducts/actions";
 import { ACTIVE_STATUSES } from "@/internal/customers/cusProducts/CusProductService";
 import { getExistingCusProducts } from "@/internal/customers/cusProducts/cusProductUtils/getExistingCusProducts";
-import { getRevenueCatOverrideCustomerId } from "../misc/getRevenueCatOverrideCustomerId";
+import {
+	getRevenueCatCustomerEmail,
+	getRevenueCatCustomerFingerprint,
+	getRevenueCatOverrideCustomerId,
+} from "../misc/getRevenueCatOverrideCustomerId";
 import { resolveRevenuecatResources } from "../misc/resolveRevenuecatResources";
 
 export const handleBillingIssue = async ({
@@ -30,6 +34,8 @@ export const handleBillingIssue = async ({
 		customerId: app_user_id,
 		originalAppUserId: original_app_user_id,
 		overrideCustomerId: getRevenueCatOverrideCustomerId(event),
+		customerEmail: getRevenueCatCustomerEmail(event),
+		customerFingerprint: getRevenueCatCustomerFingerprint(event),
 	});
 
 	const { curSameProduct } = getExistingCusProducts({

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenuecatCancellation.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenuecatCancellation.ts
@@ -1,6 +1,10 @@
 import type { WebhookCancellation } from "@puzzmo/revenue-cat-webhook-types";
 import { ErrCode, RecaseError } from "@shared/index";
-import { getRevenueCatOverrideCustomerId } from "@/external/revenueCat/misc/getRevenueCatOverrideCustomerId";
+import {
+	getRevenueCatCustomerEmail,
+	getRevenueCatCustomerFingerprint,
+	getRevenueCatOverrideCustomerId,
+} from "@/external/revenueCat/misc/getRevenueCatOverrideCustomerId";
 import { resolveRevenuecatResources } from "@/external/revenueCat/misc/resolveRevenuecatResources";
 import { refundRevenueCatInvoice } from "@/external/revenueCat/utils/refundRevenueCatInvoice";
 import type { RevenueCatWebhookContext } from "@/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext";
@@ -35,6 +39,8 @@ export const handleCancellation = async ({
 		customerId: app_user_id ?? original_app_user_id,
 		originalAppUserId: original_app_user_id,
 		overrideCustomerId: getRevenueCatOverrideCustomerId(event),
+		customerEmail: getRevenueCatCustomerEmail(event),
+		customerFingerprint: getRevenueCatCustomerFingerprint(event),
 	});
 
 	const { curSameProduct } = getExistingCusProducts({

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenuecatExpiration.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenuecatExpiration.ts
@@ -1,6 +1,10 @@
 import type { WebhookExpiration } from "@puzzmo/revenue-cat-webhook-types";
 import { ErrCode, RecaseError } from "@shared/index";
-import { getRevenueCatOverrideCustomerId } from "@/external/revenueCat/misc/getRevenueCatOverrideCustomerId";
+import {
+	getRevenueCatCustomerEmail,
+	getRevenueCatCustomerFingerprint,
+	getRevenueCatOverrideCustomerId,
+} from "@/external/revenueCat/misc/getRevenueCatOverrideCustomerId";
 import { resolveRevenuecatResources } from "@/external/revenueCat/misc/resolveRevenuecatResources";
 import type { RevenueCatWebhookContext } from "@/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext";
 import { customerProductActions } from "@/internal/customers/cusProducts/actions";
@@ -27,6 +31,8 @@ export const handleExpiration = async ({
 		customerId: app_user_id ?? original_app_user_id,
 		originalAppUserId: original_app_user_id,
 		overrideCustomerId: getRevenueCatOverrideCustomerId(event),
+		customerEmail: getRevenueCatCustomerEmail(event),
+		customerFingerprint: getRevenueCatCustomerFingerprint(event),
 	});
 
 	const { curSameProduct } = getExistingCusProducts({

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenuecatInitialPurchase.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenuecatInitialPurchase.ts
@@ -1,6 +1,10 @@
 import type { WebhookInitialPurchase } from "@puzzmo/revenue-cat-webhook-types";
 import { ErrCode, RecaseError } from "@shared/index";
-import { getRevenueCatOverrideCustomerId } from "@/external/revenueCat/misc/getRevenueCatOverrideCustomerId";
+import {
+	getRevenueCatCustomerEmail,
+	getRevenueCatCustomerFingerprint,
+	getRevenueCatOverrideCustomerId,
+} from "@/external/revenueCat/misc/getRevenueCatOverrideCustomerId";
 import { provisionRevenueCatCusProduct } from "@/external/revenueCat/misc/provisionRevenueCatCusProduct";
 import { resolveRevenuecatResources } from "@/external/revenueCat/misc/resolveRevenuecatResources";
 import { recordRevenueCatInvoice } from "@/external/revenueCat/utils/recordRevenueCatInvoice";
@@ -29,6 +33,8 @@ export const handleInitialPurchase = async ({
 		customerId: app_user_id,
 		originalAppUserId: original_app_user_id,
 		overrideCustomerId: getRevenueCatOverrideCustomerId(event),
+		customerEmail: getRevenueCatCustomerEmail(event),
+		customerFingerprint: getRevenueCatCustomerFingerprint(event),
 		autoCreateCustomer: true,
 	});
 

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenuecatNonRenewingPurchase.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenuecatNonRenewingPurchase.ts
@@ -1,6 +1,10 @@
 import type { WebhookNonRenewingPurchase } from "@puzzmo/revenue-cat-webhook-types";
 import { ErrCode, RecaseError } from "@shared/index";
-import { getRevenueCatOverrideCustomerId } from "@/external/revenueCat/misc/getRevenueCatOverrideCustomerId";
+import {
+	getRevenueCatCustomerEmail,
+	getRevenueCatCustomerFingerprint,
+	getRevenueCatOverrideCustomerId,
+} from "@/external/revenueCat/misc/getRevenueCatOverrideCustomerId";
 import { provisionRevenueCatCusProduct } from "@/external/revenueCat/misc/provisionRevenueCatCusProduct";
 import { resolveRevenuecatResources } from "@/external/revenueCat/misc/resolveRevenuecatResources";
 import { recordRevenueCatInvoice } from "@/external/revenueCat/utils/recordRevenueCatInvoice";
@@ -27,6 +31,8 @@ export const handleNonRenewingPurchase = async ({
 		customerId: event.app_user_id,
 		originalAppUserId: event.original_app_user_id,
 		overrideCustomerId: getRevenueCatOverrideCustomerId(event),
+		customerEmail: getRevenueCatCustomerEmail(event),
+		customerFingerprint: getRevenueCatCustomerFingerprint(event),
 	});
 
 	if (!oneOffOrAddOn({ product, prices: product.prices })) {

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenuecatUncancellation.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenuecatUncancellation.ts
@@ -1,6 +1,10 @@
 import type { WebhookUnCancellation } from "@puzzmo/revenue-cat-webhook-types";
 import { ErrCode, ProcessorType, RecaseError } from "@shared/index";
-import { getRevenueCatOverrideCustomerId } from "@/external/revenueCat/misc/getRevenueCatOverrideCustomerId";
+import {
+	getRevenueCatCustomerEmail,
+	getRevenueCatCustomerFingerprint,
+	getRevenueCatOverrideCustomerId,
+} from "@/external/revenueCat/misc/getRevenueCatOverrideCustomerId";
 import { resolveRevenuecatResources } from "@/external/revenueCat/misc/resolveRevenuecatResources";
 import type { RevenueCatWebhookContext } from "@/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext";
 import { customerProductActions } from "@/internal/customers/cusProducts/actions";
@@ -26,6 +30,8 @@ export const handleUncancellation = async ({
 		customerId: app_user_id ?? original_app_user_id,
 		originalAppUserId: original_app_user_id,
 		overrideCustomerId: getRevenueCatOverrideCustomerId(event),
+		customerEmail: getRevenueCatCustomerEmail(event),
+		customerFingerprint: getRevenueCatCustomerFingerprint(event),
 	});
 
 	const cusProduct = cusProducts.find(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR adds support for setting `autumn_customer_email` and `autumn_customer_fingerprint` via RevenueCat subscriber attributes. These attributes now update the customer's email and fingerprint in both cases:
- When the customer **exists** 
- When the customer **doesn't exist** (newly created)

The update is skipped if the customer exists and the fields already match the provided values.

## Changes

### Core Implementation

- **`getRevenueCatOverrideCustomerId.ts`**: Added two new helper functions:
  - `getRevenueCatCustomerEmail()` - Extracts `autumn_customer_email` from subscriber attributes
  - `getRevenueCatCustomerFingerprint()` - Extracts `autumn_customer_fingerprint` from subscriber attributes

- **`resolveRevenuecatResources.ts`**:
  - Added `customerEmail` and `customerFingerprint` parameters to `resolveRevenuecatResources()`
  - Updated `resolveRevenueCatCustomer()` to accept and process email/fingerprint attributes
  - Added `updateRevenueCatCustomerDetails()` helper function that:
    - Compares incoming email/fingerprint with existing customer values
    - Only updates if values differ (skips if already matching)
    - Fire-and-forget pattern (never blocks webhook processing)
  - Updated all customer resolution paths (override, processor match, customer ID match, auto-create) to:
    - Include email/fingerprint in customer creation when applicable
    - Call `updateRevenueCatCustomerDetails()` for existing customers
  - Fixed: Prioritize explicit `autumn_customer_email` over email-shaped `app_user_id` during auto-creation

### Webhook Handlers

Updated all RevenueCat webhook handlers to extract and pass email/fingerprint attributes:
- `handleRevenuecatInitialPurchase.ts`
- `handleRevenucatRenewal.ts`
- `handleRevenuecatBillingIssue.ts`
- `handleRevenuecatCancellation.ts`
- `handleRevenuecatExpiration.ts`
- `handleRevenuecatNonRenewingPurchase.ts`
- `handleRevenuecatUncancellation.ts`

## Behavior

### For New Customers
When auto-creating a customer, the email and fingerprint are set directly in the `customerData` passed to `getOrCreateCustomer()`.

**Email precedence during auto-creation:**
- If `app_user_id` is valid as a customer ID: use `autumn_customer_email` if provided
- If `app_user_id` is email-shaped (invalid as customer ID):
  - Use `autumn_customer_email` if explicitly set (takes precedence)
  - Fall back to the email-shaped `app_user_id` if no explicit email provided

### For Existing Customers
When a customer is resolved via any matching strategy (override attribute, processor key, or customer ID), the system:
1. Checks if the provided email/fingerprint differs from the existing values
2. If different, updates the customer record via `CusService.update()`
3. If identical, skips the update to avoid unnecessary database operations

### Error Handling
Updates are fire-and-forget with proper error logging. If an update fails, the webhook continues processing normally.

## Testing Notes

The changes follow the existing pattern used for `autumn_customer_id` override attribute and integrate seamlessly with the current RevenueCat webhook flow.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1783600647903979?thread_ts=1783600647.903979&cid=C0BCAQQK0KS)

<div><a href="https://cursor.com/agents/bc-b65efed7-ea49-528e-bcc5-a23bc36f0176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b65efed7-ea49-528e-bcc5-a23bc36f0176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for `autumn_customer_email` and `autumn_customer_fingerprint` in RevenueCat webhooks. Sets them on create and updates existing customers when values change; fixes auto-create to prefer the explicit email attribute.

- **New Features**
  - Extract email and fingerprint from subscriber attributes via new helpers.
  - Pass attributes into customer resolution; set on create and update only when values differ (fire-and-forget with logging).
  - Update all RevenueCat webhook handlers to propagate these attributes.

- **Bug Fixes**
  - Auto-create now prioritizes `autumn_customer_email` over an email-shaped `app_user_id` when selecting the initial customer email.

<sup>Written for commit c2c100e58aa50e6eb5c7b0dc71916952297e2509. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds support for two new RevenueCat subscriber attributes — `autumn_customer_email` and `autumn_customer_fingerprint` — that allow clients to set or update a customer's email and fingerprint via webhook events. The implementation follows the existing `autumn_customer_id` override pattern and applies to all seven RevenueCat webhook handlers.

- **Improvements**: New helper functions (`getRevenueCatCustomerEmail`, `getRevenueCatCustomerFingerprint`) extract the attributes; values are passed into `resolveRevenuecatResources` and applied at every customer resolution path (override, processor-key, customer-ID match, and auto-create).
- **Improvements**: Existing customers are updated via a fire-and-forget `updateRevenueCatCustomerDetails` helper that only writes when values actually differ, keeping webhook latency unaffected.
- **Bug fixes**: Auto-created customers now receive `fingerprint` and `email` from subscriber attributes; however there is a logic bug in the non-valid-ID auto-create path (see inline comment).
</details>

<h3>Confidence Score: 3/5</h3>

Safe to merge for the existing-customer update path; the auto-create path with an email-shaped app_user_id will silently discard the autumn_customer_email attribute until fixed.

The updateRevenueCatCustomerDetails helper and all the existing-customer paths work correctly. The one concrete defect is in the auto-create branch: appUserId || customerEmail always resolves to appUserId because appUserId is never falsy, so the autumn_customer_email subscriber attribute is ignored when the customer's app_user_id happens to be email-shaped. Any new RevenueCat user whose ID looks like an email and who also sets the autumn_customer_email attribute will have the attribute silently dropped on first creation.

server/src/external/revenueCat/misc/resolveRevenuecatResources.ts — specifically the auto-create email assignment at line 425.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/revenueCat/misc/getRevenueCatOverrideCustomerId.ts | Adds two new helper functions to extract autumn_customer_email and autumn_customer_fingerprint subscriber attributes; mirrors existing getRevenueCatOverrideCustomerId pattern exactly. |
| server/src/external/revenueCat/misc/resolveRevenuecatResources.ts | Core change: adds updateRevenueCatCustomerDetails (fire-and-forget update) and threads email/fingerprint through all customer resolution paths; contains a logic bug at line 425 where customerEmail is unreachable in the !idIsValid auto-create branch due to || operand order. |
| server/src/external/revenueCat/webhookHandlers/handleRevenuecatInitialPurchase.ts | Extracts and forwards email/fingerprint attributes to resolveRevenuecatResources; boilerplate change consistent with all other handlers. |
| server/src/external/revenueCat/webhookHandlers/handleRevenucatRenewal.ts | Same boilerplate attribute-forwarding change as other handlers. |
| server/src/external/revenueCat/webhookHandlers/handleRevenuecatBillingIssue.ts | Same boilerplate attribute-forwarding change as other handlers. |
| server/src/external/revenueCat/webhookHandlers/handleRevenuecatCancellation.ts | Same boilerplate attribute-forwarding change as other handlers. |
| server/src/external/revenueCat/webhookHandlers/handleRevenuecatExpiration.ts | Same boilerplate attribute-forwarding change as other handlers. |
| server/src/external/revenueCat/webhookHandlers/handleRevenuecatNonRenewingPurchase.ts | Same boilerplate attribute-forwarding change as other handlers. |
| server/src/external/revenueCat/webhookHandlers/handleRevenuecatUncancellation.ts | Same boilerplate attribute-forwarding change as other handlers. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/external/revenueCat/misc/resolveRevenuecatResources.ts:425
The operands in the falsy-ID branch are in the wrong order: `appUserId` is always a non-empty string at this point, so `appUserId || customerEmail` always resolves to `appUserId` and the `autumn_customer_email` subscriber attribute is never used. Swap them so the explicitly-set attribute wins and the email-shaped `appUserId` is the fallback.

```suggestion
			email: idIsValid ? customerEmail : (customerEmail || appUserId),
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: support autumn\_customer\_email and ..."](https://github.com/useautumn/autumn/commit/877db606f413ee951e98a2777edb7fd9286549e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43000530)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->