### PR TITLE
fix(catalog): reconcile omitted plan versions

### DIFF
--- a/server/src/internal/catalog/actions/deriveReplaceRemovals.ts
+++ b/server/src/internal/catalog/actions/deriveReplaceRemovals.ts
@@ -50,10 +50,13 @@ export const deriveReplacePlanRemovals = ({
 				.map((planId) => `${planId}:${plan.version}`);
 		}),
 	);
+	const omittedPlanIds = new Set<string>();
 
 	return products.flatMap((product): ReplacePlanRemoval[] => {
 		if (product.archived) return [];
 		if (!desiredPlanIds.has(product.id)) {
+			if (omittedPlanIds.has(product.id)) return [];
+			omittedPlanIds.add(product.id);
 			return [{ planId: product.id, allVersions: true }];
 		}
 		if (

--- a/server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts
+++ b/server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts
@@ -476,6 +476,7 @@ export const updateCatalog = async ({
 		db,
 		orgId: org.id,
 		env,
+		returnAll: true,
 	});
 	validateCatalogVariantVersionTargets({
 		params,

--- a/server/tests/integration/crud/catalog/catalog-explicit-version-removal.test.ts
+++ b/server/tests/integration/crud/catalog/catalog-explicit-version-removal.test.ts
@@ -53,3 +53,49 @@ test(`${chalk.yellowBright("catalog: update removes every omitted explicit versi
 	});
 	expect(versions.map(({ version }) => version)).toEqual([1]);
 });
+
+test(`${chalk.yellowBright("catalog: update removes an entirely omitted versioned plan once")}`, async () => {
+	const suffix = Math.random().toString(36).slice(2, 9);
+	const planId = `catalog_remove_plan_${suffix}`;
+	const product = products.pro({ id: planId, items: [] });
+	const { autumnV2_2, ctx } = await initScenario({
+		customerId: `catalog-remove-plan-${suffix}`,
+		setup: [s.products({ list: [product], prefix: "" })],
+		actions: [],
+	});
+
+	await autumnV2_2.post("/catalog.update", {
+		plans: [{ plan_id: planId, name: "Version 2", force_version: true }],
+	});
+
+	const productsBefore = await ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		returnAll: true,
+	});
+	const skipPlanIds = [
+		...new Set(
+			productsBefore
+				.map(({ id }) => id)
+				.filter((currentPlanId) => currentPlanId !== planId),
+		),
+	];
+
+	await autumnV2_2.catalog.update({
+		features: [],
+		plans: [],
+		skip_deletions: false,
+		skip_feature_ids: ctx.features.map(({ id }) => id),
+		skip_plan_ids: skipPlanIds,
+	});
+
+	const versions = await ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		inIds: [planId],
+		returnAll: true,
+	});
+	expect(versions).toHaveLength(0);
+});

--- a/server/tests/integration/crud/catalog/catalog-explicit-version-removal.test.ts
+++ b/server/tests/integration/crud/catalog/catalog-explicit-version-removal.test.ts
@@ -1,0 +1,55 @@
+/** Red left older omitted versions behind; green removes every omitted explicit version. */
+
+import { expect, test } from "bun:test";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { ProductService } from "@/internal/products/ProductService.js";
+
+test(`${chalk.yellowBright("catalog: update removes every omitted explicit version")}`, async () => {
+	const suffix = Math.random().toString(36).slice(2, 9);
+	const planId = `catalog_remove_versions_${suffix}`;
+	const product = products.pro({ id: planId, items: [] });
+	const { autumnV2_2, ctx } = await initScenario({
+		customerId: `catalog-remove-versions-${suffix}`,
+		setup: [s.products({ list: [product], prefix: "" })],
+		actions: [],
+	});
+
+	for (const name of ["Version 2", "Version 3"]) {
+		await autumnV2_2.post("/catalog.update", {
+			plans: [{ plan_id: planId, name, force_version: true }],
+		});
+	}
+
+	const productsBefore = await ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		returnAll: true,
+	});
+	const skipPlanIds = [
+		...new Set(
+			productsBefore
+				.map(({ id }) => id)
+				.filter((currentPlanId) => currentPlanId !== planId),
+		),
+	];
+
+	await autumnV2_2.catalog.update({
+		features: [],
+		plans: [{ plan_id: planId, version: 1 }],
+		skip_deletions: false,
+		skip_feature_ids: ctx.features.map(({ id }) => id),
+		skip_plan_ids: skipPlanIds,
+	});
+
+	const versions = await ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		inIds: [planId],
+		returnAll: true,
+	});
+	expect(versions.map(({ version }) => version)).toEqual([1]);
+});


### PR DESCRIPTION
## Summary
- load every stored plan version before deriving catalog removals
- remove all omitted explicit versions in one catalog update
- preserve existing unversioned/current-plan behavior

## Verification
- `bunx tsgo --build --noEmit`
- `./run.sh server/tests/integration/crud/catalog/catalog-explicit-version-removal.test.ts` (red before, green after)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes catalog updates to correctly remove omitted plan versions and dedupe whole-plan removals in one pass. Loads all stored plan versions before computing removals and keeps unversioned/current-plan behavior unchanged.

- **Bug Fixes**
  - Load every stored version with `ProductService.listFull(..., returnAll: true)` before deriving removals.
  - Remove all omitted explicit versions in a single `catalog.update`.
  - Dedupe whole-plan removals so an entirely omitted plan is removed once even if multiple versions exist.
  - Add integration tests covering explicit-version removal and whole-plan omission.

<sup>Written for commit a13b6158da4034b3d7105c296a023e37fc535a18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where `updateCatalog` only loaded the latest version of each plan before computing removals, causing all older explicit-version rows to be silently left behind when omitted from a catalog update. Adding `returnAll: true` to the pre-update `ProductService.listFull` call ensures every stored version is visible to `deriveReplacePlanRemovals`, so all omitted explicit versions are deleted or archived in a single pass.

- **[Bug fix]** `updateCatalog.ts`: passes `returnAll: true` to `ProductService.listFull` so every plan version (not just the latest) is included in the products snapshot used to derive removals.
- **[Improvements]** New integration test (`catalog-explicit-version-removal.test.ts`) creates two extra explicit versions of a plan, then verifies a catalog update specifying only version 1 removes both extras in one call.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge — the core fix is minimal and well-tested; the one concern is a weakened secondary validation that is already covered by the pre-flight check.

The one-line change is correct and the integration test directly validates the regression scenario. The only wrinkle is that `validateCatalogVariantVersionTargets` now receives all versions and its `latestByPlanId` map depends on non-deterministic query order, making the check unreliable. Because `previewUpdateCatalog` runs the same validation with only latest versions before reaching this point, there is no practical impact today — but the secondary check is silently weakened.

The secondary `validateCatalogVariantVersionTargets` call in `updateCatalog.ts` (lines 481–484) deserves a follow-up to either reduce the all-versions product list to a max-version-per-id map or remove the duplicate check entirely.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts | Single-line fix: adds `returnAll: true` to the pre-update `ProductService.listFull` call so all plan versions are visible when computing catalog removals. Secondary `validateCatalogVariantVersionTargets` call now receives multi-version products, but its latestByPlanId map relies on array-iteration order; this is a non-deterministic weakness, though it is guarded by the same validation already running in `previewUpdateCatalog`. |
| server/tests/integration/crud/catalog/catalog-explicit-version-removal.test.ts | New integration test directly verifying the fix: creates two extra explicit versions of a plan, performs a catalog update specifying only version 1, and asserts only version 1 survives. Well-scoped and covers the exact regression scenario. |


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant updateCatalog
    participant ProductService
    participant deriveReplacePlanRemovals
    participant applyMissingPlanRemovals

    Client->>updateCatalog: CatalogUpdateParams (plans with explicit versions)
    updateCatalog->>updateCatalog: previewUpdateCatalog (preflight)
    updateCatalog->>ProductService: "listFull({ returnAll: true })"
    Note over ProductService: Returns ALL versions<br/>(v1, v2, v3…) per plan
    ProductService-->>updateCatalog: productsBeforeUpdate (all versions)
    updateCatalog->>deriveReplacePlanRemovals: products (all versions), plans
    Note over deriveReplacePlanRemovals: Compares every stored version<br/>against desired versions
    deriveReplacePlanRemovals-->>updateCatalog: removals (all omitted versions)
    updateCatalog->>applyMissingPlanRemovals: removals filtered by skip_plan_ids
    applyMissingPlanRemovals->>applyMissingPlanRemovals: archive or delete each version
    updateCatalog-->>Client: CatalogUpdateResponse
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant updateCatalog
    participant ProductService
    participant deriveReplacePlanRemovals
    participant applyMissingPlanRemovals

    Client->>updateCatalog: CatalogUpdateParams (plans with explicit versions)
    updateCatalog->>updateCatalog: previewUpdateCatalog (preflight)
    updateCatalog->>ProductService: "listFull({ returnAll: true })"
    Note over ProductService: Returns ALL versions<br/>(v1, v2, v3…) per plan
    ProductService-->>updateCatalog: productsBeforeUpdate (all versions)
    updateCatalog->>deriveReplacePlanRemovals: products (all versions), plans
    Note over deriveReplacePlanRemovals: Compares every stored version<br/>against desired versions
    deriveReplacePlanRemovals-->>updateCatalog: removals (all omitted versions)
    updateCatalog->>applyMissingPlanRemovals: removals filtered by skip_plan_ids
    applyMissingPlanRemovals->>applyMissingPlanRemovals: archive or delete each version
    updateCatalog-->>Client: CatalogUpdateResponse
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts`, line 481-484 ([link](https://github.com/useautumn/autumn/blob/317092a88ed5120eae92338f02f2870895ef9070/server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts#L481-L484)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `validateCatalogVariantVersionTargets` receives `productsBeforeUpdate` which now contains every version of every plan. The function builds `latestByPlanId` with `new Map(products.map(...))`, so the map value for each `id` is the *last* element with that `id` in the array — which is non-deterministic since the underlying `SELECT` has no `ORDER BY version`. If the last row happens to be an older version (e.g. v1 when v3 exists), the guard `plan.version >= latest.version` can silently pass a variant update that targets a non-latest version. In practice this is mitigated because the identical check in `previewUpdateCatalog` runs first (using only latest versions), but the secondary check here is now unreliable. Consider either reducing to a max-version-per-id map, or just removing the duplicate check here since `previewUpdateCatalog` is authoritative.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts
   Line: 481-484

   Comment:
   `validateCatalogVariantVersionTargets` receives `productsBeforeUpdate` which now contains every version of every plan. The function builds `latestByPlanId` with `new Map(products.map(...))`, so the map value for each `id` is the *last* element with that `id` in the array — which is non-deterministic since the underlying `SELECT` has no `ORDER BY version`. If the last row happens to be an older version (e.g. v1 when v3 exists), the guard `plan.version >= latest.version` can silently pass a variant update that targets a non-latest version. In practice this is mitigated because the identical check in `previewUpdateCatalog` runs first (using only latest versions), but the secondary check here is now unreliable. Consider either reducing to a max-version-per-id map, or just removing the duplicate check here since `previewUpdateCatalog` is authoritative.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts:481-484
`validateCatalogVariantVersionTargets` receives `productsBeforeUpdate` which now contains every version of every plan. The function builds `latestByPlanId` with `new Map(products.map(...))`, so the map value for each `id` is the *last* element with that `id` in the array — which is non-deterministic since the underlying `SELECT` has no `ORDER BY version`. If the last row happens to be an older version (e.g. v1 when v3 exists), the guard `plan.version >= latest.version` can silently pass a variant update that targets a non-latest version. In practice this is mitigated because the identical check in `previewUpdateCatalog` runs first (using only latest versions), but the secondary check here is now unreliable. Consider either reducing to a max-version-per-id map, or just removing the duplicate check here since `previewUpdateCatalog` is authoritative.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(catalog): reconcile omitted plan ver..."](https://github.com/useautumn/autumn/commit/317092a88ed5120eae92338f02f2870895ef9070) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45121677)</sub>

<!-- /greptile_comment -->