### PR TITLE
Improve Slack billing approval cards

### DIFF
--- a/apps/leaf/src/ui/blocks.ts
+++ b/apps/leaf/src/ui/blocks.ts
@@ -78,6 +78,11 @@ const bold = (value: string) => `**${value}**`;
 
 const mention = (userId?: string) => (userId ? `<@${userId}>` : null);
 
+const compactCustomerLabel = (customerId: string) =>
+	/^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(customerId)
+		? `${customerId.slice(0, 8)}…${customerId.slice(-5)}`
+		: customerId;
+
 const autumnDashboardBase = () =>
 	process.env.AUTUMN_DASHBOARD_URL ?? "https://app.useautumn.com";
 
@@ -137,20 +142,32 @@ type ActionPhrases = {
 // action, so they render as a sentence — never as label/value fields.
 const actionPhrases = ({
 	env,
+	preview,
 	toolArgs,
 	toolName,
 }: {
 	env?: AppEnv;
+	preview?: unknown;
 	toolArgs?: Record<string, unknown>;
 	toolName: string;
 }): ActionPhrases => {
 	const request = getRequest(toolArgs) ?? {};
 	const customer = getString(request.customer_id);
-	const plan = getString(request.plan_id);
+	const previewPlan = BILLING_ACTION_TOOLS.has(normalizeToolName(toolName))
+		? buildBillingPreviewDisplay({
+				params: request,
+				preview: parsePreviewPayload(preview),
+			}).changes.incoming[0]?.name
+		: null;
+	const plan = previewPlan ?? getString(request.plan_id);
 	const entity = getString(request.entity_id);
 	const customerUrl = autumnCustomerLink({ customerId: customer, env });
 	const customerLabel = customer
-		? bold(customerUrl ? `<${customerUrl}|${customer}>` : customer)
+		? bold(
+				customerUrl
+					? `<${customerUrl}|${compactCustomerLabel(customer)}>`
+					: compactCustomerLabel(customer),
+			)
 		: "the customer";
 	const planLabel = plan ? bold(plan) : "the plan";
 	const entitySuffix = entity ? ` (entity ${bold(entity)})` : "";
@@ -669,39 +686,64 @@ const approvalPreviewBlocks = ({
 	if (display.intentLabel) {
 		blocks.push(CardText(display.intentLabel));
 	}
-	if (display.changes.summaryText) {
+	const repeatsAttach =
+		normalizeToolName(toolName) === "attach" &&
+		display.changes.incoming.length > 0 &&
+		display.changes.outgoing.length === 0;
+	if (display.changes.summaryText && !repeatsAttach) {
 		blocks.push(CardText(display.changes.summaryText));
 	}
-	const planId =
-		display.changes.incoming[0]?.planId ?? getString(request?.plan_id);
-	if (display.customize?.priceText && planId) {
+	if (display.customize?.priceText) {
 		blocks.push(
 			CardText(
-				`${bold(planId)} — ${display.customize.priceText}${
+				`${bold("Recurring price")}  ${display.customize.priceText}${
 					display.customize.freeTrialText
 						? ` · ${display.customize.freeTrialText}`
 						: ""
-				}  \`custom\``,
+				}`,
 			),
 		);
 	}
-	const customizeLines = [
-		...(display.customize?.replacedItems.map(
-			(item) => `• ${item} (replaces plan items)`,
-		) ?? []),
-		...(display.customize?.addedItems.map((item) => `＋ ${item}`) ?? []),
-		...(display.customize?.removedItems.map((item) => `− ${item}`) ?? []),
-		...(display.customize?.updatedItems.map((item) => `~ ${item}`) ?? []),
-	];
+	const changeGroup = ({
+		heading,
+		items,
+	}: {
+		heading: string;
+		items: string[];
+	}) =>
+		items.length
+			? [bold(heading), ...items.map((item) => `• ${item}`)].join("\n")
+			: null;
+	const customizeLines = display.customize
+		? [
+				changeGroup({
+					heading: "Updated plan items",
+					items: [
+						...display.customize.replacedItems.map(
+							(item) => `${item} (replaces plan items)`,
+						),
+						...display.customize.updatedItems,
+					],
+				}),
+				changeGroup({
+					heading: "Added to plan",
+					items: display.customize.addedItems,
+				}),
+				changeGroup({
+					heading: "Removed from plan",
+					items: display.customize.removedItems,
+				}),
+			].filter((group): group is string => group !== null)
+		: [];
 	if (customizeLines.length) {
-		blocks.push(CardText([bold("Plan changes"), ...customizeLines].join("\n")));
+		blocks.push(CardText(customizeLines.join("\n\n")));
 	}
 	// Prepaid quantities are silent money decisions — an omitted quantity
 	// defaults to 0 server-side, so the approver must see it either way.
 	const prepaidLines = display.prepaid.map((entry) =>
 		entry.quantity !== null
-			? `${entry.featureId} — ${formatCount(entry.quantity)} prepaid`
-			: `⚠️ ${entry.featureId} — prepaid quantity not set (defaults to 0${
+			? `${entry.featureName} — ${formatCount(entry.quantity)} prepaid`
+			: `⚠️ ${entry.featureName} — prepaid quantity not set (defaults to 0${
 					entry.includedDefault
 						? `; plan includes ${formatCount(entry.includedDefault)}`
 						: ""
@@ -744,7 +786,7 @@ const approvalPreviewBlocks = ({
 	if (moneyLines.length) {
 		blocks.push(CardText(moneyLines.join("\n")));
 	} else if (zeroNoCharge) {
-		blocks.push(CardText("No charge now", { style: "muted" }));
+		blocks.push(CardText(bold("No charge today")));
 	} else {
 		pushMoney();
 	}
@@ -767,9 +809,9 @@ const approvalPreviewBlocks = ({
 	const startsAt = getNumber(request?.starts_at);
 	const mutedLine = contextLine([
 		display.nextCycle
-			? `Next cycle${
+			? `Next charge${
 					display.nextCycle.startsAtText
-						? ` · ${display.nextCycle.startsAtText}`
+						? ` on ${display.nextCycle.startsAtText}`
 						: ""
 				} — ${display.nextCycle.text}`
 			: null,
@@ -809,7 +851,7 @@ const settledStatusCard = ({
 	toolArgs?: Record<string, unknown>;
 	toolName: string;
 }) => {
-	const phrases = actionPhrases({ env, toolArgs, toolName });
+	const phrases = actionPhrases({ env, preview, toolArgs, toolName });
 	return Card({
 		title: toolLabel(toolName),
 		subtitle: envLine(env) || undefined,
@@ -839,7 +881,7 @@ export const approvalCard = ({
 	toolArgs?: Record<string, unknown>;
 	toolName: string;
 }) => {
-	const phrases = actionPhrases({ env, toolArgs, toolName });
+	const phrases = actionPhrases({ env, preview, toolArgs, toolName });
 	const requester = mention(requesterId);
 	const live = env === "live";
 	const summaryText = summary?.trim() ? formatSummary(summary) : null;
@@ -870,7 +912,7 @@ export const approvalCard = ({
 				Button({
 					actionType: "modal",
 					id: "view_approval_payload",
-					label: "{} Payload",
+					label: "View Payload",
 					value: id,
 				}),
 			]),
@@ -931,7 +973,7 @@ export const approvalStatusCard = ({
 	toolArgs?: Record<string, unknown>;
 	toolName: string;
 }) => {
-	const phrases = actionPhrases({ env, toolArgs, toolName });
+	const phrases = actionPhrases({ env, preview, toolArgs, toolName });
 	const actor = mention(actorId);
 	const where = envLine(env);
 	const mutedContext = (parts: Array<string | null | undefined>) => {

--- a/apps/leaf/tests/e2e/eveSlack.e2e.ts
+++ b/apps/leaf/tests/e2e/eveSlack.e2e.ts
@@ -308,7 +308,7 @@ const main = async () => {
 			const cardJson = JSON.stringify(target.posted.at(-1)?.content ?? {});
 			check(
 				"S2 card has receipt/money facts",
-				/Due (now|today)|No charge now/.test(cardJson),
+				/Due (now|today)|No charge today/.test(cardJson),
 				cardJson.slice(0, 300),
 			);
 			check("S2 card has params badges", cardJson.includes("Prorations"));

--- a/apps/leaf/tests/unit/ui/blocks.test.ts
+++ b/apps/leaf/tests/unit/ui/blocks.test.ts
@@ -50,13 +50,38 @@ describe("approval card", () => {
 		);
 		expect(json).toContain("Due now");
 		expect(json).toContain("$400.00");
-		expect(json).toContain("Next cycle · Jul 12, 2026 — $400.00");
+		expect(json).toContain("Next charge on Jul 12, 2026 — $400.00");
 		expect(json).toContain("✓ Invoice (draft)");
 		expect(json).not.toContain("Prorations");
 		expect(card.children.at(-1)?.type).toBe("actions");
 		expect(json).toContain("approve_billing_action");
 		expect(json).toContain("Dismiss");
 		expect(json).not.toContain('"request"');
+	});
+
+	test("uses the plan name as the attach subject without repeating it", () => {
+		const card = approvalCard({
+			id: "approval_1",
+			toolName: "attach",
+			toolArgs: {
+				request: { customer_id: "testa", plan_id: "mc_e2e_sdkce88" },
+			},
+			preview: wrapMcpResult({
+				preview: {
+					incoming: [
+						{
+							plan_id: "mc_e2e_sdkce88",
+							plan: { name: "MC E2E Plan" },
+						},
+					],
+				},
+			}),
+		});
+
+		const json = JSON.stringify(card);
+		expect(json).toContain("Attach **MC E2E Plan** to **testa**?");
+		expect(json).not.toContain("Attach **mc_e2e_sdkce88**");
+		expect(json).not.toContain("Attaching MC E2E Plan");
 	});
 
 	test("escalates live environment on the subtitle and approve button", () => {
@@ -74,7 +99,7 @@ describe("approval card", () => {
 		);
 	});
 
-	test("shows custom prices as a money field, not a param dump", () => {
+	test("shows custom prices as the recurring price, not a param dump", () => {
 		const card = approvalCard({
 			id: "approval_1",
 			toolName: "updateSubscription",
@@ -89,7 +114,7 @@ describe("approval card", () => {
 
 		const json = JSON.stringify(card);
 		expect(json).toContain("Update **charlie**'s subscription to **pro**?");
-		expect(json).toContain("Custom price");
+		expect(json).toContain("Recurring price");
 		expect(json).toContain("$200.00/month");
 		expect(json).not.toContain('"customize"');
 	});
@@ -152,7 +177,7 @@ describe("approval card", () => {
 
 		const json = JSON.stringify(card);
 		expect(json).toContain("view_approval_payload");
-		expect(json).toContain("{} Payload");
+		expect(json).toContain("View Payload");
 	});
 
 	test("renders customized add_items and remove_items as grouped changes", () => {
@@ -186,23 +211,88 @@ describe("approval card", () => {
 							},
 						],
 						remove_items: [
+							{ feature_id: "credits" },
 							{ feature_id: "audit_logs" },
 							{ billing_method: "prepaid", interval: "year" },
 						],
 					},
 				},
 			},
+			preview: wrapMcpResult({
+				preview: {
+					incoming: [
+						{
+							plan: {
+								items: [
+									{ feature_id: "seats", feature: { name: "Seats" } },
+									{ feature_id: "credits", feature: { name: "Credits" } },
+									{ feature_id: "api_calls", feature: { name: "API Calls" } },
+								],
+							},
+						},
+					],
+					outgoing: [
+						{
+							plan: {
+								items: [
+									{ feature_id: "credits", feature: { name: "Credits" } },
+									{ feature_id: "audit_logs", feature: { name: "Audit Logs" } },
+								],
+							},
+						},
+					],
+				},
+			}),
 		});
 
 		const json = JSON.stringify(card);
-		expect(json).toContain("**Plan changes**");
-		expect(json).toContain("＋ seats — unlimited");
+		expect(json).toContain("**Updated plan items**");
 		expect(json).toContain(
-			"＋ credits — 5,000 included, then $0.10 each · usage-based · monthly",
+			"• Credits — 5,000 included, then $0.10 each · usage-based · monthly",
 		);
-		expect(json).toContain("＋ api_calls — $5.00 per 1,000 · usage-based");
-		expect(json).toContain("− audit_logs");
-		expect(json).toContain("− prepaid · yearly");
+		expect(json).toContain("**Added to plan**");
+		expect(json).toContain("• Seats — unlimited");
+		expect(json).toContain("• API Calls — $5.00 per 1,000 · usage-based");
+		expect(json).toContain("**Removed from plan**");
+		expect(json).toContain("• Audit Logs");
+		expect(json).toContain("• prepaid · yearly");
+		expect(json).not.toContain("**Plan changes**");
+	});
+
+	test("shows no charge today and keeps the full removal list", () => {
+		const removeItems = Array.from({ length: 10 }, (_, index) => ({
+			feature_id: `feature_${index + 1}`,
+		}));
+		const card = approvalCard({
+			id: "approval_1",
+			toolName: "attach",
+			toolArgs: {
+				request: {
+					...attachArgs.request,
+					customize: { remove_items: removeItems },
+				},
+			},
+			preview: wrapMcpResult({ preview: { total: 0, currency: "usd" } }),
+		});
+
+		const json = JSON.stringify(card);
+		expect(json).toContain("No charge today");
+		expect(json).toContain("Feature 10");
+		expect(json).not.toContain("No charge now");
+	});
+
+	test("shortens UUID customer labels without shortening their link", () => {
+		const customerId = "085298c2-2d68-429b-a583-2165976701fa";
+		const card = approvalCard({
+			id: "approval_1",
+			env: AppEnv.Live,
+			toolName: "attach",
+			toolArgs: { request: { customer_id: customerId, plan_id: "pro" } },
+		});
+		const json = JSON.stringify(card);
+
+		expect(json).toContain("085298c2…701fa");
+		expect(json).toContain(`/customers/${customerId}`);
 	});
 
 	test("omits the changes block when nothing is customized", () => {

--- a/apps/leaf/tests/unit/ui/previewContent.test.ts
+++ b/apps/leaf/tests/unit/ui/previewContent.test.ts
@@ -111,7 +111,7 @@ describe("approvalCard with structured previews", () => {
 		// Structured previews render receipt-style: line items + totals in a table.
 		expect(json).toContain("Due now");
 		expect(json).toContain("$25.50");
-		expect(json).toContain("Next cycle");
+		expect(json).toContain("Next charge");
 		expect(json).toContain("$40.00");
 		expect(card.children.at(-1)?.type).toBe("actions");
 	});

--- a/packages/mcp/src/tools/billing.ts
+++ b/packages/mcp/src/tools/billing.ts
@@ -61,6 +61,11 @@ const { billingPreview, confirmedWrite } = createDomainTools({
 	schemas,
 });
 
+const planItemExpand = [
+	"incoming.plan.items.feature",
+	"outgoing.plan.items.feature",
+];
+
 const domain = {
 	billingPreviews: [
 		billingPreview({
@@ -69,6 +74,7 @@ const domain = {
 - Preview attaching a plan before attach.
 - Follow the Billing resource.
 `.trim(),
+			expand: planItemExpand,
 			writeToolName: "attach",
 		}),
 		billingPreview({
@@ -77,6 +83,7 @@ const domain = {
 - Preview updating a subscription before updateSubscription.
 - Follow the Billing resource.
 `.trim(),
+			expand: planItemExpand,
 			writeToolName: "updateSubscription",
 		}),
 		billingPreview({
@@ -85,6 +92,7 @@ const domain = {
 - Preview billing impact of a multi-phase schedule or multi-year order form before createSchedule.
 - Follow the Billing resource.
 `.trim(),
+			expand: planItemExpand,
 			writeToolName: "createSchedule",
 		}),
 	],

--- a/packages/mcp/src/tools/utils/builders.ts
+++ b/packages/mcp/src/tools/utils/builders.ts
@@ -49,16 +49,19 @@ export const createDomainTools = <
 	const billingPreview = ({
 		id,
 		description,
+		expand,
 		writeToolName,
 	}: {
 		id: EndpointId;
 		description: string;
+		expand?: string[];
 		writeToolName: ConfirmedWriteToolName;
 	}): BillingPreviewToolConfig => ({
 		id,
 		description,
 		schema: schemas[id],
 		previewEndpoint: endpoints[id],
+		expand,
 		writeToolName,
 	});
 

--- a/packages/mcp/src/tools/utils/factories.ts
+++ b/packages/mcp/src/tools/utils/factories.ts
@@ -24,6 +24,17 @@ const getRequest = (input: unknown): unknown =>
 const signalOf = (context: { mcp?: { extra?: { signal?: AbortSignal } } }) =>
 	context?.mcp?.extra?.signal;
 
+const withExpand = ({
+	request,
+	expand,
+}: {
+	request: unknown;
+	expand?: string[];
+}) =>
+	expand?.length && request && typeof request === "object"
+		? { ...request, expand }
+		: request;
+
 /** Builds a `{ id: tool }` record from a list of configs. */
 export const toTools = <Config extends { id: string }>(
 	configs: Config[],
@@ -36,6 +47,7 @@ export const operationTool = ({
 	description,
 	schema,
 	endpoint,
+	expand,
 	destructive = false,
 	idempotent = false,
 }: OperationToolConfig) =>
@@ -48,7 +60,10 @@ export const operationTool = ({
 			callAutumn({
 				auth: getAutumnAuth(context),
 				endpoint,
-				request: schema.parse(getRequest(input)),
+				request: withExpand({
+					request: schema.parse(getRequest(input)),
+					expand,
+				}),
 				signal: signalOf(context),
 			}),
 	});
@@ -59,6 +74,7 @@ export const agentBillingPreviewTool = ({
 	description,
 	schema,
 	previewEndpoint,
+	expand,
 	writeToolName,
 }: BillingPreviewToolConfig) =>
 	createTool({
@@ -73,7 +89,7 @@ export const agentBillingPreviewTool = ({
 			const preview = await callAutumn({
 				auth,
 				endpoint: previewEndpoint,
-				request: parsedRequest,
+				request: withExpand({ request: parsedRequest, expand }),
 				signal: signalOf(context),
 			});
 			await createPendingAction({

--- a/packages/mcp/src/tools/utils/types.ts
+++ b/packages/mcp/src/tools/utils/types.ts
@@ -27,6 +27,7 @@ export type OperationToolConfig = {
 	description: string;
 	schema: z.ZodType;
 	endpoint: string;
+	expand?: string[];
 	destructive?: boolean;
 	idempotent?: boolean;
 };
@@ -37,6 +38,7 @@ export type BillingPreviewToolConfig = {
 	description: string;
 	schema: z.ZodType;
 	previewEndpoint: string;
+	expand?: string[];
 	writeToolName: ConfirmedWriteToolName;
 };
 

--- a/packages/mcp/tests/unit/mcp-server/agent/tools.test.ts
+++ b/packages/mcp/tests/unit/mcp-server/agent/tools.test.ts
@@ -688,6 +688,7 @@ describe("Autumn operation tools", () => {
 				customer_id: "cus_1",
 				plan_id: "pro",
 				redirect_mode: "if_required",
+				expand: ["incoming.plan.items.feature", "outgoing.plan.items.feature"],
 			});
 			return Response.json({ total: 50 });
 		}) as typeof fetch;
@@ -758,6 +759,7 @@ describe("Autumn operation tools", () => {
 				customer_id: "cus_1",
 				plan_id: "pro",
 				redirect_mode: "if_required",
+				expand: ["incoming.plan.items.feature", "outgoing.plan.items.feature"],
 			});
 			return Response.json({ total: 50 });
 		}) as typeof fetch;
@@ -778,13 +780,12 @@ describe("Autumn operation tools", () => {
 				} as never),
 			).resolves.toMatchObject({ pending: true, preview: { total: 50 } });
 
-			await expect(claimLatestPendingAction(auth)).resolves.toMatchObject({
-				toolName: "attach",
-				request: {
-					customer_id: "cus_1",
-					plan_id: "pro",
-					redirect_mode: "if_required",
-				},
+			const pending = await claimLatestPendingAction(auth);
+			expect(pending.toolName).toBe("attach");
+			expect(pending.request).toEqual({
+				customer_id: "cus_1",
+				plan_id: "pro",
+				redirect_mode: "if_required",
 			});
 		} finally {
 			globalThis.fetch = originalFetch;

--- a/packages/render/src/billing/previewDisplay.ts
+++ b/packages/render/src/billing/previewDisplay.ts
@@ -186,12 +186,51 @@ const billingMethodLabel = (value: unknown): string | null =>
 			? "usage-based"
 			: null;
 
-// One added plan item: feature id, then a concise descriptor of what the
-// customization grants (allowance / price / cadence).
-const addedItemText = (value: unknown): string | null => {
+const humanizeFeatureId = (featureId: string) => {
+	const text = featureId.replace(/[_-]+/g, " ");
+	return text.charAt(0).toUpperCase() + text.slice(1);
+};
+
+const featureLabels = (payload: LooseRecord) => {
+	const labels = new Map<string, string>();
+	for (const side of [payload.incoming, payload.outgoing]) {
+		for (const change of getArray(side)) {
+			const plan = asRecord(asRecord(change)?.plan);
+			for (const value of getArray(plan?.items)) {
+				const item = asRecord(value);
+				const featureId = getString(item?.feature_id);
+				const name = getString(asRecord(item?.feature)?.name);
+				if (featureId && name && !labels.has(featureId)) {
+					labels.set(featureId, name);
+				}
+			}
+		}
+	}
+	return labels;
+};
+
+const featureLabel = ({
+	featureId,
+	labels,
+}: {
+	featureId: string;
+	labels: Map<string, string>;
+}) => labels.get(featureId) ?? humanizeFeatureId(featureId);
+
+const itemFeatureId = (value: unknown) =>
+	getString(asRecord(value)?.feature_id);
+
+const addedItemText = ({
+	value,
+	labels,
+}: {
+	value: unknown;
+	labels: Map<string, string>;
+}): string | null => {
 	const item = asRecord(value);
 	if (!item) return null;
-	const feature = getString(item.feature_id) ?? "feature";
+	const featureId = getString(item.feature_id);
+	const feature = featureId ? featureLabel({ featureId, labels }) : "Feature";
 	const parts: string[] = [];
 	if (item.unlimited === true) {
 		parts.push("unlimited");
@@ -225,8 +264,13 @@ const addedItemText = (value: unknown): string | null => {
 	return detail ? `${feature} — ${detail}` : feature;
 };
 
-// One removed/updated item filter: by feature, else by qualifiers.
-const filterText = (value: unknown): string | null => {
+const filterText = ({
+	value,
+	labels,
+}: {
+	value: unknown;
+	labels: Map<string, string>;
+}): string | null => {
 	const filter = asRecord(value);
 	if (!filter) return null;
 	const feature = getString(filter.feature_id);
@@ -236,8 +280,8 @@ const filterText = (value: unknown): string | null => {
 	].filter((part): part is string => Boolean(part));
 	if (feature) {
 		return qualifiers.length
-			? `${feature} · ${qualifiers.join(" · ")}`
-			: feature;
+			? `${featureLabel({ featureId: feature, labels })} · ${qualifiers.join(" · ")}`
+			: featureLabel({ featureId: feature, labels });
 	}
 	return qualifiers.length ? qualifiers.join(" · ") : "matching items";
 };
@@ -249,7 +293,7 @@ const customPriceText = (value: unknown): string | null => {
 	const interval = getString(price.interval);
 	const intervalCount = getNumber(price.interval_count);
 	const cadence = interval
-		? ` per ${intervalCount && intervalCount > 1 ? `${intervalCount} ${interval}s` : interval}`
+		? `/${intervalCount && intervalCount > 1 ? `${intervalCount} ${interval}s` : interval}`
 		: "";
 	return `${formatMoney({ amount, currency: getString(price.currency) })}${cadence}`;
 };
@@ -262,23 +306,63 @@ const freeTrialText = (value: unknown): string | null => {
 	return days !== null ? `${formatCount(days)}-day free trial` : "free trial";
 };
 
-const customizeDisplay = (
-	params?: Record<string, unknown> | null,
-): CustomizeDisplay | null => {
+const customizeDisplay = ({
+	params,
+	payload,
+}: {
+	params?: Record<string, unknown> | null;
+	payload: LooseRecord;
+}): CustomizeDisplay | null => {
 	const customize = asRecord(params?.customize);
 	if (!customize) return null;
+	const labels = featureLabels(payload);
 	const collect = (value: unknown, render: (entry: unknown) => string | null) =>
 		getArray(value).flatMap((entry) => render(entry) ?? []);
+	const added = getArray(customize.add_items);
+	const removed = getArray(customize.remove_items);
+	const counts = (items: unknown[]) => {
+		const result = new Map<string, number>();
+		for (const item of items) {
+			const featureId = itemFeatureId(item);
+			if (featureId) result.set(featureId, (result.get(featureId) ?? 0) + 1);
+		}
+		return result;
+	};
+	const addCounts = counts(added);
+	const removeCounts = counts(removed);
+	const updatedFeatureIds = new Set(
+		[...addCounts].flatMap(([featureId, count]) =>
+			count === 1 && removeCounts.get(featureId) === 1 ? featureId : [],
+		),
+	);
 	const display: CustomizeDisplay = {
-		addedItems: collect(customize.add_items, addedItemText),
+		addedItems: collect(
+			added.filter((item) => !updatedFeatureIds.has(itemFeatureId(item) ?? "")),
+			(item) => addedItemText({ value: item, labels }),
+		),
 		freeTrialText: freeTrialText(customize.free_trial),
 		priceText: customPriceText(customize.price),
-		removedItems: collect(customize.remove_items, filterText),
-		replacedItems: collect(customize.items, addedItemText),
-		updatedItems: collect(customize.update_items, (entry) => {
-			const record = asRecord(entry);
-			return filterText(record?.filter ?? entry);
-		}),
+		removedItems: collect(
+			removed.filter(
+				(item) => !updatedFeatureIds.has(itemFeatureId(item) ?? ""),
+			),
+			(item) => filterText({ value: item, labels }),
+		),
+		replacedItems: collect(customize.items, (item) =>
+			addedItemText({ value: item, labels }),
+		),
+		updatedItems: [
+			...collect(customize.update_items, (entry) => {
+				const record = asRecord(entry);
+				return filterText({ value: record?.filter ?? entry, labels });
+			}),
+			...collect(
+				added.filter((item) =>
+					updatedFeatureIds.has(itemFeatureId(item) ?? ""),
+				),
+				(item) => addedItemText({ value: item, labels }),
+			),
+		],
 	};
 	const hasContent =
 		display.addedItems.length > 0 ||
@@ -295,6 +379,7 @@ const customizeDisplay = (
  * which approvers must see. */
 export type PrepaidQuantityDisplay = {
 	featureId: string;
+	featureName: string;
 	includedDefault: number | null;
 	quantity: number | null;
 };
@@ -306,6 +391,7 @@ const prepaidQuantityDisplays = ({
 	params?: Record<string, unknown> | null;
 	payload: LooseRecord;
 }): PrepaidQuantityDisplay[] => {
+	const labels = featureLabels(payload);
 	const quantities = new Map(
 		getArray(params?.feature_quantities).flatMap((entry) => {
 			const record = asRecord(entry);
@@ -330,6 +416,7 @@ const prepaidQuantityDisplays = ({
 			seen.add(featureId);
 			displays.push({
 				featureId,
+				featureName: featureLabel({ featureId, labels }),
 				includedDefault: getNumber(record?.included),
 				quantity: quantities.get(featureId) ?? null,
 			});
@@ -339,7 +426,12 @@ const prepaidQuantityDisplays = ({
 	// sets explicitly must still show.
 	for (const [featureId, quantity] of quantities) {
 		if (seen.has(featureId)) continue;
-		displays.push({ featureId, includedDefault: null, quantity });
+		displays.push({
+			featureId,
+			featureName: featureLabel({ featureId, labels }),
+			includedDefault: null,
+			quantity,
+		});
 	}
 	return displays;
 };
@@ -399,7 +491,7 @@ export const buildBillingPreviewDisplay = ({
 		currency,
 		customerId:
 			getString(params?.customer_id) ?? getString(payload.customer_id),
-		customize: customizeDisplay(params),
+		customize: customizeDisplay({ params, payload }),
 		dueNow: money({ amount: total, currency }),
 		entityId: getString(params?.entity_id),
 		intentLabel: intent ? (UPDATE_INTENT_LABELS[intent] ?? null) : null,


### PR DESCRIPTION
## Summary
- simplify Slack billing approval cards and remove redundant responses
- show plan and feature names, clearer recurring charges, and grouped plan changes
- enrich billing previews without changing the stored approval request

## Test plan
- bun test apps/leaf/tests/unit
- bun test packages/mcp/tests/unit
- TypeScript checks for Leaf, MCP, and render

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies Slack billing approval cards and makes billing previews clearer with real plan and feature names and clearer recurring charges. Improves readability without changing stored approval requests.

- New Features
  - Show plan and feature names from previews; fallback to IDs when missing.
  - Group plan changes into: Updated plan items, Added to plan, Removed from plan.
  - Display “Recurring price …” with free trial info; update phrasing to “No charge today” and “Next charge on …”.
  - Use feature names for prepaid quantities; warn when quantity is missing.
  - Attach cards use the plan name as the subject without repeating it; shorten UUID customer labels while preserving links.
  - Rename "{} Payload" button to "View Payload".
  - Add `expand` support to `packages/mcp` tools and pass `incoming.plan.items.feature` / `outgoing.plan.items.feature` for richer previews; preview data is used only for rendering.

<sup>Written for commit dc09d17fa1d6a9c64b8909cdce0da0e1a30b7aef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves Slack billing approval cards by enriching billing previews with human-readable plan and feature names, grouping plan customisation changes under clearer headings, and polishing several copy strings — all without altering the stored approval request.

- **[Improvements]** Billing preview API calls now include `expand: ["incoming.plan.items.feature", "outgoing.plan.items.feature"]` so feature names are available for display; `featureLabels` resolves them from the expanded payload, falling back to a humanised version of the feature ID when the expand is absent.
- **[Improvements]** `actionPhrases` now derives the plan label from the preview's first incoming change (e.g. "MC E2E Plan") instead of the raw `plan_id`; UUID customer IDs are compacted to `xxxxxxxx…xxxxx` form while the underlying link still carries the full ID.
- **[Improvements]** Plan customisation blocks are restructured into labelled groups ("Updated plan items", "Added to plan", "Removed from plan"); matching add+remove pairs for the same feature are collapsed into a single update entry; "Recurring price" replaces the old "Custom price" label; "No charge today" and "Next charge on …" replace the previous phrasings.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are display-layer only; the stored approval request is unchanged, and the new expand fields are isolated to preview calls.

The changes are contained to rendering and Slack card generation. The expand injection is applied only to preview API calls and is not persisted, so approval payloads remain stable. The smart update-detection logic (matching add+remove pairs for the same feature) is covered by updated unit tests. UUID compaction uses a well-formed regex that correctly covers the 8-4-4-4-12 UUID pattern. No auth, data-mutation, or schema changes are present.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/render/src/billing/previewDisplay.ts | Major refactor: adds feature name resolution from expanded preview payload (featureLabels/featureLabel/humanizeFeatureId), smart update detection for matching add+remove pairs, featureName added to PrepaidQuantityDisplay, and price cadence format changed from " per month" to "/month". |
| apps/leaf/src/ui/blocks.ts | Multiple UX improvements: plan name resolved from preview in actionPhrases, UUID customer IDs compacted, "No charge now"→"No charge today", "Next cycle"→"Next charge on", "{} Payload"→"View Payload", grouped plan change sections, and summaryText suppressed for simple attach to avoid repeating plan name. |
| packages/mcp/src/tools/utils/factories.ts | Adds withExpand helper to inject expand fields into requests sent to Autumn API; applied to preview calls, but expand is intentionally NOT stored in createPendingAction. |
| packages/mcp/src/tools/billing.ts | Adds planItemExpand array and passes it to all three billingPreview tools (attach, updateSubscription, createSchedule) so preview responses include expanded feature names for plan items. |
| packages/mcp/src/tools/utils/builders.ts | Threads optional expand parameter through billingPreview builder into BillingPreviewToolConfig. |
| packages/mcp/src/tools/utils/types.ts | Adds optional expand?: string[] to both OperationToolConfig and BillingPreviewToolConfig type definitions. |
| apps/leaf/tests/unit/ui/blocks.test.ts | Test suite extended with new cases for plan name display, UUID label shortening, "No charge today", and grouped plan changes; existing assertions updated to match new wording. |
| packages/mcp/tests/unit/mcp-server/agent/tools.test.ts | Updated test expectations to include expand array in the preview call body, and refactored pending action assertion to use toEqual so expand is NOT expected in the stored request. |

<sub>Reviews (1): Last reviewed commit: ["feat(slack): 🎸 improve billing approval..."](https://github.com/useautumn/autumn/commit/dc09d17fa1d6a9c64b8909cdce0da0e1a30b7aef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44413021)</sub>

<!-- /greptile_comment -->