### PR TITLE
Optimise reset cron candidate scan

### DIFF
--- a/server/src/cron/resetCron/runResetCron.ts
+++ b/server/src/cron/resetCron/runResetCron.ts
@@ -66,27 +66,40 @@ export const runResetCron = async ({ ctx }: { ctx: CronContext }) => {
 
 	try {
 		let iteration = 0;
+		let totalFetched = 0;
+		let totalUpserted = 0;
+
+		logger.info({ jobName: "reset-cus-ents" }, "[reset-cus-ents] started");
 
 		while (iteration < maxIterations && Date.now() - startTime < timeoutMs) {
 			iteration++;
 
+			const fetchStartedAt = Date.now();
 			const cusEnts = await CusEntService.getActiveResetPassed({
 				db,
 				batchSize: 5_000,
 				limit: 5_000,
 				includeSeparateIntervalResets: false,
 			});
+			totalFetched += cusEnts.length;
+
+			logger.info(
+				{
+					jobName: "reset-cus-ents",
+					iteration,
+					fetched: cusEnts.length,
+					fetchDurationMs: Date.now() - fetchStartedAt,
+				},
+				`[reset-cus-ents] iteration ${iteration}: fetched ${cusEnts.length} in ${Date.now() - fetchStartedAt}ms`,
+			);
 
 			if (cusEnts.length < 5_000) {
-				console.log(
-					`Reset cron: only ${cusEnts.length} entitlements to reset, skipping (lazy reset will handle)`,
+				logger.info(
+					{ jobName: "reset-cus-ents", fetched: cusEnts.length },
+					`[reset-cus-ents] only ${cusEnts.length} entitlements to reset, skipping (lazy reset will handle)`,
 				);
 				break;
 			}
-
-			console.log(
-				`Reset cron iteration ${iteration}: processing ${cusEnts.length} entitlements`,
-			);
 
 			const batchSize = 1000;
 			for (let i = 0; i < cusEnts.length; i += batchSize) {
@@ -137,7 +150,7 @@ export const runResetCron = async ({ ctx }: { ctx: CronContext }) => {
 					db,
 					data: toUpsert,
 				});
-				console.log(`Upserted ${toUpsert.length} short entitlements`);
+				totalUpserted += toUpsert.length;
 
 				await clearCusEntsFromCache({
 					cusEnts: updatedCusEnts,
@@ -145,12 +158,25 @@ export const runResetCron = async ({ ctx }: { ctx: CronContext }) => {
 			}
 		}
 
+		logger.info(
+			{
+				jobName: "reset-cus-ents",
+				iterations: iteration,
+				totalFetched,
+				totalUpserted,
+				durationMs: Date.now() - startTime,
+			},
+			`[reset-cus-ents] finished: fetched ${totalFetched}, upserted ${totalUpserted} (monthly/yearly resets update in place and are not counted here) across ${iteration} iteration(s) in ${Date.now() - startTime}ms`,
+		);
 		console.log(
 			"FINISHED RESET CRON:",
 			format(new UTCDate(), "yyyy-MM-dd HH:mm:ss"),
 		);
-		console.log("----------------------------------\n");
 	} catch (error) {
+		logger.error(
+			{ jobName: "reset-cus-ents", durationMs: Date.now() - startTime },
+			`[reset-cus-ents] failed: ${error}`,
+		);
 		console.error("Error getting entitlements for reset:", error);
 		return;
 	}

--- a/server/src/cron/resetCron/runResetCron.ts
+++ b/server/src/cron/resetCron/runResetCron.ts
@@ -174,8 +174,12 @@ export const runResetCron = async ({ ctx }: { ctx: CronContext }) => {
 		);
 	} catch (error) {
 		logger.error(
-			{ jobName: "reset-cus-ents", durationMs: Date.now() - startTime },
-			`[reset-cus-ents] failed: ${error}`,
+			{
+				jobName: "reset-cus-ents",
+				durationMs: Date.now() - startTime,
+				err: error,
+			},
+			"[reset-cus-ents] failed",
 		);
 		console.error("Error getting entitlements for reset:", error);
 		return;

--- a/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
@@ -176,53 +176,51 @@ export class CusEntService {
 		await db.insert(customerEntitlements).values(insertData);
 	}
 
-	static async getActiveResetPassed({
+	static buildActiveResetPassedPage({
 		db,
-		customDateUnix,
-		batchSize = 1000,
-		limit,
-		includeSeparateIntervalResets = true,
+		now,
+		batchSize,
+		cursor,
+		includeSeparateIntervalResets,
 	}: {
 		db: DrizzleCli;
-		customDateUnix?: number;
-		batchSize?: number;
-		limit?: number;
-		includeSeparateIntervalResets?: boolean;
+		now: number;
+		batchSize: number;
+		cursor: { nextResetAt: number; id: string } | null;
+		includeSeparateIntervalResets: boolean;
 	}) {
-		const allResults: FullCusEntWithProduct[] = [];
-		let offset = 0;
-		let hasMore = true;
-
-		// Shared projection across all three UNION ALL branches. Keeping the
-		// column list identical across branches is required for UNION ALL and
-		// lets the existing mapper below consume each row uniformly.
+		// Sort keys are projected as top-level output columns because Postgres
+		// only allows ORDER BY on a set operation via output column names.
 		const baseSelect = {
 			customer_entitlements: customerEntitlements,
 			entitlements: entitlements,
 			features: features,
 			customers: customers,
 			customer_products: customerProducts,
+			sort_reset: sql`${customerEntitlements.next_reset_at}`.as("sort_reset"),
+			sort_id: sql`${customerEntitlements.id} COLLATE "C"`.as("sort_id"),
 		};
 
-		// Common reset predicates applied in every branch: not marked expired
-		// (skips the backfilled terminal-product backlog via the partial index),
-		// next_reset_at has passed, and the entitlement has not expired.
 		const commonResetPredicates = () =>
 			and(
 				sql`${customerEntitlements.expired} IS NOT TRUE`,
-				lt(customerEntitlements.next_reset_at, customDateUnix ?? Date.now()),
+				lt(customerEntitlements.next_reset_at, now),
 				or(
 					isNull(customerEntitlements.expires_at),
-					gt(customerEntitlements.expires_at, customDateUnix ?? Date.now()),
+					gt(customerEntitlements.expires_at, now),
 				),
 			);
 
+		// COLLATE "C" keeps the cursor comparison aligned with sort_id's ordering.
+		const afterCursor = () =>
+			cursor
+				? sql`(${customerEntitlements.next_reset_at}, ${customerEntitlements.id} COLLATE "C") > (${cursor.nextResetAt}, ${cursor.id})`
+				: undefined;
+
 		// Exclude normal price-backed cusEnts: their reset is owned by the Stripe
-		// invoice.created handler, not this cron. Split prepaid reset intervals
-		// are included by dedicated branches below. Must stay in sync with
-		// `cusEntToCusPrice` (shared/utils/cusEntUtils/.../cusEntToCusPrice.ts)
-		// and the in-memory `getResettableCustomerEntitlements` filter.
-		// Only applies to branches with `customer_product_id` set (i.e. 2 + 3).
+		// invoice.created handler, not this cron. Must stay in sync with
+		// `cusEntToCusPrice` and the in-memory `getResettableCustomerEntitlements`
+		// filter. Only applies to branches with `customer_product_id` set (2 + 3).
 		const notPriceBacked = () =>
 			notExists(
 				db
@@ -242,123 +240,169 @@ export class CusEntService {
 				? or(eq(customerEntitlements.separate_interval, true), notPriceBacked())
 				: notPriceBacked();
 
-		while (hasMore) {
-			// Branch 1: cusEnts with no customer_product. Left-join to
-			// customer_products on a false predicate so the row shape matches
-			// the other branches (customer_products columns come back NULL).
-			const branch1 = db
-				.select(baseSelect)
-				.from(customerEntitlements)
-				.innerJoin(
-					entitlements,
-					eq(customerEntitlements.entitlement_id, entitlements.id),
-				)
-				.innerJoin(
-					features,
-					eq(entitlements.internal_feature_id, features.internal_id),
-				)
-				.innerJoin(
-					customers,
-					eq(customerEntitlements.internal_customer_id, customers.internal_id),
-				)
-				.leftJoin(customerProducts, sql`false`)
-				.where(
-					and(
-						isNull(customerEntitlements.customer_product_id),
-						commonResetPredicates(),
-					),
-				);
+		// Branch 1: cusEnts with no customer_product. Left-join to
+		// customer_products on a false predicate so the row shape matches
+		// the other branches (customer_products columns come back NULL).
+		const branch1 = db
+			.select(baseSelect)
+			.from(customerEntitlements)
+			.innerJoin(
+				entitlements,
+				eq(customerEntitlements.entitlement_id, entitlements.id),
+			)
+			.innerJoin(
+				features,
+				eq(entitlements.internal_feature_id, features.internal_id),
+			)
+			.innerJoin(
+				customers,
+				eq(customerEntitlements.internal_customer_id, customers.internal_id),
+			)
+			.leftJoin(customerProducts, sql`false`)
+			.where(
+				and(
+					isNull(customerEntitlements.customer_product_id),
+					commonResetPredicates(),
+					afterCursor(),
+				),
+			);
 
-			// Branch 2: cusEnts on active customer_products.
-			const branch2 = db
-				.select(baseSelect)
-				.from(customerEntitlements)
-				.innerJoin(
-					entitlements,
-					eq(customerEntitlements.entitlement_id, entitlements.id),
-				)
-				.innerJoin(
-					features,
-					eq(entitlements.internal_feature_id, features.internal_id),
-				)
-				.innerJoin(
-					customers,
-					eq(customerEntitlements.internal_customer_id, customers.internal_id),
-				)
-				.innerJoin(
-					customerProducts,
-					sql`${customerEntitlements.customer_product_id} COLLATE "C" = ${customerProducts.id}`,
-				)
-				.where(
-					and(
-						eq(customerProducts.status, CusProductStatus.Active),
-						commonResetPredicates(),
-						resetOwnedByAutumn(),
-					),
-				);
+		// Branch 2: cusEnts on active customer_products.
+		const branch2 = db
+			.select(baseSelect)
+			.from(customerEntitlements)
+			.innerJoin(
+				entitlements,
+				eq(customerEntitlements.entitlement_id, entitlements.id),
+			)
+			.innerJoin(
+				features,
+				eq(entitlements.internal_feature_id, features.internal_id),
+			)
+			.innerJoin(
+				customers,
+				eq(customerEntitlements.internal_customer_id, customers.internal_id),
+			)
+			.innerJoin(
+				customerProducts,
+				sql`${customerEntitlements.customer_product_id} COLLATE "C" = ${customerProducts.id}`,
+			)
+			.where(
+				and(
+					eq(customerProducts.status, CusProductStatus.Active),
+					commonResetPredicates(),
+					resetOwnedByAutumn(),
+					afterCursor(),
+				),
+			);
 
-			// Branch 3: cusEnts on past_due customer_products whose product
-			// opted into ignore_past_due via products.config.
-			const branch3 = db
-				.select(baseSelect)
-				.from(customerEntitlements)
-				.innerJoin(
-					entitlements,
-					eq(customerEntitlements.entitlement_id, entitlements.id),
-				)
-				.innerJoin(
-					features,
-					eq(entitlements.internal_feature_id, features.internal_id),
-				)
-				.innerJoin(
-					customers,
-					eq(customerEntitlements.internal_customer_id, customers.internal_id),
-				)
-				.innerJoin(
-					customerProducts,
-					sql`${customerEntitlements.customer_product_id} COLLATE "C" = ${customerProducts.id}`,
-				)
-				.innerJoin(
-					products,
-					eq(customerProducts.internal_product_id, products.internal_id),
-				)
-				.where(
-					and(
-						eq(customerProducts.status, CusProductStatus.PastDue),
-						sql`(${products.config}->>'ignore_past_due')::boolean = true`,
-						commonResetPredicates(),
-						resetOwnedByAutumn(),
-					),
-				);
+		// Branch 3: cusEnts on past_due customer_products whose product
+		// opted into ignore_past_due via products.config.
+		const branch3 = db
+			.select(baseSelect)
+			.from(customerEntitlements)
+			.innerJoin(
+				entitlements,
+				eq(customerEntitlements.entitlement_id, entitlements.id),
+			)
+			.innerJoin(
+				features,
+				eq(entitlements.internal_feature_id, features.internal_id),
+			)
+			.innerJoin(
+				customers,
+				eq(customerEntitlements.internal_customer_id, customers.internal_id),
+			)
+			.innerJoin(
+				customerProducts,
+				sql`${customerEntitlements.customer_product_id} COLLATE "C" = ${customerProducts.id}`,
+			)
+			.innerJoin(
+				products,
+				eq(customerProducts.internal_product_id, products.internal_id),
+			)
+			.where(
+				and(
+					eq(customerProducts.status, CusProductStatus.PastDue),
+					sql`(${products.config}->>'ignore_past_due')::boolean = true`,
+					commonResetPredicates(),
+					resetOwnedByAutumn(),
+					afterCursor(),
+				),
+			);
 
-			const data = await unionAll(branch1, branch2, branch3)
-				.limit(batchSize)
-				.offset(offset);
+		// One statement, one snapshot: branch consistency without a
+		// multi-statement transaction, and statement_timeout caps the whole page.
+		return unionAll(branch1, branch2, branch3)
+			.orderBy(sql`"sort_reset"`, sql`"sort_id"`)
+			.limit(batchSize);
+	}
 
-			// Note: PlanetScale tag would be added here but Drizzle 0.43.1's unionAll
-			// doesn't support .comment() method. Tag will be added after Drizzle upgrade.
-			// Target tag: planetScaleTag({ query: "getActiveResetPassed" })
+	static async getActiveResetPassed({
+		db,
+		customDateUnix,
+		batchSize = 1000,
+		limit,
+		includeSeparateIntervalResets = true,
+		onPageFetched,
+	}: {
+		db: DrizzleCli;
+		customDateUnix?: number;
+		batchSize?: number;
+		limit?: number;
+		includeSeparateIntervalResets?: boolean;
+		/** Test seam: runs between pages to exercise mid-pagination mutations. */
+		onPageFetched?: (page: ResetCusEnt[]) => void | Promise<void>;
+	}) {
+		const allResults: FullCusEntWithProduct[] = [];
+		const now = customDateUnix ?? Date.now();
+		let cursor: { nextResetAt: number; id: string } | null = null;
+		const emittedIds = new Set<string>();
 
-			if (data.length === 0 || (limit && allResults.length >= limit)) {
-				hasMore = false;
-			} else {
-				const mappedData = data.map((item) => ({
-					...item.customer_entitlements,
-					entitlement: {
-						...item.entitlements,
-						feature: item.features,
-					},
-					customer_product: item.customer_products,
-					customer: item.customers,
-					replaceables: [],
-					rollovers: [],
-				})) as ResetCusEnt[];
+		while (true) {
+			const page = await CusEntService.buildActiveResetPassedPage({
+				db,
+				now,
+				batchSize,
+				cursor,
+				includeSeparateIntervalResets,
+			});
 
-				allResults.push(...mappedData);
-				offset += batchSize;
-				hasMore = data.length === batchSize;
-				console.log(`Fetched ${allResults.length} entitlements to reset`);
+			if (page.length === 0) break;
+
+			const freshRows: typeof page = [];
+			for (const item of page) {
+				const id = item.customer_entitlements.id;
+				if (emittedIds.has(id)) continue;
+				emittedIds.add(id);
+				freshRows.push(item);
 			}
+
+			const mappedData = freshRows.map((item) => ({
+				...item.customer_entitlements,
+				entitlement: {
+					...item.entitlements,
+					feature: item.features,
+				},
+				customer_product: item.customer_products,
+				customer: item.customers,
+				replaceables: [],
+				rollovers: [],
+			})) as ResetCusEnt[];
+
+			allResults.push(...mappedData);
+			console.log(`Fetched ${allResults.length} entitlements to reset`);
+
+			const lastRow = page[page.length - 1].customer_entitlements;
+			cursor = {
+				nextResetAt: Number(lastRow.next_reset_at),
+				id: lastRow.id,
+			};
+
+			if (onPageFetched) await onPageFetched(mappedData);
+
+			if (page.length < batchSize) break;
+			if (limit && allResults.length >= limit) break;
 		}
 
 		return allResults as ResetCusEnt[];

--- a/server/tests/balances/cron/reset-keyset-pagination.test.ts
+++ b/server/tests/balances/cron/reset-keyset-pagination.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
 	ApiVersion,
 	CusProductStatus,
@@ -200,6 +200,10 @@ describe(`${chalk.yellowBright("reset-keyset-pagination: exactly-once, ordering,
 		});
 	});
 
+	afterAll(async () => {
+		await cleanupCustomers(ownCustomers);
+	});
+
 	test.concurrent(
 		"multi-page fetch returns every seeded candidate exactly once, in (next_reset_at, id) order",
 		async () => {
@@ -241,6 +245,10 @@ describe(`${chalk.yellowBright("reset-keyset-pagination: limit semantics")}`, ()
 		}
 	});
 
+	afterAll(async () => {
+		await cleanupCustomers(ownCustomers);
+	});
+
 	test.concurrent("limit stops fetching at the page boundary", async () => {
 		const results = await fetchAll({ batchSize: 3, limit: 4 });
 		expect(results.length).toBe(6);
@@ -263,10 +271,20 @@ describe(`${chalk.yellowBright("reset-keyset-pagination: shrink + re-qualify mut
 		}
 	});
 
+	afterAll(async () => {
+		await cleanupCustomers(ownCustomers);
+	});
+
 	test.concurrent(
-		"a row leaving the predicate mid-run does not skip unread rows; a re-qualifying emitted row is not duplicated",
+		"an emitted row leaving the predicate does not skip unread rows; an emitted row re-qualifying ahead of the cursor is not duplicated",
 		async () => {
-			let mutated = false;
+			// Mutation targets are chosen from rows PROVEN emitted in delivered
+			// pages, so ambient rows shifting page boundaries cannot silently
+			// downgrade this into a test that never exercises dedup.
+			const emitted = new Set<string>();
+			let shrunkId: string | undefined;
+			let requalifiedId: string | undefined;
+			let unreadAtMutation: string[] = [];
 
 			const results = await CusEntService.getActiveResetPassed({
 				db: ctx.db,
@@ -274,16 +292,30 @@ describe(`${chalk.yellowBright("reset-keyset-pagination: shrink + re-qualify mut
 				batchSize: 2,
 				limit: 1_000_000,
 				onPageFetched: async (page) => {
-					if (mutated) return;
-					if (!page.some((ce) => ce.id === seeded[0])) return;
-					mutated = true;
+					for (const ce of page) {
+						if (seeded.includes(ce.id)) emitted.add(ce.id);
+					}
+					if (requalifiedId) return;
 
-					await setResetAt(seeded[0], CUTOFF + 1_000_000);
-					await setResetAt(seeded[1], BAND + 5_000);
+					const unread = seeded.filter((id) => !emitted.has(id));
+					if (emitted.size < 2 || unread.length < 2) return;
+
+					// Both targets are behind the cursor: shrinking one is the
+					// OFFSET-skip repro; re-qualifying the other ahead of the
+					// cursor forces a second emission that dedup must filter.
+					const [first, second] = [...emitted];
+					shrunkId = first;
+					requalifiedId = second;
+					unreadAtMutation = unread;
+
+					await setResetAt(shrunkId, CUTOFF + 1_000_000);
+					await setResetAt(requalifiedId, BAND + 5_000);
 				},
 			});
 
-			expect(mutated).toBe(true);
+			expect(shrunkId).toBeDefined();
+			expect(requalifiedId).toBeDefined();
+			expect(unreadAtMutation.length).toBeGreaterThanOrEqual(2);
 
 			const returnedSeeded = results
 				.map((ce) => ce.id)
@@ -291,6 +323,9 @@ describe(`${chalk.yellowBright("reset-keyset-pagination: shrink + re-qualify mut
 
 			expect(new Set(returnedSeeded).size).toBe(returnedSeeded.length);
 			expect([...returnedSeeded].sort()).toEqual([...seeded].sort());
+			for (const id of unreadAtMutation) {
+				expect(returnedSeeded).toContain(id);
+			}
 		},
 	);
 });
@@ -309,6 +344,10 @@ describe(`${chalk.yellowBright("reset-keyset-pagination: backward cursor movemen
 		for (const [i, customerId] of ownCustomers.entries()) {
 			seeded.push(await seedLooseCusEnt({ customerId, nextResetAt: BAND + i }));
 		}
+	});
+
+	afterAll(async () => {
+		await cleanupCustomers(ownCustomers);
 	});
 
 	test.concurrent(

--- a/server/tests/balances/cron/reset-keyset-pagination.test.ts
+++ b/server/tests/balances/cron/reset-keyset-pagination.test.ts
@@ -1,0 +1,344 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import {
+	ApiVersion,
+	CusProductStatus,
+	customerEntitlements,
+	customerProducts,
+	customers,
+	type LimitedItem,
+	ProductItemInterval,
+	type ProductV2,
+	ResetInterval,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import chalk from "chalk";
+import { and, eq, inArray } from "drizzle-orm";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
+import { constructProduct } from "@/utils/scriptUtils/createTestProducts.js";
+import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
+import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
+import { findCustomerEntitlement } from "../utils/findCustomerEntitlement";
+
+const CUTOFF = 10_000_000;
+
+const autumnV1 = new AutumnInt({ version: ApiVersion.V1_2 });
+
+const cleanupCustomers = async (customerIds: string[]) => {
+	const rows = await ctx.db
+		.select({ internal_id: customers.internal_id })
+		.from(customers)
+		.where(
+			and(
+				eq(customers.org_id, ctx.org.id),
+				eq(customers.env, ctx.env),
+				inArray(customers.id, customerIds),
+			),
+		);
+	if (rows.length === 0) return;
+	await ctx.db.delete(customerEntitlements).where(
+		inArray(
+			customerEntitlements.internal_customer_id,
+			rows.map((r) => r.internal_id),
+		),
+	);
+};
+
+const setResetAt = async (cusEntId: string, nextResetAt: number) => {
+	await ctx.db
+		.update(customerEntitlements)
+		.set({ next_reset_at: nextResetAt })
+		.where(eq(customerEntitlements.id, cusEntId));
+};
+
+const seedLooseCusEnt = async ({
+	customerId,
+	nextResetAt,
+}: {
+	customerId: string;
+	nextResetAt: number;
+}) => {
+	await initCustomerV3({ ctx, customerId, withTestClock: false });
+	await autumnV1.balances.create({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		granted_balance: 100,
+		reset: { interval: ResetInterval.Month },
+	});
+	const cusEnt = await findCustomerEntitlement({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+	expect(cusEnt).toBeDefined();
+	await setResetAt(cusEnt!.id, nextResetAt);
+	return cusEnt!.id;
+};
+
+const seedProductCusEnt = async ({
+	customerId,
+	nextResetAt,
+	productStatus,
+	ignorePastDue,
+}: {
+	customerId: string;
+	nextResetAt: number;
+	productStatus: CusProductStatus;
+	ignorePastDue: boolean;
+}) => {
+	const item = constructFeatureItem({
+		featureId: TestFeature.Messages,
+		includedUsage: 100,
+		interval: ProductItemInterval.Month,
+	}) as LimitedItem;
+	const product = constructProduct({
+		items: [item],
+		type: "free",
+		isDefault: false,
+	}) as ProductV2;
+	product.config = { ignore_past_due: ignorePastDue };
+
+	await initProductsV0({
+		ctx,
+		products: [product],
+		prefix: customerId,
+		customerId,
+	});
+	await initCustomerV3({ ctx, customerId, withTestClock: false });
+	await autumnV1.attach({ customer_id: customerId, product_id: product.id });
+
+	const cusEnt = await findCustomerEntitlement({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+	expect(cusEnt?.customer_product_id).toBeDefined();
+
+	await setResetAt(cusEnt!.id, nextResetAt);
+	await ctx.db
+		.update(customerProducts)
+		.set({ status: productStatus })
+		.where(eq(customerProducts.id, cusEnt!.customer_product_id!));
+	return cusEnt!.id;
+};
+
+const fetchAll = (opts?: { batchSize?: number; limit?: number }) =>
+	CusEntService.getActiveResetPassed({
+		db: ctx.db,
+		customDateUnix: CUTOFF,
+		batchSize: opts?.batchSize ?? 3,
+		limit: opts?.limit ?? 1_000_000,
+	});
+
+describe(`${chalk.yellowBright("reset-keyset-pagination: single-statement page shape")}`, () => {
+	test.concurrent(
+		"a page is one SQL statement: union of 3 branches, ordered, no offset",
+		() => {
+			const query = CusEntService.buildActiveResetPassedPage({
+				db: ctx.db,
+				now: CUTOFF,
+				batchSize: 5,
+				cursor: { nextResetAt: 1, id: "cus_ent_x" },
+				includeSeparateIntervalResets: false,
+			});
+			const text = query.toSQL().sql.toLowerCase();
+
+			expect((text.match(/union all/g) ?? []).length).toBe(2);
+			expect(text).toContain('order by "sort_reset", "sort_id"');
+			expect(text).toContain("limit");
+			expect(text).not.toContain("offset");
+		},
+	);
+});
+
+describe(`${chalk.yellowBright("reset-keyset-pagination: exactly-once, ordering, branch merge, ties")}`, () => {
+	const BAND = 1_000_000;
+	const TIE = 1_050_000;
+	const distinctCustomers = Array.from({ length: 5 }, (_, i) => `kpg2-d-${i}`);
+	const tieCustomers = Array.from({ length: 4 }, (_, i) => `kpg2-t-${i}`);
+	const ownCustomers = [
+		...distinctCustomers,
+		...tieCustomers,
+		"kpg2-act",
+		"kpg2-pd",
+	];
+	const legacyCustomers = [
+		...Array.from({ length: 8 }, (_, i) => `keyset-pg-${i}`),
+		...Array.from({ length: 4 }, (_, i) => `keyset-tie-${i}`),
+		"keyset-br-active",
+		"keyset-br-pd",
+	];
+	const seededDistinct: string[] = [];
+	const seededTies: string[] = [];
+	let activeId: string;
+	let pastDueId: string;
+
+	beforeAll(async () => {
+		await cleanupCustomers([...ownCustomers, ...legacyCustomers]);
+
+		for (const [i, customerId] of distinctCustomers.entries()) {
+			seededDistinct.push(
+				await seedLooseCusEnt({ customerId, nextResetAt: BAND + i }),
+			);
+		}
+		for (const customerId of tieCustomers) {
+			seededTies.push(await seedLooseCusEnt({ customerId, nextResetAt: TIE }));
+		}
+		activeId = await seedProductCusEnt({
+			customerId: "kpg2-act",
+			nextResetAt: BAND + 100,
+			productStatus: CusProductStatus.Active,
+			ignorePastDue: false,
+		});
+		pastDueId = await seedProductCusEnt({
+			customerId: "kpg2-pd",
+			nextResetAt: BAND + 101,
+			productStatus: CusProductStatus.PastDue,
+			ignorePastDue: true,
+		});
+	});
+
+	test.concurrent(
+		"multi-page fetch returns every seeded candidate exactly once, in (next_reset_at, id) order",
+		async () => {
+			const results = await fetchAll();
+
+			const allSeeded = [...seededDistinct, activeId, pastDueId, ...seededTies];
+			const returnedSeeded = results
+				.map((ce) => ce.id)
+				.filter((id) => allSeeded.includes(id));
+
+			expect(new Set(returnedSeeded).size).toBe(allSeeded.length);
+
+			const expectedOrder = [
+				...seededDistinct,
+				activeId,
+				pastDueId,
+				...[...seededTies].sort(),
+			];
+			expect(returnedSeeded).toEqual(expectedOrder);
+
+			const activeRow = results.find((ce) => ce.id === activeId);
+			const pastDueRow = results.find((ce) => ce.id === pastDueId);
+			expect(activeRow?.customer_product?.status).toBe(CusProductStatus.Active);
+			expect(pastDueRow?.customer_product?.status).toBe(
+				CusProductStatus.PastDue,
+			);
+		},
+	);
+});
+
+describe(`${chalk.yellowBright("reset-keyset-pagination: limit semantics")}`, () => {
+	const BAND = 1_500_000;
+	const ownCustomers = Array.from({ length: 7 }, (_, i) => `klim-${i}`);
+
+	beforeAll(async () => {
+		await cleanupCustomers(ownCustomers);
+		for (const [i, customerId] of ownCustomers.entries()) {
+			await seedLooseCusEnt({ customerId, nextResetAt: BAND + i });
+		}
+	});
+
+	test.concurrent("limit stops fetching at the page boundary", async () => {
+		const results = await fetchAll({ batchSize: 3, limit: 4 });
+		expect(results.length).toBe(6);
+	});
+});
+
+describe(`${chalk.yellowBright("reset-keyset-pagination: shrink + re-qualify mutations")}`, () => {
+	const BAND = 2_000_000;
+	const ownCustomers = Array.from({ length: 6 }, (_, i) => `kmta-${i}`);
+	const legacyCustomers = [
+		...Array.from({ length: 6 }, (_, i) => `keyset-mut-${i}`),
+		...Array.from({ length: 6 }, (_, i) => `keyset-mut-a-${i}`),
+	];
+	const seeded: string[] = [];
+
+	beforeAll(async () => {
+		await cleanupCustomers([...ownCustomers, ...legacyCustomers]);
+		for (const [i, customerId] of ownCustomers.entries()) {
+			seeded.push(await seedLooseCusEnt({ customerId, nextResetAt: BAND + i }));
+		}
+	});
+
+	test.concurrent(
+		"a row leaving the predicate mid-run does not skip unread rows; a re-qualifying emitted row is not duplicated",
+		async () => {
+			let mutated = false;
+
+			const results = await CusEntService.getActiveResetPassed({
+				db: ctx.db,
+				customDateUnix: CUTOFF,
+				batchSize: 2,
+				limit: 1_000_000,
+				onPageFetched: async (page) => {
+					if (mutated) return;
+					if (!page.some((ce) => ce.id === seeded[0])) return;
+					mutated = true;
+
+					await setResetAt(seeded[0], CUTOFF + 1_000_000);
+					await setResetAt(seeded[1], BAND + 5_000);
+				},
+			});
+
+			expect(mutated).toBe(true);
+
+			const returnedSeeded = results
+				.map((ce) => ce.id)
+				.filter((id) => seeded.includes(id));
+
+			expect(new Set(returnedSeeded).size).toBe(returnedSeeded.length);
+			expect([...returnedSeeded].sort()).toEqual([...seeded].sort());
+		},
+	);
+});
+
+describe(`${chalk.yellowBright("reset-keyset-pagination: backward cursor movement")}`, () => {
+	const BAND = 2_500_000;
+	const ownCustomers = Array.from({ length: 6 }, (_, i) => `kmtb-${i}`);
+	const legacyCustomers = Array.from(
+		{ length: 6 },
+		(_, i) => `keyset-mut-b-${i}`,
+	);
+	const seeded: string[] = [];
+
+	beforeAll(async () => {
+		await cleanupCustomers([...ownCustomers, ...legacyCustomers]);
+		for (const [i, customerId] of ownCustomers.entries()) {
+			seeded.push(await seedLooseCusEnt({ customerId, nextResetAt: BAND + i }));
+		}
+	});
+
+	test.concurrent(
+		"a row moved backward behind the cursor is deferred to the next scan, then recovered",
+		async () => {
+			let mutated = false;
+
+			const firstRun = await CusEntService.getActiveResetPassed({
+				db: ctx.db,
+				customDateUnix: CUTOFF,
+				batchSize: 2,
+				limit: 1_000_000,
+				onPageFetched: async (page) => {
+					if (mutated) return;
+					if (!page.some((ce) => ce.id === seeded[0])) return;
+					mutated = true;
+					await setResetAt(seeded[4], BAND - 100);
+				},
+			});
+
+			expect(mutated).toBe(true);
+
+			const firstRunSeeded = firstRun
+				.map((ce) => ce.id)
+				.filter((id) => seeded.includes(id));
+			expect(firstRunSeeded).not.toContain(seeded[4]);
+			expect(firstRunSeeded.length).toBe(seeded.length - 1);
+
+			const secondRun = await fetchAll({ batchSize: 2 });
+			expect(secondRun.map((ce) => ce.id)).toContain(seeded[4]);
+		},
+	);
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the reset cron candidate scan to keyset pagination for faster, stable scans that don’t skip or duplicate entitlements. Adds structured logging and deterministic tests that cover ordering, limits, and mid-scan mutations.

- **Refactors**
  - Replace offset pagination in `CusEntitlementService.getActiveResetPassed` with keyset pagination via `buildActiveResetPassedPage` (single SQL statement, unioned branches, ordered by `(next_reset_at, id)`, no offset).
  - Deduplicate across union branches and expose an `onPageFetched` hook for mid-scan mutation tests.
  - Improve `runResetCron` logging: start/finish markers, per-iteration metrics, totals fetched/upserted, and durations.

- **Bug Fixes**
  - Prevent skipped or duplicated candidates when rows change mid-scan; guarantee ordered, exactly-once results with tie-break by `id`.
  - Handle backward-moved and re-qualifying rows safely; `limit` stops at page boundaries without offset drift.
  - Keep Stripe-owned resets excluded and `ignore_past_due` behavior intact.
  - Preserve error stack in reset cron failure logs for better diagnostics.

<sup>Written for commit 30d98d1cd970282896cd4a8ff8331a8cd5efc6ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR optimizes how the reset cron scans entitlement candidates. The main changes are:

- **Improvements:** Replaces offset pagination with ordered keyset pagination.
- **Improvements:** Merges loose, active, and eligible past-due candidates in one query per page.
- **Improvements:** Adds reset progress, timing, and total-count logs.
- **Improvements:** Adds tests for ordering, tied keys, limits, and mid-scan mutations.
</details>

<h3>Confidence Score: 5/5</h3>

The changed flow looks mergeable after a small cleanup to its failure diagnostics.

- Keyset filtering and ordering use the same composite keys and collation.
- Tests cover tied keys and rows moving during a scan.
- The new outer failure log drops the error stack.

server/src/cron/resetCron/runResetCron.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts | Replaces offset scanning with deterministic keyset pagination and per-scan deduplication. |
| server/src/cron/resetCron/runResetCron.ts | Adds progress and aggregate logging, but the new failure log discards structured error details. |
| server/tests/balances/cron/reset-keyset-pagination.test.ts | Adds coverage for query shape, ordering, page limits, branch merging, and mutation behavior. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start candidate scan] --> B[Fix cutoff time]
    B --> C[Query three candidate branches]
    C --> D[Union and order by reset time and ID]
    D --> E[Map and deduplicate page]
    E --> F[Advance keyset cursor]
    F --> G{Short page or limit reached?}
    G -- No --> C
    G -- Yes --> H[Return candidates to reset cron]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Start candidate scan] --> B[Fix cutoff time]
    B --> C[Query three candidate branches]
    C --> D[Union and order by reset time and ID]
    D --> E[Map and deduplicate page]
    E --> F[Advance keyset cursor]
    F --> G{Short page or limit reached?}
    G -- No --> C
    G -- Yes --> H[Return candidates to reset cron]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/cron/resetCron/runResetCron.ts:176-179
**Cron Failure Loses Stack Trace**

When the reset scan throws, interpolating `error` into the message reduces it to a flat string. The logger never receives the error object, so production logs omit the stack trace needed to diagnose the failed cron run.

```suggestion
		logger.error(
			error,
			{ jobName: "reset-cus-ents", durationMs: Date.now() - startTime },
			"[reset-cus-ents] failed",
		);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["keyset pagination for reset cron candida..."](https://github.com/useautumn/autumn/commit/3f228c4e6cf762d50e6ee1b97f17370247670e8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43789895)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->