### PR TITLE
fix(licenses): resolve versioned license products

### DIFF
--- a/server/src/internal/licenses/repos/planLicenseRepo.ts
+++ b/server/src/internal/licenses/repos/planLicenseRepo.ts
@@ -178,6 +178,30 @@ const listCatalogByOrgEnv = async ({
 	return rows.map(({ row }) => row);
 };
 
+const listProductsByInternalIds = async ({
+	db,
+	orgId,
+	env,
+	internalProductIds,
+}: {
+	db: DrizzleCli;
+	orgId: string;
+	env: AppEnv;
+	internalProductIds: string[];
+}) => {
+	if (internalProductIds.length === 0) return [];
+	return await db
+		.select({ id: products.id })
+		.from(products)
+		.where(
+			and(
+				eq(products.org_id, orgId),
+				eq(products.env, env),
+				inArray(products.internal_id, internalProductIds),
+			),
+		);
+};
+
 const insertMany = async ({
 	db,
 	rows,
@@ -201,6 +225,7 @@ export const planLicenseRepo = {
 	listCatalogByLicenseInternalProductIds,
 	listWithLicensePlanIdByParents,
 	listCatalogByOrgEnv,
+	listProductsByInternalIds,
 	insertMany,
 	deleteByIds,
 } as const;

--- a/server/src/internal/products/internalHandlers/handleGetProducts.ts
+++ b/server/src/internal/products/internalHandlers/handleGetProducts.ts
@@ -117,6 +117,8 @@ export const handleGetLicenseProducts = createRoute({
 		// so versioned license plans still match the latest-version list below.
 		const linkedProducts = await planLicenseRepo.listProductsByInternalIds({
 			db,
+			orgId: org.id,
+			env,
 			internalProductIds: linkedInternalIds,
 		});
 		const linkedExternalIds = new Set(

--- a/server/tests/integration/licenses/catalog-update/license-products-versioned.test.ts
+++ b/server/tests/integration/licenses/catalog-update/license-products-versioned.test.ts
@@ -1,0 +1,51 @@
+/**
+ * A parent pinned to an older license version must still expose the latest license in the catalog.
+ */
+import { expect, test } from "bun:test";
+import type { ProductV2 } from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("licenses: catalog includes latest license when parent remains pinned to v1")}`,
+	async () => {
+		const parent = products.base({
+			id: "versioned-license-catalog-parent",
+			items: [items.dashboard()],
+		});
+		const license = products.base({
+			id: "versioned-license-catalog-seat",
+			items: [items.monthlyMessages({ includedUsage: 25 })],
+		});
+		const { autumnV2_2 } = await initScenario({
+			customerId: "versioned-license-catalog",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 0,
+				}),
+			],
+		});
+
+		await autumnV2_2.post("/plans.update", {
+			plan_id: license.id,
+			force_version: true,
+			items: [itemsV2.monthlyMessages({ included: 50 })],
+		});
+
+		const { products: licenseProducts } = (await autumnV2_2.get(
+			"/products/license_products",
+		)) as { products: ProductV2[] };
+		expect(licenseProducts).toContainEqual(
+			expect.objectContaining({ id: license.id, version: 2 }),
+		);
+	},
+);


### PR DESCRIPTION
Fixes the main ECR typecheck failure and keeps licenses visible when a parent link pins an older license version.

- add the missing org/env-scoped historical product lookup
- preserve latest license catalog results for links pinned to v1
- add integration regression coverage

Validation:
- `bunx tsgo --build --noEmit` from `server/`
- focused integration test passes against an isolated local server

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix license product resolution so the latest license remains in the catalog even when a parent link is pinned to an older version. Adds an org/env-scoped lookup to return correct products and fixes a typecheck build failure.

- **Bug Fixes**
  - Added `listProductsByInternalIds` with org/env scoping to fetch historical products correctly.
  - Updated `handleGetLicenseProducts` to pass `orgId` and `env`, preserving latest catalog results for versioned links.
  - Added an integration test to ensure pinned v1 parents still expose the latest license in the catalog.

<sup>Written for commit c121c014f4e28a6dfec783653dac8c7c3d031376. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a TypeScript compilation error in `handleGetLicenseProducts` where `listProductsByInternalIds` was called without the required `orgId` and `env` parameters. It also introduces the backing DB function (`listProductsByInternalIds`) that translates a link's pinned `internal_id` (which points to a specific product version) to the stable public product ID, allowing the catalog endpoint to always surface the **latest** version of a license product even when an existing parent link was created against an older version.

- **[Bug fix]** Add missing `orgId`/`env` arguments to the `planLicenseRepo.listProductsByInternalIds` call in `handleGetLicenseProducts`, unblocking the ECR typecheck and restoring multi-tenant query scoping.
- **[Improvements]** Add `listProductsByInternalIds` to `planLicenseRepo` with a proper early-exit for empty input and correct org/env WHERE clauses.
- **[Improvements]** Add a concurrent integration regression test that force-versions a linked license product and asserts the v2 entry still appears in `/products/license_products`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are a narrowly-scoped bug fix with a direct regression test and no structural side effects.

The two-line call-site fix is straightforward: it adds the required `orgId` and `env` arguments that were always needed for correct multi-tenant scoping. The new repo function is defensive (early-exit on empty input, explicit WHERE clauses), and the logic of translating versioned `internal_id` → stable public `id` to bridge old links to the latest product catalog entry is sound. The integration test exercises the exact failure scenario end-to-end.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/licenses/repos/planLicenseRepo.ts | Adds `listProductsByInternalIds` — a correctly org/env-scoped DB query that translates versioned `internal_id` values to stable public product IDs; wired into the exported repo object. |
| server/src/internal/products/internalHandlers/handleGetProducts.ts | Adds the previously-missing `orgId` and `env` arguments to the `listProductsByInternalIds` call, fixing the TypeScript compile error and restoring proper tenant isolation. |
| server/tests/integration/licenses/catalog-update/license-products-versioned.test.ts | New integration regression test: creates a license link, forces a version bump on the license product, and asserts the v2 product is still visible in the catalog. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant handleGetLicenseProducts
    participant planLicenseRepo
    participant ProductService

    Client->>handleGetLicenseProducts: GET /products/license_products
    handleGetLicenseProducts->>planLicenseRepo: listCatalogByOrgEnv(orgId, env)
    planLicenseRepo-->>handleGetLicenseProducts: links[] (each with license_internal_product_id)
    note over handleGetLicenseProducts: extract linkedInternalIds[]
    handleGetLicenseProducts->>planLicenseRepo: listProductsByInternalIds(orgId, env, internalIds[])
    note over planLicenseRepo: SELECT id FROM products WHERE internal_id IN (...) AND org_id = orgId AND env = env
    planLicenseRepo-->>handleGetLicenseProducts: "[{id: stable-public-id}] (may be old version row)"
    note over handleGetLicenseProducts: build linkedExternalIds Set of public IDs
    handleGetLicenseProducts->>ProductService: listFull(orgId, env, returnAll)
    ProductService-->>handleGetLicenseProducts: products[] (latest versions by default)
    note over handleGetLicenseProducts: filter products where linkedExternalIds.has(product.id)
    handleGetLicenseProducts-->>Client: "{products: licenseProducts[]}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant handleGetLicenseProducts
    participant planLicenseRepo
    participant ProductService

    Client->>handleGetLicenseProducts: GET /products/license_products
    handleGetLicenseProducts->>planLicenseRepo: listCatalogByOrgEnv(orgId, env)
    planLicenseRepo-->>handleGetLicenseProducts: links[] (each with license_internal_product_id)
    note over handleGetLicenseProducts: extract linkedInternalIds[]
    handleGetLicenseProducts->>planLicenseRepo: listProductsByInternalIds(orgId, env, internalIds[])
    note over planLicenseRepo: SELECT id FROM products WHERE internal_id IN (...) AND org_id = orgId AND env = env
    planLicenseRepo-->>handleGetLicenseProducts: "[{id: stable-public-id}] (may be old version row)"
    note over handleGetLicenseProducts: build linkedExternalIds Set of public IDs
    handleGetLicenseProducts->>ProductService: listFull(orgId, env, returnAll)
    ProductService-->>handleGetLicenseProducts: products[] (latest versions by default)
    note over handleGetLicenseProducts: filter products where linkedExternalIds.has(product.id)
    handleGetLicenseProducts-->>Client: "{products: licenseProducts[]}"
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(licenses): resolve versioned license..."](https://github.com/useautumn/autumn/commit/c121c014f4e28a6dfec783653dac8c7c3d031376) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45114741)</sub>

<!-- /greptile_comment -->