### PR TITLE
fix(billing): carry rollovers to best-candidate bucket on plan updates

### DIFF
--- a/server/src/internal/billing/v2/utils/handleExistingRollovers/applyExistingRollovers.ts
+++ b/server/src/internal/billing/v2/utils/handleExistingRollovers/applyExistingRollovers.ts
@@ -2,8 +2,57 @@ import {
 	customerEntitlementAllowsRollovers,
 	type ExistingRollover,
 	type FullCusProduct,
+	type FullCustomerEntitlement,
 } from "@autumn/shared";
+import { customerEntitlementToBillingType } from "@shared/utils/cusEntUtils/convertCusEntUtils/customerEntitlementToBillingType";
+import { cusEntToEffectiveRolloverMax } from "@/internal/customers/cusProducts/cusEnts/cusRollovers/rolloverUtils";
 import { generateId } from "@/utils/genUtils";
+
+const KIND_MATCH_SCORE = 4;
+const INTERVAL_MATCH_SCORE = 2;
+const CAPACITY_SCORE = 1;
+
+// Ranks same-feature candidates by item identity (billing kind, then reset
+// interval — the same dimensions as item keys/filters), then by whether the
+// bucket's effective max can actually hold a carried balance.
+const scoreRolloverCandidate = ({
+	customerProduct,
+	cusEnt,
+	existingRollover,
+}: {
+	customerProduct: FullCusProduct;
+	cusEnt: FullCustomerEntitlement;
+	existingRollover: ExistingRollover;
+}): number => {
+	let score = 0;
+
+	const billingType = customerEntitlementToBillingType({
+		cusEnt: { ...cusEnt, customer_product: customerProduct },
+	});
+	if (
+		(billingType ?? null) === (existingRollover.source_billing_type ?? null)
+	) {
+		score += KIND_MATCH_SCORE;
+	}
+
+	const intervalMatches =
+		(cusEnt.entitlement.interval ?? null) ===
+			(existingRollover.source_interval ?? null) &&
+		(cusEnt.entitlement.interval_count ?? 1) ===
+			(existingRollover.source_interval_count ?? 1);
+	if (intervalMatches) {
+		score += INTERVAL_MATCH_SCORE;
+	}
+
+	const effectiveMax = cusEntToEffectiveRolloverMax({
+		cusEnt: { ...cusEnt, customer_product: customerProduct },
+	});
+	if (effectiveMax === null || effectiveMax > 0) {
+		score += CAPACITY_SCORE;
+	}
+
+	return score;
+};
 
 export const applyExistingRollovers = ({
 	customerProduct,
@@ -21,21 +70,41 @@ export const applyExistingRollovers = ({
 	};
 
 	for (const existingRollover of getApplicableRollovers()) {
-		const targetCusEnt = customerProduct.customer_entitlements.find(
+		const candidates = customerProduct.customer_entitlements.filter(
 			(cusEnt) =>
 				cusEnt.entitlement.internal_feature_id ===
 					existingRollover.internal_feature_id &&
 				customerEntitlementAllowsRollovers(cusEnt),
 		);
 
+		let targetCusEnt: FullCustomerEntitlement | undefined;
+		let bestScore = -1;
+		for (const cusEnt of candidates) {
+			const score = scoreRolloverCandidate({
+				customerProduct,
+				cusEnt,
+				existingRollover,
+			});
+			if (score > bestScore) {
+				targetCusEnt = cusEnt;
+				bestScore = score;
+			}
+		}
+
 		if (!targetCusEnt) continue;
 
-		if (targetCusEnt) {
-			targetCusEnt.rollovers.push({
-				...existingRollover,
-				id: generateId("roll"),
-				cus_ent_id: targetCusEnt.id,
-			});
-		} else continue;
+		const {
+			internal_feature_id: _internalFeatureId,
+			source_billing_type: _sourceBillingType,
+			source_interval: _sourceInterval,
+			source_interval_count: _sourceIntervalCount,
+			...rollover
+		} = existingRollover;
+
+		targetCusEnt.rollovers.push({
+			...rollover,
+			id: generateId("roll"),
+			cus_ent_id: targetCusEnt.id,
+		});
 	}
 };

--- a/server/src/internal/billing/v2/utils/handleExistingRollovers/cusProductToExistingRollovers.ts
+++ b/server/src/internal/billing/v2/utils/handleExistingRollovers/cusProductToExistingRollovers.ts
@@ -1,4 +1,5 @@
 import type { ExistingRollover, FullCusProduct } from "@shared/index";
+import { customerEntitlementToBillingType } from "@shared/utils/cusEntUtils/convertCusEntUtils/customerEntitlementToBillingType";
 
 export const cusProductToExistingRollovers = ({
 	cusProduct,
@@ -13,16 +14,24 @@ export const cusProductToExistingRollovers = ({
 
 	for (const cusEnt of cusEnts) {
 		const rollovers = cusEnt.rollovers;
-		if (rollovers) {
-			existingRollovers.push(
-				...rollovers.map((x) => {
-					return {
-						...x,
-						internal_feature_id: cusEnt.entitlement.internal_feature_id,
-					};
-				}),
-			);
-		}
+		if (!rollovers) continue;
+
+		const sourceBillingType =
+			customerEntitlementToBillingType({
+				cusEnt: { ...cusEnt, customer_product: cusProduct },
+			}) ?? null;
+
+		existingRollovers.push(
+			...rollovers.map((rollover) => {
+				return {
+					...rollover,
+					internal_feature_id: cusEnt.entitlement.internal_feature_id,
+					source_billing_type: sourceBillingType,
+					source_interval: cusEnt.entitlement.interval,
+					source_interval_count: cusEnt.entitlement.interval_count,
+				};
+			}),
+		);
 	}
 
 	return existingRollovers;

--- a/server/src/internal/customers/cusProducts/cusEnts/cusRollovers/rolloverUtils.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/cusRollovers/rolloverUtils.ts
@@ -96,6 +96,39 @@ function hasFullCusProduct(
 	);
 }
 
+/** Effective rollover cap for a cusEnt: null = unlimited (or no config). */
+export const cusEntToEffectiveRolloverMax = ({
+	cusEnt,
+}: {
+	cusEnt: FullCusEntWithProduct;
+}): number | null => {
+	const rolloverConfig = cusEnt.entitlement.rollover;
+	if (!rolloverConfig) return null;
+
+	if (rolloverConfig.max_percentage == null) return rolloverConfig.max ?? null;
+
+	let startingBalance: number;
+	if (hasFullCusProduct(cusEnt)) {
+		startingBalance = cusEntToStartingBalance({ cusEnt });
+	} else {
+		const options = entToOptions({
+			ent: cusEnt.entitlement,
+			options: cusEnt.customer_product?.options ?? [],
+		});
+		startingBalance = getStartingBalance({
+			entitlement: cusEnt.entitlement,
+			options,
+			productQuantity: cusEnt.customer_product?.quantity ?? 1,
+		});
+	}
+
+	return new Decimal(startingBalance)
+		.mul(rolloverConfig.max_percentage)
+		.div(100)
+		.floor()
+		.toNumber();
+};
+
 export function performMaximumClearing({
 	rows,
 	cusEnt,
@@ -109,30 +142,7 @@ export function performMaximumClearing({
 		return { toDelete: [], toUpdate: [] };
 	}
 
-	let effectiveMax: number | null = rolloverConfig.max ?? null;
-	if (rolloverConfig.max_percentage != null) {
-		let startingBalance: number;
-
-		if (hasFullCusProduct(cusEnt)) {
-			startingBalance = cusEntToStartingBalance({ cusEnt });
-		} else {
-			const options = entToOptions({
-				ent: cusEnt.entitlement,
-				options: cusEnt.customer_product?.options ?? [],
-			});
-			startingBalance = getStartingBalance({
-				entitlement: cusEnt.entitlement,
-				options,
-				productQuantity: cusEnt.customer_product?.quantity ?? 1,
-			});
-		}
-
-		effectiveMax = new Decimal(startingBalance)
-			.mul(rolloverConfig.max_percentage)
-			.div(100)
-			.floor()
-			.toNumber();
-	}
+	const effectiveMax = cusEntToEffectiveRolloverMax({ cusEnt });
 
 	if (effectiveMax == null) {
 		return { toDelete: [], toUpdate: [] };

--- a/server/tests/integration/billing/update-subscription/entities/per-entity-rollover-carry.test.ts
+++ b/server/tests/integration/billing/update-subscription/entities/per-entity-rollover-carry.test.ts
@@ -1,0 +1,1071 @@
+/**
+ * TDD test: updateSubscription must carry rollovers bucket-for-bucket when the
+ * plan has BOTH a prepaid (volume) item and an overage item for the SAME
+ * feature, with per-entity balances (multi-entity).
+ *
+ * Red-failure mode (current behavior):
+ *  - applyExistingRollovers matches carried rollovers by internal_feature_id
+ *    only (first match), so both the prepaid-bucket rollover AND the
+ *    overage-bucket rollover land on the first rollover-capable cusEnt of the
+ *    new customer product. clearExcessRollovers then clips the combined
+ *    balance against that single bucket's max (per entity), silently
+ *    destroying rollover balance.
+ *
+ * Green-success criteria (after fix):
+ *  - Each rollover is carried onto the new cusEnt of the same billing kind
+ *    (prepaid -> prepaid, overage -> overage); per-entity rollover balances
+ *    and totals are identical before and after the version update.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	type ApiEntityV0,
+	BillingInterval,
+	BillingMethod,
+	BillingVersion,
+	findActiveCustomerProductById,
+	isFixedPrice,
+	ResetInterval,
+	RolloverExpiryDurationType,
+	TierBehavior,
+	type UpdateSubscriptionV1Params,
+	type UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import {
+	cusProductToEnts,
+	cusProductToPrices,
+} from "@shared/utils/cusProductUtils/convertCusProduct";
+import { customerProductToBasePrice } from "@shared/utils/cusProductUtils/convertCusProduct/customerProductToPrice";
+import { mapToProductItems } from "@shared/utils/productV2Utils/mapToProductV2";
+import { productItemsToCustomizePlanV1 } from "@shared/utils/productV2Utils/productItemUtils/convertProductItem/productItemsToCustomizePlanV1";
+import { runUpdatePlanMigration } from "@tests/integration/billing/migrations-v2/utils/runUpdatePlanMigration";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { billingActions } from "@/internal/billing/v2/actions";
+import { setupCustomFullProduct } from "@/internal/billing/v2/setup/setupCustomFullProduct";
+import { CusService } from "@/internal/customers/CusService";
+import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
+import { ProductService } from "@/internal/products/ProductService";
+import {
+	constructArrearItem,
+	constructPrepaidItem,
+} from "@/utils/scriptUtils/constructItem";
+
+const PREPAID_ROLLOVER_MAX = 40;
+const OVERAGE_ROLLOVER_MAX = 30;
+
+// After the cycle reset, each bucket rolls over up to its own max per entity.
+const expectedRollovers = [OVERAGE_ROLLOVER_MAX, PREPAID_ROLLOVER_MAX];
+
+const entityRolloverBalances = (entity: ApiEntityV0) =>
+	(entity.features?.[TestFeature.Messages]?.rollovers ?? [])
+		.map((rollover) => rollover.balance)
+		.sort((a, b) => a - b);
+
+const buildItems = () => ({
+	prepaidVolumeMessages: constructPrepaidItem({
+		featureId: TestFeature.Messages,
+		tiers: [
+			{ to: 500, amount: 10 },
+			{ to: "inf" as unknown as number, amount: 5 },
+		],
+		tierBehaviour: TierBehavior.VolumeBased,
+		billingUnits: 100,
+		includedUsage: 100,
+		entityFeatureId: TestFeature.Users,
+		rolloverConfig: {
+			max: PREPAID_ROLLOVER_MAX,
+			length: 1,
+			duration: RolloverExpiryDurationType.Month,
+		},
+	}),
+	overageMessages: constructArrearItem({
+		featureId: TestFeature.Messages,
+		includedUsage: 50,
+		price: 0.1,
+		billingUnits: 1,
+		entityFeatureId: TestFeature.Users,
+		rolloverConfig: {
+			max: OVERAGE_ROLLOVER_MAX,
+			length: 1,
+			duration: RolloverExpiryDurationType.Month,
+		},
+	}),
+	priceItem: items.monthlyPrice({ price: 30 }),
+});
+
+// Same items expressed in the public plan-item param shape, for
+// customize.items (PUT) and add_items (PATCH) calls.
+const buildApiItems = () => ({
+	prepaidVolume: {
+		feature_id: TestFeature.Messages,
+		included: 100,
+		entity_feature_id: TestFeature.Users,
+		reset: { interval: ResetInterval.Month },
+		price: {
+			tiers: [
+				{ to: 500, amount: 10 },
+				{ to: "inf" as const, amount: 5 },
+			],
+			tier_behavior: TierBehavior.VolumeBased,
+			interval: BillingInterval.Month,
+			billing_method: BillingMethod.Prepaid,
+			billing_units: 100,
+		},
+		rollover: {
+			max: PREPAID_ROLLOVER_MAX,
+			expiry_duration_type: RolloverExpiryDurationType.Month,
+			expiry_duration_length: 1,
+		},
+	},
+	overage: {
+		feature_id: TestFeature.Messages,
+		included: 50,
+		entity_feature_id: TestFeature.Users,
+		reset: { interval: ResetInterval.Month },
+		price: {
+			amount: 0.1,
+			interval: BillingInterval.Month,
+			billing_method: BillingMethod.UsageBased,
+			billing_units: 1,
+		},
+		rollover: {
+			max: OVERAGE_ROLLOVER_MAX,
+			expiry_duration_type: RolloverExpiryDurationType.Month,
+			expiry_duration_length: 1,
+		},
+	},
+});
+
+const setupPrepaidOverageEntities = async ({
+	customerId,
+	extraProducts = [],
+}: {
+	customerId: string;
+	extraProducts?: ReturnType<typeof products.base>[];
+}) => {
+	const builtItems = buildItems();
+
+	const pro = products.base({
+		id: "pro",
+		items: [
+			builtItems.prepaidVolumeMessages,
+			builtItems.overageMessages,
+			builtItems.priceItem,
+		],
+	});
+
+	const scenario = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro, ...extraProducts] }),
+			s.entities({ count: 2, featureId: TestFeature.Users }),
+		],
+		actions: [
+			s.billing.attach({
+				productId: pro.id,
+				options: [{ feature_id: TestFeature.Messages, quantity: 200 }],
+			}),
+			s.advanceToNextInvoice(),
+		],
+	});
+
+	for (const entity of scenario.entities) {
+		const entityBefore = await scenario.autumnV1.entities.get<ApiEntityV0>(
+			scenario.customerId,
+			entity.id,
+		);
+		expect(
+			entityRolloverBalances(entityBefore),
+			`pre-update rollovers wrong for ${entity.id} — test setup issue, not the bug`,
+		).toEqual(expectedRollovers);
+	}
+
+	return { ...scenario, pro, ...builtItems };
+};
+
+test.concurrent(
+	`${chalk.yellowBright("entity rollover carry: prepaid volume + overage rollovers survive version update")}`,
+	async () => {
+		const {
+			customerId,
+			autumnV1,
+			autumnV2_2,
+			entities,
+			pro,
+			prepaidVolumeMessages,
+			overageMessages,
+		} = await setupPrepaidOverageEntities({
+			customerId: "ent-rollover-carry-prepaid-overage",
+		});
+
+		const customerBefore =
+			await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		const remainingBefore =
+			customerBefore.balances[TestFeature.Messages].remaining;
+
+		// v2 keeps BOTH feature items identical; only the base price changes.
+		await autumnV1.products.update(pro.id, {
+			items: [
+				prepaidVolumeMessages,
+				overageMessages,
+				items.monthlyPrice({ price: 35 }),
+			],
+		});
+
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: pro.id,
+			version: 2,
+		});
+
+		for (const entity of entities) {
+			const entityAfter = await autumnV1.entities.get<ApiEntityV0>(
+				customerId,
+				entity.id,
+			);
+			expect(
+				entityRolloverBalances(entityAfter),
+				`rollovers lost or misplaced for ${entity.id} after version update`,
+			).toEqual(expectedRollovers);
+		}
+
+		const customerAfter =
+			await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer: customerAfter,
+			featureId: TestFeature.Messages,
+			remaining: remainingBefore,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("entity rollover carry: patch updating both same-feature items keeps bucket rollovers")}`,
+	async () => {
+		const { customerId, autumnV1, autumnV2_2, entities, pro } =
+			await setupPrepaidOverageEntities({
+				customerId: "ent-rollover-carry-patch-both",
+			});
+
+		// Patch path: update BOTH same-feature items in one call so both cusEnts
+		// are rebuilt and land in the same feature carry group.
+		await autumnV2_2.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: {
+				update_items: [
+					{
+						filter: {
+							feature_id: TestFeature.Messages,
+							billing_method: BillingMethod.Prepaid,
+						},
+						// Must stay a multiple of billingUnits (100) so the Stripe
+						// prepaid quantity remains an integer pack count.
+						included: 200,
+					},
+					{
+						filter: {
+							feature_id: TestFeature.Messages,
+							billing_method: BillingMethod.UsageBased,
+						},
+						included: 60,
+					},
+				],
+			},
+		});
+
+		for (const entity of entities) {
+			const entityAfter = await autumnV1.entities.get<ApiEntityV0>(
+				customerId,
+				entity.id,
+			);
+			expect(
+				entityRolloverBalances(entityAfter),
+				`rollovers lost or misplaced for ${entity.id} after patch update`,
+			).toEqual(expectedRollovers);
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("entity rollover carry: PUT-style customize.items keeps bucket rollovers")}`,
+	async () => {
+		const { customerId, autumnV1, autumnV2_2, entities, pro } =
+			await setupPrepaidOverageEntities({
+				customerId: "ent-rollover-carry-put-items",
+			});
+
+		const apiItems = buildApiItems();
+
+		// PUT-style: replace the full item list; both feature items stay identical.
+		await autumnV2_2.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: {
+				items: [apiItems.prepaidVolume, apiItems.overage],
+				price: { amount: 35, interval: BillingInterval.Month },
+			},
+		});
+
+		for (const entity of entities) {
+			const entityAfter = await autumnV1.entities.get<ApiEntityV0>(
+				customerId,
+				entity.id,
+			);
+			expect(
+				entityRolloverBalances(entityAfter),
+				`rollovers lost or misplaced for ${entity.id} after PUT-style items update`,
+			).toEqual(expectedRollovers);
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("entity rollover carry: remove_items + add_items keeps bucket rollovers")}`,
+	async () => {
+		const { customerId, autumnV1, autumnV2_2, entities, pro } =
+			await setupPrepaidOverageEntities({
+				customerId: "ent-rollover-carry-remove-add",
+			});
+
+		const apiItems = buildApiItems();
+
+		// PATCH-style: remove both same-feature items and re-add equivalents.
+		await autumnV2_2.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: {
+				remove_items: [
+					{
+						feature_id: TestFeature.Messages,
+						billing_method: BillingMethod.Prepaid,
+					},
+					{
+						feature_id: TestFeature.Messages,
+						billing_method: BillingMethod.UsageBased,
+					},
+				],
+				add_items: [apiItems.prepaidVolume, apiItems.overage],
+			},
+		});
+
+		for (const entity of entities) {
+			const entityAfter = await autumnV1.entities.get<ApiEntityV0>(
+				customerId,
+				entity.id,
+			);
+			expect(
+				entityRolloverBalances(entityAfter),
+				`rollovers lost or misplaced for ${entity.id} after remove+add update`,
+			).toEqual(expectedRollovers);
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("entity rollover carry: attach plan switch (new customer product) keeps bucket rollovers")}`,
+	async () => {
+		const switchItems = buildItems();
+		const pro2 = products.base({
+			id: "pro2",
+			items: [
+				switchItems.prepaidVolumeMessages,
+				switchItems.overageMessages,
+				items.monthlyPrice({ price: 40 }),
+			],
+		});
+
+		const { customerId, autumnV1, autumnV2_2, entities } =
+			await setupPrepaidOverageEntities({
+				customerId: "ent-rollover-carry-attach-switch",
+				extraProducts: [pro2],
+			});
+
+		// Plan switch via attach: a brand-new customer product replaces the old
+		// one; both plans contain the same prepaid + overage items.
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: pro2.id,
+			options: [{ feature_id: TestFeature.Messages, quantity: 200 }],
+		});
+
+		for (const entity of entities) {
+			const entityAfter = await autumnV1.entities.get<ApiEntityV0>(
+				customerId,
+				entity.id,
+			);
+			expect(
+				entityRolloverBalances(entityAfter),
+				`rollovers lost or misplaced for ${entity.id} after attach plan switch`,
+			).toEqual(expectedRollovers);
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("entity rollover carry: migration (updateSubscription contextOverride) keeps bucket rollovers")}`,
+	async () => {
+		const { customerId, autumnV1, autumnV2_2, entities, ctx, pro } =
+			await setupPrepaidOverageEntities({
+				customerId: "ent-rollover-carry-migration",
+			});
+
+		const v2Items = buildItems();
+		await autumnV1.products.update(pro.id, {
+			items: [
+				v2Items.prepaidVolumeMessages,
+				v2Items.overageMessages,
+				items.monthlyPrice({ price: 45 }),
+			],
+		});
+
+		// migrate() drives updateSubscription with a productContext override.
+		await runUpdatePlanMigration({
+			ctx,
+			migrationClient: autumnV2_2,
+			migrationId: `${customerId}-mig`,
+			customerId,
+			filter: { customer: { plan: { plan_id: pro.id } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: pro.id },
+						version: 2,
+					},
+				],
+			},
+			runOnServer: false,
+		});
+
+		for (const entity of entities) {
+			const entityAfter = await autumnV1.entities.get<ApiEntityV0>(
+				customerId,
+				entity.id,
+			);
+			expect(
+				entityRolloverBalances(entityAfter),
+				`rollovers lost or misplaced for ${entity.id} after version migration`,
+			).toEqual(expectedRollovers);
+		}
+	},
+);
+
+// Prepaid volume with 50% max_percentage rollover; overage deliberately has
+// NO rollover config.
+const buildPctItems = ({
+	entityScoped = true,
+}: {
+	entityScoped?: boolean;
+} = {}) => ({
+	prepaidVolumeMessages: constructPrepaidItem({
+		featureId: TestFeature.Messages,
+		tiers: [
+			{ to: 500, amount: 10 },
+			{ to: "inf" as unknown as number, amount: 5 },
+		],
+		tierBehaviour: TierBehavior.VolumeBased,
+		billingUnits: 100,
+		includedUsage: 100,
+		entityFeatureId: entityScoped ? TestFeature.Users : undefined,
+		rolloverConfig: {
+			max_percentage: 50,
+			length: 1,
+			duration: RolloverExpiryDurationType.Month,
+		},
+	}),
+	overageMessages: constructArrearItem({
+		featureId: TestFeature.Messages,
+		includedUsage: 50,
+		price: 0.1,
+		billingUnits: 1,
+		entityFeatureId: entityScoped ? TestFeature.Users : undefined,
+	}),
+});
+
+test.concurrent(
+	`${chalk.yellowBright("entity rollover carry: prepaid 50% max_percentage rollover + overage without rollover survives version update")}`,
+	async () => {
+		const customerId = "ent-rollover-carry-pct-prepaid";
+
+		const { prepaidVolumeMessages, overageMessages } = buildPctItems();
+
+		const pro = products.base({
+			id: "pro",
+			items: [
+				prepaidVolumeMessages,
+				overageMessages,
+				items.monthlyPrice({ price: 30 }),
+			],
+		});
+
+		const { autumnV1, autumnV2_2, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+			],
+			actions: [
+				s.billing.attach({
+					productId: pro.id,
+					options: [{ feature_id: TestFeature.Messages, quantity: 200 }],
+				}),
+				s.advanceToNextInvoice(),
+			],
+		});
+
+		// Snapshot per-entity rollovers after the cycle reset. Exactly one
+		// positive rollover per entity is expected (prepaid bucket only).
+		const rolloversBefore: Record<string, number[]> = {};
+		for (const entity of entities) {
+			const entityBefore = await autumnV1.entities.get<ApiEntityV0>(
+				customerId,
+				entity.id,
+			);
+			const balances = entityRolloverBalances(entityBefore).filter(
+				(balance) => balance > 0,
+			);
+			expect(
+				balances.length,
+				`expected exactly one positive rollover for ${entity.id} before update — test setup issue, not the bug`,
+			).toBe(1);
+			rolloversBefore[entity.id] = balances;
+		}
+
+		const customerBefore =
+			await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		const remainingBefore =
+			customerBefore.balances[TestFeature.Messages].remaining;
+
+		// v2 keeps BOTH feature items identical; only the base price changes.
+		await autumnV1.products.update(pro.id, {
+			items: [
+				prepaidVolumeMessages,
+				overageMessages,
+				items.monthlyPrice({ price: 35 }),
+			],
+		});
+
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: pro.id,
+			version: 2,
+		});
+
+		for (const entity of entities) {
+			const entityAfter = await autumnV1.entities.get<ApiEntityV0>(
+				customerId,
+				entity.id,
+			);
+			expect(
+				entityRolloverBalances(entityAfter).filter((balance) => balance > 0),
+				`rollovers lost for ${entity.id} after version update`,
+			).toEqual(rolloversBefore[entity.id]);
+		}
+
+		const customerAfter =
+			await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer: customerAfter,
+			featureId: TestFeature.Messages,
+			remaining: remainingBefore,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("entity rollover carry: direct updateSubscription with productContext override to premium carries rollovers")}`,
+	async () => {
+		const customerId = "ent-rollover-carry-ctx-override";
+
+		const proItems = buildPctItems();
+		const premiumItems = buildPctItems();
+
+		const pro = products.base({
+			id: "pro",
+			items: [
+				proItems.prepaidVolumeMessages,
+				proItems.overageMessages,
+				items.monthlyPrice({ price: 30 }),
+			],
+		});
+		const premium = products.base({
+			id: "premium",
+			items: [
+				premiumItems.prepaidVolumeMessages,
+				premiumItems.overageMessages,
+				items.monthlyPrice({ price: 50 }),
+			],
+		});
+
+		const { autumnV1, autumnV2_2, entities, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, premium] }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+			],
+			actions: [
+				s.billing.attach({
+					productId: pro.id,
+					options: [{ feature_id: TestFeature.Messages, quantity: 200 }],
+				}),
+				s.advanceToNextInvoice(),
+			],
+		});
+
+		const rolloversBefore: Record<string, number[]> = {};
+		for (const entity of entities) {
+			const entityBefore = await autumnV1.entities.get<ApiEntityV0>(
+				customerId,
+				entity.id,
+			);
+			const balances = entityRolloverBalances(entityBefore).filter(
+				(balance) => balance > 0,
+			);
+			expect(
+				balances.length,
+				`expected exactly one positive rollover for ${entity.id} before update — test setup issue, not the bug`,
+			).toBe(1);
+			rolloversBefore[entity.id] = balances;
+		}
+
+		const customerBefore =
+			await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		const remainingBefore =
+			customerBefore.balances[TestFeature.Messages].remaining;
+
+		// Mirror the migration-script flow: load state, build a customize that
+		// copies the current prepaid/overage items + base price verbatim, then
+		// call updateSubscription directly with a productContext override
+		// selecting the premium plan.
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			withEntities: true,
+			withSubs: true,
+		});
+		const cusProduct = findActiveCustomerProductById({
+			fullCus: fullCustomer,
+			productId: pro.id,
+		});
+		expect(cusProduct, "active pro cusProduct not found").toBeDefined();
+		if (!cusProduct) throw new Error("unreachable");
+
+		const premiumFull = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: premium.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+
+		const currentPrices = cusProductToPrices({ cusProduct });
+		const currentMessageItems = mapToProductItems({
+			prices: currentPrices,
+			entitlements: cusProductToEnts({ cusProduct }),
+			features: ctx.features,
+		})
+			.filter((item) => item.feature_id === TestFeature.Messages)
+			.map((item) => ({
+				...item,
+				created_at: null,
+				entitlement_id: null,
+				price_id: null,
+			}));
+		expect(currentMessageItems.length).toBe(2);
+
+		const premiumNonMessageItems = mapToProductItems({
+			prices: premiumFull.prices,
+			entitlements: premiumFull.entitlements,
+			features: ctx.features,
+		}).filter((item) => item.feature_id !== TestFeature.Messages);
+
+		const currentBase = customerProductToBasePrice({
+			customerProduct: cusProduct,
+			errorOnNotFound: false,
+		});
+		expect(currentBase).toBeDefined();
+		if (!currentBase || !isFixedPrice(currentBase)) {
+			throw new Error("expected a fixed base price on the pro cusProduct");
+		}
+
+		const customize = {
+			...productItemsToCustomizePlanV1({
+				ctx,
+				items: [...premiumNonMessageItems, ...currentMessageItems],
+			}),
+			price: {
+				amount: currentBase.config.amount,
+				interval: currentBase.config.interval,
+				interval_count: currentBase.config.interval_count,
+			},
+		};
+
+		const {
+			fullProduct: customTargetProduct,
+			customPrices,
+			customEnts,
+		} = await setupCustomFullProduct({
+			ctx,
+			currentFullProduct: premiumFull,
+			customizePlan: customize,
+		});
+
+		const params = {
+			customer_id: customerId,
+			customer_product_id: cusProduct.id,
+			plan_id: premium.id,
+			version: premiumFull.version,
+			no_billing_changes: true,
+			proration_behavior: "none",
+			redirect_mode: "never",
+			customize,
+		} satisfies UpdateSubscriptionV1Params;
+
+		await billingActions.updateSubscription({
+			ctx,
+			params,
+			contextOverride: {
+				productContext: {
+					customerProduct: cusProduct,
+					fullProduct: customTargetProduct,
+					customPrices,
+					customEnts,
+				},
+				billingVersion: cusProduct.billing_version ?? BillingVersion.V2,
+			},
+			options: { skipAutumnCheckout: true },
+		});
+
+		await deleteCachedFullCustomer({
+			ctx,
+			customerId,
+			source: "per-entity-rollover-carry-test",
+		});
+
+		for (const entity of entities) {
+			const entityAfter = await autumnV1.entities.get<ApiEntityV0>(
+				customerId,
+				entity.id,
+			);
+			expect(
+				entityRolloverBalances(entityAfter).filter((balance) => balance > 0),
+				`rollovers lost for ${entity.id} after productContext-override update`,
+			).toEqual(rolloversBefore[entity.id]);
+		}
+
+		const customerAfterOverride =
+			await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer: customerAfterOverride,
+			featureId: TestFeature.Messages,
+			remaining: remainingBefore,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("entity rollover carry: productContext override on ENTITY-OWNED cusProduct carries rollovers")}`,
+	async () => {
+		const customerId = "ent-rollover-carry-entity-owned";
+
+		// Plain (non-entity-scoped) items: each entity owns its own cusProduct.
+		const proItems = buildPctItems({ entityScoped: false });
+		const premiumItems = buildPctItems({ entityScoped: false });
+
+		const pro = products.base({
+			id: "pro",
+			items: [
+				proItems.prepaidVolumeMessages,
+				proItems.overageMessages,
+				items.monthlyPrice({ price: 30 }),
+			],
+		});
+		const premium = products.base({
+			id: "premium",
+			items: [
+				premiumItems.prepaidVolumeMessages,
+				premiumItems.overageMessages,
+				items.monthlyPrice({ price: 50 }),
+			],
+		});
+
+		const { autumnV1, entities, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, premium] }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+			],
+			actions: [
+				s.billing.attach({
+					productId: pro.id,
+					entityIndex: 0,
+					options: [{ feature_id: TestFeature.Messages, quantity: 200 }],
+				}),
+				s.advanceToNextInvoice(),
+			],
+		});
+
+		const targetEntityId = entities[0].id;
+
+		const entityBefore = await autumnV1.entities.get<ApiEntityV0>(
+			customerId,
+			targetEntityId,
+		);
+		const rolloversBefore = (
+			entityBefore.features?.[TestFeature.Messages]?.rollovers ?? []
+		)
+			.map((rollover) => rollover.balance)
+			.filter((balance) => balance > 0)
+			.sort((a, b) => a - b);
+		expect(
+			rolloversBefore.length,
+			"expected exactly one positive rollover on the entity before update — test setup issue, not the bug",
+		).toBe(1);
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			withEntities: true,
+			withSubs: true,
+		});
+		const internalEntityId = fullCustomer.entities.find(
+			(entity) => entity.id === targetEntityId,
+		)?.internal_id;
+		const cusProduct = findActiveCustomerProductById({
+			fullCus: fullCustomer,
+			productId: pro.id,
+			internalEntityId,
+		});
+		expect(
+			cusProduct,
+			"active entity-owned pro cusProduct not found",
+		).toBeDefined();
+		if (!cusProduct) throw new Error("unreachable");
+
+		const premiumFull = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: premium.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+
+		const currentPrices = cusProductToPrices({ cusProduct });
+		const currentMessageItems = mapToProductItems({
+			prices: currentPrices,
+			entitlements: cusProductToEnts({ cusProduct }),
+			features: ctx.features,
+		})
+			.filter((item) => item.feature_id === TestFeature.Messages)
+			.map((item) => ({
+				...item,
+				created_at: null,
+				entitlement_id: null,
+				price_id: null,
+			}));
+		expect(currentMessageItems.length).toBe(2);
+
+		const premiumNonMessageItems = mapToProductItems({
+			prices: premiumFull.prices,
+			entitlements: premiumFull.entitlements,
+			features: ctx.features,
+		}).filter((item) => item.feature_id !== TestFeature.Messages);
+
+		const currentBase = customerProductToBasePrice({
+			customerProduct: cusProduct,
+			errorOnNotFound: false,
+		});
+		if (!currentBase || !isFixedPrice(currentBase)) {
+			throw new Error("expected a fixed base price on the pro cusProduct");
+		}
+
+		const customize = {
+			...productItemsToCustomizePlanV1({
+				ctx,
+				items: [...premiumNonMessageItems, ...currentMessageItems],
+			}),
+			price: {
+				amount: currentBase.config.amount,
+				interval: currentBase.config.interval,
+				interval_count: currentBase.config.interval_count,
+			},
+		};
+
+		const {
+			fullProduct: customTargetProduct,
+			customPrices,
+			customEnts,
+		} = await setupCustomFullProduct({
+			ctx,
+			currentFullProduct: premiumFull,
+			customizePlan: customize,
+		});
+
+		const params = {
+			customer_id: customerId,
+			entity_id: cusProduct.entity_id ?? undefined,
+			customer_product_id: cusProduct.id,
+			plan_id: premium.id,
+			version: premiumFull.version,
+			no_billing_changes: true,
+			proration_behavior: "none",
+			redirect_mode: "never",
+			customize,
+		} satisfies UpdateSubscriptionV1Params;
+
+		await billingActions.updateSubscription({
+			ctx,
+			params,
+			contextOverride: {
+				productContext: {
+					customerProduct: cusProduct,
+					fullProduct: customTargetProduct,
+					customPrices,
+					customEnts,
+				},
+				billingVersion: cusProduct.billing_version ?? BillingVersion.V2,
+			},
+			options: { skipAutumnCheckout: true },
+		});
+
+		await deleteCachedFullCustomer({
+			ctx,
+			customerId,
+			source: "per-entity-rollover-carry-test",
+		});
+
+		const entityAfter = await autumnV1.entities.get<ApiEntityV0>(
+			customerId,
+			targetEntityId,
+		);
+		const rolloversAfter = (
+			entityAfter.features?.[TestFeature.Messages]?.rollovers ?? []
+		)
+			.map((rollover) => rollover.balance)
+			.filter((balance) => balance > 0)
+			.sort((a, b) => a - b);
+		expect(
+			rolloversAfter,
+			"rollovers lost after productContext-override update on entity-owned cusProduct",
+		).toEqual(rolloversBefore);
+	},
+);
+
+// Mirrors the real Mintlify growth shape: the zero-allowance overage item ALSO
+// carries a max_percentage rollover config, so its cap is 50% of 0 = 0. If the
+// carried prepaid rollover lands on it, clearExcessRollovers wipes the balance.
+test.concurrent(
+	`${chalk.yellowBright("entity rollover carry: prepaid pct rollover + ZERO-allowance overage with pct rollover survives version update")}`,
+	async () => {
+		const customerId = "ent-rollover-carry-zero-overage";
+
+		const pctRollover = {
+			max_percentage: 50,
+			length: 1,
+			duration: RolloverExpiryDurationType.Month,
+		};
+
+		// Overage listed FIRST so its cusEnt is the first same-feature match.
+		const overageZeroAllowance = constructArrearItem({
+			featureId: TestFeature.Messages,
+			includedUsage: 0,
+			price: 0.01,
+			billingUnits: 1,
+			rolloverConfig: pctRollover,
+		});
+		const prepaidVolumeMessages = constructPrepaidItem({
+			featureId: TestFeature.Messages,
+			tiers: [
+				{ to: 500, amount: 10 },
+				{ to: "inf" as unknown as number, amount: 5 },
+			],
+			tierBehaviour: TierBehavior.VolumeBased,
+			billingUnits: 100,
+			includedUsage: 100,
+			rolloverConfig: pctRollover,
+		});
+
+		const pro = products.base({
+			id: "pro",
+			items: [
+				overageZeroAllowance,
+				prepaidVolumeMessages,
+				items.monthlyPrice({ price: 30 }),
+			],
+		});
+
+		const { autumnV1, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+			],
+			actions: [
+				s.billing.attach({
+					productId: pro.id,
+					entityIndex: 0,
+					options: [{ feature_id: TestFeature.Messages, quantity: 100 }],
+				}),
+				s.advanceToNextInvoice(),
+			],
+		});
+
+		const targetEntityId = entities[0].id;
+
+		const entityBefore = await autumnV1.entities.get<ApiEntityV0>(
+			customerId,
+			targetEntityId,
+		);
+		const rolloversBefore = (
+			entityBefore.features?.[TestFeature.Messages]?.rollovers ?? []
+		)
+			.map((rollover) => rollover.balance)
+			.filter((balance) => balance > 0)
+			.sort((a, b) => a - b);
+		expect(
+			rolloversBefore.length,
+			"expected a positive prepaid rollover before update — test setup issue, not the bug",
+		).toBeGreaterThanOrEqual(1);
+
+		// v2 keeps both feature items identical; only the base price changes.
+		await autumnV1.products.update(pro.id, {
+			items: [
+				overageZeroAllowance,
+				prepaidVolumeMessages,
+				items.monthlyPrice({ price: 35 }),
+			],
+		});
+
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			entity_id: targetEntityId,
+			product_id: pro.id,
+			version: 2,
+		});
+
+		const entityAfter = await autumnV1.entities.get<ApiEntityV0>(
+			customerId,
+			targetEntityId,
+		);
+		const rolloversAfter = (
+			entityAfter.features?.[TestFeature.Messages]?.rollovers ?? []
+		)
+			.map((rollover) => rollover.balance)
+			.filter((balance) => balance > 0)
+			.sort((a, b) => a - b);
+		expect(
+			rolloversAfter,
+			"rollover wiped: carried onto the zero-allowance overage bucket and cleared by its 0 cap",
+		).toEqual(rolloversBefore);
+	},
+);

--- a/server/tests/unit/billing/rollovers/applyExistingRolloversCandidates.test.ts
+++ b/server/tests/unit/billing/rollovers/applyExistingRolloversCandidates.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Candidate ordering for rollover carry: same-feature candidates are ranked by
+ * billing kind, then reset interval/interval_count, then whether the bucket's
+ * effective max can hold a balance (zero-cap buckets rank last).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	BillingType,
+	EntInterval,
+	type ExistingRollover,
+	type FullCustomerEntitlement,
+	type FullCustomerPrice,
+	type RolloverConfig,
+	RolloverExpiryDurationType,
+} from "@autumn/shared";
+import { customerEntitlements } from "@tests/utils/fixtures/db/customerEntitlements";
+import { customerProducts } from "@tests/utils/fixtures/db/customerProducts";
+import { prices } from "@tests/utils/fixtures/db/prices";
+import { applyExistingRollovers } from "@/internal/billing/v2/utils/handleExistingRollovers/applyExistingRollovers";
+
+const FEATURE_ID = "messages";
+const INTERNAL_FEATURE_ID = "int_messages";
+
+const pctRollover: RolloverConfig = {
+	max_percentage: 50,
+	length: 1,
+	duration: RolloverExpiryDurationType.Month,
+};
+
+const buildCusEnt = ({
+	entitlementId,
+	allowance,
+	interval = EntInterval.Month,
+	intervalCount = 1,
+	rollover = pctRollover,
+}: {
+	entitlementId: string;
+	allowance: number;
+	interval?: EntInterval;
+	intervalCount?: number;
+	rollover?: RolloverConfig | null;
+}): FullCustomerEntitlement =>
+	customerEntitlements.create({
+		entitlementId,
+		featureId: FEATURE_ID,
+		internalFeatureId: INTERNAL_FEATURE_ID,
+		featureName: "Messages",
+		allowance,
+		balance: allowance,
+		interval,
+		intervalCount,
+		rollover,
+	});
+
+const buildExistingRollover = ({
+	balance = 50,
+	sourceBillingType = BillingType.UsageInAdvance,
+	sourceInterval = EntInterval.Month,
+	sourceIntervalCount = 1,
+}: {
+	balance?: number;
+	sourceBillingType?: BillingType | null;
+	sourceInterval?: string | null;
+	sourceIntervalCount?: number | null;
+} = {}): ExistingRollover => ({
+	id: "roll_source",
+	cus_ent_id: "cus_ent_source",
+	balance,
+	usage: 0,
+	expires_at: null,
+	entities: {},
+	internal_feature_id: INTERNAL_FEATURE_ID,
+	source_billing_type: sourceBillingType,
+	source_interval: sourceInterval,
+	source_interval_count: sourceIntervalCount,
+});
+
+const buildCusProduct = ({
+	customerEntitlements: cusEnts,
+	customerPrices,
+}: {
+	customerEntitlements: FullCustomerEntitlement[];
+	customerPrices: FullCustomerPrice[];
+}) =>
+	customerProducts.create({
+		customerEntitlements: cusEnts,
+		customerPrices,
+	});
+
+describe("applyExistingRollovers candidate ordering", () => {
+	test("prepaid rollover skips zero-cap overage bucket listed first (kind match wins)", () => {
+		// Mirrors the Mintlify growth shape: zero-allowance overage with a pct
+		// rollover config (effective max 0) sits before the prepaid bucket.
+		const overage = buildCusEnt({ entitlementId: "ent_overage", allowance: 0 });
+		const prepaid = buildCusEnt({
+			entitlementId: "ent_prepaid",
+			allowance: 100,
+		});
+
+		const cusProduct = buildCusProduct({
+			customerEntitlements: [overage, prepaid],
+			customerPrices: [
+				prices.createCustomer({
+					price: prices.createConsumable({
+						id: "pr_overage",
+						featureId: FEATURE_ID,
+						internalFeatureId: INTERNAL_FEATURE_ID,
+						entitlementId: "ent_overage",
+					}),
+				}),
+				prices.createCustomer({
+					price: prices.createPrepaid({
+						id: "pr_prepaid",
+						featureId: FEATURE_ID,
+						internalFeatureId: INTERNAL_FEATURE_ID,
+						entitlementId: "ent_prepaid",
+					}),
+				}),
+			],
+		});
+
+		applyExistingRollovers({
+			customerProduct: cusProduct,
+			existingRollovers: [buildExistingRollover()],
+		});
+
+		expect(prepaid.rollovers.length).toBe(1);
+		expect(prepaid.rollovers[0].balance).toBe(50);
+		expect(overage.rollovers.length).toBe(0);
+	});
+
+	test("interval match disambiguates two same-kind candidates", () => {
+		const monthlyPrepaid = buildCusEnt({
+			entitlementId: "ent_prepaid_month",
+			allowance: 100,
+			interval: EntInterval.Month,
+		});
+		const yearlyPrepaid = buildCusEnt({
+			entitlementId: "ent_prepaid_year",
+			allowance: 100,
+			interval: EntInterval.Year,
+		});
+
+		const cusProduct = buildCusProduct({
+			customerEntitlements: [monthlyPrepaid, yearlyPrepaid],
+			customerPrices: [
+				prices.createCustomer({
+					price: prices.createPrepaid({
+						id: "pr_prepaid_month",
+						featureId: FEATURE_ID,
+						internalFeatureId: INTERNAL_FEATURE_ID,
+						entitlementId: "ent_prepaid_month",
+					}),
+				}),
+				prices.createCustomer({
+					price: prices.createPrepaid({
+						id: "pr_prepaid_year",
+						featureId: FEATURE_ID,
+						internalFeatureId: INTERNAL_FEATURE_ID,
+						entitlementId: "ent_prepaid_year",
+					}),
+				}),
+			],
+		});
+
+		applyExistingRollovers({
+			customerProduct: cusProduct,
+			existingRollovers: [
+				buildExistingRollover({ sourceInterval: EntInterval.Year }),
+			],
+		});
+
+		expect(yearlyPrepaid.rollovers.length).toBe(1);
+		expect(monthlyPrepaid.rollovers.length).toBe(0);
+	});
+
+	test("capacity breaks ties between identical candidates", () => {
+		// Both prepaid + monthly; the zero-cap one is listed first.
+		const zeroCapPrepaid = buildCusEnt({
+			entitlementId: "ent_prepaid_zero",
+			allowance: 0,
+		});
+		const prepaid = buildCusEnt({
+			entitlementId: "ent_prepaid_ok",
+			allowance: 100,
+		});
+
+		const cusProduct = buildCusProduct({
+			customerEntitlements: [zeroCapPrepaid, prepaid],
+			customerPrices: [
+				prices.createCustomer({
+					price: prices.createPrepaid({
+						id: "pr_prepaid_zero",
+						featureId: FEATURE_ID,
+						internalFeatureId: INTERNAL_FEATURE_ID,
+						entitlementId: "ent_prepaid_zero",
+					}),
+				}),
+				prices.createCustomer({
+					price: prices.createPrepaid({
+						id: "pr_prepaid_ok",
+						featureId: FEATURE_ID,
+						internalFeatureId: INTERNAL_FEATURE_ID,
+						entitlementId: "ent_prepaid_ok",
+					}),
+				}),
+			],
+		});
+
+		applyExistingRollovers({
+			customerProduct: cusProduct,
+			existingRollovers: [buildExistingRollover()],
+		});
+
+		expect(prepaid.rollovers.length).toBe(1);
+		expect(zeroCapPrepaid.rollovers.length).toBe(0);
+	});
+
+	test("falls back to the only candidate even when nothing matches", () => {
+		const overage = buildCusEnt({
+			entitlementId: "ent_overage_only",
+			allowance: 100,
+			interval: EntInterval.Year,
+		});
+
+		const cusProduct = buildCusProduct({
+			customerEntitlements: [overage],
+			customerPrices: [
+				prices.createCustomer({
+					price: prices.createConsumable({
+						id: "pr_overage_only",
+						featureId: FEATURE_ID,
+						internalFeatureId: INTERNAL_FEATURE_ID,
+						entitlementId: "ent_overage_only",
+					}),
+				}),
+			],
+		});
+
+		applyExistingRollovers({
+			customerProduct: cusProduct,
+			existingRollovers: [buildExistingRollover()],
+		});
+
+		expect(overage.rollovers.length).toBe(1);
+		expect(overage.rollovers[0].balance).toBe(50);
+	});
+});

--- a/shared/models/billingModels/customerProduct/existingRollovers.ts
+++ b/shared/models/billingModels/customerProduct/existingRollovers.ts
@@ -1,8 +1,14 @@
 import { RolloverSchema } from "@models/cusProductModels/cusEntModels/rolloverModels/rolloverTable";
+import { BillingType } from "@models/productModels/priceModels/priceEnums";
 import { z } from "zod/v4";
 
 export const ExistingRolloverSchema = RolloverSchema.extend({
 	internal_feature_id: z.string(),
+	// Source-item identity (billing type + reset interval); used to rank
+	// candidate cusEnts when a plan has multiple items for the same feature.
+	source_billing_type: z.enum(BillingType).nullish(),
+	source_interval: z.string().nullish(),
+	source_interval_count: z.number().nullish(),
 });
 
 export type ExistingRollover = z.infer<typeof ExistingRolloverSchema>;

--- a/vite/src/views/chat/components/LeafChatPanel.tsx
+++ b/vite/src/views/chat/components/LeafChatPanel.tsx
@@ -14,6 +14,7 @@ import {
 } from "@autumn/ui/ai-elements";
 import { ArrowUpIcon } from "@phosphor-icons/react";
 import type { ReactNode } from "react";
+import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import type {
 	DecidingState,
@@ -23,8 +24,14 @@ import type {
 } from "../chatTypes";
 import { ApprovalCard } from "./ApprovalCard";
 import { CatalogDecisionCard } from "./CatalogDecisionCard";
+import { LeafImageAttachments } from "./LeafImageAttachments";
+import { LeafImageUploadButton } from "./LeafImageUploadButton";
 import { QuestionOptions } from "./QuestionOptions";
 import { ToolStepsGroup, type WorkedEntry } from "./ToolSteps";
+
+const ACCEPTED_IMAGE_TYPES = "image/png,image/jpeg,image/webp,image/gif";
+const MAX_IMAGE_FILES = 4;
+const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
 
 interface LeafChatPanelProps {
 	messages: LeafUIMessage[];
@@ -303,10 +310,14 @@ export function LeafChatPanel({
 				))}
 				<PromptInput
 					onSubmit={onSubmit}
-					accept="image/*"
+					accept={ACCEPTED_IMAGE_TYPES}
+					maxFiles={MAX_IMAGE_FILES}
+					maxFileSize={MAX_IMAGE_BYTES}
 					multiple
+					onError={({ message }) => toast.error(message)}
 					className="[&_[data-slot=prompt-input]]:rounded-xl [&_[data-slot=prompt-input]]:shadow-sm"
 				>
+					<LeafImageAttachments />
 					<PromptInputBody>
 						{/* Keep the composer typable during a turn (like Claude/ChatGPT);
 						    only submission is gated on the stream finishing. */}
@@ -317,7 +328,8 @@ export function LeafChatPanel({
 							placeholder={placeholder}
 						/>
 					</PromptInputBody>
-					<PromptInputFooter className="justify-end px-2 pb-2">
+					<PromptInputFooter className="px-2 pb-2">
+						<LeafImageUploadButton />
 						{/* Never disabled: submit must fire mid-turn so handleSubmit can
 						    queue the message (Enter is a no-op when this is disabled). */}
 						<PromptInputSubmit

--- a/vite/src/views/chat/components/LeafImageAttachments.tsx
+++ b/vite/src/views/chat/components/LeafImageAttachments.tsx
@@ -1,0 +1,19 @@
+import {
+	PromptInputAttachment,
+	PromptInputAttachments,
+	PromptInputHeader,
+	usePromptInputAttachments,
+} from "@autumn/ui/ai-elements";
+
+export function LeafImageAttachments() {
+	const attachments = usePromptInputAttachments();
+	if (attachments.files.length === 0) return null;
+
+	return (
+		<PromptInputHeader>
+			<PromptInputAttachments className="gap-1.5 p-0">
+				{(attachment) => <PromptInputAttachment data={attachment} />}
+			</PromptInputAttachments>
+		</PromptInputHeader>
+	);
+}

--- a/vite/src/views/chat/components/LeafImageUploadButton.tsx
+++ b/vite/src/views/chat/components/LeafImageUploadButton.tsx
@@ -1,0 +1,20 @@
+import {
+	PromptInputButton,
+	usePromptInputAttachments,
+} from "@autumn/ui/ai-elements";
+import { ImageIcon } from "lucide-react";
+
+export function LeafImageUploadButton() {
+	const attachments = usePromptInputAttachments();
+
+	return (
+		<PromptInputButton
+			aria-label="Add image"
+			className="size-6 rounded-full text-tertiary-foreground"
+			onClick={() => attachments.openFileDialog()}
+			title="Add image"
+		>
+			<ImageIcon className="size-3.5" />
+		</PromptInputButton>
+	);
+}


### PR DESCRIPTION
## Problem

`applyExistingRollovers` matched carried rollovers to the new customer product's entitlements by `internal_feature_id` alone, taking the **first** rollover-capable match. When a plan has multiple items for the same feature (prepaid volume + overage), every carried rollover could land on the wrong bucket, and `clearExcessRollovers` then clipped the combined balance against that bucket's max.

The worst case is live on Mintlify growth plans: the zero-allowance overage AI_CREDITS item also carries a `max_percentage: 50` rollover config, so its effective cap is 50% of 0 = **0** — any rollover carried onto it is silently wiped. Reproduced against real plan shapes: a version update took per-entity rollovers from `[50]` to `[]`.

## Fix

- `cusProductToExistingRollovers` tags each carried rollover with its source item identity: `source_billing_type`, `source_interval`, `source_interval_count` (new optional fields on `ExistingRolloverSchema`).
- `applyExistingRollovers` scores every same-feature, rollover-capable candidate and applies each rollover to the best one — billing-kind match (4) > reset interval/interval_count match (2) > nonzero effective capacity (1), with sole-candidate fallback so single-bucket plans behave exactly as before.
- Extracted `cusEntToEffectiveRolloverMax` from `performMaximumClearing` so candidate scoring and max clearing share one cap computation.
- Reuses the existing shared `customerEntitlementToBillingType` helper.

## Tests

- **Unit** (`applyExistingRolloversCandidates.test.ts`, 4 cases): kind match beats a zero-cap overage listed first, interval disambiguates same-kind buckets, capacity breaks exact ties, sole-candidate fallback.
- **Integration** (`per-entity-rollover-carry.test.ts`, 10 cases, all multi-entity with prepaid volume + overage on the same feature): version update, `update_items` patch, PUT `customize.items`, `remove_items`+`add_items`, attach plan switch, migration via `contextOverride`, direct `billingActions.updateSubscription` with `productContext` override (customer-level and entity-owned), prepaid-pct + no-rollover-overage, and the prod-shape zero-allowance-overage case (red before this fix).
- Regressions green: `immediate-switch-rollover` (5), `update-paid-prepaid-rollover` (1), `patch-update-items-carry-rollover` (3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rollover carry on plan updates by applying each carried balance to the best same-feature bucket (prepaid vs overage), preventing silent wipes on zero-cap overage items. Also adds image attachments to the Leaf chat composer with sensible file limits.

- **Bug Fixes**
  - Tag carried rollovers with `source_billing_type`, `source_interval`, and `source_interval_count`, and score candidates: billing-kind match > interval/count match > nonzero effective cap (with sole-candidate fallback).
  - Share rollover-cap computation via `cusEntToEffectiveRolloverMax`, so zero-cap buckets never win unless they’re the only choice.
  - Added unit and integration tests covering version updates, item patches/replacements, plan switches, context overrides, and the zero-allowance overage case.

- **New Features**
  - Leaf chat: image upload in the composer with previews and a toolbar button; accepts PNG/JPEG/WebP/GIF, up to 4 files, 20MB each; errors surface via toast.

<sup>Written for commit bbd0cf24344a19c0b4857dc35273507b4bf8d8f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent rollover-balance corruption bug where `applyExistingRollovers` matched carried rollovers to the first rollover-capable entitlement with a matching `internal_feature_id`, causing all rollovers to land on the wrong bucket (e.g., a zero-allowance overage with `max_percentage: 50` whose effective cap is 0) and be wiped by `clearExcessRollovers`. The fix introduces scored candidate selection — billing-kind match (4), reset-interval match (2), nonzero-capacity (1) — with a sole-candidate fallback for single-bucket plans.

- **Bug fixes**: `cusProductToExistingRollovers` now stamps each carried rollover with `source_billing_type`, `source_interval`, and `source_interval_count`; `applyExistingRollovers` uses those tags to rank candidates instead of taking the first match.
- **Improvements**: `cusEntToEffectiveRolloverMax` is extracted from `performMaximumClearing` so the same cap computation is shared by both the scoring path and the clearing path, eliminating divergence risk.
- **Improvements**: New unit tests (4 cases) cover all scoring branches; new integration tests (10 cases) cover every update path including the exact production shape that was silently wiping rollover balances.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the scoring logic is correct and backward-compatible, the refactored cap computation is identical to the original, and the regression suite covers all meaningful update paths including the exact production failure shape.

The scoring approach cleanly handles all multi-bucket combinations: billing-kind match dominates interval, which dominates capacity, so there is no ambiguous tie when source identity is fully populated (new rollovers). For old rollovers without source identity both sides coerce to null and the capacity tiebreaker takes over, which still addresses the core zero-cap bucket problem. The extracted cusEntToEffectiveRolloverMax is a pure refactor with identical arithmetic. No data-loss path was introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/models/billingModels/customerProduct/existingRollovers.ts | Extends ExistingRolloverSchema with three optional source-identity fields (source_billing_type, source_interval, source_interval_count) used as rollover tagging metadata; schema change is backward-compatible via .nullish(). |
| server/src/internal/billing/v2/utils/handleExistingRollovers/cusProductToExistingRollovers.ts | Now stamps each carried rollover with the source cusEnt's billing type and reset interval, providing the identity tags that the updated applyExistingRollovers uses to score candidates. |
| server/src/internal/billing/v2/utils/handleExistingRollovers/applyExistingRollovers.ts | Core fix: replaces first-match with a scored candidate selection (billing kind=4, interval=2, capacity=1); correctly strips source-metadata fields before pushing to the target's rollover array; sole-candidate fallback preserves old behavior. |
| server/src/internal/customers/cusProducts/cusEnts/cusRollovers/rolloverUtils.ts | Extracts cusEntToEffectiveRolloverMax from performMaximumClearing with identical logic; both the scoring path and the clearing path now share the same cap computation, eliminating divergence risk. |
| server/tests/unit/billing/rollovers/applyExistingRolloversCandidates.test.ts | New unit tests for the scoring function: kind-match over zero-cap overage, interval disambiguation, capacity tiebreak, and sole-candidate fallback — all four critical branches are exercised. |
| server/tests/integration/billing/update-subscription/entities/per-entity-rollover-carry.test.ts | Comprehensive integration test suite (10 scenarios) covering version updates, PATCH/PUT/remove+add item paths, plan switches, migration, and the exact production failure shape (zero-allowance overage with pct rollover listed first). |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[cusProductToExistingRollovers] -->|tags each rollover with\nsource_billing_type\nsource_interval\nsource_interval_count| B[ExistingRollover list]

    B --> C[applyExistingRollovers]
    C --> D{filter candidates\nby internal_feature_id\n+ allowsRollovers}

    D --> E[Score each candidate]
    E --> E1[billingType match?\n+4]
    E --> E2[interval match?\n+2]
    E --> E3[effectiveMax > 0 or null?\n+1]
    E1 & E2 & E3 --> F{best score\ncandidate}

    F -->|sole candidate fallback| G[targetCusEnt]
    F -->|highest score wins| G

    G --> H[strip source metadata fields]
    H --> I[push rollover to targetCusEnt.rollovers]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[cusProductToExistingRollovers] -->|tags each rollover with\nsource_billing_type\nsource_interval\nsource_interval_count| B[ExistingRollover list]

    B --> C[applyExistingRollovers]
    C --> D{filter candidates\nby internal_feature_id\n+ allowsRollovers}

    D --> E[Score each candidate]
    E --> E1[billingType match?\n+4]
    E --> E2[interval match?\n+2]
    E --> E3[effectiveMax > 0 or null?\n+1]
    E1 & E2 & E3 --> F{best score\ncandidate}

    F -->|sole candidate fallback| G[targetCusEnt]
    F -->|highest score wins| G

    G --> H[strip source metadata fields]
    H --> I[push rollover to targetCusEnt.rollovers]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(leaf): 🤖 add image attachments to..."](https://github.com/useautumn/autumn/commit/bbd0cf24344a19c0b4857dc35273507b4bf8d8f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44816341)</sub>

<!-- /greptile_comment -->