### PR TITLE
fix(billing): honor phase anchor resets in schedule previews

### DIFF
--- a/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/billingPlanToNextCyclePreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/billingPlanToNextCyclePreview.ts
@@ -198,7 +198,9 @@ export const billingPlanToNextCyclePreview = ({
 			startsAtMs: event.startsAtMs - MS_PER_SECOND,
 		});
 		const billingCycleAnchorMs =
-			productsForUsageLineItems.length === 0 ? event.startsAtMs : anchorMs;
+			event.resetsBillingCycle || productsForUsageLineItems.length === 0
+				? event.startsAtMs
+				: anchorMs;
 		const lineItemsResult = billingPlanToNextCycleLineItems({
 			ctx,
 			customerProducts: event.customerProducts,

--- a/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/billingPlanToNextCyclePreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/billingPlanToNextCyclePreview.ts
@@ -157,7 +157,9 @@ export const billingPlanToNextCyclePreview = ({
 				{
 					customerProducts: event.incomingCustomerProducts,
 					direction: "charge",
-					billingCycleAnchorMs: anchorMs,
+					billingCycleAnchorMs: event.resetsBillingCycle
+						? event.startsAtMs
+						: anchorMs,
 					filterBillingPeriodStart: false,
 					priceFilters: { excludeOneOffPrices: true },
 				},

--- a/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/classifyNextCycleEvent.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/classifyNextCycleEvent.ts
@@ -10,12 +10,12 @@ import {
 	uniqueCustomerProductsById,
 } from "./customerProductDiffs";
 import { SECOND_MS, timestampsEqual } from "./timeUtils";
-import type { NextCycleEvent, SmallestInterval } from "./types";
 import {
 	getExactTransitionTimestamp,
 	hasProductTransitionAt,
 	hasTrialEndAt,
 } from "./transitionCandidates";
+import type { NextCycleEvent, SmallestInterval } from "./types";
 
 /** Classifies one candidate timestamp into the invoice event it represents. */
 export const classifyNextCycleEvent = ({
@@ -57,10 +57,14 @@ export const classifyNextCycleEvent = ({
 		};
 	}
 
-	const isAnchorReset = timestampsEqual(
-		billingContext.requestedBillingCycleAnchor,
-		startsAtMs,
-	);
+	const isAnchorReset =
+		timestampsEqual(billingContext.requestedBillingCycleAnchor, startsAtMs) ||
+		normalizedCustomerProducts.some((customerProduct) =>
+			timestampsEqual(
+				customerProduct.billing_cycle_anchor_resets_at ?? undefined,
+				startsAtMs,
+			),
+		);
 	const isProductTransition = hasProductTransitionAt({
 		customerProducts: normalizedCustomerProducts,
 		startsAtMs,
@@ -102,6 +106,7 @@ export const classifyNextCycleEvent = ({
 			kind: "scheduled_change",
 			smallestInterval,
 			startsAtMs: exactStartsAtMs,
+			resetsBillingCycle: isAnchorReset,
 			incomingCustomerProducts,
 			outgoingCustomerProducts,
 		};
@@ -121,6 +126,7 @@ export const classifyNextCycleEvent = ({
 			kind: "scheduled_change",
 			smallestInterval,
 			startsAtMs: exactStartsAtMs,
+			resetsBillingCycle: isAnchorReset,
 			incomingCustomerProducts,
 			outgoingCustomerProducts,
 		};

--- a/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/classifyNextCycleEvent.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/classifyNextCycleEvent.ts
@@ -117,6 +117,7 @@ export const classifyNextCycleEvent = ({
 			kind: "scheduled_start",
 			smallestInterval,
 			startsAtMs: exactStartsAtMs,
+			resetsBillingCycle: isAnchorReset,
 			customerProducts: incomingCustomerProducts,
 		};
 	}

--- a/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/types.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/types.ts
@@ -1,7 +1,4 @@
-import type {
-	BillingInterval,
-	FullCusProduct,
-} from "@autumn/shared";
+import type { BillingInterval, FullCusProduct } from "@autumn/shared";
 
 export type SmallestInterval = {
 	interval: BillingInterval;
@@ -33,6 +30,7 @@ export type NextCycleEvent =
 	| ({
 			kind: "scheduled_change";
 			startsAtMs: number;
+			resetsBillingCycle: boolean;
 			incomingCustomerProducts: FullCusProduct[];
 			outgoingCustomerProducts: FullCusProduct[];
 	  } & NextCycleEventContext);

--- a/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/types.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/types.ts
@@ -20,6 +20,7 @@ export type NextCycleEvent =
 	| ({
 			kind: "scheduled_start";
 			startsAtMs: number;
+			resetsBillingCycle: boolean;
 			customerProducts: FullCusProduct[];
 	  } & NextCycleEventContext)
 	| ({

--- a/server/tests/integration/billing/create-schedule/preview/create-schedule-phase-anchor-reset-preview.test.ts
+++ b/server/tests/integration/billing/create-schedule/preview/create-schedule-phase-anchor-reset-preview.test.ts
@@ -1,0 +1,77 @@
+// Before: a future phase anchor reset previews a partial cycle from the saved schedule start.
+// After: it previews a full new cycle minus the unused current-plan credit.
+
+import { expect, test } from "bun:test";
+import {
+	type AttachPreviewResponse,
+	applyProration,
+	type CreateScheduleParamsV0Input,
+	ms,
+	truncateMsToSecondPrecision,
+} from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import { addMonths } from "date-fns";
+
+test.concurrent(
+	"create-schedule preview: future plan transition with phase anchor reset starts a full cycle",
+	async () => {
+		const currentPlan = products.pro({
+			id: "phase-anchor-preview-current",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const nextPlan = products.premium({
+			id: "phase-anchor-preview-next",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+		const { customerId, autumnV1, advancedTo } = await initScenario({
+			customerId: "create-schedule-phase-anchor-reset-preview",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [currentPlan, nextPlan] }),
+			],
+			actions: [],
+		});
+
+		const currentPlanEndsAt = truncateMsToSecondPrecision(
+			addMonths(advancedTo, 1).getTime(),
+		);
+		const transitionAt = currentPlanEndsAt - ms.days(2);
+		const phases: CreateScheduleParamsV0Input["phases"] = [
+			{ starts_at: advancedTo, plans: [{ plan_id: currentPlan.id }] },
+			{ starts_at: transitionAt, plans: [{ plan_id: nextPlan.id }] },
+		];
+
+		await autumnV1.billing.createSchedule({
+			customer_id: customerId,
+			billing_behavior: "none",
+			phases,
+		});
+
+		const preview: AttachPreviewResponse = await autumnV1.post(
+			"/billing.preview_create_schedule",
+			{
+				customer_id: customerId,
+				billing_behavior: "none",
+				phases: [
+					phases[0],
+					{ ...phases[1], billing_cycle_anchor: "phase_start" },
+				],
+			},
+		);
+		const unusedCurrentPlan = applyProration({
+			now: transitionAt,
+			billingPeriod: { start: advancedTo, end: currentPlanEndsAt },
+			amount: 20,
+		});
+		const positiveTotal = preview.next_cycle?.line_items
+			.filter((lineItem) => lineItem.total > 0)
+			.reduce((total, lineItem) => total + lineItem.total, 0);
+
+		expect(preview.total).toBe(0);
+		expect(positiveTotal).toBeCloseTo(50, 2);
+		expect(preview.next_cycle?.total).toBeCloseTo(50 - unusedCurrentPlan, 2);
+		expect(preview.next_cycle?.starts_at).toBe(transitionAt);
+	},
+);

--- a/server/tests/unit/billing/next-cycle-event-anchor-reset.test.ts
+++ b/server/tests/unit/billing/next-cycle-event-anchor-reset.test.ts
@@ -1,0 +1,53 @@
+// A phase reset must survive classification when it only starts a product.
+// The preview uses this metadata to charge the incoming product from phase start.
+
+import { expect, test } from "bun:test";
+import {
+	type BillingContext,
+	BillingInterval,
+	type FullCusProduct,
+} from "@autumn/shared";
+import { classifyNextCycleEvent } from "@/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/classifyNextCycleEvent";
+
+const customerProduct = ({
+	id,
+	startsAt,
+	resetAt,
+}: {
+	id: string;
+	startsAt: number;
+	resetAt?: number;
+}) =>
+	({
+		id,
+		starts_at: startsAt,
+		ended_at: null,
+		billing_cycle_anchor_resets_at: resetAt ?? null,
+		product: { group: null, is_add_on: false },
+	}) as unknown as FullCusProduct;
+
+test("scheduled start carries its second-normalized phase anchor reset", () => {
+	const startsAtMs = Date.UTC(2026, 6, 20, 10);
+	const stableProduct = customerProduct({ id: "stable", startsAt: 0 });
+	const incomingProduct = customerProduct({
+		id: "incoming",
+		startsAt: startsAtMs,
+		resetAt: startsAtMs + 999,
+	});
+
+	const event = classifyNextCycleEvent({
+		billingContext: {} as BillingContext,
+		customerProducts: [stableProduct, incomingProduct],
+		normalizedCustomerProducts: [stableProduct, incomingProduct],
+		startsAtMs,
+		renewalBoundaryMs: startsAtMs + 86_400_000,
+		smallestInterval: { interval: BillingInterval.Month, intervalCount: 1 },
+	});
+
+	expect(event).toMatchObject({
+		kind: "scheduled_start",
+		startsAtMs,
+		resetsBillingCycle: true,
+		customerProducts: [incomingProduct],
+	});
+});


### PR DESCRIPTION
## Summary

- carry scheduled phase billing-cycle resets through next-cycle event classification
- charge the incoming plan from the phase start while preserving the outgoing plan unused-time credit
- add an integration regression test for a transition shortly before the existing cycle ends

## Verification

- regression test: 1 passed, 0 failed on latest `origin/dev`
- server TypeScript build passed (including the commit hook)
- Biome and `git diff --check` passed
- related phase-anchor, backdate, allocated-preview, and event-classification coverage passed
- broad create-schedule preview suite: 16/18; the remaining two failures reproduce unchanged on clean `dev`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix schedule previews to honor phase-level billing cycle anchor resets, including scheduled starts. New plans start a full cycle at the phase boundary, and the outgoing plan’s unused time is credited.

- **Bug Fixes**
  - Preserves phase reset metadata in next-cycle event classification for both `scheduled_change` and `scheduled_start` events via `resetsBillingCycle`.
  - Rebases `billingCycleAnchorMs` to event `startsAtMs` for incoming charges and usage line items when a reset is present; otherwise keeps the existing anchor.
  - Matches resets at second precision to handle same-second millisecond differences; adds focused unit and integration tests.

<sup>Written for commit 324d63c30d13cee7dd9cc501bdfefd7d71a368e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates schedule previews to honor phase billing-cycle resets. The main changes are:

- **Bug fixes:** Carry phase reset state into scheduled-change classification.
- **Bug fixes:** Charge the incoming plan from the phase start while preserving the outgoing-plan credit.
- **Improvements:** Add an integration test for a transition shortly before the current cycle ends.
</details>

<h3>Confidence Score: 4/5</h3>

Mixed-product schedule events can produce incorrect incoming charges and need a fix before merging.

- One product's cycle reset is applied to every incoming product in the event.
- Same-second events with different millisecond timestamps can start the new cycle at the wrong instant.
- The added test covers only a single incoming plan.

server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/classifyNextCycleEvent.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/billingPlanToNextCyclePreview.ts | Uses the phase start for incoming charges when a scheduled change resets the billing cycle. |
| server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/classifyNextCycleEvent.ts | Detects persisted phase resets but collapses product-specific state into one event-wide flag. |
| server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/types.ts | Adds reset state to the scheduled-change event type. |
| server/tests/integration/billing/create-schedule/preview/create-schedule-phase-anchor-reset-preview.test.ts | Covers a single-plan phase reset with a full incoming charge and unused outgoing credit. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/classifyNextCycleEvent.ts:60-67
**Product Reset Becomes Event-Wide**

When one product resets at the same time another product transitions, `some()` marks the whole event as resetting. The preview then rebases every incoming product to the event start, so products that should retain their existing cycle can receive an incorrect prorated charge.

### Issue 2 of 2
server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/classifyNextCycleEvent.ts:60-67
**Reset Uses Different Exact Timestamp**

The reset check compares the second-normalized candidate, but the returned event uses `exactStartsAtMs`, which may select an earlier transition within that second. If a reset and another transition have different millisecond values in the same second, the incoming cycle starts at the other transition rather than the reset time, shifting its billing period.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): honor phase anchor resets ..."](https://github.com/useautumn/autumn/commit/ac436c51ad1c6965805661894cf3f779af4f63bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43847675)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->