### PR TITLE
fix(sync): preserve matched plan version

### DIFF
--- a/server/src/internal/billing/v2/actions/sync/subscriptionToSyncParams.ts
+++ b/server/src/internal/billing/v2/actions/sync/subscriptionToSyncParams.ts
@@ -43,6 +43,7 @@ const matchedPlanToSyncPlan = ({
 		: matchedPlan.customize;
 	return {
 		plan_id: matchedPlan.product.id,
+		version: matchedPlan.product.version,
 		quantity: matchedPlan.quantity,
 		customize,
 		expire_previous: true,

--- a/server/tests/integration/billing/sync/sync-plan-version.test.ts
+++ b/server/tests/integration/billing/sync/sync-plan-version.test.ts
@@ -1,0 +1,290 @@
+/** Exact Stripe Price IDs must select and persist the matching plan version. */
+
+import { expect, test } from "bun:test";
+import {
+	filterCustomerProductsByActiveStatuses,
+	filterCustomerProductsByStripeSubscriptionId,
+	findCustomerEntitlementByFeature,
+	isFixedPrice,
+	type SyncParamsV1,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import ctx from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { billingActions } from "@/internal/billing/v2/actions";
+import { subscriptionToSyncParams } from "@/internal/billing/v2/actions/sync/subscriptionToSyncParams";
+import { CusService } from "@/internal/customers/CusService";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
+import { ProductService } from "@/internal/products/ProductService";
+import { PriceService } from "@/internal/products/prices/PriceService";
+import {
+	createStripeFixedPriceUnderProduct,
+	createStripeSubscriptionSchedule,
+	getBaseStripePriceId,
+	getProductStripeProductId,
+	getStripeCustomerId,
+} from "./utils/syncProductHelpers";
+
+const setupVersionedPlan = async ({
+	planId,
+	customerId,
+}: {
+	planId: string;
+	customerId: string;
+}) => {
+	const plan = products.pro({
+		id: planId,
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+	const { autumnV2_2 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [plan], prefix: "" }),
+		],
+		actions: [],
+	});
+
+	await autumnV2_2.post("/catalog.update", {
+		plans: [
+			{
+				plan_id: planId,
+				name: plan.name,
+				force_version: true,
+				items: [
+					{
+						feature_id: TestFeature.Messages,
+						included: 200,
+						reset: { interval: "month" },
+					},
+				],
+			},
+		],
+	});
+
+	const [v1, v2] = await Promise.all(
+		[1, 2].map((version) =>
+			ProductService.getFull({
+				db: ctx.db,
+				orgId: ctx.org.id,
+				env: ctx.env,
+				idOrInternalId: planId,
+				version,
+			}),
+		),
+	);
+
+	const v1PriceId = getBaseStripePriceId({ fullProduct: v1 });
+	const v2BasePrice = v2.prices[0];
+	if (!v2BasePrice || !isFixedPrice(v2BasePrice)) {
+		throw new Error(`Expected a fixed v2 base price for ${planId}`);
+	}
+	const v2StripePrice = await createStripeFixedPriceUnderProduct({
+		ctx,
+		stripeProductId: getProductStripeProductId({ fullProduct: v2 }),
+		unitAmount: 2_000,
+	});
+	await PriceService.updateConfig({
+		db: ctx.db,
+		id: v2BasePrice.id,
+		config: {
+			...v2BasePrice.config,
+			stripe_price_id: v2StripePrice.id,
+		},
+	});
+
+	return { v1, v2, v1PriceId, v2PriceId: v2StripePrice.id };
+};
+
+const createSubscription = async ({
+	customerId,
+	priceId,
+}: {
+	customerId: string;
+	priceId: string;
+}) =>
+	ctx.stripeCli.subscriptions.create({
+		customer: await getStripeCustomerId({ ctx, customerId }),
+		items: [{ price: priceId }],
+	});
+
+const getPhases = ({ params }: { params: SyncParamsV1 }) => {
+	if (!params.phases) throw new Error("Expected sync phases");
+	return params.phases;
+};
+
+const expectLinkedVersion = async ({
+	customerId,
+	subscriptionId,
+	internalProductId,
+	expectedAllowance,
+}: {
+	customerId: string;
+	subscriptionId: string;
+	internalProductId: string;
+	expectedAllowance: number;
+}) => {
+	const customer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+		withEntities: true,
+		withSubs: true,
+	});
+	const linked = filterCustomerProductsByActiveStatuses({
+		customerProducts: filterCustomerProductsByStripeSubscriptionId({
+			customerProducts: customer.customer_products,
+			stripeSubscriptionId: subscriptionId,
+		}),
+	});
+	expect(linked).toHaveLength(1);
+	expect(linked[0]?.internal_product_id).toBe(internalProductId);
+	const messages = findCustomerEntitlementByFeature({
+		cusEnts: linked[0]?.customer_entitlements ?? [],
+		featureId: TestFeature.Messages,
+		errorOnNotFound: true,
+	});
+	expect(messages.entitlement.allowance).toBe(expectedAllowance);
+};
+
+test(`${chalk.yellowBright("billing.sync: exact Stripe Price selects plan version")}`, async () => {
+	const suffix = Math.random().toString(36).slice(2, 9);
+	const planId = `sync_price_version_${suffix}`;
+	const v1CustomerId = `sync-price-version-v1-${suffix}`;
+	const v2CustomerId = `sync-price-version-v2-${suffix}`;
+	const { v1, v2, v1PriceId, v2PriceId } = await setupVersionedPlan({
+		planId,
+		customerId: v1CustomerId,
+	});
+	await initScenario({
+		customerId: v2CustomerId,
+		setup: [s.customer({ paymentMethod: "success" })],
+		actions: [],
+	});
+	const allVersions = await ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		returnAll: true,
+	});
+
+	const v1Subscription = await createSubscription({
+		customerId: v1CustomerId,
+		priceId: v1PriceId,
+	});
+	const v1Proposal = await subscriptionToSyncParams({
+		ctx,
+		customerId: v1CustomerId,
+		subscription: v1Subscription,
+		fullProducts: allVersions,
+	});
+	expect(getPhases({ params: v1Proposal.params })[0]?.plans[0]).toMatchObject({
+		plan_id: planId,
+		version: 1,
+	});
+	await billingActions.syncV2({ ctx, params: v1Proposal.params });
+	await expectLinkedVersion({
+		customerId: v1CustomerId,
+		subscriptionId: v1Subscription.id,
+		internalProductId: v1.internal_id,
+		expectedAllowance: 100,
+	});
+
+	const v2Subscription = await createSubscription({
+		customerId: v2CustomerId,
+		priceId: v2PriceId,
+	});
+	const v2Proposal = await subscriptionToSyncParams({
+		ctx,
+		customerId: v2CustomerId,
+		subscription: v2Subscription,
+		fullProducts: allVersions,
+	});
+	expect(getPhases({ params: v2Proposal.params })[0]?.plans[0]).toMatchObject({
+		plan_id: planId,
+		version: 2,
+	});
+	await billingActions.syncV2({ ctx, params: v2Proposal.params });
+	await expectLinkedVersion({
+		customerId: v2CustomerId,
+		subscriptionId: v2Subscription.id,
+		internalProductId: v2.internal_id,
+		expectedAllowance: 200,
+	});
+
+	await billingActions.syncV2({ ctx, params: v2Proposal.params });
+	await expectLinkedVersion({
+		customerId: v2CustomerId,
+		subscriptionId: v2Subscription.id,
+		internalProductId: v2.internal_id,
+		expectedAllowance: 200,
+	});
+});
+
+test(`${chalk.yellowBright("billing.sync: schedule phases select exact plan versions")}`, async () => {
+	const suffix = Math.random().toString(36).slice(2, 9);
+	const planId = `sync_schedule_version_${suffix}`;
+	const customerId = `sync-schedule-version-${suffix}`;
+	const { v1, v2, v1PriceId, v2PriceId } = await setupVersionedPlan({
+		planId,
+		customerId,
+	});
+	const { subscription, schedule } = await createStripeSubscriptionSchedule({
+		ctx,
+		customerId,
+		phases: [
+			{ items: [{ price: v1PriceId }] },
+			{ items: [{ price: v2PriceId }] },
+		],
+	});
+	const allVersions = await ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		returnAll: true,
+	});
+	const proposal = await subscriptionToSyncParams({
+		ctx,
+		customerId,
+		subscription,
+		schedule,
+		fullProducts: allVersions,
+	});
+
+	const phases = getPhases({ params: proposal.params });
+	expect(phases).toHaveLength(2);
+	expect(phases[0]?.plans[0]).toMatchObject({
+		plan_id: planId,
+		version: 1,
+	});
+	expect(phases[1]?.plans[0]).toMatchObject({
+		plan_id: planId,
+		version: 2,
+	});
+
+	const result = await billingActions.syncV2({ ctx, params: proposal.params });
+	await expectLinkedVersion({
+		customerId,
+		subscriptionId: subscription.id,
+		internalProductId: v1.internal_id,
+		expectedAllowance: 100,
+	});
+	expect(result.scheduled_phases).toHaveLength(2);
+	const scheduledId =
+		result.scheduled_phases[result.scheduled_phases.length - 1]
+			?.customer_product_ids[0];
+	if (!scheduledId) throw new Error("Expected a scheduled customer product");
+	const scheduled = await CusProductService.getFull({
+		db: ctx.db,
+		id: scheduledId,
+	});
+	expect(scheduled?.internal_product_id).toBe(v2.internal_id);
+	const scheduledMessages = findCustomerEntitlementByFeature({
+		cusEnts: scheduled?.customer_entitlements ?? [],
+		featureId: TestFeature.Messages,
+		errorOnNotFound: true,
+	});
+	expect(scheduledMessages.entitlement.allowance).toBe(200);
+});


### PR DESCRIPTION
## Summary
- carry the detected Autumn plan version into SyncV2 params
- prove exact Stripe Price IDs select the correct historical version
- cover direct imports, preloaded bulk catalogs, idempotent reruns, entitlements, and scheduled version transitions

## Why
Mobbin has customers on several historical Stripe Prices under the same logical plans. Bulk import preloads every catalog version; sync must preserve the exact version matched by Stripe Price ID instead of attaching the latest version.

## Tests
- new version-resolution suite: 2 passed, 20 assertions
- full billing sync suite: 43 passed; the sole failing shared-price provenance test reproduces on unmodified origin/dev and is unrelated to this diff
- baseline typecheck remains blocked by existing duplicate dependency/auth typing failures; no changed-file type errors

## Scope
One production line plus the focused integration test. Existing matching and fallback behavior are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the matched plan version in SyncV2 so exact Stripe Price IDs link to the correct historical plan version instead of defaulting to the latest. Prevents mis-linking for customers on older Stripe Prices.

- **Bug Fixes**
  - Include `version: matchedPlan.product.version` in `SyncPlanInstance` so the selected version persists across phases and schedules.
  - Added integration tests covering direct imports, preloaded catalogs, idempotent reruns, entitlements, and scheduled version transitions.

<sup>Written for commit d2d20430edf028909bdb45b1b2a430324aa9e367. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a version-drift bug in billing sync: when a Stripe Price ID is matched to a historical plan version, the detected version was not forwarded into the `SyncParamsV1` phases, causing `syncV2` to default to the latest plan version. The fix is a single-line addition that copies `matchedPlan.product.version` into the returned `SyncPlanInstance`.

- **[Bug fixes]** In `matchedPlanToSyncPlan`, the matched product's `version` field is now included in the returned `SyncPlanInstance`, ensuring Stripe Price ID → plan version resolution is preserved end-to-end through `subscriptionToSyncParams` into `syncV2`.
- **[Improvements]** New integration test suite (`sync-plan-version.test.ts`) covers version selection via direct import, preloaded bulk catalog, idempotent reruns, entitlement assertions, and subscription schedule phase transitions across two plan versions.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. The production change is a single field addition in a mapping function, the type is always a non-optional number from the database schema, and the new integration tests verify the fix end-to-end across all stated scenarios.

The fix correctly copies a well-typed, non-nullable field (FullProduct.version: number) into an already-defined optional slot on SyncPlanInstance. The field was present in the schema before this PR — it was just never populated by the sync path. All surrounding logic (entity stamping, expiry, license quantities) is untouched. The integration tests exercise direct import, preloaded bulk catalog, idempotent rerun, entitlement allowances, and schedule phase transitions.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/sync/subscriptionToSyncParams.ts | One-line fix: adds `version: matchedPlan.product.version` to the SyncPlanInstance return object; `FullProduct.version` is always a non-optional `number` and `SyncPlanInstance.version` accepts `number | undefined`, so the assignment is type-safe and correct. |
| server/tests/integration/billing/sync/sync-plan-version.test.ts | New integration test file; covers version selection via both direct import and preloaded catalog, idempotent resync, entitlement allowance verification, and schedule-phase version transitions across two plan versions. |

<sub>Reviews (1): Last reviewed commit: ["fix(sync): preserve matched plan version"](https://github.com/useautumn/autumn/commit/b1fd52d977913bbfd6cd9d125ba8e19afe2a08f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45060566)</sub>

<!-- /greptile_comment -->