### PR TITLE
fix(cron): back off pending invoice cleanup

### DIFF
--- a/server/src/cron/invoiceCron/runInvoiceCron.ts
+++ b/server/src/cron/invoiceCron/runInvoiceCron.ts
@@ -1,5 +1,6 @@
 import type { DeferredAutumnBillingPlanData } from "@autumn/shared";
 import { type Metadata, MetadataType, metadata } from "@autumn/shared";
+import { addDays } from "date-fns";
 import { and, eq, isNotNull, lt, or } from "drizzle-orm";
 import type { Stripe } from "stripe";
 import { OrgService } from "@/internal/orgs/OrgService";
@@ -93,6 +94,21 @@ export const handleVoidInvoiceCron = async ({
 				id: metadata.id,
 			});
 		} catch (error) {
+			if (
+				error instanceof Error &&
+				error.message.includes("pending payments waiting to clear")
+			) {
+				await MetadataService.update({
+					db,
+					id: metadata.id,
+					updates: { expires_at: addDays(Date.now(), 1).getTime() },
+				});
+				logger.info(
+					`Invoice ${metadata.stripe_invoice_id} has a pending payment; retrying cleanup in 24 hours`,
+				);
+				return;
+			}
+
 			logger.error(`Error voiding invoice: ${error}`);
 			if (
 				error instanceof Error &&
@@ -104,7 +120,6 @@ export const handleVoidInvoiceCron = async ({
 				});
 				return;
 			}
-			logger.error(`Error voiding invoice: ${error}`);
 		}
 	} else if (invoice.status === "void" || invoice.status === "uncollectible") {
 		await MetadataService.delete({

--- a/server/tests/unit/cron/void-invoice-cron-pending-payment.test.ts
+++ b/server/tests/unit/cron/void-invoice-cron-pending-payment.test.ts
@@ -1,0 +1,117 @@
+/** TDD: pending payments must retain continuation metadata for the eventual Stripe webhook. */
+
+import { expect, mock, test } from "bun:test";
+import { AppEnv, type Metadata, MetadataType } from "@autumn/shared";
+
+const state = {
+	deletedMetadataIds: [] as string[],
+	metadataUpdates: [] as { id: string; expiresAt: number }[],
+	errorLogs: [] as string[],
+	invoiceStatus: "open" as "open" | "paid",
+	pendingPayment: true,
+};
+
+mock.module("@/external/connect/createStripeCli.js", () => ({
+	createStripeCli: () => ({
+		invoices: {
+			retrieve: async () => ({
+				status: state.invoiceStatus,
+				subscription: null,
+			}),
+			voidInvoice: async () => {
+				if (state.pendingPayment) {
+					throw new Error(
+						"Invoices with pending payments waiting to clear cannot be paid, voided, or marked uncollectible.",
+					);
+				}
+			},
+		},
+	}),
+}));
+
+mock.module("@/internal/metadata/MetadataService.js", () => ({
+	MetadataService: {
+		delete: async ({ id }: { id: string }) => {
+			state.deletedMetadataIds.push(id);
+		},
+		update: async ({
+			id,
+			updates,
+		}: {
+			id: string;
+			updates: { expires_at: number };
+		}) => {
+			state.metadataUpdates.push({ id, expiresAt: updates.expires_at });
+		},
+	},
+}));
+
+const { handleVoidInvoiceCron } = await import(
+	"@/cron/invoiceCron/runInvoiceCron.js"
+);
+
+const metadata = {
+	id: "meta_pending_payment",
+	type: MetadataType.InvoiceActionRequired,
+	stripe_invoice_id: "in_pending_payment",
+	data: {
+		org: { slug: "test-org" },
+		customer: { id: "cus_pending_payment", env: AppEnv.Sandbox },
+	},
+} as unknown as Metadata;
+
+const resetState = () => {
+	state.deletedMetadataIds = [];
+	state.metadataUpdates = [];
+	state.errorLogs = [];
+	state.invoiceStatus = "open";
+	state.pendingPayment = true;
+};
+
+const runCron = () =>
+	handleVoidInvoiceCron({
+		metadata,
+		ctx: {
+			db: {} as never,
+			logger: {
+				error: (message: string) => state.errorLogs.push(message),
+				info: () => {},
+				warn: () => {},
+			} as never,
+		},
+	});
+
+test("backs off cleanup when Stripe has a pending payment", async () => {
+	resetState();
+	const startedAt = Date.now();
+
+	await runCron();
+
+	expect(state.deletedMetadataIds).toEqual([]);
+	expect(state.metadataUpdates).toHaveLength(1);
+	expect(state.metadataUpdates[0]?.id).toBe(metadata.id);
+	expect(state.metadataUpdates[0]?.expiresAt).toBeGreaterThan(
+		startedAt + 23 * 60 * 60 * 1000,
+	);
+	expect(state.errorLogs).toHaveLength(0);
+});
+
+test("preserves metadata when the pending payment later succeeds", async () => {
+	resetState();
+	await runCron();
+
+	state.invoiceStatus = "paid";
+	await runCron();
+
+	expect(state.deletedMetadataIds).toEqual([]);
+});
+
+test("cleans up after the pending payment later fails", async () => {
+	resetState();
+	await runCron();
+
+	state.pendingPayment = false;
+	await runCron();
+
+	expect(state.deletedMetadataIds).toEqual([metadata.id]);
+});


### PR DESCRIPTION
## Summary

- recognize the Stripe pending-payment void refusal as a transient state
- preserve invoice continuation metadata for the eventual paid webhook
- defer the next cleanup attempt by 24 hours instead of retrying every minute
- remove duplicate error logging and cover both eventual payment outcomes

## Root cause

Stripe keeps asynchronous invoice payments open while funds clear. Deleting Autumn metadata at that point prevents a later invoice.paid webhook from completing the product, upgrade, or deferred billing transition. The cron now retains that state and backs off cleanup until Stripe resolves the payment.

## Verification

- reproduced the exact production Stripe error before the fix
- focused regression suite passes: 3 tests, 7 assertions
- pending-to-paid preserves metadata
- pending-to-failed/open retries voiding and cleans up
- server typecheck passes
- Biome, Knip, and diff checks pass