### PR TITLE
Serialize entity creation per customer

### DIFF
--- a/server/src/internal/entities/actions/batchCreateEntities.ts
+++ b/server/src/internal/entities/actions/batchCreateEntities.ts
@@ -4,6 +4,7 @@ import {
 	type Entity,
 	findFeatureById,
 } from "@autumn/shared";
+import { withLock } from "@/external/redis/redisUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { EntityService } from "@/internal/api/entities/EntityService";
 import { getApiEntity } from "../entityUtils/apiEntityUtils/getApiEntity";
@@ -12,19 +13,21 @@ import { createEntityForCusProduct } from "../handlers/handleCreateEntity/create
 import { validateAndGetInputEntities } from "../handlers/handleCreateEntity/getInputEntities";
 import { attachDefaultProductsToEntities } from "./batchCreateEntities/attachDefaultProductsToEntities";
 
-export const batchCreateEntities = async ({
-	ctx,
-	customerId,
-	customerData,
-	createEntityData,
-	withAutumnId = false,
-}: {
+type BatchCreateEntitiesParams = {
 	ctx: AutumnContext;
 	customerData?: CustomerData;
 	customerId: string;
 	createEntityData: CreateEntityParams[] | CreateEntityParams;
 	withAutumnId?: boolean;
-}) => {
+};
+
+const createEntities = async ({
+	ctx,
+	customerId,
+	customerData,
+	createEntityData,
+	withAutumnId = false,
+}: BatchCreateEntitiesParams) => {
 	const { db, org, env, features } = ctx;
 
 	// 1. Get data
@@ -117,4 +120,18 @@ export const batchCreateEntities = async ({
 	}
 
 	return apiEntities;
+};
+
+export const batchCreateEntities = async (
+	params: BatchCreateEntitiesParams,
+) => {
+	const { ctx, customerId } = params;
+	const { org, env } = ctx;
+
+	return withLock({
+		lockKey: `lock:create-entity-request:${org.id}:${env}:${customerId}`,
+		errorMessage:
+			"Entity creation already in progress for this customer, try again in a few seconds",
+		fn: () => createEntities(params),
+	});
 };

--- a/server/src/internal/entities/handlers/handleCreateEntity/createEntityForCusProduct.ts
+++ b/server/src/internal/entities/handlers/handleCreateEntity/createEntityForCusProduct.ts
@@ -55,15 +55,16 @@ const updateLinkedCusEnt = async ({
 				adjustment: 0,
 			};
 		}
-
-		await CusEntService.update({
-			ctx,
-			id: linkedCusEnt.id,
-			updates: {
-				entities: newEntities,
-			},
-		});
 	}
+
+	await CusEntService.update({
+		ctx,
+		id: linkedCusEnt.id,
+		updates: { entities: newEntities },
+	});
+
+	// The create response is built from this request's customer snapshot.
+	linkedCusEnt.entities = newEntities;
 };
 
 export const createEntityForCusProduct = async ({

--- a/server/tests/integration/crud/entities/create-entity/create-entity-race.test.ts
+++ b/server/tests/integration/crud/entities/create-entity/create-entity-race.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import type { ApiEntityV0 } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
@@ -38,11 +39,10 @@ test.concurrent(`${chalk.yellowBright("create-entity-race: mainCusEnt path shoul
 	expect(failures.length).toBe(1);
 
 	const failedResult = failures[0] as PromiseRejectedResult;
-	// AutumnInt returns code: "rate_limit_exceeded" for 429 errors
-	expect(failedResult.reason.code).toBe("rate_limit_exceeded");
+	expect(failedResult.reason.code).toBe("lock_already_exists");
 });
 
-test.concurrent(`${chalk.yellowBright("create-entity-race: non-mainCusEnt path allows concurrent creation")}`, async () => {
+test.concurrent(`${chalk.yellowBright("create-entity-race: non-mainCusEnt path is protected by lock")}`, async () => {
 	// Product with messages only - no Users entitlement
 	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
 	const free = products.base({ items: [messagesItem] });
@@ -54,7 +54,7 @@ test.concurrent(`${chalk.yellowBright("create-entity-race: non-mainCusEnt path a
 	});
 
 	// Create entities for Users feature (no entitlement exists for this feature in the product)
-	// Both should succeed since there's no mainCusEnt for Users
+	// All entity creation for a customer shares the same lock
 	const [result1, result2] = await Promise.allSettled([
 		autumnV1.entities.create(customerId, [
 			{ id: "user-1", name: "User 1", feature_id: TestFeature.Users },
@@ -64,7 +64,57 @@ test.concurrent(`${chalk.yellowBright("create-entity-race: non-mainCusEnt path a
 		]),
 	]);
 
-	// Both should succeed
-	expect(result1.status).toBe("fulfilled");
-	expect(result2.status).toBe("fulfilled");
+	const successes = [result1, result2].filter((r) => r.status === "fulfilled");
+	const failures = [result1, result2].filter((r) => r.status === "rejected");
+
+	expect(successes.length).toBe(1);
+	expect(failures.length).toBe(1);
+	expect((failures[0] as PromiseRejectedResult).reason.code).toBe(
+		"lock_already_exists",
+	);
 });
+
+/** Red: separate creates race. Green: one array request creates and hydrates every entity. */
+test.concurrent(
+	`${chalk.yellowBright("create-entity-race: bulk create retains linked entitlements")}`,
+	async () => {
+		const perEntityMessages = items.monthlyMessages({
+			includedUsage: 100,
+			entityFeatureId: TestFeature.Users,
+		});
+		const pro = products.base({
+			id: "entity-race-linked-entitlements",
+			items: [perEntityMessages],
+		});
+		const entityIds = Array.from({ length: 20 }, (_, i) => `user-${i}`);
+
+		const { customerId, autumnV1 } = await initScenario({
+			customerId: "create-entity-race-linked-entitlements",
+			setup: [s.customer({}), s.products({ list: [pro] })],
+			actions: [s.attach({ productId: pro.id })],
+		});
+
+		const { list: createdEntities } = await autumnV1.entities.create(
+			customerId,
+			entityIds.map((id) => ({
+				id,
+				feature_id: TestFeature.Users,
+			})),
+		);
+		for (const entity of createdEntities) {
+			expect(entity.features?.[TestFeature.Messages]?.balance).toBe(100);
+		}
+
+		const entities = await Promise.all(
+			entityIds.map((id) =>
+				autumnV1.entities.get<ApiEntityV0>(customerId, id, {
+					skip_cache: "true",
+				}),
+			),
+		);
+
+		for (const entity of entities) {
+			expect(entity.features?.[TestFeature.Messages]?.balance).toBe(100);
+		}
+	},
+);


### PR DESCRIPTION
## Summary
- apply one customer-scoped request lock around the shared explicit entity-create action for billing and non-billing entities
- preserve the existing paid-seat lock used by auto-created entities, using a separate request-lock key to avoid nesting conflicts
- keep array-based bulk creation efficient by writing the linked entitlement map once and hydrating the response from that map

## Behavior
Concurrent explicit create requests for the same customer now allow one request through and reject the others with HTTP 423 / lock_already_exists. Callers creating many entities should pass them in the existing array request body, which creates all entities under one request lock.

## Verification
- bunx tsgo --build --noEmit
- create-entity-race integration file: 3 passed, 0 failed, 46 assertions
- cached-customer auto-create regression: 1 passed, 6 assertions
- focused source formatting checks pass