### PR TITLE
fix(settings): use generic custom button URL placeholder

### DIFF
--- a/vite/src/views/settings/sections/components/CustomButtonDialog.tsx
+++ b/vite/src/views/settings/sections/components/CustomButtonDialog.tsx
@@ -96,7 +96,7 @@ export const CustomButtonDialog = ({
 									<div>
 										<FormLabel>URL</FormLabel>
 										<Input
-											placeholder="https://internal.firecrawl.dev/{customerId}"
+											placeholder="https://example.com/{customerId}"
 											value={field.state.value}
 											onBlur={field.handleBlur}
 											onChange={(e) => field.handleChange(e.target.value)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replaces the custom button URL placeholder that referenced `firecrawl.dev` with a vendor-neutral `example.com` URL.

**Before:** `https://internal.firecrawl.dev/{customerId}`  
**After:** `https://example.com/{customerId}`

Single-line change in `CustomButtonDialog.tsx`.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1783673376040959?thread_ts=1783673376.040959&cid=C0BCAQQK0KS)

<div><a href="https://cursor.com/agents/bc-514c3889-774f-53cd-b16c-15d41f63d3d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-514c3889-774f-53cd-b16c-15d41f63d3d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the Custom Button URL placeholder from https://internal.firecrawl.dev/{customerId} to https://example.com/{customerId} to keep the UI vendor-neutral.

<sup>Written for commit 00f111ace72f94390c98595b18117994f7bebce8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the vendor-specific placeholder URL in the Custom Button dialog's URL input field with a generic one, removing the `firecrawl.dev` internal reference that would have been visible to all users in the UI.

- **[Bug fixes]** Replaces `https://internal.firecrawl.dev/{customerId}` with `https://example.com/{customerId}` as the placeholder text for the custom button URL input in `CustomButtonDialog.tsx`, ensuring the UI is vendor-neutral and doesn't expose internal tooling names to customers.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-word placeholder string swap with no logic involved.

The change touches only a UI placeholder string, making it impossible to introduce a runtime regression. The new value is a well-known generic domain (`example.com`) that correctly communicates the expected URL format without leaking internal tooling names.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/settings/sections/components/CustomButtonDialog.tsx | Single-line change replacing a vendor-specific placeholder URL with a generic `example.com` one — straightforward and correct. |

<sub>Reviews (1): Last reviewed commit: ["fix(settings): use generic custom button..."](https://github.com/useautumn/autumn/commit/00f111ace72f94390c98595b18117994f7bebce8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43252279)</sub>

<!-- /greptile_comment -->