### PR TITLE
fix(licenses): truncate license card name instead of overflowing plan card

### DIFF
--- a/vite/src/views/products/plan/components/plan-licenses/LicensePlanCardHeader.tsx
+++ b/vite/src/views/products/plan/components/plan-licenses/LicensePlanCardHeader.tsx
@@ -80,7 +80,7 @@ export function LicensePlanCardHeader({
 	if (removed) {
 		return (
 			<CardHeader className="px-3">
-				<div className="flex items-center justify-between w-full gap-2">
+				<div className="flex items-center justify-between w-full gap-2 min-w-0">
 					<div className="flex items-center gap-2 text-xs min-w-0">
 						<span className="font-medium truncate line-through text-tertiary-foreground">
 							{license.name ?? license.id}
@@ -104,7 +104,7 @@ export function LicensePlanCardHeader({
 
 	return (
 		<CardHeader className="px-3">
-			<div className="flex items-center justify-between w-full gap-2">
+			<div className="flex items-center justify-between w-full gap-2 min-w-0">
 				<div className="flex items-center gap-2 text-xs min-w-0">
 					<Tooltip>
 						<TooltipTrigger


### PR DESCRIPTION
## Problem

Long license names on a plan's license card overflow past the price badge and the card edge instead of truncating.

## Cause

The license name span already has `truncate` and its flex parent has `min-w-0`, but the header row div is a grid item (`CardHeader` renders `display: grid`). Grid items default to `min-width: auto`, so the row sized itself to the full name and the shrink chain never reached the `truncate` span.

## Fix

Add `min-w-0` to the header row div in both the normal and removed-on-save states of `LicensePlanCardHeader`. The price badge and actions menu keep `shrink-0` so they stay fully visible.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes long license names overflowing the plan license card by enabling proper truncation in the header row. Keeps the price badge and actions visible.

- **Bug Fixes**
  - Added `min-w-0` to the header row `div` in both normal and removed states of `LicensePlanCardHeader`.
  - Kept `shrink-0` on the price badge and actions to prevent clipping.

<sup>Written for commit 294d2fc5b3bd7350364057e09485ca0d36021a2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes long license names overflowing out of plan cards by adding `min-w-0` to the header row `div` in `LicensePlanCardHeader`. Because `CardHeader` renders as a CSS grid, its direct children default to `min-width: auto`, which blocked the `truncate` class from ever shrinking the name span.

- **Bug fixes** — `min-w-0` added to the outer row `div` in both the `removed` state and the normal state, completing the shrink chain (`grid item → flex container → truncate span`) so long names are truncated instead of overflowing. Price badge and actions menu keep `shrink-0` and remain fully visible.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted CSS fix with no logic or data changes.

Two identical one-line additions of `min-w-0` to flex containers that are grid items. The fix correctly resolves the full shrink chain (grid item → flex → truncate span) in both the active and removed-on-save states of the card header. `shrink-0` on the price badge and actions menu is already in place, so those elements are unaffected. No business logic, state management, or data flow is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/components/plan-licenses/LicensePlanCardHeader.tsx | Adds `min-w-0` to the outer flex row div in both the removed and normal states so that text truncation propagates correctly through the CSS grid-item → flex → truncate chain. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["CardHeader (display: grid)"]
    A --> B["outer div (flex, justify-between)\nnow: min-w-0 ✅"]
    B --> C["left div (flex, min-w-0)"]
    B --> D["right section (shrink-0)"]
    C --> E["Included qty badge / strikethrough prefix (shrink-0)"]
    C --> F["license name span (truncate)\n✂ truncates correctly now"]
    D --> G["BasePriceDisplay"]
    D --> H["Actions DropdownMenu"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["CardHeader (display: grid)"]
    A --> B["outer div (flex, justify-between)\nnow: min-w-0 ✅"]
    B --> C["left div (flex, min-w-0)"]
    B --> D["right section (shrink-0)"]
    C --> E["Included qty badge / strikethrough prefix (shrink-0)"]
    C --> F["license name span (truncate)\n✂ truncates correctly now"]
    D --> G["BasePriceDisplay"]
    D --> H["Actions DropdownMenu"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(licenses): 🐛 truncate license card ..."](https://github.com/useautumn/autumn/commit/294d2fc5b3bd7350364057e09485ca0d36021a2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44856854)</sub>

<!-- /greptile_comment -->