### PR TITLE
Release 13/07/2026

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,5 @@ apps/leaf/src/harness/claudeCode/runner/runner.mjs
 tmp/
 .env*.local
 .neon
+scripts/ops/.duckdb_export.sql
+scripts/ops/.backfill_neon_done

--- a/scripts/ops/backfill-events-neon.ts
+++ b/scripts/ops/backfill-events-neon.ts
@@ -244,6 +244,7 @@ const stageChunk = async (
 		scriptPath,
 		duckDbExportSql(s3Prefix, orgId, year, monthNumber, csvPath),
 	);
+	console.log(`[${hms()}]   ${month}: exporting from S3 (duckdb)...`);
 	const duck = await $`duckdb < ${Bun.file(scriptPath)}`.quiet().nothrow();
 	const duckErr = duck.stderr.toString();
 	if (duck.exitCode !== 0) {
@@ -252,6 +253,10 @@ const stageChunk = async (
 		}
 		throw new Error(`duckdb export failed (${month}): ${duckErr.trim()}`);
 	}
+	const csvBytes = Bun.file(csvPath).size;
+	console.log(
+		`[${hms()}]   ${month}: staging ${(csvBytes / 1e6).toFixed(0)}MB CSV into Neon (psql \\copy)...`,
+	);
 	// Truncate first so rows left by a previously crashed run aren't double-staged.
 	const result =
 		await $`psql ${withSystemRootCert(neonUrl)} -X -v ON_ERROR_STOP=1 -c ${"TRUNCATE events_staging"} -c ${SET_UTC} -c ${copyToStaging(csvPath)}`
@@ -275,6 +280,7 @@ const stageChunk = async (
 };
 
 const mergeChunk = async (neonUrl: string): Promise<number> => {
+	console.log(`[${hms()}]   merging staged rows into events (dedup on conflict)...`);
 	const result =
 		await $`psql ${withSystemRootCert(neonUrl)} -X -v ON_ERROR_STOP=1 -c ${SET_UTC} -c ${MERGE_SQL} -c ${"TRUNCATE events_staging"}`
 			.quiet()

--- a/scripts/ops/backfill-events-neon.ts
+++ b/scripts/ops/backfill-events-neon.ts
@@ -48,7 +48,9 @@ const COPY_TO_STAGING = `\\copy events_staging (${COLUMN_LIST}) FROM STDIN CSV`;
 
 const MERGE_SQL = `INSERT INTO events (${COLUMN_LIST}) SELECT ${COLUMN_LIST} FROM events_staging ON CONFLICT DO NOTHING`;
 
-// Tinybird wraps deductions as {list:[...]} (ClickHouse top-level-array limitation) while
+// Parquet string columns are un-annotated BYTE_ARRAY -> DuckDB BLOB; decode() (NOT ::VARCHAR,
+// which emits an escaped repr) restores clean UTF-8. Dot-commands silence setup banners that
+// would otherwise pollute the CSV stream. Tinybird wraps deductions as {list:[...]} while
 // live rows store the bare TrackDeduction[] — normalize every historical shape to bare array.
 // set_usage is absent from the parquet export; emit false (NOT NULL — readers and the
 // partial index filter on set_usage = false, so NULL rows would be silently excluded).
@@ -57,18 +59,23 @@ const duckDbExportSql = (
 	orgId: string,
 	year: string,
 	month: string,
-): string => `
+): string => `.output /dev/null
 INSTALL httpfs; LOAD httpfs; INSTALL aws; LOAD aws; INSTALL json; LOAD json;
 CREATE OR REPLACE SECRET s3_ambient (TYPE s3, PROVIDER credential_chain, REGION 'us-east-2');
+.output
 COPY (
-	SELECT id, org_id, COALESCE(org_slug,'') AS org_slug, internal_customer_id,
-	       COALESCE(env,'live') AS env, created_at, "timestamp",
-	       event_name, idempotency_key, value, false AS set_usage,
-	       entity_id, internal_entity_id, internal_product_id, customer_id,
-	       COALESCE(properties,'{}') AS properties, CASE
-	         WHEN deductions IS NULL OR trim(deductions) IN ('', '{}', 'null') THEN '[]'
-	         WHEN trim(deductions) LIKE '[%' THEN deductions
-	         ELSE COALESCE(CAST(json_extract(deductions, '$.list') AS VARCHAR), '[]')
+	SELECT decode(CAST(id AS BLOB)) AS id, decode(CAST(org_id AS BLOB)) AS org_id,
+	       COALESCE(decode(CAST(org_slug AS BLOB)),'') AS org_slug,
+	       decode(CAST(internal_customer_id AS BLOB)) AS internal_customer_id,
+	       COALESCE(decode(CAST(env AS BLOB)),'live') AS env, created_at, "timestamp",
+	       decode(CAST(event_name AS BLOB)) AS event_name, decode(CAST(idempotency_key AS BLOB)) AS idempotency_key,
+	       value, false AS set_usage,
+	       decode(CAST(entity_id AS BLOB)) AS entity_id, decode(CAST(internal_entity_id AS BLOB)) AS internal_entity_id,
+	       decode(CAST(internal_product_id AS BLOB)) AS internal_product_id, decode(CAST(customer_id AS BLOB)) AS customer_id,
+	       COALESCE(decode(CAST(properties AS BLOB)),'{}') AS properties, CASE
+	         WHEN deductions IS NULL OR trim(decode(CAST(deductions AS BLOB))) IN ('', '{}', 'null') THEN '[]'
+	         WHEN trim(decode(CAST(deductions AS BLOB))) LIKE '[%' THEN decode(CAST(deductions AS BLOB))
+	         ELSE COALESCE(CAST(json_extract(decode(CAST(deductions AS BLOB)), '$.list') AS VARCHAR), '[]')
 	       END AS deductions
 	FROM read_parquet('${s3Prefix}/org_id=${orgId}/year=${year}/month=${month}/**/*.parquet')
 ) TO STDOUT (FORMAT CSV, HEADER false);
@@ -226,10 +233,11 @@ const stageChunk = async (
 	month: string,
 ): Promise<{ empty: boolean; staged: number }> => {
 	const [year, monthNumber] = month.split("-") as [string, string];
-	const exportSql = duckDbExportSql(s3Prefix, orgId, year, monthNumber);
+	const scriptPath = `${import.meta.dir}/.duckdb_export.sql`;
+	await Bun.write(scriptPath, duckDbExportSql(s3Prefix, orgId, year, monthNumber));
 	// Truncate first so rows left by a previously crashed run aren't double-staged.
 	const result =
-		await $`duckdb -c ${exportSql} | psql ${withSystemRootCert(neonUrl)} -X -v ON_ERROR_STOP=1 -c ${"TRUNCATE events_staging"} -c ${SET_UTC} -c ${COPY_TO_STAGING}`
+		await $`duckdb < ${Bun.file(scriptPath)} | psql ${withSystemRootCert(neonUrl)} -X -v ON_ERROR_STOP=1 -c ${"TRUNCATE events_staging"} -c ${SET_UTC} -c ${COPY_TO_STAGING}`
 			.quiet()
 			.nothrow();
 	const stderr = result.stderr.toString();

--- a/scripts/ops/backfill-events-neon.ts
+++ b/scripts/ops/backfill-events-neon.ts
@@ -237,8 +237,9 @@ const stageChunk = async (
 	month: string,
 ): Promise<{ empty: boolean; staged: number }> => {
 	const [year, monthNumber] = month.split("-") as [string, string];
-	const scriptPath = "/tmp/backfill_export.sql";
-	const csvPath = "/tmp/backfill_chunk.csv";
+	// /var/tmp is disk-backed; /tmp is a small RAM tmpfs on Amazon Linux and fills instantly.
+	const scriptPath = "/var/tmp/backfill_export.sql";
+	const csvPath = "/var/tmp/backfill_chunk.csv";
 	await Bun.write(
 		scriptPath,
 		duckDbExportSql(s3Prefix, orgId, year, monthNumber, csvPath),

--- a/scripts/ops/backfill-events-neon.ts
+++ b/scripts/ops/backfill-events-neon.ts
@@ -44,7 +44,8 @@ const STAGING_DDL = `CREATE TABLE IF NOT EXISTS events_staging (
 	internal_product_id text, customer_id text, properties jsonb, deductions jsonb
 )`;
 
-const COPY_TO_STAGING = `\\copy events_staging (${COLUMN_LIST}) FROM STDIN CSV`;
+const copyToStaging = (csvPath: string): string =>
+	`\\copy events_staging (${COLUMN_LIST}) FROM '${csvPath}' CSV`;
 
 const MERGE_SQL = `INSERT INTO events (${COLUMN_LIST}) SELECT ${COLUMN_LIST} FROM events_staging ON CONFLICT DO NOTHING`;
 
@@ -59,6 +60,7 @@ const duckDbExportSql = (
 	orgId: string,
 	year: string,
 	month: string,
+	outPath: string,
 ): string => `.output /dev/null
 INSTALL httpfs; LOAD httpfs; INSTALL aws; LOAD aws; INSTALL json; LOAD json;
 CREATE OR REPLACE SECRET s3_ambient (TYPE s3, PROVIDER credential_chain, REGION 'us-east-2');
@@ -78,7 +80,7 @@ COPY (
 	         ELSE COALESCE(CAST(json_extract(decode(CAST(deductions AS BLOB)), '$.list') AS VARCHAR), '[]')
 	       END AS deductions
 	FROM read_parquet('${s3Prefix}/org_id=${orgId}/year=${year}/month=${month}/**/*.parquet')
-) TO STDOUT (FORMAT CSV, HEADER false);
+) TO '${outPath}' (FORMAT CSV, HEADER false);
 `;
 
 const USAGE = `Backfill S3 parquet events into Neon (events_staging -> events, dedup on conflict).
@@ -226,6 +228,8 @@ const ensureStagingTable = async (neonUrl: string): Promise<void> => {
 };
 
 // Returns rows staged; empty=true when the parquet glob matched no files (not an error).
+// duckdb and psql run as separate commands (no pipe: Bun's Linux pipeline breaks duckdb's
+// /dev/stdout, and separate exit codes make failure detection exact).
 const stageChunk = async (
 	neonUrl: string,
 	s3Prefix: string,
@@ -233,29 +237,34 @@ const stageChunk = async (
 	month: string,
 ): Promise<{ empty: boolean; staged: number }> => {
 	const [year, monthNumber] = month.split("-") as [string, string];
-	const scriptPath = `${import.meta.dir}/.duckdb_export.sql`;
-	await Bun.write(scriptPath, duckDbExportSql(s3Prefix, orgId, year, monthNumber));
+	const scriptPath = "/tmp/backfill_export.sql";
+	const csvPath = "/tmp/backfill_chunk.csv";
+	await Bun.write(
+		scriptPath,
+		duckDbExportSql(s3Prefix, orgId, year, monthNumber, csvPath),
+	);
+	const duck = await $`duckdb < ${Bun.file(scriptPath)}`.quiet().nothrow();
+	const duckErr = duck.stderr.toString();
+	if (duck.exitCode !== 0) {
+		if (/no files found/i.test(duckErr)) {
+			return { empty: true, staged: 0 };
+		}
+		throw new Error(`duckdb export failed (${month}): ${duckErr.trim()}`);
+	}
 	// Truncate first so rows left by a previously crashed run aren't double-staged.
 	const result =
-		await $`duckdb < ${Bun.file(scriptPath)} | psql ${withSystemRootCert(neonUrl)} -X -v ON_ERROR_STOP=1 -c ${"TRUNCATE events_staging"} -c ${SET_UTC} -c ${COPY_TO_STAGING}`
+		await $`psql ${withSystemRootCert(neonUrl)} -X -v ON_ERROR_STOP=1 -c ${"TRUNCATE events_staging"} -c ${SET_UTC} -c ${copyToStaging(csvPath)}`
 			.quiet()
 			.nothrow();
-	const stderr = result.stderr.toString();
-	// An unmatched glob is an expected empty month — check BEFORE the exit-code throw
-	// (duckdb exits non-zero on it and the pipeline can propagate that status).
-	if (/no files found/i.test(stderr)) {
-		return { empty: true, staged: 0 };
-	}
+	await $`rm -f ${csvPath}`.quiet().nothrow();
 	if (result.exitCode !== 0) {
-		throw new Error(`staging failed (${month}): ${stderr.trim()}`);
-	}
-	// Pipeline exit code is psql's, so a mid-pipe duckdb failure only surfaces on stderr.
-	if (/error|fatal|exception/i.test(stderr)) {
-		throw new Error(`duckdb failed (${month}): ${stderr.trim()}`);
+		throw new Error(
+			`staging failed (${month}): ${result.stderr.toString().trim()}`,
+		);
 	}
 	const staged = Number(result.stdout.toString().match(/COPY (\d+)/)?.[1] ?? 0);
-	// Files existed but zero rows staged — anomalous (silent duckdb death?); refuse to
-	// mark the chunk done. Operator can append the key to .backfill_neon_done if truly empty.
+	// Files existed but zero rows staged — anomalous; refuse to mark the chunk done.
+	// Operator can append the key to .backfill_neon_done if truly empty.
 	if (staged === 0) {
 		throw new Error(
 			`0 rows staged for ${month} despite parquet files existing — investigate before marking done`,

--- a/scripts/ops/backfill-events-neon.ts
+++ b/scripts/ops/backfill-events-neon.ts
@@ -43,6 +43,8 @@ const COPY_TO_STAGING = `\\copy events_staging (${COLUMN_LIST}) FROM STDIN CSV`;
 
 const MERGE_SQL = `INSERT INTO events (${COLUMN_LIST}) SELECT ${COLUMN_LIST} FROM events_staging ON CONFLICT DO NOTHING`;
 
+// Tinybird wraps deductions as {list:[...]} (ClickHouse top-level-array limitation) while
+// live rows store the bare TrackDeduction[] — normalize every historical shape to bare array.
 // set_usage is absent from the parquet export; emit false (NOT NULL — readers and the
 // partial index filter on set_usage = false, so NULL rows would be silently excluded).
 const duckDbExportSql = (
@@ -51,14 +53,18 @@ const duckDbExportSql = (
 	year: string,
 	month: string,
 ): string => `
-INSTALL httpfs; LOAD httpfs; INSTALL aws; LOAD aws;
+INSTALL httpfs; LOAD httpfs; INSTALL aws; LOAD aws; INSTALL json; LOAD json;
 CREATE OR REPLACE SECRET s3_ambient (TYPE s3, PROVIDER credential_chain, REGION 'us-east-2');
 COPY (
 	SELECT id, org_id, COALESCE(org_slug,'') AS org_slug, internal_customer_id,
 	       COALESCE(env,'live') AS env, created_at, "timestamp",
 	       event_name, idempotency_key, value, false AS set_usage,
 	       entity_id, internal_entity_id, internal_product_id, customer_id,
-	       COALESCE(properties,'{}') AS properties, COALESCE(deductions,'[]') AS deductions
+	       COALESCE(properties,'{}') AS properties, CASE
+	         WHEN deductions IS NULL OR trim(deductions) IN ('', '{}', 'null') THEN '[]'
+	         WHEN trim(deductions) LIKE '[%' THEN deductions
+	         ELSE COALESCE(CAST(json_extract(deductions, '$.list') AS VARCHAR), '[]')
+	       END AS deductions
 	FROM read_parquet('${s3Prefix}/org_id=${orgId}/year=${year}/month=${month}/**/*.parquet')
 ) TO STDOUT (FORMAT CSV, HEADER false);
 `;

--- a/scripts/ops/backfill-events-neon.ts
+++ b/scripts/ops/backfill-events-neon.ts
@@ -4,6 +4,11 @@
 // and ambient AWS credentials.
 import { appendFile } from "node:fs/promises";
 import { $ } from "bun";
+import { Client } from "pg";
+
+// Session-scoped advisory lock: serializes runs so two invocations can't interleave
+// TRUNCATE/COPY/MERGE on the shared events_staging table.
+const ADVISORY_LOCK_KEY = 741_006_001;
 
 const DEFAULT_FROM_MONTH = "2024-04";
 const MONTH_PATTERN = /^\d{4}-(?:0[1-9]|1[0-2])$/;
@@ -177,6 +182,23 @@ const formatDuration = (seconds: number): string => {
 	return `${Math.floor(minutes / 60)}h${minutes % 60}m`;
 };
 
+// The lock lives on this held session; it auto-releases when the process exits.
+const acquireRunLock = async (neonUrl: string): Promise<Client> => {
+	const client = new Client({ connectionString: neonUrl });
+	await client.connect();
+	const { rows } = await client.query<{ locked: boolean }>(
+		"SELECT pg_try_advisory_lock($1) AS locked",
+		[ADVISORY_LOCK_KEY],
+	);
+	if (!rows[0].locked) {
+		await client.end();
+		fail(
+			"Another backfill run holds the advisory lock — refusing to start a second.",
+		);
+	}
+	return client;
+};
+
 const ensureStagingTable = async (neonUrl: string): Promise<void> => {
 	const result =
 		await $`psql ${neonUrl} -X -v ON_ERROR_STOP=1 -c ${STAGING_DDL}`
@@ -272,6 +294,7 @@ const main = async (): Promise<void> => {
 	}
 	const orgSlugs = args.org === "all" ? Object.keys(orgs) : [args.org];
 
+	const lockClient = await acquireRunLock(neonUrl);
 	await ensureStagingTable(neonUrl);
 	const doneChunks = await loadDoneChunks();
 	const months = monthsNewestFirst(args.from, args.to);
@@ -329,6 +352,7 @@ const main = async (): Promise<void> => {
 	console.log(
 		"\nVerify in Neon:\n  SELECT org_id, count(*) FROM events GROUP BY 1;",
 	);
+	await lockClient.end();
 };
 
 await main();

--- a/scripts/ops/backfill-events-neon.ts
+++ b/scripts/ops/backfill-events-neon.ts
@@ -101,6 +101,13 @@ const fail = (message: string): never => {
 	process.exit(1);
 };
 
+// psql needs an explicit root-cert source for sslmode=verify-full URLs; Node's pg uses
+// the system CA store natively, so only the psql-facing URL gets the parameter.
+const withSystemRootCert = (url: string): string =>
+	url.includes("sslrootcert=")
+		? url
+		: `${url}${url.includes("?") ? "&" : "?"}sslrootcert=system`;
+
 const currentMonth = (): string => new Date().toISOString().slice(0, 7);
 
 const parseArgs = (argv: string[]): CliArgs => {
@@ -201,7 +208,7 @@ const acquireRunLock = async (neonUrl: string): Promise<Client> => {
 
 const ensureStagingTable = async (neonUrl: string): Promise<void> => {
 	const result =
-		await $`psql ${neonUrl} -X -v ON_ERROR_STOP=1 -c ${STAGING_DDL}`
+		await $`psql ${withSystemRootCert(neonUrl)} -X -v ON_ERROR_STOP=1 -c ${STAGING_DDL}`
 			.quiet()
 			.nothrow();
 	if (result.exitCode !== 0) {
@@ -222,7 +229,7 @@ const stageChunk = async (
 	const exportSql = duckDbExportSql(s3Prefix, orgId, year, monthNumber);
 	// Truncate first so rows left by a previously crashed run aren't double-staged.
 	const result =
-		await $`duckdb -c ${exportSql} | psql ${neonUrl} -X -v ON_ERROR_STOP=1 -c ${"TRUNCATE events_staging"} -c ${SET_UTC} -c ${COPY_TO_STAGING}`
+		await $`duckdb -c ${exportSql} | psql ${withSystemRootCert(neonUrl)} -X -v ON_ERROR_STOP=1 -c ${"TRUNCATE events_staging"} -c ${SET_UTC} -c ${COPY_TO_STAGING}`
 			.quiet()
 			.nothrow();
 	const stderr = result.stderr.toString();
@@ -251,7 +258,7 @@ const stageChunk = async (
 
 const mergeChunk = async (neonUrl: string): Promise<number> => {
 	const result =
-		await $`psql ${neonUrl} -X -v ON_ERROR_STOP=1 -c ${SET_UTC} -c ${MERGE_SQL} -c ${"TRUNCATE events_staging"}`
+		await $`psql ${withSystemRootCert(neonUrl)} -X -v ON_ERROR_STOP=1 -c ${SET_UTC} -c ${MERGE_SQL} -c ${"TRUNCATE events_staging"}`
 			.quiet()
 			.nothrow();
 	if (result.exitCode !== 0) {

--- a/server/src/cron/resetCron/runResetCron.ts
+++ b/server/src/cron/resetCron/runResetCron.ts
@@ -66,27 +66,40 @@ export const runResetCron = async ({ ctx }: { ctx: CronContext }) => {
 
 	try {
 		let iteration = 0;
+		let totalFetched = 0;
+		let totalUpserted = 0;
+
+		logger.info({ jobName: "reset-cus-ents" }, "[reset-cus-ents] started");
 
 		while (iteration < maxIterations && Date.now() - startTime < timeoutMs) {
 			iteration++;
 
+			const fetchStartedAt = Date.now();
 			const cusEnts = await CusEntService.getActiveResetPassed({
 				db,
 				batchSize: 5_000,
 				limit: 5_000,
 				includeSeparateIntervalResets: false,
 			});
+			totalFetched += cusEnts.length;
+
+			logger.info(
+				{
+					jobName: "reset-cus-ents",
+					iteration,
+					fetched: cusEnts.length,
+					fetchDurationMs: Date.now() - fetchStartedAt,
+				},
+				`[reset-cus-ents] iteration ${iteration}: fetched ${cusEnts.length} in ${Date.now() - fetchStartedAt}ms`,
+			);
 
 			if (cusEnts.length < 5_000) {
-				console.log(
-					`Reset cron: only ${cusEnts.length} entitlements to reset, skipping (lazy reset will handle)`,
+				logger.info(
+					{ jobName: "reset-cus-ents", fetched: cusEnts.length },
+					`[reset-cus-ents] only ${cusEnts.length} entitlements to reset, skipping (lazy reset will handle)`,
 				);
 				break;
 			}
-
-			console.log(
-				`Reset cron iteration ${iteration}: processing ${cusEnts.length} entitlements`,
-			);
 
 			const batchSize = 1000;
 			for (let i = 0; i < cusEnts.length; i += batchSize) {
@@ -137,7 +150,7 @@ export const runResetCron = async ({ ctx }: { ctx: CronContext }) => {
 					db,
 					data: toUpsert,
 				});
-				console.log(`Upserted ${toUpsert.length} short entitlements`);
+				totalUpserted += toUpsert.length;
 
 				await clearCusEntsFromCache({
 					cusEnts: updatedCusEnts,
@@ -145,12 +158,25 @@ export const runResetCron = async ({ ctx }: { ctx: CronContext }) => {
 			}
 		}
 
+		logger.info(
+			{
+				jobName: "reset-cus-ents",
+				iterations: iteration,
+				totalFetched,
+				totalUpserted,
+				durationMs: Date.now() - startTime,
+			},
+			`[reset-cus-ents] finished: fetched ${totalFetched}, upserted ${totalUpserted} (monthly/yearly resets update in place and are not counted here) across ${iteration} iteration(s) in ${Date.now() - startTime}ms`,
+		);
 		console.log(
 			"FINISHED RESET CRON:",
 			format(new UTCDate(), "yyyy-MM-dd HH:mm:ss"),
 		);
-		console.log("----------------------------------\n");
 	} catch (error) {
+		logger.error(
+			{ jobName: "reset-cus-ents", durationMs: Date.now() - startTime },
+			`[reset-cus-ents] failed: ${error}`,
+		);
 		console.error("Error getting entitlements for reset:", error);
 		return;
 	}

--- a/server/src/cron/resetCron/runResetCron.ts
+++ b/server/src/cron/resetCron/runResetCron.ts
@@ -174,8 +174,12 @@ export const runResetCron = async ({ ctx }: { ctx: CronContext }) => {
 		);
 	} catch (error) {
 		logger.error(
-			{ jobName: "reset-cus-ents", durationMs: Date.now() - startTime },
-			`[reset-cus-ents] failed: ${error}`,
+			{
+				jobName: "reset-cus-ents",
+				durationMs: Date.now() - startTime,
+				err: error,
+			},
+			"[reset-cus-ents] failed",
 		);
 		console.error("Error getting entitlements for reset:", error);
 		return;

--- a/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
@@ -176,53 +176,51 @@ export class CusEntService {
 		await db.insert(customerEntitlements).values(insertData);
 	}
 
-	static async getActiveResetPassed({
+	static buildActiveResetPassedPage({
 		db,
-		customDateUnix,
-		batchSize = 1000,
-		limit,
-		includeSeparateIntervalResets = true,
+		now,
+		batchSize,
+		cursor,
+		includeSeparateIntervalResets,
 	}: {
 		db: DrizzleCli;
-		customDateUnix?: number;
-		batchSize?: number;
-		limit?: number;
-		includeSeparateIntervalResets?: boolean;
+		now: number;
+		batchSize: number;
+		cursor: { nextResetAt: number; id: string } | null;
+		includeSeparateIntervalResets: boolean;
 	}) {
-		const allResults: FullCusEntWithProduct[] = [];
-		let offset = 0;
-		let hasMore = true;
-
-		// Shared projection across all three UNION ALL branches. Keeping the
-		// column list identical across branches is required for UNION ALL and
-		// lets the existing mapper below consume each row uniformly.
+		// Sort keys are projected as top-level output columns because Postgres
+		// only allows ORDER BY on a set operation via output column names.
 		const baseSelect = {
 			customer_entitlements: customerEntitlements,
 			entitlements: entitlements,
 			features: features,
 			customers: customers,
 			customer_products: customerProducts,
+			sort_reset: sql`${customerEntitlements.next_reset_at}`.as("sort_reset"),
+			sort_id: sql`${customerEntitlements.id} COLLATE "C"`.as("sort_id"),
 		};
 
-		// Common reset predicates applied in every branch: not marked expired
-		// (skips the backfilled terminal-product backlog via the partial index),
-		// next_reset_at has passed, and the entitlement has not expired.
 		const commonResetPredicates = () =>
 			and(
 				sql`${customerEntitlements.expired} IS NOT TRUE`,
-				lt(customerEntitlements.next_reset_at, customDateUnix ?? Date.now()),
+				lt(customerEntitlements.next_reset_at, now),
 				or(
 					isNull(customerEntitlements.expires_at),
-					gt(customerEntitlements.expires_at, customDateUnix ?? Date.now()),
+					gt(customerEntitlements.expires_at, now),
 				),
 			);
 
+		// COLLATE "C" keeps the cursor comparison aligned with sort_id's ordering.
+		const afterCursor = () =>
+			cursor
+				? sql`(${customerEntitlements.next_reset_at}, ${customerEntitlements.id} COLLATE "C") > (${cursor.nextResetAt}, ${cursor.id})`
+				: undefined;
+
 		// Exclude normal price-backed cusEnts: their reset is owned by the Stripe
-		// invoice.created handler, not this cron. Split prepaid reset intervals
-		// are included by dedicated branches below. Must stay in sync with
-		// `cusEntToCusPrice` (shared/utils/cusEntUtils/.../cusEntToCusPrice.ts)
-		// and the in-memory `getResettableCustomerEntitlements` filter.
-		// Only applies to branches with `customer_product_id` set (i.e. 2 + 3).
+		// invoice.created handler, not this cron. Must stay in sync with
+		// `cusEntToCusPrice` and the in-memory `getResettableCustomerEntitlements`
+		// filter. Only applies to branches with `customer_product_id` set (2 + 3).
 		const notPriceBacked = () =>
 			notExists(
 				db
@@ -242,123 +240,169 @@ export class CusEntService {
 				? or(eq(customerEntitlements.separate_interval, true), notPriceBacked())
 				: notPriceBacked();
 
-		while (hasMore) {
-			// Branch 1: cusEnts with no customer_product. Left-join to
-			// customer_products on a false predicate so the row shape matches
-			// the other branches (customer_products columns come back NULL).
-			const branch1 = db
-				.select(baseSelect)
-				.from(customerEntitlements)
-				.innerJoin(
-					entitlements,
-					eq(customerEntitlements.entitlement_id, entitlements.id),
-				)
-				.innerJoin(
-					features,
-					eq(entitlements.internal_feature_id, features.internal_id),
-				)
-				.innerJoin(
-					customers,
-					eq(customerEntitlements.internal_customer_id, customers.internal_id),
-				)
-				.leftJoin(customerProducts, sql`false`)
-				.where(
-					and(
-						isNull(customerEntitlements.customer_product_id),
-						commonResetPredicates(),
-					),
-				);
+		// Branch 1: cusEnts with no customer_product. Left-join to
+		// customer_products on a false predicate so the row shape matches
+		// the other branches (customer_products columns come back NULL).
+		const branch1 = db
+			.select(baseSelect)
+			.from(customerEntitlements)
+			.innerJoin(
+				entitlements,
+				eq(customerEntitlements.entitlement_id, entitlements.id),
+			)
+			.innerJoin(
+				features,
+				eq(entitlements.internal_feature_id, features.internal_id),
+			)
+			.innerJoin(
+				customers,
+				eq(customerEntitlements.internal_customer_id, customers.internal_id),
+			)
+			.leftJoin(customerProducts, sql`false`)
+			.where(
+				and(
+					isNull(customerEntitlements.customer_product_id),
+					commonResetPredicates(),
+					afterCursor(),
+				),
+			);
 
-			// Branch 2: cusEnts on active customer_products.
-			const branch2 = db
-				.select(baseSelect)
-				.from(customerEntitlements)
-				.innerJoin(
-					entitlements,
-					eq(customerEntitlements.entitlement_id, entitlements.id),
-				)
-				.innerJoin(
-					features,
-					eq(entitlements.internal_feature_id, features.internal_id),
-				)
-				.innerJoin(
-					customers,
-					eq(customerEntitlements.internal_customer_id, customers.internal_id),
-				)
-				.innerJoin(
-					customerProducts,
-					sql`${customerEntitlements.customer_product_id} COLLATE "C" = ${customerProducts.id}`,
-				)
-				.where(
-					and(
-						eq(customerProducts.status, CusProductStatus.Active),
-						commonResetPredicates(),
-						resetOwnedByAutumn(),
-					),
-				);
+		// Branch 2: cusEnts on active customer_products.
+		const branch2 = db
+			.select(baseSelect)
+			.from(customerEntitlements)
+			.innerJoin(
+				entitlements,
+				eq(customerEntitlements.entitlement_id, entitlements.id),
+			)
+			.innerJoin(
+				features,
+				eq(entitlements.internal_feature_id, features.internal_id),
+			)
+			.innerJoin(
+				customers,
+				eq(customerEntitlements.internal_customer_id, customers.internal_id),
+			)
+			.innerJoin(
+				customerProducts,
+				sql`${customerEntitlements.customer_product_id} COLLATE "C" = ${customerProducts.id}`,
+			)
+			.where(
+				and(
+					eq(customerProducts.status, CusProductStatus.Active),
+					commonResetPredicates(),
+					resetOwnedByAutumn(),
+					afterCursor(),
+				),
+			);
 
-			// Branch 3: cusEnts on past_due customer_products whose product
-			// opted into ignore_past_due via products.config.
-			const branch3 = db
-				.select(baseSelect)
-				.from(customerEntitlements)
-				.innerJoin(
-					entitlements,
-					eq(customerEntitlements.entitlement_id, entitlements.id),
-				)
-				.innerJoin(
-					features,
-					eq(entitlements.internal_feature_id, features.internal_id),
-				)
-				.innerJoin(
-					customers,
-					eq(customerEntitlements.internal_customer_id, customers.internal_id),
-				)
-				.innerJoin(
-					customerProducts,
-					sql`${customerEntitlements.customer_product_id} COLLATE "C" = ${customerProducts.id}`,
-				)
-				.innerJoin(
-					products,
-					eq(customerProducts.internal_product_id, products.internal_id),
-				)
-				.where(
-					and(
-						eq(customerProducts.status, CusProductStatus.PastDue),
-						sql`(${products.config}->>'ignore_past_due')::boolean = true`,
-						commonResetPredicates(),
-						resetOwnedByAutumn(),
-					),
-				);
+		// Branch 3: cusEnts on past_due customer_products whose product
+		// opted into ignore_past_due via products.config.
+		const branch3 = db
+			.select(baseSelect)
+			.from(customerEntitlements)
+			.innerJoin(
+				entitlements,
+				eq(customerEntitlements.entitlement_id, entitlements.id),
+			)
+			.innerJoin(
+				features,
+				eq(entitlements.internal_feature_id, features.internal_id),
+			)
+			.innerJoin(
+				customers,
+				eq(customerEntitlements.internal_customer_id, customers.internal_id),
+			)
+			.innerJoin(
+				customerProducts,
+				sql`${customerEntitlements.customer_product_id} COLLATE "C" = ${customerProducts.id}`,
+			)
+			.innerJoin(
+				products,
+				eq(customerProducts.internal_product_id, products.internal_id),
+			)
+			.where(
+				and(
+					eq(customerProducts.status, CusProductStatus.PastDue),
+					sql`(${products.config}->>'ignore_past_due')::boolean = true`,
+					commonResetPredicates(),
+					resetOwnedByAutumn(),
+					afterCursor(),
+				),
+			);
 
-			const data = await unionAll(branch1, branch2, branch3)
-				.limit(batchSize)
-				.offset(offset);
+		// One statement, one snapshot: branch consistency without a
+		// multi-statement transaction, and statement_timeout caps the whole page.
+		return unionAll(branch1, branch2, branch3)
+			.orderBy(sql`"sort_reset"`, sql`"sort_id"`)
+			.limit(batchSize);
+	}
 
-			// Note: PlanetScale tag would be added here but Drizzle 0.43.1's unionAll
-			// doesn't support .comment() method. Tag will be added after Drizzle upgrade.
-			// Target tag: planetScaleTag({ query: "getActiveResetPassed" })
+	static async getActiveResetPassed({
+		db,
+		customDateUnix,
+		batchSize = 1000,
+		limit,
+		includeSeparateIntervalResets = true,
+		onPageFetched,
+	}: {
+		db: DrizzleCli;
+		customDateUnix?: number;
+		batchSize?: number;
+		limit?: number;
+		includeSeparateIntervalResets?: boolean;
+		/** Test seam: runs between pages to exercise mid-pagination mutations. */
+		onPageFetched?: (page: ResetCusEnt[]) => void | Promise<void>;
+	}) {
+		const allResults: FullCusEntWithProduct[] = [];
+		const now = customDateUnix ?? Date.now();
+		let cursor: { nextResetAt: number; id: string } | null = null;
+		const emittedIds = new Set<string>();
 
-			if (data.length === 0 || (limit && allResults.length >= limit)) {
-				hasMore = false;
-			} else {
-				const mappedData = data.map((item) => ({
-					...item.customer_entitlements,
-					entitlement: {
-						...item.entitlements,
-						feature: item.features,
-					},
-					customer_product: item.customer_products,
-					customer: item.customers,
-					replaceables: [],
-					rollovers: [],
-				})) as ResetCusEnt[];
+		while (true) {
+			const page = await CusEntService.buildActiveResetPassedPage({
+				db,
+				now,
+				batchSize,
+				cursor,
+				includeSeparateIntervalResets,
+			});
 
-				allResults.push(...mappedData);
-				offset += batchSize;
-				hasMore = data.length === batchSize;
-				console.log(`Fetched ${allResults.length} entitlements to reset`);
+			if (page.length === 0) break;
+
+			const freshRows: typeof page = [];
+			for (const item of page) {
+				const id = item.customer_entitlements.id;
+				if (emittedIds.has(id)) continue;
+				emittedIds.add(id);
+				freshRows.push(item);
 			}
+
+			const mappedData = freshRows.map((item) => ({
+				...item.customer_entitlements,
+				entitlement: {
+					...item.entitlements,
+					feature: item.features,
+				},
+				customer_product: item.customer_products,
+				customer: item.customers,
+				replaceables: [],
+				rollovers: [],
+			})) as ResetCusEnt[];
+
+			allResults.push(...mappedData);
+			console.log(`Fetched ${allResults.length} entitlements to reset`);
+
+			const lastRow = page[page.length - 1].customer_entitlements;
+			cursor = {
+				nextResetAt: Number(lastRow.next_reset_at),
+				id: lastRow.id,
+			};
+
+			if (onPageFetched) await onPageFetched(mappedData);
+
+			if (page.length < batchSize) break;
+			if (limit && allResults.length >= limit) break;
 		}
 
 		return allResults as ResetCusEnt[];

--- a/server/tests/balances/cron/reset-keyset-pagination.test.ts
+++ b/server/tests/balances/cron/reset-keyset-pagination.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
 	ApiVersion,
 	CusProductStatus,
@@ -200,6 +200,10 @@ describe(`${chalk.yellowBright("reset-keyset-pagination: exactly-once, ordering,
 		});
 	});
 
+	afterAll(async () => {
+		await cleanupCustomers(ownCustomers);
+	});
+
 	test.concurrent(
 		"multi-page fetch returns every seeded candidate exactly once, in (next_reset_at, id) order",
 		async () => {
@@ -241,6 +245,10 @@ describe(`${chalk.yellowBright("reset-keyset-pagination: limit semantics")}`, ()
 		}
 	});
 
+	afterAll(async () => {
+		await cleanupCustomers(ownCustomers);
+	});
+
 	test.concurrent("limit stops fetching at the page boundary", async () => {
 		const results = await fetchAll({ batchSize: 3, limit: 4 });
 		expect(results.length).toBe(6);
@@ -263,10 +271,20 @@ describe(`${chalk.yellowBright("reset-keyset-pagination: shrink + re-qualify mut
 		}
 	});
 
+	afterAll(async () => {
+		await cleanupCustomers(ownCustomers);
+	});
+
 	test.concurrent(
-		"a row leaving the predicate mid-run does not skip unread rows; a re-qualifying emitted row is not duplicated",
+		"an emitted row leaving the predicate does not skip unread rows; an emitted row re-qualifying ahead of the cursor is not duplicated",
 		async () => {
-			let mutated = false;
+			// Mutation targets are chosen from rows PROVEN emitted in delivered
+			// pages, so ambient rows shifting page boundaries cannot silently
+			// downgrade this into a test that never exercises dedup.
+			const emitted = new Set<string>();
+			let shrunkId: string | undefined;
+			let requalifiedId: string | undefined;
+			let unreadAtMutation: string[] = [];
 
 			const results = await CusEntService.getActiveResetPassed({
 				db: ctx.db,
@@ -274,16 +292,30 @@ describe(`${chalk.yellowBright("reset-keyset-pagination: shrink + re-qualify mut
 				batchSize: 2,
 				limit: 1_000_000,
 				onPageFetched: async (page) => {
-					if (mutated) return;
-					if (!page.some((ce) => ce.id === seeded[0])) return;
-					mutated = true;
+					for (const ce of page) {
+						if (seeded.includes(ce.id)) emitted.add(ce.id);
+					}
+					if (requalifiedId) return;
 
-					await setResetAt(seeded[0], CUTOFF + 1_000_000);
-					await setResetAt(seeded[1], BAND + 5_000);
+					const unread = seeded.filter((id) => !emitted.has(id));
+					if (emitted.size < 2 || unread.length < 2) return;
+
+					// Both targets are behind the cursor: shrinking one is the
+					// OFFSET-skip repro; re-qualifying the other ahead of the
+					// cursor forces a second emission that dedup must filter.
+					const [first, second] = [...emitted];
+					shrunkId = first;
+					requalifiedId = second;
+					unreadAtMutation = unread;
+
+					await setResetAt(shrunkId, CUTOFF + 1_000_000);
+					await setResetAt(requalifiedId, BAND + 5_000);
 				},
 			});
 
-			expect(mutated).toBe(true);
+			expect(shrunkId).toBeDefined();
+			expect(requalifiedId).toBeDefined();
+			expect(unreadAtMutation.length).toBeGreaterThanOrEqual(2);
 
 			const returnedSeeded = results
 				.map((ce) => ce.id)
@@ -291,6 +323,9 @@ describe(`${chalk.yellowBright("reset-keyset-pagination: shrink + re-qualify mut
 
 			expect(new Set(returnedSeeded).size).toBe(returnedSeeded.length);
 			expect([...returnedSeeded].sort()).toEqual([...seeded].sort());
+			for (const id of unreadAtMutation) {
+				expect(returnedSeeded).toContain(id);
+			}
 		},
 	);
 });
@@ -309,6 +344,10 @@ describe(`${chalk.yellowBright("reset-keyset-pagination: backward cursor movemen
 		for (const [i, customerId] of ownCustomers.entries()) {
 			seeded.push(await seedLooseCusEnt({ customerId, nextResetAt: BAND + i }));
 		}
+	});
+
+	afterAll(async () => {
+		await cleanupCustomers(ownCustomers);
 	});
 
 	test.concurrent(

--- a/server/tests/balances/cron/reset-keyset-pagination.test.ts
+++ b/server/tests/balances/cron/reset-keyset-pagination.test.ts
@@ -1,0 +1,344 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import {
+	ApiVersion,
+	CusProductStatus,
+	customerEntitlements,
+	customerProducts,
+	customers,
+	type LimitedItem,
+	ProductItemInterval,
+	type ProductV2,
+	ResetInterval,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import chalk from "chalk";
+import { and, eq, inArray } from "drizzle-orm";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
+import { constructProduct } from "@/utils/scriptUtils/createTestProducts.js";
+import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
+import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
+import { findCustomerEntitlement } from "../utils/findCustomerEntitlement";
+
+const CUTOFF = 10_000_000;
+
+const autumnV1 = new AutumnInt({ version: ApiVersion.V1_2 });
+
+const cleanupCustomers = async (customerIds: string[]) => {
+	const rows = await ctx.db
+		.select({ internal_id: customers.internal_id })
+		.from(customers)
+		.where(
+			and(
+				eq(customers.org_id, ctx.org.id),
+				eq(customers.env, ctx.env),
+				inArray(customers.id, customerIds),
+			),
+		);
+	if (rows.length === 0) return;
+	await ctx.db.delete(customerEntitlements).where(
+		inArray(
+			customerEntitlements.internal_customer_id,
+			rows.map((r) => r.internal_id),
+		),
+	);
+};
+
+const setResetAt = async (cusEntId: string, nextResetAt: number) => {
+	await ctx.db
+		.update(customerEntitlements)
+		.set({ next_reset_at: nextResetAt })
+		.where(eq(customerEntitlements.id, cusEntId));
+};
+
+const seedLooseCusEnt = async ({
+	customerId,
+	nextResetAt,
+}: {
+	customerId: string;
+	nextResetAt: number;
+}) => {
+	await initCustomerV3({ ctx, customerId, withTestClock: false });
+	await autumnV1.balances.create({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		granted_balance: 100,
+		reset: { interval: ResetInterval.Month },
+	});
+	const cusEnt = await findCustomerEntitlement({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+	expect(cusEnt).toBeDefined();
+	await setResetAt(cusEnt!.id, nextResetAt);
+	return cusEnt!.id;
+};
+
+const seedProductCusEnt = async ({
+	customerId,
+	nextResetAt,
+	productStatus,
+	ignorePastDue,
+}: {
+	customerId: string;
+	nextResetAt: number;
+	productStatus: CusProductStatus;
+	ignorePastDue: boolean;
+}) => {
+	const item = constructFeatureItem({
+		featureId: TestFeature.Messages,
+		includedUsage: 100,
+		interval: ProductItemInterval.Month,
+	}) as LimitedItem;
+	const product = constructProduct({
+		items: [item],
+		type: "free",
+		isDefault: false,
+	}) as ProductV2;
+	product.config = { ignore_past_due: ignorePastDue };
+
+	await initProductsV0({
+		ctx,
+		products: [product],
+		prefix: customerId,
+		customerId,
+	});
+	await initCustomerV3({ ctx, customerId, withTestClock: false });
+	await autumnV1.attach({ customer_id: customerId, product_id: product.id });
+
+	const cusEnt = await findCustomerEntitlement({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+	expect(cusEnt?.customer_product_id).toBeDefined();
+
+	await setResetAt(cusEnt!.id, nextResetAt);
+	await ctx.db
+		.update(customerProducts)
+		.set({ status: productStatus })
+		.where(eq(customerProducts.id, cusEnt!.customer_product_id!));
+	return cusEnt!.id;
+};
+
+const fetchAll = (opts?: { batchSize?: number; limit?: number }) =>
+	CusEntService.getActiveResetPassed({
+		db: ctx.db,
+		customDateUnix: CUTOFF,
+		batchSize: opts?.batchSize ?? 3,
+		limit: opts?.limit ?? 1_000_000,
+	});
+
+describe(`${chalk.yellowBright("reset-keyset-pagination: single-statement page shape")}`, () => {
+	test.concurrent(
+		"a page is one SQL statement: union of 3 branches, ordered, no offset",
+		() => {
+			const query = CusEntService.buildActiveResetPassedPage({
+				db: ctx.db,
+				now: CUTOFF,
+				batchSize: 5,
+				cursor: { nextResetAt: 1, id: "cus_ent_x" },
+				includeSeparateIntervalResets: false,
+			});
+			const text = query.toSQL().sql.toLowerCase();
+
+			expect((text.match(/union all/g) ?? []).length).toBe(2);
+			expect(text).toContain('order by "sort_reset", "sort_id"');
+			expect(text).toContain("limit");
+			expect(text).not.toContain("offset");
+		},
+	);
+});
+
+describe(`${chalk.yellowBright("reset-keyset-pagination: exactly-once, ordering, branch merge, ties")}`, () => {
+	const BAND = 1_000_000;
+	const TIE = 1_050_000;
+	const distinctCustomers = Array.from({ length: 5 }, (_, i) => `kpg2-d-${i}`);
+	const tieCustomers = Array.from({ length: 4 }, (_, i) => `kpg2-t-${i}`);
+	const ownCustomers = [
+		...distinctCustomers,
+		...tieCustomers,
+		"kpg2-act",
+		"kpg2-pd",
+	];
+	const legacyCustomers = [
+		...Array.from({ length: 8 }, (_, i) => `keyset-pg-${i}`),
+		...Array.from({ length: 4 }, (_, i) => `keyset-tie-${i}`),
+		"keyset-br-active",
+		"keyset-br-pd",
+	];
+	const seededDistinct: string[] = [];
+	const seededTies: string[] = [];
+	let activeId: string;
+	let pastDueId: string;
+
+	beforeAll(async () => {
+		await cleanupCustomers([...ownCustomers, ...legacyCustomers]);
+
+		for (const [i, customerId] of distinctCustomers.entries()) {
+			seededDistinct.push(
+				await seedLooseCusEnt({ customerId, nextResetAt: BAND + i }),
+			);
+		}
+		for (const customerId of tieCustomers) {
+			seededTies.push(await seedLooseCusEnt({ customerId, nextResetAt: TIE }));
+		}
+		activeId = await seedProductCusEnt({
+			customerId: "kpg2-act",
+			nextResetAt: BAND + 100,
+			productStatus: CusProductStatus.Active,
+			ignorePastDue: false,
+		});
+		pastDueId = await seedProductCusEnt({
+			customerId: "kpg2-pd",
+			nextResetAt: BAND + 101,
+			productStatus: CusProductStatus.PastDue,
+			ignorePastDue: true,
+		});
+	});
+
+	test.concurrent(
+		"multi-page fetch returns every seeded candidate exactly once, in (next_reset_at, id) order",
+		async () => {
+			const results = await fetchAll();
+
+			const allSeeded = [...seededDistinct, activeId, pastDueId, ...seededTies];
+			const returnedSeeded = results
+				.map((ce) => ce.id)
+				.filter((id) => allSeeded.includes(id));
+
+			expect(new Set(returnedSeeded).size).toBe(allSeeded.length);
+
+			const expectedOrder = [
+				...seededDistinct,
+				activeId,
+				pastDueId,
+				...[...seededTies].sort(),
+			];
+			expect(returnedSeeded).toEqual(expectedOrder);
+
+			const activeRow = results.find((ce) => ce.id === activeId);
+			const pastDueRow = results.find((ce) => ce.id === pastDueId);
+			expect(activeRow?.customer_product?.status).toBe(CusProductStatus.Active);
+			expect(pastDueRow?.customer_product?.status).toBe(
+				CusProductStatus.PastDue,
+			);
+		},
+	);
+});
+
+describe(`${chalk.yellowBright("reset-keyset-pagination: limit semantics")}`, () => {
+	const BAND = 1_500_000;
+	const ownCustomers = Array.from({ length: 7 }, (_, i) => `klim-${i}`);
+
+	beforeAll(async () => {
+		await cleanupCustomers(ownCustomers);
+		for (const [i, customerId] of ownCustomers.entries()) {
+			await seedLooseCusEnt({ customerId, nextResetAt: BAND + i });
+		}
+	});
+
+	test.concurrent("limit stops fetching at the page boundary", async () => {
+		const results = await fetchAll({ batchSize: 3, limit: 4 });
+		expect(results.length).toBe(6);
+	});
+});
+
+describe(`${chalk.yellowBright("reset-keyset-pagination: shrink + re-qualify mutations")}`, () => {
+	const BAND = 2_000_000;
+	const ownCustomers = Array.from({ length: 6 }, (_, i) => `kmta-${i}`);
+	const legacyCustomers = [
+		...Array.from({ length: 6 }, (_, i) => `keyset-mut-${i}`),
+		...Array.from({ length: 6 }, (_, i) => `keyset-mut-a-${i}`),
+	];
+	const seeded: string[] = [];
+
+	beforeAll(async () => {
+		await cleanupCustomers([...ownCustomers, ...legacyCustomers]);
+		for (const [i, customerId] of ownCustomers.entries()) {
+			seeded.push(await seedLooseCusEnt({ customerId, nextResetAt: BAND + i }));
+		}
+	});
+
+	test.concurrent(
+		"a row leaving the predicate mid-run does not skip unread rows; a re-qualifying emitted row is not duplicated",
+		async () => {
+			let mutated = false;
+
+			const results = await CusEntService.getActiveResetPassed({
+				db: ctx.db,
+				customDateUnix: CUTOFF,
+				batchSize: 2,
+				limit: 1_000_000,
+				onPageFetched: async (page) => {
+					if (mutated) return;
+					if (!page.some((ce) => ce.id === seeded[0])) return;
+					mutated = true;
+
+					await setResetAt(seeded[0], CUTOFF + 1_000_000);
+					await setResetAt(seeded[1], BAND + 5_000);
+				},
+			});
+
+			expect(mutated).toBe(true);
+
+			const returnedSeeded = results
+				.map((ce) => ce.id)
+				.filter((id) => seeded.includes(id));
+
+			expect(new Set(returnedSeeded).size).toBe(returnedSeeded.length);
+			expect([...returnedSeeded].sort()).toEqual([...seeded].sort());
+		},
+	);
+});
+
+describe(`${chalk.yellowBright("reset-keyset-pagination: backward cursor movement")}`, () => {
+	const BAND = 2_500_000;
+	const ownCustomers = Array.from({ length: 6 }, (_, i) => `kmtb-${i}`);
+	const legacyCustomers = Array.from(
+		{ length: 6 },
+		(_, i) => `keyset-mut-b-${i}`,
+	);
+	const seeded: string[] = [];
+
+	beforeAll(async () => {
+		await cleanupCustomers([...ownCustomers, ...legacyCustomers]);
+		for (const [i, customerId] of ownCustomers.entries()) {
+			seeded.push(await seedLooseCusEnt({ customerId, nextResetAt: BAND + i }));
+		}
+	});
+
+	test.concurrent(
+		"a row moved backward behind the cursor is deferred to the next scan, then recovered",
+		async () => {
+			let mutated = false;
+
+			const firstRun = await CusEntService.getActiveResetPassed({
+				db: ctx.db,
+				customDateUnix: CUTOFF,
+				batchSize: 2,
+				limit: 1_000_000,
+				onPageFetched: async (page) => {
+					if (mutated) return;
+					if (!page.some((ce) => ce.id === seeded[0])) return;
+					mutated = true;
+					await setResetAt(seeded[4], BAND - 100);
+				},
+			});
+
+			expect(mutated).toBe(true);
+
+			const firstRunSeeded = firstRun
+				.map((ce) => ce.id)
+				.filter((id) => seeded.includes(id));
+			expect(firstRunSeeded).not.toContain(seeded[4]);
+			expect(firstRunSeeded.length).toBe(seeded.length - 1);
+
+			const secondRun = await fetchAll({ batchSize: 2 });
+			expect(secondRun.map((ce) => ce.id)).toContain(seeded[4]);
+		},
+	);
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve reset cron reliability with keyset pagination and clearer telemetry, and harden the Neon events backfill with serialized runs, robust `duckdb` → `psql` export, and consistent `deductions` data.

- **New Features**
  - Reset cron: keyset pagination on `(next_reset_at, id)` via a single UNION‑ALL page; dedup across pages; added start/iteration/final totals, durations, and failure logs.
  - Backfill: session advisory lock via `pg_try_advisory_lock` to prevent concurrent runs; progress logs for export, staging, and merge.

- **Bug Fixes**
  - Backfill: normalize Tinybird `deductions` (`{list:[...]}`/`{}`) to a bare array and decode Parquet strings to clean UTF‑8; switch to file handoff in `/var/tmp` with strict exit‑code checks; add `sslrootcert=system` for `psql` verify‑full URLs.
  - Tests: add keyset pagination suite covering page shape, ordering, ties, limits, mid‑run mutations, and backward‑cursor recovery.

<sup>Written for commit fb0e5ad5d8b2755b57eb00a039781db4036c9b3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves the event backfill and reset-entitlement cron paths. The main changes are:

- **Improvements:** Adds advisory locking, file-based export, and historical event normalization to the Neon backfill.
- **Bug fixes:** Replaces offset pagination with deterministic keyset pagination for entitlement resets.
- **Improvements:** Adds structured reset-cron telemetry and pagination mutation tests.
</details>

<h3>Confidence Score: 4/5</h3>

The backfill retry path needs a fix before merging.

- A crash can leave the fixed DuckDB output file behind.
- Later runs reuse that path and can fail before staging begins.
- The entitlement pagination changes have focused coverage for ordering and mutations.

scripts/ops/backfill-events-neon.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/ops/backfill-events-neon.ts | Adds serialized file-based exports and event normalization, but a crash artifact can block later runs. |
| server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts | Replaces offset pagination with ordered keyset pagination and deduplicates rows across changing pages. |
| server/src/cron/resetCron/runResetCron.ts | Adds structured lifecycle, iteration, and failure logging without changing reset processing. |
| server/tests/balances/cron/reset-keyset-pagination.test.ts | Covers query shape, ordering, ties, page limits, and mutations during pagination. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
scripts/ops/backfill-events-neon.ts:247-248
**Crash Artifact Blocks Retries**

If a run exits before the cleanup on line 265, `/var/tmp/backfill_chunk.csv` remains after the advisory lock is released. The next run reuses that path, so DuckDB refuses to overwrite the existing output and the backfill cannot resume without manual cleanup.

```suggestion
	console.log(`[${hms()}]   ${month}: exporting from S3 (duckdb)...`);
	await $`rm -f ${csvPath}`.quiet().nothrow();
	const duck = await $`duckdb < ${Bun.file(scriptPath)}`.quiet().nothrow();
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #2222 from useautumn/..."](https://github.com/useautumn/autumn/commit/53b8da151088b96a9996e938bd6b0dd7fbd490f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43806549)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->