### PR TITLE
Fix concurrent migrations duplicating customer plans

### DIFF
--- a/server/src/external/redis/redisUtils.ts
+++ b/server/src/external/redis/redisUtils.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from "node:crypto";
 import { ErrCode, RecaseError } from "@autumn/shared";
+import type { Redis } from "ioredis";
+import { RedisUnavailableError } from "@/external/redis/utils/errors.js";
 import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
-import { redis } from "./initRedis.js";
+import { hasRedisConfig, redis } from "./initRedis.js";
 
 const RELEASE_LOCK_SCRIPT = `
 if redis.call("GET", KEYS[1]) == ARGV[1] then
@@ -22,121 +24,52 @@ interface LockData {
 	ownerToken: string;
 }
 
+type LockRuntime = {
+	redisConfigured?: boolean;
+	redisInstance?: Redis;
+};
+
+type OwnedLockContext = {
+	assertLockOwned: () => void;
+};
+
+type LockAcquisition =
+	| { status: "acquired"; leaseExpiresAtMs: number; lockValue: string }
+	| { status: "contended" }
+	| { status: "disabled" }
+	| { status: "unavailable"; error: unknown };
+
 const DEFAULT_ERROR_MESSAGE =
 	"Operation already in progress, try again in a few seconds";
+const LOCK_RETRY_MIN_DELAY_MS = 75;
+const LOCK_RETRY_JITTER_MS = 50;
+const LOCK_RELEASE_MAX_WAIT_MS = 500;
+const LOCK_RELEASE_ATTEMPT_TIMEOUT_MS = 100;
+const LOCK_RELEASE_RETRY_DELAY_MS = 25;
 
-export const clearLock = async ({
-	lockKey,
-	lockValue,
+const resolveRedisConfigured = ({
+	redisConfigured,
+	redisInstance,
 }: {
-	lockKey: string;
-	lockValue: string | null;
-}): Promise<boolean> => {
-	if (!lockValue || redis.status !== "ready") return false;
+	redisConfigured: boolean | undefined;
+	redisInstance: Redis;
+}) => redisConfigured ?? (redisInstance === redis ? hasRedisConfig : true);
 
-	try {
-		const result = await redis.eval(RELEASE_LOCK_SCRIPT, 1, lockKey, lockValue);
-		return result === 1;
-	} catch {
-		// The TTL still guarantees eventual release if Redis becomes unavailable.
-		return false;
-	}
-};
+const waitForDelay = ({ delayMs }: { delayMs: number }) =>
+	new Promise<void>((resolve) => setTimeout(resolve, delayMs));
 
-const renewLock = async ({
-	lockKey,
-	lockValue,
-	ttlMs,
+const waitForLockRetry = ({
+	maxDelayMs,
+	minimumDelayMs = LOCK_RETRY_MIN_DELAY_MS,
 }: {
-	lockKey: string;
-	lockValue: string;
-	ttlMs: number;
-}): Promise<boolean> => {
-	if (redis.status !== "ready") return false;
-
-	const result = await runRedisOp({
-		operation: () =>
-			redis.eval(RENEW_LOCK_SCRIPT, 1, lockKey, lockValue, ttlMs),
-		source: "renewLock",
+	maxDelayMs: number;
+	minimumDelayMs?: number;
+}) => {
+	const jitterMs = Math.floor(Math.random() * LOCK_RETRY_JITTER_MS);
+	return waitForDelay({
+		delayMs: Math.max(0, Math.min(minimumDelayMs + jitterMs, maxDelayMs)),
 	});
-	return result === 1;
 };
-
-/**
- * Acquire a distributed lock using Redis.
- * If Redis is not ready or errors, returns null by default to preserve the
- * existing fail-open behavior. Pass `failOpen: false` for correctness-critical
- * callers that must never proceed without serialization.
- */
-export const acquireLock = async ({
-	lockKey,
-	ttlMs = 10000,
-	errorMessage = DEFAULT_ERROR_MESSAGE,
-	failOpen = true,
-}: {
-	lockKey: string;
-	ttlMs?: number;
-	errorMessage?: string;
-	failOpen?: boolean;
-}): Promise<string | null> => {
-	// If Redis not ready, allow operation to proceed
-	if (failOpen && redis.status !== "ready") {
-		return null;
-	}
-
-	const lockData: LockData = {
-		errorMessage,
-		ownerToken: randomUUID(),
-	};
-	const lockValue = JSON.stringify(lockData);
-	const setLock = () =>
-		redis.set(lockKey, lockValue, "PX", ttlMs, "NX") as Promise<"OK" | null>;
-
-	try {
-		// NX = only set if key doesn't exist, PX = set expiry in milliseconds
-		const result = failOpen
-			? await setLock()
-			: await runRedisOp({
-					operation: setLock,
-					source: "acquireLock",
-				});
-
-		// If result is null, lock already exists (NX failed)
-		if (result === null) {
-			const existingData = failOpen
-				? await redis.get(lockKey)
-				: await runRedisOp({
-						operation: () => redis.get(lockKey),
-						source: "acquireLock:existing",
-					});
-			const parsed = existingData
-				? (JSON.parse(existingData) as LockData)
-				: null;
-
-			throw new RecaseError({
-				message: parsed?.errorMessage || DEFAULT_ERROR_MESSAGE,
-				code: ErrCode.LockAlreadyExists,
-				statusCode: 423,
-			});
-		}
-
-		return lockValue;
-	} catch (error) {
-		// Re-throw lock conflict errors
-		if (error instanceof RecaseError || !failOpen) {
-			throw error;
-		}
-
-		// Redis error - allow operation to proceed
-		return null;
-	}
-};
-
-const waitForLockRetry = ({ maxDelayMs }: { maxDelayMs: number }) =>
-	new Promise<void>((resolve) => {
-		const jitterMs = Math.floor(Math.random() * 50);
-		setTimeout(resolve, Math.min(75 + jitterMs, maxDelayMs));
-	});
 
 const waitForLeaseRenewal = ({
 	delayMs,
@@ -160,6 +93,32 @@ const waitForLeaseRenewal = ({
 	});
 };
 
+const runWithTimeout = async <T>({
+	operation,
+	timeoutMs,
+}: {
+	operation: () => Promise<T>;
+	timeoutMs: number;
+}): Promise<T> => {
+	let timeoutId: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			operation(),
+			new Promise<never>((_resolve, reject) => {
+				timeoutId = setTimeout(
+					() => reject(new Error("Redis lock operation timed out")),
+					timeoutMs,
+				);
+			}),
+		]);
+	} finally {
+		if (timeoutId) clearTimeout(timeoutId);
+	}
+};
+
+const createRedisNotReadyError = ({ source }: { source: string }) =>
+	new RedisUnavailableError({ source, reason: "not_ready" });
+
 const createLockOwnershipLostError = () =>
 	new RecaseError({
 		message: "Lost ownership of operation lock while work was still running",
@@ -174,47 +133,337 @@ const createLockWaitTimeoutError = ({ maxWaitMs }: { maxWaitMs: number }) =>
 		statusCode: 423,
 	});
 
-type OwnedLockContext = {
-	assertLockOwned: () => void;
+const releaseOwnedLock = async ({
+	lockKey,
+	lockValue,
+	redisConfigured,
+	redisInstance,
+	retryWhenNotOwned = false,
+}: {
+	lockKey: string;
+	lockValue: string | null;
+	redisConfigured: boolean;
+	redisInstance: Redis;
+	retryWhenNotOwned?: boolean;
+}): Promise<boolean> => {
+	if (!lockValue || !redisConfigured) return false;
+
+	const deadlineMs = Date.now() + LOCK_RELEASE_MAX_WAIT_MS;
+	do {
+		if (redisInstance.status === "ready") {
+			try {
+				const remainingMs = Math.max(1, deadlineMs - Date.now());
+				const result = await runRedisOp({
+					operation: () =>
+						runWithTimeout({
+							operation: () =>
+								redisInstance.eval(RELEASE_LOCK_SCRIPT, 1, lockKey, lockValue),
+							timeoutMs: Math.min(LOCK_RELEASE_ATTEMPT_TIMEOUT_MS, remainingMs),
+						}),
+					source: "clearLock",
+					redisInstance,
+				});
+				if (result === 1) return true;
+				if (!retryWhenNotOwned) return false;
+			} catch {
+				// Retry until the short release budget is exhausted. The owner token
+				// makes duplicate or delayed release attempts safe.
+			}
+		}
+
+		const remainingMs = deadlineMs - Date.now();
+		if (remainingMs <= 0) return false;
+		await waitForDelay({
+			delayMs: Math.min(LOCK_RELEASE_RETRY_DELAY_MS, remainingMs),
+		});
+	} while (Date.now() < deadlineMs);
+
+	return false;
+};
+
+export const clearLock = async ({
+	lockKey,
+	lockValue,
+	redisConfigured,
+	redisInstance = redis,
+}: {
+	lockKey: string;
+	lockValue: string | null;
+} & LockRuntime): Promise<boolean> =>
+	releaseOwnedLock({
+		lockKey,
+		lockValue,
+		redisConfigured: resolveRedisConfigured({
+			redisConfigured,
+			redisInstance,
+		}),
+		redisInstance,
+	});
+
+const tryAcquireLock = async ({
+	lockKey,
+	ttlMs,
+	errorMessage,
+	redisConfigured,
+	redisInstance,
+}: {
+	lockKey: string;
+	ttlMs: number;
+	errorMessage: string;
+	redisConfigured: boolean;
+	redisInstance: Redis;
+}): Promise<LockAcquisition> => {
+	if (!redisConfigured) return { status: "disabled" };
+	if (redisInstance.status !== "ready") {
+		return {
+			status: "unavailable",
+			error: createRedisNotReadyError({ source: "acquireLock" }),
+		};
+	}
+
+	const lockData: LockData = {
+		errorMessage,
+		ownerToken: randomUUID(),
+	};
+	const lockValue = JSON.stringify(lockData);
+	const acquisitionStartedAtMs = Date.now();
+
+	try {
+		const result = await runRedisOp({
+			operation: () =>
+				redisInstance.set(lockKey, lockValue, "PX", ttlMs, "NX") as Promise<
+					"OK" | null
+				>,
+			source: "acquireLock",
+			redisInstance,
+		});
+
+		if (result === null) return { status: "contended" };
+		return {
+			status: "acquired",
+			lockValue,
+			leaseExpiresAtMs: acquisitionStartedAtMs + ttlMs,
+		};
+	} catch (error) {
+		// SET NX may have landed even when its reply was lost. Retain the owner
+		// token and make bounded, owner-safe cleanup attempts before returning.
+		await releaseOwnedLock({
+			lockKey,
+			lockValue,
+			redisConfigured,
+			redisInstance,
+			retryWhenNotOwned: true,
+		});
+		return { status: "unavailable", error };
+	}
+};
+
+const parseLockErrorMessage = ({
+	existingValue,
+	fallback,
+}: {
+	existingValue: string | null;
+	fallback: string;
+}) => {
+	if (!existingValue) return fallback;
+	try {
+		const parsed = JSON.parse(existingValue) as Partial<LockData>;
+		return typeof parsed.errorMessage === "string"
+			? parsed.errorMessage
+			: fallback;
+	} catch {
+		return fallback;
+	}
+};
+
+const getContendedLockErrorMessage = async ({
+	lockKey,
+	fallback,
+	redisInstance,
+}: {
+	lockKey: string;
+	fallback: string;
+	redisInstance: Redis;
+}) => {
+	if (redisInstance.status !== "ready") return fallback;
+	try {
+		return parseLockErrorMessage({
+			existingValue: await redisInstance.get(lockKey),
+			fallback,
+		});
+	} catch {
+		// SET NX already proved contention. A best-effort message lookup must
+		// never turn that definite result into a fail-open acquisition.
+		return fallback;
+	}
+};
+
+const throwLockContention = async ({
+	lockKey,
+	errorMessage,
+	redisInstance,
+}: {
+	lockKey: string;
+	errorMessage: string;
+	redisInstance: Redis;
+}): Promise<never> => {
+	throw new RecaseError({
+		message: await getContendedLockErrorMessage({
+			lockKey,
+			fallback: errorMessage,
+			redisInstance,
+		}),
+		code: ErrCode.LockAlreadyExists,
+		statusCode: 423,
+	});
+};
+
+/**
+ * Acquire a distributed lock using Redis.
+ * If Redis is intentionally unconfigured, or unavailable with failOpen=true,
+ * returns null. Configured correctness-critical callers pass failOpen=false.
+ */
+export const acquireLock = async ({
+	lockKey,
+	ttlMs = 10000,
+	errorMessage = DEFAULT_ERROR_MESSAGE,
+	failOpen = true,
+	redisConfigured,
+	redisInstance = redis,
+}: {
+	lockKey: string;
+	ttlMs?: number;
+	errorMessage?: string;
+	failOpen?: boolean;
+} & LockRuntime): Promise<string | null> => {
+	const acquisition = await tryAcquireLock({
+		lockKey,
+		ttlMs,
+		errorMessage,
+		redisConfigured: resolveRedisConfigured({
+			redisConfigured,
+			redisInstance,
+		}),
+		redisInstance,
+	});
+
+	switch (acquisition.status) {
+		case "acquired":
+			return acquisition.lockValue;
+		case "contended":
+			return throwLockContention({ lockKey, errorMessage, redisInstance });
+		case "disabled":
+			return null;
+		case "unavailable":
+			if (failOpen) return null;
+			throw acquisition.error;
+	}
+};
+
+const renewLock = async ({
+	lockKey,
+	lockValue,
+	ttlMs,
+	redisInstance,
+}: {
+	lockKey: string;
+	lockValue: string;
+	ttlMs: number;
+	redisInstance: Redis;
+}): Promise<{ leaseExpiresAtMs: number; renewed: boolean }> => {
+	if (redisInstance.status !== "ready") {
+		throw createRedisNotReadyError({ source: "renewLock" });
+	}
+
+	const renewalStartedAtMs = Date.now();
+	const result = await runRedisOp({
+		operation: () =>
+			redisInstance.eval(RENEW_LOCK_SCRIPT, 1, lockKey, lockValue, ttlMs),
+		source: "renewLock",
+		redisInstance,
+	});
+	return {
+		renewed: result === 1,
+		leaseExpiresAtMs: renewalStartedAtMs + ttlMs,
+	};
 };
 
 const runWithOwnedLock = async <T>({
 	lockKey,
 	lockValue,
 	ttlMs,
+	leaseExpiresAtMs: initialLeaseExpiresAtMs,
 	fn,
+	redisConfigured,
+	redisInstance,
 }: {
 	lockKey: string;
 	lockValue: string | null;
 	ttlMs: number;
+	leaseExpiresAtMs?: number;
 	fn: (context: OwnedLockContext) => Promise<T>;
+	redisConfigured: boolean;
+	redisInstance: Redis;
 }): Promise<T> => {
 	if (!lockValue) {
 		return fn({ assertLockOwned: () => undefined });
 	}
 
 	const renewalController = new AbortController();
+	let leaseExpiresAtMs = initialLeaseExpiresAtMs ?? Date.now() + ttlMs;
 	let ownershipError: unknown;
+	const loseOwnership = () => {
+		ownershipError ??= createLockOwnershipLostError();
+		renewalController.abort();
+	};
 	const assertLockOwned = () => {
+		if (!ownershipError && Date.now() >= leaseExpiresAtMs) loseOwnership();
 		if (ownershipError) throw ownershipError;
 	};
 	const renewalPromise = (async () => {
 		const renewalIntervalMs = Math.max(1, Math.floor(ttlMs / 3));
+		const renewalRetryDelayMs = Math.max(
+			1,
+			Math.min(100, Math.floor(ttlMs / 10)),
+		);
+
 		while (
 			await waitForLeaseRenewal({
 				delayMs: renewalIntervalMs,
 				signal: renewalController.signal,
 			})
 		) {
-			try {
-				const renewed = await renewLock({ lockKey, lockValue, ttlMs });
-				if (!renewed) {
-					ownershipError = createLockOwnershipLostError();
-					renewalController.abort();
+			while (!renewalController.signal.aborted) {
+				if (Date.now() >= leaseExpiresAtMs) {
+					loseOwnership();
+					break;
 				}
-			} catch (error) {
-				ownershipError = error;
-				renewalController.abort();
+
+				try {
+					const renewal = await renewLock({
+						lockKey,
+						lockValue,
+						ttlMs,
+						redisInstance,
+					});
+					if (!renewal.renewed) {
+						loseOwnership();
+						break;
+					}
+					leaseExpiresAtMs = renewal.leaseExpiresAtMs;
+					break;
+				} catch {
+					const remainingLeaseMs = leaseExpiresAtMs - Date.now();
+					if (remainingLeaseMs <= 0) {
+						loseOwnership();
+						break;
+					}
+					const shouldRetry = await waitForLeaseRenewal({
+						delayMs: Math.min(renewalRetryDelayMs, remainingLeaseMs),
+						signal: renewalController.signal,
+					});
+					if (!shouldRetry) break;
+				}
 			}
 		}
 	})();
@@ -226,38 +475,73 @@ const runWithOwnedLock = async <T>({
 	} finally {
 		renewalController.abort();
 		await renewalPromise;
-		await clearLock({ lockKey, lockValue });
+		await releaseOwnedLock({
+			lockKey,
+			lockValue,
+			redisConfigured,
+			redisInstance,
+		});
 	}
 };
 
 /**
- * Execute a function with a distributed lock. Acquires lock, runs the function, then releases the lock.
- * Ensures lock is always released even if the function throws an error.
+ * Execute a function with a distributed lock. Configured Redis failures are
+ * fail-open by default for backward compatibility; failOpen=false is intended
+ * for correctness-critical callers.
  */
 export const withLock = async <T>({
 	lockKey,
 	ttlMs = 10000,
 	errorMessage = DEFAULT_ERROR_MESSAGE,
+	failOpen = true,
 	fn,
+	redisConfigured,
+	redisInstance = redis,
 }: {
 	lockKey: string;
 	ttlMs?: number;
 	errorMessage?: string;
-	fn: () => Promise<T>;
-}): Promise<T> => {
-	const lockValue = await acquireLock({ lockKey, ttlMs, errorMessage });
+	failOpen?: boolean;
+	fn: (context: OwnedLockContext) => Promise<T>;
+} & LockRuntime): Promise<T> => {
+	const resolvedRedisConfigured = resolveRedisConfigured({
+		redisConfigured,
+		redisInstance,
+	});
+	const acquisition = await tryAcquireLock({
+		lockKey,
+		ttlMs,
+		errorMessage,
+		redisConfigured: resolvedRedisConfigured,
+		redisInstance,
+	});
 
-	try {
-		return await fn();
-	} finally {
-		await clearLock({ lockKey, lockValue });
+	if (acquisition.status === "contended") {
+		return throwLockContention({ lockKey, errorMessage, redisInstance });
 	}
+	if (acquisition.status === "unavailable") {
+		if (!failOpen) throw acquisition.error;
+		return fn({ assertLockOwned: () => undefined });
+	}
+	if (acquisition.status === "disabled") {
+		return fn({ assertLockOwned: () => undefined });
+	}
+
+	return runWithOwnedLock({
+		lockKey,
+		lockValue: acquisition.lockValue,
+		ttlMs,
+		leaseExpiresAtMs: acquisition.leaseExpiresAtMs,
+		fn,
+		redisConfigured: resolvedRedisConfigured,
+		redisInstance,
+	});
 };
 
 /**
  * Execute a function after waiting for exclusive ownership of a lock.
- * Unlike `withLock`, this is fail-closed when Redis is unavailable, bounds
- * acquisition by `maxWaitMs`, and renews the owned lease until work settles.
+ * Configured Redis failures are retried within maxWaitMs; intentionally
+ * unconfigured deployments retain their Postgres-only behavior.
  */
 export const withWaitingLock = async <T>({
 	lockKey,
@@ -265,42 +549,87 @@ export const withWaitingLock = async <T>({
 	maxWaitMs,
 	errorMessage = DEFAULT_ERROR_MESSAGE,
 	fn,
+	redisConfigured,
+	redisInstance = redis,
 }: {
 	lockKey: string;
 	ttlMs: number;
 	maxWaitMs: number;
 	errorMessage?: string;
 	fn: (context: OwnedLockContext) => Promise<T>;
-}): Promise<T> => {
-	let lockValue: string | null = null;
-	const deadlineMs = Date.now() + maxWaitMs;
-
-	while (!lockValue) {
-		try {
-			lockValue = await acquireLock({
-				lockKey,
-				ttlMs,
-				errorMessage,
-				failOpen: false,
-			});
-		} catch (error) {
-			if (
-				error instanceof RecaseError &&
-				error.code === ErrCode.LockAlreadyExists
-			) {
-				const remainingMs = deadlineMs - Date.now();
-				if (remainingMs <= 0) {
-					throw createLockWaitTimeoutError({ maxWaitMs });
-				}
-				await waitForLockRetry({ maxDelayMs: remainingMs });
-				if (Date.now() >= deadlineMs) {
-					throw createLockWaitTimeoutError({ maxWaitMs });
-				}
-				continue;
-			}
-			throw error;
-		}
+} & LockRuntime): Promise<T> => {
+	const resolvedRedisConfigured = resolveRedisConfigured({
+		redisConfigured,
+		redisInstance,
+	});
+	if (!resolvedRedisConfigured) {
+		return fn({ assertLockOwned: () => undefined });
 	}
 
-	return runWithOwnedLock({ lockKey, lockValue, ttlMs, fn });
+	const deadlineMs = Date.now() + maxWaitMs;
+	let sawContention = false;
+	let lastUnavailableError: unknown;
+	let unavailableAttemptCount = 0;
+
+	const throwWaitFailure = (): never => {
+		if (!sawContention && lastUnavailableError) {
+			throw lastUnavailableError;
+		}
+		throw createLockWaitTimeoutError({ maxWaitMs });
+	};
+
+	while (true) {
+		const acquisition = await tryAcquireLock({
+			lockKey,
+			ttlMs,
+			errorMessage,
+			redisConfigured: resolvedRedisConfigured,
+			redisInstance,
+		});
+
+		if (acquisition.status === "acquired") {
+			if (Date.now() >= deadlineMs) {
+				await releaseOwnedLock({
+					lockKey,
+					lockValue: acquisition.lockValue,
+					redisConfigured: resolvedRedisConfigured,
+					redisInstance,
+				});
+				throw createLockWaitTimeoutError({ maxWaitMs });
+			}
+			return runWithOwnedLock({
+				lockKey,
+				lockValue: acquisition.lockValue,
+				ttlMs,
+				leaseExpiresAtMs: acquisition.leaseExpiresAtMs,
+				fn,
+				redisConfigured: resolvedRedisConfigured,
+				redisInstance,
+			});
+		}
+
+		if (acquisition.status === "disabled") {
+			return fn({ assertLockOwned: () => undefined });
+		}
+		if (acquisition.status === "contended") {
+			sawContention = true;
+			unavailableAttemptCount = 0;
+		} else {
+			lastUnavailableError = acquisition.error;
+			unavailableAttemptCount++;
+		}
+
+		const remainingMs = deadlineMs - Date.now();
+		if (remainingMs <= 0) throwWaitFailure();
+
+		const unavailableBackoffMs =
+			acquisition.status === "unavailable"
+				? Math.min(1_000, 100 * 2 ** Math.min(unavailableAttemptCount - 1, 4))
+				: LOCK_RETRY_MIN_DELAY_MS;
+		await waitForLockRetry({
+			maxDelayMs: remainingMs,
+			minimumDelayMs: unavailableBackoffMs,
+		});
+		if (Date.now() >= deadlineMs) throwWaitFailure();
+	}
 };

--- a/server/src/external/redis/redisUtils.ts
+++ b/server/src/external/redis/redisUtils.ts
@@ -1,52 +1,88 @@
+import { randomUUID } from "node:crypto";
 import { ErrCode, RecaseError } from "@autumn/shared";
-import { tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
+import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import { redis } from "./initRedis.js";
 
-export const clearLock = async ({ lockKey }: { lockKey: string }) => {
-	await tryRedisWrite(() => redis.del(lockKey));
-};
+const RELEASE_LOCK_SCRIPT = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+	return redis.call("DEL", KEYS[1])
+end
+return 0
+`;
 
 interface LockData {
 	errorMessage: string;
+	ownerToken: string;
 }
 
 const DEFAULT_ERROR_MESSAGE =
 	"Operation already in progress, try again in a few seconds";
 
+export const clearLock = async ({
+	lockKey,
+	lockValue,
+}: {
+	lockKey: string;
+	lockValue: string | null;
+}): Promise<boolean> => {
+	if (!lockValue || redis.status !== "ready") return false;
+
+	try {
+		const result = await redis.eval(RELEASE_LOCK_SCRIPT, 1, lockKey, lockValue);
+		return result === 1;
+	} catch {
+		// The TTL still guarantees eventual release if Redis becomes unavailable.
+		return false;
+	}
+};
+
 /**
  * Acquire a distributed lock using Redis.
- * If Redis is not ready or errors, returns true to allow the operation to proceed.
- * @returns true if lock was acquired (or Redis unavailable), throws if lock already exists
+ * If Redis is not ready or errors, returns null by default to preserve the
+ * existing fail-open behavior. Pass `failOpen: false` for correctness-critical
+ * callers that must never proceed without serialization.
  */
 export const acquireLock = async ({
 	lockKey,
 	ttlMs = 10000,
 	errorMessage = DEFAULT_ERROR_MESSAGE,
+	failOpen = true,
 }: {
 	lockKey: string;
 	ttlMs?: number;
 	errorMessage?: string;
-}): Promise<boolean> => {
+	failOpen?: boolean;
+}): Promise<string | null> => {
 	// If Redis not ready, allow operation to proceed
-	if (redis.status !== "ready") {
-		return true;
+	if (failOpen && redis.status !== "ready") {
+		return null;
 	}
+
+	const lockData: LockData = {
+		errorMessage,
+		ownerToken: randomUUID(),
+	};
+	const lockValue = JSON.stringify(lockData);
+	const setLock = () =>
+		redis.set(lockKey, lockValue, "PX", ttlMs, "NX") as Promise<"OK" | null>;
 
 	try {
 		// NX = only set if key doesn't exist, PX = set expiry in milliseconds
-		// Store as JSON for future extensibility
-		const lockData: LockData = { errorMessage };
-		const result = await redis.set(
-			lockKey,
-			JSON.stringify(lockData),
-			"PX",
-			ttlMs,
-			"NX",
-		);
+		const result = failOpen
+			? await setLock()
+			: await runRedisOp({
+					operation: setLock,
+					source: "acquireLock",
+				});
 
 		// If result is null, lock already exists (NX failed)
 		if (result === null) {
-			const existingData = await redis.get(lockKey);
+			const existingData = failOpen
+				? await redis.get(lockKey)
+				: await runRedisOp({
+						operation: () => redis.get(lockKey),
+						source: "acquireLock:existing",
+					});
 			const parsed = existingData
 				? (JSON.parse(existingData) as LockData)
 				: null;
@@ -58,17 +94,23 @@ export const acquireLock = async ({
 			});
 		}
 
-		return true;
+		return lockValue;
 	} catch (error) {
 		// Re-throw lock conflict errors
-		if (error instanceof RecaseError) {
+		if (error instanceof RecaseError || !failOpen) {
 			throw error;
 		}
 
 		// Redis error - allow operation to proceed
-		return true;
+		return null;
 	}
 };
+
+const waitForLockRetry = () =>
+	new Promise<void>((resolve) => {
+		const jitterMs = Math.floor(Math.random() * 50);
+		setTimeout(resolve, 75 + jitterMs);
+	});
 
 /**
  * Execute a function with a distributed lock. Acquires lock, runs the function, then releases the lock.
@@ -85,11 +127,55 @@ export const withLock = async <T>({
 	errorMessage?: string;
 	fn: () => Promise<T>;
 }): Promise<T> => {
-	await acquireLock({ lockKey, ttlMs, errorMessage });
+	const lockValue = await acquireLock({ lockKey, ttlMs, errorMessage });
 
 	try {
 		return await fn();
 	} finally {
-		await clearLock({ lockKey });
+		await clearLock({ lockKey, lockValue });
+	}
+};
+
+/**
+ * Execute a function after waiting for exclusive ownership of a lock.
+ * Unlike `withLock`, this is fail-closed when Redis is unavailable.
+ */
+export const withWaitingLock = async <T>({
+	lockKey,
+	ttlMs,
+	errorMessage = DEFAULT_ERROR_MESSAGE,
+	fn,
+}: {
+	lockKey: string;
+	ttlMs: number;
+	errorMessage?: string;
+	fn: () => Promise<T>;
+}): Promise<T> => {
+	let lockValue: string | null = null;
+
+	while (!lockValue) {
+		try {
+			lockValue = await acquireLock({
+				lockKey,
+				ttlMs,
+				errorMessage,
+				failOpen: false,
+			});
+		} catch (error) {
+			if (
+				error instanceof RecaseError &&
+				error.code === ErrCode.LockAlreadyExists
+			) {
+				await waitForLockRetry();
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	try {
+		return await fn();
+	} finally {
+		await clearLock({ lockKey, lockValue });
 	}
 };

--- a/server/src/external/redis/redisUtils.ts
+++ b/server/src/external/redis/redisUtils.ts
@@ -29,7 +29,7 @@ type LockRuntime = {
 	redisInstance?: Redis;
 };
 
-type OwnedLockContext = {
+export type OwnedLockContext = {
 	assertLockOwned: () => void;
 };
 
@@ -46,6 +46,13 @@ const LOCK_RETRY_JITTER_MS = 50;
 const LOCK_RELEASE_MAX_WAIT_MS = 500;
 const LOCK_RELEASE_ATTEMPT_TIMEOUT_MS = 100;
 const LOCK_RELEASE_RETRY_DELAY_MS = 25;
+
+class RedisLockOperationTimeoutError extends Error {
+	constructor() {
+		super("Redis lock operation timed out");
+		this.name = "RedisLockOperationTimeoutError";
+	}
+}
 
 const resolveRedisConfigured = ({
 	redisConfigured,
@@ -106,7 +113,7 @@ const runWithTimeout = async <T>({
 			operation(),
 			new Promise<never>((_resolve, reject) => {
 				timeoutId = setTimeout(
-					() => reject(new Error("Redis lock operation timed out")),
+					() => reject(new RedisLockOperationTimeoutError()),
 					timeoutMs,
 				);
 			}),
@@ -204,12 +211,14 @@ const tryAcquireLock = async ({
 	lockKey,
 	ttlMs,
 	errorMessage,
+	deadlineMs,
 	redisConfigured,
 	redisInstance,
 }: {
 	lockKey: string;
 	ttlMs: number;
 	errorMessage: string;
+	deadlineMs?: number;
 	redisConfigured: boolean;
 	redisInstance: Redis;
 }): Promise<LockAcquisition> => {
@@ -227,16 +236,30 @@ const tryAcquireLock = async ({
 	};
 	const lockValue = JSON.stringify(lockData);
 	const acquisitionStartedAtMs = Date.now();
+	if (deadlineMs !== undefined && acquisitionStartedAtMs >= deadlineMs) {
+		return {
+			status: "unavailable",
+			error: new RedisLockOperationTimeoutError(),
+		};
+	}
+
+	const acquisitionPromise = runRedisOp({
+		operation: () =>
+			redisInstance.set(lockKey, lockValue, "PX", ttlMs, "NX") as Promise<
+				"OK" | null
+			>,
+		source: "acquireLock",
+		redisInstance,
+	});
 
 	try {
-		const result = await runRedisOp({
-			operation: () =>
-				redisInstance.set(lockKey, lockValue, "PX", ttlMs, "NX") as Promise<
-					"OK" | null
-				>,
-			source: "acquireLock",
-			redisInstance,
-		});
+		const result =
+			deadlineMs === undefined
+				? await acquisitionPromise
+				: await runWithTimeout({
+						operation: () => acquisitionPromise,
+						timeoutMs: Math.max(1, deadlineMs - acquisitionStartedAtMs),
+					});
 
 		if (result === null) return { status: "contended" };
 		return {
@@ -245,6 +268,29 @@ const tryAcquireLock = async ({
 			leaseExpiresAtMs: acquisitionStartedAtMs + ttlMs,
 		};
 	} catch (error) {
+		if (error instanceof RedisLockOperationTimeoutError) {
+			// Redis commands cannot be cancelled. Keep the owner token and clean up
+			// asynchronously if this SET lands after the caller's wait deadline.
+			void (async () => {
+				try {
+					const result = await acquisitionPromise;
+					if (result === null) return;
+				} catch {
+					// A rejected reply is ambiguous: SET may still have landed server-side.
+				}
+
+				await releaseOwnedLock({
+					lockKey,
+					lockValue,
+					redisConfigured,
+					redisInstance,
+					retryWhenNotOwned: true,
+				});
+			})().catch(() => undefined);
+
+			return { status: "unavailable", error };
+		}
+
 		// SET NX may have landed even when its reply was lost. Retain the owner
 		// token and make bounded, owner-safe cleanup attempts before returning.
 		await releaseOwnedLock({
@@ -469,9 +515,9 @@ const runWithOwnedLock = async <T>({
 	})();
 
 	try {
-		const result = await fn({ assertLockOwned });
-		assertLockOwned();
-		return result;
+		// The callback owns its safe-point checks. An implicit check after it
+		// returns could turn already-committed billing work into a retryable 423.
+		return await fn({ assertLockOwned });
 	} finally {
 		renewalController.abort();
 		await renewalPromise;
@@ -583,18 +629,26 @@ export const withWaitingLock = async <T>({
 			lockKey,
 			ttlMs,
 			errorMessage,
+			deadlineMs,
 			redisConfigured: resolvedRedisConfigured,
 			redisInstance,
 		});
 
+		if (
+			acquisition.status === "unavailable" &&
+			acquisition.error instanceof RedisLockOperationTimeoutError
+		) {
+			throw createLockWaitTimeoutError({ maxWaitMs });
+		}
+
 		if (acquisition.status === "acquired") {
 			if (Date.now() >= deadlineMs) {
-				await releaseOwnedLock({
+				void releaseOwnedLock({
 					lockKey,
 					lockValue: acquisition.lockValue,
 					redisConfigured: resolvedRedisConfigured,
 					redisInstance,
-				});
+				}).catch(() => undefined);
 				throw createLockWaitTimeoutError({ maxWaitMs });
 			}
 			return runWithOwnedLock({

--- a/server/src/external/redis/redisUtils.ts
+++ b/server/src/external/redis/redisUtils.ts
@@ -10,6 +10,13 @@ end
 return 0
 `;
 
+const RENEW_LOCK_SCRIPT = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+	return redis.call("PEXPIRE", KEYS[1], ARGV[2])
+end
+return 0
+`;
+
 interface LockData {
 	errorMessage: string;
 	ownerToken: string;
@@ -34,6 +41,25 @@ export const clearLock = async ({
 		// The TTL still guarantees eventual release if Redis becomes unavailable.
 		return false;
 	}
+};
+
+const renewLock = async ({
+	lockKey,
+	lockValue,
+	ttlMs,
+}: {
+	lockKey: string;
+	lockValue: string;
+	ttlMs: number;
+}): Promise<boolean> => {
+	if (redis.status !== "ready") return false;
+
+	const result = await runRedisOp({
+		operation: () =>
+			redis.eval(RENEW_LOCK_SCRIPT, 1, lockKey, lockValue, ttlMs),
+		source: "renewLock",
+	});
+	return result === 1;
 };
 
 /**
@@ -106,11 +132,103 @@ export const acquireLock = async ({
 	}
 };
 
-const waitForLockRetry = () =>
+const waitForLockRetry = ({ maxDelayMs }: { maxDelayMs: number }) =>
 	new Promise<void>((resolve) => {
 		const jitterMs = Math.floor(Math.random() * 50);
-		setTimeout(resolve, 75 + jitterMs);
+		setTimeout(resolve, Math.min(75 + jitterMs, maxDelayMs));
 	});
+
+const waitForLeaseRenewal = ({
+	delayMs,
+	signal,
+}: {
+	delayMs: number;
+	signal: AbortSignal;
+}): Promise<boolean> => {
+	if (signal.aborted) return Promise.resolve(false);
+
+	return new Promise((resolve) => {
+		const onAbort = () => {
+			clearTimeout(timeoutId);
+			resolve(false);
+		};
+		const timeoutId = setTimeout(() => {
+			signal.removeEventListener("abort", onAbort);
+			resolve(true);
+		}, delayMs);
+		signal.addEventListener("abort", onAbort, { once: true });
+	});
+};
+
+const createLockOwnershipLostError = () =>
+	new RecaseError({
+		message: "Lost ownership of operation lock while work was still running",
+		code: ErrCode.LockAlreadyExists,
+		statusCode: 423,
+	});
+
+const createLockWaitTimeoutError = ({ maxWaitMs }: { maxWaitMs: number }) =>
+	new RecaseError({
+		message: `Timed out after ${maxWaitMs}ms waiting for operation lock`,
+		code: ErrCode.LockAlreadyExists,
+		statusCode: 423,
+	});
+
+type OwnedLockContext = {
+	assertLockOwned: () => void;
+};
+
+const runWithOwnedLock = async <T>({
+	lockKey,
+	lockValue,
+	ttlMs,
+	fn,
+}: {
+	lockKey: string;
+	lockValue: string | null;
+	ttlMs: number;
+	fn: (context: OwnedLockContext) => Promise<T>;
+}): Promise<T> => {
+	if (!lockValue) {
+		return fn({ assertLockOwned: () => undefined });
+	}
+
+	const renewalController = new AbortController();
+	let ownershipError: unknown;
+	const assertLockOwned = () => {
+		if (ownershipError) throw ownershipError;
+	};
+	const renewalPromise = (async () => {
+		const renewalIntervalMs = Math.max(1, Math.floor(ttlMs / 3));
+		while (
+			await waitForLeaseRenewal({
+				delayMs: renewalIntervalMs,
+				signal: renewalController.signal,
+			})
+		) {
+			try {
+				const renewed = await renewLock({ lockKey, lockValue, ttlMs });
+				if (!renewed) {
+					ownershipError = createLockOwnershipLostError();
+					renewalController.abort();
+				}
+			} catch (error) {
+				ownershipError = error;
+				renewalController.abort();
+			}
+		}
+	})();
+
+	try {
+		const result = await fn({ assertLockOwned });
+		assertLockOwned();
+		return result;
+	} finally {
+		renewalController.abort();
+		await renewalPromise;
+		await clearLock({ lockKey, lockValue });
+	}
+};
 
 /**
  * Execute a function with a distributed lock. Acquires lock, runs the function, then releases the lock.
@@ -138,20 +256,24 @@ export const withLock = async <T>({
 
 /**
  * Execute a function after waiting for exclusive ownership of a lock.
- * Unlike `withLock`, this is fail-closed when Redis is unavailable.
+ * Unlike `withLock`, this is fail-closed when Redis is unavailable, bounds
+ * acquisition by `maxWaitMs`, and renews the owned lease until work settles.
  */
 export const withWaitingLock = async <T>({
 	lockKey,
 	ttlMs,
+	maxWaitMs,
 	errorMessage = DEFAULT_ERROR_MESSAGE,
 	fn,
 }: {
 	lockKey: string;
 	ttlMs: number;
+	maxWaitMs: number;
 	errorMessage?: string;
-	fn: () => Promise<T>;
+	fn: (context: OwnedLockContext) => Promise<T>;
 }): Promise<T> => {
 	let lockValue: string | null = null;
+	const deadlineMs = Date.now() + maxWaitMs;
 
 	while (!lockValue) {
 		try {
@@ -166,16 +288,19 @@ export const withWaitingLock = async <T>({
 				error instanceof RecaseError &&
 				error.code === ErrCode.LockAlreadyExists
 			) {
-				await waitForLockRetry();
+				const remainingMs = deadlineMs - Date.now();
+				if (remainingMs <= 0) {
+					throw createLockWaitTimeoutError({ maxWaitMs });
+				}
+				await waitForLockRetry({ maxDelayMs: remainingMs });
+				if (Date.now() >= deadlineMs) {
+					throw createLockWaitTimeoutError({ maxWaitMs });
+				}
 				continue;
 			}
 			throw error;
 		}
 	}
 
-	try {
-		return await fn();
-	} finally {
-		await clearLock({ lockKey, lockValue });
-	}
+	return runWithOwnedLock({ lockKey, lockValue, ttlMs, fn });
 };

--- a/server/src/honoMiddlewares/routeHandler.ts
+++ b/server/src/honoMiddlewares/routeHandler.ts
@@ -10,7 +10,7 @@ import type { Context, Env, Next } from "hono";
 import type { H } from "hono/types";
 import type { ZodType, z } from "zod/v4";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
-import { acquireLock, clearLock } from "@/external/redis/redisUtils.js";
+import { withLock } from "@/external/redis/redisUtils.js";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { expandMiddleware } from "./expandMiddleware.js";
 import { validator } from "./validatorMiddleware.js";
@@ -147,6 +147,8 @@ export function createRoute<
 		ttlMs?: number;
 		/** Error message to show when lock is already held */
 		errorMessage?: string;
+		/** Whether configured Redis failures may proceed without a lock. */
+		failOpen?: boolean;
 	};
 	/**
 	 * Required auth scopes for this route. See `RouteScopeRequirement`.
@@ -290,21 +292,7 @@ export function createRoute<
 
 		const handler = pickHandler(c);
 
-		// Acquire lock if lock config provided
-		let lockKey: string | null = null;
-		let lockValue: string | null = null;
-		if (opts.lock) {
-			lockKey = opts.lock.getKey(c);
-			if (lockKey) {
-				lockValue = await acquireLock({
-					lockKey,
-					ttlMs: opts.lock.ttlMs,
-					errorMessage: opts.lock.errorMessage,
-				});
-			}
-		}
-
-		try {
+		const executeHandler = async () => {
 			if (opts.withTx) {
 				const db = c.get("ctx").db;
 
@@ -318,12 +306,19 @@ export function createRoute<
 			} else {
 				return await handler(c);
 			}
-		} finally {
-			// Always release lock
-			if (lockKey) {
-				await clearLock({ lockKey, lockValue });
-			}
-		}
+		};
+
+		if (!opts.lock) return executeHandler();
+		const lockKey = opts.lock.getKey(c);
+		if (!lockKey) return executeHandler();
+
+		return withLock({
+			lockKey,
+			ttlMs: opts.lock.ttlMs,
+			errorMessage: opts.lock.errorMessage,
+			failOpen: opts.lock.failOpen,
+			fn: executeHandler,
+		});
 	};
 
 	return [...middlewares, wrappedHandler as H] as unknown as [H, ...H[]];

--- a/server/src/honoMiddlewares/routeHandler.ts
+++ b/server/src/honoMiddlewares/routeHandler.ts
@@ -292,10 +292,11 @@ export function createRoute<
 
 		// Acquire lock if lock config provided
 		let lockKey: string | null = null;
+		let lockValue: string | null = null;
 		if (opts.lock) {
 			lockKey = opts.lock.getKey(c);
 			if (lockKey) {
-				await acquireLock({
+				lockValue = await acquireLock({
 					lockKey,
 					ttlMs: opts.lock.ttlMs,
 					errorMessage: opts.lock.errorMessage,
@@ -320,7 +321,7 @@ export function createRoute<
 		} finally {
 			// Always release lock
 			if (lockKey) {
-				await clearLock({ lockKey });
+				await clearLock({ lockKey, lockValue });
 			}
 		}
 	};

--- a/server/src/honoMiddlewares/routeHandler.ts
+++ b/server/src/honoMiddlewares/routeHandler.ts
@@ -317,7 +317,14 @@ export function createRoute<
 			ttlMs: opts.lock.ttlMs,
 			errorMessage: opts.lock.errorMessage,
 			failOpen: opts.lock.failOpen,
-			fn: executeHandler,
+			fn: async ({ assertLockOwned }) => {
+				c.set("ctx", {
+					...c.get("ctx"),
+					assertLockOwned,
+				});
+				assertLockOwned();
+				return executeHandler();
+			},
 		});
 	};
 

--- a/server/src/honoUtils/HonoEnv.ts
+++ b/server/src/honoUtils/HonoEnv.ts
@@ -40,6 +40,9 @@ export type RequestContext = {
 	 *  middleware/worker via resolveRedisV2. Never import the singleton directly
 	 *  in request-path code. */
 	redisV2: Redis;
+	/** Ownership check injected by createRoute for lock-protected handlers.
+	 * Call immediately before the first irreversible operation. */
+	assertLockOwned?: () => void;
 
 	// Info
 	id: string;

--- a/server/src/internal/balances/autoTopUp/autoTopup.ts
+++ b/server/src/internal/balances/autoTopUp/autoTopup.ts
@@ -1,5 +1,5 @@
 import { AppEnv } from "@autumn/shared";
-import { withLock } from "@/external/redis/redisUtils.js";
+import { withWaitingLock } from "@/external/redis/redisUtils.js";
 import { voidStripeInvoiceIfOpen } from "@/external/stripe/invoices/operations/voidStripeInvoiceIfOpen.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { executeBillingPlan } from "@/internal/billing/v2/execute/executeBillingPlan.js";
@@ -13,6 +13,7 @@ import { computeAutoTopupPlan } from "./compute/computeAutoTopupPlan.js";
 import { buildAutoTopUpLockKey } from "./helpers/autoTopUpUtils.js";
 import { clearAutoTopupPendingKey } from "./helpers/enqueueAutoTopupWithBurstSuppression.js";
 import { recordAutoTopupAttempt } from "./helpers/limits/index.js";
+import { isRetryableAutoTopupError } from "./isRetryableAutoTopupError.js";
 import { logAutoTopupContext } from "./logs/logAutoTopupContext.js";
 import { setupAutoTopupContext } from "./setup/setupAutoTopupContext.js";
 import {
@@ -20,6 +21,9 @@ import {
 	sendAutoTopupFailedWebhook,
 } from "./webhooks/sendAutoTopupFailedWebhook.js";
 import { sendAutoTopupSucceededWebhook } from "./webhooks/sendAutoTopupSucceededWebhook.js";
+
+const AUTO_TOPUP_LOCK_TTL_MS = 60_000;
+const AUTO_TOPUP_LOCK_MAX_WAIT_MS = 5_000;
 
 /** Workflow handler for auto top-ups. */
 export const autoTopup = async ({
@@ -33,6 +37,7 @@ export const autoTopup = async ({
 	const { customerId, featureId } = payload;
 	let failureWebhookSent = false;
 	let lastAutoTopupContext: AutoTopupContext | undefined;
+	let preservePendingKeyForRetry = false;
 
 	const sendFailureWebhook = async ({
 		autoTopupContext,
@@ -167,18 +172,20 @@ export const autoTopup = async ({
 
 	try {
 		// 2. Execute under lock (shares attach lock to prevent concurrent attach + auto-topup)
-		await withLock({
+		await withWaitingLock({
 			lockKey: buildAutoTopUpLockKey({
 				orgId: org.id,
 				env,
 				customerId,
 			}),
-			ttlMs: 60_000,
+			ttlMs: AUTO_TOPUP_LOCK_TTL_MS,
+			maxWaitMs: AUTO_TOPUP_LOCK_MAX_WAIT_MS,
 			errorMessage: `Another billing operation is already in progress for customer ${customerId}`,
 			fn: executeAutoTopup,
 		});
 	} catch (error) {
-		if (!failureWebhookSent) {
+		preservePendingKeyForRetry = isRetryableAutoTopupError({ error });
+		if (!preservePendingKeyForRetry && !failureWebhookSent) {
 			const failure = classifyAutoTopupError({ error });
 			await sendFailureWebhook({
 				...failure,
@@ -188,6 +195,8 @@ export const autoTopup = async ({
 		}
 		throw error;
 	} finally {
-		await clearAutoTopupPendingKey({ ctx, customerId, featureId });
+		if (!preservePendingKeyForRetry) {
+			await clearAutoTopupPendingKey({ ctx, customerId, featureId });
+		}
 	}
 };

--- a/server/src/internal/balances/autoTopUp/autoTopup.ts
+++ b/server/src/internal/balances/autoTopUp/autoTopup.ts
@@ -56,7 +56,11 @@ export const autoTopup = async ({
 		});
 	};
 
-	const executeAutoTopup = async () => {
+	const executeAutoTopup = async ({
+		assertLockOwned,
+	}: {
+		assertLockOwned: () => void;
+	}) => {
 		const start = performance.now();
 
 		logger.info(
@@ -112,6 +116,7 @@ export const autoTopup = async ({
 			ctx,
 			billingContext: autoTopupContext,
 			billingPlan: { autumn: autumnBillingPlan, stripe: stripeBillingPlan },
+			assertLockOwned,
 		});
 
 		logStripeBillingResult({ ctx, result: billingResult.stripe });

--- a/server/src/internal/balances/autoTopUp/isRetryableAutoTopupError.ts
+++ b/server/src/internal/balances/autoTopUp/isRetryableAutoTopupError.ts
@@ -1,0 +1,6 @@
+import { ErrCode } from "@autumn/shared";
+import { isTransientRedisError } from "@/external/redis/utils/isTransientRedisError.js";
+
+export const isRetryableAutoTopupError = ({ error }: { error: unknown }) =>
+	(error as { code?: string } | null)?.code === ErrCode.LockAlreadyExists ||
+	isTransientRedisError({ error });

--- a/server/src/internal/balances/utils/deduction/executePostgresDeduction.ts
+++ b/server/src/internal/balances/utils/deduction/executePostgresDeduction.ts
@@ -86,13 +86,18 @@ export const executePostgresDeduction = async ({
 		});
 	}
 
-	const executeDeduction = async (): Promise<{
+	const executeDeduction = async ({
+		assertLockOwned = () => undefined,
+	}: {
+		assertLockOwned?: () => void;
+	} = {}): Promise<{
 		updates: Record<string, DeductionUpdate>;
 		mutationLogs: MutationLogItem[];
 	}> => {
 		let allUpdates: Record<string, DeductionUpdate> = {};
 		let allRolloverOverwrites: RolloverOverwrite[] = [];
 		let allMutationLogs: MutationLogItem[] = [];
+		assertLockOwned();
 
 		// Need to deduct from customer entitlement...
 		for (const deduction of deductions) {
@@ -133,9 +138,9 @@ export const executePostgresDeduction = async ({
 				continue;
 			}
 
-		// Call the stored function to deduct from entitlements with credit costs
-		const result = await db.execute(
-			sql`SELECT * FROM deduct_from_cus_ents(
+			// Call the stored function to deduct from entitlements with credit costs
+			const result = await db.execute(
+				sql`SELECT * FROM deduct_from_cus_ents(
 			${JSON.stringify({
 				sorted_entitlements: customerEntitlementDeductions,
 				spend_limit_by_feature_id: spendLimitByFeatureId ?? null,
@@ -154,7 +159,7 @@ export const executePostgresDeduction = async ({
 				feature_id: feature.id,
 			})}::jsonb
 		) ${planetScaleTag({ query: "deductFromCusEnts" })}`,
-		);
+			);
 
 			// Parse the JSONB result
 			const resultJson = result[0]?.deduct_from_cus_ents as {

--- a/server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts
@@ -19,8 +19,8 @@ import type { DeductionUpdate } from "../types/deductionUpdate.js";
 import type { FeatureDeduction } from "../types/featureDeduction.js";
 import type { MutationLogItem } from "../types/mutationLogItem.js";
 import { applyDeductionUpdateToFullSubject } from "./applyDeductionUpdateToFullSubject.js";
-import { buildUnlimitedPlanMutationLog } from "./buildUnlimitedPlanMutationLog.js";
 import { applyRolloverUpdatesToFullSubject } from "./applyRolloverUpdatesToFullSubject.js";
+import { buildUnlimitedPlanMutationLog } from "./buildUnlimitedPlanMutationLog.js";
 import { logDeductionUpdatesV2 } from "./logDeductionUpdatesV2.js";
 import { mutationLogsToFeaturesV2 } from "./mutationLogsToFeaturesV2.js";
 import { normalizeDeductionSyncStateV2 } from "./normalizeDeductionSyncStateV2.js";
@@ -85,7 +85,11 @@ export const executePostgresDeductionV2 = async ({
 		});
 	}
 
-	const executeDeduction = async (): Promise<{
+	const executeDeduction = async ({
+		assertLockOwned = () => undefined,
+	}: {
+		assertLockOwned?: () => void;
+	} = {}): Promise<{
 		updates: Record<string, DeductionUpdate>;
 		mutationLogs: MutationLogItem[];
 		modifiedCusEntIdsByFeatureId: Record<string, string[]>;
@@ -95,6 +99,7 @@ export const executePostgresDeductionV2 = async ({
 		let allRolloverOverwrites: RolloverOverwrite[] = [];
 		let allMutationLogs: MutationLogItem[] = [];
 		const allModifiedCusEntIdsByFeatureId: Record<string, string[]> = {};
+		assertLockOwned();
 
 		for (const deduction of deductions) {
 			const {
@@ -146,8 +151,8 @@ export const executePostgresDeductionV2 = async ({
 				continue;
 			}
 
-		const result = await db.execute(
-			sql`SELECT * FROM deduct_from_cus_ents(
+			const result = await db.execute(
+				sql`SELECT * FROM deduct_from_cus_ents(
 			${JSON.stringify({
 				sorted_entitlements: customerEntitlementDeductions,
 				// No usage_window_limits here: the hard usage cap is enforced only on the
@@ -169,7 +174,7 @@ export const executePostgresDeductionV2 = async ({
 				feature_id: feature.id,
 			})}::jsonb
 		) ${planetScaleTag({ query: "deductFromCusEnts" })}`,
-		);
+			);
 
 			const resultJson = result[0]?.deduct_from_cus_ents as {
 				updates: Record<string, DeductionUpdate>;
@@ -326,11 +331,11 @@ export const executePostgresDeductionV2 = async ({
 
 	const deductionResult = resolvedOptions.paidAllocatedV1
 		? await withLock({
-			lockKey: `lock:deduction:${org.id}:${env}:${customerId}`,
-			ttlMs: 60000,
-			errorMessage: `Deduction for paid feature ${deductions[0]?.feature?.name} already in progress for customer ${customerId}.`,
-			fn: executeDeduction,
-		})
+				lockKey: `lock:deduction:${org.id}:${env}:${customerId}`,
+				ttlMs: 60000,
+				errorMessage: `Deduction for paid feature ${deductions[0]?.feature?.name} already in progress for customer ${customerId}.`,
+				fn: executeDeduction,
+			})
 		: await executeDeduction();
 
 	return {

--- a/server/src/internal/billing/attach/handleAttach.ts
+++ b/server/src/internal/billing/attach/handleAttach.ts
@@ -84,6 +84,8 @@ export const handleAttach = createRoute({
 			useCheckout: config.onlyCheckout,
 		});
 
+		ctx.assertLockOwned?.();
+
 		await insertCustomItems({
 			db: ctx.db,
 			customPrices: customPrices || [],

--- a/server/src/internal/billing/attach/handleAttach.ts
+++ b/server/src/internal/billing/attach/handleAttach.ts
@@ -1,11 +1,15 @@
-import { type AttachResponseV1, AttachResponseV1Schema, Scopes } from "@autumn/shared";
+import {
+	type AttachResponseV1,
+	AttachResponseV1Schema,
+	Scopes,
+} from "@autumn/shared";
+import { buildBillingLockKey } from "@/internal/billing/v2/utils/billingLock/buildBillingLockKey";
 import { AttachBodyV0Schema } from "../../../../../shared/api/billing/attach/prevVersions/attachBodyV0";
 import {
 	AffectedResource,
 	applyResponseVersionChanges,
 } from "../../../../../shared/api/versionUtils/versionUtils";
 import { createRoute } from "../../../honoMiddlewares/routeHandler";
-import { buildBillingLockKey } from "@/internal/billing/v2/utils/billingLock/buildBillingLockKey";
 import { checkStripeConnections } from "../../customers/attach/attachRouter";
 import { getAttachParams } from "../../customers/attach/attachUtils/attachParams/getAttachParams";
 import { getAttachBranch } from "../../customers/attach/attachUtils/getAttachBranch";
@@ -24,6 +28,7 @@ export const handleAttach = createRoute({
 		process.env.NODE_ENV !== "development"
 			? {
 					ttlMs: 60000,
+					failOpen: false,
 					errorMessage:
 						"Attach already in progress for this customer, try again in a few seconds",
 

--- a/server/src/internal/billing/v2/actions/attachLicense/attachLicense.ts
+++ b/server/src/internal/billing/v2/actions/attachLicense/attachLicense.ts
@@ -25,6 +25,7 @@ export const attachLicense = async ({
 
 	// 4. Execute: entity upserts + capacity take + provision inserts +
 	// license lifecycle (converge + cache) all run inside the shared executor
+	ctx.assertLockOwned?.();
 	await executeAutumnBillingPlan({ ctx, autumnBillingPlan: plan.billingPlan });
 
 	// Response shape is undecided; callers only get an acknowledgement.

--- a/server/src/internal/billing/v2/actions/releaseLicense/releaseLicense.ts
+++ b/server/src/internal/billing/v2/actions/releaseLicense/releaseLicense.ts
@@ -24,6 +24,7 @@ export const releaseLicense = async ({
 	logReleaseLicensePlan({ ctx, context });
 
 	// 4. Execute
+	ctx.assertLockOwned?.();
 	await executeAutumnBillingPlan({ ctx, autumnBillingPlan: plan.billingPlan });
 
 	// Response shape is undecided; callers only get an acknowledgement.

--- a/server/src/internal/billing/v2/common/createAutumnCheckout.ts
+++ b/server/src/internal/billing/v2/common/createAutumnCheckout.ts
@@ -45,6 +45,8 @@ export async function createAutumnCheckout<
 	billingPlan: BillingPlan;
 	expiresInMs?: number;
 }): Promise<CreateAutumnCheckoutResult<T>> {
+	ctx.assertLockOwned?.();
+
 	const { checkout } = await billingPlanToAutumnCheckout({
 		ctx,
 		action,

--- a/server/src/internal/billing/v2/execute/executeBillingPlan.ts
+++ b/server/src/internal/billing/v2/execute/executeBillingPlan.ts
@@ -17,12 +17,18 @@ export const executeBillingPlan = async ({
 	billingContext,
 	billingPlan,
 	checkoutLockParamsHash,
+	assertLockOwned,
 }: {
 	ctx: AutumnContext;
 	billingContext: BillingContext;
 	billingPlan: BillingPlan;
 	checkoutLockParamsHash?: string;
+	assertLockOwned?: () => void;
 }): Promise<BillingResult> => {
+	// Setup and plan evaluation are intentionally outside the commit boundary.
+	// Fence the first Stripe/DB mutation against an expired or replaced lease.
+	(assertLockOwned ?? ctx.assertLockOwned)?.();
+
 	const stripeBillingResult: StripeBillingPlanResult =
 		billingContext.skipBillingChanges
 			? {}

--- a/server/src/internal/billing/v2/execute/executeMultiSubscriptionBillingPlan.ts
+++ b/server/src/internal/billing/v2/execute/executeMultiSubscriptionBillingPlan.ts
@@ -43,6 +43,8 @@ export const executeMultiSubscriptionBillingPlan = async ({
 	onStripeResult?: (result: StripeBillingPlanResult) => void;
 	awaitBillingUpdatedWebhook?: boolean;
 }): Promise<StripeBillingPlanResult[]> => {
+	ctx.assertLockOwned?.();
+
 	const stripeResults: StripeBillingPlanResult[] = [];
 	for (const subscriptionPlan of stripeBillingPlans) {
 		const result = await executeStripeBillingPlan({

--- a/server/src/internal/billing/v2/handlers/handleAttachV2.ts
+++ b/server/src/internal/billing/v2/handlers/handleAttachV2.ts
@@ -6,8 +6,8 @@ import {
 	InternalError,
 	Scopes,
 } from "@autumn/shared";
-import { buildBillingLockKey } from "@/internal/billing/v2/utils/billingLock/buildBillingLockKey";
 import { billingActions } from "@/internal/billing/v2/actions";
+import { buildBillingLockKey } from "@/internal/billing/v2/utils/billingLock/buildBillingLockKey";
 import { createRoute } from "../../../../honoMiddlewares/routeHandler";
 import { billingResultToResponse } from "../utils/billingResult/billingResultToResponse";
 
@@ -22,6 +22,7 @@ export const handleAttachV2 = createRoute({
 		process.env.NODE_ENV !== "development"
 			? {
 					ttlMs: 120000,
+					failOpen: false,
 					errorMessage:
 						"Attach already in progress for this customer, try again in a few seconds",
 					getKey: (c) => {

--- a/server/src/internal/billing/v2/handlers/handleCreateSchedule.ts
+++ b/server/src/internal/billing/v2/handlers/handleCreateSchedule.ts
@@ -1,7 +1,7 @@
 import {
-    CreateScheduleParamsV0Schema,
-    type CreateScheduleResponse,
-    Scopes,
+	CreateScheduleParamsV0Schema,
+	type CreateScheduleResponse,
+	Scopes,
 } from "@autumn/shared";
 import { billingActions } from "@/internal/billing/v2/actions";
 import { buildBillingLockKey } from "@/internal/billing/v2/utils/billingLock/buildBillingLockKey";
@@ -16,6 +16,7 @@ export const handleCreateSchedule = createRoute({
 		process.env.NODE_ENV !== "development"
 			? {
 					ttlMs: 120000,
+					failOpen: false,
 					errorMessage:
 						"Create schedule already in progress for this customer, try again in a few seconds",
 					getKey: (c) => {

--- a/server/src/internal/billing/v2/handlers/handleMultiAttach.ts
+++ b/server/src/internal/billing/v2/handlers/handleMultiAttach.ts
@@ -4,8 +4,8 @@ import {
 	MultiAttachParamsV0Schema,
 	Scopes,
 } from "@autumn/shared";
-import { buildBillingLockKey } from "@/internal/billing/v2/utils/billingLock/buildBillingLockKey";
 import { billingActions } from "@/internal/billing/v2/actions";
+import { buildBillingLockKey } from "@/internal/billing/v2/utils/billingLock/buildBillingLockKey";
 import { createRoute } from "../../../../honoMiddlewares/routeHandler";
 import { billingResultToResponse } from "../utils/billingResult/billingResultToResponse";
 
@@ -17,6 +17,7 @@ export const handleMultiAttach = createRoute({
 		process.env.NODE_ENV !== "development"
 			? {
 					ttlMs: 120000,
+					failOpen: false,
 					errorMessage:
 						"Multi-attach already in progress for this customer, try again in a few seconds",
 					getKey: (c) => {

--- a/server/src/internal/billing/v2/handlers/handleMultiUpdate.ts
+++ b/server/src/internal/billing/v2/handlers/handleMultiUpdate.ts
@@ -17,6 +17,7 @@ export const handleMultiUpdate = createRoute({
 		process.env.NODE_ENV !== "development"
 			? {
 					ttlMs: 120000,
+					failOpen: false,
 					errorMessage:
 						"Multi-update already in progress for this customer, try again in a few seconds",
 					getKey: (c) => {

--- a/server/src/internal/billing/v2/handlers/handleUpdateSubscription.ts
+++ b/server/src/internal/billing/v2/handlers/handleUpdateSubscription.ts
@@ -2,12 +2,12 @@ import {
 	AffectedResource,
 	ApiVersion,
 	InternalError,
+	Scopes,
 	UpdateSubscriptionV0ParamsSchema,
 	UpdateSubscriptionV1ParamsSchema,
-	Scopes,
 } from "@autumn/shared";
-import { buildBillingLockKey } from "@/internal/billing/v2/utils/billingLock/buildBillingLockKey";
 import { billingActions } from "@/internal/billing/v2/actions";
+import { buildBillingLockKey } from "@/internal/billing/v2/utils/billingLock/buildBillingLockKey";
 import { createRoute } from "../../../../honoMiddlewares/routeHandler";
 import { billingResultToResponse } from "../utils/billingResult/billingResultToResponse";
 
@@ -22,6 +22,7 @@ export const handleUpdateSubscription = createRoute({
 		process.env.NODE_ENV !== "development"
 			? {
 					ttlMs: 120000,
+					failOpen: false,
 					errorMessage:
 						"Update subscription already in progress for this customer, try again in a few seconds",
 					getKey: (c) => {

--- a/server/src/internal/checkouts/handlers/handleConfirmCheckout.ts
+++ b/server/src/internal/checkouts/handlers/handleConfirmCheckout.ts
@@ -27,6 +27,7 @@ export const handleConfirmCheckout = createRoute({
 		process.env.NODE_ENV !== "development"
 			? {
 					ttlMs: 120000,
+					failOpen: false,
 					errorMessage:
 						"Checkout confirmation already in progress for this customer, try again in a few seconds",
 					getKey: (c) => {

--- a/server/src/internal/checkouts/handlers/handleStartLongLivedCheckout.ts
+++ b/server/src/internal/checkouts/handlers/handleStartLongLivedCheckout.ts
@@ -1,8 +1,8 @@
 import {
-	type AttachParamsV1,
 	AffectedResource,
-	CheckoutAction,
+	type AttachParamsV1,
 	type Checkout,
+	CheckoutAction,
 	ErrCode,
 	InternalError,
 	RecaseError,
@@ -39,7 +39,8 @@ const getActiveStripeCheckoutUrl = async ({
 	try {
 		const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
 		const session = await stripeCli.checkout.sessions.retrieve(sessionId);
-		return session.status === "open" && isFuture(fromUnixTime(session.expires_at))
+		return session.status === "open" &&
+			isFuture(fromUnixTime(session.expires_at))
 			? session.url
 			: null;
 	} catch (error) {
@@ -58,6 +59,7 @@ export const handleStartLongLivedCheckout = createRoute({
 		process.env.NODE_ENV !== "development"
 			? {
 					ttlMs: 120000,
+					failOpen: false,
 					errorMessage:
 						"Checkout start already in progress for this customer, try again in a few seconds",
 					getKey: (c) => {
@@ -77,7 +79,8 @@ export const handleStartLongLivedCheckout = createRoute({
 
 		if (!isLongLivedAttachCheckout(checkout)) {
 			throw new RecaseError({
-				message: "Long-lived checkout start only supports long-lived attach checkouts",
+				message:
+					"Long-lived checkout start only supports long-lived attach checkouts",
 				code: ErrCode.InvalidRequest,
 				statusCode: StatusCodes.BAD_REQUEST,
 			});

--- a/server/src/internal/customers/cancel/handleCancelV2.ts
+++ b/server/src/internal/customers/cancel/handleCancelV2.ts
@@ -19,6 +19,7 @@ export const handleCancelV2 = createRoute({
 		process.env.NODE_ENV !== "development"
 			? {
 					ttlMs: 120000,
+					failOpen: false,
 					errorMessage:
 						"Cancel already in progress for this customer, try again in a few seconds",
 					getKey: (c) => {

--- a/server/src/internal/entities/actions/batchCreateEntities.ts
+++ b/server/src/internal/entities/actions/batchCreateEntities.ts
@@ -27,7 +27,8 @@ const createEntities = async ({
 	customerData,
 	createEntityData,
 	withAutumnId = false,
-}: BatchCreateEntitiesParams) => {
+	assertLockOwned = () => undefined,
+}: BatchCreateEntitiesParams & { assertLockOwned?: () => void }) => {
 	const { db, org, env, features } = ctx;
 
 	// 1. Get data
@@ -42,6 +43,7 @@ const createEntities = async ({
 		customerData,
 		createEntityData,
 	});
+	assertLockOwned();
 
 	for (const cusProduct of cusProducts) {
 		await createEntityForCusProduct({
@@ -132,6 +134,6 @@ export const batchCreateEntities = async (
 		lockKey: `lock:create-entity-request:${org.id}:${env}:${customerId}`,
 		errorMessage:
 			"Entity creation already in progress for this customer, try again in a few seconds",
-		fn: () => createEntities(params),
+		fn: ({ assertLockOwned }) => createEntities({ ...params, assertLockOwned }),
 	});
 };

--- a/server/src/internal/entities/handlers/handleCreateEntity/createEntityForCusProduct.ts
+++ b/server/src/internal/entities/handlers/handleCreateEntity/createEntityForCusProduct.ts
@@ -132,7 +132,7 @@ export const createEntityForCusProduct = async ({
 		if (mainCusEntWithCusProduct) {
 			// Acquire lock to prevent race conditions on seat charging
 			const lockKey = `lock:create-entity:${org.id}:${env}:${customer.id}`;
-			await acquireLock({
+			const lockValue = await acquireLock({
 				lockKey,
 				ttlMs: 10000,
 				errorMessage:
@@ -184,7 +184,7 @@ export const createEntityForCusProduct = async ({
 					amount: inputEntities.length - deletedReplaceables.length,
 				});
 			} finally {
-				await clearLock({ lockKey });
+				await clearLock({ lockKey, lockValue });
 			}
 		}
 

--- a/server/src/internal/licenses/handlers/handleAttachLicense.ts
+++ b/server/src/internal/licenses/handlers/handleAttachLicense.ts
@@ -10,6 +10,7 @@ export const handleAttachLicense = createRoute({
 		process.env.NODE_ENV !== "development"
 			? {
 					ttlMs: 120000,
+					failOpen: false,
 					errorMessage:
 						"License assignment already in progress for this customer, try again in a few seconds",
 					getKey: (c) => {

--- a/server/src/internal/licenses/handlers/handleReleaseLicense.ts
+++ b/server/src/internal/licenses/handlers/handleReleaseLicense.ts
@@ -10,6 +10,7 @@ export const handleReleaseLicense = createRoute({
 		process.env.NODE_ENV !== "development"
 			? {
 					ttlMs: 120000,
+					failOpen: false,
 					errorMessage:
 						"License release already in progress for this customer, try again in a few seconds",
 					getKey: (c) => {

--- a/server/src/internal/migrations/v2/operations/updatePlan/processUpdatePlan.ts
+++ b/server/src/internal/migrations/v2/operations/updatePlan/processUpdatePlan.ts
@@ -60,6 +60,7 @@ export const processUpdatePlan = async ({
 
 	let nextPlan = plan;
 	const billingContexts: UpdateSubscriptionBillingContext[] = [];
+	let matchedCustomerProductCount = matchedCustomerProducts.length;
 
 	for (const customerProduct of matchedCustomerProducts) {
 		const productContext = await setupUpdatePlanProductContext({
@@ -70,7 +71,15 @@ export const processUpdatePlan = async ({
 			projectedFullCustomer,
 			customerProduct,
 		});
-		if (!productContext) continue;
+		if (!productContext) {
+			const alreadyOnRequestedVersion =
+				op.version !== undefined &&
+				op.customize === undefined &&
+				op.version === customerProduct.product.version &&
+				!customerProduct.is_custom;
+			if (alreadyOnRequestedVersion) matchedCustomerProductCount -= 1;
+			continue;
+		}
 
 		appendMigrationBillingLog({
 			ctx,
@@ -119,7 +128,7 @@ export const processUpdatePlan = async ({
 	return {
 		plan: nextPlan,
 		projectedFullCustomer,
-		matchedCustomerProducts: matchedCustomerProducts.length,
+		matchedCustomerProducts: matchedCustomerProductCount,
 		billingContexts,
 	};
 };

--- a/server/src/internal/migrations/v2/operations/updatePlan/processUpdatePlan.ts
+++ b/server/src/internal/migrations/v2/operations/updatePlan/processUpdatePlan.ts
@@ -72,12 +72,7 @@ export const processUpdatePlan = async ({
 			customerProduct,
 		});
 		if (!productContext) {
-			const alreadyOnRequestedVersion =
-				op.version !== undefined &&
-				op.customize === undefined &&
-				op.version === customerProduct.product.version &&
-				!customerProduct.is_custom;
-			if (alreadyOnRequestedVersion) matchedCustomerProductCount -= 1;
+			matchedCustomerProductCount -= 1;
 			continue;
 		}
 

--- a/server/src/internal/migrations/v2/operations/updatePlan/setup/setupUpdatePlanProductContext.ts
+++ b/server/src/internal/migrations/v2/operations/updatePlan/setup/setupUpdatePlanProductContext.ts
@@ -62,10 +62,15 @@ export const setupUpdatePlanProductContext = async ({
 		...preparedOp.customize,
 		...(addItems ? { add_items: addItems } : {}),
 	};
+	const versionToApply =
+		preparedOp.version === customerProduct.product.version &&
+		!customerProduct.is_custom
+			? undefined
+			: preparedOp.version;
 	if (
-		preparedOp.version === undefined &&
+		versionToApply === undefined &&
 		customize.price === undefined &&
-		customize.add_items?.length === 0 &&
+		(customize.add_items === undefined || customize.add_items.length === 0) &&
 		customize.remove_items === undefined &&
 		(customize.update_items === undefined ||
 			customize.update_items.length === 0)
@@ -100,7 +105,7 @@ export const setupUpdatePlanProductContext = async ({
 		entity_id: customerProduct.entity_id ?? undefined,
 		customer_product_id: customerProduct.id,
 		plan_id: customerProduct.product.id,
-		version: preparedOp.version,
+		version: versionToApply,
 		...(preparedOp.customize ? { customize } : {}),
 		...(strategyFeatureQuantities.length > 0
 			? { feature_quantities: strategyFeatureQuantities }
@@ -124,7 +129,7 @@ export const setupUpdatePlanProductContext = async ({
 		fullCustomer: productFullCustomer,
 		params,
 		reusePricesAndEntitlements,
-		resetToCatalogVersion: typeof preparedOp.version === "number",
+		resetToCatalogVersion: typeof versionToApply === "number",
 	});
 
 	const operationBillingContext = await setupMigrationOperationBillingContext({

--- a/server/src/internal/migrations/v2/run/migrateCustomer/migrateCustomer.ts
+++ b/server/src/internal/migrations/v2/run/migrateCustomer/migrateCustomer.ts
@@ -26,6 +26,7 @@ export type MigrateCustomerResult = {
 };
 
 const MIGRATION_CUSTOMER_LOCK_TTL_MS = 10 * 60 * 1000;
+const MIGRATION_CUSTOMER_LOCK_MAX_WAIT_MS = 2 * 60 * 1000;
 
 /** Top-level per-customer migration runner. Preview evaluates without writes. */
 export const migrateCustomer = async ({
@@ -48,7 +49,12 @@ export const migrateCustomer = async ({
 		preview,
 	});
 
-	const migrate = async (): Promise<MigrateCustomerResult> => {
+	const migrate = async ({
+		assertLockOwned = () => undefined,
+	}: {
+		assertLockOwned?: () => void;
+	} = {}): Promise<MigrateCustomerResult> => {
+		assertLockOwned();
 		const context = await setupMigrateCustomerContext({
 			ctx: migrationCtx,
 			migration,
@@ -79,12 +85,14 @@ export const migrateCustomer = async ({
 			});
 
 			if (!preview) {
+				assertLockOwned();
 				await executeMigrateCustomerPlan({
 					ctx: migrationCtx,
 					context,
 					billingPlan,
 					billingContexts,
 				});
+				assertLockOwned();
 			}
 
 			const response = {
@@ -141,6 +149,7 @@ export const migrateCustomer = async ({
 			customerId,
 		}),
 		ttlMs: MIGRATION_CUSTOMER_LOCK_TTL_MS,
+		maxWaitMs: MIGRATION_CUSTOMER_LOCK_MAX_WAIT_MS,
 		errorMessage:
 			"Customer billing migration already in progress, try again in a few seconds",
 		fn: migrate,

--- a/server/src/internal/migrations/v2/run/migrateCustomer/migrateCustomer.ts
+++ b/server/src/internal/migrations/v2/run/migrateCustomer/migrateCustomer.ts
@@ -25,7 +25,7 @@ export type MigrateCustomerResult = {
 	response: Record<string, unknown> | null;
 };
 
-const MIGRATION_CUSTOMER_LOCK_TTL_MS = 10 * 60 * 1000;
+const MIGRATION_CUSTOMER_LOCK_TTL_MS = 60 * 1000;
 const MIGRATION_CUSTOMER_LOCK_MAX_WAIT_MS = 2 * 60 * 1000;
 
 /** Top-level per-customer migration runner. Preview evaluates without writes. */
@@ -61,6 +61,7 @@ export const migrateCustomer = async ({
 			customerId,
 			preview,
 		});
+		assertLockOwned();
 
 		const run = async (): Promise<MigrateCustomerResult> => {
 			const {
@@ -76,6 +77,7 @@ export const migrateCustomer = async ({
 					insertCustomerProducts: [],
 				},
 			});
+			assertLockOwned();
 
 			const billingPlan = await evaluateMigrateCustomerStripe({
 				ctx: migrationCtx,
@@ -83,9 +85,9 @@ export const migrateCustomer = async ({
 				billingContexts,
 				autumnBillingPlan: autumnPlan,
 			});
+			assertLockOwned();
 
 			if (!preview) {
-				assertLockOwned();
 				await executeMigrateCustomerPlan({
 					ctx: migrationCtx,
 					context,

--- a/server/src/internal/migrations/v2/run/migrateCustomer/migrateCustomer.ts
+++ b/server/src/internal/migrations/v2/run/migrateCustomer/migrateCustomer.ts
@@ -1,4 +1,6 @@
+import { withWaitingLock } from "@/external/redis/redisUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { buildBillingLockKey } from "@/internal/billing/v2/utils/billingLock/buildBillingLockKey.js";
 import { buildPreviewMigrateCustomer } from "@/internal/migrations/v2/preview/index.js";
 import type { MigrationHooks } from "../../hooks/index.js";
 import type { MigrationRuntime } from "../../types/migrationDefinition.js";
@@ -23,6 +25,8 @@ export type MigrateCustomerResult = {
 	response: Record<string, unknown> | null;
 };
 
+const MIGRATION_CUSTOMER_LOCK_TTL_MS = 10 * 60 * 1000;
+
 /** Top-level per-customer migration runner. Preview evaluates without writes. */
 export const migrateCustomer = async ({
 	ctx,
@@ -44,84 +48,101 @@ export const migrateCustomer = async ({
 		preview,
 	});
 
-	const context = await setupMigrateCustomerContext({
-		ctx: migrationCtx,
-		migration,
-		customerId,
-		preview,
-	});
-
-	const baseArgs = {
-		ctx: migrationCtx,
-		customerId,
-		context,
-		preview,
-	};
-
-	const run = async (): Promise<MigrateCustomerResult> => {
-		const {
-			plan: autumnPlan,
-			billingContexts,
-			matchedCustomerProducts,
-		} = await processOperations({
+	const migrate = async (): Promise<MigrateCustomerResult> => {
+		const context = await setupMigrateCustomerContext({
 			ctx: migrationCtx,
-			context,
-			plan: {
-				customerId: context.fullCustomer.id ?? context.fullCustomer.internal_id,
-				insertCustomerProducts: [],
-			},
+			migration,
+			customerId,
+			preview,
 		});
 
-		const billingPlan = await evaluateMigrateCustomerStripe({
-			ctx: migrationCtx,
-			context,
-			billingContexts,
-			autumnBillingPlan: autumnPlan,
-		});
-
-		if (!preview) {
-			await executeMigrateCustomerPlan({
+		const run = async (): Promise<MigrateCustomerResult> => {
+			const {
+				plan: autumnPlan,
+				billingContexts,
+				matchedCustomerProducts,
+			} = await processOperations({
 				ctx: migrationCtx,
 				context,
-				billingPlan,
-				billingContexts,
+				plan: {
+					customerId:
+						context.fullCustomer.id ?? context.fullCustomer.internal_id,
+					insertCustomerProducts: [],
+				},
 			});
-		}
 
-		const response = {
-			preview: await buildPreviewMigrateCustomer({
+			const billingPlan = await evaluateMigrateCustomerStripe({
 				ctx: migrationCtx,
-				originalFullCustomer: context.fullCustomer,
-				autumnBillingPlan: billingPlan.autumn,
-			}),
-			// Invoice line items this migration would generate (empty for
-			// charge-free ops) — surfaced so audit tooling can show what will
-			// actually be billed, not just the feature/plan diff.
-			line_items: (billingPlan.autumn.lineItems ?? []).map((item) => ({
-				description: item.description,
-				amount: item.amountAfterDiscounts ?? item.amount,
-			})),
+				context,
+				billingContexts,
+				autumnBillingPlan: autumnPlan,
+			});
+
+			if (!preview) {
+				await executeMigrateCustomerPlan({
+					ctx: migrationCtx,
+					context,
+					billingPlan,
+					billingContexts,
+				});
+			}
+
+			const response = {
+				preview: await buildPreviewMigrateCustomer({
+					ctx: migrationCtx,
+					originalFullCustomer: context.fullCustomer,
+					autumnBillingPlan: billingPlan.autumn,
+				}),
+				// Invoice line items this migration would generate (empty for
+				// charge-free ops) — surfaced so audit tooling can show what will
+				// actually be billed, not just the feature/plan diff.
+				line_items: (billingPlan.autumn.lineItems ?? []).map((item) => ({
+					description: item.description,
+					amount: item.amountAfterDiscounts ?? item.amount,
+				})),
+			};
+
+			logMigrateCustomerResult({
+				ctx: migrationCtx,
+				result: {
+					status: "success",
+				},
+			});
+
+			return {
+				itemPreview: {
+					id: context.fullCustomer.id ?? null,
+					name: context.fullCustomer.name ?? null,
+					email: context.fullCustomer.email ?? null,
+				},
+				status: matchedCustomerProducts === 0 ? "skipped" : "succeeded",
+				response,
+			};
 		};
 
-		logMigrateCustomerResult({
+		const baseArgs = {
 			ctx: migrationCtx,
-			result: {
-				status: "success",
-			},
-		});
-
-		return {
-			itemPreview: {
-				id: context.fullCustomer.id ?? null,
-				name: context.fullCustomer.name ?? null,
-				email: context.fullCustomer.email ?? null,
-			},
-			status: matchedCustomerProducts === 0 ? "skipped" : "succeeded",
-			response,
+			customerId,
+			context,
+			preview,
 		};
+
+		return hooks?.aroundMigrateCustomer
+			? hooks.aroundMigrateCustomer({ ...baseArgs, run })
+			: run();
 	};
 
-	return hooks?.aroundMigrateCustomer
-		? hooks.aroundMigrateCustomer({ ...baseArgs, run })
-		: run();
+	if (preview) return migrate();
+
+	return withWaitingLock({
+		lockKey: buildBillingLockKey({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			customerId,
+		}),
+		ttlMs: MIGRATION_CUSTOMER_LOCK_TTL_MS,
+		errorMessage:
+			"Customer billing migration already in progress, try again in a few seconds",
+		fn: migrate,
+	});
 };

--- a/server/src/internal/migrations/v2/run/migrateCustomer/migrateCustomer.ts
+++ b/server/src/internal/migrations/v2/run/migrateCustomer/migrateCustomer.ts
@@ -94,7 +94,6 @@ export const migrateCustomer = async ({
 					billingPlan,
 					billingContexts,
 				});
-				assertLockOwned();
 			}
 
 			const response = {

--- a/server/src/queue/processMessage.ts
+++ b/server/src/queue/processMessage.ts
@@ -9,6 +9,7 @@ import { isTransientRedisError } from "@/external/redis/utils/isTransientRedisEr
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { runActionHandlerTask } from "@/internal/analytics/runActionHandlerTask.js";
 import { autoTopup } from "@/internal/balances/autoTopUp/autoTopup.js";
+import { isRetryableAutoTopupError } from "@/internal/balances/autoTopUp/isRetryableAutoTopupError.js";
 import { runInsertEventBatch } from "@/internal/balances/events/runInsertEventBatch.js";
 import { expireLock } from "@/internal/balances/finalizeLock/expireLock.js";
 import { runQueuedTrack } from "@/internal/balances/track/runQueuedTrack.js";
@@ -58,6 +59,8 @@ export const shouldRetrySqsJobError = ({
 			return isTransientDbError({ error });
 		case JobName.Track:
 			return isTransientDbError({ error }) || isTransientRedisError({ error });
+		case JobName.AutoTopUp:
+			return isRetryableAutoTopupError({ error });
 		default:
 			return false;
 	}

--- a/server/tests/integration/billing/migrations-v2/controls/idempotency/cross-migration-customer-idempotency.test.ts
+++ b/server/tests/integration/billing/migrations-v2/controls/idempotency/cross-migration-customer-idempotency.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Regression coverage for customer-scoped migration serialization.
+ *
+ * Pre-fix: two migration definitions can load the same customer snapshot and
+ * each replace the same customer product, leaving duplicate active products
+ * and duplicated balances.
+ * Post-fix: live migrations serialize before loading customer state, so the
+ * second definition observes the first definition's completed update.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	CusProductStatus,
+	customerProducts,
+	customers,
+} from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { and, eq } from "drizzle-orm";
+import { prepare } from "@/internal/migrations/v2/prepare/prepare.js";
+import { migrateCustomer } from "@/internal/migrations/v2/run/migrateCustomer/index.js";
+import { preProcessMigration } from "@/internal/migrations/v2/run/preProcess/index.js";
+
+const createDeferred = <T>() => {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	const promise = new Promise<T>((resolver) => {
+		resolve = resolver;
+	});
+
+	return { promise, resolve };
+};
+
+const timeout = (milliseconds: number) =>
+	new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+
+test.concurrent(
+	`${chalk.yellowBright("migrations idempotency: different definitions cannot replace one customer from the same snapshot")}`,
+	async () => {
+		const customerId = "migration-cross-definition-idempotency";
+		const plan = products.base({
+			id: "migration-cross-definition-plan",
+			items: [items.monthlyMessages({ includedUsage: 1_500 })],
+		});
+
+		const { autumnV1, autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [plan] }),
+			],
+			actions: [s.billing.attach({ productId: plan.id })],
+		});
+
+		await autumnV1.products.update(plan.id, {
+			items: [items.monthlyMessages({ includedUsage: 1_800 })],
+		});
+
+		const prepareMigration = async ({
+			migrationId,
+		}: {
+			migrationId: string;
+		}) => {
+			const migration = preProcessMigration(
+				await autumnV2_2.migrationsV2.deleteAndCreate({
+					id: migrationId,
+					filter: { customer: { plan: { plan_id: plan.id } } },
+					operations: {
+						customer: [
+							{
+								type: "update_plan",
+								plan_filter: { plan_id: plan.id },
+								version: 2,
+							},
+						],
+					},
+				}),
+			);
+			const { preparedState } = await prepare({
+				ctx,
+				migration,
+				dryRun: false,
+			});
+
+			return { ...migration, prepared_state: preparedState };
+		};
+
+		const firstMigration = await prepareMigration({
+			migrationId: `${customerId}-first`,
+		});
+		const secondMigration = await prepareMigration({
+			migrationId: `${customerId}-second`,
+		});
+		const firstContextLoaded = createDeferred<void>();
+		const releaseFirstMigration = createDeferred<void>();
+		const secondContextLoaded = createDeferred<void>();
+
+		const firstResult = migrateCustomer({
+			ctx,
+			customerId,
+			migration: firstMigration,
+			hooks: {
+				aroundMigrateCustomer: async ({ run }) => {
+					firstContextLoaded.resolve(undefined);
+					await releaseFirstMigration.promise;
+					return run();
+				},
+			},
+		});
+		await firstContextLoaded.promise;
+
+		const secondResult = migrateCustomer({
+			ctx,
+			customerId,
+			migration: secondMigration,
+			hooks: {
+				aroundMigrateCustomer: ({ run }) => {
+					secondContextLoaded.resolve(undefined);
+					return run();
+				},
+			},
+		});
+
+		try {
+			await Promise.race([secondContextLoaded.promise, timeout(250)]);
+		} finally {
+			releaseFirstMigration.resolve(undefined);
+		}
+		const [firstMigrationResult, secondMigrationResult] = await Promise.all([
+			firstResult,
+			secondResult,
+		]);
+		expect(firstMigrationResult.status).toBe("succeeded");
+		expect(secondMigrationResult.status).toBe("skipped");
+
+		const activeCustomerProducts = await ctx.db
+			.select({ id: customerProducts.id })
+			.from(customerProducts)
+			.innerJoin(
+				customers,
+				eq(customerProducts.internal_customer_id, customers.internal_id),
+			)
+			.where(
+				and(
+					eq(customers.org_id, ctx.org.id),
+					eq(customers.env, ctx.env),
+					eq(customers.id, customerId),
+					eq(customerProducts.product_id, plan.id),
+					eq(customerProducts.status, CusProductStatus.Active),
+				),
+			);
+		expect(activeCustomerProducts).toHaveLength(1);
+
+		const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			granted: 1_800,
+			remaining: 1_800,
+			usage: 0,
+			planId: plan.id,
+		});
+	},
+);

--- a/server/tests/integration/billing/migrations-v2/controls/idempotency/cross-migration-customer-idempotency.test.ts
+++ b/server/tests/integration/billing/migrations-v2/controls/idempotency/cross-migration-customer-idempotency.test.ts
@@ -1,11 +1,11 @@
 /**
  * Regression coverage for customer-scoped migration serialization.
  *
- * Pre-fix: two migration definitions can load the same customer snapshot and
+ * Pre-fix: five migration definitions can load the same customer snapshot and
  * each replace the same customer product, leaving duplicate active products
  * and duplicated balances.
  * Post-fix: live migrations serialize before loading customer state, so the
- * second definition observes the first definition's completed update.
+ * four followers observe the first definition's completed update.
  */
 
 import { expect, test } from "bun:test";
@@ -39,7 +39,7 @@ const timeout = (milliseconds: number) =>
 	new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
 
 test.concurrent(
-	`${chalk.yellowBright("migrations idempotency: different definitions cannot replace one customer from the same snapshot")}`,
+	`${chalk.yellowBright("migrations idempotency: five definitions cannot replace one customer from the same snapshot")}`,
 	async () => {
 		const customerId = "migration-cross-definition-idempotency";
 		const plan = products.base({
@@ -89,15 +89,18 @@ test.concurrent(
 			return { ...migration, prepared_state: preparedState };
 		};
 
-		const firstMigration = await prepareMigration({
-			migrationId: `${customerId}-first`,
-		});
-		const secondMigration = await prepareMigration({
-			migrationId: `${customerId}-second`,
-		});
+		const migrations: Awaited<ReturnType<typeof prepareMigration>>[] = [];
+		for (let index = 0; index < 5; index++) {
+			migrations.push(
+				await prepareMigration({
+					migrationId: `${customerId}-${index + 1}`,
+				}),
+			);
+		}
+		const [firstMigration, ...followerMigrations] = migrations;
 		const firstContextLoaded = createDeferred<void>();
 		const releaseFirstMigration = createDeferred<void>();
-		const secondContextLoaded = createDeferred<void>();
+		let followerContextsLoaded = 0;
 
 		const firstResult = migrateCustomer({
 			ctx,
@@ -113,29 +116,35 @@ test.concurrent(
 		});
 		await firstContextLoaded.promise;
 
-		const secondResult = migrateCustomer({
-			ctx,
-			customerId,
-			migration: secondMigration,
-			hooks: {
-				aroundMigrateCustomer: ({ run }) => {
-					secondContextLoaded.resolve(undefined);
-					return run();
+		const followerResults = followerMigrations.map((migration) =>
+			migrateCustomer({
+				ctx,
+				customerId,
+				migration,
+				hooks: {
+					aroundMigrateCustomer: ({ run }) => {
+						followerContextsLoaded++;
+						return run();
+					},
 				},
-			},
-		});
+			}),
+		);
 
 		try {
-			await Promise.race([secondContextLoaded.promise, timeout(250)]);
+			await timeout(250);
+			expect(followerContextsLoaded).toBe(0);
 		} finally {
 			releaseFirstMigration.resolve(undefined);
 		}
-		const [firstMigrationResult, secondMigrationResult] = await Promise.all([
-			firstResult,
-			secondResult,
-		]);
+		const [firstMigrationResult, ...followerMigrationResults] =
+			await Promise.all([firstResult, ...followerResults]);
 		expect(firstMigrationResult.status).toBe("succeeded");
-		expect(secondMigrationResult.status).toBe("skipped");
+		expect(followerMigrationResults.map((result) => result.status)).toEqual([
+			"skipped",
+			"skipped",
+			"skipped",
+			"skipped",
+		]);
 
 		const activeCustomerProducts = await ctx.db
 			.select({ id: customerProducts.id })

--- a/server/tests/integration/billing/migrations-v2/controls/idempotency/cross-migration-customer-idempotency.test.ts
+++ b/server/tests/integration/billing/migrations-v2/controls/idempotency/cross-migration-customer-idempotency.test.ts
@@ -11,17 +11,22 @@
 import { expect, test } from "bun:test";
 import {
 	type ApiCustomerV5,
+	ApiVersion,
 	CusProductStatus,
 	customerProducts,
 	customers,
 } from "@autumn/shared";
 import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { expectFlagCorrect } from "@tests/integration/utils/expectFlagCorrect.js";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
 import { products } from "@tests/utils/fixtures/products.js";
-import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import { createProducts } from "@tests/utils/productUtils.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
 import chalk from "chalk";
 import { and, eq } from "drizzle-orm";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
 import { prepare } from "@/internal/migrations/v2/prepare/prepare.js";
 import { migrateCustomer } from "@/internal/migrations/v2/run/migrateCustomer/index.js";
 import { preProcessMigration } from "@/internal/migrations/v2/run/preProcess/index.js";
@@ -47,14 +52,41 @@ test.concurrent(
 			items: [items.monthlyMessages({ includedUsage: 1_500 })],
 		});
 
-		const { autumnV1, autumnV2_2, ctx } = await initScenario({
-			customerId,
-			setup: [
-				s.customer({ paymentMethod: "success" }),
-				s.products({ list: [plan] }),
-			],
-			actions: [s.billing.attach({ productId: plan.id })],
+		const autumnV1 = new AutumnInt({
+			version: ApiVersion.V1_2,
+			secretKey: ctx.orgSecretKey,
 		});
+		const autumnV2_2 = new AutumnInt({
+			version: ApiVersion.V2_2,
+			secretKey: ctx.orgSecretKey,
+		});
+
+		try {
+			await autumnV1.customers.delete(customerId);
+		} catch {}
+		await createProducts({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			env: ctx.env,
+			autumn: autumnV1,
+			products: [plan],
+			createInStripe: false,
+		});
+		await autumnV1.customers.create({
+			id: customerId,
+			name: customerId,
+			email: `${customerId}@example.com`,
+			skipWebhooks: true,
+			internalOptions: { disable_defaults: true },
+		});
+		await autumnV1.billing.attach(
+			{
+				customer_id: customerId,
+				product_id: plan.id,
+				no_billing_changes: true,
+			},
+			{ timeout: 0, skipWebhooks: true },
+		);
 
 		await autumnV1.products.update(plan.id, {
 			items: [items.monthlyMessages({ includedUsage: 1_800 })],
@@ -75,6 +107,7 @@ test.concurrent(
 								type: "update_plan",
 								plan_filter: { plan_id: plan.id },
 								version: 2,
+								customize: { add_items: [itemsV2.dashboard()] },
 							},
 						],
 					},
@@ -129,15 +162,17 @@ test.concurrent(
 				},
 			}),
 		);
+		const migrationResults = [firstResult, ...followerResults];
 
 		try {
 			await timeout(250);
 			expect(followerContextsLoaded).toBe(0);
 		} finally {
 			releaseFirstMigration.resolve(undefined);
+			await Promise.allSettled(migrationResults);
 		}
 		const [firstMigrationResult, ...followerMigrationResults] =
-			await Promise.all([firstResult, ...followerResults]);
+			await Promise.all(migrationResults);
 		expect(firstMigrationResult.status).toBe("succeeded");
 		expect(followerMigrationResults.map((result) => result.status)).toEqual([
 			"skipped",
@@ -168,9 +203,15 @@ test.concurrent(
 		expectBalanceCorrect({
 			customer,
 			featureId: TestFeature.Messages,
-			granted: 1_800,
-			remaining: 1_800,
+			granted: 1_500,
+			remaining: 1_500,
 			usage: 0,
+			planId: plan.id,
+		});
+		expectFlagCorrect({
+			customer,
+			featureId: TestFeature.Dashboard,
+			present: true,
 			planId: plan.id,
 		});
 	},

--- a/server/tests/integration/billing/migrations-v2/controls/idempotency/migration-idempotency.test.ts
+++ b/server/tests/integration/billing/migrations-v2/controls/idempotency/migration-idempotency.test.ts
@@ -181,7 +181,7 @@ test(`${chalk.yellowBright("migrations idempotency: run API does not replay a su
 		ctx,
 		migration: otherMigration,
 		internalCustomerId,
-		status: MigrationItemRunStatus.Succeeded,
+		status: MigrationItemRunStatus.Skipped,
 	});
 });
 

--- a/server/tests/integration/others/redis/redis-lock-ownership.test.ts
+++ b/server/tests/integration/others/redis/redis-lock-ownership.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { ErrCode } from "@autumn/shared";
 import { redis, waitForRedisReady } from "@/external/redis/initRedis.js";
@@ -20,140 +20,146 @@ const createDeferred = () => {
 const timeout = (milliseconds: number) =>
 	new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
 
-test("a stale lock owner cannot release a replacement lock", async () => {
-	await waitForRedisReady(redis, "primary");
+const describeRedis = process.env.TESTS_ORG ? describe : describe.skip;
 
-	const lockKey = `test:redis-lock-ownership:${randomUUID()}`;
-	try {
-		const staleLockValue = await acquireLock({
-			lockKey,
-			ttlMs: 5_000,
-			failOpen: false,
-		});
-		expect(staleLockValue).not.toBeNull();
+describeRedis("Redis lock ownership", () => {
+	test("a stale lock owner cannot release a replacement lock", async () => {
+		await waitForRedisReady(redis, "primary");
 
-		// Simulate the first owner's TTL expiring before its finally block runs.
-		await redis.del(lockKey);
-		const replacementLockValue = await acquireLock({
-			lockKey,
-			ttlMs: 5_000,
-			failOpen: false,
-		});
-		expect(replacementLockValue).not.toBeNull();
-
-		expect(await clearLock({ lockKey, lockValue: staleLockValue })).toBeFalse();
-		expect(await redis.get(lockKey)).toBe(replacementLockValue);
-		expect(
-			await clearLock({ lockKey, lockValue: replacementLockValue }),
-		).toBeTrue();
-		expect(await redis.get(lockKey)).toBeNull();
-	} finally {
-		await redis.del(lockKey);
-	}
-});
-
-test("a waiting lock renews ownership while its callback is still running", async () => {
-	await waitForRedisReady(redis, "primary");
-
-	const lockKey = `test:redis-lock-renewal:${randomUUID()}`;
-	const firstEntered = createDeferred();
-	const releaseFirst = createDeferred();
-	let firstIsRunning = false;
-	let callbacksOverlapped = false;
-
-	const firstOptions = {
-		lockKey,
-		ttlMs: 100,
-		maxWaitMs: 1_000,
-		fn: async () => {
-			firstIsRunning = true;
-			firstEntered.resolve();
-			await releaseFirst.promise;
-			firstIsRunning = false;
-		},
-	};
-	const first = withWaitingLock(firstOptions);
-	await firstEntered.promise;
-
-	const secondOptions = {
-		lockKey,
-		ttlMs: 100,
-		maxWaitMs: 1_000,
-		fn: async () => {
-			callbacksOverlapped = firstIsRunning;
-		},
-	};
-	const second = withWaitingLock(secondOptions);
-
-	try {
-		// The second callback must still be waiting after the original 100ms
-		// lease would have expired without renewal.
-		await timeout(250);
-		expect(callbacksOverlapped).toBeFalse();
-	} finally {
-		releaseFirst.resolve();
-		await Promise.allSettled([first, second]);
-		await redis.del(lockKey);
-	}
-});
-
-test("a waiting lock fails after its acquisition deadline", async () => {
-	await waitForRedisReady(redis, "primary");
-
-	const lockKey = `test:redis-lock-wait-timeout:${randomUUID()}`;
-	const lockValue = await acquireLock({
-		lockKey,
-		ttlMs: 500,
-		failOpen: false,
-	});
-	const startedAt = Date.now();
-	const waitingOptions = {
-		lockKey,
-		ttlMs: 500,
-		maxWaitMs: 75,
-		fn: async () => undefined,
-	};
-
-	try {
-		await expect(withWaitingLock(waitingOptions)).rejects.toMatchObject({
-			code: ErrCode.LockAlreadyExists,
-		});
-		expect(Date.now() - startedAt).toBeLessThan(400);
-	} finally {
-		await clearLock({ lockKey, lockValue });
-		await redis.del(lockKey);
-	}
-});
-
-test("a waiting lock stops at a safe point after losing ownership", async () => {
-	await waitForRedisReady(redis, "primary");
-
-	const lockKey = `test:redis-lock-renewal-loss:${randomUUID()}`;
-	let replacementLockValue: string | null = null;
-
-	try {
-		await expect(
-			withWaitingLock({
+		const lockKey = `test:redis-lock-ownership:${randomUUID()}`;
+		try {
+			const staleLockValue = await acquireLock({
 				lockKey,
-				ttlMs: 300,
-				maxWaitMs: 1_000,
-				fn: async ({ assertLockOwned }) => {
-					// Replace the lease with another owner. The next renewal must
-					// detect that this callback no longer owns the critical section.
-					await redis.del(lockKey);
-					replacementLockValue = await acquireLock({
-						lockKey,
-						ttlMs: 5_000,
-						failOpen: false,
-					});
-					await timeout(150);
-					assertLockOwned();
-				},
-			}),
-		).rejects.toMatchObject({ code: ErrCode.LockAlreadyExists });
-		expect(await redis.get(lockKey)).toBe(replacementLockValue);
-	} finally {
-		await clearLock({ lockKey, lockValue: replacementLockValue });
-		await redis.del(lockKey);
-	}
+				ttlMs: 5_000,
+				failOpen: false,
+			});
+			expect(staleLockValue).not.toBeNull();
+
+			// Simulate the first owner's TTL expiring before its finally block runs.
+			await redis.del(lockKey);
+			const replacementLockValue = await acquireLock({
+				lockKey,
+				ttlMs: 5_000,
+				failOpen: false,
+			});
+			expect(replacementLockValue).not.toBeNull();
+
+			expect(
+				await clearLock({ lockKey, lockValue: staleLockValue }),
+			).toBeFalse();
+			expect(await redis.get(lockKey)).toBe(replacementLockValue);
+			expect(
+				await clearLock({ lockKey, lockValue: replacementLockValue }),
+			).toBeTrue();
+			expect(await redis.get(lockKey)).toBeNull();
+		} finally {
+			await redis.del(lockKey);
+		}
+	});
+
+	test("a waiting lock renews ownership while its callback is still running", async () => {
+		await waitForRedisReady(redis, "primary");
+
+		const lockKey = `test:redis-lock-renewal:${randomUUID()}`;
+		const firstEntered = createDeferred();
+		const releaseFirst = createDeferred();
+		let firstIsRunning = false;
+		let callbacksOverlapped = false;
+
+		const firstOptions = {
+			lockKey,
+			ttlMs: 1_000,
+			maxWaitMs: 3_000,
+			fn: async () => {
+				firstIsRunning = true;
+				firstEntered.resolve();
+				await releaseFirst.promise;
+				firstIsRunning = false;
+			},
+		};
+		const first = withWaitingLock(firstOptions);
+		await firstEntered.promise;
+
+		const secondOptions = {
+			lockKey,
+			ttlMs: 1_000,
+			maxWaitMs: 3_000,
+			fn: async () => {
+				callbacksOverlapped = firstIsRunning;
+			},
+		};
+		const second = withWaitingLock(secondOptions);
+
+		try {
+			// The second callback must still be waiting after the original 1s
+			// lease would have expired without renewal.
+			await timeout(1_500);
+			expect(callbacksOverlapped).toBeFalse();
+		} finally {
+			releaseFirst.resolve();
+			await Promise.allSettled([first, second]);
+			await redis.del(lockKey);
+		}
+	});
+
+	test("a waiting lock fails after its acquisition deadline", async () => {
+		await waitForRedisReady(redis, "primary");
+
+		const lockKey = `test:redis-lock-wait-timeout:${randomUUID()}`;
+		const lockValue = await acquireLock({
+			lockKey,
+			ttlMs: 500,
+			failOpen: false,
+		});
+		const startedAt = Date.now();
+		const waitingOptions = {
+			lockKey,
+			ttlMs: 500,
+			maxWaitMs: 75,
+			fn: async () => undefined,
+		};
+
+		try {
+			await expect(withWaitingLock(waitingOptions)).rejects.toMatchObject({
+				code: ErrCode.LockAlreadyExists,
+			});
+			expect(Date.now() - startedAt).toBeLessThan(400);
+		} finally {
+			await clearLock({ lockKey, lockValue });
+			await redis.del(lockKey);
+		}
+	});
+
+	test("a waiting lock stops at a safe point after losing ownership", async () => {
+		await waitForRedisReady(redis, "primary");
+
+		const lockKey = `test:redis-lock-renewal-loss:${randomUUID()}`;
+		let replacementLockValue: string | null = null;
+
+		try {
+			await expect(
+				withWaitingLock({
+					lockKey,
+					ttlMs: 300,
+					maxWaitMs: 1_000,
+					fn: async ({ assertLockOwned }) => {
+						// Replace the lease with another owner. The next renewal must
+						// detect that this callback no longer owns the critical section.
+						await redis.del(lockKey);
+						replacementLockValue = await acquireLock({
+							lockKey,
+							ttlMs: 5_000,
+							failOpen: false,
+						});
+						await timeout(150);
+						assertLockOwned();
+					},
+				}),
+			).rejects.toMatchObject({ code: ErrCode.LockAlreadyExists });
+			expect(await redis.get(lockKey)).toBe(replacementLockValue);
+		} finally {
+			await clearLock({ lockKey, lockValue: replacementLockValue });
+			await redis.del(lockKey);
+		}
+	});
 });

--- a/server/tests/integration/others/redis/redis-lock-ownership.test.ts
+++ b/server/tests/integration/others/redis/redis-lock-ownership.test.ts
@@ -1,7 +1,24 @@
 import { expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
+import { ErrCode } from "@autumn/shared";
 import { redis, waitForRedisReady } from "@/external/redis/initRedis.js";
-import { acquireLock, clearLock } from "@/external/redis/redisUtils.js";
+import {
+	acquireLock,
+	clearLock,
+	withWaitingLock,
+} from "@/external/redis/redisUtils.js";
+
+const createDeferred = () => {
+	let resolve!: () => void;
+	const promise = new Promise<void>((resolver) => {
+		resolve = resolver;
+	});
+
+	return { promise, resolve };
+};
+
+const timeout = (milliseconds: number) =>
+	new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
 
 test("a stale lock owner cannot release a replacement lock", async () => {
 	await waitForRedisReady(redis, "primary");
@@ -31,6 +48,112 @@ test("a stale lock owner cannot release a replacement lock", async () => {
 		).toBeTrue();
 		expect(await redis.get(lockKey)).toBeNull();
 	} finally {
+		await redis.del(lockKey);
+	}
+});
+
+test("a waiting lock renews ownership while its callback is still running", async () => {
+	await waitForRedisReady(redis, "primary");
+
+	const lockKey = `test:redis-lock-renewal:${randomUUID()}`;
+	const firstEntered = createDeferred();
+	const releaseFirst = createDeferred();
+	let firstIsRunning = false;
+	let callbacksOverlapped = false;
+
+	const firstOptions = {
+		lockKey,
+		ttlMs: 100,
+		maxWaitMs: 1_000,
+		fn: async () => {
+			firstIsRunning = true;
+			firstEntered.resolve();
+			await releaseFirst.promise;
+			firstIsRunning = false;
+		},
+	};
+	const first = withWaitingLock(firstOptions);
+	await firstEntered.promise;
+
+	const secondOptions = {
+		lockKey,
+		ttlMs: 100,
+		maxWaitMs: 1_000,
+		fn: async () => {
+			callbacksOverlapped = firstIsRunning;
+		},
+	};
+	const second = withWaitingLock(secondOptions);
+
+	try {
+		// The second callback must still be waiting after the original 100ms
+		// lease would have expired without renewal.
+		await timeout(250);
+		expect(callbacksOverlapped).toBeFalse();
+	} finally {
+		releaseFirst.resolve();
+		await Promise.allSettled([first, second]);
+		await redis.del(lockKey);
+	}
+});
+
+test("a waiting lock fails after its acquisition deadline", async () => {
+	await waitForRedisReady(redis, "primary");
+
+	const lockKey = `test:redis-lock-wait-timeout:${randomUUID()}`;
+	const lockValue = await acquireLock({
+		lockKey,
+		ttlMs: 500,
+		failOpen: false,
+	});
+	const startedAt = Date.now();
+	const waitingOptions = {
+		lockKey,
+		ttlMs: 500,
+		maxWaitMs: 75,
+		fn: async () => undefined,
+	};
+
+	try {
+		await expect(withWaitingLock(waitingOptions)).rejects.toMatchObject({
+			code: ErrCode.LockAlreadyExists,
+		});
+		expect(Date.now() - startedAt).toBeLessThan(400);
+	} finally {
+		await clearLock({ lockKey, lockValue });
+		await redis.del(lockKey);
+	}
+});
+
+test("a waiting lock stops at a safe point after losing ownership", async () => {
+	await waitForRedisReady(redis, "primary");
+
+	const lockKey = `test:redis-lock-renewal-loss:${randomUUID()}`;
+	let replacementLockValue: string | null = null;
+
+	try {
+		await expect(
+			withWaitingLock({
+				lockKey,
+				ttlMs: 300,
+				maxWaitMs: 1_000,
+				fn: async ({ assertLockOwned }) => {
+					// Replace the lease with another owner. The next renewal must
+					// detect that this callback no longer owns the critical section.
+					await redis.del(lockKey);
+					replacementLockValue = await acquireLock({
+						lockKey,
+						ttlMs: 5_000,
+						failOpen: false,
+					});
+					await timeout(150);
+					assertLockOwned();
+				},
+			}),
+		).rejects.toMatchObject({ code: ErrCode.LockAlreadyExists });
+		expect(await redis.get(lockKey)).toBe(replacementLockValue);
+	} finally {
+		await clearLock({ lockKey, lockValue: replacementLockValue });
 		await redis.del(lockKey);
 	}
 });

--- a/server/tests/integration/others/redis/redis-lock-ownership.test.ts
+++ b/server/tests/integration/others/redis/redis-lock-ownership.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { redis, waitForRedisReady } from "@/external/redis/initRedis.js";
+import { acquireLock, clearLock } from "@/external/redis/redisUtils.js";
+
+test("a stale lock owner cannot release a replacement lock", async () => {
+	await waitForRedisReady(redis, "primary");
+
+	const lockKey = `test:redis-lock-ownership:${randomUUID()}`;
+	try {
+		const staleLockValue = await acquireLock({
+			lockKey,
+			ttlMs: 5_000,
+			failOpen: false,
+		});
+		expect(staleLockValue).not.toBeNull();
+
+		// Simulate the first owner's TTL expiring before its finally block runs.
+		await redis.del(lockKey);
+		const replacementLockValue = await acquireLock({
+			lockKey,
+			ttlMs: 5_000,
+			failOpen: false,
+		});
+		expect(replacementLockValue).not.toBeNull();
+
+		expect(await clearLock({ lockKey, lockValue: staleLockValue })).toBeFalse();
+		expect(await redis.get(lockKey)).toBe(replacementLockValue);
+		expect(
+			await clearLock({ lockKey, lockValue: replacementLockValue }),
+		).toBeTrue();
+		expect(await redis.get(lockKey)).toBeNull();
+	} finally {
+		await redis.del(lockKey);
+	}
+});

--- a/server/tests/unit/billing/execute-billing-plan-lock-ownership.test.ts
+++ b/server/tests/unit/billing/execute-billing-plan-lock-ownership.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import type { BillingContext, BillingPlan } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { executeBillingPlan } from "@/internal/billing/v2/execute/executeBillingPlan.js";
+
+describe("executeBillingPlan lock ownership", () => {
+	test("checks route lock ownership before entering the billing commit sequence", async () => {
+		const ownershipError = new Error("lock ownership lost");
+		let ownershipChecks = 0;
+		const ctx = {
+			assertLockOwned: () => {
+				ownershipChecks++;
+				throw ownershipError;
+			},
+		} as unknown as AutumnContext;
+
+		await expect(
+			executeBillingPlan({
+				ctx,
+				billingContext: {} as BillingContext,
+				billingPlan: {} as BillingPlan,
+			}),
+		).rejects.toBe(ownershipError);
+		expect(ownershipChecks).toBe(1);
+	});
+
+	test("uses an explicit worker ownership check before context state", async () => {
+		const ownershipError = new Error("worker lock ownership lost");
+		let contextOwnershipChecks = 0;
+		let workerOwnershipChecks = 0;
+		const ctx = {
+			assertLockOwned: () => {
+				contextOwnershipChecks++;
+			},
+		} as unknown as AutumnContext;
+
+		await expect(
+			executeBillingPlan({
+				ctx,
+				billingContext: {} as BillingContext,
+				billingPlan: {} as BillingPlan,
+				assertLockOwned: () => {
+					workerOwnershipChecks++;
+					throw ownershipError;
+				},
+			}),
+		).rejects.toBe(ownershipError);
+		expect(workerOwnershipChecks).toBe(1);
+		expect(contextOwnershipChecks).toBe(0);
+	});
+});

--- a/server/tests/unit/queue/processMessage.test.ts
+++ b/server/tests/unit/queue/processMessage.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { ErrCode, RecaseError } from "@autumn/shared";
 import { RedisUnavailableError } from "@/external/redis/utils/errors.js";
 import { JobName } from "@/queue/JobName.js";
 import { shouldRetrySqsJobError } from "@/queue/processMessage.js";
@@ -23,5 +24,30 @@ describe("shouldRetrySqsJobError", () => {
 				error: new Error("insufficient balance"),
 			}),
 		).toBe(false);
+	});
+
+	test("retries auto top-up jobs after billing-lock contention", () => {
+		expect(
+			shouldRetrySqsJobError({
+				jobName: JobName.AutoTopUp,
+				error: new RecaseError({
+					message: "Another billing operation is in progress",
+					code: ErrCode.LockAlreadyExists,
+					statusCode: 423,
+				}),
+			}),
+		).toBe(true);
+	});
+
+	test("retries auto top-up jobs after transient Redis failures", () => {
+		expect(
+			shouldRetrySqsJobError({
+				jobName: JobName.AutoTopUp,
+				error: new RedisUnavailableError({
+					source: "autoTopup",
+					reason: "timeout",
+				}),
+			}),
+		).toBe(true);
 	});
 });

--- a/server/tests/unit/redis/redis-lock-lifecycle.test.ts
+++ b/server/tests/unit/redis/redis-lock-lifecycle.test.ts
@@ -253,6 +253,58 @@ describe("Redis lock lifecycle", () => {
 		expect(redisClient.value).toBeNull();
 	});
 
+	test("bounds a stalled acquisition by the waiting deadline and cleans up a late lease", async () => {
+		const redisClient = new FakeRedisLockClient();
+		redisClient.setImplementation = async (lockValue) => {
+			await timeout(200);
+			redisClient.value = lockValue;
+			return "OK";
+		};
+		let callbackRan = false;
+		const startedAtMs = Date.now();
+
+		await expect(
+			withWaitingLock({
+				lockKey: "lock:stalled-acquisition",
+				ttlMs: 1_000,
+				maxWaitMs: 25,
+				redisInstance: asRedis(redisClient),
+				fn: async () => {
+					callbackRan = true;
+				},
+			}),
+		).rejects.toMatchObject({ code: ErrCode.LockAlreadyExists });
+
+		expect(Date.now() - startedAtMs).toBeLessThan(125);
+		expect(callbackRan).toBeFalse();
+
+		await timeout(250);
+		expect(redisClient.value).toBeNull();
+	});
+
+	test("does not report ownership loss after the callback has committed", async () => {
+		const redisClient = new FakeRedisLockClient();
+		let committed = false;
+
+		await expect(
+			withLock({
+				lockKey: "lock:post-commit-ownership-loss",
+				ttlMs: 90,
+				redisInstance: asRedis(redisClient),
+				fn: async () => {
+					redisClient.value = "replacement-owner";
+					await timeout(50);
+					expect(redisClient.renewalCalls).toBeGreaterThan(0);
+					committed = true;
+					return "committed";
+				},
+			}),
+		).resolves.toBe("committed");
+
+		expect(committed).toBeTrue();
+		expect(redisClient.value).toBe("replacement-owner");
+	});
+
 	test("renews ordinary route-style locks while their callback is running", async () => {
 		const redisClient = new FakeRedisLockClient();
 

--- a/server/tests/unit/redis/redis-lock-lifecycle.test.ts
+++ b/server/tests/unit/redis/redis-lock-lifecycle.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, test } from "bun:test";
+import { ErrCode, RecaseError } from "@autumn/shared";
+import type { Redis } from "ioredis";
+import {
+	acquireLock,
+	clearLock,
+	withLock,
+	withWaitingLock,
+} from "@/external/redis/redisUtils.js";
+import { RedisUnavailableError } from "@/external/redis/utils/errors.js";
+
+const timeout = (milliseconds: number) =>
+	new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+
+class FakeRedisLockClient {
+	status: "ready" | "end" = "ready";
+	value: string | null = null;
+	getCalls = 0;
+	releaseCalls = 0;
+	renewalCalls = 0;
+	setCalls = 0;
+	releaseFailuresRemaining = 0;
+	renewalFailuresRemaining = 0;
+	setImplementation?: (lockValue: string) => Promise<"OK" | null>;
+
+	async set(_lockKey: string, lockValue: string) {
+		this.setCalls++;
+		if (this.setImplementation) return this.setImplementation(lockValue);
+		if (this.value !== null) return null;
+		this.value = lockValue;
+		return "OK" as const;
+	}
+
+	async get() {
+		this.getCalls++;
+		return this.value;
+	}
+
+	async eval(
+		script: string,
+		_keyCount: number,
+		_lockKey: string,
+		lockValue: string,
+	) {
+		if (script.includes("PEXPIRE")) {
+			this.renewalCalls++;
+			if (this.renewalFailuresRemaining > 0) {
+				this.renewalFailuresRemaining--;
+				throw new Error("Command timed out");
+			}
+			return this.value === lockValue ? 1 : 0;
+		}
+
+		this.releaseCalls++;
+		if (this.releaseFailuresRemaining > 0) {
+			this.releaseFailuresRemaining--;
+			throw new Error("Command timed out");
+		}
+		if (this.value !== lockValue) return 0;
+		this.value = null;
+		return 1;
+	}
+}
+
+const asRedis = (redisClient: FakeRedisLockClient) =>
+	redisClient as unknown as Redis;
+
+describe("Redis lock lifecycle", () => {
+	test("runs without touching Redis when Redis is intentionally unconfigured", async () => {
+		const redisClient = new FakeRedisLockClient();
+		redisClient.status = "end";
+
+		await expect(
+			withWaitingLock({
+				lockKey: "lock:no-redis",
+				ttlMs: 100,
+				maxWaitMs: 25,
+				redisConfigured: false,
+				redisInstance: asRedis(redisClient),
+				fn: async () => "completed",
+			}),
+		).resolves.toBe("completed");
+		expect(redisClient.setCalls).toBe(0);
+	});
+
+	test("fails closed when configured Redis is unavailable", async () => {
+		const redisClient = new FakeRedisLockClient();
+		redisClient.status = "end";
+
+		await expect(
+			withLock({
+				lockKey: "lock:configured-unavailable",
+				ttlMs: 100,
+				failOpen: false,
+				redisConfigured: true,
+				redisInstance: asRedis(redisClient),
+				fn: async () => "must-not-run",
+			}),
+		).rejects.toBeInstanceOf(RedisUnavailableError);
+		expect(redisClient.setCalls).toBe(0);
+	});
+
+	test("retries a transient acquisition failure within the waiting budget", async () => {
+		const redisClient = new FakeRedisLockClient();
+		let acquisitionAttempts = 0;
+		redisClient.setImplementation = async (lockValue) => {
+			acquisitionAttempts++;
+			if (acquisitionAttempts === 1) throw new Error("Command timed out");
+			redisClient.value = lockValue;
+			return "OK";
+		};
+
+		await expect(
+			withWaitingLock({
+				lockKey: "lock:acquisition-retry",
+				ttlMs: 1_000,
+				maxWaitMs: 1_500,
+				redisInstance: asRedis(redisClient),
+				fn: async () => "completed",
+			}),
+		).resolves.toBe("completed");
+		expect(acquisitionAttempts).toBe(2);
+	});
+
+	test("retries a transient renewal error while the known lease is still valid", async () => {
+		const redisClient = new FakeRedisLockClient();
+		redisClient.renewalFailuresRemaining = 1;
+
+		await expect(
+			withWaitingLock({
+				lockKey: "lock:renewal-retry",
+				ttlMs: 300,
+				maxWaitMs: 100,
+				redisInstance: asRedis(redisClient),
+				fn: async ({ assertLockOwned }) => {
+					await timeout(450);
+					assertLockOwned();
+					return "completed";
+				},
+			}),
+		).resolves.toBe("completed");
+		expect(redisClient.renewalCalls).toBeGreaterThanOrEqual(2);
+	});
+
+	test("retries an owner-safe release after a transient Redis error", async () => {
+		const redisClient = new FakeRedisLockClient();
+		redisClient.value = "owner-value";
+		redisClient.releaseFailuresRemaining = 1;
+
+		await expect(
+			clearLock({
+				lockKey: "lock:release-retry",
+				lockValue: "owner-value",
+				redisInstance: asRedis(redisClient),
+			}),
+		).resolves.toBeTrue();
+		expect(redisClient.releaseCalls).toBe(2);
+		expect(redisClient.value).toBeNull();
+	});
+
+	test("retries release while the Redis client reconnects", async () => {
+		const redisClient = new FakeRedisLockClient();
+		redisClient.status = "end";
+		redisClient.value = "owner-value";
+		setTimeout(() => {
+			redisClient.status = "ready";
+		}, 50);
+
+		await expect(
+			clearLock({
+				lockKey: "lock:release-reconnect",
+				lockValue: "owner-value",
+				redisInstance: asRedis(redisClient),
+			}),
+		).resolves.toBeTrue();
+		expect(redisClient.value).toBeNull();
+	});
+
+	test("cleans up an ambiguous acquisition when SET lands but its reply is lost", async () => {
+		const redisClient = new FakeRedisLockClient();
+		redisClient.setImplementation = async (lockValue) => {
+			redisClient.value = lockValue;
+			throw new Error("Command timed out");
+		};
+
+		await expect(
+			acquireLock({
+				lockKey: "lock:ambiguous-acquire",
+				ttlMs: 1_000,
+				failOpen: false,
+				redisInstance: asRedis(redisClient),
+			}),
+		).rejects.toThrow();
+		expect(redisClient.value).toBeNull();
+		expect(redisClient.releaseCalls).toBeGreaterThan(0);
+	});
+
+	test("reports contention even when the existing lock value is malformed", async () => {
+		const redisClient = new FakeRedisLockClient();
+		redisClient.value = "not-json";
+
+		const error = await acquireLock({
+			lockKey: "lock:malformed-value",
+			ttlMs: 1_000,
+			failOpen: false,
+			redisInstance: asRedis(redisClient),
+		}).catch((caughtError: unknown) => caughtError);
+
+		expect(error).toBeInstanceOf(RecaseError);
+		expect(error).toMatchObject({ code: ErrCode.LockAlreadyExists });
+	});
+
+	test("does not GET the existing lock on each waiting acquisition attempt", async () => {
+		const redisClient = new FakeRedisLockClient();
+		redisClient.value = JSON.stringify({
+			errorMessage: "already running",
+			ownerToken: "another-owner",
+		});
+
+		await expect(
+			withWaitingLock({
+				lockKey: "lock:wait-without-get",
+				ttlMs: 1_000,
+				maxWaitMs: 25,
+				redisInstance: asRedis(redisClient),
+				fn: async () => undefined,
+			}),
+		).rejects.toMatchObject({ code: ErrCode.LockAlreadyExists });
+		expect(redisClient.getCalls).toBe(0);
+	});
+
+	test("releases a lease acquired after the waiting deadline without running work", async () => {
+		const redisClient = new FakeRedisLockClient();
+		redisClient.setImplementation = async (lockValue) => {
+			await timeout(30);
+			redisClient.value = lockValue;
+			return "OK";
+		};
+		let callbackRan = false;
+
+		await expect(
+			withWaitingLock({
+				lockKey: "lock:late-acquisition",
+				ttlMs: 1_000,
+				maxWaitMs: 5,
+				redisInstance: asRedis(redisClient),
+				fn: async () => {
+					callbackRan = true;
+				},
+			}),
+		).rejects.toMatchObject({ code: ErrCode.LockAlreadyExists });
+		expect(callbackRan).toBeFalse();
+		expect(redisClient.value).toBeNull();
+	});
+
+	test("renews ordinary route-style locks while their callback is running", async () => {
+		const redisClient = new FakeRedisLockClient();
+
+		await withLock({
+			lockKey: "lock:route-renewal",
+			ttlMs: 90,
+			redisInstance: asRedis(redisClient),
+			fn: async () => timeout(180),
+		});
+
+		expect(redisClient.renewalCalls).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
## Summary

Serializes live customer migrations across migration definitions so concurrent workers cannot replace the same customer plan from a stale snapshot.

## Root cause

Migration progress and task serialization were scoped to the migration ID. Different migrations could therefore process the same customer concurrently. Expiring the old customer product was idempotent, but every worker inserted a replacement, producing duplicate active plans and duplicated balances.

## Changes

- Acquire the shared customer billing lock before loading migration state; previews remain lock-free.
- Make Redis locks owner-safe with atomic compare-and-delete release.
- Renew active fail-closed leases with owner-checked `PEXPIRE`.
- Bound lock acquisition with a two-minute wall-clock deadline.
- Revalidate update-plan operations so an already-applied standard plan version is skipped.
- Preserve existing custom-plan reset and customization reporting behavior.
- Add regressions for cross-migration idempotency, stale lock owners, lease renewal, acquisition timeout, and ownership loss.

## Testing

- Five-way concurrent migration regression: 1 passed, 0 failed, 9 assertions.
- Focused migration/entity/Redis run: 7 passed, 0 failed, 63 assertions.
- Final Redis lock regression file: 4 passed, 0 failed, 11 assertions.
- Server typecheck passed.
- Scoped Biome and `git diff --check` passed.
- GitHub server unit tests, typecheck, Knip, and security checks passed.