### PR TITLE
Fix catalog updates with cross-version customer references

### DIFF
--- a/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
@@ -41,6 +41,23 @@ import { tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
 import RecaseError from "@/utils/errorUtils.js";
 
 export class CusEntService {
+	/** Whether any customer entitlement references one of these catalog rows. */
+	static async hasAnyEntitlementReferences({
+		db,
+		entitlementIds,
+	}: {
+		db: DrizzleCli;
+		entitlementIds: string[];
+	}): Promise<boolean> {
+		if (entitlementIds.length === 0) return false;
+		const row = await db
+			.select({ id: customerEntitlements.id })
+			.from(customerEntitlements)
+			.where(inArray(customerEntitlements.entitlement_id, entitlementIds))
+			.limit(1);
+		return row.length > 0;
+	}
+
 	/**
 	 * Which of these catalog entitlements are referenced by any
 	 * customer_entitlements row — across every status, including loose,

--- a/server/src/internal/customers/cusProducts/cusPrices/CusPriceService.ts
+++ b/server/src/internal/customers/cusProducts/cusPrices/CusPriceService.ts
@@ -8,6 +8,23 @@ import { eq, inArray } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 
 export class CusPriceService {
+	/** Whether any customer price references one of these catalog rows. */
+	static async hasAnyPriceReferences({
+		db,
+		priceIds,
+	}: {
+		db: DrizzleCli;
+		priceIds: string[];
+	}): Promise<boolean> {
+		if (priceIds.length === 0) return false;
+		const row = await db
+			.select({ id: customerPrices.id })
+			.from(customerPrices)
+			.where(inArray(customerPrices.price_id, priceIds))
+			.limit(1);
+		return row.length > 0;
+	}
+
 	/** Which of these catalog prices are referenced by any customer_prices row. */
 	static async getReferencedPriceIds({
 		db,

--- a/server/src/internal/product/actions/inPlaceUpdateUtils.ts
+++ b/server/src/internal/product/actions/inPlaceUpdateUtils.ts
@@ -1,10 +1,15 @@
-import type { Feature, FullProduct, ProductItem } from "@autumn/shared";
 import {
+	entitlements,
+	type Feature,
+	type FullProduct,
 	findSimilarItem,
 	itemsAreSame,
 	mapToProductItems,
+	type ProductItem,
+	prices,
 } from "@autumn/shared";
 import type { DrizzleCli } from "@server/db/initDrizzle";
+import { inArray } from "drizzle-orm";
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
 import { CusPriceService } from "@/internal/customers/cusProducts/cusPrices/CusPriceService.js";
 import { EntitlementService } from "@/internal/products/entitlements/EntitlementService.js";
@@ -24,6 +29,38 @@ const currentItemsOf = ({
 		entitlements: currentFullProduct.entitlements,
 		features,
 	});
+
+/** Locks sorted parent rows so FK inserts and concurrent catalog writes serialize. */
+export const lockProductItemsForUpdate = async ({
+	db,
+	currentFullProduct,
+}: {
+	db: DrizzleCli;
+	currentFullProduct: FullProduct;
+}) => {
+	const entitlementIds = currentFullProduct.entitlements
+		.map((entitlement) => entitlement.id)
+		.sort();
+	const priceIds = currentFullProduct.prices.map((price) => price.id).sort();
+
+	if (entitlementIds.length > 0) {
+		await db
+			.select({ id: entitlements.id })
+			.from(entitlements)
+			.where(inArray(entitlements.id, entitlementIds))
+			.orderBy(entitlements.id)
+			.for("update");
+	}
+
+	if (priceIds.length > 0) {
+		await db
+			.select({ id: prices.id })
+			.from(prices)
+			.where(inArray(prices.id, priceIds))
+			.orderBy(prices.id)
+			.for("update");
+	}
+};
 
 export const productItemsHaveCustomerReferences = async ({
 	db,

--- a/server/src/internal/product/actions/inPlaceUpdateUtils.ts
+++ b/server/src/internal/product/actions/inPlaceUpdateUtils.ts
@@ -32,20 +32,20 @@ export const productItemsHaveCustomerReferences = async ({
 	db: DrizzleCli;
 	currentFullProduct: FullProduct;
 }): Promise<boolean> => {
-	const [referencedEntitlementIds, referencedPriceIds] = await Promise.all([
-		CusEntService.getReferencedEntitlementIds({
+	const [hasEntitlementReferences, hasPriceReferences] = await Promise.all([
+		CusEntService.hasAnyEntitlementReferences({
 			db,
 			entitlementIds: currentFullProduct.entitlements.map(
 				(entitlement) => entitlement.id,
 			),
 		}),
-		CusPriceService.getReferencedPriceIds({
+		CusPriceService.hasAnyPriceReferences({
 			db,
 			priceIds: currentFullProduct.prices.map((price) => price.id),
 		}),
 	]);
 
-	return referencedEntitlementIds.size > 0 || referencedPriceIds.size > 0;
+	return hasEntitlementReferences || hasPriceReferences;
 };
 
 /**
@@ -101,12 +101,11 @@ const retireOrDeleteRows = async ({
 	});
 	const priceRows = await PriceService.getInIds({ db, ids: priceIds });
 	const entitlementsReferencedByRetainedPrices = new Set(
-		priceRows
-			.flatMap((price) =>
-				referencedPrices.has(price.id) && price.entitlement_id
-					? [price.entitlement_id]
-					: [],
-			),
+		priceRows.flatMap((price) =>
+			referencedPrices.has(price.id) && price.entitlement_id
+				? [price.entitlement_id]
+				: [],
+		),
 	);
 
 	for (const priceId of priceIds) {

--- a/server/src/internal/product/actions/inPlaceUpdateUtils.ts
+++ b/server/src/internal/product/actions/inPlaceUpdateUtils.ts
@@ -7,9 +7,10 @@ import {
 	mapToProductItems,
 	type ProductItem,
 	prices,
+	products,
 } from "@autumn/shared";
 import type { DrizzleCli } from "@server/db/initDrizzle";
-import { inArray } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
 import { CusPriceService } from "@/internal/customers/cusProducts/cusPrices/CusPriceService.js";
 import { EntitlementService } from "@/internal/products/entitlements/EntitlementService.js";
@@ -30,7 +31,22 @@ const currentItemsOf = ({
 		features,
 	});
 
-/** Locks sorted parent rows so FK inserts and concurrent catalog writes serialize. */
+/** Serializes item writers before they reload the current catalog rows. */
+export const lockProductForItemUpdate = async ({
+	db,
+	internalProductId,
+}: {
+	db: DrizzleCli;
+	internalProductId: string;
+}) => {
+	await db
+		.select({ internalId: products.internal_id })
+		.from(products)
+		.where(eq(products.internal_id, internalProductId))
+		.for("no key update");
+};
+
+/** Locks sorted item rows so customer references cannot race item retirement. */
 export const lockProductItemsForUpdate = async ({
 	db,
 	currentFullProduct,

--- a/server/src/internal/product/actions/inPlaceUpdateUtils.ts
+++ b/server/src/internal/product/actions/inPlaceUpdateUtils.ts
@@ -25,6 +25,29 @@ const currentItemsOf = ({
 		features,
 	});
 
+export const productItemsHaveCustomerReferences = async ({
+	db,
+	currentFullProduct,
+}: {
+	db: DrizzleCli;
+	currentFullProduct: FullProduct;
+}): Promise<boolean> => {
+	const [referencedEntitlementIds, referencedPriceIds] = await Promise.all([
+		CusEntService.getReferencedEntitlementIds({
+			db,
+			entitlementIds: currentFullProduct.entitlements.map(
+				(entitlement) => entitlement.id,
+			),
+		}),
+		CusPriceService.getReferencedPriceIds({
+			db,
+			priceIds: currentFullProduct.prices.map((price) => price.id),
+		}),
+	]);
+
+	return referencedEntitlementIds.size > 0 || referencedPriceIds.size > 0;
+};
+
 /**
  * Callers rarely echo back entitlement_id / price_id, so without this match the
  * unchanged items look new and the old rows get deleted (cascading the

--- a/server/src/internal/product/actions/updateProduct/updateProductItems.ts
+++ b/server/src/internal/product/actions/updateProduct/updateProductItems.ts
@@ -6,7 +6,10 @@ import {
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { handleNewProductItems } from "@/internal/products/product-items/productItemUtils/handleNewProductItems.js";
-import { resolveInPlaceEdit } from "../inPlaceUpdateUtils.js";
+import {
+	productItemsHaveCustomerReferences,
+	resolveInPlaceEdit,
+} from "../inPlaceUpdateUtils.js";
 
 export const updateProductItems = async ({
 	ctx,
@@ -23,7 +26,14 @@ export const updateProductItems = async ({
 	features: AutumnContext["features"];
 	useInPlaceEdit: boolean;
 }) => {
-	if (!useInPlaceEdit) {
+	const shouldUseInPlaceEdit =
+		useInPlaceEdit ||
+		(await productItemsHaveCustomerReferences({
+			db,
+			currentFullProduct: fullProduct,
+		}));
+
+	if (!shouldUseInPlaceEdit) {
 		await handleNewProductItems({
 			db,
 			curPrices: fullProduct.prices,

--- a/server/src/internal/product/actions/updateProduct/updateProductItems.ts
+++ b/server/src/internal/product/actions/updateProduct/updateProductItems.ts
@@ -7,6 +7,7 @@ import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { handleNewProductItems } from "@/internal/products/product-items/productItemUtils/handleNewProductItems.js";
 import {
+	lockProductItemsForUpdate,
 	productItemsHaveCustomerReferences,
 	resolveInPlaceEdit,
 } from "../inPlaceUpdateUtils.js";
@@ -26,30 +27,34 @@ export const updateProductItems = async ({
 	features: AutumnContext["features"];
 	useInPlaceEdit: boolean;
 }) => {
-	const shouldUseInPlaceEdit =
-		useInPlaceEdit ||
-		(await productItemsHaveCustomerReferences({
-			db,
-			currentFullProduct: fullProduct,
-		}));
-
-	if (!shouldUseInPlaceEdit) {
-		await handleNewProductItems({
-			db,
-			curPrices: fullProduct.prices,
-			curEnts: fullProduct.entitlements,
-			newItems,
-			features,
-			product: fullProduct,
-			logger: ctx.logger,
-			isCustom: false,
-			multiCurrencyEnabled: orgMultiCurrencyEnabled({ org: ctx.org }),
-		});
-		return;
-	}
-
 	await db.transaction(async (transaction) => {
 		const tx = transaction as unknown as DrizzleCli;
+		await lockProductItemsForUpdate({
+			db: tx,
+			currentFullProduct: fullProduct,
+		});
+		const shouldUseInPlaceEdit =
+			useInPlaceEdit ||
+			(await productItemsHaveCustomerReferences({
+				db: tx,
+				currentFullProduct: fullProduct,
+			}));
+
+		if (!shouldUseInPlaceEdit) {
+			await handleNewProductItems({
+				db: tx,
+				curPrices: fullProduct.prices,
+				curEnts: fullProduct.entitlements,
+				newItems,
+				features,
+				product: fullProduct,
+				logger: ctx.logger,
+				isCustom: false,
+				multiCurrencyEnabled: orgMultiCurrencyEnabled({ org: ctx.org }),
+			});
+			return;
+		}
+
 		const inPlace = await resolveInPlaceEdit({
 			db: tx,
 			items: newItems,

--- a/server/src/internal/product/actions/updateProduct/updateProductItems.ts
+++ b/server/src/internal/product/actions/updateProduct/updateProductItems.ts
@@ -5,8 +5,10 @@ import {
 } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
 import { handleNewProductItems } from "@/internal/products/product-items/productItemUtils/handleNewProductItems.js";
 import {
+	lockProductForItemUpdate,
 	lockProductItemsForUpdate,
 	productItemsHaveCustomerReferences,
 	resolveInPlaceEdit,
@@ -29,25 +31,36 @@ export const updateProductItems = async ({
 }) => {
 	await db.transaction(async (transaction) => {
 		const tx = transaction as unknown as DrizzleCli;
+		await lockProductForItemUpdate({
+			db: tx,
+			internalProductId: fullProduct.internal_id,
+		});
+		const currentFullProduct = await ProductService.getFull({
+			db: tx,
+			idOrInternalId: fullProduct.internal_id,
+			orgId: fullProduct.org_id,
+			env: fullProduct.env,
+			version: fullProduct.version,
+		});
 		await lockProductItemsForUpdate({
 			db: tx,
-			currentFullProduct: fullProduct,
+			currentFullProduct,
 		});
 		const shouldUseInPlaceEdit =
 			useInPlaceEdit ||
 			(await productItemsHaveCustomerReferences({
 				db: tx,
-				currentFullProduct: fullProduct,
+				currentFullProduct,
 			}));
 
 		if (!shouldUseInPlaceEdit) {
 			await handleNewProductItems({
 				db: tx,
-				curPrices: fullProduct.prices,
-				curEnts: fullProduct.entitlements,
+				curPrices: currentFullProduct.prices,
+				curEnts: currentFullProduct.entitlements,
 				newItems,
 				features,
-				product: fullProduct,
+				product: currentFullProduct,
 				logger: ctx.logger,
 				isCustom: false,
 				multiCurrencyEnabled: orgMultiCurrencyEnabled({ org: ctx.org }),
@@ -58,7 +71,7 @@ export const updateProductItems = async ({
 		const inPlace = await resolveInPlaceEdit({
 			db: tx,
 			items: newItems,
-			currentFullProduct: fullProduct,
+			currentFullProduct,
 			features,
 		});
 		await handleNewProductItems({
@@ -67,7 +80,7 @@ export const updateProductItems = async ({
 			curEnts: inPlace.curEnts,
 			newItems: inPlace.items,
 			features,
-			product: fullProduct,
+			product: currentFullProduct,
 			logger: ctx.logger,
 			isCustom: false,
 			multiCurrencyEnabled: orgMultiCurrencyEnabled({ org: ctx.org }),

--- a/server/tests/integration/crud/plans/update/in-place/concurrent-catalog-update.test.ts
+++ b/server/tests/integration/crud/plans/update/in-place/concurrent-catalog-update.test.ts
@@ -1,0 +1,116 @@
+// Concurrent item updates must reload the catalog state protected by the product lock.
+// Otherwise, both stale callers insert a replacement and leave duplicate active rows.
+
+import { expect, test } from "bun:test";
+import { entitlements } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { and, eq } from "drizzle-orm";
+import { updateProductItems } from "@/internal/product/actions/updateProduct/updateProductItems.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+
+test.concurrent(
+	`${chalk.yellowBright("updateProductItems: concurrent replacements leave one active row")}`,
+	async () => {
+		const suffix = Math.random().toString(36).slice(2, 9);
+		const plan = products.base({
+			id: `catalog_concurrent_update_${suffix}`,
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { ctx } = await initScenario({
+			setup: [
+				s.products({ list: [plan], prefix: suffix, createInStripe: false }),
+			],
+			actions: [],
+		});
+
+		const productBeforeUpdates = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: plan.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		const messagesEntitlement = productBeforeUpdates.entitlements.find(
+			(entitlement) => entitlement.feature?.id === TestFeature.Messages,
+		);
+		expect(messagesEntitlement).toBeDefined();
+
+		let markLockAcquired = () => {};
+		const lockAcquired = new Promise<void>((resolve) => {
+			markLockAcquired = resolve;
+		});
+		let releaseEntitlementLock = () => {};
+		const holdEntitlementLock = new Promise<void>((resolve) => {
+			releaseEntitlementLock = resolve;
+		});
+		const lockingTransaction = ctx.db.transaction(async (transaction) => {
+			await transaction
+				.select({ id: entitlements.id })
+				.from(entitlements)
+				.where(eq(entitlements.id, messagesEntitlement!.id))
+				.for("update");
+			markLockAcquired();
+			await holdEntitlementLock;
+		});
+		await Promise.race([lockAcquired, lockingTransaction]);
+
+		const catalogUpdates = Promise.allSettled([
+			updateProductItems({
+				ctx,
+				db: ctx.db,
+				fullProduct: structuredClone(productBeforeUpdates),
+				newItems: [items.monthlyMessages({ includedUsage: 200 })],
+				features: ctx.features,
+				useInPlaceEdit: false,
+			}),
+			updateProductItems({
+				ctx,
+				db: ctx.db,
+				fullProduct: structuredClone(productBeforeUpdates),
+				newItems: [items.monthlyMessages({ includedUsage: 300 })],
+				features: ctx.features,
+				useInPlaceEdit: false,
+			}),
+		]);
+
+		try {
+			await timeout(250);
+		} finally {
+			releaseEntitlementLock();
+		}
+		await lockingTransaction;
+		const catalogUpdateResults = await catalogUpdates;
+		const rejectedUpdate = catalogUpdateResults.find(
+			(result) => result.status === "rejected",
+		);
+		if (rejectedUpdate) throw rejectedUpdate.reason;
+
+		const activeMessagesEntitlements = await ctx.db
+			.select({
+				id: entitlements.id,
+				allowance: entitlements.allowance,
+			})
+			.from(entitlements)
+			.where(
+				and(
+					eq(
+						entitlements.internal_product_id,
+						productBeforeUpdates.internal_id,
+					),
+					eq(
+						entitlements.internal_feature_id,
+						messagesEntitlement!.internal_feature_id,
+					),
+					eq(entitlements.is_custom, false),
+				),
+			);
+
+		expect(activeMessagesEntitlements).toHaveLength(1);
+		expect([200, 300]).toContain(activeMessagesEntitlements[0]!.allowance!);
+	},
+);

--- a/server/tests/integration/crud/plans/update/in-place/cross-version-entitlement-reference.test.ts
+++ b/server/tests/integration/crud/plans/update/in-place/cross-version-entitlement-reference.test.ts
@@ -1,0 +1,147 @@
+/**
+ * TDD test for catalog updates when a customer product references an
+ * entitlement from a newer plan version.
+ *
+ * Red-failure mode (current behavior):
+ *  - catalog.update treats the newer version as customer-free, deletes its
+ *    referenced entitlement, and hits the customer_entitlements FK.
+ *
+ * Green-success criteria (after fix):
+ *  - catalog.update retires the referenced entitlement, preserves the
+ *    customer row, and updates every plan version successfully.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	customerEntitlements,
+	entitlements,
+	ResetInterval,
+} from "@autumn/shared";
+import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect/expectStripeSubscriptionCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { CusService } from "@/internal/customers/CusService.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+
+const messagesItem = (included: number) => ({
+	feature_id: TestFeature.Messages,
+	included,
+	reset: { interval: ResetInterval.Month },
+});
+
+test.concurrent(
+	`${chalk.yellowBright("catalog.update: preserves cross-version entitlement references")}`,
+	async () => {
+		const suffix = Math.random().toString(36).slice(2, 9);
+		const customerId = `catalog-cross-version-ref-${suffix}`;
+		const plan = products.pro({
+			id: `catalog_cross_version_ref_${suffix}`,
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV1, autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [plan] }),
+			],
+			actions: [s.billing.attach({ productId: plan.id })],
+		});
+		await expectStripeSubscriptionCorrect({ ctx, customerId });
+
+		// Create v2 while the customer remains attached to v1.
+		await autumnV1.products.update(plan.id, {
+			items: [items.monthlyMessages({ includedUsage: 200 })],
+		});
+		const latestBefore = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: plan.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		expect(latestBefore.version).toBe(2);
+		const v2MessagesEntitlement = latestBefore.entitlements.find(
+			(entitlement) => entitlement.feature?.id === TestFeature.Messages,
+		);
+		expect(v2MessagesEntitlement).toBeDefined();
+
+		// Reproduce Popfly's script-created state: the v1 customer product points
+		// at a catalog entitlement owned by v2, which has no direct customers.
+		const customer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const customerProduct = customer.customer_products.find(
+			(candidate) => candidate.product_id === plan.id,
+		);
+		const customerMessagesEntitlement =
+			customerProduct?.customer_entitlements.find(
+				(customerEntitlement) =>
+					customerEntitlement.entitlement.feature_id === TestFeature.Messages,
+			);
+		expect(customerProduct?.product.version).toBe(1);
+		expect(customerMessagesEntitlement).toBeDefined();
+		await ctx.db
+			.update(customerEntitlements)
+			.set({ entitlement_id: v2MessagesEntitlement!.id })
+			.where(eq(customerEntitlements.id, customerMessagesEntitlement!.id));
+
+		await autumnV2_3.catalog.update({
+			features: [],
+			plans: [
+				{
+					plan_id: plan.id,
+					items: [messagesItem(300)],
+					all_versions: true,
+				},
+			],
+			skip_deletions: true,
+		});
+
+		const latestAfter = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: plan.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		const newMessagesEntitlement = latestAfter.entitlements.find(
+			(entitlement) => entitlement.feature?.id === TestFeature.Messages,
+		);
+		expect(newMessagesEntitlement).toMatchObject({
+			allowance: 300,
+			is_custom: false,
+		});
+		expect(newMessagesEntitlement?.id).not.toBe(v2MessagesEntitlement!.id);
+
+		const [retiredEntitlement] = await ctx.db
+			.select()
+			.from(entitlements)
+			.where(eq(entitlements.id, v2MessagesEntitlement!.id));
+		expect(retiredEntitlement?.is_custom).toBe(true);
+
+		const [preservedCustomerEntitlement] = await ctx.db
+			.select()
+			.from(customerEntitlements)
+			.where(eq(customerEntitlements.id, customerMessagesEntitlement!.id));
+		expect(preservedCustomerEntitlement?.entitlement_id).toBe(
+			v2MessagesEntitlement!.id,
+		);
+
+		const versionOne = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: plan.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+			version: 1,
+		});
+		expect(
+			versionOne.entitlements.find(
+				(entitlement) => entitlement.feature?.id === TestFeature.Messages,
+			)?.allowance,
+		).toBe(300);
+	},
+);

--- a/server/tests/integration/crud/plans/update/in-place/cross-version-entitlement-reference.test.ts
+++ b/server/tests/integration/crud/plans/update/in-place/cross-version-entitlement-reference.test.ts
@@ -21,6 +21,7 @@ import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/util
 import { TestFeature } from "@tests/setup/v2Features";
 import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
+import { timeout } from "@tests/utils/genUtils.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 import { eq } from "drizzle-orm";
@@ -85,22 +86,49 @@ test.concurrent(
 			);
 		expect(customerProduct?.product.version).toBe(1);
 		expect(customerMessagesEntitlement).toBeDefined();
-		await ctx.db
-			.update(customerEntitlements)
-			.set({ entitlement_id: v2MessagesEntitlement!.id })
-			.where(eq(customerEntitlements.id, customerMessagesEntitlement!.id));
-
-		await autumnV2_3.catalog.update({
-			features: [],
-			plans: [
-				{
-					plan_id: plan.id,
-					items: [messagesItem(300)],
-					all_versions: true,
-				},
-			],
-			skip_deletions: true,
+		let markReferenceWritten = () => {};
+		const referenceWritten = new Promise<void>((resolve) => {
+			markReferenceWritten = resolve;
 		});
+		let releaseReferenceTransaction = () => {};
+		const holdReferenceTransaction = new Promise<void>((resolve) => {
+			releaseReferenceTransaction = resolve;
+		});
+		const referenceTransaction = ctx.db.transaction(async (transaction) => {
+			await transaction
+				.update(customerEntitlements)
+				.set({ entitlement_id: v2MessagesEntitlement!.id })
+				.where(eq(customerEntitlements.id, customerMessagesEntitlement!.id));
+			markReferenceWritten();
+			await holdReferenceTransaction;
+		});
+		await Promise.race([referenceWritten, referenceTransaction]);
+
+		let catalogUpdateSettled = false;
+		const catalogUpdate = autumnV2_3.catalog
+			.update({
+				features: [],
+				plans: [
+					{
+						plan_id: plan.id,
+						items: [messagesItem(300)],
+						all_versions: true,
+					},
+				],
+				skip_deletions: true,
+			})
+			.finally(() => {
+				catalogUpdateSettled = true;
+			});
+
+		try {
+			await timeout(250);
+			expect(catalogUpdateSettled).toBe(false);
+		} finally {
+			releaseReferenceTransaction();
+		}
+		await referenceTransaction;
+		await catalogUpdate;
 
 		const latestAfter = await ProductService.getFull({
 			db: ctx.db,

--- a/server/tests/unit/products/product-items-have-customer-references.test.ts
+++ b/server/tests/unit/products/product-items-have-customer-references.test.ts
@@ -6,6 +6,7 @@ import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntit
 import { CusPriceService } from "@/internal/customers/cusProducts/cusPrices/CusPriceService.js";
 import { productItemsHaveCustomerReferences } from "@/internal/product/actions/inPlaceUpdateUtils.js";
 import { updateProductItems } from "@/internal/product/actions/updateProduct/updateProductItems.js";
+import { ProductService } from "@/internal/products/ProductService.js";
 
 afterEach(() => {
 	mock.restore();
@@ -67,52 +68,77 @@ test("product item references: leaves unreferenced product items on the fast pat
 	).toBe(false);
 });
 
-test("product item references: locks rows before checking the fast path", async () => {
+test("product item references: reloads current rows under the product lock", async () => {
 	const callOrder: string[] = [];
-	const lockQuery = {
-		from: () => ({
-			where: () => ({
-				orderBy: () => ({
-					for: async () => {
-						callOrder.push("lock");
-					},
+	let selectCount = 0;
+	const transactionDb = {
+		select: () => {
+			selectCount += 1;
+			const lockName =
+				selectCount === 1
+					? "product-lock"
+					: selectCount === 2
+						? "entitlement-lock"
+						: "price-lock";
+			const lock = async (strength: string) => {
+				callOrder.push(`${lockName}:${strength}`);
+			};
+			return {
+				from: () => ({
+					where: () => ({
+						for: lock,
+						orderBy: () => ({ for: lock }),
+					}),
 				}),
-			}),
-		}),
-	};
+			};
+		},
+		delete: () => ({ where: async () => undefined }),
+		query: { prices: { findMany: async () => [] } },
+	} as unknown as DrizzleCli;
 	const db = {
 		transaction: async (
 			callback: (transaction: DrizzleCli) => Promise<void>,
 		) => {
 			callOrder.push("transaction");
-			await callback(db as unknown as DrizzleCli);
+			await callback(transactionDb);
 		},
-		select: () => lockQuery,
-		delete: () => ({ where: async () => undefined }),
-		query: { prices: { findMany: async () => [] } },
 	} as unknown as DrizzleCli;
 	const currentFullProduct = {
 		id: "plan",
 		internal_id: "plan_internal",
 		org_id: "org",
 		env: "sandbox",
-		entitlements: [{ id: "entitlement" }],
-		prices: [{ id: "price" }],
+		version: 1,
+		entitlements: [{ id: "stale-entitlement" }],
+		prices: [{ id: "stale-price" }],
+	} as FullProduct;
+	const refreshedFullProduct = {
+		...currentFullProduct,
+		entitlements: [{ id: "current-entitlement" }],
+		prices: [{ id: "current-price" }],
 	} as FullProduct;
 	const ctx = { org: { config: {} } } as AutumnContext;
+	const reloadSpy = spyOn(ProductService, "getFull").mockImplementation(
+		async () => {
+			callOrder.push("reload");
+			return refreshedFullProduct;
+		},
+	);
 
-	spyOn(CusEntService, "hasAnyEntitlementReferences").mockImplementation(
-		async () => {
-			callOrder.push("entitlement-check");
-			return false;
-		},
-	);
-	spyOn(CusPriceService, "hasAnyPriceReferences").mockImplementation(
-		async () => {
-			callOrder.push("price-check");
-			return false;
-		},
-	);
+	const entitlementReferenceSpy = spyOn(
+		CusEntService,
+		"hasAnyEntitlementReferences",
+	).mockImplementation(async () => {
+		callOrder.push("entitlement-check");
+		return false;
+	});
+	const priceReferenceSpy = spyOn(
+		CusPriceService,
+		"hasAnyPriceReferences",
+	).mockImplementation(async () => {
+		callOrder.push("price-check");
+		return false;
+	});
 
 	await updateProductItems({
 		ctx,
@@ -123,11 +149,28 @@ test("product item references: locks rows before checking the fast path", async 
 		useInPlaceEdit: false,
 	});
 
-	expect(callOrder.slice(0, 5)).toEqual([
+	expect(callOrder.slice(0, 7)).toEqual([
 		"transaction",
-		"lock",
-		"lock",
+		"product-lock:no key update",
+		"reload",
+		"entitlement-lock:update",
+		"price-lock:update",
 		"entitlement-check",
 		"price-check",
 	]);
+	expect(reloadSpy).toHaveBeenCalledWith({
+		db: transactionDb,
+		idOrInternalId: "plan_internal",
+		orgId: "org",
+		env: "sandbox",
+		version: 1,
+	});
+	expect(entitlementReferenceSpy).toHaveBeenCalledWith({
+		db: transactionDb,
+		entitlementIds: ["current-entitlement"],
+	});
+	expect(priceReferenceSpy).toHaveBeenCalledWith({
+		db: transactionDb,
+		priceIds: ["current-price"],
+	});
 });

--- a/server/tests/unit/products/product-items-have-customer-references.test.ts
+++ b/server/tests/unit/products/product-items-have-customer-references.test.ts
@@ -19,12 +19,12 @@ test.concurrent(
 		} as FullProduct;
 		const entitlementReferenceSpy = spyOn(
 			CusEntService,
-			"getReferencedEntitlementIds",
-		).mockResolvedValue(new Set(["ent_cross_version"]));
+			"hasAnyEntitlementReferences",
+		).mockResolvedValue(true);
 		const priceReferenceSpy = spyOn(
 			CusPriceService,
-			"getReferencedPriceIds",
-		).mockResolvedValue(new Set());
+			"hasAnyPriceReferences",
+		).mockResolvedValue(false);
 
 		expect(
 			await productItemsHaveCustomerReferences({ db, currentFullProduct }),
@@ -37,5 +37,43 @@ test.concurrent(
 			db,
 			priceIds: ["price_unreferenced"],
 		});
+	},
+);
+
+test.concurrent(
+	"product item references: detects customer prices without direct customer products",
+	async () => {
+		const db = {} as DrizzleCli;
+		const currentFullProduct = {
+			entitlements: [{ id: "ent_unreferenced" }],
+			prices: [{ id: "price_cross_version" }],
+		} as FullProduct;
+		spyOn(CusEntService, "hasAnyEntitlementReferences").mockResolvedValue(
+			false,
+		);
+		spyOn(CusPriceService, "hasAnyPriceReferences").mockResolvedValue(true);
+
+		expect(
+			await productItemsHaveCustomerReferences({ db, currentFullProduct }),
+		).toBe(true);
+	},
+);
+
+test.concurrent(
+	"product item references: leaves unreferenced product items on the fast path",
+	async () => {
+		const db = {} as DrizzleCli;
+		const currentFullProduct = {
+			entitlements: [{ id: "ent_unreferenced" }],
+			prices: [{ id: "price_unreferenced" }],
+		} as FullProduct;
+		spyOn(CusEntService, "hasAnyEntitlementReferences").mockResolvedValue(
+			false,
+		);
+		spyOn(CusPriceService, "hasAnyPriceReferences").mockResolvedValue(false);
+
+		expect(
+			await productItemsHaveCustomerReferences({ db, currentFullProduct }),
+		).toBe(false);
 	},
 );

--- a/server/tests/unit/products/product-items-have-customer-references.test.ts
+++ b/server/tests/unit/products/product-items-have-customer-references.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, expect, mock, spyOn, test } from "bun:test";
+import type { FullProduct } from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
+import { CusPriceService } from "@/internal/customers/cusProducts/cusPrices/CusPriceService.js";
+import { productItemsHaveCustomerReferences } from "@/internal/product/actions/inPlaceUpdateUtils.js";
+
+afterEach(() => {
+	mock.restore();
+});
+
+test.concurrent(
+	"product item references: detects customer entitlements without direct customer products",
+	async () => {
+		const db = {} as DrizzleCli;
+		const currentFullProduct = {
+			entitlements: [{ id: "ent_cross_version" }],
+			prices: [{ id: "price_unreferenced" }],
+		} as FullProduct;
+		const entitlementReferenceSpy = spyOn(
+			CusEntService,
+			"getReferencedEntitlementIds",
+		).mockResolvedValue(new Set(["ent_cross_version"]));
+		const priceReferenceSpy = spyOn(
+			CusPriceService,
+			"getReferencedPriceIds",
+		).mockResolvedValue(new Set());
+
+		expect(
+			await productItemsHaveCustomerReferences({ db, currentFullProduct }),
+		).toBe(true);
+		expect(entitlementReferenceSpy).toHaveBeenCalledWith({
+			db,
+			entitlementIds: ["ent_cross_version"],
+		});
+		expect(priceReferenceSpy).toHaveBeenCalledWith({
+			db,
+			priceIds: ["price_unreferenced"],
+		});
+	},
+);

--- a/server/tests/unit/products/product-items-have-customer-references.test.ts
+++ b/server/tests/unit/products/product-items-have-customer-references.test.ts
@@ -1,79 +1,133 @@
 import { afterEach, expect, mock, spyOn, test } from "bun:test";
 import type { FullProduct } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
 import { CusPriceService } from "@/internal/customers/cusProducts/cusPrices/CusPriceService.js";
 import { productItemsHaveCustomerReferences } from "@/internal/product/actions/inPlaceUpdateUtils.js";
+import { updateProductItems } from "@/internal/product/actions/updateProduct/updateProductItems.js";
 
 afterEach(() => {
 	mock.restore();
 });
 
-test.concurrent(
-	"product item references: detects customer entitlements without direct customer products",
-	async () => {
-		const db = {} as DrizzleCli;
-		const currentFullProduct = {
-			entitlements: [{ id: "ent_cross_version" }],
-			prices: [{ id: "price_unreferenced" }],
-		} as FullProduct;
-		const entitlementReferenceSpy = spyOn(
-			CusEntService,
-			"hasAnyEntitlementReferences",
-		).mockResolvedValue(true);
-		const priceReferenceSpy = spyOn(
-			CusPriceService,
-			"hasAnyPriceReferences",
-		).mockResolvedValue(false);
+test("product item references: detects customer entitlements without direct customer products", async () => {
+	const db = {} as DrizzleCli;
+	const currentFullProduct = {
+		entitlements: [{ id: "ent_cross_version" }],
+		prices: [{ id: "price_unreferenced" }],
+	} as FullProduct;
+	const entitlementReferenceSpy = spyOn(
+		CusEntService,
+		"hasAnyEntitlementReferences",
+	).mockResolvedValue(true);
+	const priceReferenceSpy = spyOn(
+		CusPriceService,
+		"hasAnyPriceReferences",
+	).mockResolvedValue(false);
 
-		expect(
-			await productItemsHaveCustomerReferences({ db, currentFullProduct }),
-		).toBe(true);
-		expect(entitlementReferenceSpy).toHaveBeenCalledWith({
-			db,
-			entitlementIds: ["ent_cross_version"],
-		});
-		expect(priceReferenceSpy).toHaveBeenCalledWith({
-			db,
-			priceIds: ["price_unreferenced"],
-		});
-	},
-);
+	expect(
+		await productItemsHaveCustomerReferences({ db, currentFullProduct }),
+	).toBe(true);
+	expect(entitlementReferenceSpy).toHaveBeenCalledWith({
+		db,
+		entitlementIds: ["ent_cross_version"],
+	});
+	expect(priceReferenceSpy).toHaveBeenCalledWith({
+		db,
+		priceIds: ["price_unreferenced"],
+	});
+});
 
-test.concurrent(
-	"product item references: detects customer prices without direct customer products",
-	async () => {
-		const db = {} as DrizzleCli;
-		const currentFullProduct = {
-			entitlements: [{ id: "ent_unreferenced" }],
-			prices: [{ id: "price_cross_version" }],
-		} as FullProduct;
-		spyOn(CusEntService, "hasAnyEntitlementReferences").mockResolvedValue(
-			false,
-		);
-		spyOn(CusPriceService, "hasAnyPriceReferences").mockResolvedValue(true);
+test("product item references: detects customer prices without direct customer products", async () => {
+	const db = {} as DrizzleCli;
+	const currentFullProduct = {
+		entitlements: [{ id: "ent_unreferenced" }],
+		prices: [{ id: "price_cross_version" }],
+	} as FullProduct;
+	spyOn(CusEntService, "hasAnyEntitlementReferences").mockResolvedValue(false);
+	spyOn(CusPriceService, "hasAnyPriceReferences").mockResolvedValue(true);
 
-		expect(
-			await productItemsHaveCustomerReferences({ db, currentFullProduct }),
-		).toBe(true);
-	},
-);
+	expect(
+		await productItemsHaveCustomerReferences({ db, currentFullProduct }),
+	).toBe(true);
+});
 
-test.concurrent(
-	"product item references: leaves unreferenced product items on the fast path",
-	async () => {
-		const db = {} as DrizzleCli;
-		const currentFullProduct = {
-			entitlements: [{ id: "ent_unreferenced" }],
-			prices: [{ id: "price_unreferenced" }],
-		} as FullProduct;
-		spyOn(CusEntService, "hasAnyEntitlementReferences").mockResolvedValue(
-			false,
-		);
-		spyOn(CusPriceService, "hasAnyPriceReferences").mockResolvedValue(false);
+test("product item references: leaves unreferenced product items on the fast path", async () => {
+	const db = {} as DrizzleCli;
+	const currentFullProduct = {
+		entitlements: [{ id: "ent_unreferenced" }],
+		prices: [{ id: "price_unreferenced" }],
+	} as FullProduct;
+	spyOn(CusEntService, "hasAnyEntitlementReferences").mockResolvedValue(false);
+	spyOn(CusPriceService, "hasAnyPriceReferences").mockResolvedValue(false);
 
-		expect(
-			await productItemsHaveCustomerReferences({ db, currentFullProduct }),
-		).toBe(false);
-	},
-);
+	expect(
+		await productItemsHaveCustomerReferences({ db, currentFullProduct }),
+	).toBe(false);
+});
+
+test("product item references: locks rows before checking the fast path", async () => {
+	const callOrder: string[] = [];
+	const lockQuery = {
+		from: () => ({
+			where: () => ({
+				orderBy: () => ({
+					for: async () => {
+						callOrder.push("lock");
+					},
+				}),
+			}),
+		}),
+	};
+	const db = {
+		transaction: async (
+			callback: (transaction: DrizzleCli) => Promise<void>,
+		) => {
+			callOrder.push("transaction");
+			await callback(db as unknown as DrizzleCli);
+		},
+		select: () => lockQuery,
+		delete: () => ({ where: async () => undefined }),
+		query: { prices: { findMany: async () => [] } },
+	} as unknown as DrizzleCli;
+	const currentFullProduct = {
+		id: "plan",
+		internal_id: "plan_internal",
+		org_id: "org",
+		env: "sandbox",
+		entitlements: [{ id: "entitlement" }],
+		prices: [{ id: "price" }],
+	} as FullProduct;
+	const ctx = { org: { config: {} } } as AutumnContext;
+
+	spyOn(CusEntService, "hasAnyEntitlementReferences").mockImplementation(
+		async () => {
+			callOrder.push("entitlement-check");
+			return false;
+		},
+	);
+	spyOn(CusPriceService, "hasAnyPriceReferences").mockImplementation(
+		async () => {
+			callOrder.push("price-check");
+			return false;
+		},
+	);
+
+	await updateProductItems({
+		ctx,
+		db,
+		fullProduct: currentFullProduct,
+		newItems: [],
+		features: [],
+		useInPlaceEdit: false,
+	});
+
+	expect(callOrder.slice(0, 5)).toEqual([
+		"transaction",
+		"lock",
+		"lock",
+		"entitlement-check",
+		"price-check",
+	]);
+});


### PR DESCRIPTION
## Summary

- detect customer references to a plan version's entitlements and prices before choosing the catalog delete path
- route referenced product items through the existing in-place update flow so referenced rows are retired instead of deleted
- add unit and integration coverage for the Popfly-shaped cross-version entitlement state

## Root cause

The update path only used direct customer-product ownership to decide whether an in-place edit was required. A customer product from an older plan version could reference an entitlement owned by the latest version, leaving that latest version with no direct customer products. `catalog.update` then chose the delete path and attempted to remove a still-referenced entitlement.

## Impact

Catalog updates now preserve cross-version customer entitlement and price references while retaining the existing fast path for genuinely unreferenced product items.

## Validation

- focused regression: failed without the fix and passed with it
- `bun test tests/unit/products/product-items-have-customer-references.test.ts`
- `bun ts`
- pre-commit `knip` and server typecheck
- Biome and `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `catalog.update` to preserve cross-version customer references and to prevent duplicate active items during concurrent updates. Reloads the current product under a product lock and routes referenced items through in-place retirement instead of delete.

- **Bug Fixes**
  - Detect cross-version references to the current product’s entitlement and price IDs before choosing the delete path.
  - Always use a transaction: lock the product (`FOR NO KEY UPDATE`), reload current items, then lock entitlements and prices (`FOR UPDATE`) before deciding; prevents races and duplicate active rows.
  - Run the fast path inside the same transaction so the decision and writes are atomic.

- **Performance**
  - Add bounded “hasAny” checks in `CusEntService` and `CusPriceService` to short-circuit on the first match and reduce query cost.

<sup>Written for commit 729ff703f0192e0c98d0ea897817e61a022589c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a FK violation in `catalog.update` where a customer product from an older plan version could reference an entitlement owned by the latest version, leading the update path to delete the still-referenced entitlement. The fix detects cross-version references (both entitlement and price) and routes those cases through the existing in-place retirement flow.

- **Bug fixes** — `updateProductItems` now always opens a transaction, acquires `FOR UPDATE` locks on the current product's entitlements/prices rows, and checks for cross-version customer references before deciding between the delete and retire paths; this prevents FK errors caused by catalog updates on product versions that have no direct customer products but are still referenced via cross-version `customer_entitlements` or `customer_prices` rows.
- **Improvements** — two new bounded "hasAny" helpers (`CusEntService.hasAnyEntitlementReferences`, `CusPriceService.hasAnyPriceReferences`) short-circuit on the first match, keeping the fast-path check cheap; the row-lock ordering (entitlements then prices, both sorted by id) is consistent across all paths, preventing deadlocks between concurrent catalog updates.
- **Bug fixes** — the fast-path `handleNewProductItems` call was previously executed outside any transaction; it is now wrapped in the same transaction as the lock acquisition and reference check, ensuring the decision and the writes are atomic.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the locking strategy is sound, all changed paths are covered by new tests, and the behavioral change (fast path now inside a transaction) is consistent with how the in-place path already worked.

The FOR UPDATE acquisition on entitlement and price rows correctly serializes with PostgreSQL's FK KEY SHARE locks, ensuring the cross-version reference check always reads committed state. Lock ordering is consistent (entitlements then prices, both sorted by id) across all concurrent callers, preventing deadlocks. The fast-path behavior change — moving handleNewProductItems inside the transaction — is safe because that function was already called inside a transaction on the in-place path. Both the race-condition scenario and the unit-level routing logic are directly exercised by the new tests.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/product/actions/updateProduct/updateProductItems.ts | Core orchestration change: wraps all paths (fast delete and in-place retire) in a single transaction, acquires row locks before the routing decision, and adds cross-version reference check to extend useInPlaceEdit to products with no direct customers. |
| server/src/internal/product/actions/inPlaceUpdateUtils.ts | Adds lockProductItemsForUpdate (FOR UPDATE on entitlements then prices, sorted by id to avoid deadlocks) and productItemsHaveCustomerReferences (parallel hasAny checks). Minor whitespace-only refactor to retireOrDeleteRows. |
| server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts | Adds hasAnyEntitlementReferences — bounded SELECT LIMIT 1 from customerEntitlements; correctly guards the empty-array case. |
| server/src/internal/customers/cusProducts/cusPrices/CusPriceService.ts | Adds hasAnyPriceReferences — bounded SELECT LIMIT 1 from customerPrices; mirrors the entitlement helper exactly. |
| server/tests/integration/crud/plans/update/in-place/cross-version-entitlement-reference.test.ts | New integration test reproducing the Popfly scenario: creates v1 customer, upgrades catalog to v2, redirects the customer entitlement to v2's row, then verifies the catalog update blocks on the lock, retires the v2 entitlement, and updates both versions without FK errors. |
| server/tests/unit/products/product-items-have-customer-references.test.ts | Unit tests for productItemsHaveCustomerReferences (entitlement-only, price-only, neither) and for updateProductItems lock-before-check ordering using a mock DB. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CA as catalog.update
    participant UPI as updateProductItems
    participant Lock as lockProductItemsForUpdate
    participant RefChk as productItemsHaveCustomerReferences
    participant DB as PostgreSQL
    participant RT as referenceTransaction (concurrent)

    RT->>DB: "UPDATE customerEntitlements SET entitlement_id = v2EntId"
    Note over RT,DB: PostgreSQL acquires KEY SHARE on entitlements(v2EntId)
    RT-->>RT: holds transaction open

    CA->>UPI: "updateProductItems(useInPlaceEdit=false)"
    UPI->>DB: BEGIN TRANSACTION
    UPI->>Lock: lockProductItemsForUpdate(v2 entitlements, v2 prices)
    Lock->>DB: SELECT FOR UPDATE on entitlements(v2EntId) ORDER BY id
    Note over Lock,DB: FOR UPDATE conflicts with KEY SHARE - BLOCKS
    RT->>DB: COMMIT (referenceTransaction released)
    DB-->>Lock: lock acquired (sees committed reference)
    Lock->>DB: SELECT FOR UPDATE on prices(v2PriceId) ORDER BY id
    Lock-->>UPI: locks held

    UPI->>RefChk: productItemsHaveCustomerReferences
    RefChk->>DB: SELECT FROM customerEntitlements WHERE entitlement_id IN (v2EntId) LIMIT 1
    Note over RefChk,DB: Committed reference visible - returns true
    RefChk->>DB: SELECT FROM customerPrices WHERE price_id IN (...) LIMIT 1
    RefChk-->>UPI: "hasReferences = true, shouldUseInPlaceEdit = true"

    UPI->>DB: "resolveInPlaceEdit - retireOrDeleteRows (retire v2EntId, is_custom=true)"
    UPI->>DB: handleNewProductItems (insert new v3 entitlement)
    UPI->>DB: COMMIT
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CA as catalog.update
    participant UPI as updateProductItems
    participant Lock as lockProductItemsForUpdate
    participant RefChk as productItemsHaveCustomerReferences
    participant DB as PostgreSQL
    participant RT as referenceTransaction (concurrent)

    RT->>DB: "UPDATE customerEntitlements SET entitlement_id = v2EntId"
    Note over RT,DB: PostgreSQL acquires KEY SHARE on entitlements(v2EntId)
    RT-->>RT: holds transaction open

    CA->>UPI: "updateProductItems(useInPlaceEdit=false)"
    UPI->>DB: BEGIN TRANSACTION
    UPI->>Lock: lockProductItemsForUpdate(v2 entitlements, v2 prices)
    Lock->>DB: SELECT FOR UPDATE on entitlements(v2EntId) ORDER BY id
    Note over Lock,DB: FOR UPDATE conflicts with KEY SHARE - BLOCKS
    RT->>DB: COMMIT (referenceTransaction released)
    DB-->>Lock: lock acquired (sees committed reference)
    Lock->>DB: SELECT FOR UPDATE on prices(v2PriceId) ORDER BY id
    Lock-->>UPI: locks held

    UPI->>RefChk: productItemsHaveCustomerReferences
    RefChk->>DB: SELECT FROM customerEntitlements WHERE entitlement_id IN (v2EntId) LIMIT 1
    Note over RefChk,DB: Committed reference visible - returns true
    RefChk->>DB: SELECT FROM customerPrices WHERE price_id IN (...) LIMIT 1
    RefChk-->>UPI: "hasReferences = true, shouldUseInPlaceEdit = true"

    UPI->>DB: "resolveInPlaceEdit - retireOrDeleteRows (retire v2EntId, is_custom=true)"
    UPI->>DB: handleNewProductItems (insert new v3 entitlement)
    UPI->>DB: COMMIT
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: serialize catalog item reference ch..."](https://github.com/useautumn/autumn/commit/e4b60005cce00325153beafecfba33ba32d17d18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44413977)</sub>

<!-- /greptile_comment -->