### PR TITLE
Invoice cron limit

### DIFF
--- a/server/src/cron/invoiceCron/runInvoiceCron.ts
+++ b/server/src/cron/invoiceCron/runInvoiceCron.ts
@@ -203,6 +203,11 @@ export const runInvoiceCron = async ({ ctx }: { ctx: CronContext }) => {
 			if (invoices.length < pageSize) break;
 		}
 
+		if (total >= pageSize * maxIterations) {
+			console.warn(
+				`INVOICE CRON: hit maxIterations (${maxIterations}); backlog likely exceeds ${pageSize * maxIterations}, more runs needed — processed ${total}`,
+			);
+		}
 		console.log(`FINISHED INVOICE CRON: processed ${total}`);
 	} catch (error) {
 		console.error("Error running invoice cron:", error);

--- a/server/src/cron/invoiceCron/runInvoiceCron.ts
+++ b/server/src/cron/invoiceCron/runInvoiceCron.ts
@@ -1,7 +1,7 @@
 import type { DeferredAutumnBillingPlanData } from "@autumn/shared";
 import { type Metadata, MetadataType, metadata } from "@autumn/shared";
 import { addDays } from "date-fns";
-import { and, eq, isNotNull, lt, or } from "drizzle-orm";
+import { and, asc, eq, isNotNull, lt, or, sql } from "drizzle-orm";
 import type { Stripe } from "stripe";
 import { OrgService } from "@/internal/orgs/OrgService";
 import { createStripeCli } from "../../external/connect/createStripeCli";
@@ -131,9 +131,17 @@ export const handleVoidInvoiceCron = async ({
 
 export const getExpiredInvoiceMetadata = async ({
 	db,
+	now,
+	limit,
+	cursor,
 }: {
 	db: CronContext["db"];
+	now: number;
+	limit: number;
+	cursor: { expiresAt: number; id: string } | null;
 }) => {
+	// Keyset over (expires_at, id) so each page is a bounded query: an
+	// unbounded SELECT * over a large expired backlog pins xmin while it ships.
 	return db
 		.select()
 		.from(metadata)
@@ -145,10 +153,15 @@ export const getExpiredInvoiceMetadata = async ({
 					eq(metadata.type, MetadataType.DeferredInvoice),
 				),
 				isNotNull(metadata.expires_at),
-				lt(metadata.expires_at, Date.now()),
+				lt(metadata.expires_at, now),
 				isNotNull(metadata.stripe_invoice_id),
+				cursor
+					? sql`(${metadata.expires_at}, ${metadata.id} COLLATE "C") > (${cursor.expiresAt}, ${cursor.id})`
+					: undefined,
 			),
-		);
+		)
+		.orderBy(asc(metadata.expires_at), sql`${metadata.id} COLLATE "C"`)
+		.limit(limit);
 };
 
 export const runInvoiceCron = async ({ ctx }: { ctx: CronContext }) => {
@@ -156,21 +169,38 @@ export const runInvoiceCron = async ({ ctx }: { ctx: CronContext }) => {
 		console.log("Running invoice cron");
 		const { db } = ctx;
 
-		const invoices = await getExpiredInvoiceMetadata({ db });
+		const now = Date.now();
+		const pageSize = 500;
+		const maxIterations = 20;
+		const concurrency = 50;
 
-		const batchSize = 50;
-		for (let i = 0; i < invoices.length; i += batchSize) {
-			const batch = invoices.slice(i, i + batchSize);
+		let cursor: { expiresAt: number; id: string } | null = null;
+		let total = 0;
 
-			const promises = [];
-			for (const metadata of batch) {
-				promises.push(handleVoidInvoiceCron({ ctx, metadata }));
+		for (let iteration = 0; iteration < maxIterations; iteration++) {
+			const invoices = await getExpiredInvoiceMetadata({
+				db,
+				now,
+				limit: pageSize,
+				cursor,
+			});
+			if (invoices.length === 0) break;
+
+			for (let i = 0; i < invoices.length; i += concurrency) {
+				const batch = invoices.slice(i, i + concurrency);
+				await Promise.all(
+					batch.map((item) => handleVoidInvoiceCron({ ctx, metadata: item })),
+				);
 			}
-			await Promise.all(promises);
-			console.log(`Handled ${i + batch.length}/${invoices.length} invoices`);
-			console.log("----------------------------------\n");
+
+			total += invoices.length;
+			const last = invoices[invoices.length - 1];
+			cursor = { expiresAt: Number(last.expires_at), id: last.id };
+
+			if (invoices.length < pageSize) break;
 		}
-		console.log("FINISHED INVOICE CRON");
+
+		console.log(`FINISHED INVOICE CRON: processed ${total}`);
 	} catch (error) {
 		console.error("Error running invoice cron:", error);
 		return;

--- a/server/src/cron/invoiceCron/runInvoiceCron.ts
+++ b/server/src/cron/invoiceCron/runInvoiceCron.ts
@@ -3,6 +3,7 @@ import { type Metadata, MetadataType, metadata } from "@autumn/shared";
 import { addDays } from "date-fns";
 import { and, asc, eq, isNotNull, lt, or, sql } from "drizzle-orm";
 import type { Stripe } from "stripe";
+import { withStatementTimeout } from "@/db/withStatementTimeout.js";
 import { OrgService } from "@/internal/orgs/OrgService";
 import { createStripeCli } from "../../external/connect/createStripeCli";
 import { stripeInvoiceToStripeSubscriptionId } from "../../external/stripe/invoices/utils/convertStripeInvoice";
@@ -142,26 +143,28 @@ export const getExpiredInvoiceMetadata = async ({
 }) => {
 	// Keyset over (expires_at, id) so each page is a bounded query: an
 	// unbounded SELECT * over a large expired backlog pins xmin while it ships.
-	return db
-		.select()
-		.from(metadata)
-		.where(
-			and(
-				or(
-					eq(metadata.type, MetadataType.InvoiceActionRequired),
-					eq(metadata.type, MetadataType.InvoiceCheckout),
-					eq(metadata.type, MetadataType.DeferredInvoice),
+	return withStatementTimeout(db, async (tx) =>
+		tx
+			.select()
+			.from(metadata)
+			.where(
+				and(
+					or(
+						eq(metadata.type, MetadataType.InvoiceActionRequired),
+						eq(metadata.type, MetadataType.InvoiceCheckout),
+						eq(metadata.type, MetadataType.DeferredInvoice),
+					),
+					isNotNull(metadata.expires_at),
+					lt(metadata.expires_at, now),
+					isNotNull(metadata.stripe_invoice_id),
+					cursor
+						? sql`(${metadata.expires_at}, ${metadata.id} COLLATE "C") > (${cursor.expiresAt}, ${cursor.id})`
+						: undefined,
 				),
-				isNotNull(metadata.expires_at),
-				lt(metadata.expires_at, now),
-				isNotNull(metadata.stripe_invoice_id),
-				cursor
-					? sql`(${metadata.expires_at}, ${metadata.id} COLLATE "C") > (${cursor.expiresAt}, ${cursor.id})`
-					: undefined,
-			),
-		)
-		.orderBy(asc(metadata.expires_at), sql`${metadata.id} COLLATE "C"`)
-		.limit(limit);
+			)
+			.orderBy(asc(metadata.expires_at), sql`${metadata.id} COLLATE "C"`)
+			.limit(limit),
+	);
 };
 
 export const runInvoiceCron = async ({ ctx }: { ctx: CronContext }) => {

--- a/server/src/db/withStatementTimeout.ts
+++ b/server/src/db/withStatementTimeout.ts
@@ -14,6 +14,8 @@ export const withStatementTimeout = async <T>(
 	timeoutMs: number = CRON_STATEMENT_TIMEOUT_MS,
 ): Promise<T> =>
 	db.transaction(async (tx) => {
-		await tx.execute(sql.raw(`SET LOCAL statement_timeout = ${timeoutMs}`));
+		await tx.execute(
+			sql.raw(`SET LOCAL statement_timeout = ${Math.floor(timeoutMs)}`),
+		);
 		return fn(tx as unknown as DrizzleCli);
 	});

--- a/server/src/db/withStatementTimeout.ts
+++ b/server/src/db/withStatementTimeout.ts
@@ -1,0 +1,19 @@
+import { sql } from "drizzle-orm";
+import type { DrizzleCli } from "./initDrizzle";
+
+export const CRON_STATEMENT_TIMEOUT_MS = 300_000;
+
+/**
+ * Runs `fn` with a per-statement timeout. Uses SET LOCAL inside a txn because a
+ * pool-level statement_timeout fails startup (08P01) behind PgBouncer at :6432;
+ * SET LOCAL is transaction-scoped so it is safe under transaction pooling.
+ */
+export const withStatementTimeout = async <T>(
+	db: DrizzleCli,
+	fn: (tx: DrizzleCli) => Promise<T>,
+	timeoutMs: number = CRON_STATEMENT_TIMEOUT_MS,
+): Promise<T> =>
+	db.transaction(async (tx) => {
+		await tx.execute(sql.raw(`SET LOCAL statement_timeout = ${timeoutMs}`));
+		return fn(tx as unknown as DrizzleCli);
+	});

--- a/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
@@ -35,6 +35,7 @@ import { StatusCodes } from "http-status-codes";
 import { buildConflictUpdateColumns } from "@/db/dbUtils.js";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { RepoContext } from "@/db/repoContext";
+import { withStatementTimeout } from "@/db/withStatementTimeout.js";
 import { redis } from "@/external/redis/initRedis.js";
 import { buildFullCustomerCacheKey } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/fullCustomerCacheConfig.js";
 import { tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
@@ -377,13 +378,15 @@ export class CusEntService {
 		const emittedIds = new Set<string>();
 
 		while (true) {
-			const page = await CusEntService.buildActiveResetPassedPage({
-				db,
-				now,
-				batchSize,
-				cursor,
-				includeSeparateIntervalResets,
-			});
+			const page = await withStatementTimeout(db, async (tx) =>
+				CusEntService.buildActiveResetPassedPage({
+					db: tx,
+					now,
+					batchSize,
+					cursor,
+					includeSeparateIntervalResets,
+				}),
+			);
 
 			if (page.length === 0) break;
 

--- a/server/tests/integration/billing/attach/invoice/invoice-mode-deferred-metadata-expiry.test.ts
+++ b/server/tests/integration/billing/attach/invoice/invoice-mode-deferred-metadata-expiry.test.ts
@@ -85,7 +85,12 @@ test.concurrent(
 			},
 		});
 
-		const voidableMetadata = await getExpiredInvoiceMetadata({ db: ctx.db });
+		const voidableMetadata = await getExpiredInvoiceMetadata({
+			db: ctx.db,
+			now: Date.now(),
+			limit: 500,
+			cursor: null,
+		});
 		const voidableIds = new Set(voidableMetadata.map((row) => row.id));
 
 		expect(voidableIds.has(deferredMetadata!.id)).toBe(false);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the invoice cron with keyset pagination and per-statement timeouts to prevent long-running scans and reduce DB load. Adds cursor-based paging, capped concurrency, and a warning when the per-run limit is reached.

- **Refactors**
  - Keyset pagination over (expires_at, id) in `getExpiredInvoiceMetadata` with `ORDER BY` and `LIMIT`; new args: `now`, `limit`, `cursor`.
  - Per-statement timeout via `withStatementTimeout` (300s via `SET LOCAL`, guarded with `Math.floor`); applied to invoice scan and `CusEntitlementService` pagination.
  - `runInvoiceCron` pages results (page size 500, max 20 iterations), processes in batches (concurrency 50), advances cursor, logs totals, and warns when `maxIterations` is hit.
  - Updated test to use the new `getExpiredInvoiceMetadata` signature.

<sup>Written for commit 2316d842d2d46ba6e6598c3b6ecaa8f30fb68e83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR bounds the invoice cron job with keyset pagination and per-statement timeouts to prevent unbounded DB scans on large expired-invoice backlogs. Both `getExpiredInvoiceMetadata` and `CusEntitlementService.buildActiveResetPassedPage` are guarded with `withStatementTimeout`, and `runInvoiceCron` now iterates in pages of 500 (up to 20 iterations) with concurrency of 50 per batch.

- **Improvements**: Keyset pagination over `(expires_at, id COLLATE "C")` replaces a single unbounded `SELECT *`; cursor advances correctly with `>` after each page.
- **Improvements**: New `withStatementTimeout` helper applies `SET LOCAL statement_timeout` inside a transaction (safe under PgBouncer transaction-pooling mode) to every page fetch in both cron paths.
- **Improvements**: `runInvoiceCron` caps total work per run at `pageSize × maxIterations` (10 000 rows), logs the total processed, and warns operators when the limit is reached.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the pagination logic, cursor advancement, and statement timeout scoping are all correct and well-guarded.

The keyset cursor correctly uses > with a consistent COLLATE C on both ORDER BY and the cursor predicate; withStatementTimeout is transaction-scoped (safe behind PgBouncer), uses Math.floor to guard the raw interpolation, and passes tx through to subqueries in buildActiveResetPassedPage. The warning condition fires precisely when all maxIterations pages were full, signaling a deeper backlog. No defects were found in the changed paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/cron/invoiceCron/runInvoiceCron.ts | Refactors the invoice cron to use keyset pagination with bounded iterations; cursor logic and warning condition are correct. |
| server/src/db/withStatementTimeout.ts | New helper wraps a query in a transaction and sets SET LOCAL statement_timeout; well-commented with the PgBouncer rationale, Math.floor guard included. |
| server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts | Wraps buildActiveResetPassedPage (a pure SELECT builder) in withStatementTimeout; transaction-safe since the method only constructs a Drizzle query and passes tx through to its subqueries. |
| server/tests/integration/billing/attach/invoice/invoice-mode-deferred-metadata-expiry.test.ts | Test updated to pass the new required now, limit, and cursor args to getExpiredInvoiceMetadata; no functional change to test assertions. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Cron as runInvoiceCron
    participant DB as Database (via withStatementTimeout)
    participant Handler as handleVoidInvoiceCron
    participant Stripe as Stripe API

    Cron->>Cron: "capture now, init cursor=null, total=0"
    loop up to 20 iterations
        Cron->>DB: BEGIN txn
        DB->>DB: "SET LOCAL statement_timeout = 300000"
        DB->>DB: "SELECT ... WHERE expires_at < now AND (expires_at, id) > cursor ORDER BY ... LIMIT 500"
        DB-->>Cron: page of up to 500 invoices
        DB->>DB: COMMIT
        alt page is empty
            Cron->>Cron: break
        end
        loop batches of 50 (concurrency)
            Cron->>Handler: handleVoidInvoiceCron(item) x50
            Handler->>Stripe: retrieve invoice
            Stripe-->>Handler: invoice status
            alt "status = open"
                Handler->>Stripe: voidInvoice
                Handler->>DB: MetadataService.delete or update
            else "status = void or uncollectible"
                Handler->>DB: MetadataService.delete
            end
        end
        Cron->>Cron: "total += page.length, advance cursor to last row"
        alt "page.length < pageSize"
            Cron->>Cron: break
        end
    end
    alt "total >= pageSize x maxIterations"
        Cron->>Cron: console.warn backlog exceeded run limit
    end
    Cron->>Cron: console.log FINISHED, total processed
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Cron as runInvoiceCron
    participant DB as Database (via withStatementTimeout)
    participant Handler as handleVoidInvoiceCron
    participant Stripe as Stripe API

    Cron->>Cron: "capture now, init cursor=null, total=0"
    loop up to 20 iterations
        Cron->>DB: BEGIN txn
        DB->>DB: "SET LOCAL statement_timeout = 300000"
        DB->>DB: "SELECT ... WHERE expires_at < now AND (expires_at, id) > cursor ORDER BY ... LIMIT 500"
        DB-->>Cron: page of up to 500 invoices
        DB->>DB: COMMIT
        alt page is empty
            Cron->>Cron: break
        end
        loop batches of 50 (concurrency)
            Cron->>Handler: handleVoidInvoiceCron(item) x50
            Handler->>Stripe: retrieve invoice
            Stripe-->>Handler: invoice status
            alt "status = open"
                Handler->>Stripe: voidInvoice
                Handler->>DB: MetadataService.delete or update
            else "status = void or uncollectible"
                Handler->>DB: MetadataService.delete
            end
        end
        Cron->>Cron: "total += page.length, advance cursor to last row"
        alt "page.length < pageSize"
            Cron->>Cron: break
        end
    end
    alt "total >= pageSize x maxIterations"
        Cron->>Cron: console.warn backlog exceeded run limit
    end
    Cron->>Cron: console.log FINISHED, total processed
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["ai code review"](https://github.com/useautumn/autumn/commit/2316d842d2d46ba6e6598c3b6ecaa8f30fb68e83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44506385)</sub>

<!-- /greptile_comment -->