### PR TITLE
feat(events): Neon dual-write lane behind NEON_EVENTS_DATABASE_URL

### DIFF
--- a/.github/workflows/validate-schema.yml
+++ b/.github/workflows/validate-schema.yml
@@ -57,5 +57,6 @@ jobs:
         if: needs.changes.outputs.schema == 'true'
         env:
           DATABASE_URL: ${{ secrets.DATABASE_READ_ONLY_URL }}
+          NEON_EVENTS_READ_ONLY_URL: ${{ secrets.NEON_EVENTS_READ_ONLY_URL }}
           DB_MAX_CONNECTIONS: 1
         run: bun scripts/migrations/validate-schema.ts

--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,4 @@ apps/leaf/src/harness/claudeCode/runner/runner.mjs
 
 tmp/
 .env*.local
+.neon

--- a/knip.json
+++ b/knip.json
@@ -43,6 +43,7 @@
 			]
 		},
 		"shared": {
+			"entry": ["drizzle.config.events.ts"],
 			"project": ["**/*.ts", "!utils/**"],
 			"includeEntryExports": false
 		},

--- a/scripts/db/create-neon-events-readonly-role.ts
+++ b/scripts/db/create-neon-events-readonly-role.ts
@@ -1,0 +1,143 @@
+// Creates/refreshes the read-only role on the Neon events DB (CI schema validation).
+// Usage: bun scripts/db/create-neon-events-readonly-role.ts --env dev|prod [--role name] [--password pw]
+import { randomBytes } from "node:crypto";
+import { Pool } from "pg";
+import {
+	getArg,
+	loadInfisicalEnv,
+	quoteIdent,
+	quoteLiteral,
+} from "./helpers/roleScriptUtils";
+
+const DEFAULT_ENV = "dev";
+const DEFAULT_ROLE = "neon_events_readonly";
+
+const main = async () => {
+	const env = getArg("--env") ?? DEFAULT_ENV;
+	const role = getArg("--role") ?? DEFAULT_ROLE;
+	const password = getArg("--password") ?? randomBytes(24).toString("base64url");
+
+	loadInfisicalEnv(env);
+
+	const adminUrl = process.env.NEON_EVENTS_DATABASE_URL;
+	if (!adminUrl) {
+		throw new Error(
+			`NEON_EVENTS_DATABASE_URL is not set in Infisical env "${env}"`,
+		);
+	}
+
+	const client = new Pool({ connectionString: adminUrl, max: 1 });
+
+	try {
+		const existing = await client.query(
+			"SELECT 1 FROM pg_roles WHERE rolname = $1",
+			[role],
+		);
+
+		if (existing.rowCount) {
+			await client.query(
+				`ALTER ROLE ${quoteIdent(role)} WITH LOGIN PASSWORD ${quoteLiteral(password)}`,
+			);
+			console.log(`Role ${role} exists — password rotated.`);
+		} else {
+			await client.query(
+				`CREATE ROLE ${quoteIdent(role)} WITH LOGIN PASSWORD ${quoteLiteral(password)}`,
+			);
+			console.log(`Role ${role} created.`);
+		}
+
+		const { rows } = await client.query<{ db: string }>(
+			"SELECT current_database() AS db",
+		);
+		const dbName = rows[0].db;
+
+		await client.query(
+			`GRANT CONNECT ON DATABASE ${quoteIdent(dbName)} TO ${quoteIdent(role)}`,
+		);
+		await client.query(`GRANT USAGE ON SCHEMA public TO ${quoteIdent(role)}`);
+		await client.query(
+			`GRANT SELECT ON ALL TABLES IN SCHEMA public TO ${quoteIdent(role)}`,
+		);
+		// Future tables (e.g. events created later via db:events:push) stay readable.
+		await client.query(
+			`ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO ${quoteIdent(role)}`,
+		);
+		// Real protection is the ABSENCE of write grants; this default is a soft belt only
+		// (session-overridable), which is why verification below flips it off first.
+		await client.query(
+			`ALTER ROLE ${quoteIdent(role)} SET default_transaction_read_only = on`,
+		);
+		await client.query(
+			`ALTER ROLE ${quoteIdent(role)} SET statement_timeout = '30s'`,
+		);
+
+		const readOnlyUrl = new URL(adminUrl);
+		readOnlyUrl.username = role;
+		readOnlyUrl.password = password;
+
+		const verifyPool = new Pool({
+			connectionString: readOnlyUrl.toString(),
+			max: 1,
+		});
+
+		try {
+			// One held connection: the SET below is session-scoped and must apply to the probes.
+			const conn = await verifyPool.connect();
+			try {
+				await conn.query("SELECT 1");
+				console.log("Verified: role can connect and read.");
+
+				// Bypass the role default the way a compromised credential would — probes must
+				// fail on missing PRIVILEGES, not on the soft read-only default.
+				await conn.query("SET default_transaction_read_only = off");
+
+				const canCreate = await conn
+					.query("CREATE TABLE _readonly_probe (id int)")
+					.then(() => true)
+					.catch(() => false);
+				if (canCreate) {
+					await conn.query("DROP TABLE _readonly_probe");
+					throw new Error(`Role ${role} can CREATE TABLE — grants are wrong.`);
+				}
+
+				const eventsExists = (
+					await conn.query<{ exists: boolean }>(
+						"SELECT to_regclass('public.events') IS NOT NULL AS exists",
+					)
+				).rows[0].exists;
+				if (eventsExists) {
+					const canInsert = await conn
+						.query(
+							"INSERT INTO events (id, org_id, org_slug, env, event_name, customer_id) VALUES ('_ro_probe','_ro_probe','','live','_ro_probe','_ro_probe')",
+						)
+						.then(() => true)
+						.catch(() => false);
+					if (canInsert) {
+						await conn.query("DELETE FROM events WHERE id = '_ro_probe'");
+						throw new Error(
+							`Role ${role} can INSERT INTO events — grants are wrong.`,
+						);
+					}
+				}
+				console.log(
+					"Verified: role cannot write (even with read-only default disabled).",
+				);
+			} finally {
+				conn.release();
+			}
+		} finally {
+			await verifyPool.end();
+		}
+
+		// Intentional local-only output: this is an operator tool (never CI); printing the
+		// URL IS the delivery mechanism for pasting into Infisical / GH secrets.
+		console.log(
+			`\nRead-only URL for env "${env}" (store as NEON_EVENTS_READ_ONLY_URL in Infisical + GH secret):`,
+		);
+		console.log(readOnlyUrl.toString());
+	} finally {
+		await client.end().catch(() => {});
+	}
+};
+
+await main();

--- a/scripts/db/helpers/roleScriptUtils.ts
+++ b/scripts/db/helpers/roleScriptUtils.ts
@@ -1,0 +1,61 @@
+// Shared helpers for the role-management scripts (set-critical-role-timeouts,
+// create-neon-events-readonly-role) so arg parsing / quoting / Infisical loading can't drift.
+
+export const quoteIdent = (value: string) => `"${value.replaceAll('"', '""')}"`;
+export const quoteLiteral = (value: string) => `'${value.replaceAll("'", "''")}'`;
+
+export const getArg = (name: string) => {
+	const prefix = `${name}=`;
+	const inlineArg = process.argv.find((arg) => arg.startsWith(prefix));
+	if (inlineArg) return inlineArg.slice(prefix.length);
+
+	const index = process.argv.indexOf(name);
+	return index === -1 ? undefined : process.argv[index + 1];
+};
+
+type InfisicalSecret = {
+	key?: string;
+	value?: string;
+	secretKey?: string;
+	secretValue?: string;
+};
+
+const setEnvFromInfisicalExport = (value: unknown) => {
+	if (Array.isArray(value)) {
+		for (const secret of value as InfisicalSecret[]) {
+			const key = secret.key ?? secret.secretKey;
+			const secretValue = secret.value ?? secret.secretValue;
+			if (key && secretValue) {
+				process.env[key] = secretValue;
+			}
+		}
+		return;
+	}
+
+	for (const [key, secretValue] of Object.entries(
+		value as Record<string, string>,
+	)) {
+		process.env[key] = secretValue;
+	}
+};
+
+export const loadInfisicalEnv = (env: string) => {
+	const result = Bun.spawnSync([
+		"infisical",
+		"secrets",
+		"--env",
+		env,
+		"--recursive",
+		"--output",
+		"json",
+		"--silent",
+	]);
+
+	if (!result.success) {
+		throw new Error(
+			`Failed to load Infisical env "${env}": ${result.stderr.toString()}`,
+		);
+	}
+
+	setEnvFromInfisicalExport(JSON.parse(result.stdout.toString()));
+};

--- a/scripts/db/set-critical-role-timeouts.ts
+++ b/scripts/db/set-critical-role-timeouts.ts
@@ -1,4 +1,10 @@
 import { Pool } from "pg";
+import {
+	getArg,
+	loadInfisicalEnv,
+	quoteIdent,
+	quoteLiteral,
+} from "./helpers/roleScriptUtils";
 
 const DEFAULT_ENV = "dev";
 const DEFAULT_CRITICAL_ROLE = "autumn_critical";
@@ -6,65 +12,6 @@ const ROLE_SETTINGS = {
 	statement_timeout: "2s",
 	lock_timeout: "1s",
 	idle_in_transaction_session_timeout: "10s",
-};
-
-const quoteIdent = (value: string) => `"${value.replaceAll('"', '""')}"`;
-const quoteLiteral = (value: string) => `'${value.replaceAll("'", "''")}'`;
-
-const getArg = (name: string) => {
-	const prefix = `${name}=`;
-	const inlineArg = process.argv.find((arg) => arg.startsWith(prefix));
-	if (inlineArg) return inlineArg.slice(prefix.length);
-
-	const index = process.argv.indexOf(name);
-	return index === -1 ? undefined : process.argv[index + 1];
-};
-
-type InfisicalSecret = {
-	key?: string;
-	value?: string;
-	secretKey?: string;
-	secretValue?: string;
-};
-
-const setEnvFromInfisicalExport = (value: unknown) => {
-	if (Array.isArray(value)) {
-		for (const secret of value as InfisicalSecret[]) {
-			const key = secret.key ?? secret.secretKey;
-			const secretValue = secret.value ?? secret.secretValue;
-			if (key && secretValue) {
-				process.env[key] = secretValue;
-			}
-		}
-		return;
-	}
-
-	for (const [key, secretValue] of Object.entries(
-		value as Record<string, string>,
-	)) {
-		process.env[key] = secretValue;
-	}
-};
-
-const loadInfisicalEnv = (env: string) => {
-	const result = Bun.spawnSync([
-		"infisical",
-		"secrets",
-		"--env",
-		env,
-		"--output",
-		"json",
-		"--recursive",
-		"--silent",
-	]);
-
-	if (!result.success) {
-		throw new Error(
-			`Failed to load Infisical env "${env}": ${result.stderr.toString()}`,
-		);
-	}
-
-	setEnvFromInfisicalExport(JSON.parse(result.stdout.toString()));
 };
 
 const main = async () => {

--- a/scripts/migrations/validate-schema.ts
+++ b/scripts/migrations/validate-schema.ts
@@ -14,20 +14,61 @@ const { db } = initDrizzle({
 // Check if --validate-content flag is passed
 const validateContent = process.argv.includes("--validate-content");
 
+// Each run reports independently so a main-DB failure can't mask the Neon result.
+const failures: string[] = [];
+
+console.log("═══ RUN 1/2 · MAIN DB (DATABASE_URL) ═══");
 try {
 	console.log("Validating database schema...");
-	await validateDbSchema({ db, concurrency: schemaValidationConcurrency });
-	console.log("✅ Database schema validated successfully\n");
+	await validateDbSchema({
+		db,
+		concurrency: schemaValidationConcurrency,
+		label: "main-db",
+	});
+	console.log("✅ [main-db] schema validated successfully\n");
 
 	console.log(
 		`Validating SQL functions${validateContent ? " (with content validation)" : ""}...`,
 	);
 	await validateSqlFunctions({ db, validateContent });
-	console.log("✅ SQL functions validated successfully\n");
-
-	console.log("✅ All validations passed!");
-	process.exit(0);
+	console.log("✅ [main-db] SQL functions validated successfully\n");
 } catch (error) {
-	console.error("❌ Validation failed:", error);
+	failures.push("main-db");
+	console.error(
+		`❌ [main-db] validation failed: ${error instanceof Error ? error.message : error}\n`,
+	);
+}
+
+console.log("═══ RUN 2/2 · NEON EVENTS DB (NEON_EVENTS_READ_ONLY_URL) ═══");
+if (process.env.NEON_EVENTS_READ_ONLY_URL) {
+	try {
+		console.log("Validating Neon events schema...");
+		const { db: neonDb } = initDrizzle({
+			databaseUrl: process.env.NEON_EVENTS_READ_ONLY_URL,
+			maxConnections: 1,
+		});
+		const { neonEventsSchema } = await import("@autumn/shared");
+		await validateDbSchema({
+			db: neonDb,
+			schemaExports: neonEventsSchema,
+			concurrency: 1,
+			label: "neon-events",
+		});
+		console.log("✅ [neon-events] schema validated successfully\n");
+	} catch (error) {
+		failures.push("neon-events");
+		console.error(
+			`❌ [neon-events] validation failed: ${error instanceof Error ? error.message : error}\n`,
+		);
+	}
+} else {
+	console.log("(skipped — NEON_EVENTS_READ_ONLY_URL not set)\n");
+}
+
+if (failures.length > 0) {
+	console.error(`❌ Validation failed in: ${failures.join(", ")}`);
 	process.exit(1);
 }
+
+console.log("✅ All validations passed!");
+process.exit(0);

--- a/scripts/ops/backfill-events-neon.ts
+++ b/scripts/ops/backfill-events-neon.ts
@@ -1,0 +1,328 @@
+#!/usr/bin/env bun
+// One-time backfill of S3 parquet events into Neon (WS4 of EVENTS-NEON-CDC-PLAN.md).
+// Requires duckdb + psql CLIs, NEON_DIRECT_URL, BACKFILL_ORGS, EVENTS_S3_BUCKET,
+// and ambient AWS credentials.
+import { appendFile } from "node:fs/promises";
+import { $ } from "bun";
+
+const DEFAULT_FROM_MONTH = "2024-04";
+const MONTH_PATTERN = /^\d{4}-(?:0[1-9]|1[0-2])$/;
+const DONE_FILE = `${import.meta.dir}/.backfill_neon_done`;
+const SET_UTC = "SET timezone='UTC'";
+
+// Single source of truth for column order across staging DDL, \copy, and the merge INSERT.
+const EVENT_COLUMNS = [
+	"id",
+	"org_id",
+	"org_slug",
+	"internal_customer_id",
+	"env",
+	"created_at",
+	'"timestamp"',
+	"event_name",
+	"idempotency_key",
+	"value",
+	"set_usage",
+	"entity_id",
+	"internal_entity_id",
+	"internal_product_id",
+	"customer_id",
+	"properties",
+	"deductions",
+] as const;
+const COLUMN_LIST = EVENT_COLUMNS.join(", ");
+
+const STAGING_DDL = `CREATE TABLE IF NOT EXISTS events_staging (
+	id text, org_id text, org_slug text, internal_customer_id text, env text,
+	created_at bigint, "timestamp" timestamptz, event_name text, idempotency_key text,
+	value numeric, set_usage boolean, entity_id text, internal_entity_id text,
+	internal_product_id text, customer_id text, properties jsonb, deductions jsonb
+)`;
+
+const COPY_TO_STAGING = `\\copy events_staging (${COLUMN_LIST}) FROM STDIN CSV`;
+
+const MERGE_SQL = `INSERT INTO events (${COLUMN_LIST}) SELECT ${COLUMN_LIST} FROM events_staging ON CONFLICT DO NOTHING`;
+
+// set_usage is absent from the parquet export; emit false (NOT NULL — readers and the
+// partial index filter on set_usage = false, so NULL rows would be silently excluded).
+const duckDbExportSql = (
+	s3Prefix: string,
+	orgId: string,
+	year: string,
+	month: string,
+): string => `
+INSTALL httpfs; LOAD httpfs; INSTALL aws; LOAD aws;
+CREATE OR REPLACE SECRET s3_ambient (TYPE s3, PROVIDER credential_chain, REGION 'us-east-2');
+COPY (
+	SELECT id, org_id, COALESCE(org_slug,'') AS org_slug, internal_customer_id,
+	       COALESCE(env,'live') AS env, created_at, "timestamp",
+	       event_name, idempotency_key, value, false AS set_usage,
+	       entity_id, internal_entity_id, internal_product_id, customer_id,
+	       COALESCE(properties,'{}') AS properties, COALESCE(deductions,'[]') AS deductions
+	FROM read_parquet('${s3Prefix}/org_id=${orgId}/year=${year}/month=${month}/**/*.parquet')
+) TO STDOUT (FORMAT CSV, HEADER false);
+`;
+
+const USAGE = `Backfill S3 parquet events into Neon (events_staging -> events, dedup on conflict).
+
+Usage:
+  bun scripts/ops/backfill-events-neon.ts [--org <slug|all>] [--from YYYY-MM] [--to YYYY-MM]
+
+Options:
+  --org   an org slug from BACKFILL_ORGS | all   (default: all)
+  --from  first month, YYYY-MM   (default: ${DEFAULT_FROM_MONTH})
+  --to    last month, YYYY-MM    (default: current month)
+  --help  show this help
+
+Env (all required):
+  NEON_DIRECT_URL    Neon direct (non-pooled) connection string
+  BACKFILL_ORGS      org map, e.g. "acme=org_123,globex=org_456"
+  EVENTS_S3_BUCKET   events landing bucket name (reads s3://<bucket>/events/org_id=<id>/...)
+  AWS credentials    ambient (env / profile / SSO)
+
+Chunks run per (org, month), newest to oldest. Completed chunks are recorded in
+scripts/ops/.backfill_neon_done and skipped on rerun.`;
+
+type CliArgs = { from: string; org: string; to: string };
+
+const fail = (message: string): never => {
+	console.error(message);
+	process.exit(1);
+};
+
+const currentMonth = (): string => new Date().toISOString().slice(0, 7);
+
+const parseArgs = (argv: string[]): CliArgs => {
+	let org = "all";
+	let from = DEFAULT_FROM_MONTH;
+	let to = currentMonth();
+	const rest = [...argv];
+	while (rest.length > 0) {
+		const flag = rest.shift();
+		if (flag === "--help" || flag === "-h") {
+			console.log(USAGE);
+			process.exit(0);
+		}
+		const value = rest.shift();
+		if (!value) {
+			fail(`${flag} requires a value\n\n${USAGE}`);
+		}
+		if (flag === "--org") {
+			org = value;
+		} else if (flag === "--from") {
+			from = value;
+		} else if (flag === "--to") {
+			to = value;
+		} else {
+			fail(`Unknown flag: ${flag}\n\n${USAGE}`);
+		}
+	}
+	if (!(MONTH_PATTERN.test(from) && MONTH_PATTERN.test(to))) {
+		fail("--from/--to must be YYYY-MM");
+	}
+	if (from > to) {
+		fail(`--from (${from}) must not be after --to (${to})`);
+	}
+	return { from, org, to };
+};
+
+// Org ids and bucket stay out of source (public repo) — supplied via env.
+const loadOrgs = (): Record<string, string> => {
+	const raw = process.env.BACKFILL_ORGS;
+	if (!raw) {
+		fail(`BACKFILL_ORGS env var is required (e.g. "acme=org_123,globex=org_456")`);
+	}
+	const orgs: Record<string, string> = {};
+	for (const pair of (raw as string).split(",")) {
+		const [slug, orgId] = pair.split("=").map((s) => s.trim());
+		if (!(slug && orgId)) {
+			fail(`BACKFILL_ORGS entry "${pair}" is not slug=org_id`);
+		}
+		orgs[slug as string] = orgId as string;
+	}
+	return orgs;
+};
+
+const monthsNewestFirst = (from: string, to: string): string[] => {
+	const months: string[] = [];
+	let [year, month] = from.split("-").map(Number) as [number, number];
+	const [toYear, toMonth] = to.split("-").map(Number) as [number, number];
+	while (year < toYear || (year === toYear && month <= toMonth)) {
+		months.push(`${year}-${String(month).padStart(2, "0")}`);
+		month += 1;
+		if (month > 12) {
+			month = 1;
+			year += 1;
+		}
+	}
+	return months.reverse();
+};
+
+const hms = (): string => new Date().toTimeString().slice(0, 8);
+
+const formatDuration = (seconds: number): string => {
+	if (seconds < 90) {
+		return `${Math.round(seconds)}s`;
+	}
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 90) {
+		return `${minutes}m${Math.round(seconds % 60)}s`;
+	}
+	return `${Math.floor(minutes / 60)}h${minutes % 60}m`;
+};
+
+const ensureStagingTable = async (neonUrl: string): Promise<void> => {
+	const result =
+		await $`psql ${neonUrl} -X -v ON_ERROR_STOP=1 -c ${STAGING_DDL}`
+			.quiet()
+			.nothrow();
+	if (result.exitCode !== 0) {
+		throw new Error(
+			`events_staging setup failed: ${result.stderr.toString().trim()}`,
+		);
+	}
+};
+
+// Returns rows staged; empty=true when the parquet glob matched no files (not an error).
+const stageChunk = async (
+	neonUrl: string,
+	s3Prefix: string,
+	orgId: string,
+	month: string,
+): Promise<{ empty: boolean; staged: number }> => {
+	const [year, monthNumber] = month.split("-") as [string, string];
+	const exportSql = duckDbExportSql(s3Prefix, orgId, year, monthNumber);
+	// Truncate first so rows left by a previously crashed run aren't double-staged.
+	const result =
+		await $`duckdb -c ${exportSql} | psql ${neonUrl} -X -v ON_ERROR_STOP=1 -c ${"TRUNCATE events_staging"} -c ${SET_UTC} -c ${COPY_TO_STAGING}`
+			.quiet()
+			.nothrow();
+	const stderr = result.stderr.toString();
+	// An unmatched glob is an expected empty month — check BEFORE the exit-code throw
+	// (duckdb exits non-zero on it and the pipeline can propagate that status).
+	if (/no files found/i.test(stderr)) {
+		return { empty: true, staged: 0 };
+	}
+	if (result.exitCode !== 0) {
+		throw new Error(`staging failed (${month}): ${stderr.trim()}`);
+	}
+	// Pipeline exit code is psql's, so a mid-pipe duckdb failure only surfaces on stderr.
+	if (/error|fatal|exception/i.test(stderr)) {
+		throw new Error(`duckdb failed (${month}): ${stderr.trim()}`);
+	}
+	const staged = Number(result.stdout.toString().match(/COPY (\d+)/)?.[1] ?? 0);
+	// Files existed but zero rows staged — anomalous (silent duckdb death?); refuse to
+	// mark the chunk done. Operator can append the key to .backfill_neon_done if truly empty.
+	if (staged === 0) {
+		throw new Error(
+			`0 rows staged for ${month} despite parquet files existing — investigate before marking done`,
+		);
+	}
+	return { empty: false, staged };
+};
+
+const mergeChunk = async (neonUrl: string): Promise<number> => {
+	const result =
+		await $`psql ${neonUrl} -X -v ON_ERROR_STOP=1 -c ${SET_UTC} -c ${MERGE_SQL} -c ${"TRUNCATE events_staging"}`
+			.quiet()
+			.nothrow();
+	if (result.exitCode !== 0) {
+		throw new Error(`merge failed: ${result.stderr.toString().trim()}`);
+	}
+	return Number(result.stdout.toString().match(/INSERT \d+ (\d+)/)?.[1] ?? 0);
+};
+
+const loadDoneChunks = async (): Promise<Set<string>> => {
+	const file = Bun.file(DONE_FILE);
+	if (!(await file.exists())) {
+		return new Set();
+	}
+	const lines = (await file.text())
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean);
+	return new Set(lines);
+};
+
+const markChunkDone = (key: string): Promise<void> =>
+	appendFile(DONE_FILE, `${key}\n`);
+
+const main = async (): Promise<void> => {
+	const args = parseArgs(process.argv.slice(2));
+	const neonUrl = process.env.NEON_DIRECT_URL;
+	if (!neonUrl) {
+		fail("NEON_DIRECT_URL env var is required (Neon direct, non-pooled URL)");
+		return;
+	}
+	const orgs = loadOrgs();
+	const bucket = process.env.EVENTS_S3_BUCKET;
+	if (!bucket) {
+		fail("EVENTS_S3_BUCKET env var is required (events landing bucket name)");
+		return;
+	}
+	const s3Prefix = `s3://${bucket}/events`;
+	if (args.org !== "all" && !(args.org in orgs)) {
+		fail(`--org must be one of: ${Object.keys(orgs).join(", ")}, all`);
+	}
+	const orgSlugs = args.org === "all" ? Object.keys(orgs) : [args.org];
+
+	await ensureStagingTable(neonUrl);
+	const doneChunks = await loadDoneChunks();
+	const months = monthsNewestFirst(args.from, args.to);
+	const chunks = orgSlugs.flatMap((slug) =>
+		months.map((month) => ({ month, slug })),
+	);
+
+	let remaining = chunks.filter(
+		({ slug, month }) => !doneChunks.has(`${slug}:${month}`),
+	).length;
+	console.log(
+		`[${hms()}] ${chunks.length} chunks (${remaining} pending) orgs=${orgSlugs.join(",")} range=${args.from}..${args.to} newest-first`,
+	);
+
+	const insertedPerOrg: Record<string, number> = {};
+	let totalInserted = 0;
+	const chunkSeconds: number[] = [];
+
+	for (const { slug, month } of chunks) {
+		const key = `${slug}:${month}`;
+		if (doneChunks.has(key)) {
+			console.log(
+				`[${hms()}] org=${slug} month=${month} already done, skipping`,
+			);
+			continue;
+		}
+
+		const startedAt = Date.now();
+		const { empty, staged } = await stageChunk(
+			neonUrl,
+			s3Prefix,
+			orgs[slug] as string,
+			month,
+		);
+		const inserted = staged > 0 ? await mergeChunk(neonUrl) : 0;
+		const elapsedSeconds = (Date.now() - startedAt) / 1000;
+
+		chunkSeconds.push(elapsedSeconds);
+		remaining -= 1;
+		totalInserted += inserted;
+		insertedPerOrg[slug] = (insertedPerOrg[slug] ?? 0) + inserted;
+		const meanSeconds =
+			chunkSeconds.reduce((sum, s) => sum + s, 0) / chunkSeconds.length;
+		const note = empty ? " (no parquet files)" : "";
+		console.log(
+			`[${hms()}] org=${slug} month=${month} staged=${staged} inserted=${inserted} skipped_dups=${staged - inserted} elapsed=${elapsedSeconds.toFixed(1)}s total_inserted=${totalInserted} eta=${formatDuration(meanSeconds * remaining)}${note}`,
+		);
+		await markChunkDone(key);
+	}
+
+	console.log("\nBackfill complete. Inserted per org:");
+	for (const slug of orgSlugs) {
+		console.log(`  ${slug} (${orgs[slug]}): ${insertedPerOrg[slug] ?? 0}`);
+	}
+	console.log(
+		"\nVerify in Neon:\n  SELECT org_id, count(*) FROM events GROUP BY 1;",
+	);
+};
+
+await main();

--- a/server/src/db/initNeonEvents.ts
+++ b/server/src/db/initNeonEvents.ts
@@ -1,0 +1,14 @@
+import { type DrizzleCli, initDrizzle } from "./initDrizzle.js";
+
+// GUARD: initDrizzle falls back to DATABASE_URL when no url is given — never let events
+// writes silently hit the main DB. Pool exists only when the Neon URL is configured.
+export const neonEventsDb: DrizzleCli | null = process.env
+	.NEON_EVENTS_DATABASE_URL
+	? initDrizzle({
+			name: "neon-events",
+			databaseUrl: process.env.NEON_EVENTS_DATABASE_URL, // POOLED (-pooler) endpoint
+			maxConnections: 5,
+			connectTimeout: 10,
+			poolConfig: { application_name: "autumn-neon-events", query_timeout: 10_000 },
+		}).db
+	: null;

--- a/server/src/db/validateDbSchema.ts
+++ b/server/src/db/validateDbSchema.ts
@@ -4,7 +4,8 @@ import { PgTable } from "drizzle-orm/pg-core";
 import { logger } from "../external/logtail/logtailUtils";
 import type { DrizzleCli } from "./initDrizzle";
 
-const SKIP_TABLES = ["migrationErrors"];
+// eventsNeon lives on the Neon DB — validated by the dedicated neon-events pass, not the main one.
+const SKIP_TABLES = ["migrationErrors", "eventsNeon"];
 
 type TableEntry = {
 	name: string;
@@ -66,13 +67,18 @@ const validateTablesWithConcurrency = async ({
 export const validateDbSchema = async ({
 	db,
 	concurrency = 5,
+	schemaExports = schema,
+	label,
 }: {
 	db: DrizzleCli;
 	concurrency?: number;
+	schemaExports?: Record<string, unknown>;
+	label?: string;
 }) => {
 	// Dynamically get all tables from schema (exclude relations)
+	const logPrefix = label ? `[${label}] ` : "";
 
-	const tableEntries = Object.entries(schema)
+	const tableEntries = Object.entries(schemaExports)
 		.filter(([name, table]) => {
 			// Filter out relations and non-table exports
 			if (name.includes("Relations")) return false;
@@ -102,15 +108,15 @@ export const validateDbSchema = async ({
 			.map((f) => `Table '${f.name}': ${f.error}`)
 			.join("; ");
 		logger.error(
-			`Health check failed - DB schema validation error: ${failureDetails}`,
+			`${logPrefix}Health check failed - DB schema validation error: ${failureDetails}`,
 		);
 		throw new Error(
-			`Health check failed - DB schema validation error: ${failureDetails}`,
+			`${logPrefix}Health check failed - DB schema validation error: ${failureDetails}`,
 		);
 	}
 
 	logger.info(
-		`Health check passed - DB schema validated for ${tableEntries.length} tables in ${elapsed}ms (concurrency=${validatedConcurrency})`,
+		`${logPrefix}Health check passed - DB schema validated for ${tableEntries.length} tables in ${elapsed}ms (concurrency=${validatedConcurrency})`,
 	);
 	return true;
 };

--- a/server/src/internal/api/events/EventService.ts
+++ b/server/src/internal/api/events/EventService.ts
@@ -14,7 +14,6 @@ export class EventService {
 		event: EventInsert | EventInsert[];
 		logger?: Logger;
 	}) {
-		if (process.env.NODE_ENV !== "development") return;
 		try {
 			const results = await db
 				.insert(events)

--- a/server/src/internal/balances/events/runInsertEventBatch.ts
+++ b/server/src/internal/balances/events/runInsertEventBatch.ts
@@ -2,6 +2,7 @@ import { RecaseError, tryCatch } from "@autumn/shared";
 import * as Sentry from "@sentry/bun";
 import type { Logger } from "pino";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { neonEventsDb } from "@/db/initNeonEvents.js";
 import { EventService } from "@/internal/api/events/EventService.js";
 import type { JobName } from "@/queue/JobName.js";
 import type { Payloads } from "@/queue/queueUtils.js";
@@ -38,6 +39,11 @@ export const runInsertEventBatch = async ({
 
 	logger.debug(`Inserting ${eventInserts.length} events`);
 
+	// prod without NEON_EVENTS_DATABASE_URL -> same no-op as today
+	const eventsDb =
+		neonEventsDb ?? (process.env.NODE_ENV === "development" ? db : null);
+	if (!eventsDb) return;
+
 	// Group events by internal_customer_id
 	const eventsByCustomer = new Map<string, typeof eventInserts>();
 	for (const event of eventInserts) {
@@ -58,7 +64,7 @@ export const runInsertEventBatch = async ({
 	const insertPromises = Array.from(eventsByCustomer.entries()).map(
 		async ([customerId, customerEvents]) => {
 			const { error } = await tryCatch(
-				EventService.insert({ db, event: customerEvents, logger }),
+				EventService.insert({ db: eventsDb, event: customerEvents, logger }),
 			);
 
 			if (error) {

--- a/shared/drizzle.config.events.ts
+++ b/shared/drizzle.config.events.ts
@@ -1,0 +1,12 @@
+import { config } from "dotenv";
+import { defineConfig } from "drizzle-kit";
+
+config({ path: "../server/.env" });
+
+export default defineConfig({
+	dialect: "postgresql",
+	schema: "./models/eventModels/eventTableNeon.ts", // ONLY eventsNeon
+	dbCredentials: {
+		url: process.env.NEON_EVENTS_DATABASE_URL!,
+	},
+});

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -113,6 +113,7 @@ export * from "./models/devModels/customerJwtFamilyTable";
 // 5. Others: events, apiKeys
 export * from "./models/eventModels/eventModels";
 export * from "./models/eventModels/eventTable";
+export * from "./models/eventModels/eventTableNeon";
 export * from "./models/eventModels/eventTypes";
 export * from "./models/featureModels/featureConfig/creditConfig";
 export * from "./models/featureModels/featureConfig/meteredConfig";

--- a/shared/models/eventModels/eventTable.ts
+++ b/shared/models/eventModels/eventTable.ts
@@ -6,6 +6,7 @@ import {
 	index,
 	jsonb,
 	numeric,
+	type PgColumn,
 	pgTable,
 	text,
 	timestamp,
@@ -14,55 +15,59 @@ import {
 import type { TrackDeduction } from "../../api/balances/track/trackResponseV3.js";
 import { customers } from "../cusModels/cusTable.js";
 
-export const events = pgTable(
-	"events",
-	{
-		id: text().primaryKey().notNull(),
-		org_id: text("org_id").notNull(),
-		org_slug: text("org_slug").notNull(),
-		internal_customer_id: text("internal_customer_id"),
-		env: text().notNull(),
-		created_at: bigint({ mode: "number" }),
-		timestamp: timestamp({ mode: "date", withTimezone: true }),
+// Factory: fresh builders per call (sharing one builder object across pgTable calls is buggy).
+export const eventColumns = () => ({
+	id: text().primaryKey().notNull(),
+	org_id: text("org_id").notNull(),
+	org_slug: text("org_slug").notNull(),
+	internal_customer_id: text("internal_customer_id"),
+	env: text().notNull(),
+	created_at: bigint({ mode: "number" }),
+	timestamp: timestamp({ mode: "date", withTimezone: true }),
 
-		event_name: text("event_name").notNull(),
-		idempotency_key: text("idempotency_key").default(sql`null`),
-		value: numeric({ mode: "number" }),
-		set_usage: boolean("set_usage").default(false),
-		entity_id: text("entity_id"),
-		internal_entity_id: text("internal_entity_id"),
-		internal_product_id: text("internal_product_id"),
+	event_name: text("event_name").notNull(),
+	idempotency_key: text("idempotency_key").default(sql`null`),
+	value: numeric({ mode: "number" }),
+	set_usage: boolean("set_usage").default(false),
+	entity_id: text("entity_id"),
+	internal_entity_id: text("internal_entity_id"),
+	internal_product_id: text("internal_product_id"),
 
-		// Optional stuff...
-		customer_id: text("customer_id").notNull(),
-		properties: jsonb().$type<Record<string, any>>(),
-		deductions: jsonb().$type<TrackDeduction[]>(),
-	},
-	(table) => [
-		foreignKey({
-			columns: [table.internal_customer_id],
-			foreignColumns: [customers.internal_id],
-			name: "events_internal_customer_id_fkey",
-		}).onDelete("cascade"),
-		unique("unique_event_constraint").on(
-			table.org_id,
-			table.env,
-			table.customer_id,
-			table.event_name,
-			table.idempotency_key,
-		),
-		index("idx_events_internal_customer_id").on(table.internal_customer_id),
-		index("idx_events_internal_entity_id").on(table.internal_entity_id),
-		index("idx_events_customer_non_usage_ts")
-			.on(
-				table.internal_customer_id,
-				sql`${table.timestamp} DESC`,
-				sql`${table.id} DESC`,
-			)
-			.where(sql`${table.set_usage} = false`),
-		index("idx_events_timestamp").on(table.timestamp).concurrently(),
-	],
-);
+	// Optional stuff...
+	customer_id: text("customer_id").notNull(),
+	properties: jsonb().$type<Record<string, any>>(),
+	deductions: jsonb().$type<TrackDeduction[]>(),
+});
+
+export const eventUnique = (
+	t: Record<keyof ReturnType<typeof eventColumns>, PgColumn>,
+) =>
+	unique("unique_event_constraint").on(
+		t.org_id,
+		t.env,
+		t.customer_id,
+		t.event_name,
+		t.idempotency_key,
+	);
+
+export const events = pgTable("events", eventColumns(), (table) => [
+	foreignKey({
+		columns: [table.internal_customer_id],
+		foreignColumns: [customers.internal_id],
+		name: "events_internal_customer_id_fkey",
+	}).onDelete("cascade"),
+	eventUnique(table),
+	index("idx_events_internal_customer_id").on(table.internal_customer_id),
+	index("idx_events_internal_entity_id").on(table.internal_entity_id),
+	index("idx_events_customer_non_usage_ts")
+		.on(
+			table.internal_customer_id,
+			sql`${table.timestamp} DESC`,
+			sql`${table.id} DESC`,
+		)
+		.where(sql`${table.set_usage} = false`),
+	index("idx_events_timestamp").on(table.timestamp).concurrently(),
+]);
 
 export type Event = typeof events.$inferSelect;
 export type EventInsert = typeof events.$inferInsert;

--- a/shared/models/eventModels/eventTableNeon.ts
+++ b/shared/models/eventModels/eventTableNeon.ts
@@ -1,0 +1,10 @@
+import { pgTable } from "drizzle-orm/pg-core";
+import { eventColumns, eventUnique } from "./eventTable.js";
+
+// Neon variant: same columns + dedup constraint. NO customers FK (no customers table on Neon),
+// no query indexes. PK(id) = replica identity for CDC update/delete propagation.
+export const eventsNeon = pgTable("events", eventColumns(), (t) => [
+	eventUnique(t),
+]);
+
+export const neonEventsSchema = { events: eventsNeon };

--- a/shared/package.json
+++ b/shared/package.json
@@ -58,7 +58,10 @@
 		"db:push": "bun db:generate && bun db:migrate",
 		"db:generate": "cross-env NODE_OPTIONS=\"--import tsx\" bunx drizzle-kit generate --config drizzle.config.ts",
 		"db:migrate": "cross-env NODE_OPTIONS=\"--import tsx\" bunx drizzle-kit migrate --config drizzle.config.ts",
-		"db:studio": "cross-env NODE_OPTIONS=\"--import tsx\" bunx drizzle-kit studio --config drizzle.config.ts"
+		"db:studio": "cross-env NODE_OPTIONS=\"--import tsx\" bunx drizzle-kit studio --config drizzle.config.ts",
+		"db:events:push": "cross-env NODE_OPTIONS=\"--import tsx\" bunx drizzle-kit push --config drizzle.config.events.ts",
+		"db:events:push:dev": "infisical run --env=dev --recursive -- bun db:events:push",
+		"db:events:push:prod": "infisical run --env=prod --recursive -- bun db:events:push"
 	},
 	"dependencies": {
 		"@autumn/ksuid": "workspace:*",


### PR DESCRIPTION
## Summary
Adds a Neon dual-write lane for events behind `NEON_EVENTS_DATABASE_URL`. Safe by default: production writes remain a no-op unless the Neon URL is set (identical to current behavior); when set, event batches write to Neon alongside the existing Tinybird publish.

- **Schema**: `eventColumns()` factory + FK-less `eventsNeon` table (own file for drizzle-kit); `drizzle.config.events.ts` + `db:events:push(:dev|:prod)`.
- **Write path**: null-guarded `neonEventsDb` pool (never falls back to the main `DATABASE_URL`); `runInsertEventBatch` routes to Neon when configured.
- **CI**: schema validation runs two labeled passes (main-db, neon-events) reporting independently, via `NEON_EVENTS_READ_ONLY_URL`.
- **Tooling**: script to create/rotate the CI read-only role (privilege-based write-probe verification); resumable S3 parquet → Neon backfill (env-driven org map + bucket, dup-safe merge).

## Migration
1. `bun db:events:push:dev` / `:prod` (drizzle-kit push, confirms plan).
2. Create the read-only role: `bun scripts/db/create-neon-events-readonly-role.ts --env <env>`; store the printed URL as `NEON_EVENTS_READ_ONLY_URL` (Infisical + GH secret).
3. Set `NEON_EVENTS_DATABASE_URL` (pooled endpoint) to enable the write path.
4. Historical data: `scripts/ops/backfill-events-neon.ts` with `NEON_DIRECT_URL`, `BACKFILL_ORGS`, `EVENTS_S3_BUCKET`.

Review findings from the bots were addressed in-branch (see resolution comment below); branch history squashed.
