### PR TITLE
fix(dashboard): allow licenses across parent plans

### DIFF
--- a/vite/src/views/products/plan/components/plan-licenses/useLinkableLicenses.ts
+++ b/vite/src/views/products/plan/components/plan-licenses/useLinkableLicenses.ts
@@ -2,19 +2,11 @@ import {
 	useIsLicenseEditor,
 	useProduct,
 } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
-import { useLicenseProductsQuery } from "@/hooks/queries/useLicenseProductsQuery";
 import { usePlanLicensesQuery } from "@/hooks/queries/usePlanLicensesQuery";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { useOptionalProductContext } from "@/views/products/product/ProductContext";
 import { usePendingLicenseLinks } from "./PendingLicenseLinksContext";
 
-/**
- * Plans that can still be linked as a license to the current plan (any plan
- * except itself, archived ones, those already linked or staged here, and —
- * one-to-one — those already offered under another plan), plus the stage
- * action. Backs both link affordances: the plan toolbar's menu item and the
- * customize editor's button.
- */
 export const useLinkableLicenses = () => {
 	const { product } = useProduct();
 	const isLicense = useIsLicenseEditor();
@@ -27,7 +19,6 @@ export const useLinkableLicenses = () => {
 		isLicense || pagePlanLicenses ? undefined : product.id,
 	);
 	const planLicenses = pagePlanLicenses ?? fallbackPlanLicenses;
-	const { licenseProducts } = useLicenseProductsQuery();
 	const { products } = useProductsQuery();
 	const { pendingLicenseIds, addPendingLink } = usePendingLicenseLinks();
 
@@ -35,14 +26,11 @@ export const useLinkableLicenses = () => {
 		...planLicenses.map((planLicense) => planLicense.license_plan_id),
 		...pendingLicenseIds,
 	]);
-	// Licenses linked anywhere are owned by their plan — one-to-one means they
-	// can't be offered here too.
-	const ownedIds = new Set(licenseProducts.map((license) => license.id));
 	const candidatePlans = products.filter(
 		(plan) => plan.id !== product.id && !plan.archived,
 	);
 	const availableLicenses = candidatePlans.filter(
-		(plan) => !(linkedIds.has(plan.id) || ownedIds.has(plan.id)),
+		(plan) => !linkedIds.has(plan.id),
 	);
 
 	return {


### PR DESCRIPTION
## Summary

- show license plans even when they are linked to another parent plan
- keep excluding the current, archived, and already-selected plans
- remove the unnecessary global license-products query from the eligibility hook

## Validation

- `bun -F @autumn/vite ts`
- ESLint on `useLinkableLicenses.ts`
- React Doctor: 100/100

The backend already supports and tests one license linked under multiple parents.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow linking a license plan to multiple parent plans in the dashboard. Drops the one-to-one restriction in `useLinkableLicenses` while still excluding the current plan, archived plans, and already linked or staged licenses.

- **Bug Fixes**
  - Removed `useLicenseProductsQuery` and the `ownedIds` filter so licenses linked under another parent remain eligible. Availability now excludes only current, archived, and already linked/staged plans.

<sup>Written for commit e5b524d6d13d660361106441c2a2fbcc1e256199. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the one-to-one license-linking constraint from the dashboard's `useLinkableLicenses` hook, allowing a license plan to appear as an option under multiple parent plans. It also drops the now-unnecessary `useLicenseProductsQuery` call that was fetching all globally-licensed plans solely to enforce that constraint.

- **[Bug fixes]** Removes the `ownedIds` filter that previously excluded any plan already linked as a license elsewhere, so users can now attach the same license plan to multiple parent plans as the backend already supports.
- **[Improvements]** Eliminates the global `/products/license_products` network request from this hook, reducing an unnecessary fetch on every plan editor open.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a straightforward removal of a frontend-only restriction that no longer matches the backend's supported behavior.

The diff touches a single hook and makes a minimal, well-scoped change: it drops the global license-ownership filter and its associated network call. The remaining filtering logic (exclude self, archived, and already-linked plans) is unchanged and correct. The useLicenseProductsQuery hook is still present and used by five other files, so nothing is broken by its removal here.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/components/plan-licenses/useLinkableLicenses.ts | Removes one-to-one license ownership constraint and the associated useLicenseProductsQuery call; available-license filtering now only excludes the current plan, archived plans, and plans already linked/staged for this specific plan. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[useLinkableLicenses] --> B[useProductsQuery\nall plans]
    A --> C[usePlanLicensesQuery\ncurrent plan's linked licenses]
    A --> D[usePendingLicenseLinks\nstaged / pending links]

    B --> E[candidatePlans\nexclude: self + archived]
    C --> F[linkedIds\nalready linked to THIS plan]
    D --> F

    E --> G[availableLicenses\nexclude: linkedIds]
    F --> G

    G --> H[Return to UI]

    style A fill:#6366f1,color:#fff
    style G fill:#22c55e,color:#fff
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[useLinkableLicenses] --> B[useProductsQuery\nall plans]
    A --> C[usePlanLicensesQuery\ncurrent plan's linked licenses]
    A --> D[usePendingLicenseLinks\nstaged / pending links]

    B --> E[candidatePlans\nexclude: self + archived]
    C --> F[linkedIds\nalready linked to THIS plan]
    D --> F

    E --> G[availableLicenses\nexclude: linkedIds]
    F --> G

    G --> H[Return to UI]

    style A fill:#6366f1,color:#fff
    style G fill:#22c55e,color:#fff
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): 🐛 allow licenses across..."](https://github.com/useautumn/autumn/commit/e5b524d6d13d660361106441c2a2fbcc1e256199) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45583800)</sub>

<!-- /greptile_comment -->