### PR TITLE
chore: copy paste item

### DIFF
--- a/vite/src/views/products/plan/components/edit-plan-feature/EditPlanFeatureSheet.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/EditPlanFeatureSheet.tsx
@@ -2,6 +2,8 @@ import { FeatureType, isAnyCreditSystem, TierBehavior } from "@autumn/shared";
 import { IconButton } from "@autumn/ui";
 import { PencilSimpleIcon } from "@phosphor-icons/react";
 import { useState } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
+import { toast } from "sonner";
 import {
 	useHasItemChanges,
 	useProduct,
@@ -15,6 +17,7 @@ import UpdateFeatureSheet from "@/views/products/features/components/UpdateFeatu
 import UpdateCreditSystemSheet from "@/views/products/features/credit-systems/components/UpdateCreditSystemSheet";
 import { useProductItemContext } from "@/views/products/product/product-item/ProductItemContext";
 import { migrateTierCurrenciesForMode } from "../../utils/currencyUtils";
+import { copyPlanItemToClipboard } from "../../utils/planItemClipboard";
 import {
 	cleanTiersForMode,
 	type VolumePricingMode,
@@ -121,11 +124,27 @@ export function EditPlanFeatureSheet({
 		}
 	};
 
+	const feature = getFeature(item?.feature_id ?? "", features);
+
+	const handleCopyItem = async () => {
+		if (!item) return;
+		try {
+			await copyPlanItemToClipboard({ item });
+		} catch {
+			toast.error("Failed to copy to clipboard");
+		}
+	};
+
+	// Copy the open item unless the user is copying selected text
+	useHotkeys("mod+c", () => {
+		if (window.getSelection()?.toString()) return;
+		handleCopyItem();
+	});
+
 	if (!item) {
 		return null;
 	}
 
-	const feature = getFeature(item?.feature_id ?? "", features);
 	const isFeaturePrice = isFeaturePriceItem(item);
 
 	// Allow confirming a priced feature that has a $0 tier (valid zero-price config)

--- a/vite/src/views/products/plan/components/plan-card/PlanCard.tsx
+++ b/vite/src/views/products/plan/components/plan-card/PlanCard.tsx
@@ -1,17 +1,14 @@
 import { Card, CardContent, Separator } from "@autumn/ui";
-import { useHotkeys } from "react-hotkeys-hook";
 import { useSheet } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 import { useFeatureNavigation } from "../../hooks/useFeatureNavigation";
+import { usePastePlanItem } from "../../hooks/usePastePlanItem";
 import { PlanCardHeader } from "./PlanCardHeader";
 import { PlanFeatureList } from "./PlanFeatureList";
 
 export default function PlanCard() {
 	useFeatureNavigation();
+	usePastePlanItem();
 	const { sheetType } = useSheet();
-
-	useHotkeys("ctrl+s", () => {
-		console.log("Save");
-	});
 
 	return (
 		<Card

--- a/vite/src/views/products/plan/hooks/usePastePlanItem.ts
+++ b/vite/src/views/products/plan/hooks/usePastePlanItem.ts
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+import { toast } from "sonner";
+import {
+	useProduct,
+	useSheet,
+} from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
+import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
+import { getFeature } from "@/utils/product/entitlementUtils";
+import { parsePlanItemClipboardText } from "../utils/planItemClipboard";
+
+const isEditableTarget = (target: EventTarget | null) =>
+	target instanceof HTMLElement &&
+	(target instanceof HTMLInputElement ||
+		target instanceof HTMLTextAreaElement ||
+		target.isContentEditable);
+
+/** Pastes a copied plan item into the current plan on cmd+V. */
+export const usePastePlanItem = () => {
+	const { product, setProduct } = useProduct();
+	const { sheetType } = useSheet();
+	const { features } = useFeaturesQuery();
+
+	useEffect(() => {
+		const handlePaste = (event: ClipboardEvent) => {
+			if (event.defaultPrevented) return;
+			if (sheetType || isEditableTarget(event.target)) return;
+
+			const text = event.clipboardData?.getData("text/plain");
+			if (!text || !product?.items) return;
+
+			const pastedItem = parsePlanItemClipboardText(text);
+			if (!pastedItem?.feature_id) return;
+
+			event.preventDefault();
+
+			const feature = getFeature(pastedItem.feature_id, features);
+			if (!feature) {
+				toast.error(
+					`Feature ${pastedItem.feature_id} doesn't exist in this org`,
+				);
+				return;
+			}
+
+			setProduct({ ...product, items: [...product.items, pastedItem] });
+		};
+
+		window.addEventListener("paste", handlePaste);
+		return () => window.removeEventListener("paste", handlePaste);
+	}, [sheetType, product, setProduct, features]);
+};

--- a/vite/src/views/products/plan/utils/planItemClipboard.ts
+++ b/vite/src/views/products/plan/utils/planItemClipboard.ts
@@ -1,0 +1,57 @@
+import { type ProductItem, ProductItemSchema } from "@autumn/shared";
+
+const PLAN_ITEM_CLIPBOARD_TYPE = "autumn/plan-item";
+
+/** Strips backend-persisted ids so a pasted item is treated as a new row. */
+const toClipboardItem = (item: ProductItem): ProductItem => ({
+	...item,
+	created_at: undefined,
+	entitlement_id: undefined,
+	price_id: undefined,
+	price_interval: undefined,
+	price_interval_count: undefined,
+	price_config: undefined,
+	feature: undefined,
+	display: undefined,
+});
+
+export const copyPlanItemToClipboard = async ({
+	item,
+}: {
+	item: ProductItem;
+}) => {
+	const payload = {
+		type: PLAN_ITEM_CLIPBOARD_TYPE,
+		item: toClipboardItem(item),
+	};
+	await navigator.clipboard.writeText(JSON.stringify(payload, null, 2));
+};
+
+export const parsePlanItemClipboardText = (
+	text: string,
+): ProductItem | null => {
+	let payload: unknown;
+	try {
+		payload = JSON.parse(text);
+	} catch {
+		return null;
+	}
+
+	if (
+		typeof payload !== "object" ||
+		payload === null ||
+		(payload as { type?: unknown }).type !== PLAN_ITEM_CLIPBOARD_TYPE
+	) {
+		return null;
+	}
+
+	// try/catch since ProductItemSchema preprocess steps can throw past safeParse
+	try {
+		const result = ProductItemSchema.safeParse(
+			(payload as { item?: unknown }).item,
+		);
+		return result.success ? result.data : null;
+	} catch {
+		return null;
+	}
+};


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add copy/paste for plan items in the plan editor. Copy the open item with mod+C and paste into the plan with mod+V; pasted items are added as new rows.

- **New Features**
  - Added clipboard utils to serialize/parse items with a custom `autumn/plan-item` payload and strip persisted IDs.
  - Copy from the edit sheet on mod+C when no text is selected; shows an error toast if copying fails.
  - Paste on mod+V via a global handler that’s ignored when a sheet is open or an input is focused.
  - Validates the payload and ensures the feature exists before appending; shows a toast if not found. Removed the old ctrl+S hotkey.

<sup>Written for commit e4d441c9fb176483a8aaa682ba87b50e7bb74b16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds copy-paste support for plan items in the plan editor — users can press `mod+C` while a feature sheet is open to copy the item, then `mod+V` on the plan card to paste it as a new row.

- **[Improvements]** New `planItemClipboard.ts` utility serialises a `ProductItem` to a namespaced JSON blob (stripping backend IDs like `entitlement_id`, `price_id`, etc.) and validates incoming clipboard text through `ProductItemSchema` before accepting it.
- **[Improvements]** New `usePastePlanItem` hook listens for native `paste` events at the window level, guards against editable targets and open sheets, looks up the feature in the current org, and appends the item to `product.items`.
- **[Improvements]** `EditPlanFeatureSheet` gains a `useHotkeys(\"mod+c\")` binding with a text-selection guard, and the `feature` variable is correctly moved above the early-return to satisfy the hooks-before-return rule.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the copy/paste flow is well-guarded (namespaced clipboard type, schema validation, editable-target guard, text-selection check) and touches only local UI state.

The paste handler appends the item unconditionally, so a user could end up with two rows for the same feature if they paste twice or paste a feature already on the plan. Whether that's blocked downstream (backend or save validation) is unclear from this diff alone, so a second look at usePastePlanItem is worthwhile before shipping.

vite/src/views/products/plan/hooks/usePastePlanItem.ts — the deduplication behaviour on paste deserves confirmation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/utils/planItemClipboard.ts | New utility for serialising/deserialising a plan item to/from the clipboard. Uses a namespaced type tag, strips backend-only IDs, and validates through ProductItemSchema with a defensive try/catch. |
| vite/src/views/products/plan/hooks/usePastePlanItem.ts | New hook that listens for native paste events and appends a valid clipboard item to the product. No deduplication check — pasting the same feature twice creates two entries. |
| vite/src/views/products/plan/components/edit-plan-feature/EditPlanFeatureSheet.tsx | Adds mod+C hotkey to copy the open item; guards against intercepting normal text selection. Also fixes hook-before-return ordering by moving feature lookup above the early-return. |
| vite/src/views/products/plan/components/plan-card/PlanCard.tsx | Wires in usePastePlanItem; removes a leftover console.log placeholder from the old ctrl+s stub. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant EditPlanFeatureSheet
    participant planItemClipboard
    participant Clipboard
    participant usePastePlanItem
    participant PlanEditorContext

    User->>EditPlanFeatureSheet: Press mod+C (no text selected)
    EditPlanFeatureSheet->>planItemClipboard: copyPlanItemToClipboard(item)
    planItemClipboard->>planItemClipboard: toClipboardItem() — strip backend IDs
    planItemClipboard->>Clipboard: navigator.clipboard.writeText(JSON)

    User->>usePastePlanItem: Press mod+V on PlanCard
    usePastePlanItem->>Clipboard: clipboardData.getData("text/plain")
    usePastePlanItem->>planItemClipboard: parsePlanItemClipboardText(text)
    planItemClipboard->>planItemClipboard: JSON.parse + type check + ProductItemSchema.safeParse
    planItemClipboard-->>usePastePlanItem: "ProductItem | null"
    usePastePlanItem->>usePastePlanItem: getFeature(feature_id, features)
    alt feature not found
        usePastePlanItem->>User: toast.error(...)
    else feature found
        usePastePlanItem->>PlanEditorContext: "setProduct({ items: [...items, pastedItem] })"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant EditPlanFeatureSheet
    participant planItemClipboard
    participant Clipboard
    participant usePastePlanItem
    participant PlanEditorContext

    User->>EditPlanFeatureSheet: Press mod+C (no text selected)
    EditPlanFeatureSheet->>planItemClipboard: copyPlanItemToClipboard(item)
    planItemClipboard->>planItemClipboard: toClipboardItem() — strip backend IDs
    planItemClipboard->>Clipboard: navigator.clipboard.writeText(JSON)

    User->>usePastePlanItem: Press mod+V on PlanCard
    usePastePlanItem->>Clipboard: clipboardData.getData("text/plain")
    usePastePlanItem->>planItemClipboard: parsePlanItemClipboardText(text)
    planItemClipboard->>planItemClipboard: JSON.parse + type check + ProductItemSchema.safeParse
    planItemClipboard-->>usePastePlanItem: "ProductItem | null"
    usePastePlanItem->>usePastePlanItem: getFeature(feature_id, features)
    alt feature not found
        usePastePlanItem->>User: toast.error(...)
    else feature found
        usePastePlanItem->>PlanEditorContext: "setProduct({ items: [...items, pastedItem] })"
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/views/products/plan/hooks/usePastePlanItem.ts:44
**No duplicate-item guard on paste**

The paste handler appends `pastedItem` unconditionally. If the plan already contains an item with the same `feature_id`, pasting will silently add a second row for that feature. Depending on how the save path handles duplicates, this could produce a confusing UX or a backend validation error.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: copy paste item"](https://github.com/useautumn/autumn/commit/e4d441c9fb176483a8aaa682ba87b50e7bb74b16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44808223)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->