### PR TITLE
fix(tests): multi-currency migration e2e uses migrations v2 API

### DIFF
--- a/server/tests/integration/billing/attach/multi-currency-migration-e2e.test.ts
+++ b/server/tests/integration/billing/attach/multi-currency-migration-e2e.test.ts
@@ -6,6 +6,7 @@ import {
 	BillingInterval,
 	type CreatePlanParamsV2Input,
 } from "@autumn/shared";
+import { runUpdatePlanMigration } from "@tests/integration/billing/migrations-v2/utils/runUpdatePlanMigration";
 import { expectProductActive } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
@@ -13,12 +14,14 @@ import { AutumnRpcCli } from "@/external/autumn/autumnRpcCli.js";
 
 const autumnRpc = new AutumnRpcCli({ version: ApiVersion.V2_1 });
 const getSuffix = () => Math.random().toString(36).slice(2, 9);
-const waitForMigration = (ms = 20000) =>
-	new Promise((resolve) => setTimeout(resolve, ms));
 
 // Migrating a locked-eur customer to a new plan version must keep the
 // subscription in eur and re-point it at the v2 eur price (migrations create no
 // new charge, so this verifies the currency-aware v2 price is used).
+//
+// Uses migrations V2 (`/v1/migrations.*`) — legacy `POST /v1/migrations` was
+// removed, and unmatched `/v1` paths fall through to the session-authed root
+// router ("Unauthorized - no session found").
 test.concurrent(
 	`${chalk.yellowBright("multi-currency e2e: migration keeps the subscription in eur on the v2 price")}`,
 	async () => {
@@ -34,7 +37,7 @@ test.concurrent(
 			},
 		});
 
-		const { customerId, autumnV1, ctx } = await initScenario({
+		const { customerId, autumnV1, autumnV2_2, ctx } = await initScenario({
 			customerId: "mc-migrate-eur",
 			setup: [
 				s.customer({ paymentMethod: "success", data: { currency: "eur" } }),
@@ -60,13 +63,28 @@ test.concurrent(
 			},
 		});
 
-		await autumnV1.migrate({
-			from_product_id: planId,
-			to_product_id: planId,
-			from_version: 1,
-			to_version: 2,
+		await runUpdatePlanMigration({
+			ctx,
+			migrationClient: autumnV2_2,
+			migrationId: `${customerId}-mc-migrate`,
+			customerId,
+			filter: { customer: { plan: { plan_id: planId } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: planId },
+						version: 2,
+					},
+				],
+			},
+			waitFor: async () => {
+				const customer =
+					await autumnV1.customers.get<ApiCustomerV3>(customerId);
+				const product = customer.products?.find((p) => p.id === planId);
+				expect(product?.version).toBe(2);
+			},
 		});
-		await waitForMigration();
 
 		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
 		await expectProductActive({ customer, productId: planId });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Hypothesis (confirmed)

The failure `Unauthorized - no session found` at `autumnV1.migrate()` was caused by the request landing on the **session-authed root/internal router**, not the public API.

Details:
- `autumnV1.migrate()` posts to legacy `POST /v1/migrations`
- That endpoint was removed (`fix: block old migrations endpoint`)
- Unmatched `/v1/*` paths fall through to `internalRouter`, which runs `betterAuthMiddleware` → `"Unauthorized - no session found"`

So the client was calling `/v1/...`, but with no matching public route it hit the dashboard/session router.

## Fix

Patched **only** `multi-currency-migration-e2e.test.ts` to use `runUpdatePlanMigration` (`/v1/migrations.*` via `autumnV2_2`). Did **not** change `initScenario`.

Please re-run:
```bash
bun test server/tests/integration/billing/attach/multi-currency-migration-e2e.test.ts --timeout 60000
```

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1784021703482219?thread_ts=1784021703.482219&cid=C0BCAQQK0KS)

<div><a href="https://cursor.com/agents/bc-5dc26c54-3c00-5e31-bd33-c286e61ce43a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5dc26c54-3c00-5e31-bd33-c286e61ce43a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the multi-currency migration E2E to use migrations v2 so it hits the public `/v1/migrations.*` routes and no longer fails with “Unauthorized - no session found”. This aligns the test with the removal of the legacy `POST /v1/migrations` endpoint.

- **Bug Fixes**
  - Replaced `autumnV1.migrate()` with `runUpdatePlanMigration` via `autumnV2_2`.
  - Removed fixed sleep and added a `waitFor` check that verifies the customer is on version 2 before assertions.

<sup>Written for commit d74782efc5fd8bdc56cd86034f3be8d5de18246d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves the multi-currency migration test to the supported migrations v2 flow. The main changes are:

- **Bug fixes:** Replace the removed legacy migration call with `runUpdatePlanMigration`.
- **API changes:** Use the v2.2 migration client and migrations v2 operation shape.
- **Improvements:** Poll for plan version 2 instead of waiting for a fixed delay.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after preventing concurrent test runs from sharing a migration ID.

- The v2 migration helper and polling flow match the updated endpoint.
- Concurrent processes can delete or replace each other's migration definition because the new ID is fixed.

server/tests/integration/billing/attach/multi-currency-migration-e2e.test.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/tests/integration/billing/attach/multi-currency-migration-e2e.test.ts | Updates the E2E test to use migrations v2 and state-based polling, but introduces a migration ID shared by concurrent runs. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/tests/integration/billing/attach/multi-currency-migration-e2e.test.ts:70
**Migration ID Collides Across Runs**

The migration ID is derived from the fixed `customerId`, while this concurrent test randomizes its plan data. When two test processes use the same test organization, each can delete and recreate the other's migration definition under this ID, causing a run to use the wrong plan filter or fail intermittently. Include the per-run suffix in the migration ID.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tests): use migrations v2 API in mul..."](https://github.com/useautumn/autumn/commit/d74782efc5fd8bdc56cd86034f3be8d5de18246d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44092581)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->