### PR TITLE
Always default attach schedule to immediate

### DIFF
--- a/vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts
@@ -91,12 +91,16 @@ export function useAttachBillingOptionsState() {
 	const defaultPlanSchedule = useMemo((): PlanTiming => {
 		if (!previewData || !hasOutgoing) return "immediate";
 
+		// Free → paid is always an upgrade; the amount check below misreads
+		// usage-only plans (null base price) as $0 and would defer them.
+		if (isFreeToPaidTransition) return "immediate";
+
 		const incomingPrice = previewData.incoming[0]?.plan.price?.amount ?? 0;
 		const outgoingPrice = previewData.outgoing[0]?.plan.price?.amount ?? 0;
 		const isUpgrade = incomingPrice > outgoingPrice;
 
 		return isUpgrade ? "immediate" : "end_of_cycle";
-	}, [previewData, hasOutgoing]);
+	}, [previewData, hasOutgoing, isFreeToPaidTransition]);
 
 	const effectivePlanSchedule = !hasOutgoing
 		? "immediate"

--- a/vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts
@@ -88,19 +88,8 @@ export function useAttachBillingOptionsState() {
 		hasPaidRecurringSubscription &&
 		!isDirectPaidTransition;
 
-	const defaultPlanSchedule = useMemo((): PlanTiming => {
-		if (!previewData || !hasOutgoing) return "immediate";
-
-		// Free → paid is always an upgrade; the amount check below misreads
-		// usage-only plans (null base price) as $0 and would defer them.
-		if (isFreeToPaidTransition) return "immediate";
-
-		const incomingPrice = previewData.incoming[0]?.plan.price?.amount ?? 0;
-		const outgoingPrice = previewData.outgoing[0]?.plan.price?.amount ?? 0;
-		const isUpgrade = incomingPrice > outgoingPrice;
-
-		return isUpgrade ? "immediate" : "end_of_cycle";
-	}, [previewData, hasOutgoing, isFreeToPaidTransition]);
+	// Always default to immediate; users can opt into end-of-cycle explicitly.
+	const defaultPlanSchedule: PlanTiming = "immediate";
 
 	const effectivePlanSchedule = !hasOutgoing
 		? "immediate"

--- a/vite/src/views/settings/sections/BillingSettingsSection.tsx
+++ b/vite/src/views/settings/sections/BillingSettingsSection.tsx
@@ -1,11 +1,10 @@
-import type { FrontendOrg, OrgConfig } from "@autumn/shared";
+import type { OrgConfig } from "@autumn/shared";
 import { Button, Switch } from "@autumn/ui";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
 import { useOrg } from "@/hooks/common/useOrg";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
-import { useEnv } from "@/utils/envUtils";
 import { SettingsSection } from "../SettingsSection";
 
 const BILLING_TOGGLES = [
@@ -71,11 +70,8 @@ const BILLING_TOGGLES = [
 }[];
 
 export const BillingSettingsSection = () => {
-	const { org } = useOrg();
+	const { org, mutate: refetchOrg } = useOrg();
 	const axiosInstance = useAxiosInstance();
-	const queryClient = useQueryClient();
-	const env = useEnv();
-	const queryKey = ["org", env];
 	const [pending, setPending] = useState<Partial<OrgConfig>>({});
 
 	const serverConfig = org?.config ?? {};
@@ -90,16 +86,13 @@ export const BillingSettingsSection = () => {
 			);
 			return data as { config: OrgConfig };
 		},
-		onSuccess: (data) => {
+		onSuccess: async () => {
+			await refetchOrg();
 			setPending({});
-			queryClient.setQueryData<FrontendOrg>(queryKey, (old) =>
-				old ? { ...old, config: data.config } : old,
-			);
 			toast.success("Billing settings saved");
 		},
 		onError: () => {
 			toast.error("Failed to update billing settings");
-			queryClient.invalidateQueries({ queryKey });
 		},
 	});
 
@@ -146,15 +139,17 @@ export const BillingSettingsSection = () => {
 					</div>
 				))}
 			</div>
-			<Button
-				variant="primary"
-				onClick={handleSave}
-				disabled={!isDirty}
-				isLoading={isPending}
-				className="w-full"
-			>
-				Save Changes
-			</Button>
+			<div className="pb-8">
+				<Button
+					variant="primary"
+					onClick={handleSave}
+					disabled={!isDirty}
+					isLoading={isPending}
+					className="w-full"
+				>
+					Save Changes
+				</Button>
+			</div>
 		</SettingsSection>
 	);
 };


### PR DESCRIPTION
## Problem

Attaching a usage-only / overage plan defaulted to `end_of_cycle` and disabled the invoice button with a misleading "end of cycle changes" message. Cause: the schedule default compared base price `amount`, which reads usage-only plans (null base price) as `$0`, so they were misclassified as non-upgrades.

## Fix

Drop the price-based upgrade/downgrade heuristic entirely. Always default to `immediate`; users can still explicitly pick end-of-cycle.

## Testing

- `bun run ts` (vite): clean
- `bun test tests/components/forms/`: 127 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)