### PR TITLE
refactor(licenses): align customer license tables with plans table

### DIFF
--- a/vite/src/hooks/stores/useSheetStore.ts
+++ b/vite/src/hooks/stores/useSheetStore.ts
@@ -16,6 +16,7 @@ export type SheetType =
 	| "attach-schedule-plan"
 	| "subscription-detail"
 	| "license-detail"
+	| "license-pool-detail"
 	| "subscription-update"
 	| "subscription-update-send-invoice"
 	| "subscription-cancel"

--- a/vite/src/views/customers2/components/customer-licenses/CustomerLicensePoolsSection.tsx
+++ b/vite/src/views/customers2/components/customer-licenses/CustomerLicensePoolsSection.tsx
@@ -5,6 +5,7 @@ import {
 import { useMemo } from "react";
 import { Table } from "@/components/general/table";
 import { LicenseIcon } from "@/components/v2/icons/LicenseIcon";
+import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { useCustomerContext } from "@/views/customers2/customer/CustomerContext";
 import { useCustomerTable } from "@/views/customers2/hooks/useCustomerTable";
 import {
@@ -16,6 +17,8 @@ import {
  * straight off the full customer's hydrated customer_licenses. */
 export function CustomerLicensePoolsSection() {
 	const { customer, entityId } = useCustomerContext();
+	const selectedItemId = useSheetStore((s) => s.itemId);
+	const setSheet = useSheetStore((s) => s.setSheet);
 
 	const rows = useMemo<CustomerLicensePoolRow[]>(
 		() =>
@@ -24,6 +27,7 @@ export function CustomerLicensePoolsSection() {
 			}).flatMap((customerProduct) =>
 				(customerProduct.customer_licenses ?? []).map((customerLicense) => ({
 					id: customerLicense.id,
+					licensePlanId: customerLicense.planLicense?.product.id ?? null,
 					name:
 						customerLicense.planLicense?.product.name ??
 						customerLicense.license_internal_product_id,
@@ -62,6 +66,11 @@ export function CustomerLicensePoolsSection() {
 				emptyStateChildren: "No licenses",
 				flexibleTableColumns: true,
 				mobileCards: true,
+				selectedItemId,
+				onRowClick: (row: CustomerLicensePoolRow) => {
+					if (!row.licensePlanId) return;
+					setSheet({ type: "license-pool-detail", itemId: row.licensePlanId });
+				},
 			}}
 		>
 			<Table.Container>

--- a/vite/src/views/customers2/components/customer-licenses/CustomerLicensePoolsSection.tsx
+++ b/vite/src/views/customers2/components/customer-licenses/CustomerLicensePoolsSection.tsx
@@ -1,4 +1,7 @@
-import { filterCustomerProductsByActiveStatuses } from "@autumn/shared";
+import {
+	filterCustomerProductsByActiveStatuses,
+	mapToProductV2,
+} from "@autumn/shared";
 import { useMemo } from "react";
 import { Table } from "@/components/general/table";
 import { LicenseIcon } from "@/components/v2/icons/LicenseIcon";
@@ -6,7 +9,7 @@ import { useCustomerContext } from "@/views/customers2/customer/CustomerContext"
 import { useCustomerTable } from "@/views/customers2/hooks/useCustomerTable";
 import {
 	type CustomerLicensePoolRow,
-	customerLicensePoolColumns,
+	createCustomerLicensePoolColumns,
 } from "./customerLicensePoolColumns";
 
 /** Customer-level license pools (used/granted seats per license), read
@@ -24,7 +27,9 @@ export function CustomerLicensePoolsSection() {
 					name:
 						customerLicense.planLicense?.product.name ??
 						customerLicense.license_internal_product_id,
-					parentPlanName: customerProduct.product.name,
+					product: customerLicense.planLicense
+						? mapToProductV2({ product: customerLicense.planLicense.product })
+						: null,
 					remaining: customerLicense.remaining,
 					granted: customerLicense.granted,
 					paidQuantity: customerLicense.paid_quantity,
@@ -34,10 +39,15 @@ export function CustomerLicensePoolsSection() {
 		[customer.customer_products],
 	);
 
-	const table = useCustomerTable({
-		data: rows,
-		columns: customerLicensePoolColumns,
-	});
+	const columns = useMemo(
+		() =>
+			createCustomerLicensePoolColumns({
+				hasEntities: customer.entities.length > 0,
+			}),
+		[customer.entities.length],
+	);
+
+	const table = useCustomerTable({ data: rows, columns });
 
 	// Entity view shows per-entity assignments via CustomerLicensesSection.
 	if (entityId || rows.length === 0) return null;
@@ -46,7 +56,7 @@ export function CustomerLicensePoolsSection() {
 		<Table.Provider
 			config={{
 				table,
-				numberOfColumns: customerLicensePoolColumns.length,
+				numberOfColumns: columns.length,
 				enableSorting: false,
 				isLoading: false,
 				emptyStateChildren: "No licenses",

--- a/vite/src/views/customers2/components/customer-licenses/CustomerLicensesSection.tsx
+++ b/vite/src/views/customers2/components/customer-licenses/CustomerLicensesSection.tsx
@@ -1,7 +1,9 @@
 import { useMemo } from "react";
 import { Table } from "@/components/general/table";
 import { LicenseIcon } from "@/components/v2/icons/LicenseIcon";
+import { useLicenseProductsQuery } from "@/hooks/queries/useLicenseProductsQuery";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
+import { useCustomerContext } from "@/views/customers2/customer/CustomerContext";
 import { useCustomerTable } from "@/views/customers2/hooks/useCustomerTable";
 import { AssignLicenseButton } from "./AssignLicenseButton";
 import {
@@ -32,6 +34,8 @@ export function CustomerLicensesSection() {
 		[assignments, publicEntityId],
 	);
 
+	const { licenseProducts } = useLicenseProductsQuery();
+
 	const rows = useMemo<LicenseAssignmentRow[]>(() => {
 		const poolByLicensePlanId = new Map(
 			pools.map((pool) => [pool.license_plan_id, pool]),
@@ -43,12 +47,19 @@ export function CustomerLicensesSection() {
 				{
 					id: assignment.id,
 					name: pool.license_plan_name,
+					product:
+						licenseProducts.find(
+							(license) => license.id === pool.license_plan_id,
+						) ?? null,
 					started_at: assignment.started_at,
 					pool,
 				},
 			];
 		});
-	}, [pools, entityAssignments]);
+	}, [pools, entityAssignments, licenseProducts]);
+
+	const { customer } = useCustomerContext();
+	const entity = customer.entities?.find((e) => e.id === publicEntityId);
 
 	const columns = useMemo(
 		() =>
@@ -58,8 +69,9 @@ export function CustomerLicensesSection() {
 						entityId: publicEntityId ?? "",
 						licensePlanId: row.pool.license_plan_id,
 					}),
+				entityName: entity?.name ?? entity?.id ?? publicEntityId ?? undefined,
 			}),
-		[cancelLicenseAssignment, publicEntityId],
+		[cancelLicenseAssignment, publicEntityId, entity],
 	);
 
 	const table = useCustomerTable({ data: rows, columns });

--- a/vite/src/views/customers2/components/customer-licenses/LicensePlanPrice.tsx
+++ b/vite/src/views/customers2/components/customer-licenses/LicensePlanPrice.tsx
@@ -1,0 +1,54 @@
+import type { ProductV2 } from "@autumn/shared";
+import { productV2ToFrontendProduct } from "@autumn/shared";
+import { useCustomerDisplayCurrency } from "@/hooks/common/useCustomerDisplayCurrency";
+import { getBasePriceDisplay } from "@/utils/product/basePriceDisplayUtils";
+
+/** Price cell for a license plan row. Included-only seats read as free; paid
+ * seats show the license plan's price, and a mixed pool shows both. */
+export function LicensePlanPrice({
+	product,
+	includedQuantity,
+	paidQuantity,
+}: {
+	product: ProductV2 | null;
+	includedQuantity: number;
+	paidQuantity: number;
+}) {
+	const { displayCurrency, productForDisplay } = useCustomerDisplayCurrency();
+
+	if (!product || !product.items || product.items.length === 0) {
+		return <div className="text-tertiary-foreground">-</div>;
+	}
+
+	const frontendProduct = productV2ToFrontendProduct({ product });
+	const priceDisplay = getBasePriceDisplay({
+		product: productForDisplay(frontendProduct),
+		currency: displayCurrency,
+	});
+
+	if (priceDisplay.type !== "price") {
+		return (
+			<div className="text-tertiary-foreground">
+				{priceDisplay.type === "placeholder" ? "-" : priceDisplay.displayText}
+			</div>
+		);
+	}
+
+	if (paidQuantity <= 0) {
+		return <div className="text-tertiary-foreground">Free</div>;
+	}
+
+	return (
+		<div className="flex items-center gap-1">
+			{includedQuantity > 0 && (
+				<span className="text-tertiary-foreground">Free +</span>
+			)}
+			<span className="text-muted-foreground">
+				{priceDisplay.formattedAmount}
+			</span>
+			<span className="text-tertiary-foreground">
+				{priceDisplay.intervalText}
+			</span>
+		</div>
+	);
+}

--- a/vite/src/views/customers2/components/customer-licenses/customerLicenseColumns.tsx
+++ b/vite/src/views/customers2/components/customer-licenses/customerLicenseColumns.tsx
@@ -1,25 +1,33 @@
-import type { ApiCustomerLicenseV0 } from "@autumn/shared";
+import type { ApiCustomerLicenseV0, ProductV2 } from "@autumn/shared";
 import { DropdownMenuItem } from "@autumn/ui";
 import type { Row } from "@tanstack/react-table";
+import { CheckIcon } from "lucide-react";
 import {
 	hiddenSkeleton,
 	nameWithIconSkeleton,
+	statusSkeleton,
 	TableDropdownMenuCell,
 } from "@/components/general/table";
 import { LicenseIcon } from "@/components/v2/icons/LicenseIcon";
 import { createDateTimeColumn } from "@/views/customers2/utils/ColumnHelpers";
+import { LicensePlanPrice } from "./LicensePlanPrice";
 
 export interface LicenseAssignmentRow {
 	id: string;
 	name: string;
+	product: ProductV2 | null;
 	started_at: number;
 	pool: ApiCustomerLicenseV0;
 }
 
 export const createCustomerLicenseColumns = ({
 	onUnassign,
+	entityName,
 }: {
 	onUnassign: (row: LicenseAssignmentRow) => void;
+	/** Shown in a Scope column mirroring the plans table's; omit when the
+	 * customer has no entities (the plans table drops Scope too). */
+	entityName?: string;
 }) => [
 	{
 		header: "Name",
@@ -33,18 +41,46 @@ export const createCustomerLicenseColumns = ({
 			</div>
 		),
 	},
+	...(entityName !== undefined
+		? [
+				{
+					header: "Scope",
+					accessorKey: "scope",
+					cell: () => (
+						<span className="text-muted-foreground truncate">{entityName}</span>
+					),
+				},
+			]
+		: []),
 	{
-		header: "Availability",
-		accessorKey: "availability",
-		size: 150,
+		header: "Price",
+		accessorKey: "price",
+		size: 120,
 		cell: ({ row }: { row: Row<LicenseAssignmentRow> }) => {
-			const { remaining, granted } = row.original.pool;
+			const { product, pool } = row.original;
 			return (
-				<span className="text-tertiary-foreground">
-					{remaining} of {granted} available
-				</span>
+				<LicensePlanPrice
+					product={product}
+					includedQuantity={pool.granted - pool.paid_quantity}
+					paidQuantity={pool.paid_quantity}
+				/>
 			);
 		},
+	},
+	{
+		header: "Status",
+		accessorKey: "status",
+		size: 110,
+		meta: { skeleton: statusSkeleton },
+		cell: () => (
+			<div className="flex items-center gap-1.5">
+				<CheckIcon
+					className="text-white rounded-full p-0.5 bg-green-500 dark:bg-green-600"
+					size={12}
+				/>
+				<span className="text-sm">Assigned</span>
+			</div>
+		),
 	},
 	{
 		...createDateTimeColumn<LicenseAssignmentRow>({

--- a/vite/src/views/customers2/components/customer-licenses/customerLicensePoolColumns.tsx
+++ b/vite/src/views/customers2/components/customer-licenses/customerLicensePoolColumns.tsx
@@ -10,6 +10,7 @@ import { LicensePlanPrice } from "./LicensePlanPrice";
 
 export interface CustomerLicensePoolRow {
 	id: string;
+	licensePlanId: string | null;
 	name: string;
 	product: ProductV2 | null;
 	remaining: number;

--- a/vite/src/views/customers2/components/customer-licenses/customerLicensePoolColumns.tsx
+++ b/vite/src/views/customers2/components/customer-licenses/customerLicensePoolColumns.tsx
@@ -1,13 +1,17 @@
-import { Badge } from "@autumn/ui";
+import type { ProductV2 } from "@autumn/shared";
 import type { Row } from "@tanstack/react-table";
-import { nameWithIconSkeleton } from "@/components/general/table";
+import {
+	hiddenSkeleton,
+	nameWithIconSkeleton,
+} from "@/components/general/table";
 import { LicenseIcon } from "@/components/v2/icons/LicenseIcon";
 import { createDateTimeColumn } from "@/views/customers2/utils/ColumnHelpers";
+import { LicensePlanPrice } from "./LicensePlanPrice";
 
 export interface CustomerLicensePoolRow {
 	id: string;
 	name: string;
-	parentPlanName: string;
+	product: ProductV2 | null;
 	remaining: number;
 	granted: number;
 	paidQuantity: number;
@@ -16,7 +20,19 @@ export interface CustomerLicensePoolRow {
 
 const formatNumber = (value: number) => new Intl.NumberFormat().format(value);
 
-export const customerLicensePoolColumns = [
+/** Mirrors the plans table's Scope column so both tables' flexible columns
+ * resolve to identical widths. License pools are always customer-scoped. */
+const scopeColumn = {
+	header: "Scope",
+	accessorKey: "scope",
+	cell: () => <span className="text-muted-foreground">Customer</span>,
+};
+
+export const createCustomerLicensePoolColumns = ({
+	hasEntities,
+}: {
+	hasEntities: boolean;
+}) => [
 	{
 		header: "Name",
 		accessorKey: "name",
@@ -29,33 +45,36 @@ export const customerLicensePoolColumns = [
 			</div>
 		),
 	},
+	...(hasEntities ? [scopeColumn] : []),
 	{
-		header: "Plan",
-		accessorKey: "parentPlanName",
-		size: 150,
-		cell: ({ row }: { row: Row<CustomerLicensePoolRow> }) => (
-			<span className="text-tertiary-foreground">
-				{row.original.parentPlanName}
-			</span>
-		),
+		header: "Price",
+		accessorKey: "price",
+		size: 120,
+		cell: ({ row }: { row: Row<CustomerLicensePoolRow> }) => {
+			const { product, granted, paidQuantity } = row.original;
+			return (
+				<LicensePlanPrice
+					product={product}
+					includedQuantity={granted - paidQuantity}
+					paidQuantity={paidQuantity}
+				/>
+			);
+		},
 	},
 	{
-		header: "Seats",
-		accessorKey: "remaining",
-		size: 180,
+		header: "Status",
+		accessorKey: "status",
+		size: 110,
 		cell: ({ row }: { row: Row<CustomerLicensePoolRow> }) => {
-			const { remaining, granted, paidQuantity } = row.original;
+			const { remaining, granted } = row.original;
 			return (
-				<div className="flex items-baseline gap-2 truncate">
-					<div className="flex items-baseline gap-1">
-						<span className="text-foreground">{formatNumber(remaining)}</span>
-						<span className="text-subtle">/ {formatNumber(granted)} left</span>
-					</div>
-					{paidQuantity > 0 && (
-						<Badge variant="muted" size="sm" className="shrink-0">
-							{formatNumber(paidQuantity)} paid
-						</Badge>
-					)}
+				<div className="flex items-baseline gap-1 truncate">
+					<span className="text-muted-foreground">
+						{formatNumber(granted - remaining)}
+					</span>
+					<span className="text-subtle">
+						/ {formatNumber(granted)} assigned
+					</span>
 				</div>
 			);
 		},
@@ -67,5 +86,14 @@ export const customerLicensePoolColumns = [
 			withYear: true,
 		}),
 		size: 150,
+	},
+	{
+		id: "actions",
+		header: "",
+		size: 40,
+		meta: { skeleton: hiddenSkeleton },
+		// Spacer matching the plans table's actions column so both tables'
+		// flexible columns resolve to identical widths.
+		cell: () => null,
 	},
 ];

--- a/vite/src/views/customers2/components/customer-licenses/useCustomerLicenseActions.ts
+++ b/vite/src/views/customers2/components/customer-licenses/useCustomerLicenseActions.ts
@@ -9,15 +9,18 @@ import { runWithErrorToast } from "@/views/products/plan/components/plan-license
 export const useCustomerLicenseActions = ({
 	customerId,
 	entityId,
+	enabled,
 }: {
 	customerId?: string;
 	entityId?: string;
+	/** Defaults to fetching only when an entity is selected. */
+	enabled?: boolean;
 }) => {
 	const { pools, assignments, isLoading, assign, unassign } =
 		useLicenseBalancesQuery({
 			customerId,
 			entityId,
-			enabled: Boolean(entityId),
+			enabled: enabled ?? Boolean(entityId),
 		});
 
 	const attachLicense = (pool: ApiCustomerLicenseV0) => {

--- a/vite/src/views/customers2/components/customer-licenses/useCustomerLicenseBalances.ts
+++ b/vite/src/views/customers2/components/customer-licenses/useCustomerLicenseBalances.ts
@@ -6,7 +6,12 @@ import { useCustomerLicenseActions } from "./useCustomerLicenseActions";
  * the URL's entity_id (which may hold the internal id, e.g. via the plans
  * table's Scope column) to the public id the licenses API expects.
  */
-export const useCustomerLicenseBalances = () => {
+export const useCustomerLicenseBalances = ({
+	enabled,
+}: {
+	/** Defaults to fetching only when an entity is selected. */
+	enabled?: boolean;
+} = {}) => {
 	const { customer, entityId } = useCustomerContext();
 	const customerId = customer.id ?? customer.internal_id;
 
@@ -19,6 +24,10 @@ export const useCustomerLicenseBalances = () => {
 
 	return {
 		publicEntityId,
-		...useCustomerLicenseActions({ customerId, entityId: publicEntityId }),
+		...useCustomerLicenseActions({
+			customerId,
+			entityId: publicEntityId,
+			enabled,
+		}),
 	};
 };

--- a/vite/src/views/customers2/components/sheets/LicensePoolDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/LicensePoolDetailSheet.tsx
@@ -1,0 +1,166 @@
+import { productV2ToFrontendProduct } from "@autumn/shared";
+import { Button, CopyButton, InfoRow } from "@autumn/ui";
+import { ChartBarIcon, HashIcon } from "@phosphor-icons/react";
+import { format } from "date-fns";
+import { useState } from "react";
+import { LicenseIcon } from "@/components/v2/icons/LicenseIcon";
+import { SheetHeader, SheetSection } from "@/components/v2/sheets/InlineSheet";
+import { useLicenseProductsQuery } from "@/hooks/queries/useLicenseProductsQuery";
+import { useSheetStore } from "@/hooks/stores/useSheetStore";
+import { useEntity } from "@/hooks/stores/useSubscriptionStore";
+import { useCustomerContext } from "../../customer/CustomerContext";
+import { useCustomerLicenseBalances } from "../customer-licenses/useCustomerLicenseBalances";
+import { SubscriptionDetailItems } from "./SubscriptionDetailItems";
+
+const ID_CHIP_INNER_CLASS = "max-w-40 text-tiny-id truncate !font-normal";
+
+/** Detail sheet for a customer-level license pool (itemId = license plan id):
+ * the license's items, pool inventory, and every entity holding a seat. */
+export function LicensePoolDetailSheet() {
+	const licensePlanId = useSheetStore((s) => s.itemId);
+	const closeSheet = useSheetStore((s) => s.closeSheet);
+	const { customer } = useCustomerContext();
+	const { setEntityId } = useEntity();
+	const { pools, assignments, isLoading, cancelLicenseAssignment } =
+		useCustomerLicenseBalances({ enabled: true });
+	const [unassigningEntityId, setUnassigningEntityId] = useState<string | null>(
+		null,
+	);
+	const { licenseProducts } = useLicenseProductsQuery();
+
+	const pool = pools.find(
+		(candidate) => candidate.license_plan_id === licensePlanId,
+	);
+	const license = licenseProducts.find(
+		(candidate) => candidate.id === licensePlanId,
+	);
+	const poolAssignments = assignments.filter(
+		(assignment) => assignment.license_plan_id === licensePlanId,
+	);
+
+	if (!pool) {
+		return (
+			<div className="flex flex-col h-full">
+				<SheetHeader
+					title="License Details"
+					description={
+						isLoading
+							? "Loading license information..."
+							: "This license no longer exists."
+					}
+				/>
+			</div>
+		);
+	}
+
+	const entityLabel = (entityId: string) => {
+		const entity = customer.entities?.find(
+			(candidate) => candidate.id === entityId,
+		);
+		return entity?.name || entityId;
+	};
+
+	const goToEntity = (entityId: string) => {
+		const entity = customer.entities?.find(
+			(candidate) => candidate.id === entityId,
+		);
+		if (!entity) return;
+		closeSheet();
+		setEntityId(entity.internal_id);
+	};
+
+	return (
+		<div className="flex flex-col h-full overflow-y-auto">
+			<SheetHeader
+				title={
+					<span className="flex items-center gap-2">
+						<LicenseIcon size={16} />
+						{pool.license_plan_name}
+					</span>
+				}
+				description={`Entities assigned ${pool.license_plan_name}`}
+			/>
+
+			{license && license.items.length > 0 && (
+				<SubscriptionDetailItems
+					items={license.items}
+					product={productV2ToFrontendProduct({ product: license })}
+				/>
+			)}
+
+			<SheetSection withSeparator={true}>
+				<div className="space-y-3">
+					<InfoRow
+						icon={<HashIcon size={16} />}
+						label="ID"
+						value={
+							<CopyButton
+								text={pool.license_plan_id}
+								size="mini"
+								className="text-tertiary-foreground"
+								innerClassName={ID_CHIP_INNER_CLASS}
+							/>
+						}
+					/>
+					<InfoRow
+						icon={<ChartBarIcon size={16} weight="duotone" />}
+						label="Availability"
+						value={`${pool.remaining} of ${pool.granted} available`}
+					/>
+				</div>
+			</SheetSection>
+
+			<SheetSection withSeparator={true}>
+				<h3 className="text-sub mb-2">Assigned Entities</h3>
+				{poolAssignments.length === 0 ? (
+					<p className="text-sm text-tertiary-foreground">
+						No entities assigned
+					</p>
+				) : (
+					<div className="flex flex-col">
+						{poolAssignments.map((assignment) => (
+							<div
+								key={assignment.id}
+								className="flex items-center justify-between h-9 gap-2 text-sm"
+							>
+								<Button
+									variant="skeleton"
+									onClick={() => goToEntity(assignment.entity_id)}
+									className="font-medium hover:text-purple-600 cursor-pointer min-w-0 px-0! hover:bg-transparent active:bg-transparent active:border-none"
+								>
+									<span className="truncate">
+										{entityLabel(assignment.entity_id)}
+									</span>
+								</Button>
+								<div className="flex items-center gap-3 shrink-0">
+									<span className="text-tertiary-foreground">
+										{format(new Date(assignment.started_at), "MMM d, yyyy")}
+									</span>
+									<Button
+										variant="secondary"
+										size="sm"
+										isLoading={unassigningEntityId === assignment.entity_id}
+										disabled={unassigningEntityId !== null}
+										onClick={async () => {
+											setUnassigningEntityId(assignment.entity_id);
+											try {
+												await cancelLicenseAssignment({
+													entityId: assignment.entity_id,
+													licensePlanId: pool.license_plan_id,
+												});
+											} finally {
+												setUnassigningEntityId(null);
+											}
+										}}
+									>
+										Unassign
+									</Button>
+								</div>
+							</div>
+						))}
+					</div>
+				)}
+			</SheetSection>
+		</div>
+	);
+}

--- a/vite/src/views/customers2/customer/CustomerSheets.tsx
+++ b/vite/src/views/customers2/customer/CustomerSheets.tsx
@@ -23,6 +23,7 @@ import { CreateScheduleSheet } from "../components/sheets/CreateScheduleSheet";
 import { CustomerConfigSheet } from "../components/sheets/CustomerConfigSheet";
 import { InvoiceDetailSheet } from "../components/sheets/InvoiceDetailSheet";
 import { LicenseDetailSheet } from "../components/sheets/LicenseDetailSheet";
+import { LicensePoolDetailSheet } from "../components/sheets/LicensePoolDetailSheet";
 import { RecordUsageSheet } from "../components/sheets/RecordUsageSheet";
 import { SubscriptionDetailSheet } from "../components/sheets/SubscriptionDetailSheet";
 import { SyncStripeSheet } from "../components/sync-stripe/SyncStripeSheet";
@@ -54,6 +55,8 @@ export function CustomerSheets() {
 				return <SubscriptionDetailSheet />;
 			case "license-detail":
 				return <LicenseDetailSheet />;
+			case "license-pool-detail":
+				return <LicensePoolDetailSheet />;
 			case "subscription-update":
 			case "subscription-update-send-invoice":
 				return <SubscriptionUpdateSheet />;


### PR DESCRIPTION
Both customer license tables now mirror the plans table layout — **Name | Scope | Price | Status | Date | actions** — so the columns line up exactly in every view:

- **Price** (new `LicensePlanPrice` cell): the license plan's price — `Free` for included-only pools, the plan's price for paid-only, and `Free + $25 per month` for mixed included/paid pools.
- **Status** is context-dependent: the customer-level pools table shows seat assignment (`2 / 5 assigned`); the entity view shows a green `Assigned` badge (same styling as the plans table's Active).
- **Scope** mirrors the plans table: rendered only when the customer has entities — `Customer` on the pools table, the entity's name on the entity view.
- A trailing spacer matches the plans table's actions column so `flexibleTableColumns` resolves identical widths; dropped the old parent-plan and availability columns.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This refactor aligns the two customer license tables (pool view and entity assignment view) with the plans table layout, adding unified **Name | Scope | Price | Status | Date | Actions** columns. A new `LicensePlanPrice` component handles Free / paid / mixed pricing display, and both column factories become dynamic functions that conditionally include the Scope column based on whether the customer has entities.

- **[Improvements]** Both customer license tables now mirror the plans table column structure — `LicensePlanPrice` renders Free, paid, or mixed pricing; Status shows seat-assignment counts on the pools table and a green "Assigned" badge on the entity view.
- **[Improvements]** Column definitions converted from static arrays to factory functions (`createCustomerLicensePoolColumns`, refactored `createCustomerLicenseColumns`), enabling the Scope column to be conditionally included based on entity presence.
- **[Improvements]** `CustomerLicensesSection` introduces `useLicenseProductsQuery` to resolve a `ProductV2` for each assignment row; a trailing spacer column is added to the pool table to match the plans table's actions column width.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix: `customer.entities.length` in `CustomerLicensePoolsSection` should use optional chaining to match how the same field is accessed in the sibling component.

The column refactor is straightforward and the new `LicensePlanPrice` component handles all three pricing states correctly. The one concern is `customer.entities.length` being accessed without a null guard in `CustomerLicensePoolsSection` while the sibling component defensively uses `customer.entities?.find(...)` — if a customer record ever arrives without an `entities` array, this line throws and crashes the pool section.

vite/src/views/customers2/components/customer-licenses/CustomerLicensePoolsSection.tsx — the `customer.entities.length` access on line 45 needs an optional chaining guard.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/customer-licenses/CustomerLicensePoolsSection.tsx | Switched from a static column array to a factory `createCustomerLicensePoolColumns`; introduces a potential null-dereference on `customer.entities.length` when the sibling section guards the same field with optional chaining. |
| vite/src/views/customers2/components/customer-licenses/CustomerLicensesSection.tsx | Adds `useLicenseProductsQuery` to resolve a `ProductV2` for each assignment row; introduces `entity` lookup for the new Scope column with proper optional-chaining and fallback chain. |
| vite/src/views/customers2/components/customer-licenses/LicensePlanPrice.tsx | New presentational component that renders Free / paid / mixed pricing for a license plan row; logic is correct and handles all three states cleanly. |
| vite/src/views/customers2/components/customer-licenses/customerLicenseColumns.tsx | Adds Scope, Price, and Status columns to the entity assignment view; the Scope column is conditionally included based on `entityName`, and Status always shows a green "Assigned" badge appropriate for already-filtered active rows. |
| vite/src/views/customers2/components/customer-licenses/customerLicensePoolColumns.tsx | Replaces Plan/Seats/Availability columns with Scope/Price/Status; Status now shows a seat-assignment count and a trailing actions spacer ensures width parity with the plans table. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Customer License View] --> B{entityId set?}
    B -- Yes --> C[CustomerLicensesSection]
    B -- No --> D[CustomerLicensePoolsSection]
    C --> E[useLicenseProductsQuery]
    C --> F[useCustomerLicenseBalances]
    E --> G[Match product by license_plan_id]
    F --> G
    G --> H[LicenseAssignmentRow]
    H --> I[createCustomerLicenseColumns]
    D --> J[customer.customer_products]
    J --> K[mapToProductV2 on planLicense.product]
    K --> L[CustomerLicensePoolRow]
    L --> M[createCustomerLicensePoolColumns]
    I --> N[LicensePlanPrice]
    M --> N
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Customer License View] --> B{entityId set?}
    B -- Yes --> C[CustomerLicensesSection]
    B -- No --> D[CustomerLicensePoolsSection]
    C --> E[useLicenseProductsQuery]
    C --> F[useCustomerLicenseBalances]
    E --> G[Match product by license_plan_id]
    F --> G
    G --> H[LicenseAssignmentRow]
    H --> I[createCustomerLicenseColumns]
    D --> J[customer.customer_products]
    J --> K[mapToProductV2 on planLicense.product]
    K --> L[CustomerLicensePoolRow]
    L --> M[createCustomerLicensePoolColumns]
    I --> N[LicensePlanPrice]
    M --> N
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/views/customers2/components/customer-licenses/CustomerLicensePoolsSection.tsx:42-48
Using optional chaining here is consistent with how `CustomerLicensesSection` reads the same field (`customer.entities?.find(...)`). Without the guard, a customer record that arrives with `entities: null` or `entities: undefined` will throw and crash the section.

```suggestion
	const columns = useMemo(
		() =>
			createCustomerLicensePoolColumns({
				hasEntities: (customer.entities?.length ?? 0) > 0,
			}),
		[customer.entities?.length],
	);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(licenses): 💡 align customer li..."](https://github.com/useautumn/autumn/commit/6a016b5ea26a684d9fd9cdc688d869cf518e46ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44749892)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns both customer license tables with the plans table (Name | Scope | Price | Status | Date | Actions) and adds a license-pool detail sheet to view items, availability, and assigned entities. This makes columns consistent and lets users inspect and manage pool assignments in place.

- **New Features**
  - Clicking a customer-level license row opens `license-pool-detail` with license items, pool availability, and all assigned entities; entity names jump to that entity’s scope and each has its own unassign action with per-row loading.
  - Price uses `LicensePlanPrice` to show Free, plan price, or Free + price for mixed pools.

- **Refactors**
  - Both license tables mirror the plans table; Scope appears only when the customer has entities (“Customer” on pools, entity name on the entity view).
  - Status shows “assigned/granted” on pools and a green “Assigned” badge on the entity view.
  - Columns switched to factory functions (`createCustomerLicensePoolColumns`, `createCustomerLicenseColumns`); a trailing actions spacer is added on the pools table for width parity.
  - Product data pulled via `useLicenseProductsQuery` for pricing and sheet content; license balance queries accept an `enabled` override to fetch for the customer-level sheet.

<sup>Written for commit 8a9dbbd233ba8cc4b5c2bbe16c7895d958897ccd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

