### PR TITLE
Fix updated coupon scope on existing subscriptions

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/discounts/subToDiscounts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/discounts/subToDiscounts.ts
@@ -1,5 +1,5 @@
 import { notNullish, type StripeDiscountWithCoupon } from "@autumn/shared";
-import type Stripe from "stripe";
+import Stripe from "stripe";
 import { createStripeCli } from "@/external/connect/createStripeCli";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 
@@ -36,6 +36,7 @@ export const subToDiscounts = async ({
 	// If deleted coupons exist, re-fetch the subscription via the legacy API which
 	// exposes discounts under `discount.coupon` with all original fields intact.
 	const deletedCouponMap = new Map<string, Stripe.Coupon>();
+	const currentCouponMap = new Map<string, Stripe.Coupon>();
 	if (hasDeletedCoupon) {
 		const legacyStripeCli = createStripeCli({
 			org: ctx.org,
@@ -53,6 +54,24 @@ export const subToDiscounts = async ({
 				deletedCouponMap.set(discount.id, coupon);
 			}
 		}
+
+		const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
+		await Promise.all(
+			[...deletedCouponMap.values()].map(async (coupon) => {
+				try {
+					const currentCoupon = await stripeCli.coupons.retrieve(coupon.id, {
+						expand: ["applies_to"],
+					});
+					currentCouponMap.set(coupon.id, currentCoupon);
+				} catch (error) {
+					if (
+						!(error instanceof Stripe.errors.StripeError) ||
+						!error.code?.includes("resource_missing")
+					)
+						throw error;
+				}
+			}),
+		);
 	}
 
 	return sub.discounts
@@ -69,9 +88,15 @@ export const subToDiscounts = async ({
 			if ("deleted" in coupon && coupon.deleted) {
 				const fullCoupon = deletedCouponMap.get(discount.id);
 				if (!fullCoupon) return discount as StripeDiscountWithCoupon;
+				const currentCoupon = currentCouponMap.get(fullCoupon.id);
+				// Reapply same-ID replacements because old discount IDs retain deleted coupon scope.
 				return {
 					...discount,
-					source: { ...discount.source, coupon: fullCoupon },
+					id: currentCoupon ? undefined : discount.id,
+					source: {
+						...discount.source,
+						coupon: currentCoupon ?? fullCoupon,
+					},
 				} as StripeDiscountWithCoupon;
 			}
 

--- a/server/tests/integration/billing/attach/immediate-switch/discounts/coupon-update-product-scope.test.ts
+++ b/server/tests/integration/billing/attach/immediate-switch/discounts/coupon-update-product-scope.test.ts
@@ -1,0 +1,68 @@
+/** Red: an attached coupon keeps discounting an excluded upgrade after its product scope is updated.
+ * Green: the excluded plan gets no discount and the invoice matches its corrected preview. */
+import { expect, test } from "bun:test";
+import { type AttachPreviewResponse, RewardType } from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { constructCoupon } from "@/utils/scriptUtils/createTestProducts.js";
+
+test(chalk.yellowBright(
+	"coupon update stops applying an attached discount to excluded plans",
+), async () => {
+	const customerId = "coupon-update-product-scope";
+	const promoCode = `SCOPE${Date.now()}`;
+	const current = products.base({
+		id: "current",
+		items: [items.monthlyPrice({ price: 20 })],
+	});
+	const excluded = products.base({
+		id: "excluded",
+		items: [items.annualPrice({ price: 240 })],
+	});
+	const reward = constructCoupon({
+		id: "scope-coupon",
+		promoCode,
+		discountType: RewardType.PercentageDiscount,
+		discountValue: 20,
+	});
+
+	const { autumnV1, autumnV2_2 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.products({ list: [current, excluded] }),
+			s.reward({ reward, productId: current.id }),
+		],
+		actions: [],
+	});
+
+	await autumnV2_2.billing.attach({
+		customer_id: customerId,
+		plan_id: current.id,
+		discounts: [{ promotion_code: promoCode }],
+	});
+
+	reward.discount_config!.apply_to_all = false;
+	await autumnV1.rewards.update({ internalId: reward.id, reward });
+
+	const preview = (await autumnV2_2.billing.previewAttach({
+		customer_id: customerId,
+		plan_id: excluded.id,
+	})) as AttachPreviewResponse;
+	const excludedLine = preview.line_items.find(
+		(lineItem) => lineItem.plan_id === excluded.id,
+	);
+
+	expect(excludedLine).toBeDefined();
+	expect(excludedLine?.discounts).not.toContainEqual(
+		expect.objectContaining({ reward_id: reward.id }),
+	);
+
+	const result = await autumnV2_2.billing.attach({
+		customer_id: customerId,
+		plan_id: excluded.id,
+	});
+	expect(result.invoice?.total).toBeCloseTo(preview.total, 2);
+}, 300_000);


### PR DESCRIPTION
## Summary

- detect when an attached Stripe discount references a deleted coupon that has a same-ID replacement
- reapply the current coupon so updated product scope affects both previews and finalized invoices
- preserve the existing fallback when a deleted coupon has no replacement
- add an end-to-end regression for upgrading to an excluded plan

## Testing

- bunx tsgo --build --noEmit
- coupon-update-product-scope.test.ts: 1 passed
- immediate-switch-discounts.test.ts: 5 passed
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reapplies the current `stripe` coupon when an attached discount references a deleted coupon with the same ID, so updated product scope is honored in previews and invoices and excluded plans aren’t discounted.

- **Bug Fixes**
  - Detects deleted coupons on existing subscription discounts and loads the full legacy coupon.
  - Retrieves the current same-ID coupon and replaces stale references so updated `applies_to` scope applies to both previews and invoices.
  - Preserves existing behavior when no replacement exists and adds an end-to-end test for upgrading to an excluded plan.

<sup>Written for commit 8c28a9967e69fd7c419a7e0baf043336c90b5615. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a scoping bug where a Stripe subscription discount that references a deleted (but same-ID-replaced) coupon continues to apply the old coupon's `applies_to` product list after the reward's scope is narrowed. It adds logic to `subToDiscounts` to retrieve the live replacement coupon and, when found, clears `id` so downstream code treats the discount as a fresh coupon application rather than reusing the existing discount ID.

- **[Bug fixes]** In `subToDiscounts`, after hydrating deleted-coupon data from the legacy Stripe API, a second pass now retrieves any same-ID replacement coupon (modern API, with `applies_to` expanded). When a replacement is found the discount's `id` is set to `undefined`, so `stripeDiscountsToParams` emits `{ coupon: id }` instead of `{ discount: di_xxx }`, causing Stripe to re-evaluate product scope using the updated coupon.
- **[Bug fixes]** The fallback when no same-ID replacement exists (e.g. coupon truly deleted) is preserved: `resource_missing` errors are silently swallowed, `currentCouponMap` stays empty, and the original `discount.id` is kept unchanged.
- **[Improvements]** A new integration test (`coupon-update-product-scope.test.ts`) covers the regression end-to-end: it attaches a coupon, narrows its scope, then asserts the excluded plan is not discounted in both the preview and the finalised invoice.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge for the intended replacement-coupon path; the no-replacement fallback relies on an assumption about Stripe API error behaviour that is consistent with existing code but not exercised by the new test.

The core logic — detecting a same-ID replacement coupon, clearing the discount ID to force fresh coupon application, and preserving the existing fallback — is implemented cleanly and backed by a passing integration test. The one open question is whether `stripe.coupons.retrieve` on a deleted-but-not-replaced coupon throws `resource_missing` or returns the tombstone object; if the latter, the fallback branch would emit a deleted coupon to Stripe instead of reusing the original discount ID. This assumption is already baked into `filterDeletedCouponDiscounts`, so it is a pre-existing risk rather than something newly introduced here.

The `resource_missing` error-path in `subToDiscounts.ts` (lines 66–71) and the matching assumption in the commented-out `filterDeletedCouponDiscounts` in `fetchStripeDiscountsForBilling.ts` are worth verifying against a live Stripe test-mode account for the deleted-coupon-no-replacement scenario.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/discounts/subToDiscounts.ts | Adds a second Stripe API pass to detect same-ID coupon replacements; clears `id` to force fresh coupon application with updated scope. Logic is sound for the replacement path; the no-replacement fallback relies on `resource_missing` being thrown by the modern API for deleted coupons, consistent with existing codebase patterns. |
| server/tests/integration/billing/attach/immediate-switch/discounts/coupon-update-product-scope.test.ts | New integration test covering the scope-narrowing regression. Hardcoded reward ID `"scope-coupon"` could collide across runs; `Date.now()`-suffixed promo code avoids the promo code conflict, but the reward ID is not similarly unique. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[subToDiscounts called] --> B{any deleted coupon in sub.discounts?}
    B -- No --> Z[return discounts as-is]
    B -- Yes --> C[Fetch legacy sub via acacia API]
    C --> D[Build deletedCouponMap: discount.id → full Coupon]
    D --> E[For each deleted coupon: modern API coupons.retrieve]
    E --> F{resource_missing thrown?}
    F -- Yes --> G[skip — no same-ID replacement]
    F -- No --> H[currentCouponMap.set coupon.id → currentCoupon]
    G & H --> I[Map sub.discounts]
    I --> J{coupon deleted?}
    J -- No --> K[return discount as-is]
    J -- Yes --> L{fullCoupon in deletedCouponMap?}
    L -- No --> M[return discount as-is, fallback via discount id]
    L -- Yes --> N{currentCoupon in currentCouponMap?}
    N -- No --> O[id = discount.id, coupon = fullCoupon]
    N -- Yes --> P[id = undefined, coupon = currentCoupon]
    O & P & K & M --> Q[stripeDiscountsToParams]
    Q --> R{d.id defined?}
    R -- Yes --> S[emit: discount id]
    R -- No --> T[emit: coupon id with updated scope]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[subToDiscounts called] --> B{any deleted coupon in sub.discounts?}
    B -- No --> Z[return discounts as-is]
    B -- Yes --> C[Fetch legacy sub via acacia API]
    C --> D[Build deletedCouponMap: discount.id → full Coupon]
    D --> E[For each deleted coupon: modern API coupons.retrieve]
    E --> F{resource_missing thrown?}
    F -- Yes --> G[skip — no same-ID replacement]
    F -- No --> H[currentCouponMap.set coupon.id → currentCoupon]
    G & H --> I[Map sub.discounts]
    I --> J{coupon deleted?}
    J -- No --> K[return discount as-is]
    J -- Yes --> L{fullCoupon in deletedCouponMap?}
    L -- No --> M[return discount as-is, fallback via discount id]
    L -- Yes --> N{currentCoupon in currentCouponMap?}
    N -- No --> O[id = discount.id, coupon = fullCoupon]
    N -- Yes --> P[id = undefined, coupon = currentCoupon]
    O & P & K & M --> Q[stripeDiscountsToParams]
    Q --> R{d.id defined?}
    R -- Yes --> S[emit: discount id]
    R -- No --> T[emit: coupon id with updated scope]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/tests/integration/billing/attach/immediate-switch/discounts/coupon-update-product-scope.test.ts:24-29
**Hardcoded reward ID may collide across test runs**

`constructCoupon` is called with the fixed `id: "scope-coupon"`. If a previous test run left this reward in the environment (e.g. a failed or cancelled run that didn't clean up), the `s.reward(...)` setup step may conflict with the existing record and leave the test in an unexpected state. `promoCode` is already guarded with `Date.now()`, but the reward ID is not. Consider appending the same timestamp suffix (e.g. `` `scope-coupon-${Date.now()}` ``) so each run creates a fully independent reward.

### Issue 2 of 2
server/src/internal/billing/v2/providers/stripe/utils/discounts/subToDiscounts.ts:58-74
**No-replacement fallback depends on `resource_missing` being thrown for deleted coupons**

The `resource_missing` catch is the mechanism that distinguishes "coupon deleted, no replacement" from "coupon deleted and recreated at the same ID". Stripe's docs state that a deleted coupon *can* still be retrieved (returning `{ deleted: true }`), which would not throw `resource_missing`. If the modern API (`2025-09-30.clover`) instead returns the tombstone object rather than erroring, `currentCouponMap` would be populated with a deleted coupon object, `id` would be incorrectly cleared to `undefined`, and `stripeDiscountsToParams` would emit `{ coupon: deletedId }` — a Stripe API call that would fail at write time. The same `resource_missing` assumption is present in `filterDeletedCouponDiscounts`, so this is a pre-existing pattern; worth confirming the modern API actually raises this error for deleted-but-not-replaced coupons.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): 🐛 reapply updated coupons..."](https://github.com/useautumn/autumn/commit/8c28a9967e69fd7c419a7e0baf043336c90b5615) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44737502)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->