### PR TITLE
release

### DIFF
--- a/server/tests/integration/billing/attach/multi-currency-migration-e2e.test.ts
+++ b/server/tests/integration/billing/attach/multi-currency-migration-e2e.test.ts
@@ -66,7 +66,7 @@ test.concurrent(
 		await runUpdatePlanMigration({
 			ctx,
 			migrationClient: autumnV2_2,
-			migrationId: `${customerId}-mc-migrate`,
+			migrationId: `${customerId}-${planId}`,
 			customerId,
 			filter: { customer: { plan: { plan_id: planId } } },
 			operations: {

--- a/vite/src/views/products/plan/components/SaveChangesBar.tsx
+++ b/vite/src/views/products/plan/components/SaveChangesBar.tsx
@@ -14,12 +14,12 @@ import {
 	useProductStore,
 } from "@/hooks/stores/useProductStore";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
-import { ProductService } from "@/services/products/ProductService";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { useProductCountsQuery } from "../../product/hooks/queries/useProductCountsQuery";
 import { useProductQuery } from "../../product/hooks/useProductQuery";
 import { useProductContext } from "../../product/ProductContext";
 import { updateProduct } from "../../product/utils/updateProduct";
+import { checkItemCurrenciesValid } from "../utils/currencyUtils";
 import { buildPreviewUpdatePlanParams } from "../versioning/buildMigrationDraft";
 import { PlanEditorBar } from "./PlanEditorBar";
 
@@ -65,15 +65,9 @@ export const SaveChangesBar = ({
 	);
 
 	const handleSaveClicked = async () => {
-		// if (
-		// 	product.planType === "paid" &&
-		// 	product.basePriceType !== "usage" &&
-		// 	!basePrice?.price
-		// ) {
-		// 	toast.error("Please add a plan price greater than 0, or remove it.");
-		// 	setSaving(false);
-		// 	return;
-		// }
+		for (const item of product.items) {
+			if (!checkItemCurrenciesValid(item)) return;
+		}
 
 		if (!isOnboarding) {
 			if (isCountsLoading) {

--- a/vite/src/views/products/plan/components/edit-plan-feature/BillingUnits.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/BillingUnits.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from "react";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { cn } from "@/lib/utils";
 import { useProductItemContext } from "@/views/products/product/product-item/ProductItemContext";
+import { billingUnitsLabel } from "../../utils/billingUnitsUtils";
 
 export function BillingUnits() {
 	const { features } = useFeaturesQuery();
@@ -50,9 +51,7 @@ export function BillingUnits() {
 						)}
 					>
 						<span className={cn("truncate text-xs")}>
-							{item.billing_units === 1
-								? `per ${unitName}`
-								: `per ${item.billing_units} ${unitName}`}
+							{billingUnitsLabel({ item, features })}
 						</span>
 					</Button>
 				</PopoverTrigger>

--- a/vite/src/views/products/plan/components/edit-plan-feature/EditPlanFeatureSheet.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/EditPlanFeatureSheet.tsx
@@ -14,6 +14,7 @@ import { isFeaturePriceItem } from "@/utils/product/getItemType";
 import UpdateFeatureSheet from "@/views/products/features/components/UpdateFeatureSheet";
 import UpdateCreditSystemSheet from "@/views/products/features/credit-systems/components/UpdateCreditSystemSheet";
 import { useProductItemContext } from "@/views/products/product/product-item/ProductItemContext";
+import { migrateTierCurrenciesForMode } from "../../utils/currencyUtils";
 import {
 	cleanTiersForMode,
 	type VolumePricingMode,
@@ -58,6 +59,10 @@ export function EditPlanFeatureSheet({
 				newItem.tiers = newItem.tiers.map((tier) => ({
 					...tier,
 					flat_amount: undefined,
+					additional_currencies: migrateTierCurrenciesForMode({
+						entries: tier.additional_currencies,
+						mode: "per_unit",
+					}),
 				}));
 			}
 		}
@@ -69,17 +74,23 @@ export function EditPlanFeatureSheet({
 		if (!item?.tiers) return;
 
 		const migratedTiers = item.tiers.map((tier) => {
+			const additionalCurrencies = migrateTierCurrenciesForMode({
+				entries: tier.additional_currencies,
+				mode,
+			});
 			if (mode === "flat") {
 				return {
 					...tier,
 					flat_amount: tier.flat_amount ?? tier.amount,
 					amount: 0,
+					additional_currencies: additionalCurrencies,
 				};
 			}
 			return {
 				...tier,
 				amount: tier.amount !== 0 ? tier.amount : (tier.flat_amount ?? 0),
 				flat_amount: undefined,
+				additional_currencies: additionalCurrencies,
 			};
 		});
 

--- a/vite/src/views/products/plan/components/edit-plan-feature/PriceTiers.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/PriceTiers.tsx
@@ -1,60 +1,24 @@
-import {
-	Infinite,
-	type PriceTier,
-	TierBehavior,
-	UsageModel,
-} from "@autumn/shared";
-import {
-	IconButton,
-	Input,
-	InputGroup,
-	InputGroupAddon,
-	InputGroupInput,
-} from "@autumn/ui";
+import { type PriceTier, TierBehavior, UsageModel } from "@autumn/shared";
+import { IconButton, Input } from "@autumn/ui";
 import { PlusIcon, TrashIcon } from "@phosphor-icons/react";
 import { useEffect, useState } from "react";
 import { useOrg } from "@/hooks/common/useOrg";
 import { useProductItemContext } from "@/views/products/product/product-item/ProductItemContext";
-import {
-	addCurrencyToTiers,
-	itemCurrencyCodes,
-	removeCurrencyFromTiers,
-	stampBaseCurrency,
-	updateTierCurrencyAmount,
-} from "../../utils/currencyUtils";
+import { stampBaseCurrency } from "../../utils/currencyUtils";
 import {
 	addTier,
 	removeTier,
+	tierToDisplay,
 	updateTier,
 	type VolumePricingMode,
 } from "../../utils/tierUtils";
 import { AdditionalCurrenciesEditor } from "../shared/AdditionalCurrenciesEditor";
-import { CurrencyPicker } from "../shared/CurrencyPicker";
+import {
+	amountDisplayValue,
+	CurrencyAmountInput,
+} from "../shared/CurrencyAmountInput";
+import { TieredCurrenciesEditor } from "../shared/TieredCurrenciesEditor";
 import { BillingUnits } from "./BillingUnits";
-
-const getTierToDisplay = ({
-	tiers,
-	index,
-	includedUsage,
-}: {
-	tiers: PriceTier[];
-	index: number;
-	includedUsage: number | string | null;
-}) => {
-	const tier = tiers[index];
-	if (!tier) return "0";
-
-	// 1. If infinite, return "∞"
-	if (tier.to === Infinite) return "∞";
-
-	// 2. Return tier.to + includedUsage
-	if (typeof includedUsage === "number" && includedUsage > 0) {
-		return ((tier.to || 0) + includedUsage).toString();
-	}
-
-	// 3. Return tier.to + 0
-	return (tier.to || 0).toString();
-};
 
 const TierToInput = ({ index }: { index: number }) => {
 	const { item, setItem } = useProductItemContext();
@@ -66,26 +30,19 @@ const TierToInput = ({ index }: { index: number }) => {
 
 	const handleInputBlur = (value: string) => {
 		if (isInfinite) return;
-		// Set tier value in tiers array...
-		const valueWithIncludedUsage =
-			parseFloat(value) -
-			(typeof includedUsage === "number" ? includedUsage : 0);
+		const valueWithIncludedUsage = parseFloat(value) - includedUsage;
 		const newTiers = [...tiers];
 		newTiers[index] = { ...newTiers[index], to: valueWithIncludedUsage };
 		setItem({ ...item, tiers: newTiers });
 	};
 
 	const [tierVal, setTierVal] = useState<string>(
-		getTierToDisplay({ tiers, index, includedUsage }),
+		tierToDisplay({ tier: tiers[index], includedUsage }),
 	);
 
 	return (
 		<Input
-			// value={isInfinite ? "∞" : getDisplayValue(toKey, tier.to)}
 			value={tierVal}
-			// onFocus={() =>
-			// 	!isInfinite && handleInputFocus(toKey, tier.to)
-			// }
 			onBlur={() => handleInputBlur(tierVal)}
 			onChange={(e) => setTierVal(e.target.value)}
 			className="w-full"
@@ -104,11 +61,6 @@ export function PriceTiers({
 	const { item, setItem } = useProductItemContext();
 	const { org } = useOrg();
 	const currency = org?.default_currency?.toUpperCase() ?? "USD";
-	// Track raw input values during editing
-	const [editingValues, setEditingValues] = useState<Record<string, string>>(
-		{},
-	);
-	const [isEditing, setIsEditing] = useState<Record<string, boolean>>({});
 
 	// Auto-select prepaid when volume-based is active with multiple tiers
 	useEffect(() => {
@@ -126,49 +78,6 @@ export function PriceTiers({
 	const tiers = item.tiers || [];
 	const includedUsage = item.included_usage || 0;
 
-	// Helper functions for managing input editing state
-	const handleInputFocus = (key: string, currentValue: number | string) => {
-		setIsEditing((prev) => ({ ...prev, [key]: true }));
-		setEditingValues((prev) => ({
-			...prev,
-			[key]: currentValue === 0 ? "" : currentValue.toString(),
-		}));
-	};
-
-	const handleInputBlur = (
-		key: string,
-		field: "amount" | "to" | "flat_amount",
-		tierIndex?: number,
-	) => {
-		const rawValue = editingValues[key] || "";
-		setIsEditing((prev) => ({ ...prev, [key]: false }));
-
-		if (tierIndex !== undefined) {
-			updateTier({ item, setItem, index: tierIndex, field, value: rawValue });
-		}
-	};
-
-	const handleInputChange = (
-		key: string,
-		value: string,
-		field: "amount" | "to" | "flat_amount",
-		tierIndex?: number,
-	) => {
-		setEditingValues((prev) => ({ ...prev, [key]: value }));
-
-		// Live update the item as user types
-		if (tierIndex !== undefined) {
-			updateTier({ item, setItem, index: tierIndex, field, value });
-		}
-	};
-
-	const getDisplayValue = (key: string, actualValue: number | string) => {
-		if (isEditing[key]) {
-			return editingValues[key] || "";
-		}
-		return actualValue === 0 ? "" : actualValue.toString();
-	};
-
 	// Only show pricing UI if billing type is "priced" (has tiers)
 	if (!tiers || tiers.length === 0) {
 		return null;
@@ -177,34 +86,23 @@ export function PriceTiers({
 	// Simple single tier UI - just amount input with billing units
 	if (tiers.length === 1) {
 		const firstTier = tiers[0];
-		const amountKey = "single-tier-amount";
 
 		return (
 			<div className="space-y-2">
 				<div className="flex gap-2 w-full items-center">
-					<InputGroup>
-						<InputGroupInput
-							value={getDisplayValue(amountKey, firstTier.amount)}
-							onFocus={() => handleInputFocus(amountKey, firstTier.amount)}
-							onBlur={() => handleInputBlur(amountKey, "amount", 0)}
-							onChange={(e) =>
-								handleInputChange(amountKey, e.target.value, "amount", 0)
-							}
-							inputMode="decimal"
-							placeholder="0.00"
-							onKeyDown={(e) => {
-								// Prevent typing minus sign
-								if (e.key === "-" || e.key === "Minus") {
-									e.preventDefault();
-								}
-							}}
-						/>
-						<InputGroupAddon align="inline-end">
-							<span className="text-tertiary-foreground text-xs">
-								{currency}
-							</span>
-						</InputGroupAddon>
-					</InputGroup>
+					<CurrencyAmountInput
+						currencyCode={currency}
+						displayValue={amountDisplayValue(firstTier.amount)}
+						onRawChange={(raw) =>
+							updateTier({
+								item,
+								setItem,
+								index: 0,
+								field: "amount",
+								value: raw,
+							})
+						}
+					/>
 
 					<BillingUnits />
 
@@ -250,27 +148,16 @@ export function PriceTiers({
 	// Multi-tier UI - full tier management
 	const isFlatMode = volumePricingMode === "flat";
 	const amountField = isFlatMode ? "flat_amount" : "amount";
-	const currencyCodes = itemCurrencyCodes(item);
-
-	const addCurrency = (code: string) => {
-		setItem(
-			stampBaseCurrency({
-				item: addCurrencyToTiers({ item, code: code.toLowerCase() }),
-				orgCurrency: currency,
-			}),
-		);
-	};
 
 	return (
 		<div className="space-y-2">
 			{tiers.map((tier: PriceTier, index: number) => {
-				const amountKey = `tier-${index}-${amountField}`;
 				const amountValue = isFlatMode ? (tier.flat_amount ?? 0) : tier.amount;
 
 				return (
 					<div
 						key={`${index}-${tier.to}`}
-						className="flex flex-wrap gap-2 w-full items-center"
+						className="flex gap-2 w-full items-center"
 					>
 						<span className="text-tertiary-foreground text-xs min-w-0 w-18 shrink-0 h-full">
 							{Number(includedUsage) === 0 && index === 0
@@ -280,75 +167,20 @@ export function PriceTiers({
 
 						<TierToInput index={index} />
 
-						<InputGroup className="min-w-0 w-26 shrink-0">
-							<InputGroupInput
-								value={getDisplayValue(amountKey, amountValue)}
-								onFocus={() => handleInputFocus(amountKey, amountValue)}
-								onBlur={() => handleInputBlur(amountKey, amountField, index)}
-								onChange={(e) =>
-									handleInputChange(
-										amountKey,
-										e.target.value,
-										amountField,
-										index,
-									)
-								}
-								inputMode="decimal"
-								placeholder="0.00"
-							/>
-							<InputGroupAddon align="inline-end">
-								<span className="text-tertiary-foreground text-xs">
-									{currency}
-								</span>
-							</InputGroupAddon>
-						</InputGroup>
-
-						{currencyCodes.map((code) => {
-							const entry = tier.additional_currencies?.find(
-								(candidate) => candidate.currency.toLowerCase() === code,
-							);
-							const entryValue = isFlatMode
-								? (entry?.flat_amount ?? 0)
-								: (entry?.amount ?? 0);
-							const entryKey = `tier-${index}-${code}-${amountField}`;
-
-							return (
-								<InputGroup key={code} className="min-w-0 w-26 shrink-0">
-									<InputGroupInput
-										value={getDisplayValue(entryKey, entryValue)}
-										onFocus={() => handleInputFocus(entryKey, entryValue)}
-										onBlur={() =>
-											setIsEditing((prev) => ({ ...prev, [entryKey]: false }))
-										}
-										onChange={(e) => {
-											setEditingValues((prev) => ({
-												...prev,
-												[entryKey]: e.target.value,
-											}));
-											setItem(
-												stampBaseCurrency({
-													item: updateTierCurrencyAmount({
-														item,
-														tierIndex: index,
-														code,
-														field: amountField,
-														value: e.target.value,
-													}),
-													orgCurrency: currency,
-												}),
-											);
-										}}
-										inputMode="decimal"
-										placeholder="0.00"
-									/>
-									<InputGroupAddon align="inline-end">
-										<span className="text-tertiary-foreground text-xs uppercase">
-											{code}
-										</span>
-									</InputGroupAddon>
-								</InputGroup>
-							);
-						})}
+						<CurrencyAmountInput
+							className="min-w-0 w-26 shrink-0"
+							currencyCode={currency}
+							displayValue={amountDisplayValue(amountValue)}
+							onRawChange={(raw) =>
+								updateTier({
+									item,
+									setItem,
+									index,
+									field: amountField,
+									value: raw,
+								})
+							}
+						/>
 
 						{!isFlatMode && <BillingUnits />}
 
@@ -374,31 +206,12 @@ export function PriceTiers({
 			</IconButton>
 
 			{org?.config?.multi_currency && (
-				<div className="flex flex-wrap items-center gap-2">
-					<CurrencyPicker
-						excludedCodes={[currency, ...currencyCodes]}
-						label="Add currency"
-						onSelect={addCurrency}
-					/>
-					{currencyCodes.map((code) => (
-						<IconButton
-							className="text-tertiary-foreground text-xs uppercase"
-							icon={<TrashIcon size={10} />}
-							key={code}
-							onClick={() =>
-								setItem(
-									stampBaseCurrency({
-										item: removeCurrencyFromTiers({ item, code }),
-										orgCurrency: currency,
-									}),
-								)
-							}
-							variant="muted"
-						>
-							{code}
-						</IconButton>
-					))}
-				</div>
+				<TieredCurrenciesEditor
+					amountField={amountField}
+					baseCurrency={currency}
+					item={item}
+					onItemChange={setItem}
+				/>
 			)}
 		</div>
 	);

--- a/vite/src/views/products/plan/components/edit-plan-feature/SheetFooterActions.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/SheetFooterActions.tsx
@@ -4,6 +4,7 @@ import {
 } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 import { PlanSheetFooter } from "@/components/v2/sheets/PlanSheetFooter";
 import { useProductItemContext } from "@/views/products/product/product-item/ProductItemContext";
+import { checkItemCurrenciesValid } from "../../utils/currencyUtils";
 
 export function SheetFooterActions({
 	isDirty,
@@ -14,7 +15,7 @@ export function SheetFooterActions({
 	canConfirm: boolean;
 	onBeforeCommit?: () => void;
 }) {
-	const { handleUpdateProductItem } = useProductItemContext();
+	const { item, handleUpdateProductItem } = useProductItemContext();
 	const { initialItem, itemDraft, closeSheet } = useSheet();
 	const setCurrentItem = useSetCurrentItem();
 
@@ -29,6 +30,7 @@ export function SheetFooterActions({
 	};
 
 	const handleUpdateItem = async () => {
+		if (item && !checkItemCurrenciesValid(item)) return;
 		await onBeforeCommit?.();
 		await handleUpdateProductItem();
 	};

--- a/vite/src/views/products/plan/components/plan-card/AdditionalCurrenciesHint.tsx
+++ b/vite/src/views/products/plan/components/plan-card/AdditionalCurrenciesHint.tsx
@@ -1,6 +1,5 @@
 import { type AdditionalCurrencyPrice, formatAmount } from "@autumn/shared";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@autumn/ui";
-import { CoinsIcon } from "@phosphor-icons/react";
 
 const formatCurrencyAmount = (entry: AdditionalCurrencyPrice) =>
 	entry.amount === 0
@@ -21,9 +20,8 @@ export const AdditionalCurrenciesHint = ({
 }) => (
 	<Tooltip>
 		<TooltipTrigger asChild>
-			<span className="mt-0.5 flex items-center gap-0.5 text-tertiary-foreground text-xs">
+			<span className="mt-0.5 text-tertiary-foreground text-xs">
 				+{currencies.length}
-				<CoinsIcon size={12} />
 			</span>
 		</TooltipTrigger>
 		<TooltipContent>

--- a/vite/src/views/products/plan/components/shared/AddCurrencyButton.tsx
+++ b/vite/src/views/products/plan/components/shared/AddCurrencyButton.tsx
@@ -1,0 +1,22 @@
+import { CurrencyPicker } from "./CurrencyPicker";
+
+export const AddCurrencyButton = ({
+	baseCurrency,
+	currencyCodes,
+	onSelect,
+}: {
+	baseCurrency: string;
+	currencyCodes: string[];
+	onSelect: (code: string) => void;
+}) => (
+	<CurrencyPicker
+		className="w-full"
+		excludedCodes={[baseCurrency, ...currencyCodes]}
+		label={
+			currencyCodes.length === 0
+				? `Add currency (base ${baseCurrency.toUpperCase()})`
+				: "Add currency"
+		}
+		onSelect={onSelect}
+	/>
+);

--- a/vite/src/views/products/plan/components/shared/AdditionalCurrenciesEditor.tsx
+++ b/vite/src/views/products/plan/components/shared/AdditionalCurrenciesEditor.tsx
@@ -2,10 +2,10 @@ import {
 	type AdditionalCurrencyPrice,
 	roundToCurrencyPrecision,
 } from "@autumn/shared";
-import { IconButton } from "@autumn/ui";
+import { FormLabel, IconButton } from "@autumn/ui";
 import { TrashIcon } from "@phosphor-icons/react";
-import { CurrencyAmountInput } from "./CurrencyAmountInput";
-import { CurrencyPicker } from "./CurrencyPicker";
+import { AddCurrencyButton } from "./AddCurrencyButton";
+import { amountDisplayValue, CurrencyAmountInput } from "./CurrencyAmountInput";
 
 export const AdditionalCurrenciesEditor = ({
 	currencies,
@@ -31,40 +31,32 @@ export const AdditionalCurrenciesEditor = ({
 	};
 
 	return (
-		<div className="space-y-2">
-			{entries.map((entry, index) => (
-				<div
-					className="flex items-center gap-2"
-					key={`currency-${
-						// biome-ignore lint/suspicious/noArrayIndexKey: rows are positional, codes are picked once
-						index
-					}`}
-				>
-					<CurrencyAmountInput
-						currencyCode={entry.currency}
-						displayValue={entry.amount === 0 ? "" : entry.amount.toString()}
-						onRawChange={(raw) => updateAmount(index, raw)}
-					/>
-					<IconButton
-						className="shrink-0 p-1 text-tertiary-foreground hover:text-red-500"
-						icon={<TrashIcon size={10} />}
-						onClick={() => onChange(entries.filter((_, i) => i !== index))}
-						variant="muted"
-					/>
-				</div>
-			))}
-			<CurrencyPicker
-				className="w-full"
-				excludedCodes={[baseCurrency, ...entries.map((e) => e.currency)]}
-				label={
-					entries.length === 0
-						? `Add currency (base ${baseCurrency.toUpperCase()})`
-						: "Add currency"
-				}
-				onSelect={(code) =>
-					onChange([...entries, { currency: code, amount: 0 }])
-				}
-			/>
+		<div>
+			<FormLabel>Additional currencies</FormLabel>
+			<div className="space-y-2">
+				{entries.map((entry, index) => (
+					<div className="flex items-center gap-2" key={`currency-${index}`}>
+						<CurrencyAmountInput
+							currencyCode={entry.currency}
+							displayValue={amountDisplayValue(entry.amount)}
+							onRawChange={(raw) => updateAmount(index, raw)}
+						/>
+						<IconButton
+							className="shrink-0 p-1 text-tertiary-foreground hover:text-red-500"
+							icon={<TrashIcon size={10} />}
+							onClick={() => onChange(entries.filter((_, i) => i !== index))}
+							variant="muted"
+						/>
+					</div>
+				))}
+				<AddCurrencyButton
+					baseCurrency={baseCurrency}
+					currencyCodes={entries.map((entry) => entry.currency)}
+					onSelect={(code) =>
+						onChange([...entries, { currency: code, amount: 0 }])
+					}
+				/>
+			</div>
 		</div>
 	);
 };

--- a/vite/src/views/products/plan/components/shared/CurrencyAmountInput.tsx
+++ b/vite/src/views/products/plan/components/shared/CurrencyAmountInput.tsx
@@ -1,14 +1,19 @@
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@autumn/ui";
 import { useState } from "react";
 
+export const amountDisplayValue = (amount: number) =>
+	amount === 0 ? "" : amount.toString();
+
 export const CurrencyAmountInput = ({
 	displayValue,
 	currencyCode,
 	onRawChange,
+	className,
 }: {
 	displayValue: string;
 	currencyCode: string;
 	onRawChange: (raw: string) => void;
+	className?: string;
 }) => {
 	const [editingValue, setEditingValue] = useState<string | undefined>();
 
@@ -20,7 +25,7 @@ export const CurrencyAmountInput = ({
 	};
 
 	return (
-		<InputGroup>
+		<InputGroup className={className}>
 			<InputGroupInput
 				inputMode="decimal"
 				onBlur={() => setEditingValue(undefined)}

--- a/vite/src/views/products/plan/components/shared/TieredCurrenciesEditor.tsx
+++ b/vite/src/views/products/plan/components/shared/TieredCurrenciesEditor.tsx
@@ -1,0 +1,173 @@
+import type { PriceTier, ProductItem } from "@autumn/shared";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+	cn,
+	FormLabel,
+	IconButton,
+} from "@autumn/ui";
+import { CaretDownIcon, TrashIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
+import { billingUnitsLabel } from "../../utils/billingUnitsUtils";
+import {
+	addCurrencyToTiers,
+	itemCurrencyCodes,
+	removeCurrencyFromTiers,
+	stampBaseCurrency,
+	updateTierCurrencyAmount,
+} from "../../utils/currencyUtils";
+import { tierToDisplay } from "../../utils/tierUtils";
+import { AddCurrencyButton } from "./AddCurrencyButton";
+import { amountDisplayValue, CurrencyAmountInput } from "./CurrencyAmountInput";
+
+const tierAmountFor = ({
+	tier,
+	code,
+	amountField,
+}: {
+	tier: PriceTier;
+	code: string;
+	amountField: "amount" | "flat_amount";
+}) => {
+	const entry = tier.additional_currencies?.find(
+		(candidate) => candidate.currency.toLowerCase() === code,
+	);
+	return entry?.[amountField] ?? 0;
+};
+
+export const TieredCurrenciesEditor = ({
+	item,
+	onItemChange,
+	baseCurrency,
+	amountField,
+}: {
+	item: ProductItem;
+	onItemChange: (item: ProductItem) => void;
+	baseCurrency: string;
+	amountField: "amount" | "flat_amount";
+}) => {
+	const [expandedCode, setExpandedCode] = useState<string | null>(null);
+	const { features } = useFeaturesQuery();
+
+	const tiers = item.tiers ?? [];
+	const perUnitLabel =
+		amountField === "amount" ? billingUnitsLabel({ item, features }) : null;
+	const codes = itemCurrencyCodes(item);
+	const includedUsage =
+		typeof item.included_usage === "number" ? item.included_usage : 0;
+
+	const applyChange = (nextItem: ProductItem) => {
+		onItemChange(
+			stampBaseCurrency({ item: nextItem, orgCurrency: baseCurrency }),
+		);
+	};
+
+	const addCurrency = (code: string) => {
+		const normalized = code.toLowerCase();
+		applyChange(addCurrencyToTiers({ item, code: normalized }));
+		setExpandedCode(normalized);
+	};
+
+	const removeCurrency = (code: string) => {
+		applyChange(removeCurrencyFromTiers({ item, code }));
+		if (expandedCode === code) setExpandedCode(null);
+	};
+
+	const summaryFor = (code: string) => {
+		const setCount = tiers.filter(
+			(tier) => tierAmountFor({ tier, code, amountField }) > 0,
+		).length;
+		if (setCount === 0) return "not set";
+		return `${setCount} of ${tiers.length} set`;
+	};
+
+	return (
+		<div>
+			<FormLabel>Additional currencies</FormLabel>
+			<div className="space-y-2">
+				{codes.map((code) => {
+					const isOpen = expandedCode === code;
+					return (
+						<Collapsible
+							className="w-full rounded-lg border shadow-sm dark:bg-input/30"
+							key={code}
+							onOpenChange={(open) => setExpandedCode(open ? code : null)}
+							open={isOpen}
+						>
+							<div className="flex h-input w-full items-center">
+								<CollapsibleTrigger className="flex h-full flex-1 items-center justify-between px-2 outline-none">
+									<span className="text-tertiary-foreground text-xs uppercase">
+										{code}
+									</span>
+									<span className="flex items-center gap-1.5 text-tertiary-foreground text-xs">
+										{summaryFor(code)}
+										<CaretDownIcon
+											className={cn(
+												"transition-transform duration-200",
+												isOpen && "rotate-180",
+											)}
+											size={10}
+										/>
+									</span>
+								</CollapsibleTrigger>
+								<IconButton
+									className="mr-1 shrink-0 bg-transparent p-1 text-tertiary-foreground hover:bg-transparent hover:text-red-500 active:bg-transparent"
+									icon={<TrashIcon size={10} />}
+									onClick={() => removeCurrency(code)}
+									variant="muted"
+								/>
+							</div>
+							<CollapsibleContent className="h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-200 ease-out data-ending-style:h-0 data-starting-style:h-0">
+								<div className="space-y-2 p-2 pt-0">
+									{tiers.map((tier, index) => {
+										const amount = tierAmountFor({ tier, code, amountField });
+										const boundary = tierToDisplay({ tier, includedUsage });
+										return (
+											<div
+												className="flex items-center gap-2"
+												key={`${code}-${index}`}
+											>
+												<span className="w-18 shrink-0 text-tertiary-foreground text-xs">
+													{index === 0 && includedUsage === 0
+														? `first ${boundary}`
+														: `up to ${boundary}`}
+												</span>
+												<CurrencyAmountInput
+													currencyCode={code}
+													displayValue={amountDisplayValue(amount)}
+													onRawChange={(raw) =>
+														applyChange(
+															updateTierCurrencyAmount({
+																item,
+																tierIndex: index,
+																code,
+																field: amountField,
+																value: raw,
+															}),
+														)
+													}
+												/>
+												{perUnitLabel && (
+													<span className="max-w-20 shrink-0 truncate text-tertiary-foreground text-xs">
+														{perUnitLabel}
+													</span>
+												)}
+											</div>
+										);
+									})}
+								</div>
+							</CollapsibleContent>
+						</Collapsible>
+					);
+				})}
+				<AddCurrencyButton
+					baseCurrency={baseCurrency}
+					currencyCodes={codes}
+					onSelect={addCurrency}
+				/>
+			</div>
+		</div>
+	);
+};

--- a/vite/src/views/products/plan/utils/billingUnitsUtils.ts
+++ b/vite/src/views/products/plan/utils/billingUnitsUtils.ts
@@ -1,0 +1,18 @@
+import { type Feature, getFeatureName, type ProductItem } from "@autumn/shared";
+
+export const billingUnitsLabel = ({
+	item,
+	features,
+}: {
+	item: ProductItem;
+	features: Feature[];
+}) => {
+	const unitName = getFeatureName({
+		feature: features.find((feature) => feature.id === item.feature_id),
+		plural: Boolean(item.billing_units && item.billing_units > 1),
+		capitalize: false,
+	});
+	return item.billing_units === 1
+		? `per ${unitName}`
+		: `per ${item.billing_units} ${unitName}`;
+};

--- a/vite/src/views/products/plan/utils/currencyUtils.ts
+++ b/vite/src/views/products/plan/utils/currencyUtils.ts
@@ -4,6 +4,36 @@ import {
 	type ProductItem,
 	roundToCurrencyPrecision,
 } from "@autumn/shared";
+import { toast } from "sonner";
+
+export const unsetCurrencyCodes = (item: ProductItem): string[] => {
+	const codes = new Set<string>();
+	for (const entry of item.additional_currencies ?? []) {
+		if (!entry.amount) codes.add(entry.currency.toUpperCase());
+	}
+	for (const tier of item.tiers ?? []) {
+		for (const entry of tier.additional_currencies ?? []) {
+			if (!entry.amount && !entry.flat_amount) {
+				codes.add(entry.currency.toUpperCase());
+			}
+		}
+	}
+	return [...codes];
+};
+
+export const checkItemCurrenciesValid = (
+	item: ProductItem,
+	showToast = true,
+) => {
+	const codes = unsetCurrencyCodes(item);
+	if (codes.length === 0) return true;
+	if (showToast) {
+		toast.error(
+			`Set an amount for ${codes.join(", ")} or remove ${codes.length === 1 ? "it" : "them"} from the plan`,
+		);
+	}
+	return false;
+};
 
 export const stampBaseCurrency = ({
 	item,
@@ -105,6 +135,43 @@ export const updateTierCurrencyAmount = ({
 	return { ...item, tiers };
 };
 
+export const migrateTierCurrenciesForMode = ({
+	entries,
+	mode,
+}: {
+	entries: AdditionalCurrencyTier[] | null | undefined;
+	mode: "flat" | "per_unit";
+}): AdditionalCurrencyTier[] | undefined =>
+	entries?.map((entry) =>
+		mode === "flat"
+			? {
+					...entry,
+					flat_amount: entry.flat_amount ?? entry.amount ?? 0,
+					amount: 0,
+				}
+			: {
+					...entry,
+					amount: entry.amount || entry.flat_amount || 0,
+					flat_amount: undefined,
+				},
+	);
+
+// The API rejects currency tiers whose flat_amount presence differs from the
+// base tier, so realign entries before building request payloads.
+export const alignTierCurrencyShapes = (item: ProductItem): ProductItem => {
+	if (!item.tiers) return item;
+	return {
+		...item,
+		tiers: item.tiers.map((tier) => ({
+			...tier,
+			additional_currencies: migrateTierCurrenciesForMode({
+				entries: tier.additional_currencies,
+				mode: tier.flat_amount != null ? "flat" : "per_unit",
+			}),
+		})),
+	};
+};
+
 const cleanCurrencyEntries = <
 	T extends AdditionalCurrencyPrice | AdditionalCurrencyTier,
 >(
@@ -135,9 +202,12 @@ export const normalizeItemCurrencies = ({
 
 	const tiers = item.tiers?.map((tier) => ({
 		...tier,
-		additional_currencies: cleanCurrencyEntries(
-			tier.additional_currencies,
-		)?.filter((entry) => entry.currency !== orgCurrency.toLowerCase()),
+		additional_currencies: migrateTierCurrenciesForMode({
+			entries: cleanCurrencyEntries(tier.additional_currencies)?.filter(
+				(entry) => entry.currency !== orgCurrency.toLowerCase(),
+			),
+			mode: tier.flat_amount != null ? "flat" : "per_unit",
+		}),
 	}));
 
 	return stampBaseCurrency({

--- a/vite/src/views/products/plan/utils/tierUtils.ts
+++ b/vite/src/views/products/plan/utils/tierUtils.ts
@@ -1,4 +1,19 @@
 import { Infinite, type PriceTier, type ProductItem } from "@autumn/shared";
+import { migrateTierCurrenciesForMode } from "./currencyUtils";
+
+export const tierToDisplay = ({
+	tier,
+	includedUsage,
+}: {
+	tier: PriceTier | undefined;
+	includedUsage: number;
+}): string => {
+	if (!tier) return "0";
+	if (tier.to === Infinite) return "∞";
+	return (
+		(typeof tier.to === "number" ? tier.to : 0) + includedUsage
+	).toString();
+};
 
 const zeroedCurrencyEntries = (tier: PriceTier | undefined) =>
 	tier?.additional_currencies?.length
@@ -53,16 +68,6 @@ export const addTier = ({
 		});
 		setItem({ ...item, tiers: newTiers });
 	}
-};
-
-const removeTiers = ({
-	item,
-	setItem,
-}: {
-	item: ProductItem;
-	setItem: (item: ProductItem) => void;
-}) => {
-	setItem({ ...item, tiers: null });
 };
 
 export const removeTier = ({
@@ -158,12 +163,14 @@ export const cleanTiersForMode = ({
 }): ProductItem => {
 	if (!item.tiers) return item;
 
-	const cleanedTiers = item.tiers.map((tier) => {
-		if (mode === "flat") {
-			return { ...tier, amount: 0 };
-		}
-		return { ...tier, flat_amount: undefined };
-	});
+	const cleanedTiers = item.tiers.map((tier) => ({
+		...tier,
+		...(mode === "flat" ? { amount: 0 } : { flat_amount: undefined }),
+		additional_currencies: migrateTierCurrenciesForMode({
+			entries: tier.additional_currencies,
+			mode,
+		}),
+	}));
 
 	return { ...item, tiers: cleanedTiers };
 };

--- a/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
+++ b/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
@@ -5,6 +5,7 @@ import type {
 	FrontendProduct,
 	MigrationFilter,
 	Operations,
+	ProductItem,
 	UpdatePlanOp,
 	UpdatePlanParamsV2Input,
 } from "@autumn/shared";
@@ -17,6 +18,7 @@ import {
 	sortProductItems,
 } from "@autumn/shared";
 import { migrationUid } from "@/views/migrations/migration/shared/operationUtils";
+import { alignTierCurrencyShapes } from "../utils/currencyUtils";
 
 export interface MigrationDraft {
 	id: string;
@@ -116,7 +118,15 @@ export function buildInPlaceUpdatePlanParams({
 	editedProduct: FrontendProduct;
 	features: Feature[];
 }): UpdatePlanParamsV2Input {
-	const plan = frontendProductToApiPlanV1(editedProduct, features);
+	const plan = frontendProductToApiPlanV1(
+		{
+			...editedProduct,
+			items: editedProduct.items.map((item) =>
+				alignTierCurrencyShapes(item as ProductItem),
+			) as typeof editedProduct.items,
+		},
+		features,
+	);
 
 	return {
 		plan_id: baseProduct.id,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds tier‑level multi‑currency editing for plan features and blocks saving if any added currencies have no amount. Also fixes test migration ID collisions and aligns tier currency payloads for API compatibility.

- **New Features**
  - New tier editor to set additional currency amounts per tier with collapsible rows; includes `AddCurrencyButton` and unified `CurrencyAmountInput`.
  - Save validation: prevents commit if any additional currency is unset; shows a toast with missing codes.
  - Auto‑migrates additional currency fields when switching between flat and per‑unit pricing; clearer billing unit labels.

- **Bug Fixes**
  - Aligns additional currency tier shapes to the base tier mode before building migration requests to avoid API rejections.
  - Uses unique migration IDs in multi‑currency e2e tests to prevent collisions in parallel runs.

<sup>Written for commit d8a976a08c2e03871a9b54a4081ed84f0981d20f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR expands multi-currency editing and normalizes tier prices across pricing modes. The main changes are:

- **Improvements:** Shared amount inputs and editors for flat and tiered currencies.
- **Improvements:** Shared billing-unit and tier-boundary formatting helpers.
- **Bug fixes:** Currency tier shapes aligned during mode changes and update payload creation.
- **Bug fixes:** Additional-currency values checked before item and plan saves.
- **Improvements:** Migration test identifiers made plan-specific.
</details>

<h3>Confidence Score: 4/5</h3>

Zero-priced currencies and included-usage boundary edits can be saved incorrectly or blocked; these paths need fixes before merging.

- Valid zero prices are rejected by the new pre-save validation.
- Changing included usage can leave a stale boundary value that overwrites the stored tier on blur.
- No security issue was identified.

vite/src/views/products/plan/utils/currencyUtils.ts; vite/src/views/products/plan/components/edit-plan-feature/PriceTiers.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/utils/currencyUtils.ts | Adds save validation and tier-shape conversion, but treats valid zero prices as missing. |
| vite/src/views/products/plan/components/edit-plan-feature/PriceTiers.tsx | Moves tier amounts to shared inputs, while tier-boundary state can become stale after included usage changes. |
| vite/src/views/products/plan/components/shared/TieredCurrenciesEditor.tsx | Adds collapsible editing for additional-currency amounts across pricing tiers. |
| vite/src/views/products/plan/components/edit-plan-feature/EditPlanFeatureSheet.tsx | Migrates additional-currency values when switching tier pricing modes. |
| vite/src/views/products/plan/versioning/buildMigrationDraft.ts | Aligns tier currency shapes before building in-place update payloads. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/views/products/plan/utils/currencyUtils.ts:9-22
**Zero Prices Become Unset**

An additional currency with an intentional price of `0` is accepted by the API schema, but these falsy checks classify it as missing. The new save guards then reject the plan with “Set an amount…” until the user removes the currency or enters a nonzero price.

```suggestion
export const unsetCurrencyCodes = (item: ProductItem): string[] => {
	const codes = new Set<string>();
	for (const entry of item.additional_currencies ?? []) {
		if (entry.amount == null) codes.add(entry.currency.toUpperCase());
	}
	for (const tier of item.tiers ?? []) {
		for (const entry of tier.additional_currencies ?? []) {
			if (entry.amount == null && entry.flat_amount == null) {
				codes.add(entry.currency.toUpperCase());
			}
		}
	}
	return [...codes];
};
```

### Issue 2 of 2
vite/src/views/products/plan/components/edit-plan-feature/PriceTiers.tsx:39-41
**Included Usage Leaves Stale Boundary**

`tierVal` is initialized from `includedUsage` only once. If included usage changes from 10 to 20 while the stored tier boundary remains 90, the input still shows 100 instead of 110; blurring it then saves `100 - 20 = 80`, silently moving the tier boundary.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #2233 from useautumn/..."](https://github.com/useautumn/autumn/commit/d8a976a08c2e03871a9b54a4081ed84f0981d20f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44115391)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->