### PR TITLE
Allow invoice-mode start for usage-in-arrears subscriptions

### DIFF
--- a/vite/src/components/forms/attach-v2/components/AttachAdvancedSection.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachAdvancedSection.tsx
@@ -158,6 +158,7 @@ export function AttachAdvancedSection() {
 		isEndOfCycleSelected,
 		isNoChargesAllowed,
 		canChooseBillingCycle,
+		createsNewStripeSubscription,
 		handleScheduleChange,
 		handleBillingCycleChange,
 		handleProrationBehaviorChange,
@@ -172,8 +173,6 @@ export function AttachAdvancedSection() {
 		isPaidRecurringProduct &&
 		!trialEnabled &&
 		effectivePlanSchedule !== "end_of_cycle";
-	const createsNewStripeSubscription =
-		!hasActiveSubscription || newBillingSubscription;
 	const allowBackdatedStartDate = showStartDate && createsNewStripeSubscription;
 	const showEndDate = !!product && !isFreeProductV2({ items: product.items });
 	const attachStartsAt =

--- a/vite/src/components/forms/attach-v2/components/AttachFooterV3.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachFooterV3.tsx
@@ -41,12 +41,13 @@ export function getConfirmLabel({
 }
 
 export function AttachFooterV3() {
-	const { isPending, previewQuery, handleConfirm, formValues } =
+	const { isPending, previewQuery, handleConfirm, handleInvoiceAttach, formValues } =
 		useAttachFormContext();
 	const { setSheet } = useSheetStore();
 	const itemId = useSheetStore((s) => s.itemId);
 
-	const { isEndOfCycleSelected } = useAttachBillingOptionsState();
+	const { isEndOfCycleSelected, createsRecurringSubscription } =
+		useAttachBillingOptionsState();
 
 	const previewData = previewQuery.data;
 	const hasFutureStartDate = isFutureStartDate(formValues.startDate);
@@ -55,15 +56,36 @@ export function AttachFooterV3() {
 		startDate: formValues.startDate,
 	});
 
-	const isZeroAmount = previewData && previewData.total <= 0;
+	const hasNothingToInvoice =
+		!!previewData && previewData.total <= 0 && !createsRecurringSubscription;
 
 	const invoiceDisabledReason = isEndOfCycleSelected
 		? "Invoices are not available for end of cycle changes as there is no immediate charge to invoice"
 		: hasFutureStartDate
 			? "Invoices are not available for future start dates. Schedule the plan instead."
-			: isZeroAmount
+			: hasNothingToInvoice
 				? "Cannot send an invoice for $0 amounts. Please confirm the change instead."
 				: null;
+
+	// Usage-in-arrears subscription: nothing to invoice now, so start it directly
+	// in invoice mode instead of opening the send-invoice sheet.
+	const isInvoiceOnlyStart =
+		!!previewData && previewData.total <= 0 && createsRecurringSubscription;
+
+	const invoiceButtonLabel = isInvoiceOnlyStart
+		? "Start subscription in invoice mode"
+		: "Send an Invoice";
+
+	const handleInvoiceButtonClick = () => {
+		if (isInvoiceOnlyStart) {
+			handleInvoiceAttach({
+				enableProductImmediately: true,
+				finalizeInvoice: true,
+			});
+			return;
+		}
+		setSheet({ type: "attach-send-invoice", itemId });
+	};
 
 	return (
 		<SheetFooter className="flex flex-col grid-cols-1 mt-0">
@@ -83,11 +105,10 @@ export function AttachFooterV3() {
 									invoiceDisabledReason && "pointer-events-none opacity-50",
 								)}
 								disabled={!invoiceDisabledReason && isPending}
-								onClick={() =>
-									setSheet({ type: "attach-send-invoice", itemId })
-								}
+								isLoading={isInvoiceOnlyStart && isPending}
+								onClick={handleInvoiceButtonClick}
 							>
-								Send an Invoice
+								{invoiceButtonLabel}
 							</Button>
 						</span>
 					</TooltipTrigger>

--- a/vite/src/components/forms/attach-v2/components/AttachFooterV3.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachFooterV3.tsx
@@ -67,10 +67,18 @@ export function AttachFooterV3() {
 				? "Cannot send an invoice for $0 amounts. Please confirm the change instead."
 				: null;
 
-	// Usage-in-arrears subscription: nothing to invoice now, so start it directly
-	// in invoice mode instead of opening the send-invoice sheet.
+	// Trials and credit-covered charges still create a $0 invoice, so keep the
+	// invoice sheet for those; only bypass it when no invoice is created at all.
+	const willCreateZeroDollarInvoice =
+		(previewData?.subtotal ?? 0) > 0 ||
+		(previewData?.invoice_credits?.balance ?? 0) > 0 ||
+		formValues.trialEnabled === true;
+
 	const isInvoiceOnlyStart =
-		!!previewData && previewData.total <= 0 && createsRecurringSubscription;
+		!!previewData &&
+		previewData.total <= 0 &&
+		createsRecurringSubscription &&
+		!willCreateZeroDollarInvoice;
 
 	const invoiceButtonLabel = isInvoiceOnlyStart
 		? "Start subscription in invoice mode"

--- a/vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts
@@ -63,6 +63,23 @@ export function useAttachBillingOptionsState() {
 		(outgoingPlan?.price?.amount ?? 0) > 0 &&
 		outgoingPlan?.price?.interval !== BillingInterval.OneOff;
 
+	const createsNewStripeSubscription =
+		!hasActiveSubscription || newBillingSubscription;
+
+	// Usage-only plans have a null base price (billing lives on items), so a
+	// recurring sub can be created even when the base price and immediate total are $0.
+	const incomingPlanHasRecurringPrice =
+		(incomingPlan?.price != null &&
+			incomingPlan.price.interval !== BillingInterval.OneOff) ||
+		(incomingPlan?.items?.some(
+			(item) =>
+				item.price != null && item.price.interval !== BillingInterval.OneOff,
+		) ??
+			false);
+
+	const createsRecurringSubscription =
+		incomingPlanHasRecurringPrice && createsNewStripeSubscription;
+
 	const isDirectPaidTransition =
 		hasOutgoing && isPaidRecurringAttach && isOutgoingPaidRecurring;
 
@@ -200,6 +217,8 @@ export function useAttachBillingOptionsState() {
 		hasOutgoing,
 		hasPaidRecurringSubscription,
 		canChooseBillingCycle,
+		createsNewStripeSubscription,
+		createsRecurringSubscription,
 		defaultPlanSchedule,
 		effectivePlanSchedule,
 		showProrationRow,

--- a/vite/src/components/forms/attach-v2/hooks/useAttachMutation.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachMutation.ts
@@ -80,6 +80,11 @@ export function useAttachMutation({
 			if (useInvoice) {
 				if (data?.invoice) {
 					toast.success("Invoice created successfully");
+				} else {
+					// Invoice-mode subscription with no immediate invoice (usage-in-arrears):
+					// nothing to send now, so confirm and close instead of dead-ending.
+					toast.success("Subscription started");
+					onSuccess?.();
 				}
 			} else if (data?.payment_url) {
 				onCheckoutRedirect?.(data.payment_url);


### PR DESCRIPTION
## Problem

The attach flow's **"Send an Invoice"** action was disabled whenever the immediate total was `$0`. That correctly blocks genuinely-nothing-to-invoice cases (free plans, entitlement-only changes), but it also blocked a legitimate case: **metered-only / usage-in-arrears plans**.

A usage-in-arrears plan creates a real Stripe subscription with `collection_method: send_invoice` (no card required, billed at the end of each cycle) — but nothing is due at attach time, so the immediate total is `$0` and the guard tripped. Merchants couldn't start an invoice-billed usage subscription from the dashboard. Even when bypassed, the backend returned a `null` payment URL and the send-invoice sheet dead-ended (enabled the plan, no feedback, sheet stayed open).

## Fix

- **Detect recurring subscriptions from item-level prices.** Usage-only plans have a `null` base price (billing lives on items), so the previous amount-gated check missed them. Detection now also inspects `plan.items[].price`, gated on new-subscription creation (`!hasActiveSubscription || newBillingSubscription` — the codebase's existing `createsNewStripeSubscription` primitive, hoisted into the hook and reused).
- **Relax the footer guard** so it only blocks when there is genuinely nothing to invoice — no immediate charge **and** no subscription being created.
- **Direct start only when no invoice is created.** For usage-in-arrears the button becomes **"Start subscription in invoice mode"** and starts the sub directly — no secondary sheet. Crucially, this bypass is scoped to the *no-invoice* case only: **trials and credit-covered charges still create a `$0` invoice**, so they keep the normal invoice sheet (`willCreateZeroDollarInvoice` = subtotal > 0, invoice credits, or a trial).
- **Confirm + close on success** when an invoice-mode attach returns no immediate invoice, instead of the previous silent dead-end.

## Cases

| Attach | Behavior |
|---|---|
| Free / $0, no sub created | Button stays disabled (unchanged) |
| Usage-in-arrears (no invoice created) | **"Start subscription in invoice mode"** → starts `send_invoice` sub directly, toast + close |
| Trial ($0 invoice created) | "Send an Invoice" → full sheet, creates the $0 invoice |
| Invoice-credit covered ($0 invoice created) | "Send an Invoice" → full sheet, creates the $0 invoice |
| Immediate charge (total > 0) | "Send an Invoice" → full sheet (unchanged) |
| Scheduled / future start | Blocked by existing guards (unchanged) |

## Testing

- `bun run ts` (vite): clean
- `bun test tests/components/forms/`: 127 pass, 0 fail

## Follow-ups / considerations

- The direct path skips the "customer email required" step the send-invoice sheet enforced. The subscription is still created, but `send_invoice` needs a customer email to deliver the cycle-end invoice. Customer can add it later; a lightweight email guard could be added if we want to guarantee deliverability.
- No direct unit test for the new branch yet — the `invoiceDisabledReason` / recurring-detection logic is inline/context-dependent. Could extract pure helpers (mirroring `getConfirmLabel`) and add fixtures if we want coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)