### PR TITLE
Fix false plan save errors in dashboard

### DIFF
--- a/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
+++ b/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
@@ -28,7 +28,9 @@ import { ItemChangeList } from "@/components/v2/ItemChangeList";
 import { LAYOUT_TRANSITION } from "@/components/v2/sheets/SharedSheetComponents";
 import { useOrg } from "@/hooks/common/useOrg";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
+import { useLicenseProductsQuery } from "@/hooks/queries/useLicenseProductsQuery";
 import { useMigrationsQuery } from "@/hooks/queries/useMigrationsQuery";
+import { usePlanLicensesQuery } from "@/hooks/queries/usePlanLicensesQuery";
 import { usePlanUpdatePreview } from "@/hooks/queries/usePlanUpdatePreview";
 import { usePlanVariants } from "@/hooks/queries/usePlanVariants";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
@@ -156,6 +158,9 @@ export default function PlanChangeDialog({
 	} = useProductQuery();
 	const { setQueryStates } = useProductQueryState();
 	const { invalidate: invalidateProducts } = useProductsQuery();
+	const { invalidate: invalidateLicenseProducts } = useLicenseProductsQuery();
+	const { planLicenses, invalidate: invalidatePlanLicenses } =
+		usePlanLicensesQuery(product.id);
 	const { invalidate: invalidateMigrations } = useMigrationsQuery();
 	const { org } = useOrg();
 
@@ -398,7 +403,17 @@ export default function PlanChangeDialog({
 			);
 			// The save bar early-returns into this dialog, so dirty licenses are
 			// persisted here too (failures toast their own error).
-			const licensesSaved = await saveAllLicenses();
+			const licensesSaved = await saveAllLicenses({
+				axiosInstance,
+				parentPlanId: product.id,
+				persistedLinks: planLicenses,
+				onSuccess: () =>
+					Promise.all([
+						invalidatePlanLicenses(),
+						invalidateLicenseProducts(),
+						invalidateProducts(),
+					]),
+			});
 			if (!licensesSaved) {
 				toast.error("Some license changes failed to save");
 				return;


### PR DESCRIPTION
## Summary

- pass the required license-save context from `PlanChangeDialog`
- invalidate plan-license and license-product caches after saving
- prevent a successful `plans.update` response from falling into the false error toast

## Root cause

`saveAllLicenses` was changed to require an options object, but the versioning dialog still called it without arguments. After the plan API returned 200, destructuring the missing argument threw and the dialog caught it as “Failed to save plan.”

## Verification

- `bun run ts`
- `bun test tests/views/products/plan/versioning` (8 passed)
- `bunx eslint src/views/products/plan/versioning/PlanChangeDialog.tsx`
- live dashboard save verified successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false “Failed to save plan” errors by passing the required license-save context from PlanChangeDialog and refreshing related caches after a successful save. Successful plan updates no longer trigger an error toast.

- **Bug Fixes**
  - Call `saveAllLicenses` with `axiosInstance`, `parentPlanId`, and `persistedLinks` from plan licenses.
  - On success, invalidate plan-license, license-product, and product queries to keep the UI in sync.

<sup>Written for commit 01d2d4617882f84ded4e4cce23652d5150dd4de7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a false "Failed to save plan" error that appeared in the dashboard after a successful plan save. The root cause was that `saveAllLicenses` was refactored to require an options object, but `PlanChangeDialog` still called it with no arguments, causing a destructuring error that was silently caught and surfaced as a spurious error toast.

- **Bug fixes**: Pass the required `{ axiosInstance, parentPlanId, persistedLinks, onSuccess }` argument to `saveAllLicenses` so the call no longer throws on destructuring.
- **Improvements**: Add `usePlanLicensesQuery` and `useLicenseProductsQuery` hooks to the dialog so the `persistedLinks` snapshot is available and the `plan_licenses` / `license_products` caches are properly invalidated after a successful license save.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is a targeted call-site fix — it only affects the argument passed to `saveAllLicenses`, making no structural changes to the save flow or the surrounding error handling.

The diff is small and well-scoped: the two new hooks add a data dependency (`planLicenses`) that was already needed, and the `onSuccess` invalidations are additive. The only observable redundancy is that `invalidateProducts` is called inside `onSuccess` and again at line 429, which is harmless. No missing guards, no new error paths, and the original bug (destructuring `undefined`) is fully addressed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/versioning/PlanChangeDialog.tsx | Passes the required options to `saveAllLicenses` (fixing the destructuring crash), wires in `usePlanLicensesQuery` for `persistedLinks`, and invalidates plan-license and license-product caches on success. No logic regressions found. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant D as PlanChangeDialog
    participant PS as ProductService.updatePlan
    participant SAL as saveAllLicenses
    participant API as /v1/plans.update (licenses)
    participant QC as QueryClient

    D->>PS: updatePlan(axiosInstance, params)
    PS-->>D: result (200 OK)

    D->>SAL: "saveAllLicenses({ axiosInstance, parentPlanId, persistedLinks, onSuccess })"
    Note over SAL: Check registry for dirty entries
    alt no dirty license entries
        SAL-->>D: true (early return — no cache invalidation)
    else dirty entries exist
        SAL->>API: "POST /v1/plans.update { plan_id, licenses }"
        API-->>SAL: 200 OK
        SAL->>SAL: commit() each entry
        SAL->>QC: onSuccess → invalidatePlanLicenses(), invalidateLicenseProducts(), invalidateProducts()
        SAL-->>D: true
    end

    D->>QC: invalidateProduct(), invalidateProducts()
    D->>D: markSaved(), toast.success, closeDialog()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant D as PlanChangeDialog
    participant PS as ProductService.updatePlan
    participant SAL as saveAllLicenses
    participant API as /v1/plans.update (licenses)
    participant QC as QueryClient

    D->>PS: updatePlan(axiosInstance, params)
    PS-->>D: result (200 OK)

    D->>SAL: "saveAllLicenses({ axiosInstance, parentPlanId, persistedLinks, onSuccess })"
    Note over SAL: Check registry for dirty entries
    alt no dirty license entries
        SAL-->>D: true (early return — no cache invalidation)
    else dirty entries exist
        SAL->>API: "POST /v1/plans.update { plan_id, licenses }"
        API-->>SAL: 200 OK
        SAL->>SAL: commit() each entry
        SAL->>QC: onSuccess → invalidatePlanLicenses(), invalidateLicenseProducts(), invalidateProducts()
        SAL-->>D: true
    end

    D->>QC: invalidateProduct(), invalidateProducts()
    D->>D: markSaved(), toast.success, closeDialog()
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): 🐛 pass license context ..."](https://github.com/useautumn/autumn/commit/01d2d4617882f84ded4e4cce23652d5150dd4de7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44901250)</sub>

<!-- /greptile_comment -->