### PR TITLE
fix: keyset pagination for reset cron candidate scan

### DIFF
--- a/server/src/cron/resetCron/runResetCron.ts
+++ b/server/src/cron/resetCron/runResetCron.ts
@@ -66,27 +66,40 @@ export const runResetCron = async ({ ctx }: { ctx: CronContext }) => {
 
 	try {
 		let iteration = 0;
+		let totalFetched = 0;
+		let totalUpserted = 0;
+
+		logger.info({ jobName: "reset-cus-ents" }, "[reset-cus-ents] started");
 
 		while (iteration < maxIterations && Date.now() - startTime < timeoutMs) {
 			iteration++;
 
+			const fetchStartedAt = Date.now();
 			const cusEnts = await CusEntService.getActiveResetPassed({
 				db,
 				batchSize: 5_000,
 				limit: 5_000,
 				includeSeparateIntervalResets: false,
 			});
+			totalFetched += cusEnts.length;
+
+			logger.info(
+				{
+					jobName: "reset-cus-ents",
+					iteration,
+					fetched: cusEnts.length,
+					fetchDurationMs: Date.now() - fetchStartedAt,
+				},
+				`[reset-cus-ents] iteration ${iteration}: fetched ${cusEnts.length} in ${Date.now() - fetchStartedAt}ms`,
+			);
 
 			if (cusEnts.length < 5_000) {
-				console.log(
-					`Reset cron: only ${cusEnts.length} entitlements to reset, skipping (lazy reset will handle)`,
+				logger.info(
+					{ jobName: "reset-cus-ents", fetched: cusEnts.length },
+					`[reset-cus-ents] only ${cusEnts.length} entitlements to reset, skipping (lazy reset will handle)`,
 				);
 				break;
 			}
-
-			console.log(
-				`Reset cron iteration ${iteration}: processing ${cusEnts.length} entitlements`,
-			);
 
 			const batchSize = 1000;
 			for (let i = 0; i < cusEnts.length; i += batchSize) {
@@ -137,7 +150,7 @@ export const runResetCron = async ({ ctx }: { ctx: CronContext }) => {
 					db,
 					data: toUpsert,
 				});
-				console.log(`Upserted ${toUpsert.length} short entitlements`);
+				totalUpserted += toUpsert.length;
 
 				await clearCusEntsFromCache({
 					cusEnts: updatedCusEnts,
@@ -145,12 +158,25 @@ export const runResetCron = async ({ ctx }: { ctx: CronContext }) => {
 			}
 		}
 
+		logger.info(
+			{
+				jobName: "reset-cus-ents",
+				iterations: iteration,
+				totalFetched,
+				totalUpserted,
+				durationMs: Date.now() - startTime,
+			},
+			`[reset-cus-ents] finished: ${totalUpserted} reset across ${iteration} iteration(s) in ${Date.now() - startTime}ms`,
+		);
 		console.log(
 			"FINISHED RESET CRON:",
 			format(new UTCDate(), "yyyy-MM-dd HH:mm:ss"),
 		);
-		console.log("----------------------------------\n");
 	} catch (error) {
+		logger.error(
+			{ jobName: "reset-cus-ents", durationMs: Date.now() - startTime },
+			`[reset-cus-ents] failed: ${error}`,
+		);
 		console.error("Error getting entitlements for reset:", error);
 		return;
 	}

--- a/server/src/cron/resetCron/runResetCron.ts
+++ b/server/src/cron/resetCron/runResetCron.ts
@@ -166,7 +166,7 @@ export const runResetCron = async ({ ctx }: { ctx: CronContext }) => {
 				totalUpserted,
 				durationMs: Date.now() - startTime,
 			},
-			`[reset-cus-ents] finished: ${totalUpserted} reset across ${iteration} iteration(s) in ${Date.now() - startTime}ms`,
+			`[reset-cus-ents] finished: fetched ${totalFetched}, upserted ${totalUpserted} (monthly/yearly resets update in place and are not counted here) across ${iteration} iteration(s) in ${Date.now() - startTime}ms`,
 		);
 		console.log(
 			"FINISHED RESET CRON:",

--- a/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
@@ -30,6 +30,7 @@ import {
 	or,
 	sql,
 } from "drizzle-orm";
+import { unionAll } from "drizzle-orm/pg-core";
 import { StatusCodes } from "http-status-codes";
 import { buildConflictUpdateColumns } from "@/db/dbUtils.js";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
@@ -175,40 +176,31 @@ export class CusEntService {
 		await db.insert(customerEntitlements).values(insertData);
 	}
 
-	static async getActiveResetPassed({
+	static buildActiveResetPassedPage({
 		db,
-		customDateUnix,
-		batchSize = 1000,
-		limit,
-		includeSeparateIntervalResets = true,
-		onPageFetched,
+		now,
+		batchSize,
+		cursor,
+		includeSeparateIntervalResets,
 	}: {
 		db: DrizzleCli;
-		customDateUnix?: number;
-		batchSize?: number;
-		limit?: number;
-		includeSeparateIntervalResets?: boolean;
-		/** Test seam: runs between pages to exercise mid-pagination mutations. */
-		onPageFetched?: (page: ResetCusEnt[]) => void | Promise<void>;
+		now: number;
+		batchSize: number;
+		cursor: { nextResetAt: number; id: string } | null;
+		includeSeparateIntervalResets: boolean;
 	}) {
-		const allResults: FullCusEntWithProduct[] = [];
-		const now = customDateUnix ?? Date.now();
-		let cursor: { nextResetAt: number; id: string } | null = null;
-
-		// Shared projection across all three UNION ALL branches. Keeping the
-		// column list identical across branches is required for UNION ALL and
-		// lets the existing mapper below consume each row uniformly.
+		// Sort keys are projected as top-level output columns because Postgres
+		// only allows ORDER BY on a set operation via output column names.
 		const baseSelect = {
 			customer_entitlements: customerEntitlements,
 			entitlements: entitlements,
 			features: features,
 			customers: customers,
 			customer_products: customerProducts,
+			sort_reset: sql`${customerEntitlements.next_reset_at}`.as("sort_reset"),
+			sort_id: sql`${customerEntitlements.id} COLLATE "C"`.as("sort_id"),
 		};
 
-		// Common reset predicates applied in every branch: not marked expired
-		// (skips the backfilled terminal-product backlog via the partial index),
-		// next_reset_at has passed, and the entitlement has not expired.
 		const commonResetPredicates = () =>
 			and(
 				sql`${customerEntitlements.expired} IS NOT TRUE`,
@@ -219,18 +211,16 @@ export class CusEntService {
 				),
 			);
 
-		// COLLATE "C" must match the JS merge comparison (code-unit order).
+		// COLLATE "C" keeps the cursor comparison aligned with sort_id's ordering.
 		const afterCursor = () =>
 			cursor
 				? sql`(${customerEntitlements.next_reset_at}, ${customerEntitlements.id} COLLATE "C") > (${cursor.nextResetAt}, ${cursor.id})`
 				: undefined;
 
 		// Exclude normal price-backed cusEnts: their reset is owned by the Stripe
-		// invoice.created handler, not this cron. Split prepaid reset intervals
-		// are included by dedicated branches below. Must stay in sync with
-		// `cusEntToCusPrice` (shared/utils/cusEntUtils/.../cusEntToCusPrice.ts)
-		// and the in-memory `getResettableCustomerEntitlements` filter.
-		// Only applies to branches with `customer_product_id` set (i.e. 2 + 3).
+		// invoice.created handler, not this cron. Must stay in sync with
+		// `cusEntToCusPrice` and the in-memory `getResettableCustomerEntitlements`
+		// filter. Only applies to branches with `customer_product_id` set (2 + 3).
 		const notPriceBacked = () =>
 			notExists(
 				db
@@ -250,150 +240,142 @@ export class CusEntService {
 				? or(eq(customerEntitlements.separate_interval, true), notPriceBacked())
 				: notPriceBacked();
 
-		const orderKey = [
-			customerEntitlements.next_reset_at,
-			sql`${customerEntitlements.id} COLLATE "C"`,
-		];
+		// Branch 1: cusEnts with no customer_product. Left-join to
+		// customer_products on a false predicate so the row shape matches
+		// the other branches (customer_products columns come back NULL).
+		const branch1 = db
+			.select(baseSelect)
+			.from(customerEntitlements)
+			.innerJoin(
+				entitlements,
+				eq(customerEntitlements.entitlement_id, entitlements.id),
+			)
+			.innerJoin(
+				features,
+				eq(entitlements.internal_feature_id, features.internal_id),
+			)
+			.innerJoin(
+				customers,
+				eq(customerEntitlements.internal_customer_id, customers.internal_id),
+			)
+			.leftJoin(customerProducts, sql`false`)
+			.where(
+				and(
+					isNull(customerEntitlements.customer_product_id),
+					commonResetPredicates(),
+					afterCursor(),
+				),
+			);
 
-		// One snapshot per page: the three branch reads run inside a repeatable-read
-		// transaction so a status transition mid-page cannot duplicate or omit a row.
-		const fetchBranches = (client: DrizzleCli) => {
-			// Branch 1: cusEnts with no customer_product. Left-join to
-			// customer_products on a false predicate so the row shape matches
-			// the other branches (customer_products columns come back NULL).
-			const branch1 = client
-				.select(baseSelect)
-				.from(customerEntitlements)
-				.innerJoin(
-					entitlements,
-					eq(customerEntitlements.entitlement_id, entitlements.id),
-				)
-				.innerJoin(
-					features,
-					eq(entitlements.internal_feature_id, features.internal_id),
-				)
-				.innerJoin(
-					customers,
-					eq(customerEntitlements.internal_customer_id, customers.internal_id),
-				)
-				.leftJoin(customerProducts, sql`false`)
-				.where(
-					and(
-						isNull(customerEntitlements.customer_product_id),
-						commonResetPredicates(),
-						afterCursor(),
-					),
-				)
-				.orderBy(...orderKey)
-				.limit(batchSize);
+		// Branch 2: cusEnts on active customer_products.
+		const branch2 = db
+			.select(baseSelect)
+			.from(customerEntitlements)
+			.innerJoin(
+				entitlements,
+				eq(customerEntitlements.entitlement_id, entitlements.id),
+			)
+			.innerJoin(
+				features,
+				eq(entitlements.internal_feature_id, features.internal_id),
+			)
+			.innerJoin(
+				customers,
+				eq(customerEntitlements.internal_customer_id, customers.internal_id),
+			)
+			.innerJoin(
+				customerProducts,
+				sql`${customerEntitlements.customer_product_id} COLLATE "C" = ${customerProducts.id}`,
+			)
+			.where(
+				and(
+					eq(customerProducts.status, CusProductStatus.Active),
+					commonResetPredicates(),
+					resetOwnedByAutumn(),
+					afterCursor(),
+				),
+			);
 
-			// Branch 2: cusEnts on active customer_products.
-			const branch2 = client
-				.select(baseSelect)
-				.from(customerEntitlements)
-				.innerJoin(
-					entitlements,
-					eq(customerEntitlements.entitlement_id, entitlements.id),
-				)
-				.innerJoin(
-					features,
-					eq(entitlements.internal_feature_id, features.internal_id),
-				)
-				.innerJoin(
-					customers,
-					eq(customerEntitlements.internal_customer_id, customers.internal_id),
-				)
-				.innerJoin(
-					customerProducts,
-					sql`${customerEntitlements.customer_product_id} COLLATE "C" = ${customerProducts.id}`,
-				)
-				.where(
-					and(
-						eq(customerProducts.status, CusProductStatus.Active),
-						commonResetPredicates(),
-						resetOwnedByAutumn(),
-						afterCursor(),
-					),
-				)
-				.orderBy(...orderKey)
-				.limit(batchSize);
+		// Branch 3: cusEnts on past_due customer_products whose product
+		// opted into ignore_past_due via products.config.
+		const branch3 = db
+			.select(baseSelect)
+			.from(customerEntitlements)
+			.innerJoin(
+				entitlements,
+				eq(customerEntitlements.entitlement_id, entitlements.id),
+			)
+			.innerJoin(
+				features,
+				eq(entitlements.internal_feature_id, features.internal_id),
+			)
+			.innerJoin(
+				customers,
+				eq(customerEntitlements.internal_customer_id, customers.internal_id),
+			)
+			.innerJoin(
+				customerProducts,
+				sql`${customerEntitlements.customer_product_id} COLLATE "C" = ${customerProducts.id}`,
+			)
+			.innerJoin(
+				products,
+				eq(customerProducts.internal_product_id, products.internal_id),
+			)
+			.where(
+				and(
+					eq(customerProducts.status, CusProductStatus.PastDue),
+					sql`(${products.config}->>'ignore_past_due')::boolean = true`,
+					commonResetPredicates(),
+					resetOwnedByAutumn(),
+					afterCursor(),
+				),
+			);
 
-			// Branch 3: cusEnts on past_due customer_products whose product
-			// opted into ignore_past_due via products.config.
-			const branch3 = client
-				.select(baseSelect)
-				.from(customerEntitlements)
-				.innerJoin(
-					entitlements,
-					eq(customerEntitlements.entitlement_id, entitlements.id),
-				)
-				.innerJoin(
-					features,
-					eq(entitlements.internal_feature_id, features.internal_id),
-				)
-				.innerJoin(
-					customers,
-					eq(customerEntitlements.internal_customer_id, customers.internal_id),
-				)
-				.innerJoin(
-					customerProducts,
-					sql`${customerEntitlements.customer_product_id} COLLATE "C" = ${customerProducts.id}`,
-				)
-				.innerJoin(
-					products,
-					eq(customerProducts.internal_product_id, products.internal_id),
-				)
-				.where(
-					and(
-						eq(customerProducts.status, CusProductStatus.PastDue),
-						sql`(${products.config}->>'ignore_past_due')::boolean = true`,
-						commonResetPredicates(),
-						resetOwnedByAutumn(),
-						afterCursor(),
-					),
-				)
-				.orderBy(...orderKey)
-				.limit(batchSize);
+		// One statement, one snapshot: branch consistency without a
+		// multi-statement transaction, and statement_timeout caps the whole page.
+		return unionAll(branch1, branch2, branch3)
+			.orderBy(sql`"sort_reset"`, sql`"sort_id"`)
+			.limit(batchSize);
+	}
 
-			return { branch1, branch2, branch3 };
-		};
-
+	static async getActiveResetPassed({
+		db,
+		customDateUnix,
+		batchSize = 1000,
+		limit,
+		includeSeparateIntervalResets = true,
+		onPageFetched,
+	}: {
+		db: DrizzleCli;
+		customDateUnix?: number;
+		batchSize?: number;
+		limit?: number;
+		includeSeparateIntervalResets?: boolean;
+		/** Test seam: runs between pages to exercise mid-pagination mutations. */
+		onPageFetched?: (page: ResetCusEnt[]) => void | Promise<void>;
+	}) {
+		const allResults: FullCusEntWithProduct[] = [];
+		const now = customDateUnix ?? Date.now();
+		let cursor: { nextResetAt: number; id: string } | null = null;
 		const emittedIds = new Set<string>();
 
 		while (true) {
-			const [rows1, rows2, rows3] = await db.transaction(
-				async (transaction) => {
-					const tx = transaction as unknown as DrizzleCli;
-					const { branch1, branch2, branch3 } = fetchBranches(tx);
-					const r1 = await branch1;
-					const r2 = await branch2;
-					const r3 = await branch3;
-					return [r1, r2, r3] as const;
-				},
-				{ isolationLevel: "repeatable read", accessMode: "read only" },
-			);
-
-			// Branches are status-disjoint within the shared snapshot, so the merge
-			// only needs cross-page dedup (a row whose next_reset_at advanced but is
-			// still overdue can reappear past the cursor).
-			const page = [...rows1, ...rows2, ...rows3]
-				.sort((a, b) => {
-					const aReset = Number(a.customer_entitlements.next_reset_at);
-					const bReset = Number(b.customer_entitlements.next_reset_at);
-					if (aReset !== bReset) return aReset - bReset;
-					const aId = a.customer_entitlements.id;
-					const bId = b.customer_entitlements.id;
-					return aId < bId ? -1 : aId > bId ? 1 : 0;
-				})
-				.slice(0, batchSize);
+			const page = await CusEntService.buildActiveResetPassedPage({
+				db,
+				now,
+				batchSize,
+				cursor,
+				includeSeparateIntervalResets,
+			});
 
 			if (page.length === 0) break;
 
-			const freshRows = page.filter(
-				(item) => !emittedIds.has(item.customer_entitlements.id),
-			);
-			for (const item of freshRows) {
-				emittedIds.add(item.customer_entitlements.id);
+			const freshRows: typeof page = [];
+			for (const item of page) {
+				const id = item.customer_entitlements.id;
+				if (emittedIds.has(id)) continue;
+				emittedIds.add(id);
+				freshRows.push(item);
 			}
 
 			const mappedData = freshRows.map((item) => ({

--- a/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
@@ -181,12 +181,15 @@ export class CusEntService {
 		batchSize = 1000,
 		limit,
 		includeSeparateIntervalResets = true,
+		onPageFetched,
 	}: {
 		db: DrizzleCli;
 		customDateUnix?: number;
 		batchSize?: number;
 		limit?: number;
 		includeSeparateIntervalResets?: boolean;
+		/** Test seam: runs between pages to exercise mid-pagination mutations. */
+		onPageFetched?: (page: ResetCusEnt[]) => void | Promise<void>;
 	}) {
 		const allResults: FullCusEntWithProduct[] = [];
 		const now = customDateUnix ?? Date.now();
@@ -252,11 +255,13 @@ export class CusEntService {
 			sql`${customerEntitlements.id} COLLATE "C"`,
 		];
 
-		while (true) {
+		// One snapshot per page: the three branch reads run inside a repeatable-read
+		// transaction so a status transition mid-page cannot duplicate or omit a row.
+		const fetchBranches = (client: DrizzleCli) => {
 			// Branch 1: cusEnts with no customer_product. Left-join to
 			// customer_products on a false predicate so the row shape matches
 			// the other branches (customer_products columns come back NULL).
-			const branch1 = db
+			const branch1 = client
 				.select(baseSelect)
 				.from(customerEntitlements)
 				.innerJoin(
@@ -283,7 +288,7 @@ export class CusEntService {
 				.limit(batchSize);
 
 			// Branch 2: cusEnts on active customer_products.
-			const branch2 = db
+			const branch2 = client
 				.select(baseSelect)
 				.from(customerEntitlements)
 				.innerJoin(
@@ -315,7 +320,7 @@ export class CusEntService {
 
 			// Branch 3: cusEnts on past_due customer_products whose product
 			// opted into ignore_past_due via products.config.
-			const branch3 = db
+			const branch3 = client
 				.select(baseSelect)
 				.from(customerEntitlements)
 				.innerJoin(
@@ -350,13 +355,27 @@ export class CusEntService {
 				.orderBy(...orderKey)
 				.limit(batchSize);
 
-			const [rows1, rows2, rows3] = await Promise.all([
-				branch1,
-				branch2,
-				branch3,
-			]);
+			return { branch1, branch2, branch3 };
+		};
 
-			// The three branches are status-disjoint, so a plain merge is dedup-free.
+		const emittedIds = new Set<string>();
+
+		while (true) {
+			const [rows1, rows2, rows3] = await db.transaction(
+				async (transaction) => {
+					const tx = transaction as unknown as DrizzleCli;
+					const { branch1, branch2, branch3 } = fetchBranches(tx);
+					const r1 = await branch1;
+					const r2 = await branch2;
+					const r3 = await branch3;
+					return [r1, r2, r3] as const;
+				},
+				{ isolationLevel: "repeatable read", accessMode: "read only" },
+			);
+
+			// Branches are status-disjoint within the shared snapshot, so the merge
+			// only needs cross-page dedup (a row whose next_reset_at advanced but is
+			// still overdue can reappear past the cursor).
 			const page = [...rows1, ...rows2, ...rows3]
 				.sort((a, b) => {
 					const aReset = Number(a.customer_entitlements.next_reset_at);
@@ -370,7 +389,14 @@ export class CusEntService {
 
 			if (page.length === 0) break;
 
-			const mappedData = page.map((item) => ({
+			const freshRows = page.filter(
+				(item) => !emittedIds.has(item.customer_entitlements.id),
+			);
+			for (const item of freshRows) {
+				emittedIds.add(item.customer_entitlements.id);
+			}
+
+			const mappedData = freshRows.map((item) => ({
 				...item.customer_entitlements,
 				entitlement: {
 					...item.entitlements,
@@ -390,6 +416,8 @@ export class CusEntService {
 				nextResetAt: Number(lastRow.next_reset_at),
 				id: lastRow.id,
 			};
+
+			if (onPageFetched) await onPageFetched(mappedData);
 
 			if (page.length < batchSize) break;
 			if (limit && allResults.length >= limit) break;

--- a/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
@@ -30,7 +30,6 @@ import {
 	or,
 	sql,
 } from "drizzle-orm";
-import { unionAll } from "drizzle-orm/pg-core";
 import { StatusCodes } from "http-status-codes";
 import { buildConflictUpdateColumns } from "@/db/dbUtils.js";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
@@ -190,8 +189,8 @@ export class CusEntService {
 		includeSeparateIntervalResets?: boolean;
 	}) {
 		const allResults: FullCusEntWithProduct[] = [];
-		let offset = 0;
-		let hasMore = true;
+		const now = customDateUnix ?? Date.now();
+		let cursor: { nextResetAt: number; id: string } | null = null;
 
 		// Shared projection across all three UNION ALL branches. Keeping the
 		// column list identical across branches is required for UNION ALL and
@@ -210,12 +209,18 @@ export class CusEntService {
 		const commonResetPredicates = () =>
 			and(
 				sql`${customerEntitlements.expired} IS NOT TRUE`,
-				lt(customerEntitlements.next_reset_at, customDateUnix ?? Date.now()),
+				lt(customerEntitlements.next_reset_at, now),
 				or(
 					isNull(customerEntitlements.expires_at),
-					gt(customerEntitlements.expires_at, customDateUnix ?? Date.now()),
+					gt(customerEntitlements.expires_at, now),
 				),
 			);
+
+		// COLLATE "C" must match the JS merge comparison (code-unit order).
+		const afterCursor = () =>
+			cursor
+				? sql`(${customerEntitlements.next_reset_at}, ${customerEntitlements.id} COLLATE "C") > (${cursor.nextResetAt}, ${cursor.id})`
+				: undefined;
 
 		// Exclude normal price-backed cusEnts: their reset is owned by the Stripe
 		// invoice.created handler, not this cron. Split prepaid reset intervals
@@ -242,7 +247,12 @@ export class CusEntService {
 				? or(eq(customerEntitlements.separate_interval, true), notPriceBacked())
 				: notPriceBacked();
 
-		while (hasMore) {
+		const orderKey = [
+			customerEntitlements.next_reset_at,
+			sql`${customerEntitlements.id} COLLATE "C"`,
+		];
+
+		while (true) {
 			// Branch 1: cusEnts with no customer_product. Left-join to
 			// customer_products on a false predicate so the row shape matches
 			// the other branches (customer_products columns come back NULL).
@@ -266,8 +276,11 @@ export class CusEntService {
 					and(
 						isNull(customerEntitlements.customer_product_id),
 						commonResetPredicates(),
+						afterCursor(),
 					),
-				);
+				)
+				.orderBy(...orderKey)
+				.limit(batchSize);
 
 			// Branch 2: cusEnts on active customer_products.
 			const branch2 = db
@@ -294,8 +307,11 @@ export class CusEntService {
 						eq(customerProducts.status, CusProductStatus.Active),
 						commonResetPredicates(),
 						resetOwnedByAutumn(),
+						afterCursor(),
 					),
-				);
+				)
+				.orderBy(...orderKey)
+				.limit(batchSize);
 
 			// Branch 3: cusEnts on past_due customer_products whose product
 			// opted into ignore_past_due via products.config.
@@ -328,37 +344,55 @@ export class CusEntService {
 						sql`(${products.config}->>'ignore_past_due')::boolean = true`,
 						commonResetPredicates(),
 						resetOwnedByAutumn(),
+						afterCursor(),
 					),
-				);
+				)
+				.orderBy(...orderKey)
+				.limit(batchSize);
 
-			const data = await unionAll(branch1, branch2, branch3)
-				.limit(batchSize)
-				.offset(offset);
+			const [rows1, rows2, rows3] = await Promise.all([
+				branch1,
+				branch2,
+				branch3,
+			]);
 
-			// Note: PlanetScale tag would be added here but Drizzle 0.43.1's unionAll
-			// doesn't support .comment() method. Tag will be added after Drizzle upgrade.
-			// Target tag: planetScaleTag({ query: "getActiveResetPassed" })
+			// The three branches are status-disjoint, so a plain merge is dedup-free.
+			const page = [...rows1, ...rows2, ...rows3]
+				.sort((a, b) => {
+					const aReset = Number(a.customer_entitlements.next_reset_at);
+					const bReset = Number(b.customer_entitlements.next_reset_at);
+					if (aReset !== bReset) return aReset - bReset;
+					const aId = a.customer_entitlements.id;
+					const bId = b.customer_entitlements.id;
+					return aId < bId ? -1 : aId > bId ? 1 : 0;
+				})
+				.slice(0, batchSize);
 
-			if (data.length === 0 || (limit && allResults.length >= limit)) {
-				hasMore = false;
-			} else {
-				const mappedData = data.map((item) => ({
-					...item.customer_entitlements,
-					entitlement: {
-						...item.entitlements,
-						feature: item.features,
-					},
-					customer_product: item.customer_products,
-					customer: item.customers,
-					replaceables: [],
-					rollovers: [],
-				})) as ResetCusEnt[];
+			if (page.length === 0) break;
 
-				allResults.push(...mappedData);
-				offset += batchSize;
-				hasMore = data.length === batchSize;
-				console.log(`Fetched ${allResults.length} entitlements to reset`);
-			}
+			const mappedData = page.map((item) => ({
+				...item.customer_entitlements,
+				entitlement: {
+					...item.entitlements,
+					feature: item.features,
+				},
+				customer_product: item.customer_products,
+				customer: item.customers,
+				replaceables: [],
+				rollovers: [],
+			})) as ResetCusEnt[];
+
+			allResults.push(...mappedData);
+			console.log(`Fetched ${allResults.length} entitlements to reset`);
+
+			const lastRow = page[page.length - 1].customer_entitlements;
+			cursor = {
+				nextResetAt: Number(lastRow.next_reset_at),
+				id: lastRow.id,
+			};
+
+			if (page.length < batchSize) break;
+			if (limit && allResults.length >= limit) break;
 		}
 
 		return allResults as ResetCusEnt[];

--- a/server/tests/balances/cron/reset-keyset-pagination.test.ts
+++ b/server/tests/balances/cron/reset-keyset-pagination.test.ts
@@ -4,6 +4,7 @@ import {
 	CusProductStatus,
 	customerEntitlements,
 	customerProducts,
+	customers,
 	type LimitedItem,
 	ProductItemInterval,
 	type ProductV2,
@@ -12,7 +13,7 @@ import {
 import { TestFeature } from "@tests/setup/v2Features.js";
 import ctx from "@tests/utils/testInitUtils/createTestContext.js";
 import chalk from "chalk";
-import { eq, lt } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
 import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
@@ -25,11 +26,25 @@ const CUTOFF = 10_000_000;
 
 const autumnV1 = new AutumnInt({ version: ApiVersion.V1_2 });
 
-beforeAll(async () => {
-	await ctx.db
-		.delete(customerEntitlements)
-		.where(lt(customerEntitlements.next_reset_at, CUTOFF));
-});
+const cleanupCustomers = async (customerIds: string[]) => {
+	const rows = await ctx.db
+		.select({ internal_id: customers.internal_id })
+		.from(customers)
+		.where(
+			and(
+				eq(customers.org_id, ctx.org.id),
+				eq(customers.env, ctx.env),
+				inArray(customers.id, customerIds),
+			),
+		);
+	if (rows.length === 0) return;
+	await ctx.db.delete(customerEntitlements).where(
+		inArray(
+			customerEntitlements.internal_customer_id,
+			rows.map((r) => r.internal_id),
+		),
+	);
+};
 
 const setResetAt = async (cusEntId: string, nextResetAt: number) => {
 	await ctx.db
@@ -118,165 +133,212 @@ const fetchAll = (opts?: { batchSize?: number; limit?: number }) =>
 	});
 
 describe(`${chalk.yellowBright("reset-keyset-pagination: single-statement page shape")}`, () => {
-	test("a page is one SQL statement: union of 3 branches, ordered, no offset", () => {
-		const query = CusEntService.buildActiveResetPassedPage({
-			db: ctx.db,
-			now: CUTOFF,
-			batchSize: 5,
-			cursor: { nextResetAt: 1, id: "cus_ent_x" },
-			includeSeparateIntervalResets: false,
-		});
-		const text = query.toSQL().sql.toLowerCase();
+	test.concurrent(
+		"a page is one SQL statement: union of 3 branches, ordered, no offset",
+		() => {
+			const query = CusEntService.buildActiveResetPassedPage({
+				db: ctx.db,
+				now: CUTOFF,
+				batchSize: 5,
+				cursor: { nextResetAt: 1, id: "cus_ent_x" },
+				includeSeparateIntervalResets: false,
+			});
+			const text = query.toSQL().sql.toLowerCase();
 
-		expect((text.match(/union all/g) ?? []).length).toBe(2);
-		expect(text).toContain('order by "sort_reset", "sort_id"');
-		expect(text).toContain("limit");
-		expect(text).not.toContain("offset");
-	});
+			expect((text.match(/union all/g) ?? []).length).toBe(2);
+			expect(text).toContain('order by "sort_reset", "sort_id"');
+			expect(text).toContain("limit");
+			expect(text).not.toContain("offset");
+		},
+	);
 });
 
 describe(`${chalk.yellowBright("reset-keyset-pagination: exactly-once, ordering, branch merge, ties")}`, () => {
-	const BASE = 1_000_000;
-	const TIE = 2_000_000;
+	const BAND = 1_000_000;
+	const TIE = 1_050_000;
+	const distinctCustomers = Array.from({ length: 5 }, (_, i) => `kpg2-d-${i}`);
+	const tieCustomers = Array.from({ length: 4 }, (_, i) => `kpg2-t-${i}`);
+	const ownCustomers = [
+		...distinctCustomers,
+		...tieCustomers,
+		"kpg2-act",
+		"kpg2-pd",
+	];
+	const legacyCustomers = [
+		...Array.from({ length: 8 }, (_, i) => `keyset-pg-${i}`),
+		...Array.from({ length: 4 }, (_, i) => `keyset-tie-${i}`),
+		"keyset-br-active",
+		"keyset-br-pd",
+	];
 	const seededDistinct: string[] = [];
 	const seededTies: string[] = [];
 	let activeId: string;
 	let pastDueId: string;
 
 	beforeAll(async () => {
-		for (let i = 0; i < 5; i++) {
+		await cleanupCustomers([...ownCustomers, ...legacyCustomers]);
+
+		for (const [i, customerId] of distinctCustomers.entries()) {
 			seededDistinct.push(
-				await seedLooseCusEnt({
-					customerId: `keyset-pg-${i}`,
-					nextResetAt: BASE + i,
-				}),
+				await seedLooseCusEnt({ customerId, nextResetAt: BAND + i }),
 			);
 		}
-		for (let i = 0; i < 4; i++) {
-			seededTies.push(
-				await seedLooseCusEnt({
-					customerId: `keyset-tie-${i}`,
-					nextResetAt: TIE,
-				}),
-			);
+		for (const customerId of tieCustomers) {
+			seededTies.push(await seedLooseCusEnt({ customerId, nextResetAt: TIE }));
 		}
 		activeId = await seedProductCusEnt({
-			customerId: "keyset-br-active",
-			nextResetAt: BASE + 100,
+			customerId: "kpg2-act",
+			nextResetAt: BAND + 100,
 			productStatus: CusProductStatus.Active,
 			ignorePastDue: false,
 		});
 		pastDueId = await seedProductCusEnt({
-			customerId: "keyset-br-pd",
-			nextResetAt: BASE + 101,
+			customerId: "kpg2-pd",
+			nextResetAt: BAND + 101,
 			productStatus: CusProductStatus.PastDue,
 			ignorePastDue: true,
 		});
 	});
 
-	test("multi-page fetch returns exactly the seeded candidates, every branch, exactly once", async () => {
-		const results = await fetchAll();
+	test.concurrent(
+		"multi-page fetch returns every seeded candidate exactly once, in (next_reset_at, id) order",
+		async () => {
+			const results = await fetchAll();
 
-		const expected = [
-			...seededDistinct,
-			activeId,
-			pastDueId,
-			...[...seededTies].sort(),
-		];
+			const allSeeded = [...seededDistinct, activeId, pastDueId, ...seededTies];
+			const returnedSeeded = results
+				.map((ce) => ce.id)
+				.filter((id) => allSeeded.includes(id));
 
-		expect(results.map((ce) => ce.id)).toEqual(expected);
+			expect(new Set(returnedSeeded).size).toBe(allSeeded.length);
 
-		const activeRow = results.find((ce) => ce.id === activeId);
-		const pastDueRow = results.find((ce) => ce.id === pastDueId);
-		expect(activeRow?.customer_product?.status).toBe(CusProductStatus.Active);
-		expect(pastDueRow?.customer_product?.status).toBe(CusProductStatus.PastDue);
+			const expectedOrder = [
+				...seededDistinct,
+				activeId,
+				pastDueId,
+				...[...seededTies].sort(),
+			];
+			expect(returnedSeeded).toEqual(expectedOrder);
+
+			const activeRow = results.find((ce) => ce.id === activeId);
+			const pastDueRow = results.find((ce) => ce.id === pastDueId);
+			expect(activeRow?.customer_product?.status).toBe(CusProductStatus.Active);
+			expect(pastDueRow?.customer_product?.status).toBe(
+				CusProductStatus.PastDue,
+			);
+		},
+	);
+});
+
+describe(`${chalk.yellowBright("reset-keyset-pagination: limit semantics")}`, () => {
+	const BAND = 1_500_000;
+	const ownCustomers = Array.from({ length: 7 }, (_, i) => `klim-${i}`);
+
+	beforeAll(async () => {
+		await cleanupCustomers(ownCustomers);
+		for (const [i, customerId] of ownCustomers.entries()) {
+			await seedLooseCusEnt({ customerId, nextResetAt: BAND + i });
+		}
 	});
 
-	test("limit stops fetching at the page boundary", async () => {
+	test.concurrent("limit stops fetching at the page boundary", async () => {
 		const results = await fetchAll({ batchSize: 3, limit: 4 });
 		expect(results.length).toBe(6);
 	});
 });
 
-describe(`${chalk.yellowBright("reset-keyset-pagination: mid-pagination mutations")}`, () => {
-	const A_BASE = 500_000;
-	const B_BASE = 700_000;
-	const seededA: string[] = [];
-	const seededB: string[] = [];
+describe(`${chalk.yellowBright("reset-keyset-pagination: shrink + re-qualify mutations")}`, () => {
+	const BAND = 2_000_000;
+	const ownCustomers = Array.from({ length: 6 }, (_, i) => `kmta-${i}`);
+	const legacyCustomers = [
+		...Array.from({ length: 6 }, (_, i) => `keyset-mut-${i}`),
+		...Array.from({ length: 6 }, (_, i) => `keyset-mut-a-${i}`),
+	];
+	const seeded: string[] = [];
 
 	beforeAll(async () => {
-		for (let i = 0; i < 6; i++) {
-			seededA.push(
-				await seedLooseCusEnt({
-					customerId: `keyset-mut-a-${i}`,
-					nextResetAt: A_BASE + i,
-				}),
-			);
-		}
-		for (let i = 0; i < 6; i++) {
-			seededB.push(
-				await seedLooseCusEnt({
-					customerId: `keyset-mut-b-${i}`,
-					nextResetAt: B_BASE + i,
-				}),
-			);
+		await cleanupCustomers([...ownCustomers, ...legacyCustomers]);
+		for (const [i, customerId] of ownCustomers.entries()) {
+			seeded.push(await seedLooseCusEnt({ customerId, nextResetAt: BAND + i }));
 		}
 	});
 
-	test("shrinking result set does not skip unread rows; re-qualifying emitted row is not duplicated", async () => {
-		let mutated = false;
+	test.concurrent(
+		"a row leaving the predicate mid-run does not skip unread rows; a re-qualifying emitted row is not duplicated",
+		async () => {
+			let mutated = false;
 
-		const results = await CusEntService.getActiveResetPassed({
-			db: ctx.db,
-			customDateUnix: CUTOFF,
-			batchSize: 2,
-			limit: 1_000_000,
-			onPageFetched: async (page) => {
-				if (mutated) return;
-				mutated = true;
+			const results = await CusEntService.getActiveResetPassed({
+				db: ctx.db,
+				customDateUnix: CUTOFF,
+				batchSize: 2,
+				limit: 1_000_000,
+				onPageFetched: async (page) => {
+					if (mutated) return;
+					if (!page.some((ce) => ce.id === seeded[0])) return;
+					mutated = true;
 
-				expect(page.map((ce) => ce.id)).toEqual([seededA[0], seededA[1]]);
+					await setResetAt(seeded[0], CUTOFF + 1_000_000);
+					await setResetAt(seeded[1], BAND + 5_000);
+				},
+			});
 
-				await setResetAt(seededA[0], CUTOFF + 1_000_000);
-				await setResetAt(seededA[1], 600_000);
-			},
-		});
+			expect(mutated).toBe(true);
 
-		expect(mutated).toBe(true);
+			const returnedSeeded = results
+				.map((ce) => ce.id)
+				.filter((id) => seeded.includes(id));
 
-		const returnedA = results
-			.map((ce) => ce.id)
-			.filter((id) => seededA.includes(id));
+			expect(new Set(returnedSeeded).size).toBe(returnedSeeded.length);
+			expect([...returnedSeeded].sort()).toEqual([...seeded].sort());
+		},
+	);
+});
 
-		expect(new Set(returnedA).size).toBe(returnedA.length);
-		expect([...returnedA].sort()).toEqual([...seededA].sort());
+describe(`${chalk.yellowBright("reset-keyset-pagination: backward cursor movement")}`, () => {
+	const BAND = 2_500_000;
+	const ownCustomers = Array.from({ length: 6 }, (_, i) => `kmtb-${i}`);
+	const legacyCustomers = Array.from(
+		{ length: 6 },
+		(_, i) => `keyset-mut-b-${i}`,
+	);
+	const seeded: string[] = [];
+
+	beforeAll(async () => {
+		await cleanupCustomers([...ownCustomers, ...legacyCustomers]);
+		for (const [i, customerId] of ownCustomers.entries()) {
+			seeded.push(await seedLooseCusEnt({ customerId, nextResetAt: BAND + i }));
+		}
 	});
 
-	test("a row moved backward behind the cursor is deferred to the next scan, then recovered", async () => {
-		let mutated = false;
+	test.concurrent(
+		"a row moved backward behind the cursor is deferred to the next scan, then recovered",
+		async () => {
+			let mutated = false;
 
-		const firstRun = await CusEntService.getActiveResetPassed({
-			db: ctx.db,
-			customDateUnix: CUTOFF,
-			batchSize: 2,
-			limit: 1_000_000,
-			onPageFetched: async (page) => {
-				if (mutated) return;
-				if (!page.some((ce) => ce.id === seededB[0])) return;
-				mutated = true;
-				await setResetAt(seededB[4], 400_000);
-			},
-		});
+			const firstRun = await CusEntService.getActiveResetPassed({
+				db: ctx.db,
+				customDateUnix: CUTOFF,
+				batchSize: 2,
+				limit: 1_000_000,
+				onPageFetched: async (page) => {
+					if (mutated) return;
+					if (!page.some((ce) => ce.id === seeded[0])) return;
+					mutated = true;
+					await setResetAt(seeded[4], BAND - 100);
+				},
+			});
 
-		expect(mutated).toBe(true);
+			expect(mutated).toBe(true);
 
-		const firstRunB = firstRun
-			.map((ce) => ce.id)
-			.filter((id) => seededB.includes(id));
-		expect(firstRunB).not.toContain(seededB[4]);
-		expect(firstRunB.length).toBe(seededB.length - 1);
+			const firstRunSeeded = firstRun
+				.map((ce) => ce.id)
+				.filter((id) => seeded.includes(id));
+			expect(firstRunSeeded).not.toContain(seeded[4]);
+			expect(firstRunSeeded.length).toBe(seeded.length - 1);
 
-		const secondRun = await fetchAll({ batchSize: 2 });
-		expect(secondRun.map((ce) => ce.id)).toContain(seededB[4]);
-	});
+			const secondRun = await fetchAll({ batchSize: 2 });
+			expect(secondRun.map((ce) => ce.id)).toContain(seeded[4]);
+		},
+	);
 });

--- a/server/tests/balances/cron/reset-keyset-pagination.test.ts
+++ b/server/tests/balances/cron/reset-keyset-pagination.test.ts
@@ -1,0 +1,95 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import {
+	ApiVersion,
+	customerEntitlements,
+	ResetInterval,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
+import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
+import { findCustomerEntitlement } from "../utils/findCustomerEntitlement";
+
+describe(`${chalk.yellowBright("reset-keyset-pagination: getActiveResetPassed pages deterministically")}`, () => {
+	const autumnV1 = new AutumnInt({ version: ApiVersion.V1_2 });
+	const customerIds = Array.from({ length: 8 }, (_, i) => `keyset-pg-${i}`);
+	const seededCusEntIds: string[] = [];
+
+	beforeAll(async () => {
+		const now = Date.now();
+
+		for (const [i, customerId] of customerIds.entries()) {
+			await initCustomerV3({ ctx, customerId, withTestClock: false });
+
+			await autumnV1.balances.create({
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				granted_balance: 100,
+				reset: { interval: ResetInterval.Month },
+			});
+
+			const cusEnt = await findCustomerEntitlement({
+				ctx,
+				customerId,
+				featureId: TestFeature.Messages,
+			});
+			expect(cusEnt).toBeDefined();
+
+			await ctx.db
+				.update(customerEntitlements)
+				.set({ next_reset_at: now - 60_000 - i * 1000 })
+				.where(eq(customerEntitlements.id, cusEnt!.id));
+
+			seededCusEntIds.push(cusEnt!.id);
+		}
+	});
+
+	test("multi-page fetch returns every due candidate exactly once", async () => {
+		const results = await CusEntService.getActiveResetPassed({
+			db: ctx.db,
+			batchSize: 3,
+			limit: 100_000,
+		});
+
+		const returnedSeeded = results
+			.map((ce) => ce.id)
+			.filter((id) => seededCusEntIds.includes(id));
+
+		expect(returnedSeeded.length).toBe(seededCusEntIds.length);
+		expect(new Set(returnedSeeded).size).toBe(seededCusEntIds.length);
+	});
+
+	test("results are ordered by (next_reset_at, id) across pages", async () => {
+		const results = await CusEntService.getActiveResetPassed({
+			db: ctx.db,
+			batchSize: 3,
+			limit: 100_000,
+		});
+
+		expect(results.length).toBeGreaterThanOrEqual(seededCusEntIds.length);
+
+		for (let i = 1; i < results.length; i++) {
+			const prev = results[i - 1];
+			const curr = results[i];
+			const prevKey = Number(prev.next_reset_at);
+			const currKey = Number(curr.next_reset_at);
+			const ordered =
+				prevKey < currKey || (prevKey === currKey && prev.id <= curr.id);
+			expect(ordered).toBe(true);
+		}
+	});
+
+	test("limit stops fetching at the page boundary", async () => {
+		const results = await CusEntService.getActiveResetPassed({
+			db: ctx.db,
+			batchSize: 3,
+			limit: 4,
+		});
+
+		expect(results.length).toBeGreaterThanOrEqual(4);
+		expect(results.length).toBeLessThanOrEqual(6);
+	});
+});

--- a/server/tests/balances/cron/reset-keyset-pagination.test.ts
+++ b/server/tests/balances/cron/reset-keyset-pagination.test.ts
@@ -1,7 +1,12 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import {
 	ApiVersion,
+	CusProductStatus,
 	customerEntitlements,
+	customerProducts,
+	type LimitedItem,
+	ProductItemInterval,
+	type ProductV2,
 	ResetInterval,
 } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
@@ -10,66 +15,157 @@ import chalk from "chalk";
 import { eq } from "drizzle-orm";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
+import { constructProduct } from "@/utils/scriptUtils/createTestProducts.js";
 import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
+import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
 import { findCustomerEntitlement } from "../utils/findCustomerEntitlement";
 
-describe(`${chalk.yellowBright("reset-keyset-pagination: getActiveResetPassed pages deterministically")}`, () => {
-	const autumnV1 = new AutumnInt({ version: ApiVersion.V1_2 });
-	const customerIds = Array.from({ length: 8 }, (_, i) => `keyset-pg-${i}`);
-	const seededCusEntIds: string[] = [];
+const autumnV1 = new AutumnInt({ version: ApiVersion.V1_2 });
+
+const seedLooseCusEnt = async ({
+	customerId,
+	nextResetAt,
+}: {
+	customerId: string;
+	nextResetAt: number;
+}) => {
+	await initCustomerV3({ ctx, customerId, withTestClock: false });
+	await autumnV1.balances.create({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		granted_balance: 100,
+		reset: { interval: ResetInterval.Month },
+	});
+	const cusEnt = await findCustomerEntitlement({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+	expect(cusEnt).toBeDefined();
+	await ctx.db
+		.update(customerEntitlements)
+		.set({ next_reset_at: nextResetAt })
+		.where(eq(customerEntitlements.id, cusEnt!.id));
+	return cusEnt!.id;
+};
+
+const seedProductCusEnt = async ({
+	customerId,
+	nextResetAt,
+	productStatus,
+	ignorePastDue,
+}: {
+	customerId: string;
+	nextResetAt: number;
+	productStatus: CusProductStatus;
+	ignorePastDue: boolean;
+}) => {
+	const item = constructFeatureItem({
+		featureId: TestFeature.Messages,
+		includedUsage: 100,
+		interval: ProductItemInterval.Month,
+	}) as LimitedItem;
+	const product = constructProduct({
+		items: [item],
+		type: "free",
+		isDefault: false,
+	}) as ProductV2;
+	product.config = { ignore_past_due: ignorePastDue };
+
+	await initProductsV0({
+		ctx,
+		products: [product],
+		prefix: customerId,
+		customerId,
+	});
+	await initCustomerV3({ ctx, customerId, withTestClock: false });
+	await autumnV1.attach({ customer_id: customerId, product_id: product.id });
+
+	const cusEnt = await findCustomerEntitlement({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+	expect(cusEnt?.customer_product_id).toBeDefined();
+
+	await ctx.db
+		.update(customerEntitlements)
+		.set({ next_reset_at: nextResetAt })
+		.where(eq(customerEntitlements.id, cusEnt!.id));
+	await ctx.db
+		.update(customerProducts)
+		.set({ status: productStatus })
+		.where(eq(customerProducts.id, cusEnt!.customer_product_id!));
+	return cusEnt!.id;
+};
+
+describe(`${chalk.yellowBright("reset-keyset-pagination: exactly-once, ordering, branch merge, ties")}`, () => {
+	const BASE = 1_000_000;
+	const TIE = 2_000_000;
+	const seededDistinct: string[] = [];
+	const seededTies: string[] = [];
+	let activeId: string;
+	let pastDueId: string;
 
 	beforeAll(async () => {
-		const now = Date.now();
-
-		for (const [i, customerId] of customerIds.entries()) {
-			await initCustomerV3({ ctx, customerId, withTestClock: false });
-
-			await autumnV1.balances.create({
-				customer_id: customerId,
-				feature_id: TestFeature.Messages,
-				granted_balance: 100,
-				reset: { interval: ResetInterval.Month },
-			});
-
-			const cusEnt = await findCustomerEntitlement({
-				ctx,
-				customerId,
-				featureId: TestFeature.Messages,
-			});
-			expect(cusEnt).toBeDefined();
-
-			await ctx.db
-				.update(customerEntitlements)
-				.set({ next_reset_at: now - 60_000 - i * 1000 })
-				.where(eq(customerEntitlements.id, cusEnt!.id));
-
-			seededCusEntIds.push(cusEnt!.id);
+		for (let i = 0; i < 5; i++) {
+			seededDistinct.push(
+				await seedLooseCusEnt({
+					customerId: `keyset-pg-${i}`,
+					nextResetAt: BASE + i,
+				}),
+			);
 		}
+		for (let i = 0; i < 4; i++) {
+			seededTies.push(
+				await seedLooseCusEnt({
+					customerId: `keyset-tie-${i}`,
+					nextResetAt: TIE,
+				}),
+			);
+		}
+		activeId = await seedProductCusEnt({
+			customerId: "keyset-br-active",
+			nextResetAt: BASE + 100,
+			productStatus: CusProductStatus.Active,
+			ignorePastDue: false,
+		});
+		pastDueId = await seedProductCusEnt({
+			customerId: "keyset-br-pd",
+			nextResetAt: BASE + 101,
+			productStatus: CusProductStatus.PastDue,
+			ignorePastDue: true,
+		});
 	});
 
-	test("multi-page fetch returns every due candidate exactly once", async () => {
+	test("multi-page fetch returns every branch's candidates exactly once, incl. equal-timestamp pages", async () => {
 		const results = await CusEntService.getActiveResetPassed({
 			db: ctx.db,
 			batchSize: 3,
-			limit: 100_000,
+			limit: 1_000_000,
 		});
 
+		const allSeeded = [...seededDistinct, ...seededTies, activeId, pastDueId];
 		const returnedSeeded = results
 			.map((ce) => ce.id)
-			.filter((id) => seededCusEntIds.includes(id));
+			.filter((id) => allSeeded.includes(id));
 
-		expect(returnedSeeded.length).toBe(seededCusEntIds.length);
-		expect(new Set(returnedSeeded).size).toBe(seededCusEntIds.length);
+		expect(returnedSeeded.length).toBe(allSeeded.length);
+		expect(new Set(returnedSeeded).size).toBe(allSeeded.length);
+
+		const activeRow = results.find((ce) => ce.id === activeId);
+		const pastDueRow = results.find((ce) => ce.id === pastDueId);
+		expect(activeRow?.customer_product?.status).toBe(CusProductStatus.Active);
+		expect(pastDueRow?.customer_product?.status).toBe(CusProductStatus.PastDue);
 	});
 
 	test("results are ordered by (next_reset_at, id) across pages", async () => {
 		const results = await CusEntService.getActiveResetPassed({
 			db: ctx.db,
 			batchSize: 3,
-			limit: 100_000,
+			limit: 1_000_000,
 		});
-
-		expect(results.length).toBeGreaterThanOrEqual(seededCusEntIds.length);
 
 		for (let i = 1; i < results.length; i++) {
 			const prev = results[i - 1];
@@ -91,5 +187,58 @@ describe(`${chalk.yellowBright("reset-keyset-pagination: getActiveResetPassed pa
 
 		expect(results.length).toBeGreaterThanOrEqual(4);
 		expect(results.length).toBeLessThanOrEqual(6);
+	});
+});
+
+describe(`${chalk.yellowBright("reset-keyset-pagination: mid-pagination mutations")}`, () => {
+	const MUT_BASE = 500_000;
+	const seeded: string[] = [];
+
+	beforeAll(async () => {
+		for (let i = 0; i < 6; i++) {
+			seeded.push(
+				await seedLooseCusEnt({
+					customerId: `keyset-mut-${i}`,
+					nextResetAt: MUT_BASE + i,
+				}),
+			);
+		}
+	});
+
+	test("a re-qualifying emitted row is not duplicated; a concurrently-reset row is skipped", async () => {
+		let mutated = false;
+
+		const results = await CusEntService.getActiveResetPassed({
+			db: ctx.db,
+			batchSize: 2,
+			limit: 1_000_000,
+			onPageFetched: async (page) => {
+				if (mutated) return;
+				const emittedSeeded = page.find((ce) => seeded.includes(ce.id));
+				if (!emittedSeeded) return;
+				mutated = true;
+
+				await ctx.db
+					.update(customerEntitlements)
+					.set({ next_reset_at: MUT_BASE + 5000 })
+					.where(eq(customerEntitlements.id, emittedSeeded.id));
+
+				const unemitted = seeded.find((id) => !page.some((ce) => ce.id === id));
+				expect(unemitted).toBeDefined();
+				await ctx.db
+					.update(customerEntitlements)
+					.set({ next_reset_at: Date.now() + 86_400_000 })
+					.where(eq(customerEntitlements.id, unemitted!));
+			},
+		});
+
+		expect(mutated).toBe(true);
+
+		const returnedSeeded = results
+			.map((ce) => ce.id)
+			.filter((id) => seeded.includes(id));
+
+		expect(new Set(returnedSeeded).size).toBe(returnedSeeded.length);
+		expect(returnedSeeded.length).toBe(seeded.length - 1);
 	});
 });

--- a/server/tests/balances/cron/reset-keyset-pagination.test.ts
+++ b/server/tests/balances/cron/reset-keyset-pagination.test.ts
@@ -12,7 +12,7 @@ import {
 import { TestFeature } from "@tests/setup/v2Features.js";
 import ctx from "@tests/utils/testInitUtils/createTestContext.js";
 import chalk from "chalk";
-import { eq } from "drizzle-orm";
+import { eq, lt } from "drizzle-orm";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
 import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
@@ -21,7 +21,22 @@ import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js"
 import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
 import { findCustomerEntitlement } from "../utils/findCustomerEntitlement";
 
+const CUTOFF = 10_000_000;
+
 const autumnV1 = new AutumnInt({ version: ApiVersion.V1_2 });
+
+beforeAll(async () => {
+	await ctx.db
+		.delete(customerEntitlements)
+		.where(lt(customerEntitlements.next_reset_at, CUTOFF));
+});
+
+const setResetAt = async (cusEntId: string, nextResetAt: number) => {
+	await ctx.db
+		.update(customerEntitlements)
+		.set({ next_reset_at: nextResetAt })
+		.where(eq(customerEntitlements.id, cusEntId));
+};
 
 const seedLooseCusEnt = async ({
 	customerId,
@@ -43,10 +58,7 @@ const seedLooseCusEnt = async ({
 		featureId: TestFeature.Messages,
 	});
 	expect(cusEnt).toBeDefined();
-	await ctx.db
-		.update(customerEntitlements)
-		.set({ next_reset_at: nextResetAt })
-		.where(eq(customerEntitlements.id, cusEnt!.id));
+	await setResetAt(cusEnt!.id, nextResetAt);
 	return cusEnt!.id;
 };
 
@@ -89,16 +101,39 @@ const seedProductCusEnt = async ({
 	});
 	expect(cusEnt?.customer_product_id).toBeDefined();
 
-	await ctx.db
-		.update(customerEntitlements)
-		.set({ next_reset_at: nextResetAt })
-		.where(eq(customerEntitlements.id, cusEnt!.id));
+	await setResetAt(cusEnt!.id, nextResetAt);
 	await ctx.db
 		.update(customerProducts)
 		.set({ status: productStatus })
 		.where(eq(customerProducts.id, cusEnt!.customer_product_id!));
 	return cusEnt!.id;
 };
+
+const fetchAll = (opts?: { batchSize?: number; limit?: number }) =>
+	CusEntService.getActiveResetPassed({
+		db: ctx.db,
+		customDateUnix: CUTOFF,
+		batchSize: opts?.batchSize ?? 3,
+		limit: opts?.limit ?? 1_000_000,
+	});
+
+describe(`${chalk.yellowBright("reset-keyset-pagination: single-statement page shape")}`, () => {
+	test("a page is one SQL statement: union of 3 branches, ordered, no offset", () => {
+		const query = CusEntService.buildActiveResetPassedPage({
+			db: ctx.db,
+			now: CUTOFF,
+			batchSize: 5,
+			cursor: { nextResetAt: 1, id: "cus_ent_x" },
+			includeSeparateIntervalResets: false,
+		});
+		const text = query.toSQL().sql.toLowerCase();
+
+		expect((text.match(/union all/g) ?? []).length).toBe(2);
+		expect(text).toContain('order by "sort_reset", "sort_id"');
+		expect(text).toContain("limit");
+		expect(text).not.toContain("offset");
+	});
+});
 
 describe(`${chalk.yellowBright("reset-keyset-pagination: exactly-once, ordering, branch merge, ties")}`, () => {
 	const BASE = 1_000_000;
@@ -139,20 +174,17 @@ describe(`${chalk.yellowBright("reset-keyset-pagination: exactly-once, ordering,
 		});
 	});
 
-	test("multi-page fetch returns every branch's candidates exactly once, incl. equal-timestamp pages", async () => {
-		const results = await CusEntService.getActiveResetPassed({
-			db: ctx.db,
-			batchSize: 3,
-			limit: 1_000_000,
-		});
+	test("multi-page fetch returns exactly the seeded candidates, every branch, exactly once", async () => {
+		const results = await fetchAll();
 
-		const allSeeded = [...seededDistinct, ...seededTies, activeId, pastDueId];
-		const returnedSeeded = results
-			.map((ce) => ce.id)
-			.filter((id) => allSeeded.includes(id));
+		const expected = [
+			...seededDistinct,
+			activeId,
+			pastDueId,
+			...[...seededTies].sort(),
+		];
 
-		expect(returnedSeeded.length).toBe(allSeeded.length);
-		expect(new Set(returnedSeeded).size).toBe(allSeeded.length);
+		expect(results.map((ce) => ce.id)).toEqual(expected);
 
 		const activeRow = results.find((ce) => ce.id === activeId);
 		const pastDueRow = results.find((ce) => ce.id === pastDueId);
@@ -160,85 +192,91 @@ describe(`${chalk.yellowBright("reset-keyset-pagination: exactly-once, ordering,
 		expect(pastDueRow?.customer_product?.status).toBe(CusProductStatus.PastDue);
 	});
 
-	test("results are ordered by (next_reset_at, id) across pages", async () => {
-		const results = await CusEntService.getActiveResetPassed({
-			db: ctx.db,
-			batchSize: 3,
-			limit: 1_000_000,
-		});
-
-		for (let i = 1; i < results.length; i++) {
-			const prev = results[i - 1];
-			const curr = results[i];
-			const prevKey = Number(prev.next_reset_at);
-			const currKey = Number(curr.next_reset_at);
-			const ordered =
-				prevKey < currKey || (prevKey === currKey && prev.id <= curr.id);
-			expect(ordered).toBe(true);
-		}
-	});
-
 	test("limit stops fetching at the page boundary", async () => {
-		const results = await CusEntService.getActiveResetPassed({
-			db: ctx.db,
-			batchSize: 3,
-			limit: 4,
-		});
-
-		expect(results.length).toBeGreaterThanOrEqual(4);
-		expect(results.length).toBeLessThanOrEqual(6);
+		const results = await fetchAll({ batchSize: 3, limit: 4 });
+		expect(results.length).toBe(6);
 	});
 });
 
 describe(`${chalk.yellowBright("reset-keyset-pagination: mid-pagination mutations")}`, () => {
-	const MUT_BASE = 500_000;
-	const seeded: string[] = [];
+	const A_BASE = 500_000;
+	const B_BASE = 700_000;
+	const seededA: string[] = [];
+	const seededB: string[] = [];
 
 	beforeAll(async () => {
 		for (let i = 0; i < 6; i++) {
-			seeded.push(
+			seededA.push(
 				await seedLooseCusEnt({
-					customerId: `keyset-mut-${i}`,
-					nextResetAt: MUT_BASE + i,
+					customerId: `keyset-mut-a-${i}`,
+					nextResetAt: A_BASE + i,
+				}),
+			);
+		}
+		for (let i = 0; i < 6; i++) {
+			seededB.push(
+				await seedLooseCusEnt({
+					customerId: `keyset-mut-b-${i}`,
+					nextResetAt: B_BASE + i,
 				}),
 			);
 		}
 	});
 
-	test("a re-qualifying emitted row is not duplicated; a concurrently-reset row is skipped", async () => {
+	test("shrinking result set does not skip unread rows; re-qualifying emitted row is not duplicated", async () => {
 		let mutated = false;
 
 		const results = await CusEntService.getActiveResetPassed({
 			db: ctx.db,
+			customDateUnix: CUTOFF,
 			batchSize: 2,
 			limit: 1_000_000,
 			onPageFetched: async (page) => {
 				if (mutated) return;
-				const emittedSeeded = page.find((ce) => seeded.includes(ce.id));
-				if (!emittedSeeded) return;
 				mutated = true;
 
-				await ctx.db
-					.update(customerEntitlements)
-					.set({ next_reset_at: MUT_BASE + 5000 })
-					.where(eq(customerEntitlements.id, emittedSeeded.id));
+				expect(page.map((ce) => ce.id)).toEqual([seededA[0], seededA[1]]);
 
-				const unemitted = seeded.find((id) => !page.some((ce) => ce.id === id));
-				expect(unemitted).toBeDefined();
-				await ctx.db
-					.update(customerEntitlements)
-					.set({ next_reset_at: Date.now() + 86_400_000 })
-					.where(eq(customerEntitlements.id, unemitted!));
+				await setResetAt(seededA[0], CUTOFF + 1_000_000);
+				await setResetAt(seededA[1], 600_000);
 			},
 		});
 
 		expect(mutated).toBe(true);
 
-		const returnedSeeded = results
+		const returnedA = results
 			.map((ce) => ce.id)
-			.filter((id) => seeded.includes(id));
+			.filter((id) => seededA.includes(id));
 
-		expect(new Set(returnedSeeded).size).toBe(returnedSeeded.length);
-		expect(returnedSeeded.length).toBe(seeded.length - 1);
+		expect(new Set(returnedA).size).toBe(returnedA.length);
+		expect([...returnedA].sort()).toEqual([...seededA].sort());
+	});
+
+	test("a row moved backward behind the cursor is deferred to the next scan, then recovered", async () => {
+		let mutated = false;
+
+		const firstRun = await CusEntService.getActiveResetPassed({
+			db: ctx.db,
+			customDateUnix: CUTOFF,
+			batchSize: 2,
+			limit: 1_000_000,
+			onPageFetched: async (page) => {
+				if (mutated) return;
+				if (!page.some((ce) => ce.id === seededB[0])) return;
+				mutated = true;
+				await setResetAt(seededB[4], 400_000);
+			},
+		});
+
+		expect(mutated).toBe(true);
+
+		const firstRunB = firstRun
+			.map((ce) => ce.id)
+			.filter((id) => seededB.includes(id));
+		expect(firstRunB).not.toContain(seededB[4]);
+		expect(firstRunB.length).toBe(seededB.length - 1);
+
+		const secondRun = await fetchAll({ batchSize: 2 });
+		expect(secondRun.map((ce) => ce.id)).toContain(seededB[4]);
 	});
 });


### PR DESCRIPTION
## Problem

`CusEntService.getActiveResetPassed` (the reset cron's candidate scan) paginated with `LIMIT/OFFSET` and **no ORDER BY**. Against the current multi-million due-reset backlog (inflated by the runable migration campaign + resend import), single executions ran up to **9m29s** (`pg_stat_statements` max 568,864ms; 47 calls = 35% of all DB time in one 30-min window on 2026-07-12). Each long statement pins the xmin horizon, blocking vacuum DB-wide; when a pin ended within minutes of a top-of-hour burst, degraded hot rows produced customer-visible blips (2026-07-12 08:02: 5,929 fail-open 202s + 2,937 shed 503s). Full mechanism + evidence: `tickets/DB_XMIN_PIN_FIXES.md`.

## Change

- **Keyset pagination**: each union branch gets a `(next_reset_at, id COLLATE "C") > (cursor)` predicate; the union orders by sort keys projected as output columns (`sort_reset`, `sort_id` — set-operation ORDER BY only accepts output columns) and takes `LIMIT batchSize`. OFFSET is gone; page cost is independent of backlog depth.
- **One SQL statement per page** (`buildActiveResetPassedPage`, extracted for testability): one snapshot, branch consistency by construction, `statement_timeout` caps the whole page.
- **Cross-page dedup** (`emittedIds`): a row whose `next_reset_at` advances mid-run but re-qualifies past the cursor is emitted exactly once. Backward movement (manual-ops only) is defined + tested as deferred to the next scan.
- **Removed a latent wasted query**: the old loop always executed one extra full union at the next OFFSET and discarded it.
- **Determinism fix**: OFFSET-without-ORDER-BY over a concurrently-mutating result set could skip/double-fetch candidates; explicit ordering closes it.
- **Structured run logging** in `runResetCron` (`jobName: reset-cus-ents`: start, per-iteration fetch+duration, finish totals, error path).

**Caller contract unchanged**: same params, same `ResetCusEnt[]` shape, same candidate set (all branch predicates untouched). Pre-existing behavior tests (`loose-reset`, `past-due-reset`) pass unmodified.

## Validation

- Contract tests (`tests/balances/cron/reset-keyset-pagination.test.ts`, all `test.concurrent` with per-case fixtures/windows/scoped cleanup): exactly-once across pages incl. equal-timestamp pages spanning page boundaries; all three branches merged in order; limit semantics; mid-pagination mutations (shrinking set, re-qualifying row, backward move + recovery); structural test pinning the one-statement/ordered/no-OFFSET page shape via `toSQL()`.
- Ordering contract was red on the old implementation, green on the new.
- 11/11 across `tests/balances/cron/`; typecheck + biome clean.
- **Prod `EXPLAIN` (plan-only) of the exact union shape**: all three branches drive from the partial `next_reset_at` indexes with the cursor **pushed into the Index Cond**; ordered `LIMIT` plan. Note: at today's inflated backlog the active-product branch plans as a bounded hash join (~449k-row estimated window) — seconds per page, flipping to nested-loop probes as the backlog drains. No new index needed.

## Review history

Three rounds addressed in-branch: r1 P1 (Promise.all split the union's snapshot → status-transition race with non-idempotent rollover consequences) → r2 P1 (repeatable-read txn held the snapshot across 3 statements, up to ~3× statement_timeout) → final single-statement design. r3: removed an unscoped test-DB DELETE (shared-DB hazard), per-case isolation + `test.concurrent`.

## Deploy notes

- Ships alone; no migration.
- Sequencing (see ticket): the role-level `statement_timeout` starts at **300s** (active migration batches run 210-233s) and tightens to 60s **after** this deploys.
- Acceptance signals: `db_long_txn` events ≥120s stop appearing at cron times; `[reset-cus-ents]` logs report per-fetch durations in ms-seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Afef2Wg97ZnWwAbvTQYFbM

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the reset cron candidate scan to keyset pagination on (next_reset_at, id) with a single ordered SQL page, eliminating slow OFFSET scans and preventing skipped/duplicated candidates under concurrent updates. This reduces long-running queries that pinned the xmin horizon and adds clear run logging.

- **Bug Fixes**
  - Replaced LIMIT/OFFSET with keyset pagination using `(next_reset_at, id)` and explicit ORDER BY; OFFSET removed.
  - Deterministic paging with cross-page dedup to avoid skips/duplicates when rows change mid-run.
  - Removed the extra union fetch the old loop always executed and discarded.

- **Refactors**
  - One SQL statement per page (ordered union of 3 branches) for a single snapshot; `statement_timeout` caps the whole page.
  - Structured logs in `runResetCron` (start, per-iteration fetch duration and counts, finish totals, errors).
  - Added `buildActiveResetPassedPage` and a focused test suite to pin query shape and exactly-once behavior; no schema or API changes.

<sup>Written for commit 6ec6dc70b05248c589f79f282ced0a5c514014de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the reset candidate scan with deterministic keyset pagination. The main changes are:

- **Bug fixes:** Ordered pagination by reset time and C-collated entitlement ID.
- **Improvements:** One union query per page with cross-page deduplication.
- **Improvements:** Structured reset-cron progress and duration logging.
- **Improvements:** Integration tests for ordering, page boundaries, branches, and concurrent mutations.
</details>

<h3>Confidence Score: 5/5</h3>

The changed flow looks mergeable after a small cleanup to its failure diagnostics.

- The cursor comparison matches the query ordering.
- The union branches are mutually exclusive.
- Concurrent backward movement is explicitly deferred to the next scan.
- The failure log should retain the original error object.

server/src/cron/resetCron/runResetCron.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts | Adds an ordered union query, keyset cursor, stable scan timestamp, and cross-page deduplication. |
| server/src/cron/resetCron/runResetCron.ts | Adds structured lifecycle metrics, but the failure event stringifies the exception. |
| server/tests/balances/cron/reset-keyset-pagination.test.ts | Adds integration coverage for SQL shape, ordering, limits, branch merging, and row movement. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Build three candidate branches] --> B[UNION ALL in one statement]
    B --> C[Order by reset time and ID]
    C --> D[Apply page limit]
    D --> E[Deduplicate emitted IDs]
    E --> F[Advance keyset cursor]
    F --> G{Short page or limit reached?}
    G -- No --> A
    G -- Yes --> H[Return candidates]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Build three candidate branches] --> B[UNION ALL in one statement]
    B --> C[Order by reset time and ID]
    C --> D[Apply page limit]
    D --> E[Deduplicate emitted IDs]
    E --> F[Advance keyset cursor]
    F --> G{Short page or limit reached?}
    G -- No --> A
    G -- Yes --> H[Return candidates]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/cron/resetCron/runResetCron.ts:176-179
**Failure Log Drops Error Details**

When the reset cron throws, `${error}` converts the exception to text before it reaches the structured logger. The stored failure event can lose the stack and error fields needed to diagnose a failed run.

```suggestion
		logger.error(
			{
				jobName: "reset-cus-ents",
				durationMs: Date.now() - startTime,
				error,
			},
			"[reset-cus-ents] failed",
		);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: per-case fixture isolation, scoped..."](https://github.com/useautumn/autumn/commit/6ec6dc70b05248c589f79f282ced0a5c514014de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43789353)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->