### PR TITLE
fix(sync): preserve versioned license schedules

### DIFF
--- a/server/src/internal/billing/v2/actions/sync/compute/computeSyncFuturePhases.ts
+++ b/server/src/internal/billing/v2/actions/sync/compute/computeSyncFuturePhases.ts
@@ -77,6 +77,7 @@ export const computeSyncFuturePhases = ({
 				fullCustomer,
 				fullProduct: productContext.fullProduct,
 				featureQuantities: productContext.featureQuantities,
+				customerLicenseQuantities: productContext.customerLicenseQuantities,
 				entity: productContext.entity,
 				startsAt: phaseContext.startsAt,
 				endsAt: phaseContext.endsAt,

--- a/server/src/internal/billing/v2/actions/sync/scope/buildIncrementalSyncParams.ts
+++ b/server/src/internal/billing/v2/actions/sync/scope/buildIncrementalSyncParams.ts
@@ -222,7 +222,14 @@ export const buildIncrementalSyncParams = ({
 		}
 
 		const linkedProduct = linkedTargets.targets.get(target.key);
-		if (!linkedProduct || linkedProduct.product.id !== target.productId) {
+		const versionChanged =
+			syncPlan.version !== undefined &&
+			linkedProduct?.product.version !== syncPlan.version;
+		if (
+			!linkedProduct ||
+			linkedProduct.product.id !== target.productId ||
+			versionChanged
+		) {
 			changedPlans.push(syncPlan);
 			continue;
 		}

--- a/server/src/internal/billing/v2/utils/initFullCustomerProduct/initScheduledCustomerProduct.ts
+++ b/server/src/internal/billing/v2/utils/initFullCustomerProduct/initScheduledCustomerProduct.ts
@@ -1,6 +1,7 @@
 import {
 	BillingVersion,
 	CusProductStatus,
+	type CustomerLicenseQuantity,
 	type Entity,
 	type FeatureOptions,
 	type FullCusProduct,
@@ -23,6 +24,7 @@ export const initScheduledCustomerProduct = ({
 	fullCustomer,
 	fullProduct,
 	featureQuantities,
+	customerLicenseQuantities,
 	entity,
 	startsAt,
 	endsAt,
@@ -39,6 +41,7 @@ export const initScheduledCustomerProduct = ({
 	fullCustomer: FullCustomer;
 	fullProduct: FullProduct;
 	featureQuantities: FeatureOptions[];
+	customerLicenseQuantities?: CustomerLicenseQuantity[];
 	entity?: Entity;
 	startsAt: number;
 	endsAt: number | null | undefined;
@@ -67,6 +70,7 @@ export const initScheduledCustomerProduct = ({
 			fullCustomer,
 			fullProduct,
 			featureQuantities,
+			customerLicenseQuantities,
 			entity,
 			resetCycleAnchor: startsAtSecondsPrecision,
 			freeTrial: null,
@@ -76,7 +80,8 @@ export const initScheduledCustomerProduct = ({
 		initOptions: {
 			startsAt: startsAtSecondsPrecision,
 			endedAt: endsAtSecondsPrecision,
-			status: accessStartsAt === undefined ? CusProductStatus.Scheduled : undefined,
+			status:
+				accessStartsAt === undefined ? CusProductStatus.Scheduled : undefined,
 			accessStartsAt,
 			externalId,
 			isCustom,

--- a/server/tests/unit/billing/sync/build-incremental-sync-params.spec.ts
+++ b/server/tests/unit/billing/sync/build-incremental-sync-params.spec.ts
@@ -15,27 +15,30 @@ import type {
 	SyncParamsV1,
 	SyncPlanInstance,
 } from "@autumn/shared";
-import { buildIncrementalSyncParams } from "@/internal/billing/v2/actions/sync/scope/buildIncrementalSyncParams";
 import type {
 	ItemDiff,
 	MatchedPlan,
 	SubscriptionMatch,
 } from "@/internal/billing/v2/actions/sync/detect/types";
+import { buildIncrementalSyncParams } from "@/internal/billing/v2/actions/sync/scope/buildIncrementalSyncParams";
 
 const product = ({
 	id,
 	group = "main",
 	isAddOn = false,
+	version = 1,
 }: {
 	id: string;
 	group?: string | null;
 	isAddOn?: boolean;
+	version?: number;
 }): FullProduct =>
 	({
 		id,
 		internal_id: `${id}_internal`,
 		group,
 		is_add_on: isAddOn,
+		version,
 		prices: [],
 		entitlements: [],
 		items: [],
@@ -147,7 +150,9 @@ const draft = ({
 describe("buildIncrementalSyncParams", () => {
 	test("keeps a plan when no linked customer product exists for its target", () => {
 		const pro = product({ id: "pro" });
-		const { match, params } = draft({ matchedPlans: [matchedPlan({ product: pro })] });
+		const { match, params } = draft({
+			matchedPlans: [matchedPlan({ product: pro })],
+		});
 
 		const result = buildIncrementalSyncParams({
 			match,
@@ -158,14 +163,16 @@ describe("buildIncrementalSyncParams", () => {
 		expect(result.shouldSync).toBe(true);
 		if (!result.shouldSync) throw new Error(result.reason);
 		if (!result.params) throw new Error("expected incremental params");
-		expect(result.params.phases?.[0]?.plans.map((plan) => plan.plan_id)).toEqual([
-			"pro",
-		]);
+		expect(
+			result.params.phases?.[0]?.plans.map((plan) => plan.plan_id),
+		).toEqual(["pro"]);
 	});
 
 	test("prunes a plan when the linked target already has the same product", () => {
 		const pro = product({ id: "pro" });
-		const { match, params } = draft({ matchedPlans: [matchedPlan({ product: pro })] });
+		const { match, params } = draft({
+			matchedPlans: [matchedPlan({ product: pro })],
+		});
 
 		const result = buildIncrementalSyncParams({
 			match,
@@ -177,6 +184,27 @@ describe("buildIncrementalSyncParams", () => {
 			shouldSync: false,
 			reason: "no_changed_targets",
 		});
+	});
+
+	test("keeps a plan when the public id matches but the version changed", () => {
+		const proV1 = product({ id: "pro", version: 1 });
+		const proV2 = product({ id: "pro", version: 2 });
+		const { match, params } = draft({
+			matchedPlans: [matchedPlan({ product: proV2 })],
+			syncPlans: [{ ...syncPlan({ productId: "pro" }), version: 2 }],
+		});
+
+		const result = buildIncrementalSyncParams({
+			match,
+			params,
+			linkedCustomerProducts: [linkedCustomerProduct({ product: proV1 })],
+		});
+
+		expect(result.shouldSync).toBe(true);
+		if (!result.shouldSync) throw new Error(result.reason);
+		expect(result.params?.phases?.[0]?.plans).toEqual([
+			{ expire_previous: true, plan_id: "pro", quantity: 1, version: 2 },
+		]);
 	});
 
 	test("keeps a plan when the linked target has a different product", () => {
@@ -202,7 +230,6 @@ describe("buildIncrementalSyncParams", () => {
 	test("preserves params metadata and sync plan fields while pruning no-op targets", () => {
 		const pro = product({ id: "pro", group: "main" });
 		const premium = product({ id: "premium", group: "main" });
-		const analytics = product({ id: "analytics", group: "analytics" });
 		const analyticsV2 = product({ id: "analytics_v2", group: "analytics" });
 		const featureQuantities: FeatureOptions[] = [
 			{
@@ -239,7 +266,9 @@ describe("buildIncrementalSyncParams", () => {
 		if (!result.shouldSync) throw new Error(result.reason);
 		if (!result.params) throw new Error("expected incremental params");
 		expect(result.params.customer_id).toBe(params.customer_id);
-		expect(result.params.stripe_subscription_id).toBe(params.stripe_subscription_id);
+		expect(result.params.stripe_subscription_id).toBe(
+			params.stripe_subscription_id,
+		);
 		expect(result.params.stripe_schedule_id).toBe("sched_incremental");
 		expect(result.params.carry_over_usage).toBe(false);
 		expect(result.params.phases?.[0]?.starts_at).toBe("now");
@@ -271,7 +300,9 @@ describe("buildIncrementalSyncParams", () => {
 	test("rejects duplicate linked targets", () => {
 		const pro = product({ id: "pro" });
 		const premium = product({ id: "premium" });
-		const { match, params } = draft({ matchedPlans: [matchedPlan({ product: pro })] });
+		const { match, params } = draft({
+			matchedPlans: [matchedPlan({ product: pro })],
+		});
 
 		const result = buildIncrementalSyncParams({
 			match,
@@ -305,17 +336,19 @@ describe("buildIncrementalSyncParams", () => {
 
 			expect(result.shouldSync).toBe(true);
 			if (!result.shouldSync) throw new Error(result.reason);
-		if (!result.params) throw new Error("expected incremental params");
-			expect(result.params.phases?.[0]?.plans.map((plan) => plan.plan_id)).toEqual([
-				unsupported.id,
-			]);
+			if (!result.params) throw new Error("expected incremental params");
+			expect(
+				result.params.phases?.[0]?.plans.map((plan) => plan.plan_id),
+			).toEqual([unsupported.id]);
 		}
 	});
 
 	test("syncs a downgrade between two ungrouped products with a single linked target (production regression)", () => {
 		const ultra = product({ id: "poke_ultra", group: "" });
 		const pro = product({ id: "poke_pro", group: "" });
-		const { match, params } = draft({ matchedPlans: [matchedPlan({ product: pro })] });
+		const { match, params } = draft({
+			matchedPlans: [matchedPlan({ product: pro })],
+		});
 
 		const result = buildIncrementalSyncParams({
 			match,
@@ -326,9 +359,9 @@ describe("buildIncrementalSyncParams", () => {
 		expect(result.shouldSync).toBe(true);
 		if (!result.shouldSync) throw new Error(result.reason);
 		if (!result.params) throw new Error("expected incremental params");
-		expect(result.params.phases?.[0]?.plans.map((plan) => plan.plan_id)).toEqual([
-			"poke_pro",
-		]);
+		expect(
+			result.params.phases?.[0]?.plans.map((plan) => plan.plan_id),
+		).toEqual(["poke_pro"]);
 	});
 
 	test("rejects genuinely ambiguous ungrouped linked targets", () => {

--- a/server/tests/unit/billing/sync/compute-sync-future-phases.test.ts
+++ b/server/tests/unit/billing/sync/compute-sync-future-phases.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "bun:test";
+import type {
+	FullCustomer,
+	FullPlanLicense,
+	FullProduct,
+	SyncBillingContext,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { computeSyncFuturePhases } from "@/internal/billing/v2/actions/sync/compute/computeSyncFuturePhases";
+
+const product = ({ id }: { id: string }): FullProduct =>
+	({
+		id,
+		internal_id: `${id}_internal`,
+		version: 1,
+		group: "main",
+		is_add_on: false,
+		prices: [],
+		entitlements: [],
+		licenses: [],
+	}) as unknown as FullProduct;
+
+test("future sync phases preserve customer license quantities", () => {
+	const customerId = "workspace_123";
+	const seat = product({ id: "team_seat" });
+	const team = product({ id: "team" });
+	team.licenses = [
+		{
+			id: "plan_license_team_seat",
+			parent_internal_product_id: team.internal_id,
+			license_internal_product_id: seat.internal_id,
+			included: 0,
+			prepaid_only: true,
+			is_custom: false,
+			customized: false,
+			product: seat,
+		} as unknown as FullPlanLicense,
+	];
+
+	const fullCustomer = {
+		id: customerId,
+		internal_id: "customer_internal_123",
+		customer_products: [],
+		entities: [],
+		extra_customer_entitlements: [],
+	} as unknown as FullCustomer;
+	const syncContext = {
+		customer_id: customerId,
+		fullCustomer,
+		stripeSubscription: null,
+		stripeSchedule: null,
+		currency: "usd",
+		immediatePhase: null,
+		futurePhases: [
+			{
+				startsAt: Date.now() + 86_400_000,
+				endsAt: null,
+				productContexts: [
+					{
+						plan: {
+							plan_id: team.id,
+							license_quantities: [{ license_plan_id: seat.id, quantity: 7 }],
+						},
+						fullProduct: team,
+						customPrices: [],
+						customEntitlements: [],
+						featureQuantities: [],
+						customerLicenseQuantities: [
+							{ licensePlanId: seat.id, totalQuantity: 7 },
+						],
+					},
+				],
+			},
+		],
+		currentEpochMs: Date.now(),
+		acknowledgedWarnings: [],
+		carryOverUsage: true,
+	} satisfies SyncBillingContext;
+	const ctx = {
+		features: [],
+		logger: { debug: () => undefined },
+	} as unknown as AutumnContext;
+
+	const result = computeSyncFuturePhases({ ctx, syncContext });
+
+	expect(result.insertCustomerProducts).toHaveLength(1);
+	expect(result.insertCustomerProducts[0]?.customer_licenses).toMatchObject([
+		{
+			license_internal_product_id: seat.internal_id,
+			granted: 7,
+			remaining: 7,
+			paid_quantity: 7,
+		},
+	]);
+});


### PR DESCRIPTION
## Summary
- keep same-plan version changes in incremental sync params
- preserve customer license quantities when building future scheduled customer products
- cover both regressions with focused unit tests

## Verification
- `bun test tests/unit/billing/sync/build-incremental-sync-params.spec.ts tests/unit/billing/sync/compute-sync-future-phases.test.ts`
- `bunx tsgo --build --noEmit`
- `bunx biome check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two billing sync regressions: incremental syncs now include same-plan version changes, and future scheduled customer products preserve license quantities.

- **Bug Fixes**
  - Incremental sync: treat a plan as changed when the linked target has the same `plan_id` but a different `version`. Keeps the plan in params with `expire_previous: true` and the new `version`.
  - Future phases: pass `customerLicenseQuantities` into scheduled product initialization so seat/license counts are carried forward and not reset.
  - Tests: added focused unit tests for both cases (versioned plan changes and license quantity preservation).

<sup>Written for commit b296fab446ae0a741a96bc0e27bbf43ab47b832f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two regressions in the billing sync flow: versioned same-plan changes being silently skipped during incremental sync, and license seat quantities being lost when building future scheduled customer products.

- **Bug fixes**: `buildIncrementalSyncParams` now detects when a `syncPlan` specifies a `version` that differs from the currently linked product's version and includes it in `changedPlans`, preventing stale entitlements after an in-place plan version bump.
- **Bug fixes**: `computeSyncFuturePhases` and `initScheduledCustomerProduct` are updated to thread `customerLicenseQuantities` through to `initFullCustomerProduct`, so future scheduled phases correctly populate `customer_licenses` with the requested seat quantities instead of dropping them.
- **Improvements**: Both regressions are covered by new focused unit tests (`build-incremental-sync-params.spec.ts` new case, new `compute-sync-future-phases.test.ts` file).
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; both changes are narrowly scoped fixes to two distinct sync regressions, each covered by a new unit test.

The version-change detection in buildIncrementalSyncParams compares syncPlan.version against linkedProduct.product.version, but when the linked product has no version field (undefined) and the syncPlan carries an explicit version, the product is unconditionally treated as outdated and queued for re-sync. Depending on whether all live product rows are guaranteed to carry a version, this could trigger unnecessary re-attachments for pre-existing customers. Everything else is straightforward wiring with clear test coverage.

server/src/internal/billing/v2/actions/sync/scope/buildIncrementalSyncParams.ts — the versionChanged guard behaves unexpectedly when the linked product version is undefined.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/sync/scope/buildIncrementalSyncParams.ts | Adds version-change detection for same-plan incremental sync: compares syncPlan.version against the linked product's version and marks the plan as changed when they differ. |
| server/src/internal/billing/v2/utils/initFullCustomerProduct/initScheduledCustomerProduct.ts | Threads customerLicenseQuantities through initScheduledCustomerProduct so that future scheduled phases carry the correct license seat counts. |
| server/src/internal/billing/v2/actions/sync/compute/computeSyncFuturePhases.ts | Passes productContext.customerLicenseQuantities into initScheduledCustomerProduct — the missing wiring that caused license quantities to be dropped for future scheduled phases. |
| server/tests/unit/billing/sync/build-incremental-sync-params.spec.ts | Adds a focused unit test for the version-change detection plus formatting cleanup. |
| server/tests/unit/billing/sync/compute-sync-future-phases.test.ts | New test file verifying that customer license quantities are preserved when computing future sync phases. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant buildIncrementalSyncParams
    participant computeSyncFuturePhases
    participant initScheduledCustomerProduct
    participant initFullCustomerProduct

    Caller->>buildIncrementalSyncParams: match, params, linkedCustomerProducts
    Note over buildIncrementalSyncParams: For each syncPlan in phase
    buildIncrementalSyncParams->>buildIncrementalSyncParams: Check versionChanged
    alt version changed OR product id changed OR no linked product
        buildIncrementalSyncParams-->>Caller: changedPlans includes syncPlan
    else same product + same version
        buildIncrementalSyncParams->>buildIncrementalSyncParams: check licenseQuantityDrifts
        buildIncrementalSyncParams-->>Caller: conditionally include plan
    end

    Caller->>computeSyncFuturePhases: ctx, syncContext (futurePhases)
    loop each future phase / each productContext
        computeSyncFuturePhases->>initScheduledCustomerProduct: fullProduct, featureQuantities, customerLicenseQuantities (NEW)
        initScheduledCustomerProduct->>initFullCustomerProduct: initContext with customerLicenseQuantities
        initFullCustomerProduct-->>computeSyncFuturePhases: FullCusProduct (with customer_licenses)
    end
    computeSyncFuturePhases-->>Caller: insertCustomerProducts, scheduledPhases
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant buildIncrementalSyncParams
    participant computeSyncFuturePhases
    participant initScheduledCustomerProduct
    participant initFullCustomerProduct

    Caller->>buildIncrementalSyncParams: match, params, linkedCustomerProducts
    Note over buildIncrementalSyncParams: For each syncPlan in phase
    buildIncrementalSyncParams->>buildIncrementalSyncParams: Check versionChanged
    alt version changed OR product id changed OR no linked product
        buildIncrementalSyncParams-->>Caller: changedPlans includes syncPlan
    else same product + same version
        buildIncrementalSyncParams->>buildIncrementalSyncParams: check licenseQuantityDrifts
        buildIncrementalSyncParams-->>Caller: conditionally include plan
    end

    Caller->>computeSyncFuturePhases: ctx, syncContext (futurePhases)
    loop each future phase / each productContext
        computeSyncFuturePhases->>initScheduledCustomerProduct: fullProduct, featureQuantities, customerLicenseQuantities (NEW)
        initScheduledCustomerProduct->>initFullCustomerProduct: initContext with customerLicenseQuantities
        initFullCustomerProduct-->>computeSyncFuturePhases: FullCusProduct (with customer_licenses)
    end
    computeSyncFuturePhases-->>Caller: insertCustomerProducts, scheduledPhases
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/billing/v2/actions/sync/scope/buildIncrementalSyncParams.ts:225-227
**Version change triggers sync for unversioned linked products**

When `syncPlan.version` is set (e.g. `2`) but the existing `linkedProduct.product.version` is `undefined`, `versionChanged` evaluates to `true` and the plan is pushed for re-sync. This may be intentional as a "treat unversioned as outdated" policy, but it would silently force a re-attachment on any customer whose linked product record pre-dates the `version` column being populated. Confirm that all live `FullProduct` rows have a non-null `version`, or guard with `linkedProduct.product.version !== undefined` before comparing.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sync): preserve versioned license sc..."](https://github.com/useautumn/autumn/commit/b296fab446ae0a741a96bc0e27bbf43ab47b832f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45129619)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->