### PR TITLE
fix(emails): use real invite link in org invitation email

### DIFF
--- a/server/src/internal/emails/sendInvitationEmail.ts
+++ b/server/src/internal/emails/sendInvitationEmail.ts
@@ -3,12 +3,18 @@ import { sendTextEmail } from "@/external/resend/resendUtils.js";
 import { safeResend } from "@/external/resend/safeResend.js";
 import { FROM_AUTUMN } from "./constants.js";
 
-const getInvitationEmailBody = ({ orgName }: { orgName: string }) => {
-	return `Hey there! You've been invited to join ${orgName} on Autumn. 
+const getInvitationEmailBody = ({
+	orgName,
+	inviteLink,
+}: {
+	orgName: string;
+	inviteLink: string;
+}) => {
+	return `Hey there! You've been invited to join ${orgName} on Autumn.
 
-Click the link below to create an account / sign in to Autumn and accept the invitation.
+Click the link below to create an account / sign in to Autumn and accept the invitation. This invitation expires in 7 days.
 
-${process.env.CLIENT_URL}/sign-in
+${inviteLink}
   `;
 };
 
@@ -20,14 +26,14 @@ export const sendInvitationEmail = safeResend({
 	}: {
 		email: string;
 		orgName: string;
-		inviteLink?: string;
+		inviteLink: string;
 	}) => {
 		logger.info(`Sending invitation email to ${email}`);
 		await sendTextEmail({
 			from: FROM_AUTUMN,
 			to: email,
 			subject: `Join ${orgName} on Autumn`,
-			body: getInvitationEmailBody({ orgName }),
+			body: getInvitationEmailBody({ orgName, inviteLink }),
 		});
 	},
 	action: "send org invitation email",


### PR DESCRIPTION
## Problem

The org invitation email tells recipients to "click the link below … and accept the invitation", but the link it prints is a generic `${CLIENT_URL}/sign-in`. `getInvitationEmailBody` accepted no `inviteLink` and hardcoded the sign-in URL, even though `sendInvitationEmail` received a correct `/accept?id=<id>` link from `auth.ts` and passed it in.

Recipients therefore land on a sign-in page with no invitation id and no route to `/accept`. The invite is only reachable if they happen to find it via the in-app notification UI after signing in with the invited address.

Reported by a user who received an invite to an org, followed the email, and saw no invitation. Their invite row was `pending` and correctly set to a 7 day TTL — the expiry was a red herring; the email never carried a usable link in the first place.

## Change

- `getInvitationEmailBody` takes `inviteLink` and prints it instead of `${CLIENT_URL}/sign-in`.
- `inviteLink` goes from optional to required, so a caller cannot silently reintroduce a linkless email. `auth.ts:331` is the only caller and already passes it.
- Copy now states the 7 day expiry, which was previously unmentioned.

## Testing

- `bun ts` passes in `server/`.
- No behaviour change to expiry, invite creation, or the accept flow — this is email body copy only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix org invitation emails to include the real invite URL so recipients land on the Accept Invite page instead of the generic sign-in. Copy now mentions the 7‑day expiry.

- **Bug Fixes**
  - Render the passed `inviteLink` in the email body (replaces `${CLIENT_URL}/sign-in`).
  - Make `inviteLink` required in `sendInvitationEmail` and `getInvitationEmailBody` to prevent regressions.

<sup>Written for commit 52851d3f9bef1ab19dcd6622a7377d3f44602630. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where org invitation emails directed recipients to a generic sign-in page (`/sign-in`) instead of the actual invitation-accept URL (`/accept?id=<id>`), making invitations unreachable via email.

- **Bug fixes** — `getInvitationEmailBody` now accepts and renders the real `inviteLink` passed by the caller instead of hardcoding `${CLIENT_URL}/sign-in`.
- **API changes** — `inviteLink` is promoted from optional to required in both `getInvitationEmailBody` and `sendInvitationEmail`, preventing silent regression.
- **Improvements** — Email copy now discloses the 7-day expiry that was already enforced in the database but never communicated to recipients.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted one-file fix that corrects a broken email link and makes the parameter required; the only caller already passes the correct value.

The fix is minimal and surgical: one function gains a required parameter it always should have had, and the single caller in auth.ts already supplied the right value. No logic around invite creation, expiry, or the accept flow is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/emails/sendInvitationEmail.ts | Fixes the bug: passes the real invite link through to the email body and makes inviteLink required; the sole caller in auth.ts already supplies it correctly. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant A as auth.ts
    participant S as sendInvitationEmail
    participant G as getInvitationEmailBody
    participant R as Resend (sendTextEmail)

    A->>A: "Build inviteLink = CLIENT_URL + /accept?id=<id>"
    A->>S: "{ email, orgName, inviteLink }"
    S->>G: "{ orgName, inviteLink }"
    G-->>S: email body with real inviteLink
    S->>R: "sendTextEmail({ to: email, body })"
    R-->>S: sent
    Note over A: Also updates DB expiry to +7 days
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant A as auth.ts
    participant S as sendInvitationEmail
    participant G as getInvitationEmailBody
    participant R as Resend (sendTextEmail)

    A->>A: "Build inviteLink = CLIENT_URL + /accept?id=<id>"
    A->>S: "{ email, orgName, inviteLink }"
    S->>G: "{ orgName, inviteLink }"
    G-->>S: email body with real inviteLink
    S->>R: "sendTextEmail({ to: email, body })"
    R-->>S: sent
    Note over A: Also updates DB expiry to +7 days
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(emails): use real invite link in org..."](https://github.com/useautumn/autumn/commit/52851d3f9bef1ab19dcd6622a7377d3f44602630) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45067023)</sub>

<!-- /greptile_comment -->