### PR TITLE
feat: emit billing.updated webhook from manual sync operations

### DIFF
--- a/server/src/internal/billing/v2/actions/sync/syncV2.ts
+++ b/server/src/internal/billing/v2/actions/sync/syncV2.ts
@@ -1,11 +1,8 @@
-import type {
-	AutumnBillingPlan,
-	FullCustomer,
-	SyncParamsV1,
-} from "@autumn/shared";
+import type { SyncParamsV1 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { persistCreateSchedule } from "@/internal/billing/v2/actions/createSchedule/utils/persistCreateSchedule";
 import { executeAutumnBillingPlan } from "@/internal/billing/v2/execute/executeAutumnBillingPlan";
+import { sendBillingUpdatedWebhook } from "@/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook";
 import { computeSyncPlan } from "./compute/computeSyncPlan";
 import { handleSyncErrors } from "./errors/handleSyncErrors";
 import { logSyncContext } from "./logs/logSyncContext";
@@ -26,11 +23,6 @@ export type SyncV2Result = {
 	expired_cus_product_ids: string[];
 	schedule_id: string | null;
 	scheduled_phases: SyncV2PersistedPhase[];
-	/** @internal - Used by handler to emit webhooks, not returned to API consumers */
-	_internal?: {
-		autumnBillingPlan: AutumnBillingPlan;
-		fullCustomer: FullCustomer;
-	};
 };
 
 /**
@@ -44,13 +36,19 @@ export type SyncV2Result = {
  *   5. persist — write any scheduled phase rows (reuses createSchedule's
  *                `persistCreateSchedule` so the schedule + schedule_phases
  *                tables are written identically across actions)
+ *
+ * Webhook emission is opt-in via `webhook` so Stripe auto-sync callers
+ * (which already emit billing.updated from the originating action) don't
+ * double-send.
  */
 export const syncV2 = async ({
 	ctx,
 	params,
+	webhook,
 }: {
 	ctx: AutumnContext;
 	params: SyncParamsV1;
+	webhook?: { tags?: string[] };
 }): Promise<SyncV2Result> => {
 	// 1. Setup
 	const syncContext = await setupSyncContext({ ctx, params });
@@ -81,6 +79,15 @@ export const syncV2 = async ({
 		scheduledPhases = persisted.insertedPhases;
 	}
 
+	if (webhook) {
+		void sendBillingUpdatedWebhook({
+			ctx,
+			autumnBillingPlan,
+			originalFullCustomer: syncContext.fullCustomer,
+			tags: webhook.tags,
+		});
+	}
+
 	return {
 		customer_id: syncContext.customer_id,
 		stripe_subscription_id: syncContext.stripeSubscription?.id ?? null,
@@ -97,9 +104,5 @@ export const syncV2 = async ({
 			.map((u) => u.customerProduct.id),
 		schedule_id: scheduleId,
 		scheduled_phases: scheduledPhases,
-		_internal: {
-			autumnBillingPlan,
-			fullCustomer: syncContext.fullCustomer,
-		},
 	};
 };

--- a/server/src/internal/billing/v2/actions/sync/syncV2.ts
+++ b/server/src/internal/billing/v2/actions/sync/syncV2.ts
@@ -1,4 +1,8 @@
-import type { SyncParamsV1 } from "@autumn/shared";
+import type {
+	AutumnBillingPlan,
+	FullCustomer,
+	SyncParamsV1,
+} from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { persistCreateSchedule } from "@/internal/billing/v2/actions/createSchedule/utils/persistCreateSchedule";
 import { executeAutumnBillingPlan } from "@/internal/billing/v2/execute/executeAutumnBillingPlan";
@@ -22,6 +26,11 @@ export type SyncV2Result = {
 	expired_cus_product_ids: string[];
 	schedule_id: string | null;
 	scheduled_phases: SyncV2PersistedPhase[];
+	/** @internal - Used by handler to emit webhooks, not returned to API consumers */
+	_internal?: {
+		autumnBillingPlan: AutumnBillingPlan;
+		fullCustomer: FullCustomer;
+	};
 };
 
 /**
@@ -88,5 +97,9 @@ export const syncV2 = async ({
 			.map((u) => u.customerProduct.id),
 		schedule_id: scheduleId,
 		scheduled_phases: scheduledPhases,
+		_internal: {
+			autumnBillingPlan,
+			fullCustomer: syncContext.fullCustomer,
+		},
 	};
 };

--- a/server/src/internal/billing/v2/handlers/handleSyncV2.ts
+++ b/server/src/internal/billing/v2/handlers/handleSyncV2.ts
@@ -1,7 +1,6 @@
 import { Scopes, SyncParamsV1Schema } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler";
 import { billingActions } from "@/internal/billing/v2/actions";
-import { sendBillingUpdatedWebhook } from "@/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook";
 
 export const handleSyncV2 = createRoute({
 	scopes: [Scopes.Billing.Write],
@@ -13,20 +12,9 @@ export const handleSyncV2 = createRoute({
 		const result = await billingActions.syncV2({
 			ctx,
 			params: body,
+			webhook: { tags: ["resync"] },
 		});
 
-		// Emit billing.updated webhook for manual sync operations
-		if (result._internal) {
-			void sendBillingUpdatedWebhook({
-				ctx,
-				autumnBillingPlan: result._internal.autumnBillingPlan,
-				originalFullCustomer: result._internal.fullCustomer,
-				tags: ["reconciled"],
-			});
-		}
-
-		// Strip internal data from API response
-		const { _internal, ...publicResult } = result;
-		return c.json(publicResult, 200);
+		return c.json(result, 200);
 	},
 });

--- a/server/src/internal/billing/v2/handlers/handleSyncV2.ts
+++ b/server/src/internal/billing/v2/handlers/handleSyncV2.ts
@@ -1,6 +1,7 @@
 import { Scopes, SyncParamsV1Schema } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler";
 import { billingActions } from "@/internal/billing/v2/actions";
+import { sendBillingUpdatedWebhook } from "@/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook";
 
 export const handleSyncV2 = createRoute({
 	scopes: [Scopes.Billing.Write],
@@ -14,6 +15,18 @@ export const handleSyncV2 = createRoute({
 			params: body,
 		});
 
-		return c.json(result, 200);
+		// Emit billing.updated webhook for manual sync operations
+		if (result._internal) {
+			void sendBillingUpdatedWebhook({
+				ctx,
+				autumnBillingPlan: result._internal.autumnBillingPlan,
+				originalFullCustomer: result._internal.fullCustomer,
+				tags: ["reconciled"],
+			});
+		}
+
+		// Strip internal data from API response
+		const { _internal, ...publicResult } = result;
+		return c.json(publicResult, 200);
 	},
 });

--- a/server/tests/integration/billing/autumn-webhooks/billing-updated/billing-updated-sync.test.ts
+++ b/server/tests/integration/billing/autumn-webhooks/billing-updated/billing-updated-sync.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Integration test: `billing.updated` webhook fires when manually syncing
+ * a Stripe subscription via `billing.sync_v2`.
+ *
+ * Scenario: A customer has a Stripe subscription that needs to be synced into
+ * Autumn state (e.g., after correcting customer mapping, importing existing
+ * subscriptions, or reconciling state). The sync operation should emit
+ * `billing.updated` so downstream systems can update their local state.
+ */
+
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import type {
+	BillingChangeResponse,
+	CustomerPlanChange,
+} from "@autumn/shared";
+import { getSubscriptionId } from "@tests/integration/billing/utils/stripe/getSubscriptionId.js";
+import {
+	getTestSvixAppId,
+	setupWebhookTest,
+	type WebhookTestSetup,
+	waitForWebhook,
+} from "@tests/integration/utils/svixWebhookTestUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+type BillingUpdatedPayload = {
+	type: string;
+	data: BillingChangeResponse & { tags?: string[] };
+};
+
+const findChange = (
+	plan_changes: CustomerPlanChange[] | undefined,
+	{ action, planId }: { action: string; planId: string },
+): CustomerPlanChange | undefined =>
+	plan_changes?.find(
+		(change) =>
+			change.action === action &&
+			(change.subscription?.plan_id ?? change.purchase?.plan_id) === planId,
+	);
+
+let webhook: WebhookTestSetup;
+let playToken: string;
+
+beforeAll(async () => {
+	const appId = getTestSvixAppId({ svixConfig: ctx.org.svix_config });
+	webhook = await setupWebhookTest({
+		appId,
+		filterTypes: ["billing.updated"],
+	});
+	playToken = webhook.playToken;
+});
+
+afterAll(async () => {
+	await webhook?.cleanup();
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// SYNC EMITS WEBHOOK
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("billing.updated: manual sync emits webhook with 'reconciled' tag")}`, async () => {
+	const customerId = "billing-updated-sync";
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const pro = products.pro({ id: "pro", items: [messagesItem] });
+
+	const { autumnV2_2 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success", skipWebhooks: true }),
+			s.products({ list: [pro] }),
+		],
+		actions: [
+			// Attach creates the Stripe subscription
+			s.attach({ productId: pro.id }),
+		],
+	});
+
+	// Get the subscription ID that was created
+	const subscriptionId = await getSubscriptionId({
+		ctx,
+		customerId,
+		productId: pro.id,
+	});
+
+	// Manual sync operation (simulates admin reconciliation)
+	await autumnV2_2.post("/v1/billing.sync_v2", {
+		customer_id: customerId,
+		plans: [
+			{
+				plan_id: pro.id,
+				stripe_subscription_id: subscriptionId,
+			},
+		],
+	});
+
+	// Wait for the billing.updated webhook
+	const result = await waitForWebhook<BillingUpdatedPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "billing.updated" &&
+			payload.data?.customer_id === customerId &&
+			(payload.data?.tags ?? []).includes("reconciled"),
+		timeoutMs: 15000,
+	});
+
+	expect(result).not.toBeNull();
+	const { data } = result!.payload;
+	
+	// Verify the webhook has the reconciled tag
+	expect(data.tags).toContain("reconciled");
+	
+	// Verify there's an activated change for the synced plan
+	const activated = findChange(data.plan_changes, {
+		action: "activated",
+		planId: pro.id,
+	});
+	expect(activated).toBeDefined();
+	expect(activated?.subscription?.plan_id).toBe(pro.id);
+});

--- a/server/tests/integration/billing/autumn-webhooks/billing-updated/billing-updated-sync.test.ts
+++ b/server/tests/integration/billing/autumn-webhooks/billing-updated/billing-updated-sync.test.ts
@@ -12,6 +12,7 @@ import { afterAll, beforeAll, expect, test } from "bun:test";
 import type {
 	BillingChangeResponse,
 	CustomerPlanChange,
+	SyncParamsV1,
 } from "@autumn/shared";
 import { getSubscriptionId } from "@tests/integration/billing/utils/stripe/getSubscriptionId.js";
 import {
@@ -61,12 +62,12 @@ afterAll(async () => {
 // SYNC EMITS WEBHOOK
 // ═══════════════════════════════════════════════════════════════════════════════
 
-test(`${chalk.yellowBright("billing.updated: manual sync emits webhook with 'reconciled' tag")}`, async () => {
+test(`${chalk.yellowBright("billing.updated: manual sync emits webhook with 'resync' tag")}`, async () => {
 	const customerId = "billing-updated-sync";
 	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
 	const pro = products.pro({ id: "pro", items: [messagesItem] });
 
-	const { autumnV2_2 } = await initScenario({
+	const { autumnV1 } = await initScenario({
 		customerId,
 		setup: [
 			s.customer({ paymentMethod: "success", skipWebhooks: true }),
@@ -78,45 +79,42 @@ test(`${chalk.yellowBright("billing.updated: manual sync emits webhook with 'rec
 		],
 	});
 
-	// Get the subscription ID that was created
 	const subscriptionId = await getSubscriptionId({
 		ctx,
 		customerId,
 		productId: pro.id,
 	});
 
-	// Manual sync operation (simulates admin reconciliation)
-	await autumnV2_2.post("/v1/billing.sync_v2", {
+	// expire_previous so re-sync produces real plan_changes (activated + expired)
+	await autumnV1.post("/billing.sync_v2", {
 		customer_id: customerId,
-		plans: [
+		stripe_subscription_id: subscriptionId,
+		phases: [
 			{
-				plan_id: pro.id,
-				stripe_subscription_id: subscriptionId,
+				starts_at: "now",
+				plans: [{ plan_id: pro.id, expire_previous: true }],
 			},
 		],
-	});
+	} satisfies SyncParamsV1);
 
-	// Wait for the billing.updated webhook
 	const result = await waitForWebhook<BillingUpdatedPayload>({
 		token: playToken,
 		predicate: (payload) =>
 			payload.type === "billing.updated" &&
 			payload.data?.customer_id === customerId &&
-			(payload.data?.tags ?? []).includes("reconciled"),
+			(payload.data?.tags ?? []).includes("resync"),
 		timeoutMs: 15000,
 	});
 
 	expect(result).not.toBeNull();
 	const { data } = result!.payload;
-	
-	// Verify the webhook has the reconciled tag
-	expect(data.tags).toContain("reconciled");
-	
-	// Verify there's an activated change for the synced plan
-	const activated = findChange(data.plan_changes, {
-		action: "activated",
+
+	expect(data.tags).toContain("resync");
+
+	const updated = findChange(data.plan_changes, {
+		action: "updated",
 		planId: pro.id,
 	});
-	expect(activated).toBeDefined();
-	expect(activated?.subscription?.plan_id).toBe(pro.id);
+	expect(updated).toBeDefined();
+	expect(updated?.subscription?.plan_id).toBe(pro.id);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Manual sync operations (`billing.sync_v2`) were not emitting webhooks, causing downstream systems that depend on `billing.updated` webhooks to have stale state after admin reconciliation.

**Example scenario:**
1. Admin corrects customer mapping (swaps Stripe customer IDs)
2. Runs manual sync to pull subscription into correct Autumn customer
3. Autumn DB state is correct ✅
4. But downstream app never receives webhook ❌
5. App's local entitlement/provisioning state remains stale until manual workaround

## Solution

Emit `billing.updated` webhook after successful `billing.sync_v2` operations:

- Added `_internal` field to `syncV2` return value containing `autumnBillingPlan` and `fullCustomer`
- Handler emits webhook using this data, then strips `_internal` from API response
- Added `"reconciled"` tag to distinguish sync webhooks from normal operations
- Webhook emission is at **handler level**, not inside the action, avoiding double-emission on Stripe webhook auto-sync path

## Changes

### Core Implementation
- `server/src/internal/billing/v2/actions/sync/syncV2.ts` - Return billing plan & customer via `_internal`
- `server/src/internal/billing/v2/handlers/handleSyncV2.ts` - Emit webhook, strip `_internal` from response

### Testing
- `server/tests/integration/billing/autumn-webhooks/billing-updated/billing-updated-sync.test.ts` - Integration test verifying webhook emission with `"reconciled"` tag

## Testing Notes

The test verifies:
- `billing.updated` webhook fires after manual sync
- Webhook contains `"reconciled"` tag
- Payload includes activated plan change

**Stripe webhook dependency:** Test requires Svix/webhook infrastructure. If it fails locally due to webhook setup, it can be validated on a machine with proper Stripe/Svix configuration.

## Design Decisions

1. **v2 only** - Only implemented for `billing.sync_v2`, not legacy v0 sync (which has per-mapping complexity)
2. **Handler-level emission** - Prevents double-emission on Stripe webhook auto-sync paths
3. **"reconciled" tag** - Allows consumers to distinguish reconciliation from genuine billing changes
4. **Private `_internal` field** - Keeps API response clean while passing data to handler

## Related

This addresses the webhook gap identified in sync operations. The automatic back-sync from Stripe webhooks (`customer.subscription.updated`) already emits webhooks via a different path and is not affected by this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1783426870470469?thread_ts=1783426870.470469&cid=C0BCAQQK0KS)

<div><a href="https://cursor.com/agents/bc-b7cf5b2d-9570-55c6-a636-ca035ccc30b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7cf5b2d-9570-55c6-a636-ca035ccc30b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit `billing.updated` webhooks after manual `billing.sync_v2` runs so downstream apps update immediately. Webhooks are tagged `resync` to mark admin reconciliation.

- New Features
  - Make webhook emission opt-in in `syncV2` via a `webhook` param; the handler passes `tags: ["resync"]`, avoiding double-sends on Stripe auto-sync paths.
  - Call `sendBillingUpdatedWebhook` from `syncV2` using internal context (no `_internal` fields in the API response). Added an integration test verifying emission and the `resync` tag.

<sup>Written for commit 7e7a2c7d8d6b4299d9802932efc2123cefa52391. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `billing.updated` webhook emission to manual `billing.sync_v2` operations so downstream systems stay up-to-date after admin reconciliation. The implementation uses an opt-in `webhook` parameter on `syncV2` to prevent double-emission on the existing Stripe auto-sync paths, tags the emitted event with `"resync"` to distinguish it from organic billing changes, and includes an integration test exercising the full flow.

- **Improvements**: Adds `webhook?: { tags?: string[] }` opt-in parameter to `syncV2` — Stripe auto-sync callers pass nothing and are unaffected; the manual handler passes `{ tags: ["resync"] }`.
- **Improvements**: Emits `billing.updated` fire-and-forget (consistent with all other call sites in the codebase) using the established `sendBillingUpdatedWebhook` helper, with errors caught and logged internally.
- **API changes**: `billing.updated` webhook payloads from manual sync operations now include `"resync"` in the `tags` array, enabling consumers to differentiate reconciliation events from normal billing changes.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is additive, all existing Stripe auto-sync callers are unaffected, and errors are caught inside the webhook helper.

The core implementation is correct and consistent with how every other `sendBillingUpdatedWebhook` call site works in the codebase. The only wrinkle is that a no-op sync (subscription already in sync, zero plan changes) will still emit `billing.updated` with an empty `plan_changes` array because the `"resync"` tag alone satisfies the content gate — worth clarifying intent before shipping to consumers who key off that event.

syncV2.ts — the webhook emission block around line 82 warrants a quick review of the no-op-sync scenario.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/sync/syncV2.ts | Adds optional `webhook` param and fires `sendBillingUpdatedWebhook` fire-and-forget before returning; consistent with established codebase pattern and correctly guarded so auto-sync callers are unaffected. |
| server/src/internal/billing/v2/handlers/handleSyncV2.ts | Passes `webhook: { tags: ["resync"] }` to `syncV2`; minimal, correct one-line change at the handler layer. |
| server/tests/integration/billing/autumn-webhooks/billing-updated/billing-updated-sync.test.ts | New integration test exercises the full webhook-emission flow and correctly checks for `"resync"` tag and an `action: "updated"` plan change (which `collapseSamePlanIdPairs` produces from the activated+expired pair). Note: a no-op sync scenario is not covered. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Admin
    participant Handler as handleSyncV2
    participant Action as syncV2
    participant Webhook as sendBillingUpdatedWebhook
    participant Svix

    Admin->>Handler: POST /billing.sync_v2
    Handler->>Action: "syncV2({ ctx, params, webhook: { tags: ["resync"] } })"
    Action->>Action: setupSyncContext
    Action->>Action: computeSyncPlan
    Action->>Action: executeAutumnBillingPlan
    Action->>Action: persistCreateSchedule (if phases)
    Note over Action,Webhook: fire-and-forget (void)
    Action-->>Webhook: sendBillingUpdatedWebhook (async, not awaited)
    Action-->>Handler: SyncV2Result
    Handler-->>Admin: "200 { customer_id, ... }"
    Webhook->>Webhook: buildBillingChangeResponse (tags: ["resync"])
    Webhook->>Svix: sendSvixEvent billing.updated
    Svix-->>Admin App: billing.updated webhook (tags: ["resync"])
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Admin
    participant Handler as handleSyncV2
    participant Action as syncV2
    participant Webhook as sendBillingUpdatedWebhook
    participant Svix

    Admin->>Handler: POST /billing.sync_v2
    Handler->>Action: "syncV2({ ctx, params, webhook: { tags: ["resync"] } })"
    Action->>Action: setupSyncContext
    Action->>Action: computeSyncPlan
    Action->>Action: executeAutumnBillingPlan
    Action->>Action: persistCreateSchedule (if phases)
    Note over Action,Webhook: fire-and-forget (void)
    Action-->>Webhook: sendBillingUpdatedWebhook (async, not awaited)
    Action-->>Handler: SyncV2Result
    Handler-->>Admin: "200 { customer_id, ... }"
    Webhook->>Webhook: buildBillingChangeResponse (tags: ["resync"])
    Webhook->>Svix: sendSvixEvent billing.updated
    Svix-->>Admin App: billing.updated webhook (tags: ["resync"])
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/billing/v2/actions/sync/syncV2.ts:82-89
**No-op sync always fires webhook**

Because `tags: ["resync"]` is always present in the response, `billingChangeResponseHasContent` (which gates on `plan_changes.length > 0 || tags.length > 0`) will always return `true`. A sync that finds everything already in sync — zero insertions, zero updates — will still emit `billing.updated` with an empty `plan_changes: []`. Consumers that drive provisioning logic from `plan_changes` won't misfire, but those that use receipt of `billing.updated` as a signal that something changed may be surprised. Consider whether emitting only when `autumnBillingPlan` produced actual changes (non-empty `insertCustomerProducts` or `updateCustomerProducts`) is the right gate here, or document the "always-emit-on-reconcile" intent explicitly.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 clean up sloppy implementation"](https://github.com/useautumn/autumn/commit/7e7a2c7d8d6b4299d9802932efc2123cefa52391) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43013059)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->