### PR TITLE
feat: attach-time currency selection and customer-currency displays

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/errors/handleCurrencyMismatchErrors.ts
+++ b/server/src/internal/billing/v2/actions/attach/errors/handleCurrencyMismatchErrors.ts
@@ -65,16 +65,21 @@ export const assertPlanOffersCurrency = ({
 	prices,
 	planName,
 	currency,
+	customerConfigured = false,
 }: {
 	ctx: AutumnContext;
 	prices: Price[];
 	planName: string;
 	currency: string;
+	customerConfigured?: boolean;
 }) => {
 	if (!planOffersCurrency({ ctx, prices, currency })) {
+		const code = currency.toUpperCase();
 		throw new RecaseError({
 			code: ErrCode.CurrencyMismatch,
-			message: `Plan '${planName}' does not offer a price in ${currency.toUpperCase()}`,
+			message: customerConfigured
+				? `This customer pays in ${code}, but plan '${planName}' has no ${code} price. Add ${code} pricing to the plan or pick a plan that offers it.`
+				: `Plan '${planName}' does not offer a price in ${code}. Add ${code} pricing to the plan or bill in a currency it supports.`,
 			statusCode: 400,
 		});
 	}
@@ -136,5 +141,6 @@ export const handleCurrencyMismatchErrors = ({
 		prices,
 		planName: attachProduct.name,
 		currency: resolved,
+		customerConfigured: !!locked && resolved === locked,
 	});
 };

--- a/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
@@ -7,6 +7,7 @@ import {
 	type MultiAttachParamsV0,
 	type MultiAttachProductContext,
 	orgToReturnUrl,
+	resolveCustomerCurrency,
 } from "@autumn/shared";
 import type { FreeTrialParamsV1 } from "@shared/api/common/freeTrial/freeTrialParamsV1";
 import type Stripe from "stripe";
@@ -249,6 +250,12 @@ export const setupImmediateMultiProductBillingContext = async ({
 		fullCustomer,
 		fullProducts,
 		productContexts,
+		currency: resolveCustomerCurrency({
+			customer: fullCustomer,
+			org: ctx.org,
+			requested: params.currency,
+			stripeCurrency: stripeCustomer?.currency,
+		}),
 		featureQuantities: productContexts.flatMap(
 			(productContext) => productContext.featureQuantities,
 		),

--- a/server/src/internal/billing/v2/actions/multiAttach/compute/computeMultiAttachPlan.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/compute/computeMultiAttachPlan.ts
@@ -1,6 +1,7 @@
-import type {
-	AutumnBillingPlan,
-	MultiAttachBillingContext,
+import {
+	type AutumnBillingPlan,
+	isFreeProduct,
+	type MultiAttachBillingContext,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { computeImmediateMultiProductPlan } from "../../common/immediateMultiProduct/computeImmediateMultiProductPlan";
@@ -18,8 +19,29 @@ export const computeMultiAttachPlan = ({
 }: {
 	ctx: AutumnContext;
 	multiAttachBillingContext: MultiAttachBillingContext;
-}): AutumnBillingPlan =>
-	computeImmediateMultiProductPlan({
+}): AutumnBillingPlan => {
+	const plan = computeImmediateMultiProductPlan({
 		ctx,
 		billingContext: multiAttachBillingContext,
 	});
+
+	// Lock the customer's currency on the first paid multi-attach (only when they
+	// have none yet). Free attaches don't commit a currency. Applied conditionally at execute.
+	const {
+		fullCustomer,
+		fullProducts,
+		currency: resolvedCurrency,
+	} = multiAttachBillingContext;
+	const allPrices = fullProducts.flatMap((fullProduct) => fullProduct.prices);
+	const lockCustomerCurrency =
+		resolvedCurrency &&
+		!fullCustomer.currency &&
+		!isFreeProduct({ prices: allPrices })
+			? {
+					internalCustomerId: fullCustomer.internal_id,
+					currency: resolvedCurrency,
+				}
+			: undefined;
+
+	return { ...plan, lockCustomerCurrency };
+};

--- a/server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachCurrencyErrors.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachCurrencyErrors.ts
@@ -1,25 +1,75 @@
 import {
-	billingContextToCurrency,
+	ErrCode,
+	isFreeProduct,
 	type MultiAttachBillingContext,
+	type MultiAttachParamsV0,
+	orgMultiCurrencyEnabled,
+	RecaseError,
+	resolveCustomerCurrency,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { assertPlanOffersCurrency } from "@/internal/billing/v2/actions/attach/errors/handleCurrencyMismatchErrors";
 
+/**
+ * Blocks a multi-attach that would bill the customer in an unsupported currency.
+ * Runs pre-Stripe (before evaluateStripeBillingPlan, which creates Stripe prices).
+ */
 export const handleMultiAttachCurrencyErrors = ({
 	ctx,
 	billingContext,
+	params,
 }: {
 	ctx: AutumnContext;
 	billingContext: MultiAttachBillingContext;
+	params: Pick<MultiAttachParamsV0, "currency">;
 }) => {
-	const currency = billingContextToCurrency({ org: ctx.org, billingContext });
+	const { fullCustomer } = billingContext;
 
+	if (params.currency && !orgMultiCurrencyEnabled({ org: ctx.org })) {
+		throw new RecaseError({
+			code: ErrCode.InvalidRequest,
+			message: "Multi-currency is not enabled for this organization",
+			statusCode: 400,
+		});
+	}
+
+	// Free / auto-enabled plans neither need nor lock a currency.
+	const allPrices = billingContext.productContexts.flatMap(
+		(productContext) => productContext.fullProduct.prices,
+	);
+	if (isFreeProduct({ prices: allPrices })) return;
+
+	const locked =
+		(
+			fullCustomer.currency ?? billingContext.stripeCustomer?.currency
+		)?.toLowerCase() || null;
+	const requested = params.currency?.toLowerCase() || null;
+	const resolved =
+		billingContext.currency ??
+		resolveCustomerCurrency({
+			customer: fullCustomer,
+			org: ctx.org,
+			requested: params.currency,
+			stripeCurrency: billingContext.stripeCustomer?.currency,
+		});
+
+	// A locked customer cannot switch currencies (Stripe forbids it anyway).
+	if (locked && requested && requested !== locked) {
+		throw new RecaseError({
+			code: ErrCode.CurrencyMismatch,
+			message: `Customer is locked to ${locked.toUpperCase()} and cannot be billed in ${requested.toUpperCase()}`,
+			statusCode: 400,
+		});
+	}
+
+	// Every charging price on every plan must offer the resolved currency (no FX fallback).
 	for (const productContext of billingContext.productContexts) {
 		assertPlanOffersCurrency({
 			ctx,
 			prices: productContext.fullProduct.prices,
 			planName: productContext.fullProduct.name,
-			currency,
+			currency: resolved,
+			customerConfigured: !!locked && resolved === locked,
 		});
 	}
 };

--- a/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
@@ -48,7 +48,7 @@ export async function multiAttach({
 		redirectMode: params.redirect_mode,
 	});
 
-	handleMultiAttachCurrencyErrors({ ctx, billingContext });
+	handleMultiAttachCurrencyErrors({ ctx, billingContext, params });
 
 	// 2b. Log context
 	logMultiAttachContext({ ctx, billingContext });

--- a/server/src/internal/billing/v2/utils/billingPlan/preview/invoiceCredits/computeAttachInvoiceCreditPreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/preview/invoiceCredits/computeAttachInvoiceCreditPreview.ts
@@ -1,8 +1,5 @@
-import type {
-	BillingContext,
-	PreviewInvoiceCredits,
-} from "@autumn/shared";
-import { orgToCurrency, stripeToAtmnAmount } from "@autumn/shared";
+import type { BillingContext, PreviewInvoiceCredits } from "@autumn/shared";
+import { billingContextToCurrency, stripeToAtmnAmount } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 
 /**
@@ -20,7 +17,7 @@ export const computeAttachInvoiceCreditPreview = ({
 	if (!billingContext.stripeCustomer) return undefined;
 
 	const stripeBalance = billingContext.stripeCustomer.balance ?? 0;
-	const currency = orgToCurrency({ org: ctx.org });
+	const currency = billingContextToCurrency({ org: ctx.org, billingContext });
 
 	// Flip sign: Stripe stores credit as negative; we surface as positive.
 	return {

--- a/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxPreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxPreview.ts
@@ -5,7 +5,7 @@ import type {
 } from "@autumn/shared";
 import {
 	atmnToStripeAmount,
-	orgToCurrency,
+	billingContextToCurrency,
 	stripeToAtmnAmount,
 } from "@autumn/shared";
 import { createStripeCli } from "@/external/connect/createStripeCli";
@@ -93,7 +93,7 @@ export const computeStripeTaxPreviewForNetSubtotal = async ({
 	if (billingContext.checkoutMode === "stripe_checkout") return undefined;
 	if (!billingContext.stripeCustomer?.id) return undefined;
 
-	const currency = orgToCurrency({ org: ctx.org });
+	const currency = billingContextToCurrency({ org: ctx.org, billingContext });
 	const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
 
 	if (netSubtotal === 0) {
@@ -128,8 +128,7 @@ export const computeStripeTaxPreviewForNetSubtotal = async ({
 			total:
 				stripeToAtmnAmount({
 					amount:
-						(calc.tax_amount_exclusive ?? 0) +
-						(calc.tax_amount_inclusive ?? 0),
+						(calc.tax_amount_exclusive ?? 0) + (calc.tax_amount_inclusive ?? 0),
 					currency,
 				}) * taxSign,
 			amount_inclusive:

--- a/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxRateIdPreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxRateIdPreview.ts
@@ -6,7 +6,7 @@ import type {
 } from "@autumn/shared";
 import {
 	atmnToStripeAmount,
-	orgToCurrency,
+	billingContextToCurrency,
 	stripeToAtmnAmount,
 } from "@autumn/shared";
 import { Decimal } from "decimal.js";
@@ -83,7 +83,7 @@ export const computeAttachTaxRateIdPreview = async ({
 	const immediateLines = allLineItems.filter((line) => line.chargeImmediately);
 	if (immediateLines.length === 0) return undefined;
 
-	const currency = orgToCurrency({ org: ctx.org });
+	const currency = billingContextToCurrency({ org: ctx.org, billingContext });
 	const taxableMinorUnits = immediateLines.map((lineItem) =>
 		lineItemToTaxableMinorUnits({ lineItem, currency }),
 	);
@@ -107,7 +107,7 @@ export const computeTaxRateIdPreviewFromTaxableMinorUnits = ({
 }): PreviewTax | undefined => {
 	if (!billingContext.taxRateId) return undefined;
 
-	const currency = orgToCurrency({ org: ctx.org });
+	const currency = billingContextToCurrency({ org: ctx.org, billingContext });
 	const totalTaxableMinorUnits = taxableMinorUnits.reduce(
 		(sum, amount) => sum + amount,
 		0,

--- a/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeNextCycleTaxPreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeNextCycleTaxPreview.ts
@@ -1,5 +1,5 @@
 import type { BillingContext, PreviewTax } from "@autumn/shared";
-import { atmnToStripeAmount, orgToCurrency } from "@autumn/shared";
+import { atmnToStripeAmount, billingContextToCurrency } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { computeStripeTaxPreviewForNetSubtotal } from "./computeAttachTaxPreview";
 import { computeTaxRateIdPreviewFromTaxableMinorUnits } from "./computeAttachTaxRateIdPreview";
@@ -18,7 +18,10 @@ export const computeNextCycleTaxPreview = async ({
 	netSubtotal: number;
 }): Promise<PreviewTax | undefined> => {
 	if (billingContext.taxRateId) {
-		const currency = orgToCurrency({ org: ctx.org });
+		const currency = billingContextToCurrency({
+			org: ctx.org,
+			billingContext,
+		});
 		return computeTaxRateIdPreviewFromTaxableMinorUnits({
 			ctx,
 			billingContext,

--- a/server/src/internal/billing/v2/utils/billingPlanToPreviewResponse.ts
+++ b/server/src/internal/billing/v2/utils/billingPlanToPreviewResponse.ts
@@ -3,7 +3,10 @@ import type {
 	BillingPlan,
 	FullCusProduct,
 } from "@autumn/shared";
-import { type BillingPreviewResponse, orgToCurrency } from "@autumn/shared";
+import {
+	type BillingPreviewResponse,
+	billingContextToCurrency,
+} from "@autumn/shared";
 import { Decimal } from "decimal.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { computeNextCycleTaxPreview } from "./billingPlan/preview/tax/computeNextCycleTaxPreview";
@@ -88,7 +91,7 @@ export const billingPlanToPreviewResponse = async ({
 
 	const autumnBillingPlan = billingPlan.autumn;
 	const allLineItems = autumnBillingPlan.lineItems ?? [];
-	const currency = orgToCurrency({ org: ctx.org });
+	const currency = billingContextToCurrency({ org: ctx.org, billingContext });
 
 	const {
 		immediateLineItems,

--- a/server/tests/integration/billing/attach/multi-currency-currency-lock-e2e.test.ts
+++ b/server/tests/integration/billing/attach/multi-currency-currency-lock-e2e.test.ts
@@ -1,0 +1,274 @@
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV3,
+	type ApiPlanV1,
+	ApiVersion,
+	type AttachParamsV0Input,
+	type AttachParamsV1Input,
+	BillingInterval,
+	type CreatePlanParamsV2Input,
+	customers,
+} from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import { expectProductActive } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { completeInvoiceCheckoutV2 } from "@tests/utils/browserPool/completeInvoiceCheckoutV2";
+import { completeStripeCheckoutFormV2 } from "@tests/utils/browserPool/completeStripeCheckoutFormV2";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { and, eq } from "drizzle-orm";
+import { AutumnRpcCli } from "@/external/autumn/autumnRpcCli.js";
+
+const autumnRpc = new AutumnRpcCli({ version: ApiVersion.V2_1 });
+const getSuffix = () => Math.random().toString(36).slice(2, 9);
+
+const USD_AMOUNT = 150;
+const CNY_AMOUNT = 1000;
+
+const createCnyPlan = async () => {
+	const planId = `mc_lock_${getSuffix()}`;
+	await autumnRpc.plans.create<ApiPlanV1, CreatePlanParamsV2Input>({
+		plan_id: planId,
+		name: "MC Currency Lock Plan",
+		auto_enable: false,
+		price: {
+			amount: USD_AMOUNT,
+			interval: BillingInterval.Month,
+			additional_currencies: [{ currency: "cny", amount: CNY_AMOUNT }],
+		},
+	});
+	return planId;
+};
+
+const getDbCustomerCurrency = async ({
+	ctx,
+	customerId,
+}: {
+	ctx: TestContext;
+	customerId: string;
+}) => {
+	const row = await ctx.db.query.customers.findFirst({
+		where: and(
+			eq(customers.id, customerId),
+			eq(customers.org_id, ctx.org.id),
+			eq(customers.env, ctx.env),
+		),
+	});
+	expect(row).toBeDefined();
+	return row?.currency ?? null;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("mc currency lock 1: direct attach with currency=cny locks customers.currency (latest api)")}`,
+	async () => {
+		const planId = await createCnyPlan();
+
+		const { customerId, autumnV1, autumnV2_2, ctx } = await initScenario({
+			customerId: "mc-lock-direct-latest",
+			setup: [s.customer({ paymentMethod: "success" })],
+			actions: [],
+		});
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBeNull();
+
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: planId,
+			currency: "cny",
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectProductActive({ customer, productId: planId });
+		expectCustomerInvoiceCorrect({
+			customer,
+			count: 1,
+			latestTotal: CNY_AMOUNT,
+		});
+
+		const subs = await ctx.stripeCli.subscriptions.list({
+			customer: customer.stripe_id as string,
+		});
+		expect(subs.data).toHaveLength(1);
+		expect(subs.data[0].currency).toBe("cny");
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBe("cny");
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("mc currency lock 2: direct attach with currency=cny locks customers.currency (x-api-version 1.2)")}`,
+	async () => {
+		const planId = await createCnyPlan();
+
+		const { customerId, autumnV1, ctx } = await initScenario({
+			customerId: "mc-lock-direct-v1-2",
+			setup: [s.customer({ paymentMethod: "success" })],
+			actions: [],
+		});
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBeNull();
+
+		await autumnV1.billing.attach<AttachParamsV0Input>({
+			customer_id: customerId,
+			product_id: planId,
+			currency: "cny",
+			redirect_mode: "if_required",
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectProductActive({ customer, productId: planId });
+		expectCustomerInvoiceCorrect({
+			customer,
+			count: 1,
+			latestTotal: CNY_AMOUNT,
+		});
+
+		const subs = await ctx.stripeCli.subscriptions.list({
+			customer: customer.stripe_id as string,
+		});
+		expect(subs.data).toHaveLength(1);
+		expect(subs.data[0].currency).toBe("cny");
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBe("cny");
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("mc currency lock 3: attach with no currency param locks to org default (usd)")}`,
+	async () => {
+		const planId = await createCnyPlan();
+
+		const { customerId, autumnV1, autumnV2_2, ctx } = await initScenario({
+			customerId: "mc-lock-default-usd",
+			setup: [s.customer({ paymentMethod: "success" })],
+			actions: [],
+		});
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBeNull();
+
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: planId,
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectProductActive({ customer, productId: planId });
+		expectCustomerInvoiceCorrect({
+			customer,
+			count: 1,
+			latestTotal: USD_AMOUNT,
+		});
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBe("usd");
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("mc currency lock 4a: invoice-mode attach (immediate) with currency=cny locks customers.currency")}`,
+	async () => {
+		const planId = await createCnyPlan();
+
+		const { customerId, autumnV1, ctx } = await initScenario({
+			customerId: "mc-lock-invoice-imm",
+			setup: [s.customer({ paymentMethod: "success" })],
+			actions: [],
+		});
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBeNull();
+
+		await autumnV1.billing.attach<AttachParamsV0Input>({
+			customer_id: customerId,
+			product_id: planId,
+			currency: "cny",
+			invoice: true,
+			finalize_invoice: true,
+			enable_product_immediately: true,
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectProductActive({ customer, productId: planId });
+		expectCustomerInvoiceCorrect({
+			customer,
+			count: 1,
+			latestTotal: CNY_AMOUNT,
+		});
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBe("cny");
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("mc currency lock 4b: deferred invoice attach with currency=cny locks after invoice paid")}`,
+	async () => {
+		const planId = await createCnyPlan();
+
+		const { customerId, autumnV1, ctx } = await initScenario({
+			customerId: "mc-lock-invoice-def",
+			setup: [s.customer({ paymentMethod: "success" })],
+			actions: [],
+		});
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBeNull();
+
+		const result = await autumnV1.billing.attach<AttachParamsV0Input>({
+			customer_id: customerId,
+			product_id: planId,
+			currency: "cny",
+			invoice: true,
+			finalize_invoice: true,
+			enable_product_immediately: false,
+		});
+		expect(result.invoice?.status).toBe("open");
+		expect(result.payment_url).toBeDefined();
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBeNull();
+
+		await completeInvoiceCheckoutV2({ url: result.payment_url as string });
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectProductActive({ customer, productId: planId });
+		expectCustomerInvoiceCorrect({
+			customer,
+			count: 1,
+			latestTotal: CNY_AMOUNT,
+			latestStatus: "paid",
+		});
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBe("cny");
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("mc currency lock 5: stripe-checkout attach with currency=cny locks after checkout completes")}`,
+	async () => {
+		const planId = await createCnyPlan();
+
+		const { customerId, autumnV1, ctx } = await initScenario({
+			customerId: "mc-lock-checkout",
+			setup: [s.customer({})],
+			actions: [],
+		});
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBeNull();
+
+		const result = await autumnV1.billing.attach<AttachParamsV0Input>({
+			customer_id: customerId,
+			product_id: planId,
+			currency: "cny",
+		});
+		expect(result.payment_url).toBeDefined();
+		expect(result.payment_url).toContain("checkout.stripe.com");
+
+		await completeStripeCheckoutFormV2({ url: result.payment_url as string });
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectProductActive({ customer, productId: planId });
+		expectCustomerInvoiceCorrect({
+			customer,
+			count: 1,
+			latestTotal: CNY_AMOUNT,
+		});
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBe("cny");
+	},
+);

--- a/server/tests/integration/billing/attach/multi-currency-multi-attach-currency-lock-e2e.test.ts
+++ b/server/tests/integration/billing/attach/multi-currency-multi-attach-currency-lock-e2e.test.ts
@@ -1,0 +1,247 @@
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV3,
+	type ApiPlanV1,
+	ApiVersion,
+	BillingInterval,
+	type CreatePlanParamsV2Input,
+	customers,
+	ErrCode,
+} from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { and, eq } from "drizzle-orm";
+import type Stripe from "stripe";
+import { AutumnRpcCli } from "@/external/autumn/autumnRpcCli.js";
+
+const autumnRpc = new AutumnRpcCli({ version: ApiVersion.V2_1 });
+const getSuffix = () => Math.random().toString(36).slice(2, 9);
+
+const MAIN_USD = 150;
+const MAIN_CNY = 1000;
+const SECOND_USD = 80;
+const SECOND_CNY = 600;
+
+const createCnyPlanPair = async () => {
+	const suffix = getSuffix();
+	const mainId = `mc_ma_lock_main_${suffix}`;
+	const secondId = `mc_ma_lock_second_${suffix}`;
+	await autumnRpc.plans.create<ApiPlanV1, CreatePlanParamsV2Input>({
+		plan_id: mainId,
+		name: mainId,
+		auto_enable: false,
+		group: `g_a_${suffix}`,
+		price: {
+			amount: MAIN_USD,
+			interval: BillingInterval.Month,
+			additional_currencies: [{ currency: "cny", amount: MAIN_CNY }],
+		},
+	});
+	await autumnRpc.plans.create<ApiPlanV1, CreatePlanParamsV2Input>({
+		plan_id: secondId,
+		name: secondId,
+		auto_enable: false,
+		group: `g_b_${suffix}`,
+		price: {
+			amount: SECOND_USD,
+			interval: BillingInterval.Month,
+			additional_currencies: [{ currency: "cny", amount: SECOND_CNY }],
+		},
+	});
+	return { mainId, secondId };
+};
+
+const getDbCustomerCurrency = async ({
+	ctx,
+	customerId,
+}: {
+	ctx: TestContext;
+	customerId: string;
+}) => {
+	const row = await ctx.db.query.customers.findFirst({
+		where: and(
+			eq(customers.id, customerId),
+			eq(customers.org_id, ctx.org.id),
+			eq(customers.env, ctx.env),
+		),
+	});
+	expect(row).toBeDefined();
+	return row?.currency ?? null;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("mc multi-attach lock 1: multiAttach with currency=cny bills cny and locks customers.currency")}`,
+	async () => {
+		const { mainId, secondId } = await createCnyPlanPair();
+
+		const { customerId, autumnV1, ctx } = await initScenario({
+			customerId: "mc-ma-lock-cny",
+			setup: [s.customer({ paymentMethod: "success" })],
+			actions: [],
+		});
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBeNull();
+
+		await autumnV1.billing.multiAttach({
+			customer_id: customerId,
+			plans: [{ plan_id: mainId }, { plan_id: secondId }],
+			currency: "cny",
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerProducts({ customer, active: [mainId, secondId] });
+		expectCustomerInvoiceCorrect({
+			customer,
+			count: 1,
+			latestTotal: MAIN_CNY + SECOND_CNY,
+		});
+
+		const subs = await ctx.stripeCli.subscriptions.list({
+			customer: customer.stripe_id as string,
+		});
+		expect(subs.data.length).toBeGreaterThanOrEqual(1);
+		for (const sub of subs.data as Stripe.Subscription[]) {
+			expect(sub.currency).toBe("cny");
+		}
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBe("cny");
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("mc multi-attach lock 2: multiAttach with no currency param locks to org default (usd)")}`,
+	async () => {
+		const { mainId, secondId } = await createCnyPlanPair();
+
+		const { customerId, autumnV1, ctx } = await initScenario({
+			customerId: "mc-ma-lock-default",
+			setup: [s.customer({ paymentMethod: "success" })],
+			actions: [],
+		});
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBeNull();
+
+		await autumnV1.billing.multiAttach({
+			customer_id: customerId,
+			plans: [{ plan_id: mainId }, { plan_id: secondId }],
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerProducts({ customer, active: [mainId, secondId] });
+		expectCustomerInvoiceCorrect({
+			customer,
+			count: 1,
+			latestTotal: MAIN_USD + SECOND_USD,
+		});
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBe("usd");
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("mc multi-attach lock 3: multiAttach currency a plan does not offer is a 400 CurrencyMismatch")}`,
+	async () => {
+		const suffix = getSuffix();
+		const usdOnlyId = `mc_ma_lock_usdonly_${suffix}`;
+		await autumnRpc.plans.create<ApiPlanV1, CreatePlanParamsV2Input>({
+			plan_id: usdOnlyId,
+			name: usdOnlyId,
+			auto_enable: false,
+			price: { amount: 25, interval: BillingInterval.Month },
+		});
+
+		const { customerId, autumnV1, ctx } = await initScenario({
+			customerId: "mc-ma-lock-mismatch",
+			setup: [s.customer({ paymentMethod: "success" })],
+			actions: [],
+		});
+
+		await expectAutumnError({
+			errCode: ErrCode.CurrencyMismatch,
+			func: () =>
+				autumnV1.billing.multiAttach(
+					{
+						customer_id: customerId,
+						plans: [{ plan_id: usdOnlyId }],
+						currency: "cny",
+					},
+					{ timeout: 0 },
+				),
+		});
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBeNull();
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("mc multi-attach lock 4: locked customer with conflicting requested currency is a 400")}`,
+	async () => {
+		const { mainId, secondId } = await createCnyPlanPair();
+
+		const { customerId, autumnV1, ctx } = await initScenario({
+			customerId: "mc-ma-lock-conflict",
+			setup: [
+				s.customer({ paymentMethod: "success", data: { currency: "usd" } }),
+			],
+			actions: [],
+		});
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBe("usd");
+
+		await expectAutumnError({
+			errCode: ErrCode.CurrencyMismatch,
+			func: () =>
+				autumnV1.billing.multiAttach(
+					{
+						customer_id: customerId,
+						plans: [{ plan_id: mainId }, { plan_id: secondId }],
+						currency: "cny",
+					},
+					{ timeout: 0 },
+				),
+		});
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBe("usd");
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("mc multi-attach lock 5: all-free multiAttach does not lock a currency")}`,
+	async () => {
+		const suffix = getSuffix();
+		const freeAId = `mc_ma_lock_free_a_${suffix}`;
+		const freeBId = `mc_ma_lock_free_b_${suffix}`;
+		await autumnRpc.plans.create<ApiPlanV1, CreatePlanParamsV2Input>({
+			plan_id: freeAId,
+			name: freeAId,
+			auto_enable: false,
+			group: `g_a_${suffix}`,
+		});
+		await autumnRpc.plans.create<ApiPlanV1, CreatePlanParamsV2Input>({
+			plan_id: freeBId,
+			name: freeBId,
+			auto_enable: false,
+			group: `g_b_${suffix}`,
+		});
+
+		const { customerId, autumnV1, ctx } = await initScenario({
+			customerId: "mc-ma-lock-free",
+			setup: [s.customer({ paymentMethod: "success" })],
+			actions: [],
+		});
+
+		await autumnV1.billing.multiAttach({
+			customer_id: customerId,
+			plans: [{ plan_id: freeAId }, { plan_id: freeBId }],
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerProducts({ customer, active: [freeAId, freeBId] });
+
+		expect(await getDbCustomerCurrency({ ctx, customerId })).toBeNull();
+	},
+);

--- a/server/tests/integration/billing/attach/multi-currency-update-subscription-currency-e2e.test.ts
+++ b/server/tests/integration/billing/attach/multi-currency-update-subscription-currency-e2e.test.ts
@@ -1,0 +1,315 @@
+/**
+ * TDD test: update subscription must recognize a currency-only price edit for a
+ * customer locked to a non-default currency (dashboard "Update Subscription").
+ *
+ * Red-failure mode (current behavior):
+ *  - The dashboard sends V0 params (top-level `items`) at x-api-version 1.2. The
+ *    V0 -> V1 transform (productItemToBasePriceParams / productItemToPlanItemParamsV1)
+ *    drops `additional_currencies`, so an inr-only edit (base usd untouched)
+ *    reaches compute as "base amount unchanged" — preview reports no charge and
+ *    the Stripe subscription keeps billing the old inr amount.
+ *
+ * Green-success criteria (after fix):
+ *  - Currency-only edits survive the V0 -> V1 mapping: preview reports the
+ *    prorated inr difference, a prorated inr invoice is produced, the Stripe
+ *    subscription item moves to a price with the new inr unit_amount, and the
+ *    stored customer price config carries the new inr amount.
+ *  - An update with identical amounts stays a no-op (control).
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV3,
+	type ApiPlanV1,
+	ApiVersion,
+	BillingInterval,
+	type CreatePlanParamsV2Input,
+	type FixedPriceConfig,
+	type ProductItem,
+	ProductItemInterval,
+	type UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { AutumnRpcCli } from "@/external/autumn/autumnRpcCli.js";
+import { CusService } from "@/internal/customers/CusService";
+
+const autumnRpc = new AutumnRpcCli({ version: ApiVersion.V2_1 });
+const getSuffix = () => Math.random().toString(36).slice(2, 9);
+
+const USD_BASE = 100;
+const INR_BASE = 100;
+const INR_UPDATED = 200;
+
+const createInrPlan = async () => {
+	const planId = `mc_upsub_ccy_${getSuffix()}`;
+	await autumnRpc.plans.create<ApiPlanV1, CreatePlanParamsV2Input>({
+		plan_id: planId,
+		name: "MC Update Subscription Currency Plan",
+		auto_enable: false,
+		price: {
+			amount: USD_BASE,
+			interval: BillingInterval.Month,
+			additional_currencies: [{ currency: "inr", amount: INR_BASE }],
+		},
+	});
+	return planId;
+};
+
+const getStoredBasePriceConfig = async ({
+	ctx,
+	customerId,
+	planId,
+}: {
+	ctx: TestContext;
+	customerId: string;
+	planId: string;
+}) => {
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	const customerProduct = fullCustomer.customer_products.find(
+		(cusProduct) =>
+			cusProduct.product.id === planId && cusProduct.status === "active",
+	);
+	expect(customerProduct).toBeDefined();
+	const customerPrice = customerProduct?.customer_prices.find(
+		(cusPrice) => cusPrice.price.config?.type === "fixed",
+	);
+	expect(customerPrice).toBeDefined();
+	return customerPrice?.price.config as FixedPriceConfig;
+};
+
+const getActiveStripeSubscription = async ({
+	ctx,
+	stripeCustomerId,
+}: {
+	ctx: TestContext;
+	stripeCustomerId: string;
+}) => {
+	const subs = await ctx.stripeCli.subscriptions.list({
+		customer: stripeCustomerId,
+	});
+	expect(subs.data).toHaveLength(1);
+	return subs.data[0];
+};
+
+test.concurrent(
+	`${chalk.yellowBright("mc update sub currency 1: V1 customize.price inr-only edit is recognized (preview + stripe + invoice + stored config)")}`,
+	async () => {
+		const planId = await createInrPlan();
+
+		const { customerId, autumnV1, autumnV2_2, ctx } = await initScenario({
+			customerId: "mc-upsub-ccy-v1",
+			setup: [s.customer({ paymentMethod: "success" })],
+			actions: [],
+		});
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: planId,
+			currency: "inr",
+		});
+
+		const updateParams: UpdateSubscriptionV1ParamsInput = {
+			customer_id: customerId,
+			plan_id: planId,
+			customize: {
+				price: {
+					amount: USD_BASE,
+					interval: BillingInterval.Month,
+					additional_currencies: [{ currency: "inr", amount: INR_UPDATED }],
+				},
+			},
+		};
+
+		// The preview must recognize the currency-only edit (dashboard preview).
+		const preview =
+			await autumnV2_2.subscriptions.previewUpdate<UpdateSubscriptionV1ParamsInput>(
+				updateParams,
+			);
+		expect(preview.currency).toBe("inr");
+		expect(preview.total).toBeGreaterThanOrEqual(INR_UPDATED - INR_BASE - 1);
+		expect(preview.total).toBeLessThanOrEqual(INR_UPDATED - INR_BASE);
+
+		await autumnV2_2.subscriptions.update<UpdateSubscriptionV1ParamsInput>(
+			updateParams,
+		);
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		expect(customer.invoices).toHaveLength(2);
+
+		// Prorated inr difference (~100, minus a few seconds of elapsed period).
+		const stripeInvoices = await ctx.stripeCli.invoices.list({
+			customer: customer.stripe_id as string,
+		});
+		const latestInvoice = stripeInvoices.data[0];
+		expect(latestInvoice.currency).toBe("inr");
+		expect(latestInvoice.total).toBeGreaterThanOrEqual(
+			(INR_UPDATED - INR_BASE) * 100 - 100,
+		);
+		expect(latestInvoice.total).toBeLessThanOrEqual(
+			(INR_UPDATED - INR_BASE) * 100,
+		);
+
+		const subscription = await getActiveStripeSubscription({
+			ctx,
+			stripeCustomerId: customer.stripe_id as string,
+		});
+		expect(subscription.currency).toBe("inr");
+		expect(subscription.items.data).toHaveLength(1);
+		expect(subscription.items.data[0].price.currency).toBe("inr");
+		expect(subscription.items.data[0].price.unit_amount).toBe(
+			INR_UPDATED * 100,
+		);
+
+		const storedConfig = await getStoredBasePriceConfig({
+			ctx,
+			customerId,
+			planId,
+		});
+		expect(storedConfig.amount).toBe(USD_BASE);
+		expect(storedConfig.currencies?.inr?.amount).toBe(INR_UPDATED);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("mc update sub currency 2: dashboard V0 items shape inr-only edit is recognized (x-api-version 1.2)")}`,
+	async () => {
+		const planId = await createInrPlan();
+
+		const { customerId, autumnV1, autumnV2_2, ctx } = await initScenario({
+			customerId: "mc-upsub-ccy-v0",
+			setup: [s.customer({ paymentMethod: "success" })],
+			actions: [],
+		});
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: planId,
+			currency: "inr",
+		});
+
+		// The dashboard sends the full item list with only the inr amount edited.
+		const items: ProductItem[] = [
+			{
+				price: USD_BASE,
+				interval: ProductItemInterval.Month,
+				additional_currencies: [{ currency: "inr", amount: INR_UPDATED }],
+			},
+		];
+
+		const preview = await autumnV1.subscriptions.previewUpdate({
+			customer_id: customerId,
+			product_id: planId,
+			items,
+		});
+		expect(preview.currency).toBe("inr");
+		expect(preview.total).toBeGreaterThanOrEqual(INR_UPDATED - INR_BASE - 1);
+		expect(preview.total).toBeLessThanOrEqual(INR_UPDATED - INR_BASE);
+
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: planId,
+			items,
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		expect(customer.invoices).toHaveLength(2);
+
+		const stripeInvoices = await ctx.stripeCli.invoices.list({
+			customer: customer.stripe_id as string,
+		});
+		const latestInvoice = stripeInvoices.data[0];
+		expect(latestInvoice.currency).toBe("inr");
+		expect(latestInvoice.total).toBeGreaterThanOrEqual(
+			(INR_UPDATED - INR_BASE) * 100 - 100,
+		);
+		expect(latestInvoice.total).toBeLessThanOrEqual(
+			(INR_UPDATED - INR_BASE) * 100,
+		);
+
+		const subscription = await getActiveStripeSubscription({
+			ctx,
+			stripeCustomerId: customer.stripe_id as string,
+		});
+		expect(subscription.currency).toBe("inr");
+		expect(subscription.items.data).toHaveLength(1);
+		expect(subscription.items.data[0].price.currency).toBe("inr");
+		expect(subscription.items.data[0].price.unit_amount).toBe(
+			INR_UPDATED * 100,
+		);
+
+		const storedConfig = await getStoredBasePriceConfig({
+			ctx,
+			customerId,
+			planId,
+		});
+		expect(storedConfig.amount).toBe(USD_BASE);
+		expect(storedConfig.currencies?.inr?.amount).toBe(INR_UPDATED);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("mc update sub currency 3: unchanged currencies stay a no-op (control)")}`,
+	async () => {
+		const planId = await createInrPlan();
+
+		const { customerId, autumnV1, autumnV2_2, ctx } = await initScenario({
+			customerId: "mc-upsub-ccy-noop",
+			setup: [s.customer({ paymentMethod: "success" })],
+			actions: [],
+		});
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: planId,
+			currency: "inr",
+		});
+
+		const noopParams: UpdateSubscriptionV1ParamsInput = {
+			customer_id: customerId,
+			plan_id: planId,
+			customize: {
+				price: {
+					amount: USD_BASE,
+					interval: BillingInterval.Month,
+					additional_currencies: [{ currency: "inr", amount: INR_BASE }],
+				},
+			},
+		};
+
+		// The identical-plan guard (which must treat identical currency maps as
+		// unchanged) is the existing no-op semantic for both preview and update.
+		await expect(
+			autumnV2_2.subscriptions.previewUpdate<UpdateSubscriptionV1ParamsInput>(
+				noopParams,
+			),
+		).rejects.toThrow(/identical to the current subscription/);
+		await expect(
+			autumnV2_2.subscriptions.update<UpdateSubscriptionV1ParamsInput>(
+				noopParams,
+			),
+		).rejects.toThrow(/identical to the current subscription/);
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		expect(customer.invoices).toHaveLength(1);
+
+		const subscription = await getActiveStripeSubscription({
+			ctx,
+			stripeCustomerId: customer.stripe_id as string,
+		});
+		expect(subscription.items.data).toHaveLength(1);
+		expect(subscription.items.data[0].price.currency).toBe("inr");
+		expect(subscription.items.data[0].price.unit_amount).toBe(INR_BASE * 100);
+
+		const storedConfig = await getStoredBasePriceConfig({
+			ctx,
+			customerId,
+			planId,
+		});
+		expect(storedConfig.currencies?.inr?.amount).toBe(INR_BASE);
+	},
+);

--- a/server/tests/unit/billing/attach-params-schema.test.ts
+++ b/server/tests/unit/billing/attach-params-schema.test.ts
@@ -37,3 +37,14 @@ describe("attach params starts_at", () => {
 		},
 	);
 });
+
+describe("attach params currency", () => {
+	test.each(schemas)("%s preserves currency", (_, schema, params) => {
+		const result = schema.safeParse({
+			...params,
+			currency: "eur",
+		});
+		expect(result.success).toBe(true);
+		expect(result.data).toMatchObject({ currency: "eur" });
+	});
+});

--- a/server/tests/unit/billing/handleCurrencyMismatchErrors.test.ts
+++ b/server/tests/unit/billing/handleCurrencyMismatchErrors.test.ts
@@ -85,7 +85,7 @@ describe("handleCurrencyMismatchErrors", () => {
 
 	test("blocks when the plan does not offer the locked customer's currency", () => {
 		expect(() => run({ customerCurrency: "eur", prices: [paidUsd] })).toThrow(
-			/does not offer/i,
+			/has no eur price/i,
 		);
 	});
 

--- a/server/tests/unit/billing/handleMultiAttachCurrencyErrors.test.ts
+++ b/server/tests/unit/billing/handleMultiAttachCurrencyErrors.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, test } from "bun:test";
-import type { MultiAttachBillingContext, Price } from "@autumn/shared";
+import type {
+	MultiAttachBillingContext,
+	MultiAttachParamsV0,
+	Price,
+} from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { handleMultiAttachCurrencyErrors } from "@/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachCurrencyErrors";
 
-const ctx = { org: { default_currency: "usd" } } as unknown as AutumnContext;
+const buildCtx = ({ multiCurrency = true }: { multiCurrency?: boolean } = {}) =>
+	({
+		org: { default_currency: "usd", config: { multi_currency: multiCurrency } },
+	}) as unknown as AutumnContext;
 
 const price = (config: Record<string, unknown>): Price =>
 	({ config }) as unknown as Price;
@@ -18,10 +25,14 @@ const paidWithEur = price({
 const freeBase = price({ type: "fixed", amount: 0, interval: "month" });
 
 const run = ({
+	ctx = buildCtx(),
 	customerCurrency = null,
+	requestedCurrency,
 	productPrices,
 }: {
+	ctx?: AutumnContext;
 	customerCurrency?: string | null;
+	requestedCurrency?: string;
 	productPrices: Price[][];
 }) =>
 	handleMultiAttachCurrencyErrors({
@@ -32,6 +43,7 @@ const run = ({
 				fullProduct: { name: `Plan ${i}`, prices },
 			})),
 		} as unknown as MultiAttachBillingContext,
+		params: { currency: requestedCurrency } as MultiAttachParamsV0,
 	});
 
 describe("handleMultiAttachCurrencyErrors", () => {
@@ -47,7 +59,7 @@ describe("handleMultiAttachCurrencyErrors", () => {
 				customerCurrency: "eur",
 				productPrices: [[paidWithEur], [paidUsd]],
 			}),
-		).toThrow(/does not offer/i);
+		).toThrow(/has no eur price/i);
 	});
 
 	test("all plans offering the locked currency pass", () => {
@@ -59,6 +71,41 @@ describe("handleMultiAttachCurrencyErrors", () => {
 	test("free plans impose no constraint", () => {
 		expect(() =>
 			run({ customerCurrency: "eur", productPrices: [[freeBase]] }),
+		).not.toThrow();
+	});
+
+	test("requested currency rejected when org lacks multi_currency", () => {
+		expect(() =>
+			run({
+				ctx: buildCtx({ multiCurrency: false }),
+				requestedCurrency: "eur",
+				productPrices: [[paidWithEur]],
+			}),
+		).toThrow(/multi-currency is not enabled/i);
+	});
+
+	test("requested currency conflicting with the lock is rejected", () => {
+		expect(() =>
+			run({
+				customerCurrency: "usd",
+				requestedCurrency: "eur",
+				productPrices: [[paidWithEur]],
+			}),
+		).toThrow(/locked to usd/i);
+	});
+
+	test("requested currency a plan does not offer is rejected", () => {
+		expect(() =>
+			run({
+				requestedCurrency: "eur",
+				productPrices: [[paidWithEur], [paidUsd]],
+			}),
+		).toThrow(/does not offer/i);
+	});
+
+	test("requested currency offered by every plan passes", () => {
+		expect(() =>
+			run({ requestedCurrency: "eur", productPrices: [[paidWithEur]] }),
 		).not.toThrow();
 	});
 });

--- a/shared/api/billing/attachV2/attachParamsV0.ts
+++ b/shared/api/billing/attachV2/attachParamsV0.ts
@@ -39,6 +39,11 @@ export const ExtAttachParamsV0Schema = BillingParamsBaseV0Schema.extend({
 	no_billing_changes: z.boolean().optional(),
 
 	tax_rate_id: z.string().optional(),
+
+	currency: z.string().optional().meta({
+		description:
+			"Currency to bill this attach in (e.g. usd, eur). Must match the customer's currency if they are already locked to one, and the plan must offer a paid price in it. Defaults to the customer's currency, then the org default.",
+	}),
 });
 
 export const AttachParamsV0Schema = ExtAttachParamsV0Schema.extend({

--- a/shared/api/billing/attachV2/attachParamsV0.ts
+++ b/shared/api/billing/attachV2/attachParamsV0.ts
@@ -1,3 +1,4 @@
+import { CurrencyCodeSchema } from "@api/products/components/additionalCurrencies";
 import { z } from "zod/v4";
 import { PlanTimingSchema } from "../../../models/billingModels/context/attachBillingContext";
 import { ProductItemSchema } from "../../../models/productV2Models/productItemModels/productItemModels";
@@ -40,7 +41,7 @@ export const ExtAttachParamsV0Schema = BillingParamsBaseV0Schema.extend({
 
 	tax_rate_id: z.string().optional(),
 
-	currency: z.string().optional().meta({
+	currency: CurrencyCodeSchema.optional().meta({
 		description:
 			"Currency to bill this attach in (e.g. usd, eur). Must match the customer's currency if they are already locked to one, and the plan must offer a paid price in it. Defaults to the customer's currency, then the org default.",
 	}),

--- a/shared/api/billing/attachV2/attachParamsV1.ts
+++ b/shared/api/billing/attachV2/attachParamsV1.ts
@@ -1,4 +1,5 @@
 import { BillingParamsBaseV1Schema } from "@api/billing/common/billingParamsBase/billingParamsBaseV1";
+import { CurrencyCodeSchema } from "@api/products/components/additionalCurrencies";
 import { z } from "zod/v4";
 import { PlanTimingSchema } from "../../../models/billingModels/context/attachBillingContext";
 import { BillingCycleAnchorSchema } from "../common/billingCycleAnchor";
@@ -94,7 +95,7 @@ export const AttachParamsV1Schema = BillingParamsBaseV1Schema.extend({
 			"Stripe tax rate ID (txr_...) to apply as the default tax rate on the created subscription, invoice, or checkout session line items.",
 	}),
 
-	currency: z.string().optional().meta({
+	currency: CurrencyCodeSchema.optional().meta({
 		description:
 			"Currency to bill this attach in (e.g. usd, eur). Must match the customer's currency if they are already locked to one, and the plan must offer a paid price in it. Defaults to the customer's currency, then the org default.",
 	}),

--- a/shared/api/billing/attachV2/multiAttachParamsV0.ts
+++ b/shared/api/billing/attachV2/multiAttachParamsV0.ts
@@ -64,6 +64,11 @@ export const MultiAttachParamsV0Schema = z.object({
 			"Free trial configuration applied to all plans. Pass an object to set a custom trial, or null to remove any trial.",
 	}),
 
+	currency: z.string().optional().meta({
+		description:
+			"Currency to bill this multi-attach in (e.g. usd, eur). Must match the customer's currency if they are already locked to one, and every plan must offer a paid price in it. Defaults to the customer's currency, then the org default.",
+	}),
+
 	invoice_mode: InvoiceModeParamsSchema.optional().meta({
 		description:
 			"Invoice mode creates a draft or open invoice and sends it to the customer, instead of charging their card immediately.",

--- a/shared/api/billing/attachV2/multiAttachParamsV0.ts
+++ b/shared/api/billing/attachV2/multiAttachParamsV0.ts
@@ -1,5 +1,6 @@
 import { FeatureQuantityParamsV0Schema } from "@api/billing/common/featureQuantity/featureQuantityParamsV0";
 import { FreeTrialParamsV1Schema } from "@api/common/freeTrial/freeTrialParamsV1";
+import { CurrencyCodeSchema } from "@api/products/components/additionalCurrencies";
 import { BasePriceParamsSchema } from "@api/products/components/basePrice/basePrice";
 import { CreatePlanItemParamsV1Schema } from "@api/products/items/crud/createPlanItemParamsV1";
 import { z } from "zod/v4";
@@ -64,7 +65,7 @@ export const MultiAttachParamsV0Schema = z.object({
 			"Free trial configuration applied to all plans. Pass an object to set a custom trial, or null to remove any trial.",
 	}),
 
-	currency: z.string().optional().meta({
+	currency: CurrencyCodeSchema.optional().meta({
 		description:
 			"Currency to bill this multi-attach in (e.g. usd, eur). Must match the customer's currency if they are already locked to one, and every plan must offer a paid price in it. Defaults to the customer's currency, then the org default.",
 	}),

--- a/shared/api/products/components/additionalCurrencies.ts
+++ b/shared/api/products/components/additionalCurrencies.ts
@@ -2,7 +2,7 @@ import { Infinite } from "@models/productModels/productEnums.js";
 import { isValidCurrencyCode } from "@utils/currencyUtils/stripeCurrencies.js";
 import { z } from "zod/v4";
 
-const currencyCodeSchema = z
+export const CurrencyCodeSchema = z
 	.string()
 	.refine(isValidCurrencyCode, "must be a Stripe-supported currency code")
 	.meta({
@@ -11,7 +11,7 @@ const currencyCodeSchema = z
 	});
 
 export const AdditionalCurrencyPriceSchema = z.object({
-	currency: currencyCodeSchema,
+	currency: CurrencyCodeSchema,
 	amount: z.number().meta({
 		description:
 			"Price amount in this currency. Set explicitly per currency, not converted from the base amount.",
@@ -24,7 +24,7 @@ export type AdditionalCurrencyPrice = z.infer<
 
 export const AdditionalCurrencyTierSchema = z
 	.object({
-		currency: currencyCodeSchema,
+		currency: CurrencyCodeSchema,
 		amount: z.number().optional().meta({
 			description: "Per-unit amount for this tier in this currency.",
 		}),

--- a/shared/models/billingModels/context/multiAttachBillingContext.ts
+++ b/shared/models/billingModels/context/multiAttachBillingContext.ts
@@ -24,4 +24,7 @@ export interface MultiAttachProductContext {
 export interface MultiAttachBillingContext extends BillingContext {
 	productContexts: MultiAttachProductContext[];
 	checkoutMode: CheckoutMode;
+
+	// Resolved billing currency for this multi-attach (requested -> customer -> org default).
+	currency?: string;
 }

--- a/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.currency.test.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.currency.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import type { ProductItem } from "@autumn/shared";
+import { generateItemChanges } from "./generateItemChanges.js";
+
+const basePriceItem = (
+	additionalCurrencies?: { currency: string; amount: number }[],
+): ProductItem =>
+	({
+		price: 100,
+		interval: "month",
+		...(additionalCurrencies
+			? { additional_currencies: additionalCurrencies }
+			: {}),
+	}) as ProductItem;
+
+describe("generateItemChanges base price currencies", () => {
+	test("currency-only amount change is detected", () => {
+		const changes = generateItemChanges({
+			originalItems: [basePriceItem([{ currency: "inr", amount: 200 }])],
+			updatedItems: [basePriceItem([{ currency: "inr", amount: 400 }])],
+		});
+
+		expect(changes).toHaveLength(1);
+		expect(changes[0].id).toBe("base-price-modified-0");
+	});
+
+	test("adding a currency is detected", () => {
+		const changes = generateItemChanges({
+			originalItems: [basePriceItem()],
+			updatedItems: [basePriceItem([{ currency: "inr", amount: 200 }])],
+		});
+
+		expect(changes).toHaveLength(1);
+		expect(changes[0].id).toBe("base-price-modified-0");
+	});
+
+	test("identical currencies produce no changes", () => {
+		const changes = generateItemChanges({
+			originalItems: [basePriceItem([{ currency: "inr", amount: 200 }])],
+			updatedItems: [basePriceItem([{ currency: "inr", amount: 200 }])],
+		});
+
+		expect(changes).toHaveLength(0);
+	});
+});

--- a/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts
@@ -57,6 +57,15 @@ function hasValue<T>(value: T | null | undefined): value is T {
 	return value !== null && value !== undefined;
 }
 
+function currencySignature(
+	entries: ProductItem["additional_currencies"],
+): string {
+	const sorted = [...(entries ?? [])].sort((a, b) =>
+		a.currency.localeCompare(b.currency),
+	);
+	return JSON.stringify(sortAndNormalize(sorted));
+}
+
 function formatPriceWithUnits(price: number, billingUnits: number): string {
 	return billingUnits > 1
 		? `$${price} per ${billingUnits}`
@@ -258,8 +267,8 @@ export function generateItemChanges({
 
 			if (original && updated) {
 				const currenciesChanged =
-					JSON.stringify(sortAndNormalize(original.additional_currencies)) !==
-					JSON.stringify(sortAndNormalize(updated.additional_currencies));
+					currencySignature(original.additional_currencies) !==
+					currencySignature(updated.additional_currencies);
 				const hasChanged =
 					original.price !== updated.price ||
 					currenciesChanged ||

--- a/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts
@@ -257,8 +257,12 @@ export function generateItemChanges({
 			const updated = updatedPriceItems[i];
 
 			if (original && updated) {
+				const currenciesChanged =
+					JSON.stringify(sortAndNormalize(original.additional_currencies)) !==
+					JSON.stringify(sortAndNormalize(updated.additional_currencies));
 				const hasChanged =
 					original.price !== updated.price ||
+					currenciesChanged ||
 					itemToBillingInterval({ item: original }) !==
 						itemToBillingInterval({ item: updated }) ||
 					itemToBillingIntervalCount({ item: original }) !==

--- a/shared/utils/productV2Utils/productItemUtils/convertProductItem/productItemToBasePriceParams.ts
+++ b/shared/utils/productV2Utils/productItemUtils/convertProductItem/productItemToBasePriceParams.ts
@@ -18,6 +18,9 @@ export const productItemToBasePriceParams = ({
 		interval: itemToBillingInterval({ item }),
 		interval_count: itemToBillingIntervalCount({ item }) ?? undefined,
 
+		additional_currencies: item.additional_currencies ?? undefined,
+		base_currency: item.base_currency ?? undefined,
+
 		entitlement_id: item.entitlement_id ?? undefined,
 		price_id: item.price_id ?? undefined,
 	};

--- a/shared/utils/productV2Utils/productItemUtils/convertProductItem/productItemToPlanItemParamsV1.ts
+++ b/shared/utils/productV2Utils/productItemUtils/convertProductItem/productItemToPlanItemParamsV1.ts
@@ -75,6 +75,7 @@ export const productItemToPlanItemParamsV1 = ({
 		price: planItemV1.price
 			? {
 					amount: planItemV1.price.amount,
+					additional_currencies: planItemV1.price.additional_currencies,
 					tiers: planItemV1.price.tiers,
 					interval: planItemV1.price.interval,
 					interval_count: planItemV1.price.interval_count,
@@ -86,8 +87,7 @@ export const productItemToPlanItemParamsV1 = ({
 			: undefined,
 		proration: proration
 			? {
-					on_increase:
-						proration.on_increase ?? OnIncrease.ProrateImmediately,
+					on_increase: proration.on_increase ?? OnIncrease.ProrateImmediately,
 					on_decrease: proration.on_decrease ?? OnDecrease.Prorate,
 				}
 			: undefined,

--- a/vite/src/components/forms/attach-v2/attachFormSchema.ts
+++ b/vite/src/components/forms/attach-v2/attachFormSchema.ts
@@ -34,6 +34,7 @@ export const AttachFormSchema = z.object({
 	resetBillingCycle: z.boolean(),
 	discounts: z.custom<FormDiscount[]>(),
 	grantFree: z.boolean(),
+	currency: z.string().nullable(),
 
 	noBillingChanges: z.boolean(),
 	enablePlanImmediately: z.boolean(),

--- a/vite/src/components/forms/attach-v2/components/AttachCurrencyRow.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachCurrencyRow.tsx
@@ -1,0 +1,72 @@
+import {
+	Button,
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@autumn/ui";
+import { CaretDownIcon, CheckIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import { ConfigRow } from "@/components/forms/shared/ConfigRow";
+import { cn } from "@/lib/utils";
+import { useAttachFormContext } from "../context/AttachFormProvider";
+
+export function AttachCurrencyRow() {
+	const { form, attachCurrency } = useAttachFormContext();
+	const { orgDefaultCurrency, currencyOptions } = attachCurrency;
+	const [open, setOpen] = useState(false);
+
+	const orgDefaultCode = orgDefaultCurrency.toLowerCase();
+
+	return (
+		<ConfigRow
+			title="Currency"
+			description="Bill this customer in one of the plan's configured currencies"
+			action={
+				<form.AppField name="currency">
+					{(field) => {
+						const selectedCode = (
+							field.state.value ?? orgDefaultCode
+						).toLowerCase();
+
+						return (
+							<DropdownMenu open={open} onOpenChange={setOpen}>
+								<DropdownMenuTrigger asChild>
+									<Button
+										variant="secondary"
+										size="mini"
+										className={cn("gap-1", open && "btn-secondary-active")}
+									>
+										{selectedCode.toUpperCase()}
+										<CaretDownIcon className="size-3.5 text-tertiary-foreground" />
+									</Button>
+								</DropdownMenuTrigger>
+								<DropdownMenuContent align="end">
+									{currencyOptions.map((code) => (
+										<DropdownMenuItem
+											key={code}
+											onClick={() =>
+												field.handleChange(
+													code === orgDefaultCode ? null : code,
+												)
+											}
+											className="flex gap-3"
+										>
+											<CheckIcon
+												size={12}
+												className={
+													selectedCode === code ? "opacity-100" : "opacity-0"
+												}
+											/>
+											{code.toUpperCase()}
+										</DropdownMenuItem>
+									))}
+								</DropdownMenuContent>
+							</DropdownMenu>
+						);
+					}}
+				</form.AppField>
+			}
+		/>
+	);
+}

--- a/vite/src/components/forms/attach-v2/components/AttachFooterV3.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachFooterV3.tsx
@@ -41,8 +41,13 @@ export function getConfirmLabel({
 }
 
 export function AttachFooterV3() {
-	const { isPending, previewQuery, handleConfirm, handleInvoiceAttach, formValues } =
-		useAttachFormContext();
+	const {
+		isPending,
+		previewQuery,
+		handleConfirm,
+		handleInvoiceAttach,
+		formValues,
+	} = useAttachFormContext();
 	const { setSheet } = useSheetStore();
 	const itemId = useSheetStore((s) => s.itemId);
 
@@ -50,6 +55,7 @@ export function AttachFooterV3() {
 		useAttachBillingOptionsState();
 
 	const previewData = previewQuery.data;
+	const previewFailed = !!previewQuery.error;
 	const hasFutureStartDate = isFutureStartDate(formValues.startDate);
 	const confirmLabel = getConfirmLabel({
 		previewData,
@@ -112,7 +118,9 @@ export function AttachFooterV3() {
 									"w-full",
 									invoiceDisabledReason && "pointer-events-none opacity-50",
 								)}
-								disabled={!invoiceDisabledReason && isPending}
+								disabled={
+									previewFailed || (!invoiceDisabledReason && isPending)
+								}
 								isLoading={isInvoiceOnlyStart && isPending}
 								onClick={handleInvoiceButtonClick}
 							>
@@ -129,6 +137,7 @@ export function AttachFooterV3() {
 				<Button
 					variant="primary"
 					className="w-full"
+					disabled={previewFailed}
 					onClick={() => {
 						if (hasFutureStartDate) {
 							setSheet({ type: "attach-schedule-plan", itemId });

--- a/vite/src/components/forms/attach-v2/components/AttachPlanOptions.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachPlanOptions.tsx
@@ -1,16 +1,18 @@
-import { Button, Switch } from "@autumn/ui";
-import { CaretDownIcon, CheckIcon } from "@phosphor-icons/react";
-import { useState } from "react";
-import { ConfigRow } from "@/components/forms/shared/ConfigRow";
-import { FreeTrialConfigRow } from "@/components/forms/shared/FreeTrialConfigRow";
 import {
+	Button,
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuTrigger,
+	Switch,
 } from "@autumn/ui";
+import { CaretDownIcon, CheckIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import { ConfigRow } from "@/components/forms/shared/ConfigRow";
+import { FreeTrialConfigRow } from "@/components/forms/shared/FreeTrialConfigRow";
 import { cn } from "@/lib/utils";
 import { useAttachFormContext } from "../context/AttachFormProvider";
+import { AttachCurrencyRow } from "./AttachCurrencyRow";
 
 export function AttachPlanOptions() {
 	const {
@@ -20,6 +22,7 @@ export function AttachPlanOptions() {
 		product,
 		handleGrantFreeToggle,
 		hasActiveSubscription,
+		attachCurrency,
 	} = useAttachFormContext();
 	const { trialEnabled, trialCardRequired, trialOnEnd, grantFree } = formValues;
 	const [versionOpen, setVersionOpen] = useState(false);
@@ -87,6 +90,8 @@ export function AttachPlanOptions() {
 					}
 				/>
 			)}
+
+			{attachCurrency.showCurrencySelector && <AttachCurrencyRow />}
 
 			<FreeTrialConfigRow
 				form={form}

--- a/vite/src/components/forms/attach-v2/components/AttachPlanSection.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachPlanSection.tsx
@@ -1,6 +1,7 @@
+import { useMemo } from "react";
 import { PlanItemsSection } from "@/components/forms/shared";
 import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
-import { useOrg } from "@/hooks/common/useOrg";
+import { productItemsForCurrency } from "@/views/products/plan/utils/currencyUtils";
 import { useAttachFormContext } from "../context/AttachFormProvider";
 import { AttachSectionTitle } from "./AttachSectionTitle";
 
@@ -22,6 +23,7 @@ export function AttachPlanSection({
 		previewPrepaidOptions,
 		handleEditPlan,
 		previewDiff,
+		attachCurrency,
 	} = useAttachFormContext();
 
 	const hideEditButton = readOnly || formValues.grantFree;
@@ -31,23 +33,46 @@ export function AttachPlanSection({
 		? previewPrepaidOptions
 		: initialPrepaidOptions;
 
-	const { org } = useOrg();
-	const currency = org?.default_currency ?? "USD";
+	const { displayCurrency: currency, orgDefaultCurrency } = attachCurrency;
+
+	const displayProduct = useMemo(
+		() =>
+			product && {
+				...product,
+				items: productItemsForCurrency({
+					items: product.items,
+					currency,
+					orgDefaultCurrency,
+				}),
+			},
+		[product, currency, orgDefaultCurrency],
+	);
 
 	const outgoingItems = showDiff ? previewDiff.outgoingItems : [];
 
 	const originalItemsForDiff =
 		outgoingItems.length > 0 ? outgoingItems : productTemplateItems;
 
+	const displayOriginalItems = useMemo(
+		() =>
+			originalItemsForDiff &&
+			productItemsForCurrency({
+				items: originalItemsForDiff,
+				currency,
+				orgDefaultCurrency,
+			}),
+		[originalItemsForDiff, currency, orgDefaultCurrency],
+	);
+
 	const shouldShowDiff = showDiff
 		? outgoingItems.length > 0 || hasCustomizations
 		: false;
 
-	if (!product) return null;
+	if (!displayProduct || !product) return null;
 
 	const planItemsProps = {
-		product,
-		originalItems: originalItemsForDiff,
+		product: displayProduct,
+		originalItems: displayOriginalItems,
 		features,
 		prepaidOptions,
 		initialPrepaidOptions: effectiveInitialPrepaidOptions,

--- a/vite/src/components/forms/attach-v2/components/AttachPlanSection.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachPlanSection.tsx
@@ -50,8 +50,13 @@ export function AttachPlanSection({
 
 	const outgoingItems = showDiff ? previewDiff.outgoingItems : [];
 
-	const originalItemsForDiff =
-		outgoingItems.length > 0 ? outgoingItems : productTemplateItems;
+	const originalItemsForDiff = useMemo(
+		() =>
+			showDiff && previewDiff.outgoingItems.length > 0
+				? previewDiff.outgoingItems
+				: productTemplateItems,
+		[showDiff, previewDiff.outgoingItems, productTemplateItems],
+	);
 
 	const displayOriginalItems = useMemo(
 		() =>

--- a/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
+++ b/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
@@ -42,6 +42,10 @@ import type { PrepaidItemWithFeature } from "@/hooks/stores/useProductStore";
 import { usePrepaidItems } from "@/hooks/stores/useProductStore";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import type { AttachForm } from "../attachFormSchema";
+import {
+	type UseAttachCurrencyReturn,
+	useAttachCurrency,
+} from "../hooks/useAttachCurrency";
 import { type UseAttachForm, useAttachForm } from "../hooks/useAttachForm";
 import { useAttachMutation } from "../hooks/useAttachMutation";
 import {
@@ -75,6 +79,8 @@ interface AttachFormContextValue {
 
 	isFreeToPaidTransition: boolean;
 	hasActiveSubscription: boolean;
+
+	attachCurrency: UseAttachCurrencyReturn;
 
 	previewQuery: UseAttachPreviewReturn;
 	previewDiff: UsePreviewDiffReturn;
@@ -188,6 +194,7 @@ export function AttachFormProvider({
 		resetBillingCycle,
 		discounts,
 		grantFree,
+		currency,
 		noBillingChanges,
 		enablePlanImmediately,
 		carryOverBalances,
@@ -292,6 +299,12 @@ export function AttachFormProvider({
 
 	const { prepaidItems } = usePrepaidItems({ product: effectiveProduct });
 
+	const attachCurrency = useAttachCurrency({
+		items: items ?? (effectiveProduct?.items as ProductItem[] | null) ?? [],
+		customerCurrency: fullCustomer?.currency,
+		selectedCurrency: currency,
+	});
+
 	const resolveCurrentItems = useCallback(
 		() => items ?? (effectiveProduct?.items as ProductItem[]) ?? [],
 		[items, effectiveProduct?.items],
@@ -333,6 +346,7 @@ export function AttachFormProvider({
 			form.setFieldValue("trialCardRequired", true);
 			form.setFieldValue("trialOnEnd", "bill");
 			form.setFieldValue("grantFree", false);
+			form.setFieldValue("currency", null);
 			resetGrantFree();
 		}
 
@@ -428,6 +442,7 @@ export function AttachFormProvider({
 		carryOverUsageFeatureIds,
 		customLineItems,
 		disableProration,
+		currency: attachCurrency.requestCurrency,
 	});
 	const previewQuery = useAttachPreview({
 		requestBody,
@@ -535,6 +550,7 @@ export function AttachFormProvider({
 			previewPrepaidOptions,
 			isFreeToPaidTransition,
 			hasActiveSubscription,
+			attachCurrency,
 			previewQuery,
 			previewDiff,
 			showPlanEditor,
@@ -563,6 +579,7 @@ export function AttachFormProvider({
 			previewPrepaidOptions,
 			isFreeToPaidTransition,
 			hasActiveSubscription,
+			attachCurrency,
 			previewQuery,
 			previewDiff,
 			showPlanEditor,

--- a/vite/src/components/forms/attach-v2/hooks/useAttachCurrency.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachCurrency.ts
@@ -3,6 +3,17 @@ import { useMemo } from "react";
 import { useOrg } from "@/hooks/common/useOrg";
 import { itemCurrencyCodes } from "@/views/products/plan/utils/currencyUtils";
 
+// Options must survive the backend's every-charging-price-offers-currency
+// guard, so only currencies present on all charging items are selectable.
+const itemCharges = (item: ProductItem): boolean => {
+	if (item.tiers?.length) {
+		return item.tiers.some(
+			(tier) => (tier.amount ?? 0) + (tier.flat_amount ?? 0) > 0,
+		);
+	}
+	return (item.price ?? 0) > 0;
+};
+
 export interface UseAttachCurrencyReturn {
 	orgDefaultCurrency: string;
 	currencyOptions: string[];
@@ -24,14 +35,19 @@ export function useAttachCurrency({
 	const orgDefaultCurrency = org?.default_currency ?? "USD";
 
 	const planCurrencyCodes = useMemo(() => {
-		const codes = new Set<string>();
-		for (const item of items) {
-			for (const code of itemCurrencyCodes(item)) {
-				codes.add(code);
-			}
+		const chargingItems = items.filter(itemCharges);
+		if (chargingItems.length === 0) return [];
+
+		let codes: Set<string> | null = null;
+		for (const item of chargingItems) {
+			const itemCodes = new Set(itemCurrencyCodes(item));
+			codes =
+				codes === null
+					? itemCodes
+					: new Set([...codes].filter((code) => itemCodes.has(code)));
 		}
-		codes.delete(orgDefaultCurrency.toLowerCase());
-		return [...codes];
+		codes?.delete(orgDefaultCurrency.toLowerCase());
+		return [...(codes ?? [])];
 	}, [items, orgDefaultCurrency]);
 
 	const showCurrencySelector =

--- a/vite/src/components/forms/attach-v2/hooks/useAttachCurrency.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachCurrency.ts
@@ -1,0 +1,69 @@
+import type { ProductItem } from "@autumn/shared";
+import { useMemo } from "react";
+import { useOrg } from "@/hooks/common/useOrg";
+import { itemCurrencyCodes } from "@/views/products/plan/utils/currencyUtils";
+
+export interface UseAttachCurrencyReturn {
+	orgDefaultCurrency: string;
+	currencyOptions: string[];
+	showCurrencySelector: boolean;
+	displayCurrency: string;
+	requestCurrency: string | null;
+}
+
+export function useAttachCurrency({
+	items,
+	customerCurrency,
+	selectedCurrency,
+}: {
+	items: ProductItem[];
+	customerCurrency: string | null | undefined;
+	selectedCurrency: string | null;
+}): UseAttachCurrencyReturn {
+	const { org } = useOrg();
+	const orgDefaultCurrency = org?.default_currency ?? "USD";
+
+	const planCurrencyCodes = useMemo(() => {
+		const codes = new Set<string>();
+		for (const item of items) {
+			for (const code of itemCurrencyCodes(item)) {
+				codes.add(code);
+			}
+		}
+		codes.delete(orgDefaultCurrency.toLowerCase());
+		return [...codes];
+	}, [items, orgDefaultCurrency]);
+
+	const showCurrencySelector =
+		!!org?.config?.multi_currency &&
+		!customerCurrency &&
+		planCurrencyCodes.length > 0;
+
+	const currencyOptions = useMemo(
+		() => [orgDefaultCurrency.toLowerCase(), ...planCurrencyCodes],
+		[orgDefaultCurrency, planCurrencyCodes],
+	);
+
+	const formCurrency =
+		showCurrencySelector &&
+		selectedCurrency &&
+		currencyOptions.includes(selectedCurrency.toLowerCase())
+			? selectedCurrency.toLowerCase()
+			: null;
+
+	const displayCurrency =
+		formCurrency ?? customerCurrency ?? orgDefaultCurrency;
+
+	const requestCurrency =
+		formCurrency && formCurrency !== orgDefaultCurrency.toLowerCase()
+			? formCurrency
+			: null;
+
+	return {
+		orgDefaultCurrency,
+		currencyOptions,
+		showCurrencySelector,
+		displayCurrency,
+		requestCurrency,
+	};
+}

--- a/vite/src/components/forms/attach-v2/hooks/useAttachForm.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachForm.ts
@@ -37,6 +37,7 @@ export function useAttachForm({
 			resetBillingCycle: false,
 			discounts: [],
 			grantFree: false,
+			currency: null,
 			noBillingChanges: false,
 			enablePlanImmediately: false,
 			longLivedCheckout: false,

--- a/vite/src/components/forms/attach-v2/hooks/useAttachPreview.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachPreview.ts
@@ -59,6 +59,7 @@ export function useAttachPreview({
 		},
 		enabled: shouldEnable,
 		staleTime: 0,
+		refetchOnWindowFocus: false,
 		placeholderData: keepPreviousData,
 		retry: (failureCount, error) => {
 			const status = (error as AxiosError)?.response?.status;

--- a/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
@@ -49,6 +49,7 @@ export interface BuildAttachRequestBodyParams {
 	carryOverUsageFeatureIds: string[];
 	customLineItems: FormCustomLineItem[];
 	disableProration: boolean;
+	currency: string | null;
 }
 
 /** Pure function to build the attach request body. Extracted for testability. */
@@ -81,6 +82,7 @@ export function buildAttachRequestBody({
 	carryOverUsageFeatureIds = [],
 	customLineItems,
 	disableProration,
+	currency,
 }: BuildAttachRequestBodyParams): AttachParamsV0 | null {
 	if (!customerId || !product) {
 		return null;
@@ -99,6 +101,10 @@ export function buildAttachRequestBody({
 
 	if (entityId) {
 		body.entity_id = entityId;
+	}
+
+	if (currency) {
+		body.currency = currency.toLowerCase();
 	}
 
 	if (options && options.length > 0) {
@@ -235,6 +241,7 @@ export function useAttachRequestBody(params: BuildAttachRequestBodyParams) {
 		carryOverUsageFeatureIds,
 		customLineItems,
 		disableProration,
+		currency,
 	} = params;
 
 	const requestBody = useMemo(
@@ -268,6 +275,7 @@ export function useAttachRequestBody(params: BuildAttachRequestBodyParams) {
 				carryOverUsageFeatureIds,
 				customLineItems,
 				disableProration,
+				currency,
 			}),
 		[
 			customerId,
@@ -298,6 +306,7 @@ export function useAttachRequestBody(params: BuildAttachRequestBodyParams) {
 			carryOverUsageFeatureIds,
 			customLineItems,
 			disableProration,
+			currency,
 		],
 	);
 

--- a/vite/src/components/forms/create-schedule/components/SchedulePlanRow.tsx
+++ b/vite/src/components/forms/create-schedule/components/SchedulePlanRow.tsx
@@ -7,8 +7,10 @@ import {
 	XIcon,
 } from "@phosphor-icons/react";
 import { PriceDisplay } from "@/components/forms/update-subscription-v2/components/PriceDisplay";
-import { useOrg } from "@/hooks/common/useOrg";
+import { useCustomerDisplayCurrency } from "@/hooks/common/useCustomerDisplayCurrency";
 import { cn } from "@/lib/utils";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { productItemsForCurrency } from "@/views/products/plan/utils/currencyUtils";
 import { useCreateScheduleFormContext } from "../context/CreateScheduleFormProvider";
 import { CopyFromPreviousPhaseButton } from "./CopyFromPreviousPhaseButton";
 
@@ -42,7 +44,10 @@ export function SchedulePlanRow({
 		isPhaseLocked,
 		setEditingPlan,
 	} = useCreateScheduleFormContext();
-	const { org } = useOrg();
+	const { customer } = useCusQuery();
+	const { displayCurrency, orgDefaultCurrency } = useCustomerDisplayCurrency({
+		customer,
+	});
 
 	const plan = formValues.phases[phaseIndex]?.plans[planIndex];
 	if (!plan) return null;
@@ -51,12 +56,20 @@ export function SchedulePlanRow({
 	const availableProducts = products.filter((p) => !p.archived);
 	const selectedProduct = products.find((p) => p.id === plan.productId);
 	const hasCustomizations = plan.isCustom;
-	const priceProduct = selectedProduct
+	const basePriceProduct = selectedProduct
 		? getSchedulePlanPriceProduct({
 				product: selectedProduct,
 				customItems: plan.items,
 			})
 		: null;
+	const priceProduct = basePriceProduct && {
+		...basePriceProduct,
+		items: productItemsForCurrency({
+			items: basePriceProduct.items,
+			currency: displayCurrency,
+			orgDefaultCurrency,
+		}),
+	};
 
 	const selectedProductIdsInPhase = new Set(
 		formValues.phases[phaseIndex]?.plans
@@ -154,10 +167,7 @@ export function SchedulePlanRow({
 					)}
 					{priceProduct && (
 						<span className="text-xs text-tertiary-foreground tabular-nums">
-							<PriceDisplay
-								product={priceProduct}
-								currency={org?.default_currency ?? "USD"}
-							/>
+							<PriceDisplay product={priceProduct} currency={displayCurrency} />
 						</span>
 					)}
 				</div>

--- a/vite/src/components/forms/create-schedule/components/SchedulePlanRow.tsx
+++ b/vite/src/components/forms/create-schedule/components/SchedulePlanRow.tsx
@@ -9,8 +9,6 @@ import {
 import { PriceDisplay } from "@/components/forms/update-subscription-v2/components/PriceDisplay";
 import { useCustomerDisplayCurrency } from "@/hooks/common/useCustomerDisplayCurrency";
 import { cn } from "@/lib/utils";
-import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
-import { productItemsForCurrency } from "@/views/products/plan/utils/currencyUtils";
 import { useCreateScheduleFormContext } from "../context/CreateScheduleFormProvider";
 import { CopyFromPreviousPhaseButton } from "./CopyFromPreviousPhaseButton";
 
@@ -44,10 +42,7 @@ export function SchedulePlanRow({
 		isPhaseLocked,
 		setEditingPlan,
 	} = useCreateScheduleFormContext();
-	const { customer } = useCusQuery();
-	const { displayCurrency, orgDefaultCurrency } = useCustomerDisplayCurrency({
-		customer,
-	});
+	const { displayCurrency, productForDisplay } = useCustomerDisplayCurrency();
 
 	const plan = formValues.phases[phaseIndex]?.plans[planIndex];
 	if (!plan) return null;
@@ -62,14 +57,7 @@ export function SchedulePlanRow({
 				customItems: plan.items,
 			})
 		: null;
-	const priceProduct = basePriceProduct && {
-		...basePriceProduct,
-		items: productItemsForCurrency({
-			items: basePriceProduct.items,
-			currency: displayCurrency,
-			orgDefaultCurrency,
-		}),
-	};
+	const priceProduct = basePriceProduct && productForDisplay(basePriceProduct);
 
 	const selectedProductIdsInPhase = new Set(
 		formValues.phases[phaseIndex]?.plans

--- a/vite/src/components/forms/shared/PlanItemsSection.tsx
+++ b/vite/src/components/forms/shared/PlanItemsSection.tsx
@@ -207,6 +207,7 @@ export function PlanItemsSection({
 		form,
 		showDiff,
 		readOnly,
+		currency,
 	};
 
 	const itemKey = (item: ProductItem) =>
@@ -255,6 +256,7 @@ export function PlanItemsSection({
 							key={`deleted-${itemKey(item)}`}
 							item={item}
 							index={index}
+							currency={currency}
 						/>
 					))}
 					<PlanVersionChangeRow versionChange={versionChange} />

--- a/vite/src/components/forms/shared/plan-items/DeletedItemRow.tsx
+++ b/vite/src/components/forms/shared/plan-items/DeletedItemRow.tsx
@@ -6,9 +6,11 @@ import { LAYOUT_TRANSITION } from "@/components/v2/sheets/SharedSheetComponents"
 export function DeletedItemRow({
 	item,
 	index,
+	currency,
 }: {
 	item: ProductItem;
 	index: number;
+	currency?: string;
 }) {
 	return (
 		<motion.div
@@ -16,7 +18,7 @@ export function DeletedItemRow({
 			layout="position"
 			transition={{ layout: LAYOUT_TRANSITION }}
 		>
-			<SubscriptionItemRow item={item} isDeleted />
+			<SubscriptionItemRow currency={currency} item={item} isDeleted />
 		</motion.div>
 	);
 }

--- a/vite/src/components/forms/shared/plan-items/PlanItemRow.tsx
+++ b/vite/src/components/forms/shared/plan-items/PlanItemRow.tsx
@@ -80,6 +80,7 @@ export function PlanItemRow({
 	form,
 	showDiff,
 	readOnly,
+	currency,
 }: {
 	item: ProductItem;
 	index: number;
@@ -92,6 +93,7 @@ export function PlanItemRow({
 	form?: UseUpdateSubscriptionForm | UseAttachForm;
 	showDiff: boolean;
 	readOnly?: boolean;
+	currency?: string;
 }) {
 	if (!item.feature_id) return null;
 
@@ -125,6 +127,7 @@ export function PlanItemRow({
 				featureId={featureId}
 				isCreated={isCreated}
 				readOnly={readOnly}
+				currency={currency}
 			/>
 		</motion.div>
 	);

--- a/vite/src/components/forms/update-subscription-v2/components/EditPlanSection.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/EditPlanSection.tsx
@@ -2,7 +2,9 @@ import { formatAmount, formatInterval, isPriceItem } from "@autumn/shared";
 import { useMemo } from "react";
 import { PlanItemsSection } from "@/components/forms/shared";
 import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
-import { useOrg } from "@/hooks/common/useOrg";
+import { useCustomerDisplayCurrency } from "@/hooks/common/useCustomerDisplayCurrency";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { productItemsForCurrency } from "@/views/products/plan/utils/currencyUtils";
 import { useUpdateSubscriptionFormContext } from "../context/UpdateSubscriptionFormProvider";
 import { SectionTitle } from "./SectionTitle";
 
@@ -23,12 +25,37 @@ export function EditPlanSection() {
 	const { prepaidOptions } = formValues;
 	const hasCustomizations = formValues.items !== null || isVersionReady;
 
-	const { org } = useOrg();
-	const currency = org?.default_currency ?? "USD";
+	const { customer } = useCusQuery();
+	const { displayCurrency: currency, orgDefaultCurrency } =
+		useCustomerDisplayCurrency({ customer });
+
+	const displayProduct = useMemo(
+		() =>
+			product && {
+				...product,
+				items: productItemsForCurrency({
+					items: product.items,
+					currency,
+					orgDefaultCurrency,
+				}),
+			},
+		[product, currency, orgDefaultCurrency],
+	);
+
+	const displayOriginalItems = useMemo(
+		() =>
+			originalItems &&
+			productItemsForCurrency({
+				items: originalItems,
+				currency,
+				orgDefaultCurrency,
+			}),
+		[originalItems, currency, orgDefaultCurrency],
+	);
 
 	const priceChange = useMemo(() => {
-		const originalPriceItem = originalItems?.find((i) => isPriceItem(i));
-		const currentPriceItem = product?.items?.find((i) => isPriceItem(i));
+		const originalPriceItem = displayOriginalItems?.find((i) => isPriceItem(i));
+		const currentPriceItem = displayProduct?.items?.find((i) => isPriceItem(i));
 
 		const originalPrice = originalPriceItem?.price ?? 0;
 		const currentPrice = currentPriceItem?.price ?? 0;
@@ -85,7 +112,7 @@ export function EditPlanSection() {
 			newIntervalText,
 			isUpgrade: currentPrice > originalPrice,
 		};
-	}, [originalItems, product?.items, currency]);
+	}, [displayOriginalItems, displayProduct?.items, currency]);
 
 	return (
 		<SheetSection
@@ -93,8 +120,8 @@ export function EditPlanSection() {
 			withSeparator
 		>
 			<PlanItemsSection
-				product={product}
-				originalItems={originalItems}
+				product={displayProduct}
+				originalItems={displayOriginalItems}
 				features={features}
 				prepaidOptions={prepaidOptions}
 				initialPrepaidOptions={initialPrepaidOptions}

--- a/vite/src/components/forms/update-subscription-v2/components/EditPlanSection.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/EditPlanSection.tsx
@@ -3,8 +3,6 @@ import { useMemo } from "react";
 import { PlanItemsSection } from "@/components/forms/shared";
 import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
 import { useCustomerDisplayCurrency } from "@/hooks/common/useCustomerDisplayCurrency";
-import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
-import { productItemsForCurrency } from "@/views/products/plan/utils/currencyUtils";
 import { useUpdateSubscriptionFormContext } from "../context/UpdateSubscriptionFormProvider";
 import { SectionTitle } from "./SectionTitle";
 
@@ -25,32 +23,20 @@ export function EditPlanSection() {
 	const { prepaidOptions } = formValues;
 	const hasCustomizations = formValues.items !== null || isVersionReady;
 
-	const { customer } = useCusQuery();
-	const { displayCurrency: currency, orgDefaultCurrency } =
-		useCustomerDisplayCurrency({ customer });
+	const {
+		displayCurrency: currency,
+		itemsForDisplay,
+		productForDisplay,
+	} = useCustomerDisplayCurrency();
 
 	const displayProduct = useMemo(
-		() =>
-			product && {
-				...product,
-				items: productItemsForCurrency({
-					items: product.items,
-					currency,
-					orgDefaultCurrency,
-				}),
-			},
-		[product, currency, orgDefaultCurrency],
+		() => product && productForDisplay(product),
+		[product, productForDisplay],
 	);
 
 	const displayOriginalItems = useMemo(
-		() =>
-			originalItems &&
-			productItemsForCurrency({
-				items: originalItems,
-				currency,
-				orgDefaultCurrency,
-			}),
-		[originalItems, currency, orgDefaultCurrency],
+		() => originalItems && itemsForDisplay(originalItems),
+		[originalItems, itemsForDisplay],
 	);
 
 	const priceChange = useMemo(() => {

--- a/vite/src/components/forms/update-subscription-v2/components/SubscriptionItemRow.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/SubscriptionItemRow.tsx
@@ -23,6 +23,7 @@ interface SubscriptionItemRowProps {
 	isDeleted?: boolean;
 	isCreated?: boolean;
 	readOnly?: boolean;
+	currency?: string;
 }
 
 function usePrepaidDisplayState({
@@ -173,6 +174,7 @@ export function SubscriptionItemRow({
 	isDeleted = false,
 	isCreated = false,
 	readOnly = false,
+	currency,
 }: SubscriptionItemRowProps) {
 	const [isEditingQuantity, setIsEditingQuantity] = useState(false);
 
@@ -210,7 +212,7 @@ export function SubscriptionItemRow({
 				)}
 			>
 				<div className="flex flex-row items-center flex-1 gap-2 min-w-0 overflow-hidden">
-					<PlanItemLabel item={item} />
+					<PlanItemLabel currency={currency} item={item} />
 				</div>
 
 				<div className="flex items-center gap-2 shrink-0">

--- a/vite/src/components/v2/PlanItemLabel.tsx
+++ b/vite/src/components/v2/PlanItemLabel.tsx
@@ -278,12 +278,7 @@ function PriceText({
 		}) ??
 		text;
 
-	return (
-		<span className="text-body-secondary">
-			{" "}
-			{content}
-		</span>
-	);
+	return <span className="text-body-secondary"> {content}</span>;
 }
 
 interface PlanItemLabelProps {
@@ -292,6 +287,8 @@ interface PlanItemLabelProps {
 	wrapIcons?: (icons: ReactNode) => ReactNode;
 	/** Text shown when the feature has no name yet. */
 	unnamedText?: string;
+	/** Display currency for amounts; defaults to the org default. */
+	currency?: string;
 }
 
 /** Feature icon cluster + label text + rollover indicator. Shared by the plan
@@ -300,10 +297,11 @@ export function PlanItemLabel({
 	item,
 	wrapIcons,
 	unnamedText = "Name your feature",
+	currency: currencyOverride,
 }: PlanItemLabelProps) {
 	const { org } = useOrg();
 	const { features } = useFeaturesQuery();
-	const currency = org?.default_currency || "USD";
+	const currency = currencyOverride || org?.default_currency || "USD";
 
 	const display = getProductItemDisplay({
 		item,

--- a/vite/src/hooks/common/useCustomerDisplayCurrency.ts
+++ b/vite/src/hooks/common/useCustomerDisplayCurrency.ts
@@ -1,0 +1,12 @@
+import { useOrg } from "@/hooks/common/useOrg";
+
+export const useCustomerDisplayCurrency = ({
+	customer,
+}: {
+	customer: { currency?: string | null } | null | undefined;
+}): { displayCurrency: string; orgDefaultCurrency: string } => {
+	const { org } = useOrg();
+	const orgDefaultCurrency = org?.default_currency ?? "USD";
+	const displayCurrency = customer?.currency ?? orgDefaultCurrency;
+	return { displayCurrency, orgDefaultCurrency };
+};

--- a/vite/src/hooks/common/useCustomerDisplayCurrency.ts
+++ b/vite/src/hooks/common/useCustomerDisplayCurrency.ts
@@ -1,12 +1,42 @@
+import type { ProductItem } from "@autumn/shared";
+import { useCallback } from "react";
 import { useOrg } from "@/hooks/common/useOrg";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { productItemsForCurrency } from "@/views/products/plan/utils/currencyUtils";
 
-export const useCustomerDisplayCurrency = ({
-	customer,
-}: {
-	customer: { currency?: string | null } | null | undefined;
-}): { displayCurrency: string; orgDefaultCurrency: string } => {
+export const useCustomerDisplayCurrency = (): {
+	displayCurrency: string;
+	orgDefaultCurrency: string;
+	itemsForDisplay: (items: ProductItem[]) => ProductItem[];
+	productForDisplay: <T extends { items: ProductItem[] }>(product: T) => T;
+} => {
 	const { org } = useOrg();
+	const { customer } = useCusQuery();
 	const orgDefaultCurrency = org?.default_currency ?? "USD";
 	const displayCurrency = customer?.currency ?? orgDefaultCurrency;
-	return { displayCurrency, orgDefaultCurrency };
+
+	const itemsForDisplay = useCallback(
+		(items: ProductItem[]) =>
+			productItemsForCurrency({
+				items,
+				currency: displayCurrency,
+				orgDefaultCurrency,
+			}),
+		[displayCurrency, orgDefaultCurrency],
+	);
+
+	const productForDisplay = useCallback(
+		<T extends { items: ProductItem[] }>(product: T): T => ({
+			...product,
+			items: itemsForDisplay(product.items),
+		}),
+		[itemsForDisplay],
+	);
+
+	return {
+		displayCurrency,
+		orgDefaultCurrency,
+		itemsForDisplay,
+		productForDisplay,
+	};
 };

--- a/vite/src/views/customers2/components/sheets/AttachProductSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/AttachProductSheet.tsx
@@ -111,7 +111,7 @@ function ReviewPreviewBlock() {
 		isLoading: previewLoading,
 	} = previewQuery;
 
-	const showSkeleton = previewLoading || (!previewData && !queryError);
+	const showSkeleton = !queryError && (previewLoading || !previewData);
 	const hasShownSkeleton = useRef(false);
 	if (showSkeleton) hasShownSkeleton.current = true;
 	const animateIn = hasShownSkeleton.current && !showSkeleton;

--- a/vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx
@@ -62,7 +62,7 @@ export function BillingAutoTopupSheet() {
 	const sheetData = useSheetStore((s) => s.data);
 	const sheetType = useSheetStore((s) => s.type);
 	const { customer, refetch } = useCusQuery();
-	const { displayCurrency } = useCustomerDisplayCurrency({ customer });
+	const { displayCurrency } = useCustomerDisplayCurrency();
 	const { features } = useFeaturesQuery();
 	const axiosInstance = useAxiosInstance();
 

--- a/vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx
@@ -41,7 +41,7 @@ import {
 	SheetHeader,
 	SheetSection,
 } from "@/components/v2/sheets/SharedSheetComponents";
-import { useOrg } from "@/hooks/common/useOrg";
+import { useCustomerDisplayCurrency } from "@/hooks/common/useCustomerDisplayCurrency";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { CusService } from "@/services/customers/CusService";
@@ -62,8 +62,8 @@ export function BillingAutoTopupSheet() {
 	const sheetData = useSheetStore((s) => s.data);
 	const sheetType = useSheetStore((s) => s.type);
 	const { customer, refetch } = useCusQuery();
+	const { displayCurrency } = useCustomerDisplayCurrency({ customer });
 	const { features } = useFeaturesQuery();
-	const { org } = useOrg();
 	const axiosInstance = useAxiosInstance();
 
 	const isEdit = sheetType === "billing-auto-topup-edit";
@@ -301,7 +301,7 @@ export function BillingAutoTopupSheet() {
 							<InfoBox variant="note">
 								{topupPriceInfo.isTiered
 									? "Pricing for this feature is tiered — the charge per top-up depends on current usage."
-									: `Customer will be charged ${formatAmount({ org, amount: topupPriceInfo.unitAmount })} per ${topupPriceInfo.billingUnits === 1 ? "unit" : `${topupPriceInfo.billingUnits} units`}.`}
+									: `Customer will be charged ${formatAmount({ currency: displayCurrency, amount: topupPriceInfo.unitAmount })} per ${topupPriceInfo.billingUnits === 1 ? "unit" : `${topupPriceInfo.billingUnits} units`}.`}
 							</InfoBox>
 						) : (
 							<InfoBox variant="warning">

--- a/vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx
@@ -47,7 +47,6 @@ import { getCusProductKind, getPlanKindConfig } from "@/utils/planKind";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { BasePriceDisplay } from "@/views/products/plan/components/plan-card/BasePriceDisplay";
 import { PlanFeatureRow } from "@/views/products/plan/components/plan-card/PlanFeatureRow";
-import { productItemsForCurrency } from "@/views/products/plan/utils/currencyUtils";
 import { CustomerProductsStatus } from "../table/customer-products/CustomerProductsStatus";
 
 const ID_CHIP_INNER_CLASS = "max-w-40 text-tiny-id truncate !font-normal";
@@ -128,9 +127,7 @@ function SubscriptionDetailItems({
 
 export function SubscriptionDetailSheet() {
 	const { customer, features = [], testClockFrozenTimeMs } = useCusQuery();
-	const { displayCurrency, orgDefaultCurrency } = useCustomerDisplayCurrency({
-		customer,
-	});
+	const { displayCurrency, itemsForDisplay } = useCustomerDisplayCurrency();
 	const itemId = useSheetStore((s) => s.itemId);
 	const setSheet = useSheetStore((s) => s.setSheet);
 	// Get customer product and productV2 by itemId
@@ -152,14 +149,8 @@ export function SubscriptionDetailSheet() {
 		[features],
 	);
 	const displayItems = useMemo(
-		() =>
-			productV2?.items &&
-			productItemsForCurrency({
-				items: productV2.items,
-				currency: displayCurrency,
-				orgDefaultCurrency,
-			}),
-		[productV2?.items, displayCurrency, orgDefaultCurrency],
+		() => productV2?.items && itemsForDisplay(productV2.items),
+		[productV2?.items, itemsForDisplay],
 	);
 
 	if (!cusProduct) {

--- a/vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx
@@ -35,6 +35,7 @@ import {
 import { CollapsedBooleanItems } from "@/components/forms/shared/plan-items/CollapsedBooleanItems";
 import { OpenInStripeButton } from "@/components/v2/buttons/OpenInStripeButton";
 import { SheetHeader, SheetSection } from "@/components/v2/sheets/InlineSheet";
+import { useCustomerDisplayCurrency } from "@/hooks/common/useCustomerDisplayCurrency";
 import { useCusRewardsQuery } from "@/hooks/queries/useCusRewardsQuery";
 import { useProductVersionQuery } from "@/hooks/queries/useProductVersionQuery";
 import { usePrepaidItems } from "@/hooks/stores/useProductStore";
@@ -46,6 +47,7 @@ import { getCusProductKind, getPlanKindConfig } from "@/utils/planKind";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { BasePriceDisplay } from "@/views/products/plan/components/plan-card/BasePriceDisplay";
 import { PlanFeatureRow } from "@/views/products/plan/components/plan-card/PlanFeatureRow";
+import { productItemsForCurrency } from "@/views/products/plan/utils/currencyUtils";
 import { CustomerProductsStatus } from "../table/customer-products/CustomerProductsStatus";
 
 const ID_CHIP_INNER_CLASS = "max-w-40 text-tiny-id truncate !font-normal";
@@ -64,11 +66,13 @@ function SubscriptionDetailItems({
 	product,
 	prepaidDisplayQuantities,
 	adminIds,
+	currency,
 }: {
 	items: ProductItem[];
 	product: FrontendProduct;
 	prepaidDisplayQuantities: Record<string, number>;
 	adminIds?: import("@/components/forms/shared/admin/AdminPlanIdsTooltip").AdminPlanIds;
+	currency: string;
 }) {
 	const sortedItems = useMemo(() => sortPlanItems({ items }), [items]);
 	const { visibleItems, collapsedBooleanItems } = useMemo(
@@ -90,6 +94,7 @@ function SubscriptionDetailItems({
 				index={index}
 				readOnly={true}
 				prepaidQuantity={prepaidQuantity}
+				currency={currency}
 			/>
 		);
 	};
@@ -101,6 +106,7 @@ function SubscriptionDetailItems({
 					product={product}
 					readOnly={true}
 					adminIds={adminIds}
+					currency={currency}
 				/>
 			</div>
 
@@ -122,6 +128,9 @@ function SubscriptionDetailItems({
 
 export function SubscriptionDetailSheet() {
 	const { customer, features = [], testClockFrozenTimeMs } = useCusQuery();
+	const { displayCurrency, orgDefaultCurrency } = useCustomerDisplayCurrency({
+		customer,
+	});
 	const itemId = useSheetStore((s) => s.itemId);
 	const setSheet = useSheetStore((s) => s.setSheet);
 	// Get customer product and productV2 by itemId
@@ -141,6 +150,16 @@ export function SubscriptionDetailSheet() {
 	const featureNameById = useMemo(
 		() => new Map(features.map((feature) => [feature.id, feature.name])),
 		[features],
+	);
+	const displayItems = useMemo(
+		() =>
+			productV2?.items &&
+			productItemsForCurrency({
+				items: productV2.items,
+				currency: displayCurrency,
+				orgDefaultCurrency,
+			}),
+		[productV2?.items, displayCurrency, orgDefaultCurrency],
 	);
 
 	if (!cusProduct) {
@@ -214,12 +233,13 @@ export function SubscriptionDetailSheet() {
 				description={`Subscription details for ${cusProduct.product.name}`}
 			/>
 
-			{productV2?.items && productV2.items.length > 0 && (
+			{productV2 && displayItems && displayItems.length > 0 && (
 				<SubscriptionDetailItems
-					items={productV2.items}
-					product={productV2}
+					items={displayItems}
+					product={{ ...productV2, items: displayItems }}
 					prepaidDisplayQuantities={prepaidDisplayQuantities}
 					adminIds={adminIds}
+					currency={displayCurrency}
 				/>
 			)}
 

--- a/vite/src/views/customers2/components/sync-stripe-v2/SyncPlanRow.tsx
+++ b/vite/src/views/customers2/components/sync-stripe-v2/SyncPlanRow.tsx
@@ -12,8 +12,6 @@ import { useState } from "react";
 import { useCustomerDisplayCurrency } from "@/hooks/common/useCustomerDisplayCurrency";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { cn } from "@/lib/utils";
-import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
-import { productItemsForCurrency } from "@/views/products/plan/utils/currencyUtils";
 import { applyCustomizeToProduct, getBasePriceLabel } from "./syncPlanRowUtils";
 
 export type DraftPlan = SyncPlanInstance & { _key: string };
@@ -126,11 +124,8 @@ export function SyncPlanRow({
 	onRemove: () => void;
 	onCustomize: () => void;
 }) {
-	const { customer } = useCusQuery();
 	const { features } = useFeaturesQuery();
-	const { displayCurrency, orgDefaultCurrency } = useCustomerDisplayCurrency({
-		customer,
-	});
+	const { displayCurrency, productForDisplay } = useCustomerDisplayCurrency();
 
 	const availableProducts = products.filter((p) => !p.archived);
 	const selectedProduct = products.find((p) => p.id === plan.plan_id);
@@ -167,15 +162,6 @@ export function SyncPlanRow({
 				features: features ?? [],
 			})
 		: null;
-
-	const productForDisplay = (product: ProductV2): ProductV2 => ({
-		...product,
-		items: productItemsForCurrency({
-			items: product.items,
-			currency: displayCurrency,
-			orgDefaultCurrency,
-		}),
-	});
 
 	const originalPriceLabel = selectedProduct
 		? getBasePriceLabel({

--- a/vite/src/views/customers2/components/sync-stripe-v2/SyncPlanRow.tsx
+++ b/vite/src/views/customers2/components/sync-stripe-v2/SyncPlanRow.tsx
@@ -9,9 +9,11 @@ import {
 } from "@phosphor-icons/react";
 import { CheckIcon } from "lucide-react";
 import { useState } from "react";
-import { useOrg } from "@/hooks/common/useOrg";
+import { useCustomerDisplayCurrency } from "@/hooks/common/useCustomerDisplayCurrency";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { cn } from "@/lib/utils";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { productItemsForCurrency } from "@/views/products/plan/utils/currencyUtils";
 import { applyCustomizeToProduct, getBasePriceLabel } from "./syncPlanRowUtils";
 
 export type DraftPlan = SyncPlanInstance & { _key: string };
@@ -124,9 +126,11 @@ export function SyncPlanRow({
 	onRemove: () => void;
 	onCustomize: () => void;
 }) {
-	const { org } = useOrg();
+	const { customer } = useCusQuery();
 	const { features } = useFeaturesQuery();
-	const currency = org?.default_currency ?? "USD";
+	const { displayCurrency, orgDefaultCurrency } = useCustomerDisplayCurrency({
+		customer,
+	});
 
 	const availableProducts = products.filter((p) => !p.archived);
 	const selectedProduct = products.find((p) => p.id === plan.plan_id);
@@ -164,11 +168,26 @@ export function SyncPlanRow({
 			})
 		: null;
 
+	const productForDisplay = (product: ProductV2): ProductV2 => ({
+		...product,
+		items: productItemsForCurrency({
+			items: product.items,
+			currency: displayCurrency,
+			orgDefaultCurrency,
+		}),
+	});
+
 	const originalPriceLabel = selectedProduct
-		? getBasePriceLabel({ product: selectedProduct, currency })
+		? getBasePriceLabel({
+				product: productForDisplay(selectedProduct),
+				currency: displayCurrency,
+			})
 		: null;
 	const currentPriceLabel = customizedProduct
-		? getBasePriceLabel({ product: customizedProduct, currency })
+		? getBasePriceLabel({
+				product: productForDisplay(customizedProduct),
+				currency: displayCurrency,
+			})
 		: null;
 	const isPriceCustom =
 		hasCustomize &&

--- a/vite/src/views/customers2/components/table/customer-products/CustomerProductPrice.tsx
+++ b/vite/src/views/customers2/components/table/customer-products/CustomerProductPrice.tsx
@@ -6,18 +6,13 @@ import {
 } from "@autumn/shared";
 import { useCustomerDisplayCurrency } from "@/hooks/common/useCustomerDisplayCurrency";
 import { getBasePriceDisplay } from "@/utils/product/basePriceDisplayUtils";
-import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
-import { productItemsForCurrency } from "@/views/products/plan/utils/currencyUtils";
 
 export const CustomerProductPrice = ({
 	cusProduct,
 }: {
 	cusProduct: FullCusProduct;
 }) => {
-	const { customer } = useCusQuery();
-	const { displayCurrency, orgDefaultCurrency } = useCustomerDisplayCurrency({
-		customer,
-	});
+	const { displayCurrency, productForDisplay } = useCustomerDisplayCurrency();
 
 	// Convert FullCusProduct to FullProduct, then to ProductV2, then to FrontendProduct
 	const fullProduct = cusProductToProduct({ cusProduct });
@@ -29,18 +24,8 @@ export const CustomerProductPrice = ({
 		return <div className="text-tertiary-foreground">-</div>;
 	}
 
-	const displayProduct = {
-		...frontendProduct,
-		items: productItemsForCurrency({
-			items: frontendProduct.items,
-			currency: displayCurrency,
-			orgDefaultCurrency,
-		}),
-	};
-
-	// Get the base price display information
 	const priceDisplay = getBasePriceDisplay({
-		product: displayProduct,
+		product: productForDisplay(frontendProduct),
 		currency: displayCurrency,
 	});
 

--- a/vite/src/views/customers2/components/table/customer-products/CustomerProductPrice.tsx
+++ b/vite/src/views/customers2/components/table/customer-products/CustomerProductPrice.tsx
@@ -4,15 +4,20 @@ import {
 	mapToProductV2,
 	productV2ToFrontendProduct,
 } from "@autumn/shared";
-import { useOrg } from "@/hooks/common/useOrg";
+import { useCustomerDisplayCurrency } from "@/hooks/common/useCustomerDisplayCurrency";
 import { getBasePriceDisplay } from "@/utils/product/basePriceDisplayUtils";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { productItemsForCurrency } from "@/views/products/plan/utils/currencyUtils";
 
 export const CustomerProductPrice = ({
 	cusProduct,
 }: {
 	cusProduct: FullCusProduct;
 }) => {
-	const { org } = useOrg();
+	const { customer } = useCusQuery();
+	const { displayCurrency, orgDefaultCurrency } = useCustomerDisplayCurrency({
+		customer,
+	});
 
 	// Convert FullCusProduct to FullProduct, then to ProductV2, then to FrontendProduct
 	const fullProduct = cusProductToProduct({ cusProduct });
@@ -24,10 +29,19 @@ export const CustomerProductPrice = ({
 		return <div className="text-tertiary-foreground">-</div>;
 	}
 
+	const displayProduct = {
+		...frontendProduct,
+		items: productItemsForCurrency({
+			items: frontendProduct.items,
+			currency: displayCurrency,
+			orgDefaultCurrency,
+		}),
+	};
+
 	// Get the base price display information
 	const priceDisplay = getBasePriceDisplay({
-		product: frontendProduct,
-		currency: org?.default_currency,
+		product: displayProduct,
+		currency: displayCurrency,
 	});
 
 	// Render based on the display type

--- a/vite/src/views/products/plan/components/plan-card/BasePriceDisplay.tsx
+++ b/vite/src/views/products/plan/components/plan-card/BasePriceDisplay.tsx
@@ -19,11 +19,14 @@ export const BasePriceDisplay = ({
 	product,
 	readOnly = false,
 	adminIds,
+	currency,
 }: {
 	isOnboarding?: boolean;
 	product: FrontendProduct;
 	readOnly?: boolean;
 	adminIds?: AdminPlanIds;
+	/** Display currency for amounts; defaults to the org default. */
+	currency?: string;
 }) => {
 	const { sheetType, setSheet } = useSheet();
 	const { org } = useOrg();
@@ -39,7 +42,7 @@ export const BasePriceDisplay = ({
 	const renderPriceContent = () => {
 		const priceDisplay = getBasePriceDisplay({
 			product,
-			currency: org?.default_currency,
+			currency: currency ?? org?.default_currency,
 			showPlaceholder: true,
 		});
 

--- a/vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx
+++ b/vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx
@@ -23,6 +23,8 @@ interface PlanFeatureRowProps {
 	index: number;
 	readOnly?: boolean;
 	prepaidQuantity?: number | null;
+	/** Display currency for amounts; defaults to the org default. */
+	currency?: string;
 }
 
 export const PlanFeatureRow = ({
@@ -31,6 +33,7 @@ export const PlanFeatureRow = ({
 	index,
 	readOnly = false,
 	prepaidQuantity,
+	currency,
 }: PlanFeatureRowProps) => {
 	const { setItem } = useProductItemContext();
 	const { product } = useProduct();
@@ -170,6 +173,7 @@ export const PlanFeatureRow = ({
 			<div className="flex flex-row items-center flex-1 gap-2 min-w-0 overflow-hidden">
 				<PlanItemLabel
 					item={item}
+					currency={currency}
 					wrapIcons={(icons) => (
 						<AdminHover texts={adminHoverText()}>{icons}</AdminHover>
 					)}

--- a/vite/src/views/products/plan/utils/currencyUtils.ts
+++ b/vite/src/views/products/plan/utils/currencyUtils.ts
@@ -6,6 +6,53 @@ import {
 } from "@autumn/shared";
 import { toast } from "sonner";
 
+type ProductItemTier = NonNullable<ProductItem["tiers"]>[number];
+
+const findCurrencyEntry = <T extends { currency: string }>(
+	entries: T[] | null | undefined,
+	code: string,
+): T | undefined =>
+	entries?.find((entry) => entry.currency.toLowerCase() === code);
+
+const tierForCurrency = ({
+	tier,
+	code,
+}: {
+	tier: ProductItemTier;
+	code: string;
+}): ProductItemTier => {
+	const entry = findCurrencyEntry(tier.additional_currencies, code);
+	if (!entry) return tier;
+	return {
+		...tier,
+		amount: entry.amount ?? tier.amount,
+		flat_amount: entry.flat_amount ?? tier.flat_amount,
+	};
+};
+
+export const productItemsForCurrency = ({
+	items,
+	currency,
+	orgDefaultCurrency,
+}: {
+	items: ProductItem[];
+	currency: string | null | undefined;
+	orgDefaultCurrency: string;
+}): ProductItem[] => {
+	const code = currency?.toLowerCase();
+	if (!code || code === orgDefaultCurrency.toLowerCase()) return items;
+
+	return items.map((item) => {
+		const priceEntry = findCurrencyEntry(item.additional_currencies, code);
+		const tiers = item.tiers?.map((tier) => tierForCurrency({ tier, code }));
+		return {
+			...item,
+			price: priceEntry?.amount ?? item.price,
+			tiers: tiers ?? item.tiers,
+		};
+	});
+};
+
 export const unsetCurrencyCodes = (item: ProductItem): string[] => {
 	const codes = new Set<string>();
 	for (const entry of item.additional_currencies ?? []) {

--- a/vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts
+++ b/vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts
@@ -50,6 +50,7 @@ const baseParams: Omit<
 	customLineItems: [],
 	disableProration: false,
 	enablePlanImmediately: false,
+	currency: null,
 };
 
 describe("buildAttachRequestBody — billing_units handling", () => {


### PR DESCRIPTION
## Summary

Completes the multi-currency dashboard flow: attaching in a plan-configured currency, previewing consistently, and displaying customer-scoped prices in the customer's currency.

### Attach currency selection
- The Attach Product sheet shows a **Currency** selector when the org has `multi_currency` enabled, the customer has no locked currency yet, and the selected plan configures additional currencies. Options are the org default plus the plan's configured codes; the org default sends nothing.
- The selection flows into every request built from the attach body: `billing.attach`, `billing.preview_attach`, checkout generation, invoice and schedule stages.

### Backend fixes
- `AttachParamsV0Schema` now accepts `currency` — the dashboard sends `x-api-version: 1.2`, so the version layer parsed bodies with the V0 schema and zod silently stripped the field before the billing engine saw it.
- `billingPlanToPreviewResponse` (and the tax/invoice-credit preview decorations) resolve `currency` via `billingContextToCurrency` instead of hardcoding the org default, so preview totals/line items format correctly for locked customers and selected currencies across attach, update-subscription, cancel, schedule and checkout-recompute previews.

### Customer-currency displays
- New `useCustomerDisplayCurrency` hook centralizes resolution (`customer.currency ?? org default`); `EditPlanSection` refactored onto it.
- Customer-scoped surfaces now render amounts swapped via `productItemsForCurrency`: customer plans table price column, subscription detail sheet (base price + feature rows), create-schedule plan rows, sync-Stripe plan row, and the auto-topup charge copy (format-only — its amount is already a customer snapshot).
- `BasePriceDisplay` / `PlanFeatureRow` accept an optional `currency` prop defaulting to the org currency, so catalog and plan-editor callers are unchanged.

### Tests
- New e2e suite `multi-currency-currency-lock-e2e.test.ts`: first paid attach locks `customers.currency` across direct attach (latest + `x-api-version: 1.2`), no-currency default, invoice mode, deferred invoice paid via hosted invoice, and completed Stripe hosted checkout — all passing. The 1.2 case doubles as the regression test for the V0 schema fix.
- `attach-params-schema.test.ts` covers currency surviving both V0 and V1 parsing; attach request-body unit tests updated.

## Notes for review
- Deliberately untouched: the customer plan editor (editing surfaces intentionally show base-currency amounts) and all surfaces formatting backend-response currency (invoices, previews, Stripe sync, analytics).
- `computeMultiAttachPlan` has no currency lock and `MultiAttachParams` no currency param — known gap, out of scope here (dashboard uses single attach).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds attach-time currency selection, switches customer-facing prices to the customer’s currency, and brings `multiAttach` to parity with single attach (currency param, resolution, and first‑paid lock). Also validates currency codes, tightens the selector to only currencies present on every charging item, and fixes preview/update edge cases and memo stability.

- New Features
  - Attach Product sheet shows a Currency selector when `multi_currency` is enabled, the customer isn’t locked, and the plan offers more currencies; options are the org default plus the intersection of currencies across all charging items; selection flows into attach, preview, checkout, invoice, and schedule requests.
  - `multiAttach` accepts optional `currency`, resolves billing currency from requested → customer → org default, and locks `customers.currency` on the first paid multi‑attach; all‑free multi‑attach does not lock.
  - `useCustomerDisplayCurrency` and `productItemsForCurrency` render customer‑scoped UIs in the customer’s currency across the plans table, subscription detail sheet, schedule rows, Sync to Stripe row, and auto‑topup copy. `BasePriceDisplay`, `PlanFeatureRow`, and `PlanItemLabel` accept an optional `currency` prop.
  - Currency params validate against Stripe‑supported codes.

- Bug Fixes
  - Clearer error when the customer is locked to a currency the plan doesn’t offer, with guidance to add pricing or choose a different plan.
  - `AttachParamsV0` and `MultiAttachParamsV0` preserve `currency`; previews (totals, tax, invoice‑credit) resolve currency from `billingContext`.
  - `multiAttach` enforces currency rules: requires org `multi_currency` for a requested currency, blocks locked‑currency conflicts, and verifies each plan offers the resolved currency.
  - Update‑subscription mappers keep `additional_currencies` (and base currency), so currency‑only edits are recognized, prorated, and Stripe prices update; change gating compares base‑price `additional_currencies` order‑insensitively.
  - Attach preview errors now display; confirm/invoice actions disable while failing; preview no longer refetches on window focus; `originalItemsForDiff` is memoized so currency display transforms short‑circuit correctly.

<sup>Written for commit e303c897b38dbef2299c85ea372e3b2f9a9cb249. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR completes the multi-currency dashboard flow by wiring currency selection into the Attach Product sheet, fixing a V0 schema stripping bug that silently dropped `currency` before the billing engine, and swapping customer-facing price displays to show the customer's locked or chosen currency instead of the org default.

- **[Bug fixes] `AttachParamsV0Schema` now accepts `currency`**, fixing the silent strip that occurred when the dashboard sent `x-api-version: 1.2` and zod parsed with the V0 schema; the field is preserved through all preview, invoice, checkout, and schedule paths.
- **[Improvements] `billingContextToCurrency` replaces `orgToCurrency`** across five server-side preview/tax helpers, so preview totals and line items correctly reflect the customer's locked currency or the currency selected at attach time.
- **[Improvements] New `useAttachCurrency` hook and `AttachCurrencyRow` UI component** surface a currency selector in the Attach sheet when `multi_currency` is enabled, the customer has no locked currency, and the plan configures additional currencies; the selection flows into the request body and preview, and resets on product switch.
- **[Improvements] `productItemsForCurrency` utility and `useCustomerDisplayCurrency` hook** centralize client-side amount swapping; six customer-scoped surfaces (plans table price column, subscription detail sheet, schedule plan rows, sync-Stripe plan row, auto-topup copy, update-subscription edit section) now render in the customer's currency.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core schema fix and server-side currency routing are correct, and the new e2e suite exercises the full attach-to-lock cycle across six scenarios including the V0-schema regression.

The implementation is thorough and the test coverage is strong. The one area worth watching is the currency-option derivation in `useAttachCurrency`: it draws codes from all item types rather than only priced items, so a plan that happens to have a currency entry on a feature row (but not on its price row) would surface that currency in the selector. In the worst case a user selects it, sees a misleading price display, and the backend rejects or mishandles the attach. The memo-stability issue in `AttachPlanSection` is a pure performance nit.

`useAttachCurrency.ts` — the `planCurrencyCodes` derivation; `AttachPlanSection.tsx` — `originalItemsForDiff` reference stability.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/api/billing/attachV2/attachParamsV0.ts | Adds optional `currency` field to `ExtAttachParamsV0Schema`; directly fixes the V0-schema-stripping regression for v1.2 API callers. |
| server/src/internal/billing/v2/utils/billingPlanToPreviewResponse.ts | Swaps `orgToCurrency` for `billingContextToCurrency` so preview totals honour the customer's locked or selected currency rather than always using the org default. |
| vite/src/views/products/plan/utils/currencyUtils.ts | Adds `productItemsForCurrency` which swaps item amounts for a given currency; correctly handles tiered pricing via `tierForCurrency`. Currency selector options are built from all item types (including non-price feature items), which could surface a currency that has no actual price entry. |
| vite/src/components/forms/attach-v2/hooks/useAttachCurrency.ts | New hook deriving currency options, showCurrencySelector, displayCurrency, and requestCurrency from plan items and customer state; logic is clear and the requestCurrency correctly sends null for the org default. |
| vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx | Threads `attachCurrency` through context and correctly resets the `currency` form field on product change; `requestCurrency` flows into the request body builder. |
| server/tests/integration/billing/attach/multi-currency-currency-lock-e2e.test.ts | New e2e suite with 6 concurrent tests covering direct attach, v1.2 API regression, no-currency default, invoice mode, hosted invoice, and Stripe checkout — comprehensive coverage of the new currency-lock paths. |
| vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx | Correctly derives `displayItems` via `productItemsForCurrency` and passes `currency` down to `BasePriceDisplay` and `PlanFeatureRow` for formatting. |
| vite/src/hooks/common/useCustomerDisplayCurrency.ts | Small, focused hook centralising `customer.currency ?? orgDefault` resolution; used consistently across the customer-scoped display surfaces. |
| vite/src/components/forms/attach-v2/components/AttachCurrencyRow.tsx | New dropdown row for currency selection in the Attach sheet; stores null for org default (correctly elided from the request body) and uppercase display with lowercase storage. |
| vite/src/components/forms/update-subscription-v2/components/EditPlanSection.tsx | Correctly adopts `useCustomerDisplayCurrency` and `productItemsForCurrency`, passes the resolved `currency` to `PlanItemsSection` for both items and formatting. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as Dashboard (Attach Sheet)
    participant Hook as useAttachCurrency
    participant Body as buildAttachRequestBody
    participant API as /billing/attach (v1.2)
    participant Schema as AttachParamsV0Schema
    participant Engine as Billing Engine
    participant Preview as billingPlanToPreviewResponse

    UI->>Hook: items, customerCurrency, selectedCurrency
    Hook-->>UI: currencyOptions, showCurrencySelector, requestCurrency

    UI->>Body: "{ ..., currency: requestCurrency }"
    Body-->>API: "POST { customer_id, plan_id, currency: cny }"

    API->>Schema: zod.parse(body)
    Note over Schema: currency field now preserved (was stripped before)
    Schema-->>Engine: "{ ..., currency: cny }"

    Engine->>Preview: billingPlanToPreviewResponse
    Preview->>Preview: billingContextToCurrency(org, billingContext)
    Note over Preview: resolves customer.currency or billingContext.currency
    Preview-->>UI: preview totals in correct currency
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as Dashboard (Attach Sheet)
    participant Hook as useAttachCurrency
    participant Body as buildAttachRequestBody
    participant API as /billing/attach (v1.2)
    participant Schema as AttachParamsV0Schema
    participant Engine as Billing Engine
    participant Preview as billingPlanToPreviewResponse

    UI->>Hook: items, customerCurrency, selectedCurrency
    Hook-->>UI: currencyOptions, showCurrencySelector, requestCurrency

    UI->>Body: "{ ..., currency: requestCurrency }"
    Body-->>API: "POST { customer_id, plan_id, currency: cny }"

    API->>Schema: zod.parse(body)
    Note over Schema: currency field now preserved (was stripped before)
    Schema-->>Engine: "{ ..., currency: cny }"

    Engine->>Preview: billingPlanToPreviewResponse
    Preview->>Preview: billingContextToCurrency(org, billingContext)
    Note over Preview: resolves customer.currency or billingContext.currency
    Preview-->>UI: preview totals in correct currency
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/components/forms/attach-v2/hooks/useAttachCurrency.ts:25-33
**Currency options include non-price items**

`itemCurrencyCodes` collects currency codes from every item, including boolean/metered feature rows that have no price. A plan that has a CNY entry on a feature item but no CNY entry on its price item will surface "CNY" in the selector. The user selects it, `requestCurrency: "cny"` is sent, and the backend either rejects it or bills in an unintended currency. The display also shows the org-default price amount formatted as CNY, making the plan look like it has a CNY price when it doesn't.

Consider filtering to only items that have a `price` or `tiers` (i.e., are price items) before collecting codes, or pre-intersecting with the set of codes actually present on price items.

### Issue 2 of 2
vite/src/components/forms/attach-v2/components/AttachPlanSection.tsx:56-65
**`originalItemsForDiff` reference instability defeats the memo**

`originalItemsForDiff` is a plain `const` computed in the render body, so it gets a new object reference on every render even when its value hasn't changed. The `useMemo` for `displayOriginalItems` therefore runs on every render, negating any benefit of memoizing the currency conversion. Wrapping `originalItemsForDiff` itself in a `useMemo` (depending on `outgoingItems`, `productTemplateItems`) would stabilise the reference and allow the downstream memo to short-circuit correctly.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: attach-time currency selection and..."](https://github.com/useautumn/autumn/commit/2719f4192f22e4146c9bcb1af5ea064e1a7cde23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44410432)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->