### PR TITLE
feat: allow expiry on free recurring balances + expires_at dashboard tweaks

### DIFF
--- a/server/src/internal/balances/updateBalance/updateExpiresAt.ts
+++ b/server/src/internal/balances/updateBalance/updateExpiresAt.ts
@@ -3,6 +3,7 @@ import {
 	EntInterval,
 	type FullCustomer,
 	fullCustomerToCustomerEntitlements,
+	isPaidCustomerEntitlement,
 	notNullish,
 	orgToInStatuses,
 	RecaseError,
@@ -56,15 +57,16 @@ export const updateExpiresAt = async ({
 
 	const targetCusEnt = sorted[0];
 
-	// expires_at only makes sense on one-off balances (loose grants and one-off
-	// prepaid top-ups). Recurring balances reset each cycle — expiry belongs at
-	// the plan level (trial / ends_at) — and usage-based/arrear balances are
-	// recurring, so this guard covers them too. A null interval is treated as
-	// one-off (loose).
+	// Only paid recurring balances are off-limits: their lifetime follows the
+	// billing cycle, so expiry belongs at the plan level (trial / ends_at).
+	// Free grants (recurring OR one-off) and one-off prepaid top-ups are fine —
+	// e.g. "100 credits/month for 6 months" is a free recurring grant that the
+	// reset cron keeps refilling until it expires. A null interval is one-off.
 	const interval = targetCusEnt.entitlement.interval;
-	if (notNullish(interval) && interval !== EntInterval.Lifetime) {
+	const isRecurring = notNullish(interval) && interval !== EntInterval.Lifetime;
+	if (isRecurring && isPaidCustomerEntitlement(targetCusEnt)) {
 		throw new RecaseError({
-			message: `expires_at can only be set on one-off balances, not recurring balances (feature ${targetCusEnt.entitlement.feature.id})`,
+			message: `expires_at cannot be set on a paid recurring balance (feature ${targetCusEnt.entitlement.feature.id}); its lifetime follows the billing cycle`,
 			statusCode: 400,
 		});
 	}

--- a/server/src/internal/balances/updateBalance/v2/updateExpiresAtV2.ts
+++ b/server/src/internal/balances/updateBalance/v2/updateExpiresAtV2.ts
@@ -3,6 +3,7 @@ import {
 	EntInterval,
 	type FullSubject,
 	fullSubjectToCustomerEntitlements,
+	isPaidCustomerEntitlement,
 	notNullish,
 	orgToInStatuses,
 	RecaseError,
@@ -52,15 +53,16 @@ export const updateExpiresAtV2 = async ({
 
 	const targetCusEnt = sorted[0];
 
-	// expires_at only makes sense on one-off balances (loose grants and one-off
-	// prepaid top-ups). Recurring balances reset each cycle — expiry belongs at
-	// the plan level (trial / ends_at) — and usage-based/arrear balances are
-	// recurring, so this guard covers them too. A null interval is treated as
-	// one-off (loose).
+	// Only paid recurring balances are off-limits: their lifetime follows the
+	// billing cycle, so expiry belongs at the plan level (trial / ends_at).
+	// Free grants (recurring OR one-off) and one-off prepaid top-ups are fine —
+	// e.g. "100 credits/month for 6 months" is a free recurring grant that the
+	// reset cron keeps refilling until it expires. A null interval is one-off.
 	const interval = targetCusEnt.entitlement.interval;
-	if (notNullish(interval) && interval !== EntInterval.Lifetime) {
+	const isRecurring = notNullish(interval) && interval !== EntInterval.Lifetime;
+	if (isRecurring && isPaidCustomerEntitlement(targetCusEnt)) {
 		throw new RecaseError({
-			message: `expires_at can only be set on one-off balances, not recurring balances (feature ${targetCusEnt.entitlement.feature.id})`,
+			message: `expires_at cannot be set on a paid recurring balance (feature ${targetCusEnt.entitlement.feature.id}); its lifetime follows the billing cycle`,
 			statusCode: 400,
 		});
 	}

--- a/server/tests/integration/balances/update/expires-at/update-expires-at.test.ts
+++ b/server/tests/integration/balances/update/expires-at/update-expires-at.test.ts
@@ -15,8 +15,9 @@
  *   Validation:
  *     - a non-future expires_at (<= now) is rejected, since it would instantly
  *       filter the balance out of the customer's active entitlements.
- *     - expires_at is only allowed on one-off balances; setting it on a
- *       recurring (resetting) balance is rejected.
+ *     - expires_at is allowed on free grants (recurring or one-off) and one-off
+ *       prepaid top-ups; it is rejected only on paid recurring balances, whose
+ *       lifetime follows the billing cycle.
  *   Side effects:
  *     - customer_entitlements.expires_at updated for the targeted row; the
  *       change is visible via check.balance.breakdown[n].expires_at on both the
@@ -214,13 +215,13 @@ test.concurrent(
 );
 
 // ═══════════════════════════════════════════════════════════════════
-// UPDATE-EXPIRES-AT-4: expires_at is rejected on a recurring balance
-// Only one-off balances (loose grants / one-off top-ups) may expire;
-// a resetting monthly balance's expiry belongs at the plan level.
+// UPDATE-EXPIRES-AT-4: expires_at IS allowed on a FREE recurring balance
+// e.g. "100 credits/month for 6 months" — the reset cron keeps refilling
+// the grant each cycle until the expiry date filters it out.
 // ═══════════════════════════════════════════════════════════════════
 
 test.concurrent(
-	`${chalk.yellowBright("update-expires-at-4: expires_at rejected on recurring balance")}`,
+	`${chalk.yellowBright("update-expires-at-4: expires_at allowed on free recurring balance")}`,
 	async () => {
 		const customerId = "update-expires-at-4";
 		const monthlyProd = products.base({
@@ -237,23 +238,107 @@ test.concurrent(
 			actions: [s.attach({ productId: monthlyProd.id })],
 		});
 
+		const expiresAt = Date.now() + ms.days(180);
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			expires_at: expiresAt,
+		});
+
+		const check = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		// Expiry is set, and the balance still recurs (untouched) until then.
+		expect(check.balance?.breakdown?.[0].expires_at).toBeCloseTo(expiresAt, -3);
+		expect(check.balance?.breakdown?.[0].current_balance).toBe(100);
+		expect(check.balance?.breakdown?.[0].reset?.interval).toBe(
+			ResetInterval.Month,
+		);
+
+		// DB sync (skip_cache) agrees.
+		const checkFromDb = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(checkFromDb.balance?.breakdown?.[0].expires_at).toBeCloseTo(
+			expiresAt,
+			-3,
+		);
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// UPDATE-EXPIRES-AT-6: expires_at is rejected on a PAID recurring balance
+// A prepaid (purchased) recurring balance's lifetime follows the billing
+// cycle, so it cannot be given an ad-hoc expiry.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("update-expires-at-6: expires_at rejected on paid recurring balance")}`,
+	async () => {
+		const customerId = "update-expires-at-6";
+		const freeProd = products.base({
+			id: "free-base",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const prepaidProd = products.base({
+			id: "prepaid-addon",
+			items: [
+				items.prepaidMessages({ includedUsage: 0, price: 1, billingUnits: 1 }),
+			],
+			isAddOn: true,
+		});
+
+		const { autumnV2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [freeProd, prepaidProd] }),
+			],
+			actions: [
+				s.attach({ productId: freeProd.id }),
+				s.attach({
+					productId: prepaidProd.id,
+					options: [{ feature_id: TestFeature.Messages, quantity: 200 }],
+				}),
+			],
+		});
+
+		// Wait for Stripe webhooks.
+		await new Promise((resolve) => setTimeout(resolve, 3000));
+
+		const initialCheck = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		// The paid (prepaid) breakdown is the one carrying purchased balance.
+		const prepaidBreakdown = initialCheck.balance?.breakdown?.find(
+			(b) => (b.purchased_balance ?? 0) > 0,
+		);
+		expect(prepaidBreakdown).toBeTruthy();
+		const prepaidCusEntId = prepaidBreakdown?.id ?? "";
+
 		await expectAutumnError({
 			func: async () => {
 				await autumnV2.balances.update({
 					customer_id: customerId,
 					feature_id: TestFeature.Messages,
+					balance_id: prepaidCusEntId,
 					expires_at: Date.now() + ms.days(30),
 				});
 			},
 		});
 
-		// Balance still present and unexpired.
 		const check = await autumnV2.check<CheckResponseV2>({
 			customer_id: customerId,
 			feature_id: TestFeature.Messages,
 		});
-		expect(check.balance?.breakdown?.[0].expires_at ?? null).toBeNull();
-		expect(check.balance?.current_balance).toBe(100);
+		const prepaidAfter = check.balance?.breakdown?.find(
+			(b) => b.id === prepaidCusEntId,
+		);
+		expect(prepaidAfter?.expires_at ?? null).toBeNull();
 	},
 );
 

--- a/vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
@@ -7,7 +7,6 @@ import {
 	type FullCustomerEntitlement,
 	type FullCustomerPrice,
 	getRolloverFields,
-	isPayPerUsePrice,
 	isUnlimitedCusEnt,
 	numberWithCommas,
 } from "@autumn/shared";
@@ -416,17 +415,17 @@ function SetBalanceFields({
 	const balance = useStore(form.store, (s) => s.values.balance);
 	const gpb = useStore(form.store, (s) => s.values.grantedAndPurchasedBalance);
 
-	// Mirror the backend guard (updateExpiresAt): expires_at is only valid on
-	// one-off balances (loose grants / one-off top-ups). Recurring balances
-	// reset each cycle — expiry belongs at the plan level (trial / ends_at) —
-	// and usage-based (pay-per-use) meters shouldn't expire.
+	// Mirror the backend guard (updateExpiresAt): only paid recurring balances
+	// can't expire (their lifetime follows the billing cycle). Free grants —
+	// recurring or one-off — and one-off prepaid top-ups are all fine.
 	const interval = selectedCusEnt.entitlement.interval;
 	const isRecurringBalance =
 		notNullish(interval) && interval !== EntInterval.Lifetime;
-	const isUsageBasedBalance = cusPrice
-		? isPayPerUsePrice({ price: cusPrice.price })
-		: false;
-	const expiresAtDisabled = isRecurringBalance || isUsageBasedBalance;
+	const isPaidBalance = !!cusPrice;
+	const expiresAtDisabled = isRecurringBalance && isPaidBalance;
+	// Setting a brand-new expiry is a rare, API-only flow — only surface the
+	// field in the dashboard when the balance already has one (to view/edit/clear).
+	const showExpiresAt = notNullish(selectedCusEnt.expires_at);
 
 	return (
 		<div className="flex flex-col gap-3">
@@ -491,34 +490,37 @@ function SetBalanceFields({
 				</form.Field>
 			</div>
 
-			<div className="flex flex-col shrink-0 w-full">
-				<div className="text-form-label block mb-1">Expires At</div>
-				<form.Field name="expiresAt">
-					{(field) => (
-						<DateInputUnix
-							disabled={expiresAtDisabled}
-							unixDate={field.state.value}
-							setUnixDate={(v) => field.handleChange(v)}
-							withTime
-							use24Hour
-						/>
-					)}
-				</form.Field>
-				{expiresAtDisabled && (
-					<div className="text-subtle text-xs mt-1">
-						{isUsageBasedBalance
-							? "Usage-based balances can't be set to expire."
-							: "Only one-off balances can be set to expire."}
-					</div>
-				)}
-			</div>
-
+			{/* Reset-related notes (e.g. "Lifetime balances have no reset date")
+			    pertain to Next Reset, so they sit directly under it. */}
 			<BalanceEditPreviews
 				cusPrice={cusPrice}
 				interval={selectedCusEnt.entitlement.interval}
 				featureUsageType={feature.config?.usage_type}
 				currentBalance={balance}
 			/>
+
+			{showExpiresAt && (
+				<div className="flex flex-col shrink-0 w-full">
+					<div className="text-form-label block mb-1">Expires At</div>
+					<form.Field name="expiresAt">
+						{(field) => (
+							<DateInputUnix
+								disabled={expiresAtDisabled}
+								unixDate={field.state.value}
+								setUnixDate={(v) => field.handleChange(v)}
+								withTime
+								use24Hour
+							/>
+						)}
+					</form.Field>
+					{expiresAtDisabled && (
+						<div className="text-subtle text-xs mt-1">
+							Paid recurring balances follow the billing cycle and can't be set
+							to expire.
+						</div>
+					)}
+				</div>
+			)}
 		</div>
 	);
 }


### PR DESCRIPTION
Follow-up to the merged \`expires_at\` on \`balances.update\` work.

## Policy change

Previously \`expires_at\` was blocked on **all** recurring balances. Now it's blocked only on **paid recurring** balances (prepaid / usage-based), whose lifetime follows the billing cycle. **Free** grants — recurring *or* one-off — and one-off prepaid top-ups can now expire.

This enables e.g. *"100 credits/month for the next 6 months, then nothing"*: a free recurring grant the reset cron keeps refilling until the expiry date filters it out. Enforced on both the V1 and V2 (rollout) paths via \`isPaidCustomerEntitlement\`.

## Dashboard tweaks

- Moved the reset-related callouts (e.g. "Lifetime balances have no reset date") **above** the Expires At field — they pertain to Next Reset, not expiry.
- The Expires At picker is now only shown when the balance **already has** an expiry value. Setting a brand-new expiry is a rare, API-first flow; keeping it out of the sheet reduces clutter.
- Disable logic updated to match the backend (only paid recurring is disabled).

## Tests

\`update-expires-at\` now 6, all green: raw \`cus_ent_\` id, external id, past-date rejected, **free recurring allowed**, one-off top-up alongside a recurring grant, and **paid recurring rejected**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows setting expires_at on free recurring balances and one-off prepaid top-ups, while keeping it blocked on paid recurring balances. Also simplifies the dashboard Expires At UI to match the backend rules.

- **New Features**
  - Backend: Restrict the block to paid recurring balances via isPaidCustomerEntitlement on both V1 and V2; supports time-limited free recurring grants (e.g., 100 credits/month for 6 months).
  - Dashboard: Move reset-related notes above Expires At; hide the picker unless an expiry already exists; disable only for paid recurring.
  - Tests: Add cases for free recurring allowed, paid recurring rejected, past-date rejection, and mixed balances.

<sup>Written for commit 457b0eddcf520c35b5e4605689993443eb778569. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR relaxes the `expires_at` restriction on recurring balances: previously blocked for all recurring balances, it is now blocked only for **paid** recurring balances (whose lifetime is tied to the billing cycle). Free recurring grants and one-off top-ups may now carry an `expires_at`, enabling patterns like "100 credits/month for the next 6 months."

- **[Improvements] Backend (V1 + V2):** `updateExpiresAt` / `updateExpiresAtV2` now gate on `isRecurring && isPaidCustomerEntitlement(targetCusEnt)` instead of `isRecurring` alone, using the existing shared `isPaidCustomerEntitlement` utility consistently across both paths.
- **[Improvements] Dashboard (`BalanceEditSheet`):** Disable logic updated to mirror the backend (only paid-recurring disables the picker); `Expires At` field is now hidden when no expiry exists, keeping the sheet uncluttered for the common case; `BalanceEditPreviews` callouts moved above the Expires At field where they belong.
- **[Improvements] Tests:** Suite expanded to 6 cases — free recurring allowed (test 4 renamed), paid recurring rejected (new test 6), one-off top-up alongside a recurring grant (test 5).
</details>


<h3>Confidence Score: 4/5</h3>

The core change is a deliberate relaxation of a validation guard, is well-tested with targeted integration cases, and the dashboard mirrors the backend logic correctly.

Both backend files make an identical, symmetric change covered by new integration tests including positive (free recurring allowed) and negative (paid recurring rejected) cases. The frontend disable logic correctly maps to the backend predicate. The only observations are a stale comment in test 5 and a hardcoded 3-second sleep in test 6 that could be flaky on slow CI. Neither affects runtime correctness.

The test file warrants a quick pass to fix the stale comment in test 5 and the hardcoded 3-second Stripe wait in test 6.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/updateBalance/updateExpiresAt.ts | Guard relaxed from 'any recurring' to 'paid recurring only' via isPaidCustomerEntitlement; logic is clean and mirrors the V2 path exactly. |
| server/src/internal/balances/updateBalance/v2/updateExpiresAtV2.ts | V2 rollout path updated identically to V1; change is a one-for-one mirror with no functional divergence. |
| server/tests/integration/balances/update/expires-at/update-expires-at.test.ts | Tests expanded to 6 cases covering all new policy paths; test 5's 'cannot itself be expired' comment is now stale after the policy change, and test 6 uses a fixed 3-second sleep for Stripe webhooks. |
| vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx | Dashboard disable logic updated to match backend (only paid+recurring disables), and Expires At field is conditionally hidden when no expiry exists; unused isPayPerUsePrice import removed. |


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[balances.update with expires_at] --> B{Balance found?}
    B -- No --> E[404 Not Found]
    B -- Yes --> C{isRecurring?\nnon-null interval\n!= Lifetime}
    C -- No\none-off --> G[Set expires_at]
    C -- Yes --> D{isPaidCustomerEntitlement?\ncusPrice != null}
    D -- Yes\npaid recurring --> F[400 Rejected\nlifetime follows billing cycle]
    D -- No\nfree recurring --> G
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[balances.update with expires_at] --> B{Balance found?}
    B -- No --> E[404 Not Found]
    B -- Yes --> C{isRecurring?\nnon-null interval\n!= Lifetime}
    C -- No\none-off --> G[Set expires_at]
    C -- Yes --> D{isPaidCustomerEntitlement?\ncusPrice != null}
    D -- Yes\npaid recurring --> F[400 Rejected\nlifetime follows billing cycle]
    D -- No\nfree recurring --> G
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/tests/integration/balances/update/expires-at/update-expires-at.test.ts`, line 404-408 ([link](https://github.com/useautumn/autumn/blob/457b0eddcf520c35b5e4605689993443eb778569/server/tests/integration/balances/update/expires-at/update-expires-at.test.ts#L404-L408)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale "cannot be expired" comment after policy change**

   The inline comment "The recurring grant is unaffected and **cannot itself be expired**" was accurate under the old policy but is now incorrect. After this PR, free recurring grants *can* be expired (proven by the new test 4). A future reader will conclude from this comment that monthly free balances are always unexpirable, which directly contradicts the new behaviour this PR introduces.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/tests/integration/balances/update/expires-at/update-expires-at.test.ts
   Line: 404-408

   Comment:
   **Stale "cannot be expired" comment after policy change**

   The inline comment "The recurring grant is unaffected and **cannot itself be expired**" was accurate under the old policy but is now incorrect. After this PR, free recurring grants *can* be expired (proven by the new test 4). A future reader will conclude from this comment that monthly free balances are always unexpirable, which directly contradicts the new behaviour this PR introduces.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/tests/integration/balances/update/expires-at/update-expires-at.test.ts:404-408
**Stale "cannot be expired" comment after policy change**

The inline comment "The recurring grant is unaffected and **cannot itself be expired**" was accurate under the old policy but is now incorrect. After this PR, free recurring grants *can* be expired (proven by the new test 4). A future reader will conclude from this comment that monthly free balances are always unexpirable, which directly contradicts the new behaviour this PR introduces.

### Issue 2 of 2
server/tests/integration/balances/update/expires-at/update-expires-at.test.ts:282-283
**Hardcoded sleep for Stripe webhook propagation**

`await new Promise((resolve) => setTimeout(resolve, 3000))` is a fixed 3-second pause waiting for Stripe webhooks to arrive. On a slow or busy CI runner the window may not be enough, making this test flaky. If the test harness already provides a utility to poll until Stripe events are processed (as appears to be the case elsewhere in the suite), using that would be more robust.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: allow expiry on free recurring bal..."](https://github.com/useautumn/autumn/commit/457b0eddcf520c35b5e4605689993443eb778569) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43008337)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->