### PR TITLE
fix(billing): apply manual tax_rate_id to one-time and deferred charges

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
@@ -25,9 +25,8 @@ const stripeDiscountsToInvoiceParams = ({
 	stripeDiscounts: StripeDiscountWithCoupon[];
 }): Stripe.InvoiceCreateParams["discounts"] => {
 	return stripeDiscounts
-		.filter(
-			(discount): discount is StripeDiscountWithCoupon & { id: string } =>
-				Boolean(discount.id),
+		.filter((discount): discount is StripeDiscountWithCoupon & { id: string } =>
+			Boolean(discount.id),
 		)
 		.map((discount) => ({ discount: discount.id }));
 };
@@ -108,6 +107,9 @@ export const createInvoiceForBilling = async ({
 		metadata: invoiceMetadata,
 		discounts: invoiceDiscounts,
 		automaticTax: wantsAutoTax,
+		defaultTaxRates: billingContext.taxRateId
+			? [billingContext.taxRateId]
+			: undefined,
 	});
 
 	const invoiceWithLines = await addStripeInvoiceLines({

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/stripeInvoiceOps.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/stripeInvoiceOps.ts
@@ -18,6 +18,7 @@ type CreateInvoiceParams = {
 	footer?: string;
 	metadata?: Stripe.InvoiceCreateParams["metadata"];
 	automaticTax?: boolean;
+	defaultTaxRates?: string[];
 };
 
 export const createStripeInvoice = async ({
@@ -32,7 +33,10 @@ export const createStripeInvoice = async ({
 	metadata,
 	discounts,
 	automaticTax,
+	defaultTaxRates,
 }: CreateInvoiceParams): Promise<Stripe.Invoice> => {
+	// Stripe rejects default_tax_rates alongside automatic_tax; a manual rate takes precedence.
+	const hasManualTaxRates = Boolean(defaultTaxRates?.length);
 	const invoice = await stripeCli.invoices.create({
 		customer: stripeCusId,
 		auto_advance: false,
@@ -45,7 +49,10 @@ export const createStripeInvoice = async ({
 		days_until_due:
 			collectionMethod === "send_invoice" ? (daysUntilDue ?? 30) : undefined,
 		...(discounts ? { discounts } : {}),
-		...(automaticTax ? { automatic_tax: { enabled: true } } : {}),
+		...(hasManualTaxRates ? { default_tax_rates: defaultTaxRates } : {}),
+		...(automaticTax && !hasManualTaxRates
+			? { automatic_tax: { enabled: true } }
+			: {}),
 	});
 
 	return invoice;

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/customerProductsToPhaseInvoiceItems.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/customerProductsToPhaseInvoiceItems.ts
@@ -28,6 +28,12 @@ export const customerProductsToPhaseInvoiceItems = ({
 	const addInvoiceItems: Stripe.SubscriptionScheduleUpdateParams.Phase.AddInvoiceItem[] =
 		[];
 
+	// One-off items don't inherit the subscription's default_tax_rates, so a manual
+	// rate must be set per item or the deferred charge is billed untaxed.
+	const taxRates = billingContext.taxRateId
+		? [billingContext.taxRateId]
+		: undefined;
+
 	for (const customerProduct of customerProducts) {
 		const productStartsAt = customerProduct.starts_at;
 		const startsInThisPhase =
@@ -43,7 +49,12 @@ export const customerProductsToPhaseInvoiceItems = ({
 
 		for (const item of oneOffItems) {
 			if (item.quantity !== undefined && item.quantity <= 0) continue;
-			addInvoiceItems.push(stripeItemSpecToPhaseAddInvoiceItem({ spec: item }));
+			const addInvoiceItem = stripeItemSpecToPhaseAddInvoiceItem({
+				spec: item,
+			});
+			addInvoiceItems.push(
+				taxRates ? { ...addInvoiceItem, tax_rates: taxRates } : addInvoiceItem,
+			);
 		}
 	}
 

--- a/server/tests/integration/billing/tax/attach-tax-rates/attach-tax-rate-id-deferred-one-off.test.ts
+++ b/server/tests/integration/billing/tax/attach-tax-rates/attach-tax-rate-id-deferred-one-off.test.ts
@@ -1,0 +1,88 @@
+/**
+ * A one-off fee deferred to a future activation phase must carry the explicit
+ * `tax_rate_id`. One-off `add_invoice_items` don't inherit the subscription's
+ * default_tax_rates, so without a per-item rate the deferred charge is billed
+ * untaxed — the delayed twin of the immediate one-off bug.
+ */
+
+import { expect, test } from "bun:test";
+import type { AttachParamsV1Input } from "@autumn/shared";
+import { getCustomerProduct } from "@tests/integration/billing/attach/params/start-date/utils";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { addDays } from "date-fns";
+import type Stripe from "stripe";
+
+const ONBOARDING_FEE = 20;
+
+const addInvoiceItemTaxRateIds = (
+	item: Stripe.SubscriptionSchedule.Phase.AddInvoiceItem,
+): string[] =>
+	(item.tax_rates ?? []).map((rate) =>
+		typeof rate === "string" ? rate : rate.id,
+	);
+
+test.concurrent(
+	`${chalk.yellowBright("attach-tax-rate-id (deferred one-off): explicit tax_rate_id rides the activating phase add_invoice_item")}`,
+	async () => {
+		const customerId = "attach-tax-rate-deferred-one-off";
+		const pro = products.pro({
+			id: "pro-deferred-oneoff-tax",
+			items: [
+				items.oneOffMessages({
+					includedUsage: 0,
+					billingUnits: 1,
+					price: ONBOARDING_FEE,
+				}),
+			],
+		});
+
+		const { autumnV2_2, ctx, advancedTo } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [],
+		});
+
+		const taxRate = await ctx.stripeCli.taxRates.create({
+			display_name: "Test Tax",
+			percentage: 10,
+			inclusive: false,
+		});
+
+		const startDate = addDays(advancedTo, 7).getTime();
+
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			starts_at: startDate,
+			feature_quantities: [{ feature_id: TestFeature.Messages, quantity: 1 }],
+			tax_rate_id: taxRate.id,
+		});
+
+		const cusProduct = await getCustomerProduct({
+			ctx,
+			customerId,
+			productId: pro.id,
+		});
+		const scheduleId = cusProduct.scheduled_ids?.[0];
+		expect(scheduleId).toBeDefined();
+
+		const schedule = (await ctx.stripeCli.subscriptionSchedules.retrieve(
+			scheduleId!,
+		)) as Stripe.SubscriptionSchedule;
+
+		const firstPhase = schedule.phases[0];
+		expect(firstPhase?.add_invoice_items.length ?? 0).toBeGreaterThanOrEqual(1);
+
+		const taxedItem = firstPhase.add_invoice_items.find((item) =>
+			addInvoiceItemTaxRateIds(item).includes(taxRate.id),
+		);
+		expect(taxedItem).toBeDefined();
+	},
+);

--- a/server/tests/integration/billing/tax/attach-tax-rates/attach-tax-rate-id-one-time.test.ts
+++ b/server/tests/integration/billing/tax/attach-tax-rates/attach-tax-rate-id-one-time.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Explicit `tax_rate_id` on one-time (non-subscription) charges must be applied
+ * to the standalone Stripe invoice, matching what preview_attach returns.
+ *
+ * Covers two branches that share `createInvoiceForBilling`:
+ *   - A one-off product attach (standalone invoice, no subscription).
+ *   - An upgrade with `custom_line_items` (custom invoice lines).
+ */
+
+import { expect, test } from "bun:test";
+import { type ApiCustomerV3, atmnToStripeAmount } from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("attach-tax-rate-id (one-off): $10 one-time + explicit 10% tax_rate_id = $11 standalone invoice")}`,
+	async () => {
+		const customerId = "attach-tax-rate-one-off";
+		const oneOff = products.oneOff({ id: "one-off", items: [] });
+
+		const { autumnV1, ctx: scenarioCtx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [oneOff] }),
+			],
+			actions: [],
+		});
+
+		const taxRate = await scenarioCtx.stripeCli.taxRates.create({
+			display_name: "Test Tax",
+			percentage: 10,
+			inclusive: false,
+		});
+
+		const result = await autumnV1.billing.attach({
+			customer_id: customerId,
+			product_id: oneOff.id,
+			redirect_mode: "if_required",
+			tax_rate_id: taxRate.id,
+		});
+
+		expect(result.invoice?.stripe_id).toBeDefined();
+
+		const invoice = await scenarioCtx.stripeCli.invoices.retrieve(
+			result.invoice!.stripe_id,
+		);
+
+		const expectedSubtotal = atmnToStripeAmount({
+			amount: 10,
+			currency: "usd",
+		});
+		expect(invoice.subtotal).toBe(expectedSubtotal);
+		expect(invoice.total).toBe(expectedSubtotal + expectedSubtotal / 10);
+		expect(invoice.total - invoice.subtotal).toBe(expectedSubtotal / 10);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("attach-tax-rate-id (custom_line_items): explicit 10% tax_rate_id taxes custom invoice lines")}`,
+	async () => {
+		const customerId = "attach-tax-rate-custom-lines";
+
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+		const premium = products.premium({
+			id: "premium",
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+		});
+
+		const { autumnV1, ctx: scenarioCtx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [s.billing.attach({ productId: pro.id })],
+		});
+
+		const taxRate = await scenarioCtx.stripeCli.taxRates.create({
+			display_name: "Test Tax",
+			percentage: 10,
+			inclusive: false,
+		});
+
+		const customLineItems = [
+			{ amount: 15, description: "Custom upgrade charge" },
+			{ amount: 5, description: "Setup fee" },
+		];
+
+		const result = await autumnV1.billing.attach({
+			customer_id: customerId,
+			product_id: premium.id,
+			redirect_mode: "if_required",
+			custom_line_items: customLineItems,
+			tax_rate_id: taxRate.id,
+		});
+
+		expect(result.invoice?.stripe_id).toBeDefined();
+
+		const invoice = await scenarioCtx.stripeCli.invoices.retrieve(
+			result.invoice!.stripe_id,
+		);
+
+		const expectedSubtotal = atmnToStripeAmount({
+			amount: 20,
+			currency: "usd",
+		});
+		expect(invoice.subtotal).toBe(expectedSubtotal);
+		expect(invoice.total).toBe(expectedSubtotal + expectedSubtotal / 10);
+		expect(invoice.total - invoice.subtotal).toBe(expectedSubtotal / 10);
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		expect(customer.invoices?.[0]?.total).toBe(22);
+	},
+);


### PR DESCRIPTION
## Problem

`previewAttach` applies an explicit `tax_rate_id` to one-time (non-subscription) charges, but **`attach` drops it** — so for a one-time plan (e.g. a top-up) attached with a `tax_rate_id`, the preview total includes tax while the actual invoice does not. The two totals diverge.

Reported case: attaching `top-up_large_pack` with `tax_rate_id` → preview showed the taxed total, but the attach produced a standalone Stripe invoice with `total = subtotal` (no tax).

## Root cause

Only two paths in V2 ever applied `billingContext.taxRateId`: the Stripe **subscription** (`default_tax_rates`) and **checkout**. Every other path that puts a line/item on an invoice ignored it. In Stripe, one-off invoice items / `add_invoice_items` do **not** inherit a subscription's `default_tax_rates`, so any non-subscription-line charge was billed untaxed. Only affects orgs using a **manual** `tax_rate_id` (automatic-tax orgs are unaffected).

## Fix

- **`createStripeInvoice`** — accepts `default_tax_rates`; a manual rate takes precedence over `automatic_tax` (Stripe rejects both together).
- **`createInvoiceForBilling`** — passes `billingContext.taxRateId`. Fixes the standalone one-time invoice path, covering **one-off products and `custom_line_items`** (shared code path).
- **`customerProductsToPhaseInvoiceItems`** — sets per-item `tax_rates` on deferred schedule-phase `add_invoice_items`, so an end-of-cycle / future-dated one-off fee is taxed when it activates.

## Tests

New `tax/attach-tax-rates/` tests, all with an explicit `tax_rate_id`:
- one-off product → standalone invoice, `subtotal 1000 / total 1100`
- `custom_line_items` upgrade → custom invoice lines taxed
- deferred one-off fee → tax rides the activating phase `add_invoice_item`

Verified green against the local integration harness (`bun ts` clean, biome-formatted). The existing `custom-line-items` suite still passes.

## Follow-ups (not attach-driven, same gap, separate fix shape)

Manual tax rate is also dropped on: ProrateNextCycle deferred items, consumable usage-arrears invoice items (`invoice.created`), the final consumable charge on `subscription.deleted`, and legacy V1 `add_invoice_items`. Worth separate tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing manual tax on one-time and deferred charges so invoice totals match previews. One-off invoices and deferred add_invoice_items now apply the explicit `tax_rate_id`.

- **Bug Fixes**
  - `createStripeInvoice`: use `default_tax_rates` when a manual rate is set; skip `automatic_tax` in that case.
  - `createInvoiceForBilling`: pass `billingContext.taxRateId` to cover one-off products and `custom_line_items`.
  - `customerProductsToPhaseInvoiceItems`: set per-item `tax_rates` on deferred schedule `add_invoice_items`.
  - Added integration tests for one-off, `custom_line_items`, and deferred one-off scenarios.

<sup>Written for commit eccfa840a8c54270b2e6d40ddd2e106a2b126aa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a tax gap where attaching a product with an explicit `tax_rate_id` would produce a taxed preview but an untaxed actual invoice. The root cause was that only the subscription creation and checkout paths forwarded `billingContext.taxRateId` to Stripe; all invoice-based paths ignored it entirely.

- **Bug fixes** — `createStripeInvoice` now accepts `defaultTaxRates` and correctly suppresses `automatic_tax` when a manual rate is present (Stripe rejects both together); `createInvoiceForBilling` passes `billingContext.taxRateId` as `defaultTaxRates`, fixing the standalone one-off and custom-line-items invoice paths.
- **Bug fixes** — `customerProductsToPhaseInvoiceItems` sets `tax_rates` per `add_invoice_item` on deferred schedule phases, so future-activated one-off fees are billed with the correct tax rate when the phase fires.
- **Improvements** — Three new integration tests verify the corrected behavior end-to-end: standalone one-off invoice, custom-line-items upgrade invoice, and deferred phase add_invoice_item.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the three changed production files are tightly scoped to the tax-rate forwarding gap, and the mutual-exclusion guard between manual rates and automatic_tax matches Stripe's documented constraint.

All three production changes are narrow and correct: the mutual-exclusion logic in createStripeInvoice handles the Stripe constraint properly, the defaultTaxRates threading in createInvoiceForBilling mirrors the existing subscription path, and the per-item tax_rates spread in customerProductsToPhaseInvoiceItems is the only way to tax deferred add_invoice_items. The new tests cover each path. The only observation is a minor test fragility around phases[0] indexing in the deferred scenario.

No files require special attention. The test that hardcodes schedule.phases[0] is worth a comment but not a blocker.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/invoices/stripeInvoiceOps.ts | Adds defaultTaxRates parameter to createStripeInvoice; correctly mutually-excludes it from automatic_tax since Stripe rejects both together. |
| server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts | Passes billingContext.taxRateId as defaultTaxRates to createStripeInvoice, fixing the one-off and custom-line-items tax gap; also includes a minor formatting-only change to stripeDiscountsToInvoiceParams. |
| server/src/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/customerProductsToPhaseInvoiceItems.ts | Sets per-item tax_rates on deferred phase add_invoice_items so a future-activated one-off fee carries the manual tax rate, fixing the deferred charge tax gap. |
| server/tests/integration/billing/tax/attach-tax-rates/attach-tax-rate-id-one-time.test.ts | New integration tests for one-off and custom-line-items tax paths; covers both branches that share createInvoiceForBilling. |
| server/tests/integration/billing/tax/attach-tax-rates/attach-tax-rate-id-deferred-one-off.test.ts | New integration test for deferred one-off tax; uses schedule.phases[0] which is correct for this scenario but relies on implicit schedule structure assumptions. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant createInvoiceForBilling
    participant createStripeInvoice
    participant customerProductsToPhaseInvoiceItems
    participant Stripe

    rect rgb(200, 220, 255)
        Note over Client,Stripe: Immediate one-off or custom_line_items path
        Client->>createInvoiceForBilling: attach with tax_rate_id
        createInvoiceForBilling->>createStripeInvoice: "defaultTaxRates=[taxRateId]"
        createStripeInvoice->>Stripe: invoices.create with default_tax_rates
        Stripe-->>createStripeInvoice: draft invoice
        createInvoiceForBilling->>Stripe: invoices.addLines
        createInvoiceForBilling->>Stripe: invoices.finalizeInvoice
        Stripe-->>Client: taxed invoice total
    end

    rect rgb(200, 255, 220)
        Note over Client,Stripe: Deferred one-off path with future starts_at
        Client->>customerProductsToPhaseInvoiceItems: attach with starts_at and tax_rate_id
        customerProductsToPhaseInvoiceItems->>Stripe: scheduleUpdate phases add_invoice_items with tax_rates
        Stripe-->>Client: schedule updated tax applied on activation
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant createInvoiceForBilling
    participant createStripeInvoice
    participant customerProductsToPhaseInvoiceItems
    participant Stripe

    rect rgb(200, 220, 255)
        Note over Client,Stripe: Immediate one-off or custom_line_items path
        Client->>createInvoiceForBilling: attach with tax_rate_id
        createInvoiceForBilling->>createStripeInvoice: "defaultTaxRates=[taxRateId]"
        createStripeInvoice->>Stripe: invoices.create with default_tax_rates
        Stripe-->>createStripeInvoice: draft invoice
        createInvoiceForBilling->>Stripe: invoices.addLines
        createInvoiceForBilling->>Stripe: invoices.finalizeInvoice
        Stripe-->>Client: taxed invoice total
    end

    rect rgb(200, 255, 220)
        Note over Client,Stripe: Deferred one-off path with future starts_at
        Client->>customerProductsToPhaseInvoiceItems: attach with starts_at and tax_rate_id
        customerProductsToPhaseInvoiceItems->>Stripe: scheduleUpdate phases add_invoice_items with tax_rates
        Stripe-->>Client: schedule updated tax applied on activation
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/tests/integration/billing/tax/attach-tax-rates/attach-tax-rate-id-deferred-one-off.test.ts:72-83
**`phases[0]` assertion relies on implicit schedule structure**

The test hard-codes `schedule.phases[0]` to find the activating phase. This is correct when the customer has no prior subscription (so the schedule starts at `starts_at` with no preceding phase), but if this fixture ever gains a prior state or the schedule gains a setup phase, the `add_invoice_items` check will silently pass against an empty leading phase. Consider using `phases.find(p => p.start_date === startDate / 1000)` or at least adding an inline comment explaining why index 0 is always the activating phase in this scenario.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): apply manual tax\_rate\_id t..."](https://github.com/useautumn/autumn/commit/eccfa840a8c54270b2e6d40ddd2e106a2b126aa9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43037020)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->