### PR TITLE
fix(catalog): variant customize inherits base plan entitlement ids

### DIFF
--- a/server/src/internal/product/actions/common/planTransformUtils.ts
+++ b/server/src/internal/product/actions/common/planTransformUtils.ts
@@ -51,6 +51,19 @@ export const fullProductToApiPlanV1 = ({
 		features: ctx.features,
 	});
 
+// Row ids on a plan response belong to the source product; strip them whenever
+// the plan seeds a different product so it mints its own entitlement/price rows.
+export const stripPlanRowIds = ({ plan }: { plan: ApiPlanV1 }): ApiPlanV1 => ({
+	...plan,
+	price: plan.price
+		? (({ entitlement_id: _entitlementId, price_id: _priceId, ...rest }) =>
+				rest)(plan.price)
+		: plan.price,
+	items: plan.items.map(
+		({ entitlement_id: _entitlementId, price_id: _priceId, ...rest }) => rest,
+	),
+});
+
 export const getApiPlanDiff = ({
 	from,
 	to,

--- a/server/src/internal/product/actions/previewUpdatePlan/previewAffectedVariants.ts
+++ b/server/src/internal/product/actions/previewUpdatePlan/previewAffectedVariants.ts
@@ -13,6 +13,7 @@ import { getPlanResponse } from "@/internal/products/productUtils/productRespons
 import {
 	applyDiffToVariantPlan,
 	omitVariantOwnedSettings,
+	stripPlanRowIds,
 	type VariantSettingsPatch,
 } from "../common/planTransformUtils.js";
 import { resolveVariantUpdateSource } from "../common/variantUpdateSource.js";
@@ -103,7 +104,7 @@ export const previewAffectedVariants = async ({
 			const previewPlan = variantUpdate
 				? {
 						...applyDiffToVariantPlan({
-							plan: editedBasePlan,
+							plan: stripPlanRowIds({ plan: editedBasePlan }),
 							diff: variantUpdate.customize,
 						}),
 						id: variant.id,

--- a/server/src/internal/product/actions/updateVariants/updateVariants.ts
+++ b/server/src/internal/product/actions/updateVariants/updateVariants.ts
@@ -49,6 +49,19 @@ const buildVariantUpdateIndex = (variantUpdates: UpdateVariantParams[]) =>
 		]),
 	);
 
+// The base plan's rows belong to a different product; carrying their ids into
+// the variant would insert entitlements/prices that collide with the base's.
+const stripBasePlanRowIds = (plan: ApiPlanV1): ApiPlanV1 => ({
+	...plan,
+	price: plan.price
+		? (({ entitlement_id: _entitlementId, price_id: _priceId, ...rest }) =>
+				rest)(plan.price)
+		: plan.price,
+	items: plan.items.map(
+		({ entitlement_id: _entitlementId, price_id: _priceId, ...rest }) => rest,
+	),
+});
+
 const buildVariantTargetPlan = ({
 	incomingBasePlan,
 	variant,
@@ -58,10 +71,12 @@ const buildVariantTargetPlan = ({
 	variant: FullProduct;
 	variantUpdate: UpdateVariantParams;
 }): ApiPlanV1 => ({
-	...applyDiffToVariantPlan({
-		plan: incomingBasePlan,
-		diff: variantUpdate.customize,
-	}),
+	...stripBasePlanRowIds(
+		applyDiffToVariantPlan({
+			plan: incomingBasePlan,
+			diff: variantUpdate.customize,
+		}),
+	),
 	id: variant.id,
 	name: variantUpdate.name ?? variant.name,
 });

--- a/server/src/internal/product/actions/updateVariants/updateVariants.ts
+++ b/server/src/internal/product/actions/updateVariants/updateVariants.ts
@@ -15,6 +15,7 @@ import {
 	getApiPlanDiff,
 	getVariantSettingsPatch,
 	omitVariantOwnedSettings,
+	stripPlanRowIds,
 	variantSettingsPatchHasValues,
 } from "../common/planTransformUtils.js";
 import { createVariant } from "../createVariant/createVariant.js";
@@ -49,19 +50,6 @@ const buildVariantUpdateIndex = (variantUpdates: UpdateVariantParams[]) =>
 		]),
 	);
 
-// The base plan's rows belong to a different product; carrying their ids into
-// the variant would insert entitlements/prices that collide with the base's.
-const stripBasePlanRowIds = (plan: ApiPlanV1): ApiPlanV1 => ({
-	...plan,
-	price: plan.price
-		? (({ entitlement_id: _entitlementId, price_id: _priceId, ...rest }) =>
-				rest)(plan.price)
-		: plan.price,
-	items: plan.items.map(
-		({ entitlement_id: _entitlementId, price_id: _priceId, ...rest }) => rest,
-	),
-});
-
 const buildVariantTargetPlan = ({
 	incomingBasePlan,
 	variant,
@@ -71,12 +59,10 @@ const buildVariantTargetPlan = ({
 	variant: FullProduct;
 	variantUpdate: UpdateVariantParams;
 }): ApiPlanV1 => ({
-	...stripBasePlanRowIds(
-		applyDiffToVariantPlan({
-			plan: incomingBasePlan,
-			diff: variantUpdate.customize,
-		}),
-	),
+	...applyDiffToVariantPlan({
+		plan: stripPlanRowIds({ plan: incomingBasePlan }),
+		diff: variantUpdate.customize,
+	}),
 	id: variant.id,
 	name: variantUpdate.name ?? variant.name,
 });

--- a/server/tests/integration/crud/catalog/catalog-variant-inherited-item.test.ts
+++ b/server/tests/integration/crud/catalog/catalog-variant-inherited-item.test.ts
@@ -1,121 +1,122 @@
-/**
- * TDD test for catalog.update failing when a variant customize replaces one
- * base item while inheriting another unchanged (Remy `atmn push` report).
- *
- * Red-failure mode (current behavior):
- *  - catalog.update 500s with `duplicate key value violates unique constraint
- *    "entitlements_id_key"`: the variant target plan is built from the base
- *    plan's API response, whose items carry the base's entitlement_id/price_id,
- *    so the inherited item is inserted reusing the base plan's entitlement id.
- *
- * Green-success criteria (after fix):
- *  - catalog.update succeeds, the variant owns entitlement rows distinct from
- *    the base plan's, and an identical re-push also succeeds.
- */
+// Repro for catalog.update 500 `duplicate key ... "entitlements_id_key"`: a variant
+// customize inheriting unchanged base rows must not reuse the base plan's row ids.
 
 import { expect, test } from "bun:test";
 import { FeatureType } from "@autumn/shared";
-import ctx from "@tests/utils/testInitUtils/createTestContext.js";
 import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { ProductService } from "@/internal/products/ProductService.js";
 
-test(`${chalk.yellowBright("catalog: variant customize inherits unchanged base item without entitlement id collision")}`, async () => {
-	const suffix = Math.random().toString(36).slice(2, 9);
-	const planId = `catalog_variant_inherit_${suffix}`;
-	const variantId = `${planId}_enterprise`;
-	const seatsFeatureId = `seats_${suffix}`;
-	const creditsFeatureId = `credits_${suffix}`;
+test.concurrent(
+	`${chalk.yellowBright("catalog: variant customize inherits unchanged base item without entitlement id collision")}`,
+	async () => {
+		const suffix = Math.random().toString(36).slice(2, 9);
+		const planId = `catalog_variant_inherit_${suffix}`;
+		const variantId = `${planId}_enterprise`;
+		const seatsFeatureId = `seats_${suffix}`;
+		const creditsFeatureId = `credits_${suffix}`;
 
-	const { autumnV2_2 } = await initScenario({ setup: [], actions: [] });
+		const { autumnV2_2, ctx } = await initScenario({ setup: [], actions: [] });
 
-	const catalogParams = {
-		features: [
-			{
-				feature_id: seatsFeatureId,
-				name: "Seats",
-				type: FeatureType.Metered,
-				consumable: true,
-			},
-			{
-				feature_id: creditsFeatureId,
-				name: "Credits",
-				type: FeatureType.Metered,
-				consumable: true,
-			},
-		],
-		plans: [
-			{
-				plan_id: planId,
-				name: "Base",
-				items: [
-					{
-						feature_id: seatsFeatureId,
-						included: 5,
-						reset: { interval: "month" },
-					},
-					{
-						feature_id: creditsFeatureId,
-						included: 100,
-						reset: { interval: "month" },
-					},
-				],
-				variants: [
-					{
-						variant_plan_id: variantId,
-						name: "Enterprise",
-						customize: {
-							remove_items: [
-								{ feature_id: seatsFeatureId, interval: "month" },
-							],
-							add_items: [
-								{
-									feature_id: seatsFeatureId,
-									included: 25,
-									reset: { interval: "month" },
-								},
-							],
+		const catalogParams = {
+			features: [
+				{
+					feature_id: seatsFeatureId,
+					name: "Seats",
+					type: FeatureType.Metered,
+					consumable: true,
+				},
+				{
+					feature_id: creditsFeatureId,
+					name: "Credits",
+					type: FeatureType.Metered,
+					consumable: true,
+				},
+			],
+			plans: [
+				{
+					plan_id: planId,
+					name: "Base",
+					price: { amount: 35, interval: "month" },
+					items: [
+						{
+							feature_id: seatsFeatureId,
+							included: 5,
+							reset: { interval: "month" },
 						},
-					},
-				],
-			},
-		],
-	};
+						{
+							feature_id: creditsFeatureId,
+							included: 100,
+							reset: { interval: "month" },
+						},
+					],
+					variants: [
+						{
+							variant_plan_id: variantId,
+							name: "Enterprise",
+							customize: {
+								remove_items: [
+									{ feature_id: seatsFeatureId, interval: "month" },
+								],
+								add_items: [
+									{
+										feature_id: seatsFeatureId,
+										included: 25,
+										reset: { interval: "month" },
+									},
+								],
+							},
+						},
+					],
+				},
+			],
+		};
 
-	await autumnV2_2.catalog.update(catalogParams);
+		const expectVariantOwnsItsRows = async () => {
+			const [base, variant] = await Promise.all([
+				ProductService.getFull({
+					db: ctx.db,
+					idOrInternalId: planId,
+					orgId: ctx.org.id,
+					env: ctx.env,
+				}),
+				ProductService.getFull({
+					db: ctx.db,
+					idOrInternalId: variantId,
+					orgId: ctx.org.id,
+					env: ctx.env,
+				}),
+			]);
 
-	const [base, variant] = await Promise.all([
-		ProductService.getFull({
-			db: ctx.db,
-			idOrInternalId: planId,
-			orgId: ctx.org.id,
-			env: ctx.env,
-		}),
-		ProductService.getFull({
-			db: ctx.db,
-			idOrInternalId: variantId,
-			orgId: ctx.org.id,
-			env: ctx.env,
-		}),
-	]);
+			const baseEntitlementIds = new Set(
+				base.entitlements.map((entitlement) => entitlement.id),
+			);
+			const basePriceIds = new Set(base.prices.map((price) => price.id));
 
-	const baseEntitlementIds = new Set(
-		base.entitlements.map((entitlement) => entitlement.id),
-	);
-	expect(variant.entitlements).toHaveLength(2);
-	for (const entitlement of variant.entitlements) {
-		expect(baseEntitlementIds.has(entitlement.id)).toBe(false);
-	}
+			expect(variant.entitlements).toHaveLength(2);
+			expect(variant.prices).toHaveLength(1);
+			for (const entitlement of variant.entitlements) {
+				expect(baseEntitlementIds.has(entitlement.id)).toBe(false);
+			}
+			for (const price of variant.prices) {
+				expect(basePriceIds.has(price.id)).toBe(false);
+			}
 
-	const variantSeats = variant.entitlements.find(
-		(entitlement) => entitlement.feature_id === seatsFeatureId,
-	);
-	const variantCredits = variant.entitlements.find(
-		(entitlement) => entitlement.feature_id === creditsFeatureId,
-	);
-	expect(variantSeats?.allowance).toBe(25);
-	expect(variantCredits?.allowance).toBe(100);
+			const variantSeats = variant.entitlements.find(
+				(entitlement) => entitlement.feature_id === seatsFeatureId,
+			);
+			const variantCredits = variant.entitlements.find(
+				(entitlement) => entitlement.feature_id === creditsFeatureId,
+			);
+			expect(variantSeats?.allowance).toBe(25);
+			expect(variantCredits?.allowance).toBe(100);
+		};
 
-	// The customer report: retrying the same push kept failing.
-	await autumnV2_2.catalog.update(catalogParams);
-});
+		await autumnV2_2.catalog.update(catalogParams);
+		await expectVariantOwnsItsRows();
+
+		// The customer report: retrying the identical push also failed.
+		await autumnV2_2.catalog.update(catalogParams);
+		await expectVariantOwnsItsRows();
+	},
+);

--- a/server/tests/integration/crud/catalog/catalog-variant-inherited-item.test.ts
+++ b/server/tests/integration/crud/catalog/catalog-variant-inherited-item.test.ts
@@ -1,0 +1,121 @@
+/**
+ * TDD test for catalog.update failing when a variant customize replaces one
+ * base item while inheriting another unchanged (Remy `atmn push` report).
+ *
+ * Red-failure mode (current behavior):
+ *  - catalog.update 500s with `duplicate key value violates unique constraint
+ *    "entitlements_id_key"`: the variant target plan is built from the base
+ *    plan's API response, whose items carry the base's entitlement_id/price_id,
+ *    so the inherited item is inserted reusing the base plan's entitlement id.
+ *
+ * Green-success criteria (after fix):
+ *  - catalog.update succeeds, the variant owns entitlement rows distinct from
+ *    the base plan's, and an identical re-push also succeeds.
+ */
+
+import { expect, test } from "bun:test";
+import { FeatureType } from "@autumn/shared";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { ProductService } from "@/internal/products/ProductService.js";
+
+test(`${chalk.yellowBright("catalog: variant customize inherits unchanged base item without entitlement id collision")}`, async () => {
+	const suffix = Math.random().toString(36).slice(2, 9);
+	const planId = `catalog_variant_inherit_${suffix}`;
+	const variantId = `${planId}_enterprise`;
+	const seatsFeatureId = `seats_${suffix}`;
+	const creditsFeatureId = `credits_${suffix}`;
+
+	const { autumnV2_2 } = await initScenario({ setup: [], actions: [] });
+
+	const catalogParams = {
+		features: [
+			{
+				feature_id: seatsFeatureId,
+				name: "Seats",
+				type: FeatureType.Metered,
+				consumable: true,
+			},
+			{
+				feature_id: creditsFeatureId,
+				name: "Credits",
+				type: FeatureType.Metered,
+				consumable: true,
+			},
+		],
+		plans: [
+			{
+				plan_id: planId,
+				name: "Base",
+				items: [
+					{
+						feature_id: seatsFeatureId,
+						included: 5,
+						reset: { interval: "month" },
+					},
+					{
+						feature_id: creditsFeatureId,
+						included: 100,
+						reset: { interval: "month" },
+					},
+				],
+				variants: [
+					{
+						variant_plan_id: variantId,
+						name: "Enterprise",
+						customize: {
+							remove_items: [
+								{ feature_id: seatsFeatureId, interval: "month" },
+							],
+							add_items: [
+								{
+									feature_id: seatsFeatureId,
+									included: 25,
+									reset: { interval: "month" },
+								},
+							],
+						},
+					},
+				],
+			},
+		],
+	};
+
+	await autumnV2_2.catalog.update(catalogParams);
+
+	const [base, variant] = await Promise.all([
+		ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: planId,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		}),
+		ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: variantId,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		}),
+	]);
+
+	const baseEntitlementIds = new Set(
+		base.entitlements.map((entitlement) => entitlement.id),
+	);
+	expect(variant.entitlements).toHaveLength(2);
+	for (const entitlement of variant.entitlements) {
+		expect(baseEntitlementIds.has(entitlement.id)).toBe(false);
+	}
+
+	const variantSeats = variant.entitlements.find(
+		(entitlement) => entitlement.feature_id === seatsFeatureId,
+	);
+	const variantCredits = variant.entitlements.find(
+		(entitlement) => entitlement.feature_id === creditsFeatureId,
+	);
+	expect(variantSeats?.allowance).toBe(25);
+	expect(variantCredits?.allowance).toBe(100);
+
+	// The customer report: retrying the same push kept failing.
+	await autumnV2_2.catalog.update(catalogParams);
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate-key errors when variant customizations inherit unchanged base items by stripping base plan `entitlement_id`/`price_id` before applying changes. Variants and previews now mint their own entitlement and price rows, so catalog.update and re-push succeed.

- **Bug Fixes**
  - Use `stripPlanRowIds` before `applyDiffToVariantPlan` in both update and preview paths to avoid reusing base plan row IDs.
  - Added integration test covering inherit-one/replace-one and a repeat push.

<sup>Written for commit e006600037f6ab4799a57ea2f6c261635b517c3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a duplicate-key constraint violation that occurred when `catalog.update` was called with a variant that customized only some base-plan items while inheriting others unchanged. The root cause was that `incomingBasePlan` (built from the base product's API response) carries internal `entitlement_id` and `price_id` fields; when the customized plan was built with `applyDiffToVariantPlan`, the unchanged (inherited) items still held those base-plan row IDs, causing an `INSERT` collision on re-use.

- **Bug fixes** — `stripBasePlanRowIds` is introduced in `updateVariants.ts` and applied after `applyDiffToVariantPlan`, clearing `entitlement_id` and `price_id` from both the top-level `price` and all `items` before the plan is persisted as the variant's own rows.
- **Bug fixes** — An integration test (`catalog-variant-inherited-item.test.ts`) reproduces the exact failure scenario and validates both the first push and an idempotent re-push.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a narrow, well-scoped fix that strips two internal fields from the variant's target plan before insertion, with no downstream consumers of those fields on the variant path.

The fix is minimal and correct: `stripBasePlanRowIds` is called in every place `buildVariantTargetPlan` is used (both existing and newly-created variants), the null-price guard is in place, and the accompanying integration test reproduces the exact failure and validates idempotent re-push. No unrelated code is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/product/actions/updateVariants/updateVariants.ts | Adds `stripBasePlanRowIds` helper and wraps `applyDiffToVariantPlan` output with it in `buildVariantTargetPlan`; fix is applied in both the selected-variant and newly-created-variant code paths. |
| server/tests/integration/crud/catalog/catalog-variant-inherited-item.test.ts | New integration test covering the exact regression scenario: one item customized, one inherited; validates no entitlement-ID collision on both the first and second push. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[catalog.update called with variant customize] --> B[fullProductToApiPlanV1\nbuilds incomingBasePlan\nwith entitlement_id & price_id]
    B --> C[applyDiffToVariantPlan\napplies customize diff\ninherited items keep base IDs]
    C --> D{Before fix}
    D -->|entitlement_id carried over| E[INSERT variant entitlement\nusing base plan's ID\n→ duplicate key constraint!]
    C --> F{After fix}
    F --> G[stripBasePlanRowIds\nremoves entitlement_id & price_id\nfrom price and all items]
    G --> H[INSERT variant entitlement\nwith fresh generated ID\n→ success ✓]
    H --> I[Re-push also succeeds ✓]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[catalog.update called with variant customize] --> B[fullProductToApiPlanV1\nbuilds incomingBasePlan\nwith entitlement_id & price_id]
    B --> C[applyDiffToVariantPlan\napplies customize diff\ninherited items keep base IDs]
    C --> D{Before fix}
    D -->|entitlement_id carried over| E[INSERT variant entitlement\nusing base plan's ID\n→ duplicate key constraint!]
    C --> F{After fix}
    F --> G[stripBasePlanRowIds\nremoves entitlement_id & price_id\nfrom price and all items]
    G --> H[INSERT variant entitlement\nwith fresh generated ID\n→ success ✓]
    H --> I[Re-push also succeeds ✓]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(catalog): variant customize inherits..."](https://github.com/useautumn/autumn/commit/07f6cfeebc8d73a72b9ab70f4e10848679e81bc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45584425)</sub>

<!-- /greptile_comment -->