### PR TITLE
fix(licenses): recognize staged license links in customize editor

### DIFF
--- a/vite/src/components/forms/shared/plan-items/LicenseQuantityControl.tsx
+++ b/vite/src/components/forms/shared/plan-items/LicenseQuantityControl.tsx
@@ -43,7 +43,7 @@ export function LicenseQuantityControl({
 			)}
 			<QuantityEditControl
 				readOnly={false}
-				displayText={`x${totalQuantity}`}
+				displayText={paidQuantity > 0 ? undefined : `x${totalQuantity}`}
 				isEditing={isEditing}
 				onEditingChange={handleEditingChange}
 			>

--- a/vite/src/components/v2/inline-custom-plan-editor/InlinePlanEditor.tsx
+++ b/vite/src/components/v2/inline-custom-plan-editor/InlinePlanEditor.tsx
@@ -21,7 +21,10 @@ import {
 } from "@/views/products/plan/components/plan-licenses/LicenseCustomizeCollector";
 import { LicensePlanCards } from "@/views/products/plan/components/plan-licenses/LicensePlanCards";
 import { LinkLicenseButton } from "@/views/products/plan/components/plan-licenses/LinkLicenseButton";
-import { PendingLicenseLinksProvider } from "@/views/products/plan/components/plan-licenses/PendingLicenseLinksContext";
+import {
+	PendingLicenseLinksProvider,
+	usePendingLicenseLinks,
+} from "@/views/products/plan/components/plan-licenses/PendingLicenseLinksContext";
 import { SheetPanelHost } from "@/views/products/plan/components/SheetPanelHost";
 import { ProductSheets } from "@/views/products/plan/ProductSheets";
 import { SHEET_ANIMATION } from "@/views/products/plan/planAnimations";
@@ -106,7 +109,11 @@ function InlinePlanEditorContent({
 	const { sheetType } = useSheet();
 	const hasPlanChanges = useHasPlanChanges();
 	const collectorStore = useLicenseCollectorStore();
-	const hasLicenseChanges = useHasCollectedLicenseChanges();
+	const { pendingLicenseIds } = usePendingLicenseLinks();
+	// Staged links are primary state — don't depend solely on each card's
+	// effect having registered with the collector.
+	const hasLicenseChanges =
+		useHasCollectedLicenseChanges() || pendingLicenseIds.length > 0;
 	const hasChanges = hasPlanChanges || hasLicenseChanges;
 
 	const handleSave = () => {

--- a/vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts
+++ b/vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts
@@ -29,6 +29,8 @@ const baseParams: Omit<
 	customerId: "cus_123",
 	entityId: undefined,
 	items: null,
+	licenseQuantities: {},
+	addLicenses: null,
 	grantFree: false,
 	version: undefined,
 	trialLength: null,


### PR DESCRIPTION
Follow-up to #2259 — two commits that landed after it merged:

- **Staged links enable Save Changes reliably**: the inline customize editor's save bar derived license dirtiness solely from each card's effect registering with the collector; staged links are primary state, so the bar now reads `pendingLicenseIds` directly. Linking a license enables Save Changes with no dependency on card mount/registration timing.
- **Test fixtures**: adds the missing `licenseQuantities` / `addLicenses` params to the attach request body test fixtures (11 failing unit tests → suite green).
- **Label tweak**: the seat row shows `5 included + 2 paid ✎` when extras are purchased, dropping the redundant `x7`; `x{N}` still shows when at the included amount.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This follow-up to #2259 fixes three related issues in the inline customize editor's license handling. The "Save Changes" bar now reacts to staged license links directly via `pendingLicenseIds`, rather than depending solely on each newly-rendered card's effect registering with the collector.

- **Bug fixes | Improvements**: `InlinePlanEditor` adds `pendingLicenseIds.length > 0` as a second gate for `hasLicenseChanges`, so the save bar appears as soon as a license is linked regardless of card-mount timing.
- **Bug fixes**: The attach request body test fixtures gain the missing `licenseQuantities` and `addLicenses` parameters, resolving 11 failing unit tests.
- **Improvements**: `LicenseQuantityControl` suppresses the `x{N}` label when paid extras are present, since the "N included + M paid" span already conveys the total — `x{N}` still shows at the included amount.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge; the core fix is sound and the test changes are straightforward.

The handleSave path still builds the addLicenses payload exclusively from collectLicensePatchAdds, which only sees cards that have completed their registration effect. Because pendingLicenseIds now makes the Save button appear before that effect runs, there is a narrow window after a link is staged where clicking Save could silently drop the new license from the payload.

vite/src/components/v2/inline-custom-plan-editor/InlinePlanEditor.tsx — the save handler reads only from the collector, not from pendingLicenseIds, so a very quick Save after linking could omit the new license.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/components/v2/inline-custom-plan-editor/InlinePlanEditor.tsx | Reads pendingLicenseIds to unblock the Save Changes bar for staged links; save payload still built solely from the collector, creating a narrow window where a freshly-linked license could be omitted. |
| vite/src/components/forms/shared/plan-items/LicenseQuantityControl.tsx | Hides redundant x{N} label when paid extras are present, matching QuantityEditControl's undefined-guard; label is already provided by the "N included + M paid" span. |
| vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts | Adds licenseQuantities and addLicenses to the shared baseParams fixture, fixing 11 previously failing unit tests. |


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant PLL as PendingLicenseLinksContext
    participant IPE as InlinePlanEditorContent
    participant Card as LicenseCard (effect)
    participant Col as LicenseCollectorStore

    U->>PLL: link license (addPendingLink)
    PLL-->>IPE: "pendingLicenseIds.length > 0"
    note over IPE: hasLicenseChanges = true
    IPE-->>Card: re-render with new pending license
    Card->>Col: "register(licenseId, {dirty:true, get})"
    U->>IPE: click Save Changes
    IPE->>Col: collectLicensePatchAdds(collectorStore)
    Col-->>IPE: [CustomizePlanLicense, ...]
    IPE->>U: onSave(product, addLicenses)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant PLL as PendingLicenseLinksContext
    participant IPE as InlinePlanEditorContent
    participant Card as LicenseCard (effect)
    participant Col as LicenseCollectorStore

    U->>PLL: link license (addPendingLink)
    PLL-->>IPE: "pendingLicenseIds.length > 0"
    note over IPE: hasLicenseChanges = true
    IPE-->>Card: re-render with new pending license
    Card->>Col: "register(licenseId, {dirty:true, get})"
    U->>IPE: click Save Changes
    IPE->>Col: collectLicensePatchAdds(collectorStore)
    Col-->>IPE: [CustomizePlanLicense, ...]
    IPE->>U: onSave(product, addLicenses)
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/src/components/v2/inline-custom-plan-editor/InlinePlanEditor.tsx`, line 115-130 ([link](https://github.com/useautumn/autumn/blob/3753bd3906cb8daa52cfaec2b609eb678cd82753/vite/src/components/v2/inline-custom-plan-editor/InlinePlanEditor.tsx#L115-L130)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Save payload doesn't include pending links that haven't yet registered**

   `hasLicenseChanges` now becomes true as soon as a license is staged, before its card has mounted and called `register` on the collector. The `handleSave` path still builds `addLicenses` exclusively from `collectLicensePatchAdds(collectorStore)`, which only snapshots entries already in the collector. In React 18 `useEffect` runs after paint, so between the render that shows the Save Changes button and the effects that register the new card there is a brief window where clicking Save produces a collector snapshot that silently omits the just-linked license.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/components/v2/inline-custom-plan-editor/InlinePlanEditor.tsx
   Line: 115-130

   Comment:
   **Save payload doesn't include pending links that haven't yet registered**

   `hasLicenseChanges` now becomes true as soon as a license is staged, before its card has mounted and called `register` on the collector. The `handleSave` path still builds `addLicenses` exclusively from `collectLicensePatchAdds(collectorStore)`, which only snapshots entries already in the collector. In React 18 `useEffect` runs after paint, so between the render that shows the Save Changes button and the effects that register the new card there is a brief window where clicking Save produces a collector snapshot that silently omits the just-linked license.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/components/v2/inline-custom-plan-editor/InlinePlanEditor.tsx:115-130
**Save payload doesn't include pending links that haven't yet registered**

`hasLicenseChanges` now becomes true as soon as a license is staged, before its card has mounted and called `register` on the collector. The `handleSave` path still builds `addLicenses` exclusively from `collectLicensePatchAdds(collectorStore)`, which only snapshots entries already in the collector. In React 18 `useEffect` runs after paint, so between the render that shows the Save Changes button and the effects that register the new card there is a brief window where clicking Save produces a collector snapshot that silently omits the just-linked license.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["style(licenses): 🎨 drop redundant seat ..."](https://github.com/useautumn/autumn/commit/3753bd3906cb8daa52cfaec2b609eb678cd82753) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44742562)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the Save Changes bar as soon as a license link is staged in the inline customize editor. Also fixes attach request body tests and removes a redundant seat total label.

- **Bug Fixes**
  - Detect license changes via `pendingLicenseIds` in addition to the collector, so linking a license immediately enables Save.
  - Add `licenseQuantities` and `addLicenses` to attach request body test fixtures to unblock failing tests.
  - Hide `x{N}` when paid extras are present; still show `x{N}` at the included amount.

<sup>Written for commit 3753bd3906cb8daa52cfaec2b609eb678cd82753. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

