### PR TITLE
Pay down overages for one-off add-ons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ TAKEHOME.md
 # .context/
 
 # ai-sync: generated files (source of truth is ai/)
+.pi-subagents/
 .cursor/
 .claude/
 .codex/

--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionEnabledImmediately/handleCheckoutSessionEnabledImmediately.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionEnabledImmediately/handleCheckoutSessionEnabledImmediately.ts
@@ -124,6 +124,7 @@ export const handleCheckoutSessionEnabledImmediately = async ({
 			updateCustomerProducts,
 			insertCustomerEntitlements: undefined,
 			updateCustomerEntitlements: [],
+			oneOffPurchaseRebalance: undefined,
 		},
 		stripeInvoice,
 	});

--- a/server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts
+++ b/server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts
@@ -10,6 +10,7 @@ import { cusProductToExistingBalanceCarryOvers } from "@/internal/billing/v2/uti
 import { cusProductToOneOffPrepaidCarryOvers } from "@/internal/billing/v2/utils/handleOneOffPrepaidCarryOvers/cusProductToOneOffPrepaidCarryOvers";
 import { computeAttachNewCustomerProduct } from "./computeAttachNewCustomerProduct";
 import { computeAttachTransitionUpdates } from "./computeAttachTransitionUpdates";
+import { computeOneOffPurchaseRebalance } from "./computeOneOffPurchaseRebalance";
 import { finalizeAttachPlan } from "./finalizeAttachPlan";
 import { shouldBuildImmediateLineItems } from "./shouldBuildImmediateLineItems";
 
@@ -44,6 +45,10 @@ export const computeAttachPlan = ({
 		ctx,
 		attachBillingContext,
 		params,
+	});
+	const oneOffPurchaseRebalance = computeOneOffPurchaseRebalance({
+		ctx,
+		newCustomerProduct,
 	});
 
 	const updateCustomerProduct = computeAttachTransitionUpdates({
@@ -125,6 +130,7 @@ export const computeAttachPlan = ({
 			...oneOffPrepaidCarryOvers.customerEntitlements,
 		],
 		updateCustomerEntitlements,
+		oneOffPurchaseRebalance,
 	};
 
 	plan = finalizeAttachPlan({

--- a/server/src/internal/billing/v2/actions/attach/compute/computeOneOffPurchaseRebalance.ts
+++ b/server/src/internal/billing/v2/actions/attach/compute/computeOneOffPurchaseRebalance.ts
@@ -1,0 +1,44 @@
+import {
+	customerProductHasActiveStatus,
+	type FullCusProduct,
+	isCustomerProductAddOn,
+	isCustomerProductOneOff,
+	orgPersistFreeOverage,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { oneOffPrepaidCusEntsByFeatureId } from "@/internal/billing/v2/utils/handleOneOffPrepaidCarryOvers/cusProductToOneOffPrepaidCarryOvers";
+
+export type OneOffPurchaseRebalance = {
+	purchases: {
+		customerEntitlementId: string;
+		featureId: string;
+		quantity: number;
+	}[];
+};
+
+export const computeOneOffPurchaseRebalance = ({
+	ctx,
+	newCustomerProduct,
+}: {
+	ctx: AutumnContext;
+	newCustomerProduct: FullCusProduct;
+}): OneOffPurchaseRebalance | undefined => {
+	if (orgPersistFreeOverage({ org: ctx.org })) return undefined;
+	if (!isCustomerProductAddOn(newCustomerProduct)) return undefined;
+	if (!isCustomerProductOneOff(newCustomerProduct)) return undefined;
+	if (!customerProductHasActiveStatus(newCustomerProduct)) return undefined;
+
+	const purchases = Array.from(
+		oneOffPrepaidCusEntsByFeatureId(newCustomerProduct),
+	).flatMap(([featureId, customerEntitlement]) => {
+		const quantity = customerEntitlement.balance ?? 0;
+		if (quantity <= 0) return [];
+
+		customerEntitlement.balance = 0;
+		return [
+			{ customerEntitlementId: customerEntitlement.id, featureId, quantity },
+		];
+	});
+
+	return purchases.length > 0 ? { purchases } : undefined;
+};

--- a/server/src/internal/billing/v2/execute/executeAutumnActions/executeOneOffPurchaseRebalance.ts
+++ b/server/src/internal/billing/v2/execute/executeAutumnActions/executeOneOffPurchaseRebalance.ts
@@ -1,0 +1,35 @@
+import type { AutumnBillingPlan } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { computeRebalancedAutoTopUp } from "@/internal/balances/autoTopUp/compute/computeRebalancedAutoTopUp.js";
+import { CusService } from "@/internal/customers/CusService.js";
+import { executeAutoTopupRebalance } from "./executeAutoTopupRebalance.js";
+
+type OneOffPurchaseRebalance = NonNullable<
+	AutumnBillingPlan["oneOffPurchaseRebalance"]
+>;
+
+export const executeOneOffPurchaseRebalance = async ({
+	ctx,
+	customerId,
+	rebalance,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	rebalance: OneOffPurchaseRebalance;
+}): Promise<void> => {
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	const deltas = rebalance.purchases.flatMap(
+		({ customerEntitlementId, featureId, quantity }) =>
+			computeRebalancedAutoTopUp({
+				fullCustomer,
+				featureId,
+				quantity,
+				prepaidCustomerEntitlementId: customerEntitlementId,
+			}).deltas,
+	);
+
+	await executeAutoTopupRebalance({ ctx, customerId, deltas });
+};

--- a/server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts
+++ b/server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts
@@ -2,6 +2,7 @@ import type { AutumnBillingPlan, Invoice } from "@autumn/shared";
 import type Stripe from "stripe";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { executeAutoTopupRebalance } from "@/internal/billing/v2/execute/executeAutumnActions/executeAutoTopupRebalance";
+import { executeOneOffPurchaseRebalance } from "@/internal/billing/v2/execute/executeAutumnActions/executeOneOffPurchaseRebalance";
 import { executePatchCustomerProducts } from "@/internal/billing/v2/execute/executeAutumnActions/executePatchCustomerProducts";
 import { insertNewCusProducts } from "@/internal/billing/v2/execute/executeAutumnActions/insertNewCusProducts";
 import { updateCustomerEntitlements } from "@/internal/billing/v2/execute/executeAutumnActions/updateCustomerEntitlements";
@@ -142,6 +143,14 @@ export const executeAutumnBillingPlan = async ({
 		customerId: autumnBillingPlan.customerId,
 		updates: autumnBillingPlan.updateCustomerEntitlements,
 	});
+
+	if (autumnBillingPlan.oneOffPurchaseRebalance) {
+		await executeOneOffPurchaseRebalance({
+			ctx,
+			customerId: autumnBillingPlan.customerId,
+			rebalance: autumnBillingPlan.oneOffPurchaseRebalance,
+		});
+	}
 
 	// 5a. Auto top-up rebalance: apply pre-computed paydown + remainder deltas as
 	// atomic SQL `balance + delta` increments.

--- a/server/src/internal/billing/v2/utils/billingPlan/mergeAutumnBillingPlans.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/mergeAutumnBillingPlans.ts
@@ -86,6 +86,17 @@ export const mergeAutumnBillingPlans = ({
 						}) ?? [],
 				}
 			: undefined,
+	oneOffPurchaseRebalance:
+		base.oneOffPurchaseRebalance || incoming.oneOffPurchaseRebalance
+			? {
+					purchases:
+						mergeByKey({
+							base: base.oneOffPurchaseRebalance?.purchases,
+							incoming: incoming.oneOffPurchaseRebalance?.purchases,
+							getKey: (purchase) => purchase.customerEntitlementId,
+						}) ?? [],
+				}
+			: undefined,
 	upsertSubscription: incoming.upsertSubscription ?? base.upsertSubscription,
 	upsertInvoice: incoming.upsertInvoice ?? base.upsertInvoice,
 	refundPlan: incoming.refundPlan ?? base.refundPlan,

--- a/server/src/internal/billing/v2/utils/logs/logAutumnBillingPlan.ts
+++ b/server/src/internal/billing/v2/utils/logs/logAutumnBillingPlan.ts
@@ -91,6 +91,9 @@ export const logAutumnBillingPlan = ({
 							)
 							.join(", ") || "no-op"
 					: "none",
+
+				oneOffPurchaseRebalance:
+					plan.oneOffPurchaseRebalance?.purchases ?? "none",
 			},
 		},
 	});

--- a/server/tests/integration/billing/attach/new-plan/one-off-addon-overage-paydown.test.ts
+++ b/server/tests/integration/billing/attach/new-plan/one-off-addon-overage-paydown.test.ts
@@ -155,6 +155,91 @@ test.concurrent(
 );
 
 test.concurrent(
+	`${chalk.yellowBright("one-off add-on overage paydown: included and prepaid credits both pay overage")}`,
+	async () => {
+		const includedCredits = 1_000;
+		const totalCredits = 2_000;
+		const existingOverage = 1_500;
+		const recurringPlan = products.base({
+			id: "combined-balance-recurring",
+			items: [
+				items.annualPrice({ price: 200 }),
+				items.monthlyMessages({ includedUsage: includedCredits }),
+			],
+			billingControls: {
+				overage_allowed: [{ feature_id: TestFeature.Messages, enabled: true }],
+			},
+		});
+		const oneOffAddOn = products.oneOffAddOn({
+			id: "combined-balance-add-on",
+			items: [
+				items.oneOffMessages({
+					includedUsage: includedCredits,
+					billingUnits: includedCredits,
+					price: 10,
+				}),
+			],
+		});
+
+		const { customerId, autumnV2_2, ctx } = await initScenario({
+			customerId: "one-off-included-and-prepaid-paydown",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [recurringPlan, oneOffAddOn] }),
+			],
+			actions: [
+				s.billing.attach({ productId: recurringPlan.id }),
+				s.track({
+					featureId: TestFeature.Messages,
+					value: includedCredits + existingOverage,
+					timeout: 2000,
+				}),
+			],
+		});
+
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: oneOffAddOn.id,
+			feature_quantities: [
+				{ feature_id: TestFeature.Messages, quantity: totalCredits },
+			],
+			redirect_mode: "if_required",
+		});
+
+		const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		const recurring = findPlanBreakdown({
+			customer,
+			planId: recurringPlan.id,
+			interval: "month",
+		});
+		const addOn = findPlanBreakdown({
+			customer,
+			planId: oneOffAddOn.id,
+			interval: "one_off",
+		});
+
+		expect(recurring).toMatchObject({
+			remaining: 0,
+			usage: includedCredits,
+		});
+		expect(addOn).toMatchObject({
+			included_grant: includedCredits,
+			prepaid_grant: includedCredits,
+			remaining: totalCredits - existingOverage,
+			usage: existingOverage,
+		});
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			granted: includedCredits + totalCredits,
+			remaining: totalCredits - existingOverage,
+			usage: includedCredits + existingOverage,
+		});
+		await expectStripeSubscriptionCorrect({ ctx, customerId });
+	},
+);
+
+test.concurrent(
 	`${chalk.yellowBright("one-off add-on overage paydown: persisted overage remains separate")}`,
 	async () => {
 		const { recurringPlan, oneOffAddOn } = buildScenarioProducts();

--- a/server/tests/integration/billing/attach/new-plan/one-off-addon-overage-paydown.test.ts
+++ b/server/tests/integration/billing/attach/new-plan/one-off-addon-overage-paydown.test.ts
@@ -1,0 +1,344 @@
+// Red: a direct one-off add-on leaves recurring overage untouched and grants the full purchased balance.
+// Green: the purchase clears that overage first and grants only the remainder on the add-on.
+
+import { expect, test } from "bun:test";
+import type {
+	ApiCustomerV3,
+	ApiCustomerV5,
+	AttachParamsV1Input,
+} from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect.js";
+import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { completeStripeCheckoutFormV2 } from "@tests/utils/browserPool/completeStripeCheckoutFormV2.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const INCLUDED_PER_BALANCE = 15_000_000;
+const OVERAGE = 127_803;
+const PURCHASED_CREDITS = 5_000_000;
+const PENDING_CHECKOUT_OVERAGE = 100_000;
+
+const buildScenarioProducts = () => {
+	const recurringPlan = products.base({
+		id: "recurring-plan",
+		items: [
+			items.annualPrice({ price: 200 }),
+			items.monthlyMessages({ includedUsage: INCLUDED_PER_BALANCE }),
+			items.lifetimeMessages({ includedUsage: INCLUDED_PER_BALANCE }),
+		],
+		billingControls: {
+			overage_allowed: [{ feature_id: TestFeature.Messages, enabled: true }],
+		},
+	});
+	const oneOffAddOn = products.oneOffAddOn({
+		id: "credit-add-on",
+		items: [
+			items.oneOffMessages({
+				billingUnits: PURCHASED_CREDITS,
+				price: 10,
+			}),
+		],
+	});
+
+	return { recurringPlan, oneOffAddOn };
+};
+
+const findPlanBreakdown = ({
+	customer,
+	planId,
+	interval,
+}: {
+	customer: ApiCustomerV5;
+	planId: string;
+	interval: "month" | "one_off";
+}) => {
+	const breakdown = customer.balances[TestFeature.Messages].breakdown?.find(
+		(item) => item.plan_id === planId && item.reset?.interval === interval,
+	);
+
+	expect(breakdown).toBeDefined();
+	return breakdown!;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("one-off add-on overage paydown: purchase clears recurring overage before granting remainder")}`,
+	async () => {
+		const { recurringPlan, oneOffAddOn } = buildScenarioProducts();
+
+		const { customerId, autumnV1, autumnV2_2, ctx } = await initScenario({
+			customerId: "one-off-overage-paydown",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [recurringPlan, oneOffAddOn] }),
+			],
+			actions: [
+				s.billing.attach({ productId: recurringPlan.id }),
+				s.track({
+					featureId: TestFeature.Messages,
+					value: INCLUDED_PER_BALANCE * 2 + OVERAGE,
+					timeout: 2000,
+				}),
+			],
+		});
+
+		const before = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		const recurringBefore = findPlanBreakdown({
+			customer: before,
+			planId: recurringPlan.id,
+			interval: "month",
+		});
+		const lifetimeBefore = findPlanBreakdown({
+			customer: before,
+			planId: recurringPlan.id,
+			interval: "one_off",
+		});
+		expect(recurringBefore).toMatchObject({
+			remaining: 0,
+			usage: INCLUDED_PER_BALANCE + OVERAGE,
+		});
+		expect(lifetimeBefore).toMatchObject({
+			remaining: 0,
+			usage: INCLUDED_PER_BALANCE,
+		});
+
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: oneOffAddOn.id,
+			feature_quantities: [
+				{ feature_id: TestFeature.Messages, quantity: PURCHASED_CREDITS },
+			],
+			redirect_mode: "if_required",
+		});
+
+		const after = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		const recurringAfter = findPlanBreakdown({
+			customer: after,
+			planId: recurringPlan.id,
+			interval: "month",
+		});
+		const addOnAfter = findPlanBreakdown({
+			customer: after,
+			planId: oneOffAddOn.id,
+			interval: "one_off",
+		});
+
+		expect(recurringAfter).toMatchObject({
+			remaining: 0,
+			usage: INCLUDED_PER_BALANCE,
+		});
+		expect(addOnAfter).toMatchObject({
+			prepaid_grant: PURCHASED_CREDITS,
+			remaining: PURCHASED_CREDITS - OVERAGE,
+			usage: OVERAGE,
+		});
+		expectBalanceCorrect({
+			customer: after,
+			featureId: TestFeature.Messages,
+			granted: INCLUDED_PER_BALANCE * 2 + PURCHASED_CREDITS,
+			remaining: PURCHASED_CREDITS - OVERAGE,
+			usage: INCLUDED_PER_BALANCE * 2 + OVERAGE,
+		});
+
+		const invoiceCustomer =
+			await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({
+			customer: invoiceCustomer,
+			count: 2,
+			latestTotal: 20,
+		});
+		await expectStripeSubscriptionCorrect({ ctx, customerId });
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("one-off add-on overage paydown: persisted overage remains separate")}`,
+	async () => {
+		const { recurringPlan, oneOffAddOn } = buildScenarioProducts();
+		const { customerId, autumnV2_2, ctx } = await initScenario({
+			customerId: "one-off-persisted-overage",
+			setup: [
+				s.platform.create({
+					userEmail: `one-off-overage-${Math.random().toString(36).slice(2)}@autumn.test`,
+					configOverrides: { persist_free_overage: true },
+					setupDefaultFeatures: true,
+				}),
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [recurringPlan, oneOffAddOn] }),
+			],
+			actions: [
+				s.billing.attach({ productId: recurringPlan.id }),
+				s.track({
+					featureId: TestFeature.Messages,
+					value: INCLUDED_PER_BALANCE * 2 + OVERAGE,
+					timeout: 2000,
+				}),
+			],
+		});
+
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: oneOffAddOn.id,
+			feature_quantities: [
+				{ feature_id: TestFeature.Messages, quantity: PURCHASED_CREDITS },
+			],
+			redirect_mode: "if_required",
+		});
+
+		const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		const recurring = findPlanBreakdown({
+			customer,
+			planId: recurringPlan.id,
+			interval: "month",
+		});
+		const addOn = findPlanBreakdown({
+			customer,
+			planId: oneOffAddOn.id,
+			interval: "one_off",
+		});
+
+		expect(recurring).toMatchObject({
+			remaining: 0,
+			usage: INCLUDED_PER_BALANCE + OVERAGE,
+		});
+		expect(addOn).toMatchObject({
+			prepaid_grant: PURCHASED_CREDITS,
+			remaining: PURCHASED_CREDITS,
+			usage: 0,
+		});
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			granted: INCLUDED_PER_BALANCE * 2 + PURCHASED_CREDITS,
+			remaining: PURCHASED_CREDITS,
+			usage: INCLUDED_PER_BALANCE * 2 + OVERAGE,
+		});
+		await expectStripeSubscriptionCorrect({ ctx, customerId });
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("one-off add-on overage paydown: immediate-access checkout applies paydown once")}`,
+	async () => {
+		const { recurringPlan, oneOffAddOn } = buildScenarioProducts();
+		const { customerId, autumnV2_2, ctx } = await initScenario({
+			customerId: "one-off-overage-immediate-checkout",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [recurringPlan, oneOffAddOn] }),
+			],
+			actions: [
+				s.billing.attach({ productId: recurringPlan.id }),
+				s.track({
+					featureId: TestFeature.Messages,
+					value: INCLUDED_PER_BALANCE * 2 + OVERAGE,
+					timeout: 2000,
+				}),
+				s.removePaymentMethod(),
+			],
+		});
+
+		const result = await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: oneOffAddOn.id,
+			feature_quantities: [
+				{ feature_id: TestFeature.Messages, quantity: PURCHASED_CREDITS },
+			],
+			enable_plan_immediately: true,
+			redirect_mode: "if_required",
+		});
+		expect(result.payment_url).toContain("checkout.stripe.com");
+
+		await completeStripeCheckoutFormV2({ url: result.payment_url! });
+
+		const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		const recurring = findPlanBreakdown({
+			customer,
+			planId: recurringPlan.id,
+			interval: "month",
+		});
+		const addOn = findPlanBreakdown({
+			customer,
+			planId: oneOffAddOn.id,
+			interval: "one_off",
+		});
+
+		expect(recurring).toMatchObject({
+			remaining: 0,
+			usage: INCLUDED_PER_BALANCE,
+		});
+		expect(addOn).toMatchObject({
+			prepaid_grant: PURCHASED_CREDITS,
+			remaining: PURCHASED_CREDITS - OVERAGE,
+			usage: OVERAGE,
+		});
+		await expectStripeSubscriptionCorrect({ ctx, customerId });
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("one-off add-on overage paydown: deferred checkout uses completion-time overage")}`,
+	async () => {
+		const { recurringPlan, oneOffAddOn } = buildScenarioProducts();
+		const { customerId, autumnV2_2, ctx } = await initScenario({
+			customerId: "one-off-overage-deferred-checkout",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [recurringPlan, oneOffAddOn] }),
+			],
+			actions: [
+				s.billing.attach({ productId: recurringPlan.id }),
+				s.track({
+					featureId: TestFeature.Messages,
+					value: INCLUDED_PER_BALANCE * 2 + OVERAGE,
+					timeout: 2000,
+				}),
+				s.removePaymentMethod(),
+			],
+		});
+
+		const result = await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: oneOffAddOn.id,
+			feature_quantities: [
+				{ feature_id: TestFeature.Messages, quantity: PURCHASED_CREDITS },
+			],
+			redirect_mode: "if_required",
+		});
+		expect(result.payment_url).toContain("checkout.stripe.com");
+
+		await autumnV2_2.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: PENDING_CHECKOUT_OVERAGE,
+		});
+		await completeStripeCheckoutFormV2({ url: result.payment_url! });
+
+		const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		const recurring = findPlanBreakdown({
+			customer,
+			planId: recurringPlan.id,
+			interval: "month",
+		});
+		const addOn = findPlanBreakdown({
+			customer,
+			planId: oneOffAddOn.id,
+			interval: "one_off",
+		});
+		const totalOverage = OVERAGE + PENDING_CHECKOUT_OVERAGE;
+
+		expect(recurring).toMatchObject({
+			remaining: 0,
+			usage: INCLUDED_PER_BALANCE,
+		});
+		expect(addOn).toMatchObject({
+			prepaid_grant: PURCHASED_CREDITS,
+			remaining: PURCHASED_CREDITS - totalOverage,
+			usage: totalOverage,
+		});
+		await expectStripeSubscriptionCorrect({ ctx, customerId });
+	},
+);

--- a/shared/models/billingModels/plan/autumnBillingPlan.ts
+++ b/shared/models/billingModels/plan/autumnBillingPlan.ts
@@ -131,6 +131,18 @@ export const AutumnBillingPlanSchema = z.object({
 		})
 		.optional(),
 
+	oneOffPurchaseRebalance: z
+		.object({
+			purchases: z.array(
+				z.object({
+					customerEntitlementId: z.string(),
+					featureId: z.string(),
+					quantity: z.number(),
+				}),
+			),
+		})
+		.optional(),
+
 	// Lock the customer to a currency on the first paid attach (only set when the
 	// customer has none yet). Applied as a conditional, race-safe DB update.
 	lockCustomerCurrency: z


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces overage paydown for one-off add-on purchases: when a customer buys a one-off add-on while in overage, the purchased credits are first applied to clear the outstanding negative balance before the remainder is granted to the add-on entitlement. The feature is gated behind `orgPersistFreeOverage` and applies only to active, one-off add-on products.

- **Improvements**: Adds `computeOneOffPurchaseRebalance` and `executeOneOffPurchaseRebalance` that integrate into the existing `AutumnBillingPlan` pipeline, reusing `computeRebalancedAutoTopUp` for the distribution logic; `mergeAutumnBillingPlans` is extended to merge the new field consistently with existing patterns.
- **Bug fixes / Improvements**: `handleCheckoutSessionEnabledImmediately` explicitly sets `oneOffPurchaseRebalance: undefined` to prevent double-application when the plan already executed at attach time (the `enable_plan_immediately` path).
- **Improvements**: Five integration tests covering direct attach, persisted-overage bypass, immediate-checkout, and deferred-checkout (completion-time overage) scenarios validate the full feature surface.
</details>

<h3>Confidence Score: 4/5</h3>

The feature is well-tested across all four checkout paths; the main concern is an in-place mutation inside a compute function that must always execute alongside its paired execute step.

The `computeOneOffPurchaseRebalance` function mutates `customerEntitlement.balance = 0` directly on the shared `newCustomerProduct` object. The correctness of the final balance depends on both the mutation (zeroing the insert value) and `executeOneOffPurchaseRebalance` running afterwards: if the rebalance were ever skipped while the insert still ran, the customer would end up with a paid-for entitlement sitting at zero. Conversely, removing the mutation while keeping the rebalance would double-credit the customer. The coupling is load-bearing but invisible at the call site in `computeAttachPlan`.

server/src/internal/billing/v2/actions/attach/compute/computeOneOffPurchaseRebalance.ts — the side-effect mutation and its dependency on executeOneOffPurchaseRebalance always running together deserves a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/attach/compute/computeOneOffPurchaseRebalance.ts | New file computing the overage-paydown plan for one-off add-ons; contains an in-place mutation of customerEntitlement.balance that creates a fragile implicit contract with the execute step. |
| server/src/internal/billing/v2/execute/executeAutumnActions/executeOneOffPurchaseRebalance.ts | New execute file that fetches live customer state and delegates to computeRebalancedAutoTopUp; redefines OneOffPurchaseRebalance locally instead of importing it from the compute file. |
| server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts | Correctly slots executeOneOffPurchaseRebalance between updateCustomerEntitlements and autoTopupRebalance; sequencing looks safe. |
| server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionEnabledImmediately/handleCheckoutSessionEnabledImmediately.ts | Correctly sets oneOffPurchaseRebalance: undefined to prevent double-application when the plan already executed at attach time (enable_plan_immediately path). |
| server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts | Integrates computeOneOffPurchaseRebalance before buildAutumnLineItems; ordering is load-bearing because the balance mutation must happen first. |
| server/src/internal/billing/v2/utils/billingPlan/mergeAutumnBillingPlans.ts | Adds oneOffPurchaseRebalance merge logic consistent with the existing autoTopupRebalance pattern, keyed by customerEntitlementId. |
| shared/models/billingModels/plan/autumnBillingPlan.ts | Adds optional oneOffPurchaseRebalance field to the Zod schema; well-formed and consistent with the rest of the schema. |
| server/tests/integration/billing/attach/new-plan/one-off-addon-overage-paydown.test.ts | Comprehensive integration tests covering direct attach, persisted-overage bypass, immediate-checkout, and deferred-checkout scenarios. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant computeAttachPlan
    participant computeOneOffPurchaseRebalance
    participant executeAutumnBillingPlan
    participant executeOneOffPurchaseRebalance
    participant computeRebalancedAutoTopUp
    participant DB

    Client->>computeAttachPlan: attach one-off add-on
    computeAttachPlan->>computeOneOffPurchaseRebalance: newCustomerProduct
    Note over computeOneOffPurchaseRebalance: quantity = entitlement.balance<br/>entitlement.balance = 0 (mutation)
    computeOneOffPurchaseRebalance-->>computeAttachPlan: purchases list
    computeAttachPlan-->>Client: AutumnBillingPlan (oneOffPurchaseRebalance set)

    Note over Client,DB: Execute path

    Client->>executeAutumnBillingPlan: autumnBillingPlan
    executeAutumnBillingPlan->>DB: "insertNewCusProducts (balance=0)"
    executeAutumnBillingPlan->>DB: updateCustomerEntitlements
    executeAutumnBillingPlan->>executeOneOffPurchaseRebalance: rebalance
    executeOneOffPurchaseRebalance->>DB: CusService.getFull (live state)
    executeOneOffPurchaseRebalance->>computeRebalancedAutoTopUp: fullCustomer, quantity
    computeRebalancedAutoTopUp-->>executeOneOffPurchaseRebalance: deltas
    executeOneOffPurchaseRebalance->>DB: executeAutoTopupRebalance

    Note over Client,DB: enable_plan_immediately checkout completion
    Client->>executeAutumnBillingPlan: "insertCustomerProducts=[], oneOffPurchaseRebalance=undefined"
    Note over executeAutumnBillingPlan: Rebalance skipped - already ran at attach time
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant computeAttachPlan
    participant computeOneOffPurchaseRebalance
    participant executeAutumnBillingPlan
    participant executeOneOffPurchaseRebalance
    participant computeRebalancedAutoTopUp
    participant DB

    Client->>computeAttachPlan: attach one-off add-on
    computeAttachPlan->>computeOneOffPurchaseRebalance: newCustomerProduct
    Note over computeOneOffPurchaseRebalance: quantity = entitlement.balance<br/>entitlement.balance = 0 (mutation)
    computeOneOffPurchaseRebalance-->>computeAttachPlan: purchases list
    computeAttachPlan-->>Client: AutumnBillingPlan (oneOffPurchaseRebalance set)

    Note over Client,DB: Execute path

    Client->>executeAutumnBillingPlan: autumnBillingPlan
    executeAutumnBillingPlan->>DB: "insertNewCusProducts (balance=0)"
    executeAutumnBillingPlan->>DB: updateCustomerEntitlements
    executeAutumnBillingPlan->>executeOneOffPurchaseRebalance: rebalance
    executeOneOffPurchaseRebalance->>DB: CusService.getFull (live state)
    executeOneOffPurchaseRebalance->>computeRebalancedAutoTopUp: fullCustomer, quantity
    computeRebalancedAutoTopUp-->>executeOneOffPurchaseRebalance: deltas
    executeOneOffPurchaseRebalance->>DB: executeAutoTopupRebalance

    Note over Client,DB: enable_plan_immediately checkout completion
    Client->>executeAutumnBillingPlan: "insertCustomerProducts=[], oneOffPurchaseRebalance=undefined"
    Note over executeAutumnBillingPlan: Rebalance skipped - already ran at attach time
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/billing/v2/actions/attach/compute/computeOneOffPurchaseRebalance.ts:31-41
**Side-effect mutation in a `compute*` function creates a fragile implicit contract**

`customerEntitlement.balance = 0` directly mutates the in-memory `FullCusProduct` that is passed in, which means the entitlement ends up inserted with `balance = 0` by `insertNewCusProducts`. Correctness depends on both sides always executing together: if `executeOneOffPurchaseRebalance` is ever disabled while the insert still runs (e.g. a future refactor adds an early return or overrides the field), the customer's paid-for entitlement silently has a zero balance. Conversely, if a future engineer removes the mutation thinking it's accidental, the rebalance delta would be stacked on top of the already-granted balance, doubling the customer's credits.

The coupling here is invisible at the call site in `computeAttachPlan` — the function is named `compute*` but it modifies shared state as a side effect. A safer approach would be to either (a) zero the balance inside `initFullCustomerProduct` / `computeAttachNewCustomerProduct` when a rebalance context is detected, or (b) make this function return both the `OneOffPurchaseRebalance` and the intended initial balance explicitly, so callers can set it intentionally.

### Issue 2 of 2
server/src/internal/billing/v2/execute/executeAutumnActions/executeOneOffPurchaseRebalance.ts:7-9
The local `OneOffPurchaseRebalance` type re-derives the same shape that `computeOneOffPurchaseRebalance.ts` already exports. Importing the exported type ties both files to the same source of truth and avoids silent drift if the schema changes.

```suggestion
import type { OneOffPurchaseRebalance } from "@/internal/billing/v2/actions/attach/compute/computeOneOffPurchaseRebalance";
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(billing): 💍 cover included and pre..."](https://github.com/useautumn/autumn/commit/7a6e07d9c40e9519bab8c92769902af8451b342b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44428342)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->