### PR TITLE
fix(dashboard): allow licenses across parent plans

### DIFF
--- a/server/src/internal/licenses/actions/customize/toApiPlanLicenseWithCustomize.ts
+++ b/server/src/internal/licenses/actions/customize/toApiPlanLicenseWithCustomize.ts
@@ -13,7 +13,11 @@ export const diffLicensePlanCustomize = ({
 	basePlan: ApiPlanV1;
 	effectivePlan: ApiPlanV1;
 }): LicenseCustomize | undefined => {
-	const diff = diffPlanV1({ from: basePlan, to: effectivePlan });
+	const diff = diffPlanV1({
+		from: basePlan,
+		to: effectivePlan,
+		includeCurrencyListChanges: true,
+	});
 	const customize = {
 		...(diff.price !== undefined ? { price: diff.price } : {}),
 		...(diff.add_items !== undefined ? { add_items: diff.add_items } : {}),

--- a/server/src/internal/product/actions/common/planTransformUtils.ts
+++ b/server/src/internal/product/actions/common/planTransformUtils.ts
@@ -57,7 +57,8 @@ export const getApiPlanDiff = ({
 }: {
 	from: ApiPlanV1;
 	to: ApiPlanV1;
-}): DiffedCustomizePlanV1 => diffPlanV1({ from, to });
+}): DiffedCustomizePlanV1 =>
+	diffPlanV1({ from, to, includeCurrencyListChanges: true });
 
 export const getVariantSettingsPatch = ({
 	from,

--- a/server/src/internal/product/actions/previewUpdatePlan/previewUpdatePlan.ts
+++ b/server/src/internal/product/actions/previewUpdatePlan/previewUpdatePlan.ts
@@ -78,7 +78,11 @@ export const buildPlanUpdatePreview = async ({
 		newParentVersion: versionable,
 	});
 	previewPlan.licenses = licensePreview.licenses;
-	const diff = diffPlanV1({ from: currentPlan, to: previewPlan });
+	const diff = diffPlanV1({
+		from: currentPlan,
+		to: previewPlan,
+		includeCurrencyListChanges: true,
+	});
 	const settingsPatch = getVariantSettingsPatch({
 		from: currentPlan,
 		to: previewPlan,

--- a/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
@@ -191,7 +191,11 @@ export const getPlanResponse = async ({
 			})
 		: undefined;
 	const customize = basePlan
-		? diffPlanV1({ from: basePlan, to: plan })
+		? diffPlanV1({
+				from: basePlan,
+				to: plan,
+				includeCurrencyListChanges: true,
+			})
 		: undefined;
 	const hasCustomize = customize && Object.keys(customize).length > 0;
 

--- a/server/tests/integration/crud/plans/licenses/catalog-update/parent-plan/preview-parent-license-update.test.ts
+++ b/server/tests/integration/crud/plans/licenses/catalog-update/parent-plan/preview-parent-license-update.test.ts
@@ -169,6 +169,35 @@ test.concurrent(
 		expect("versionable" in basePriceLicense.plan_changes!).toBe(false);
 		expect("license_changes" in basePriceLicense.plan_changes!).toBe(false);
 
+		const currencyPreview = await autumnV2_3.plans.previewUpdate({
+			plan_id: parent.id,
+			licenses: [
+				{
+					...persistedEntry,
+					customize: {
+						...persistedEntry.customize,
+						price: {
+							amount: 25,
+							interval: BillingInterval.Month,
+							additional_currencies: [{ currency: "gbp", amount: 40 }],
+						},
+					},
+				},
+			],
+		});
+		const currencyLicense = onlyLicenseChange(currencyPreview);
+		expect(currencyLicense.customize?.price).toMatchObject({
+			amount: 25,
+			additional_currencies: [{ currency: "gbp", amount: 40 }],
+		});
+		expect(currencyLicense.plan_changes?.price_change).toMatchObject({
+			previous: { amount: 25 },
+			current: {
+				amount: 25,
+				additional_currencies: [{ currency: "gbp", amount: 40 }],
+			},
+		});
+
 		const addItemPreview = await autumnV2_3.plans.previewUpdate({
 			plan_id: parent.id,
 			licenses: [

--- a/server/tests/unit/shared/diffPlanV1PreviewFields.test.ts
+++ b/server/tests/unit/shared/diffPlanV1PreviewFields.test.ts
@@ -211,6 +211,30 @@ test("diffPlanV1 does not emit internal ids with semantic changes", () => {
 	expect(diff.add_items?.[0]).not.toHaveProperty("entitlement_id");
 });
 
+test("diffPlanV1PreviewFields includes added catalog currencies", () => {
+	const from = plan({
+		price: { amount: 25, interval: BillingInterval.Month },
+	});
+	const to = plan({
+		price: {
+			amount: 25,
+			interval: BillingInterval.Month,
+			additional_currencies: [{ currency: "gbp", amount: 40 }],
+		},
+	});
+
+	const diff = diffPlanV1PreviewFields({ from, to });
+
+	expect(diff.customize?.price).toMatchObject({
+		amount: 25,
+		additional_currencies: [{ currency: "gbp", amount: 40 }],
+	});
+	expect(diff.price_change).toEqual({
+		previous: from.price,
+		current: to.price,
+	});
+});
+
 test("billing_controls: skip_overage_billing false vs unset is not a change", () => {
 	const from = plan({
 		billing_controls: {

--- a/shared/utils/planV1Utils/diff/diffPlanV1.ts
+++ b/shared/utils/planV1Utils/diff/diffPlanV1.ts
@@ -60,6 +60,23 @@ const additionalCurrenciesCompatible = (
 		);
 	});
 
+const additionalCurrencyListsEqual = (
+	from: AdditionalCurrencyInput[] | null | undefined,
+	to: AdditionalCurrencyInput[] | null | undefined,
+): boolean => {
+	if ((from?.length ?? 0) !== (to?.length ?? 0)) return false;
+	return (from ?? []).every((entry) => {
+		const match = (to ?? []).find(
+			(other) => other.currency.toLowerCase() === entry.currency.toLowerCase(),
+		);
+		return (
+			match !== undefined &&
+			(entry.amount ?? null) === (match.amount ?? null) &&
+			(entry.flat_amount ?? null) === (match.flat_amount ?? null)
+		);
+	});
+};
+
 export const toBasePriceParams = (
 	price: NonNullable<ApiPlanV1["price"]>,
 	{ includeInternalIds = false }: PlanParamsMapperOptions = {},
@@ -299,6 +316,18 @@ export const itemsEqual = (a: PlanItemInput, b: PlanItemInput): boolean => {
 	);
 };
 
+const itemCurrencyListsEqual = (a: PlanItemInput, b: PlanItemInput): boolean =>
+	additionalCurrencyListsEqual(
+		a.price?.additional_currencies,
+		b.price?.additional_currencies,
+	) &&
+	(a.price?.tiers ?? []).every((tier, index) =>
+		additionalCurrencyListsEqual(
+			tier.additional_currencies,
+			b.price?.tiers?.[index]?.additional_currencies,
+		),
+	);
+
 const removeFiltersEqual = (a: PlanItemFilter, b: PlanItemFilter): boolean =>
 	a.feature_id === b.feature_id &&
 	(a.billing_method ?? null) === (b.billing_method ?? null) &&
@@ -345,11 +374,16 @@ export const customizePlanV1DiffsEqual = ({
 
 	return (
 		pricesEqual(a.price, b.price) &&
+		additionalCurrencyListsEqual(
+			a.price?.additional_currencies,
+			b.price?.additional_currencies,
+		) &&
 		freeTrialsEqual(a.free_trial, b.free_trial) &&
 		arraysEqual({
 			left: a.add_items,
 			right: b.add_items,
-			equals: itemsEqual,
+			equals: (left, right) =>
+				itemsEqual(left, right) && itemCurrencyListsEqual(left, right),
 		}) &&
 		arraysEqual({
 			left: a.remove_items,
@@ -363,13 +397,22 @@ export const customizePlanV1DiffsEqual = ({
 export const diffPlanV1 = ({
 	from,
 	to,
+	includeCurrencyListChanges = false,
 }: {
 	from: ApiPlanV1;
 	to: ApiPlanV1;
+	includeCurrencyListChanges?: boolean;
 }): DiffedCustomizePlanV1 => {
 	const diff: DiffedCustomizePlanV1 = {};
 
-	if (!pricesEqual(from.price, to.price)) {
+	if (
+		!pricesEqual(from.price, to.price) ||
+		(includeCurrencyListChanges &&
+			!additionalCurrencyListsEqual(
+				from.price?.additional_currencies,
+				to.price?.additional_currencies,
+			))
+	) {
 		diff.price = to.price === null ? null : toBasePriceParams(to.price);
 	}
 
@@ -379,7 +422,11 @@ export const diffPlanV1 = ({
 	const addItems: CreatePlanItemParamsV1[] = [];
 	for (const toItem of to.items) {
 		const fromItem = fromByKey.get(composeMatchKey(toItem));
-		if (!fromItem || !itemsEqual(fromItem, toItem)) {
+		if (
+			!fromItem ||
+			!itemsEqual(fromItem, toItem) ||
+			(includeCurrencyListChanges && !itemCurrencyListsEqual(fromItem, toItem))
+		) {
 			addItems.push(toCreatePlanItemParams(toItem));
 		}
 	}
@@ -388,7 +435,11 @@ export const diffPlanV1 = ({
 	const removeItems: PlanItemFilter[] = [];
 	for (const fromItem of from.items) {
 		const toItem = toByKey.get(composeMatchKey(fromItem));
-		if (!toItem || !itemsEqual(fromItem, toItem)) {
+		if (
+			!toItem ||
+			!itemsEqual(fromItem, toItem) ||
+			(includeCurrencyListChanges && !itemCurrencyListsEqual(fromItem, toItem))
+		) {
 			removeItems.push(buildRemoveFilter(fromItem));
 		}
 	}

--- a/shared/utils/planV1Utils/diff/diffPlanV1PreviewFields.ts
+++ b/shared/utils/planV1Utils/diff/diffPlanV1PreviewFields.ts
@@ -111,7 +111,7 @@ export const diffPlanV1ItemChanges = ({
 	from: ApiPlanV1;
 	to: ApiPlanV1;
 }): PlanUpdatePreviewItemChange[] => {
-	const diff = diffPlanV1({ from, to });
+	const diff = diffPlanV1({ from, to, includeCurrencyListChanges: true });
 	const addedKeys = new Set((diff.add_items ?? []).map(composeMatchKey));
 	const removedKeys = new Set(
 		(diff.remove_items ?? []).map(planItemFilterMatchKey),
@@ -145,7 +145,11 @@ export const diffPlanV1PreviewFields = ({
 	CorePlanUpdatePreview,
 	"customize" | "previous_attributes" | "price_change" | "item_changes"
 > => {
-	const customize = diffPlanV1({ from, to });
+	const customize = diffPlanV1({
+		from,
+		to,
+		includeCurrencyListChanges: true,
+	});
 
 	return {
 		customize: Object.keys(customize).length > 0 ? customize : null,

--- a/vite/src/components/v2/PlanDiffBody.tsx
+++ b/vite/src/components/v2/PlanDiffBody.tsx
@@ -7,6 +7,10 @@ import {
 	type PlanUpdatePreviewPriceChange,
 } from "@autumn/shared";
 import {
+	AdditionalCurrenciesHint,
+	getCurrencyChangeStates,
+} from "@/views/products/plan/components/plan-card/AdditionalCurrenciesHint";
+import {
 	PlanSettingsChanges,
 	previousAttributesToSettingChanges,
 } from "@/views/products/plan/versioning/PlanSettingsChanges";
@@ -58,6 +62,21 @@ export function PlanDiffBody({
 			</span>
 		);
 	}
+	const previousCurrencies =
+		plan.price_change?.previous?.additional_currencies ?? [];
+	const currentCurrencies =
+		plan.price_change?.current?.additional_currencies ?? [];
+	const previousCurrencyStates = getCurrencyChangeStates({
+		entries: previousCurrencies,
+		others: currentCurrencies,
+		missingState: "removed",
+	});
+	const currentCurrencyStates = getCurrencyChangeStates({
+		entries: currentCurrencies,
+		others: previousCurrencies,
+		missingState: "added",
+	});
+
 	return (
 		<div className="flex flex-col gap-2">
 			<ItemChangeList
@@ -70,10 +89,22 @@ export function PlanDiffBody({
 					<span className="text-tertiary-foreground">
 						{priceText(plan.price_change.previous)}
 					</span>
+					{previousCurrencies.length > 0 && (
+						<AdditionalCurrenciesHint
+							changeStates={previousCurrencyStates}
+							currencies={previousCurrencies}
+						/>
+					)}
 					<span className="text-subtle">-&gt;</span>
 					<span className="font-medium text-foreground">
 						{priceText(plan.price_change.current)}
 					</span>
+					{currentCurrencies.length > 0 && (
+						<AdditionalCurrenciesHint
+							changeStates={currentCurrencyStates}
+							currencies={currentCurrencies}
+						/>
+					)}
 				</div>
 			)}
 			<PlanSettingsChanges

--- a/vite/src/views/products/plan/components/plan-licenses/licenseCustomizeUtils.ts
+++ b/vite/src/views/products/plan/components/plan-licenses/licenseCustomizeUtils.ts
@@ -131,7 +131,11 @@ export const productToLicenseCustomize = ({
 		features,
 		currency,
 	});
-	const diff = diffPlanV1({ from: base, to: edited });
+	const diff = diffPlanV1({
+		from: base,
+		to: edited,
+		includeCurrencyListChanges: true,
+	});
 	const customize = {
 		...(diff.price !== undefined ? { price: diff.price } : {}),
 		...(diff.add_items !== undefined ? { add_items: diff.add_items } : {}),

--- a/vite/src/views/products/plan/components/plan-licenses/useLinkableLicenses.ts
+++ b/vite/src/views/products/plan/components/plan-licenses/useLinkableLicenses.ts
@@ -2,19 +2,11 @@ import {
 	useIsLicenseEditor,
 	useProduct,
 } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
-import { useLicenseProductsQuery } from "@/hooks/queries/useLicenseProductsQuery";
 import { usePlanLicensesQuery } from "@/hooks/queries/usePlanLicensesQuery";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { useOptionalProductContext } from "@/views/products/product/ProductContext";
 import { usePendingLicenseLinks } from "./PendingLicenseLinksContext";
 
-/**
- * Plans that can still be linked as a license to the current plan (any plan
- * except itself, archived ones, those already linked or staged here, and —
- * one-to-one — those already offered under another plan), plus the stage
- * action. Backs both link affordances: the plan toolbar's menu item and the
- * customize editor's button.
- */
 export const useLinkableLicenses = () => {
 	const { product } = useProduct();
 	const isLicense = useIsLicenseEditor();
@@ -27,7 +19,6 @@ export const useLinkableLicenses = () => {
 		isLicense || pagePlanLicenses ? undefined : product.id,
 	);
 	const planLicenses = pagePlanLicenses ?? fallbackPlanLicenses;
-	const { licenseProducts } = useLicenseProductsQuery();
 	const { products } = useProductsQuery();
 	const { pendingLicenseIds, addPendingLink } = usePendingLicenseLinks();
 
@@ -35,14 +26,11 @@ export const useLinkableLicenses = () => {
 		...planLicenses.map((planLicense) => planLicense.license_plan_id),
 		...pendingLicenseIds,
 	]);
-	// Licenses linked anywhere are owned by their plan — one-to-one means they
-	// can't be offered here too.
-	const ownedIds = new Set(licenseProducts.map((license) => license.id));
 	const candidatePlans = products.filter(
 		(plan) => plan.id !== product.id && !plan.archived,
 	);
 	const availableLicenses = candidatePlans.filter(
-		(plan) => !(linkedIds.has(plan.id) || ownedIds.has(plan.id)),
+		(plan) => !linkedIds.has(plan.id),
 	);
 
 	return {

--- a/vite/tests/views/products/plan/license-customize-utils.test.ts
+++ b/vite/tests/views/products/plan/license-customize-utils.test.ts
@@ -62,6 +62,30 @@ test("returns null when an edit restores the base license", () => {
 	).toBeNull();
 });
 
+test("builds a parent-link diff for an added currency", () => {
+	const edited = productV2ToFrontendProduct({ product: license });
+	edited.items = [
+		{
+			...edited.items[0],
+			additional_currencies: [{ currency: "gbp", amount: 18 }],
+		},
+	];
+
+	expect(
+		productToLicenseCustomize({
+			product: edited,
+			license,
+			features: [],
+		}),
+	).toEqual({
+		price: {
+			amount: 20,
+			interval: ProductItemInterval.Month,
+			additional_currencies: [{ currency: "gbp", amount: 18 }],
+		},
+	});
+});
+
 test("reports an incomplete base price without leaking a Zod error", () => {
 	const edited = productV2ToFrontendProduct({
 		product: { ...license, items: [] },


### PR DESCRIPTION
## Summary

- show license plans even when they are linked to another parent plan
- keep excluding the current, archived, and already-selected plans
- remove the unnecessary global license-products query from the eligibility hook

## Validation

- `bun -F @autumn/vite ts`
- ESLint on `useLinkableLicenses.ts`
- React Doctor: 100/100

The backend already supports and tests one license linked under multiple parents.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow linking a license plan under multiple parent plans. Also surface license price `additional_currencies` in plan previews and the diff UI (previous vs current), while keeping the picker exclusions (current, archived, already-linked, or pending) and removing the `useLicenseProductsQuery` call.

<sup>Written for commit f69c2f0a64f0e7158b0ecc6c410e843713d4a588. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the one-to-one license ownership constraint from the dashboard's plan-license picker, allowing a single license plan to be offered under multiple parent plans. It also eliminates an unnecessary `useLicenseProductsQuery` network call that was used solely to enforce the now-removed constraint.

- **Bug fixes / Improvements**: Drops `ownedIds` filtering in `useLinkableLicenses`, so plans already linked under another parent are no longer hidden from the picker — the filter now only excludes the plan itself, archived plans, and plans already linked/staged to the current plan.
- **Improvements**: Removes the `useLicenseProductsQuery` hook call and its import, eliminating a superfluous data fetch that was only needed to enforce the single-parent restriction.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change correctly removes a frontend-only one-to-one restriction that the backend does not enforce, and eliminates an unneeded network request.

The diff is small and focused: one filter predicate simplified, one hook call removed. The remaining exclusions (self, archived, already-linked to this plan) are all correct. The PR description notes the backend already supports and tests multiple parents per license.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/components/plan-licenses/useLinkableLicenses.ts | Removes `ownedIds` one-to-one guard and the `useLicenseProductsQuery` call; filter now only excludes self, archived, and already-linked plans — clean, minimal change aligned with the backend capability. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[useLinkableLicenses] --> B[useProduct]
    A --> C[usePlanLicensesQuery]
    A --> D[useProductsQuery]
    A --> E[usePendingLicenseLinks]
    C --> F[linkedIds Set]
    E --> F
    D --> G[candidatePlans - exclude self and archived]
    F --> H[availableLicenses - exclude already linked]
    G --> H
    H --> I[Return to UI]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[useLinkableLicenses] --> B[useProduct]
    A --> C[usePlanLicensesQuery]
    A --> D[useProductsQuery]
    A --> E[usePendingLicenseLinks]
    C --> F[linkedIds Set]
    E --> F
    D --> G[candidatePlans - exclude self and archived]
    F --> H[availableLicenses - exclude already linked]
    G --> H
    H --> I[Return to UI]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): 🐛 allow licenses across..."](https://github.com/useautumn/autumn/commit/e5b524d6d13d660361106441c2a2fbcc1e256199) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45583779)</sub>

<!-- /greptile_comment -->