### PR TITLE
Hotfix/update non consumable prepaid quantities

### DIFF
--- a/vite/src/components/forms/update-subscription-v2/context/UpdateSubscriptionFormProvider.tsx
+++ b/vite/src/components/forms/update-subscription-v2/context/UpdateSubscriptionFormProvider.tsx
@@ -5,7 +5,10 @@ import type {
 	ProductItem,
 	ProductV2,
 } from "@autumn/shared";
-import { productV2ToFrontendProduct } from "@autumn/shared";
+import {
+	ProductItemFeatureType,
+	productV2ToFrontendProduct,
+} from "@autumn/shared";
 import { useStore } from "@tanstack/react-form";
 
 import {
@@ -243,8 +246,10 @@ export function UpdateSubscriptionFormProvider({
 				(it) => it.feature_id === featureId,
 			);
 			const initialQuantity = initialPrepaidOptions[featureId];
-			const isOneOff = item?.interval == null;
-			const changedQuantity = isOneOff
+			const isOneOffTopUp =
+				item?.interval == null &&
+				item?.feature_type !== ProductItemFeatureType.ContinuousUse;
+			const changedQuantity = isOneOffTopUp
 				? quantity > (initialQuantity ?? 0)
 				: quantity !== initialQuantity;
 			if (changedQuantity) {

--- a/vite/src/components/forms/update-subscription-v2/hooks/useHasSubscriptionChanges.ts
+++ b/vite/src/components/forms/update-subscription-v2/hooks/useHasSubscriptionChanges.ts
@@ -7,6 +7,7 @@ import {
 	generateTrialChanges,
 	generateVersionChanges,
 	type ProductItem,
+	ProductItemFeatureType,
 } from "@autumn/shared";
 import { useMemo } from "react";
 import type { PrepaidItemWithFeature } from "@/hooks/stores/useProductStore";
@@ -79,7 +80,12 @@ export function useHasSubscriptionChanges({
 			const featureId = change.id.replace("prepaid-", "");
 			if (newlyAddedFeatureIds.has(featureId)) return false;
 			const item = prepaidItems.find((it) => it.feature_id === featureId);
-			if (item?.interval == null) {
+			// Consumable one-off top-ups only count as a change when increasing;
+			// non-consumables (continuous use) change on any delta, including a decrease.
+			const isConsumableOneOff =
+				item?.interval == null &&
+				item?.feature_type !== ProductItemFeatureType.ContinuousUse;
+			if (isConsumableOneOff) {
 				const initial = initialPrepaidOptions[featureId] ?? 0;
 				return (formValues.prepaidOptions[featureId] ?? 0) > initial;
 			}

--- a/vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody.ts
+++ b/vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody.ts
@@ -3,6 +3,7 @@ import type {
 	ProductItemInterval,
 	UpdateSubscriptionV0Params,
 } from "@autumn/shared";
+import { ProductItemFeatureType } from "@autumn/shared";
 import { useCallback } from "react";
 import { normalizeBillingRequestItems } from "@/components/forms/shared/utils/normalizeBillingRequestItems";
 import type { UpdateSubscriptionFormContext } from "../context/UpdateSubscriptionFormProvider";
@@ -14,6 +15,7 @@ type PrepaidItemInput = {
 	feature?: { internal_id?: string | null } | null;
 	included_usage?: number | "inf" | null;
 	interval?: ProductItemInterval | null;
+	feature_type?: ProductItemFeatureType | null;
 };
 
 /** Pure function to build update subscription options from prepaid form values. Extracted for testability. */
@@ -81,8 +83,12 @@ export function buildUpdateSubscriptionOptions({
 				includedUsage: currentIncludedUsage,
 			});
 
-			const isOneOff = item.interval === null;
-			if (isOneOff) {
+			// Only consumable (single-use) items top up by delta. Non-consumables
+			// are continuous-use levels with interval === null — always absolute.
+			const isOneOffTopUp =
+				item.interval === null &&
+				item.feature_type !== ProductItemFeatureType.ContinuousUse;
+			if (isOneOffTopUp) {
 				const topUpDelta = newPurchasedQuantity - currentPurchasedQuantity;
 				if (topUpDelta <= 0) return null;
 				return { feature_id: featureId, quantity: topUpDelta };

--- a/vite/tests/components/forms/update-subscription-v2/hooks/build-update-subscription-options.test.ts
+++ b/vite/tests/components/forms/update-subscription-v2/hooks/build-update-subscription-options.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { type ProductItem, ProductItemInterval } from "@autumn/shared";
+import {
+	type ProductItem,
+	ProductItemFeatureType,
+	ProductItemInterval,
+} from "@autumn/shared";
 import { normalizeBillingRequestItems } from "@/components/forms/shared/utils/normalizeBillingRequestItems";
 import { buildUpdateSubscriptionOptions } from "@/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody";
 
@@ -232,6 +236,66 @@ describe("buildUpdateSubscriptionOptions — included usage handling", () => {
 		});
 
 		expect(result).toEqual([]);
+	});
+
+	test("should send the absolute total for a non-consumable item (interval null, continuous use)", () => {
+		// Non-consumables are continuous-use levels that happen to have interval null.
+		// They must send the selected total, never the delta.
+		const result = buildUpdateSubscriptionOptions({
+			prepaidItems: [
+				{
+					feature_id: "mailable_contacts",
+					included_usage: 0,
+					interval: null,
+					feature_type: ProductItemFeatureType.ContinuousUse,
+				},
+			],
+			prepaidOptions: { mailable_contacts: 352 },
+			initialPrepaidOptions: { mailable_contacts: 350 },
+			initialBackendQuantities: { mailable_contacts: 350 },
+		});
+
+		expect(result).toEqual([
+			{ feature_id: "mailable_contacts", quantity: 352 },
+		]);
+	});
+
+	test("should still send the delta for a consumable one-off item (interval null, single use)", () => {
+		const result = buildUpdateSubscriptionOptions({
+			prepaidItems: [
+				{
+					feature_id: "credits",
+					included_usage: 0,
+					interval: null,
+					feature_type: ProductItemFeatureType.SingleUse,
+				},
+			],
+			prepaidOptions: { credits: 1500 },
+			initialPrepaidOptions: { credits: 1000 },
+			initialBackendQuantities: { credits: 1000 },
+		});
+
+		expect(result).toEqual([{ feature_id: "credits", quantity: 500 }]);
+	});
+
+	test("should resubmit a decreased non-consumable total (no delta clamping)", () => {
+		const result = buildUpdateSubscriptionOptions({
+			prepaidItems: [
+				{
+					feature_id: "mailable_contacts",
+					included_usage: 0,
+					interval: null,
+					feature_type: ProductItemFeatureType.ContinuousUse,
+				},
+			],
+			prepaidOptions: { mailable_contacts: 300 },
+			initialPrepaidOptions: { mailable_contacts: 350 },
+			initialBackendQuantities: { mailable_contacts: 350 },
+		});
+
+		expect(result).toEqual([
+			{ feature_id: "mailable_contacts", quantity: 300 },
+		]);
 	});
 
 	test("should still skip recurring items when quantity has not changed", () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes prepaid quantity updates: absolute totals for non-consumable continuous-use; delta top-ups for consumable one-off. Decreases for non-consumables with `interval: null` are now applied.

- **Bug Fixes**
  - Classify `interval: null` items via `ProductItemFeatureType`: deltas for `SingleUse`, absolute totals for `ContinuousUse` (including decreases); updated change checks in the form provider and `useHasSubscriptionChanges`.
  - Updated request body builder to always send absolute totals for continuous-use and ignore non-positive top-up deltas; added tests for continuous-use totals, single-use deltas, and decreased non-consumables.

<sup>Written for commit 2c26e3cba75427585556538b973b29d83f422a00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes how prepaid quantities are sent when updating subscriptions. The main changes are:

- **Bug fixes:** Send absolute quantities for interval-less continuous-use items.
- **Bug fixes:** Keep delta-based updates for consumable one-off items.
- **Improvements:** Add tests for continuous-use increases and decreases.
</details>

<h3>Confidence Score: 4/5</h3>

The optional feature-type path can still misapply or silently skip prepaid quantity changes.

- Explicit continuous-use and single-use items follow the intended behavior.
- Feature-only and legacy items can omit `feature_type`.
- An omitted type makes an interval-less continuous-use item send a delta or ignore a decrease.

vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody.ts and the matching classification in UpdateSubscriptionFormProvider.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/forms/update-subscription-v2/context/UpdateSubscriptionFormProvider.tsx | Uses feature type when deciding whether a prepaid quantity changed, but missing type metadata still selects top-up behavior. |
| vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody.ts | Selects delta or absolute quantity updates from feature type, with incorrect handling when that optional field is absent. |
| vite/tests/components/forms/update-subscription-v2/hooks/build-update-subscription-options.test.ts | Covers explicit continuous-use and single-use types but not null or omitted feature types. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody.ts:88-90
**Missing Type Becomes Top-Up**

When an interval-less continuous-use item has a null or omitted `feature_type`, this condition classifies it as a consumable top-up. Feature-only items can omit this optional field, so increases send a delta and decreases are discarded by `topUpDelta <= 0` instead of sending the selected absolute quantity.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fixed bad logic for non consumable featu..."](https://github.com/useautumn/autumn/commit/1c17f6b9710cb28678a305681660a7c162a40460) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43675215)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->