### PR TITLE
fix: multi-currency plan updates in preview, save and migration flows

### DIFF
--- a/server/src/internal/product/actions/updateProduct/createPlanMigrationDraft.ts
+++ b/server/src/internal/product/actions/updateProduct/createPlanMigrationDraft.ts
@@ -1,10 +1,12 @@
 import {
+	type ApiPlanV1,
 	buildAllVersionsUpdateMigrationDraft,
 	buildCombinedVariantMigrationDraft,
 	diffPlanV1,
-	planDiffHasBillingChanges,
-	type ApiPlanV1,
 	type FullProduct,
+	type Operations,
+	planDiffHasBillingChanges,
+	toBasePriceParams,
 	type UpdateVariantParams,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
@@ -37,6 +39,34 @@ const hasVersionableUsage = ({
 	);
 
 const unique = (ids: string[]) => [...new Set(ids)];
+
+// Stamped onto price-change ops so the migration UI can show per-currency
+// diffs after the catalog has already been updated in place.
+const withPreviousPrice = <T extends { operations: Operations }>({
+	draft,
+	fromPlan,
+}: {
+	draft: T;
+	fromPlan: ApiPlanV1;
+}): T => ({
+	...draft,
+	operations: {
+		...draft.operations,
+		customer: draft.operations.customer?.map((op) =>
+			op.type === "update_plan" && op.customize?.price !== undefined
+				? {
+						...op,
+						customize: {
+							...op.customize,
+							previous_price: fromPlan.price
+								? toBasePriceParams(fromPlan.price)
+								: null,
+						},
+					}
+				: op,
+		),
+	},
+});
 
 export const getVariantMigrationSnapshots = async ({
 	ctx,
@@ -120,7 +150,10 @@ export const createPlanMigrationDraft = async ({
 	const selectedVariantsBefore =
 		variantsBefore.length > 0 || selectedVariantIds.length === 0
 			? variantsBefore
-			: await getVariantMigrationSnapshots({ ctx, variantIds: selectedVariantIds });
+			: await getVariantMigrationSnapshots({
+					ctx,
+					variantIds: selectedVariantIds,
+				});
 
 	if (mode === "version") {
 		const baseUsage = await customerProductRepo.getVersioningUsageForProduct({
@@ -144,7 +177,10 @@ export const createPlanMigrationDraft = async ({
 		});
 		if (!draft) return;
 
-		const migration = await migrationRepo.insert({ ctx, insert: draft });
+		const migration = await migrationRepo.insert({
+			ctx,
+			insert: withPreviousPrice({ draft, fromPlan }),
+		});
 		return migration.id;
 	}
 
@@ -176,6 +212,9 @@ export const createPlanMigrationDraft = async ({
 	});
 	if (!draft) return;
 
-	const migration = await migrationRepo.insert({ ctx, insert: draft });
+	const migration = await migrationRepo.insert({
+		ctx,
+		insert: withPreviousPrice({ draft, fromPlan }),
+	});
 	return migration.id;
 };

--- a/shared/api/migrations/operations/customer/updatePlan/updatePlanOp.ts
+++ b/shared/api/migrations/operations/customer/updatePlan/updatePlanOp.ts
@@ -8,6 +8,11 @@ import { PlanFilterSchema } from "../../../filters/planFilter.js";
 export const MigrationUpdatePlanCustomizeSchema = z
 	.object({
 		price: BasePriceParamsSchema.nullable().optional(),
+		previous_price: BasePriceParamsSchema.nullable().optional().meta({
+			internal: true,
+			description:
+				"Base price before the plan update that created this migration. Display-only.",
+		}),
 		add_items: z.array(CreatePlanItemParamsV1Schema).optional(),
 		remove_items: z.array(PlanItemFilterSchema).optional(),
 		update_items: z.array(UpdatePlanItemParamsV1Schema).optional().meta({

--- a/shared/utils/planV1Utils/diff/diffPlanV1.ts
+++ b/shared/utils/planV1Utils/diff/diffPlanV1.ts
@@ -1,12 +1,12 @@
 import type { BasePriceParams } from "@api/products/components/basePrice/basePrice.js";
-import { FreeTrialDuration } from "@models/productModels/freeTrialModels/freeTrialEnums.js";
-import { TierBehavior } from "@models/productModels/priceModels/priceConfig/usagePriceConfig.js";
 import {
 	type ApiPlanV1,
 	type CreatePlanItemParamsV1,
 	CustomizePlanV1Schema,
 	type PlanItemFilter,
 } from "@autumn/shared";
+import { FreeTrialDuration } from "@models/productModels/freeTrialModels/freeTrialEnums.js";
+import { TierBehavior } from "@models/productModels/priceModels/priceConfig/usagePriceConfig.js";
 import type { z } from "zod/v4";
 
 export const DiffedCustomizePlanV1Schema = CustomizePlanV1Schema.omit({
@@ -20,19 +20,46 @@ type PlanItemInput = ApiPlanItem | CreatePlanItemParamsV1;
 type PlanItemPrice = NonNullable<PlanItemInput["price"]>;
 type PlanItemRollover = NonNullable<PlanItemInput["rollover"]>;
 type PlanItemProration = NonNullable<PlanItemInput["proration"]>;
+type AdditionalCurrencyInput = {
+	currency: string;
+	amount?: number | null;
+	flat_amount?: number | null;
+};
+
 type BasePriceInput = {
 	amount: number;
 	interval?: string | null;
 	interval_count?: number | null;
+	additional_currencies?: AdditionalCurrencyInput[] | null;
 };
 
-const toBasePriceParams = (
+// Currencies added in `to` don't change what existing customers pay, so they
+// don't force a version; changed or removed ones do.
+const additionalCurrenciesCompatible = (
+	from: AdditionalCurrencyInput[] | null | undefined,
+	to: AdditionalCurrencyInput[] | null | undefined,
+): boolean =>
+	(from ?? []).every((entry) => {
+		const match = (to ?? []).find(
+			(other) => other.currency.toLowerCase() === entry.currency.toLowerCase(),
+		);
+		return (
+			!!match &&
+			(entry.amount ?? null) === (match.amount ?? null) &&
+			(entry.flat_amount ?? null) === (match.flat_amount ?? null)
+		);
+	});
+
+export const toBasePriceParams = (
 	price: NonNullable<ApiPlanV1["price"]>,
 ): BasePriceParams => ({
 	amount: price.amount,
 	interval: price.interval,
 	...(price.interval_count !== undefined
 		? { interval_count: price.interval_count }
+		: {}),
+	...(price.additional_currencies?.length
+		? { additional_currencies: price.additional_currencies }
 		: {}),
 });
 
@@ -94,10 +121,12 @@ export const composeMatchKey = (item: MatchKeyItem): string => {
 /** Match key for a remove_items filter, in the same format as composeMatchKey
  * (buildRemoveFilter already flattens the matched item's fields onto it). */
 export const planItemFilterMatchKey = (filter: PlanItemFilter): string =>
-	`${filter.feature_id}|${filter.billing_method ?? ""}|${filter.interval ?? ""}|${normalizeIntervalCount({
-		interval: filter.interval,
-		intervalCount: filter.interval_count,
-	})}`;
+	`${filter.feature_id}|${filter.billing_method ?? ""}|${filter.interval ?? ""}|${normalizeIntervalCount(
+		{
+			interval: filter.interval,
+			intervalCount: filter.interval_count,
+		},
+	)}`;
 
 const normalizeIntervalCount = ({
 	interval,
@@ -130,7 +159,11 @@ const pricesEqual = (
 	return (
 		a.amount === b.amount &&
 		a.interval === b.interval &&
-		(a.interval_count ?? 1) === (b.interval_count ?? 1)
+		(a.interval_count ?? 1) === (b.interval_count ?? 1) &&
+		additionalCurrenciesCompatible(
+			a.additional_currencies,
+			b.additional_currencies,
+		)
 	);
 };
 
@@ -162,7 +195,11 @@ const tiersEqual = (
 		return (
 			tier.to === other.to &&
 			(tier.amount ?? 0) === (other.amount ?? 0) &&
-			(tier.flat_amount ?? null) === (other.flat_amount ?? null)
+			(tier.flat_amount ?? null) === (other.flat_amount ?? null) &&
+			additionalCurrenciesCompatible(
+				tier.additional_currencies,
+				other.additional_currencies,
+			)
 		);
 	});
 };
@@ -182,6 +219,10 @@ const itemPricesEqual = (
 
 	return (
 		(a.amount ?? null) === (b.amount ?? null) &&
+		additionalCurrenciesCompatible(
+			a.additional_currencies,
+			b.additional_currencies,
+		) &&
 		tiersEqual(a.tiers, b.tiers) &&
 		aTierBehavior === bTierBehavior &&
 		a.interval === b.interval &&
@@ -213,8 +254,7 @@ const rolloversEqual = (
 
 	return (
 		a.expiry_duration_type === b.expiry_duration_type &&
-		(a.expiry_duration_length ?? null) ===
-			(b.expiry_duration_length ?? null) &&
+		(a.expiry_duration_length ?? null) === (b.expiry_duration_length ?? null) &&
 		(a.max ?? null) === (b.max ?? null) &&
 		(a.max_percentage ?? null) === (b.max_percentage ?? null)
 	);
@@ -235,10 +275,7 @@ export const itemsEqual = (a: PlanItemInput, b: PlanItemInput): boolean => {
 	);
 };
 
-const removeFiltersEqual = (
-	a: PlanItemFilter,
-	b: PlanItemFilter,
-): boolean =>
+const removeFiltersEqual = (a: PlanItemFilter, b: PlanItemFilter): boolean =>
 	a.feature_id === b.feature_id &&
 	(a.billing_method ?? null) === (b.billing_method ?? null) &&
 	(a.interval ?? null) === (b.interval ?? null) &&

--- a/vite/src/components/forms/shared/plan-items/PlanPriceHeader.tsx
+++ b/vite/src/components/forms/shared/plan-items/PlanPriceHeader.tsx
@@ -1,15 +1,24 @@
-import type { FrontendProduct } from "@autumn/shared";
+import type { AdditionalCurrencyPrice, FrontendProduct } from "@autumn/shared";
 import {
 	type AdminPlanIds,
 	AdminPlanIdsTooltip,
 } from "@/components/forms/shared/admin/AdminPlanIdsTooltip";
 import { PriceDisplay } from "@/components/forms/update-subscription-v2/components/PriceDisplay";
+import { ItemStatusDot } from "@/components/v2/ItemStatusDot";
+import {
+	AdditionalCurrenciesHint,
+	type CurrencyChangeState,
+} from "@/views/products/plan/components/plan-card/AdditionalCurrenciesHint";
 
 interface PriceChange {
 	oldPrice: string;
 	newPrice: string;
 	oldIntervalText: string | null;
 	newIntervalText: string | null;
+	oldCurrencies?: AdditionalCurrencyPrice[];
+	newCurrencies?: AdditionalCurrencyPrice[];
+	oldCurrencyStates?: Record<string, CurrencyChangeState>;
+	newCurrencyStates?: Record<string, CurrencyChangeState>;
 	isUpgrade: boolean;
 }
 
@@ -26,10 +35,17 @@ export function PlanPriceHeader({
 }) {
 	const content = priceChange ? (
 		<span className="flex items-center gap-1.5">
+			<ItemStatusDot state="updated" />
 			<span className="text-tertiary-foreground">
 				{priceChange.oldPrice}
 				{priceChange.oldIntervalText && ` ${priceChange.oldIntervalText}`}
 			</span>
+			{!!priceChange.oldCurrencies?.length && (
+				<AdditionalCurrenciesHint
+					changeStates={priceChange.oldCurrencyStates}
+					currencies={priceChange.oldCurrencies}
+				/>
+			)}
 			<span className="text-subtle">-&gt;</span>
 			<span className="font-semibold text-foreground">
 				{priceChange.newPrice}
@@ -37,6 +53,12 @@ export function PlanPriceHeader({
 			<span className="text-tertiary-foreground">
 				{priceChange.newIntervalText}
 			</span>
+			{!!priceChange.newCurrencies?.length && (
+				<AdditionalCurrenciesHint
+					changeStates={priceChange.newCurrencyStates}
+					currencies={priceChange.newCurrencies}
+				/>
+			)}
 		</span>
 	) : (
 		<PriceDisplay product={product} currency={currency} />

--- a/vite/src/components/v2/ItemStatusDot.tsx
+++ b/vite/src/components/v2/ItemStatusDot.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 const ITEM_STATE_CONFIG = {
 	new: { color: "bg-green-500", label: "New feature" },
 	removed: { color: "bg-red-500", label: "Removed" },
+	updated: { color: "bg-amber-500", label: "Updated" },
 } as const;
 
 export type ItemStatusState = keyof typeof ITEM_STATE_CONFIG;

--- a/vite/src/views/migrations/migration/shared/OperationsPreview.tsx
+++ b/vite/src/views/migrations/migration/shared/OperationsPreview.tsx
@@ -15,6 +15,10 @@ import { useOrg } from "@/hooks/common/useOrg";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import {
+	AdditionalCurrenciesHint,
+	getCurrencyChangeStates,
+} from "@/views/products/plan/components/plan-card/AdditionalCurrenciesHint";
+import {
 	filterToProductItem,
 	getFilterSummary,
 	type ItemFilter,
@@ -23,14 +27,21 @@ import { extractPlanIds } from "../operations/UpdatePlanOpForm";
 import { migrationItemToProductItem } from "./migrationItemUtils";
 
 /** Full-width row matching SubscriptionItemRow, with an amber dot for an edited value. */
-function EditedRow({ icon, text }: { icon: ReactNode; text: ReactNode }) {
+function EditedRow({
+	icon,
+	text,
+	hint,
+}: {
+	icon: ReactNode;
+	text: ReactNode;
+	hint?: ReactNode;
+}) {
 	return (
 		<div className="flex items-center flex-1 min-w-0 h-10 px-3 rounded-xl input-base gap-2">
 			<div className="flex flex-row items-center flex-1 gap-2 min-w-0 overflow-hidden">
 				{icon}
-				<p className="whitespace-nowrap truncate flex-1 min-w-0 text-body">
-					{text}
-				</p>
+				<p className="whitespace-nowrap truncate min-w-0 text-body">{text}</p>
+				{hint}
 			</div>
 			<span className="size-2 rounded-full shrink-0 bg-amber-500" />
 		</div>
@@ -93,6 +104,34 @@ export function OperationsPreview({ operations }: { operations: Operations }) {
 					const addItems = customize?.add_items ?? [];
 					const removeItems = customize?.remove_items ?? [];
 
+					const priceCurrencies = customize?.price?.additional_currencies ?? [];
+					const previousCurrencies =
+						customize?.previous_price?.additional_currencies ?? [];
+					const removedCurrencies = previousCurrencies.filter(
+						(previous) =>
+							!priceCurrencies.some(
+								(current) =>
+									current.currency.toLowerCase() ===
+									previous.currency.toLowerCase(),
+							),
+					);
+					const hintCurrencies = [...priceCurrencies, ...removedCurrencies];
+					const currencyChangeStates =
+						customize?.previous_price !== undefined
+							? {
+									...getCurrencyChangeStates({
+										entries: previousCurrencies,
+										others: priceCurrencies,
+										missingState: "removed",
+									}),
+									...getCurrencyChangeStates({
+										entries: priceCurrencies,
+										others: previousCurrencies,
+										missingState: "added",
+									}),
+								}
+							: undefined;
+
 					return (
 						<div key={`op-${index}`} className="flex flex-col gap-2 min-w-0">
 							<div className="flex items-center gap-2 min-w-0">
@@ -121,6 +160,14 @@ export function OperationsPreview({ operations }: { operations: Operations }) {
 
 							{customize?.price !== undefined && (
 								<EditedRow
+									hint={
+										hintCurrencies.length > 0 ? (
+											<AdditionalCurrenciesHint
+												changeStates={currencyChangeStates}
+												currencies={hintCurrencies}
+											/>
+										) : undefined
+									}
 									icon={
 										<CurrencyCircleDollarIcon
 											size={16}

--- a/vite/src/views/products/plan/components/plan-card/AdditionalCurrenciesHint.tsx
+++ b/vite/src/views/products/plan/components/plan-card/AdditionalCurrenciesHint.tsx
@@ -1,5 +1,32 @@
 import { type AdditionalCurrencyPrice, formatAmount } from "@autumn/shared";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@autumn/ui";
+import { cn, Tooltip, TooltipContent, TooltipTrigger } from "@autumn/ui";
+
+const STATE_DOT_COLOR = {
+	added: "bg-green-500",
+	updated: "bg-amber-500",
+	removed: "bg-red-500",
+} as const;
+
+export type CurrencyChangeState = keyof typeof STATE_DOT_COLOR;
+
+export const getCurrencyChangeStates = ({
+	entries,
+	others,
+	missingState,
+}: {
+	entries: AdditionalCurrencyPrice[];
+	others: AdditionalCurrencyPrice[];
+	missingState: "added" | "removed";
+}): Record<string, CurrencyChangeState> => {
+	const states: Record<string, CurrencyChangeState> = {};
+	for (const entry of entries) {
+		const code = entry.currency.toLowerCase();
+		const match = others.find((other) => other.currency.toLowerCase() === code);
+		if (!match) states[code] = missingState;
+		else if (match.amount !== entry.amount) states[code] = "updated";
+	}
+	return states;
+};
 
 const formatCurrencyAmount = (entry: AdditionalCurrencyPrice) =>
 	entry.amount === 0
@@ -15,26 +42,43 @@ const formatCurrencyAmount = (entry: AdditionalCurrencyPrice) =>
 
 export const AdditionalCurrenciesHint = ({
 	currencies,
+	changeStates,
 }: {
 	currencies: AdditionalCurrencyPrice[];
-}) => (
-	<Tooltip>
-		<TooltipTrigger asChild>
-			<span className="mt-0.5 text-tertiary-foreground text-xs">
-				+{currencies.length}
-			</span>
-		</TooltipTrigger>
-		<TooltipContent>
-			<div className="space-y-0.5">
-				{currencies.map((entry) => (
-					<div className="flex items-center gap-2" key={entry.currency}>
-						<span className="w-8 text-tertiary-foreground uppercase">
-							{entry.currency}
-						</span>
-						<span>{formatCurrencyAmount(entry)}</span>
-					</div>
-				))}
-			</div>
-		</TooltipContent>
-	</Tooltip>
-);
+	changeStates?: Record<string, CurrencyChangeState>;
+}) => {
+	const showDots = Object.keys(changeStates ?? {}).length > 0;
+
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<span className="mt-0.5 text-tertiary-foreground text-xs">
+					+{currencies.length}
+				</span>
+			</TooltipTrigger>
+			<TooltipContent>
+				<div className="space-y-0.5">
+					{currencies.map((entry) => {
+						const state = changeStates?.[entry.currency.toLowerCase()];
+						return (
+							<div className="flex items-center gap-2" key={entry.currency}>
+								{showDots && (
+									<span
+										className={cn(
+											"size-1.5 shrink-0 rounded-full",
+											state ? STATE_DOT_COLOR[state] : "bg-transparent",
+										)}
+									/>
+								)}
+								<span className="w-8 text-tertiary-foreground uppercase">
+									{entry.currency}
+								</span>
+								<span>{formatCurrencyAmount(entry)}</span>
+							</div>
+						);
+					})}
+				</div>
+			</TooltipContent>
+		</Tooltip>
+	);
+};

--- a/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
+++ b/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
@@ -603,7 +603,14 @@ export default function PlanChangeDialog({
 												</span>
 											</div>
 											{isMetadataOnly ? (
-												<div className="rounded-lg bg-secondary/40 px-3 py-2.5">
+												<div className="rounded-lg bg-secondary/40 px-3 py-2.5 flex flex-col gap-2">
+													{priceChange && (
+														<PlanPriceHeader
+															priceChange={priceChange}
+															product={product}
+															currency={currency}
+														/>
+													)}
 													<PlanSettingsChanges changes={settingsChanges} />
 												</div>
 											) : (

--- a/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
+++ b/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
@@ -45,6 +45,9 @@ export function frontendProductToApiPlanV1(
 	const basePrice: ApiPlanV1["price"] = basePriceItem
 		? {
 				amount: basePriceItem.price,
+				...(basePriceItem.additional_currencies?.length
+					? { additional_currencies: basePriceItem.additional_currencies }
+					: {}),
 				interval: itemToBillingInterval({ item: basePriceItem }),
 				...(basePriceItem.interval_count !== 1 &&
 				typeof basePriceItem.interval_count === "number"

--- a/vite/src/views/products/plan/versioning/planMigrationDiff.ts
+++ b/vite/src/views/products/plan/versioning/planMigrationDiff.ts
@@ -1,7 +1,14 @@
-import type { FrontendProduct } from "@autumn/shared";
+import type { AdditionalCurrencyPrice, FrontendProduct } from "@autumn/shared";
 import { isPriceItem } from "@autumn/shared";
 import { getPlanItemsDiff } from "@/components/forms/shared";
 import { getProductPriceDisplay } from "@/components/forms/update-subscription-v2/components/PriceDisplay";
+import { getCurrencyChangeStates } from "../components/plan-card/AdditionalCurrenciesHint";
+
+const currencySignature = (entries: AdditionalCurrencyPrice[]) =>
+	entries
+		.map((entry) => `${entry.currency.toLowerCase()}:${entry.amount}`)
+		.sort()
+		.join(",");
 
 export function getPlanPriceChange({
 	baseProduct,
@@ -25,16 +32,37 @@ export function getPlanPriceChange({
 	const newInterval =
 		newDisplay.type === "price" ? newDisplay.intervalText : null;
 
-	if (oldPrice === newPrice && oldInterval === newInterval) return null;
-
 	const originalPriceItem = baseProduct.items?.find((i) => isPriceItem(i));
 	const currentPriceItem = product.items?.find((i) => isPriceItem(i));
+	const oldCurrencies = originalPriceItem?.additional_currencies ?? [];
+	const newCurrencies = currentPriceItem?.additional_currencies ?? [];
+	const currenciesChanged =
+		currencySignature(oldCurrencies) !== currencySignature(newCurrencies);
+
+	if (
+		oldPrice === newPrice &&
+		oldInterval === newInterval &&
+		!currenciesChanged
+	)
+		return null;
 
 	return {
 		oldPrice,
 		newPrice,
 		oldIntervalText: oldInterval !== newInterval ? oldInterval : null,
 		newIntervalText: newInterval,
+		oldCurrencies,
+		newCurrencies,
+		oldCurrencyStates: getCurrencyChangeStates({
+			entries: oldCurrencies,
+			others: newCurrencies,
+			missingState: "removed",
+		}),
+		newCurrencyStates: getCurrencyChangeStates({
+			entries: newCurrencies,
+			others: oldCurrencies,
+			missingState: "added",
+		}),
 		isUpgrade: (currentPriceItem?.price ?? 0) > (originalPriceItem?.price ?? 0),
 	};
 }


### PR DESCRIPTION
## Summary

Fixes a set of gaps where additional currencies were invisible to the plan update flows:

- **`diffPlanV1` was currency-blind** — `pricesEqual`, `itemPricesEqual` and `tiersEqual` ignored `additional_currencies`, so currency-only edits produced an empty diff and the save dialog's preview rendered blank. The diff now compares currencies at all three levels, and `toBasePriceParams` carries them through instead of stripping them.
- **Adding vs updating a currency version correctly** — currency comparison is directional: adding a new currency doesn't change what existing customers pay, so it applies in place without offering new-version/migration options; updating or removing an existing currency produces a versionable diff with the normal migration flow.
- **Preview/update params dropped base price currencies** — `frontendProductToApiPlanV1` built `price` as `{ amount, interval }` only, which also silently wiped currencies on save. It now includes `additional_currencies`, mirroring the shared `productV2ToApiPlanV1`.
- **Save dialog currency display** — base price changes show an amber updated dot, and the `+N` currency hint tooltips mark each currency green/amber/red for added/updated/removed on both sides of the old → new line. The metadata-only review step also shows the price change instead of an empty box.
- **Run Migration dialog** — price-change ops are stamped with an internal `previous_price` at draft creation (the catalog is already updated by the time the dialog renders), so the `+N` tooltip shows the same per-currency diff, including removed currencies at their old amounts. Old drafts without `previous_price` render without dots rather than mislabeling everything as added.

## Testing

- `diffPlanV1` verified: add → no diff, update/remove → diff carrying currencies, reorder-only → no diff; existing `applyDiff` and currency mapper/schema suites pass
- `bun ts` clean in vite and server; biome clean
- Manually exercised the save dialog preview, in-place saves, and a fresh migration draft (verified `previous_price` stored on the op)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multi-currency plan updates: diffs detect currency-only changes, saves preserve `additional_currencies`, and migration previews show accurate per-currency changes. Prevents blank previews and unintended currency loss.

- **Bug Fixes**
  - `diffPlanV1` now compares `additional_currencies` on base price, item prices, and tiers; added currencies are non-versioned, while updates/removals create a versionable diff.
  - Save/preview keep `additional_currencies` via `frontendProductToApiPlanV1`; the save dialog shows an amber “updated” dot and a `+N` tooltip with added/updated/removed markers.

- **Migration**
  - Drafts stamp `previous_price` on `update_plan` ops so the Run Migration dialog shows per-currency diffs (including removed currencies); older drafts without it render without dots.

<sup>Written for commit 681115fda9cf9df6337d26af28772bd62167ad2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds multi-currency support across plan update flows. The main changes are:

- **Bug fixes:** Compare additional currencies in base, item, and tier prices.
- **Bug fixes:** Preserve base-price currencies in preview and save parameters.
- **Improvements:** Show added, updated, and removed currencies in change previews.
- **API changes:** Store an internal previous price on migration operations.
</details>

<h3>Confidence Score: 4/5</h3>

Multi-target migration previews can show the wrong prior currency data.

- Single-plan currency comparison and propagation are consistent.
- Variant and historical-version operations reuse one base-plan price snapshot.
- The incorrect snapshot can produce misleading migration review details.

server/src/internal/product/actions/updateProduct/createPlanMigrationDraft.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/planV1Utils/diff/diffPlanV1.ts | Adds directional additional-currency comparisons and preserves currencies in base-price parameters. |
| server/src/internal/product/actions/updateProduct/createPlanMigrationDraft.ts | Stores the base plan's previous price on migration operations, including operations for targets with potentially different prior prices. |
| shared/api/migrations/operations/customer/updatePlan/updatePlanOp.ts | Adds an optional internal previous-price field to migration customization data. |
| vite/src/views/products/plan/versioning/buildMigrationDraft.ts | Preserves additional currencies when converting frontend base prices. |
| vite/src/views/products/plan/versioning/planMigrationDiff.ts | Detects currency-only changes and calculates per-currency display states. |
| vite/src/views/migrations/migration/shared/OperationsPreview.tsx | Displays migration currency changes using the stored current and previous prices. |
| vite/src/views/products/plan/components/plan-card/AdditionalCurrenciesHint.tsx | Adds colored currency-state indicators to the additional-currencies tooltip. |
| vite/src/components/forms/shared/plan-items/PlanPriceHeader.tsx | Shows updated status and old/new currency hints for base-price changes. |
| vite/src/views/products/plan/versioning/PlanChangeDialog.tsx | Shows price changes in the metadata-only confirmation view. |
| vite/src/components/v2/ItemStatusDot.tsx | Adds an amber updated state to the shared status indicator. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Edited plan] --> B[Currency-aware diff]
    B --> C[Plan update]
    B --> D[Migration draft]
    E[Base plan previous price] --> D
    D --> F[Migration preview]
    F --> G[Currency change indicators]
    H[Variant and historical prices] -. not used for previous_price .-> D
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart LR
    A[Edited plan] --> B[Currency-aware diff]
    B --> C[Plan update]
    B --> D[Migration draft]
    E[Base plan previous price] --> D
    D --> F[Migration preview]
    F --> G[Currency change indicators]
    H[Variant and historical prices] -. not used for previous_price .-> D
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/product/actions/updateProduct/createPlanMigrationDraft.ts:62-64
**Shared Snapshot Mislabels Target Prices**

When a draft targets selected variants or multiple historical versions, this stamps the base plan's `fromPlan.price` onto every price operation. A target with different prior currencies is then previewed against the wrong price, so its currencies and amounts can be mislabeled as added, updated, or removed.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: multi-currency plan updates in prev..."](https://github.com/useautumn/autumn/commit/681115fda9cf9df6337d26af28772bd62167ad2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44190856)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->