### PR TITLE
fix(licenses): 🐛 truncate license card name instead of overflowing pl…

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/compute/computeOneOffPurchaseRebalance.ts
+++ b/server/src/internal/billing/v2/actions/attach/compute/computeOneOffPurchaseRebalance.ts
@@ -23,7 +23,7 @@ export const computeOneOffPurchaseRebalance = ({
 	ctx: AutumnContext;
 	newCustomerProduct: FullCusProduct;
 }): OneOffPurchaseRebalance | undefined => {
-	if (orgPersistFreeOverage({ org: ctx.org })) return undefined;
+	if (!orgPersistFreeOverage({ org: ctx.org })) return undefined;
 	if (!isCustomerProductAddOn(newCustomerProduct)) return undefined;
 	if (!isCustomerProductOneOff(newCustomerProduct)) return undefined;
 	if (!customerProductHasActiveStatus(newCustomerProduct)) return undefined;

--- a/server/tests/integration/billing/attach/new-plan/one-off-addon-overage-paydown.test.ts
+++ b/server/tests/integration/billing/attach/new-plan/one-off-addon-overage-paydown.test.ts
@@ -1,5 +1,5 @@
-// Red: a direct one-off add-on leaves recurring overage untouched and grants the full purchased balance.
-// Green: the purchase clears that overage first and grants only the remainder on the add-on.
+// With persist_free_overage: true, a one-off add-on purchase clears recurring overage
+// first and grants only the remainder. Without it, overage stays on the recurring balance.
 
 import { expect, test } from "bun:test";
 import type {
@@ -72,6 +72,11 @@ test.concurrent(
 		const { customerId, autumnV1, autumnV2_2, ctx } = await initScenario({
 			customerId: "one-off-overage-paydown",
 			setup: [
+				s.platform.create({
+					userEmail: `one-off-overage-paydown-${Math.random().toString(36).slice(2)}@autumn.test`,
+					configOverrides: { persist_free_overage: true },
+					setupDefaultFeatures: true,
+				}),
 				s.customer({ paymentMethod: "success" }),
 				s.products({ list: [recurringPlan, oneOffAddOn] }),
 			],
@@ -184,6 +189,11 @@ test.concurrent(
 		const { customerId, autumnV2_2, ctx } = await initScenario({
 			customerId: "one-off-included-and-prepaid-paydown",
 			setup: [
+				s.platform.create({
+					userEmail: `one-off-included-prepaid-${Math.random().toString(36).slice(2)}@autumn.test`,
+					configOverrides: { persist_free_overage: true },
+					setupDefaultFeatures: true,
+				}),
 				s.customer({ paymentMethod: "success" }),
 				s.products({ list: [recurringPlan, oneOffAddOn] }),
 			],
@@ -240,17 +250,12 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("one-off add-on overage paydown: persisted overage remains separate")}`,
+	`${chalk.yellowBright("one-off add-on overage paydown: without persist_free_overage, overage remains separate")}`,
 	async () => {
 		const { recurringPlan, oneOffAddOn } = buildScenarioProducts();
 		const { customerId, autumnV2_2, ctx } = await initScenario({
-			customerId: "one-off-persisted-overage",
+			customerId: "one-off-no-persist-overage",
 			setup: [
-				s.platform.create({
-					userEmail: `one-off-overage-${Math.random().toString(36).slice(2)}@autumn.test`,
-					configOverrides: { persist_free_overage: true },
-					setupDefaultFeatures: true,
-				}),
 				s.customer({ paymentMethod: "success" }),
 				s.products({ list: [recurringPlan, oneOffAddOn] }),
 			],
@@ -312,6 +317,11 @@ test.concurrent(
 		const { customerId, autumnV2_2, ctx } = await initScenario({
 			customerId: "one-off-overage-immediate-checkout",
 			setup: [
+				s.platform.create({
+					userEmail: `one-off-immediate-${Math.random().toString(36).slice(2)}@autumn.test`,
+					configOverrides: { persist_free_overage: true },
+					setupDefaultFeatures: true,
+				}),
 				s.customer({ paymentMethod: "success" }),
 				s.products({ list: [recurringPlan, oneOffAddOn] }),
 			],
@@ -371,6 +381,11 @@ test.concurrent(
 		const { customerId, autumnV2_2, ctx } = await initScenario({
 			customerId: "one-off-overage-deferred-checkout",
 			setup: [
+				s.platform.create({
+					userEmail: `one-off-deferred-${Math.random().toString(36).slice(2)}@autumn.test`,
+					configOverrides: { persist_free_overage: true },
+					setupDefaultFeatures: true,
+				}),
 				s.customer({ paymentMethod: "success" }),
 				s.products({ list: [recurringPlan, oneOffAddOn] }),
 			],

--- a/vite/src/views/products/plan/components/plan-licenses/LicensePlanCardHeader.tsx
+++ b/vite/src/views/products/plan/components/plan-licenses/LicensePlanCardHeader.tsx
@@ -80,7 +80,7 @@ export function LicensePlanCardHeader({
 	if (removed) {
 		return (
 			<CardHeader className="px-3">
-				<div className="flex items-center justify-between w-full gap-2">
+				<div className="flex items-center justify-between w-full gap-2 min-w-0">
 					<div className="flex items-center gap-2 text-xs min-w-0">
 						<span className="font-medium truncate line-through text-tertiary-foreground">
 							{license.name ?? license.id}
@@ -104,7 +104,7 @@ export function LicensePlanCardHeader({
 
 	return (
 		<CardHeader className="px-3">
-			<div className="flex items-center justify-between w-full gap-2">
+			<div className="flex items-center justify-between w-full gap-2 min-w-0">
 				<div className="flex items-center gap-2 text-xs min-w-0">
 					<Tooltip>
 						<TooltipTrigger


### PR DESCRIPTION
…an card

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overflowing license names by truncating them in the plan card, and updates billing so one‑off prepaid add‑ons pay down recurring overage only when `persist_free_overage` is enabled.

- **Bug Fixes**
  - UI: Truncate license name in `LicensePlanCardHeader` by adding `min-w-0` so long names ellipsize in both normal and removed states.
  - Billing: In `computeOneOffPurchaseRebalance`, only clear recurring overage when `persist_free_overage` is true; otherwise leave overage on the recurring balance.

<sup>Written for commit aa7e0dd54d6317f352fdd8bed095b1e698a47813. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two independent bugs: a UI truncation issue in license plan card headers where long names would overflow, and a billing logic inversion in `computeOneOffPurchaseRebalance` where the `persist_free_overage` guard was negated.

- **Bug fix** (`LicensePlanCardHeader.tsx`): Adds `min-w-0` to the outer flex container in both the normal and "removed" states, allowing the inner `truncate` class on the name `<span>` to actually take effect and ellipsize long license names.
- **Bug fix** (`computeOneOffPurchaseRebalance.ts`): Corrects an inverted condition — previously the function returned early (no rebalance) when `persist_free_overage` was `true`, and performed rebalance when it was `false`; now the logic is correct.
- **Improvements** (test file): Updates integration tests to match the corrected billing semantics, adding `persist_free_overage: true` platform config to tests that expect overage paydown and removing it from the test that expects overage to remain separate.
</details>

<h3>Confidence Score: 5/5</h3>

Both changes are minimal, targeted bug fixes with clear intent and matching test coverage.

The billing fix is a single ! negation correction with integration tests that explicitly exercise both the persist_free_overage: true and persist_free_overage: false paths. The UI fix adds a standard Tailwind utility class to unblock an already-present truncate class. No new logic paths, no data model changes, and the test updates precisely mirror the corrected behavior.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/attach/compute/computeOneOffPurchaseRebalance.ts | Single-line bug fix: inverted `!` on `orgPersistFreeOverage` guard — now correctly skips rebalance when persist_free_overage is false. |
| server/tests/integration/billing/attach/new-plan/one-off-addon-overage-paydown.test.ts | Test updates align scenarios with corrected billing logic: adds `persist_free_overage: true` platform config to four paydown tests and removes it from the "no persist" test. |
| vite/src/views/products/plan/components/plan-licenses/LicensePlanCardHeader.tsx | UI fix: adds `min-w-0` to outer flex containers in both card states so the inner `truncate` span can ellipsize long license names correctly. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[computeOneOffPurchaseRebalance called] --> B{orgPersistFreeOverage?}
    B -- false --> C[return undefined\nno rebalance]
    B -- true --> D{isCustomerProductAddOn?}
    D -- false --> C
    D -- true --> E{isCustomerProductOneOff?}
    E -- false --> C
    E -- true --> F{customerProductHasActiveStatus?}
    F -- false --> C
    F -- true --> G[Collect one-off prepaid entitlements\nwith positive balance]
    G --> H{Any purchases\nfound?}
    H -- no --> C
    H -- yes --> I[Return OneOffPurchaseRebalance\nwith purchases list]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[computeOneOffPurchaseRebalance called] --> B{orgPersistFreeOverage?}
    B -- false --> C[return undefined\nno rebalance]
    B -- true --> D{isCustomerProductAddOn?}
    D -- false --> C
    D -- true --> E{isCustomerProductOneOff?}
    E -- false --> C
    E -- true --> F{customerProductHasActiveStatus?}
    F -- false --> C
    F -- true --> G[Collect one-off prepaid entitlements\nwith positive balance]
    G --> H{Any purchases\nfound?}
    H -- no --> C
    H -- yes --> I[Return OneOffPurchaseRebalance\nwith purchases list]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #2274 from useautumn/..."](https://github.com/useautumn/autumn/commit/aa7e0dd54d6317f352fdd8bed095b1e698a47813) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44881505)</sub>

<!-- /greptile_comment -->