### PR TITLE
feat(analytics): refetch analytics data on window focus

### DIFF
--- a/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
@@ -85,6 +85,8 @@ export const useAnalyticsData = ({
 			const { data } = await axiosInstance.post("/query/events", postBody);
 			return data;
 		},
+		staleTime: 30 * 1000,
+		refetchOnWindowFocus: true,
 	});
 
 	const queryLoading = !isReady || isLoading;
@@ -161,6 +163,8 @@ export const useRawAnalyticsData = () => {
 			const { data } = await axiosInstance.post("/query/raw", postBody);
 			return data;
 		},
+		staleTime: 30 * 1000,
+		refetchOnWindowFocus: true,
 	});
 
 	const queryLoading = !isReady || isLoading;

--- a/vite/src/views/customers/customer/analytics/hooks/useRevenueAnalytics.ts
+++ b/vite/src/views/customers/customer/analytics/hooks/useRevenueAnalytics.ts
@@ -76,6 +76,7 @@ export const useRevenueByProduct = ({
 		queryKey: buildKey(["revenue-by-product", granularity]),
 		queryFn: () => fetchGranularity({ g: granularity }),
 		staleTime: 5 * 60 * 1000,
+		refetchOnWindowFocus: true,
 		enabled,
 	});
 
@@ -111,6 +112,7 @@ export const useRevenueProductShare = () => {
 			return data as ProductShareRow[];
 		},
 		staleTime: 5 * 60 * 1000,
+		refetchOnWindowFocus: true,
 		enabled:
 			env === "live" && !flags.maintenanceModes.analytics.disableRevenueMetrics,
 	});
@@ -131,6 +133,7 @@ export const useArpc = () => {
 			return data as ArpcRow[];
 		},
 		staleTime: 5 * 60 * 1000,
+		refetchOnWindowFocus: true,
 		enabled:
 			env === "live" && !flags.maintenanceModes.analytics.disableRevenueMetrics,
 	});
@@ -154,6 +157,7 @@ export const useInvoiceStatus = () => {
 			return data as InvoiceStatusRow[];
 		},
 		staleTime: 5 * 60 * 1000,
+		refetchOnWindowFocus: true,
 		enabled:
 			env === "live" && !flags.maintenanceModes.analytics.disableRevenueMetrics,
 	});
@@ -177,6 +181,7 @@ export const useCustomerLeaderboard = () => {
 			return data as CustomerLeaderboardResult;
 		},
 		staleTime: 5 * 60 * 1000,
+		refetchOnWindowFocus: true,
 		enabled:
 			env === "live" && !flags.maintenanceModes.analytics.disableRevenueMetrics,
 	});
@@ -206,6 +211,7 @@ export const useEstimatedMrr = () => {
 			return data as EstimatedMrrResult;
 		},
 		staleTime: 5 * 60 * 1000,
+		refetchOnWindowFocus: true,
 		enabled:
 			env === "live" && !flags.maintenanceModes.analytics.disableRevenueMetrics,
 	});


### PR DESCRIPTION
Analytics data went permanently stale when the tab sat in the background, since the global QueryClient sets `refetchOnWindowFocus: false`. Opt the analytics queries back in per-query (same pattern as `useOrg` / `useMigrationRunsQuery`):

- **Chart + events table** (`/query/events`, `/query/raw`): `refetchOnWindowFocus: true` with a 30s `staleTime` so rapid tab switching doesn't hammer ClickHouse.
- **Revenue queries** (by-product, product-share, ARPC, invoice status, leaderboard, estimated MRR): `refetchOnWindowFocus: true`, keeping their existing 5-minute `staleTime` so refocus only refetches once stale.

`useEventNames` is intentionally left cached so the default top-3 event selection doesn't jump around on refocus.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh analytics data when the window regains focus so charts and revenue metrics stay up to date after the tab was in the background. Uses per-query refetch with conservative stale times to avoid extra load.

- **Bug Fixes**
  - Events chart and raw events: `refetchOnWindowFocus: true`, `staleTime: 30s`.
  - Revenue queries (by-product, product-share, ARPC, invoice status, leaderboard, estimated MRR): `refetchOnWindowFocus: true`, `staleTime: 5m` (unchanged); event names remain cached to keep default selections stable.

<sup>Written for commit 1d032689303994369e905f912bbdc1208397c260. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refreshes stale analytics data when the browser window regains focus. The main changes are:

- **[Bug fixes] [Improvements]** Add a 30-second freshness window and focus refetching to chart and raw-event queries.
- **[Bug fixes] [Improvements]** Enable focus refetching for revenue queries while retaining their five-minute freshness window.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx | Adds focus refetching and a 30-second stale time to chart and raw-event queries. |
| vite/src/views/customers/customer/analytics/hooks/useRevenueAnalytics.ts | Enables focus refetching for six revenue queries without changing their existing stale time or guards. |

<sub>Reviews (1): Last reviewed commit: ["feat(analytics): refetch analytics data ..."](https://github.com/useautumn/autumn/commit/1d032689303994369e905f912bbdc1208397c260) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44234564)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->