### PR TITLE
fix: renewal edge case

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleStripeSubscriptionRenewed/isStripeSubscriptionRenewedEvent.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleStripeSubscriptionRenewed/isStripeSubscriptionRenewedEvent.ts
@@ -1,4 +1,5 @@
 import type { ExpandedStripeSubscription } from "@/external/stripe/subscriptions/operations/getExpandedStripeSubscription";
+import { isStripeSubscriptionCanceling } from "@/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils";
 import { notNullish, nullish } from "@/utils/genUtils";
 import type { SubscriptionPreviousAttributes } from "../../stripeSubscriptionUpdatedContext";
 
@@ -32,13 +33,18 @@ export const isStripeSubscriptionRenewedEvent = ({
 		notNullish(previousAttributes.cancel_at) &&
 		nullish(stripeSubscription.cancel_at);
 
-	// canceled_at was set (edge case)
+	// canceled_at was set, now cleared
 	const uncanceledAt =
 		notNullish(previousAttributes.canceled_at) &&
-		stripeSubscription.canceled_at;
+		nullish(stripeSubscription.canceled_at);
+
+	// Duplicate cancel calls can wiggle individual cancel fields (e.g. switch
+	// cancel_at_period_end to an explicit cancel_at) — never a renewal.
+	const stillCanceling = isStripeSubscriptionCanceling(stripeSubscription);
 
 	return {
-		renewed: !!(uncanceledAtPeriodEnd || uncancelAt || uncanceledAt),
+		renewed:
+			!stillCanceling && !!(uncanceledAtPeriodEnd || uncancelAt || uncanceledAt),
 		renewedAtMs: Date.now(),
 	};
 };

--- a/server/src/internal/admin/adminRouter.ts
+++ b/server/src/internal/admin/adminRouter.ts
@@ -10,6 +10,7 @@ import {
 	handleDeleteAdminOrgRedisConfig,
 	handleGetAdminOrgRedisConfig,
 	handleUpdateAdminOrgRedisMigration,
+	handleUpdateAdminOrgRedisPublicUrl,
 	handleUpsertAdminOrgRedisConfig,
 } from "./handleAdminOrgRedisConfig";
 import { handleGetAdminCustomerBlockConfig } from "./handleGetAdminCustomerBlockConfig";
@@ -79,6 +80,10 @@ honoAdminRouter.patch(
 honoAdminRouter.patch(
 	"/orgs/:org_id/redis/migration",
 	...handleUpdateAdminOrgRedisMigration,
+);
+honoAdminRouter.patch(
+	"/orgs/:org_id/redis/public-url",
+	...handleUpdateAdminOrgRedisPublicUrl,
 );
 honoAdminRouter.delete(
 	"/orgs/:org_id/redis",

--- a/server/src/internal/admin/handleAdminOrgRedisConfig.ts
+++ b/server/src/internal/admin/handleAdminOrgRedisConfig.ts
@@ -4,11 +4,23 @@ import { getOrgRedis, removeOrgRedis } from "@/external/redis/orgRedisPool.js";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { OrgService } from "@/internal/orgs/OrgService.js";
 import { clearOrgCache } from "@/internal/orgs/orgUtils/clearOrgCache.js";
-import { encryptData } from "@/utils/encryptUtils.js";
+import { decryptData, encryptData } from "@/utils/encryptUtils.js";
 
 const REDIS_PROTOCOLS = new Set(["redis:", "rediss:"]);
 
 const orgIdParam = z.object({ org_id: z.string().min(1) });
+
+/** Host of the encrypted public mirror, for display — never the credentials. */
+const publicHostForDisplay = (
+	publicConnectionString: string | undefined,
+): string | null => {
+	if (!publicConnectionString) return null;
+	try {
+		return new URL(decryptData(publicConnectionString)).host;
+	} catch {
+		return null;
+	}
+};
 
 /**
  * GET /admin/orgs/:org_id/redis
@@ -29,6 +41,9 @@ export const handleGetAdminOrgRedisConfig = createRoute({
 				? {
 						host: org.redis_config.url,
 						hasPublicUrl: Boolean(org.redis_config.publicConnectionString),
+						publicHost: publicHostForDisplay(
+							org.redis_config.publicConnectionString,
+						),
 						migrationPercent: org.redis_config.migrationPercent,
 						previousMigrationPercent: org.redis_config.previousMigrationPercent,
 						migrationChangedAt: org.redis_config.migrationChangedAt,
@@ -136,6 +151,75 @@ export const handleUpsertAdminOrgRedisConfig = createRoute({
 				`[admin/handleUpsertAdminOrgRedisConfig] org=${org.id}: redis_config created, url=${redisUrl.host}, actor=${ctx.user?.email ?? ctx.userId ?? "unknown"}`,
 			);
 		}
+
+		return c.json({ success: true });
+	},
+});
+
+/**
+ * PATCH /admin/orgs/:org_id/redis/public-url  body: { publicConnectionString }
+ * Set or update the public mirror on an existing config — the create route
+ * refuses once a config exists, and delete is blocked mid-migration.
+ */
+export const handleUpdateAdminOrgRedisPublicUrl = createRoute({
+	scopes: [Scopes.Superuser],
+	params: orgIdParam,
+	body: z.object({ publicConnectionString: z.string().min(1) }),
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { db, logger } = ctx;
+		const { org_id: orgId } = c.req.param();
+		const { publicConnectionString: rawPublicConnectionString } =
+			c.req.valid("json");
+		const publicConnectionString = rawPublicConnectionString.trim();
+
+		const org = await OrgService.get({ db, orgId });
+
+		if (!org.redis_config) {
+			throw new RecaseError({
+				message: "No Redis config set on this org. Connect one first.",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		let publicRedisUrl: URL;
+		try {
+			publicRedisUrl = new URL(publicConnectionString);
+		} catch {
+			throw new RecaseError({
+				message: "Invalid public connection string: could not parse URL",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+		if (!REDIS_PROTOCOLS.has(publicRedisUrl.protocol)) {
+			throw new RecaseError({
+				message:
+					"Invalid public connection string: expected redis:// or rediss://",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		await OrgService.update({
+			db,
+			orgId: org.id,
+			updates: {
+				redis_config: {
+					...org.redis_config,
+					publicConnectionString: encryptData(publicConnectionString),
+				},
+			},
+		});
+		await clearOrgCache({ db, orgId: org.id, env: ctx.env, logger });
+		// Pool keys on redis_config.url, which didn't change — evict so the next
+		// getOrgRedis re-resolves with the new public string.
+		removeOrgRedis({ orgId: org.id });
+
+		logger.info(
+			`[admin/handleUpdateAdminOrgRedisPublicUrl] org=${org.id}: public url set to ${publicRedisUrl.host}, actor=${ctx.user?.email ?? ctx.userId ?? "unknown"}`,
+		);
 
 		return c.json({ success: true });
 	},

--- a/server/src/internal/billing/v2/providers/stripe/utils/matchUtils/stripePriceShape.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/matchUtils/stripePriceShape.ts
@@ -5,7 +5,6 @@ type InlinePriceLike = {
 	product?: string;
 	currency?: string;
 	billing_scheme?: string;
-	tax_behavior?: string | null;
 	recurring?: {
 		interval?: string;
 		interval_count?: number;
@@ -30,7 +29,6 @@ export type StripePriceShape = {
 	product?: string;
 	currency?: string;
 	billingScheme?: string;
-	taxBehavior?: string | null;
 	interval?: string;
 	intervalCount?: number;
 	recurringUsageType?: string | null;
@@ -71,7 +69,8 @@ export const stripeShapeDecimalAmount = (
 	return new Decimal(amount).toString();
 };
 
-const taxBehavior = (value?: string | null) => value ?? "unspecified";
+// Stripe returns lowercase codes; org.default_currency may be uppercase.
+const currencyCode = (value?: string) => value?.toLowerCase();
 
 const transformQuantityKey = (
 	transformQuantity?: {
@@ -127,9 +126,8 @@ export const stripePriceToShape = ({
 	price: Stripe.Price;
 }): StripePriceShape => ({
 	product: stripeProductId(price.product),
-	currency: price.currency,
+	currency: currencyCode(price.currency),
 	billingScheme: price.billing_scheme ?? "per_unit",
-	taxBehavior: taxBehavior(price.tax_behavior),
 	interval: price.recurring?.interval,
 	intervalCount: price.recurring?.interval_count,
 	recurringUsageType: recurringUsageType(price.recurring?.usage_type),
@@ -152,9 +150,8 @@ export const inlinePriceToShape = ({
 	price: InlinePriceLike;
 }): StripePriceShape => ({
 	product: price.product,
-	currency: price.currency,
+	currency: currencyCode(price.currency),
 	billingScheme: price.billing_scheme ?? "per_unit",
-	taxBehavior: taxBehavior(price.tax_behavior),
 	interval: price.recurring?.interval,
 	intervalCount: price.recurring?.interval_count,
 	recurringUsageType: recurringUsageType(price.recurring?.usage_type),
@@ -223,6 +220,7 @@ const tiersEqual = ({
 	});
 };
 
+// Tax behavior is intentionally not compared: Autumn doesn't model tax on prices.
 export const stripePriceShapesEqual = (
 	left: StripePriceShape,
 	right: StripePriceShape,
@@ -230,7 +228,6 @@ export const stripePriceShapesEqual = (
 	left.product === right.product &&
 	left.currency === right.currency &&
 	left.billingScheme === right.billingScheme &&
-	left.taxBehavior === right.taxBehavior &&
 	left.interval === right.interval &&
 	left.intervalCount === right.intervalCount &&
 	left.recurringUsageType === right.recurringUsageType &&

--- a/server/src/internal/billing/v2/providers/stripe/utils/sync/matchUtils/stripePriceMatchesAutumnPrice.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/sync/matchUtils/stripePriceMatchesAutumnPrice.ts
@@ -37,7 +37,10 @@ export const stripePriceMatchesFixedPrice = ({
 	});
 	if (!autumnShape) return false;
 
-	return stripePriceShapesEqual(stripePriceToShape({ price: stripePrice }), autumnShape);
+	return stripePriceShapesEqual(
+		stripePriceToShape({ price: stripePrice }),
+		autumnShape,
+	);
 };
 
 export const findMatchingStripePriceForFixedPrice = ({
@@ -65,10 +68,13 @@ const stripeMeterId = ({
 }: {
 	recurring: Stripe.Price.Recurring | null;
 }) => {
-	const meter = (recurring as (Stripe.Price.Recurring & { meter?: unknown }) | null)
-		?.meter;
+	const meter = (
+		recurring as (Stripe.Price.Recurring & { meter?: unknown }) | null
+	)?.meter;
 	if (!meter) return null;
-	return typeof meter === "string" ? meter : ((meter as { id?: string }).id ?? null);
+	return typeof meter === "string"
+		? meter
+		: ((meter as { id?: string }).id ?? null);
 };
 
 export const stripePriceMatchesConsumablePrice = ({
@@ -103,7 +109,10 @@ export const stripePriceMatchesConsumablePrice = ({
 	});
 	if (!autumnShape) return false;
 
-	return stripePriceShapesEqual(stripePriceToShape({ price: stripePrice }), autumnShape);
+	return stripePriceShapesEqual(
+		stripePriceToShape({ price: stripePrice }),
+		autumnShape,
+	);
 };
 
 export const findMatchingStripePriceForConsumablePrice = ({
@@ -135,7 +144,9 @@ export const findMatchingStripePriceForConsumablePrice = ({
 	return matchedStripePrice
 		? {
 				stripePriceId: matchedStripePrice.id,
-				stripeMeterId: stripeMeterId({ recurring: matchedStripePrice.recurring }),
+				stripeMeterId: stripeMeterId({
+					recurring: matchedStripePrice.recurring,
+				}),
 			}
 		: null;
 };

--- a/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-duplicate-cancel.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-duplicate-cancel.test.ts
@@ -1,0 +1,120 @@
+/**
+ * TDD test: a duplicate cancel-at-period-end call must not clear the cancellation.
+ *
+ * When a subscription is already set to cancel at period end and another
+ * `cancel_at_period_end: true` update comes in, Stripe bumps `canceled_at` and
+ * fires `customer.subscription.updated` with previous_attributes containing only
+ * `canceled_at` — while the subscription is still canceling.
+ *
+ * Red-failure mode (pre-fix):
+ *  - isStripeSubscriptionRenewedEvent treated any change to `canceled_at` as an
+ *    un-cancellation, so the duplicate cancel cleared the customer product's
+ *    cancellation fields and deleted the scheduled default product.
+ *
+ * Green-success criteria (post-fix):
+ *  - Pro stays canceling, the scheduled default product stays scheduled, and the
+ *    Autumn subscription still shows canceled.
+ */
+
+import { test } from "bun:test";
+import type { ApiCustomerV3 } from "@autumn/shared";
+import {
+	expectProductActive,
+	expectProductCanceling,
+	expectProductScheduled,
+} from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { getSubscriptionId } from "@tests/integration/billing/utils/stripe/getSubscriptionId";
+import { expectSubToBeCorrect } from "@tests/merged/mergeUtils/expectSubCorrect";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { timeout } from "@/utils/genUtils";
+
+test.concurrent(`${chalk.yellowBright("sub.updated: duplicate cancel via Stripe CLI keeps product canceling")}`, async () => {
+	const customerId = "sub-updated-duplicate-cancel";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+
+	const free = products.base({
+		id: "free",
+		items: [messagesItem],
+		isDefault: true,
+	});
+
+	const pro = products.pro({
+		id: "pro",
+		items: [messagesItem],
+	});
+
+	const { autumnV1, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [free, pro] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	const customerAfterAttach =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductActive({
+		customer: customerAfterAttach,
+		productId: pro.id,
+	});
+
+	const subscriptionId = await getSubscriptionId({
+		ctx,
+		customerId,
+		productId: pro.id,
+	});
+
+	// Cancel via Stripe CLI (simulating external cancellation)
+	await ctx.stripeCli.subscriptions.update(subscriptionId, {
+		cancel_at_period_end: true,
+	});
+
+	await timeout(10000);
+
+	const customerAfterCancel =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductCanceling({
+		customer: customerAfterCancel,
+		productId: pro.id,
+	});
+	await expectProductScheduled({
+		customer: customerAfterCancel,
+		productId: free.id,
+	});
+
+	// Duplicate cancel: re-sending cancel_at_period_end is a Stripe no-op, but
+	// re-setting cancel_at to the same timestamp re-stamps canceled_at and fires
+	// sub.updated with previous_attributes containing only canceled_at.
+	const stripeSubscription =
+		await ctx.stripeCli.subscriptions.retrieve(subscriptionId);
+	await ctx.stripeCli.subscriptions.update(subscriptionId, {
+		cancel_at: stripeSubscription.cancel_at ?? undefined,
+	});
+
+	await timeout(10000);
+
+	// Cancellation must survive the duplicate event
+	const customerAfterDuplicate =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductCanceling({
+		customer: customerAfterDuplicate,
+		productId: pro.id,
+	});
+	await expectProductScheduled({
+		customer: customerAfterDuplicate,
+		productId: free.id,
+	});
+
+	await expectSubToBeCorrect({
+		db: ctx.db,
+		customerId,
+		org: ctx.org,
+		env: ctx.env,
+		shouldBeCanceled: true,
+	});
+});

--- a/server/tests/integration/crud/catalog/catalog-mapping-base-price-reuse.test.ts
+++ b/server/tests/integration/crud/catalog/catalog-mapping-base-price-reuse.test.ts
@@ -1,0 +1,120 @@
+/**
+ * TDD test: linking a Stripe product to a plan family (scope: base_price) must
+ * reuse matching existing Stripe prices for the base plan AND every variant,
+ * even when the Stripe prices carry tax_behavior (e.g. "exclusive").
+ *
+ * Red-failure mode (current behavior):
+ *  - stripePriceShapesEqual compares taxBehavior strictly; Autumn shapes never
+ *    set it ("unspecified"), so Stripe prices with tax_behavior "exclusive"
+ *    never match and config.stripe_price_id stays null on every fixed price.
+ *
+ * Green-success criteria (after fix):
+ *  - Base plan's $20/mo price links to the $20/mo Stripe price; the variant's
+ *    $35/mo price links to the $35/mo Stripe price.
+ */
+
+import { test } from "bun:test";
+import {
+	type ApiPlanV1,
+	ApiVersion,
+	BillingInterval,
+	type UpdatePlanParamsV2Input,
+} from "@autumn/shared";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { AutumnRpcCli } from "@/external/autumn/autumnRpcCli.js";
+import { createVariantPlan } from "../plans/variants/utils/variantTestPlanUtils.js";
+import {
+	createCatalogMappingProducts,
+	expectFixedStripePriceId,
+	expectPriceStripeProduct,
+	findBasePrice,
+	getPlanFamilyVersions,
+} from "./utils/catalogMappingTestUtils.js";
+
+type RpcUpdate = Omit<UpdatePlanParamsV2Input, "plan_id">;
+
+test.concurrent(
+	`${chalk.yellowBright("catalog mappings: base_price scope reuses tax-exclusive Stripe prices across variant family")}`,
+	async () => {
+		const planId = "catalog_mappings_base_reuse_tax";
+		const variantPlanId = `${planId}_35`;
+		// products.pro already includes a $20/mo base price
+		const product = products.pro({ id: planId, items: [] });
+
+		const { autumnV2_2, ctx } = await initScenario({
+			customerId: "catalog-mappings-base-reuse-tax",
+			setup: [],
+			actions: [],
+		});
+		await createCatalogMappingProducts({
+			ctx,
+			autumn: autumnV2_2,
+			products: [product],
+		});
+
+		const rpc = new AutumnRpcCli({
+			secretKey: ctx.orgSecretKey,
+			version: ApiVersion.V2_1,
+		});
+		await createVariantPlan({
+			rpc,
+			basePlanId: planId,
+			variantPlanId,
+			name: "Base Reuse Tax 35",
+		});
+		await rpc.plans.update<ApiPlanV1, RpcUpdate>(variantPlanId, {
+			price: { amount: 35, interval: BillingInterval.Month },
+			disable_version: true,
+		});
+
+		const stripeProduct = await ctx.stripeCli.products.create({
+			name: `Catalog mapping base reuse ${planId}`,
+		});
+		const stripePrice20 = await ctx.stripeCli.prices.create({
+			product: stripeProduct.id,
+			currency: "usd",
+			unit_amount: 2000,
+			recurring: { interval: "month" },
+			tax_behavior: "exclusive",
+		});
+		const stripePrice35 = await ctx.stripeCli.prices.create({
+			product: stripeProduct.id,
+			currency: "usd",
+			unit_amount: 3500,
+			recurring: { interval: "month" },
+			tax_behavior: "exclusive",
+		});
+
+		await autumnV2_2.post("/catalog.update_mappings", {
+			processor_type: "stripe",
+			plan_mappings: [
+				{
+					plan_id: planId,
+					stripe_product_id: stripeProduct.id,
+					scope: "base_price",
+					item_mappings: [],
+				},
+			],
+		});
+
+		const family = await getPlanFamilyVersions({ ctx, basePlanId: planId });
+		const expectedByPlanId: Record<string, string> = {
+			[planId]: stripePrice20.id,
+			[variantPlanId]: stripePrice35.id,
+		};
+
+		for (const version of family) {
+			const basePrice = findBasePrice(version.prices);
+			expectPriceStripeProduct({
+				price: basePrice,
+				stripeProductId: stripeProduct.id,
+			});
+			expectFixedStripePriceId({
+				price: basePrice,
+				stripePriceId: expectedByPlanId[version.id] ?? null,
+			});
+		}
+	},
+);

--- a/server/tests/unit/billing/stripe/match-utils/match-stripe-inline-price.spec.ts
+++ b/server/tests/unit/billing/stripe/match-utils/match-stripe-inline-price.spec.ts
@@ -66,13 +66,21 @@ describe("matchStripeInlinePrice", () => {
 		).toBe(true);
 	});
 
+	test("ignores tax behavior when matching", () => {
+		expect(
+			stripeInlinePriceMatchesStripePrice({
+				inlinePrice,
+				stripePrice: subscriptionItem({ taxBehavior: "exclusive" }).price,
+			}),
+		).toBe(true);
+	});
+
 	test("does not match non-inline-compatible Stripe prices", () => {
 		const incompatiblePrices = [
 			subscriptionItem({ billingScheme: "tiered", tiersMode: "graduated" }),
 			subscriptionItem({
 				transformQuantity: { divide_by: 10, round: "up" },
 			}),
-			subscriptionItem({ taxBehavior: "exclusive" }),
 		];
 
 		for (const item of incompatiblePrices) {

--- a/server/tests/unit/billing/stripe/match-utils/stripe-price-shape.spec.ts
+++ b/server/tests/unit/billing/stripe/match-utils/stripe-price-shape.spec.ts
@@ -123,7 +123,6 @@ describe("autumnConsumablePriceToStripePriceShape", () => {
 			product: "prod_messages",
 			currency: "usd",
 			billingScheme: "tiered",
-			taxBehavior: "unspecified",
 			interval: "month",
 			intervalCount: 1,
 			recurringUsageType: "metered",
@@ -340,5 +339,26 @@ describe("autumnBasePriceToStripePriceShape", () => {
 			billingScheme: "per_unit",
 			unitAmountDecimal: "2000",
 		});
+	});
+
+	test("matches a Stripe price when the org currency is uppercase", () => {
+		const autumnShape = autumnBasePriceToStripePriceShape({
+			price: fixedPrice(),
+			stripeProductId: "prod_base",
+			currency: "EUR",
+		});
+		const stripeShape = stripePriceToShape({
+			price: stripePrice({
+				product: "prod_base",
+				currency: "eur",
+				billingScheme: "per_unit",
+				tiersMode: null,
+				usageType: "licensed",
+				unitAmountDecimal: "2000",
+			}),
+		});
+
+		expect(autumnShape).not.toBeNull();
+		expect(stripePriceShapesEqual(autumnShape!, stripeShape)).toBe(true);
 	});
 });

--- a/vite/src/views/admin/components/OrgRedisConfigDialog.tsx
+++ b/vite/src/views/admin/components/OrgRedisConfigDialog.tsx
@@ -31,6 +31,7 @@ type AdminOrgRedisConfigResponse = {
 	redis_config: {
 		host: string;
 		hasPublicUrl: boolean;
+		publicHost: string | null;
 		migrationPercent: number;
 		previousMigrationPercent: number;
 		migrationChangedAt: number;
@@ -65,6 +66,7 @@ export function OrgRedisConfigDialog({
 
 	const [saving, setSaving] = useState(false);
 	const [updatingMigration, setUpdatingMigration] = useState(false);
+	const [savingPublicUrl, setSavingPublicUrl] = useState(false);
 	const [removing, setRemoving] = useState(false);
 
 	const { data, isLoading, isError, refetch } =
@@ -142,6 +144,23 @@ export function OrgRedisConfigDialog({
 		}
 	};
 
+	const handleUpdatePublicUrl = async () => {
+		if (!orgId || !publicConnectionString.trim()) return;
+		setSavingPublicUrl(true);
+		try {
+			await axiosInstance.patch(`/admin/orgs/${orgId}/redis/public-url`, {
+				publicConnectionString: publicConnectionString.trim(),
+			});
+			setPublicConnectionString("");
+			toast.success("Public URL updated");
+			await refreshAfterMutation();
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to update public URL"));
+		} finally {
+			setSavingPublicUrl(false);
+		}
+	};
+
 	const handleUpdateMigration = async () => {
 		if (!orgId) return;
 		const parsed = migrationPercentSchema.safeParse(migrationInput);
@@ -210,6 +229,32 @@ export function OrgRedisConfigDialog({
 									? "Configured — used off-AWS (local dev, trigger.dev)."
 									: "Not set — off-AWS callers fall back to the private URL, which may not be reachable."}
 							</span>
+							{cfg.publicHost && (
+								<Input
+									value={cfg.publicHost}
+									readOnly
+									className="font-mono text-xs"
+								/>
+							)}
+							<div className="flex items-center gap-2">
+								<Input
+									value={publicConnectionString}
+									onChange={(e) => setPublicConnectionString(e.target.value)}
+									placeholder="rediss://default:password@public-host:6379"
+									className="font-mono text-xs"
+								/>
+								<Button
+									variant="secondary"
+									disabled={savingPublicUrl || !publicConnectionString.trim()}
+									onClick={handleUpdatePublicUrl}
+								>
+									{savingPublicUrl
+										? "Saving…"
+										: cfg.hasPublicUrl
+											? "Update"
+											: "Set"}
+								</Button>
+							</div>
 						</div>
 
 						<div className="flex flex-col gap-1">


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a renewal edge case where duplicate Stripe cancels were misclassified as renewals, and improves Stripe price matching. Adds an admin endpoint and UI to set a Redis public URL.

- **Bug Fixes**
  - Stripe: duplicate cancel events no longer count as renewals by checking if the subscription is still canceling.
  - Stripe price matching: ignore `tax_behavior` and normalize currency to lowercase to reuse existing Stripe prices (base + variants).
  - Added tests for duplicate cancel handling and catalog mapping price reuse.

- **New Features**
  - Admin: `PATCH /admin/orgs/:org_id/redis/public-url` to set/update an encrypted public Redis connection string.
  - Admin UI: shows `publicHost`, allows setting/updating the public URL, and handles cache/pool invalidation.

<sup>Written for commit aea74bac4719921e50d9c086ae551e25e2bb577f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two independent billing correctness bugs and adds a new admin capability for managing the Redis public URL. Both bug fixes are accompanied by TDD integration tests that describe the red-failure mode before the fix.

- **[Bug fixes]** `isStripeSubscriptionRenewedEvent`: the old `uncanceledAt` condition checked `stripeSubscription.canceled_at` as a truthy value (meaning "still set") rather than checking it was cleared (`nullish()`), so a Stripe duplicate-cancel event that re-stamps `canceled_at` was misclassified as a renewal, wiping the cancellation state. A new `stillCanceling` guard short-circuits renewal detection when any cancel field is still active on the current subscription.
- **[Bug fixes]** `stripePriceShape`: `taxBehavior` was included in price-shape equality comparisons; Autumn never sets it, so Stripe prices carrying `tax_behavior: "exclusive"` never matched, breaking catalog mapping. Also adds currency normalisation to lowercase so org currencies stored as e.g. `"EUR"` match Stripe's `"eur"`.
- **[Improvements, API changes]** New superuser-only `PATCH /admin/orgs/:org_id/redis/public-url` endpoint lets operators set or replace the public Redis mirror URL on an existing config without having to delete and recreate the full config. The GET response also now exposes `publicHost` (host fragment only, credentials omitted) for display in the admin dialog.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — both bug fixes are targeted and well-isolated, and each is covered by a new integration test that demonstrates the broken behaviour before the change.

The renewal-detection fix corrects an inverted boolean check that was live in production (truthy guard instead of nullish guard), and the `stillCanceling` guard adds an explicit safety net for related duplicate-cancel variants. The tax-behavior and currency-case fixes are similarly narrow. The new admin Redis endpoint follows the same validation and encryption patterns as the existing upsert handler. No unguarded data paths or missing validations were found.

No files require special attention — all changed paths are well-scoped and covered by new tests.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleStripeSubscriptionRenewed/isStripeSubscriptionRenewedEvent.ts | Core bug fix: `uncanceledAt` previously performed a truthy check on `stripeSubscription.canceled_at` (detecting it was still set) rather than checking it was cleared; now uses `nullish()`. A new `stillCanceling` guard short-circuits renewal detection whenever any cancel field is still active. |
| server/src/internal/billing/v2/providers/stripe/utils/matchUtils/stripePriceShape.ts | Removes `taxBehavior` from shape comparison (Autumn doesn't model tax) and adds `currencyCode()` normaliser that lowercases currency strings to prevent mismatch when org currency is stored uppercase. |
| server/src/internal/admin/handleAdminOrgRedisConfig.ts | Adds `handleUpdateAdminOrgRedisPublicUrl` (PATCH /admin/orgs/:org_id/redis/public-url) and `publicHostForDisplay` helper; the GET response now includes `publicHost` (decrypted host-only for display). Connection string is validated, encrypted before storage, and the Redis pool is evicted so the next request re-resolves. |
| server/src/internal/admin/adminRouter.ts | Wires the new `PATCH /orgs/:org_id/redis/public-url` route into the admin Hono router. |
| vite/src/views/admin/components/OrgRedisConfigDialog.tsx | Adds `publicHost` display (read-only input showing current host) and an update-public-URL input + button wired to the new PATCH endpoint; shares the existing `publicConnectionString` state which is cleared on dialog open. |
| server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-duplicate-cancel.test.ts | New integration test that verifies a duplicate `cancel_at_period_end` call (which re-stamps `canceled_at` in Stripe) keeps the Autumn product in canceling state and does not remove the scheduled default product. |
| server/tests/integration/crud/catalog/catalog-mapping-base-price-reuse.test.ts | New integration test covering catalog mapping with tax-exclusive Stripe prices; verifies that base plan and variant Stripe price IDs are correctly linked after removing tax_behavior from comparison. |
| server/src/internal/billing/v2/providers/stripe/utils/sync/matchUtils/stripePriceMatchesAutumnPrice.ts | Formatting-only changes (line wraps for long lines); no logic changes. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Stripe customer.subscription.updated webhook] --> B{previousAttributes present?}
    B -- No --> Z[renewed: false]
    B -- Yes --> C[Compute uncanceledAtPeriodEnd\nuncancelAt\nuncanceledAt]

    C --> D{stillCanceling?\ncanceled_at OR cancel_at\nOR cancel_at_period_end set}
    D -- Yes --> Z
    D -- No --> E{Any un-cancel\ncondition true?}
    E -- No --> Z
    E -- Yes --> F[renewed: true\nTrigger renewal flow]

    subgraph Bug before fix
        BUG[uncanceledAt = notNullish prev.canceled_at\n AND stripeSubscription.canceled_at\n truthy fires on duplicate cancel]
    end

    subgraph Fix after
        FIX[uncanceledAt = notNullish prev.canceled_at\n AND nullish stripeSubscription.canceled_at\n only fires when canceled_at cleared]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Stripe customer.subscription.updated webhook] --> B{previousAttributes present?}
    B -- No --> Z[renewed: false]
    B -- Yes --> C[Compute uncanceledAtPeriodEnd\nuncancelAt\nuncanceledAt]

    C --> D{stillCanceling?\ncanceled_at OR cancel_at\nOR cancel_at_period_end set}
    D -- Yes --> Z
    D -- No --> E{Any un-cancel\ncondition true?}
    E -- No --> Z
    E -- Yes --> F[renewed: true\nTrigger renewal flow]

    subgraph Bug before fix
        BUG[uncanceledAt = notNullish prev.canceled_at\n AND stripeSubscription.canceled_at\n truthy fires on duplicate cancel]
    end

    subgraph Fix after
        FIX[uncanceledAt = notNullish prev.canceled_at\n AND nullish stripeSubscription.canceled_at\n only fires when canceled_at cleared]
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: renewal edge case"](https://github.com/useautumn/autumn/commit/aea74bac4719921e50d9c086ae551e25e2bb577f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43004215)</sub>

<!-- /greptile_comment -->