### PR TITLE
fix(licenses): scope custom stripe prices to parent products

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
@@ -24,6 +24,10 @@ import { orgDisableStripeWrites } from "@/internal/orgs/orgUtils/convertOrgUtils
 import { checkStripeProductExists } from "@/internal/products/productUtils";
 import { applyStripeResourceReuseForProduct } from "@/internal/products/stripeResourceUtils/applyStripeResourceReuseForProduct";
 import { applyStripeReuseFromVariantFamilies } from "@/internal/products/stripeResourceUtils/applyStripeReuseFromVariantFamilies";
+import {
+	planLicenseToParentStripeInitProduct,
+	planLicenseToStripeInitProduct,
+} from "./licenseStripeResourceUtils";
 
 export const initStripeResourcesForProducts = async ({
 	ctx,
@@ -64,9 +68,17 @@ export const initStripeResourcesForProducts = async ({
 	}
 	await Promise.all(batchProductUpdates);
 
+	const customLicenseProducts = products.flatMap((parentProduct) =>
+		(parentProduct.licenses ?? [])
+			.map((planLicense) =>
+				planLicenseToParentStripeInitProduct({ planLicense, parentProduct }),
+			)
+			.filter((licenseProduct) => licenseProduct !== null),
+	);
+
 	const batchPriceUpdates = [];
 
-	for (const product of products) {
+	for (const product of [...products, ...customLicenseProducts]) {
 		for (const price of product.prices) {
 			batchPriceUpdates.push(
 				createStripePriceIFNotExist({
@@ -170,21 +182,19 @@ export const initStripeResourcesForBillingPlan = async ({
 			(product) => nullish(product.processor?.id) || product.prices.length > 0,
 		);
 
-	// License child products bill through their parents, so their prices need
-	// Stripe resources too. Price objects are shared refs — init mutates them.
-	// Keyed per DEFINITION: a custom plan_license and the catalog link share a
-	// product internal_id but carry different price rows.
+	// Definitions can share a child product id while carrying distinct custom rows.
 	const licenseProductsByDefinition = new Map<string, FullProduct>();
 	for (const customerProduct of [
 		...insertCustomerProducts,
 		...fullCustomer.customer_products,
 	]) {
+		const parentProduct = cusProductToProduct({ cusProduct: customerProduct });
 		for (const customerLicense of customerProduct.customer_licenses ?? []) {
-			const licenseProduct = customerLicense.planLicense?.product;
-			if (!licenseProduct) continue;
+			const planLicense = customerLicense.planLicense;
+			if (!planLicense) continue;
 			licenseProductsByDefinition.set(
-				customerLicense.plan_license_id ?? licenseProduct.internal_id,
-				licenseProduct,
+				customerLicense.plan_license_id ?? planLicense.product.internal_id,
+				planLicenseToStripeInitProduct({ planLicense, parentProduct }),
 			);
 		}
 	}
@@ -192,7 +202,24 @@ export const initStripeResourcesForBillingPlan = async ({
 	for (const transition of autumnBillingPlan.customerLicenseTransitions ?? []) {
 		const planLicense = transition.incomingCustomerLicense.planLicense;
 		if (!planLicense) continue;
-		licenseProductsByDefinition.set(planLicense.id, planLicense.product);
+		const parentCustomerProduct = [
+			...insertCustomerProducts,
+			...fullCustomer.customer_products,
+		].find(
+			(customerProduct) =>
+				customerProduct.id ===
+				transition.incomingCustomerLicense.parent_customer_product_id,
+		);
+		if (!parentCustomerProduct) continue;
+		licenseProductsByDefinition.set(
+			planLicense.id,
+			planLicenseToStripeInitProduct({
+				planLicense,
+				parentProduct: cusProductToProduct({
+					cusProduct: parentCustomerProduct,
+				}),
+			}),
+		);
 	}
 	const licenseProducts = Array.from(licenseProductsByDefinition.values());
 

--- a/server/src/internal/billing/v2/providers/stripe/utils/common/licenseStripeResourceUtils.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/licenseStripeResourceUtils.ts
@@ -1,0 +1,35 @@
+import {
+	type FullPlanLicense,
+	type FullProduct,
+	planLicenseToCustomizedBasePrice,
+} from "@autumn/shared";
+
+export const planLicenseToParentStripeInitProduct = ({
+	planLicense,
+	parentProduct,
+}: {
+	planLicense: FullPlanLicense;
+	parentProduct: FullProduct;
+}): FullProduct | null => {
+	const customizedBasePrice = planLicenseToCustomizedBasePrice({ planLicense });
+
+	if (!customizedBasePrice || !parentProduct.processor?.id) {
+		return null;
+	}
+
+	return {
+		...planLicense.product,
+		processor: parentProduct.processor,
+		prices: [customizedBasePrice],
+	};
+};
+
+export const planLicenseToStripeInitProduct = ({
+	planLicense,
+	parentProduct,
+}: {
+	planLicense: FullPlanLicense;
+	parentProduct: FullProduct;
+}): FullProduct =>
+	planLicenseToParentStripeInitProduct({ planLicense, parentProduct }) ??
+	planLicense.product;

--- a/server/src/internal/billing/v2/providers/stripe/utils/sync/matchUtils/licenseMatchUtils/climbLicenseMatch.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/sync/matchUtils/licenseMatchUtils/climbLicenseMatch.ts
@@ -1,9 +1,4 @@
-import {
-	type FullProduct,
-	type ParentPlanLicense,
-	type Price,
-	productToBasePrice,
-} from "@autumn/shared";
+import type { FullProduct } from "@autumn/shared";
 import type { ItemMatch } from "@/internal/billing/v2/actions/sync/detect/types";
 import type { StripeItemSnapshot } from "@/internal/billing/v2/providers/stripe/utils/sync/stripeItemSnapshot/types";
 import {
@@ -11,7 +6,7 @@ import {
 	isAutumnPriceMatch,
 	matchesOnBasePrice,
 } from "../classifyItemMatch";
-import { stripeItemMatchesBasePrice } from "../findProductLevelMatchForStripeItem";
+import { findShapeMatchedLicenseLinks } from "./findLicenseMatchForStripeItem";
 
 /** Multiple parents require exactly one effective base-price shape match. */
 const findShapeMatchedLink = ({
@@ -19,27 +14,15 @@ const findShapeMatchedLink = ({
 	licenseProduct,
 	item,
 }: {
-	links: ParentPlanLicense[];
+	links: NonNullable<FullProduct["parent_plan_licenses"]>;
 	licenseProduct: FullProduct;
 	item: StripeItemSnapshot;
-}): { link: ParentPlanLicense; price: Price } | null => {
-	const matches: { link: ParentPlanLicense; price: Price }[] = [];
-	for (const link of links) {
-		const effectiveProduct = link.customized
-			? { ...licenseProduct, prices: link.license_prices }
-			: licenseProduct;
-		const price = productToBasePrice({ product: effectiveProduct });
-		if (
-			price &&
-			stripeItemMatchesBasePrice({
-				item,
-				basePrice: price,
-				stripeProductId: item.stripe_product_id,
-			})
-		) {
-			matches.push({ link, price });
-		}
-	}
+}) => {
+	const matches = findShapeMatchedLicenseLinks({
+		links,
+		licenseProduct,
+		item,
+	});
 	return matches.length === 1 ? matches[0] : null;
 };
 

--- a/server/src/internal/billing/v2/providers/stripe/utils/sync/matchUtils/licenseMatchUtils/findLicenseMatchForStripeItem.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/sync/matchUtils/licenseMatchUtils/findLicenseMatchForStripeItem.ts
@@ -1,0 +1,154 @@
+import {
+	type FullProduct,
+	getAllPriceStripeIds,
+	type ParentPlanLicense,
+	type Price,
+	productToBasePrice,
+	productToStripeIds,
+} from "@autumn/shared";
+import type { ItemMatch } from "@/internal/billing/v2/actions/sync/detect/types";
+import type { StripeItemSnapshot } from "@/internal/billing/v2/providers/stripe/utils/sync/stripeItemSnapshot/types";
+import { stripeItemMatchesBasePrice } from "../findProductLevelMatchForStripeItem";
+
+type LicenseLinkPriceMatch = {
+	link: ParentPlanLicense;
+	licenseProduct: FullProduct;
+	price: Price;
+};
+
+const licenseLinkToBasePrice = ({
+	link,
+	licenseProduct,
+}: {
+	link: ParentPlanLicense;
+	licenseProduct: FullProduct;
+}): Price | null =>
+	productToBasePrice({
+		product: link.customized
+			? { ...licenseProduct, prices: link.license_prices }
+			: licenseProduct,
+	});
+
+const basePriceToStripeProductIds = ({
+	price,
+	link,
+	licenseProduct,
+}: LicenseLinkPriceMatch): string[] => {
+	const stripeProductIds = [
+		...(price.config.stripe_product_id ? [price.config.stripe_product_id] : []),
+		...productToStripeIds({ product: licenseProduct }),
+	];
+	if (link.customized && price.is_custom) {
+		stripeProductIds.push(...productToStripeIds({ product: link.product }));
+	}
+	return [...new Set(stripeProductIds)];
+};
+
+export const findShapeMatchedLicenseLinks = ({
+	links,
+	licenseProduct,
+	item,
+}: {
+	links: ParentPlanLicense[];
+	licenseProduct: FullProduct;
+	item: StripeItemSnapshot;
+}): LicenseLinkPriceMatch[] => {
+	const matches: LicenseLinkPriceMatch[] = [];
+	for (const link of links) {
+		const price = licenseLinkToBasePrice({ link, licenseProduct });
+		if (!price) continue;
+		const candidate = { link, licenseProduct, price };
+		if (
+			basePriceToStripeProductIds(candidate).some((stripeProductId) =>
+				stripeItemMatchesBasePrice({ item, basePrice: price, stripeProductId }),
+			)
+		) {
+			matches.push(candidate);
+		}
+	}
+	return matches;
+};
+
+const findExactLicenseLinks = ({
+	fullProducts,
+	item,
+}: {
+	fullProducts: FullProduct[];
+	item: StripeItemSnapshot;
+}): LicenseLinkPriceMatch[] => {
+	const matches: LicenseLinkPriceMatch[] = [];
+	for (const licenseProduct of fullProducts) {
+		for (const link of licenseProduct.parent_plan_licenses ?? []) {
+			const price = licenseLinkToBasePrice({ link, licenseProduct });
+			if (!price) continue;
+			if (
+				getAllPriceStripeIds({ config: price.config }).includes(
+					item.stripe_price_id,
+				)
+			) {
+				matches.push({ link, licenseProduct, price });
+			}
+		}
+	}
+	return matches;
+};
+
+const licenseLinkMatchToItemMatch = ({
+	match,
+	item,
+	exact,
+}: {
+	match: LicenseLinkPriceMatch;
+	item: StripeItemSnapshot;
+	exact: boolean;
+}): ItemMatch => ({
+	kind: "autumn_license",
+	matched_on: exact
+		? {
+				type: "stripe_price_id",
+				stripe_price_id: item.stripe_price_id,
+			}
+		: {
+				type: "stripe_base_price_shape",
+				stripe_product_id: item.stripe_product_id,
+				stripe_price_id: item.stripe_price_id,
+			},
+	price: match.price,
+	product: match.licenseProduct,
+	parent_plan_license: match.link,
+});
+
+export const findLicenseMatchForStripeItem = ({
+	fullProducts,
+	item,
+}: {
+	fullProducts: FullProduct[];
+	item: StripeItemSnapshot;
+}): ItemMatch | null => {
+	const exactMatches = findExactLicenseLinks({ fullProducts, item });
+	if (exactMatches.length > 0) {
+		return exactMatches.length === 1
+			? licenseLinkMatchToItemMatch({
+					match: exactMatches[0]!,
+					item,
+					exact: true,
+				})
+			: { kind: "none" };
+	}
+
+	const shapeMatches = fullProducts.flatMap((licenseProduct) =>
+		findShapeMatchedLicenseLinks({
+			links: licenseProduct.parent_plan_licenses ?? [],
+			licenseProduct,
+			item,
+		}),
+	);
+	if (shapeMatches.length === 0) return null;
+	return shapeMatches.length === 1
+		? licenseLinkMatchToItemMatch({
+				match: shapeMatches[0]!,
+				item,
+				exact: false,
+			})
+		: { kind: "none" };
+};

--- a/server/src/internal/billing/v2/providers/stripe/utils/sync/stripeToAutumn/findAutumnMatchForStripeItem.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/sync/stripeToAutumn/findAutumnMatchForStripeItem.ts
@@ -7,27 +7,10 @@ import {
 import { findStripeMatchForAutumnProduct } from "../matchUtils/findStripeMatchForAutumnProduct";
 import { getStripePriceIdsForAutumnPrice } from "../matchUtils/getStripePriceIdsForAutumnPrice";
 import { climbLicenseMatch } from "../matchUtils/licenseMatchUtils/climbLicenseMatch";
+import { findLicenseMatchForStripeItem } from "../matchUtils/licenseMatchUtils/findLicenseMatchForStripeItem";
 import type { StripeItemSnapshot } from "../stripeItemSnapshot/types";
 
-/**
- * Match a single StripeItemSnapshot against the supplied Autumn products.
- * First hit wins, in order:
- *
- *   1. stripe_price_id — an Autumn price stores this exact Stripe price id.
- *   2. Product-level — the item's Stripe product is linked to Autumn
- *      product(s), via the product mapping or a price's
- *      config.stripe_product_id. Within candidates the item resolves by
- *      keying/shape: non-fixed price keyed to the product (stripe_product_id,
- *      id-only — covers Autumn's custom price variants), base price
- *      (stripe_base_price_shape), prepaid price (stripe_prepaid_price_shape),
- *      or the product itself (autumn_product = unrecognized price on a known
- *      plan, single candidate only).
- *   3. kind: "none" — unresolved.
- *
- * Pure and sibling-blind — shared-price misattribution across plans is fixed
- * afterwards by rematchFeaturesWithinAnchoredPlans. `org` enables prepaid
- * shape matching at tier 2.
- */
+/** Matches exact top-level prices, license links, then product-level identity. */
 export const findAutumnMatchForStripeItem = ({
 	item,
 	fullProducts,
@@ -61,6 +44,9 @@ export const findAutumnMatchForStripeItem = ({
 			}
 		}
 	}
+
+	const licenseMatch = findLicenseMatchForStripeItem({ fullProducts, item });
+	if (licenseMatch) return { stripe: item, match: licenseMatch };
 
 	const stripeProductIds = new Set([item.stripe_product_id]);
 	const productCandidates: ProductLevelMatchCandidate[] = [];

--- a/server/tests/integration/billing/stripe-webhooks/subscription-created/licenses/sub-created-parent-product-license-backsync.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/subscription-created/licenses/sub-created-parent-product-license-backsync.test.ts
@@ -1,0 +1,446 @@
+/** Contract: parent-customized fixed license prices use the parent Stripe Product.
+ * Back-sync resolves product identity before price shape within shared products. */
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	ApiVersion,
+	BillingInterval,
+	productToBasePrice,
+} from "@autumn/shared";
+import { createExternalStripeSubscription } from "@tests/integration/billing/stripe-webhooks/utils/sharedStripeProductAutoSyncUtils";
+import { createStripeFixedPriceUnderProduct } from "@tests/integration/billing/sync/utils/syncProductHelpers";
+import {
+	expectProductActive,
+	expectProductNotPresent,
+} from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { getFullLicenseProduct } from "@tests/integration/crud/plans/licenses/utils/getFullLicenseProduct";
+import { createVariantPlan } from "@tests/integration/crud/plans/variants/utils/variantTestPlanUtils";
+import { expectCustomerLicenses } from "@tests/integration/licenses/utils/expectCustomerLicenses";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { timeout } from "@tests/utils/genUtils";
+import testCtx, {
+	type TestContext,
+} from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import type { AutumnInt } from "@/external/autumn/autumnCli";
+import { AutumnRpcCli } from "@/external/autumn/autumnRpcCli";
+import { ProductService } from "@/internal/products/ProductService";
+
+const INCLUDED_SEATS = 1;
+const INITIAL_PAID_SEATS = 2;
+const UPDATED_PAID_SEATS = 4;
+
+type Scenario = {
+	ctx: TestContext;
+	autumnV2_2: AutumnInt;
+	autumnV2_3: AutumnInt;
+};
+
+const stripeProductId = ({ price }: { price: Stripe.Price }) =>
+	typeof price.product === "string" ? price.product : price.product.id;
+
+const expectCustomizedPriceUnderParent = async ({
+	ctx,
+	parentPlanId,
+	licensePlanId,
+}: {
+	ctx: Scenario["ctx"];
+	parentPlanId: string;
+	licensePlanId: string;
+}) => {
+	const [parent, customized] = await Promise.all([
+		ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: parentPlanId,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		}),
+		getFullLicenseProduct({ ctx, parentPlanId, licensePlanId }),
+	]);
+	const price = productToBasePrice({
+		product: customized.fullLicenseProduct,
+	});
+	const parentStripeProductId = parent.processor?.id;
+	if (!parentStripeProductId) {
+		throw new Error(`Parent ${parentPlanId} has no Stripe product`);
+	}
+
+	expect(customized.planLicense.customized).toBe(true);
+	expect(price?.is_custom).toBe(true);
+	expect(parentStripeProductId).toBeDefined();
+	expect(price?.config.stripe_product_id).toBe(parentStripeProductId);
+	expect(price?.config.stripe_price_id).toBeDefined();
+
+	const stripePrice = await ctx.stripeCli.prices.retrieve(
+		price!.config.stripe_price_id!,
+	);
+	expect(stripeProductId({ price: stripePrice })).toBe(parentStripeProductId);
+
+	return {
+		parent,
+		price: price!,
+		stripePrice,
+		stripePriceId: stripePrice.id,
+		stripeProductId: parentStripeProductId,
+	};
+};
+
+const waitForLicensePool = async ({
+	scenario,
+	customerId,
+	parentPlanId,
+	licensePlanId,
+	paidQuantity,
+}: {
+	scenario: Scenario;
+	customerId: string;
+	parentPlanId: string;
+	licensePlanId: string;
+	paidQuantity: number;
+}) => {
+	const deadline = Date.now() + 60_000;
+	let lastError: unknown;
+	while (Date.now() < deadline) {
+		try {
+			const customer =
+				await scenario.autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+			expectCustomerLicenses({
+				customer,
+				count: 1,
+				licenses: [
+					{
+						license_plan_id: licensePlanId,
+						parent_plan_id: parentPlanId,
+						paid_quantity: paidQuantity,
+						granted: INCLUDED_SEATS + paidQuantity,
+					},
+				],
+			});
+			return customer;
+		} catch (error) {
+			lastError = error;
+			await timeout(2_000);
+		}
+	}
+	throw lastError;
+};
+
+const customizeLicensePrice = async ({
+	scenario,
+	parentPlanId,
+	licensePlanId,
+	amount,
+	interval,
+}: {
+	scenario: Scenario;
+	parentPlanId: string;
+	licensePlanId: string;
+	amount: number;
+	interval: BillingInterval.Month | BillingInterval.Year;
+}) => {
+	await scenario.autumnV2_2.post("/plans.update", {
+		plan_id: parentPlanId,
+		licenses: [
+			{
+				license_plan_id: licensePlanId,
+				included: INCLUDED_SEATS,
+				customize: { price: { amount, interval } },
+			},
+		],
+	});
+};
+
+const createLicenseSubscription = async ({
+	scenario,
+	customerId,
+	stripePriceId,
+}: {
+	scenario: Scenario;
+	customerId: string;
+	stripePriceId: string;
+}) =>
+	createExternalStripeSubscription({
+		ctx: scenario.ctx,
+		customerId,
+		items: [{ price: stripePriceId, quantity: INITIAL_PAID_SEATS }],
+	});
+
+test(`${chalk.yellowBright("license back-sync: equal shapes under different parent products select by product")}`, async () => {
+	const customerId = "sub-license-parent-product-distinct";
+	const parentA = products.base({
+		id: `${customerId}-a`,
+		items: [items.dashboard()],
+	});
+	const parentB = products.base({
+		id: `${customerId}-b`,
+		items: [items.dashboard()],
+	});
+	const teamSeat = products.base({
+		id: `${customerId}-seat`,
+		items: [items.monthlyPrice({ price: 5 })],
+		group: `${customerId}-licenses`,
+	});
+	const scenario = await initScenario({
+		customerId,
+		ctx: testCtx,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [parentA, parentB, teamSeat] }),
+		],
+		actions: [],
+	});
+
+	await customizeLicensePrice({
+		scenario,
+		parentPlanId: parentA.id,
+		licensePlanId: teamSeat.id,
+		amount: 12,
+		interval: BillingInterval.Month,
+	});
+	await customizeLicensePrice({
+		scenario,
+		parentPlanId: parentB.id,
+		licensePlanId: teamSeat.id,
+		amount: 12,
+		interval: BillingInterval.Month,
+	});
+
+	const [customA, customB] = await Promise.all([
+		expectCustomizedPriceUnderParent({
+			ctx: scenario.ctx,
+			parentPlanId: parentA.id,
+			licensePlanId: teamSeat.id,
+		}),
+		expectCustomizedPriceUnderParent({
+			ctx: scenario.ctx,
+			parentPlanId: parentB.id,
+			licensePlanId: teamSeat.id,
+		}),
+	]);
+	expect(customA.stripeProductId).not.toBe(customB.stripeProductId);
+	expect(customA.stripePriceId).not.toBe(customB.stripePriceId);
+
+	const externalPrice = await createStripeFixedPriceUnderProduct({
+		ctx: scenario.ctx,
+		stripeProductId: customB.stripeProductId,
+		unitAmount: 12 * 100,
+	});
+	const subscription = await createLicenseSubscription({
+		scenario,
+		customerId,
+		stripePriceId: externalPrice.id,
+	});
+	let customer = await waitForLicensePool({
+		scenario,
+		customerId,
+		parentPlanId: parentB.id,
+		licensePlanId: teamSeat.id,
+		paidQuantity: INITIAL_PAID_SEATS,
+	});
+	await expectProductActive({ customer, productId: parentB.id });
+	await expectProductNotPresent({ customer, productId: parentA.id });
+
+	await scenario.ctx.stripeCli.subscriptions.update(subscription.id, {
+		items: [
+			{
+				id: subscription.items.data[0]!.id,
+				quantity: UPDATED_PAID_SEATS,
+			},
+		],
+		proration_behavior: "none",
+	});
+	customer = await waitForLicensePool({
+		scenario,
+		customerId,
+		parentPlanId: parentB.id,
+		licensePlanId: teamSeat.id,
+		paidQuantity: UPDATED_PAID_SEATS,
+	});
+	await expectProductActive({ customer, productId: parentB.id });
+});
+
+test(`${chalk.yellowBright("license back-sync: shared parent product selects by customized base shape")}`, async () => {
+	const customerId = "sub-license-parent-product-shared";
+	const pro = products.base({
+		id: `${customerId}-pro`,
+		items: [items.dashboard()],
+	});
+	const annualId = `${customerId}-annual`;
+	const teamSeat = products.base({
+		id: `${customerId}-seat`,
+		items: [items.monthlyPrice({ price: 5 })],
+		group: `${customerId}-licenses`,
+	});
+	const scenario = await initScenario({
+		customerId,
+		ctx: testCtx,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro, teamSeat] }),
+		],
+		actions: [],
+	});
+	const rpc = new AutumnRpcCli({
+		secretKey: scenario.ctx.orgSecretKey,
+		version: ApiVersion.V2_1,
+	});
+	await createVariantPlan({
+		rpc,
+		basePlanId: pro.id,
+		variantPlanId: annualId,
+		name: "Pro Annual",
+	});
+	const [proFull, annualFull] = await Promise.all([
+		ProductService.getFull({
+			db: scenario.ctx.db,
+			idOrInternalId: pro.id,
+			orgId: scenario.ctx.org.id,
+			env: scenario.ctx.env,
+		}),
+		ProductService.getFull({
+			db: scenario.ctx.db,
+			idOrInternalId: annualId,
+			orgId: scenario.ctx.org.id,
+			env: scenario.ctx.env,
+		}),
+	]);
+	await ProductService.updateByInternalId({
+		db: scenario.ctx.db,
+		internalId: annualFull.internal_id,
+		update: { processor: proFull.processor },
+	});
+
+	await customizeLicensePrice({
+		scenario,
+		parentPlanId: pro.id,
+		licensePlanId: teamSeat.id,
+		amount: 20,
+		interval: BillingInterval.Month,
+	});
+	await customizeLicensePrice({
+		scenario,
+		parentPlanId: annualId,
+		licensePlanId: teamSeat.id,
+		amount: 200,
+		interval: BillingInterval.Year,
+	});
+
+	const [monthly, annual] = await Promise.all([
+		expectCustomizedPriceUnderParent({
+			ctx: scenario.ctx,
+			parentPlanId: pro.id,
+			licensePlanId: teamSeat.id,
+		}),
+		expectCustomizedPriceUnderParent({
+			ctx: scenario.ctx,
+			parentPlanId: annualId,
+			licensePlanId: teamSeat.id,
+		}),
+	]);
+	expect(monthly.stripeProductId).toBe(annual.stripeProductId);
+	expect(monthly.stripePriceId).not.toBe(annual.stripePriceId);
+
+	const externalAnnualPrice = await createStripeFixedPriceUnderProduct({
+		ctx: scenario.ctx,
+		stripeProductId: annual.stripeProductId,
+		unitAmount: 200 * 100,
+		interval: "year",
+	});
+	await createLicenseSubscription({
+		scenario,
+		customerId,
+		stripePriceId: externalAnnualPrice.id,
+	});
+	const customer = await waitForLicensePool({
+		scenario,
+		customerId,
+		parentPlanId: annualId,
+		licensePlanId: teamSeat.id,
+		paidQuantity: INITIAL_PAID_SEATS,
+	});
+	await expectProductActive({ customer, productId: annualId });
+	await expectProductNotPresent({ customer, productId: pro.id });
+});
+
+test(`${chalk.yellowBright("license back-sync: parent and child sharing a product still select the parent")}`, async () => {
+	const customerId = "sub-license-parent-product-child-shared";
+	const parent = products.base({
+		id: `${customerId}-parent`,
+		items: [items.dashboard()],
+	});
+	const teamSeat = products.base({
+		id: `${customerId}-seat`,
+		items: [items.monthlyPrice({ price: 5 })],
+		group: `${customerId}-licenses`,
+	});
+	const scenario = await initScenario({
+		customerId,
+		ctx: testCtx,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [parent, teamSeat] }),
+		],
+		actions: [],
+	});
+	const [parentFull, childFull] = await Promise.all([
+		ProductService.getFull({
+			db: scenario.ctx.db,
+			idOrInternalId: parent.id,
+			orgId: scenario.ctx.org.id,
+			env: scenario.ctx.env,
+		}),
+		ProductService.getFull({
+			db: scenario.ctx.db,
+			idOrInternalId: teamSeat.id,
+			orgId: scenario.ctx.org.id,
+			env: scenario.ctx.env,
+		}),
+	]);
+	await ProductService.updateByInternalId({
+		db: scenario.ctx.db,
+		internalId: childFull.internal_id,
+		update: { processor: parentFull.processor },
+	});
+
+	await customizeLicensePrice({
+		scenario,
+		parentPlanId: parent.id,
+		licensePlanId: teamSeat.id,
+		amount: 15,
+		interval: BillingInterval.Month,
+	});
+	const customized = await expectCustomizedPriceUnderParent({
+		ctx: scenario.ctx,
+		parentPlanId: parent.id,
+		licensePlanId: teamSeat.id,
+	});
+	const refreshedChild = await ProductService.getFull({
+		db: scenario.ctx.db,
+		idOrInternalId: teamSeat.id,
+		orgId: scenario.ctx.org.id,
+		env: scenario.ctx.env,
+	});
+	expect(refreshedChild.processor?.id).toBe(parentFull.processor?.id);
+
+	const externalPrice = await createStripeFixedPriceUnderProduct({
+		ctx: scenario.ctx,
+		stripeProductId: customized.stripeProductId,
+		unitAmount: 15 * 100,
+	});
+	await createLicenseSubscription({
+		scenario,
+		customerId,
+		stripePriceId: externalPrice.id,
+	});
+	const customer = await waitForLicensePool({
+		scenario,
+		customerId,
+		parentPlanId: parent.id,
+		licensePlanId: teamSeat.id,
+		paidQuantity: INITIAL_PAID_SEATS,
+	});
+	await expectProductActive({ customer, productId: parent.id });
+});

--- a/server/tests/integration/licenses/billing/attach/attach-license-parent-stripe-product.test.ts
+++ b/server/tests/integration/licenses/billing/attach/attach-license-parent-stripe-product.test.ts
@@ -1,0 +1,260 @@
+/** Contract: only custom fixed license prices inherit their parent Stripe Product.
+ * Ordinary and feature-only links retain the shared child base price resources. */
+import { expect, test } from "bun:test";
+import {
+	type AttachParamsV1Input,
+	BillingInterval,
+	type FullProduct,
+	productToBasePrice,
+} from "@autumn/shared";
+import { getFullLicenseProduct } from "@tests/integration/crud/plans/licenses/utils/getFullLicenseProduct";
+import { expectLicenseDefinitionCorrect } from "@tests/integration/licenses/utils/expectLicenseDefinitionCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { ProductService } from "@/internal/products/ProductService";
+
+const expectLicenseProductStripeResourcesUnchanged = ({
+	before,
+	after,
+}: {
+	before: FullProduct;
+	after: FullProduct;
+}) => {
+	const beforeBasePrice = productToBasePrice({ product: before });
+	const afterBasePrice = productToBasePrice({ product: after });
+	expect(after.processor?.id).toBe(before.processor?.id);
+	expect(afterBasePrice?.id).toBe(beforeBasePrice?.id);
+	expect(afterBasePrice?.config.stripe_price_id).toBe(
+		beforeBasePrice?.config.stripe_price_id,
+	);
+	expect(afterBasePrice?.config.stripe_product_id).toBe(
+		beforeBasePrice?.config.stripe_product_id,
+	);
+};
+
+test.concurrent(
+	`${chalk.yellowBright("license attach: custom base price is created under the parent Stripe product")}`,
+	async () => {
+		const customerId = "attach-license-parent-stripe-product";
+		const parent = products.base({
+			id: `${customerId}-parent`,
+			items: [items.dashboard()],
+		});
+		const teamSeat = products.base({
+			id: `${customerId}-seat`,
+			items: [items.monthlyPrice({ price: 10 })],
+			group: `${customerId}-licenses`,
+		});
+		const scenario = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.products({ list: [parent, teamSeat] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: teamSeat.id,
+					included: 0,
+				}),
+			],
+		});
+		const [parentBefore, childBefore] = await Promise.all([
+			ProductService.getFull({
+				db: scenario.ctx.db,
+				idOrInternalId: parent.id,
+				orgId: scenario.ctx.org.id,
+				env: scenario.ctx.env,
+			}),
+			ProductService.getFull({
+				db: scenario.ctx.db,
+				idOrInternalId: teamSeat.id,
+				orgId: scenario.ctx.org.id,
+				env: scenario.ctx.env,
+			}),
+		]);
+		const parentStripeProductId = parentBefore.processor?.id;
+		if (!parentStripeProductId) {
+			throw new Error(`Parent ${parent.id} has no Stripe product`);
+		}
+
+		await scenario.autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: parent.id,
+			redirect_mode: "if_required",
+			license_quantities: [{ license_plan_id: teamSeat.id, quantity: 2 }],
+			customize: {
+				upsert_licenses: [
+					{
+						license_plan_id: teamSeat.id,
+						customize: {
+							price: {
+								amount: 25,
+								interval: BillingInterval.Month,
+							},
+						},
+					},
+				],
+			},
+		});
+
+		await expectLicenseDefinitionCorrect({
+			ctx: scenario.ctx,
+			customerId,
+			parentPlanId: parent.id,
+			isCustom: true,
+			isCustomized: true,
+			basePrice: {
+				amount: 25,
+				interval: BillingInterval.Month,
+				isCustom: true,
+				stripeProductId: parentStripeProductId,
+			},
+		});
+
+		const childAfter = await ProductService.getFull({
+			db: scenario.ctx.db,
+			idOrInternalId: teamSeat.id,
+			orgId: scenario.ctx.org.id,
+			env: scenario.ctx.env,
+		});
+		expectLicenseProductStripeResourcesUnchanged({
+			before: childBefore,
+			after: childAfter,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license attach: ordinary links never re-home the shared child base price")}`,
+	async () => {
+		const customerId = "attach-license-shared-base-price-guard";
+		const parentA = products.base({
+			id: `${customerId}-a`,
+			items: [items.dashboard()],
+		});
+		const parentB = products.base({
+			id: `${customerId}-b`,
+			items: [items.dashboard()],
+		});
+		const teamSeat = products.base({
+			id: `${customerId}-seat`,
+			items: [items.monthlyPrice({ price: 10 })],
+			group: `${customerId}-licenses`,
+		});
+		const scenario = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.products({ list: [parentA, parentB, teamSeat] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parentA.id,
+					licenseProductId: teamSeat.id,
+					included: 0,
+				}),
+				s.licenses.link({
+					parentProductId: parentB.id,
+					licenseProductId: teamSeat.id,
+					included: 0,
+				}),
+			],
+		});
+		const childBefore = await ProductService.getFull({
+			db: scenario.ctx.db,
+			idOrInternalId: teamSeat.id,
+			orgId: scenario.ctx.org.id,
+			env: scenario.ctx.env,
+		});
+		for (const parent of [parentA, parentB]) {
+			await scenario.autumnV2_3.billing.attach<AttachParamsV1Input>({
+				customer_id: customerId,
+				plan_id: parent.id,
+				redirect_mode: "if_required",
+				license_quantities: [{ license_plan_id: teamSeat.id, quantity: 1 }],
+			});
+		}
+
+		const childAfter = await ProductService.getFull({
+			db: scenario.ctx.db,
+			idOrInternalId: teamSeat.id,
+			orgId: scenario.ctx.org.id,
+			env: scenario.ctx.env,
+		});
+		expectLicenseProductStripeResourcesUnchanged({
+			before: childBefore,
+			after: childAfter,
+		});
+		expect(
+			productToBasePrice({ product: childAfter })?.config.stripe_product_id,
+		).toBe(childBefore.processor?.id);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license attach: feature-only customization retains the child base price")}`,
+	async () => {
+		const customerId = "attach-license-feature-only-price-guard";
+		const parent = products.base({
+			id: `${customerId}-parent`,
+			items: [items.dashboard()],
+		});
+		const teamSeat = products.base({
+			id: `${customerId}-seat`,
+			items: [items.monthlyPrice({ price: 10 })],
+			group: `${customerId}-licenses`,
+		});
+		const scenario = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.products({ list: [parent, teamSeat] }),
+			],
+			actions: [],
+		});
+		const childBefore = await ProductService.getFull({
+			db: scenario.ctx.db,
+			idOrInternalId: teamSeat.id,
+			orgId: scenario.ctx.org.id,
+			env: scenario.ctx.env,
+		});
+		await scenario.autumnV2_2.post("/plans.update", {
+			plan_id: parent.id,
+			licenses: [
+				{
+					license_plan_id: teamSeat.id,
+					customize: {
+						add_items: [itemsV2.monthlyWords({ included: 50 })],
+					},
+				},
+			],
+		});
+		await scenario.autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: parent.id,
+			redirect_mode: "if_required",
+			license_quantities: [{ license_plan_id: teamSeat.id, quantity: 1 }],
+		});
+
+		const customized = await getFullLicenseProduct({
+			ctx: scenario.ctx,
+			parentPlanId: parent.id,
+			licensePlanId: teamSeat.id,
+		});
+		expect(customized.planLicense.customized).toBe(true);
+		expectLicenseProductStripeResourcesUnchanged({
+			before: childBefore,
+			after: customized.fullLicenseProduct,
+		});
+		expect(
+			customized.fullLicenseProduct.entitlements.some(
+				(entitlement) => entitlement.feature_id === TestFeature.Words,
+			),
+		).toBe(true);
+	},
+);

--- a/server/tests/integration/licenses/utils/expectLicenseDefinitionCorrect.ts
+++ b/server/tests/integration/licenses/utils/expectLicenseDefinitionCorrect.ts
@@ -7,17 +7,14 @@ import {
 import type { TestContext } from "@tests/utils/testInitUtils/createTestContext";
 import { CusService } from "@/internal/customers/CusService";
 
-/**
- * Asserts the DB-side license definition behind a customer's pool: the parent
- * customer product (+ optional Stripe sub linkage) and the plan license the
- * pool anchors to — catalog (is_custom false) or custom, with its base price.
- */
+/** Asserts the customer pool's parent product and effective license definition. */
 export const expectLicenseDefinitionCorrect = async ({
 	ctx,
 	customerId,
 	parentPlanId,
 	subscriptionId,
 	isCustom,
+	isCustomized,
 	basePrice,
 }: {
 	ctx: TestContext;
@@ -26,7 +23,13 @@ export const expectLicenseDefinitionCorrect = async ({
 	/** When set, the parent customer product must be linked to this Stripe sub. */
 	subscriptionId?: string;
 	isCustom: boolean;
-	basePrice?: { amount: number; interval: BillingInterval };
+	isCustomized?: boolean;
+	basePrice?: {
+		amount: number;
+		interval: BillingInterval;
+		isCustom?: boolean;
+		stripeProductId?: string;
+	};
 }): Promise<FullCustomerLicense> => {
 	const fullCustomer = await CusService.getFull({
 		ctx,
@@ -51,6 +54,9 @@ export const expectLicenseDefinitionCorrect = async ({
 		`Parent ${parentPlanId} has no customer license pool`,
 	).toBeDefined();
 	expect(customerLicense?.planLicense?.is_custom).toBe(isCustom);
+	if (isCustomized !== undefined) {
+		expect(customerLicense?.planLicense?.customized).toBe(isCustomized);
+	}
 
 	if (basePrice) {
 		const planLicenseProduct = customerLicense?.planLicense?.product;
@@ -60,6 +66,23 @@ export const expectLicenseDefinitionCorrect = async ({
 		expect(licenseBasePrice).not.toBeNull();
 		expect(licenseBasePrice?.config.amount).toBe(basePrice.amount);
 		expect(licenseBasePrice?.config.interval).toBe(basePrice.interval);
+		if (basePrice.isCustom !== undefined) {
+			expect(licenseBasePrice?.is_custom).toBe(basePrice.isCustom);
+		}
+		if (basePrice.stripeProductId) {
+			expect(licenseBasePrice?.config.stripe_product_id).toBe(
+				basePrice.stripeProductId,
+			);
+			expect(licenseBasePrice?.config.stripe_price_id).toBeDefined();
+			const stripePrice = await ctx.stripeCli.prices.retrieve(
+				licenseBasePrice!.config.stripe_price_id!,
+			);
+			const actualStripeProductId =
+				typeof stripePrice.product === "string"
+					? stripePrice.product
+					: stripePrice.product.id;
+			expect(actualStripeProductId).toBe(basePrice.stripeProductId);
+		}
 	}
 
 	if (!customerLicense) {

--- a/shared/utils/productUtils/index.ts
+++ b/shared/utils/productUtils/index.ts
@@ -1,5 +1,7 @@
 import { productToEmptyFeatureQuantities } from "@utils/productUtils/convertProduct/productToEmptyFeatureQuantities";
 
+export * from "./planLicenseUtils/index.js";
+
 export const productUtils = {
 	convert: {
 		toEmptyFeatureQuantities: productToEmptyFeatureQuantities,

--- a/shared/utils/productUtils/planLicenseUtils/convertPlanLicense/planLicenseToCustomizedBasePrice.test.ts
+++ b/shared/utils/productUtils/planLicenseUtils/convertPlanLicense/planLicenseToCustomizedBasePrice.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import type { FullPlanLicense } from "@models/licenseModels/fullPlanLicenseModel.js";
+import { BillingInterval } from "@models/productModels/intervals/billingInterval.js";
+import { PriceType } from "@models/productModels/priceModels/priceEnums.js";
+import { planLicenseToCustomizedBasePrice } from "./planLicenseToCustomizedBasePrice.js";
+
+const planLicenseWithBasePrice = ({
+	customized,
+	isCustomPrice,
+}: {
+	customized: boolean;
+	isCustomPrice: boolean;
+}): FullPlanLicense =>
+	({
+		customized,
+		product: {
+			prices: [
+				{
+					id: "price_test",
+					is_custom: isCustomPrice,
+					config: {
+						type: PriceType.Fixed,
+						amount: 20,
+						interval: BillingInterval.Month,
+					},
+				},
+			],
+		},
+	}) as FullPlanLicense;
+
+describe("planLicenseToCustomizedBasePrice", () => {
+	test("returns the custom base price for a customized link", () => {
+		const planLicense = planLicenseWithBasePrice({
+			customized: true,
+			isCustomPrice: true,
+		});
+
+		expect(planLicenseToCustomizedBasePrice({ planLicense })?.id).toBe(
+			"price_test",
+		);
+	});
+
+	test("requires the link itself to be customized", () => {
+		const planLicense = planLicenseWithBasePrice({
+			customized: false,
+			isCustomPrice: true,
+		});
+
+		expect(planLicenseToCustomizedBasePrice({ planLicense })).toBeNull();
+	});
+
+	test("ignores a reused stock base price", () => {
+		const planLicense = planLicenseWithBasePrice({
+			customized: true,
+			isCustomPrice: false,
+		});
+
+		expect(planLicenseToCustomizedBasePrice({ planLicense })).toBeNull();
+	});
+});

--- a/shared/utils/productUtils/planLicenseUtils/convertPlanLicense/planLicenseToCustomizedBasePrice.ts
+++ b/shared/utils/productUtils/planLicenseUtils/convertPlanLicense/planLicenseToCustomizedBasePrice.ts
@@ -1,0 +1,12 @@
+import type { FullPlanLicense } from "@models/licenseModels/fullPlanLicenseModel.js";
+import { productToBasePrice } from "@utils/productUtils/convertProductUtils.js";
+
+export const planLicenseToCustomizedBasePrice = ({
+	planLicense,
+}: {
+	planLicense: FullPlanLicense;
+}) => {
+	if (!planLicense.customized) return null;
+	const basePrice = productToBasePrice({ product: planLicense.product });
+	return basePrice?.is_custom ? basePrice : null;
+};

--- a/shared/utils/productUtils/planLicenseUtils/index.ts
+++ b/shared/utils/productUtils/planLicenseUtils/index.ts
@@ -1,0 +1,1 @@
+export * from "./convertPlanLicense/planLicenseToCustomizedBasePrice.js";


### PR DESCRIPTION
## Summary

- create customized license prices under each parent Stripe product
- match Stripe subscription items against effective license definitions
- cover attach and webhook back-sync behavior with focused tests

## Testing

- `bun test ./shared/utils/productUtils/planLicenseUtils/convertPlanLicense/planLicenseToCustomizedBasePrice.test.ts`
- focused attach and subscription-created integration suites (6 tests)
- `bunx biome check` on all 12 touched files
- commit hook: Knip and `@autumn/server` TypeScript build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes customized license base prices to their parent Stripe Product and updates Stripe item matching so back-synced subscriptions attach to the correct parent/license definition. Adds focused tests covering attach flows and subscription-created webhooks.

- **Bug Fixes**
  - Create customized license base prices under each parent product during init, reusing the parent’s Stripe product ID.
  - Match subscription items against license links: exact `stripe_price_id` first, then base price shape keyed to the parent product; otherwise fall back to product-level matching.
  - Preserve shared child product/base price for ordinary links and feature-only customizations; only custom fixed license prices are re-homed to the parent product.
  - Introduce `planLicenseToCustomizedBasePrice` in `@autumn/shared` and use new Stripe init utilities; add unit tests and integration tests for attach and webhook back-sync.

<sup>Written for commit f16f009dccb21d7cb08c22b02e36aed136711975. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes custom Stripe license prices so they are created under their **parent** product's Stripe product rather than the child's, and adds matching logic that can resolve those prices back to the correct license during Stripe subscription back-sync.

- **Bug fixes / Improvements**: `planLicenseToCustomizedBasePrice` and `planLicenseToParentStripeInitProduct` are new shared utilities that detect when a plan-license link carries a custom fixed price and construct a synthetic `FullProduct` with the parent's `processor` so `createStripePriceIFNotExist` targets the right Stripe product.
- **Bug fixes / Improvements**: `findLicenseMatchForStripeItem` introduces an exact-then-shape license match pass in `findAutumnMatchForStripeItem`, sitting between the existing Stripe-price-ID exact match and the product-level candidate search; this ensures back-synced subscriptions resolve to the correct parent product even when multiple parents share the same Stripe product.
- **Improvements**: `climbLicenseMatch` now delegates to the shared `findShapeMatchedLicenseLinks`, removing duplicated shape-matching logic and adding explicit handling of the parent Stripe product ID via `basePriceToStripeProductIds`.
</details>

<h3>Confidence Score: 3/5</h3>

The core price-creation and back-sync matching logic is well-structured and covered by tests, but a silent early exit in the billing-plan transition path can cause license prices to be skipped during Stripe initialisation.

Almost all of the change is correct: the new utilities, the license match pass, and the test suite are solid. The one concern is in `initStripeResourcesForBillingPlan` — when `parent_customer_product_id` is null or the parent hasn't yet been materialised into either `insertCustomerProducts` or `fullCustomer.customer_products`, the `continue` now drops the entry from `licenseProductsByDefinition` entirely. Before this PR the same code path unconditionally wrote `planLicense.product` to the map, so prices were always included in Stripe resource initialisation. For non-customised license transitions the fallback in `planLicenseToStripeInitProduct` would have preserved the old behaviour, but the early `continue` means we never reach it.

The `initStripeResourcesForBillingPlan` function in `initStripeResourcesForProducts.ts`, specifically the transitions loop around line 213.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts | Correctly scopes custom license prices to parent Stripe products, but a silent `continue` in the transitions loop drops license entries when the parent customer product isn't found, regressing from previous always-add behaviour. |
| server/src/internal/billing/v2/providers/stripe/utils/common/licenseStripeResourceUtils.ts | New helper that builds synthetic FullProduct objects with the parent's Stripe processor; clean separation between the nullable `planLicenseToParentStripeInitProduct` and the safe-fallback `planLicenseToStripeInitProduct`. |
| server/src/internal/billing/v2/providers/stripe/utils/sync/matchUtils/licenseMatchUtils/findLicenseMatchForStripeItem.ts | New file implementing exact-then-shape license matching with correct deduplication via `basePriceToStripeProductIds`; ambiguous matches correctly return `{ kind: "none" }` rather than guessing. |
| server/src/internal/billing/v2/providers/stripe/utils/sync/stripeToAutumn/findAutumnMatchForStripeItem.ts | Inserts the new license-first match pass between exact-price-ID matching and product-level candidate search; the ordering is correct and `{ kind: "none" }` short-circuit on ambiguous license matches is intentional. |
| server/src/internal/billing/v2/providers/stripe/utils/sync/matchUtils/licenseMatchUtils/climbLicenseMatch.ts | Delegates to the new shared `findShapeMatchedLicenseLinks`, removing duplicated shape-matching logic; no behaviour change for callers of `climbLicenseMatch`. |
| shared/utils/productUtils/planLicenseUtils/convertPlanLicense/planLicenseToCustomizedBasePrice.ts | Minimal, well-guarded helper: returns the custom base price only when both `planLicense.customized` is true and the base price is flagged `is_custom`. |
| shared/utils/productUtils/planLicenseUtils/convertPlanLicense/planLicenseToCustomizedBasePrice.test.ts | Three focused unit tests cover the happy path and both early-exit branches; correctly imported and runnable with bun test. |
| server/tests/integration/licenses/billing/attach/attach-license-parent-stripe-product.test.ts | Three concurrent integration tests covering custom-price parent scoping, shared base-price guard, and feature-only customisation guard; clean setup and assertion helpers. |
| server/tests/integration/billing/stripe-webhooks/subscription-created/licenses/sub-created-parent-product-license-backsync.test.ts | Three back-sync integration tests covering distinct-parent disambiguation, shared-parent shape disambiguation, and the parent-child sharing edge case; uses a polling loop with a 60 s deadline for async webhook processing. |
| server/tests/integration/licenses/utils/expectLicenseDefinitionCorrect.ts | Extends the assertion helper with `isCustomized` and `basePrice.isCustom`/`stripeProductId` fields; the live Stripe price retrieval confirms the server-side product assignment. |
| shared/utils/productUtils/index.ts | Re-exports `planLicenseUtils` from the shared package barrel; one-line addition, no issues. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant initStripe as initStripeResourcesForProducts
    participant licUtils as licenseStripeResourceUtils
    participant Stripe

    Client->>initStripe: products (with licenses)
    initStripe->>licUtils: planLicenseToParentStripeInitProduct(planLicense, parentProduct)
    licUtils-->>initStripe: "FullProduct { processor: parentProduct.processor, prices: [customizedBasePrice] }"
    initStripe->>Stripe: createStripePriceIFNotExist (under parent Stripe product)
    Stripe-->>initStripe: stripe_price_id stored on customizedBasePrice

    Note over Client,Stripe: Back-sync flow (subscription.created webhook)

    participant webhook as Webhook Handler
    participant findMatch as findAutumnMatchForStripeItem
    participant licMatch as findLicenseMatchForStripeItem

    webhook->>findMatch: item (stripe_price_id, stripe_product_id)
    findMatch->>licMatch: fullProducts, item
    licMatch->>licMatch: findExactLicenseLinks (stripe_price_id in license_prices)
    alt exact match found (1 result)
        licMatch-->>findMatch: "{ kind: autumn_license }"
    else no exact match
        licMatch->>licMatch: findShapeMatchedLicenseLinks (price shape x parent product IDs)
        alt 1 shape match
            licMatch-->>findMatch: "{ kind: autumn_license }"
        else 0 matches
            licMatch-->>findMatch: null (fall through to product-level)
        else more than 1 match
            licMatch-->>findMatch: "{ kind: none }"
        end
    end
    findMatch-->>webhook: ItemDiff with matched license + parent product
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant initStripe as initStripeResourcesForProducts
    participant licUtils as licenseStripeResourceUtils
    participant Stripe

    Client->>initStripe: products (with licenses)
    initStripe->>licUtils: planLicenseToParentStripeInitProduct(planLicense, parentProduct)
    licUtils-->>initStripe: "FullProduct { processor: parentProduct.processor, prices: [customizedBasePrice] }"
    initStripe->>Stripe: createStripePriceIFNotExist (under parent Stripe product)
    Stripe-->>initStripe: stripe_price_id stored on customizedBasePrice

    Note over Client,Stripe: Back-sync flow (subscription.created webhook)

    participant webhook as Webhook Handler
    participant findMatch as findAutumnMatchForStripeItem
    participant licMatch as findLicenseMatchForStripeItem

    webhook->>findMatch: item (stripe_price_id, stripe_product_id)
    findMatch->>licMatch: fullProducts, item
    licMatch->>licMatch: findExactLicenseLinks (stripe_price_id in license_prices)
    alt exact match found (1 result)
        licMatch-->>findMatch: "{ kind: autumn_license }"
    else no exact match
        licMatch->>licMatch: findShapeMatchedLicenseLinks (price shape x parent product IDs)
        alt 1 shape match
            licMatch-->>findMatch: "{ kind: autumn_license }"
        else 0 matches
            licMatch-->>findMatch: null (fall through to product-level)
        else more than 1 match
            licMatch-->>findMatch: "{ kind: none }"
        end
    end
    findMatch-->>webhook: ItemDiff with matched license + parent product
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts:213
**Silent skip drops license entries on missing parent**

When `parentCustomerProduct` cannot be found (e.g. `parent_customer_product_id` is `null` or the product hasn't been materialised into either `insertCustomerProducts` or `fullCustomer.customer_products`), the `continue` skips adding the entry to `licenseProductsByDefinition` entirely. Before this PR the code was an unconditional `licenseProductsByDefinition.set(planLicense.id, planLicense.product)`, so the license's prices were always included in Stripe resource initialisation. For non-customized license transitions `planLicenseToStripeInitProduct` falls back to `planLicense.product` anyway, meaning the regression happens whenever the parent lookup fails even for ordinary links—those licenses will not have their Stripe prices initialised during the transition.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(licenses): scope custom stripe price..."](https://github.com/useautumn/autumn/commit/f16f009dccb21d7cb08c22b02e36aed136711975) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45055029)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->