### PR TITLE
fix(tests): unique migration ID for multi-currency e2e concurrent runs

### DIFF
--- a/server/tests/integration/billing/attach/multi-currency-migration-e2e.test.ts
+++ b/server/tests/integration/billing/attach/multi-currency-migration-e2e.test.ts
@@ -66,7 +66,7 @@ test.concurrent(
 		await runUpdatePlanMigration({
 			ctx,
 			migrationClient: autumnV2_2,
-			migrationId: `${customerId}-mc-migrate`,
+			migrationId: `${customerId}-${planId}`,
 			customerId,
 			filter: { customer: { plan: { plan_id: planId } } },
 			operations: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Addresses Greptile review feedback on the multi-currency migration e2e: migration IDs derived only from the fixed `customerId` could collide across concurrent test processes sharing an org.
- Migration ID is now `${customerId}-${planId}`, so the per-run randomized plan suffix makes each migration definition unique.

## Test plan
- [ ] Re-run: `bun test server/tests/integration/billing/attach/multi-currency-migration-e2e.test.ts --timeout 60000`

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1784021703482219?thread_ts=1784021703.482219&cid=C0BCAQQK0KS)

<div><a href="https://cursor.com/agents/bc-6b5b65c1-2fce-5d2d-ac0c-8d23a29c991e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b5b65c1-2fce-5d2d-ac0c-8d23a29c991e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `${customerId}-${planId}` for the migration ID instead of `${customerId}-mc-migrate` to prevent collisions in concurrent multi-currency e2e runs that share an org. This makes each run’s migration definition unique and avoids overwrites.

<sup>Written for commit c80089eaf396dd007f1d5754ce6f4108e61d43b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents migration ID collisions in the concurrent multi-currency test. The main change is:

- **Bug fixes:** Derive the migration ID from the fixed customer ID and randomized plan ID.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The generated ID meets the migration API's format and length requirements.
- The randomized plan ID separates concurrent runs within the shared organization and environment.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/tests/integration/billing/attach/multi-currency-migration-e2e.test.ts | Uses the randomized plan ID in the migration ID so concurrent runs do not replace each other's migration definitions. |

<sub>Reviews (1): Last reviewed commit: ["fix(tests): make migration ID unique per..."](https://github.com/useautumn/autumn/commit/c80089eaf396dd007f1d5754ce6f4108e61d43b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44094407)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->