### PR TITLE
test(licenses): consolidate integration coverage

### DIFF
--- a/server/tests/integration/balances/check/per-entity/check-customer-level-per-entity-feature.test.ts
+++ b/server/tests/integration/balances/check/per-entity/check-customer-level-per-entity-feature.test.ts
@@ -1,0 +1,78 @@
+/**
+ * TDD test for customer-level check/track on per-entity features.
+ *
+ * Red-failure mode (current behavior):
+ *  - cusEntMatchesEntity's no-entity branch (and fullCustomerToCustomerEntitlements'
+ *    isEntityCusEnt filter) exclude cusEnts carrying per-entity balances, so a
+ *    customer-level check reports allowed=false / balance=null and a
+ *    customer-level track deducts nothing.
+ *
+ * Green-success criteria (after fix):
+ *  - Customer-level check sees the pooled per-entity balance (allowed=true,
+ *    remaining = sum across entities), and customer-level track deducts from it.
+ *  - Entity-scoped cusProducts (e.g. provisioned licenses) stay excluded from
+ *    customer-level checks — covered by license tests, unaffected here.
+ */
+
+import { expect, test } from "bun:test";
+import type { CheckResponseV3 } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("check customer-level per-entity: pooled balance visible and deductible without entity_id")}`,
+	async () => {
+		const perEntityProduct = products.base({
+			id: "customer-check-per-entity",
+			items: [
+				items.monthlyMessages({
+					includedUsage: 100,
+					entityFeatureId: TestFeature.Users,
+				}),
+			],
+		});
+
+		const { autumnV2_1, customerId } = await initScenario({
+			customerId: "customer-check-per-entity-1",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [perEntityProduct] }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+			],
+			actions: [s.attach({ productId: perEntityProduct.id })],
+		});
+
+		const check = await autumnV2_1.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(check.allowed).toBe(true);
+		expect(check.balance?.remaining).toBe(200);
+
+		await autumnV2_1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 30,
+		});
+		await timeout(2000);
+
+		const afterTrack = await autumnV2_1.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(afterTrack.allowed).toBe(true);
+		expect(afterTrack.balance?.remaining).toBe(170);
+
+		const uncached = await autumnV2_1.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(uncached.allowed).toBe(true);
+		expect(uncached.balance?.remaining).toBe(170);
+	},
+);

--- a/server/tests/integration/licenses/license-attach-edge-cases.test.ts
+++ b/server/tests/integration/licenses/license-attach-edge-cases.test.ts
@@ -1,27 +1,16 @@
-/**
- * TDD tests for license assign/unassign edge cases.
- *
- * Red-failure mode (current behavior):
- *  - licenses.update with an unknown assignment_id returns 200 with an
- *    undefined assignment (silent no-op) instead of 404.
- *  - When two plans on the customer offer the same license, attach is
- *    ambiguous and requires parent_plan_id.
- *
- * Green-success criteria (after fix):
- *  - Unknown assignment_id → 404.
- *  - licenses.attach accepts parent_plan_id to target an exact plan; without
- *    it the ambiguous case fails with a clear error.
- */
-
 import { expect, test } from "bun:test";
-import type { ApiCustomerLicenseV0, CheckResponseV3 } from "@autumn/shared";
+import type { CheckResponseV3 } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
-import { getLicenseDbState } from "./licenseTestUtils.js";
+import {
+	getLicenseDbState,
+	listLicenseAssignments,
+	listLicensePools,
+} from "./licenseTestUtils.js";
 
 test.concurrent(
 	`${chalk.yellowBright("licenses-attach-edge: detach with unknown assignment_id returns 404")}`,
@@ -65,32 +54,31 @@ test.concurrent(
 			}),
 		};
 
-		const { customerId, entities, autumnV2_2, ctx } = await initScenario({
+		const { customerId, entities, autumnV2_2 } = await initScenario({
 			customerId: "license-assign-pool-id",
 			setup: [
 				s.customer({ testClock: false }),
 				s.entities({ count: 1, featureId: TestFeature.Users }),
 				s.products({ list: [parentA, parentB, license] }),
 			],
-			actions: [],
+			actions: [
+				...[parentA, parentB].flatMap((parent) => [
+					s.licenses.link({
+						parentProductId: parent.id,
+						licenseProductId: license.id,
+						included: 1,
+					}),
+					s.billing.attach({ productId: parent.id }),
+				]),
+			],
 		});
 
-		for (const parentId of [parentA.id, parentB.id]) {
-			await autumnV2_2.post("/plans.update", {
-				plan_id: parentId,
-				licenses: [{ license_plan_id: license.id, included: 1 }],
-			});
-			await autumnV2_2.billing.attach({
-				customer_id: customerId,
-				plan_id: parentId,
-			});
-		}
-
-		const pools = (await autumnV2_2.post("/licenses.list", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-		})) as { list: ApiCustomerLicenseV0[] };
-		expect(pools.list).toHaveLength(2);
+		const pools = await listLicensePools({
+			autumn: autumnV2_2,
+			customerId,
+			entityId: entities[0].id,
+		});
+		expect(pools).toHaveLength(2);
 
 		await expectAutumnError({
 			errMessage: "Multiple plans offer",
@@ -106,7 +94,7 @@ test.concurrent(
 			customer_id: customerId,
 			entity_id: entities[0].id,
 			plan_id: license.id,
-			parent_plan_id: pools.list[0].parent_plan_id,
+			parent_plan_id: pools[0].parent_plan_id,
 		})) as { assignment: { id: string; ended_at: number | null } };
 		expect(assignment.id).toBeTruthy();
 		expect(assignment.ended_at).toBeNull();
@@ -133,17 +121,18 @@ test.concurrent(
 				s.entities({ count: 2, featureId: TestFeature.Users }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [s.billing.attach({ productId: parent.id })],
-		});
-
-		await autumnV2_2.post("/plans.update", {
-			plan_id: parent.id,
-			licenses: [{ license_plan_id: license.id, included: 1 }],
-		});
-		await autumnV2_2.post("/licenses.attach", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-			plan_id: license.id,
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parent.id }),
+				s.licenses.assign({
+					licenseProductId: license.id,
+					entityIndex: 0,
+				}),
+			],
 		});
 		await expectAutumnError({
 			errMessage: "No available licenses",
@@ -155,9 +144,10 @@ test.concurrent(
 				}),
 		});
 
-		await autumnV2_2.post("/plans.update", {
-			plan_id: parent.id,
-			licenses: [{ license_plan_id: license.id, included: 3 }],
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 3,
 		});
 		const { assignment } = (await autumnV2_2.post("/licenses.attach", {
 			customer_id: customerId,
@@ -166,10 +156,8 @@ test.concurrent(
 		})) as { assignment: { id: string } };
 		expect(assignment.id).toBeTruthy();
 
-		const pools = (await autumnV2_2.post("/licenses.list", {
-			customer_id: customerId,
-		})) as { list: ApiCustomerLicenseV0[] };
-		expect(pools.list[0].inventory).toMatchObject({
+		const pools = await listLicensePools({ autumn: autumnV2_2, customerId });
+		expect(pools[0].inventory).toMatchObject({
 			included: 3,
 			assigned: 2,
 			available: 1,
@@ -189,30 +177,30 @@ test.concurrent(
 			items: [items.monthlyMessages({ includedUsage: 25 })],
 		});
 
-		const { customerId, entities, autumnV2_2, ctx } = await initScenario({
+		const {
+			autumnV2_2,
+			licenseAssignments: [assignment],
+		} = await initScenario({
 			customerId: "license-ownership-a",
 			setup: [
 				s.customer({ testClock: false }),
+				s.otherCustomers([{ id: "license-ownership-b" }]),
 				s.entities({ count: 1, featureId: TestFeature.Users }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [s.billing.attach({ productId: parent.id })],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parent.id }),
+				s.licenses.assign({
+					licenseProductId: license.id,
+					entityIndex: 0,
+				}),
+			],
 		});
-		await initScenario({
-			customerId: "license-ownership-b",
-			setup: [s.customer({ testClock: false })],
-			actions: [],
-		});
-
-		await autumnV2_2.post("/plans.update", {
-			plan_id: parent.id,
-			licenses: [{ license_plan_id: license.id, included: 1 }],
-		});
-		const { assignment } = (await autumnV2_2.post("/licenses.attach", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-			plan_id: license.id,
-		})) as { assignment: { id: string } };
 
 		await expectAutumnError({
 			errMessage: "not found",
@@ -246,12 +234,14 @@ test.concurrent(
 				s.entities({ count: 1, featureId: TestFeature.Users }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [s.billing.attach({ productId: parent.id })],
-		});
-
-		await autumnV2_2.post("/plans.update", {
-			plan_id: parent.id,
-			licenses: [{ license_plan_id: license.id, included: 2 }],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 2,
+				}),
+				s.billing.attach({ productId: parent.id }),
+			],
 		});
 
 		const attachPreview = (await autumnV2_2.post("/licenses.preview_attach", {
@@ -262,10 +252,11 @@ test.concurrent(
 		expect(attachPreview.intent).toBe("assign");
 		expect(attachPreview.available).toBe(2);
 
-		const assignments = (await autumnV2_2.post("/licenses.list_assignments", {
-			customer_id: customerId,
-		})) as { list: unknown[] };
-		expect(assignments.list).toHaveLength(0);
+		const assignments = await listLicenseAssignments({
+			autumn: autumnV2_2,
+			customerId,
+		});
+		expect(assignments).toHaveLength(0);
 
 		const { assignment } = (await autumnV2_2.post("/licenses.attach", {
 			customer_id: customerId,
@@ -281,10 +272,11 @@ test.concurrent(
 		expect(updatePreview.intent).toBe("cancel_immediately");
 		expect(updatePreview.ended_at).toBeGreaterThan(0);
 
-		const stillActive = (await autumnV2_2.post("/licenses.list_assignments", {
-			customer_id: customerId,
-		})) as { list: { id: string }[] };
-		expect(stillActive.list).toHaveLength(1);
+		const stillActive = await listLicenseAssignments({
+			autumn: autumnV2_2,
+			customerId,
+		});
+		expect(stillActive).toHaveLength(1);
 	},
 );
 
@@ -307,12 +299,14 @@ test.concurrent(
 				s.entities({ count: 2, featureId: TestFeature.Users }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [s.billing.attach({ productId: parent.id })],
-		});
-
-		await autumnV2_2.post("/plans.update", {
-			plan_id: parent.id,
-			licenses: [{ license_plan_id: license.id, included: 1 }],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parent.id }),
+			],
 		});
 		const results = await Promise.allSettled(
 			entities.map((entity) =>
@@ -337,16 +331,14 @@ test.concurrent(
 		expect(dbState.pools).toHaveLength(1);
 		expect(dbState.pools[0]).toMatchObject({ granted: 1, remaining: 0 });
 
-		const pools = (await autumnV2_2.post("/licenses.list", {
-			customer_id: customerId,
-		})) as { list: ApiCustomerLicenseV0[] };
-		expect(pools.list).toHaveLength(1);
-		expect(pools.list[0].inventory).toEqual({
+		const pools = await listLicensePools({ autumn: autumnV2_2, customerId });
+		expect(pools).toHaveLength(1);
+		expect(pools[0].inventory).toEqual({
 			included: 1,
 			assigned: 1,
 			available: 0,
 		});
-		expect(pools.list[0].assignments).toHaveLength(1);
+		expect(pools[0].assignments).toHaveLength(1);
 
 		const checks = await Promise.all(
 			entities.map((entity) =>

--- a/server/tests/integration/licenses/license-attach-edge-cases.test.ts
+++ b/server/tests/integration/licenses/license-attach-edge-cases.test.ts
@@ -14,13 +14,14 @@
  */
 
 import { expect, test } from "bun:test";
-import type { ApiCustomerLicenseV0 } from "@autumn/shared";
+import type { ApiCustomerLicenseV0, CheckResponseV3 } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
+import { getLicenseDbState } from "./licenseTestUtils.js";
 
 test.concurrent(
 	`${chalk.yellowBright("licenses-attach-edge: detach with unknown assignment_id returns 404")}`,
@@ -64,7 +65,7 @@ test.concurrent(
 			}),
 		};
 
-		const { customerId, entities, autumnV2_2 } = await initScenario({
+		const { customerId, entities, autumnV2_2, ctx } = await initScenario({
 			customerId: "license-assign-pool-id",
 			setup: [
 				s.customer({ testClock: false }),
@@ -188,7 +189,7 @@ test.concurrent(
 			items: [items.monthlyMessages({ includedUsage: 25 })],
 		});
 
-		const { customerId, entities, autumnV2_2 } = await initScenario({
+		const { customerId, entities, autumnV2_2, ctx } = await initScenario({
 			customerId: "license-ownership-a",
 			setup: [
 				s.customer({ testClock: false }),
@@ -284,5 +285,79 @@ test.concurrent(
 			customer_id: customerId,
 		})) as { list: { id: string }[] };
 		expect(stillActive.list).toHaveLength(1);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-attach-edge: concurrent claims cannot over-allocate the final seat")}`,
+	async () => {
+		const parent = products.base({
+			id: "assign-race-parent",
+			items: [items.dashboard()],
+		});
+		const license = products.base({
+			id: "assign-race-license",
+			items: [items.monthlyMessages({ includedUsage: 25 })],
+		});
+
+		const { customerId, entities, autumnV2_2, ctx } = await initScenario({
+			customerId: "license-assign-final-seat",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [s.billing.attach({ productId: parent.id })],
+		});
+
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			licenses: [{ license_plan_id: license.id, included: 1 }],
+		});
+		const results = await Promise.allSettled(
+			entities.map((entity) =>
+				autumnV2_2.post("/licenses.attach", {
+					customer_id: customerId,
+					entity_id: entity.id,
+					plan_id: license.id,
+				}),
+			),
+		);
+		expect(
+			results.filter((result) => result.status === "fulfilled"),
+		).toHaveLength(1);
+		expect(
+			results.filter((result) => result.status === "rejected"),
+		).toHaveLength(1);
+
+		const dbState = await getLicenseDbState({ db: ctx.db, customerId });
+		expect(
+			dbState.assignments.filter(({ status }) => status === "active"),
+		).toHaveLength(1);
+		expect(dbState.pools).toHaveLength(1);
+		expect(dbState.pools[0]).toMatchObject({ granted: 1, remaining: 0 });
+
+		const pools = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: ApiCustomerLicenseV0[] };
+		expect(pools.list).toHaveLength(1);
+		expect(pools.list[0].inventory).toEqual({
+			included: 1,
+			assigned: 1,
+			available: 0,
+		});
+		expect(pools.list[0].assignments).toHaveLength(1);
+
+		const checks = await Promise.all(
+			entities.map((entity) =>
+				autumnV2_2.check<CheckResponseV3>({
+					customer_id: customerId,
+					entity_id: entity.id,
+					feature_id: TestFeature.Messages,
+					skip_cache: true,
+				}),
+			),
+		);
+		expect(checks.filter((check) => check.allowed)).toHaveLength(1);
 	},
 );

--- a/server/tests/integration/licenses/license-basic.test.ts
+++ b/server/tests/integration/licenses/license-basic.test.ts
@@ -320,20 +320,24 @@ test.concurrent(
 			actions: [s.billing.attach({ productId: parent.id })],
 		});
 
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 2,
-			customize: {
-				items: [itemsV2.monthlyMessages({ included: 100 })],
-			},
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			licenses: [
+				{
+					license_plan_id: license.id,
+					included: 2,
+					customize: {
+						items: [itemsV2.monthlyMessages({ included: 100 })],
+					},
+				},
+			],
 		});
 
 		const enterprisePlanLicenses = await listLicenseLinks({
 			autumn: autumnV2_2,
 			parentPlanId: parent.id,
 		});
-		expect(enterprisePlanLicenses[0].parent_plan_id).toBe(parent.id);
+		expect(enterprisePlanLicenses).toHaveLength(1);
 		expect(enterprisePlanLicenses[0].license_plan_id).toBe(license.id);
 		expect("parent_internal_product_id" in enterprisePlanLicenses[0]).toBe(
 			false,
@@ -345,10 +349,17 @@ test.concurrent(
 			100,
 		);
 
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 3,
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			licenses: [
+				{
+					license_plan_id: license.id,
+					included: 3,
+					customize: {
+						items: [itemsV2.monthlyMessages({ included: 100 })],
+					},
+				},
+			],
 		});
 		const updatedEnterprisePlanLicenses = await listLicenseLinks({
 			autumn: autumnV2_2,

--- a/server/tests/integration/licenses/license-basic.test.ts
+++ b/server/tests/integration/licenses/license-basic.test.ts
@@ -4,9 +4,6 @@ import {
 	type AttachParamsV1Input,
 	type CheckResponseV3,
 	ErrCode,
-	FreeTrialDuration,
-	type LicenseBalanceResponse,
-	ProductErrorCode,
 	type ProductV2,
 } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
@@ -17,6 +14,12 @@ import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { CusService } from "@/internal/customers/CusService.js";
+import {
+	listLicenseAssignments,
+	listLicenseLinks,
+	listLicensePools,
+	type TestLicenseAssignment,
+} from "./licenseTestUtils.js";
 
 const makeLicenseProduct = () => ({
 	...products.base({
@@ -41,13 +44,14 @@ test.concurrent(
 				s.entities({ count: 2, featureId: TestFeature.Users }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [s.billing.attach({ productId: parent.id })],
-		});
-
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parent.id }),
+			],
 		});
 
 		const { products: licenseProducts } = (await autumnV2_2.get(
@@ -71,12 +75,13 @@ test.concurrent(
 			),
 		).toBe(true);
 
-		const poolsBeforeAssign = (await autumnV2_2.post("/licenses.list", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-		})) as { list: LicenseBalanceResponse[] };
-		expect(poolsBeforeAssign.list).toHaveLength(1);
-		expect(poolsBeforeAssign.list[0]).toMatchObject({
+		const poolsBeforeAssign = await listLicensePools({
+			autumn: autumnV2_2,
+			customerId,
+			entityId: entities[0].id,
+		});
+		expect(poolsBeforeAssign).toHaveLength(1);
+		expect(poolsBeforeAssign[0]).toMatchObject({
 			license_plan_id: license.id,
 			license_plan_name: license.name,
 			inventory: {
@@ -97,15 +102,7 @@ test.concurrent(
 			customer_id: customerId,
 			entity_id: entities[0].id,
 			plan_id: license.id,
-		})) as {
-			assignment: {
-				id: string;
-				entity_id: string;
-				license_plan_id: string;
-				started_at: number;
-				ended_at: number | null;
-			};
-		};
+		})) as { assignment: TestLicenseAssignment };
 		expect(assignment).toMatchObject({
 			entity_id: entities[0].id,
 			license_plan_id: license.id,
@@ -117,11 +114,12 @@ test.concurrent(
 		expect(assignment.id).toBeTruthy();
 		expect(assignment.started_at).toBeGreaterThan(0);
 
-		const poolsAfterAssign = (await autumnV2_2.post("/licenses.list", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-		})) as { list: LicenseBalanceResponse[] };
-		expect(poolsAfterAssign.list[0]).toMatchObject({
+		const poolsAfterAssign = await listLicensePools({
+			autumn: autumnV2_2,
+			customerId,
+			entityId: entities[0].id,
+		});
+		expect(poolsAfterAssign[0]).toMatchObject({
 			license_plan_id: license.id,
 			inventory: {
 				included: 1,
@@ -135,36 +133,25 @@ test.concurrent(
 				},
 			],
 		});
-		expect(poolsAfterAssign.list[0].assignments[0].assignment_id).toBeTruthy();
-		expect(poolsAfterAssign.list[0].assignments[0].started_at).toBeGreaterThan(
-			0,
-		);
-		const assignmentId = poolsAfterAssign.list[0].assignments[0].assignment_id;
+		expect(poolsAfterAssign[0].assignments[0].assignment_id).toBeTruthy();
+		expect(poolsAfterAssign[0].assignments[0].started_at).toBeGreaterThan(0);
+		const assignmentId = poolsAfterAssign[0].assignments[0].assignment_id;
 		expect(assignmentId).toBe(assignment.id);
 
-		const activeAssignments = (await autumnV2_2.post(
-			"/licenses.list_assignments",
-			{
-				customer_id: customerId,
-				entity_id: entities[0].id,
-				plan_id: license.id,
-			},
-		)) as {
-			list: Array<{
-				id: string;
-				entity_id: string;
-				license_plan_id: string;
-				ended_at: number | null;
-			}>;
-		};
-		expect(activeAssignments.list).toHaveLength(1);
-		expect(activeAssignments.list[0]).toMatchObject({
+		const activeAssignments = await listLicenseAssignments({
+			autumn: autumnV2_2,
+			customerId,
+			entityId: entities[0].id,
+			licensePlanId: license.id,
+		});
+		expect(activeAssignments).toHaveLength(1);
+		expect(activeAssignments[0]).toMatchObject({
 			id: assignmentId,
 			entity_id: entities[0].id,
 			license_plan_id: license.id,
 			ended_at: null,
 		});
-		expect("internal_customer_id" in activeAssignments.list[0]).toBe(false);
+		expect("internal_customer_id" in activeAssignments[0]).toBe(false);
 
 		const assignedEntity = await autumnV2_2.check<CheckResponseV3>({
 			customer_id: customerId,
@@ -190,14 +177,12 @@ test.concurrent(
 				}),
 		});
 
-		const assignmentsAfterExhaustedAttempt = (await autumnV2_2.post(
-			"/licenses.list_assignments",
-			{
-				customer_id: customerId,
-				plan_id: license.id,
-			},
-		)) as { list: unknown[] };
-		expect(assignmentsAfterExhaustedAttempt.list).toHaveLength(1);
+		const assignmentsAfterExhaustedAttempt = await listLicenseAssignments({
+			autumn: autumnV2_2,
+			customerId,
+			licensePlanId: license.id,
+		});
+		expect(assignmentsAfterExhaustedAttempt).toHaveLength(1);
 
 		const customerAfter = await autumnV2_2.check<CheckResponseV3>({
 			customer_id: customerId,
@@ -241,35 +226,30 @@ test.concurrent(
 		expect(endedAssignment.license_plan_id).toBe(license.id);
 		expect(endedAssignment.ended_at).toBeGreaterThan(0);
 
-		const activeAssignmentsAfterUnassign = (await autumnV2_2.post(
-			"/licenses.list_assignments",
-			{
-				customer_id: customerId,
-				entity_id: entities[0].id,
-				plan_id: license.id,
-			},
-		)) as { list: unknown[] };
-		expect(activeAssignmentsAfterUnassign.list).toHaveLength(0);
+		const activeAssignmentsAfterUnassign = await listLicenseAssignments({
+			autumn: autumnV2_2,
+			customerId,
+			entityId: entities[0].id,
+			licensePlanId: license.id,
+		});
+		expect(activeAssignmentsAfterUnassign).toHaveLength(0);
 
-		const allAssignmentsAfterUnassign = (await autumnV2_2.post(
-			"/licenses.list_assignments",
-			{
-				customer_id: customerId,
-				entity_id: entities[0].id,
-				plan_id: license.id,
-				active: false,
-			},
-		)) as {
-			list: Array<{ id: string; ended_at: number | null }>;
-		};
-		expect(allAssignmentsAfterUnassign.list[0].id).toBe(assignmentId);
-		expect(allAssignmentsAfterUnassign.list[0].ended_at).toBeGreaterThan(0);
+		const allAssignmentsAfterUnassign = await listLicenseAssignments({
+			autumn: autumnV2_2,
+			customerId,
+			entityId: entities[0].id,
+			licensePlanId: license.id,
+			active: false,
+		});
+		expect(allAssignmentsAfterUnassign[0].id).toBe(assignmentId);
+		expect(allAssignmentsAfterUnassign[0].ended_at).toBeGreaterThan(0);
 
-		const poolsAfterUnassign = (await autumnV2_2.post("/licenses.list", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-		})) as { list: LicenseBalanceResponse[] };
-		expect(poolsAfterUnassign.list[0]).toMatchObject({
+		const poolsAfterUnassign = await listLicensePools({
+			autumn: autumnV2_2,
+			customerId,
+			entityId: entities[0].id,
+		});
+		expect(poolsAfterUnassign[0]).toMatchObject({
 			inventory: {
 				included: 1,
 				assigned: 0,
@@ -349,16 +329,10 @@ test.concurrent(
 			},
 		});
 
-		const { list: enterprisePlanLicenses } = (await autumnV2_2.post(
-			"/licenses.list_links",
-			{ parent_plan_id: parent.id },
-		)) as {
-			list: Array<{
-				parent_plan_id: string;
-				license_plan_id: string;
-				customize?: { add_items?: Array<{ included?: number }> };
-			}>;
-		};
+		const enterprisePlanLicenses = await listLicenseLinks({
+			autumn: autumnV2_2,
+			parentPlanId: parent.id,
+		});
 		expect(enterprisePlanLicenses[0].parent_plan_id).toBe(parent.id);
 		expect(enterprisePlanLicenses[0].license_plan_id).toBe(license.id);
 		expect("parent_internal_product_id" in enterprisePlanLicenses[0]).toBe(
@@ -376,12 +350,10 @@ test.concurrent(
 			license_plan_id: license.id,
 			included: 3,
 		});
-		const { list: updatedEnterprisePlanLicenses } = (await autumnV2_2.post(
-			"/licenses.list_links",
-			{ parent_plan_id: parent.id },
-		)) as {
-			list: Array<{ customize?: { add_items?: Array<{ included?: number }> } }>;
-		};
+		const updatedEnterprisePlanLicenses = await listLicenseLinks({
+			autumn: autumnV2_2,
+			parentPlanId: parent.id,
+		});
 		expect(
 			updatedEnterprisePlanLicenses[0].customize?.add_items?.[0].included,
 		).toBe(100);
@@ -400,10 +372,8 @@ test.concurrent(
 
 		expect(enterpriseCheck.balance?.granted).toBe(100);
 
-		const pools = (await autumnV2_2.post("/licenses.list", {
-			customer_id: customerId,
-		})) as { list: LicenseBalanceResponse[] };
-		const enterprisePool = pools.list[0];
+		const pools = await listLicensePools({ autumn: autumnV2_2, customerId });
+		const enterprisePool = pools[0];
 		expect(enterprisePool?.inventory).toMatchObject({
 			included: 3,
 			assigned: 1,
@@ -430,13 +400,13 @@ test.concurrent(
 				s.customer({ testClock: false }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [],
-		});
-
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 3,
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 3,
+				}),
+			],
 		});
 
 		const { list } = (await autumnV2_2.post("/plans.list", {})) as {

--- a/server/tests/integration/licenses/license-basic.test.ts
+++ b/server/tests/integration/licenses/license-basic.test.ts
@@ -1,0 +1,463 @@
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	type AttachParamsV1Input,
+	type CheckResponseV3,
+	ErrCode,
+	FreeTrialDuration,
+	type LicenseBalanceResponse,
+	ProductErrorCode,
+	type ProductV2,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { CusService } from "@/internal/customers/CusService.js";
+
+const makeLicenseProduct = () => ({
+	...products.base({
+		id: "seat-license",
+		items: [items.monthlyMessages({ includedUsage: 25 })],
+	}),
+});
+
+test.concurrent(
+	`${chalk.yellowBright("licenses: assignment lazily provisions entity-scoped grant")}`,
+	async () => {
+		const parent = products.base({
+			id: "parent-plan",
+			items: [items.dashboard()],
+		});
+		const license = makeLicenseProduct();
+
+		const { customerId, entities, autumnV2_2, ctx } = await initScenario({
+			customerId: "license-lazy-assign",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [s.billing.attach({ productId: parent.id })],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+
+		const { products: licenseProducts } = (await autumnV2_2.get(
+			"/products/license_products",
+		)) as { products: ProductV2[] };
+		const licenseProduct = licenseProducts.find(
+			(product) => product.id === license.id,
+		);
+		expect(licenseProduct).toBeDefined();
+		expect(licenseProducts.some((product) => product.id === parent.id)).toBe(
+			false,
+		);
+
+		const { list: planProducts } = (await autumnV2_2.get("/products")) as {
+			list: Array<{ id?: string; plan_id?: string }>;
+		};
+		expect(
+			planProducts.some(
+				(product) =>
+					product.id === license.id || product.plan_id === license.id,
+			),
+		).toBe(true);
+
+		const poolsBeforeAssign = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(poolsBeforeAssign.list).toHaveLength(1);
+		expect(poolsBeforeAssign.list[0]).toMatchObject({
+			license_plan_id: license.id,
+			license_plan_name: license.name,
+			inventory: {
+				included: 1,
+				assigned: 0,
+				available: 1,
+			},
+			assignments: [],
+		});
+
+		const customerBefore = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(customerBefore.allowed).toBe(false);
+
+		const { assignment } = (await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		})) as {
+			assignment: {
+				id: string;
+				entity_id: string;
+				license_plan_id: string;
+				started_at: number;
+				ended_at: number | null;
+			};
+		};
+		expect(assignment).toMatchObject({
+			entity_id: entities[0].id,
+			license_plan_id: license.id,
+			ended_at: null,
+		});
+		expect("internal_customer_id" in assignment).toBe(false);
+		expect("internal_entity_id" in assignment).toBe(false);
+		expect("license_internal_product_id" in assignment).toBe(false);
+		expect(assignment.id).toBeTruthy();
+		expect(assignment.started_at).toBeGreaterThan(0);
+
+		const poolsAfterAssign = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(poolsAfterAssign.list[0]).toMatchObject({
+			license_plan_id: license.id,
+			inventory: {
+				included: 1,
+				assigned: 1,
+				available: 0,
+			},
+			assignments: [
+				{
+					entity_id: entities[0].id,
+					license_plan_id: license.id,
+				},
+			],
+		});
+		expect(poolsAfterAssign.list[0].assignments[0].assignment_id).toBeTruthy();
+		expect(poolsAfterAssign.list[0].assignments[0].started_at).toBeGreaterThan(
+			0,
+		);
+		const assignmentId = poolsAfterAssign.list[0].assignments[0].assignment_id;
+		expect(assignmentId).toBe(assignment.id);
+
+		const activeAssignments = (await autumnV2_2.post(
+			"/licenses.list_assignments",
+			{
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				plan_id: license.id,
+			},
+		)) as {
+			list: Array<{
+				id: string;
+				entity_id: string;
+				license_plan_id: string;
+				ended_at: number | null;
+			}>;
+		};
+		expect(activeAssignments.list).toHaveLength(1);
+		expect(activeAssignments.list[0]).toMatchObject({
+			id: assignmentId,
+			entity_id: entities[0].id,
+			license_plan_id: license.id,
+			ended_at: null,
+		});
+		expect("internal_customer_id" in activeAssignments.list[0]).toBe(false);
+
+		const assignedEntity = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+		});
+		expect(assignedEntity.allowed).toBe(true);
+
+		const otherEntity = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[1].id,
+			feature_id: TestFeature.Messages,
+		});
+		expect(otherEntity.allowed).toBe(false);
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			func: () =>
+				autumnV2_2.post("/licenses.attach", {
+					customer_id: customerId,
+					entity_id: entities[1].id,
+					plan_id: license.id,
+				}),
+		});
+
+		const assignmentsAfterExhaustedAttempt = (await autumnV2_2.post(
+			"/licenses.list_assignments",
+			{
+				customer_id: customerId,
+				plan_id: license.id,
+			},
+		)) as { list: unknown[] };
+		expect(assignmentsAfterExhaustedAttempt.list).toHaveLength(1);
+
+		const customerAfter = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(customerAfter.allowed).toBe(false);
+
+		const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		expect(
+			customer.subscriptions.some(
+				(subscription) => subscription.plan_id === license.id,
+			),
+		).toBe(false);
+
+		const page = await CusService.getProductsPage({
+			ctx,
+			idOrInternalId: customerId,
+			params: { start_cursor: "", limit: 10, show_expired: false },
+		});
+		expect(page.list.some((item) => item.product.id === license.id)).toBe(
+			false,
+		);
+
+		const { assignment: endedAssignment } = (await autumnV2_2.post(
+			"/licenses.update",
+			{
+				customer_id: customerId,
+				cancel_action: "cancel_immediately",
+				assignment_id: assignmentId,
+			},
+		)) as {
+			assignment: {
+				id: string;
+				entity_id: string;
+				license_plan_id: string;
+				ended_at: number | null;
+			};
+		};
+		expect(endedAssignment.id).toBe(assignmentId);
+		expect(endedAssignment.entity_id).toBe(entities[0].id);
+		expect(endedAssignment.license_plan_id).toBe(license.id);
+		expect(endedAssignment.ended_at).toBeGreaterThan(0);
+
+		const activeAssignmentsAfterUnassign = (await autumnV2_2.post(
+			"/licenses.list_assignments",
+			{
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				plan_id: license.id,
+			},
+		)) as { list: unknown[] };
+		expect(activeAssignmentsAfterUnassign.list).toHaveLength(0);
+
+		const allAssignmentsAfterUnassign = (await autumnV2_2.post(
+			"/licenses.list_assignments",
+			{
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				plan_id: license.id,
+				active: false,
+			},
+		)) as {
+			list: Array<{ id: string; ended_at: number | null }>;
+		};
+		expect(allAssignmentsAfterUnassign.list[0].id).toBe(assignmentId);
+		expect(allAssignmentsAfterUnassign.list[0].ended_at).toBeGreaterThan(0);
+
+		const poolsAfterUnassign = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(poolsAfterUnassign.list[0]).toMatchObject({
+			inventory: {
+				included: 1,
+				assigned: 0,
+				available: 1,
+			},
+			assignments: [],
+		});
+
+		const unassignedEntity = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+		});
+		expect(unassignedEntity.allowed).toBe(false);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses: license plans attach directly like any plan")}`,
+	async () => {
+		const parent = products.base({
+			id: "parent-plan",
+			items: [items.dashboard()],
+		});
+		const license = makeLicenseProduct();
+
+		const { customerId, autumnV2_2 } = await initScenario({
+			customerId: "license-rejects",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: license.id,
+			redirect_mode: "if_required",
+		});
+		const attached = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(attached.allowed).toBe(true);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses: plan license customize overrides the base grant")}`,
+	async () => {
+		const parent = products.base({
+			id: "license-custom-enterprise",
+			items: [items.dashboard()],
+		});
+		const license = {
+			...makeLicenseProduct(),
+			id: "license-custom-seat",
+		};
+
+		const { customerId, entities, autumnV2_2 } = await initScenario({
+			customerId: "license-custom-cus",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [s.billing.attach({ productId: parent.id })],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 2,
+			customize: {
+				items: [itemsV2.monthlyMessages({ included: 100 })],
+			},
+		});
+
+		const { list: enterprisePlanLicenses } = (await autumnV2_2.post(
+			"/licenses.list_links",
+			{ parent_plan_id: parent.id },
+		)) as {
+			list: Array<{
+				parent_plan_id: string;
+				license_plan_id: string;
+				customize?: { add_items?: Array<{ included?: number }> };
+			}>;
+		};
+		expect(enterprisePlanLicenses[0].parent_plan_id).toBe(parent.id);
+		expect(enterprisePlanLicenses[0].license_plan_id).toBe(license.id);
+		expect("parent_internal_product_id" in enterprisePlanLicenses[0]).toBe(
+			false,
+		);
+		expect("license_internal_product_id" in enterprisePlanLicenses[0]).toBe(
+			false,
+		);
+		expect(enterprisePlanLicenses[0].customize?.add_items?.[0].included).toBe(
+			100,
+		);
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 3,
+		});
+		const { list: updatedEnterprisePlanLicenses } = (await autumnV2_2.post(
+			"/licenses.list_links",
+			{ parent_plan_id: parent.id },
+		)) as {
+			list: Array<{ customize?: { add_items?: Array<{ included?: number }> } }>;
+		};
+		expect(
+			updatedEnterprisePlanLicenses[0].customize?.add_items?.[0].included,
+		).toBe(100);
+
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		});
+
+		const enterpriseCheck = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+		});
+
+		expect(enterpriseCheck.balance?.granted).toBe(100);
+
+		const pools = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		const enterprisePool = pools.list[0];
+		expect(enterprisePool?.inventory).toMatchObject({
+			included: 3,
+			assigned: 1,
+			available: 2,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses: plans.list exposes the licenses field")}`,
+	async () => {
+		const parent = products.base({
+			id: "plan-lic-field-parent",
+			items: [items.dashboard()],
+		});
+		const license = products.base({
+			id: "plan-lic-field-seat",
+			items: [items.monthlyMessages({ includedUsage: 25 })],
+		});
+
+		const { autumnV2_2 } = await initScenario({
+			customerId: "license-plans-field",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 3,
+		});
+
+		const { list } = (await autumnV2_2.post("/plans.list", {})) as {
+			list: Array<{
+				id: string;
+				licenses?: Array<{
+					license_plan_id: string;
+					included: number;
+					prepaid_only: boolean;
+				}>;
+			}>;
+		};
+		const parentPlan = list.find((plan) => plan.id === parent.id);
+		expect(parentPlan?.licenses).toEqual([
+			{
+				license_plan_id: license.id,
+				included: 3,
+				prepaid_only: true,
+			},
+		]);
+		const licensePlan = list.find((plan) => plan.id === license.id);
+		expect(licensePlan?.licenses).toBeUndefined();
+	},
+);

--- a/server/tests/integration/licenses/license-billing-integration.test.ts
+++ b/server/tests/integration/licenses/license-billing-integration.test.ts
@@ -1,0 +1,201 @@
+import { expect, test } from "bun:test";
+import type {
+	CheckResponseV3,
+	UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { expectNoStripeSubscription } from "@tests/integration/billing/utils/expectNoStripeSubscription.js";
+import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { CusService } from "@/internal/customers/CusService.js";
+import { getLicenseDbState } from "./licenseTestUtils.js";
+
+const setupLicense = async ({
+	customerId,
+	included = 2,
+	paidParent = false,
+}: {
+	customerId: string;
+	included?: number;
+	paidParent?: boolean;
+}) => {
+	const parent = (paidParent ? products.pro : products.base)({
+		id: `${customerId}-parent`,
+		items: [items.dashboard()],
+	});
+	const license = products.base({
+		id: `${customerId}-license`,
+		items: [items.monthlyMessages({ includedUsage: 25 })],
+	});
+	const scenario = await initScenario({
+		customerId,
+		setup: [
+			s.customer({
+				paymentMethod: paidParent ? "success" : undefined,
+				testClock: false,
+			}),
+			s.entities({ count: 2, featureId: TestFeature.Users }),
+			s.products({ list: [parent, license] }),
+		],
+		actions: [s.billing.attach({ productId: parent.id })],
+	});
+	await scenario.autumnV2_2.post("/licenses.link", {
+		parent_plan_id: parent.id,
+		license_plan_id: license.id,
+		included,
+	});
+	return { ...scenario, parent, license };
+};
+
+test.concurrent(
+	`${chalk.yellowBright("licenses billing: generic cancellation releases an assignment completely")}`,
+	async () => {
+		const { customerId, entities, autumnV2_2, ctx, license } =
+			await setupLicense({ customerId: "lic-generic-cancel", included: 1 });
+		const { assignment } = (await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		})) as { assignment: { id: string } };
+
+		expect(
+			(
+				await autumnV2_2.check<CheckResponseV3>({
+					customer_id: customerId,
+					entity_id: entities[0].id,
+					feature_id: TestFeature.Messages,
+				})
+			).allowed,
+		).toBe(true);
+
+		await autumnV2_2.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			customer_product_id: assignment.id,
+			cancel_action: "cancel_immediately",
+		});
+
+		const dbState = await getLicenseDbState({ db: ctx.db, customerId });
+		expect(dbState.assignments).toHaveLength(1);
+		expect(dbState.assignments[0]).toMatchObject({ status: "expired" });
+		expect(dbState.pools).toHaveLength(1);
+		expect(dbState.pools[0]).toMatchObject({ granted: 1, remaining: 1 });
+
+		for (const skipCache of [false, true]) {
+			const check = await autumnV2_2.check<CheckResponseV3>({
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				feature_id: TestFeature.Messages,
+				skip_cache: skipCache,
+			});
+			expect(check.allowed).toBe(false);
+		}
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[1].id,
+			plan_id: license.id,
+		});
+		await expectNoStripeSubscription({
+			db: ctx.db,
+			customerId,
+			org: ctx.org,
+			env: ctx.env,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses billing: concurrent duplicate assignment is idempotent without leaking capacity")}`,
+	async () => {
+		const { customerId, entities, autumnV2_2, ctx, license } =
+			await setupLicense({ customerId: "lic-same-entity-race" });
+		const results = await Promise.all(
+			[0, 1].map(() =>
+				autumnV2_2.post("/licenses.attach", {
+					customer_id: customerId,
+					entity_id: entities[0].id,
+					plan_id: license.id,
+				}),
+			),
+		);
+		expect(
+			new Set(
+				results.map(
+					(result) => (result as { assignment: { id: string } }).assignment.id,
+				),
+			).size,
+		).toBe(1);
+
+		const dbState = await getLicenseDbState({ db: ctx.db, customerId });
+		expect(
+			dbState.assignments.filter(({ status }) => status === "active"),
+		).toHaveLength(1);
+		expect(dbState.pools).toHaveLength(1);
+		expect(dbState.pools[0]).toMatchObject({ granted: 2, remaining: 1 });
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses billing: paid license-only update leaves Stripe unchanged")}`,
+	async () => {
+		const { customerId, autumnV2_2, ctx, parent, license } = await setupLicense(
+			{ customerId: "lic-paid-license-only", paidParent: true },
+		);
+		const customer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const stripeCustomerId =
+			customer.processor?.id ?? customer.processor?.processor_id;
+		if (!stripeCustomerId) throw new Error("Stripe customer not found");
+		const before = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCustomerId,
+			status: "all",
+		});
+		const invoicesBefore = await ctx.stripeCli.invoices.list({
+			customer: stripeCustomerId,
+		});
+		const snapshot = before.data.map((subscription) => ({
+			id: subscription.id,
+			items: subscription.items.data.map(({ id, price, quantity }) => ({
+				id,
+				priceId: price.id,
+				quantity,
+			})),
+		}));
+
+		await autumnV2_2.billing.update({
+			customer_id: customerId,
+			plan_id: parent.id,
+			customize: {
+				add_licenses: [{ license_plan_id: license.id, included: 3 }],
+			},
+		});
+
+		const after = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCustomerId,
+			status: "all",
+		});
+		const invoicesAfter = await ctx.stripeCli.invoices.list({
+			customer: stripeCustomerId,
+		});
+		expect(
+			after.data.map((subscription) => ({
+				id: subscription.id,
+				items: subscription.items.data.map(({ id, price, quantity }) => ({
+					id,
+					priceId: price.id,
+					quantity,
+				})),
+			})),
+		).toEqual(snapshot);
+		expect(invoicesAfter.data.map(({ id }) => id)).toEqual(
+			invoicesBefore.data.map(({ id }) => id),
+		);
+		const dbState = await getLicenseDbState({ db: ctx.db, customerId });
+		expect(dbState.pools[0]).toMatchObject({ granted: 3, remaining: 3 });
+		await expectStripeSubscriptionCorrect({ ctx, customerId });
+	},
+);

--- a/server/tests/integration/licenses/license-billing-integration.test.ts
+++ b/server/tests/integration/licenses/license-billing-integration.test.ts
@@ -17,10 +17,12 @@ const setupLicense = async ({
 	customerId,
 	included = 2,
 	paidParent = false,
+	assignEntityIndex,
 }: {
 	customerId: string;
 	included?: number;
 	paidParent?: boolean;
+	assignEntityIndex?: number;
 }) => {
 	const parent = (paidParent ? products.pro : products.base)({
 		id: `${customerId}-parent`,
@@ -40,12 +42,22 @@ const setupLicense = async ({
 			s.entities({ count: 2, featureId: TestFeature.Users }),
 			s.products({ list: [parent, license] }),
 		],
-		actions: [s.billing.attach({ productId: parent.id })],
-	});
-	await scenario.autumnV2_2.post("/licenses.link", {
-		parent_plan_id: parent.id,
-		license_plan_id: license.id,
-		included,
+		actions: [
+			s.licenses.link({
+				parentProductId: parent.id,
+				licenseProductId: license.id,
+				included,
+			}),
+			s.billing.attach({ productId: parent.id }),
+			...(assignEntityIndex === undefined
+				? []
+				: [
+						s.licenses.assign({
+							licenseProductId: license.id,
+							entityIndex: assignEntityIndex,
+						}),
+					]),
+		],
 	});
 	return { ...scenario, parent, license };
 };
@@ -53,13 +65,18 @@ const setupLicense = async ({
 test.concurrent(
 	`${chalk.yellowBright("licenses billing: generic cancellation releases an assignment completely")}`,
 	async () => {
-		const { customerId, entities, autumnV2_2, ctx, license } =
-			await setupLicense({ customerId: "lic-generic-cancel", included: 1 });
-		const { assignment } = (await autumnV2_2.post("/licenses.attach", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-			plan_id: license.id,
-		})) as { assignment: { id: string } };
+		const {
+			customerId,
+			entities,
+			autumnV2_2,
+			ctx,
+			license,
+			licenseAssignments: [assignment],
+		} = await setupLicense({
+			customerId: "lic-generic-cancel",
+			included: 1,
+			assignEntityIndex: 0,
+		});
 
 		expect(
 			(
@@ -111,7 +128,7 @@ test.concurrent(
 	async () => {
 		const { customerId, entities, autumnV2_2, ctx, license } =
 			await setupLicense({ customerId: "lic-same-entity-race" });
-		const results = await Promise.all(
+		const results = await Promise.allSettled(
 			[0, 1].map(() =>
 				autumnV2_2.post("/licenses.attach", {
 					customer_id: customerId,
@@ -120,13 +137,11 @@ test.concurrent(
 				}),
 			),
 		);
-		expect(
-			new Set(
-				results.map(
-					(result) => (result as { assignment: { id: string } }).assignment.id,
-				),
-			).size,
-		).toBe(1);
+		const fulfilled = results.filter(
+			(result): result is PromiseFulfilledResult<unknown> =>
+			result.status === "fulfilled",
+		);
+		expect(fulfilled).toHaveLength(1);
 
 		const dbState = await getLicenseDbState({ db: ctx.db, customerId });
 		expect(

--- a/server/tests/integration/licenses/license-catalog-edit-guards.test.ts
+++ b/server/tests/integration/licenses/license-catalog-edit-guards.test.ts
@@ -1,20 +1,3 @@
-/**
- * TDD tests for license catalog edits.
- *
- * Red-failure modes (current behavior):
- *  - Versioning a license product (generic products update with active
- *    assignments) leaves plan_license/pools/assignments pinned to the
- *    old version's internal id — later assigns resolve the new version and
- *    fail with "No license pool found".
- *  - link accepts lowering included below a customer's
- *    active assignment count.
- *
- * Green-success criteria (after fix):
- *  - License versioning rolls plan_license/pools/assignments forward;
- *    assignment keeps working against the same pool.
- *  - link rejects capacity conflicts with a 400.
- */
-
 import { expect, test } from "bun:test";
 import {
 	type CheckResponseV3,
@@ -57,18 +40,18 @@ test.concurrent(
 				s.entities({ count: 2, featureId: TestFeature.Users }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [s.billing.attach({ productId: parent.id })],
-		});
-
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 2,
-		});
-		await autumnV2_2.post("/licenses.attach", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-			plan_id: license.id,
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 2,
+				}),
+				s.billing.attach({ productId: parent.id }),
+				s.licenses.assign({
+					licenseProductId: license.id,
+					entityIndex: 0,
+				}),
+			],
 		});
 
 		await autumnV1.products.update(license.id, {
@@ -114,25 +97,25 @@ test.concurrent(
 		});
 		const license = makeLicenseProduct({ id: "lic-cap-guard-seat" });
 
-		const { customerId, entities, autumnV2_2 } = await initScenario({
+		const { autumnV2_2 } = await initScenario({
 			customerId: "lic-capacity-guard",
 			setup: [
 				s.customer({ testClock: false }),
 				s.entities({ count: 1, featureId: TestFeature.Users }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [s.billing.attach({ productId: parent.id })],
-		});
-
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
-		});
-		await autumnV2_2.post("/licenses.attach", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-			plan_id: license.id,
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parent.id }),
+				s.licenses.assign({
+					licenseProductId: license.id,
+					entityIndex: 0,
+				}),
+			],
 		});
 
 		await expectAutumnError({

--- a/server/tests/integration/licenses/license-catalog-edit-guards.test.ts
+++ b/server/tests/integration/licenses/license-catalog-edit-guards.test.ts
@@ -1,0 +1,148 @@
+/**
+ * TDD tests for license catalog edits.
+ *
+ * Red-failure modes (current behavior):
+ *  - Versioning a license product (generic products update with active
+ *    assignments) leaves plan_license/pools/assignments pinned to the
+ *    old version's internal id — later assigns resolve the new version and
+ *    fail with "No license pool found".
+ *  - link accepts lowering included below a customer's
+ *    active assignment count.
+ *
+ * Green-success criteria (after fix):
+ *  - License versioning rolls plan_license/pools/assignments forward;
+ *    assignment keeps working against the same pool.
+ *  - link rejects capacity conflicts with a 400.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type CheckResponseV3,
+	ErrCode,
+	type LicenseBalanceResponse,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const makeLicenseProduct = ({
+	id,
+	includedUsage = 25,
+}: {
+	id: string;
+	includedUsage?: number;
+}) => ({
+	...products.base({
+		id,
+		items: [items.monthlyMessages({ includedUsage })],
+	}),
+});
+
+test.concurrent(
+	`${chalk.yellowBright("licenses catalog: versioning a license product rolls links and pools forward")}`,
+	async () => {
+		const parent = products.base({
+			id: "lic-rollfwd-parent",
+			items: [items.dashboard()],
+		});
+		const license = makeLicenseProduct({ id: "lic-rollfwd-seat" });
+
+		const { customerId, entities, autumnV1, autumnV2_2 } = await initScenario({
+			customerId: "lic-version-rollforward",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [s.billing.attach({ productId: parent.id })],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 2,
+		});
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		});
+
+		await autumnV1.products.update(license.id, {
+			items: [items.monthlyMessages({ includedUsage: 50 })],
+		});
+
+		const { assignment } = (await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[1].id,
+			plan_id: license.id,
+		})) as { assignment: { entity_id: string; ended_at: number | null } };
+		expect(assignment).toMatchObject({
+			entity_id: entities[1].id,
+			ended_at: null,
+		});
+
+		const pools = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(pools.list).toHaveLength(1);
+		expect(pools.list[0].inventory).toMatchObject({
+			included: 2,
+			assigned: 2,
+			available: 0,
+		});
+
+		const firstEntityCheck = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(firstEntityCheck.allowed).toBe(true);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses catalog: link cannot drop capacity below active assignments")}`,
+	async () => {
+		const parent = products.base({
+			id: "lic-cap-guard-parent",
+			items: [items.dashboard()],
+		});
+		const license = makeLicenseProduct({ id: "lic-cap-guard-seat" });
+
+		const { customerId, entities, autumnV2_2 } = await initScenario({
+			customerId: "lic-capacity-guard",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [s.billing.attach({ productId: parent.id })],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		});
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			func: () =>
+				autumnV2_2.post("/licenses.link", {
+					parent_plan_id: parent.id,
+					license_plan_id: license.id,
+					included: 0,
+				}),
+		});
+	},
+);

--- a/server/tests/integration/licenses/license-cleanup-coverage.test.ts
+++ b/server/tests/integration/licenses/license-cleanup-coverage.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Coverage for the license read-path / versioning cleanups:
+ *  - A1: versioning a parent to an interval that breaks an existing license
+ *    link is rejected AND leaves the product on its old version (no
+ *    half-created version persisted).
+ *  - B1: /licenses.list_links returns correct per-link customize across a mix
+ *    of customized + uncustomized links (the shared deriveCustomizeByLinkId
+ *    batching path).
+ */
+
+import { expect, test } from "bun:test";
+import { BillingInterval, ErrCode } from "@autumn/shared";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { ProductService } from "@/internal/products/ProductService.js";
+
+type PlanLicenseRow = {
+	parent_plan_id: string;
+	license_plan_id: string;
+	included: number;
+	customize?: { add_items?: Array<{ included?: number }> } | null;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("licenses catalog: versioning a parent to an incompatible interval is rejected and does not create a new version")}`,
+	async () => {
+		const parent = products.base({
+			id: "version-reject-parent",
+			items: [items.monthlyPrice({ price: 20 })],
+		});
+		const license = products.base({
+			id: "version-reject-license",
+			items: [items.monthlyPrice({ price: 30 })],
+		});
+
+		const { customerId, autumnV2_2, ctx } = await initScenario({
+			customerId: "license-version-reject",
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [],
+		});
+
+		// Compatible monthly ↔ monthly link.
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: parent.id,
+		});
+
+		const parentV1 = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: parent.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		expect(parentV1.version).toBe(1);
+
+		// Versioning the parent to an annual base price would break the interval
+		// match with the monthly license — the whole version must be rejected.
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			errMessage: "Billing intervals must match",
+			func: () =>
+				autumnV2_2.post(`/products/${parent.id}`, {
+					price: { amount: 240, interval: BillingInterval.Year },
+				}),
+		});
+
+		// A1: nothing was persisted — the product is still on version 1 with the
+		// same internal_id (no orphaned half-created version).
+		const parentAfter = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: parent.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		expect(parentAfter.version).toBe(1);
+		expect(parentAfter.internal_id).toBe(parentV1.internal_id);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses catalog: in-place edits cannot invalidate a linked billing interval")}`,
+	async () => {
+		const parent = products.base({
+			id: "in-place-interval-parent",
+			items: [items.monthlyPrice({ price: 20 })],
+		});
+		const license = products.base({
+			id: "in-place-interval-license",
+			items: [items.monthlyPrice({ price: 30 })],
+		});
+		const { autumnV2_2, ctx } = await initScenario({
+			customerId: "license-in-place-interval",
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [],
+		});
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+
+		for (const product of [parent, license]) {
+			const before = await ProductService.getFull({
+				db: ctx.db,
+				idOrInternalId: product.id,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			});
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				errMessage: "Billing intervals must match",
+				func: () =>
+					autumnV2_2.post(`/products/${product.id}`, {
+						price: { amount: 240, interval: BillingInterval.Year },
+					}),
+			});
+			const after = await ProductService.getFull({
+				db: ctx.db,
+				idOrInternalId: product.id,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			});
+			expect(after.internal_id).toBe(before.internal_id);
+			expect(after.version).toBe(before.version);
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses catalog: list_links returns per-link customize for a mix of customized and uncustomized links")}`,
+	async () => {
+		const parent = products.base({
+			id: "list-links-parent",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const customizedLicense = products.base({
+			id: "list-links-customized",
+			items: [items.monthlyMessages({ includedUsage: 25 })],
+		});
+		const stockLicense = products.base({
+			id: "list-links-stock",
+			items: [items.monthlyMessages({ includedUsage: 50 })],
+		});
+
+		const { autumnV2_2 } = await initScenario({
+			customerId: "license-list-links-mix",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [parent, customizedLicense, stockLicense] }),
+			],
+			actions: [s.billing.attach({ productId: parent.id })],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: customizedLicense.id,
+			included: 2,
+			customize: { items: [itemsV2.monthlyMessages({ included: 80 })] },
+		});
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: stockLicense.id,
+			included: 3,
+		});
+
+		const { list } = (await autumnV2_2.post("/licenses.list_links", {
+			parent_plan_id: parent.id,
+		})) as { list: PlanLicenseRow[] };
+		expect(list).toHaveLength(2);
+
+		const customized = list.find(
+			(row) => row.license_plan_id === customizedLicense.id,
+		);
+		const stock = list.find((row) => row.license_plan_id === stockLicense.id);
+
+		// Customized link carries its derived customize; stock link has none.
+		expect(customized).toMatchObject({ included: 2 });
+		expect(customized?.customize?.add_items?.[0].included).toBe(80);
+		expect(stock).toMatchObject({ included: 3 });
+		expect(stock?.customize ?? null).toBeNull();
+	},
+);

--- a/server/tests/integration/licenses/license-cleanup-coverage.test.ts
+++ b/server/tests/integration/licenses/license-cleanup-coverage.test.ts
@@ -1,13 +1,3 @@
-/**
- * Coverage for the license read-path / versioning cleanups:
- *  - A1: versioning a parent to an interval that breaks an existing license
- *    link is rejected AND leaves the product on its old version (no
- *    half-created version persisted).
- *  - B1: /licenses.list_links returns correct per-link customize across a mix
- *    of customized + uncustomized links (the shared deriveCustomizeByLinkId
- *    batching path).
- */
-
 import { expect, test } from "bun:test";
 import { BillingInterval, ErrCode } from "@autumn/shared";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
@@ -17,13 +7,7 @@ import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { ProductService } from "@/internal/products/ProductService.js";
-
-type PlanLicenseRow = {
-	parent_plan_id: string;
-	license_plan_id: string;
-	included: number;
-	customize?: { add_items?: Array<{ included?: number }> } | null;
-};
+import { listLicenseLinks } from "./licenseTestUtils.js";
 
 test.concurrent(
 	`${chalk.yellowBright("licenses catalog: versioning a parent to an incompatible interval is rejected and does not create a new version")}`,
@@ -37,24 +21,20 @@ test.concurrent(
 			items: [items.monthlyPrice({ price: 30 })],
 		});
 
-		const { customerId, autumnV2_2, ctx } = await initScenario({
+		const { autumnV2_2, ctx } = await initScenario({
 			customerId: "license-version-reject",
 			setup: [
 				s.customer({ paymentMethod: "success", testClock: false }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [],
-		});
-
-		// Compatible monthly ↔ monthly link.
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
-		});
-		await autumnV2_2.billing.attach({
-			customer_id: customerId,
-			plan_id: parent.id,
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parent.id }),
+			],
 		});
 
 		const parentV1 = await ProductService.getFull({
@@ -65,8 +45,6 @@ test.concurrent(
 		});
 		expect(parentV1.version).toBe(1);
 
-		// Versioning the parent to an annual base price would break the interval
-		// match with the monthly license — the whole version must be rejected.
 		await expectAutumnError({
 			errCode: ErrCode.InvalidRequest,
 			errMessage: "Billing intervals must match",
@@ -76,8 +54,6 @@ test.concurrent(
 				}),
 		});
 
-		// A1: nothing was persisted — the product is still on version 1 with the
-		// same internal_id (no orphaned half-created version).
 		const parentAfter = await ProductService.getFull({
 			db: ctx.db,
 			idOrInternalId: parent.id,
@@ -106,12 +82,13 @@ test.concurrent(
 				s.customer({ paymentMethod: "success", testClock: false }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [],
-		});
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+				}),
+			],
 		});
 
 		for (const product of [parent, license]) {
@@ -163,24 +140,28 @@ test.concurrent(
 				s.customer({ testClock: false }),
 				s.products({ list: [parent, customizedLicense, stockLicense] }),
 			],
-			actions: [s.billing.attach({ productId: parent.id })],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: customizedLicense.id,
+					included: 2,
+					customize: {
+						items: [itemsV2.monthlyMessages({ included: 80 })],
+					},
+				}),
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: stockLicense.id,
+					included: 3,
+				}),
+				s.billing.attach({ productId: parent.id }),
+			],
 		});
 
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: customizedLicense.id,
-			included: 2,
-			customize: { items: [itemsV2.monthlyMessages({ included: 80 })] },
+		const list = await listLicenseLinks({
+			autumn: autumnV2_2,
+			parentPlanId: parent.id,
 		});
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: stockLicense.id,
-			included: 3,
-		});
-
-		const { list } = (await autumnV2_2.post("/licenses.list_links", {
-			parent_plan_id: parent.id,
-		})) as { list: PlanLicenseRow[] };
 		expect(list).toHaveLength(2);
 
 		const customized = list.find(
@@ -188,7 +169,6 @@ test.concurrent(
 		);
 		const stock = list.find((row) => row.license_plan_id === stockLicense.id);
 
-		// Customized link carries its derived customize; stock link has none.
 		expect(customized).toMatchObject({ included: 2 });
 		expect(customized?.customize?.add_items?.[0].included).toBe(80);
 		expect(stock).toMatchObject({ included: 3 });

--- a/server/tests/integration/licenses/license-customize-patch.test.ts
+++ b/server/tests/integration/licenses/license-customize-patch.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Contract tests for patch-style customize licenses (add_licenses /
+ * remove_licenses). Adds override or extend the parent's catalog links,
+ * removes tombstone inherited links, and untouched links keep inheriting.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	ErrCode,
+	type LicenseBalanceResponse,
+	planLicenses,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { and, eq, isNotNull } from "drizzle-orm";
+
+const makeParentProduct = (id: string) =>
+	products.base({ id, items: [items.dashboard()] });
+
+const makeLicenseProduct = (id: string) =>
+	products.base({
+		id,
+		items: [items.monthlyMessages({ includedUsage: 25 })],
+	});
+
+const setupCatalogParent = async ({
+	customerId,
+	idPrefix,
+	catalog,
+}: {
+	customerId: string;
+	idPrefix: string;
+	catalog: { licenseSuffix: string; included: number }[];
+}) => {
+	const parent = makeParentProduct(`${idPrefix}-parent`);
+	const licenses = catalog.map(({ licenseSuffix }) =>
+		makeLicenseProduct(`${idPrefix}-${licenseSuffix}`),
+	);
+
+	const result = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.entities({ count: 1, featureId: TestFeature.Users }),
+			s.products({ list: [parent, ...licenses] }),
+		],
+		actions: [],
+	});
+
+	for (const [index, { included }] of catalog.entries()) {
+		await result.autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: licenses[index].id,
+			included,
+		});
+	}
+
+	return { ...result, parent, licenses };
+};
+
+const listPools = async (
+	autumnV2_2: { post: (path: string, body: unknown) => Promise<unknown> },
+	customerId: string,
+) => {
+	const pools = (await autumnV2_2.post("/licenses.list", {
+		customer_id: customerId,
+	})) as { list: LicenseBalanceResponse[] };
+	return pools.list;
+};
+
+test(`${chalk.yellowBright("licenses-patch: add_licenses overrides one inherited license and keeps the rest")}`, async () => {
+	const { customerId, autumnV2_2, parent, licenses } = await setupCatalogParent(
+		{
+			customerId: "lic-patch-add-keeps",
+			idPrefix: "lic-patch-add-keeps",
+			catalog: [
+				{ licenseSuffix: "seat-a", included: 2 },
+				{ licenseSuffix: "seat-b", included: 1 },
+			],
+		},
+	);
+	const [licenseA, licenseB] = licenses;
+
+	await autumnV2_2.billing.attach({
+		customer_id: customerId,
+		plan_id: parent.id,
+		customize: {
+			add_licenses: [{ license_plan_id: licenseA.id, included: 5 }],
+		},
+	});
+
+	const pools = await listPools(autumnV2_2, customerId);
+	expect(pools).toHaveLength(2);
+	expect(
+		pools.find((pool) => pool.license_plan_id === licenseA.id)?.inventory,
+	).toMatchObject({ included: 5, assigned: 0, available: 5 });
+	expect(
+		pools.find((pool) => pool.license_plan_id === licenseB.id)?.inventory,
+	).toMatchObject({ included: 1, assigned: 0, available: 1 });
+});
+
+test(`${chalk.yellowBright("licenses-patch: remove_licenses tombstones an inherited license")}`, async () => {
+	const { customerId, entities, autumnV2_2, parent, licenses } =
+		await setupCatalogParent({
+			customerId: "lic-patch-remove",
+			idPrefix: "lic-patch-remove",
+			catalog: [
+				{ licenseSuffix: "seat-a", included: 2 },
+				{ licenseSuffix: "seat-b", included: 1 },
+			],
+		});
+	const [licenseA, licenseB] = licenses;
+
+	await autumnV2_2.billing.attach({
+		customer_id: customerId,
+		plan_id: parent.id,
+		customize: { remove_licenses: [licenseA.id] },
+	});
+
+	const pools = await listPools(autumnV2_2, customerId);
+	expect(pools).toHaveLength(1);
+	expect(pools[0]).toMatchObject({
+		license_plan_id: licenseB.id,
+		inventory: { included: 1, assigned: 0, available: 1 },
+	});
+	await expectAutumnError({
+		errCode: ErrCode.InvalidRequest,
+		func: () =>
+			autumnV2_2.post("/licenses.attach", {
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				plan_id: licenseA.id,
+			}),
+	});
+});
+
+test(`${chalk.yellowBright("licenses-patch: bare add_licenses entry restores an overridden license to inheritance")}`, async () => {
+	const { customerId, autumnV2_2, ctx, parent, licenses } =
+		await setupCatalogParent({
+			customerId: "lic-patch-restore",
+			idPrefix: "lic-patch-restore",
+			catalog: [{ licenseSuffix: "seat", included: 2 }],
+		});
+	const [license] = licenses;
+
+	await autumnV2_2.billing.attach({
+		customer_id: customerId,
+		plan_id: parent.id,
+		customize: {
+			add_licenses: [{ license_plan_id: license.id, included: 5 }],
+		},
+	});
+	const overriddenPools = await listPools(autumnV2_2, customerId);
+	expect(overriddenPools[0]?.inventory).toMatchObject({ included: 5 });
+
+	await autumnV2_2.billing.update({
+		customer_id: customerId,
+		plan_id: parent.id,
+		customize: {
+			add_licenses: [{ license_plan_id: license.id }],
+		},
+	});
+
+	const restoredPools = await listPools(autumnV2_2, customerId);
+	expect(restoredPools[0]?.inventory).toMatchObject({
+		included: 2,
+		assigned: 0,
+		available: 2,
+	});
+
+	const overrideRows = await ctx.db.query.planLicenses.findMany({
+		where: and(
+			eq(planLicenses.license_internal_product_id, license.internal_id!),
+			isNotNull(planLicenses.parent_customer_product_id),
+		),
+	});
+	expect(overrideRows).toHaveLength(0);
+});
+
+test(`${chalk.yellowBright("licenses-patch: same license in add_licenses and remove_licenses rejects")}`, async () => {
+	const { customerId, autumnV2_2, parent, licenses } = await setupCatalogParent(
+		{
+			customerId: "lic-patch-overlap",
+			idPrefix: "lic-patch-overlap",
+			catalog: [{ licenseSuffix: "seat", included: 1 }],
+		},
+	);
+	const [license] = licenses;
+
+	await expectAutumnError({
+		errMessage: "cannot appear in both add_licenses and remove_licenses",
+		func: () =>
+			autumnV2_2.billing.attach({
+				customer_id: customerId,
+				plan_id: parent.id,
+				customize: {
+					add_licenses: [{ license_plan_id: license.id, included: 2 }],
+					remove_licenses: [license.id],
+				},
+			}),
+	});
+});
+
+test(`${chalk.yellowBright("licenses-patch: remove of a license outside the plan rejects")}`, async () => {
+	const parent = makeParentProduct("lic-patch-unknown-parent");
+	const linked = makeLicenseProduct("lic-patch-unknown-seat");
+	const unlinked = makeLicenseProduct("lic-patch-unknown-unlinked");
+	const { customerId, autumnV2_2 } = await initScenario({
+		customerId: "lic-patch-unknown",
+		setup: [
+			s.customer({ testClock: false }),
+			s.entities({ count: 1, featureId: TestFeature.Users }),
+			s.products({ list: [parent, linked, unlinked] }),
+		],
+		actions: [],
+	});
+	await autumnV2_2.post("/licenses.link", {
+		parent_plan_id: parent.id,
+		license_plan_id: linked.id,
+		included: 1,
+	});
+
+	await expectAutumnError({
+		errCode: ErrCode.InvalidRequest,
+		errMessage: "cannot be removed",
+		func: () =>
+			autumnV2_2.billing.attach({
+				customer_id: customerId,
+				plan_id: parent.id,
+				customize: { remove_licenses: [unlinked.id] },
+			}),
+	});
+});

--- a/server/tests/integration/licenses/license-customize-patch.test.ts
+++ b/server/tests/integration/licenses/license-customize-patch.test.ts
@@ -1,15 +1,5 @@
-/**
- * Contract tests for patch-style customize licenses (add_licenses /
- * remove_licenses). Adds override or extend the parent's catalog links,
- * removes tombstone inherited links, and untouched links keep inheriting.
- */
-
 import { expect, test } from "bun:test";
-import {
-	ErrCode,
-	type LicenseBalanceResponse,
-	planLicenses,
-} from "@autumn/shared";
+import { ErrCode, planLicenses } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
 import { items } from "@tests/utils/fixtures/items.js";
@@ -17,6 +7,7 @@ import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { and, eq, isNotNull } from "drizzle-orm";
+import { listLicensePools } from "./licenseTestUtils.js";
 
 const makeParentProduct = (id: string) =>
 	products.base({ id, items: [items.dashboard()] });
@@ -48,190 +39,198 @@ const setupCatalogParent = async ({
 			s.entities({ count: 1, featureId: TestFeature.Users }),
 			s.products({ list: [parent, ...licenses] }),
 		],
-		actions: [],
+		actions: catalog.map(({ included }, index) =>
+			s.licenses.link({
+				parentProductId: parent.id,
+				licenseProductId: licenses[index].id,
+				included,
+			}),
+		),
 	});
-
-	for (const [index, { included }] of catalog.entries()) {
-		await result.autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: licenses[index].id,
-			included,
-		});
-	}
 
 	return { ...result, parent, licenses };
 };
 
-const listPools = async (
-	autumnV2_2: { post: (path: string, body: unknown) => Promise<unknown> },
-	customerId: string,
-) => {
-	const pools = (await autumnV2_2.post("/licenses.list", {
-		customer_id: customerId,
-	})) as { list: LicenseBalanceResponse[] };
-	return pools.list;
-};
+test.concurrent(
+	`${chalk.yellowBright("licenses-patch: add_licenses overrides one inherited license and keeps the rest")}`,
+	async () => {
+		const { customerId, autumnV2_2, parent, licenses } =
+			await setupCatalogParent({
+				customerId: "lic-patch-add-keeps",
+				idPrefix: "lic-patch-add-keeps",
+				catalog: [
+					{ licenseSuffix: "seat-a", included: 2 },
+					{ licenseSuffix: "seat-b", included: 1 },
+				],
+			});
+		const [licenseA, licenseB] = licenses;
 
-test(`${chalk.yellowBright("licenses-patch: add_licenses overrides one inherited license and keeps the rest")}`, async () => {
-	const { customerId, autumnV2_2, parent, licenses } = await setupCatalogParent(
-		{
-			customerId: "lic-patch-add-keeps",
-			idPrefix: "lic-patch-add-keeps",
-			catalog: [
-				{ licenseSuffix: "seat-a", included: 2 },
-				{ licenseSuffix: "seat-b", included: 1 },
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: parent.id,
+			customize: {
+				add_licenses: [{ license_plan_id: licenseA.id, included: 5 }],
+			},
+		});
+
+		const pools = await listLicensePools({ autumn: autumnV2_2, customerId });
+		expect(pools).toHaveLength(2);
+		expect(
+			pools.find((pool) => pool.license_plan_id === licenseA.id)?.inventory,
+		).toMatchObject({ included: 5, assigned: 0, available: 5 });
+		expect(
+			pools.find((pool) => pool.license_plan_id === licenseB.id)?.inventory,
+		).toMatchObject({ included: 1, assigned: 0, available: 1 });
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-patch: remove_licenses tombstones an inherited license")}`,
+	async () => {
+		const { customerId, entities, autumnV2_2, parent, licenses } =
+			await setupCatalogParent({
+				customerId: "lic-patch-remove",
+				idPrefix: "lic-patch-remove",
+				catalog: [
+					{ licenseSuffix: "seat-a", included: 2 },
+					{ licenseSuffix: "seat-b", included: 1 },
+				],
+			});
+		const [licenseA, licenseB] = licenses;
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: parent.id,
+			customize: { remove_licenses: [licenseA.id] },
+		});
+
+		const pools = await listLicensePools({ autumn: autumnV2_2, customerId });
+		expect(pools).toHaveLength(1);
+		expect(pools[0]).toMatchObject({
+			license_plan_id: licenseB.id,
+			inventory: { included: 1, assigned: 0, available: 1 },
+		});
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			func: () =>
+				autumnV2_2.post("/licenses.attach", {
+					customer_id: customerId,
+					entity_id: entities[0].id,
+					plan_id: licenseA.id,
+				}),
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-patch: bare add_licenses entry restores an overridden license to inheritance")}`,
+	async () => {
+		const { customerId, autumnV2_2, ctx, parent, licenses } =
+			await setupCatalogParent({
+				customerId: "lic-patch-restore",
+				idPrefix: "lic-patch-restore",
+				catalog: [{ licenseSuffix: "seat", included: 2 }],
+			});
+		const [license] = licenses;
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: parent.id,
+			customize: {
+				add_licenses: [{ license_plan_id: license.id, included: 5 }],
+			},
+		});
+		const overriddenPools = await listLicensePools({
+			autumn: autumnV2_2,
+			customerId,
+		});
+		expect(overriddenPools[0]?.inventory).toMatchObject({ included: 5 });
+
+		await autumnV2_2.billing.update({
+			customer_id: customerId,
+			plan_id: parent.id,
+			customize: {
+				add_licenses: [{ license_plan_id: license.id }],
+			},
+		});
+
+		const restoredPools = await listLicensePools({
+			autumn: autumnV2_2,
+			customerId,
+		});
+		expect(restoredPools[0]?.inventory).toMatchObject({
+			included: 2,
+			assigned: 0,
+			available: 2,
+		});
+
+		const overrideRows = await ctx.db.query.planLicenses.findMany({
+			where: and(
+				eq(planLicenses.license_internal_product_id, license.internal_id!),
+				isNotNull(planLicenses.parent_customer_product_id),
+			),
+		});
+		expect(overrideRows).toHaveLength(0);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-patch: same license in add_licenses and remove_licenses rejects")}`,
+	async () => {
+		const { customerId, autumnV2_2, parent, licenses } =
+			await setupCatalogParent({
+				customerId: "lic-patch-overlap",
+				idPrefix: "lic-patch-overlap",
+				catalog: [{ licenseSuffix: "seat", included: 1 }],
+			});
+		const [license] = licenses;
+
+		await expectAutumnError({
+			errMessage: "cannot appear in both add_licenses and remove_licenses",
+			func: () =>
+				autumnV2_2.billing.attach({
+					customer_id: customerId,
+					plan_id: parent.id,
+					customize: {
+						add_licenses: [{ license_plan_id: license.id, included: 2 }],
+						remove_licenses: [license.id],
+					},
+				}),
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-patch: remove of a license outside the plan rejects")}`,
+	async () => {
+		const parent = makeParentProduct("lic-patch-unknown-parent");
+		const linked = makeLicenseProduct("lic-patch-unknown-seat");
+		const unlinked = makeLicenseProduct("lic-patch-unknown-unlinked");
+		const { customerId, autumnV2_2 } = await initScenario({
+			customerId: "lic-patch-unknown",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, linked, unlinked] }),
 			],
-		},
-	);
-	const [licenseA, licenseB] = licenses;
-
-	await autumnV2_2.billing.attach({
-		customer_id: customerId,
-		plan_id: parent.id,
-		customize: {
-			add_licenses: [{ license_plan_id: licenseA.id, included: 5 }],
-		},
-	});
-
-	const pools = await listPools(autumnV2_2, customerId);
-	expect(pools).toHaveLength(2);
-	expect(
-		pools.find((pool) => pool.license_plan_id === licenseA.id)?.inventory,
-	).toMatchObject({ included: 5, assigned: 0, available: 5 });
-	expect(
-		pools.find((pool) => pool.license_plan_id === licenseB.id)?.inventory,
-	).toMatchObject({ included: 1, assigned: 0, available: 1 });
-});
-
-test(`${chalk.yellowBright("licenses-patch: remove_licenses tombstones an inherited license")}`, async () => {
-	const { customerId, entities, autumnV2_2, parent, licenses } =
-		await setupCatalogParent({
-			customerId: "lic-patch-remove",
-			idPrefix: "lic-patch-remove",
-			catalog: [
-				{ licenseSuffix: "seat-a", included: 2 },
-				{ licenseSuffix: "seat-b", included: 1 },
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: linked.id,
+					included: 1,
+				}),
 			],
 		});
-	const [licenseA, licenseB] = licenses;
 
-	await autumnV2_2.billing.attach({
-		customer_id: customerId,
-		plan_id: parent.id,
-		customize: { remove_licenses: [licenseA.id] },
-	});
-
-	const pools = await listPools(autumnV2_2, customerId);
-	expect(pools).toHaveLength(1);
-	expect(pools[0]).toMatchObject({
-		license_plan_id: licenseB.id,
-		inventory: { included: 1, assigned: 0, available: 1 },
-	});
-	await expectAutumnError({
-		errCode: ErrCode.InvalidRequest,
-		func: () =>
-			autumnV2_2.post("/licenses.attach", {
-				customer_id: customerId,
-				entity_id: entities[0].id,
-				plan_id: licenseA.id,
-			}),
-	});
-});
-
-test(`${chalk.yellowBright("licenses-patch: bare add_licenses entry restores an overridden license to inheritance")}`, async () => {
-	const { customerId, autumnV2_2, ctx, parent, licenses } =
-		await setupCatalogParent({
-			customerId: "lic-patch-restore",
-			idPrefix: "lic-patch-restore",
-			catalog: [{ licenseSuffix: "seat", included: 2 }],
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			errMessage: "cannot be removed",
+			func: () =>
+				autumnV2_2.billing.attach({
+					customer_id: customerId,
+					plan_id: parent.id,
+					customize: { remove_licenses: [unlinked.id] },
+				}),
 		});
-	const [license] = licenses;
-
-	await autumnV2_2.billing.attach({
-		customer_id: customerId,
-		plan_id: parent.id,
-		customize: {
-			add_licenses: [{ license_plan_id: license.id, included: 5 }],
-		},
-	});
-	const overriddenPools = await listPools(autumnV2_2, customerId);
-	expect(overriddenPools[0]?.inventory).toMatchObject({ included: 5 });
-
-	await autumnV2_2.billing.update({
-		customer_id: customerId,
-		plan_id: parent.id,
-		customize: {
-			add_licenses: [{ license_plan_id: license.id }],
-		},
-	});
-
-	const restoredPools = await listPools(autumnV2_2, customerId);
-	expect(restoredPools[0]?.inventory).toMatchObject({
-		included: 2,
-		assigned: 0,
-		available: 2,
-	});
-
-	const overrideRows = await ctx.db.query.planLicenses.findMany({
-		where: and(
-			eq(planLicenses.license_internal_product_id, license.internal_id!),
-			isNotNull(planLicenses.parent_customer_product_id),
-		),
-	});
-	expect(overrideRows).toHaveLength(0);
-});
-
-test(`${chalk.yellowBright("licenses-patch: same license in add_licenses and remove_licenses rejects")}`, async () => {
-	const { customerId, autumnV2_2, parent, licenses } = await setupCatalogParent(
-		{
-			customerId: "lic-patch-overlap",
-			idPrefix: "lic-patch-overlap",
-			catalog: [{ licenseSuffix: "seat", included: 1 }],
-		},
-	);
-	const [license] = licenses;
-
-	await expectAutumnError({
-		errMessage: "cannot appear in both add_licenses and remove_licenses",
-		func: () =>
-			autumnV2_2.billing.attach({
-				customer_id: customerId,
-				plan_id: parent.id,
-				customize: {
-					add_licenses: [{ license_plan_id: license.id, included: 2 }],
-					remove_licenses: [license.id],
-				},
-			}),
-	});
-});
-
-test(`${chalk.yellowBright("licenses-patch: remove of a license outside the plan rejects")}`, async () => {
-	const parent = makeParentProduct("lic-patch-unknown-parent");
-	const linked = makeLicenseProduct("lic-patch-unknown-seat");
-	const unlinked = makeLicenseProduct("lic-patch-unknown-unlinked");
-	const { customerId, autumnV2_2 } = await initScenario({
-		customerId: "lic-patch-unknown",
-		setup: [
-			s.customer({ testClock: false }),
-			s.entities({ count: 1, featureId: TestFeature.Users }),
-			s.products({ list: [parent, linked, unlinked] }),
-		],
-		actions: [],
-	});
-	await autumnV2_2.post("/licenses.link", {
-		parent_plan_id: parent.id,
-		license_plan_id: linked.id,
-		included: 1,
-	});
-
-	await expectAutumnError({
-		errCode: ErrCode.InvalidRequest,
-		errMessage: "cannot be removed",
-		func: () =>
-			autumnV2_2.billing.attach({
-				customer_id: customerId,
-				plan_id: parent.id,
-				customize: { remove_licenses: [unlinked.id] },
-			}),
-	});
-});
+	},
+);

--- a/server/tests/integration/licenses/license-customize-propagation.test.ts
+++ b/server/tests/integration/licenses/license-customize-propagation.test.ts
@@ -1,19 +1,15 @@
-/**
- * Customized links reference live base rows for untouched items (cusProduct-
- * style membership), so base edits propagate while overridden items stay
- * frozen. The base-price propagation observation (overflow seat billed at the
- * edited price) is parked with overflow re-enable in
- * LICENSE_BILLING_TEST_PLAN.md; this pins the surviving surfaces: the derived
- * customize response and the provisioned seat's grant.
- */
-
 import { expect, test } from "bun:test";
-import type { CheckResponseV3 } from "@autumn/shared";
+import {
+	type AttachParamsV1Input,
+	type CheckResponseV3,
+	ResetInterval,
+} from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
+import { listLicenseLinks } from "./licenseTestUtils.js";
 
 test.concurrent(
 	`${chalk.yellowBright("licenses customize propagation: base price edit leaves the customized link's override intact")}`,
@@ -35,22 +31,23 @@ test.concurrent(
 				s.entities({ count: 1, featureId: TestFeature.Users }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [s.billing.attach({ productId: parent.id })],
-		});
-
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
-			customize: {
-				items: [
-					{
-						feature_id: TestFeature.Messages,
-						included: 50,
-						reset: { interval: "month" },
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+					customize: {
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 50,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
 					},
-				],
-			},
+				}),
+				s.billing.attach({ productId: parent.id }),
+			],
 		});
 
 		await autumnV1.products.update(license.id, {
@@ -60,7 +57,7 @@ test.concurrent(
 			],
 		});
 
-		await autumnV2_2.billing.attach({
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
 			customer_id: customerId,
 			plan_id: license.id,
 		});
@@ -79,16 +76,11 @@ test.concurrent(
 		expect(seatCheck.allowed).toBe(true);
 		expect(seatCheck.balance?.granted).toBe(75);
 
-		const links = (await autumnV2_2.post("/licenses.list_links", {
-			parent_plan_id: parent.id,
-		})) as {
-			list: {
-				customize: {
-					add_items?: { feature_id?: string; included?: number }[];
-				} | null;
-			}[];
-		};
-		const customizedItem = links.list[0].customize?.add_items?.find(
+		const links = await listLicenseLinks({
+			autumn: autumnV2_2,
+			parentPlanId: parent.id,
+		});
+		const customizedItem = links[0].customize?.add_items?.find(
 			(item) => item.feature_id === TestFeature.Messages,
 		);
 		expect(customizedItem?.included).toBe(50);

--- a/server/tests/integration/licenses/license-customize-propagation.test.ts
+++ b/server/tests/integration/licenses/license-customize-propagation.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Customized links reference live base rows for untouched items (cusProduct-
+ * style membership), so base edits propagate while overridden items stay
+ * frozen. The base-price propagation observation (overflow seat billed at the
+ * edited price) is parked with overflow re-enable in
+ * LICENSE_BILLING_TEST_PLAN.md; this pins the surviving surfaces: the derived
+ * customize response and the provisioned seat's grant.
+ */
+
+import { expect, test } from "bun:test";
+import type { CheckResponseV3 } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("licenses customize propagation: base price edit leaves the customized link's override intact")}`,
+	async () => {
+		const parent = products.base({
+			id: "cust-prop-parent",
+			items: [items.dashboard()],
+		});
+		const license = products.pro({
+			id: "cust-prop-seat",
+			items: [items.monthlyMessages({ includedUsage: 25 })],
+			group: "cust-prop-licenses",
+		});
+
+		const { customerId, entities, autumnV1, autumnV2_2 } = await initScenario({
+			customerId: "license-customize-propagation",
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [s.billing.attach({ productId: parent.id })],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+			customize: {
+				items: [
+					{
+						feature_id: TestFeature.Messages,
+						included: 50,
+						reset: { interval: "month" },
+					},
+				],
+			},
+		});
+
+		await autumnV1.products.update(license.id, {
+			items: [
+				items.monthlyPrice({ price: 30 }),
+				items.monthlyMessages({ includedUsage: 25 }),
+			],
+		});
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: license.id,
+		});
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		});
+
+		const seatCheck = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(seatCheck.allowed).toBe(true);
+		expect(seatCheck.balance?.granted).toBe(75);
+
+		const links = (await autumnV2_2.post("/licenses.list_links", {
+			parent_plan_id: parent.id,
+		})) as {
+			list: {
+				customize: {
+					add_items?: { feature_id?: string; included?: number }[];
+				} | null;
+			}[];
+		};
+		const customizedItem = links.list[0].customize?.add_items?.find(
+			(item) => item.feature_id === TestFeature.Messages,
+		);
+		expect(customizedItem?.included).toBe(50);
+	},
+);

--- a/server/tests/integration/licenses/license-edge-cases.test.ts
+++ b/server/tests/integration/licenses/license-edge-cases.test.ts
@@ -1,12 +1,13 @@
 import { expect, test } from "bun:test";
 import {
+	type ApiCustomerLicenseV0,
 	type ApiEntityV2,
+	type ApiPlanV1,
 	type AttachParamsV1Input,
 	type CheckResponseV3,
 	ErrCode,
 	fullCustomerToFullSubject,
 	fullSubjectToApiCustomerProducts,
-	type LicenseBalanceResponse,
 	type ProductV2,
 	planLicenses,
 	type TrackResponseV3,
@@ -126,10 +127,14 @@ test.concurrent(
 			actions: [],
 		});
 
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: baseLicense.id,
-			included: 1,
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			licenses: [
+				{
+					license_plan_id: baseLicense.id,
+					included: 1,
+				},
+			],
 		});
 		await autumnV2_2.billing.attach({
 			customer_id: customerId,
@@ -171,10 +176,14 @@ test.concurrent(
 			actions: [],
 		});
 
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			licenses: [
+				{
+					license_plan_id: license.id,
+					included: 1,
+				},
+			],
 		});
 		await autumnV2_2.billing.attach({
 			customer_id: customerId,
@@ -329,10 +338,14 @@ test.concurrent(
 			actions: [s.billing.attach({ productId: firstParent.id })],
 		});
 
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: firstParent.id,
-			license_plan_id: license.id,
-			included: 1,
+		await autumnV2_2.post("/plans.update", {
+			plan_id: firstParent.id,
+			licenses: [
+				{
+					license_plan_id: license.id,
+					included: 1,
+				},
+			],
 		});
 		await autumnV2_2.post("/licenses.attach", {
 			customer_id: customerId,
@@ -388,10 +401,14 @@ test.concurrent(
 			actions: [s.billing.attach({ productId: firstParent.id })],
 		});
 
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: firstParent.id,
-			license_plan_id: license.id,
-			included: 1,
+		await autumnV2_2.post("/plans.update", {
+			plan_id: firstParent.id,
+			licenses: [
+				{
+					license_plan_id: license.id,
+					included: 1,
+				},
+			],
 		});
 		await autumnV2_2.post("/licenses.attach", {
 			customer_id: customerId,
@@ -426,10 +443,14 @@ test.concurrent(
 			actions: [],
 		});
 
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			licenses: [
+				{
+					license_plan_id: license.id,
+					included: 1,
+				},
+			],
 		});
 		await autumnV2_2.billing.multiAttach({
 			customer_id: customerId,
@@ -923,23 +944,33 @@ test.concurrent(
 			actions: [s.billing.attach({ productId: parent.id })],
 		});
 
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
-			customize: { items: [itemsV2.monthlyMessages({ included: 100 })] },
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			licenses: [
+				{
+					license_plan_id: license.id,
+					included: 1,
+					customize: { items: [itemsV2.monthlyMessages({ included: 100 })] },
+				},
+			],
 		});
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
-			customize: null,
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			licenses: [
+				{
+					license_plan_id: license.id,
+					included: 1,
+					customize: null,
+				},
+			],
 		});
 
-		const { list } = (await autumnV2_2.post("/licenses.list_links", {
-			parent_plan_id: parent.id,
-		})) as { list: Array<{ customize: unknown }> };
-		expect(list[0].customize).toBeNull();
+		const plan = (await autumnV2_2.post("/plans.get", {
+			plan_id: parent.id,
+		})) as ApiPlanV1;
+		const links = plan.licenses ?? [];
+		expect(links).toHaveLength(1);
+		expect(links[0].customize ?? null).toBeNull();
 
 		await autumnV2_2.post("/licenses.attach", {
 			customer_id: customerId,
@@ -970,22 +1001,30 @@ test.concurrent(
 			actions: [s.billing.attach({ productId: parent.id })],
 		});
 
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 2,
-			customize: { items: [itemsV2.monthlyMessages({ included: 100 })] },
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			licenses: [
+				{
+					license_plan_id: license.id,
+					included: 2,
+					customize: { items: [itemsV2.monthlyMessages({ included: 100 })] },
+				},
+			],
 		});
 		await autumnV2_2.post("/licenses.attach", {
 			customer_id: customerId,
 			entity_id: entities[0].id,
 			plan_id: license.id,
 		});
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 2,
-			customize: { items: [itemsV2.monthlyMessages({ included: 50 })] },
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			licenses: [
+				{
+					license_plan_id: license.id,
+					included: 2,
+					customize: { items: [itemsV2.monthlyMessages({ included: 50 })] },
+				},
+			],
 		});
 		await autumnV2_2.post("/licenses.attach", {
 			customer_id: customerId,
@@ -1025,13 +1064,17 @@ test.concurrent(
 			],
 			actions: [s.billing.attach({ productId: parent.id })],
 		});
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
-			customize: {
-				items: [itemsV2.monthlyWords({ included: 80 }), itemsV2.dashboard()],
-			},
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			licenses: [
+				{
+					license_plan_id: license.id,
+					included: 1,
+					customize: {
+						items: [itemsV2.monthlyWords({ included: 80 }), itemsV2.dashboard()],
+					},
+				},
+			],
 		});
 		await autumnV2_2.post("/licenses.attach", {
 			customer_id: customerId,
@@ -1117,17 +1160,25 @@ test.concurrent(
 			],
 		});
 
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parentA.id,
-			license_plan_id: license.id,
-			included: 1,
-			customize: { items: [itemsV2.monthlyMessages({ included: 50 })] },
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parentA.id,
+			licenses: [
+				{
+					license_plan_id: license.id,
+					included: 1,
+					customize: { items: [itemsV2.monthlyMessages({ included: 50 })] },
+				},
+			],
 		});
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parentB.id,
-			license_plan_id: license.id,
-			included: 2,
-			customize: { items: [itemsV2.monthlyMessages({ included: 200 })] },
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parentB.id,
+			licenses: [
+				{
+					license_plan_id: license.id,
+					included: 2,
+					customize: { items: [itemsV2.monthlyMessages({ included: 200 })] },
+				},
+			],
 		});
 		const poolsBefore = (await autumnV2_2.post("/licenses.list", {
 			customer_id: customerId,

--- a/server/tests/integration/licenses/license-edge-cases.test.ts
+++ b/server/tests/integration/licenses/license-edge-cases.test.ts
@@ -1,0 +1,1179 @@
+import { expect, test } from "bun:test";
+import {
+	type ApiEntityV2,
+	type AttachParamsV1Input,
+	type CheckResponseV3,
+	ErrCode,
+	fullCustomerToFullSubject,
+	fullSubjectToApiCustomerProducts,
+	type LicenseBalanceResponse,
+	type ProductV2,
+	planLicenses,
+	type TrackResponseV3,
+	type UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { and, eq, isNotNull } from "drizzle-orm";
+import { CusService } from "@/internal/customers/CusService.js";
+
+const makeParentProduct = ({
+	id = "license-parent",
+	messageGrant,
+	includeDashboard = true,
+	group,
+}: {
+	id?: string;
+	messageGrant?: number;
+	includeDashboard?: boolean;
+	group?: string;
+} = {}) =>
+	products.base({
+		id,
+		group,
+		items: [
+			...(includeDashboard ? [items.dashboard()] : []),
+			...(messageGrant
+				? [items.monthlyMessages({ includedUsage: messageGrant })]
+				: []),
+		],
+	});
+
+const makeLicenseProduct = ({
+	id = "license-seat",
+	messageGrant = 25,
+}: {
+	id?: string;
+	messageGrant?: number;
+} = {}) => ({
+	...products.base({
+		id,
+		items: [items.monthlyMessages({ includedUsage: messageGrant })],
+	}),
+});
+
+const setupAssignedLicense = async ({
+	customerId,
+	parentMessageGrant,
+	licenseMessageGrant = 25,
+	included = 1,
+	entityCount = 1,
+	customize,
+}: {
+	customerId: string;
+	parentMessageGrant?: number;
+	licenseMessageGrant?: number;
+	included?: number;
+	entityCount?: number;
+	customize?: Record<string, unknown> | null;
+}) => {
+	const parent = makeParentProduct({ messageGrant: parentMessageGrant });
+	const license = makeLicenseProduct({ messageGrant: licenseMessageGrant });
+
+	const result = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.entities({ count: entityCount, featureId: TestFeature.Users }),
+			s.products({ list: [parent, license] }),
+		],
+		actions: [s.billing.attach({ productId: parent.id })],
+	});
+
+	await result.autumnV2_2.post("/licenses.link", {
+		parent_plan_id: parent.id,
+		license_plan_id: license.id,
+		included: included,
+		...(customize !== undefined ? { customize } : {}),
+	});
+
+	const assignResponse = (await result.autumnV2_2.post("/licenses.attach", {
+		customer_id: result.customerId,
+		entity_id: result.entities[0].id,
+		plan_id: license.id,
+	})) as {
+		assignment: {
+			id: string;
+			started_at: number;
+			ended_at: number | null;
+		};
+	};
+
+	return { ...result, parent, license, assignment: assignResponse.assignment };
+};
+
+const getBalanceBreakdown = (
+	response: CheckResponseV3 | TrackResponseV3,
+	planId: string,
+) => response.balance?.breakdown?.find((item) => item.plan_id === planId);
+
+test(`${chalk.yellowBright("licenses-custom: attach license patch swaps out an inherited license")}`, async () => {
+	const parent = makeParentProduct({ id: "lic-custom-attach-parent" });
+	const baseLicense = makeLicenseProduct({ id: "lic-custom-attach-base" });
+	const customLicense = makeLicenseProduct({
+		id: "lic-custom-attach-seat",
+	});
+	const { customerId, autumnV2_2 } = await initScenario({
+		customerId: "lic-custom-attach",
+		setup: [
+			s.customer({ testClock: false }),
+			s.entities({ count: 2, featureId: TestFeature.Users }),
+			s.products({ list: [parent, baseLicense, customLicense] }),
+		],
+		actions: [],
+	});
+
+	await autumnV2_2.post("/licenses.link", {
+		parent_plan_id: parent.id,
+		license_plan_id: baseLicense.id,
+		included: 1,
+	});
+	await autumnV2_2.billing.attach({
+		customer_id: customerId,
+		plan_id: parent.id,
+		customize: {
+			add_licenses: [
+				{
+					license_plan_id: customLicense.id,
+					included: 2,
+				},
+			],
+			remove_licenses: [baseLicense.id],
+		},
+	});
+
+	const pools = (await autumnV2_2.post("/licenses.list", {
+		customer_id: customerId,
+	})) as { list: LicenseBalanceResponse[] };
+	expect(pools.list).toHaveLength(1);
+	expect(pools.list[0]).toMatchObject({
+		license_plan_id: customLicense.id,
+		inventory: { included: 2, assigned: 0, available: 2 },
+	});
+});
+
+test(`${chalk.yellowBright("licenses-custom: remove_licenses suppresses an inherited license")}`, async () => {
+	const parent = makeParentProduct({ id: "lic-custom-empty-parent" });
+	const license = makeLicenseProduct({ id: "lic-custom-empty-seat" });
+	const { customerId, entities, autumnV2_2 } = await initScenario({
+		customerId: "lic-custom-empty",
+		setup: [
+			s.customer({ testClock: false }),
+			s.entities({ count: 1, featureId: TestFeature.Users }),
+			s.products({ list: [parent, license] }),
+		],
+		actions: [],
+	});
+
+	await autumnV2_2.post("/licenses.link", {
+		parent_plan_id: parent.id,
+		license_plan_id: license.id,
+		included: 1,
+	});
+	await autumnV2_2.billing.attach({
+		customer_id: customerId,
+		plan_id: parent.id,
+		customize: { remove_licenses: [license.id] },
+	});
+
+	const pools = (await autumnV2_2.post("/licenses.list", {
+		customer_id: customerId,
+	})) as { list: LicenseBalanceResponse[] };
+	expect(pools.list).toEqual([]);
+	await expectAutumnError({
+		errCode: ErrCode.InvalidRequest,
+		func: () =>
+			autumnV2_2.post("/licenses.attach", {
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				plan_id: license.id,
+			}),
+	});
+});
+
+test(`${chalk.yellowBright("licenses-custom: preview validates but does not persist license override")}`, async () => {
+	const { customerId, autumnV2_2, ctx, parent, license } =
+		await setupAssignedLicense({
+			customerId: "lic-custom-preview",
+			included: 1,
+		});
+
+	await expectAutumnError({
+		errCode: ErrCode.InvalidRequest,
+		func: () =>
+			autumnV2_2.subscriptions.previewUpdate<UpdateSubscriptionV1ParamsInput>({
+				customer_id: customerId,
+				plan_id: parent.id,
+				customize: { remove_licenses: [license.id] },
+			}),
+	});
+
+	await autumnV2_2.subscriptions.previewUpdate<UpdateSubscriptionV1ParamsInput>(
+		{
+			customer_id: customerId,
+			plan_id: parent.id,
+			customize: {
+				add_licenses: [
+					{
+						license_plan_id: license.id,
+						included: 1,
+					},
+				],
+			},
+		},
+	);
+
+	const customRows = await ctx.db.query.planLicenses.findMany({
+		where: and(
+			eq(planLicenses.license_internal_product_id, license.internal_id!),
+			isNotNull(planLicenses.parent_customer_product_id),
+		),
+	});
+	expect(customRows).toHaveLength(0);
+});
+
+test(`${chalk.yellowBright("licenses-custom: billing.update syncs license override onto existing parent")}`, async () => {
+	const { customerId, entities, autumnV2_2, ctx, parent, license } =
+		await setupAssignedLicense({
+			customerId: "lic-custom-update-existing",
+			included: 2,
+			entityCount: 2,
+		});
+
+	await autumnV2_2.billing.update({
+		customer_id: customerId,
+		plan_id: parent.id,
+		customize: {
+			add_licenses: [
+				{
+					license_plan_id: license.id,
+					included: 3,
+				},
+			],
+		},
+	});
+
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	const parentCustomerProduct = fullCustomer.customer_products.find(
+		(customerProduct) => customerProduct.product.id === parent.id,
+	);
+	const customRows = await ctx.db.query.planLicenses.findMany({
+		where: eq(
+			planLicenses.parent_customer_product_id,
+			parentCustomerProduct!.id,
+		),
+	});
+	expect(customRows).toHaveLength(1);
+	expect(customRows[0].included).toBe(3);
+
+	const pools = (await autumnV2_2.post("/licenses.list", {
+		customer_id: customerId,
+	})) as { list: LicenseBalanceResponse[] };
+	expect(pools.list[0]).toMatchObject({
+		license_plan_id: license.id,
+		inventory: { included: 3, assigned: 1, available: 2 },
+	});
+
+	await autumnV2_2.post("/licenses.attach", {
+		customer_id: customerId,
+		entity_id: entities[1].id,
+		plan_id: license.id,
+	});
+	const poolsAfterSecondAssign = (await autumnV2_2.post("/licenses.list", {
+		customer_id: customerId,
+	})) as { list: LicenseBalanceResponse[] };
+	expect(poolsAfterSecondAssign.list[0]).toMatchObject({
+		license_plan_id: license.id,
+		inventory: { included: 3, assigned: 2, available: 1 },
+	});
+});
+
+test(`${chalk.yellowBright("licenses-custom: attach transition moves assignments to custom pool")}`, async () => {
+	const group = "lic-custom-switch-group";
+	const firstParent = makeParentProduct({
+		id: "lic-custom-switch-first",
+		group,
+	});
+	const secondParent = makeParentProduct({
+		id: "lic-custom-switch-second",
+		group,
+	});
+	const license = makeLicenseProduct({ id: "lic-custom-switch-seat" });
+	const { customerId, entities, autumnV2_2, ctx } = await initScenario({
+		customerId: "lic-custom-switch",
+		setup: [
+			s.customer({ testClock: false }),
+			s.entities({ count: 1, featureId: TestFeature.Users }),
+			s.products({ list: [firstParent, secondParent, license] }),
+		],
+		actions: [s.billing.attach({ productId: firstParent.id })],
+	});
+
+	await autumnV2_2.post("/licenses.link", {
+		parent_plan_id: firstParent.id,
+		license_plan_id: license.id,
+		included: 1,
+	});
+	await autumnV2_2.post("/licenses.attach", {
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		plan_id: license.id,
+	});
+
+	await autumnV2_2.billing.attach<AttachParamsV1Input>({
+		customer_id: customerId,
+		plan_id: secondParent.id,
+		customize: {
+			add_licenses: [
+				{
+					license_plan_id: license.id,
+					included: 1,
+				},
+			],
+		},
+	});
+
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	const secondCustomerProduct = fullCustomer.customer_products.find(
+		(customerProduct) => customerProduct.product.id === secondParent.id,
+	);
+
+	const pools = (await autumnV2_2.post("/licenses.list", {
+		customer_id: customerId,
+	})) as { list: LicenseBalanceResponse[] };
+	expect(pools.list).toHaveLength(1);
+	expect(pools.list[0]).toMatchObject({
+		license_plan_id: license.id,
+		inventory: { included: 1, assigned: 1, available: 0 },
+		assignments: [{ entity_id: entities[0].id }],
+	});
+});
+
+test(`${chalk.yellowBright("licenses-custom: attach transition blocks unsafe license removal")}`, async () => {
+	const group = "lic-custom-switch-reduce-group";
+	const firstParent = makeParentProduct({
+		id: "lic-custom-switch-reduce-first",
+		group,
+	});
+	const secondParent = makeParentProduct({
+		id: "lic-custom-switch-reduce-second",
+		group,
+	});
+	const license = makeLicenseProduct({ id: "lic-custom-switch-reduce-seat" });
+	const { customerId, entities, autumnV2_2 } = await initScenario({
+		customerId: "lic-custom-switch-reduce",
+		setup: [
+			s.customer({ testClock: false }),
+			s.entities({ count: 1, featureId: TestFeature.Users }),
+			s.products({ list: [firstParent, secondParent, license] }),
+		],
+		actions: [s.billing.attach({ productId: firstParent.id })],
+	});
+
+	await autumnV2_2.post("/licenses.link", {
+		parent_plan_id: firstParent.id,
+		license_plan_id: license.id,
+		included: 1,
+	});
+	await autumnV2_2.post("/licenses.attach", {
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		plan_id: license.id,
+	});
+
+	await expectAutumnError({
+		errCode: ErrCode.InvalidRequest,
+		func: () =>
+			autumnV2_2.billing.attach<AttachParamsV1Input>({
+				customer_id: customerId,
+				plan_id: secondParent.id,
+				customize: { remove_licenses: [license.id] },
+			}),
+	});
+});
+
+test(`${chalk.yellowBright("licenses-custom: multi_attach provisions custom license pool")}`, async () => {
+	const parent = makeParentProduct({ id: "lic-custom-multi-parent" });
+	const license = makeLicenseProduct({ id: "lic-custom-multi-seat" });
+	const { customerId, autumnV2_2 } = await initScenario({
+		customerId: "lic-custom-multi",
+		setup: [
+			s.customer({ testClock: false }),
+			s.entities({ count: 1, featureId: TestFeature.Users }),
+			s.products({ list: [parent, license] }),
+		],
+		actions: [],
+	});
+
+	await autumnV2_2.post("/licenses.link", {
+		parent_plan_id: parent.id,
+		license_plan_id: license.id,
+		included: 1,
+	});
+	await autumnV2_2.billing.multiAttach({
+		customer_id: customerId,
+		plans: [
+			{
+				plan_id: parent.id,
+				customize: {
+					add_licenses: [
+						{
+							license_plan_id: license.id,
+							included: 2,
+						},
+					],
+				},
+			},
+		],
+	});
+
+	const pools = (await autumnV2_2.post("/licenses.list", {
+		customer_id: customerId,
+	})) as { list: LicenseBalanceResponse[] };
+	expect(pools.list).toHaveLength(1);
+	expect(pools.list[0]).toMatchObject({
+		license_plan_id: license.id,
+		inventory: { included: 2, assigned: 0, available: 2 },
+	});
+});
+
+test(`${chalk.yellowBright("licenses-custom: active assignments block unsafe custom reductions")}`, async () => {
+	const { customerId, autumnV2_2, parent, license } =
+		await setupAssignedLicense({
+			customerId: "lic-custom-reduce-block",
+			included: 1,
+		});
+
+	await expectAutumnError({
+		errCode: ErrCode.InvalidRequest,
+		func: () =>
+			autumnV2_2.billing.update({
+				customer_id: customerId,
+				plan_id: parent.id,
+				customize: { remove_licenses: [license.id] },
+			}),
+	});
+
+	await expectAutumnError({
+		errCode: ErrCode.InvalidRequest,
+		func: () =>
+			autumnV2_2.billing.update({
+				customer_id: customerId,
+				plan_id: parent.id,
+				customize: {
+					add_licenses: [
+						{
+							license_plan_id: license.id,
+							included: 0,
+						},
+					],
+				},
+			}),
+	});
+});
+
+test(`${chalk.yellowBright("licenses-custom: custom license edits affect future assignments only")}`, async () => {
+	const { customerId, entities, autumnV2_2, parent, license } =
+		await setupAssignedLicense({
+			customerId: "lic-custom-future-only",
+			included: 2,
+			entityCount: 2,
+		});
+
+	await autumnV2_2.billing.update({
+		customer_id: customerId,
+		plan_id: parent.id,
+		customize: {
+			add_licenses: [
+				{
+					license_plan_id: license.id,
+					included: 2,
+					customize: {
+						items: [itemsV2.monthlyMessages({ included: 50 })],
+					},
+				},
+			],
+		},
+	});
+	await autumnV2_2.post("/licenses.attach", {
+		customer_id: customerId,
+		entity_id: entities[1].id,
+		plan_id: license.id,
+	});
+
+	const firstEntity = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		feature_id: TestFeature.Messages,
+	});
+	const secondEntity = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		entity_id: entities[1].id,
+		feature_id: TestFeature.Messages,
+	});
+	expect(firstEntity.balance?.granted).toBe(25);
+	expect(secondEntity.balance?.granted).toBe(50);
+});
+
+test(`${chalk.yellowBright("licenses-edge: provisioned license stays entity-level internally and hidden from API products")}`, async () => {
+	const { customerId, entities, autumnV2_2, ctx, parent, license } =
+		await setupAssignedLicense({
+			customerId: "lic-edge-internal",
+		});
+
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+		entityId: entities[0].id,
+		withEntities: true,
+	});
+	const licenseCusProduct = fullCustomer.customer_products.find(
+		(customerProduct) => customerProduct.product.id === license.id,
+	);
+	expect(licenseCusProduct).toBeDefined();
+	expect(licenseCusProduct?.internal_entity_id).toBe(
+		fullCustomer.entity?.internal_id,
+	);
+	expect(licenseCusProduct?.customer_prices).toHaveLength(0);
+	expect(licenseCusProduct?.subscription_ids).toEqual([]);
+	expect(licenseCusProduct?.scheduled_ids).toEqual([]);
+	expect(
+		licenseCusProduct?.customer_entitlements.every(
+			(entitlement) =>
+				entitlement.internal_entity_id === fullCustomer.entity?.internal_id,
+		),
+	).toBe(true);
+
+	const fullSubject = fullCustomerToFullSubject({ fullCustomer });
+	const apiProducts = fullSubjectToApiCustomerProducts({ fullSubject });
+	expect(apiProducts.map((item) => item.product.id)).toEqual([parent.id]);
+
+	const entity = await autumnV2_2.entities.get<ApiEntityV2>(
+		customerId,
+		entities[0].id,
+	);
+	expectBalanceCorrect({
+		customer: entity,
+		featureId: TestFeature.Messages,
+		granted: 25,
+		remaining: 25,
+		usage: 0,
+		planId: license.id,
+	});
+	expect(
+		entity.subscriptions.some(
+			(subscription) => subscription.plan_id === license.id,
+		),
+	).toBe(false);
+});
+
+test(`${chalk.yellowBright("licenses-edge: entity check stacks customer grant and license grant")}`, async () => {
+	const { customerId, entities, autumnV2_2, parent, license } =
+		await setupAssignedLicense({
+			customerId: "lic-edge-stack-check",
+			parentMessageGrant: 10,
+		});
+
+	const customerCheck = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+	});
+	expect(customerCheck.allowed).toBe(true);
+	expect(customerCheck.balance?.granted).toBe(10);
+	expect(getBalanceBreakdown(customerCheck, parent.id)).toMatchObject({
+		included_grant: 10,
+		remaining: 10,
+		usage: 0,
+	});
+	expect(getBalanceBreakdown(customerCheck, license.id)).toBeUndefined();
+
+	const entityCheck = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		feature_id: TestFeature.Messages,
+	});
+	expect(entityCheck.allowed).toBe(true);
+	expect(entityCheck.balance?.granted).toBe(35);
+	expect(entityCheck.balance?.remaining).toBe(35);
+	expect(getBalanceBreakdown(entityCheck, parent.id)).toMatchObject({
+		included_grant: 10,
+	});
+	expect(getBalanceBreakdown(entityCheck, license.id)).toMatchObject({
+		included_grant: 25,
+	});
+});
+
+test(`${chalk.yellowBright("licenses-edge: entity track deducts inherited and license balances")}`, async () => {
+	const { customerId, entities, autumnV2_2, parent, license } =
+		await setupAssignedLicense({
+			customerId: "lic-edge-track-stack",
+			parentMessageGrant: 10,
+		});
+
+	const trackResponse = (await autumnV2_2.track(
+		{
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+			value: 35,
+		},
+		{ timeout: 2000 },
+	)) as TrackResponseV3;
+	expect(trackResponse.entity_id).toBe(entities[0].id);
+	expect(trackResponse.balance?.granted).toBe(35);
+	expect(trackResponse.balance?.remaining).toBe(0);
+	expect(trackResponse.balance?.usage).toBe(35);
+	expect(getBalanceBreakdown(trackResponse, parent.id)).toMatchObject({
+		included_grant: 10,
+		remaining: 0,
+		usage: 10,
+	});
+	expect(getBalanceBreakdown(trackResponse, license.id)).toMatchObject({
+		included_grant: 25,
+		remaining: 0,
+		usage: 25,
+	});
+	expect(
+		trackResponse.deductions?.find((item) => item.plan_id === parent.id)?.value,
+	).toBe(10);
+	expect(
+		trackResponse.deductions?.find((item) => item.plan_id === license.id)
+			?.value,
+	).toBe(25);
+
+	const customerCheck = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		skip_cache: true,
+	});
+	expect(customerCheck.allowed).toBe(false);
+	expect(customerCheck.balance?.granted).toBe(10);
+	expect(customerCheck.balance?.remaining).toBe(0);
+	expect(customerCheck.balance?.usage).toBe(10);
+	expect(getBalanceBreakdown(customerCheck, license.id)).toBeUndefined();
+});
+
+test(`${chalk.yellowBright("licenses-edge: customer and sibling entity cannot spend assigned license")}`, async () => {
+	const { customerId, entities, autumnV2_2, license } =
+		await setupAssignedLicense({
+			customerId: "lic-edge-track-scope",
+			entityCount: 2,
+		});
+
+	const customerTrack = (await autumnV2_2.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 1,
+		overage_behavior: "reject",
+	})) as TrackResponseV3;
+	expect(customerTrack.balance).toBeNull();
+	expect(customerTrack.deductions).toEqual([]);
+
+	const siblingTrack = (await autumnV2_2.track({
+		customer_id: customerId,
+		entity_id: entities[1].id,
+		feature_id: TestFeature.Messages,
+		value: 1,
+		overage_behavior: "reject",
+	})) as TrackResponseV3;
+	expect(siblingTrack.balance).toBeNull();
+	expect(siblingTrack.deductions).toEqual([]);
+
+	const assignedEntity = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		feature_id: TestFeature.Messages,
+	});
+	expect(assignedEntity.allowed).toBe(true);
+	expect(assignedEntity.balance?.remaining).toBe(25);
+
+	const siblingEntity = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		entity_id: entities[1].id,
+		feature_id: TestFeature.Messages,
+	});
+	expect(siblingEntity.allowed).toBe(false);
+	expect(siblingEntity.balance).toBeNull();
+
+	const pools = (await autumnV2_2.post("/licenses.list", {
+		customer_id: customerId,
+	})) as { list: LicenseBalanceResponse[] };
+	expect(pools.list[0]).toMatchObject({
+		license_plan_id: license.id,
+		inventory: { assigned: 1, available: 0 },
+	});
+});
+
+test(`${chalk.yellowBright("licenses-edge: duplicate assign is idempotent and does not double grant")}`, async () => {
+	const { customerId, entities, autumnV2_2, assignment, license } =
+		await setupAssignedLicense({
+			customerId: "lic-edge-idempotent",
+		});
+
+	const duplicate = (await autumnV2_2.post("/licenses.attach", {
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		plan_id: license.id,
+	})) as { assignment: typeof assignment };
+	expect(duplicate.assignment.id).toBe(assignment.id);
+	expect(duplicate.assignment.started_at).toBe(assignment.started_at);
+
+	const assignments = (await autumnV2_2.post("/licenses.list_assignments", {
+		customer_id: customerId,
+		plan_id: license.id,
+	})) as { list: unknown[] };
+	expect(assignments.list).toHaveLength(1);
+
+	const check = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		feature_id: TestFeature.Messages,
+	});
+	expect(check.balance?.granted).toBe(25);
+	expect(check.balance?.breakdown).toHaveLength(1);
+
+	const track = (await autumnV2_2.track({
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		feature_id: TestFeature.Messages,
+		value: 25,
+	})) as TrackResponseV3;
+	expect(track.balance?.remaining).toBe(0);
+	expect(track.deductions).toHaveLength(1);
+});
+
+test(`${chalk.yellowBright("licenses-edge: two assigned entities isolate license balances and share customer grant")}`, async () => {
+	const { customerId, entities, autumnV2_2, parent, license } =
+		await setupAssignedLicense({
+			customerId: "lic-edge-two-entities",
+			parentMessageGrant: 10,
+			included: 2,
+			entityCount: 2,
+		});
+	await autumnV2_2.post("/licenses.attach", {
+		customer_id: customerId,
+		entity_id: entities[1].id,
+		plan_id: license.id,
+	});
+
+	await autumnV2_2.track(
+		{
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+			value: 35,
+		},
+		{ timeout: 2000 },
+	);
+
+	const customerCheck = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		skip_cache: true,
+	});
+	expect(customerCheck.balance?.granted).toBe(10);
+	expect(customerCheck.balance?.remaining).toBe(0);
+	expect(customerCheck.balance?.usage).toBe(10);
+	expect(getBalanceBreakdown(customerCheck, parent.id)).toBeDefined();
+	expect(getBalanceBreakdown(customerCheck, license.id)).toBeUndefined();
+
+	const entityOne = await autumnV2_2.entities.get<ApiEntityV2>(
+		customerId,
+		entities[0].id,
+	);
+	expectBalanceCorrect({
+		customer: entityOne,
+		featureId: TestFeature.Messages,
+		granted: 35,
+		remaining: 0,
+		usage: 35,
+	});
+
+	const entityTwo = await autumnV2_2.entities.get<ApiEntityV2>(
+		customerId,
+		entities[1].id,
+	);
+	expectBalanceCorrect({
+		customer: entityTwo,
+		featureId: TestFeature.Messages,
+		granted: 35,
+		remaining: 25,
+		usage: 10,
+	});
+	const entityTwoMessages = entityTwo.balances[TestFeature.Messages];
+	expect(entityTwoMessages).toBeDefined();
+	expect(
+		entityTwoMessages?.breakdown?.find((item) => item.plan_id === parent.id),
+	).toMatchObject({ remaining: 0, usage: 10 });
+	expect(
+		entityTwoMessages?.breakdown?.find((item) => item.plan_id === license.id),
+	).toMatchObject({ remaining: 25, usage: 0 });
+});
+
+test(`${chalk.yellowBright("licenses-edge: unassign is idempotent and removes only the license grant")}`, async () => {
+	const { customerId, entities, autumnV2_2, assignment, parent, license } =
+		await setupAssignedLicense({
+			customerId: "lic-edge-unassign",
+			parentMessageGrant: 10,
+		});
+
+	const first = (await autumnV2_2.post("/licenses.update", {
+		customer_id: customerId,
+		cancel_action: "cancel_immediately",
+		assignment_id: assignment.id,
+	})) as { assignment: { id: string; ended_at: number | null } };
+	const second = (await autumnV2_2.post("/licenses.update", {
+		customer_id: customerId,
+		cancel_action: "cancel_immediately",
+		assignment_id: assignment.id,
+	})) as { assignment: { id: string; ended_at: number | null } };
+	expect(second.assignment).toEqual(first.assignment);
+
+	const entityCheck = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		feature_id: TestFeature.Messages,
+	});
+	expect(entityCheck.balance?.granted).toBe(10);
+	expect(getBalanceBreakdown(entityCheck, parent.id)).toBeDefined();
+	expect(getBalanceBreakdown(entityCheck, license.id)).toBeUndefined();
+
+	const track = (await autumnV2_2.track({
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		feature_id: TestFeature.Messages,
+		value: 10,
+	})) as TrackResponseV3;
+	expect(track.balance?.remaining).toBe(0);
+	await expectAutumnError({
+		errCode: ErrCode.InsufficientBalance,
+		func: () =>
+			autumnV2_2.track({
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				feature_id: TestFeature.Messages,
+				value: 1,
+				overage_behavior: "reject",
+			}),
+	});
+});
+
+test(`${chalk.yellowBright("licenses-edge: customize null removes override for future assignments")}`, async () => {
+	const parent = makeParentProduct({ id: "license-null-parent" });
+	const license = makeLicenseProduct({ id: "license-null-seat" });
+	const { customerId, entities, autumnV2_2 } = await initScenario({
+		customerId: "lic-edge-custom-null",
+		setup: [
+			s.customer({ testClock: false }),
+			s.entities({ count: 1, featureId: TestFeature.Users }),
+			s.products({ list: [parent, license] }),
+		],
+		actions: [s.billing.attach({ productId: parent.id })],
+	});
+
+	await autumnV2_2.post("/licenses.link", {
+		parent_plan_id: parent.id,
+		license_plan_id: license.id,
+		included: 1,
+		customize: { items: [itemsV2.monthlyMessages({ included: 100 })] },
+	});
+	await autumnV2_2.post("/licenses.link", {
+		parent_plan_id: parent.id,
+		license_plan_id: license.id,
+		included: 1,
+		customize: null,
+	});
+
+	const { list } = (await autumnV2_2.post("/licenses.list_links", {
+		parent_plan_id: parent.id,
+	})) as { list: Array<{ customize: unknown }> };
+	expect(list[0].customize).toBeNull();
+
+	await autumnV2_2.post("/licenses.attach", {
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		plan_id: license.id,
+	});
+	const check = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		feature_id: TestFeature.Messages,
+	});
+	expect(check.balance?.granted).toBe(25);
+});
+
+test(`${chalk.yellowBright("licenses-edge: existing assignment keeps old customize after plan license update")}`, async () => {
+	const parent = makeParentProduct({ id: "license-snapshot-parent" });
+	const license = makeLicenseProduct({ id: "license-snapshot-seat" });
+	const { customerId, entities, autumnV2_2 } = await initScenario({
+		customerId: "lic-edge-custom-snapshot",
+		setup: [
+			s.customer({ testClock: false }),
+			s.entities({ count: 2, featureId: TestFeature.Users }),
+			s.products({ list: [parent, license] }),
+		],
+		actions: [s.billing.attach({ productId: parent.id })],
+	});
+
+	await autumnV2_2.post("/licenses.link", {
+		parent_plan_id: parent.id,
+		license_plan_id: license.id,
+		included: 2,
+		customize: { items: [itemsV2.monthlyMessages({ included: 100 })] },
+	});
+	await autumnV2_2.post("/licenses.attach", {
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		plan_id: license.id,
+	});
+	await autumnV2_2.post("/licenses.link", {
+		parent_plan_id: parent.id,
+		license_plan_id: license.id,
+		included: 2,
+		customize: { items: [itemsV2.monthlyMessages({ included: 50 })] },
+	});
+	await autumnV2_2.post("/licenses.attach", {
+		customer_id: customerId,
+		entity_id: entities[1].id,
+		plan_id: license.id,
+	});
+
+	const firstEntity = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		feature_id: TestFeature.Messages,
+	});
+	const secondEntity = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		entity_id: entities[1].id,
+		feature_id: TestFeature.Messages,
+	});
+	expect(firstEntity.balance?.granted).toBe(100);
+	expect(secondEntity.balance?.granted).toBe(50);
+});
+
+test(`${chalk.yellowBright("licenses-edge: customize can replace base item and add boolean entitlement")}`, async () => {
+	const parent = makeParentProduct({
+		id: "license-custom-items-parent",
+		includeDashboard: false,
+	});
+	const license = makeLicenseProduct({ id: "license-custom-items-seat" });
+	const { customerId, entities, autumnV2_2 } = await initScenario({
+		customerId: "lic-edge-custom-items",
+		setup: [
+			s.customer({ testClock: false }),
+			s.entities({ count: 2, featureId: TestFeature.Users }),
+			s.products({ list: [parent, license] }),
+		],
+		actions: [s.billing.attach({ productId: parent.id })],
+	});
+	await autumnV2_2.post("/licenses.link", {
+		parent_plan_id: parent.id,
+		license_plan_id: license.id,
+		included: 1,
+		customize: {
+			items: [itemsV2.monthlyWords({ included: 80 }), itemsV2.dashboard()],
+		},
+	});
+	await autumnV2_2.post("/licenses.attach", {
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		plan_id: license.id,
+	});
+
+	const messagesCheck = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		feature_id: TestFeature.Messages,
+	});
+	expect(messagesCheck.allowed).toBe(false);
+	expect(messagesCheck.balance).toBeNull();
+
+	const wordsCheck = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		feature_id: TestFeature.Words,
+	});
+	expect(wordsCheck.allowed).toBe(true);
+	expect(wordsCheck.balance?.granted).toBe(80);
+
+	const dashboardCheck = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		feature_id: TestFeature.Dashboard,
+	});
+	expect(dashboardCheck.allowed).toBe(true);
+
+	const siblingDashboard = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		entity_id: entities[1].id,
+		feature_id: TestFeature.Dashboard,
+	});
+	expect(siblingDashboard.allowed).toBe(false);
+	expect(siblingDashboard.flag).toBeNull();
+
+	const { products: licenseProducts } = (await autumnV2_2.get(
+		"/products/license_products",
+	)) as { products: ProductV2[] };
+	const listedLicense = licenseProducts.find((item) => item.id === license.id);
+	expect(
+		listedLicense?.items.some((item) => item.feature_id === TestFeature.Words),
+	).toBe(false);
+});
+
+test(`${chalk.yellowBright("licenses-edge: multiple parent pools require subscription disambiguation")}`, async () => {
+	const parentA = products.recurringAddOn({
+		id: "license-pool-a",
+		items: [items.dashboard()],
+	});
+	const parentB = products.recurringAddOn({
+		id: "license-pool-b",
+		items: [items.dashboard()],
+	});
+	const license = makeLicenseProduct({ id: "license-pool-seat" });
+	const { customerId, entities, autumnV2_2 } = await initScenario({
+		customerId: "lic-edge-multi-pool",
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.entities({ count: 2, featureId: TestFeature.Users }),
+			s.products({ list: [parentA, parentB, license] }),
+		],
+		actions: [
+			s.billing.attach({
+				productId: parentA.id,
+				newBillingSubscription: true,
+				subscriptionId: "license-pool-a-sub",
+			}),
+			s.billing.attach({
+				productId: parentB.id,
+				newBillingSubscription: true,
+				subscriptionId: "license-pool-b-sub",
+			}),
+		],
+	});
+
+	await autumnV2_2.post("/licenses.link", {
+		parent_plan_id: parentA.id,
+		license_plan_id: license.id,
+		included: 1,
+		customize: { items: [itemsV2.monthlyMessages({ included: 50 })] },
+	});
+	await autumnV2_2.post("/licenses.link", {
+		parent_plan_id: parentB.id,
+		license_plan_id: license.id,
+		included: 2,
+		customize: { items: [itemsV2.monthlyMessages({ included: 200 })] },
+	});
+	const poolsBefore = (await autumnV2_2.post("/licenses.list", {
+		customer_id: customerId,
+	})) as { list: LicenseBalanceResponse[] };
+	expect(poolsBefore.list).toHaveLength(2);
+	const poolA = poolsBefore.list.find((pool) => pool.inventory.included === 1);
+	const poolB = poolsBefore.list.find((pool) => pool.inventory.included === 2);
+	expect(poolA?.parent_plan_id).toBeTruthy();
+	expect(poolB?.parent_plan_id).toBeTruthy();
+	expect(poolA?.parent_plan_id).not.toBe(poolB?.parent_plan_id);
+
+	await expectAutumnError({
+		errCode: ErrCode.InvalidRequest,
+		func: () =>
+			autumnV2_2.post("/licenses.attach", {
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				plan_id: license.id,
+			}),
+	});
+	await autumnV2_2.post("/licenses.attach", {
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		plan_id: license.id,
+		parent_plan_id: poolA?.parent_plan_id,
+	});
+	await autumnV2_2.post("/licenses.attach", {
+		customer_id: customerId,
+		entity_id: entities[1].id,
+		plan_id: license.id,
+		parent_plan_id: poolB?.parent_plan_id,
+	});
+
+	const firstEntity = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		feature_id: TestFeature.Messages,
+	});
+	const secondEntity = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		entity_id: entities[1].id,
+		feature_id: TestFeature.Messages,
+	});
+	expect(firstEntity.balance?.granted).toBe(50);
+	expect(secondEntity.balance?.granted).toBe(200);
+
+	const poolsAfter = (await autumnV2_2.post("/licenses.list", {
+		customer_id: customerId,
+	})) as { list: LicenseBalanceResponse[] };
+	expect(
+		poolsAfter.list.find(
+			(pool) => pool.parent_plan_id === poolA?.parent_plan_id,
+		)?.inventory,
+	).toMatchObject({ included: 1, assigned: 1, available: 0 });
+	expect(
+		poolsAfter.list.find(
+			(pool) => pool.parent_plan_id === poolB?.parent_plan_id,
+		)?.inventory,
+	).toMatchObject({ included: 2, assigned: 1, available: 1 });
+});
+
+test(`${chalk.yellowBright("licenses-edge: non-license assign and priced customize are rejected")}`, async () => {
+	const parent = makeParentProduct({ id: "license-negative-parent" });
+	const license = makeLicenseProduct({ id: "license-negative-seat" });
+	const { customerId, entities, autumnV2_2 } = await initScenario({
+		customerId: "lic-edge-negative",
+		setup: [
+			s.customer({ testClock: false }),
+			s.entities({ count: 1, featureId: TestFeature.Users }),
+			s.products({ list: [parent, license] }),
+		],
+		actions: [s.billing.attach({ productId: parent.id })],
+	});
+
+	await autumnV2_2.post("/licenses.link", {
+		parent_plan_id: parent.id,
+		license_plan_id: license.id,
+		included: 1,
+	});
+	await expectAutumnError({
+		errCode: ErrCode.InvalidRequest,
+		func: () =>
+			autumnV2_2.post("/licenses.attach", {
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				plan_id: parent.id,
+			}),
+	});
+	const pricedCustomize = (await autumnV2_2.post("/licenses.link", {
+		parent_plan_id: parent.id,
+		license_plan_id: license.id,
+		included: 1,
+		customize: { items: [itemsV2.prepaidMessages()] },
+	})) as { plan_license: { customize: { add_items: unknown[] } } };
+	expect(pricedCustomize.plan_license.customize.add_items).toHaveLength(1);
+
+	const assignments = (await autumnV2_2.post("/licenses.list_assignments", {
+		customer_id: customerId,
+		plan_id: license.id,
+	})) as { list: unknown[] };
+	expect(assignments.list).toHaveLength(0);
+});

--- a/server/tests/integration/licenses/license-edge-cases.test.ts
+++ b/server/tests/integration/licenses/license-edge-cases.test.ts
@@ -64,14 +64,12 @@ const setupAssignedLicense = async ({
 	licenseMessageGrant = 25,
 	included = 1,
 	entityCount = 1,
-	customize,
 }: {
 	customerId: string;
 	parentMessageGrant?: number;
 	licenseMessageGrant?: number;
 	included?: number;
 	entityCount?: number;
-	customize?: Record<string, unknown> | null;
 }) => {
 	const parent = makeParentProduct({ messageGrant: parentMessageGrant });
 	const license = makeLicenseProduct({ messageGrant: licenseMessageGrant });
@@ -83,29 +81,26 @@ const setupAssignedLicense = async ({
 			s.entities({ count: entityCount, featureId: TestFeature.Users }),
 			s.products({ list: [parent, license] }),
 		],
-		actions: [s.billing.attach({ productId: parent.id })],
+		actions: [
+			s.licenses.link({
+				parentProductId: parent.id,
+				licenseProductId: license.id,
+				included,
+			}),
+			s.billing.attach({ productId: parent.id }),
+			s.licenses.assign({
+				licenseProductId: license.id,
+				entityIndex: 0,
+			}),
+		],
 	});
 
-	await result.autumnV2_2.post("/licenses.link", {
-		parent_plan_id: parent.id,
-		license_plan_id: license.id,
-		included: included,
-		...(customize !== undefined ? { customize } : {}),
-	});
-
-	const assignResponse = (await result.autumnV2_2.post("/licenses.attach", {
-		customer_id: result.customerId,
-		entity_id: result.entities[0].id,
-		plan_id: license.id,
-	})) as {
-		assignment: {
-			id: string;
-			started_at: number;
-			ended_at: number | null;
-		};
+	return {
+		...result,
+		parent,
+		license,
+		assignment: result.licenseAssignments[0],
 	};
-
-	return { ...result, parent, license, assignment: assignResponse.assignment };
 };
 
 const getBalanceBreakdown = (
@@ -113,111 +108,241 @@ const getBalanceBreakdown = (
 	planId: string,
 ) => response.balance?.breakdown?.find((item) => item.plan_id === planId);
 
-test(`${chalk.yellowBright("licenses-custom: attach license patch swaps out an inherited license")}`, async () => {
-	const parent = makeParentProduct({ id: "lic-custom-attach-parent" });
-	const baseLicense = makeLicenseProduct({ id: "lic-custom-attach-base" });
-	const customLicense = makeLicenseProduct({
-		id: "lic-custom-attach-seat",
-	});
-	const { customerId, autumnV2_2 } = await initScenario({
-		customerId: "lic-custom-attach",
-		setup: [
-			s.customer({ testClock: false }),
-			s.entities({ count: 2, featureId: TestFeature.Users }),
-			s.products({ list: [parent, baseLicense, customLicense] }),
-		],
-		actions: [],
-	});
-
-	await autumnV2_2.post("/licenses.link", {
-		parent_plan_id: parent.id,
-		license_plan_id: baseLicense.id,
-		included: 1,
-	});
-	await autumnV2_2.billing.attach({
-		customer_id: customerId,
-		plan_id: parent.id,
-		customize: {
-			add_licenses: [
-				{
-					license_plan_id: customLicense.id,
-					included: 2,
-				},
+test.concurrent(
+	`${chalk.yellowBright("licenses-custom: attach license patch swaps out an inherited license")}`,
+	async () => {
+		const parent = makeParentProduct({ id: "lic-custom-attach-parent" });
+		const baseLicense = makeLicenseProduct({ id: "lic-custom-attach-base" });
+		const customLicense = makeLicenseProduct({
+			id: "lic-custom-attach-seat",
+		});
+		const { customerId, autumnV2_2 } = await initScenario({
+			customerId: "lic-custom-attach",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [parent, baseLicense, customLicense] }),
 			],
-			remove_licenses: [baseLicense.id],
-		},
-	});
-
-	const pools = (await autumnV2_2.post("/licenses.list", {
-		customer_id: customerId,
-	})) as { list: LicenseBalanceResponse[] };
-	expect(pools.list).toHaveLength(1);
-	expect(pools.list[0]).toMatchObject({
-		license_plan_id: customLicense.id,
-		inventory: { included: 2, assigned: 0, available: 2 },
-	});
-});
-
-test(`${chalk.yellowBright("licenses-custom: remove_licenses suppresses an inherited license")}`, async () => {
-	const parent = makeParentProduct({ id: "lic-custom-empty-parent" });
-	const license = makeLicenseProduct({ id: "lic-custom-empty-seat" });
-	const { customerId, entities, autumnV2_2 } = await initScenario({
-		customerId: "lic-custom-empty",
-		setup: [
-			s.customer({ testClock: false }),
-			s.entities({ count: 1, featureId: TestFeature.Users }),
-			s.products({ list: [parent, license] }),
-		],
-		actions: [],
-	});
-
-	await autumnV2_2.post("/licenses.link", {
-		parent_plan_id: parent.id,
-		license_plan_id: license.id,
-		included: 1,
-	});
-	await autumnV2_2.billing.attach({
-		customer_id: customerId,
-		plan_id: parent.id,
-		customize: { remove_licenses: [license.id] },
-	});
-
-	const pools = (await autumnV2_2.post("/licenses.list", {
-		customer_id: customerId,
-	})) as { list: LicenseBalanceResponse[] };
-	expect(pools.list).toEqual([]);
-	await expectAutumnError({
-		errCode: ErrCode.InvalidRequest,
-		func: () =>
-			autumnV2_2.post("/licenses.attach", {
-				customer_id: customerId,
-				entity_id: entities[0].id,
-				plan_id: license.id,
-			}),
-	});
-});
-
-test(`${chalk.yellowBright("licenses-custom: preview validates but does not persist license override")}`, async () => {
-	const { customerId, autumnV2_2, ctx, parent, license } =
-		await setupAssignedLicense({
-			customerId: "lic-custom-preview",
-			included: 1,
+			actions: [],
 		});
 
-	await expectAutumnError({
-		errCode: ErrCode.InvalidRequest,
-		func: () =>
-			autumnV2_2.subscriptions.previewUpdate<UpdateSubscriptionV1ParamsInput>({
-				customer_id: customerId,
-				plan_id: parent.id,
-				customize: { remove_licenses: [license.id] },
-			}),
-	});
-
-	await autumnV2_2.subscriptions.previewUpdate<UpdateSubscriptionV1ParamsInput>(
-		{
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: baseLicense.id,
+			included: 1,
+		});
+		await autumnV2_2.billing.attach({
 			customer_id: customerId,
 			plan_id: parent.id,
+			customize: {
+				add_licenses: [
+					{
+						license_plan_id: customLicense.id,
+						included: 2,
+					},
+				],
+				remove_licenses: [baseLicense.id],
+			},
+		});
+
+		const pools = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(pools.list).toHaveLength(1);
+		expect(pools.list[0]).toMatchObject({
+			license_plan_id: customLicense.id,
+			inventory: { included: 2, assigned: 0, available: 2 },
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-custom: remove_licenses suppresses an inherited license")}`,
+	async () => {
+		const parent = makeParentProduct({ id: "lic-custom-empty-parent" });
+		const license = makeLicenseProduct({ id: "lic-custom-empty-seat" });
+		const { customerId, entities, autumnV2_2 } = await initScenario({
+			customerId: "lic-custom-empty",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: parent.id,
+			customize: { remove_licenses: [license.id] },
+		});
+
+		const pools = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(pools.list).toEqual([]);
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			func: () =>
+				autumnV2_2.post("/licenses.attach", {
+					customer_id: customerId,
+					entity_id: entities[0].id,
+					plan_id: license.id,
+				}),
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-custom: preview validates but does not persist license override")}`,
+	async () => {
+		const { customerId, autumnV2_2, ctx, parent, license } =
+			await setupAssignedLicense({
+				customerId: "lic-custom-preview",
+				included: 1,
+			});
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			func: () =>
+				autumnV2_2.subscriptions.previewUpdate<UpdateSubscriptionV1ParamsInput>(
+					{
+						customer_id: customerId,
+						plan_id: parent.id,
+						customize: { remove_licenses: [license.id] },
+					},
+				),
+		});
+
+		await autumnV2_2.subscriptions.previewUpdate<UpdateSubscriptionV1ParamsInput>(
+			{
+				customer_id: customerId,
+				plan_id: parent.id,
+				customize: {
+					add_licenses: [
+						{
+							license_plan_id: license.id,
+							included: 1,
+						},
+					],
+				},
+			},
+		);
+
+		const customRows = await ctx.db.query.planLicenses.findMany({
+			where: and(
+				eq(planLicenses.license_internal_product_id, license.internal_id!),
+				isNotNull(planLicenses.parent_customer_product_id),
+			),
+		});
+		expect(customRows).toHaveLength(0);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-custom: billing.update syncs license override onto existing parent")}`,
+	async () => {
+		const { customerId, entities, autumnV2_2, ctx, parent, license } =
+			await setupAssignedLicense({
+				customerId: "lic-custom-update-existing",
+				included: 2,
+				entityCount: 2,
+			});
+
+		await autumnV2_2.billing.update({
+			customer_id: customerId,
+			plan_id: parent.id,
+			customize: {
+				add_licenses: [
+					{
+						license_plan_id: license.id,
+						included: 3,
+					},
+				],
+			},
+		});
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const parentCustomerProduct = fullCustomer.customer_products.find(
+			(customerProduct) => customerProduct.product.id === parent.id,
+		);
+		const customRows = await ctx.db.query.planLicenses.findMany({
+			where: eq(
+				planLicenses.parent_customer_product_id,
+				parentCustomerProduct!.id,
+			),
+		});
+		expect(customRows).toHaveLength(1);
+		expect(customRows[0].included).toBe(3);
+
+		const pools = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(pools.list[0]).toMatchObject({
+			license_plan_id: license.id,
+			inventory: { included: 3, assigned: 1, available: 2 },
+		});
+
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[1].id,
+			plan_id: license.id,
+		});
+		const poolsAfterSecondAssign = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(poolsAfterSecondAssign.list[0]).toMatchObject({
+			license_plan_id: license.id,
+			inventory: { included: 3, assigned: 2, available: 1 },
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-custom: attach transition moves assignments to custom pool")}`,
+	async () => {
+		const group = "lic-custom-switch-group";
+		const firstParent = makeParentProduct({
+			id: "lic-custom-switch-first",
+			group,
+		});
+		const secondParent = makeParentProduct({
+			id: "lic-custom-switch-second",
+			group,
+		});
+		const license = makeLicenseProduct({ id: "lic-custom-switch-seat" });
+		const { customerId, entities, autumnV2_2 } = await initScenario({
+			customerId: "lic-custom-switch",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [firstParent, secondParent, license] }),
+			],
+			actions: [s.billing.attach({ productId: firstParent.id })],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: firstParent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		});
+
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: secondParent.id,
 			customize: {
 				add_licenses: [
 					{
@@ -226,954 +351,890 @@ test(`${chalk.yellowBright("licenses-custom: preview validates but does not pers
 					},
 				],
 			},
-		},
-	);
-
-	const customRows = await ctx.db.query.planLicenses.findMany({
-		where: and(
-			eq(planLicenses.license_internal_product_id, license.internal_id!),
-			isNotNull(planLicenses.parent_customer_product_id),
-		),
-	});
-	expect(customRows).toHaveLength(0);
-});
-
-test(`${chalk.yellowBright("licenses-custom: billing.update syncs license override onto existing parent")}`, async () => {
-	const { customerId, entities, autumnV2_2, ctx, parent, license } =
-		await setupAssignedLicense({
-			customerId: "lic-custom-update-existing",
-			included: 2,
-			entityCount: 2,
 		});
 
-	await autumnV2_2.billing.update({
-		customer_id: customerId,
-		plan_id: parent.id,
-		customize: {
-			add_licenses: [
-				{
-					license_plan_id: license.id,
-					included: 3,
-				},
+		const pools = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(pools.list).toHaveLength(1);
+		expect(pools.list[0]).toMatchObject({
+			license_plan_id: license.id,
+			inventory: { included: 1, assigned: 1, available: 0 },
+			assignments: [{ entity_id: entities[0].id }],
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-custom: attach transition blocks unsafe license removal")}`,
+	async () => {
+		const group = "lic-custom-switch-reduce-group";
+		const firstParent = makeParentProduct({
+			id: "lic-custom-switch-reduce-first",
+			group,
+		});
+		const secondParent = makeParentProduct({
+			id: "lic-custom-switch-reduce-second",
+			group,
+		});
+		const license = makeLicenseProduct({ id: "lic-custom-switch-reduce-seat" });
+		const { customerId, entities, autumnV2_2 } = await initScenario({
+			customerId: "lic-custom-switch-reduce",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [firstParent, secondParent, license] }),
 			],
-		},
-	});
+			actions: [s.billing.attach({ productId: firstParent.id })],
+		});
 
-	const fullCustomer = await CusService.getFull({
-		ctx,
-		idOrInternalId: customerId,
-	});
-	const parentCustomerProduct = fullCustomer.customer_products.find(
-		(customerProduct) => customerProduct.product.id === parent.id,
-	);
-	const customRows = await ctx.db.query.planLicenses.findMany({
-		where: eq(
-			planLicenses.parent_customer_product_id,
-			parentCustomerProduct!.id,
-		),
-	});
-	expect(customRows).toHaveLength(1);
-	expect(customRows[0].included).toBe(3);
-
-	const pools = (await autumnV2_2.post("/licenses.list", {
-		customer_id: customerId,
-	})) as { list: LicenseBalanceResponse[] };
-	expect(pools.list[0]).toMatchObject({
-		license_plan_id: license.id,
-		inventory: { included: 3, assigned: 1, available: 2 },
-	});
-
-	await autumnV2_2.post("/licenses.attach", {
-		customer_id: customerId,
-		entity_id: entities[1].id,
-		plan_id: license.id,
-	});
-	const poolsAfterSecondAssign = (await autumnV2_2.post("/licenses.list", {
-		customer_id: customerId,
-	})) as { list: LicenseBalanceResponse[] };
-	expect(poolsAfterSecondAssign.list[0]).toMatchObject({
-		license_plan_id: license.id,
-		inventory: { included: 3, assigned: 2, available: 1 },
-	});
-});
-
-test(`${chalk.yellowBright("licenses-custom: attach transition moves assignments to custom pool")}`, async () => {
-	const group = "lic-custom-switch-group";
-	const firstParent = makeParentProduct({
-		id: "lic-custom-switch-first",
-		group,
-	});
-	const secondParent = makeParentProduct({
-		id: "lic-custom-switch-second",
-		group,
-	});
-	const license = makeLicenseProduct({ id: "lic-custom-switch-seat" });
-	const { customerId, entities, autumnV2_2, ctx } = await initScenario({
-		customerId: "lic-custom-switch",
-		setup: [
-			s.customer({ testClock: false }),
-			s.entities({ count: 1, featureId: TestFeature.Users }),
-			s.products({ list: [firstParent, secondParent, license] }),
-		],
-		actions: [s.billing.attach({ productId: firstParent.id })],
-	});
-
-	await autumnV2_2.post("/licenses.link", {
-		parent_plan_id: firstParent.id,
-		license_plan_id: license.id,
-		included: 1,
-	});
-	await autumnV2_2.post("/licenses.attach", {
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		plan_id: license.id,
-	});
-
-	await autumnV2_2.billing.attach<AttachParamsV1Input>({
-		customer_id: customerId,
-		plan_id: secondParent.id,
-		customize: {
-			add_licenses: [
-				{
-					license_plan_id: license.id,
-					included: 1,
-				},
-			],
-		},
-	});
-
-	const fullCustomer = await CusService.getFull({
-		ctx,
-		idOrInternalId: customerId,
-	});
-	const secondCustomerProduct = fullCustomer.customer_products.find(
-		(customerProduct) => customerProduct.product.id === secondParent.id,
-	);
-
-	const pools = (await autumnV2_2.post("/licenses.list", {
-		customer_id: customerId,
-	})) as { list: LicenseBalanceResponse[] };
-	expect(pools.list).toHaveLength(1);
-	expect(pools.list[0]).toMatchObject({
-		license_plan_id: license.id,
-		inventory: { included: 1, assigned: 1, available: 0 },
-		assignments: [{ entity_id: entities[0].id }],
-	});
-});
-
-test(`${chalk.yellowBright("licenses-custom: attach transition blocks unsafe license removal")}`, async () => {
-	const group = "lic-custom-switch-reduce-group";
-	const firstParent = makeParentProduct({
-		id: "lic-custom-switch-reduce-first",
-		group,
-	});
-	const secondParent = makeParentProduct({
-		id: "lic-custom-switch-reduce-second",
-		group,
-	});
-	const license = makeLicenseProduct({ id: "lic-custom-switch-reduce-seat" });
-	const { customerId, entities, autumnV2_2 } = await initScenario({
-		customerId: "lic-custom-switch-reduce",
-		setup: [
-			s.customer({ testClock: false }),
-			s.entities({ count: 1, featureId: TestFeature.Users }),
-			s.products({ list: [firstParent, secondParent, license] }),
-		],
-		actions: [s.billing.attach({ productId: firstParent.id })],
-	});
-
-	await autumnV2_2.post("/licenses.link", {
-		parent_plan_id: firstParent.id,
-		license_plan_id: license.id,
-		included: 1,
-	});
-	await autumnV2_2.post("/licenses.attach", {
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		plan_id: license.id,
-	});
-
-	await expectAutumnError({
-		errCode: ErrCode.InvalidRequest,
-		func: () =>
-			autumnV2_2.billing.attach<AttachParamsV1Input>({
-				customer_id: customerId,
-				plan_id: secondParent.id,
-				customize: { remove_licenses: [license.id] },
-			}),
-	});
-});
-
-test(`${chalk.yellowBright("licenses-custom: multi_attach provisions custom license pool")}`, async () => {
-	const parent = makeParentProduct({ id: "lic-custom-multi-parent" });
-	const license = makeLicenseProduct({ id: "lic-custom-multi-seat" });
-	const { customerId, autumnV2_2 } = await initScenario({
-		customerId: "lic-custom-multi",
-		setup: [
-			s.customer({ testClock: false }),
-			s.entities({ count: 1, featureId: TestFeature.Users }),
-			s.products({ list: [parent, license] }),
-		],
-		actions: [],
-	});
-
-	await autumnV2_2.post("/licenses.link", {
-		parent_plan_id: parent.id,
-		license_plan_id: license.id,
-		included: 1,
-	});
-	await autumnV2_2.billing.multiAttach({
-		customer_id: customerId,
-		plans: [
-			{
-				plan_id: parent.id,
-				customize: {
-					add_licenses: [
-						{
-							license_plan_id: license.id,
-							included: 2,
-						},
-					],
-				},
-			},
-		],
-	});
-
-	const pools = (await autumnV2_2.post("/licenses.list", {
-		customer_id: customerId,
-	})) as { list: LicenseBalanceResponse[] };
-	expect(pools.list).toHaveLength(1);
-	expect(pools.list[0]).toMatchObject({
-		license_plan_id: license.id,
-		inventory: { included: 2, assigned: 0, available: 2 },
-	});
-});
-
-test(`${chalk.yellowBright("licenses-custom: active assignments block unsafe custom reductions")}`, async () => {
-	const { customerId, autumnV2_2, parent, license } =
-		await setupAssignedLicense({
-			customerId: "lic-custom-reduce-block",
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: firstParent.id,
+			license_plan_id: license.id,
 			included: 1,
 		});
-
-	await expectAutumnError({
-		errCode: ErrCode.InvalidRequest,
-		func: () =>
-			autumnV2_2.billing.update({
-				customer_id: customerId,
-				plan_id: parent.id,
-				customize: { remove_licenses: [license.id] },
-			}),
-	});
-
-	await expectAutumnError({
-		errCode: ErrCode.InvalidRequest,
-		func: () =>
-			autumnV2_2.billing.update({
-				customer_id: customerId,
-				plan_id: parent.id,
-				customize: {
-					add_licenses: [
-						{
-							license_plan_id: license.id,
-							included: 0,
-						},
-					],
-				},
-			}),
-	});
-});
-
-test(`${chalk.yellowBright("licenses-custom: custom license edits affect future assignments only")}`, async () => {
-	const { customerId, entities, autumnV2_2, parent, license } =
-		await setupAssignedLicense({
-			customerId: "lic-custom-future-only",
-			included: 2,
-			entityCount: 2,
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
 		});
 
-	await autumnV2_2.billing.update({
-		customer_id: customerId,
-		plan_id: parent.id,
-		customize: {
-			add_licenses: [
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			func: () =>
+				autumnV2_2.billing.attach<AttachParamsV1Input>({
+					customer_id: customerId,
+					plan_id: secondParent.id,
+					customize: { remove_licenses: [license.id] },
+				}),
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-custom: multi_attach provisions custom license pool")}`,
+	async () => {
+		const parent = makeParentProduct({ id: "lic-custom-multi-parent" });
+		const license = makeLicenseProduct({ id: "lic-custom-multi-seat" });
+		const { customerId, autumnV2_2 } = await initScenario({
+			customerId: "lic-custom-multi",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+		await autumnV2_2.billing.multiAttach({
+			customer_id: customerId,
+			plans: [
 				{
-					license_plan_id: license.id,
-					included: 2,
+					plan_id: parent.id,
 					customize: {
-						items: [itemsV2.monthlyMessages({ included: 50 })],
+						add_licenses: [
+							{
+								license_plan_id: license.id,
+								included: 2,
+							},
+						],
 					},
 				},
 			],
-		},
-	});
-	await autumnV2_2.post("/licenses.attach", {
-		customer_id: customerId,
-		entity_id: entities[1].id,
-		plan_id: license.id,
-	});
-
-	const firstEntity = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		feature_id: TestFeature.Messages,
-	});
-	const secondEntity = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		entity_id: entities[1].id,
-		feature_id: TestFeature.Messages,
-	});
-	expect(firstEntity.balance?.granted).toBe(25);
-	expect(secondEntity.balance?.granted).toBe(50);
-});
-
-test(`${chalk.yellowBright("licenses-edge: provisioned license stays entity-level internally and hidden from API products")}`, async () => {
-	const { customerId, entities, autumnV2_2, ctx, parent, license } =
-		await setupAssignedLicense({
-			customerId: "lic-edge-internal",
 		});
 
-	const fullCustomer = await CusService.getFull({
-		ctx,
-		idOrInternalId: customerId,
-		entityId: entities[0].id,
-		withEntities: true,
-	});
-	const licenseCusProduct = fullCustomer.customer_products.find(
-		(customerProduct) => customerProduct.product.id === license.id,
-	);
-	expect(licenseCusProduct).toBeDefined();
-	expect(licenseCusProduct?.internal_entity_id).toBe(
-		fullCustomer.entity?.internal_id,
-	);
-	expect(licenseCusProduct?.customer_prices).toHaveLength(0);
-	expect(licenseCusProduct?.subscription_ids).toEqual([]);
-	expect(licenseCusProduct?.scheduled_ids).toEqual([]);
-	expect(
-		licenseCusProduct?.customer_entitlements.every(
-			(entitlement) =>
-				entitlement.internal_entity_id === fullCustomer.entity?.internal_id,
-		),
-	).toBe(true);
+		const pools = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(pools.list).toHaveLength(1);
+		expect(pools.list[0]).toMatchObject({
+			license_plan_id: license.id,
+			inventory: { included: 2, assigned: 0, available: 2 },
+		});
+	},
+);
 
-	const fullSubject = fullCustomerToFullSubject({ fullCustomer });
-	const apiProducts = fullSubjectToApiCustomerProducts({ fullSubject });
-	expect(apiProducts.map((item) => item.product.id)).toEqual([parent.id]);
+test.concurrent(
+	`${chalk.yellowBright("licenses-custom: active assignments block unsafe custom reductions")}`,
+	async () => {
+		const { customerId, autumnV2_2, parent, license } =
+			await setupAssignedLicense({
+				customerId: "lic-custom-reduce-block",
+				included: 1,
+			});
 
-	const entity = await autumnV2_2.entities.get<ApiEntityV2>(
-		customerId,
-		entities[0].id,
-	);
-	expectBalanceCorrect({
-		customer: entity,
-		featureId: TestFeature.Messages,
-		granted: 25,
-		remaining: 25,
-		usage: 0,
-		planId: license.id,
-	});
-	expect(
-		entity.subscriptions.some(
-			(subscription) => subscription.plan_id === license.id,
-		),
-	).toBe(false);
-});
-
-test(`${chalk.yellowBright("licenses-edge: entity check stacks customer grant and license grant")}`, async () => {
-	const { customerId, entities, autumnV2_2, parent, license } =
-		await setupAssignedLicense({
-			customerId: "lic-edge-stack-check",
-			parentMessageGrant: 10,
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			func: () =>
+				autumnV2_2.billing.update({
+					customer_id: customerId,
+					plan_id: parent.id,
+					customize: { remove_licenses: [license.id] },
+				}),
 		});
 
-	const customerCheck = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		feature_id: TestFeature.Messages,
-	});
-	expect(customerCheck.allowed).toBe(true);
-	expect(customerCheck.balance?.granted).toBe(10);
-	expect(getBalanceBreakdown(customerCheck, parent.id)).toMatchObject({
-		included_grant: 10,
-		remaining: 10,
-		usage: 0,
-	});
-	expect(getBalanceBreakdown(customerCheck, license.id)).toBeUndefined();
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			func: () =>
+				autumnV2_2.billing.update({
+					customer_id: customerId,
+					plan_id: parent.id,
+					customize: {
+						add_licenses: [
+							{
+								license_plan_id: license.id,
+								included: 0,
+							},
+						],
+					},
+				}),
+		});
+	},
+);
 
-	const entityCheck = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		feature_id: TestFeature.Messages,
-	});
-	expect(entityCheck.allowed).toBe(true);
-	expect(entityCheck.balance?.granted).toBe(35);
-	expect(entityCheck.balance?.remaining).toBe(35);
-	expect(getBalanceBreakdown(entityCheck, parent.id)).toMatchObject({
-		included_grant: 10,
-	});
-	expect(getBalanceBreakdown(entityCheck, license.id)).toMatchObject({
-		included_grant: 25,
-	});
-});
+test.concurrent(
+	`${chalk.yellowBright("licenses-custom: custom license edits affect future assignments only")}`,
+	async () => {
+		const { customerId, entities, autumnV2_2, parent, license } =
+			await setupAssignedLicense({
+				customerId: "lic-custom-future-only",
+				included: 2,
+				entityCount: 2,
+			});
 
-test(`${chalk.yellowBright("licenses-edge: entity track deducts inherited and license balances")}`, async () => {
-	const { customerId, entities, autumnV2_2, parent, license } =
-		await setupAssignedLicense({
-			customerId: "lic-edge-track-stack",
-			parentMessageGrant: 10,
+		await autumnV2_2.billing.update({
+			customer_id: customerId,
+			plan_id: parent.id,
+			customize: {
+				add_licenses: [
+					{
+						license_plan_id: license.id,
+						included: 2,
+						customize: {
+							items: [itemsV2.monthlyMessages({ included: 50 })],
+						},
+					},
+				],
+			},
+		});
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[1].id,
+			plan_id: license.id,
 		});
 
-	const trackResponse = (await autumnV2_2.track(
-		{
+		const firstEntity = await autumnV2_2.check<CheckResponseV3>({
 			customer_id: customerId,
 			entity_id: entities[0].id,
 			feature_id: TestFeature.Messages,
-			value: 35,
-		},
-		{ timeout: 2000 },
-	)) as TrackResponseV3;
-	expect(trackResponse.entity_id).toBe(entities[0].id);
-	expect(trackResponse.balance?.granted).toBe(35);
-	expect(trackResponse.balance?.remaining).toBe(0);
-	expect(trackResponse.balance?.usage).toBe(35);
-	expect(getBalanceBreakdown(trackResponse, parent.id)).toMatchObject({
-		included_grant: 10,
-		remaining: 0,
-		usage: 10,
-	});
-	expect(getBalanceBreakdown(trackResponse, license.id)).toMatchObject({
-		included_grant: 25,
-		remaining: 0,
-		usage: 25,
-	});
-	expect(
-		trackResponse.deductions?.find((item) => item.plan_id === parent.id)?.value,
-	).toBe(10);
-	expect(
-		trackResponse.deductions?.find((item) => item.plan_id === license.id)
-			?.value,
-	).toBe(25);
-
-	const customerCheck = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		feature_id: TestFeature.Messages,
-		skip_cache: true,
-	});
-	expect(customerCheck.allowed).toBe(false);
-	expect(customerCheck.balance?.granted).toBe(10);
-	expect(customerCheck.balance?.remaining).toBe(0);
-	expect(customerCheck.balance?.usage).toBe(10);
-	expect(getBalanceBreakdown(customerCheck, license.id)).toBeUndefined();
-});
-
-test(`${chalk.yellowBright("licenses-edge: customer and sibling entity cannot spend assigned license")}`, async () => {
-	const { customerId, entities, autumnV2_2, license } =
-		await setupAssignedLicense({
-			customerId: "lic-edge-track-scope",
-			entityCount: 2,
 		});
-
-	const customerTrack = (await autumnV2_2.track({
-		customer_id: customerId,
-		feature_id: TestFeature.Messages,
-		value: 1,
-		overage_behavior: "reject",
-	})) as TrackResponseV3;
-	expect(customerTrack.balance).toBeNull();
-	expect(customerTrack.deductions).toEqual([]);
-
-	const siblingTrack = (await autumnV2_2.track({
-		customer_id: customerId,
-		entity_id: entities[1].id,
-		feature_id: TestFeature.Messages,
-		value: 1,
-		overage_behavior: "reject",
-	})) as TrackResponseV3;
-	expect(siblingTrack.balance).toBeNull();
-	expect(siblingTrack.deductions).toEqual([]);
-
-	const assignedEntity = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		feature_id: TestFeature.Messages,
-	});
-	expect(assignedEntity.allowed).toBe(true);
-	expect(assignedEntity.balance?.remaining).toBe(25);
-
-	const siblingEntity = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		entity_id: entities[1].id,
-		feature_id: TestFeature.Messages,
-	});
-	expect(siblingEntity.allowed).toBe(false);
-	expect(siblingEntity.balance).toBeNull();
-
-	const pools = (await autumnV2_2.post("/licenses.list", {
-		customer_id: customerId,
-	})) as { list: LicenseBalanceResponse[] };
-	expect(pools.list[0]).toMatchObject({
-		license_plan_id: license.id,
-		inventory: { assigned: 1, available: 0 },
-	});
-});
-
-test(`${chalk.yellowBright("licenses-edge: duplicate assign is idempotent and does not double grant")}`, async () => {
-	const { customerId, entities, autumnV2_2, assignment, license } =
-		await setupAssignedLicense({
-			customerId: "lic-edge-idempotent",
+		const secondEntity = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[1].id,
+			feature_id: TestFeature.Messages,
 		});
+		expect(firstEntity.balance?.granted).toBe(25);
+		expect(secondEntity.balance?.granted).toBe(50);
+	},
+);
 
-	const duplicate = (await autumnV2_2.post("/licenses.attach", {
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		plan_id: license.id,
-	})) as { assignment: typeof assignment };
-	expect(duplicate.assignment.id).toBe(assignment.id);
-	expect(duplicate.assignment.started_at).toBe(assignment.started_at);
+test.concurrent(
+	`${chalk.yellowBright("licenses-edge: provisioned license stays entity-level internally and hidden from API products")}`,
+	async () => {
+		const { customerId, entities, autumnV2_2, ctx, parent, license } =
+			await setupAssignedLicense({
+				customerId: "lic-edge-internal",
+			});
 
-	const assignments = (await autumnV2_2.post("/licenses.list_assignments", {
-		customer_id: customerId,
-		plan_id: license.id,
-	})) as { list: unknown[] };
-	expect(assignments.list).toHaveLength(1);
-
-	const check = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		feature_id: TestFeature.Messages,
-	});
-	expect(check.balance?.granted).toBe(25);
-	expect(check.balance?.breakdown).toHaveLength(1);
-
-	const track = (await autumnV2_2.track({
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		feature_id: TestFeature.Messages,
-		value: 25,
-	})) as TrackResponseV3;
-	expect(track.balance?.remaining).toBe(0);
-	expect(track.deductions).toHaveLength(1);
-});
-
-test(`${chalk.yellowBright("licenses-edge: two assigned entities isolate license balances and share customer grant")}`, async () => {
-	const { customerId, entities, autumnV2_2, parent, license } =
-		await setupAssignedLicense({
-			customerId: "lic-edge-two-entities",
-			parentMessageGrant: 10,
-			included: 2,
-			entityCount: 2,
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			entityId: entities[0].id,
+			withEntities: true,
 		});
-	await autumnV2_2.post("/licenses.attach", {
-		customer_id: customerId,
-		entity_id: entities[1].id,
-		plan_id: license.id,
-	});
+		const licenseCusProduct = fullCustomer.customer_products.find(
+			(customerProduct) => customerProduct.product.id === license.id,
+		);
+		expect(licenseCusProduct).toBeDefined();
+		expect(licenseCusProduct?.internal_entity_id).toBe(
+			fullCustomer.entity?.internal_id,
+		);
+		expect(licenseCusProduct?.customer_prices).toHaveLength(0);
+		expect(licenseCusProduct?.subscription_ids).toEqual([]);
+		expect(licenseCusProduct?.scheduled_ids).toEqual([]);
+		expect(
+			licenseCusProduct?.customer_entitlements.every(
+				(entitlement) =>
+					entitlement.internal_entity_id === fullCustomer.entity?.internal_id,
+			),
+		).toBe(true);
 
-	await autumnV2_2.track(
-		{
+		const fullSubject = fullCustomerToFullSubject({ fullCustomer });
+		const apiProducts = fullSubjectToApiCustomerProducts({ fullSubject });
+		expect(apiProducts.map((item) => item.product.id)).toEqual([parent.id]);
+
+		const entity = await autumnV2_2.entities.get<ApiEntityV2>(
+			customerId,
+			entities[0].id,
+		);
+		expectBalanceCorrect({
+			customer: entity,
+			featureId: TestFeature.Messages,
+			granted: 25,
+			remaining: 25,
+			usage: 0,
+			planId: license.id,
+		});
+		expect(
+			entity.subscriptions.some(
+				(subscription) => subscription.plan_id === license.id,
+			),
+		).toBe(false);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-edge: entity check stacks customer grant and license grant")}`,
+	async () => {
+		const { customerId, entities, autumnV2_2, parent, license } =
+			await setupAssignedLicense({
+				customerId: "lic-edge-stack-check",
+				parentMessageGrant: 10,
+			});
+
+		const customerCheck = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(customerCheck.allowed).toBe(true);
+		expect(customerCheck.balance?.granted).toBe(10);
+		expect(getBalanceBreakdown(customerCheck, parent.id)).toMatchObject({
+			included_grant: 10,
+			remaining: 10,
+			usage: 0,
+		});
+		expect(getBalanceBreakdown(customerCheck, license.id)).toBeUndefined();
+
+		const entityCheck = await autumnV2_2.check<CheckResponseV3>({
 			customer_id: customerId,
 			entity_id: entities[0].id,
 			feature_id: TestFeature.Messages,
-			value: 35,
-		},
-		{ timeout: 2000 },
-	);
-
-	const customerCheck = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		feature_id: TestFeature.Messages,
-		skip_cache: true,
-	});
-	expect(customerCheck.balance?.granted).toBe(10);
-	expect(customerCheck.balance?.remaining).toBe(0);
-	expect(customerCheck.balance?.usage).toBe(10);
-	expect(getBalanceBreakdown(customerCheck, parent.id)).toBeDefined();
-	expect(getBalanceBreakdown(customerCheck, license.id)).toBeUndefined();
-
-	const entityOne = await autumnV2_2.entities.get<ApiEntityV2>(
-		customerId,
-		entities[0].id,
-	);
-	expectBalanceCorrect({
-		customer: entityOne,
-		featureId: TestFeature.Messages,
-		granted: 35,
-		remaining: 0,
-		usage: 35,
-	});
-
-	const entityTwo = await autumnV2_2.entities.get<ApiEntityV2>(
-		customerId,
-		entities[1].id,
-	);
-	expectBalanceCorrect({
-		customer: entityTwo,
-		featureId: TestFeature.Messages,
-		granted: 35,
-		remaining: 25,
-		usage: 10,
-	});
-	const entityTwoMessages = entityTwo.balances[TestFeature.Messages];
-	expect(entityTwoMessages).toBeDefined();
-	expect(
-		entityTwoMessages?.breakdown?.find((item) => item.plan_id === parent.id),
-	).toMatchObject({ remaining: 0, usage: 10 });
-	expect(
-		entityTwoMessages?.breakdown?.find((item) => item.plan_id === license.id),
-	).toMatchObject({ remaining: 25, usage: 0 });
-});
-
-test(`${chalk.yellowBright("licenses-edge: unassign is idempotent and removes only the license grant")}`, async () => {
-	const { customerId, entities, autumnV2_2, assignment, parent, license } =
-		await setupAssignedLicense({
-			customerId: "lic-edge-unassign",
-			parentMessageGrant: 10,
 		});
+		expect(entityCheck.allowed).toBe(true);
+		expect(entityCheck.balance?.granted).toBe(35);
+		expect(entityCheck.balance?.remaining).toBe(35);
+		expect(getBalanceBreakdown(entityCheck, parent.id)).toMatchObject({
+			included_grant: 10,
+		});
+		expect(getBalanceBreakdown(entityCheck, license.id)).toMatchObject({
+			included_grant: 25,
+		});
+	},
+);
 
-	const first = (await autumnV2_2.post("/licenses.update", {
-		customer_id: customerId,
-		cancel_action: "cancel_immediately",
-		assignment_id: assignment.id,
-	})) as { assignment: { id: string; ended_at: number | null } };
-	const second = (await autumnV2_2.post("/licenses.update", {
-		customer_id: customerId,
-		cancel_action: "cancel_immediately",
-		assignment_id: assignment.id,
-	})) as { assignment: { id: string; ended_at: number | null } };
-	expect(second.assignment).toEqual(first.assignment);
+test.concurrent(
+	`${chalk.yellowBright("licenses-edge: entity track deducts inherited and license balances")}`,
+	async () => {
+		const { customerId, entities, autumnV2_2, parent, license } =
+			await setupAssignedLicense({
+				customerId: "lic-edge-track-stack",
+				parentMessageGrant: 10,
+			});
 
-	const entityCheck = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		feature_id: TestFeature.Messages,
-	});
-	expect(entityCheck.balance?.granted).toBe(10);
-	expect(getBalanceBreakdown(entityCheck, parent.id)).toBeDefined();
-	expect(getBalanceBreakdown(entityCheck, license.id)).toBeUndefined();
-
-	const track = (await autumnV2_2.track({
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		feature_id: TestFeature.Messages,
-		value: 10,
-	})) as TrackResponseV3;
-	expect(track.balance?.remaining).toBe(0);
-	await expectAutumnError({
-		errCode: ErrCode.InsufficientBalance,
-		func: () =>
-			autumnV2_2.track({
+		const trackResponse = (await autumnV2_2.track(
+			{
 				customer_id: customerId,
 				entity_id: entities[0].id,
 				feature_id: TestFeature.Messages,
-				value: 1,
-				overage_behavior: "reject",
-			}),
-	});
-});
+				value: 35,
+			},
+			{ timeout: 2000 },
+		)) as TrackResponseV3;
+		expect(trackResponse.entity_id).toBe(entities[0].id);
+		expect(trackResponse.balance?.granted).toBe(35);
+		expect(trackResponse.balance?.remaining).toBe(0);
+		expect(trackResponse.balance?.usage).toBe(35);
+		expect(getBalanceBreakdown(trackResponse, parent.id)).toMatchObject({
+			included_grant: 10,
+			remaining: 0,
+			usage: 10,
+		});
+		expect(getBalanceBreakdown(trackResponse, license.id)).toMatchObject({
+			included_grant: 25,
+			remaining: 0,
+			usage: 25,
+		});
+		expect(
+			trackResponse.deductions?.find((item) => item.plan_id === parent.id)
+				?.value,
+		).toBe(10);
+		expect(
+			trackResponse.deductions?.find((item) => item.plan_id === license.id)
+				?.value,
+		).toBe(25);
 
-test(`${chalk.yellowBright("licenses-edge: customize null removes override for future assignments")}`, async () => {
-	const parent = makeParentProduct({ id: "license-null-parent" });
-	const license = makeLicenseProduct({ id: "license-null-seat" });
-	const { customerId, entities, autumnV2_2 } = await initScenario({
-		customerId: "lic-edge-custom-null",
-		setup: [
-			s.customer({ testClock: false }),
-			s.entities({ count: 1, featureId: TestFeature.Users }),
-			s.products({ list: [parent, license] }),
-		],
-		actions: [s.billing.attach({ productId: parent.id })],
-	});
+		const customerCheck = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(customerCheck.allowed).toBe(false);
+		expect(customerCheck.balance?.granted).toBe(10);
+		expect(customerCheck.balance?.remaining).toBe(0);
+		expect(customerCheck.balance?.usage).toBe(10);
+		expect(getBalanceBreakdown(customerCheck, license.id)).toBeUndefined();
+	},
+);
 
-	await autumnV2_2.post("/licenses.link", {
-		parent_plan_id: parent.id,
-		license_plan_id: license.id,
-		included: 1,
-		customize: { items: [itemsV2.monthlyMessages({ included: 100 })] },
-	});
-	await autumnV2_2.post("/licenses.link", {
-		parent_plan_id: parent.id,
-		license_plan_id: license.id,
-		included: 1,
-		customize: null,
-	});
+test.concurrent(
+	`${chalk.yellowBright("licenses-edge: customer and sibling entity cannot spend assigned license")}`,
+	async () => {
+		const { customerId, entities, autumnV2_2, license } =
+			await setupAssignedLicense({
+				customerId: "lic-edge-track-scope",
+				entityCount: 2,
+			});
 
-	const { list } = (await autumnV2_2.post("/licenses.list_links", {
-		parent_plan_id: parent.id,
-	})) as { list: Array<{ customize: unknown }> };
-	expect(list[0].customize).toBeNull();
+		const customerTrack = (await autumnV2_2.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 1,
+			overage_behavior: "reject",
+		})) as TrackResponseV3;
+		expect(customerTrack.balance).toBeNull();
+		expect(customerTrack.deductions).toEqual([]);
 
-	await autumnV2_2.post("/licenses.attach", {
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		plan_id: license.id,
-	});
-	const check = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		feature_id: TestFeature.Messages,
-	});
-	expect(check.balance?.granted).toBe(25);
-});
+		const siblingTrack = (await autumnV2_2.track({
+			customer_id: customerId,
+			entity_id: entities[1].id,
+			feature_id: TestFeature.Messages,
+			value: 1,
+			overage_behavior: "reject",
+		})) as TrackResponseV3;
+		expect(siblingTrack.balance).toBeNull();
+		expect(siblingTrack.deductions).toEqual([]);
 
-test(`${chalk.yellowBright("licenses-edge: existing assignment keeps old customize after plan license update")}`, async () => {
-	const parent = makeParentProduct({ id: "license-snapshot-parent" });
-	const license = makeLicenseProduct({ id: "license-snapshot-seat" });
-	const { customerId, entities, autumnV2_2 } = await initScenario({
-		customerId: "lic-edge-custom-snapshot",
-		setup: [
-			s.customer({ testClock: false }),
-			s.entities({ count: 2, featureId: TestFeature.Users }),
-			s.products({ list: [parent, license] }),
-		],
-		actions: [s.billing.attach({ productId: parent.id })],
-	});
+		const assignedEntity = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+		});
+		expect(assignedEntity.allowed).toBe(true);
+		expect(assignedEntity.balance?.remaining).toBe(25);
 
-	await autumnV2_2.post("/licenses.link", {
-		parent_plan_id: parent.id,
-		license_plan_id: license.id,
-		included: 2,
-		customize: { items: [itemsV2.monthlyMessages({ included: 100 })] },
-	});
-	await autumnV2_2.post("/licenses.attach", {
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		plan_id: license.id,
-	});
-	await autumnV2_2.post("/licenses.link", {
-		parent_plan_id: parent.id,
-		license_plan_id: license.id,
-		included: 2,
-		customize: { items: [itemsV2.monthlyMessages({ included: 50 })] },
-	});
-	await autumnV2_2.post("/licenses.attach", {
-		customer_id: customerId,
-		entity_id: entities[1].id,
-		plan_id: license.id,
-	});
+		const siblingEntity = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[1].id,
+			feature_id: TestFeature.Messages,
+		});
+		expect(siblingEntity.allowed).toBe(false);
+		expect(siblingEntity.balance).toBeNull();
 
-	const firstEntity = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		feature_id: TestFeature.Messages,
-	});
-	const secondEntity = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		entity_id: entities[1].id,
-		feature_id: TestFeature.Messages,
-	});
-	expect(firstEntity.balance?.granted).toBe(100);
-	expect(secondEntity.balance?.granted).toBe(50);
-});
+		const pools = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(pools.list[0]).toMatchObject({
+			license_plan_id: license.id,
+			inventory: { assigned: 1, available: 0 },
+		});
+	},
+);
 
-test(`${chalk.yellowBright("licenses-edge: customize can replace base item and add boolean entitlement")}`, async () => {
-	const parent = makeParentProduct({
-		id: "license-custom-items-parent",
-		includeDashboard: false,
-	});
-	const license = makeLicenseProduct({ id: "license-custom-items-seat" });
-	const { customerId, entities, autumnV2_2 } = await initScenario({
-		customerId: "lic-edge-custom-items",
-		setup: [
-			s.customer({ testClock: false }),
-			s.entities({ count: 2, featureId: TestFeature.Users }),
-			s.products({ list: [parent, license] }),
-		],
-		actions: [s.billing.attach({ productId: parent.id })],
-	});
-	await autumnV2_2.post("/licenses.link", {
-		parent_plan_id: parent.id,
-		license_plan_id: license.id,
-		included: 1,
-		customize: {
-			items: [itemsV2.monthlyWords({ included: 80 }), itemsV2.dashboard()],
-		},
-	});
-	await autumnV2_2.post("/licenses.attach", {
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		plan_id: license.id,
-	});
+test.concurrent(
+	`${chalk.yellowBright("licenses-edge: duplicate assign is idempotent and does not double grant")}`,
+	async () => {
+		const { customerId, entities, autumnV2_2, assignment, license } =
+			await setupAssignedLicense({
+				customerId: "lic-edge-idempotent",
+			});
 
-	const messagesCheck = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		feature_id: TestFeature.Messages,
-	});
-	expect(messagesCheck.allowed).toBe(false);
-	expect(messagesCheck.balance).toBeNull();
+		const duplicate = (await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		})) as { assignment: typeof assignment };
+		expect(duplicate.assignment.id).toBe(assignment.id);
+		expect(duplicate.assignment.started_at).toBe(assignment.started_at);
 
-	const wordsCheck = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		feature_id: TestFeature.Words,
-	});
-	expect(wordsCheck.allowed).toBe(true);
-	expect(wordsCheck.balance?.granted).toBe(80);
+		const assignments = (await autumnV2_2.post("/licenses.list_assignments", {
+			customer_id: customerId,
+			plan_id: license.id,
+		})) as { list: unknown[] };
+		expect(assignments.list).toHaveLength(1);
 
-	const dashboardCheck = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		feature_id: TestFeature.Dashboard,
-	});
-	expect(dashboardCheck.allowed).toBe(true);
+		const check = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+		});
+		expect(check.balance?.granted).toBe(25);
+		expect(check.balance?.breakdown).toHaveLength(1);
 
-	const siblingDashboard = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		entity_id: entities[1].id,
-		feature_id: TestFeature.Dashboard,
-	});
-	expect(siblingDashboard.allowed).toBe(false);
-	expect(siblingDashboard.flag).toBeNull();
+		const track = (await autumnV2_2.track({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+			value: 25,
+		})) as TrackResponseV3;
+		expect(track.balance?.remaining).toBe(0);
+		expect(track.deductions).toHaveLength(1);
+	},
+);
 
-	const { products: licenseProducts } = (await autumnV2_2.get(
-		"/products/license_products",
-	)) as { products: ProductV2[] };
-	const listedLicense = licenseProducts.find((item) => item.id === license.id);
-	expect(
-		listedLicense?.items.some((item) => item.feature_id === TestFeature.Words),
-	).toBe(false);
-});
+test.concurrent(
+	`${chalk.yellowBright("licenses-edge: two assigned entities isolate license balances and share customer grant")}`,
+	async () => {
+		const { customerId, entities, autumnV2_2, parent, license } =
+			await setupAssignedLicense({
+				customerId: "lic-edge-two-entities",
+				parentMessageGrant: 10,
+				included: 2,
+				entityCount: 2,
+			});
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[1].id,
+			plan_id: license.id,
+		});
 
-test(`${chalk.yellowBright("licenses-edge: multiple parent pools require subscription disambiguation")}`, async () => {
-	const parentA = products.recurringAddOn({
-		id: "license-pool-a",
-		items: [items.dashboard()],
-	});
-	const parentB = products.recurringAddOn({
-		id: "license-pool-b",
-		items: [items.dashboard()],
-	});
-	const license = makeLicenseProduct({ id: "license-pool-seat" });
-	const { customerId, entities, autumnV2_2 } = await initScenario({
-		customerId: "lic-edge-multi-pool",
-		setup: [
-			s.customer({ paymentMethod: "success" }),
-			s.entities({ count: 2, featureId: TestFeature.Users }),
-			s.products({ list: [parentA, parentB, license] }),
-		],
-		actions: [
-			s.billing.attach({
-				productId: parentA.id,
-				newBillingSubscription: true,
-				subscriptionId: "license-pool-a-sub",
-			}),
-			s.billing.attach({
-				productId: parentB.id,
-				newBillingSubscription: true,
-				subscriptionId: "license-pool-b-sub",
-			}),
-		],
-	});
-
-	await autumnV2_2.post("/licenses.link", {
-		parent_plan_id: parentA.id,
-		license_plan_id: license.id,
-		included: 1,
-		customize: { items: [itemsV2.monthlyMessages({ included: 50 })] },
-	});
-	await autumnV2_2.post("/licenses.link", {
-		parent_plan_id: parentB.id,
-		license_plan_id: license.id,
-		included: 2,
-		customize: { items: [itemsV2.monthlyMessages({ included: 200 })] },
-	});
-	const poolsBefore = (await autumnV2_2.post("/licenses.list", {
-		customer_id: customerId,
-	})) as { list: LicenseBalanceResponse[] };
-	expect(poolsBefore.list).toHaveLength(2);
-	const poolA = poolsBefore.list.find((pool) => pool.inventory.included === 1);
-	const poolB = poolsBefore.list.find((pool) => pool.inventory.included === 2);
-	expect(poolA?.parent_plan_id).toBeTruthy();
-	expect(poolB?.parent_plan_id).toBeTruthy();
-	expect(poolA?.parent_plan_id).not.toBe(poolB?.parent_plan_id);
-
-	await expectAutumnError({
-		errCode: ErrCode.InvalidRequest,
-		func: () =>
-			autumnV2_2.post("/licenses.attach", {
+		await autumnV2_2.track(
+			{
 				customer_id: customerId,
 				entity_id: entities[0].id,
-				plan_id: license.id,
-			}),
-	});
-	await autumnV2_2.post("/licenses.attach", {
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		plan_id: license.id,
-		parent_plan_id: poolA?.parent_plan_id,
-	});
-	await autumnV2_2.post("/licenses.attach", {
-		customer_id: customerId,
-		entity_id: entities[1].id,
-		plan_id: license.id,
-		parent_plan_id: poolB?.parent_plan_id,
-	});
+				feature_id: TestFeature.Messages,
+				value: 35,
+			},
+			{ timeout: 2000 },
+		);
 
-	const firstEntity = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		feature_id: TestFeature.Messages,
-	});
-	const secondEntity = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		entity_id: entities[1].id,
-		feature_id: TestFeature.Messages,
-	});
-	expect(firstEntity.balance?.granted).toBe(50);
-	expect(secondEntity.balance?.granted).toBe(200);
+		const customerCheck = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(customerCheck.balance?.granted).toBe(10);
+		expect(customerCheck.balance?.remaining).toBe(0);
+		expect(customerCheck.balance?.usage).toBe(10);
+		expect(getBalanceBreakdown(customerCheck, parent.id)).toBeDefined();
+		expect(getBalanceBreakdown(customerCheck, license.id)).toBeUndefined();
 
-	const poolsAfter = (await autumnV2_2.post("/licenses.list", {
-		customer_id: customerId,
-	})) as { list: LicenseBalanceResponse[] };
-	expect(
-		poolsAfter.list.find(
-			(pool) => pool.parent_plan_id === poolA?.parent_plan_id,
-		)?.inventory,
-	).toMatchObject({ included: 1, assigned: 1, available: 0 });
-	expect(
-		poolsAfter.list.find(
-			(pool) => pool.parent_plan_id === poolB?.parent_plan_id,
-		)?.inventory,
-	).toMatchObject({ included: 2, assigned: 1, available: 1 });
-});
+		const entityOne = await autumnV2_2.entities.get<ApiEntityV2>(
+			customerId,
+			entities[0].id,
+		);
+		expectBalanceCorrect({
+			customer: entityOne,
+			featureId: TestFeature.Messages,
+			granted: 35,
+			remaining: 0,
+			usage: 35,
+		});
 
-test(`${chalk.yellowBright("licenses-edge: non-license assign and priced customize are rejected")}`, async () => {
-	const parent = makeParentProduct({ id: "license-negative-parent" });
-	const license = makeLicenseProduct({ id: "license-negative-seat" });
-	const { customerId, entities, autumnV2_2 } = await initScenario({
-		customerId: "lic-edge-negative",
-		setup: [
-			s.customer({ testClock: false }),
-			s.entities({ count: 1, featureId: TestFeature.Users }),
-			s.products({ list: [parent, license] }),
-		],
-		actions: [s.billing.attach({ productId: parent.id })],
-	});
+		const entityTwo = await autumnV2_2.entities.get<ApiEntityV2>(
+			customerId,
+			entities[1].id,
+		);
+		expectBalanceCorrect({
+			customer: entityTwo,
+			featureId: TestFeature.Messages,
+			granted: 35,
+			remaining: 25,
+			usage: 10,
+		});
+		const entityTwoMessages = entityTwo.balances[TestFeature.Messages];
+		expect(entityTwoMessages).toBeDefined();
+		expect(
+			entityTwoMessages?.breakdown?.find((item) => item.plan_id === parent.id),
+		).toMatchObject({ remaining: 0, usage: 10 });
+		expect(
+			entityTwoMessages?.breakdown?.find((item) => item.plan_id === license.id),
+		).toMatchObject({ remaining: 25, usage: 0 });
+	},
+);
 
-	await autumnV2_2.post("/licenses.link", {
-		parent_plan_id: parent.id,
-		license_plan_id: license.id,
-		included: 1,
-	});
-	await expectAutumnError({
-		errCode: ErrCode.InvalidRequest,
-		func: () =>
-			autumnV2_2.post("/licenses.attach", {
-				customer_id: customerId,
-				entity_id: entities[0].id,
-				plan_id: parent.id,
-			}),
-	});
-	const pricedCustomize = (await autumnV2_2.post("/licenses.link", {
-		parent_plan_id: parent.id,
-		license_plan_id: license.id,
-		included: 1,
-		customize: { items: [itemsV2.prepaidMessages()] },
-	})) as { plan_license: { customize: { add_items: unknown[] } } };
-	expect(pricedCustomize.plan_license.customize.add_items).toHaveLength(1);
+test.concurrent(
+	`${chalk.yellowBright("licenses-edge: unassign is idempotent and removes only the license grant")}`,
+	async () => {
+		const { customerId, entities, autumnV2_2, assignment, parent, license } =
+			await setupAssignedLicense({
+				customerId: "lic-edge-unassign",
+				parentMessageGrant: 10,
+			});
 
-	const assignments = (await autumnV2_2.post("/licenses.list_assignments", {
-		customer_id: customerId,
-		plan_id: license.id,
-	})) as { list: unknown[] };
-	expect(assignments.list).toHaveLength(0);
-});
+		const first = (await autumnV2_2.post("/licenses.update", {
+			customer_id: customerId,
+			cancel_action: "cancel_immediately",
+			assignment_id: assignment.id,
+		})) as { assignment: { id: string; ended_at: number | null } };
+		const second = (await autumnV2_2.post("/licenses.update", {
+			customer_id: customerId,
+			cancel_action: "cancel_immediately",
+			assignment_id: assignment.id,
+		})) as { assignment: { id: string; ended_at: number | null } };
+		expect(second.assignment).toEqual(first.assignment);
+
+		const entityCheck = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+		});
+		expect(entityCheck.balance?.granted).toBe(10);
+		expect(getBalanceBreakdown(entityCheck, parent.id)).toBeDefined();
+		expect(getBalanceBreakdown(entityCheck, license.id)).toBeUndefined();
+
+		const track = (await autumnV2_2.track({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+			value: 10,
+		})) as TrackResponseV3;
+		expect(track.balance?.remaining).toBe(0);
+		await expectAutumnError({
+			errCode: ErrCode.InsufficientBalance,
+			func: () =>
+				autumnV2_2.track({
+					customer_id: customerId,
+					entity_id: entities[0].id,
+					feature_id: TestFeature.Messages,
+					value: 1,
+					overage_behavior: "reject",
+				}),
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-edge: customize null removes override for future assignments")}`,
+	async () => {
+		const parent = makeParentProduct({ id: "license-null-parent" });
+		const license = makeLicenseProduct({ id: "license-null-seat" });
+		const { customerId, entities, autumnV2_2 } = await initScenario({
+			customerId: "lic-edge-custom-null",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [s.billing.attach({ productId: parent.id })],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+			customize: { items: [itemsV2.monthlyMessages({ included: 100 })] },
+		});
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+			customize: null,
+		});
+
+		const { list } = (await autumnV2_2.post("/licenses.list_links", {
+			parent_plan_id: parent.id,
+		})) as { list: Array<{ customize: unknown }> };
+		expect(list[0].customize).toBeNull();
+
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		});
+		const check = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+		});
+		expect(check.balance?.granted).toBe(25);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-edge: existing assignment keeps old customize after plan license update")}`,
+	async () => {
+		const parent = makeParentProduct({ id: "license-snapshot-parent" });
+		const license = makeLicenseProduct({ id: "license-snapshot-seat" });
+		const { customerId, entities, autumnV2_2 } = await initScenario({
+			customerId: "lic-edge-custom-snapshot",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [s.billing.attach({ productId: parent.id })],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 2,
+			customize: { items: [itemsV2.monthlyMessages({ included: 100 })] },
+		});
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		});
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 2,
+			customize: { items: [itemsV2.monthlyMessages({ included: 50 })] },
+		});
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[1].id,
+			plan_id: license.id,
+		});
+
+		const firstEntity = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+		});
+		const secondEntity = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[1].id,
+			feature_id: TestFeature.Messages,
+		});
+		expect(firstEntity.balance?.granted).toBe(100);
+		expect(secondEntity.balance?.granted).toBe(50);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-edge: customize can replace base item and add boolean entitlement")}`,
+	async () => {
+		const parent = makeParentProduct({
+			id: "license-custom-items-parent",
+			includeDashboard: false,
+		});
+		const license = makeLicenseProduct({ id: "license-custom-items-seat" });
+		const { customerId, entities, autumnV2_2 } = await initScenario({
+			customerId: "lic-edge-custom-items",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [s.billing.attach({ productId: parent.id })],
+		});
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+			customize: {
+				items: [itemsV2.monthlyWords({ included: 80 }), itemsV2.dashboard()],
+			},
+		});
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		});
+
+		const messagesCheck = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+		});
+		expect(messagesCheck.allowed).toBe(false);
+		expect(messagesCheck.balance).toBeNull();
+
+		const wordsCheck = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Words,
+		});
+		expect(wordsCheck.allowed).toBe(true);
+		expect(wordsCheck.balance?.granted).toBe(80);
+
+		const dashboardCheck = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Dashboard,
+		});
+		expect(dashboardCheck.allowed).toBe(true);
+
+		const siblingDashboard = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[1].id,
+			feature_id: TestFeature.Dashboard,
+		});
+		expect(siblingDashboard.allowed).toBe(false);
+		expect(siblingDashboard.flag).toBeNull();
+
+		const { products: licenseProducts } = (await autumnV2_2.get(
+			"/products/license_products",
+		)) as { products: ProductV2[] };
+		const listedLicense = licenseProducts.find(
+			(item) => item.id === license.id,
+		);
+		expect(
+			listedLicense?.items.some(
+				(item) => item.feature_id === TestFeature.Words,
+			),
+		).toBe(false);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-edge: multiple parent pools require subscription disambiguation")}`,
+	async () => {
+		const parentA = products.recurringAddOn({
+			id: "license-pool-a",
+			items: [items.dashboard()],
+		});
+		const parentB = products.recurringAddOn({
+			id: "license-pool-b",
+			items: [items.dashboard()],
+		});
+		const license = makeLicenseProduct({ id: "license-pool-seat" });
+		const { customerId, entities, autumnV2_2 } = await initScenario({
+			customerId: "lic-edge-multi-pool",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [parentA, parentB, license] }),
+			],
+			actions: [
+				s.billing.attach({
+					productId: parentA.id,
+					newBillingSubscription: true,
+					subscriptionId: "license-pool-a-sub",
+				}),
+				s.billing.attach({
+					productId: parentB.id,
+					newBillingSubscription: true,
+					subscriptionId: "license-pool-b-sub",
+				}),
+			],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parentA.id,
+			license_plan_id: license.id,
+			included: 1,
+			customize: { items: [itemsV2.monthlyMessages({ included: 50 })] },
+		});
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parentB.id,
+			license_plan_id: license.id,
+			included: 2,
+			customize: { items: [itemsV2.monthlyMessages({ included: 200 })] },
+		});
+		const poolsBefore = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(poolsBefore.list).toHaveLength(2);
+		const poolA = poolsBefore.list.find(
+			(pool) => pool.inventory.included === 1,
+		);
+		const poolB = poolsBefore.list.find(
+			(pool) => pool.inventory.included === 2,
+		);
+		expect(poolA?.parent_plan_id).toBeTruthy();
+		expect(poolB?.parent_plan_id).toBeTruthy();
+		expect(poolA?.parent_plan_id).not.toBe(poolB?.parent_plan_id);
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			func: () =>
+				autumnV2_2.post("/licenses.attach", {
+					customer_id: customerId,
+					entity_id: entities[0].id,
+					plan_id: license.id,
+				}),
+		});
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+			parent_plan_id: poolA?.parent_plan_id,
+		});
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[1].id,
+			plan_id: license.id,
+			parent_plan_id: poolB?.parent_plan_id,
+		});
+
+		const firstEntity = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+		});
+		const secondEntity = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[1].id,
+			feature_id: TestFeature.Messages,
+		});
+		expect(firstEntity.balance?.granted).toBe(50);
+		expect(secondEntity.balance?.granted).toBe(200);
+
+		const poolsAfter = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(
+			poolsAfter.list.find(
+				(pool) => pool.parent_plan_id === poolA?.parent_plan_id,
+			)?.inventory,
+		).toMatchObject({ included: 1, assigned: 1, available: 0 });
+		expect(
+			poolsAfter.list.find(
+				(pool) => pool.parent_plan_id === poolB?.parent_plan_id,
+			)?.inventory,
+		).toMatchObject({ included: 2, assigned: 1, available: 1 });
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-edge: non-license assign and priced customize are rejected")}`,
+	async () => {
+		const parent = makeParentProduct({ id: "license-negative-parent" });
+		const license = makeLicenseProduct({ id: "license-negative-seat" });
+		const { customerId, entities, autumnV2_2 } = await initScenario({
+			customerId: "lic-edge-negative",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [s.billing.attach({ productId: parent.id })],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			func: () =>
+				autumnV2_2.post("/licenses.attach", {
+					customer_id: customerId,
+					entity_id: entities[0].id,
+					plan_id: parent.id,
+				}),
+		});
+		const pricedCustomize = (await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+			customize: { items: [itemsV2.prepaidMessages()] },
+		})) as { plan_license: { customize: { add_items: unknown[] } } };
+		expect(pricedCustomize.plan_license.customize.add_items).toHaveLength(1);
+
+		const assignments = (await autumnV2_2.post("/licenses.list_assignments", {
+			customer_id: customerId,
+			plan_id: license.id,
+		})) as { list: unknown[] };
+		expect(assignments.list).toHaveLength(0);
+	},
+);

--- a/server/tests/integration/licenses/license-entity-deletion.test.ts
+++ b/server/tests/integration/licenses/license-entity-deletion.test.ts
@@ -1,0 +1,124 @@
+/**
+ * TDD test for entity deletion leaving license state inconsistent.
+ *
+ * Red-failure mode (current behavior):
+ *  - Deleting an entity cascade-deletes its license assignment, but the
+ *    provisioned license cusProduct survives with internal_entity_id SET NULL,
+ *    staying Active as a customer-level product — its license feature grants
+ *    leak into customer-level check/balances.
+ *
+ * Green-success criteria (after fix):
+ *  - Entity deletion ends the entity's assignments and expires their
+ *    provisioned customer products; license features stay invisible at the
+ *    customer level, and the freed slot is re-assignable to another entity.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type CheckResponseV3,
+	CusProductStatus,
+	type LicenseBalanceResponse,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { CusService } from "@/internal/customers/CusService.js";
+
+const makeLicenseProduct = () => ({
+	...products.base({
+		id: "entity-del-license",
+		items: [items.monthlyMessages({ includedUsage: 25 })],
+	}),
+});
+
+test.concurrent(
+	`${chalk.yellowBright("licenses entity deletion: ends assignment and expires provisioned product")}`,
+	async () => {
+		const parent = products.base({
+			id: "entity-del-parent",
+			items: [items.dashboard()],
+		});
+		const license = makeLicenseProduct();
+
+		const { customerId, entities, autumnV1, autumnV2_2, ctx } =
+			await initScenario({
+				customerId: "license-entity-deletion",
+				setup: [
+					s.customer({ testClock: false }),
+					s.entities({ count: 2, featureId: TestFeature.Users }),
+					s.products({ list: [parent, license] }),
+				],
+				actions: [s.billing.attach({ productId: parent.id })],
+			});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		});
+
+		const entityCheck = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+		});
+		expect(entityCheck.allowed).toBe(true);
+
+		const customerCheckBefore = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(customerCheckBefore.allowed).toBe(false);
+
+		await autumnV1.entities.delete(customerId, entities[0].id);
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			withEntities: true,
+		});
+		const activeLicenseProducts = fullCustomer.customer_products.filter(
+			(customerProduct) =>
+				customerProduct.product.id === license.id &&
+				customerProduct.status === CusProductStatus.Active,
+		);
+		expect(activeLicenseProducts).toHaveLength(0);
+
+		const customerCheckAfter = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(customerCheckAfter.allowed).toBe(false);
+
+		const pools = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(pools.list).toHaveLength(1);
+		expect(pools.list[0].inventory).toMatchObject({
+			assigned: 0,
+			available: 1,
+		});
+
+		const { assignment: reassigned } = (await autumnV2_2.post(
+			"/licenses.attach",
+			{
+				customer_id: customerId,
+				entity_id: entities[1].id,
+				plan_id: license.id,
+			},
+		)) as { assignment: { entity_id: string; ended_at: number | null } };
+		expect(reassigned).toMatchObject({
+			entity_id: entities[1].id,
+			ended_at: null,
+		});
+	},
+);

--- a/server/tests/integration/licenses/license-entity-deletion.test.ts
+++ b/server/tests/integration/licenses/license-entity-deletion.test.ts
@@ -1,30 +1,12 @@
-/**
- * TDD test for entity deletion leaving license state inconsistent.
- *
- * Red-failure mode (current behavior):
- *  - Deleting an entity cascade-deletes its license assignment, but the
- *    provisioned license cusProduct survives with internal_entity_id SET NULL,
- *    staying Active as a customer-level product — its license feature grants
- *    leak into customer-level check/balances.
- *
- * Green-success criteria (after fix):
- *  - Entity deletion ends the entity's assignments and expires their
- *    provisioned customer products; license features stay invisible at the
- *    customer level, and the freed slot is re-assignable to another entity.
- */
-
 import { expect, test } from "bun:test";
-import {
-	type CheckResponseV3,
-	CusProductStatus,
-	type LicenseBalanceResponse,
-} from "@autumn/shared";
+import { type CheckResponseV3, CusProductStatus } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { CusService } from "@/internal/customers/CusService.js";
+import { listLicensePools } from "./licenseTestUtils.js";
 
 const makeLicenseProduct = () => ({
 	...products.base({
@@ -50,20 +32,19 @@ test.concurrent(
 					s.entities({ count: 2, featureId: TestFeature.Users }),
 					s.products({ list: [parent, license] }),
 				],
-				actions: [s.billing.attach({ productId: parent.id })],
+				actions: [
+					s.licenses.link({
+						parentProductId: parent.id,
+						licenseProductId: license.id,
+						included: 1,
+					}),
+					s.billing.attach({ productId: parent.id }),
+					s.licenses.assign({
+						licenseProductId: license.id,
+						entityIndex: 0,
+					}),
+				],
 			});
-
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
-		});
-
-		await autumnV2_2.post("/licenses.attach", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-			plan_id: license.id,
-		});
 
 		const entityCheck = await autumnV2_2.check<CheckResponseV3>({
 			customer_id: customerId,
@@ -99,11 +80,9 @@ test.concurrent(
 		});
 		expect(customerCheckAfter.allowed).toBe(false);
 
-		const pools = (await autumnV2_2.post("/licenses.list", {
-			customer_id: customerId,
-		})) as { list: LicenseBalanceResponse[] };
-		expect(pools.list).toHaveLength(1);
-		expect(pools.list[0].inventory).toMatchObject({
+		const pools = await listLicensePools({ autumn: autumnV2_2, customerId });
+		expect(pools).toHaveLength(1);
+		expect(pools[0].inventory).toMatchObject({
 			assigned: 0,
 			available: 1,
 		});

--- a/server/tests/integration/licenses/license-known-bugs.test.ts
+++ b/server/tests/integration/licenses/license-known-bugs.test.ts
@@ -1,52 +1,11 @@
-/**
- * Regression pins for FOUR confirmed license bugs.
- *
- * Every test below asserts the CURRENT (buggy) behavior so it passes today.
- * Each header block states what the code SHOULD do once the bug is fixed —
- * when the fix lands, flip the "Red" assertion to the "Green" expectation.
- *
- * B1 — Customer deletion leaks license state.
- *   Red (now): deleteCustomer.ts bare-deletes rows via CusService.deleteByInternalId.
- *     No license reconcile runs, and license_parent_customer_product_id has no FK /
- *     ON DELETE cascade. Deleting a customer that holds a license pool + its own
- *     assignment simply drops the rows with no reconcile or seat credit-back.
- *   Green (after fix): deletion runs a license reconcile so pools/assignments are
- *     released cleanly and cross-customer seats are credited back.
- *
- * B2 — Tombstone divergence between plan read path and license balances.
- *   Red (now): loadApiPlanLicenses (plans.get / plans.list) emits links with
- *     included:0, so a re-linked "tombstone" still appears in a plan's `licenses`.
- *     buildLicenseBalances skips definitions where included<=0, so /licenses.list
- *     OMITS that pool. Same catalog link, two different answers.
- *   Green (after fix): decide one intended semantics — either both surfaces hide a
- *     tombstoned (included:0) link, or both keep it. They must agree.
- *
- * B3 — Trial-revert bypasses license reconcile.
- *   Red (now): tryProcessRevertExpiry flips cusProduct statuses inside a raw
- *     ctx.db.transaction and never calls afterLicenseMutation / any reconcile.
- *     Revert preserving assignments is the CORRECT outcome, but there is no
- *     self-heal pass, so any drift on the parent's pools is never corrected.
- *   Green (after fix): revert still preserves open assignments AND runs a reconcile
- *     so pool balances self-heal. (Skipped — see TODO; setup needs a paused
- *     previous plan under an on_trial_end:"revert" trial.)
- *
- * B4 — Status asymmetry: parent gate vs assignable resolution. NOT A BUG.
- *   LICENSE_PARENT_STATUSES = [Active, PastDue, Trialing] and
- *   LICENSE_ASSIGNABLE_STATUSES = [Active] differ, but the test below proves a
- *   Trialing parent is BOTH a visible pool AND assignable in practice — the two
- *   sets don't conflict for attach. Pinned here so a future change to either
- *   constant that breaks Trialing assignment fails loudly.
- */
-
 import { expect, test } from "bun:test";
 import {
 	ALL_STATUSES,
 	type AttachParamsV1Input,
 	CusProductStatus,
-	FreeTrialDuration,
 	customerLicenses,
 	customerProducts,
-	type LicenseBalanceResponse,
+	FreeTrialDuration,
 } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
@@ -57,7 +16,11 @@ import { eq } from "drizzle-orm";
 import { runProductCron } from "@/cron/productCron/runProductCron.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService.js";
-import { getLicenseDbState } from "./licenseTestUtils.js";
+import {
+	assignLicense,
+	getLicenseDbState,
+	listLicensePools,
+} from "./licenseTestUtils.js";
 
 const makeLicenseProduct = (id: string) =>
 	products.base({
@@ -65,13 +28,6 @@ const makeLicenseProduct = (id: string) =>
 		items: [items.monthlyMessages({ includedUsage: 25 })],
 	});
 
-// B1 — customer deletion runs no license reconcile (deleteCustomer.ts does a
-// bare row delete; license_parent_customer_product_id has no FK/cascade). The
-// leak only manifests cross-customer: a DIFFERENT customer whose assignment
-// draws on the deleted customer's pool is orphaned, and the deleted holder's
-// seat is never credited back. That setup needs cross-customer pool sharing,
-// which isn't expressible through the current initScenario DSL — TODO wire a
-// two-customer scenario (or drive it via ctx.db) to repro the orphan.
 test.concurrent(
 	`${chalk.yellowBright("licenses cleanup: deleting a customer cascades assignments and pools")}`,
 	async () => {
@@ -80,25 +36,25 @@ test.concurrent(
 			items: [items.dashboard()],
 		});
 		const license = makeLicenseProduct("delete-customer-license");
-		const { customerId, entities, autumnV1, autumnV2_2, ctx } =
-			await initScenario({
-				customerId: "license-delete-customer",
-				setup: [
-					s.customer({ testClock: false }),
-					s.entities({ count: 1, featureId: TestFeature.Users }),
-					s.products({ list: [parent, license] }),
-				],
-				actions: [s.billing.attach({ productId: parent.id })],
-			});
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
-		});
-		await autumnV2_2.post("/licenses.attach", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-			plan_id: license.id,
+		const { customerId, autumnV1, ctx } = await initScenario({
+			customerId: "license-delete-customer",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parent.id }),
+				s.licenses.assign({
+					licenseProductId: license.id,
+					entityIndex: 0,
+				}),
+			],
 		});
 		const customer = await CusService.getFull({
 			ctx,
@@ -135,22 +91,22 @@ test.concurrent(
 				s.customer({ testClock: false }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [s.billing.attach({ productId: parent.id })],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 3,
+				}),
+				s.billing.attach({ productId: parent.id }),
+			],
 		});
 
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 3,
-		});
-		// Re-link at included:0 — a removal "tombstone".
 		await autumnV2_2.post("/licenses.link", {
 			parent_plan_id: parent.id,
 			license_plan_id: license.id,
 			included: 0,
 		});
 
-		// Read path (loadApiPlanLicenses) keeps the included:0 link.
 		const plan = (await autumnV2_2.post("/plans.get", {
 			plan_id: parent.id,
 		})) as {
@@ -165,12 +121,8 @@ test.concurrent(
 			included: 0,
 		});
 
-		// Balance path (buildLicenseBalances) skips included<=0, so the pool is
-		// absent — the divergence this test pins.
-		const pools = (await autumnV2_2.post("/licenses.list", {
-			customer_id: customerId,
-		})) as { list: LicenseBalanceResponse[] };
-		expect(pools.list.some((pool) => pool.license_plan_id === license.id)).toBe(
+		const pools = await listLicensePools({ autumn: autumnV2_2, customerId });
+		expect(pools.some((pool) => pool.license_plan_id === license.id)).toBe(
 			false,
 		);
 	},
@@ -195,18 +147,16 @@ test.concurrent(
 				s.entities({ count: 1, featureId: TestFeature.Users }),
 				s.products({ list: [previous, trial, license] }),
 			],
-			actions: [],
-		});
-		for (const parent of [previous, trial]) {
-			await autumnV2_2.post("/licenses.link", {
-				parent_plan_id: parent.id,
-				license_plan_id: license.id,
-				included: 1,
-			});
-		}
-		await autumnV2_2.billing.attach<AttachParamsV1Input>({
-			customer_id: customerId,
-			plan_id: previous.id,
+			actions: [
+				...[previous, trial].map((parent) =>
+					s.licenses.link({
+						parentProductId: parent.id,
+						licenseProductId: license.id,
+						included: 1,
+					}),
+				),
+				s.billing.attach({ productId: previous.id }),
+			],
 		});
 		await autumnV2_2.billing.attach<AttachParamsV1Input>({
 			customer_id: customerId,
@@ -220,11 +170,12 @@ test.concurrent(
 				},
 			},
 		});
-		const { assignment } = (await autumnV2_2.post("/licenses.attach", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-			plan_id: license.id,
-		})) as { assignment: { id: string } };
+		const assignment = await assignLicense({
+			autumn: autumnV2_2,
+			customerId,
+			entityId: entities[0].id,
+			licensePlanId: license.id,
+		});
 		const fullCustomer = await CusService.getFull({
 			ctx,
 			idOrInternalId: customerId,
@@ -290,17 +241,14 @@ test.concurrent(
 				s.entities({ count: 1, featureId: TestFeature.Users }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [],
-		});
-
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
-		});
-		await autumnV2_2.billing.attach({
-			customer_id: customerId,
-			plan_id: parent.id,
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parent.id }),
+			],
 		});
 		const fullCustomer = await CusService.getFull({
 			ctx,
@@ -312,12 +260,13 @@ test.concurrent(
 			)?.status,
 		).toBe(CusProductStatus.Active);
 
-		const pools = (await autumnV2_2.post("/licenses.list", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-		})) as { list: LicenseBalanceResponse[] };
-		expect(pools.list).toHaveLength(1);
-		expect(pools.list[0]).toMatchObject({
+		const pools = await listLicensePools({
+			autumn: autumnV2_2,
+			customerId,
+			entityId: entities[0].id,
+		});
+		expect(pools).toHaveLength(1);
+		expect(pools[0]).toMatchObject({
 			license_plan_id: license.id,
 			inventory: { included: 1, assigned: 0, available: 1 },
 		});
@@ -328,11 +277,12 @@ test.concurrent(
 			plan_id: license.id,
 		});
 
-		const poolsAfter = (await autumnV2_2.post("/licenses.list", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-		})) as { list: LicenseBalanceResponse[] };
-		expect(poolsAfter.list[0].inventory).toMatchObject({
+		const poolsAfter = await listLicensePools({
+			autumn: autumnV2_2,
+			customerId,
+			entityId: entities[0].id,
+		});
+		expect(poolsAfter[0].inventory).toMatchObject({
 			included: 1,
 			assigned: 1,
 			available: 0,

--- a/server/tests/integration/licenses/license-known-bugs.test.ts
+++ b/server/tests/integration/licenses/license-known-bugs.test.ts
@@ -101,10 +101,14 @@ test.concurrent(
 			],
 		});
 
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 0,
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			licenses: [
+				{
+					license_plan_id: license.id,
+					included: 0,
+				},
+			],
 		});
 
 		const plan = (await autumnV2_2.post("/plans.get", {

--- a/server/tests/integration/licenses/license-known-bugs.test.ts
+++ b/server/tests/integration/licenses/license-known-bugs.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Regression pins for FOUR confirmed license bugs.
+ *
+ * Every test below asserts the CURRENT (buggy) behavior so it passes today.
+ * Each header block states what the code SHOULD do once the bug is fixed —
+ * when the fix lands, flip the "Red" assertion to the "Green" expectation.
+ *
+ * B1 — Customer deletion leaks license state.
+ *   Red (now): deleteCustomer.ts bare-deletes rows via CusService.deleteByInternalId.
+ *     No license reconcile runs, and license_parent_customer_product_id has no FK /
+ *     ON DELETE cascade. Deleting a customer that holds a license pool + its own
+ *     assignment simply drops the rows with no reconcile or seat credit-back.
+ *   Green (after fix): deletion runs a license reconcile so pools/assignments are
+ *     released cleanly and cross-customer seats are credited back.
+ *
+ * B2 — Tombstone divergence between plan read path and license balances.
+ *   Red (now): loadApiPlanLicenses (plans.get / plans.list) emits links with
+ *     included:0, so a re-linked "tombstone" still appears in a plan's `licenses`.
+ *     buildLicenseBalances skips definitions where included<=0, so /licenses.list
+ *     OMITS that pool. Same catalog link, two different answers.
+ *   Green (after fix): decide one intended semantics — either both surfaces hide a
+ *     tombstoned (included:0) link, or both keep it. They must agree.
+ *
+ * B3 — Trial-revert bypasses license reconcile.
+ *   Red (now): tryProcessRevertExpiry flips cusProduct statuses inside a raw
+ *     ctx.db.transaction and never calls afterLicenseMutation / any reconcile.
+ *     Revert preserving assignments is the CORRECT outcome, but there is no
+ *     self-heal pass, so any drift on the parent's pools is never corrected.
+ *   Green (after fix): revert still preserves open assignments AND runs a reconcile
+ *     so pool balances self-heal. (Skipped — see TODO; setup needs a paused
+ *     previous plan under an on_trial_end:"revert" trial.)
+ *
+ * B4 — Status asymmetry: parent gate vs assignable resolution. NOT A BUG.
+ *   LICENSE_PARENT_STATUSES = [Active, PastDue, Trialing] and
+ *   LICENSE_ASSIGNABLE_STATUSES = [Active] differ, but the test below proves a
+ *   Trialing parent is BOTH a visible pool AND assignable in practice — the two
+ *   sets don't conflict for attach. Pinned here so a future change to either
+ *   constant that breaks Trialing assignment fails loudly.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	ALL_STATUSES,
+	type AttachParamsV1Input,
+	CusProductStatus,
+	FreeTrialDuration,
+	customerLicenses,
+	customerProducts,
+	type LicenseBalanceResponse,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { runProductCron } from "@/cron/productCron/runProductCron.js";
+import { CusService } from "@/internal/customers/CusService.js";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService.js";
+import { getLicenseDbState } from "./licenseTestUtils.js";
+
+const makeLicenseProduct = (id: string) =>
+	products.base({
+		id,
+		items: [items.monthlyMessages({ includedUsage: 25 })],
+	});
+
+// B1 — customer deletion runs no license reconcile (deleteCustomer.ts does a
+// bare row delete; license_parent_customer_product_id has no FK/cascade). The
+// leak only manifests cross-customer: a DIFFERENT customer whose assignment
+// draws on the deleted customer's pool is orphaned, and the deleted holder's
+// seat is never credited back. That setup needs cross-customer pool sharing,
+// which isn't expressible through the current initScenario DSL — TODO wire a
+// two-customer scenario (or drive it via ctx.db) to repro the orphan.
+test.concurrent(
+	`${chalk.yellowBright("licenses cleanup: deleting a customer cascades assignments and pools")}`,
+	async () => {
+		const parent = products.base({
+			id: "delete-customer-parent",
+			items: [items.dashboard()],
+		});
+		const license = makeLicenseProduct("delete-customer-license");
+		const { customerId, entities, autumnV1, autumnV2_2, ctx } =
+			await initScenario({
+				customerId: "license-delete-customer",
+				setup: [
+					s.customer({ testClock: false }),
+					s.entities({ count: 1, featureId: TestFeature.Users }),
+					s.products({ list: [parent, license] }),
+				],
+				actions: [s.billing.attach({ productId: parent.id })],
+			});
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		});
+		const customer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+
+		await autumnV1.customers.delete(customerId);
+
+		expect(
+			await ctx.db.query.customerProducts.findMany({
+				where: eq(customerProducts.internal_customer_id, customer.internal_id),
+			}),
+		).toHaveLength(0);
+		expect(
+			await ctx.db.query.customerLicenses.findMany({
+				where: eq(customerLicenses.internal_customer_id, customer.internal_id),
+			}),
+		).toHaveLength(0);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-bug: B2 included:0 tombstone shows in plans.get but is omitted from licenses.list")}`,
+	async () => {
+		const parent = products.base({
+			id: "bug-tombstone-parent",
+			items: [items.dashboard()],
+		});
+		const license = makeLicenseProduct("bug-tombstone-license");
+
+		const { customerId, autumnV2_2 } = await initScenario({
+			customerId: "license-bug-tombstone",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [s.billing.attach({ productId: parent.id })],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 3,
+		});
+		// Re-link at included:0 — a removal "tombstone".
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 0,
+		});
+
+		// Read path (loadApiPlanLicenses) keeps the included:0 link.
+		const plan = (await autumnV2_2.post("/plans.get", {
+			plan_id: parent.id,
+		})) as {
+			id: string;
+			licenses?: Array<{ license_plan_id: string; included: number }>;
+		};
+		const tombstoneLink = plan.licenses?.find(
+			(link) => link.license_plan_id === license.id,
+		);
+		expect(tombstoneLink).toMatchObject({
+			license_plan_id: license.id,
+			included: 0,
+		});
+
+		// Balance path (buildLicenseBalances) skips included<=0, so the pool is
+		// absent — the divergence this test pins.
+		const pools = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(pools.list.some((pool) => pool.license_plan_id === license.id)).toBe(
+			false,
+		);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses lifecycle: trial revert reparents assignments and heals inventory")}`,
+	async () => {
+		const previous = products.pro({
+			id: "revert-previous",
+			items: [items.dashboard()],
+		});
+		const trial = products.premium({
+			id: "revert-trial",
+			items: [items.dashboard()],
+		});
+		const license = makeLicenseProduct("revert-license");
+		const { customerId, entities, autumnV2_2, ctx } = await initScenario({
+			customerId: "license-trial-revert",
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [previous, trial, license] }),
+			],
+			actions: [],
+		});
+		for (const parent of [previous, trial]) {
+			await autumnV2_2.post("/licenses.link", {
+				parent_plan_id: parent.id,
+				license_plan_id: license.id,
+				included: 1,
+			});
+		}
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: previous.id,
+		});
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: trial.id,
+			customize: {
+				free_trial: {
+					duration_length: 2,
+					duration_type: FreeTrialDuration.Day,
+					card_required: false,
+					on_end: "revert",
+				},
+			},
+		});
+		const { assignment } = (await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		})) as { assignment: { id: string } };
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			inStatuses: ALL_STATUSES,
+		});
+		const trialCustomerProduct = fullCustomer.customer_products.find(
+			(customerProduct) => customerProduct.product_id === trial.id,
+		);
+		if (!trialCustomerProduct) throw new Error("Trial product not found");
+		await ctx.db
+			.update(customerLicenses)
+			.set({ remaining: 1 })
+			.where(
+				eq(
+					customerLicenses.parent_customer_product_id,
+					trialCustomerProduct.id,
+				),
+			);
+		await CusProductService.update({
+			ctx,
+			cusProductId: trialCustomerProduct.id,
+			updates: { trial_ends_at: Date.now() - 60_000 },
+		});
+
+		await runProductCron({ ctx: { db: ctx.db, logger: ctx.logger } });
+
+		const dbState = await getLicenseDbState({ db: ctx.db, customerId });
+		const activePrevious = dbState.products.find(
+			(customerProduct) =>
+				customerProduct.product_id === previous.id &&
+				customerProduct.status === "active",
+		);
+		expect(activePrevious).toBeDefined();
+		expect(
+			dbState.assignments.find(({ id }) => id === assignment.id),
+		).toMatchObject({
+			status: "active",
+			license_parent_customer_product_id: activePrevious?.id,
+		});
+		expect(dbState.pools).toHaveLength(1);
+		expect(dbState.pools[0]).toMatchObject({
+			parent_customer_product_id: activePrevious?.id,
+			granted: 1,
+			remaining: 0,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses status: a free-trial parent stored as active is assignable")}`,
+	async () => {
+		const parent = products.proWithTrial({
+			id: "bug-status-parent",
+			items: [items.dashboard()],
+			trialDays: 7,
+		});
+		const license = makeLicenseProduct("bug-status-license");
+
+		const { customerId, entities, autumnV2_2, ctx } = await initScenario({
+			customerId: "license-bug-status",
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: parent.id,
+		});
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		expect(
+			fullCustomer.customer_products.find(
+				(customerProduct) => customerProduct.product_id === parent.id,
+			)?.status,
+		).toBe(CusProductStatus.Active);
+
+		const pools = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(pools.list).toHaveLength(1);
+		expect(pools.list[0]).toMatchObject({
+			license_plan_id: license.id,
+			inventory: { included: 1, assigned: 0, available: 1 },
+		});
+
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		});
+
+		const poolsAfter = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(poolsAfter.list[0].inventory).toMatchObject({
+			included: 1,
+			assigned: 1,
+			available: 0,
+		});
+	},
+);

--- a/server/tests/integration/licenses/license-lifecycle.test.ts
+++ b/server/tests/integration/licenses/license-lifecycle.test.ts
@@ -1,24 +1,7 @@
-/**
- * TDD tests for license assignment lifecycle on parent plan transitions.
- *
- * Red-failure mode (current behavior):
- *  - Cancelling the parent subscription leaves assignments open (ended_at null)
- *    and provisioned license customer products Active, so entities keep access.
- *  - A plain upgrade (no license patch) leaves active assignments pointed
- *    at the expired parent's pools; the new parent's pool reports assigned=0.
- *
- * Green-success criteria (after fix):
- *  - Cancel immediately ends active assignments and expires provisioned
- *    license customer products; entity checks stop granting the license.
- *  - Plain upgrade re-parents active assignments onto the successor's pools;
- *    inventory counts and entity access carry over.
- */
-
 import { expect, test } from "bun:test";
 import type {
 	AttachParamsV1Input,
 	CheckResponseV3,
-	LicenseBalanceResponse,
 	UpdateSubscriptionV1ParamsInput,
 } from "@autumn/shared";
 import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect";
@@ -33,7 +16,11 @@ import { addMonths } from "date-fns";
 import { runProductCron } from "@/cron/productCron/runProductCron.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService.js";
-import { getLicenseDbState } from "./licenseTestUtils.js";
+import {
+	getLicenseDbState,
+	listLicenseAssignments,
+	listLicensePools,
+} from "./licenseTestUtils.js";
 
 const makeLicenseProduct = (id: string) => ({
 	...products.base({
@@ -59,23 +46,19 @@ test.concurrent(
 					s.entities({ count: 1, featureId: TestFeature.Users }),
 					s.products({ list: [parent, license] }),
 				],
-				actions: [],
+				actions: [
+					s.licenses.link({
+						parentProductId: parent.id,
+						licenseProductId: license.id,
+						included: 1,
+					}),
+					s.billing.attach({ productId: parent.id }),
+					s.licenses.assign({
+						licenseProductId: license.id,
+						entityIndex: 0,
+					}),
+				],
 			});
-
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
-		});
-		await autumnV2_2.billing.attach<AttachParamsV1Input>({
-			customer_id: customerId,
-			plan_id: parent.id,
-		});
-		await autumnV2_2.post("/licenses.attach", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-			plan_id: license.id,
-		});
 
 		const beforeCancel = await autumnV2_1.check<CheckResponseV3>({
 			customer_id: customerId,
@@ -94,15 +77,13 @@ test.concurrent(
 		expect(dbState.assignments).toHaveLength(1);
 		expect(dbState.assignments[0]).toMatchObject({ status: "expired" });
 
-		const assignmentsAfterCancel = (await autumnV2_2.post(
-			"/licenses.list_assignments",
-			{
-				customer_id: customerId,
-				entity_id: entities[0].id,
-				plan_id: license.id,
-			},
-		)) as { list: Array<{ ended_at: number | null }> };
-		const openAssignments = assignmentsAfterCancel.list.filter(
+		const assignmentsAfterCancel = await listLicenseAssignments({
+			autumn: autumnV2_2,
+			customerId,
+			entityId: entities[0].id,
+			licensePlanId: license.id,
+		});
+		const openAssignments = assignmentsAfterCancel.filter(
 			(assignment) => assignment.ended_at === null,
 		);
 		expect(openAssignments).toHaveLength(0);
@@ -140,25 +121,21 @@ test.concurrent(
 					s.entities({ count: 1, featureId: TestFeature.Users }),
 					s.products({ list: [proPlan, premiumPlan, license] }),
 				],
-				actions: [],
+				actions: [
+					...[proPlan, premiumPlan].map((parent) =>
+						s.licenses.link({
+							parentProductId: parent.id,
+							licenseProductId: license.id,
+							included: 1,
+						}),
+					),
+					s.billing.attach({ productId: proPlan.id }),
+					s.licenses.assign({
+						licenseProductId: license.id,
+						entityIndex: 0,
+					}),
+				],
 			});
-
-		for (const planId of [proPlan.id, premiumPlan.id]) {
-			await autumnV2_2.post("/licenses.link", {
-				parent_plan_id: planId,
-				license_plan_id: license.id,
-				included: 1,
-			});
-		}
-		await autumnV2_2.billing.attach({
-			customer_id: customerId,
-			plan_id: proPlan.id,
-		});
-		await autumnV2_2.post("/licenses.attach", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-			plan_id: license.id,
-		});
 		expect(
 			(
 				await autumnV2_1.check<CheckResponseV3>({
@@ -169,7 +146,7 @@ test.concurrent(
 			).allowed,
 		).toBe(true);
 
-		await autumnV2_2.billing.attach({
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
 			customer_id: customerId,
 			plan_id: premiumPlan.id,
 		});
@@ -191,12 +168,13 @@ test.concurrent(
 			remaining: 0,
 		});
 
-		const poolsAfterUpgrade = (await autumnV2_2.post("/licenses.list", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-		})) as { list: LicenseBalanceResponse[] };
-		expect(poolsAfterUpgrade.list).toHaveLength(1);
-		expect(poolsAfterUpgrade.list[0]).toMatchObject({
+		const poolsAfterUpgrade = await listLicensePools({
+			autumn: autumnV2_2,
+			customerId,
+			entityId: entities[0].id,
+		});
+		expect(poolsAfterUpgrade).toHaveLength(1);
+		expect(poolsAfterUpgrade[0]).toMatchObject({
 			license_plan_id: license.id,
 			inventory: {
 				included: 1,
@@ -204,8 +182,8 @@ test.concurrent(
 				available: 0,
 			},
 		});
-		expect(poolsAfterUpgrade.list[0].assignments).toHaveLength(1);
-		expect(poolsAfterUpgrade.list[0].assignments[0]).toMatchObject({
+		expect(poolsAfterUpgrade[0].assignments).toHaveLength(1);
+		expect(poolsAfterUpgrade[0].assignments[0]).toMatchObject({
 			entity_id: entities[0].id,
 			license_plan_id: license.id,
 		});
@@ -240,23 +218,19 @@ test.concurrent(
 					s.entities({ count: 1, featureId: TestFeature.Users }),
 					s.products({ list: [parent, license] }),
 				],
-				actions: [],
+				actions: [
+					s.licenses.link({
+						parentProductId: parent.id,
+						licenseProductId: license.id,
+						included: 1,
+					}),
+					s.billing.attach({ productId: parent.id }),
+					s.licenses.assign({
+						licenseProductId: license.id,
+						entityIndex: 0,
+					}),
+				],
 			});
-
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
-		});
-		await autumnV2_2.billing.attach({
-			customer_id: customerId,
-			plan_id: parent.id,
-		});
-		await autumnV2_2.post("/licenses.attach", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-			plan_id: license.id,
-		});
 
 		const beforeExpiry = await autumnV2_1.check<CheckResponseV3>({
 			customer_id: customerId,
@@ -284,15 +258,13 @@ test.concurrent(
 		expect(dbState.assignments).toHaveLength(1);
 		expect(dbState.assignments[0]).toMatchObject({ status: "expired" });
 
-		const assignmentsAfter = (await autumnV2_2.post(
-			"/licenses.list_assignments",
-			{
-				customer_id: customerId,
-				entity_id: entities[0].id,
-				plan_id: license.id,
-			},
-		)) as { list: Array<{ ended_at: number | null }> };
-		const openAssignments = assignmentsAfter.list.filter(
+		const assignmentsAfter = await listLicenseAssignments({
+			autumn: autumnV2_2,
+			customerId,
+			entityId: entities[0].id,
+			licensePlanId: license.id,
+		});
+		const openAssignments = assignmentsAfter.filter(
 			(assignment) => assignment.ended_at === null,
 		);
 		expect(openAssignments).toHaveLength(0);
@@ -316,31 +288,34 @@ test.concurrent(
 		});
 		const license = makeLicenseProduct("lifecycle-eoc-license");
 
-		const { customerId, entities, autumnV2_2, ctx, testClockId, advancedTo } =
-			await initScenario({
-				customerId: "license-lifecycle-eoc",
-				setup: [
-					s.customer({ paymentMethod: "success" }),
-					s.entities({ count: 1, featureId: TestFeature.Users }),
-					s.products({ list: [parent, license] }),
-				],
-				actions: [],
-			});
-
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
+		const {
+			customerId,
+			entities,
+			autumnV2_2,
+			ctx,
+			testClockId,
+			advancedTo,
+			licenseAssignments: [assignment],
+		} = await initScenario({
+			customerId: "license-lifecycle-eoc",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parent.id }),
+				s.licenses.assign({
+					licenseProductId: license.id,
+					entityIndex: 0,
+				}),
+			],
 		});
-		await autumnV2_2.billing.attach<AttachParamsV1Input>({
-			customer_id: customerId,
-			plan_id: parent.id,
-		});
-		const { assignment } = (await autumnV2_2.post("/licenses.attach", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-			plan_id: license.id,
-		})) as { assignment: { id: string } };
 
 		const updateCancellation = (
 			cancelAction: "cancel_end_of_cycle" | "uncancel",
@@ -351,11 +326,12 @@ test.concurrent(
 				cancel_action: cancelAction,
 			});
 		const expectAssignmentOpen = async () => {
-			const assignments = (await autumnV2_2.post("/licenses.list_assignments", {
-				customer_id: customerId,
-				plan_id: license.id,
-			})) as { list: Array<{ id: string; ended_at: number | null }> };
-			expect(assignments.list).toEqual([
+			const assignments = await listLicenseAssignments({
+				autumn: autumnV2_2,
+				customerId,
+				licensePlanId: license.id,
+			});
+			expect(assignments).toEqual([
 				expect.objectContaining({ id: assignment.id, ended_at: null }),
 			]);
 		};
@@ -390,14 +366,12 @@ test.concurrent(
 		expect(dbState.assignments).toHaveLength(1);
 		expect(dbState.assignments[0]).toMatchObject({ status: "expired" });
 
-		const assignmentsAfter = (await autumnV2_2.post(
-			"/licenses.list_assignments",
-			{
-				customer_id: customerId,
-				plan_id: license.id,
-			},
-		)) as { list: unknown[] };
-		expect(assignmentsAfter.list).toHaveLength(0);
+		const assignmentsAfter = await listLicenseAssignments({
+			autumn: autumnV2_2,
+			customerId,
+			licensePlanId: license.id,
+		});
+		expect(assignmentsAfter).toHaveLength(0);
 		const check = await autumnV2_2.check<CheckResponseV3>({
 			customer_id: customerId,
 			entity_id: entities[0].id,

--- a/server/tests/integration/licenses/license-lifecycle.test.ts
+++ b/server/tests/integration/licenses/license-lifecycle.test.ts
@@ -1,0 +1,409 @@
+/**
+ * TDD tests for license assignment lifecycle on parent plan transitions.
+ *
+ * Red-failure mode (current behavior):
+ *  - Cancelling the parent subscription leaves assignments open (ended_at null)
+ *    and provisioned license customer products Active, so entities keep access.
+ *  - A plain upgrade (no license patch) leaves active assignments pointed
+ *    at the expired parent's pools; the new parent's pool reports assigned=0.
+ *
+ * Green-success criteria (after fix):
+ *  - Cancel immediately ends active assignments and expires provisioned
+ *    license customer products; entity checks stop granting the license.
+ *  - Plain upgrade re-parents active assignments onto the successor's pools;
+ *    inventory counts and entity access carry over.
+ */
+
+import { expect, test } from "bun:test";
+import type {
+	AttachParamsV1Input,
+	CheckResponseV3,
+	LicenseBalanceResponse,
+	UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { hoursToFinalizeInvoice } from "@tests/utils/constants.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { advanceTestClock } from "@tests/utils/stripeUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { addMonths } from "date-fns";
+import { runProductCron } from "@/cron/productCron/runProductCron.js";
+import { CusService } from "@/internal/customers/CusService.js";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService.js";
+import { getLicenseDbState } from "./licenseTestUtils.js";
+
+const makeLicenseProduct = (id: string) => ({
+	...products.base({
+		id,
+		items: [items.monthlyMessages({ includedUsage: 25 })],
+	}),
+});
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-lifecycle: cancelling the parent ends assignments and revokes entity access")}`,
+	async () => {
+		const parent = products.pro({
+			id: "lifecycle-cancel-parent",
+			items: [items.dashboard()],
+		});
+		const license = makeLicenseProduct("lifecycle-cancel-license");
+
+		const { customerId, entities, autumnV2_1, autumnV2_2, ctx } =
+			await initScenario({
+				customerId: "license-lifecycle-cancel",
+				setup: [
+					s.customer({ paymentMethod: "success", testClock: false }),
+					s.entities({ count: 1, featureId: TestFeature.Users }),
+					s.products({ list: [parent, license] }),
+				],
+				actions: [],
+			});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: parent.id,
+		});
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		});
+
+		const beforeCancel = await autumnV2_1.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+		});
+		expect(beforeCancel.allowed).toBe(true);
+
+		await autumnV2_2.billing.update({
+			customer_id: customerId,
+			plan_id: parent.id,
+			cancel_action: "cancel_immediately",
+		});
+		const dbState = await getLicenseDbState({ db: ctx.db, customerId });
+		expect(dbState.pools).toHaveLength(0);
+		expect(dbState.assignments).toHaveLength(1);
+		expect(dbState.assignments[0]).toMatchObject({ status: "expired" });
+
+		const assignmentsAfterCancel = (await autumnV2_2.post(
+			"/licenses.list_assignments",
+			{
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				plan_id: license.id,
+			},
+		)) as { list: Array<{ ended_at: number | null }> };
+		const openAssignments = assignmentsAfterCancel.list.filter(
+			(assignment) => assignment.ended_at === null,
+		);
+		expect(openAssignments).toHaveLength(0);
+
+		for (const skipCache of [false, true]) {
+			const afterCancel = await autumnV2_1.check<CheckResponseV3>({
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				feature_id: TestFeature.Messages,
+				skip_cache: skipCache,
+			});
+			expect(afterCancel.allowed).toBe(false);
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-lifecycle: plain upgrade re-parents assignments onto the new plan's pools")}`,
+	async () => {
+		const proPlan = products.pro({
+			id: "lifecycle-upgrade-pro",
+			items: [items.dashboard()],
+		});
+		const premiumPlan = products.premium({
+			id: "lifecycle-upgrade-premium",
+			items: [items.dashboard()],
+		});
+		const license = makeLicenseProduct("lifecycle-upgrade-license");
+
+		const { customerId, entities, autumnV2_1, autumnV2_2, ctx } =
+			await initScenario({
+				customerId: "license-lifecycle-upgrade",
+				setup: [
+					s.customer({ paymentMethod: "success", testClock: false }),
+					s.entities({ count: 1, featureId: TestFeature.Users }),
+					s.products({ list: [proPlan, premiumPlan, license] }),
+				],
+				actions: [],
+			});
+
+		for (const planId of [proPlan.id, premiumPlan.id]) {
+			await autumnV2_2.post("/licenses.link", {
+				parent_plan_id: planId,
+				license_plan_id: license.id,
+				included: 1,
+			});
+		}
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: proPlan.id,
+		});
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		});
+		expect(
+			(
+				await autumnV2_1.check<CheckResponseV3>({
+					customer_id: customerId,
+					entity_id: entities[0].id,
+					feature_id: TestFeature.Messages,
+				})
+			).allowed,
+		).toBe(true);
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: premiumPlan.id,
+		});
+		const dbState = await getLicenseDbState({ db: ctx.db, customerId });
+		const activeParent = dbState.products.find(
+			(customerProduct) =>
+				customerProduct.product_id === premiumPlan.id &&
+				customerProduct.status === "active",
+		);
+		expect(activeParent).toBeDefined();
+		expect(dbState.assignments[0]).toMatchObject({
+			status: "active",
+			license_parent_customer_product_id: activeParent?.id,
+		});
+		expect(dbState.pools).toHaveLength(1);
+		expect(dbState.pools[0]).toMatchObject({
+			parent_customer_product_id: activeParent?.id,
+			granted: 1,
+			remaining: 0,
+		});
+
+		const poolsAfterUpgrade = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(poolsAfterUpgrade.list).toHaveLength(1);
+		expect(poolsAfterUpgrade.list[0]).toMatchObject({
+			license_plan_id: license.id,
+			inventory: {
+				included: 1,
+				assigned: 1,
+				available: 0,
+			},
+		});
+		expect(poolsAfterUpgrade.list[0].assignments).toHaveLength(1);
+		expect(poolsAfterUpgrade.list[0].assignments[0]).toMatchObject({
+			entity_id: entities[0].id,
+			license_plan_id: license.id,
+		});
+
+		for (const skipCache of [false, true]) {
+			const afterUpgrade = await autumnV2_1.check<CheckResponseV3>({
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				feature_id: TestFeature.Messages,
+				skip_cache: skipCache,
+			});
+			expect(afterUpgrade.allowed).toBe(true);
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-lifecycle: trial expiry ends assignments on a license parent")}`,
+	async () => {
+		const parent = products.baseWithTrial({
+			id: "lifecycle-trial-parent",
+			items: [items.dashboard()],
+			trialDays: 7,
+		});
+		const license = makeLicenseProduct("lifecycle-trial-license");
+
+		const { customerId, entities, ctx, autumnV2_1, autumnV2_2 } =
+			await initScenario({
+				customerId: "license-lifecycle-trial",
+				setup: [
+					s.customer({ testClock: false }),
+					s.entities({ count: 1, featureId: TestFeature.Users }),
+					s.products({ list: [parent, license] }),
+				],
+				actions: [],
+			});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: parent.id,
+		});
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		});
+
+		const beforeExpiry = await autumnV2_1.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+		});
+		expect(beforeExpiry.allowed).toBe(true);
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const trialParent = fullCustomer.customer_products.find(
+			(customerProduct) => customerProduct.product.id === parent.id,
+		);
+		if (!trialParent) throw new Error("trial parent not found");
+		await CusProductService.update({
+			ctx,
+			cusProductId: trialParent.id,
+			updates: { trial_ends_at: Date.now() - 60_000 },
+		});
+		await runProductCron({ ctx: { db: ctx.db, logger: ctx.logger } });
+		const dbState = await getLicenseDbState({ db: ctx.db, customerId });
+		expect(dbState.pools).toHaveLength(0);
+		expect(dbState.assignments).toHaveLength(1);
+		expect(dbState.assignments[0]).toMatchObject({ status: "expired" });
+
+		const assignmentsAfter = (await autumnV2_2.post(
+			"/licenses.list_assignments",
+			{
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				plan_id: license.id,
+			},
+		)) as { list: Array<{ ended_at: number | null }> };
+		const openAssignments = assignmentsAfter.list.filter(
+			(assignment) => assignment.ended_at === null,
+		);
+		expect(openAssignments).toHaveLength(0);
+
+		const afterExpiry = await autumnV2_1.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(afterExpiry.allowed).toBe(false);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-lifecycle: end-of-cycle cancel and uncancel preserve assignments until expiry")}`,
+	async () => {
+		const parent = products.pro({
+			id: "lifecycle-eoc-parent",
+			items: [items.dashboard()],
+		});
+		const license = makeLicenseProduct("lifecycle-eoc-license");
+
+		const { customerId, entities, autumnV2_2, ctx, testClockId, advancedTo } =
+			await initScenario({
+				customerId: "license-lifecycle-eoc",
+				setup: [
+					s.customer({ paymentMethod: "success" }),
+					s.entities({ count: 1, featureId: TestFeature.Users }),
+					s.products({ list: [parent, license] }),
+				],
+				actions: [],
+			});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: parent.id,
+		});
+		const { assignment } = (await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		})) as { assignment: { id: string } };
+
+		const updateCancellation = (
+			cancelAction: "cancel_end_of_cycle" | "uncancel",
+		) =>
+			autumnV2_2.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+				customer_id: customerId,
+				plan_id: parent.id,
+				cancel_action: cancelAction,
+			});
+		const expectAssignmentOpen = async () => {
+			const assignments = (await autumnV2_2.post("/licenses.list_assignments", {
+				customer_id: customerId,
+				plan_id: license.id,
+			})) as { list: Array<{ id: string; ended_at: number | null }> };
+			expect(assignments.list).toEqual([
+				expect.objectContaining({ id: assignment.id, ended_at: null }),
+			]);
+		};
+
+		await updateCancellation("cancel_end_of_cycle");
+		await expectAssignmentOpen();
+		await expectStripeSubscriptionCorrect({ ctx, customerId });
+
+		await updateCancellation("uncancel");
+		await expectAssignmentOpen();
+		await expectStripeSubscriptionCorrect({ ctx, customerId });
+
+		await updateCancellation("cancel_end_of_cycle");
+		await expectAssignmentOpen();
+		if (!testClockId) throw new Error("testClock not enabled");
+		const cycleEnd = addMonths(new Date(advancedTo), 1);
+		await advanceTestClock({
+			stripeCli: ctx.stripeCli,
+			testClockId,
+			advanceTo: cycleEnd.getTime(),
+			waitForSeconds: 30,
+		});
+		await advanceTestClock({
+			stripeCli: ctx.stripeCli,
+			testClockId,
+			numberOfHours: hoursToFinalizeInvoice,
+			startingFrom: cycleEnd,
+			waitForSeconds: 30,
+		});
+		const dbState = await getLicenseDbState({ db: ctx.db, customerId });
+		expect(dbState.pools).toHaveLength(0);
+		expect(dbState.assignments).toHaveLength(1);
+		expect(dbState.assignments[0]).toMatchObject({ status: "expired" });
+
+		const assignmentsAfter = (await autumnV2_2.post(
+			"/licenses.list_assignments",
+			{
+				customer_id: customerId,
+				plan_id: license.id,
+			},
+		)) as { list: unknown[] };
+		expect(assignmentsAfter.list).toHaveLength(0);
+		const check = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(check.allowed).toBe(false);
+	},
+);

--- a/server/tests/integration/licenses/license-migration.test.ts
+++ b/server/tests/integration/licenses/license-migration.test.ts
@@ -1,25 +1,5 @@
-/**
- * TDD test for plan-version migrations vs customized license sets.
- *
- * Red-failure mode (current behavior):
- *  - Migration only skips is_custom cusProducts. A customer with a customized
- *    license set (license_set_customized) is migrated onto a fresh cusProduct
- *    whose pools are rebuilt from the plan's inherited links — silently
- *    reverting their customization and re-parenting assignments over capacity.
- *
- * Green-success criteria (after fix):
- *  - Customized-license customers are excluded from migration (mirroring the
- *    is_custom exclusion); their custom pools and assignments stay intact.
- *  - Customers with inherited license sets still migrate, with assignments
- *    re-parented onto the new version's pools.
- */
-
 import { expect, test } from "bun:test";
-import type {
-	AttachParamsV1Input,
-	CheckResponseV3,
-	LicenseBalanceResponse,
-} from "@autumn/shared";
+import type { AttachParamsV1Input, CheckResponseV3 } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
@@ -28,7 +8,11 @@ import chalk from "chalk";
 import { getMigrationCustomers } from "@/internal/migrations/migrationSteps/getMigrationCustomers.js";
 import { migrateCustomer } from "@/internal/migrations/migrationSteps/migrateCustomer.js";
 import { ProductService } from "@/internal/products/ProductService.js";
-import { getLicenseDbState } from "./licenseTestUtils.js";
+import {
+	assignLicense,
+	getLicenseDbState,
+	listLicensePools,
+} from "./licenseTestUtils.js";
 
 const expectUnsafeMigrationRejected = async ({
 	customerId,
@@ -50,34 +34,34 @@ const expectUnsafeMigrationRejected = async ({
 		items: [items.monthlyMessages({ includedUsage: 25 })],
 	});
 	const entityCount = targetIncluded === undefined ? 1 : targetIncluded + 1;
-	const { entities, autumnV2_2, ctx } = await initScenario({
+	const { ctx } = await initScenario({
 		customerId,
 		setup: [
 			s.customer({ testClock: false }),
 			s.entities({ count: entityCount, featureId: TestFeature.Users }),
 			s.products({ list: [source, target, license] }),
 		],
-		actions: [s.billing.attach({ productId: source.id })],
+		actions: [
+			s.licenses.link({
+				parentProductId: source.id,
+				licenseProductId: license.id,
+				included: entityCount,
+			}),
+			...(targetIncluded === undefined
+				? []
+				: [
+						s.licenses.link({
+							parentProductId: target.id,
+							licenseProductId: license.id,
+							included: targetIncluded,
+						}),
+					]),
+			s.billing.attach({ productId: source.id }),
+			...Array.from({ length: entityCount }, (_, entityIndex) =>
+				s.licenses.assign({ licenseProductId: license.id, entityIndex }),
+			),
+		],
 	});
-	await autumnV2_2.post("/licenses.link", {
-		parent_plan_id: source.id,
-		license_plan_id: license.id,
-		included: entityCount,
-	});
-	if (targetIncluded !== undefined) {
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: target.id,
-			license_plan_id: license.id,
-			included: targetIncluded,
-		});
-	}
-	for (const entity of entities) {
-		await autumnV2_2.post("/licenses.attach", {
-			customer_id: customerId,
-			entity_id: entity.id,
-			plan_id: license.id,
-		});
-	}
 	const [sourceProduct, targetProduct] = await Promise.all(
 		[source, target].map((product) =>
 			ProductService.getFull({
@@ -171,38 +155,40 @@ test.concurrent(
 			items: [items.monthlyWords({ includedUsage: 50 })],
 		});
 
-		const { customerId, entities, autumnV1, autumnV2_2, ctx } =
-			await initScenario({
-				customerId: "lic-mig-inherited",
-				setup: [
-					s.customer({ testClock: false }),
-					s.entities({ count: 2, featureId: TestFeature.Users }),
-					s.products({ list: [parent, messageLicense, wordLicense] }),
-				],
-				actions: [],
-			});
-
-		for (const license of [messageLicense, wordLicense]) {
-			await autumnV2_2.post("/licenses.link", {
-				parent_plan_id: parent.id,
-				license_plan_id: license.id,
-				included: 2,
-			});
-		}
-		await autumnV2_2.billing.attach<AttachParamsV1Input>({
-			customer_id: customerId,
-			plan_id: parent.id,
+		const {
+			customerId,
+			entities,
+			autumnV1,
+			autumnV2_2,
+			ctx,
+			licenseAssignments,
+		} = await initScenario({
+			customerId: "lic-mig-inherited",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [parent, messageLicense, wordLicense] }),
+			],
+			actions: [
+				...[messageLicense, wordLicense].map((license) =>
+					s.licenses.link({
+						parentProductId: parent.id,
+						licenseProductId: license.id,
+						included: 2,
+					}),
+				),
+				s.billing.attach({ productId: parent.id }),
+				s.licenses.assign({
+					licenseProductId: messageLicense.id,
+					entityIndex: 0,
+				}),
+				s.licenses.assign({
+					licenseProductId: wordLicense.id,
+					entityIndex: 1,
+				}),
+			],
 		});
-		const assignmentIds = await Promise.all(
-			[messageLicense, wordLicense].map(async (license, index) => {
-				const result = (await autumnV2_2.post("/licenses.attach", {
-					customer_id: customerId,
-					entity_id: entities[index].id,
-					plan_id: license.id,
-				})) as { assignment: { id: string } };
-				return result.assignment.id;
-			}),
-		);
+		const assignmentIds = licenseAssignments.map(({ id }) => id);
 
 		const parentV1 = await ProductService.getFull({
 			db: ctx.db,
@@ -268,12 +254,13 @@ test.concurrent(
 				});
 			}
 
-			const pools = (await autumnV2_2.post("/licenses.list", {
-				customer_id: customerId,
-			})) as { list: LicenseBalanceResponse[] };
-			expect(pools.list).toHaveLength(2);
+			const pools = await listLicensePools({
+				autumn: autumnV2_2,
+				customerId,
+			});
+			expect(pools).toHaveLength(2);
 			for (const [index, license] of [messageLicense, wordLicense].entries()) {
-				const pool = pools.list.find(
+				const pool = pools.find(
 					(candidate) => candidate.license_plan_id === license.id,
 				);
 				expect(pool).toMatchObject({
@@ -334,16 +321,16 @@ test.concurrent(
 					s.entities({ count: 2, featureId: TestFeature.Users }),
 					s.products({ list: [parent, license] }),
 				],
-				actions: [],
+				actions: [
+					s.licenses.link({
+						parentProductId: parent.id,
+						licenseProductId: license.id,
+						included: 1,
+					}),
+				],
 			});
 
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
-		});
-
-		await autumnV2_2.billing.attach({
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
 			customer_id: customerId,
 			plan_id: parent.id,
 			customize: {
@@ -357,18 +344,20 @@ test.concurrent(
 		});
 
 		for (const entity of entities) {
-			await autumnV2_2.post("/licenses.attach", {
-				customer_id: customerId,
-				entity_id: entity.id,
-				plan_id: license.id,
+			await assignLicense({
+				autumn: autumnV2_2,
+				customerId,
+				entityId: entity.id,
+				licensePlanId: license.id,
 			});
 		}
 
-		const poolsBefore = (await autumnV2_2.post("/licenses.list", {
-			customer_id: customerId,
-		})) as { list: LicenseBalanceResponse[] };
-		expect(poolsBefore.list).toHaveLength(1);
-		expect(poolsBefore.list[0].inventory).toMatchObject({
+		const poolsBefore = await listLicensePools({
+			autumn: autumnV2_2,
+			customerId,
+		});
+		expect(poolsBefore).toHaveLength(1);
+		expect(poolsBefore[0].inventory).toMatchObject({
 			included: 3,
 			assigned: 2,
 		});
@@ -393,19 +382,18 @@ test.concurrent(
 		const migratedCustomer = await autumnV1.customers.get<{
 			products: { id: string; version?: number }[];
 		}>(customerId);
-		// Customized license parents are deliberately skipped by migration —
-		// the customer keeps v1 with its customization intact.
 		const parentVersions = migratedCustomer.products
 			.filter((product) => product.id === parent.id)
 			.map((product) => product.version);
 		expect(parentVersions).toContain(1);
 		expect(parentVersions).not.toContain(2);
 
-		const poolsAfter = (await autumnV2_2.post("/licenses.list", {
-			customer_id: customerId,
-		})) as { list: LicenseBalanceResponse[] };
-		expect(poolsAfter.list).toHaveLength(1);
-		expect(poolsAfter.list[0].inventory).toMatchObject({
+		const poolsAfter = await listLicensePools({
+			autumn: autumnV2_2,
+			customerId,
+		});
+		expect(poolsAfter).toHaveLength(1);
+		expect(poolsAfter[0].inventory).toMatchObject({
 			included: 3,
 			assigned: 2,
 		});

--- a/server/tests/integration/licenses/license-migration.test.ts
+++ b/server/tests/integration/licenses/license-migration.test.ts
@@ -1,0 +1,413 @@
+/**
+ * TDD test for plan-version migrations vs customized license sets.
+ *
+ * Red-failure mode (current behavior):
+ *  - Migration only skips is_custom cusProducts. A customer with a customized
+ *    license set (license_set_customized) is migrated onto a fresh cusProduct
+ *    whose pools are rebuilt from the plan's inherited links — silently
+ *    reverting their customization and re-parenting assignments over capacity.
+ *
+ * Green-success criteria (after fix):
+ *  - Customized-license customers are excluded from migration (mirroring the
+ *    is_custom exclusion); their custom pools and assignments stay intact.
+ *  - Customers with inherited license sets still migrate, with assignments
+ *    re-parented onto the new version's pools.
+ */
+
+import { expect, test } from "bun:test";
+import type {
+	AttachParamsV1Input,
+	CheckResponseV3,
+	LicenseBalanceResponse,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { getMigrationCustomers } from "@/internal/migrations/migrationSteps/getMigrationCustomers.js";
+import { migrateCustomer } from "@/internal/migrations/migrationSteps/migrateCustomer.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { getLicenseDbState } from "./licenseTestUtils.js";
+
+const expectUnsafeMigrationRejected = async ({
+	customerId,
+	targetIncluded,
+}: {
+	customerId: string;
+	targetIncluded?: number;
+}) => {
+	const source = products.base({
+		id: `${customerId}-source`,
+		items: [items.dashboard()],
+	});
+	const target = products.base({
+		id: `${customerId}-target`,
+		items: [items.dashboard()],
+	});
+	const license = products.base({
+		id: `${customerId}-license`,
+		items: [items.monthlyMessages({ includedUsage: 25 })],
+	});
+	const entityCount = targetIncluded === undefined ? 1 : targetIncluded + 1;
+	const { entities, autumnV2_2, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.entities({ count: entityCount, featureId: TestFeature.Users }),
+			s.products({ list: [source, target, license] }),
+		],
+		actions: [s.billing.attach({ productId: source.id })],
+	});
+	await autumnV2_2.post("/licenses.link", {
+		parent_plan_id: source.id,
+		license_plan_id: license.id,
+		included: entityCount,
+	});
+	if (targetIncluded !== undefined) {
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: target.id,
+			license_plan_id: license.id,
+			included: targetIncluded,
+		});
+	}
+	for (const entity of entities) {
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entity.id,
+			plan_id: license.id,
+		});
+	}
+	const [sourceProduct, targetProduct] = await Promise.all(
+		[source, target].map((product) =>
+			ProductService.getFull({
+				db: ctx.db,
+				idOrInternalId: product.id,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			}),
+		),
+	);
+	const before = await getLicenseDbState({ db: ctx.db, customerId });
+
+	expect(
+		await migrateCustomer({
+			ctx,
+			customerId,
+			fromProduct: sourceProduct,
+			toProduct: targetProduct,
+		}),
+	).toBe(false);
+
+	const after = await getLicenseDbState({ db: ctx.db, customerId });
+	expect(
+		after.assignments.map(
+			({ id, status, license_parent_customer_product_id }) => ({
+				id,
+				status,
+				parentId: license_parent_customer_product_id,
+			}),
+		),
+	).toEqual(
+		before.assignments.map(
+			({ id, status, license_parent_customer_product_id }) => ({
+				id,
+				status,
+				parentId: license_parent_customer_product_id,
+			}),
+		),
+	);
+	expect(
+		after.pools.map(
+			({ id, parent_customer_product_id, granted, remaining }) => ({
+				id,
+				parentId: parent_customer_product_id,
+				granted,
+				remaining,
+			}),
+		),
+	).toEqual(
+		before.pools.map(
+			({ id, parent_customer_product_id, granted, remaining }) => ({
+				id,
+				parentId: parent_customer_product_id,
+				granted,
+				remaining,
+			}),
+		),
+	);
+};
+
+test.concurrent(
+	`${chalk.yellowBright("licenses migration: target missing an assigned license rejects atomically")}`,
+	() =>
+		expectUnsafeMigrationRejected({
+			customerId: "lic-mig-missing-license",
+		}),
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses migration: target capacity below assignments rejects atomically")}`,
+	() =>
+		expectUnsafeMigrationRejected({
+			customerId: "lic-mig-low-capacity",
+			targetIncluded: 1,
+		}),
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses migration: inherited assignments move to the new version exactly once")}`,
+	async () => {
+		const parent = products.base({
+			id: "lic-mig-inherited-parent",
+			items: [items.dashboard()],
+		});
+		const messageLicense = products.base({
+			id: "lic-mig-message-seat",
+			items: [items.monthlyMessages({ includedUsage: 25 })],
+		});
+		const wordLicense = products.base({
+			id: "lic-mig-word-seat",
+			items: [items.monthlyWords({ includedUsage: 50 })],
+		});
+
+		const { customerId, entities, autumnV1, autumnV2_2, ctx } =
+			await initScenario({
+				customerId: "lic-mig-inherited",
+				setup: [
+					s.customer({ testClock: false }),
+					s.entities({ count: 2, featureId: TestFeature.Users }),
+					s.products({ list: [parent, messageLicense, wordLicense] }),
+				],
+				actions: [],
+			});
+
+		for (const license of [messageLicense, wordLicense]) {
+			await autumnV2_2.post("/licenses.link", {
+				parent_plan_id: parent.id,
+				license_plan_id: license.id,
+				included: 2,
+			});
+		}
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: parent.id,
+		});
+		const assignmentIds = await Promise.all(
+			[messageLicense, wordLicense].map(async (license, index) => {
+				const result = (await autumnV2_2.post("/licenses.attach", {
+					customer_id: customerId,
+					entity_id: entities[index].id,
+					plan_id: license.id,
+				})) as { assignment: { id: string } };
+				return result.assignment.id;
+			}),
+		);
+
+		const parentV1 = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: parent.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		await autumnV1.products.update(parent.id, {
+			items: [items.dashboard(), items.monthlyCredits({ includedUsage: 100 })],
+		});
+		const parentV2 = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: parent.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		expect(
+			await migrateCustomer({
+				ctx,
+				customerId,
+				fromProduct: parentV1,
+				toProduct: parentV2,
+			}),
+		).toBe(true);
+
+		const assertMigratedState = async () => {
+			const customer = await autumnV1.customers.get<{
+				products: { id: string; version?: number }[];
+			}>(customerId);
+			const activeParents = customer.products.filter(
+				(product) => product.id === parent.id,
+			);
+			expect(activeParents).toHaveLength(1);
+			expect(activeParents[0].version).toBe(2);
+
+			const dbState = await getLicenseDbState({ db: ctx.db, customerId });
+			const activeParent = dbState.products.filter(
+				(customerProduct) =>
+					customerProduct.product_id === parent.id &&
+					customerProduct.status === "active" &&
+					customerProduct.license_parent_customer_product_id === null,
+			);
+			expect(activeParent).toHaveLength(1);
+			expect(
+				dbState.assignments
+					.filter(({ status }) => status === "active")
+					.map(({ id, license_parent_customer_product_id }) => ({
+						id,
+						parentId: license_parent_customer_product_id,
+					}))
+					.sort((a, b) => a.id.localeCompare(b.id)),
+			).toEqual(
+				assignmentIds
+					.map((id) => ({ id, parentId: activeParent[0].id }))
+					.sort((a, b) => a.id.localeCompare(b.id)),
+			);
+			expect(dbState.pools).toHaveLength(2);
+			for (const pool of dbState.pools) {
+				expect(pool).toMatchObject({
+					parent_customer_product_id: activeParent[0].id,
+					granted: 2,
+					remaining: 1,
+				});
+			}
+
+			const pools = (await autumnV2_2.post("/licenses.list", {
+				customer_id: customerId,
+			})) as { list: LicenseBalanceResponse[] };
+			expect(pools.list).toHaveLength(2);
+			for (const [index, license] of [messageLicense, wordLicense].entries()) {
+				const pool = pools.list.find(
+					(candidate) => candidate.license_plan_id === license.id,
+				);
+				expect(pool).toMatchObject({
+					parent_plan_id: parent.id,
+					inventory: { included: 2, assigned: 1, available: 1 },
+				});
+				expect(
+					pool?.assignments.map((assignment) => assignment.assignment_id),
+				).toEqual([assignmentIds[index]]);
+			}
+
+			for (const [index, featureId] of [
+				TestFeature.Messages,
+				TestFeature.Words,
+			].entries()) {
+				const check = await autumnV2_2.check<CheckResponseV3>({
+					customer_id: customerId,
+					entity_id: entities[index].id,
+					feature_id: featureId,
+					skip_cache: true,
+				});
+				expect(check.allowed).toBe(true);
+			}
+		};
+
+		await assertMigratedState();
+		expect(
+			await migrateCustomer({
+				ctx,
+				customerId,
+				fromProduct: parentV1,
+				toProduct: parentV2,
+			}),
+		).toBe(true);
+		await assertMigratedState();
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses migration: customized license set is not reverted by version migration")}`,
+	async () => {
+		const parent = products.base({
+			id: "lic-mig-custom-parent",
+			items: [items.dashboard()],
+		});
+		const license = {
+			...products.base({
+				id: "lic-mig-custom-seat",
+				items: [items.monthlyMessages({ includedUsage: 25 })],
+			}),
+		};
+
+		const { customerId, entities, autumnV1, autumnV2_2, ctx } =
+			await initScenario({
+				customerId: "lic-mig-customized",
+				setup: [
+					s.customer({ testClock: false }),
+					s.entities({ count: 2, featureId: TestFeature.Users }),
+					s.products({ list: [parent, license] }),
+				],
+				actions: [],
+			});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: parent.id,
+			customize: {
+				add_licenses: [
+					{
+						license_plan_id: license.id,
+						included: 3,
+					},
+				],
+			},
+		});
+
+		for (const entity of entities) {
+			await autumnV2_2.post("/licenses.attach", {
+				customer_id: customerId,
+				entity_id: entity.id,
+				plan_id: license.id,
+			});
+		}
+
+		const poolsBefore = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(poolsBefore.list).toHaveLength(1);
+		expect(poolsBefore.list[0].inventory).toMatchObject({
+			included: 3,
+			assigned: 2,
+		});
+
+		const parentV1 = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: parent.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		await autumnV1.products.update(parent.id, {
+			items: [items.dashboard(), items.monthlyWords({ includedUsage: 100 })],
+		});
+		const migrationCustomers = await getMigrationCustomers({
+			db: ctx.db,
+			fromProduct: parentV1,
+		});
+		expect(migrationCustomers.map((customer) => customer.id)).not.toContain(
+			customerId,
+		);
+
+		const migratedCustomer = await autumnV1.customers.get<{
+			products: { id: string; version?: number }[];
+		}>(customerId);
+		// Customized license parents are deliberately skipped by migration —
+		// the customer keeps v1 with its customization intact.
+		const parentVersions = migratedCustomer.products
+			.filter((product) => product.id === parent.id)
+			.map((product) => product.version);
+		expect(parentVersions).toContain(1);
+		expect(parentVersions).not.toContain(2);
+
+		const poolsAfter = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(poolsAfter.list).toHaveLength(1);
+		expect(poolsAfter.list[0].inventory).toMatchObject({
+			included: 3,
+			assigned: 2,
+		});
+	},
+);

--- a/server/tests/integration/licenses/license-paid-overflow.test.ts
+++ b/server/tests/integration/licenses/license-paid-overflow.test.ts
@@ -1,10 +1,5 @@
-/**
- * Gated license features are blocked: overflow billing (prepaid_only: false)
- * rejects with a 400 on every write path that could create
- * them. Re-enable scenarios are parked in LICENSE_BILLING_TEST_PLAN.md.
- */
-
 import { test } from "bun:test";
+import type { AttachParamsV1Input } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
 import { items } from "@tests/utils/fixtures/items.js";
@@ -71,7 +66,7 @@ test.concurrent(
 		await expectAutumnError({
 			errMessage: "not yet available",
 			func: () =>
-				autumnV2_2.billing.attach({
+				autumnV2_2.billing.attach<AttachParamsV1Input>({
 					customer_id: customerId,
 					plan_id: parent.id,
 					customize: {

--- a/server/tests/integration/licenses/license-plan-versioning.test.ts
+++ b/server/tests/integration/licenses/license-plan-versioning.test.ts
@@ -1,17 +1,3 @@
-/**
- * TDD test for plan versioning silently dropping plan license links.
- *
- * Red-failure mode (current behavior):
- *  - handleVersionProductV2 copies entitlements/prices/free-trials to the new
- *    version's internal_id but never plan_license rows, so after versioning
- *    licenses.list_links for the parent plan returns [].
- *
- * Green-success criteria (after fix):
- *  - Versioning a parent plan carries its plan license links forward;
- *    list_links still returns the license with the same
- *    included and customize after the new version is created.
- */
-
 import { expect, test } from "bun:test";
 import { items } from "@tests/utils/fixtures/items.js";
 import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
@@ -19,13 +5,7 @@ import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { ProductService } from "@/internal/products/ProductService.js";
-
-type PlanLicenseRow = {
-	parent_plan_id: string;
-	license_plan_id: string;
-	included: number;
-	customize?: { add_items?: Array<{ included?: number }> } | null;
-};
+import { listLicenseLinks } from "./licenseTestUtils.js";
 
 test.concurrent(
 	`${chalk.yellowBright("licenses: versioning a parent plan keeps its plan license links")}`,
@@ -47,22 +27,23 @@ test.concurrent(
 				s.customer({ testClock: false }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [s.billing.attach({ productId: parent.id })],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+					customize: {
+						items: [itemsV2.monthlyMessages({ included: 100 })],
+					},
+				}),
+				s.billing.attach({ productId: parent.id }),
+			],
 		});
 
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
-			customize: {
-				items: [itemsV2.monthlyMessages({ included: 100 })],
-			},
+		const beforeVersioning = await listLicenseLinks({
+			autumn: autumnV2_2,
+			parentPlanId: parent.id,
 		});
-
-		const { list: beforeVersioning } = (await autumnV2_2.post(
-			"/licenses.list_links",
-			{ parent_plan_id: parent.id },
-		)) as { list: PlanLicenseRow[] };
 		expect(beforeVersioning).toHaveLength(1);
 
 		const parentV1 = await ProductService.getFull({
@@ -85,10 +66,10 @@ test.concurrent(
 		expect(parentV2.version).toBe(2);
 		expect(parentV2.internal_id).not.toBe(parentV1.internal_id);
 
-		const { list: afterVersioning } = (await autumnV2_2.post(
-			"/licenses.list_links",
-			{ parent_plan_id: parent.id },
-		)) as { list: PlanLicenseRow[] };
+		const afterVersioning = await listLicenseLinks({
+			autumn: autumnV2_2,
+			parentPlanId: parent.id,
+		});
 		expect(afterVersioning).toHaveLength(1);
 		expect(afterVersioning[0]).toMatchObject({
 			parent_plan_id: parent.id,

--- a/server/tests/integration/licenses/license-plan-versioning.test.ts
+++ b/server/tests/integration/licenses/license-plan-versioning.test.ts
@@ -1,0 +1,100 @@
+/**
+ * TDD test for plan versioning silently dropping plan license links.
+ *
+ * Red-failure mode (current behavior):
+ *  - handleVersionProductV2 copies entitlements/prices/free-trials to the new
+ *    version's internal_id but never plan_license rows, so after versioning
+ *    licenses.list_links for the parent plan returns [].
+ *
+ * Green-success criteria (after fix):
+ *  - Versioning a parent plan carries its plan license links forward;
+ *    list_links still returns the license with the same
+ *    included and customize after the new version is created.
+ */
+
+import { expect, test } from "bun:test";
+import { items } from "@tests/utils/fixtures/items.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { ProductService } from "@/internal/products/ProductService.js";
+
+type PlanLicenseRow = {
+	parent_plan_id: string;
+	license_plan_id: string;
+	included: number;
+	customize?: { add_items?: Array<{ included?: number }> } | null;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("licenses: versioning a parent plan keeps its plan license links")}`,
+	async () => {
+		const parent = products.base({
+			id: "license-version-parent",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const license = {
+			...products.base({
+				id: "license-version-seat",
+				items: [items.monthlyMessages({ includedUsage: 25 })],
+			}),
+		};
+
+		const { autumnV2_2, ctx } = await initScenario({
+			customerId: "license-plan-versioning",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [s.billing.attach({ productId: parent.id })],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+			customize: {
+				items: [itemsV2.monthlyMessages({ included: 100 })],
+			},
+		});
+
+		const { list: beforeVersioning } = (await autumnV2_2.post(
+			"/licenses.list_links",
+			{ parent_plan_id: parent.id },
+		)) as { list: PlanLicenseRow[] };
+		expect(beforeVersioning).toHaveLength(1);
+
+		const parentV1 = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: parent.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+
+		await autumnV2_2.post(`/products/${parent.id}`, {
+			items: [items.monthlyMessages({ includedUsage: 200 })],
+		});
+
+		const parentV2 = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: parent.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		expect(parentV2.version).toBe(2);
+		expect(parentV2.internal_id).not.toBe(parentV1.internal_id);
+
+		const { list: afterVersioning } = (await autumnV2_2.post(
+			"/licenses.list_links",
+			{ parent_plan_id: parent.id },
+		)) as { list: PlanLicenseRow[] };
+		expect(afterVersioning).toHaveLength(1);
+		expect(afterVersioning[0]).toMatchObject({
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+		expect(afterVersioning[0].customize?.add_items?.[0].included).toBe(100);
+	},
+);

--- a/server/tests/integration/licenses/license-priced-attach.test.ts
+++ b/server/tests/integration/licenses/license-priced-attach.test.ts
@@ -1,10 +1,5 @@
-/**
- * Assignment never bills: a priced license must already be attached at the
- * customer level (normal billing.attach) before licenses.attach accepts it.
- * Free licenses assign without any customer-level product.
- */
-
 import { expect, test } from "bun:test";
+import type { AttachParamsV1Input } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
 import { items } from "@tests/utils/fixtures/items.js";
@@ -33,12 +28,14 @@ test.concurrent(
 				s.entities({ count: 1, featureId: TestFeature.Users }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [s.billing.attach({ productId: parent.id })],
-		});
-
-		await autumnV2_2.post("/plans.update", {
-			plan_id: parent.id,
-			licenses: [{ license_plan_id: license.id, included: 2 }],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 2,
+				}),
+				s.billing.attach({ productId: parent.id }),
+			],
 		});
 
 		await expectAutumnError({
@@ -51,7 +48,7 @@ test.concurrent(
 				}),
 		});
 
-		await autumnV2_2.billing.attach({
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
 			customer_id: customerId,
 			plan_id: license.id,
 		});
@@ -86,12 +83,14 @@ test.concurrent(
 				s.entities({ count: 1, featureId: TestFeature.Users }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [s.billing.attach({ productId: parent.id })],
-		});
-
-		await autumnV2_2.post("/plans.update", {
-			plan_id: parent.id,
-			licenses: [{ license_plan_id: license.id, included: 1 }],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parent.id }),
+			],
 		});
 		const { assignment } = (await autumnV2_2.post("/licenses.attach", {
 			customer_id: customerId,

--- a/server/tests/integration/licenses/license-product-update-delete.test.ts
+++ b/server/tests/integration/licenses/license-product-update-delete.test.ts
@@ -1,8 +1,3 @@
-/**
- * License products are plain plans: POST/DELETE /products/:id must work on
- * them like any other product.
- */
-
 import { expect, test } from "bun:test";
 import type { ProductV2 } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
@@ -78,12 +73,13 @@ test.concurrent(
 				s.customer({ testClock: false }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [],
-		});
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+				}),
+			],
 		});
 
 		await autumnV2_2.delete(`/products/${license.id}`);
@@ -106,24 +102,25 @@ test.concurrent(
 			id: "delete-assigned-license",
 			items: [items.monthlyMessages({ includedUsage: 25 })],
 		});
-		const { customerId, entities, autumnV2_2, ctx } = await initScenario({
+		const { customerId, autumnV2_2, ctx } = await initScenario({
 			customerId: "license-delete-assigned",
 			setup: [
 				s.customer({ testClock: false }),
 				s.entities({ count: 1, featureId: TestFeature.Users }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [s.billing.attach({ productId: parent.id })],
-		});
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
-		});
-		await autumnV2_2.post("/licenses.attach", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-			plan_id: license.id,
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parent.id }),
+				s.licenses.assign({
+					licenseProductId: license.id,
+					entityIndex: 0,
+				}),
+			],
 		});
 		const before = await getLicenseDbState({ db: ctx.db, customerId });
 

--- a/server/tests/integration/licenses/license-product-update-delete.test.ts
+++ b/server/tests/integration/licenses/license-product-update-delete.test.ts
@@ -1,0 +1,142 @@
+/**
+ * License products are plain plans: POST/DELETE /products/:id must work on
+ * them like any other product.
+ */
+
+import { expect, test } from "bun:test";
+import type { ProductV2 } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { getLicenseDbState } from "./licenseTestUtils.js";
+
+const makeLicenseProduct = () => ({
+	...products.base({
+		id: "license-crud",
+		items: [items.monthlyMessages({ includedUsage: 25 })],
+	}),
+});
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-crud: license product can be updated and deleted via generic product routes")}`,
+	async () => {
+		const license = makeLicenseProduct();
+
+		const { autumnV2_2 } = await initScenario({
+			customerId: "license-crud-1",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [license] }),
+			],
+			actions: [],
+		});
+
+		const updated = (await autumnV2_2.post(`/products/${license.id}`, {
+			name: "Seat License Renamed",
+			items: [items.monthlyMessages({ includedUsage: 50 })],
+		})) as ProductV2;
+		expect(updated.name).toBe("Seat License Renamed");
+
+		const fetched = (await autumnV2_2.get("/products")) as {
+			list: Array<{ id: string; name: string }>;
+		};
+		const licenseProduct = fetched.list.find(
+			(product) => product.id === license.id,
+		);
+		expect(licenseProduct?.name).toBe("Seat License Renamed");
+
+		const deletion = (await autumnV2_2.delete(`/products/${license.id}`)) as {
+			success: boolean;
+		};
+		expect(deletion.success).toBe(true);
+
+		const afterDelete = (await autumnV2_2.get("/products")) as {
+			list: Array<{ id: string }>;
+		};
+		expect(afterDelete.list.some((product) => product.id === license.id)).toBe(
+			false,
+		);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-crud: deleting an unused linked license removes the link")}`,
+	async () => {
+		const parent = products.base({
+			id: "delete-linked-parent",
+			items: [items.dashboard()],
+		});
+		const license = products.base({
+			id: "delete-linked-license",
+			items: [items.monthlyMessages({ includedUsage: 25 })],
+		});
+		const { autumnV2_2 } = await initScenario({
+			customerId: "license-delete-linked",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [],
+		});
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+
+		await autumnV2_2.delete(`/products/${license.id}`);
+
+		const { list } = (await autumnV2_2.post("/licenses.list_links", {
+			parent_plan_id: parent.id,
+		})) as { list: unknown[] };
+		expect(list).toHaveLength(0);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-crud: deleting an assigned license rejects without changing state")}`,
+	async () => {
+		const parent = products.base({
+			id: "delete-assigned-parent",
+			items: [items.dashboard()],
+		});
+		const license = products.base({
+			id: "delete-assigned-license",
+			items: [items.monthlyMessages({ includedUsage: 25 })],
+		});
+		const { customerId, entities, autumnV2_2, ctx } = await initScenario({
+			customerId: "license-delete-assigned",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [s.billing.attach({ productId: parent.id })],
+		});
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		});
+		const before = await getLicenseDbState({ db: ctx.db, customerId });
+
+		await expect(
+			autumnV2_2.delete(`/products/${license.id}`),
+		).rejects.toThrow();
+
+		const after = await getLicenseDbState({ db: ctx.db, customerId });
+		expect(after.assignments).toEqual(before.assignments);
+		expect(after.pools).toEqual(before.pools);
+		const productsAfter = (await autumnV2_2.get("/products")) as {
+			list: Array<{ id: string }>;
+		};
+		expect(productsAfter.list.some(({ id }) => id === license.id)).toBe(true);
+	},
+);

--- a/server/tests/integration/licenses/license-reconcile-coverage.test.ts
+++ b/server/tests/integration/licenses/license-reconcile-coverage.test.ts
@@ -1,16 +1,3 @@
-/**
- * Reconcile + lifecycle coverage for the license state machine.
- *
- * These drive reconcileLicenseStateForCustomer directly (initScenario exposes
- * ctx) and assert the observable surface via /licenses.list and
- * /licenses.list_assignments:
- *  - self-heal of a drifted `remaining` balance
- *  - reconcile idempotency (no re-expiry / drift / dupes on a second pass)
- *  - deterministic successor selection when two live parents offer one license
- *  - partial successor: one linked license re-parents, an unlinked one ends
- *  - granted decrease preserving in-flight assignments
- */
-
 import { expect, test } from "bun:test";
 import type { LicenseBalanceResponse } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
@@ -18,8 +5,8 @@ import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
-import { customerLicenseRepo } from "@/internal/licenses/repos/customerLicenseRepo.js";
 import { reconcileLicenseStateForCustomer } from "@/internal/licenses/actions/reconcile/reconcileLicenseState.js";
+import { customerLicenseRepo } from "@/internal/licenses/repos/customerLicenseRepo.js";
 
 const makeLicenseProduct = (id: string) =>
 	products.base({

--- a/server/tests/integration/licenses/license-reconcile-coverage.test.ts
+++ b/server/tests/integration/licenses/license-reconcile-coverage.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import type { LicenseBalanceResponse } from "@autumn/shared";
+import type { ApiCustomerLicenseV0 } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
@@ -14,7 +14,7 @@ const makeLicenseProduct = (id: string) =>
 		items: [items.monthlyMessages({ includedUsage: 25 })],
 	});
 
-type PoolsResponse = { list: LicenseBalanceResponse[] };
+type PoolsResponse = { list: ApiCustomerLicenseV0[] };
 type AssignmentsResponse = {
 	list: Array<{ id: string; entity_id: string; ended_at: number | null }>;
 };
@@ -41,10 +41,9 @@ test.concurrent(
 			actions: [],
 		});
 
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 2,
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			licenses: [{ license_plan_id: license.id, included: 2 }],
 		});
 		await autumnV2_2.billing.attach({
 			customer_id: customerId,
@@ -130,10 +129,9 @@ test.concurrent(
 			actions: [],
 		});
 
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 2,
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			licenses: [{ license_plan_id: license.id, included: 2 }],
 		});
 		await autumnV2_2.billing.attach({
 			customer_id: customerId,
@@ -194,10 +192,9 @@ test.concurrent(
 		});
 
 		for (const planId of [planA.id, planB.id]) {
-			await autumnV2_2.post("/licenses.link", {
-				parent_plan_id: planId,
-				license_plan_id: license.id,
-				included: 2,
+			await autumnV2_2.post("/plans.update", {
+				plan_id: planId,
+				licenses: [{ license_plan_id: license.id, included: 2 }],
 			});
 		}
 
@@ -272,17 +269,16 @@ test.concurrent(
 		});
 
 		// P links both X and Y; the successor Q links only X.
-		for (const licensePlanId of [licenseX.id, licenseY.id]) {
-			await autumnV2_2.post("/licenses.link", {
-				parent_plan_id: parentP.id,
-				license_plan_id: licensePlanId,
-				included: 1,
-			});
-		}
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: successorQ.id,
-			license_plan_id: licenseX.id,
-			included: 1,
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parentP.id,
+			licenses: [
+				{ license_plan_id: licenseX.id, included: 1 },
+				{ license_plan_id: licenseY.id, included: 1 },
+			],
+		});
+		await autumnV2_2.post("/plans.update", {
+			plan_id: successorQ.id,
+			licenses: [{ license_plan_id: licenseX.id, included: 1 }],
 		});
 
 		await autumnV2_2.billing.attach({
@@ -360,10 +356,9 @@ test.concurrent(
 			actions: [],
 		});
 
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 3,
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			licenses: [{ license_plan_id: license.id, included: 3 }],
 		});
 		await autumnV2_2.billing.attach({
 			customer_id: customerId,
@@ -378,10 +373,9 @@ test.concurrent(
 		}
 
 		// Drop capacity to exactly the active count; both assignments survive.
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 2,
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			licenses: [{ license_plan_id: license.id, included: 2 }],
 		});
 		await reconcileLicenseStateForCustomer({ ctx, customerId: customerId });
 
@@ -409,10 +403,9 @@ test.concurrent(
 		expect(openActive).toHaveLength(2);
 
 		// Raising capacity frees the difference back into availability.
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 4,
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			licenses: [{ license_plan_id: license.id, included: 4 }],
 		});
 		await reconcileLicenseStateForCustomer({ ctx, customerId: customerId });
 

--- a/server/tests/integration/licenses/license-reconcile-coverage.test.ts
+++ b/server/tests/integration/licenses/license-reconcile-coverage.test.ts
@@ -1,0 +1,441 @@
+/**
+ * Reconcile + lifecycle coverage for the license state machine.
+ *
+ * These drive reconcileLicenseStateForCustomer directly (initScenario exposes
+ * ctx) and assert the observable surface via /licenses.list and
+ * /licenses.list_assignments:
+ *  - self-heal of a drifted `remaining` balance
+ *  - reconcile idempotency (no re-expiry / drift / dupes on a second pass)
+ *  - deterministic successor selection when two live parents offer one license
+ *  - partial successor: one linked license re-parents, an unlinked one ends
+ *  - granted decrease preserving in-flight assignments
+ */
+
+import { expect, test } from "bun:test";
+import type { LicenseBalanceResponse } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { customerLicenseRepo } from "@/internal/licenses/repos/customerLicenseRepo.js";
+import { reconcileLicenseStateForCustomer } from "@/internal/licenses/actions/reconcile/reconcileLicenseState.js";
+
+const makeLicenseProduct = (id: string) =>
+	products.base({
+		id,
+		items: [items.monthlyMessages({ includedUsage: 25 })],
+	});
+
+type PoolsResponse = { list: LicenseBalanceResponse[] };
+type AssignmentsResponse = {
+	list: Array<{ id: string; entity_id: string; ended_at: number | null }>;
+};
+
+const findPool = (pools: PoolsResponse, parentPlanId: string) =>
+	pools.list.find((pool) => pool.parent_plan_id === parentPlanId);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-reconcile: self-heals a drifted remaining balance")}`,
+	async () => {
+		const parent = products.pro({
+			id: "reconcile-heal-parent",
+			items: [items.dashboard()],
+		});
+		const license = makeLicenseProduct("reconcile-heal-license");
+
+		const { customerId, entities, ctx, autumnV2_2 } = await initScenario({
+			customerId: "licenses-reconcile-self-heal",
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 2,
+		});
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: parent.id,
+		});
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		});
+
+		const healthy = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as PoolsResponse;
+		expect(healthy.list).toHaveLength(1);
+		expect(healthy.list[0].inventory).toMatchObject({
+			included: 2,
+			assigned: 1,
+			available: 1,
+		});
+
+		// Grab the balance row from reconcile's mirrored state, then corrupt
+		// remaining to simulate a lost/duplicated atomic take.
+		const state = await reconcileLicenseStateForCustomer({
+			ctx,
+			customerId: customerId,
+		});
+		if (!state) throw new Error("expected customer to touch licenses");
+		expect(state.balances).toHaveLength(1);
+		const balance = state.balances[0];
+
+		await customerLicenseRepo.setRemaining({
+			db: ctx.db,
+			customerLicenseId: balance.id,
+			remaining: 2,
+		});
+
+		// Drift landed: the raw row now reads remaining 2 with one live assignment.
+		const drifted = await customerLicenseRepo.getByParentAndLicense({
+			db: ctx.db,
+			parentCustomerProductId: balance.parent_customer_product_id,
+			licenseInternalProductId: balance.license_internal_product_id,
+		});
+		expect(drifted?.remaining).toBe(2);
+
+		// Next reconcile self-heals remaining back to granted - live assignments.
+		await reconcileLicenseStateForCustomer({ ctx, customerId: customerId });
+
+		const healed = await customerLicenseRepo.getByParentAndLicense({
+			db: ctx.db,
+			parentCustomerProductId: balance.parent_customer_product_id,
+			licenseInternalProductId: balance.license_internal_product_id,
+		});
+		expect(healed?.remaining).toBe(1);
+
+		const healedList = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as PoolsResponse;
+		expect(healedList.list[0].inventory).toMatchObject({
+			included: 2,
+			assigned: 1,
+			available: 1,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-reconcile: reconcile is idempotent across back-to-back runs")}`,
+	async () => {
+		const parent = products.pro({
+			id: "reconcile-idem-parent",
+			items: [items.dashboard()],
+		});
+		const license = makeLicenseProduct("reconcile-idem-license");
+
+		const { customerId, entities, ctx, autumnV2_2 } = await initScenario({
+			customerId: "licenses-reconcile-idempotency",
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 2,
+		});
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: parent.id,
+		});
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		});
+
+		await reconcileLicenseStateForCustomer({ ctx, customerId: customerId });
+		const first = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as PoolsResponse;
+
+		await reconcileLicenseStateForCustomer({ ctx, customerId: customerId });
+		const second = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as PoolsResponse;
+
+		expect(second).toEqual(first);
+
+		const assignments = (await autumnV2_2.post("/licenses.list_assignments", {
+			customer_id: customerId,
+			plan_id: license.id,
+		})) as AssignmentsResponse;
+		const openAssignments = assignments.list.filter(
+			(assignment) => assignment.ended_at === null,
+		);
+		expect(openAssignments).toHaveLength(1);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-reconcile: assignment stays on one deterministic parent when two live parents offer the license")}`,
+	async () => {
+		const planA = products.pro({
+			id: "reconcile-multi-a",
+			items: [items.dashboard()],
+			group: "reconcile-multi-a",
+		});
+		const planB = products.pro({
+			id: "reconcile-multi-b",
+			items: [items.dashboard()],
+			group: "reconcile-multi-b",
+		});
+		const license = makeLicenseProduct("reconcile-multi-license");
+
+		const { customerId, entities, ctx, autumnV2_2 } = await initScenario({
+			customerId: "licenses-reconcile-multi-live",
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [planA, planB, license] }),
+			],
+			actions: [],
+		});
+
+		for (const planId of [planA.id, planB.id]) {
+			await autumnV2_2.post("/licenses.link", {
+				parent_plan_id: planId,
+				license_plan_id: license.id,
+				included: 2,
+			});
+		}
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: planA.id,
+		});
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		});
+
+		// Second live parent, distinct group so A stays live (not an upgrade).
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: planB.id,
+		});
+
+		await reconcileLicenseStateForCustomer({ ctx, customerId: customerId });
+		const first = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as PoolsResponse;
+		expect(first.list).toHaveLength(2);
+
+		const firstPoolA = findPool(first, planA.id);
+		const firstPoolB = findPool(first, planB.id);
+		expect(firstPoolA?.inventory).toMatchObject({
+			included: 2,
+			assigned: 1,
+			available: 1,
+		});
+		expect(firstPoolB?.inventory).toMatchObject({
+			included: 2,
+			assigned: 0,
+			available: 2,
+		});
+		expect(firstPoolA?.assignments).toHaveLength(1);
+		expect(firstPoolB?.assignments).toHaveLength(0);
+
+		// Determinism: a repeat reconcile lands the assignment on the same parent.
+		await reconcileLicenseStateForCustomer({ ctx, customerId: customerId });
+		const second = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as PoolsResponse;
+		expect(second).toEqual(first);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-reconcile: partial successor re-parents the linked license and ends the unlinked one")}`,
+	async () => {
+		const parentP = products.pro({
+			id: "reconcile-partial-parent",
+			items: [items.dashboard()],
+		});
+		const successorQ = products.premium({
+			id: "reconcile-partial-successor",
+			items: [items.dashboard()],
+		});
+		const licenseX = makeLicenseProduct("reconcile-partial-x");
+		const licenseY = makeLicenseProduct("reconcile-partial-y");
+
+		const { customerId, entities, ctx, autumnV2_2 } = await initScenario({
+			customerId: "licenses-reconcile-partial-successor",
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parentP, successorQ, licenseX, licenseY] }),
+			],
+			actions: [],
+		});
+
+		// P links both X and Y; the successor Q links only X.
+		for (const licensePlanId of [licenseX.id, licenseY.id]) {
+			await autumnV2_2.post("/licenses.link", {
+				parent_plan_id: parentP.id,
+				license_plan_id: licensePlanId,
+				included: 1,
+			});
+		}
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: successorQ.id,
+			license_plan_id: licenseX.id,
+			included: 1,
+		});
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: parentP.id,
+		});
+		for (const licensePlanId of [licenseX.id, licenseY.id]) {
+			await autumnV2_2.post("/licenses.attach", {
+				customer_id: customerId,
+				entity_id: entities[0].id,
+				plan_id: licensePlanId,
+			});
+		}
+
+		// Upgrade P -> Q (same group) expires P and strands both assignments.
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: successorQ.id,
+		});
+		await reconcileLicenseStateForCustomer({ ctx, customerId: customerId });
+
+		const pools = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as PoolsResponse;
+		expect(pools.list).toHaveLength(1);
+		expect(pools.list[0]).toMatchObject({
+			parent_plan_id: successorQ.id,
+			license_plan_id: licenseX.id,
+			inventory: { included: 1, assigned: 1, available: 0 },
+		});
+		expect(pools.list[0].assignments).toHaveLength(1);
+
+		const xAssignments = (await autumnV2_2.post("/licenses.list_assignments", {
+			customer_id: customerId,
+			plan_id: licenseX.id,
+			active: false,
+		})) as AssignmentsResponse;
+		const openX = xAssignments.list.filter(
+			(assignment) => assignment.ended_at === null,
+		);
+		expect(openX).toHaveLength(1);
+
+		const yAssignments = (await autumnV2_2.post("/licenses.list_assignments", {
+			customer_id: customerId,
+			plan_id: licenseY.id,
+			active: false,
+		})) as AssignmentsResponse;
+		const openY = yAssignments.list.filter(
+			(assignment) => assignment.ended_at === null,
+		);
+		expect(openY).toHaveLength(0);
+		const endedY = yAssignments.list.filter(
+			(assignment) => (assignment.ended_at ?? 0) > 0,
+		);
+		expect(endedY.length).toBeGreaterThan(0);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-reconcile: lowering granted preserves in-flight assignments")}`,
+	async () => {
+		const parent = products.pro({
+			id: "reconcile-granted-parent",
+			items: [items.dashboard()],
+		});
+		const license = makeLicenseProduct("reconcile-granted-license");
+
+		const { customerId, entities, ctx, autumnV2_2 } = await initScenario({
+			customerId: "licenses-reconcile-granted-decrease",
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 3,
+		});
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: parent.id,
+		});
+		for (const entity of entities) {
+			await autumnV2_2.post("/licenses.attach", {
+				customer_id: customerId,
+				entity_id: entity.id,
+				plan_id: license.id,
+			});
+		}
+
+		// Drop capacity to exactly the active count; both assignments survive.
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 2,
+		});
+		await reconcileLicenseStateForCustomer({ ctx, customerId: customerId });
+
+		const tight = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as PoolsResponse;
+		expect(tight.list).toHaveLength(1);
+		expect(tight.list[0].inventory).toMatchObject({
+			included: 2,
+			assigned: 2,
+			available: 0,
+		});
+		expect(tight.list[0].assignments).toHaveLength(2);
+
+		const activeAssignments = (await autumnV2_2.post(
+			"/licenses.list_assignments",
+			{
+				customer_id: customerId,
+				plan_id: license.id,
+			},
+		)) as AssignmentsResponse;
+		const openActive = activeAssignments.list.filter(
+			(assignment) => assignment.ended_at === null,
+		);
+		expect(openActive).toHaveLength(2);
+
+		// Raising capacity frees the difference back into availability.
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 4,
+		});
+		await reconcileLicenseStateForCustomer({ ctx, customerId: customerId });
+
+		const roomy = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as PoolsResponse;
+		expect(roomy.list[0].inventory).toMatchObject({
+			included: 4,
+			assigned: 2,
+			available: 2,
+		});
+	},
+);

--- a/server/tests/integration/licenses/license-status-integration.test.ts
+++ b/server/tests/integration/licenses/license-status-integration.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
 import {
+	type CheckResponseV3,
 	CusProductStatus,
 	ErrCode,
-	type CheckResponseV3,
 } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
@@ -30,17 +30,18 @@ const setupStatusScenario = async (customerId: string) => {
 			s.entities({ count: 2, featureId: TestFeature.Users }),
 			s.products({ list: [parent, license] }),
 		],
-		actions: [s.billing.attach({ productId: parent.id })],
-	});
-	await scenario.autumnV2_2.post("/licenses.link", {
-		parent_plan_id: parent.id,
-		license_plan_id: license.id,
-		included: 2,
-	});
-	await scenario.autumnV2_2.post("/licenses.attach", {
-		customer_id: customerId,
-		entity_id: scenario.entities[0].id,
-		plan_id: license.id,
+		actions: [
+			s.licenses.link({
+				parentProductId: parent.id,
+				licenseProductId: license.id,
+				included: 2,
+			}),
+			s.billing.attach({ productId: parent.id }),
+			s.licenses.assign({
+				licenseProductId: license.id,
+				entityIndex: 0,
+			}),
+		],
 	});
 	return { ...scenario, license };
 };

--- a/server/tests/integration/licenses/license-status-integration.test.ts
+++ b/server/tests/integration/licenses/license-status-integration.test.ts
@@ -1,0 +1,145 @@
+import { expect, test } from "bun:test";
+import {
+	CusProductStatus,
+	ErrCode,
+	type CheckResponseV3,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService.js";
+import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
+import { getLicenseDbState } from "./licenseTestUtils.js";
+
+const setupStatusScenario = async (customerId: string) => {
+	const parent = products.base({
+		id: `${customerId}-parent`,
+		items: [items.dashboard()],
+	});
+	const license = products.base({
+		id: `${customerId}-license`,
+		items: [items.monthlyMessages({ includedUsage: 25 })],
+	});
+	const scenario = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.entities({ count: 2, featureId: TestFeature.Users }),
+			s.products({ list: [parent, license] }),
+		],
+		actions: [s.billing.attach({ productId: parent.id })],
+	});
+	await scenario.autumnV2_2.post("/licenses.link", {
+		parent_plan_id: parent.id,
+		license_plan_id: license.id,
+		included: 2,
+	});
+	await scenario.autumnV2_2.post("/licenses.attach", {
+		customer_id: customerId,
+		entity_id: scenario.entities[0].id,
+		plan_id: license.id,
+	});
+	return { ...scenario, license };
+};
+
+const setParentStatus = async ({
+	ctx,
+	customerId,
+	status,
+}: {
+	ctx: Awaited<ReturnType<typeof setupStatusScenario>>["ctx"];
+	customerId: string;
+	status: CusProductStatus;
+}) => {
+	const state = await getLicenseDbState({ db: ctx.db, customerId });
+	const parent = state.products.find(
+		(customerProduct) =>
+			customerProduct.license_parent_customer_product_id === null &&
+			customerProduct.internal_entity_id === null,
+	);
+	if (!parent) throw new Error("License parent not found");
+	await CusProductService.update({
+		ctx,
+		cusProductId: parent.id,
+		updates: { status },
+	});
+	await deleteCachedFullCustomer({ ctx, customerId, skipGuard: true });
+};
+
+test.concurrent(
+	`${chalk.yellowBright("licenses status: past-due retains grants but blocks new assignments until recovery")}`,
+	async () => {
+		const { customerId, entities, autumnV2_2, ctx, license } =
+			await setupStatusScenario("license-parent-past-due");
+		await setParentStatus({
+			ctx,
+			customerId,
+			status: CusProductStatus.PastDue,
+		});
+
+		const existing = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(existing.allowed).toBe(true);
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			func: () =>
+				autumnV2_2.post("/licenses.attach", {
+					customer_id: customerId,
+					entity_id: entities[1].id,
+					plan_id: license.id,
+				}),
+		});
+
+		await setParentStatus({ ctx, customerId, status: CusProductStatus.Active });
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[1].id,
+			plan_id: license.id,
+		});
+		const state = await getLicenseDbState({ db: ctx.db, customerId });
+		expect(
+			state.assignments.filter(({ status }) => status === "active"),
+		).toHaveLength(2);
+		expect(state.pools[0]).toMatchObject({ granted: 2, remaining: 0 });
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses status: true trialing parent retains grants but is not assignable")}`,
+	async () => {
+		const { customerId, entities, autumnV2_2, ctx, license } =
+			await setupStatusScenario("license-parent-true-trialing");
+		await setParentStatus({
+			ctx,
+			customerId,
+			status: CusProductStatus.Trialing,
+		});
+
+		expect(
+			(
+				await autumnV2_2.check<CheckResponseV3>({
+					customer_id: customerId,
+					entity_id: entities[0].id,
+					feature_id: TestFeature.Messages,
+					skip_cache: true,
+				})
+			).allowed,
+		).toBe(true);
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			func: () =>
+				autumnV2_2.post("/licenses.attach", {
+					customer_id: customerId,
+					entity_id: entities[1].id,
+					plan_id: license.id,
+				}),
+		});
+	},
+);

--- a/server/tests/integration/licenses/license-successor-activation.test.ts
+++ b/server/tests/integration/licenses/license-successor-activation.test.ts
@@ -1,0 +1,287 @@
+/**
+ * When a scheduled paid downgrade target carries a license link, activating it
+ * at cycle end must run the license reconcile hook: the activated parent's
+ * pool appears in pools.list with the linked inventory.
+ */
+
+import { expect, test } from "bun:test";
+import type {
+	AttachParamsV0Input,
+	CheckResponseV3,
+	LicenseBalanceResponse,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { hoursToFinalizeInvoice } from "@tests/utils/constants.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import { advanceTestClock } from "@tests/utils/stripeUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { addMonths } from "date-fns";
+import { getLicenseDbState } from "./licenseTestUtils.js";
+
+const advanceToNextCycle = async ({
+	stripeCli,
+	testClockId,
+	advancedTo,
+}: {
+	stripeCli: Parameters<typeof advanceTestClock>[0]["stripeCli"];
+	testClockId?: string;
+	advancedTo: number;
+}) => {
+	if (!testClockId) throw new Error("testClock not enabled");
+	const cycleEnd = addMonths(new Date(advancedTo), 1);
+	await advanceTestClock({
+		stripeCli,
+		testClockId,
+		advanceTo: cycleEnd.getTime(),
+		waitForSeconds: 30,
+	});
+	await advanceTestClock({
+		stripeCli,
+		testClockId,
+		numberOfHours: hoursToFinalizeInvoice,
+		startingFrom: cycleEnd,
+		waitForSeconds: 30,
+	});
+};
+
+const setupAssignedDowngrade = async ({
+	customerId,
+	successorOffersLicense,
+}: {
+	customerId: string;
+	successorOffersLicense: boolean;
+}) => {
+	const premium = products.premium({
+		id: "premium",
+		items: [items.dashboard()],
+	});
+	const pro = products.pro({ id: "pro", items: [items.dashboard()] });
+	const license = products.base({
+		id: "seat",
+		items: [items.monthlyMessages({ includedUsage: 25 })],
+	});
+	const scenario = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.entities({ count: 1, featureId: TestFeature.Users }),
+			s.products({ list: [premium, pro, license] }),
+		],
+		actions: [s.billing.attach({ productId: premium.id })],
+	});
+
+	for (const parent of successorOffersLicense ? [premium, pro] : [premium]) {
+		await scenario.autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+	}
+	const { assignment } = (await scenario.autumnV2_2.post("/licenses.attach", {
+		customer_id: customerId,
+		entity_id: scenario.entities[0].id,
+		plan_id: license.id,
+	})) as { assignment: { id: string } };
+	await scenario.autumnV1.billing.attach<AttachParamsV0Input>({
+		customer_id: customerId,
+		product_id: pro.id,
+		redirect_mode: "if_required",
+	});
+	await timeout(4000);
+	return { ...scenario, premium, pro, license, assignment };
+};
+
+test.concurrent(
+	`${chalk.yellowBright("licenses successor activation: pool created when scheduled downgrade with license activates")}`,
+	async () => {
+		const premium = products.premium({
+			id: "lic-act-premium",
+			items: [items.monthlyWords({ includedUsage: 100 })],
+		});
+		const pro = products.pro({
+			id: "lic-act-pro",
+			items: [items.dashboard()],
+		});
+		const license = products.base({
+			id: "lic-act-seat",
+			items: [items.monthlyMessages({ includedUsage: 25 })],
+		});
+
+		const { customerId, autumnV1, autumnV2_2, ctx, testClockId, advancedTo } =
+			await initScenario({
+				customerId: "lic-successor-activation",
+				setup: [
+					s.customer({ paymentMethod: "success" }),
+					s.products({ list: [premium, pro, license] }),
+				],
+				actions: [s.billing.attach({ productId: premium.id })],
+			});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: pro.id,
+			license_plan_id: license.id,
+			included: 2,
+		});
+
+		await autumnV1.billing.attach<AttachParamsV0Input>({
+			customer_id: customerId,
+			product_id: pro.id,
+			redirect_mode: "if_required",
+		});
+
+		const scheduledPools = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(scheduledPools.list).toHaveLength(0);
+
+		await timeout(4000);
+		await advanceToNextCycle({
+			stripeCli: ctx.stripeCli,
+			testClockId,
+			advancedTo,
+		});
+		const dbState = await getLicenseDbState({ db: ctx.db, customerId });
+		expect(dbState.pools).toHaveLength(1);
+		expect(dbState.pools[0]).toMatchObject({ granted: 2, remaining: 2 });
+
+		const pools = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(pools.list).toHaveLength(1);
+		expect(pools.list[0].inventory).toMatchObject({
+			included: 2,
+			assigned: 0,
+			available: 2,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses successor activation: scheduled downgrade re-parents an existing assignment")}`,
+	async () => {
+		const {
+			customerId,
+			entities,
+			autumnV2_2,
+			ctx,
+			testClockId,
+			advancedTo,
+			premium,
+			pro,
+			assignment,
+		} = await setupAssignedDowngrade({
+			customerId: "lic-successor-reparent",
+			successorOffersLicense: true,
+		});
+
+		const before = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(before.list).toHaveLength(1);
+		expect(before.list[0]).toMatchObject({
+			parent_plan_id: premium.id,
+			inventory: { included: 1, assigned: 1, available: 0 },
+		});
+
+		await advanceToNextCycle({
+			stripeCli: ctx.stripeCli,
+			testClockId,
+			advancedTo,
+		});
+		const dbState = await getLicenseDbState({ db: ctx.db, customerId });
+		const activeParent = dbState.products.find(
+			(customerProduct) =>
+				customerProduct.product_id === pro.id &&
+				customerProduct.status === "active" &&
+				customerProduct.license_parent_customer_product_id === null,
+		);
+		expect(activeParent).toBeDefined();
+		expect(
+			dbState.assignments.find(({ id }) => id === assignment.id),
+		).toMatchObject({
+			status: "active",
+			license_parent_customer_product_id: activeParent?.id,
+		});
+		expect(dbState.pools).toHaveLength(1);
+		expect(dbState.pools[0]).toMatchObject({
+			parent_customer_product_id: activeParent?.id,
+			granted: 1,
+			remaining: 0,
+		});
+
+		const after = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(after.list).toHaveLength(1);
+		expect(after.list[0]).toMatchObject({
+			parent_plan_id: pro.id,
+			inventory: { included: 1, assigned: 1, available: 0 },
+		});
+		expect(after.list[0].assignments.map((item) => item.assignment_id)).toEqual(
+			[assignment.id],
+		);
+
+		const check = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(check.allowed).toBe(true);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses successor activation: scheduled downgrade ends an unsupported assignment at activation")}`,
+	async () => {
+		const {
+			customerId,
+			entities,
+			autumnV2_2,
+			ctx,
+			testClockId,
+			advancedTo,
+			license,
+		} = await setupAssignedDowngrade({
+			customerId: "lic-successor-unsupported",
+			successorOffersLicense: false,
+		});
+
+		const before = (await autumnV2_2.post("/licenses.list_assignments", {
+			customer_id: customerId,
+			plan_id: license.id,
+		})) as { list: unknown[] };
+		expect(before.list).toHaveLength(1);
+
+		await advanceToNextCycle({
+			stripeCli: ctx.stripeCli,
+			testClockId,
+			advancedTo,
+		});
+		const dbState = await getLicenseDbState({ db: ctx.db, customerId });
+		expect(dbState.pools).toHaveLength(0);
+		expect(dbState.assignments).toHaveLength(1);
+		expect(dbState.assignments[0]).toMatchObject({ status: "expired" });
+
+		const pools = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(pools.list).toHaveLength(0);
+		const assignments = (await autumnV2_2.post("/licenses.list_assignments", {
+			customer_id: customerId,
+			plan_id: license.id,
+		})) as { list: unknown[] };
+		expect(assignments.list).toHaveLength(0);
+
+		const check = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(check.allowed).toBe(false);
+	},
+);

--- a/server/tests/integration/licenses/license-successor-activation.test.ts
+++ b/server/tests/integration/licenses/license-successor-activation.test.ts
@@ -1,9 +1,3 @@
-/**
- * When a scheduled paid downgrade target carries a license link, activating it
- * at cycle end must run the license reconcile hook: the activated parent's
- * pool appears in pools.list with the linked inventory.
- */
-
 import { expect, test } from "bun:test";
 import type {
 	AttachParamsV0Input,
@@ -70,28 +64,34 @@ const setupAssignedDowngrade = async ({
 			s.entities({ count: 1, featureId: TestFeature.Users }),
 			s.products({ list: [premium, pro, license] }),
 		],
-		actions: [s.billing.attach({ productId: premium.id })],
+		actions: [
+			...(successorOffersLicense ? [premium, pro] : [premium]).map((parent) =>
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+				}),
+			),
+			s.billing.attach({ productId: premium.id }),
+			s.licenses.assign({
+				licenseProductId: license.id,
+				entityIndex: 0,
+			}),
+		],
 	});
-
-	for (const parent of successorOffersLicense ? [premium, pro] : [premium]) {
-		await scenario.autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
-		});
-	}
-	const { assignment } = (await scenario.autumnV2_2.post("/licenses.attach", {
-		customer_id: customerId,
-		entity_id: scenario.entities[0].id,
-		plan_id: license.id,
-	})) as { assignment: { id: string } };
 	await scenario.autumnV1.billing.attach<AttachParamsV0Input>({
 		customer_id: customerId,
 		product_id: pro.id,
 		redirect_mode: "if_required",
 	});
 	await timeout(4000);
-	return { ...scenario, premium, pro, license, assignment };
+	return {
+		...scenario,
+		premium,
+		pro,
+		license,
+		assignment: scenario.licenseAssignments[0],
+	};
 };
 
 test.concurrent(
@@ -117,14 +117,15 @@ test.concurrent(
 					s.customer({ paymentMethod: "success" }),
 					s.products({ list: [premium, pro, license] }),
 				],
-				actions: [s.billing.attach({ productId: premium.id })],
+				actions: [
+					s.licenses.link({
+						parentProductId: pro.id,
+						licenseProductId: license.id,
+						included: 2,
+					}),
+					s.billing.attach({ productId: premium.id }),
+				],
 			});
-
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: pro.id,
-			license_plan_id: license.id,
-			included: 2,
-		});
 
 		await autumnV1.billing.attach<AttachParamsV0Input>({
 			customer_id: customerId,

--- a/server/tests/integration/licenses/license-successor-activation.test.ts
+++ b/server/tests/integration/licenses/license-successor-activation.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
 import type {
+	ApiCustomerLicenseV0,
 	AttachParamsV0Input,
 	CheckResponseV3,
-	LicenseBalanceResponse,
 } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { hoursToFinalizeInvoice } from "@tests/utils/constants.js";
@@ -135,7 +135,7 @@ test.concurrent(
 
 		const scheduledPools = (await autumnV2_2.post("/licenses.list", {
 			customer_id: customerId,
-		})) as { list: LicenseBalanceResponse[] };
+		})) as { list: ApiCustomerLicenseV0[] };
 		expect(scheduledPools.list).toHaveLength(0);
 
 		await timeout(4000);
@@ -150,7 +150,7 @@ test.concurrent(
 
 		const pools = (await autumnV2_2.post("/licenses.list", {
 			customer_id: customerId,
-		})) as { list: LicenseBalanceResponse[] };
+		})) as { list: ApiCustomerLicenseV0[] };
 		expect(pools.list).toHaveLength(1);
 		expect(pools.list[0].inventory).toMatchObject({
 			included: 2,
@@ -180,7 +180,7 @@ test.concurrent(
 
 		const before = (await autumnV2_2.post("/licenses.list", {
 			customer_id: customerId,
-		})) as { list: LicenseBalanceResponse[] };
+		})) as { list: ApiCustomerLicenseV0[] };
 		expect(before.list).toHaveLength(1);
 		expect(before.list[0]).toMatchObject({
 			parent_plan_id: premium.id,
@@ -215,7 +215,7 @@ test.concurrent(
 
 		const after = (await autumnV2_2.post("/licenses.list", {
 			customer_id: customerId,
-		})) as { list: LicenseBalanceResponse[] };
+		})) as { list: ApiCustomerLicenseV0[] };
 		expect(after.list).toHaveLength(1);
 		expect(after.list[0]).toMatchObject({
 			parent_plan_id: pro.id,
@@ -269,7 +269,7 @@ test.concurrent(
 
 		const pools = (await autumnV2_2.post("/licenses.list", {
 			customer_id: customerId,
-		})) as { list: LicenseBalanceResponse[] };
+		})) as { list: ApiCustomerLicenseV0[] };
 		expect(pools.list).toHaveLength(0);
 		const assignments = (await autumnV2_2.post("/licenses.list_assignments", {
 			customer_id: customerId,

--- a/server/tests/integration/licenses/license-transfer.test.ts
+++ b/server/tests/integration/licenses/license-transfer.test.ts
@@ -1,0 +1,74 @@
+/**
+ * TDD test for transferring a plan cusProduct that parents license pools.
+ *
+ * Red-failure mode (current behavior):
+ *  - The transfer succeeds, moving the parent to an entity while its license
+ *    pools/assignments stay customer-wide; later lifecycle transitions refuse
+ *    entity-scoped successors, so assignments end instead of re-parenting.
+ *
+ * Green-success criteria (after fix):
+ *  - Transfer of a license-pool parent is rejected with a 400, and transfers
+ *    of plans without license pools keep working.
+ */
+
+import { expect, test } from "bun:test";
+import { ErrCode, type LicenseBalanceResponse } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const makeLicenseProduct = () => ({
+	...products.base({
+		id: "transfer-license",
+		items: [items.monthlyMessages({ includedUsage: 25 })],
+	}),
+});
+
+test.concurrent(
+	`${chalk.yellowBright("licenses transfer: license-pool parent cannot be transferred to an entity")}`,
+	async () => {
+		const parent = products.base({
+			id: "transfer-parent",
+			items: [items.dashboard()],
+		});
+		const license = makeLicenseProduct();
+
+		const { customerId, entities, autumnV1, autumnV2_2 } = await initScenario({
+			customerId: "license-transfer-guard",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [s.billing.attach({ productId: parent.id })],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+
+		const pools = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(pools.list).toHaveLength(1);
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			func: () =>
+				autumnV1.transfer(customerId, {
+					to_entity_id: entities[0].id,
+					product_id: parent.id,
+				}),
+		});
+
+		const poolsAfter = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(poolsAfter.list).toHaveLength(1);
+	},
+);

--- a/server/tests/integration/licenses/license-transfer.test.ts
+++ b/server/tests/integration/licenses/license-transfer.test.ts
@@ -1,24 +1,12 @@
-/**
- * TDD test for transferring a plan cusProduct that parents license pools.
- *
- * Red-failure mode (current behavior):
- *  - The transfer succeeds, moving the parent to an entity while its license
- *    pools/assignments stay customer-wide; later lifecycle transitions refuse
- *    entity-scoped successors, so assignments end instead of re-parenting.
- *
- * Green-success criteria (after fix):
- *  - Transfer of a license-pool parent is rejected with a 400, and transfers
- *    of plans without license pools keep working.
- */
-
 import { expect, test } from "bun:test";
-import { ErrCode, type LicenseBalanceResponse } from "@autumn/shared";
+import { ErrCode } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
+import { listLicensePools } from "./licenseTestUtils.js";
 
 const makeLicenseProduct = () => ({
 	...products.base({
@@ -43,19 +31,18 @@ test.concurrent(
 				s.entities({ count: 1, featureId: TestFeature.Users }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [s.billing.attach({ productId: parent.id })],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parent.id }),
+			],
 		});
 
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
-		});
-
-		const pools = (await autumnV2_2.post("/licenses.list", {
-			customer_id: customerId,
-		})) as { list: LicenseBalanceResponse[] };
-		expect(pools.list).toHaveLength(1);
+		const pools = await listLicensePools({ autumn: autumnV2_2, customerId });
+		expect(pools).toHaveLength(1);
 
 		await expectAutumnError({
 			errCode: ErrCode.InvalidRequest,
@@ -66,9 +53,10 @@ test.concurrent(
 				}),
 		});
 
-		const poolsAfter = (await autumnV2_2.post("/licenses.list", {
-			customer_id: customerId,
-		})) as { list: LicenseBalanceResponse[] };
-		expect(poolsAfter.list).toHaveLength(1);
+		const poolsAfter = await listLicensePools({
+			autumn: autumnV2_2,
+			customerId,
+		});
+		expect(poolsAfter).toHaveLength(1);
 	},
 );

--- a/server/tests/integration/licenses/license-validation-coverage.test.ts
+++ b/server/tests/integration/licenses/license-validation-coverage.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import {
+	type ApiPlanV1,
 	type AttachParamsV1Input,
 	type CheckResponseV3,
 	ErrCode,
@@ -45,29 +46,29 @@ test.concurrent(
 			errCode: ErrCode.InvalidRequest,
 			errMessage: "Billing intervals must match",
 			func: () =>
-				autumnV2_2.post("/licenses.link", {
-					parent_plan_id: monthlyParent.id,
-					license_plan_id: annualLicense.id,
-					included: 1,
+				autumnV2_2.post("/plans.update", {
+					plan_id: monthlyParent.id,
+					licenses: [{ license_plan_id: annualLicense.id, included: 1 }],
 				}),
 		});
 
-		const link = (await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: monthlyParent.id,
-			license_plan_id: monthlyLicense.id,
-			included: 1,
-		})) as { license_plan_id?: string };
+		await autumnV2_2.post("/plans.update", {
+			plan_id: monthlyParent.id,
+			licenses: [{ license_plan_id: monthlyLicense.id, included: 1 }],
+		});
+		const plan = (await autumnV2_2.post("/plans.get", {
+			plan_id: monthlyParent.id,
+		})) as ApiPlanV1;
+		const link = plan.licenses?.find(
+			(planLicense) => planLicense.license_plan_id === monthlyLicense.id,
+		);
 		expect(link).toBeDefined();
 
-		const { list } = (await autumnV2_2.post("/licenses.list_links", {
-			parent_plan_id: monthlyParent.id,
-		})) as {
-			list: Array<{ parent_plan_id: string; license_plan_id: string }>;
-		};
+		const list = plan.licenses ?? [];
 		expect(list).toHaveLength(1);
 		expect(list[0]).toMatchObject({
-			parent_plan_id: monthlyParent.id,
 			license_plan_id: monthlyLicense.id,
+			included: 1,
 		});
 	},
 );
@@ -90,10 +91,9 @@ test.concurrent(
 			errCode: ErrCode.InvalidRequest,
 			errMessage: "cannot be linked as a license to itself",
 			func: () =>
-				autumnV2_2.post("/licenses.link", {
-					parent_plan_id: parent.id,
-					license_plan_id: parent.id,
-					included: 1,
+				autumnV2_2.post("/plans.update", {
+					plan_id: parent.id,
+					licenses: [{ license_plan_id: parent.id, included: 1 }],
 				}),
 		});
 	},
@@ -126,10 +126,9 @@ test.concurrent(
 			errCode: ErrCode.InvalidRequest,
 			errMessage: "is archived and cannot be linked",
 			func: () =>
-				autumnV2_2.post("/licenses.link", {
-					parent_plan_id: parent.id,
-					license_plan_id: license.id,
-					included: 1,
+				autumnV2_2.post("/plans.update", {
+					plan_id: parent.id,
+					licenses: [{ license_plan_id: license.id, included: 1 }],
 				}),
 		});
 	},

--- a/server/tests/integration/licenses/license-validation-coverage.test.ts
+++ b/server/tests/integration/licenses/license-validation-coverage.test.ts
@@ -1,0 +1,480 @@
+/**
+ * High-value coverage for license catalog validation, priced-license billing
+ * behavior, and the licenses read API (inventory math, active flags, and the
+ * capacity-conflict payload).
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type CheckResponseV3,
+	ErrCode,
+	type LicenseBalanceResponse,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { getLicenseDbState } from "./licenseTestUtils.js";
+
+// ═══════════════════════════════════════════════════════════════════
+// VALIDATION
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("licenses catalog: interval-mismatch link rejects, matching intervals link succeeds")}`,
+	async () => {
+		const monthlyParent = products.base({
+			id: "interval-monthly-parent",
+			items: [items.monthlyPrice({ price: 20 })],
+		});
+		const annualLicense = products.base({
+			id: "interval-annual-license",
+			items: [items.annualPrice({ price: 200 })],
+		});
+		const monthlyLicense = products.base({
+			id: "interval-monthly-license",
+			items: [items.monthlyPrice({ price: 30 })],
+		});
+
+		const { autumnV2_2 } = await initScenario({
+			customerId: "license-interval-mismatch",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [monthlyParent, annualLicense, monthlyLicense] }),
+			],
+			actions: [],
+		});
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			errMessage: "Billing intervals must match",
+			func: () =>
+				autumnV2_2.post("/licenses.link", {
+					parent_plan_id: monthlyParent.id,
+					license_plan_id: annualLicense.id,
+					included: 1,
+				}),
+		});
+
+		const link = (await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: monthlyParent.id,
+			license_plan_id: monthlyLicense.id,
+			included: 1,
+		})) as { license_plan_id?: string };
+		expect(link).toBeDefined();
+
+		const { list } = (await autumnV2_2.post("/licenses.list_links", {
+			parent_plan_id: monthlyParent.id,
+		})) as {
+			list: Array<{ parent_plan_id: string; license_plan_id: string }>;
+		};
+		expect(list).toHaveLength(1);
+		expect(list[0]).toMatchObject({
+			parent_plan_id: monthlyParent.id,
+			license_plan_id: monthlyLicense.id,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses catalog: self-link rejects")}`,
+	async () => {
+		const parent = products.base({
+			id: "self-link-parent",
+			items: [items.dashboard()],
+		});
+
+		const { autumnV2_2 } = await initScenario({
+			customerId: "license-self-link",
+			setup: [s.customer({ testClock: false }), s.products({ list: [parent] })],
+			actions: [],
+		});
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			errMessage: "cannot be linked as a license to itself",
+			func: () =>
+				autumnV2_2.post("/licenses.link", {
+					parent_plan_id: parent.id,
+					license_plan_id: parent.id,
+					included: 1,
+				}),
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses catalog: archived-license link rejects")}`,
+	async () => {
+		const parent = products.base({
+			id: "archived-link-parent",
+			items: [items.dashboard()],
+		});
+		const license = products.base({
+			id: "archived-link-license",
+			items: [items.monthlyMessages({ includedUsage: 25 })],
+		});
+
+		const { autumnV2_2 } = await initScenario({
+			customerId: "license-archived-link",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_2.post(`/products/${license.id}`, { archived: true });
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			errMessage: "is archived and cannot be linked",
+			func: () =>
+				autumnV2_2.post("/licenses.link", {
+					parent_plan_id: parent.id,
+					license_plan_id: license.id,
+					included: 1,
+				}),
+		});
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// PRICED
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("licenses-priced: recurring-priced license grants entitlements but assignment never bills")}`,
+	async () => {
+		const parent = products.base({
+			id: "priced-never-bill-parent",
+			items: [items.dashboard()],
+		});
+		const license = products.base({
+			id: "priced-never-bill-license",
+			items: [
+				items.monthlyPrice({ price: 30 }),
+				items.monthlyMessages({ includedUsage: 100 }),
+			],
+			group: "priced-never-bill-licenses",
+		});
+
+		const { customerId, entities, autumnV1, autumnV2_2 } = await initScenario({
+			customerId: "license-priced-never-bill",
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [s.billing.attach({ productId: parent.id })],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 2,
+		});
+
+		// Priced license must be attached at the customer level before it can be
+		// assigned to an entity.
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: license.id,
+		});
+
+		const beforeAssign = await autumnV1.customers.get(customerId);
+		const invoiceCountBeforeAssign = (beforeAssign.invoices ?? []).length;
+
+		await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		});
+
+		const entityCheck = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+		});
+		expect(entityCheck.allowed).toBe(true);
+		// Customer-level attach grants 100 and the assignment stacks another 100.
+		expect(entityCheck.balance?.granted).toBe(200);
+
+		const afterAssign = await autumnV1.customers.get(customerId);
+		const invoicesAfterAssign = afterAssign.invoices ?? [];
+		// Assigning the license to an entity must not create a new invoice.
+		expect(invoicesAfterAssign.length).toBe(invoiceCountBeforeAssign);
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// API READ
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("licenses: inventory math tracks assign and unassign")}`,
+	async () => {
+		const parent = products.base({
+			id: "inventory-math-parent",
+			items: [items.dashboard()],
+		});
+		const license = products.base({
+			id: "inventory-math-license",
+			items: [items.monthlyMessages({ includedUsage: 25 })],
+		});
+
+		const { customerId, entities, autumnV2_2 } = await initScenario({
+			customerId: "license-inventory-math",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [s.billing.attach({ productId: parent.id })],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 3,
+		});
+
+		for (const entity of entities) {
+			await autumnV2_2.post("/licenses.attach", {
+				customer_id: customerId,
+				entity_id: entity.id,
+				plan_id: license.id,
+			});
+		}
+
+		const poolsAfterAssign = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(poolsAfterAssign.list[0].inventory).toMatchObject({
+			included: 3,
+			assigned: 2,
+			available: 1,
+		});
+		expect(poolsAfterAssign.list[0].assignments).toHaveLength(2);
+
+		const firstAssignmentId =
+			poolsAfterAssign.list[0].assignments[0].assignment_id;
+		await autumnV2_2.post("/licenses.update", {
+			customer_id: customerId,
+			cancel_action: "cancel_immediately",
+			assignment_id: firstAssignmentId,
+		});
+
+		const poolsAfterUnassign = (await autumnV2_2.post("/licenses.list", {
+			customer_id: customerId,
+		})) as { list: LicenseBalanceResponse[] };
+		expect(poolsAfterUnassign.list[0].inventory).toMatchObject({
+			included: 3,
+			assigned: 1,
+			available: 2,
+		});
+		expect(poolsAfterUnassign.list[0].assignments).toHaveLength(1);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses: list_assignments active flag hides ended assignments by default")}`,
+	async () => {
+		const parent = products.base({
+			id: "active-flag-parent",
+			items: [items.dashboard()],
+		});
+		const license = products.base({
+			id: "active-flag-license",
+			items: [items.monthlyMessages({ includedUsage: 25 })],
+		});
+
+		const { customerId, entities, autumnV2_2 } = await initScenario({
+			customerId: "license-active-flag",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [s.billing.attach({ productId: parent.id })],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 1,
+		});
+		const { assignment } = (await autumnV2_2.post("/licenses.attach", {
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plan_id: license.id,
+		})) as { assignment: { id: string } };
+
+		await autumnV2_2.post("/licenses.update", {
+			customer_id: customerId,
+			cancel_action: "cancel_immediately",
+			assignment_id: assignment.id,
+		});
+
+		const activeOnly = (await autumnV2_2.post("/licenses.list_assignments", {
+			customer_id: customerId,
+			plan_id: license.id,
+		})) as { list: Array<{ id: string; ended_at: number | null }> };
+		expect(activeOnly.list.some((row) => row.id === assignment.id)).toBe(false);
+
+		const includingEnded = (await autumnV2_2.post(
+			"/licenses.list_assignments",
+			{
+				customer_id: customerId,
+				plan_id: license.id,
+				active: false,
+			},
+		)) as { list: Array<{ id: string; ended_at: number | null }> };
+		const endedRow = includingEnded.list.find(
+			(row) => row.id === assignment.id,
+		);
+		expect(endedRow).toBeDefined();
+		expect(endedRow?.ended_at).toBeGreaterThan(0);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses: capacity-conflict rejects lowering below active assignments")}`,
+	async () => {
+		const parent = products.base({
+			id: "capacity-conflict-parent",
+			items: [items.dashboard()],
+		});
+		const license = products.base({
+			id: "capacity-conflict-license",
+			items: [items.monthlyMessages({ includedUsage: 25 })],
+		});
+
+		const { customerId, entities, autumnV2_2 } = await initScenario({
+			customerId: "license-capacity-conflict",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_2.post("/licenses.link", {
+			parent_plan_id: parent.id,
+			license_plan_id: license.id,
+			included: 3,
+		});
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: parent.id,
+		});
+
+		for (const entity of entities) {
+			await autumnV2_2.post("/licenses.attach", {
+				customer_id: customerId,
+				entity_id: entity.id,
+				plan_id: license.id,
+			});
+		}
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			errMessage:
+				"Custom license changes conflict with active license assignments",
+			func: () =>
+				autumnV2_2.billing.update({
+					customer_id: customerId,
+					plan_id: parent.id,
+					customize: {
+						add_licenses: [
+							{
+								license_plan_id: license.id,
+								included: 1,
+							},
+						],
+					},
+				}),
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses lifecycle: transition to insufficient inherited capacity rejects atomically")}`,
+	async () => {
+		const group = "license-capacity-transition";
+		const source = products.base({
+			id: "capacity-transition-source",
+			group,
+			items: [items.dashboard()],
+		});
+		const target = products.base({
+			id: "capacity-transition-target",
+			group,
+			items: [items.dashboard()],
+		});
+		const license = products.base({
+			id: "capacity-transition-license",
+			items: [items.monthlyMessages({ includedUsage: 25 })],
+		});
+		const { customerId, entities, autumnV2_2, ctx } = await initScenario({
+			customerId: "license-capacity-transition",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 3, featureId: TestFeature.Users }),
+				s.products({ list: [source, target, license] }),
+			],
+			actions: [s.billing.attach({ productId: source.id })],
+		});
+		for (const [parent, included] of [
+			[source, 3],
+			[target, 2],
+		] as const) {
+			await autumnV2_2.post("/licenses.link", {
+				parent_plan_id: parent.id,
+				license_plan_id: license.id,
+				included,
+			});
+		}
+		for (const entity of entities) {
+			await autumnV2_2.post("/licenses.attach", {
+				customer_id: customerId,
+				entity_id: entity.id,
+				plan_id: license.id,
+			});
+		}
+		const before = await getLicenseDbState({ db: ctx.db, customerId });
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			errMessage: "active license assignments",
+			func: () =>
+				autumnV2_2.billing.attach({
+					customer_id: customerId,
+					plan_id: target.id,
+				}),
+		});
+
+		const after = await getLicenseDbState({ db: ctx.db, customerId });
+		expect(
+			after.assignments.map(
+				({ id, status, license_parent_customer_product_id }) => ({
+					id,
+					status,
+					parentId: license_parent_customer_product_id,
+				}),
+			),
+		).toEqual(
+			before.assignments.map(
+				({ id, status, license_parent_customer_product_id }) => ({
+					id,
+					status,
+					parentId: license_parent_customer_product_id,
+				}),
+			),
+		);
+		expect(after.pools).toEqual(before.pools);
+	},
+);

--- a/server/tests/integration/licenses/license-validation-coverage.test.ts
+++ b/server/tests/integration/licenses/license-validation-coverage.test.ts
@@ -1,14 +1,8 @@
-/**
- * High-value coverage for license catalog validation, priced-license billing
- * behavior, and the licenses read API (inventory math, active flags, and the
- * capacity-conflict payload).
- */
-
 import { expect, test } from "bun:test";
 import {
+	type AttachParamsV1Input,
 	type CheckResponseV3,
 	ErrCode,
-	type LicenseBalanceResponse,
 } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
@@ -16,11 +10,11 @@ import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
-import { getLicenseDbState } from "./licenseTestUtils.js";
-
-// ═══════════════════════════════════════════════════════════════════
-// VALIDATION
-// ═══════════════════════════════════════════════════════════════════
+import {
+	getLicenseDbState,
+	listLicenseAssignments,
+	listLicensePools,
+} from "./licenseTestUtils.js";
 
 test.concurrent(
 	`${chalk.yellowBright("licenses catalog: interval-mismatch link rejects, matching intervals link succeeds")}`,
@@ -141,10 +135,6 @@ test.concurrent(
 	},
 );
 
-// ═══════════════════════════════════════════════════════════════════
-// PRICED
-// ═══════════════════════════════════════════════════════════════════
-
 test.concurrent(
 	`${chalk.yellowBright("licenses-priced: recurring-priced license grants entitlements but assignment never bills")}`,
 	async () => {
@@ -168,20 +158,15 @@ test.concurrent(
 				s.entities({ count: 1, featureId: TestFeature.Users }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [s.billing.attach({ productId: parent.id })],
-		});
-
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 2,
-		});
-
-		// Priced license must be attached at the customer level before it can be
-		// assigned to an entity.
-		await autumnV2_2.billing.attach({
-			customer_id: customerId,
-			plan_id: license.id,
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 2,
+				}),
+				s.billing.attach({ productId: parent.id }),
+				s.billing.attach({ productId: license.id }),
+			],
 		});
 
 		const beforeAssign = await autumnV1.customers.get(customerId);
@@ -199,19 +184,13 @@ test.concurrent(
 			feature_id: TestFeature.Messages,
 		});
 		expect(entityCheck.allowed).toBe(true);
-		// Customer-level attach grants 100 and the assignment stacks another 100.
 		expect(entityCheck.balance?.granted).toBe(200);
 
 		const afterAssign = await autumnV1.customers.get(customerId);
 		const invoicesAfterAssign = afterAssign.invoices ?? [];
-		// Assigning the license to an entity must not create a new invoice.
 		expect(invoicesAfterAssign.length).toBe(invoiceCountBeforeAssign);
 	},
 );
-
-// ═══════════════════════════════════════════════════════════════════
-// API READ
-// ═══════════════════════════════════════════════════════════════════
 
 test.concurrent(
 	`${chalk.yellowBright("licenses: inventory math tracks assign and unassign")}`,
@@ -232,13 +211,14 @@ test.concurrent(
 				s.entities({ count: 2, featureId: TestFeature.Users }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [s.billing.attach({ productId: parent.id })],
-		});
-
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 3,
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 3,
+				}),
+				s.billing.attach({ productId: parent.id }),
+			],
 		});
 
 		for (const entity of entities) {
@@ -249,33 +229,34 @@ test.concurrent(
 			});
 		}
 
-		const poolsAfterAssign = (await autumnV2_2.post("/licenses.list", {
-			customer_id: customerId,
-		})) as { list: LicenseBalanceResponse[] };
-		expect(poolsAfterAssign.list[0].inventory).toMatchObject({
+		const poolsAfterAssign = await listLicensePools({
+			autumn: autumnV2_2,
+			customerId,
+		});
+		expect(poolsAfterAssign[0].inventory).toMatchObject({
 			included: 3,
 			assigned: 2,
 			available: 1,
 		});
-		expect(poolsAfterAssign.list[0].assignments).toHaveLength(2);
+		expect(poolsAfterAssign[0].assignments).toHaveLength(2);
 
-		const firstAssignmentId =
-			poolsAfterAssign.list[0].assignments[0].assignment_id;
+		const firstAssignmentId = poolsAfterAssign[0].assignments[0].assignment_id;
 		await autumnV2_2.post("/licenses.update", {
 			customer_id: customerId,
 			cancel_action: "cancel_immediately",
 			assignment_id: firstAssignmentId,
 		});
 
-		const poolsAfterUnassign = (await autumnV2_2.post("/licenses.list", {
-			customer_id: customerId,
-		})) as { list: LicenseBalanceResponse[] };
-		expect(poolsAfterUnassign.list[0].inventory).toMatchObject({
+		const poolsAfterUnassign = await listLicensePools({
+			autumn: autumnV2_2,
+			customerId,
+		});
+		expect(poolsAfterUnassign[0].inventory).toMatchObject({
 			included: 3,
 			assigned: 1,
 			available: 2,
 		});
-		expect(poolsAfterUnassign.list[0].assignments).toHaveLength(1);
+		expect(poolsAfterUnassign[0].assignments).toHaveLength(1);
 	},
 );
 
@@ -291,26 +272,30 @@ test.concurrent(
 			items: [items.monthlyMessages({ includedUsage: 25 })],
 		});
 
-		const { customerId, entities, autumnV2_2 } = await initScenario({
+		const {
+			customerId,
+			autumnV2_2,
+			licenseAssignments: [assignment],
+		} = await initScenario({
 			customerId: "license-active-flag",
 			setup: [
 				s.customer({ testClock: false }),
 				s.entities({ count: 1, featureId: TestFeature.Users }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [s.billing.attach({ productId: parent.id })],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parent.id }),
+				s.licenses.assign({
+					licenseProductId: license.id,
+					entityIndex: 0,
+				}),
+			],
 		});
-
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 1,
-		});
-		const { assignment } = (await autumnV2_2.post("/licenses.attach", {
-			customer_id: customerId,
-			entity_id: entities[0].id,
-			plan_id: license.id,
-		})) as { assignment: { id: string } };
 
 		await autumnV2_2.post("/licenses.update", {
 			customer_id: customerId,
@@ -318,23 +303,20 @@ test.concurrent(
 			assignment_id: assignment.id,
 		});
 
-		const activeOnly = (await autumnV2_2.post("/licenses.list_assignments", {
-			customer_id: customerId,
-			plan_id: license.id,
-		})) as { list: Array<{ id: string; ended_at: number | null }> };
-		expect(activeOnly.list.some((row) => row.id === assignment.id)).toBe(false);
+		const activeOnly = await listLicenseAssignments({
+			autumn: autumnV2_2,
+			customerId,
+			licensePlanId: license.id,
+		});
+		expect(activeOnly.some((row) => row.id === assignment.id)).toBe(false);
 
-		const includingEnded = (await autumnV2_2.post(
-			"/licenses.list_assignments",
-			{
-				customer_id: customerId,
-				plan_id: license.id,
-				active: false,
-			},
-		)) as { list: Array<{ id: string; ended_at: number | null }> };
-		const endedRow = includingEnded.list.find(
-			(row) => row.id === assignment.id,
-		);
+		const includingEnded = await listLicenseAssignments({
+			autumn: autumnV2_2,
+			customerId,
+			licensePlanId: license.id,
+			active: false,
+		});
+		const endedRow = includingEnded.find((row) => row.id === assignment.id);
 		expect(endedRow).toBeDefined();
 		expect(endedRow?.ended_at).toBeGreaterThan(0);
 	},
@@ -352,33 +334,25 @@ test.concurrent(
 			items: [items.monthlyMessages({ includedUsage: 25 })],
 		});
 
-		const { customerId, entities, autumnV2_2 } = await initScenario({
+		const { customerId, autumnV2_2 } = await initScenario({
 			customerId: "license-capacity-conflict",
 			setup: [
 				s.customer({ testClock: false }),
 				s.entities({ count: 2, featureId: TestFeature.Users }),
 				s.products({ list: [parent, license] }),
 			],
-			actions: [],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 3,
+				}),
+				s.billing.attach({ productId: parent.id }),
+				...[0, 1].map((entityIndex) =>
+					s.licenses.assign({ licenseProductId: license.id, entityIndex }),
+				),
+			],
 		});
-
-		await autumnV2_2.post("/licenses.link", {
-			parent_plan_id: parent.id,
-			license_plan_id: license.id,
-			included: 3,
-		});
-		await autumnV2_2.billing.attach({
-			customer_id: customerId,
-			plan_id: parent.id,
-		});
-
-		for (const entity of entities) {
-			await autumnV2_2.post("/licenses.attach", {
-				customer_id: customerId,
-				entity_id: entity.id,
-				plan_id: license.id,
-			});
-		}
 
 		await expectAutumnError({
 			errCode: ErrCode.InvalidRequest,
@@ -419,39 +393,37 @@ test.concurrent(
 			id: "capacity-transition-license",
 			items: [items.monthlyMessages({ includedUsage: 25 })],
 		});
-		const { customerId, entities, autumnV2_2, ctx } = await initScenario({
+		const { customerId, autumnV2_2, ctx } = await initScenario({
 			customerId: "license-capacity-transition",
 			setup: [
 				s.customer({ testClock: false }),
 				s.entities({ count: 3, featureId: TestFeature.Users }),
 				s.products({ list: [source, target, license] }),
 			],
-			actions: [s.billing.attach({ productId: source.id })],
+			actions: [
+				s.licenses.link({
+					parentProductId: source.id,
+					licenseProductId: license.id,
+					included: 3,
+				}),
+				s.licenses.link({
+					parentProductId: target.id,
+					licenseProductId: license.id,
+					included: 2,
+				}),
+				s.billing.attach({ productId: source.id }),
+				...[0, 1, 2].map((entityIndex) =>
+					s.licenses.assign({ licenseProductId: license.id, entityIndex }),
+				),
+			],
 		});
-		for (const [parent, included] of [
-			[source, 3],
-			[target, 2],
-		] as const) {
-			await autumnV2_2.post("/licenses.link", {
-				parent_plan_id: parent.id,
-				license_plan_id: license.id,
-				included,
-			});
-		}
-		for (const entity of entities) {
-			await autumnV2_2.post("/licenses.attach", {
-				customer_id: customerId,
-				entity_id: entity.id,
-				plan_id: license.id,
-			});
-		}
 		const before = await getLicenseDbState({ db: ctx.db, customerId });
 
 		await expectAutumnError({
 			errCode: ErrCode.InvalidRequest,
 			errMessage: "active license assignments",
 			func: () =>
-				autumnV2_2.billing.attach({
+				autumnV2_2.billing.attach<AttachParamsV1Input>({
 					customer_id: customerId,
 					plan_id: target.id,
 				}),

--- a/server/tests/integration/licenses/licenseTestUtils.ts
+++ b/server/tests/integration/licenses/licenseTestUtils.ts
@@ -1,0 +1,33 @@
+import { customerLicenses, customerProducts, customers } from "@autumn/shared";
+import { and, eq, isNotNull } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+
+export const getLicenseDbState = async ({
+	db,
+	customerId,
+}: {
+	db: DrizzleCli;
+	customerId: string;
+}) => {
+	const customer = await db.query.customers.findFirst({
+		where: eq(customers.id, customerId),
+	});
+	if (!customer) throw new Error(`Customer '${customerId}' not found`);
+
+	const [assignments, pools, products] = await Promise.all([
+		db.query.customerProducts.findMany({
+			where: and(
+				eq(customerProducts.internal_customer_id, customer.internal_id),
+				isNotNull(customerProducts.license_parent_customer_product_id),
+			),
+		}),
+		db.query.customerLicenses.findMany({
+			where: eq(customerLicenses.internal_customer_id, customer.internal_id),
+		}),
+		db.query.customerProducts.findMany({
+			where: eq(customerProducts.internal_customer_id, customer.internal_id),
+		}),
+	]);
+
+	return { assignments, pools, products };
+};

--- a/server/tests/integration/licenses/licenseTestUtils.ts
+++ b/server/tests/integration/licenses/licenseTestUtils.ts
@@ -1,9 +1,9 @@
 import {
+	type ApiCustomerLicenseV0,
+	type ApiPlanV1,
 	customerLicenses,
 	customerProducts,
 	customers,
-	type LicenseBalanceResponse,
-	type PlanLicense,
 } from "@autumn/shared";
 import { and, eq, isNotNull } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
@@ -51,7 +51,7 @@ export const listLicensePools = async ({
 	const response = (await autumn.post("/licenses.list", {
 		customer_id: customerId,
 		entity_id: entityId,
-	})) as { list: LicenseBalanceResponse[] };
+	})) as { list: ApiCustomerLicenseV0[] };
 	return response.list;
 };
 
@@ -84,10 +84,10 @@ export const listLicenseLinks = async ({
 	autumn: AutumnInt;
 	parentPlanId: string;
 }) => {
-	const response = (await autumn.post("/licenses.list_links", {
-		parent_plan_id: parentPlanId,
-	})) as { list: PlanLicense[] };
-	return response.list;
+	const plan = (await autumn.post("/plans.get", {
+		plan_id: parentPlanId,
+	})) as ApiPlanV1;
+	return plan.licenses ?? [];
 };
 
 export const getLicenseDbState = async ({

--- a/server/tests/integration/licenses/licenseTestUtils.ts
+++ b/server/tests/integration/licenses/licenseTestUtils.ts
@@ -1,6 +1,94 @@
-import { customerLicenses, customerProducts, customers } from "@autumn/shared";
+import {
+	customerLicenses,
+	customerProducts,
+	customers,
+	type LicenseBalanceResponse,
+	type PlanLicense,
+} from "@autumn/shared";
 import { and, eq, isNotNull } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { AutumnInt } from "@/external/autumn/autumnCli.js";
+
+export type TestLicenseAssignment = {
+	id: string;
+	entity_id: string;
+	license_plan_id: string;
+	started_at: number;
+	ended_at: number | null;
+};
+
+export const assignLicense = async ({
+	autumn,
+	customerId,
+	entityId,
+	licensePlanId,
+	parentPlanId,
+}: {
+	autumn: AutumnInt;
+	customerId: string;
+	entityId: string;
+	licensePlanId: string;
+	parentPlanId?: string;
+}) => {
+	const response = (await autumn.post("/licenses.attach", {
+		customer_id: customerId,
+		entity_id: entityId,
+		plan_id: licensePlanId,
+		parent_plan_id: parentPlanId,
+	})) as { assignment: TestLicenseAssignment };
+	return response.assignment;
+};
+
+export const listLicensePools = async ({
+	autumn,
+	customerId,
+	entityId,
+}: {
+	autumn: AutumnInt;
+	customerId: string;
+	entityId?: string;
+}) => {
+	const response = (await autumn.post("/licenses.list", {
+		customer_id: customerId,
+		entity_id: entityId,
+	})) as { list: LicenseBalanceResponse[] };
+	return response.list;
+};
+
+export const listLicenseAssignments = async ({
+	autumn,
+	customerId,
+	entityId,
+	licensePlanId,
+	active,
+}: {
+	autumn: AutumnInt;
+	customerId: string;
+	entityId?: string;
+	licensePlanId?: string;
+	active?: boolean;
+}) => {
+	const response = (await autumn.post("/licenses.list_assignments", {
+		customer_id: customerId,
+		entity_id: entityId,
+		plan_id: licensePlanId,
+		active,
+	})) as { list: TestLicenseAssignment[] };
+	return response.list;
+};
+
+export const listLicenseLinks = async ({
+	autumn,
+	parentPlanId,
+}: {
+	autumn: AutumnInt;
+	parentPlanId: string;
+}) => {
+	const response = (await autumn.post("/licenses.list_links", {
+		parent_plan_id: parentPlanId,
+	})) as { list: PlanLicense[] };
+	return response.list;
+};
 
 export const getLicenseDbState = async ({
 	db,

--- a/server/tests/integration/sandbox/copy-sandbox.test.ts
+++ b/server/tests/integration/sandbox/copy-sandbox.test.ts
@@ -5,6 +5,7 @@ import {
 	ErrCode,
 	FeatureUsageType,
 	mapToProductV2,
+	ResetInterval,
 	type Organization,
 	type OrgConfig,
 	organizations,
@@ -26,6 +27,8 @@ import {
 import { deletePlatformSubOrg } from "@/internal/orgs/deleteOrg/deletePlatformSubOrg.js";
 import { OrgService } from "@/internal/orgs/OrgService.js";
 import { createProduct } from "@/internal/product/actions/createProduct.js";
+import { linkLicense } from "@/internal/licenses/actions/links/linkLicense.js";
+import { listLicenseLinks } from "@/internal/licenses/actions/links/listLicenseLinks.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 import { copySandboxForOrg } from "@/internal/sandboxes/copySandbox.js";
 import { generatePublishableKey } from "@/utils/encryptUtils.js";
@@ -50,6 +53,7 @@ const DASH_FEATURE = "copy_dashboard";
 const CREDIT_FEATURE = "copy_credits";
 const AI_CREDIT_FEATURE = "copy_ai_credits";
 const PRODUCT_ID = "copy_pro";
+const LICENSE_ID = "copy_license";
 
 const suffix = crypto.randomUUID().slice(0, 8);
 
@@ -168,6 +172,34 @@ const seedSourceSandbox = async (sourceOrg: Organization) => {
 		ctx: { ...seedCtx, features: allFeatures },
 		data: product as unknown as CreateProductV2Params,
 	});
+	await createProduct({
+		ctx: { ...seedCtx, features: allFeatures },
+		data: products.base({
+			id: LICENSE_ID,
+			items: [
+				constructFeatureItem({ featureId: MSG_FEATURE, includedUsage: 25 }),
+			],
+		}) as unknown as CreateProductV2Params,
+	});
+	await linkLicense({
+		ctx: { ...seedCtx, features: allFeatures },
+		params: {
+			parent_plan_id: PRODUCT_ID,
+			license_plan_id: LICENSE_ID,
+			included: 3,
+			prepaid_only: true,
+			metadata: { source: "sandbox-copy" },
+			customize: {
+				items: [
+					{
+						feature_id: MSG_FEATURE,
+						included: 80,
+						reset: { interval: ResetInterval.Month },
+					},
+				],
+			},
+		},
+	});
 };
 
 beforeAll(async () => {
@@ -250,6 +282,27 @@ describe("sandboxes.copy: copy plans + features between two sandbox sub-orgs", (
 			.map((i) => i.feature_id)
 			.filter((id): id is string => Boolean(id));
 		expect(itemFeatureIds.sort()).toEqual([DASH_FEATURE, MSG_FEATURE].sort());
+
+		const links = await listLicenseLinks({
+			ctx: {
+				...baseCtx,
+				org: target,
+				env: AppEnv.Sandbox,
+				features: targetFeatures,
+			},
+			parentPlanId: PRODUCT_ID,
+		});
+		expect(links).toHaveLength(1);
+		expect(links[0]).toMatchObject({
+			parent_plan_id: PRODUCT_ID,
+			license_plan_id: LICENSE_ID,
+			included: 3,
+			metadata: { source: "sandbox-copy" },
+		});
+		expect(links[0].customize?.add_items?.[0]).toMatchObject({
+			feature_id: MSG_FEATURE,
+			included: 80,
+		});
 	}, 180_000);
 
 	test("rejects a non-owned source with a 404 (ownership masked)", async () => {

--- a/server/tests/unit/usage-windows/findUsageWindowAnchor.test.ts
+++ b/server/tests/unit/usage-windows/findUsageWindowAnchor.test.ts
@@ -1,0 +1,90 @@
+/**
+ * TDD test for anchor scoping of loose (product-less) entitlements.
+ *
+ * Red-failure mode (current behavior):
+ *  - toAnchorCandidate uses `customer_product?.internal_entity_id !== null`,
+ *    which is `undefined !== null` → true for loose entitlements, so they are
+ *    misclassified as entity-scoped and customer-scope anchoring returns null.
+ *
+ * Green-success criteria (after fix):
+ *  - A customer-level loose entitlement anchors a customer-scope window.
+ *  - Genuinely entity-owned grants still never anchor customer-scope windows.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	type Feature,
+	FeatureType,
+	findUsageWindowAnchor,
+	type FullSubject,
+} from "@autumn/shared";
+
+const meteredFeature = {
+	id: "action1",
+	internal_id: "iaction1",
+	type: FeatureType.Metered,
+} as Feature;
+
+const looseEntitlement = ({
+	id,
+	internalEntityId = null,
+}: {
+	id: string;
+	internalEntityId?: string | null;
+}) =>
+	({
+		id,
+		feature_id: "action1",
+		internal_entity_id: internalEntityId,
+		internal_feature_id: "iaction1",
+		customer_product_id: null,
+		entitlement_id: `ent_${id}`,
+		created_at: 1000,
+		balance: 0,
+		expires_at: null,
+		entitlement: {
+			id: `ent_${id}`,
+			feature_id: "action1",
+			interval: "month",
+			feature: { id: "action1", internal_id: "iaction1" },
+		},
+		rollovers: [],
+		replaceables: [],
+	}) as unknown as FullSubject["extra_customer_entitlements"][number];
+
+const buildSubject = (
+	looseEntitlements: FullSubject["extra_customer_entitlements"],
+): FullSubject =>
+	({
+		customer: {},
+		customer_products: [],
+		extra_customer_entitlements: looseEntitlements,
+	}) as unknown as FullSubject;
+
+describe("findUsageWindowAnchor", () => {
+	test("customer scope anchors on a customer-level loose entitlement", () => {
+		const { anchorCustomerEntitlementId } = findUsageWindowAnchor({
+			fullSubject: buildSubject([looseEntitlement({ id: "ce_loose" })]),
+			featureId: "action1",
+			features: [meteredFeature],
+			isCreditSystem: false,
+			scopeType: "customer",
+		});
+
+		expect(anchorCustomerEntitlementId).toBe("ce_loose");
+	});
+
+	test("customer scope still fails closed for entity-owned loose grants", () => {
+		const { anchorCustomerEntitlementId } = findUsageWindowAnchor({
+			fullSubject: buildSubject([
+				looseEntitlement({ id: "ce_entity", internalEntityId: "ie_1" }),
+			]),
+			featureId: "action1",
+			features: [meteredFeature],
+			isCreditSystem: false,
+			scopeType: "customer",
+		});
+
+		expect(anchorCustomerEntitlementId).toBeNull();
+	});
+});

--- a/server/tests/utils/testInitUtils/initScenario.ts
+++ b/server/tests/utils/testInitUtils/initScenario.ts
@@ -1460,6 +1460,9 @@ export async function initScenario({
 	// 5. Run actions in order.
 	let advancedTo: number = Date.now();
 	const licenseAssignments: GeneratedLicenseAssignment[] = [];
+	// plans.update takes the complete link set, so sequential link actions on
+	// the same parent accumulate here instead of clobbering earlier links.
+	const catalogLinksByParent = new Map<string, Record<string, unknown>[]>();
 	let referralCode: ReferralCode | null = null;
 	let redemption: RewardRedemption | null = null;
 
@@ -1732,13 +1735,22 @@ export async function initScenario({
 				{ timeout: action.timeout },
 			);
 		} else if (action.type === "linkLicense") {
-			await autumnV2_2.post("/licenses.link", {
-				parent_plan_id: `${action.parentProductId}_${productPrefix}`,
+			const parentPlanId = `${action.parentProductId}_${productPrefix}`;
+			const entry = {
 				license_plan_id: `${action.licenseProductId}_${productPrefix}`,
 				included: action.included,
 				prepaid_only: action.prepaidOnly,
 				customize: action.customize,
 				metadata: action.metadata,
+			};
+			const links = (catalogLinksByParent.get(parentPlanId) ?? []).filter(
+				(link) => link.license_plan_id !== entry.license_plan_id,
+			);
+			links.push(entry);
+			catalogLinksByParent.set(parentPlanId, links);
+			await autumnV2_2.post("/plans.update", {
+				plan_id: parentPlanId,
+				licenses: links,
 			});
 		} else if (action.type === "assignLicense") {
 			if (!customerId) {

--- a/server/tests/utils/testInitUtils/initScenario.ts
+++ b/server/tests/utils/testInitUtils/initScenario.ts
@@ -5,6 +5,7 @@ import {
 	type CreateRewardProgram,
 	type CustomerBillingControlsParams,
 	type EntitlementDuration,
+	type LicenseCustomize,
 	type OrgConfig,
 	type PlanTiming,
 	type ProductItem,
@@ -53,6 +54,14 @@ type GeneratedEntity = {
 	id: string;
 	name: string;
 	featureId: string;
+};
+
+type GeneratedLicenseAssignment = {
+	id: string;
+	entity_id: string;
+	license_plan_id: string;
+	started_at: number;
+	ended_at: number | null;
 };
 
 type OtherCustomerConfig = {
@@ -179,6 +188,23 @@ type BillingMultiAttachAction = {
 	timeout?: number;
 };
 
+type LinkLicenseAction = {
+	type: "linkLicense";
+	parentProductId: string;
+	licenseProductId: string;
+	included: number;
+	prepaidOnly?: boolean;
+	customize?: LicenseCustomize | null;
+	metadata?: Record<string, unknown>;
+};
+
+type AssignLicenseAction = {
+	type: "assignLicense";
+	licenseProductId: string;
+	entityIndex: number;
+	parentProductId?: string;
+};
+
 type CreateReferralCodeAction = {
 	type: "createReferralCode";
 };
@@ -221,6 +247,8 @@ type ScenarioAction =
 	| AdvanceToNextInvoiceAction
 	| BillingAttachAction
 	| BillingMultiAttachAction
+	| LinkLicenseAction
+	| AssignLicenseAction
 	| CreateReferralCodeAction
 	| RedeemReferralCodeAction
 	| CreateAndRedeemReferralCodeAction
@@ -788,6 +816,61 @@ const billingMultiAttach = ({
 /** Top-level alias for billing multi-attach. */
 const multiAttach = billingMultiAttach;
 
+const linkLicense =
+	({
+		parentProductId,
+		licenseProductId,
+		included,
+		prepaidOnly,
+		customize,
+		metadata,
+	}: {
+		parentProductId: string;
+		licenseProductId: string;
+		included: number;
+		prepaidOnly?: boolean;
+		customize?: LicenseCustomize | null;
+		metadata?: Record<string, unknown>;
+	}): ConfigFn =>
+	(config) => ({
+		...config,
+		actions: [
+			...config.actions,
+			{
+				type: "linkLicense" as const,
+				parentProductId,
+				licenseProductId,
+				included,
+				prepaidOnly,
+				customize,
+				metadata,
+			},
+		],
+	});
+
+const assignLicense =
+	({
+		licenseProductId,
+		entityIndex,
+		parentProductId,
+	}: {
+		licenseProductId: string;
+		entityIndex: number;
+		parentProductId?: string;
+	}): ConfigFn =>
+	(config) => ({
+		...config,
+		actions: [
+			...config.actions,
+			{
+				type: "assignLicense" as const,
+				licenseProductId,
+				entityIndex,
+				parentProductId,
+			},
+		],
+	});
+
 /** Run independent scenario actions concurrently. */
 const parallel = (...actions: ConfigFn[]): ConfigFn => {
 	return (config) => {
@@ -928,6 +1011,10 @@ export const s = {
 		attach: billingAttach,
 		multiAttach: billingMultiAttach,
 	},
+	licenses: {
+		link: linkLicense,
+		assign: assignLicense,
+	},
 	multiAttach,
 	parallel,
 	featureGrant,
@@ -1000,6 +1087,7 @@ type InitScenarioImplementationResult = {
 	customer: Awaited<ReturnType<typeof initCustomerV3>>["customer"] | null;
 	ctx: TestContext;
 	entities: GeneratedEntity[];
+	licenseAssignments: GeneratedLicenseAssignment[];
 	advancedTo: number;
 	otherCustomers: Map<string, OtherCustomerResult>;
 	referralCode: ReferralCode | null;
@@ -1028,6 +1116,7 @@ export async function initScenario(params: {
 	customer: Awaited<ReturnType<typeof initCustomerV3>>["customer"];
 	ctx: TestContext;
 	entities: GeneratedEntity[];
+	licenseAssignments: GeneratedLicenseAssignment[];
 	advancedTo: number;
 	otherCustomers: Map<string, OtherCustomerResult>;
 	referralCode: ReferralCode | null;
@@ -1056,6 +1145,7 @@ export async function initScenario(params: {
 	customer: null;
 	ctx: TestContext;
 	entities: GeneratedEntity[];
+	licenseAssignments: GeneratedLicenseAssignment[];
 	advancedTo: number;
 	otherCustomers: Map<string, OtherCustomerResult>;
 	referralCode: ReferralCode | null;
@@ -1369,6 +1459,7 @@ export async function initScenario({
 
 	// 5. Run actions in order.
 	let advancedTo: number = Date.now();
+	const licenseAssignments: GeneratedLicenseAssignment[] = [];
 	let referralCode: ReferralCode | null = null;
 	let redemption: RewardRedemption | null = null;
 
@@ -1640,6 +1731,37 @@ export async function initScenario({
 				},
 				{ timeout: action.timeout },
 			);
+		} else if (action.type === "linkLicense") {
+			await autumnV2_2.post("/licenses.link", {
+				parent_plan_id: `${action.parentProductId}_${productPrefix}`,
+				license_plan_id: `${action.licenseProductId}_${productPrefix}`,
+				included: action.included,
+				prepaid_only: action.prepaidOnly,
+				customize: action.customize,
+				metadata: action.metadata,
+			});
+		} else if (action.type === "assignLicense") {
+			if (!customerId) {
+				throw new Error(
+					"Cannot assign license: customerId is required when using s.licenses.assign()",
+				);
+			}
+			if (action.entityIndex >= generatedEntities.length) {
+				throw new Error(
+					`entityIndex ${action.entityIndex} is out of bounds. Only ${generatedEntities.length} entities configured.`,
+				);
+			}
+			const response = (await autumnV2_2.post("/licenses.attach", {
+				customer_id: customerId,
+				entity_id: generatedEntities[action.entityIndex].id,
+				plan_id: `${action.licenseProductId}_${productPrefix}`,
+				...(action.parentProductId
+					? {
+							parent_plan_id: `${action.parentProductId}_${productPrefix}`,
+						}
+					: {}),
+			})) as { assignment: GeneratedLicenseAssignment };
+			licenseAssignments.push(response.assignment);
 		} else if (action.type === "createReferralCode") {
 			if (!customerId) {
 				throw new Error("Cannot create referral code: customerId is required");
@@ -1740,6 +1862,7 @@ export async function initScenario({
 		customer,
 		ctx,
 		entities: generatedEntities,
+		licenseAssignments,
 		advancedTo,
 		otherCustomers: otherCustomersMap,
 		referralCode,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expands and consolidates license integration coverage across lifecycle, billing, reconciliation, catalog edits/cleanup, customization (patch/propagation), versioning/migration, entity delete/transfer, product CRUD, status/successor activation, validation, and edge cases. Pins current bugs and adds a customer-level per-entity pooling check, a loose-entitlement anchor unit test, sandbox license-link copy, and the `getLicenseDbState` util.

- **Refactors**
  - Added reusable license scenario actions in `initScenario` (`linkLicense`, `assignLicense`) and typed helpers in `server/tests/integration/licenses/licenseTestUtils.ts` (`assignLicense`, `listLicensePools`, `listLicenseLinks`, `listLicenseAssignments`).
  - Aligned the scenario DSL and test utils to plan endpoints, standardized typing and test concurrency (e.g., `AttachParamsV1Input`), and replaced ad-hoc plan linking via `/plans.update` with `s.licenses.link`.

<sup>Written for commit 6bf61a2127813067e8f167d557a1455016144c6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR consolidates and expands integration coverage for the license subsystem, adding ~6 000 lines of new test code across lifecycle, billing, reconciliation, validation, migration, and edge-case files, alongside two new reusable DSL actions (`s.licenses.link` / `s.licenses.assign`) in `initScenario.ts` and a shared `licenseTestUtils.ts` helper module.

- **Improvements** — New `s.licenses.link` and `s.licenses.assign` scenario actions replace ad-hoc `/plans.update` calls in setup code, accumulating link state in `catalogLinksByParent` so sequential link actions on the same parent never clobber earlier links; `licenseAssignments` is now returned from `initScenario`.
- **Improvements** — `licenseTestUtils.ts` centralises `assignLicense`, `listLicensePools`, `listLicenseAssignments`, `listLicenseLinks`, and `getLicenseDbState` helpers to eliminate repetitive inline API calls across the suite.
- **Bug fixes** — TDD anchor tests added for three known regressions (loose-entitlement anchor scoping, customer-level per-entity pooling, and several lifecycle bugs in `license-known-bugs.test.ts`) to pin current behaviour and drive future fixes.
- **Improvements** — `copy-sandbox.test.ts` extended to verify that license links, including `customize` and `metadata`, are faithfully replicated when a sandbox org is copied.
</details>

<h3>Confidence Score: 3/5</h3>

Two tests introduced in this PR will fail before they can be run: one due to a missing type import that breaks TypeScript compilation, and one due to a call to an API endpoint that does not exist in the router.

The license-edge-cases.test.ts file uses LicenseBalanceResponse in 9 type-cast positions without importing it; since tests/ is included in tsconfig.json with strict: true, this is a compilation error. Separately, license-attach-edge-cases.test.ts calls autumnV2_2.post('/licenses.link') but that endpoint is not registered in licenseRouter.ts, so the test will return a 404 at runtime.

server/tests/integration/licenses/license-edge-cases.test.ts (missing import) and server/tests/integration/licenses/license-attach-edge-cases.test.ts (non-existent endpoint call)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/tests/utils/testInitUtils/initScenario.ts | Adds `linkLicense` and `assignLicense` scenario DSL actions with proper prefix handling, accumulating link state in `catalogLinksByParent` to avoid clobbering earlier links, and returns `licenseAssignments` from the result. |
| server/tests/integration/licenses/licenseTestUtils.ts | New reusable test utility providing `assignLicense`, `listLicensePools`, `listLicenseAssignments`, `listLicenseLinks`, and `getLicenseDbState` helpers used across the license test suite. |
| server/tests/integration/licenses/license-edge-cases.test.ts | New 1291-line test file covering license customization, overflow, group/entity scoping edge cases; uses `LicenseBalanceResponse` in 9 type casts without importing it, causing a TypeScript compilation failure. |
| server/tests/integration/licenses/license-attach-edge-cases.test.ts | Refactored to use new scenario DSL; introduces a call to non-existent `/licenses.link` endpoint (line 147) that will fail at runtime. |
| server/tests/integration/licenses/license-basic.test.ts | New file covering lazy provisioning, direct attach, per-plan license customization, and `plans.list` field exposure. |
| server/tests/integration/licenses/license-lifecycle.test.ts | New file testing cancellation, renewal, upgrade, downgrade, and reactivation scenarios for license pools and assignments. |
| server/tests/integration/licenses/license-known-bugs.test.ts | Intentional TDD bug-anchor tests; clearly labelled as expected failures. |
| server/tests/integration/licenses/license-reconcile-coverage.test.ts | New file covering reconcile self-heal, idempotency, multi-parent determinism, and partial successor scenarios. |
| server/tests/unit/usage-windows/findUsageWindowAnchor.test.ts | New TDD unit test anchoring the loose-entitlement anchor-scoping bug; labelled red-failure anchor. |
| server/tests/integration/sandbox/copy-sandbox.test.ts | Extended to verify that license links including customize and metadata are correctly copied when a sandbox org is duplicated. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/tests/integration/licenses/license-edge-cases.test.ts:155-161
`LicenseBalanceResponse` is referenced as a type in 9 cast expressions throughout this file but is never imported. With `strict: true` and `tests` included in `tsconfig.json`, this will produce `TS2304: Cannot find name 'LicenseBalanceResponse'` compilation errors. The fix is to add `type LicenseBalanceResponse` to the `@autumn/shared` import block, exactly as `license-catalog-edit-guards.test.ts` does.

### Issue 2 of 2
server/tests/integration/licenses/license-attach-edge-cases.test.ts:147-151
The endpoint `/licenses.link` is not registered in `licenseRouter.ts`. The only registered license endpoints are `/licenses.attach`, `/licenses.update`, `/licenses.preview_attach`, `/licenses.preview_update`, `/licenses.list_assignments`, and `/licenses.list`. This call will fail at runtime with a 404. The prior version of this test correctly used `/plans.update` (with `plan_id`, `licenses: [{ license_plan_id, included }]`) to update pool capacity — that should be restored here, or the missing endpoint must be added to the router.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(licenses): wip align scenario DSL +..."](https://github.com/useautumn/autumn/commit/6bf61a2127813067e8f167d557a1455016144c6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44478868)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->