### PR TITLE
Only pay down overage on one-off prepaid addons when persist_free_overage is true

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/compute/computeOneOffPurchaseRebalance.ts
+++ b/server/src/internal/billing/v2/actions/attach/compute/computeOneOffPurchaseRebalance.ts
@@ -23,7 +23,7 @@ export const computeOneOffPurchaseRebalance = ({
 	ctx: AutumnContext;
 	newCustomerProduct: FullCusProduct;
 }): OneOffPurchaseRebalance | undefined => {
-	if (orgPersistFreeOverage({ org: ctx.org })) return undefined;
+	if (!orgPersistFreeOverage({ org: ctx.org })) return undefined;
 	if (!isCustomerProductAddOn(newCustomerProduct)) return undefined;
 	if (!isCustomerProductOneOff(newCustomerProduct)) return undefined;
 	if (!customerProductHasActiveStatus(newCustomerProduct)) return undefined;

--- a/server/tests/integration/billing/attach/new-plan/one-off-addon-overage-paydown.test.ts
+++ b/server/tests/integration/billing/attach/new-plan/one-off-addon-overage-paydown.test.ts
@@ -1,5 +1,5 @@
-// Red: a direct one-off add-on leaves recurring overage untouched and grants the full purchased balance.
-// Green: the purchase clears that overage first and grants only the remainder on the add-on.
+// With persist_free_overage: true, a one-off add-on purchase clears recurring overage
+// first and grants only the remainder. Without it, overage stays on the recurring balance.
 
 import { expect, test } from "bun:test";
 import type {
@@ -72,6 +72,11 @@ test.concurrent(
 		const { customerId, autumnV1, autumnV2_2, ctx } = await initScenario({
 			customerId: "one-off-overage-paydown",
 			setup: [
+				s.platform.create({
+					userEmail: `one-off-overage-paydown-${Math.random().toString(36).slice(2)}@autumn.test`,
+					configOverrides: { persist_free_overage: true },
+					setupDefaultFeatures: true,
+				}),
 				s.customer({ paymentMethod: "success" }),
 				s.products({ list: [recurringPlan, oneOffAddOn] }),
 			],
@@ -184,6 +189,11 @@ test.concurrent(
 		const { customerId, autumnV2_2, ctx } = await initScenario({
 			customerId: "one-off-included-and-prepaid-paydown",
 			setup: [
+				s.platform.create({
+					userEmail: `one-off-included-prepaid-${Math.random().toString(36).slice(2)}@autumn.test`,
+					configOverrides: { persist_free_overage: true },
+					setupDefaultFeatures: true,
+				}),
 				s.customer({ paymentMethod: "success" }),
 				s.products({ list: [recurringPlan, oneOffAddOn] }),
 			],
@@ -240,17 +250,12 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("one-off add-on overage paydown: persisted overage remains separate")}`,
+	`${chalk.yellowBright("one-off add-on overage paydown: without persist_free_overage, overage remains separate")}`,
 	async () => {
 		const { recurringPlan, oneOffAddOn } = buildScenarioProducts();
 		const { customerId, autumnV2_2, ctx } = await initScenario({
-			customerId: "one-off-persisted-overage",
+			customerId: "one-off-no-persist-overage",
 			setup: [
-				s.platform.create({
-					userEmail: `one-off-overage-${Math.random().toString(36).slice(2)}@autumn.test`,
-					configOverrides: { persist_free_overage: true },
-					setupDefaultFeatures: true,
-				}),
 				s.customer({ paymentMethod: "success" }),
 				s.products({ list: [recurringPlan, oneOffAddOn] }),
 			],
@@ -312,6 +317,11 @@ test.concurrent(
 		const { customerId, autumnV2_2, ctx } = await initScenario({
 			customerId: "one-off-overage-immediate-checkout",
 			setup: [
+				s.platform.create({
+					userEmail: `one-off-immediate-${Math.random().toString(36).slice(2)}@autumn.test`,
+					configOverrides: { persist_free_overage: true },
+					setupDefaultFeatures: true,
+				}),
 				s.customer({ paymentMethod: "success" }),
 				s.products({ list: [recurringPlan, oneOffAddOn] }),
 			],
@@ -371,6 +381,11 @@ test.concurrent(
 		const { customerId, autumnV2_2, ctx } = await initScenario({
 			customerId: "one-off-overage-deferred-checkout",
 			setup: [
+				s.platform.create({
+					userEmail: `one-off-deferred-${Math.random().toString(36).slice(2)}@autumn.test`,
+					configOverrides: { persist_free_overage: true },
+					setupDefaultFeatures: true,
+				}),
 				s.customer({ paymentMethod: "success" }),
 				s.products({ list: [recurringPlan, oneOffAddOn] }),
 			],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

One-off prepaid add-on overage paydown previously ran only when `persist_free_overage` was **false**. That gate is flipped so paydown runs only when the org config is **true**.

### Changes
- `computeOneOffPurchaseRebalance`: return early when `!orgPersistFreeOverage(...)` instead of when it is enabled
- Integration tests updated so paydown cases opt into `persist_free_overage: true`, and the no-paydown case covers the default (`false`) path

## Test plan
- [ ] Run `one-off-addon-overage-paydown.test.ts`
- [ ] Confirm paydown applies for orgs with `persist_free_overage: true`
- [ ] Confirm purchase leaves recurring overage untouched when `persist_free_overage` is false

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1784226613118259?thread_ts=1784226613.118259&cid=C0BCAQQK0KS)

<div><a href="https://cursor.com/agents/bc-bc6ae99b-4ed2-5136-abba-4c8e4604142e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc6ae99b-4ed2-5136-abba-4c8e4604142e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flips the gate so one-off prepaid add-on purchases pay down recurring overage only when `persist_free_overage` is true. By default (`false`), purchases no longer touch recurring overage.

- **Bug Fixes**
  - Flip the check in `computeOneOffPurchaseRebalance` to return early when `persist_free_overage` is not enabled.
  - Update integration tests: paydown cases now set `persist_free_overage: true`; add a default (`false`) case to assert no paydown.

<sup>Written for commit 1bb11dd035e760a1b2a55aca7a01f51c85488af3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR flips the condition in `computeOneOffPurchaseRebalance` so that one-off prepaid add-on overage paydown now runs only when `persist_free_overage` is **true** (previously it ran only when the flag was **false**). Integration tests are updated to match: paydown scenarios opt into `persist_free_overage: true`, and the "no-paydown" test now covers the default (`false`) path without a platform override.

- **Bug fixes**: Invert the `orgPersistFreeOverage` guard in `computeOneOffPurchaseRebalance` so overage paydown is gated on `persist_free_overage: true`, not its absence.
- **Improvements**: Update four integration tests to create isolated platforms with `persist_free_overage: true`; rename and restructure the separation-assertion test to exercise the default `false` path.
</details>


<h3>Confidence Score: 4/5</h3>

The core logic change is a single, deliberate boolean inversion that correctly aligns the paydown gate with the intended flag semantics. The main concern is in the test suite, not production code.

The production change is minimal and well-understood — one negation operator — and the four updated tests each create an isolated platform with an explicit persist_free_overage: true override. The no-paydown test, however, omits a platform setup entirely, leaving it dependent on whatever default the environment provides; if that default ever flips to true, the test would pass for the wrong reason.

The no-paydown test case in one-off-addon-overage-paydown.test.ts (around line 252) would benefit from an explicit persist_free_overage: false platform override to match the hermetic pattern used by every other test in the file.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/attach/compute/computeOneOffPurchaseRebalance.ts | Single-character logical inversion of the orgPersistFreeOverage guard — correct and intentional; no other logic changed. |
| server/tests/integration/billing/attach/new-plan/one-off-addon-overage-paydown.test.ts | Four tests gain isolated persist_free_overage: true platform setups; the no-paydown test drops its platform override to rely on the default false — but uses no s.platform.create() at all, which may share a default platform context with concurrent tests. |


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[computeOneOffPurchaseRebalance called] --> B{orgPersistFreeOverage?}
    B -- false --> C[return undefined\nno paydown]
    B -- true --> D{isCustomerProductAddOn?}
    D -- false --> C
    D -- true --> E{isCustomerProductOneOff?}
    E -- false --> C
    E -- true --> F{customerProductHasActiveStatus?}
    F -- false --> C
    F -- true --> G[Collect one-off prepaid entitlements with balance > 0]
    G --> H{Any purchases?}
    H -- no --> C
    H -- yes --> I[Return OneOffPurchaseRebalance with paydown entries]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[computeOneOffPurchaseRebalance called] --> B{orgPersistFreeOverage?}
    B -- false --> C[return undefined\nno paydown]
    B -- true --> D{isCustomerProductAddOn?}
    D -- false --> C
    D -- true --> E{isCustomerProductOneOff?}
    E -- false --> C
    E -- true --> F{customerProductHasActiveStatus?}
    F -- false --> C
    F -- true --> G[Collect one-off prepaid entitlements with balance > 0]
    G --> H{Any purchases?}
    H -- no --> C
    H -- yes --> I[Return OneOffPurchaseRebalance with paydown entries]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/tests/integration/billing/attach/new-plan/one-off-addon-overage-paydown.test.ts`, line 252-270 ([link](https://github.com/useautumn/autumn/blob/1bb11dd035e760a1b2a55aca7a01f51c85488af3/server/tests/integration/billing/attach/new-plan/one-off-addon-overage-paydown.test.ts#L252-L270)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **No-paydown test relies on implicit/shared platform context**

   This test omits `s.platform.create()` entirely, so it attaches to whatever default platform `initScenario` resolves for the `"one-off-no-persist-overage"` customer. If the default platform has `persist_free_overage` set to `true` (e.g. from a previous test run that left state, or from a shared dev-environment platform), the assertion that overage remains untouched will fail silently in the wrong direction — paydown would fire but the test would compare stale values. The other four tests in this file each spin up an isolated platform with an explicit config override; adding a matching `s.platform.create({ configOverrides: { persist_free_overage: false } })` here would make the invariant explicit and keep this test hermetic.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/tests/integration/billing/attach/new-plan/one-off-addon-overage-paydown.test.ts
   Line: 252-270

   Comment:
   **No-paydown test relies on implicit/shared platform context**

   This test omits `s.platform.create()` entirely, so it attaches to whatever default platform `initScenario` resolves for the `"one-off-no-persist-overage"` customer. If the default platform has `persist_free_overage` set to `true` (e.g. from a previous test run that left state, or from a shared dev-environment platform), the assertion that overage remains untouched will fail silently in the wrong direction — paydown would fire but the test would compare stale values. The other four tests in this file each spin up an isolated platform with an explicit config override; adding a matching `s.platform.create({ configOverrides: { persist_free_overage: false } })` here would make the invariant explicit and keep this test hermetic.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/tests/integration/billing/attach/new-plan/one-off-addon-overage-paydown.test.ts:252-270
**No-paydown test relies on implicit/shared platform context**

This test omits `s.platform.create()` entirely, so it attaches to whatever default platform `initScenario` resolves for the `"one-off-no-persist-overage"` customer. If the default platform has `persist_free_overage` set to `true` (e.g. from a previous test run that left state, or from a shared dev-environment platform), the assertion that overage remains untouched will fail silently in the wrong direction — paydown would fire but the test would compare stale values. The other four tests in this file each spin up an isolated platform with an explicit config override; adding a matching `s.platform.create({ configOverrides: { persist_free_overage: false } })` here would make the invariant explicit and keep this test hermetic.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: only pay down overage on one-off pr..."](https://github.com/useautumn/autumn/commit/1bb11dd035e760a1b2a55aca7a01f51c85488af3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44881260)</sub>

<!-- /greptile_comment -->