### PR TITLE
feat(atmn): add plan license configuration

### DIFF
--- a/packages/atmn/src/commands/auth/oauth.ts
+++ b/packages/atmn/src/commands/auth/oauth.ts
@@ -1,20 +1,12 @@
 import * as http from "node:http";
 import * as arctic from "arctic";
 import open from "open";
-import { BACKEND_URL, LOCAL_BACKEND_URL } from "../../constants.js";
-import { isLocal } from "../../lib/env/cliContext.js";
+import { getBackendUrl } from "../../lib/env/backendUrl.js";
 import {
 	getErrorHtml,
 	getSuccessHtml,
 } from "../../views/html/oauth-callback.js";
 import { getOAuthRedirectUri, OAUTH_PORTS } from "./constants.js";
-
-/**
- * Get the current backend URL based on CLI flags
- */
-function getBackendUrl(): string {
-	return isLocal() ? LOCAL_BACKEND_URL : BACKEND_URL;
-}
 
 const getAuthorizationEndpoint = () =>
 	`${getBackendUrl()}/api/auth/oauth2/authorize`;

--- a/packages/atmn/src/commands/push/push.ts
+++ b/packages/atmn/src/commands/push/push.ts
@@ -523,7 +523,10 @@ function getPlanFeatureIds(plan: Plan): string[] {
  * Strips default/empty values so semantically identical plans
  * produce the same representation.
  */
-function normalizePlanForCompare(plan: Plan): Record<string, unknown> {
+function normalizePlanForCompare(
+	plan: Plan,
+	licenseVersionFallbacks?: Map<string, number | undefined>,
+): Record<string, unknown> {
 	const result: Record<string, unknown> = {
 		id: plan.id,
 		name: plan.name,
@@ -562,6 +565,14 @@ function normalizePlanForCompare(plan: Plan): Record<string, unknown> {
 			.sort((a, b) => a.featureId.localeCompare(b.featureId))
 			.map(normalizePlanFeatureForCompare);
 	}
+	result.licenses = [...(plan.licenses ?? [])]
+		.sort((a, b) => a.licensePlanId.localeCompare(b.licensePlanId))
+		.map((license) => ({
+			licensePlanId: license.licensePlanId,
+			version:
+				license.version ?? licenseVersionFallbacks?.get(license.licensePlanId),
+			included: license.included ?? 0,
+		}));
 
 	return result;
 }
@@ -582,9 +593,16 @@ function hasFeatureChanged(local: Feature, remoteRaw: unknown): boolean {
  * Transforms the remote API data to SDK format before comparing.
  */
 function hasPlanChanged(local: Plan, remoteRaw: unknown): boolean {
+	const remote = remoteRaw as Plan;
+	const licenseVersionFallbacks = new Map(
+		(remote.licenses ?? []).map((license) => [
+			license.licensePlanId,
+			license.version,
+		]),
+	);
 	return !valuesEqual(
-		normalizePlanForCompare(local),
-		normalizePlanForCompare(remoteRaw as Plan),
+		normalizePlanForCompare(local, licenseVersionFallbacks),
+		normalizePlanForCompare(remote),
 	);
 }
 

--- a/packages/atmn/src/commands/push/validate.ts
+++ b/packages/atmn/src/commands/push/validate.ts
@@ -14,6 +14,25 @@ export interface ValidationResult {
 	errors: ValidationError[];
 }
 
+const hasPlanLicenseCycle = (plans: Plan[]): boolean => {
+	const byId = new Map(plans.map((plan) => [plan.id, plan]));
+	const visiting = new Set<string>();
+	const visited = new Set<string>();
+	const visit = (plan: Plan): boolean => {
+		if (visiting.has(plan.id)) return true;
+		if (visited.has(plan.id)) return false;
+		visiting.add(plan.id);
+		for (const license of plan.licenses ?? []) {
+			const dependency = byId.get(license.licensePlanId);
+			if (dependency !== plan && dependency && visit(dependency)) return true;
+		}
+		visiting.delete(plan.id);
+		visited.add(plan.id);
+		return false;
+	};
+	return plans.some(visit);
+};
+
 /**
  * Get the price.interval from a PlanItem (handling the discriminated union)
  */
@@ -379,6 +398,33 @@ export function validateConfig(
 	// Validate plans (passing features for feature type lookups)
 	for (const plan of plans) {
 		errors.push(...validatePlan(plan, features));
+	}
+
+	const localPlanIds = new Set(plans.map((plan) => plan.id));
+	for (const plan of plans) {
+		const seen = new Set<string>();
+		for (const [index, license] of (plan.licenses ?? []).entries()) {
+			const path = `plan "${plan.id}" → licenses[${index}]`;
+			if (seen.has(license.licensePlanId)) {
+				errors.push({
+					path,
+					message: `Duplicate license link "${license.licensePlanId}".`,
+				});
+			}
+			seen.add(license.licensePlanId);
+			if (!localPlanIds.has(license.licensePlanId)) {
+				errors.push({
+					path,
+					message: `License plan "${license.licensePlanId}" is not exported from your config.`,
+				});
+			}
+			if (license.licensePlanId === plan.id) {
+				errors.push({ path, message: "A plan cannot license itself." });
+			}
+		}
+	}
+	if (hasPlanLicenseCycle(plans)) {
+		errors.push({ path: "plans", message: "Plan dependency cycle detected" });
 	}
 
 	return {

--- a/packages/atmn/src/compose/index.ts
+++ b/packages/atmn/src/compose/index.ts
@@ -10,6 +10,7 @@ import type {
 	BillingControls,
 	FreeTrial,
 	PlanItem,
+	PlanLicense,
 } from "./models/planModels.js";
 import type {
 	CustomizePlan,
@@ -28,6 +29,7 @@ export type {
 	Plan,
 	PlanItem,
 	PlanItemFilter,
+	PlanLicense,
 	Variant,
 };
 

--- a/packages/atmn/src/compose/models/planModels.ts
+++ b/packages/atmn/src/compose/models/planModels.ts
@@ -241,6 +241,12 @@ export const FreeTrialSchema = z.object({
 
 export const BillingControlsSchema = z.custom<BillingControls>();
 
+export const PlanLicenseSchema = z.object({
+	licensePlanId: z.string().nonempty(),
+	version: z.number().int().min(1).optional(),
+	included: z.number().int().min(0).optional(),
+});
+
 export const PlanSchema = z.object({
 	description: z.string().nullable().default(null).meta({
 		description: "Optional description of the plan.",
@@ -268,6 +274,7 @@ export const PlanSchema = z.object({
 	billingControls: BillingControlsSchema.optional().meta({
 		description: "Plan-level billing controls used as customer defaults.",
 	}),
+	licenses: z.array(PlanLicenseSchema).optional(),
 	/** Unique identifier for the plan */
 	id: z.string().nonempty().regex(idRegex),
 	/** Display name for the plan */
@@ -439,6 +446,7 @@ export type PlanItem = PlanItemWithReset | PlanItemWithPrice | PlanItemNoReset;
 // Override Plan type to use PlanItem discriminated union
 type PlanBase = z.infer<typeof PlanSchema>;
 export type FreeTrial = z.infer<typeof FreeTrialSchema>;
+export type PlanLicense = z.infer<typeof PlanLicenseSchema>;
 
 export type Plan = {
 	/** Unique identifier for the plan. */
@@ -476,6 +484,9 @@ export type Plan = {
 
 	/** Plan-level billing controls used as customer defaults */
 	billingControls?: BillingControls;
+
+	/** Plans offered as assignable licenses under this plan. */
+	licenses?: PlanLicense[];
 
 	/** Whether the plan is archived */
 	archived?: boolean;

--- a/packages/atmn/src/lib/api/client.ts
+++ b/packages/atmn/src/lib/api/client.ts
@@ -1,12 +1,4 @@
-import { BACKEND_URL, LOCAL_BACKEND_URL } from "../../constants.js";
-import { isLocal } from "../env/cliContext.js";
-
-/**
- * Get the current backend URL based on CLI flags
- */
-function getBackendUrl(): string {
-	return isLocal() ? LOCAL_BACKEND_URL : BACKEND_URL;
-}
+import { getBackendUrl } from "../env/backendUrl.js";
 
 /**
  * Low-level API client for making authenticated requests
@@ -38,10 +30,12 @@ export function formatError(err: unknown): string {
 	}
 
 	const apiError = err as ApiError;
-	const lines: string[] = [];
+	const response = apiError.response as { message?: unknown } | undefined;
+	const message =
+		typeof response?.message === "string" ? response.message : err.message;
+	if (!process.env.ATMN_DEBUG) return message;
 
-	// Start with the basic error message
-	lines.push(err.message);
+	const lines = [message];
 
 	// Add request context if available
 	if (apiError.method && apiError.url) {
@@ -107,7 +101,7 @@ export async function request<T = unknown>(
 	// Make request
 	try {
 		// Debug: log the request URL (can be removed later)
-		if (process.env['ATMN_DEBUG']) {
+		if (process.env.ATMN_DEBUG) {
 			console.log(`[DEBUG] ${method} ${url.toString()}`);
 		}
 		const response = await fetch(url.toString(), requestInit);

--- a/packages/atmn/src/lib/env/backendUrl.ts
+++ b/packages/atmn/src/lib/env/backendUrl.ts
@@ -1,0 +1,5 @@
+import { BACKEND_URL, LOCAL_BACKEND_URL } from "../../constants.js";
+import { isLocal } from "./cliContext.js";
+
+export const getBackendUrl = () =>
+	process.env.ATMN_BACKEND_URL ?? (isLocal() ? LOCAL_BACKEND_URL : BACKEND_URL);

--- a/packages/atmn/src/lib/transforms/apiToSdk/plan.ts
+++ b/packages/atmn/src/lib/transforms/apiToSdk/plan.ts
@@ -66,6 +66,13 @@ export const planTransformer = createTransformer<ApiPlan, BasePlan>({
 			hasBillingControls(api.billing_controls)
 				? api.billing_controls
 				: undefined,
+
+		licenses: (api) =>
+			api.licenses?.map((license) => ({
+				licensePlanId: license.license_plan_id,
+				version: license.version,
+				included: license.included,
+			})),
 	},
 });
 

--- a/packages/atmn/src/lib/transforms/sdkToApi/plan.ts
+++ b/packages/atmn/src/lib/transforms/sdkToApi/plan.ts
@@ -1,5 +1,11 @@
 import type { Plan, PlanItem } from "../../../compose/models/index.js";
 
+export interface ApiPlanLicenseParams {
+	license_plan_id: string;
+	version?: number;
+	included: number;
+}
+
 /**
  * API plan format expected by the server's CreatePlanParams schema
  */
@@ -21,6 +27,7 @@ export interface ApiPlanParams {
 		card_required: boolean;
 	};
 	billing_controls?: Plan["billingControls"];
+	licenses: ApiPlanLicenseParams[];
 }
 
 export interface ApiPlanItemParams {
@@ -165,6 +172,11 @@ export function transformPlanToApi(plan: Plan): ApiPlanParams {
 	const result: ApiPlanParams = {
 		id: plan.id,
 		name: plan.name,
+		licenses: (plan.licenses ?? []).map((license) => ({
+			license_plan_id: license.licensePlanId,
+			...(license.version !== undefined ? { version: license.version } : {}),
+			included: license.included ?? 0,
+		})),
 	};
 
 	if (plan.description !== undefined) {

--- a/packages/atmn/src/lib/transforms/sdkToCode/plan.ts
+++ b/packages/atmn/src/lib/transforms/sdkToCode/plan.ts
@@ -74,6 +74,9 @@ export function buildPlanCode(
 		}
 	}
 	lines.push(`\t],`);
+	if (plan.licenses?.length) {
+		lines.push(`\tlicenses: ${formatValue(plan.licenses)},`);
+	}
 
 	// Add freeTrial
 	if (plan.freeTrial) {

--- a/packages/atmn/test/codegen/in-place-licenses.test.ts
+++ b/packages/atmn/test/codegen/in-place-licenses.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeConfig } from "../../src/commands/pull/writeConfig.js";
+import type { Plan } from "../../src/compose/index.js";
+
+const plans: Plan[] = [
+	{ id: "seats", name: "Seats", items: [] },
+	{
+		id: "pro",
+		name: "Pro",
+		items: [],
+		licenses: [{ licensePlanId: "seats", version: 1 }],
+	},
+];
+
+const declaration = (name: string) =>
+	`export const ${name} = plan({ id: '${name}', name: '${name}', items: [] });`;
+
+test.concurrent(
+	"licensed plans update in place regardless of declaration order",
+	async () => {
+		const cwd = mkdtempSync(join(tmpdir(), "atmn-license-order-"));
+		const configPath = join(cwd, "autumn.config.ts");
+		try {
+			writeFileSync(
+				configPath,
+				`import { plan } from 'atmn';\n\n// keep me\n${declaration("pro")}\n\n${declaration("seats")}\n`,
+			);
+			expect((await writeConfig([], plans, cwd)).inPlace).toBe(true);
+			const config = readFileSync(configPath, "utf8");
+			expect(config).toContain("// keep me");
+			expect(config).toContain("licensePlanId: 'seats'");
+			expect(config.indexOf("export const pro")).toBeLessThan(
+				config.indexOf("export const seats"),
+			);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	},
+);

--- a/packages/atmn/test/codegen/variants.test.ts
+++ b/packages/atmn/test/codegen/variants.test.ts
@@ -26,7 +26,34 @@ const baseApiPlan = (overrides: Partial<ApiPlan>): ApiPlan =>
 		...overrides,
 	}) as ApiPlan;
 
-describe("variant config generation", () => {
+describe("config generation", () => {
+	test("license pull and codegen preserve pins", () => {
+		const plans = transformApiPlans([
+			baseApiPlan({
+				id: "pro",
+				name: "Pro",
+				licenses: [
+					{
+						license_plan_id: "seats",
+						version: 2,
+						included: 5,
+						prepaid_only: true,
+					},
+				],
+			}),
+			baseApiPlan({ id: "seats", name: "Seats", version: 2 }),
+		]);
+		const code = buildConfigFile([], plans);
+
+		expect(code).toContain("licensePlanId: 'seats'");
+		expect(code).toContain("version: 2");
+		expect(plans[0]?.licenses?.[0]).toEqual({
+			licensePlanId: "seats",
+			version: 2,
+			included: 5,
+		});
+	});
+
 	test("transformApiPlans nests variants under their base plan", () => {
 		const plans = transformApiPlans([
 			baseApiPlan({

--- a/packages/atmn/test/integration/catalog/license-config.test.ts
+++ b/packages/atmn/test/integration/catalog/license-config.test.ts
@@ -1,0 +1,79 @@
+/// <reference types="bun" />
+
+import { expect, test } from "bun:test";
+import { readFile, writeFile } from "node:fs/promises";
+import { ProductService } from "../../../../../server/src/internal/products/ProductService.js";
+import {
+	createCleanAtmnIntegrationContext,
+	prepareAtmnIntegrationWorkspace,
+	runAtmnWorkspaceCli,
+} from "../utils/atmnTestWorkspace.js";
+
+const config = (included?: number) => `import { plan } from 'atmn';
+
+export const pro = plan({
+	id: 'atmn_license_pro',
+	name: 'Pro',
+	${included === undefined ? "" : `licenses: [{ licensePlanId: 'atmn_license_seats', version: 1, included: ${included} }],`}
+});
+
+export const seats = plan({ id: 'atmn_license_seats', name: 'Seats' });
+`;
+
+test.concurrent(
+	"atmn plan licenses push, pull, update in place, and remove authoritatively",
+	async () => {
+		const ctx = await createCleanAtmnIntegrationContext();
+		const workspace = await prepareAtmnIntegrationWorkspace({
+			secretKey: ctx.orgSecretKey,
+		});
+		const push = (args = ["--yes"]) =>
+			runAtmnWorkspaceCli({ args, command: "push", headless: true, workspace });
+
+		await writeFile(workspace.configPath, config(5));
+		await push();
+
+		let parent = await ProductService.getFull({
+			db: ctx.db,
+			env: ctx.env,
+			idOrInternalId: "atmn_license_pro",
+			orgId: ctx.org.id,
+		});
+		expect(parent.licenses?.[0]?.included).toBe(5);
+		expect(parent.licenses?.[0]?.product).toMatchObject({
+			id: "atmn_license_seats",
+			version: 1,
+		});
+		await runAtmnWorkspaceCli({
+			args: ["--force", "--no-declaration-file"],
+			command: "pull",
+			headless: true,
+			workspace,
+		});
+		const pulled = await readFile(workspace.configPath, "utf8");
+		expect(pulled).toContain("licensePlanId: 'atmn_license_seats'");
+		expect(pulled).toContain("version: 1");
+		await push();
+
+		await writeFile(workspace.configPath, config(6));
+		await push();
+		parent = await ProductService.getFull({
+			db: ctx.db,
+			env: ctx.env,
+			idOrInternalId: "atmn_license_pro",
+			orgId: ctx.org.id,
+		});
+		expect(parent.version).toBe(1);
+		expect(parent.licenses?.[0]?.included).toBe(6);
+
+		await writeFile(workspace.configPath, config());
+		await push([]);
+		parent = await ProductService.getFull({
+			db: ctx.db,
+			env: ctx.env,
+			idOrInternalId: "atmn_license_pro",
+			orgId: ctx.org.id,
+		});
+		expect(parent.licenses).toHaveLength(0);
+	},
+);

--- a/packages/atmn/test/push/catalog-params.test.ts
+++ b/packages/atmn/test/push/catalog-params.test.ts
@@ -174,6 +174,30 @@ test("buildCatalogUpdateParams maps plan billing controls", () => {
 	});
 });
 
+test("buildCatalogUpdateParams maps authoritative plan licenses", () => {
+	const params = buildCatalogUpdateParams({
+		features: [],
+		plans: [
+			{
+				id: "pro",
+				name: "Pro",
+				licenses: [{ licensePlanId: "seats", version: 2, included: 5 }],
+			},
+			{ id: "seats", name: "Seats" },
+		],
+	});
+
+	expect(params.plans.map((plan) => plan.plan_id)).toEqual(["pro", "seats"]);
+	expect(params.plans[0]?.licenses).toEqual([
+		{
+			license_plan_id: "seats",
+			version: 2,
+			included: 5,
+		},
+	]);
+	expect(params.plans[1]?.licenses).toEqual([]);
+});
+
 test("buildCatalogUpdateParams maps direct variant update-current migration controls", () => {
 	const params = buildCatalogUpdateParams({
 		features: [],

--- a/packages/atmn/test/push/validate.test.ts
+++ b/packages/atmn/test/push/validate.test.ts
@@ -32,3 +32,34 @@ test("validateConfig rejects plan items that reference unexported features", () 
 		]),
 	);
 });
+
+test("validateConfig rejects invalid license configuration and cycles", () => {
+	const result = validateConfig(
+		[],
+		[
+			{
+				id: "a",
+				name: "A",
+				licenses: [
+					{ licensePlanId: "a" },
+					{ licensePlanId: "b" },
+					{ licensePlanId: "b" },
+					{ licensePlanId: "missing" },
+				],
+			},
+			{ id: "b", name: "B", licenses: [{ licensePlanId: "a" }] },
+		],
+	);
+
+	expect(result.valid).toBe(false);
+	expect(result.errors.map((error) => error.message).join("\n")).toContain(
+		"Plan dependency cycle",
+	);
+	expect(result.errors.map((error) => error.message)).toEqual(
+		expect.arrayContaining([
+			"A plan cannot license itself.",
+			'Duplicate license link "b".',
+			'License plan "missing" is not exported from your config.',
+		]),
+	);
+});

--- a/server/src/internal/catalog/actions/catalogPlanDependencies.ts
+++ b/server/src/internal/catalog/actions/catalogPlanDependencies.ts
@@ -1,0 +1,51 @@
+import { type CatalogPlanParams, ErrCode, RecaseError } from "@autumn/shared";
+
+const referenceKey = (id: string, version?: number) =>
+	version === undefined ? id : `${id}@${version}`;
+
+const dependenciesForPlan = (plan: CatalogPlanParams) =>
+	(plan.licenses ?? []).map((license) => ({
+		id: license.license_plan_id,
+		version: license.version,
+	}));
+
+export const sortCatalogPlansByDependencies = (
+	plans: CatalogPlanParams[],
+): CatalogPlanParams[] => {
+	const byReference = new Map<string, CatalogPlanParams>();
+	for (const plan of plans) {
+		byReference.set(referenceKey(plan.plan_id, plan.version), plan);
+		const latestKey = plan.new_plan_id ?? plan.plan_id;
+		const latest = byReference.get(latestKey);
+		if (!latest || (plan.version ?? 0) > (latest.version ?? 0)) {
+			byReference.set(latestKey, plan);
+		}
+	}
+
+	const visiting = new Set<string>();
+	const visited = new Set<string>();
+	const sorted: CatalogPlanParams[] = [];
+	const visit = (plan: CatalogPlanParams) => {
+		const key = referenceKey(plan.plan_id, plan.version);
+		if (visiting.has(key)) {
+			throw new RecaseError({
+				message: "Plan dependency cycle detected.",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+		if (visited.has(key)) return;
+		visiting.add(key);
+		for (const reference of dependenciesForPlan(plan)) {
+			const dependency =
+				byReference.get(referenceKey(reference.id, reference.version)) ??
+				byReference.get(reference.id);
+			if (dependency && dependency !== plan) visit(dependency);
+		}
+		visiting.delete(key);
+		visited.add(key);
+		sorted.push(plan);
+	};
+	for (const plan of plans) visit(plan);
+	return sorted;
+};

--- a/server/src/internal/catalog/actions/catalogPlanPreflight.ts
+++ b/server/src/internal/catalog/actions/catalogPlanPreflight.ts
@@ -1,0 +1,131 @@
+import {
+	type CatalogPlanParams,
+	ErrCode,
+	type FullProduct,
+	type PlanUpdatePreview,
+	RecaseError,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import {
+	previewPlanLicenseSync,
+	validatePlanLicenseUpdate,
+} from "@/internal/licenses/actions/links/syncPlanLicenses.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { sortCatalogPlansByDependencies } from "./catalogPlanDependencies.js";
+
+const virtualProduct = ({
+	current,
+	id,
+	version,
+	archived,
+}: {
+	current?: FullProduct;
+	id: string;
+	version: number;
+	archived?: boolean;
+}): FullProduct =>
+	({
+		...(current ?? {}),
+		id,
+		version,
+		archived: archived ?? current?.archived ?? false,
+		internal_id:
+			current?.version === version
+				? current.internal_id
+				: `virtual:${id}:${version}`,
+		licenses: current?.licenses ?? [],
+	}) as FullProduct;
+
+const preflightCatalogLicenses = async ({
+	ctx,
+	plans,
+	previews,
+}: {
+	ctx: AutumnContext;
+	plans: CatalogPlanParams[];
+	previews: PlanUpdatePreview[];
+}) => {
+	const persistedProducts = await ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		returnAll: true,
+	});
+	const currentById = new Map<string, FullProduct>();
+	for (const product of persistedProducts) {
+		const current = currentById.get(product.id);
+		if (!current || product.version > current.version) {
+			currentById.set(product.id, product);
+		}
+	}
+	const currentForPlan = (plan: CatalogPlanParams) =>
+		plan.version === undefined
+			? currentById.get(plan.plan_id)
+			: persistedProducts.find(
+					(product) =>
+						product.id === plan.plan_id && product.version === plan.version,
+				);
+	const virtualParents = plans.map((plan, index) => {
+		const current = currentForPlan(plan);
+		const latest = currentById.get(plan.plan_id);
+		return virtualProduct({
+			current,
+			id: plan.new_plan_id ?? plan.plan_id,
+			version: current
+				? previews[index]?.versionable
+					? (latest?.version ?? current.version) + 1
+					: current.version
+				: 1,
+			archived: plan.archived,
+		});
+	});
+	const licenseProducts = [...virtualParents, ...persistedProducts];
+	const ownerByLicenseId = new Map<string, string>();
+
+	for (const [index, plan] of plans.entries()) {
+		const preview = previews[index]!;
+		const current = currentForPlan(plan);
+		const parent = virtualParents[index]!;
+		for (const license of plan.licenses ?? []) {
+			const owner = ownerByLicenseId.get(license.license_plan_id);
+			if (owner && owner !== parent.id) {
+				throw new RecaseError({
+					message: `License plan ${license.license_plan_id} is already offered by plan ${owner}.`,
+					code: ErrCode.InvalidRequest,
+					statusCode: 400,
+				});
+			}
+			ownerByLicenseId.set(license.license_plan_id, parent.id);
+		}
+		const licensePreview = await previewPlanLicenseSync({
+			ctx,
+			parentProduct: { ...parent, licenses: current?.licenses ?? [] },
+			licenses: plan.licenses,
+			fromInternalProductId: current?.internal_id ?? parent.internal_id,
+			newParentVersion: preview.versionable || !current,
+			licenseProducts,
+		});
+		preview.license_changes = licensePreview.changes;
+		if (preview.plan) preview.plan.licenses = licensePreview.licenses;
+	}
+};
+
+export const preflightCatalogPlans = async ({
+	ctx,
+	plans,
+	previews,
+}: {
+	ctx: AutumnContext;
+	plans: CatalogPlanParams[];
+	previews: PlanUpdatePreview[];
+}) => {
+	for (const plan of plans) {
+		validatePlanLicenseUpdate({
+			allVersions: plan.all_versions,
+			licenses: plan.licenses,
+		});
+	}
+	// Validate cycles without disturbing plan/previews index alignment.
+	sortCatalogPlansByDependencies(plans);
+	await preflightCatalogLicenses({ ctx, plans, previews });
+};

--- a/server/src/internal/catalog/actions/previewUpdateCatalog/previewCatalogPlanUpdate.ts
+++ b/server/src/internal/catalog/actions/previewUpdateCatalog/previewCatalogPlanUpdate.ts
@@ -1,7 +1,7 @@
 import {
 	apiPlan,
-	expandPathIncludes,
 	type CatalogPlanParams,
+	expandPathIncludes,
 	type FullProduct,
 	type PlanUpdatePreview,
 	PlanUpdatePreviewSchema,
@@ -92,7 +92,6 @@ export const previewCatalogPlanUpdate = async ({
 	customerCount: number;
 	currency: string;
 }): Promise<PlanUpdatePreview> => {
-	const { plan_id } = planParams;
 	const { variants, ...basePlanParams } = planParams;
 
 	if (!current) {
@@ -121,13 +120,23 @@ export const previewCatalogPlanUpdate = async ({
 						(variants?.length ?? 0) > 0)),
 		),
 	};
-	const incoming = buildIncomingProductV2({ ctx, base: current, data });
+	// Catalog licenses are resolved together against the virtual post-update
+	// catalog after ordinary plan previews are built.
+	const previewData = {
+		...data,
+		licenses: undefined,
+	};
+	const incoming = buildIncomingProductV2({
+		ctx,
+		base: current,
+		data: previewData,
+	});
 
 	return buildPlanUpdatePreview({
 		ctx,
 		currentFullProduct: current,
 		incomingProductV2: incoming,
-		data,
+		data: previewData,
 		variantUpdates: variants,
 		hasCustomers,
 		customerCount,

--- a/server/src/internal/catalog/actions/previewUpdateCatalog/previewUpdateCatalog.ts
+++ b/server/src/internal/catalog/actions/previewUpdateCatalog/previewUpdateCatalog.ts
@@ -1,7 +1,7 @@
 import type {
 	CatalogMigrationPreview,
-	CatalogPreviewUpdateResponse,
 	CatalogPlanPreview,
+	CatalogPreviewUpdateResponse,
 	CatalogUpdateParams,
 	FullProduct,
 	PlanUpdatePreview,
@@ -10,29 +10,30 @@ import {
 	buildAllVersionsUpdateMigrationDraft,
 	buildCombinedVariantMigrationDraft,
 	PlanUpdatePreviewSchema,
-	planUpdatePreviewHasDiff,
 	planDiffHasBillingChanges,
+	planUpdatePreviewHasDiff,
+	scopeExpandForCtx,
 } from "@autumn/shared";
-import { scopeExpandForCtx } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { CusProdReadService } from "@/internal/customers/cusProducts/CusProdReadService.js";
 import { getPlanResponse } from "@/internal/products/productUtils/productResponseUtils/getPlanResponse.js";
+import { preflightCatalogPlans } from "../catalogPlanPreflight.js";
 import {
 	deriveReplaceFeatureIds,
 	deriveReplacePlanIds,
 } from "../deriveReplaceRemovals.js";
 import { sortRemoveFeatureIds } from "../featureRemovalOrder.js";
 import {
+	validateCatalogVariantUpdates,
+	validateCatalogVariantVersionTargets,
+} from "../validateCatalogVariantUpdates.js";
+import { previewCatalogPlanUpdate } from "./previewCatalogPlanUpdate.js";
+import {
 	previewFeature,
 	previewRemoveFeature,
 	previewSkippedFeature,
 } from "./previewFeature.js";
-import { previewCatalogPlanUpdate } from "./previewCatalogPlanUpdate.js";
 import { setupPreviewCatalogContext } from "./setupPreviewCatalogContext.js";
-import {
-	validateCatalogVariantUpdates,
-	validateCatalogVariantVersionTargets,
-} from "../validateCatalogVariantUpdates.js";
 
 const productUsesFeature = ({
 	product,
@@ -203,7 +204,13 @@ const previewMigrationForInPlaceUpdate = async ({
 
 	const targets = [
 		...(preview.versionable
-			? [{ id: current.id, version: current.version, customize: preview.customize }]
+			? [
+					{
+						id: current.id,
+						version: current.version,
+						customize: preview.customize,
+					},
+				]
 			: []),
 		...preview.variants
 			.filter((variant) => variant.will_apply && variant.has_customers)
@@ -262,11 +269,10 @@ export const previewUpdateCatalog = async ({
 		customerCountByInternalId,
 		proposedFeatures,
 		planCtx,
-	} =
-		await setupPreviewCatalogContext({
-			ctx,
-			params: { ...params, plans: activePlans, features: activeFeatures },
-		});
+	} = await setupPreviewCatalogContext({
+		ctx,
+		params: { ...params, plans: activePlans, features: activeFeatures },
+	});
 	validateCatalogVariantVersionTargets({
 		params: { ...params, plans: activePlans },
 		products,
@@ -342,6 +348,11 @@ export const previewUpdateCatalog = async ({
 			),
 		),
 	]);
+	await preflightCatalogPlans({
+		ctx: planChangesCtx,
+		plans: activePlans,
+		previews: planResults,
+	});
 	const removePlanResults = missingProducts.map((product) =>
 		previewRemovePlan({
 			product,

--- a/server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts
+++ b/server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts
@@ -16,14 +16,15 @@ import { updateFeature } from "@/internal/features/featureActions/updateFeature.
 import { getObjectsUsingFeature } from "@/internal/features/utils/updateFeatureUtils/getObjectsUsingFeature.js";
 import { createProduct } from "@/internal/product/actions/createProduct.js";
 import { deleteProduct } from "@/internal/product/actions/deleteProduct.js";
-import { updateProduct } from "@/internal/product/actions/updateProduct.js";
 import {
 	createPlanMigrationDraft,
 	getVariantMigrationSnapshots,
 	validateNoDirectVariantMigrationDrafts,
 } from "@/internal/product/actions/updateProduct/createPlanMigrationDraft.js";
+import { updateProduct } from "@/internal/product/actions/updateProduct.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 import { getPlanResponse } from "@/internal/products/productUtils/productResponseUtils/getPlanResponse.js";
+import { sortCatalogPlansByDependencies } from "../catalogPlanDependencies.js";
 import {
 	deriveReplaceFeatureIds,
 	deriveReplacePlanRemovals,
@@ -31,6 +32,7 @@ import {
 } from "../deriveReplaceRemovals.js";
 import { sortRemoveFeatureIds } from "../featureRemovalOrder.js";
 import { getFeatureUpdateBlockedReason } from "../previewUpdateCatalog/previewFeature.js";
+import { previewUpdateCatalog } from "../previewUpdateCatalog/previewUpdateCatalog.js";
 import {
 	validateCatalogVariantUpdates,
 	validateCatalogVariantVersionTargets,
@@ -124,8 +126,13 @@ const upsertPlans = async ({
 }) => {
 	const { db, org, env } = ctx;
 	const skipPlanIds = new Set(params.skip_plan_ids);
+	const activePlans = params.plans.filter(
+		(plan) =>
+			!skipPlanIds.has(plan.plan_id) &&
+			(!plan.new_plan_id || !skipPlanIds.has(plan.new_plan_id)),
+	);
 
-	for (const planParams of params.plans) {
+	for (const planParams of sortCatalogPlansByDependencies(activePlans)) {
 		const {
 			plan_id,
 			new_plan_id,
@@ -140,13 +147,6 @@ const upsertPlans = async ({
 			include_variants: _includeVariants,
 			...rest
 		} = planParams;
-		if (
-			skipPlanIds.has(plan_id) ||
-			(new_plan_id !== undefined && skipPlanIds.has(new_plan_id))
-		) {
-			continue;
-		}
-
 		const current = await ProductService.getFull({
 			db,
 			idOrInternalId: plan_id,
@@ -273,7 +273,8 @@ const upsertPlans = async ({
 			ctx,
 			current,
 			fromPlan,
-			includeCustom: migration?.include_custom ?? params.migration?.include_custom,
+			includeCustom:
+				migration?.include_custom ?? params.migration?.include_custom,
 			mode: all_versions ? "all_versions" : "version",
 			planId: plan_id,
 			selectedVariantIds,
@@ -467,6 +468,9 @@ export const updateCatalog = async ({
 	ctx: AutumnContext;
 	params: CatalogUpdateParams;
 }) => {
+	// Preflight the whole virtual catalog before any mutation; individual writes
+	// revalidate against the real product identities created by earlier plans.
+	await previewUpdateCatalog({ ctx, params });
 	const { db, org, env } = ctx;
 	const productsBeforeUpdate = await ProductService.listFull({
 		db,

--- a/server/src/internal/licenses/actions/links/syncPlanLicenses.ts
+++ b/server/src/internal/licenses/actions/links/syncPlanLicenses.ts
@@ -1,12 +1,16 @@
 import {
 	ErrCode,
 	type FullProduct,
+	findDuplicate,
 	type PlanLicenseParams,
 	RecaseError,
 } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { getFullLicenseProduct } from "../../licenseUtils.js";
+import {
+	getFullLicenseProduct,
+	toApiPlanLicenses,
+} from "../../licenseUtils.js";
 import { licenseAssignmentRepo } from "../../repos/licenseAssignmentRepo.js";
 import { planLicenseRepo } from "../../repos/planLicenseRepo.js";
 import { logLicenseAction } from "../logs/logLicenseAction.js";
@@ -19,31 +23,99 @@ type ResolvedLink = {
 	prepaidOnly: boolean;
 };
 
-/** Resolves one incoming link entry against the license product and validates
- * it — a pure read step before the writes. */
+export type PreparedPlanLicenseSync = {
+	parentProduct: FullProduct;
+	resolved: ResolvedLink[];
+	removed: Awaited<
+		ReturnType<typeof planLicenseRepo.listCatalogByParentInternalProductIds>
+	>;
+};
+
+export const validatePlanLicenseUpdate = ({
+	allVersions,
+	licenses,
+}: {
+	allVersions?: boolean;
+	licenses?: PlanLicenseParams[];
+}) => {
+	if (allVersions && licenses !== undefined) {
+		throw new RecaseError({
+			message: "Updating licenses across all plan versions is not supported.",
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+};
+
+export const previewPlanLicenseSync = async (
+	args: Parameters<typeof preparePlanLicenseSync>[0],
+) => {
+	const previous = toApiPlanLicenses(args.parentProduct.licenses ?? []);
+	const prepared = await preparePlanLicenseSync(args);
+	const current = prepared
+		? prepared.resolved.map((license) => ({
+				license_plan_id: license.licenseProduct.id,
+				version: license.licenseProduct.version,
+				included: license.included,
+				prepaid_only: license.prepaidOnly,
+			}))
+		: previous;
+	const before = new Map(
+		previous.map((license) => [license.license_plan_id, license]),
+	);
+	const after = new Map(
+		current.map((license) => [license.license_plan_id, license]),
+	);
+	const changes = [...new Set([...before.keys(), ...after.keys()])].flatMap(
+		(licensePlanId) => {
+			const oldLicense = before.get(licensePlanId) ?? null;
+			const newLicense = after.get(licensePlanId) ?? null;
+			if (JSON.stringify(oldLicense) === JSON.stringify(newLicense)) return [];
+			return [
+				{
+					action: oldLicense ? (newLicense ? "update" : "remove") : "create",
+					license_plan_id: licensePlanId,
+				} as const,
+			];
+		},
+	);
+	return { licenses: current, changes };
+};
+
+/** Resolves and validates one link without writing it. */
 const resolveLink = async ({
 	ctx,
 	parentProduct,
 	entry,
+	licenseProducts,
 	pinnedInternalIdByPublicId,
 }: {
 	ctx: AutumnContext;
 	parentProduct: FullProduct;
 	entry: PlanLicenseParams;
+	licenseProducts?: FullProduct[];
 	pinnedInternalIdByPublicId: Map<string, string>;
 }): Promise<ResolvedLink> => {
-	// An explicit entry.version pins the link to that version of the license
-	// plan (the manual re-link after versioning it). Otherwise existing links
-	// keep their pinned version and only new links resolve to latest.
-	const licenseProduct = await getFullLicenseProduct({
-		ctx,
-		idOrInternalId:
-			entry.version !== undefined
-				? entry.license_plan_id
-				: (pinnedInternalIdByPublicId.get(entry.license_plan_id) ??
-					entry.license_plan_id),
-		version: entry.version,
-	});
+	const pinnedInternalId =
+		entry.version === undefined
+			? pinnedInternalIdByPublicId.get(entry.license_plan_id)
+			: undefined;
+	const virtualCandidates = licenseProducts
+		?.filter(
+			(product) =>
+				product.id === entry.license_plan_id &&
+				(entry.version === undefined || product.version === entry.version),
+		)
+		.sort((a, b) => b.version - a.version);
+	const licenseProduct =
+		(pinnedInternalId
+			? await getFullLicenseProduct({ ctx, idOrInternalId: pinnedInternalId })
+			: virtualCandidates?.[0]) ??
+		(await getFullLicenseProduct({
+			ctx,
+			idOrInternalId: entry.license_plan_id,
+			version: entry.version,
+		}));
 
 	validateLicenseLink({
 		parentProduct,
@@ -60,8 +132,7 @@ const resolveLink = async ({
 	};
 };
 
-/** One-to-one ownership guard: a license plan may be offered by only one
- * parent plan lineage. Links held by any version of another plan block it. */
+/** A license plan may be offered by only one parent plan lineage. */
 const assertLicenseNotOwnedElsewhere = async ({
 	ctx,
 	parentProduct,
@@ -88,8 +159,7 @@ const assertLicenseNotOwnedElsewhere = async ({
 	}
 };
 
-/** Guards a link removal or capacity reduction against active assignments —
- * a plan cannot drop below what customers are already using. */
+/** A plan cannot drop below what customers are already using. */
 const assertCapacityAllowed = async ({
 	ctx,
 	parentInternalProductId,
@@ -117,42 +187,57 @@ const assertCapacityAllowed = async ({
 	}
 };
 
-/**
- * Declaratively syncs a plan's catalog `licenses`: the array is the complete
- * set — links absent from it are removed (guarded against active
- * assignments), present ones are upserted, and entries carrying `items` have
- * them applied to the license plan itself. No-op when `licenses` is undefined
- * (the field was not part of the update).
- */
-export const syncPlanLicenses = async ({
+/** Resolves and validates the complete desired license list without writing. */
+export const preparePlanLicenseSync = async ({
 	ctx,
 	parentProduct,
 	licenses,
+	fromInternalProductId = parentProduct.internal_id,
+	newParentVersion = false,
+	licenseProducts,
 }: {
 	ctx: AutumnContext;
 	parentProduct: FullProduct;
 	licenses?: PlanLicenseParams[];
-}) => {
-	if (licenses === undefined) return;
+	fromInternalProductId?: string;
+	newParentVersion?: boolean;
+	licenseProducts?: FullProduct[];
+}): Promise<PreparedPlanLicenseSync | undefined> => {
+	if (licenses === undefined) return undefined;
+	const duplicate = findDuplicate(
+		licenses.map((license) => license.license_plan_id),
+	);
+	if (duplicate) {
+		throw new RecaseError({
+			message: `Duplicate license ${duplicate} in licenses`,
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
 
-	const existingLinks =
+	const sourceLinks =
 		await planLicenseRepo.listCatalogByParentInternalProductIds({
 			db: ctx.db,
-			parentInternalProductIds: [parentProduct.internal_id],
+			parentInternalProductIds: [fromInternalProductId],
 		});
 	const existingLinkProducts = await planLicenseRepo.listProductsByInternalIds({
 		db: ctx.db,
-		internalProductIds: existingLinks.map(
+		internalProductIds: sourceLinks.map(
 			(link) => link.license_internal_product_id,
 		),
 	});
 	const pinnedInternalIdByPublicId = new Map(
 		existingLinkProducts.map((product) => [product.id, product.internal_id]),
 	);
-
 	const resolved = await Promise.all(
 		licenses.map((entry) =>
-			resolveLink({ ctx, parentProduct, entry, pinnedInternalIdByPublicId }),
+			resolveLink({
+				ctx,
+				parentProduct,
+				entry,
+				licenseProducts,
+				pinnedInternalIdByPublicId,
+			}),
 		),
 	);
 	const newLinks = resolved.filter(
@@ -172,6 +257,7 @@ export const syncPlanLicenses = async ({
 	);
 
 	// Removals + capacity reductions must clear the active-assignment guard.
+	const existingLinks = newParentVersion ? [] : sourceLinks;
 	const removed = existingLinks.filter(
 		(link) => !keepInternalIds.has(link.license_internal_product_id),
 	);
@@ -209,6 +295,20 @@ export const syncPlanLicenses = async ({
 		),
 	);
 
+	return { parentProduct, resolved, removed };
+};
+
+export const applyPreparedPlanLicenseSync = async ({
+	ctx,
+	prepared,
+	parentInternalProductId = prepared.parentProduct.internal_id,
+}: {
+	ctx: AutumnContext;
+	prepared: PreparedPlanLicenseSync;
+	parentInternalProductId?: string;
+}) => {
+	const { parentProduct, resolved, removed } = prepared;
+
 	logLicenseAction({
 		ctx,
 		action: "link",
@@ -224,7 +324,7 @@ export const syncPlanLicenses = async ({
 		for (const link of resolved) {
 			await planLicenseRepo.upsert({
 				db: txDb,
-				parentInternalProductId: parentProduct.internal_id,
+				parentInternalProductId,
 				licenseInternalProductId: link.licenseProduct.internal_id,
 				included: link.included,
 				prepaidOnly: link.prepaidOnly,
@@ -238,4 +338,13 @@ export const syncPlanLicenses = async ({
 			});
 		}
 	});
+};
+
+export const syncPlanLicenses = async (args: {
+	ctx: AutumnContext;
+	parentProduct: FullProduct;
+	licenses?: PlanLicenseParams[];
+}) => {
+	const prepared = await preparePlanLicenseSync(args);
+	if (prepared) await applyPreparedPlanLicenseSync({ ctx: args.ctx, prepared });
 };

--- a/server/src/internal/licenses/actions/links/syncPlanLicenses.ts
+++ b/server/src/internal/licenses/actions/links/syncPlanLicenses.ts
@@ -180,7 +180,7 @@ const assertCapacityAllowed = async ({
 	});
 	if (maxAssigned > included) {
 		throw new RecaseError({
-			message: `Cannot set included to ${included}: a customer has ${maxAssigned} active assignments for ${licensePlanId}. Unassign licenses first.`,
+			message: `Cannot set ${licensePlanId} included to ${included}: a customer has ${maxAssigned} active assignment${maxAssigned === 1 ? "" : "s"}. Unassign ${maxAssigned === 1 ? "it" : "them"} first.`,
 			code: ErrCode.InvalidRequest,
 			statusCode: 400,
 		});

--- a/server/src/internal/licenses/licenseUtils.ts
+++ b/server/src/internal/licenses/licenseUtils.ts
@@ -1,13 +1,25 @@
 import {
+	type ApiPlanLicenseV1,
 	type CusProductStatus,
 	ErrCode,
 	type FullCusProduct,
+	type FullProduct,
 	LICENSE_ASSIGNABLE_STATUSES,
 	RecaseError,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 import { nullish } from "@/utils/genUtils.js";
+
+export const toApiPlanLicenses = (
+	licenses: NonNullable<FullProduct["licenses"]>,
+): ApiPlanLicenseV1[] =>
+	licenses.map((license) => ({
+		license_plan_id: license.product.id,
+		version: license.product.version,
+		included: license.included,
+		prepaid_only: license.prepaid_only,
+	}));
 
 export const getFullLicenseProduct = async ({
 	ctx,

--- a/server/src/internal/product/actions/createProduct.ts
+++ b/server/src/internal/product/actions/createProduct.ts
@@ -7,7 +7,10 @@ import type {
 } from "@autumn/shared";
 import { ProductAlreadyExistsError } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { syncPlanLicenses } from "@/internal/licenses/actions/links/syncPlanLicenses.js";
+import {
+	applyPreparedPlanLicenseSync,
+	preparePlanLicenseSync,
+} from "@/internal/licenses/actions/links/syncPlanLicenses.js";
 import { getEntsWithFeature } from "@/internal/products/entitlements/entitlementUtils.js";
 import {
 	handleNewFreeTrial,
@@ -16,6 +19,7 @@ import {
 import { ProductService } from "@/internal/products/ProductService.js";
 import { handleNewProductItems } from "@/internal/products/product-items/productItemUtils/handleNewProductItems.js";
 import { getProductResponse } from "@/internal/products/productUtils/productResponseUtils/getProductResponse.js";
+import { buildFullProductFromV2 } from "@/internal/products/productUtils/productV2Utils/buildFullProductFromV2.js";
 import {
 	constructProduct,
 	initProductInStripe,
@@ -48,15 +52,23 @@ export const createProduct = async ({
 		body: data,
 	});
 
-	const product = await ProductService.insert({
-		db,
-		product: constructProduct({
-			productData: data,
-			orgId: org.id,
-			env,
-			baseInternalProductId: data.base_internal_product_id,
-		}),
+	const product = constructProduct({
+		productData: data,
+		orgId: org.id,
+		env,
+		baseInternalProductId: data.base_internal_product_id,
 	});
+	const preparedLicenses = await preparePlanLicenseSync({
+		ctx,
+		parentProduct: buildFullProductFromV2({
+			product: { ...product, items: data.items ?? [] },
+			base: product,
+			org,
+			features,
+		}),
+		licenses: data.licenses,
+	});
+	await ProductService.insert({ db, product });
 
 	const { items, free_trial } = data;
 
@@ -107,11 +119,13 @@ export const createProduct = async ({
 		free_trial: newFreeTrial,
 	};
 
-	await syncPlanLicenses({
-		ctx,
-		parentProduct: newFullProduct,
-		licenses: data.licenses,
-	});
+	if (preparedLicenses) {
+		await applyPreparedPlanLicenseSync({
+			ctx,
+			prepared: preparedLicenses,
+			parentInternalProductId: newFullProduct.internal_id,
+		});
+	}
 
 	if (data.create_in_stripe !== false) {
 		await initProductInStripe({

--- a/server/src/internal/product/actions/previewUpdatePlan/buildCorePlanUpdatePreview.ts
+++ b/server/src/internal/product/actions/previewUpdatePlan/buildCorePlanUpdatePreview.ts
@@ -30,6 +30,7 @@ export const buildCorePlanUpdatePreview = ({
 
 	return {
 		plan_id: planId,
+		license_changes: [],
 		...(shouldExpandPlanFromScopedCtx ? { plan: preview } : {}),
 		has_customers: hasCustomers,
 		customer_count: customerCount,

--- a/server/src/internal/product/actions/previewUpdatePlan/previewUpdatePlan.ts
+++ b/server/src/internal/product/actions/previewUpdatePlan/previewUpdatePlan.ts
@@ -8,6 +8,10 @@ import {
 	type UpdateVariantParams,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import {
+	previewPlanLicenseSync,
+	validatePlanLicenseUpdate,
+} from "@/internal/licenses/actions/links/syncPlanLicenses.js";
 import { getPlanResponse } from "@/internal/products/productUtils/productResponseUtils/getPlanResponse.js";
 import { getVariantSettingsPatch } from "../common/planTransformUtils.js";
 import { previewOtherProductVersions } from "../updateProduct/updateOtherProductVersions.js";
@@ -66,6 +70,13 @@ export const buildPlanUpdatePreview = async ({
 		updates: data,
 		hasCustomers,
 	});
+	const licensePreview = await previewPlanLicenseSync({
+		ctx,
+		parentProduct: incomingFullProduct,
+		licenses: data.licenses,
+		newParentVersion: versionable,
+	});
+	previewPlan.licenses = licensePreview.licenses;
 	const diff = diffPlanV1({ from: currentPlan, to: previewPlan });
 	const settingsPatch = getVariantSettingsPatch({
 		from: currentPlan,
@@ -114,6 +125,7 @@ export const buildPlanUpdatePreview = async ({
 			customerCount,
 			versionable,
 		}),
+		license_changes: licensePreview.changes,
 		variants,
 		other_versions: otherVersions,
 	});
@@ -126,6 +138,10 @@ export const previewUpdatePlan = async ({
 	ctx: AutumnContext;
 	data: PreviewUpdatePlanParamsV2;
 }): Promise<PlanUpdatePreview> => {
+	validatePlanLicenseUpdate({
+		allVersions: data.all_versions,
+		licenses: data.licenses,
+	});
 	const baseFullProduct = await getPreviewTargetProduct({
 		ctx,
 		planId: data.plan_id,

--- a/server/src/internal/product/actions/updateProduct.ts
+++ b/server/src/internal/product/actions/updateProduct.ts
@@ -22,8 +22,8 @@ import {
 	handleNewFreeTrial,
 	validateOneOffTrial,
 } from "@/internal/products/free-trials/freeTrialUtils.js";
+import { prepareProductLicenseSync } from "@/internal/products/handlers/handleUpdatePlan/prepareProductLicenseSync.js";
 import { handleUpdateProductDetails } from "@/internal/products/handlers/handleUpdatePlan/updateProductDetails.js";
-import { validateProductLicenseLinks } from "@/internal/products/handlers/handleUpdatePlan/validateProductLicenseLinks.js";
 import { handleVersionProductV2 } from "@/internal/products/handlers/handleVersionProduct.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 import { getProductResponse } from "@/internal/products/productUtils/productResponseUtils/getProductResponse.js";
@@ -107,10 +107,14 @@ export const updateProduct = async ({
 	const { version, disable_version, force_version, all_versions } = query;
 	const effectiveDisableVersion = disable_version || all_versions;
 	const basePlanIdProvided = "base_plan_id" in rawProductUpdates;
-	const { base_plan_id: basePlanId, ...productUpdates } = rawProductUpdates;
+	const {
+		base_plan_id: basePlanId,
+		licenses,
+		...productUpdates
+	} = rawProductUpdates;
 	validatePlanLicenseUpdate({
 		allVersions: all_versions,
-		licenses: productUpdates.licenses,
+		licenses,
 	});
 
 	if (force_version && disable_version) {
@@ -231,11 +235,9 @@ export const updateProduct = async ({
 			? ((productUpdates.free_trial as FreeTrial | undefined) ?? undefined)
 			: (curProductV2.free_trial ?? undefined);
 
-	const productFields = { ...productUpdates };
-	delete productFields.licenses;
 	const newProductV2: ProductV2 = {
 		...curProductV2,
-		...productFields,
+		...productUpdates,
 		group: productUpdates.group || curProductV2.group || "",
 		items: productUpdates.items ?? curProductV2.items,
 		free_trial: newFreeTrial,
@@ -245,7 +247,7 @@ export const updateProduct = async ({
 		),
 	};
 
-	if (Object.keys(productUpdates).length === 0) {
+	if (Object.keys(productUpdates).length === 0 && licenses === undefined) {
 		await applyBasePlanLink();
 		const latestProduct = basePlanIdProvided
 			? await ProductService.getFull({
@@ -299,29 +301,26 @@ export const updateProduct = async ({
 	const productWillVersion = productVersioningEligible && productChanged;
 	const willVersion =
 		force_version || billingControlsWillVersion || productWillVersion;
-	const preparedLicenses = await validateProductLicenseLinks({
+	const preparedLicenseSync = await prepareProductLicenseSync({
 		ctx,
 		fromInternalProductId: fullProduct.internal_id,
 		newProductV2,
 		baseProduct: fullProduct,
 		org,
 		features,
-		licenses: productUpdates.licenses,
+		licenses,
 		newParentVersion: willVersion,
 	});
-	const createVersion = () =>
-		handleVersionProductV2({
+	const createVersion = async () => {
+		const newProduct = await handleVersionProductV2({
 			ctx,
 			newProductV2,
 			latestProduct: fullProduct,
 			org,
 			env,
 			baseInternalProductId: nextBaseInternalProductId,
-			preparedPlanLicenseSync: preparedLicenses,
+			preparedPlanLicenseSync: preparedLicenseSync,
 		});
-
-	if (billingControlsWillVersion) {
-		const newProduct = await createVersion();
 		const latestBase = await ProductService.getFull({
 			db,
 			idOrInternalId: newProduct.id,
@@ -330,6 +329,10 @@ export const updateProduct = async ({
 		});
 		await applyVariantUpdates({ latestBase });
 		return newProduct;
+	};
+
+	if (billingControlsWillVersion) {
+		return createVersion();
 	}
 
 	await handleUpdateProductDetails({
@@ -342,8 +345,11 @@ export const updateProduct = async ({
 		rewardPrograms,
 		logger: ctx.logger,
 	});
-	if (preparedLicenses && !willVersion) {
-		await applyPreparedPlanLicenseSync({ ctx, prepared: preparedLicenses });
+	if (preparedLicenseSync && !willVersion) {
+		await applyPreparedPlanLicenseSync({
+			ctx,
+			prepared: preparedLicenseSync,
+		});
 	}
 
 	if (notNullish(productUpdates.metadata)) {
@@ -359,30 +365,12 @@ export const updateProduct = async ({
 
 	// Check if versioning is needed (customers exist AND items or free trial changed)
 	if (force_version) {
-		const newProduct = await createVersion();
-		const latestBase = await ProductService.getFull({
-			db,
-			idOrInternalId: newProduct.id,
-			orgId: org.id,
-			env,
-		});
-		await applyVariantUpdates({ latestBase });
-		return newProduct;
+		return createVersion();
 	}
 
 	if (productVersioningEligible) {
 		if (productWillVersion) {
-			const newProduct = await createVersion();
-
-			const latestBase = await ProductService.getFull({
-				db,
-				idOrInternalId: newProduct.id,
-				orgId: org.id,
-				env,
-			});
-			await applyVariantUpdates({ latestBase });
-
-			return newProduct;
+			return createVersion();
 		}
 
 		await applyHistoricalVersions({ latestProduct: fullProduct });
@@ -407,7 +395,6 @@ export const updateProduct = async ({
 	const latestProductId = productUpdates.id || fullProduct.id;
 	await applyBasePlanLink();
 
-	// New full product
 	let newFullProduct = await ProductService.getFull({
 		db,
 		idOrInternalId: latestProductId,
@@ -437,8 +424,6 @@ export const updateProduct = async ({
 			version: fullProduct.version,
 		});
 	}
-
-	// New full product
 
 	await applyHistoricalVersions({ latestProduct: newFullProduct });
 	await applyVariantUpdates({ latestBase: newFullProduct });

--- a/server/src/internal/product/actions/updateProduct.ts
+++ b/server/src/internal/product/actions/updateProduct.ts
@@ -13,7 +13,10 @@ import {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { initStripeResourcesForProducts } from "@/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.js";
-import { syncPlanLicenses } from "@/internal/licenses/actions/links/syncPlanLicenses.js";
+import {
+	applyPreparedPlanLicenseSync,
+	validatePlanLicenseUpdate,
+} from "@/internal/licenses/actions/links/syncPlanLicenses.js";
 import { updateVariants } from "@/internal/product/actions/updateVariants/updateVariants.js";
 import {
 	handleNewFreeTrial,
@@ -105,6 +108,10 @@ export const updateProduct = async ({
 	const effectiveDisableVersion = disable_version || all_versions;
 	const basePlanIdProvided = "base_plan_id" in rawProductUpdates;
 	const { base_plan_id: basePlanId, ...productUpdates } = rawProductUpdates;
+	validatePlanLicenseUpdate({
+		allVersions: all_versions,
+		licenses: productUpdates.licenses,
+	});
 
 	if (force_version && disable_version) {
 		throw new RecaseError({
@@ -224,9 +231,11 @@ export const updateProduct = async ({
 			? ((productUpdates.free_trial as FreeTrial | undefined) ?? undefined)
 			: (curProductV2.free_trial ?? undefined);
 
+	const productFields = { ...productUpdates };
+	delete productFields.licenses;
 	const newProductV2: ProductV2 = {
 		...curProductV2,
-		...productUpdates,
+		...productFields,
 		group: productUpdates.group || curProductV2.group || "",
 		items: productUpdates.items ?? curProductV2.items,
 		free_trial: newFreeTrial,
@@ -260,26 +269,6 @@ export const updateProduct = async ({
 		curProduct: fullProduct,
 	});
 
-	// Guard license links against the new item state before any write, so an
-	// in-place interval change can't silently invalidate a link (the versioning
-	// path validates the same way inside handleVersionProductV2).
-	await validateProductLicenseLinks({
-		ctx,
-		fromInternalProductId: fullProduct.internal_id,
-		newProductV2,
-		baseProduct: fullProduct,
-		org,
-		features,
-	});
-
-	// Sync the plan's catalog license links before any versioning branch, so a
-	// new version carries the updated links forward via copyPlanLicensesToNewVersion.
-	await syncPlanLicenses({
-		ctx,
-		parentProduct: fullProduct,
-		licenses: productUpdates.licenses,
-	});
-
 	const itemsExist = notNullish(productUpdates.items);
 	const customerProductExists = customerUsage.hasAnyCustomerProducts;
 	const versionableCustomerProductExists =
@@ -287,37 +276,52 @@ export const updateProduct = async ({
 	const freeTrialProvided = "free_trial" in productUpdates;
 	const billingControlsProvided = "billing_controls" in productUpdates;
 
-	// Billing controls are a global setting: changing only them versions the
-	// product without going through the item/detail update paths. Returns false
-	// if anything else changed so those paths still run.
-	const isBillingControlsOnlyChange = () => {
-		const same = productsAreSame({ newProductV2, curProductV2, features });
-		return (
-			!same.billingControlsSame &&
-			same.itemsSame &&
-			same.freeTrialsSame &&
-			same.detailsSame &&
-			same.configSame &&
-			same.optionsSame &&
-			same.metadataSame
-		);
-	};
-
-	if (
+	const same = productsAreSame({ newProductV2, curProductV2, features });
+	const billingControlsOnlyChanged =
+		billingControlsProvided &&
+		!same.billingControlsSame &&
+		same.itemsSame &&
+		same.freeTrialsSame &&
+		same.detailsSame &&
+		same.configSame &&
+		same.optionsSame &&
+		same.metadataSame;
+	const productVersioningEligible =
 		versionableCustomerProductExists &&
 		!effectiveDisableVersion &&
+		(itemsExist || freeTrialProvided);
+	const productChanged = !same.itemsSame || !same.freeTrialsSame;
+	const billingControlsWillVersion =
 		!force_version &&
-		billingControlsProvided &&
-		isBillingControlsOnlyChange()
-	) {
-		const newProduct = await handleVersionProductV2({
+		versionableCustomerProductExists &&
+		!effectiveDisableVersion &&
+		billingControlsOnlyChanged;
+	const productWillVersion = productVersioningEligible && productChanged;
+	const willVersion =
+		force_version || billingControlsWillVersion || productWillVersion;
+	const preparedLicenses = await validateProductLicenseLinks({
+		ctx,
+		fromInternalProductId: fullProduct.internal_id,
+		newProductV2,
+		baseProduct: fullProduct,
+		org,
+		features,
+		licenses: productUpdates.licenses,
+		newParentVersion: willVersion,
+	});
+	const createVersion = () =>
+		handleVersionProductV2({
 			ctx,
-			newProductV2: newProductV2,
+			newProductV2,
 			latestProduct: fullProduct,
 			org,
 			env,
 			baseInternalProductId: nextBaseInternalProductId,
+			preparedPlanLicenseSync: preparedLicenses,
 		});
+
+	if (billingControlsWillVersion) {
+		const newProduct = await createVersion();
 		const latestBase = await ProductService.getFull({
 			db,
 			idOrInternalId: newProduct.id,
@@ -338,6 +342,9 @@ export const updateProduct = async ({
 		rewardPrograms,
 		logger: ctx.logger,
 	});
+	if (preparedLicenses && !willVersion) {
+		await applyPreparedPlanLicenseSync({ ctx, prepared: preparedLicenses });
+	}
 
 	if (notNullish(productUpdates.metadata)) {
 		await productRepo.updateMetadataByExternalId({
@@ -352,14 +359,7 @@ export const updateProduct = async ({
 
 	// Check if versioning is needed (customers exist AND items or free trial changed)
 	if (force_version) {
-		const newProduct = await handleVersionProductV2({
-			ctx,
-			newProductV2: newProductV2,
-			latestProduct: fullProduct,
-			org,
-			env,
-			baseInternalProductId: nextBaseInternalProductId,
-		});
+		const newProduct = await createVersion();
 		const latestBase = await ProductService.getFull({
 			db,
 			idOrInternalId: newProduct.id,
@@ -370,28 +370,9 @@ export const updateProduct = async ({
 		return newProduct;
 	}
 
-	if (
-		versionableCustomerProductExists &&
-		!effectiveDisableVersion &&
-		(itemsExist || freeTrialProvided)
-	) {
-		const { itemsSame, freeTrialsSame } = productsAreSame({
-			newProductV2: newProductV2,
-			curProductV1: fullProduct,
-			features,
-		});
-
-		const productSame = itemsSame && freeTrialsSame;
-
-		if (!productSame) {
-			const newProduct = await handleVersionProductV2({
-				ctx,
-				newProductV2: newProductV2,
-				latestProduct: fullProduct,
-				org,
-				env,
-				baseInternalProductId: nextBaseInternalProductId,
-			});
+	if (productVersioningEligible) {
+		if (productWillVersion) {
+			const newProduct = await createVersion();
 
 			const latestBase = await ProductService.getFull({
 				db,

--- a/server/src/internal/products/handlers/handleUpdatePlan/prepareProductLicenseSync.ts
+++ b/server/src/internal/products/handlers/handleUpdatePlan/prepareProductLicenseSync.ts
@@ -16,7 +16,7 @@ import { buildFullProductFromV2 } from "@/internal/products/productUtils/product
  * an interval change silently invalidates a link. Runs for both versioning and
  * in-place edits.
  */
-export const validateProductLicenseLinks = async ({
+export const prepareProductLicenseSync = async ({
 	ctx,
 	fromInternalProductId,
 	newProductV2,

--- a/server/src/internal/products/handlers/handleUpdatePlan/validateProductLicenseLinks.ts
+++ b/server/src/internal/products/handlers/handleUpdatePlan/validateProductLicenseLinks.ts
@@ -1,43 +1,14 @@
 import type {
 	Feature,
-	FullProduct,
 	Organization,
+	PlanLicenseParams,
 	Product,
 	ProductV2,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { validateCopiedPlanLicenses } from "@/internal/licenses/actions/links/copyPlanLicensesToNewVersion.js";
-import { getEntsWithFeature } from "@/internal/products/entitlements/entitlementUtils.js";
-import { convertProductV2ToV1 } from "@/internal/products/productUtils/productV2Utils/convertProductV2ToV1.js";
-
-/** The product's post-edit item state as an in-memory FullProduct, so link
- * rules can be checked before anything is persisted. */
-export const buildFullProductFromV2 = ({
-	newProductV2,
-	baseProduct,
-	org,
-	features,
-}: {
-	newProductV2: ProductV2;
-	baseProduct: Product;
-	org: Organization;
-	features: Feature[];
-}): FullProduct => {
-	const { prices, entitlements } = convertProductV2ToV1({
-		productV2: newProductV2,
-		orgId: org.id,
-		features,
-	});
-	return {
-		...baseProduct,
-		prices,
-		entitlements: getEntsWithFeature({
-			ents: Object.values(entitlements),
-			features,
-		}),
-		free_trial: null,
-	};
-};
+import { preparePlanLicenseSync } from "@/internal/licenses/actions/links/syncPlanLicenses.js";
+import { buildFullProductFromV2 } from "@/internal/products/productUtils/productV2Utils/buildFullProductFromV2.js";
 
 /**
  * Parent-side link guard: the plan's outgoing license links must still satisfy
@@ -52,6 +23,8 @@ export const validateProductLicenseLinks = async ({
 	baseProduct,
 	org,
 	features,
+	licenses,
+	newParentVersion = false,
 }: {
 	ctx: AutumnContext;
 	fromInternalProductId: string;
@@ -59,17 +32,30 @@ export const validateProductLicenseLinks = async ({
 	baseProduct: Product;
 	org: Organization;
 	features: Feature[];
+	licenses?: PlanLicenseParams[];
+	newParentVersion?: boolean;
 }) => {
 	const newFullProduct = buildFullProductFromV2({
-		newProductV2,
-		baseProduct,
+		product: newProductV2,
+		base: baseProduct,
 		org,
 		features,
 	});
+
+	if (licenses !== undefined) {
+		return preparePlanLicenseSync({
+			ctx,
+			parentProduct: newFullProduct,
+			licenses,
+			fromInternalProductId,
+			newParentVersion,
+		});
+	}
 
 	await validateCopiedPlanLicenses({
 		ctx,
 		fromInternalProductId,
 		newParentProduct: newFullProduct,
 	});
+	return undefined;
 };

--- a/server/src/internal/products/handlers/handleVersionProduct.ts
+++ b/server/src/internal/products/handlers/handleVersionProduct.ts
@@ -24,7 +24,7 @@ import {
 	applyPreparedPlanLicenseSync,
 	type PreparedPlanLicenseSync,
 } from "@/internal/licenses/actions/links/syncPlanLicenses.js";
-import { validateProductLicenseLinks } from "./handleUpdatePlan/validateProductLicenseLinks.js";
+import { prepareProductLicenseSync } from "./handleUpdatePlan/prepareProductLicenseSync.js";
 
 const clearDefaultFlagFromOtherVersions = async ({
 	ctx,
@@ -122,9 +122,9 @@ export const handleVersionProductV2 = async ({
 	// License links must satisfy the link rules against the NEW version before
 	// anything is persisted — otherwise a rejected link leaves a half-created
 	// version behind.
-	const preparedLicenses =
+	const preparedLicenseSync =
 		preparedPlanLicenseSync ??
-		(await validateProductLicenseLinks({
+		(await prepareProductLicenseSync({
 			ctx,
 			fromInternalProductId: latestProduct.internal_id,
 			newProductV2,
@@ -163,10 +163,10 @@ export const handleVersionProductV2 = async ({
 		data: customPrices,
 	});
 
-	if (preparedLicenses) {
+	if (preparedLicenseSync) {
 		await applyPreparedPlanLicenseSync({
 			ctx,
-			prepared: preparedLicenses,
+			prepared: preparedLicenseSync,
 			parentInternalProductId: newProduct.internal_id,
 		});
 	} else {

--- a/server/src/internal/products/handlers/handleVersionProduct.ts
+++ b/server/src/internal/products/handlers/handleVersionProduct.ts
@@ -20,6 +20,10 @@ import { addTaskToQueue } from "@server/queue/queueUtils.js";
 import { and, eq, ne } from "drizzle-orm";
 import { initStripeResourcesForProducts } from "@/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.js";
 import { copyPlanLicensesToNewVersion } from "@/internal/licenses/actions/links/copyPlanLicensesToNewVersion.js";
+import {
+	applyPreparedPlanLicenseSync,
+	type PreparedPlanLicenseSync,
+} from "@/internal/licenses/actions/links/syncPlanLicenses.js";
 import { validateProductLicenseLinks } from "./handleUpdatePlan/validateProductLicenseLinks.js";
 
 const clearDefaultFlagFromOtherVersions = async ({
@@ -51,6 +55,7 @@ export const handleVersionProductV2 = async ({
 	env,
 	skipStripeInit = false,
 	baseInternalProductId,
+	preparedPlanLicenseSync,
 }: {
 	ctx: AutumnContext;
 	newProductV2: ProductV2;
@@ -59,6 +64,7 @@ export const handleVersionProductV2 = async ({
 	env: AppEnv;
 	skipStripeInit?: boolean;
 	baseInternalProductId?: string | null;
+	preparedPlanLicenseSync?: PreparedPlanLicenseSync;
 }) => {
 	const { db, features } = ctx;
 
@@ -96,6 +102,7 @@ export const handleVersionProductV2 = async ({
 			...latestProduct,
 			...newProductV2,
 			config: mergedConfig,
+			licenses: undefined,
 		}),
 		version: newVersion,
 		orgId: org.id,
@@ -115,14 +122,17 @@ export const handleVersionProductV2 = async ({
 	// License links must satisfy the link rules against the NEW version before
 	// anything is persisted — otherwise a rejected link leaves a half-created
 	// version behind.
-	await validateProductLicenseLinks({
-		ctx,
-		fromInternalProductId: latestProduct.internal_id,
-		newProductV2,
-		baseProduct: newProduct,
-		org,
-		features,
-	});
+	const preparedLicenses =
+		preparedPlanLicenseSync ??
+		(await validateProductLicenseLinks({
+			ctx,
+			fromInternalProductId: latestProduct.internal_id,
+			newProductV2,
+			baseProduct: newProduct,
+			org,
+			features,
+			newParentVersion: true,
+		}));
 
 	await ProductService.insert({ db, product: newProduct });
 
@@ -153,11 +163,19 @@ export const handleVersionProductV2 = async ({
 		data: customPrices,
 	});
 
-	await copyPlanLicensesToNewVersion({
-		ctx,
-		fromInternalProductId: latestProduct.internal_id,
-		toInternalProductId: newProduct.internal_id,
-	});
+	if (preparedLicenses) {
+		await applyPreparedPlanLicenseSync({
+			ctx,
+			prepared: preparedLicenses,
+			parentInternalProductId: newProduct.internal_id,
+		});
+	} else {
+		await copyPlanLicensesToNewVersion({
+			ctx,
+			fromInternalProductId: latestProduct.internal_id,
+			toInternalProductId: newProduct.internal_id,
+		});
+	}
 
 	// Handle new free trial (create new)
 	// newProductV2.free_trial can be:

--- a/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
@@ -17,6 +17,7 @@ import {
 	sortProductItems,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { toApiPlanLicenses } from "@/internal/licenses/licenseUtils.js";
 
 import { ProductService } from "../../ProductService.js";
 import { mapToProductItems } from "../../productV2Utils.js";
@@ -134,11 +135,7 @@ export const getPlanResponse = async ({
 		price: basePrice,
 		items: planItems ?? [],
 		licenses: product.licenses?.length
-			? product.licenses.map((license) => ({
-					license_plan_id: license.product.id,
-					included: license.included,
-					prepaid_only: license.prepaid_only,
-				}))
+			? toApiPlanLicenses(product.licenses)
 			: undefined,
 		free_trial: freeTrial,
 

--- a/server/src/internal/products/productUtils/productV2Utils/buildFullProductFromV2.ts
+++ b/server/src/internal/products/productUtils/productV2Utils/buildFullProductFromV2.ts
@@ -1,0 +1,36 @@
+import type {
+	Feature,
+	FullProduct,
+	Organization,
+	Product,
+	ProductV2,
+} from "@autumn/shared";
+import { getEntsWithFeature } from "@/internal/products/entitlements/entitlementUtils.js";
+import { convertProductV2ToV1 } from "./convertProductV2ToV1.js";
+
+export const buildFullProductFromV2 = ({
+	product,
+	base,
+	org,
+	features,
+}: {
+	product: ProductV2;
+	base: Product;
+	org: Organization;
+	features: Feature[];
+}): FullProduct => {
+	const { prices, entitlements } = convertProductV2ToV1({
+		productV2: product,
+		orgId: org.id,
+		features,
+	});
+	return {
+		...base,
+		prices,
+		entitlements: getEntsWithFeature({
+			ents: Object.values(entitlements),
+			features,
+		}),
+		free_trial: null,
+	};
+};

--- a/server/tests/integration/licenses/catalog-update/license-catalog-response.test.ts
+++ b/server/tests/integration/licenses/catalog-update/license-catalog-response.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from "bun:test";
-import type { CheckResponseV3 } from "@autumn/shared";
+import type {
+	CatalogPreviewUpdateResponse,
+	CheckResponseV3,
+} from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
@@ -13,6 +16,167 @@ const makeLicenseProduct = () => ({
 		items: [items.monthlyMessages({ includedUsage: 25 })],
 	}),
 });
+
+test.concurrent(
+	`${chalk.yellowBright("licenses: catalog resolves same-batch dependencies and rejects cycles")}`,
+	async () => {
+		const { autumnV2_2 } = await initScenario({
+			customerId: "license-catalog-batch",
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+		const parentId = "license_catalog_batch_parent";
+		const childId = "license_catalog_batch_child";
+
+		await autumnV2_2.post("/catalog.update", {
+			plans: [
+				{
+					plan_id: parentId,
+					name: "Parent",
+					licenses: [{ license_plan_id: childId, included: 4 }],
+				},
+				{ plan_id: childId, name: "Child", licenses: [] },
+			],
+		});
+		const parent = await autumnV2_2.post("/plans.get", { plan_id: parentId });
+		expect(parent.licenses).toEqual([
+			{
+				license_plan_id: childId,
+				version: 1,
+				included: 4,
+				prepaid_only: true,
+			},
+		]);
+
+		await expect(
+			autumnV2_2.post("/catalog.preview_update", {
+				plans: [
+					{ plan_id: parentId, licenses: [{ license_plan_id: childId }] },
+					{ plan_id: childId, licenses: [{ license_plan_id: parentId }] },
+				],
+			}),
+		).rejects.toThrow("Plan dependency cycle");
+		await autumnV2_2.post("/catalog.update", {
+			skip_plan_ids: [parentId, childId],
+			plans: [
+				{ plan_id: parentId, licenses: [{ license_plan_id: childId }] },
+				{ plan_id: childId, licenses: [{ license_plan_id: parentId }] },
+			],
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses: same-batch historical versioning resolves from the latest version")}`,
+	async () => {
+		const child = products.base({
+			id: "license-historical-child",
+			items: [items.monthlyMessages()],
+		});
+		const { autumnV2_2 } = await initScenario({
+			customerId: "license-historical-batch",
+			setup: [s.customer({ testClock: false }), s.products({ list: [child] })],
+			actions: [],
+		});
+		await autumnV2_2.post("/plans.update", {
+			plan_id: child.id,
+			force_version: true,
+		});
+
+		const preview = (await autumnV2_2.post("/catalog.preview_update", {
+			expand: ["plan_changes.plan"],
+			plans: [
+				{
+					plan_id: "license-historical-parent",
+					licenses: [{ license_plan_id: child.id }],
+				},
+				{
+					plan_id: child.id,
+					version: 1,
+					force_version: true,
+					items: [
+						{
+							feature_id: TestFeature.Messages,
+							included: 50,
+							reset: { interval: "month" },
+						},
+					],
+				},
+			],
+		})) as CatalogPreviewUpdateResponse;
+		const parent = preview.plan_changes.find(
+			(change) => change.plan_id === "license-historical-parent",
+		);
+		expect(parent?.plan?.licenses?.[0]?.version).toBe(3);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses: catalog preview reports update and removal")}`,
+	async () => {
+		const parent = products.base({
+			id: "license-preview-parent",
+			items: [items.dashboard()],
+		});
+		const license = products.base({
+			id: "license-preview-child",
+			items: [items.monthlyMessages()],
+		});
+		const { autumnV2_2 } = await initScenario({
+			customerId: "license-preview",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 2,
+				}),
+			],
+		});
+
+		const updatePreview = (await autumnV2_2.post("/catalog.preview_update", {
+			expand: ["plan_changes.plan"],
+			plans: [
+				{
+					plan_id: parent.id,
+					licenses: [
+						{
+							license_plan_id: license.id,
+							version: 1,
+							included: 3,
+						},
+					],
+				},
+			],
+		})) as CatalogPreviewUpdateResponse;
+		const change = updatePreview.plan_changes[0]!;
+		expect(change.action).toBe("updated");
+		expect(change.license_changes).toEqual([
+			{
+				action: "update",
+				license_plan_id: license.id,
+			},
+		]);
+		expect(change.plan?.licenses).toEqual([
+			{
+				license_plan_id: license.id,
+				version: 1,
+				included: 3,
+				prepaid_only: true,
+			},
+		]);
+
+		const removePreview = (await autumnV2_2.post("/catalog.preview_update", {
+			plans: [{ plan_id: parent.id, licenses: [] }],
+		})) as CatalogPreviewUpdateResponse;
+		expect(removePreview.plan_changes[0]?.license_changes[0]?.action).toBe(
+			"remove",
+		);
+	},
+);
 
 test.concurrent(
 	`${chalk.yellowBright("licenses: plan license included updates in place, assignments grant stock items")}`,
@@ -130,6 +294,7 @@ test.concurrent(
 				id: string;
 				licenses?: Array<{
 					license_plan_id: string;
+					version: number;
 					included: number;
 					prepaid_only: boolean;
 				}>;
@@ -139,6 +304,7 @@ test.concurrent(
 		expect(parentPlan?.licenses).toEqual([
 			{
 				license_plan_id: license.id,
+				version: 1,
 				included: 3,
 				prepaid_only: true,
 			},

--- a/server/tests/integration/licenses/catalog-update/license-plan-versioning.test.ts
+++ b/server/tests/integration/licenses/catalog-update/license-plan-versioning.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
@@ -71,5 +72,82 @@ test.concurrent(
 			license_plan_id: license.id,
 			included: 1,
 		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses: combined item and explicit license update leaves old links unchanged")}`,
+	async () => {
+		const parent = products.base({
+			id: "license-combined-version-parent",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const license = products.base({
+			id: "license-combined-version-child",
+			items: [items.monthlyMessages({ includedUsage: 25 })],
+		});
+		const { autumnV2_2, ctx } = await initScenario({
+			customerId: "license-combined-version",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 2,
+				}),
+				s.billing.attach({ productId: parent.id }),
+			],
+		});
+		const v1 = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: parent.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		await expect(
+			autumnV2_2.post("/plans.update", {
+				plan_id: parent.id,
+				all_versions: true,
+				licenses: [],
+			}),
+		).rejects.toThrow("Updating licenses across all plan versions");
+		await expect(
+			autumnV2_2.post("/catalog.preview_update", {
+				plans: [{ plan_id: parent.id, all_versions: true, licenses: [] }],
+			}),
+		).rejects.toThrow("Updating licenses across all plan versions");
+
+		await autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			items: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 200,
+					reset: { interval: "month" },
+				},
+			],
+			licenses: [],
+		});
+
+		const v2 = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: parent.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		const old = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: parent.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+			version: 1,
+		});
+		expect(v2.version).toBe(2);
+		expect(v2.licenses).toHaveLength(0);
+		expect(old.licenses?.map((link) => link.product.id)).toEqual([license.id]);
+		expect(old.internal_id).toBe(v1.internal_id);
 	},
 );

--- a/server/tests/unit/catalog/catalog-plan-dependencies.test.ts
+++ b/server/tests/unit/catalog/catalog-plan-dependencies.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import type { CatalogPlanParams } from "@autumn/shared";
+import { sortCatalogPlansByDependencies } from "@/internal/catalog/actions/catalogPlanDependencies.js";
+
+const plan = (
+	plan_id: string,
+	version?: number,
+	licenses?: CatalogPlanParams["licenses"],
+): CatalogPlanParams => ({ plan_id, version, licenses });
+
+test.concurrent(
+	"unpinned dependencies select the highest batch version",
+	() => {
+		const sorted = sortCatalogPlansByDependencies([
+			plan("parent", undefined, [{ license_plan_id: "child" }]),
+			plan("child", 2),
+			plan("child", 1),
+		]);
+
+		expect(
+			sorted.map(({ plan_id, version }) => `${plan_id}@${version ?? 0}`),
+		).toEqual(["child@2", "parent@0", "child@1"]);
+	},
+);

--- a/shared/api/products/apiPlanV1.ts
+++ b/shared/api/products/apiPlanV1.ts
@@ -65,6 +65,9 @@ export const ApiPlanLicenseV1Schema = z.object({
 	license_plan_id: z.string().meta({
 		description: "The plan offered as a license under this plan.",
 	}),
+	version: z.number().int().min(1).meta({
+		description: "The exact license-plan version pinned by this link.",
+	}),
 	included: z.number().meta({
 		description:
 			"Number of license assignments included with this plan for free.",

--- a/shared/api/products/previewUpdatePlan/components/corePlanUpdatePreview.ts
+++ b/shared/api/products/previewUpdatePlan/components/corePlanUpdatePreview.ts
@@ -1,8 +1,9 @@
-import { ApiPlanV1Schema } from "../../apiPlanV1.js";
 import { DiffedCustomizePlanV1Schema } from "@utils/planV1Utils/diff/diffPlanV1.js";
 import { z } from "zod/v4";
+import { ApiPlanV1Schema } from "../../apiPlanV1.js";
 import {
 	PlanUpdatePreviewItemChangeSchema,
+	PlanUpdatePreviewLicenseChangeSchema,
 	PlanUpdatePreviewPriceChangeSchema,
 } from "./planUpdatePreviewChanges.js";
 
@@ -41,8 +42,12 @@ export const CorePlanUpdatePreviewSchema = z.object({
 	item_changes: z.array(PlanUpdatePreviewItemChangeSchema).default([]).meta({
 		description: "Items that would be added to or removed from this plan.",
 	}),
+	license_changes: z
+		.array(PlanUpdatePreviewLicenseChangeSchema)
+		.default([])
+		.meta({
+			description: "License links that would be created, updated, or removed.",
+		}),
 });
 
-export type CorePlanUpdatePreview = z.infer<
-	typeof CorePlanUpdatePreviewSchema
->;
+export type CorePlanUpdatePreview = z.infer<typeof CorePlanUpdatePreviewSchema>;

--- a/shared/api/products/previewUpdatePlan/components/planUpdatePreviewChanges.ts
+++ b/shared/api/products/previewUpdatePlan/components/planUpdatePreviewChanges.ts
@@ -1,6 +1,6 @@
+import { z } from "zod/v4";
 import { ApiPlanV1Schema } from "../../apiPlanV1.js";
 import { ApiPlanItemV1Schema } from "../../items/apiPlanItemV1.js";
-import { z } from "zod/v4";
 
 export const PlanUpdatePreviewPriceChangeSchema = z.object({
 	previous: ApiPlanV1Schema.shape.price.meta({
@@ -21,6 +21,11 @@ export const PlanUpdatePreviewItemChangeSchema = z.object({
 	item: ApiPlanItemV1Schema.meta({
 		description: "The plan item snapshot that was added or removed.",
 	}),
+});
+
+export const PlanUpdatePreviewLicenseChangeSchema = z.object({
+	action: z.enum(["create", "update", "remove"]),
+	license_plan_id: z.string(),
 });
 
 export type PlanUpdatePreviewItemChange = z.infer<

--- a/shared/utils/planV1Utils/diff/diffPlanV1PreviewFields.ts
+++ b/shared/utils/planV1Utils/diff/diffPlanV1PreviewFields.ts
@@ -58,12 +58,21 @@ export const planUpdatePreviewHasDiff = ({
 	previous_attributes,
 	price_change,
 	item_changes,
+	license_changes,
 }: Pick<
 	CorePlanUpdatePreview,
-	"customize" | "previous_attributes" | "price_change" | "item_changes"
+	| "customize"
+	| "previous_attributes"
+	| "price_change"
+	| "item_changes"
+	| "license_changes"
 >): boolean =>
 	Boolean(
-		customize || previous_attributes || price_change || item_changes.length > 0,
+		customize ||
+			previous_attributes ||
+			price_change ||
+			item_changes.length > 0 ||
+			license_changes.length > 0,
 	);
 
 export const diffPlanV1PreviousAttributes = ({


### PR DESCRIPTION
## Summary

- add concise `licenses` configuration for plans with `licensePlanId`, optional pinned `version`, and optional `included`
- preserve exact pins through pull/codegen/push while emitting ordinary string IDs
- validate references after collecting the complete local plan set; order only server mutations that require an existing child row
- share license resolution and preflight across preview, catalog updates, creates, and product versioning
- keep atmn authoritative while preserving low-level API compatibility when `licenses` is omitted

## Scope

- plans only; variants remain unchanged
- no atmn `prepaidOnly`, metadata, or special removal flag
- no explicit license changes with `all_versions`; preview and update reject this consistently
- structured preview changes are limited to action and license plan ID

## Tests

- atmn focused unit/codegen suite: 22 passed
- real atmn CLI against an isolated migrated server: parent-before-child string reference push → pull/codegen → no-op push → in-place license update → removal
- server license integrations: catalog response 5 passed; versioning 2 passed
- server dependency unit regression: 1 passed
- atmn and server typechecks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds declarative plan licenses to `atmn` and updates the server to resolve, preview, and apply license links safely against a virtual post-update catalog. Product license updates are now prepared and applied atomically with clear license diffs in previews.

- New Features
  - `atmn` config supports `licenses: [{ licensePlanId, version?, included? }]`; pull/codegen preserve pinned versions, codegen emits the block, and push compare fills missing local pins from the remote to avoid false diffs.
  - Local validation rejects self-links, duplicates, unknown plan IDs, and cycles; CLI error output is concise by default (full details with `ATMN_DEBUG`) and backend URL can be overridden via `ATMN_BACKEND_URL`.
  - API responses include exact license pins and preview surfaces `license_changes`; same-batch catalog updates resolve unpinned links to the latest in-batch version and reject cycles/duplicate ownership.

- Refactors
  - License sync split into prepare/preview/apply; used across catalog preview/update, plan updates, creates, and versioning for early validation and single atomic apply. Versioning accepts precomputed license sync or prepares it on demand.
  - Catalog updates preflight the entire plan set: build virtual post-update products, topologically sort by dependencies (highest-version “latest”), enforce one-owner per license, and attach `license_changes` without mutating state.
  - `updateProduct` simplifies versioning decisions and applies prepared license changes only once; legacy copy-on-version path falls back when no explicit licenses are provided.
  - Shared utilities: `toApiPlanLicenses`, `buildFullProductFromV2`, and SDK/API transforms for plan licenses; schemas updated so `ApiPlanLicenseV1` requires `version`, and previews include `license_changes`.
  - Tests cover pull/codegen pin preservation, in-place config writes with licensed plans, CLI validation errors and cycles, catalog cycle detection and same-batch resolution, historical versioning, and license preview/update/remove flows.

<sup>Written for commit 17ad2a14c0be8962ee3df5f9ebf5e76f80bea586. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a concise `licenses` configuration block for plans in the `atmn` CLI tool, wiring it through codegen (with topological ordering), push/pull/validate, and into the server's catalog update, create-product, update-product, and versioning paths. A new `preparePlanLicenseSync` / `applyPreparedPlanLicenseSync` split enables pre-flight preview and validation without writes, and `preflightCatalogPlans` is called from both `previewUpdateCatalog` and `updateCatalog` to enforce dependency ordering and ownership rules.

- **Improvements / API changes**: `licenses` array on `Plan` supports `licensePlanId`, optional pinned `version`, and optional `included`; exact version pins are preserved through pull/codegen/push; topological sort ensures declared plan references are valid JavaScript in the generated config file.
- **Improvements**: `preparePlanLicenseSync` + `applyPreparedPlanLicenseSync` split lets the catalog preview path compute license diffs against a virtual post-update catalog without any DB writes, then apply them atomically in the write path.
- **API changes**: `ApiPlanLicenseV1Schema` gains a required `version` field in the plan-get response (previously absent); `CorePlanUpdatePreview` gains a `license_changes` array; `planUpdatePreviewHasDiff` now returns `true` when license links change.
</details>

<h3>Confidence Score: 4/5</h3>

The functional logic for license sync, versioning, and codegen is correct end-to-end, but server integration tests could not run due to missing migrations, and the double-preview in updateCatalog adds meaningful latency to every catalog write.

The prepare/apply split and virtual-product preflight are well-reasoned, and the versioning paths all correctly route licenses through a single applyPreparedPlanLicenseSync call. The main concerns are non-functional: calling previewUpdateCatalog at the top of updateCatalog doubles DB work on every push, sortCatalogPlansByDependencies silently discards its return value making cycle detection look like dead code, and the latest-version tracking in catalogPlanDependencies.ts diverges from the client's stricter logic.

server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts (double previewUpdateCatalog call), server/src/internal/catalog/actions/catalogPlanPreflight.ts (discarded sort result), server/src/internal/catalog/actions/catalogPlanDependencies.ts (last-seen vs highest-version for latest key)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/catalog/actions/catalogPlanPreflight.ts | New preflight module: builds virtual post-update products, runs same-batch ownership check, and calls previewPlanLicenseSync for each plan. Correctly keeps plans in original order so previews[index] alignment holds, but sortCatalogPlansByDependencies result is silently discarded. |
| server/src/internal/catalog/actions/catalogPlanDependencies.ts | New topological sort + cycle detection for catalog plan batches. The latest key uses last-seen semantics rather than highest-version, inconsistent with the client-side planDependencies.ts. |
| server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts | Adds previewUpdateCatalog call at the top of updateCatalog for pre-write validation, effectively doubling DB queries for every catalog write. |
| server/src/internal/licenses/actions/links/syncPlanLicenses.ts | Refactored into prepare/apply split + new previewPlanLicenseSync. Logic is correct: newParentVersion flag bypasses capacity checks for fresh versions, duplicate detection moved here. |
| server/src/internal/product/actions/updateProduct.ts | Integrates prepared-license pattern into versioning decisions. willVersion eagerly computed; licenses applied via applyPreparedPlanLicenseSync exactly once. |
| server/src/internal/product/actions/createProduct.ts | Moves preparePlanLicenseSync before ProductService.insert for read-only validation before write, then applies prepared licenses after full product construction. |
| packages/atmn/src/lib/utils/planDependencies.ts | New topological sort utility for the client side. Correctly tracks highest-version entry as latest and throws a clear error on cycles. |
| packages/atmn/src/lib/transforms/sdkToCode/plan.ts | Adds buildLicensesCode emitting plan variable references when available, falling back to escaped string literals. Pinned versions preserved. |
| shared/api/products/apiPlanV1.ts | Adds required version field to ApiPlanLicenseV1Schema. Runtime-safe since toApiPlanLicenses always provides version >= 1, but breaking for clients validating against the old schema. |
| packages/atmn/src/commands/push/validate.ts | Adds validatePlanLicenses checking for self-reference, duplicates, and unknown plan IDs; integrates cycle detection via sortPlansByDependencies. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
server/src/internal/catalog/actions/catalogPlanPreflight.ts:113
**Discarded sort result used only for cycle detection**

`sortCatalogPlansByDependencies` returns a new array and does not mutate `plans`. Discarding the return value means the function is called solely to throw when a cycle exists. The `plans` passed to `preflightCatalogLicenses` below remains in its original (caller-aligned) order, which is required for the `previews[index]` correspondence to hold. This is correct, but any future reader will likely assume the call is dead code. A comment (or a renamed `validateNoCatalogPlanCycles` helper) would make the intent explicit and prevent someone from removing the "unused" call.

### Issue 2 of 4
server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts:473
**Full preview run on every catalog write doubles DB load**

`previewUpdateCatalog` fetches all products, queries customer counts once per plan, and runs `preparePlanLicenseSync` (two repo queries per plan) for every entry. Adding this call at the top of `updateCatalog` means every catalog write now performs all of that work twice — once here, and again inside `upsertPlans` when each plan is individually processed. For a catalog with N licensed plans this adds roughly 3N extra DB round-trips on every push. If the goal is cycle/ownership validation before writes, a lighter `preflightCatalogPlans`-only call (without the full plan-by-plan preview machinery) would be significantly cheaper.

### Issue 3 of 4
server/src/internal/catalog/actions/catalogPlanDependencies.ts:15-19
**"Latest" key uses last-seen rather than highest version, inconsistent with client**

The client-side `sortPlansByDependencies` in `planDependencies.ts` explicitly keeps the highest-version entry as the "latest" for a given plan ID. Here the last entry in iteration order wins unconditionally. If a batch ever contains two entries for the same `plan_id` targeting different versions, the "latest" pointer resolves to whichever appeared last rather than the highest version, which could route a third plan's license dependency to the wrong target.

```suggestion
	const byReference = new Map<string, CatalogPlanParams>();
	for (const plan of plans) {
		byReference.set(referenceKey(plan.plan_id, plan.version), plan);
		const latestKey = plan.new_plan_id ?? plan.plan_id;
		const existing = byReference.get(latestKey);
		if (!existing || (plan.version ?? 0) > (existing.version ?? 0)) {
			byReference.set(latestKey, plan);
		}
	}
```

### Issue 4 of 4
packages/atmn/src/lib/transforms/inPlaceUpdate/updateConfig.ts:37-39
**Full regeneration triggered by any licensed plan, even for unrelated edits**

`canUpdateConfigInPlace` blocks in-place updates whenever any plan in the pulled result carries a `licenses` array, regardless of whether those licenses or their ordering constraints are relevant to the changed plan. A user who has one licensed plan and edits only a feature on a different plan will always get a full file rewrite, which can produce noisy diffs in version control.

```suggestion
/**
 * Full regeneration is required when any plan with licenses is present,
 * because the topological ordering of declarations may change.
 */
export const canUpdateConfigInPlace = ({ plans }: { plans: Plan[] }) =>
	plans.every((plan) => !plan.licenses?.length);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(atmn): add plan license configurati..."](https://github.com/useautumn/autumn/commit/69e4bf18b31d974c0210cee77c3e051fbc1bb737) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44428771)</sub>

> Greptile also left **4 inline comments** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->
