### PR TITLE
Add CI retry logic for bun segfault failures in server unit tests

### DIFF
--- a/.github/workflows/server-unit-tests.yml
+++ b/.github/workflows/server-unit-tests.yml
@@ -45,5 +45,44 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run unit tests
-        run: bun test --isolate tests/unit
+        run: |
+          set +e
+          ATTEMPT=1
+          MAX_ATTEMPTS=2
+          
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+            echo "Attempt $ATTEMPT of $MAX_ATTEMPTS..."
+            
+            # Run the test and capture output
+            OUTPUT=$(bun test --isolate tests/unit 2>&1)
+            EXIT_CODE=$?
+            
+            # Print the output
+            echo "$OUTPUT"
+            
+            # Check if the test passed
+            if [ $EXIT_CODE -eq 0 ]; then
+              echo "Tests passed!"
+              exit 0
+            fi
+            
+            # Check if the failure was due to a segfault
+            if echo "$OUTPUT" | grep -iq "segmentation fault\|Segmentation fault\|bun:.*SIGSEGV\|core dumped"; then
+              if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+                echo "Detected bun segfault. Retrying..."
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep 2
+                continue
+              else
+                echo "Detected bun segfault on final attempt. Failing."
+                exit $EXIT_CODE
+              fi
+            else
+              # Non-segfault failure, exit immediately
+              echo "Test failure (not a segfault). Exit code: $EXIT_CODE"
+              exit $EXIT_CODE
+            fi
+          done
+          
+          exit 1
         working-directory: server


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR adds automatic retry logic to the server unit tests CI workflow to handle intermittent bun segfault failures.

## Changes

- Modified `.github/workflows/server-unit-tests.yml` to include retry logic
- Detects segfault failures by scanning test output for common patterns:
  - `segmentation fault`
  - `Segmentation fault`
  - `bun:.*SIGSEGV`
  - `core dumped`
- Retries **up to 1 time** (2 total attempts) when a segfault is detected
- **Non-segfault test failures are not retried** and fail immediately
- Adds clear logging for retry attempts

## Behavior

1. **First attempt** runs the test suite
2. **If tests pass**: Job succeeds immediately
3. **If tests fail with segfault**: Retry once after a 2-second delay
4. **If tests fail without segfault**: Job fails immediately (no retry)
5. **If second attempt also fails**: Job fails regardless of failure type

## Rationale

Bun occasionally has segfault issues that are transient in nature. Re-running the job typically resolves the issue. This change automates the retry process while ensuring that legitimate test failures are not masked by unnecessary retries.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1783605075216519?thread_ts=1783605075.216519&cid=C0BCAQQK0KS)

<div><a href="https://cursor.com/agents/bc-b8a25491-c060-5d3d-98a9-7149b5ce7573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8a25491-c060-5d3d-98a9-7149b5ce7573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automatic retry to the server unit tests CI to handle intermittent `bun` segfaults. This reduces flaky failures without retrying real test failures.

- **Bug Fixes**
  - Detects segfault patterns in `bun test` output and retries once after a 2s delay; otherwise fails.
  - Skips retries for non-segfault failures and prints clear retry logs.

<sup>Written for commit fb8b61c34dd22481fabda8fdd8efbd26bc95cd56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

