### PR TITLE
fix: stamp previous_price per plan so variant ops keep their own history

### DIFF
--- a/server/src/internal/product/actions/updateProduct/createPlanMigrationDraft.ts
+++ b/server/src/internal/product/actions/updateProduct/createPlanMigrationDraft.ts
@@ -5,6 +5,7 @@ import {
 	diffPlanV1,
 	type FullProduct,
 	type Operations,
+	type PlanFilter,
 	planDiffHasBillingChanges,
 	toBasePriceParams,
 	type UpdateVariantParams,
@@ -40,33 +41,64 @@ const hasVersionableUsage = ({
 
 const unique = (ids: string[]) => [...new Set(ids)];
 
+type PreviousBasePrice = ReturnType<typeof toBasePriceParams> | null;
+
+const matchedPlanIds = (matcher: PlanFilter["plan_id"]): string[] => {
+	if (typeof matcher === "string") return [matcher];
+	if (matcher && typeof matcher === "object" && matcher.$in) return matcher.$in;
+	return [];
+};
+
+const previousPriceKey = (price: PreviousBasePrice) => JSON.stringify(price);
+
 // Stamped onto price-change ops so the migration UI can show per-currency
-// diffs after the catalog has already been updated in place.
+// diffs after the catalog has already been updated in place. An op covering
+// plans with differing previous prices is left unstamped rather than showing
+// the base plan's history for a variant.
 const withPreviousPrice = <T extends { operations: Operations }>({
 	draft,
-	fromPlan,
+	previousPriceByPlanId,
 }: {
 	draft: T;
-	fromPlan: ApiPlanV1;
+	previousPriceByPlanId: Map<string, PreviousBasePrice>;
 }): T => ({
 	...draft,
 	operations: {
 		...draft.operations,
-		customer: draft.operations.customer?.map((op) =>
-			op.type === "update_plan" && op.customize?.price !== undefined
-				? {
-						...op,
-						customize: {
-							...op.customize,
-							previous_price: fromPlan.price
-								? toBasePriceParams(fromPlan.price)
-								: null,
-						},
-					}
-				: op,
-		),
+		customer: draft.operations.customer?.map((op) => {
+			if (op.type !== "update_plan" || op.customize?.price === undefined) {
+				return op;
+			}
+			const prices = matchedPlanIds(op.plan_filter.plan_id).map(
+				(id) => previousPriceByPlanId.get(id) ?? null,
+			);
+			if (prices.length === 0) return op;
+			const keys = new Set(prices.map(previousPriceKey));
+			if (keys.size > 1) return op;
+			return {
+				...op,
+				customize: { ...op.customize, previous_price: prices[0] },
+			};
+		}),
 	},
 });
+
+const buildPreviousPriceMap = ({
+	planId,
+	fromPlan,
+	variantsBefore,
+}: {
+	planId: string;
+	fromPlan: ApiPlanV1;
+	variantsBefore: VariantMigrationSnapshot[];
+}): Map<string, PreviousBasePrice> =>
+	new Map([
+		[planId, fromPlan.price ? toBasePriceParams(fromPlan.price) : null],
+		...variantsBefore.map((before): [string, PreviousBasePrice] => [
+			before.product.id,
+			before.plan.price ? toBasePriceParams(before.plan.price) : null,
+		]),
+	]);
 
 export const getVariantMigrationSnapshots = async ({
 	ctx,
@@ -179,7 +211,14 @@ export const createPlanMigrationDraft = async ({
 
 		const migration = await migrationRepo.insert({
 			ctx,
-			insert: withPreviousPrice({ draft, fromPlan }),
+			insert: withPreviousPrice({
+				draft,
+				previousPriceByPlanId: buildPreviousPriceMap({
+					planId,
+					fromPlan,
+					variantsBefore: selectedVariantsBefore,
+				}),
+			}),
 		});
 		return migration.id;
 	}
@@ -214,7 +253,14 @@ export const createPlanMigrationDraft = async ({
 
 	const migration = await migrationRepo.insert({
 		ctx,
-		insert: withPreviousPrice({ draft, fromPlan }),
+		insert: withPreviousPrice({
+			draft,
+			previousPriceByPlanId: buildPreviousPriceMap({
+				planId,
+				fromPlan,
+				variantsBefore: selectedVariantsBefore,
+			}),
+		}),
 	});
 	return migration.id;
 };

--- a/vite/src/views/migrations/migration/shared/OperationsPreview.tsx
+++ b/vite/src/views/migrations/migration/shared/OperationsPreview.tsx
@@ -164,6 +164,7 @@ export function OperationsPreview({ operations }: { operations: Operations }) {
 										hintCurrencies.length > 0 ? (
 											<AdditionalCurrenciesHint
 												changeStates={currencyChangeStates}
+												count={priceCurrencies.length}
 												currencies={hintCurrencies}
 											/>
 										) : undefined

--- a/vite/src/views/products/plan/components/plan-card/AdditionalCurrenciesHint.tsx
+++ b/vite/src/views/products/plan/components/plan-card/AdditionalCurrenciesHint.tsx
@@ -43,9 +43,11 @@ const formatCurrencyAmount = (entry: AdditionalCurrencyPrice) =>
 export const AdditionalCurrenciesHint = ({
 	currencies,
 	changeStates,
+	count,
 }: {
 	currencies: AdditionalCurrencyPrice[];
 	changeStates?: Record<string, CurrencyChangeState>;
+	count?: number;
 }) => {
 	const showDots = Object.keys(changeStates ?? {}).length > 0;
 
@@ -53,7 +55,7 @@ export const AdditionalCurrenciesHint = ({
 		<Tooltip>
 			<TooltipTrigger asChild>
 				<span className="mt-0.5 text-tertiary-foreground text-xs">
-					+{currencies.length}
+					+{count ?? currencies.length}
 				</span>
 			</TooltipTrigger>
 			<TooltipContent>


### PR DESCRIPTION
Follow-up to #2236 (the review-comment fix was pushed after the merge).

An op grouped over base plan + variants was stamped with the base plan's previous price even when a variant charged differently, so the Run Migration diff showed the wrong historical amounts for that variant's customers. `createPlanMigrationDraft` now builds a per-plan previous-price map (base from `fromPlan`, variants from their snapshots) and only stamps an op when every plan it covers shared the same previous price — otherwise the op is left unstamped and the tooltip renders without diff dots rather than showing incorrect history.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes previous_price stamping so each plan keeps its own history in migration previews, and corrects the +N currency hint to ignore removed currencies for accurate counts.

- **Bug Fixes**
  - Build a per-plan previous-price map from the base plan and variant snapshots.
  - For grouped `update_plan` ops, stamp only when all covered plans share the same previous price (IDs read from `plan_filter.plan_id`); otherwise leave the op unstamped (no diff dots).
  - Fix "+N" currency hint to exclude removed currencies while the tooltip still lists them so change dots can show.

<sup>Written for commit 087288b899cde0264744ba6f517c75be86a2a94f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR records historical prices per plan when creating migration drafts. The main changes are:

- **Bug fixes:** Build a previous-price map for the base plan and selected variants.
- **Bug fixes:** Stamp grouped operations only when all covered plans share the same previous price.
- **Improvements:** Leave mixed-price operations unstamped instead of showing incorrect history.
</details>

<h3>Confidence Score: 4/5</h3>

Version-mode migrations can lose historical price details and need a contained fix before merging.

- Direct and `$in` plan filters use the new price map correctly.
- `$or` filters generated for plans on different versions bypass price stamping.
- No security or data-integrity issue was identified.

server/src/internal/product/actions/updateProduct/createPlanMigrationDraft.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/product/actions/updateProduct/createPlanMigrationDraft.ts | Adds per-plan historical-price stamping, but does not extract plan IDs from the `$or` filters generated in version mode. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/product/actions/updateProduct/createPlanMigrationDraft.ts:72
**Versioned Filters Lose Price History**

When version mode groups plans from different versions, `versionedPlanFilter` puts their IDs inside `$or` branches and leaves the top-level `plan_id` undefined. This call therefore finds no IDs and skips `previous_price`, so the migration preview omits valid history even when every covered plan had the same previous price.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: stamp previous\_price per plan so va..."](https://github.com/useautumn/autumn/commit/a8c213cb5dd45e0371d3b0358bf41fca5aaea9d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44196338)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->