### PR TITLE
fix(billing): reject inapplicable promotion codes

### DIFF
--- a/server/src/external/stripe/coupons/resolvePromotionCode.ts
+++ b/server/src/external/stripe/coupons/resolvePromotionCode.ts
@@ -41,7 +41,7 @@ export const resolvePromotionCode = async ({
 			code,
 			active: true,
 			limit: 1,
-			expand: ["data.promotion.coupon"],
+			expand: ["data.promotion.coupon.applies_to"],
 		});
 
 		if (promos.data.length === 0) {
@@ -67,12 +67,9 @@ export const resolvePromotionCode = async ({
 		}
 
 		const minimumAmountsByCurrency = Object.fromEntries(
-			Object.entries(
-				promo.restrictions?.currency_options ?? {},
-			).map(([currency, option]) => [
-				currency.toLowerCase(),
-				option.minimum_amount,
-			]),
+			Object.entries(promo.restrictions?.currency_options ?? {}).map(
+				([currency, option]) => [currency.toLowerCase(), option.minimum_amount],
+			),
 		);
 
 		const hasCurrencyOptions = Object.keys(minimumAmountsByCurrency).length > 0;

--- a/server/src/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors.ts
+++ b/server/src/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors.ts
@@ -1,7 +1,36 @@
 import type { BillingContext, BillingPlan } from "@autumn/shared";
-import { ErrCode, InternalError } from "@autumn/shared";
+import { ErrCode, InternalError, RecaseError } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { validatePromotionCodeMinimums } from "@/internal/billing/v2/providers/stripe/errors/validatePromotionCodeMinimums";
+import { discountAppliesToLineItem } from "@/internal/billing/v2/providers/stripe/utils/discounts/discountAppliesToLineItem";
+
+const validatePromotionCodeProducts = ({
+	billingContext,
+	billingPlan,
+}: {
+	billingContext: BillingContext;
+	billingPlan: BillingPlan;
+}) => {
+	const lineItems = billingPlan.autumn.lineItems ?? [];
+	if (lineItems.length === 0) return;
+
+	const invalidPromotionCode = billingContext.stripeDiscounts?.find(
+		(discount) =>
+			!discount.id &&
+			discount.promotionCodeId &&
+			discount.source.coupon.applies_to?.products?.length &&
+			!lineItems.some((lineItem) =>
+				discountAppliesToLineItem({ discount, lineItem }),
+			),
+	);
+	if (!invalidPromotionCode) return;
+
+	throw new RecaseError({
+		message: "Promotion code does not apply to any products in this order.",
+		code: ErrCode.InvalidRequest,
+		statusCode: 400,
+	});
+};
 
 /**
  * Validates Stripe-specific billing context requirements before executing billing plan.
@@ -19,6 +48,7 @@ export const handleStripeBillingPlanErrors = ({
 	const { stripeSubscriptionSchedule } = billingContext;
 	const { subscriptionScheduleAction } = billingPlan.stripe;
 
+	validatePromotionCodeProducts({ billingContext, billingPlan });
 	validatePromotionCodeMinimums({ ctx, billingContext, billingPlan });
 
 	if (subscriptionScheduleAction?.type !== "update") return;

--- a/server/tests/integration/billing/attach/discounts/promotion-code-applies-to-validation.test.ts
+++ b/server/tests/integration/billing/attach/discounts/promotion-code-applies-to-validation.test.ts
@@ -1,0 +1,52 @@
+import { test } from "bun:test";
+import { type AttachParamsV1Input, ErrCode } from "@autumn/shared";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import {
+	createPercentCoupon,
+	createPromotionCode,
+} from "../../utils/discounts/discountTestUtils.js";
+
+test.concurrent(
+	`${chalk.yellowBright("attach discount: rejects promo restricted to another product")}`,
+	async () => {
+		const customerId = "promo-applies-to-other-product";
+		const pro = products.pro({
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		const { autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [s.customer({}), s.products({ list: [pro] })],
+			actions: [],
+		});
+
+		const otherProduct = await ctx.stripeCli.products.create({
+			name: customerId,
+		});
+		const coupon = await createPercentCoupon({
+			stripeCli: ctx.stripeCli,
+			percentOff: 50,
+			appliesToProducts: [otherProduct.id],
+		});
+		const promotionCode = await createPromotionCode({
+			stripeCli: ctx.stripeCli,
+			coupon,
+			code: "OTHER_PRODUCT",
+		});
+		const params: AttachParamsV1Input = {
+			customer_id: customerId,
+			plan_id: pro.id,
+			discounts: [{ promotion_code: promotionCode.code }],
+		};
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			errMessage: "does not apply to any products in this order",
+			func: () => autumnV2_2.billing.previewAttach<AttachParamsV1Input>(params),
+		});
+	},
+);


### PR DESCRIPTION
## Summary
- hydrate Stripe product restrictions when resolving promotion codes
- reject restricted promotion codes during preview when no billed line item matches
- add regression coverage for the Flim failure

## Red / green
- red: preview accepted the unrelated promo and discounted $20 to $10
- green: preview returns invalid_request before attach reaches Stripe

## Test plan
- bunx tsgo --build --noEmit
- ./run.sh server/tests/integration/billing/attach/discounts/promotion-code-applies-to-validation.test.ts

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where a promotion code restricted to a specific Stripe product (via `coupon.applies_to.products`) was incorrectly accepted during `previewAttach` even when none of the billed products matched. The fix has two parts: hydrating `applies_to` on the Stripe coupon via an expanded expand path, and adding pre-execution validation that rejects such codes before they reach Stripe.

- **Bug fix** — `resolvePromotionCode` now expands `data.promotion.coupon.applies_to` instead of `data.promotion.coupon`, ensuring `coupon.applies_to.products` is populated on the resolved `StripeDiscountWithCoupon`.
- **Bug fix** — New `validatePromotionCodeProducts` function in `handleStripeBillingPlanErrors` checks that at least one billing-plan line item belongs to a product in the coupon's `applies_to` list, throwing `InvalidRequest` early if none match.
- **Improvements** — Regression test exercises the full `previewAttach` path with a coupon restricted to an unrelated Stripe product and asserts the correct error is returned.
</details>

<h3>Confidence Score: 4/5</h3>

The core fix is correct and well-tested; the only concern is a narrow edge case in the new validation logic around proration-only billing plans.

Both changed source files address a real billing correctness bug and the new validation is gated correctly on `!discount.id` and `promotionCodeId`. The one logic concern is that `validatePromotionCodeProducts` delegates to `discountAppliesToLineItem`, which always returns `false` for new discounts on proration-credit items. A billing plan that consists entirely of proration credits would cause a false rejection of a valid restricted promotion code. This is an edge case unlikely to occur in typical flows, but it is a latent logic gap introduced by reusing a function that mixes billing-application semantics with product-applicability checks. The integration test also uses a hardcoded promotion-code string that could collide in long-running or parallel test environments.

handleStripeBillingPlanErrors.ts — the new `validatePromotionCodeProducts` logic and its delegation to `discountAppliesToLineItem`

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/coupons/resolvePromotionCode.ts | Expands `data.promotion.coupon.applies_to` instead of `data.promotion.coupon` so the product-restriction list is hydrated from Stripe; also minor formatting refactor with no logic change. |
| server/src/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors.ts | Adds `validatePromotionCodeProducts` that rejects a new promotion code whose `applies_to.products` list has no overlap with the billing plan's line items; reuses `discountAppliesToLineItem` which may falsely reject valid codes when all line items are proration credits. |
| server/tests/integration/billing/attach/discounts/promotion-code-applies-to-validation.test.ts | New regression test that creates a coupon restricted to an unrelated Stripe product and asserts `previewAttach` returns `InvalidRequest`; uses a hardcoded promotion code string that could collide across concurrent runs. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant previewAttach
    participant resolvePromotionCode
    participant Stripe
    participant handleStripeBillingPlanErrors
    participant validatePromotionCodeProducts
    participant discountAppliesToLineItem

    Client->>previewAttach: "attach({ plan_id, discounts: [{ promotion_code }] })"
    previewAttach->>resolvePromotionCode: resolve(code)
    resolvePromotionCode->>Stripe: "promotionCodes.list({ expand: ["data.promotion.coupon.applies_to"] })"
    Stripe-->>resolvePromotionCode: PromotionCode + Coupon (with applies_to.products hydrated)
    resolvePromotionCode-->>previewAttach: StripeDiscountWithCoupon (coupon.applies_to populated)

    previewAttach->>handleStripeBillingPlanErrors: validate(billingContext, billingPlan)
    handleStripeBillingPlanErrors->>validatePromotionCodeProducts: check product restrictions
    loop for each stripeDiscount with applies_to.products
        validatePromotionCodeProducts->>discountAppliesToLineItem: applies to any line item?
        discountAppliesToLineItem-->>validatePromotionCodeProducts: false (no matching product)
    end
    validatePromotionCodeProducts-->>handleStripeBillingPlanErrors: throw RecaseError(InvalidRequest)
    handleStripeBillingPlanErrors-->>previewAttach: error propagated
    previewAttach-->>Client: 400 invalid_request
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant previewAttach
    participant resolvePromotionCode
    participant Stripe
    participant handleStripeBillingPlanErrors
    participant validatePromotionCodeProducts
    participant discountAppliesToLineItem

    Client->>previewAttach: "attach({ plan_id, discounts: [{ promotion_code }] })"
    previewAttach->>resolvePromotionCode: resolve(code)
    resolvePromotionCode->>Stripe: "promotionCodes.list({ expand: ["data.promotion.coupon.applies_to"] })"
    Stripe-->>resolvePromotionCode: PromotionCode + Coupon (with applies_to.products hydrated)
    resolvePromotionCode-->>previewAttach: StripeDiscountWithCoupon (coupon.applies_to populated)

    previewAttach->>handleStripeBillingPlanErrors: validate(billingContext, billingPlan)
    handleStripeBillingPlanErrors->>validatePromotionCodeProducts: check product restrictions
    loop for each stripeDiscount with applies_to.products
        validatePromotionCodeProducts->>discountAppliesToLineItem: applies to any line item?
        discountAppliesToLineItem-->>validatePromotionCodeProducts: false (no matching product)
    end
    validatePromotionCodeProducts-->>handleStripeBillingPlanErrors: throw RecaseError(InvalidRequest)
    handleStripeBillingPlanErrors-->>previewAttach: error propagated
    previewAttach-->>Client: 400 invalid_request
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors.ts:17-25
**Proration-credit items cause false rejection** — `discountAppliesToLineItem` is designed for billing application, not product-restriction checking: for new discounts (`!discount.id`) it immediately returns `false` for any line item whose `context.direction === "refund"` via `discountWasActiveForCreditedPeriod`. If `billingPlan.autumn.lineItems` contains *only* proration-credit items (e.g., a pure downgrade phase), every call to `discountAppliesToLineItem` returns `false`, so `lineItems.some(...)` is `false` and a valid restricted code is rejected. Filtering out proration credits before the check, or evaluating product membership directly (`applies_to.products.includes(lineItem.stripeProductId)`), would avoid this.

### Issue 2 of 2
server/tests/integration/billing/attach/discounts/promotion-code-applies-to-validation.test.ts:36-39
**Hardcoded promotion code string risks concurrent-run collision** — `code: "OTHER_PRODUCT"` is a fixed, globally-unique human-readable string in Stripe. If another parallel test shard has also created an active `OTHER_PRODUCT` promotion code (e.g., from a previous failed run that didn't clean up), `resolvePromotionCode` will resolve whichever code Stripe returns first and the assertion may pass for the wrong reason or fail. Appending a short random suffix (e.g., `"OTHER_PRODUCT_" + crypto.randomUUID().slice(0, 8)`) makes each run independent.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): 🐛 reject inapplicable pro..."](https://github.com/useautumn/autumn/commit/2dc636158690cc8632d9c5712962d60ad83e0fec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44753555)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject promotion codes that are restricted to other Stripe products during discount preview. We now hydrate coupon product restrictions and return a 400 invalid_request before calling Stripe.

- **Bug Fixes**
  - `resolvePromotionCode` expands `data.promotion.coupon.applies_to` so `coupon.applies_to.products` is populated.
  - Added validation to reject new promotion codes that don’t match any billed line item products, returning InvalidRequest (400) with a clear message.
  - Added regression test `promotion-code-applies-to-validation.test.ts` to cover the unrelated-product promo case.

<sup>Written for commit 2dc636158690cc8632d9c5712962d60ad83e0fec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

