### PR TITLE
add tests

### DIFF
--- a/vite/src/components/forms/update-subscription-v2/hooks/useHasSubscriptionChanges.ts
+++ b/vite/src/components/forms/update-subscription-v2/hooks/useHasSubscriptionChanges.ts
@@ -8,10 +8,40 @@ import {
 	generateVersionChanges,
 	type ProductItem,
 	ProductItemFeatureType,
+	type ProductItemInterval,
 } from "@autumn/shared";
 import { useMemo } from "react";
 import type { PrepaidItemWithFeature } from "@/hooks/stores/useProductStore";
 import type { UpdateSubscriptionForm } from "../updateSubscriptionFormSchema";
+
+type PrepaidChangeItem = {
+	interval?: ProductItemInterval | null;
+	feature_type?: ProductItemFeatureType | null;
+};
+
+/** Whether a prepaid quantity change counts as a subscription change. Extracted for testability. */
+export function shouldCountPrepaidChange({
+	item,
+	newlyAdded,
+	initialQuantity,
+	updatedQuantity,
+}: {
+	item?: PrepaidChangeItem;
+	newlyAdded: boolean;
+	initialQuantity: number;
+	updatedQuantity: number;
+}): boolean {
+	if (newlyAdded) return false;
+	// Consumable one-off top-ups only count when increasing; non-consumables
+	// (continuous use) count on any delta, including a decrease.
+	const isConsumableOneOff =
+		item?.interval == null &&
+		item?.feature_type !== ProductItemFeatureType.ContinuousUse;
+	if (isConsumableOneOff) {
+		return updatedQuantity > initialQuantity;
+	}
+	return true;
+}
 
 export function useHasSubscriptionChanges({
 	formValues,
@@ -78,18 +108,13 @@ export function useHasSubscriptionChanges({
 			originalOptions: initialPrepaidOptions,
 		}).filter((change) => {
 			const featureId = change.id.replace("prepaid-", "");
-			if (newlyAddedFeatureIds.has(featureId)) return false;
 			const item = prepaidItems.find((it) => it.feature_id === featureId);
-			// Consumable one-off top-ups only count as a change when increasing;
-			// non-consumables (continuous use) change on any delta, including a decrease.
-			const isConsumableOneOff =
-				item?.interval == null &&
-				item?.feature_type !== ProductItemFeatureType.ContinuousUse;
-			if (isConsumableOneOff) {
-				const initial = initialPrepaidOptions[featureId] ?? 0;
-				return (formValues.prepaidOptions[featureId] ?? 0) > initial;
-			}
-			return true;
+			return shouldCountPrepaidChange({
+				item,
+				newlyAdded: newlyAddedFeatureIds.has(featureId),
+				initialQuantity: initialPrepaidOptions[featureId] ?? 0,
+				updatedQuantity: formValues.prepaidOptions[featureId] ?? 0,
+			});
 		});
 
 		return prepaidChanges.length > 0;

--- a/vite/tests/components/forms/update-subscription-v2/hooks/should-count-prepaid-change.test.ts
+++ b/vite/tests/components/forms/update-subscription-v2/hooks/should-count-prepaid-change.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { ProductItemFeatureType, ProductItemInterval } from "@autumn/shared";
+import { shouldCountPrepaidChange } from "@/components/forms/update-subscription-v2/hooks/useHasSubscriptionChanges";
+
+describe("shouldCountPrepaidChange", () => {
+	test("counts a decrease on a non-consumable (continuous use) one-off item", () => {
+		// Non-consumables are continuous-use levels with interval null. Lowering the
+		// quantity (300 -> 200) is a real change and must trigger the update call.
+		const result = shouldCountPrepaidChange({
+			item: {
+				interval: null,
+				feature_type: ProductItemFeatureType.ContinuousUse,
+			},
+			newlyAdded: false,
+			initialQuantity: 300,
+			updatedQuantity: 200,
+		});
+
+		expect(result).toBe(true);
+	});
+
+	test("does NOT count a decrease on a consumable one-off top-up", () => {
+		// Consumable top-ups can only be increased — a lower total is not a purchase.
+		const result = shouldCountPrepaidChange({
+			item: {
+				interval: null,
+				feature_type: ProductItemFeatureType.SingleUse,
+			},
+			newlyAdded: false,
+			initialQuantity: 1000,
+			updatedQuantity: 800,
+		});
+
+		expect(result).toBe(false);
+	});
+
+	test("counts an increase on a consumable one-off top-up", () => {
+		const result = shouldCountPrepaidChange({
+			item: {
+				interval: null,
+				feature_type: ProductItemFeatureType.SingleUse,
+			},
+			newlyAdded: false,
+			initialQuantity: 1000,
+			updatedQuantity: 1500,
+		});
+
+		expect(result).toBe(true);
+	});
+
+	test("counts any change on a recurring item", () => {
+		const result = shouldCountPrepaidChange({
+			item: {
+				interval: ProductItemInterval.Month,
+				feature_type: ProductItemFeatureType.SingleUse,
+			},
+			newlyAdded: false,
+			initialQuantity: 300,
+			updatedQuantity: 200,
+		});
+
+		expect(result).toBe(true);
+	});
+
+	test("ignores newly added items (handled elsewhere)", () => {
+		const result = shouldCountPrepaidChange({
+			item: {
+				interval: null,
+				feature_type: ProductItemFeatureType.ContinuousUse,
+			},
+			newlyAdded: true,
+			initialQuantity: 0,
+			updatedQuantity: 200,
+		});
+
+		expect(result).toBe(false);
+	});
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Extracted prepaid quantity-change rules into `shouldCountPrepaidChange` and added unit tests. This ensures we only trigger subscription updates for valid changes and ignore newly added items.

- **Refactors**
  - Moved logic from `useHasSubscriptionChanges` into `shouldCountPrepaidChange` and wired it into the hook for better testability.

<sup>Written for commit 668fc9ea946d90c351e69d4fd26c00aa3ea9ba6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extracts and tests the prepaid subscription-change predicate. The main changes are:

- **Improvements:** Moves prepaid quantity classification into an exported pure helper.
- **Bug fixes:** Covers decreases for continuous-use one-off items and consumable top-ups.
- **Improvements:** Adds cases for increases, recurring items, and newly added items.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The extracted helper preserves the previous inline behavior.
- The new imports follow existing test and alias conventions.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/forms/update-subscription-v2/hooks/useHasSubscriptionChanges.ts | Extracts the existing prepaid-change predicate without changing its effective behavior. |
| vite/tests/components/forms/update-subscription-v2/hooks/should-count-prepaid-change.test.ts | Adds focused tests for the predicate's main item and quantity branches. |

<sub>Reviews (1): Last reviewed commit: ["add tests"](https://github.com/useautumn/autumn/commit/668fc9ea946d90c351e69d4fd26c00aa3ea9ba6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43823458)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->