### PR TITLE
feat(licenses): separate seat purchase quantity from included amount

### DIFF
--- a/vite/src/components/forms/attach-v2/attachFormSchema.ts
+++ b/vite/src/components/forms/attach-v2/attachFormSchema.ts
@@ -18,10 +18,7 @@ export interface FormCustomLineItem {
 export const AttachFormSchema = z.object({
 	productId: z.string(),
 	prepaidOptions: z.record(z.string(), z.number().nonnegative().optional()),
-	licenseIncludedQuantities: z.record(
-		z.string(),
-		z.number().nonnegative().optional(),
-	),
+	licenseQuantities: z.record(z.string(), z.number().nonnegative().optional()),
 	items: z.custom<ProductItem[]>().nullable(),
 	addLicenses: z.custom<CustomizePlanLicense[]>().nullable(),
 	isCustom: z.boolean(),

--- a/vite/src/components/forms/attach-v2/components/AttachPlanSection.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachPlanSection.tsx
@@ -18,7 +18,6 @@ export function AttachPlanSection({
 		features,
 		originalItems: productTemplateItems,
 		productWithFormItems: product,
-		effectiveAddLicenses,
 		hasCustomizations,
 		initialPrepaidOptions,
 		previewPrepaidOptions,
@@ -28,11 +27,11 @@ export function AttachPlanSection({
 	} = useAttachFormContext();
 
 	const hideEditButton = readOnly || formValues.grantFree;
-	const { prepaidOptions, licenseIncludedQuantities } = formValues;
+	const { prepaidOptions, licenseQuantities } = formValues;
 
 	const licenseQuantityEditor = hideEditButton
 		? undefined
-		: { form, includedQuantities: licenseIncludedQuantities };
+		: { form, quantities: licenseQuantities };
 
 	const effectiveInitialPrepaidOptions = readOnly
 		? previewPrepaidOptions
@@ -89,7 +88,7 @@ export function AttachPlanSection({
 		form,
 		showDiff: shouldShowDiff,
 		currency,
-		addLicenses: effectiveAddLicenses,
+		addLicenses: formValues.addLicenses,
 		licenseQuantityEditor,
 		onEditPlan: handleEditPlan,
 		gateDeletedItemsByDiff: true,

--- a/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
+++ b/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
@@ -41,7 +41,7 @@ import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { useProductVersionQuery } from "@/hooks/queries/useProductVersionQuery";
 import type { PrepaidItemWithFeature } from "@/hooks/stores/useProductStore";
 import { usePrepaidItems } from "@/hooks/stores/useProductStore";
-import { mergeLicenseIncludedQuantities } from "@/utils/billing/licenseQuantityUtils";
+import { clampLicenseQuantitiesToIncluded } from "@/utils/billing/licenseQuantityUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import type { AttachForm } from "../attachFormSchema";
 import {
@@ -74,8 +74,6 @@ interface AttachFormContextValue {
 	prepaidItems: PrepaidItemWithFeature[];
 	originalItems: ProductItem[] | undefined;
 	productWithFormItems: FrontendProduct | undefined;
-	/** addLicenses patch with staged included-quantity row edits merged in. */
-	effectiveAddLicenses: CustomizePlanLicense[] | null;
 	hasCustomizations: boolean;
 	numVersions: number;
 	initialPrepaidOptions: Record<string, number>;
@@ -186,7 +184,7 @@ export function AttachFormProvider({
 	const {
 		productId,
 		prepaidOptions,
-		licenseIncludedQuantities,
+		licenseQuantities,
 		items,
 		addLicenses,
 		version,
@@ -332,7 +330,7 @@ export function AttachFormProvider({
 		previousVersionRef.current = version;
 		form.setFieldValue("items", null);
 		form.setFieldValue("addLicenses", null);
-		form.setFieldValue("licenseIncludedQuantities", {});
+		form.setFieldValue("licenseQuantities", {});
 	}, [version, form]);
 
 	// Track product changes and initialize prepaid options
@@ -352,7 +350,7 @@ export function AttachFormProvider({
 		if (isProductChange) {
 			form.setFieldValue("items", null);
 			form.setFieldValue("addLicenses", null);
-			form.setFieldValue("licenseIncludedQuantities", {});
+			form.setFieldValue("licenseQuantities", {});
 			form.setFieldValue("version", undefined);
 			form.setFieldValue("trialEnabled", false);
 			form.setFieldValue("trialLength", null);
@@ -397,17 +395,8 @@ export function AttachFormProvider({
 
 	const originalItems = effectiveProduct?.items as ProductItem[] | undefined;
 
-	const effectiveAddLicenses = useMemo(
-		() =>
-			mergeLicenseIncludedQuantities({
-				addLicenses,
-				licenseIncludedQuantities,
-			}),
-		[addLicenses, licenseIncludedQuantities],
-	);
-
 	const hasCustomizations =
-		(items !== null && items.length > 0) || effectiveAddLicenses !== null;
+		(items !== null && items.length > 0) || addLicenses !== null;
 
 	const productWithFormItems = useMemo((): FrontendProduct | undefined => {
 		if (!effectiveProduct) return undefined;
@@ -442,8 +431,9 @@ export function AttachFormProvider({
 		entityId,
 		product: effectiveProduct,
 		prepaidOptions,
+		licenseQuantities,
 		items,
-		addLicenses: effectiveAddLicenses,
+		addLicenses,
 		grantFree,
 		version,
 		trialLength,
@@ -562,9 +552,15 @@ export function AttachFormProvider({
 
 			if (editedAddLicenses) {
 				form.setFieldValue("addLicenses", editedAddLicenses);
-				// Row edits were seeded into the editor via effectiveAddLicenses, so
-				// its output already carries them — clear to avoid double-application.
-				form.setFieldValue("licenseIncludedQuantities", {});
+				// Seat totals are inclusive of included, so a customized included
+				// amount raises any staged total that fell below it.
+				form.setFieldValue(
+					"licenseQuantities",
+					clampLicenseQuantitiesToIncluded({
+						licenseQuantities: form.store.state.values.licenseQuantities,
+						upsertLicenses: editedAddLicenses,
+					}),
+				);
 			}
 
 			setShowPlanEditor(false);
@@ -590,7 +586,6 @@ export function AttachFormProvider({
 			prepaidItems,
 			originalItems,
 			productWithFormItems,
-			effectiveAddLicenses,
 			hasCustomizations,
 			numVersions,
 			initialPrepaidOptions,
@@ -622,7 +617,6 @@ export function AttachFormProvider({
 			prepaidItems,
 			originalItems,
 			productWithFormItems,
-			effectiveAddLicenses,
 			hasCustomizations,
 			numVersions,
 			previewPrepaidOptions,

--- a/vite/src/components/forms/attach-v2/hooks/useAttachForm.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachForm.ts
@@ -20,7 +20,7 @@ export function useAttachForm({
 		defaultValues: {
 			productId: initialProductId || "",
 			prepaidOptions: initialPrepaidOptions ?? {},
-			licenseIncludedQuantities: {},
+			licenseQuantities: {},
 			items: initialItems ?? null,
 			addLicenses: null,
 			isCustom: initialIsCustom ?? false,

--- a/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
@@ -13,6 +13,7 @@ import type {
 import { useMemo } from "react";
 import { normalizeBillingRequestItems } from "@/components/forms/shared/utils/normalizeBillingRequestItems";
 import { getFreeTrial } from "@/components/forms/update-subscription-v2/utils/getFreeTrial";
+import { convertLicenseQuantitiesToParams } from "@/utils/billing/licenseQuantityUtils";
 import { convertPrepaidOptionsToFeatureOptions } from "@/utils/billing/prepaidQuantityUtils";
 import type { FormCustomLineItem } from "../attachFormSchema";
 import { normalizeAttachProrationBehavior } from "../utils/attachProrationBehaviorRules";
@@ -26,6 +27,7 @@ export interface BuildAttachRequestBodyParams {
 	entityId: string | undefined;
 	product: ProductV2 | undefined;
 	prepaidOptions: Record<string, number | undefined>;
+	licenseQuantities: Record<string, number | undefined>;
 	items: ProductItem[] | null;
 	addLicenses: CustomizePlanLicense[] | null;
 	grantFree: boolean;
@@ -60,6 +62,7 @@ export function buildAttachRequestBody({
 	entityId,
 	product,
 	prepaidOptions,
+	licenseQuantities,
 	items,
 	addLicenses,
 	grantFree,
@@ -112,6 +115,13 @@ export function buildAttachRequestBody({
 
 	if (options && options.length > 0) {
 		body.options = options;
+	}
+
+	const licenseQuantityParams = convertLicenseQuantitiesToParams({
+		licenseQuantities,
+	});
+	if (licenseQuantityParams) {
+		body.license_quantities = licenseQuantityParams;
 	}
 
 	if (items !== null) {
@@ -224,6 +234,7 @@ export function useAttachRequestBody(params: BuildAttachRequestBodyParams) {
 		entityId,
 		product,
 		prepaidOptions,
+		licenseQuantities,
 		items,
 		addLicenses,
 		grantFree,
@@ -259,6 +270,7 @@ export function useAttachRequestBody(params: BuildAttachRequestBodyParams) {
 				entityId,
 				product,
 				prepaidOptions,
+				licenseQuantities,
 				items,
 				addLicenses,
 				grantFree,
@@ -291,6 +303,7 @@ export function useAttachRequestBody(params: BuildAttachRequestBodyParams) {
 			entityId,
 			product,
 			prepaidOptions,
+			licenseQuantities,
 			items,
 			addLicenses,
 			grantFree,

--- a/vite/src/components/forms/shared/plan-items/LicenseQuantityControl.tsx
+++ b/vite/src/components/forms/shared/plan-items/LicenseQuantityControl.tsx
@@ -4,11 +4,11 @@ import { QuantityEditControl } from "./QuantityEditControl";
 
 export interface LicenseQuantityEditor {
 	form: UseAttachForm;
-	includedQuantities: Record<string, number | undefined>;
+	quantities: Record<string, number | undefined>;
 }
 
-/** Edits a license's included seat quantity — the same value the customize
- * plan editor stages via upsert_licenses. */
+/** Edits the total seats purchased for a license (sent as license_quantities).
+ * Totals are inclusive of the included amount; extras are billed prepaid. */
 export function LicenseQuantityControl({
 	editor,
 	licensePlanId,
@@ -19,28 +19,44 @@ export function LicenseQuantityControl({
 	includedQuantity: number;
 }) {
 	const [isEditing, setIsEditing] = useState(false);
-	const { form, includedQuantities } = editor;
+	const { form, quantities } = editor;
+	const stagedQuantity = quantities[licensePlanId];
+	const totalQuantity = Math.max(
+		stagedQuantity ?? includedQuantity,
+		includedQuantity,
+	);
+	const paidQuantity = totalQuantity - includedQuantity;
 
 	const handleEditingChange = (editing: boolean) => {
-		if (editing && includedQuantities[licensePlanId] === undefined) {
-			form.setFieldValue(
-				`licenseIncludedQuantities.${licensePlanId}`,
-				includedQuantity,
-			);
+		if (editing && stagedQuantity !== totalQuantity) {
+			form.setFieldValue(`licenseQuantities.${licensePlanId}`, totalQuantity);
 		}
 		setIsEditing(editing);
 	};
 
 	return (
-		<QuantityEditControl
-			readOnly={false}
-			displayText={`x${includedQuantity}`}
-			isEditing={isEditing}
-			onEditingChange={handleEditingChange}
-		>
-			<form.AppField name={`licenseIncludedQuantities.${licensePlanId}`}>
-				{(field) => <field.QuantityField label="" min={0} hideFieldInfo />}
-			</form.AppField>
-		</QuantityEditControl>
+		<div className="flex items-center gap-2 shrink-0">
+			{paidQuantity > 0 && (
+				<span className="text-tertiary-foreground">
+					{includedQuantity} included + {paidQuantity} paid
+				</span>
+			)}
+			<QuantityEditControl
+				readOnly={false}
+				displayText={`x${totalQuantity}`}
+				isEditing={isEditing}
+				onEditingChange={handleEditingChange}
+			>
+				<form.AppField name={`licenseQuantities.${licensePlanId}`}>
+					{(field) => (
+						<field.QuantityField
+							label=""
+							min={includedQuantity}
+							hideFieldInfo
+						/>
+					)}
+				</form.AppField>
+			</QuantityEditControl>
+		</div>
 	);
 }

--- a/vite/src/utils/billing/licenseQuantityUtils.ts
+++ b/vite/src/utils/billing/licenseQuantityUtils.ts
@@ -1,32 +1,50 @@
-import type { CustomizePlanLicense } from "@autumn/shared";
+import type {
+	CustomizePlanLicense,
+	LicenseQuantityParams,
+} from "@autumn/shared";
 
 /**
- * Overlays included-quantity edits staged from the attach summary rows onto
- * the upsert_licenses patch, so both stay a single source of truth.
+ * Converts staged license seat totals into license_quantities params.
+ * Unset quantities are omitted so the backend defaults to included seats.
  */
-export function mergeLicenseIncludedQuantities({
-	addLicenses,
-	licenseIncludedQuantities,
+export function convertLicenseQuantitiesToParams({
+	licenseQuantities,
 }: {
-	addLicenses: CustomizePlanLicense[] | null;
-	licenseIncludedQuantities: Record<string, number | undefined>;
-}): CustomizePlanLicense[] | null {
-	const overrides = Object.entries(licenseIncludedQuantities).filter(
-		([, included]) => included !== undefined,
-	);
-	if (overrides.length === 0) return addLicenses;
+	licenseQuantities: Record<string, number | undefined>;
+}): LicenseQuantityParams[] | undefined {
+	const params: LicenseQuantityParams[] = [];
 
-	const merged = (addLicenses ?? []).map((license) => {
-		const included = licenseIncludedQuantities[license.license_plan_id];
-		return included === undefined ? license : { ...license, included };
-	});
+	for (const [licensePlanId, quantity] of Object.entries(licenseQuantities)) {
+		if (quantity === undefined) continue;
+		params.push({ license_plan_id: licensePlanId, quantity });
+	}
 
-	const patchedIds = new Set(merged.map((license) => license.license_plan_id));
-	for (const [licensePlanId, included] of overrides) {
-		if (included !== undefined && !patchedIds.has(licensePlanId)) {
-			merged.push({ license_plan_id: licensePlanId, included });
+	return params.length > 0 ? params : undefined;
+}
+
+/**
+ * Raises staged seat totals that fell below a customized included amount,
+ * since total seats are always inclusive of included.
+ */
+export function clampLicenseQuantitiesToIncluded({
+	licenseQuantities,
+	upsertLicenses,
+}: {
+	licenseQuantities: Record<string, number | undefined>;
+	upsertLicenses: CustomizePlanLicense[];
+}): Record<string, number | undefined> {
+	const clamped = { ...licenseQuantities };
+
+	for (const license of upsertLicenses) {
+		const quantity = clamped[license.license_plan_id];
+		if (
+			license.included !== undefined &&
+			quantity !== undefined &&
+			quantity < license.included
+		) {
+			clamped[license.license_plan_id] = license.included;
 		}
 	}
 
-	return merged;
+	return clamped;
 }

--- a/vite/src/views/customers2/components/sheets/AttachProductSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/AttachProductSheet.tsx
@@ -430,7 +430,7 @@ function SheetContent() {
 		showPlanEditor,
 		handlePlanEditorSave,
 		handlePlanEditorCancel,
-		effectiveAddLicenses,
+		formValues,
 	} = useAttachFormContext();
 
 	const StageContent =
@@ -456,7 +456,7 @@ function SheetContent() {
 						onCancel={handlePlanEditorCancel}
 						isOpen={showPlanEditor}
 						enableLicenseEditing
-						initialAddLicenses={effectiveAddLicenses}
+						initialAddLicenses={formValues.addLicenses}
 					/>
 				)}
 			</div>


### PR DESCRIPTION
## What

Follow-up to #2258 — separates the two license seat concepts that were conflated into one knob:

- **Included** (free seats) is exclusively a customize concern: edited in the customize plan editor and staged via `upsert_licenses`. The attach row no longer writes to it.
- **Purchase quantity** (total seats, inclusive of included) is what the attach row's inline selector edits, staged as `licenseQuantities` and sent as **`license_quantities`** in the attach payload. Seats beyond included are billed prepaid at the license price.

## Behavior

- Row control displays `x{total}` with `min = included`; when extras are purchased the row shows the split explicitly: `6 included + 2 paid · x8`.
- Customizing included above a staged total raises the total (`clampLicenseQuantitiesToIncluded`), since totals are inclusive of included — no impossible below-included states.
- Unset quantities are omitted from the payload (backend defaults the pool to included seats), matching the prepaid options convention.
- The preview picks up seat charges automatically since it posts the same request body.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separate license seat “included” from “purchased total” in the attach flow. The row selector now edits total seats and sends them as `license_quantities`, while included seats are only set in Customize.

- **New Features**
  - Replaced form field `licenseIncludedQuantities` with `licenseQuantities`; removed `effectiveAddLicenses`.
  - Added `license_quantities` to the attach payload; unset quantities are omitted.
  - License row shows “x{total}”, and when extras are bought: “{included} included + {paid} paid · x{total}”; min = included.
  - Raising included in Customize clamps staged totals up to included to prevent below-included states.
  - New utils: `convertLicenseQuantitiesToParams` and `clampLicenseQuantitiesToIncluded`; removed `mergeLicenseIncludedQuantities`.
  - Preview reflects seat charges automatically via the shared request body.

<sup>Written for commit bd3034bb4919ce973cbdc4520bf3c4d5640e64dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR separates two previously conflated license seat concepts: \"included\" (free seats, owned by the plan customization editor) and \"purchase quantity\" (total seats including extras billed prepaid, owned by the inline row selector). The rename from `licenseIncludedQuantities` to `licenseQuantities` propagates cleanly across the form schema, context, hook, and request builder.

- **[Improvements]** `LicenseQuantityControl` now edits and displays the *total* seat count (inclusive of included) with a `x{N} included + M paid` breakdown, and the `min` prop prevents sub-included input at the UI level.
- **[Improvements]** `clampLicenseQuantitiesToIncluded` replaces `mergeLicenseIncludedQuantities`; when a plan-editor save raises the included amount above a staged total, the total is bumped up automatically to preserve the invariant that total ≥ included.
- **[API changes]** `license_quantities` is now sent in the attach request body as a separate top-level field (omitted entirely when no quantities are staged), decoupled from the `upsert_licenses` customize-plan payload.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the separation of included vs. purchase quantity is architecturally clean and the request body plumbing is correct.

The core change is well-scoped and the invariant (total ≥ included) is enforced through `clampLicenseQuantitiesToIncluded` and the UI `min` prop. One edge case worth watching: when a plan-editor save removes a license from the custom include list, its previously staged purchase quantity is not pruned, so the backend may receive an unexpected `license_quantities` entry. This is unlikely to cause a hard failure if the backend handles extra entries gracefully, but the behaviour could surprise users who reverted a license customisation and still see extra seats billed.

vite/src/utils/billing/licenseQuantityUtils.ts — the `clampLicenseQuantitiesToIncluded` function is the only place where stale quantity entries could be cleaned up but currently aren't.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/utils/billing/licenseQuantityUtils.ts | Replaced `mergeLicenseIncludedQuantities` with two focused utilities: `convertLicenseQuantitiesToParams` (builds the wire payload, omits undefined) and `clampLicenseQuantitiesToIncluded` (raises staged totals that fell below a newly-customized included amount). Clamp only raises; stale entries for licenses absent from `upsertLicenses` are preserved as-is. |
| vite/src/components/forms/shared/plan-items/LicenseQuantityControl.tsx | Reworked to edit total seat count (inclusive of included) with split display when extras are purchased. Seeds the form field on edit-open only when staged value differs from total. Min prop correctly prevents UI input below included amount. |
| vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx | Removed `effectiveAddLicenses` memo and replaces it with direct `formValues.addLicenses`; `licenseQuantities` is now threaded through to the request builder. `hasCustomizations` correctly ignores purchase quantities (only plan schema changes count as customizations). |
| vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts | Adds `licenseQuantities` to `BuildAttachRequestBodyParams`, builds `license_quantities` via `convertLicenseQuantitiesToParams`, and includes it in the `useMemo` dependency array — all correctly handled. |
| vite/src/components/forms/attach-v2/attachFormSchema.ts | Renames `licenseIncludedQuantities` to `licenseQuantities` in the Zod schema. Schema only enforces `nonnegative` (≥0) while the UI enforces `min=includedQuantity`; reasonable tradeoff given included amounts are not available at schema-definition time. |
| vite/src/components/forms/attach-v2/components/AttachPlanSection.tsx | Passes `licenseQuantities` into the editor and uses `formValues.addLicenses` directly instead of the removed `effectiveAddLicenses`. Clean and correct. |
| vite/src/views/customers2/components/sheets/AttachProductSheet.tsx | Switches `initialAddLicenses` from the removed `effectiveAddLicenses` to `formValues.addLicenses`. Correct — the plan editor now receives only the plan-customization patch, not the merged purchase quantities. |
| vite/src/components/forms/attach-v2/hooks/useAttachForm.ts | Default value renamed from `licenseIncludedQuantities: {}` to `licenseQuantities: {}`. Straightforward rename. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as LicenseQuantityControl
    participant Form as Form State (licenseQuantities)
    participant Editor as Plan Editor (handlePlanEditorSave)
    participant Clamp as clampLicenseQuantitiesToIncluded
    participant Builder as buildAttachRequestBody
    participant API as Attach API

    UI->>Form: "setFieldValue(licenseQuantities.{id}, totalQuantity) on edit-open"
    UI->>Form: "field.QuantityField update (min=includedQuantity enforced)"

    Editor->>Form: setFieldValue(addLicenses, editedAddLicenses)
    Editor->>Clamp: licenseQuantities + upsertLicenses
    Clamp-->>Form: raise any total below new included amount

    Form->>Builder: licenseQuantities + addLicenses + prepaidOptions
    Builder->>Builder: convertLicenseQuantitiesToParams() omit undefined
    Builder->>API: license_quantities + upsert_licenses
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as LicenseQuantityControl
    participant Form as Form State (licenseQuantities)
    participant Editor as Plan Editor (handlePlanEditorSave)
    participant Clamp as clampLicenseQuantitiesToIncluded
    participant Builder as buildAttachRequestBody
    participant API as Attach API

    UI->>Form: "setFieldValue(licenseQuantities.{id}, totalQuantity) on edit-open"
    UI->>Form: "field.QuantityField update (min=includedQuantity enforced)"

    Editor->>Form: setFieldValue(addLicenses, editedAddLicenses)
    Editor->>Clamp: licenseQuantities + upsertLicenses
    Clamp-->>Form: raise any total below new included amount

    Form->>Builder: licenseQuantities + addLicenses + prepaidOptions
    Builder->>Builder: convertLicenseQuantitiesToParams() omit undefined
    Builder->>API: license_quantities + upsert_licenses
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/utils/billing/licenseQuantityUtils.ts:29-50
**Stale quantities not pruned for licenses absent from `upsertLicenses`**

`clampLicenseQuantitiesToIncluded` spreads the full `licenseQuantities` object into `clamped` and only touches entries whose `license_plan_id` appears in `upsertLicenses`. If a license's included customisation is later *removed* in the plan editor (so it no longer appears in `editedAddLicenses`), its staged purchase quantity silently persists in the form and gets included in the attach payload via `license_quantities`. A concrete path: user stages 5 total seats for license A → opens plan editor, sets included=7 (clamp raises to 7) → opens plan editor again and reverts that customisation (A absent from `editedAddLicenses`) → `licenseQuantities` still carries `{A: 7}`, sending 7 total seats (4 paid) even though the user un-customised the license.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(licenses): 🎸 separate seat purchas..."](https://github.com/useautumn/autumn/commit/bd3034bb4919ce973cbdc4520bf3c4d5640e64dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44524384)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->