### PR TITLE
Fix versioned license pricing in plan dashboard

### DIFF
--- a/vite/src/hooks/queries/usePlanLicensesQuery.tsx
+++ b/vite/src/hooks/queries/usePlanLicensesQuery.tsx
@@ -3,7 +3,9 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 
-const EMPTY_PLAN_LICENSES: PlanLicense[] = [];
+export type VersionedPlanLicense = PlanLicense & { version: number };
+
+const EMPTY_PLAN_LICENSES: VersionedPlanLicense[] = [];
 
 const toPlanLicenses = ({
 	parentPlanId,
@@ -11,11 +13,12 @@ const toPlanLicenses = ({
 }: {
 	parentPlanId: string;
 	licenses: NonNullable<ApiPlanV1["licenses"]>;
-}): PlanLicense[] =>
+}): VersionedPlanLicense[] =>
 	licenses.map((link) => ({
 		id: `${parentPlanId}:${link.license_plan_id}`,
 		parent_plan_id: parentPlanId,
 		license_plan_id: link.license_plan_id,
+		version: link.version,
 		included: link.included,
 		prepaid_only: link.prepaid_only,
 		customize: link.customize ?? null,
@@ -45,7 +48,7 @@ export const usePlanLicensesQuery = (parentPlanId?: string) => {
 		});
 	};
 
-	const { data, isLoading, error, refetch } = useQuery<PlanLicense[]>({
+	const { data, isLoading, error, refetch } = useQuery<VersionedPlanLicense[]>({
 		queryKey: buildKey(["plan_licenses", parentPlanId ?? null]),
 		queryFn: () => fetchPlanLicenses(parentPlanId as string),
 		enabled: Boolean(parentPlanId),

--- a/vite/src/views/products/plan/components/plan-licenses/resolvePlanLicenseProduct.ts
+++ b/vite/src/views/products/plan/components/plan-licenses/resolvePlanLicenseProduct.ts
@@ -1,0 +1,14 @@
+import type { ProductV2 } from "@autumn/shared";
+
+export const resolvePlanLicenseProduct = ({
+	products,
+	planId,
+	version,
+}: {
+	products: ProductV2[];
+	planId: string;
+	version: number;
+}) =>
+	products.find(
+		(product) => product.id === planId && product.version === version,
+	);

--- a/vite/src/views/products/plan/components/plan-licenses/useResolvedPlanLicenses.ts
+++ b/vite/src/views/products/plan/components/plan-licenses/useResolvedPlanLicenses.ts
@@ -12,6 +12,7 @@ import {
 	pendingPlanLicense,
 	usePendingLicenseLinks,
 } from "./PendingLicenseLinksContext";
+import { resolvePlanLicenseProduct } from "./resolvePlanLicenseProduct";
 
 export interface ResolvedPlanLicense {
 	planLicense: PlanLicense;
@@ -33,7 +34,7 @@ export function useResolvedPlanLicenses(): ResolvedPlanLicense[] {
 	const { planLicenses: fallbackPlanLicenses } = usePlanLicensesQuery(
 		isLicense || pageCatalogLicenses ? undefined : product?.id,
 	);
-	const { products } = useProductsQuery();
+	const { products } = useProductsQuery({ allVersions: true });
 	const { pendingLicenseIds } = usePendingLicenseLinks();
 	const initialPatches = useInitialLicensePatches();
 
@@ -44,10 +45,20 @@ export function useResolvedPlanLicenses(): ResolvedPlanLicense[] {
 		const licenseById = new Map(
 			products.map((license) => [license.id, license]),
 		);
+		for (const license of products) {
+			const latest = licenseById.get(license.id);
+			if (!latest || license.version > latest.version) {
+				licenseById.set(license.id, license);
+			}
+		}
 		const persistedLicenses = pageCatalogLicenses
 			? pageCatalogLicenses.map((entry) => ({ ...entry, isPendingLink: false }))
 			: fallbackPlanLicenses.flatMap((planLicense) => {
-					const license = licenseById.get(planLicense.license_plan_id);
+					const license = resolvePlanLicenseProduct({
+						products,
+						planId: planLicense.license_plan_id,
+						version: planLicense.version,
+					});
 					return license
 						? [{ planLicense, license, isPendingLink: false }]
 						: [];

--- a/vite/tests/views/products/plan/resolve-plan-license-product.test.ts
+++ b/vite/tests/views/products/plan/resolve-plan-license-product.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test";
+import type { ProductV2 } from "@autumn/shared";
+import { resolvePlanLicenseProduct } from "@/views/products/plan/components/plan-licenses/resolvePlanLicenseProduct";
+
+test("resolves the license version pinned by the parent plan", () => {
+	const products = [
+		{ id: "team_seat", version: 1, name: "$54" },
+		{ id: "team_seat", version: 5, name: "$72" },
+	] as ProductV2[];
+
+	expect(
+		resolvePlanLicenseProduct({ products, planId: "team_seat", version: 1 })
+			?.name,
+	).toBe("$54");
+});


### PR DESCRIPTION
## Summary
- preserve the license plan version returned by `plans.get`
- resolve linked license products by public ID and pinned version
- keep staged license links resolving to the latest available version

## Validation
- `bun test tests/views/products/plan/resolve-plan-license-product.test.ts`
- `bun run ts`
- pre-commit `knip` and scoped Vite typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes plan dashboard license pricing by resolving linked license products using the plan-pinned version. Staged links still use the latest version so previews stay current.

- **Bug Fixes**
  - Preserve license link version from `plans.get` via `VersionedPlanLicense`.
  - Resolve linked products by `id` + `version` using `resolvePlanLicenseProduct` and `useProductsQuery({ allVersions: true })`.
  - Keep staged (pending) links pointing to the latest available version.
  - Add unit test to confirm pinned-version resolution.

<sup>Written for commit fcc09de90b840ad4e7cfe67dcf12bf5b6ee74021. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes incorrect pricing shown for versioned license products in the plan dashboard by preserving the version number returned by `plans.get` and using it to resolve persisted license links to their pinned product version rather than an arbitrary latest entry.

- **Bug fixes** | **Improvements**: `usePlanLicensesQuery` now maps `link.version` into a new `VersionedPlanLicense` type, and `useResolvedPlanLicenses` passes that version to a new `resolvePlanLicenseProduct` helper that matches on both `id` and `version` — ensuring the dashboard shows the price configured at the time the link was created.
- **Improvements**: Staged/pending license links continue to resolve to the latest available version via a `licenseById` map built from the full `allVersions: true` product list, which was already a supported query option with its own cache key.
- **Improvements**: A targeted unit test is added to verify the version-pinning behaviour of `resolvePlanLicenseProduct`.
</details>


<h3>Confidence Score: 4/5</h3>

- The change is a focused, well-scoped fix: it threads the version number from the API response through to product resolution and correctly splits persisted vs. staged license lookup paths.
- The new resolution logic is correct and the unit test validates the core helper. Two minor style concerns exist: the `licenseById` map is built with a redundant first pass that makes the `!latest` branch unreachable, and `ResolvedPlanLicense.planLicense` is still typed as the base `PlanLicense` rather than `VersionedPlanLicense`, hiding the `.version` field from downstream consumers without a cast.
- vite/src/views/products/plan/components/plan-licenses/useResolvedPlanLicenses.ts — the redundant map initialization and the interface type narrowing are both worth a second look before merge.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/hooks/queries/usePlanLicensesQuery.tsx | Exports new VersionedPlanLicense type and maps link.version from the API response into the returned plan-license objects; straightforward and correct. |
| vite/src/views/products/plan/components/plan-licenses/resolvePlanLicenseProduct.ts | New helper that finds a ProductV2 by public id and exact version; logic is correct and well-covered by the new unit test. |
| vite/src/views/products/plan/components/plan-licenses/useResolvedPlanLicenses.ts | Switches persisted licenses to version-pinned resolution and staged licenses to latest-version resolution; contains a redundant two-pass map construction where the first pass's result is immediately overwritten by the loop. |
| vite/tests/views/products/plan/resolve-plan-license-product.test.ts | New unit test validating that resolvePlanLicenseProduct picks the pinned version over the latest; happy-path coverage is correct. |


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[useResolvedPlanLicenses] --> B{pageCatalogLicenses?}
    B -- Yes --> C[Use server-resolved licenses]
    B -- No --> D[usePlanLicensesQuery returns VersionedPlanLicense array]

    D --> E[resolvePlanLicenseProduct - match by id AND version]
    E --> F[persistedLicenses with version-pinned ProductV2]

    A --> G[useProductsQuery with allVersions true]
    G --> H[licenseById Map - id to latest version ProductV2]

    A --> I[pendingLicenseIds + initialPatches]
    I --> J[stagedIds not in persistedIds]
    J --> K[licenseById.get - latest version ProductV2]
    K --> L[pendingLicenses]

    F --> M[return persistedLicenses + pendingLicenses]
    C --> M
    L --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[useResolvedPlanLicenses] --> B{pageCatalogLicenses?}
    B -- Yes --> C[Use server-resolved licenses]
    B -- No --> D[usePlanLicensesQuery returns VersionedPlanLicense array]

    D --> E[resolvePlanLicenseProduct - match by id AND version]
    E --> F[persistedLicenses with version-pinned ProductV2]

    A --> G[useProductsQuery with allVersions true]
    G --> H[licenseById Map - id to latest version ProductV2]

    A --> I[pendingLicenseIds + initialPatches]
    I --> J[stagedIds not in persistedIds]
    J --> K[licenseById.get - latest version ProductV2]
    K --> L[pendingLicenses]

    F --> M[return persistedLicenses + pendingLicenses]
    C --> M
    L --> M
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/src/views/products/plan/components/plan-licenses/useResolvedPlanLicenses.ts`, line 17-21 ([link](https://github.com/useautumn/autumn/blob/fcc09de90b840ad4e7cfe67dcf12bf5b6ee74021/vite/src/views/products/plan/components/plan-licenses/useResolvedPlanLicenses.ts#L17-L21)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `ResolvedPlanLicense.planLicense` is still typed as the base `PlanLicense`, not the narrower `VersionedPlanLicense`. Persisted licenses are now resolved from `fallbackPlanLicenses` (type `VersionedPlanLicense[]`), so the runtime object does carry `.version` — but it is invisible to callers through this interface. Any downstream component that needs the pinned version for display or comparison would have to cast. Consider widening the type to `PlanLicense | VersionedPlanLicense` or replacing it with `VersionedPlanLicense` to make the contract explicit.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/views/products/plan/components/plan-licenses/useResolvedPlanLicenses.ts
   Line: 17-21

   Comment:
   `ResolvedPlanLicense.planLicense` is still typed as the base `PlanLicense`, not the narrower `VersionedPlanLicense`. Persisted licenses are now resolved from `fallbackPlanLicenses` (type `VersionedPlanLicense[]`), so the runtime object does carry `.version` — but it is invisible to callers through this interface. Any downstream component that needs the pinned version for display or comparison would have to cast. Consider widening the type to `PlanLicense | VersionedPlanLicense` or replacing it with `VersionedPlanLicense` to make the contract explicit.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/views/products/plan/components/plan-licenses/useResolvedPlanLicenses.ts:45-53
Redundant two-pass map construction — `new Map(products.map(...))` already populates every ID, so `!latest` in the loop is always `false` (dead code). The first pass builds a map where the last item for each duplicate ID wins arbitrarily; the subsequent loop then fully rewrites it to highest-version-wins anyway. A single loop is both clearer and avoids the intermediate allocation.

```suggestion
		const licenseById = new Map<string, (typeof products)[0]>();
		for (const license of products) {
			const latest = licenseById.get(license.id);
			if (!latest || license.version > latest.version) {
				licenseById.set(license.id, license);
			}
		}
```

### Issue 2 of 2
vite/src/views/products/plan/components/plan-licenses/useResolvedPlanLicenses.ts:17-21
`ResolvedPlanLicense.planLicense` is still typed as the base `PlanLicense`, not the narrower `VersionedPlanLicense`. Persisted licenses are now resolved from `fallbackPlanLicenses` (type `VersionedPlanLicense[]`), so the runtime object does carry `.version` — but it is invisible to callers through this interface. Any downstream component that needs the pinned version for display or comparison would have to cast. Consider widening the type to `PlanLicense | VersionedPlanLicense` or replacing it with `VersionedPlanLicense` to make the contract explicit.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): resolve pinned license p..."](https://github.com/useautumn/autumn/commit/fcc09de90b840ad4e7cfe67dcf12bf5b6ee74021) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45101449)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->