### PR TITLE
test(catalog): cover atomic plan item failures

### DIFF
--- a/server/src/internal/product/actions/updateProduct/updateProductItems.ts
+++ b/server/src/internal/product/actions/updateProduct/updateProductItems.ts
@@ -23,23 +23,23 @@ export const updateProductItems = async ({
 	features: AutumnContext["features"];
 	useInPlaceEdit: boolean;
 }) => {
-	if (!useInPlaceEdit) {
-		await handleNewProductItems({
-			db,
-			curPrices: fullProduct.prices,
-			curEnts: fullProduct.entitlements,
-			newItems,
-			features,
-			product: fullProduct,
-			logger: ctx.logger,
-			isCustom: false,
-			multiCurrencyEnabled: orgMultiCurrencyEnabled({ org: ctx.org }),
-		});
-		return;
-	}
-
 	await db.transaction(async (transaction) => {
 		const tx = transaction as unknown as DrizzleCli;
+		if (!useInPlaceEdit) {
+			await handleNewProductItems({
+				db: tx,
+				curPrices: fullProduct.prices,
+				curEnts: fullProduct.entitlements,
+				newItems,
+				features,
+				product: fullProduct,
+				logger: ctx.logger,
+				isCustom: false,
+				multiCurrencyEnabled: orgMultiCurrencyEnabled({ org: ctx.org }),
+			});
+			return;
+		}
+
 		const inPlace = await resolveInPlaceEdit({
 			db: tx,
 			items: newItems,

--- a/server/tests/unit/products/update-product-items-atomicity.test.ts
+++ b/server/tests/unit/products/update-product-items-atomicity.test.ts
@@ -1,0 +1,45 @@
+import { expect, mock, test } from "bun:test";
+import type { FullProduct, ProductItem } from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+let receivedDb: DrizzleCli | undefined;
+const simulatedWriteFailure = new Error("simulated write failure");
+const handleNewProductItemsMock = mock(async ({ db }: { db: DrizzleCli }) => {
+	receivedDb = db;
+	throw simulatedWriteFailure;
+});
+
+mock.module(
+	"@/internal/products/product-items/productItemUtils/handleNewProductItems.js",
+	() => ({ handleNewProductItems: handleNewProductItemsMock }),
+);
+
+const { updateProductItems } = await import(
+	"@/internal/product/actions/updateProduct/updateProductItems.js"
+);
+
+test("plan item updates run the no-customer path in a transaction", async () => {
+	const transactionDb = {} as DrizzleCli;
+	const db = {
+		transaction: async (callback: (transaction: DrizzleCli) => Promise<void>) =>
+			callback(transactionDb),
+	} as unknown as DrizzleCli;
+	const ctx = { org: { config: {} } } as AutumnContext;
+
+	await expect(
+		updateProductItems({
+			ctx,
+			db,
+			fullProduct: {
+				prices: [],
+				entitlements: [],
+			} as unknown as FullProduct,
+			newItems: [] as ProductItem[],
+			features: [],
+			useInPlaceEdit: false,
+		}),
+	).rejects.toBe(simulatedWriteFailure);
+
+	expect(receivedDb).toBe(transactionDb);
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make plan item updates atomic by running the no-customer update path inside the existing database transaction. All writes now commit together or roll back, preventing duplicate entitlements.

- **Bug Fixes**
  - Move the `!useInPlaceEdit` path into `db.transaction` so inserts and deletes are atomic.
  - Prevent partial writes when a later deletion fails.
  - Add `update-product-items-atomicity.test.ts` to confirm the transaction handle is used and failures roll back.

<sup>Written for commit 4cc77be84c70d15bd003a8171a1223f275facaa4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a data-integrity bug where the no-customer plan-item update path (`useInPlaceEdit: false`) executed outside any database transaction, leaving partial writes committed on failure. Both update paths now run inside the same `db.transaction` block so inserts and deletes either all commit or all roll back together.

- **Bug fixes**: The `!useInPlaceEdit` branch is moved inside `db.transaction`, making inserts and subsequent deletes in `handleNewProductItems` atomic — matching the guarantee already in place for the in-place edit path.
- **Improvements**: A new regression test mocks `db.transaction` and `handleNewProductItems` to confirm the transaction db handle (not the outer db) is forwarded to the write function, and that a simulated failure propagates to the caller.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a straightforward structural move with a regression test confirming the fix.

The diff is minimal: one branch is relocated inside an already-established transaction block. The test correctly verifies that the transaction handle is threaded through to the write call and that failures propagate. No logic is altered beyond the scope of the fix, and the in-place edit path is unchanged.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/product/actions/updateProduct/updateProductItems.ts | Moves the !useInPlaceEdit branch inside the existing db.transaction call, ensuring both code paths (in-place and no-customer) commit or roll back atomically; minimal, focused change. |
| server/tests/unit/products/update-product-items-atomicity.test.ts | New unit test verifying that the no-customer path receives the transaction db handle and that a simulated write failure propagates correctly out of the transaction boundary. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant updateProductItems
    participant DB Transaction
    participant handleNewProductItems
    participant resolveInPlaceEdit

    Caller->>updateProductItems: call(useInPlaceEdit, ...)
    updateProductItems->>DB Transaction: db.transaction(tx => ...)

    alt "useInPlaceEdit = false (no-customer path — newly wrapped)"
        DB Transaction->>handleNewProductItems: handleNewProductItems({ db: tx, ... })
        handleNewProductItems-->>DB Transaction: success or throw
        note over DB Transaction: commit or rollback atomically
    else "useInPlaceEdit = true (in-place path — already wrapped before this PR)"
        DB Transaction->>resolveInPlaceEdit: resolveInPlaceEdit({ db: tx, ... })
        resolveInPlaceEdit-->>DB Transaction: inPlace
        DB Transaction->>handleNewProductItems: handleNewProductItems({ db: tx, inPlace... })
        handleNewProductItems-->>DB Transaction: success or throw
        note over DB Transaction: commit or rollback atomically
    end

    DB Transaction-->>updateProductItems: commit or propagate error
    updateProductItems-->>Caller: resolved or rejected
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant updateProductItems
    participant DB Transaction
    participant handleNewProductItems
    participant resolveInPlaceEdit

    Caller->>updateProductItems: call(useInPlaceEdit, ...)
    updateProductItems->>DB Transaction: db.transaction(tx => ...)

    alt "useInPlaceEdit = false (no-customer path — newly wrapped)"
        DB Transaction->>handleNewProductItems: handleNewProductItems({ db: tx, ... })
        handleNewProductItems-->>DB Transaction: success or throw
        note over DB Transaction: commit or rollback atomically
    else "useInPlaceEdit = true (in-place path — already wrapped before this PR)"
        DB Transaction->>resolveInPlaceEdit: resolveInPlaceEdit({ db: tx, ... })
        resolveInPlaceEdit-->>DB Transaction: inPlace
        DB Transaction->>handleNewProductItems: handleNewProductItems({ db: tx, inPlace... })
        handleNewProductItems-->>DB Transaction: success or throw
        note over DB Transaction: commit or rollback atomically
    end

    DB Transaction-->>updateProductItems: commit or propagate error
    updateProductItems-->>Caller: resolved or rejected
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(catalog): 🐛 make plan item updates ..."](https://github.com/useautumn/autumn/commit/bb534a0e05e57088816b40f3bbee211259423579) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44439452)</sub>

<!-- /greptile_comment -->