### PR TITLE
fix(licenses): show currency edits in plan previews

### DIFF
--- a/server/src/internal/licenses/actions/customize/toApiPlanLicenseWithCustomize.ts
+++ b/server/src/internal/licenses/actions/customize/toApiPlanLicenseWithCustomize.ts
@@ -13,7 +13,11 @@ export const diffLicensePlanCustomize = ({
 	basePlan: ApiPlanV1;
 	effectivePlan: ApiPlanV1;
 }): LicenseCustomize | undefined => {
-	const diff = diffPlanV1({ from: basePlan, to: effectivePlan });
+	const diff = diffPlanV1({
+		from: basePlan,
+		to: effectivePlan,
+		includeCurrencyListChanges: true,
+	});
 	const customize = {
 		...(diff.price !== undefined ? { price: diff.price } : {}),
 		...(diff.add_items !== undefined ? { add_items: diff.add_items } : {}),

--- a/server/src/internal/product/actions/common/planTransformUtils.ts
+++ b/server/src/internal/product/actions/common/planTransformUtils.ts
@@ -57,7 +57,8 @@ export const getApiPlanDiff = ({
 }: {
 	from: ApiPlanV1;
 	to: ApiPlanV1;
-}): DiffedCustomizePlanV1 => diffPlanV1({ from, to });
+}): DiffedCustomizePlanV1 =>
+	diffPlanV1({ from, to, includeCurrencyListChanges: true });
 
 export const getVariantSettingsPatch = ({
 	from,

--- a/server/src/internal/product/actions/previewUpdatePlan/previewUpdatePlan.ts
+++ b/server/src/internal/product/actions/previewUpdatePlan/previewUpdatePlan.ts
@@ -78,7 +78,11 @@ export const buildPlanUpdatePreview = async ({
 		newParentVersion: versionable,
 	});
 	previewPlan.licenses = licensePreview.licenses;
-	const diff = diffPlanV1({ from: currentPlan, to: previewPlan });
+	const diff = diffPlanV1({
+		from: currentPlan,
+		to: previewPlan,
+		includeCurrencyListChanges: true,
+	});
 	const settingsPatch = getVariantSettingsPatch({
 		from: currentPlan,
 		to: previewPlan,

--- a/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
@@ -191,7 +191,11 @@ export const getPlanResponse = async ({
 			})
 		: undefined;
 	const customize = basePlan
-		? diffPlanV1({ from: basePlan, to: plan })
+		? diffPlanV1({
+				from: basePlan,
+				to: plan,
+				includeCurrencyListChanges: true,
+			})
 		: undefined;
 	const hasCustomize = customize && Object.keys(customize).length > 0;
 

--- a/server/tests/integration/crud/plans/licenses/catalog-update/parent-plan/preview-parent-license-update.test.ts
+++ b/server/tests/integration/crud/plans/licenses/catalog-update/parent-plan/preview-parent-license-update.test.ts
@@ -169,6 +169,35 @@ test.concurrent(
 		expect("versionable" in basePriceLicense.plan_changes!).toBe(false);
 		expect("license_changes" in basePriceLicense.plan_changes!).toBe(false);
 
+		const currencyPreview = await autumnV2_3.plans.previewUpdate({
+			plan_id: parent.id,
+			licenses: [
+				{
+					...persistedEntry,
+					customize: {
+						...persistedEntry.customize,
+						price: {
+							amount: 25,
+							interval: BillingInterval.Month,
+							additional_currencies: [{ currency: "gbp", amount: 40 }],
+						},
+					},
+				},
+			],
+		});
+		const currencyLicense = onlyLicenseChange(currencyPreview);
+		expect(currencyLicense.customize?.price).toMatchObject({
+			amount: 25,
+			additional_currencies: [{ currency: "gbp", amount: 40 }],
+		});
+		expect(currencyLicense.plan_changes?.price_change).toMatchObject({
+			previous: { amount: 25 },
+			current: {
+				amount: 25,
+				additional_currencies: [{ currency: "gbp", amount: 40 }],
+			},
+		});
+
 		const addItemPreview = await autumnV2_3.plans.previewUpdate({
 			plan_id: parent.id,
 			licenses: [

--- a/server/tests/unit/shared/diffPlanV1PreviewFields.test.ts
+++ b/server/tests/unit/shared/diffPlanV1PreviewFields.test.ts
@@ -211,6 +211,30 @@ test("diffPlanV1 does not emit internal ids with semantic changes", () => {
 	expect(diff.add_items?.[0]).not.toHaveProperty("entitlement_id");
 });
 
+test("diffPlanV1PreviewFields includes added catalog currencies", () => {
+	const from = plan({
+		price: { amount: 25, interval: BillingInterval.Month },
+	});
+	const to = plan({
+		price: {
+			amount: 25,
+			interval: BillingInterval.Month,
+			additional_currencies: [{ currency: "gbp", amount: 40 }],
+		},
+	});
+
+	const diff = diffPlanV1PreviewFields({ from, to });
+
+	expect(diff.customize?.price).toMatchObject({
+		amount: 25,
+		additional_currencies: [{ currency: "gbp", amount: 40 }],
+	});
+	expect(diff.price_change).toEqual({
+		previous: from.price,
+		current: to.price,
+	});
+});
+
 test("billing_controls: skip_overage_billing false vs unset is not a change", () => {
 	const from = plan({
 		billing_controls: {

--- a/shared/utils/planV1Utils/diff/diffPlanV1.ts
+++ b/shared/utils/planV1Utils/diff/diffPlanV1.ts
@@ -60,6 +60,23 @@ const additionalCurrenciesCompatible = (
 		);
 	});
 
+const additionalCurrencyListsEqual = (
+	from: AdditionalCurrencyInput[] | null | undefined,
+	to: AdditionalCurrencyInput[] | null | undefined,
+): boolean => {
+	if ((from?.length ?? 0) !== (to?.length ?? 0)) return false;
+	return (from ?? []).every((entry) => {
+		const match = (to ?? []).find(
+			(other) => other.currency.toLowerCase() === entry.currency.toLowerCase(),
+		);
+		return (
+			match !== undefined &&
+			(entry.amount ?? null) === (match.amount ?? null) &&
+			(entry.flat_amount ?? null) === (match.flat_amount ?? null)
+		);
+	});
+};
+
 export const toBasePriceParams = (
 	price: NonNullable<ApiPlanV1["price"]>,
 	{ includeInternalIds = false }: PlanParamsMapperOptions = {},
@@ -299,6 +316,18 @@ export const itemsEqual = (a: PlanItemInput, b: PlanItemInput): boolean => {
 	);
 };
 
+const itemCurrencyListsEqual = (a: PlanItemInput, b: PlanItemInput): boolean =>
+	additionalCurrencyListsEqual(
+		a.price?.additional_currencies,
+		b.price?.additional_currencies,
+	) &&
+	(a.price?.tiers ?? []).every((tier, index) =>
+		additionalCurrencyListsEqual(
+			tier.additional_currencies,
+			b.price?.tiers?.[index]?.additional_currencies,
+		),
+	);
+
 const removeFiltersEqual = (a: PlanItemFilter, b: PlanItemFilter): boolean =>
 	a.feature_id === b.feature_id &&
 	(a.billing_method ?? null) === (b.billing_method ?? null) &&
@@ -345,11 +374,16 @@ export const customizePlanV1DiffsEqual = ({
 
 	return (
 		pricesEqual(a.price, b.price) &&
+		additionalCurrencyListsEqual(
+			a.price?.additional_currencies,
+			b.price?.additional_currencies,
+		) &&
 		freeTrialsEqual(a.free_trial, b.free_trial) &&
 		arraysEqual({
 			left: a.add_items,
 			right: b.add_items,
-			equals: itemsEqual,
+			equals: (left, right) =>
+				itemsEqual(left, right) && itemCurrencyListsEqual(left, right),
 		}) &&
 		arraysEqual({
 			left: a.remove_items,
@@ -363,13 +397,22 @@ export const customizePlanV1DiffsEqual = ({
 export const diffPlanV1 = ({
 	from,
 	to,
+	includeCurrencyListChanges = false,
 }: {
 	from: ApiPlanV1;
 	to: ApiPlanV1;
+	includeCurrencyListChanges?: boolean;
 }): DiffedCustomizePlanV1 => {
 	const diff: DiffedCustomizePlanV1 = {};
 
-	if (!pricesEqual(from.price, to.price)) {
+	if (
+		!pricesEqual(from.price, to.price) ||
+		(includeCurrencyListChanges &&
+			!additionalCurrencyListsEqual(
+				from.price?.additional_currencies,
+				to.price?.additional_currencies,
+			))
+	) {
 		diff.price = to.price === null ? null : toBasePriceParams(to.price);
 	}
 
@@ -379,7 +422,11 @@ export const diffPlanV1 = ({
 	const addItems: CreatePlanItemParamsV1[] = [];
 	for (const toItem of to.items) {
 		const fromItem = fromByKey.get(composeMatchKey(toItem));
-		if (!fromItem || !itemsEqual(fromItem, toItem)) {
+		if (
+			!fromItem ||
+			!itemsEqual(fromItem, toItem) ||
+			(includeCurrencyListChanges && !itemCurrencyListsEqual(fromItem, toItem))
+		) {
 			addItems.push(toCreatePlanItemParams(toItem));
 		}
 	}
@@ -388,7 +435,11 @@ export const diffPlanV1 = ({
 	const removeItems: PlanItemFilter[] = [];
 	for (const fromItem of from.items) {
 		const toItem = toByKey.get(composeMatchKey(fromItem));
-		if (!toItem || !itemsEqual(fromItem, toItem)) {
+		if (
+			!toItem ||
+			!itemsEqual(fromItem, toItem) ||
+			(includeCurrencyListChanges && !itemCurrencyListsEqual(fromItem, toItem))
+		) {
 			removeItems.push(buildRemoveFilter(fromItem));
 		}
 	}

--- a/shared/utils/planV1Utils/diff/diffPlanV1PreviewFields.ts
+++ b/shared/utils/planV1Utils/diff/diffPlanV1PreviewFields.ts
@@ -111,7 +111,7 @@ export const diffPlanV1ItemChanges = ({
 	from: ApiPlanV1;
 	to: ApiPlanV1;
 }): PlanUpdatePreviewItemChange[] => {
-	const diff = diffPlanV1({ from, to });
+	const diff = diffPlanV1({ from, to, includeCurrencyListChanges: true });
 	const addedKeys = new Set((diff.add_items ?? []).map(composeMatchKey));
 	const removedKeys = new Set(
 		(diff.remove_items ?? []).map(planItemFilterMatchKey),
@@ -145,7 +145,11 @@ export const diffPlanV1PreviewFields = ({
 	CorePlanUpdatePreview,
 	"customize" | "previous_attributes" | "price_change" | "item_changes"
 > => {
-	const customize = diffPlanV1({ from, to });
+	const customize = diffPlanV1({
+		from,
+		to,
+		includeCurrencyListChanges: true,
+	});
 
 	return {
 		customize: Object.keys(customize).length > 0 ? customize : null,

--- a/vite/src/components/v2/PlanDiffBody.tsx
+++ b/vite/src/components/v2/PlanDiffBody.tsx
@@ -7,6 +7,10 @@ import {
 	type PlanUpdatePreviewPriceChange,
 } from "@autumn/shared";
 import {
+	AdditionalCurrenciesHint,
+	getCurrencyChangeStates,
+} from "@/views/products/plan/components/plan-card/AdditionalCurrenciesHint";
+import {
 	PlanSettingsChanges,
 	previousAttributesToSettingChanges,
 } from "@/views/products/plan/versioning/PlanSettingsChanges";
@@ -58,6 +62,21 @@ export function PlanDiffBody({
 			</span>
 		);
 	}
+	const previousCurrencies =
+		plan.price_change?.previous?.additional_currencies ?? [];
+	const currentCurrencies =
+		plan.price_change?.current?.additional_currencies ?? [];
+	const previousCurrencyStates = getCurrencyChangeStates({
+		entries: previousCurrencies,
+		others: currentCurrencies,
+		missingState: "removed",
+	});
+	const currentCurrencyStates = getCurrencyChangeStates({
+		entries: currentCurrencies,
+		others: previousCurrencies,
+		missingState: "added",
+	});
+
 	return (
 		<div className="flex flex-col gap-2">
 			<ItemChangeList
@@ -70,10 +89,22 @@ export function PlanDiffBody({
 					<span className="text-tertiary-foreground">
 						{priceText(plan.price_change.previous)}
 					</span>
+					{previousCurrencies.length > 0 && (
+						<AdditionalCurrenciesHint
+							changeStates={previousCurrencyStates}
+							currencies={previousCurrencies}
+						/>
+					)}
 					<span className="text-subtle">-&gt;</span>
 					<span className="font-medium text-foreground">
 						{priceText(plan.price_change.current)}
 					</span>
+					{currentCurrencies.length > 0 && (
+						<AdditionalCurrenciesHint
+							changeStates={currentCurrencyStates}
+							currencies={currentCurrencies}
+						/>
+					)}
 				</div>
 			)}
 			<PlanSettingsChanges

--- a/vite/src/views/products/plan/components/plan-licenses/licenseCustomizeUtils.ts
+++ b/vite/src/views/products/plan/components/plan-licenses/licenseCustomizeUtils.ts
@@ -131,7 +131,11 @@ export const productToLicenseCustomize = ({
 		features,
 		currency,
 	});
-	const diff = diffPlanV1({ from: base, to: edited });
+	const diff = diffPlanV1({
+		from: base,
+		to: edited,
+		includeCurrencyListChanges: true,
+	});
 	const customize = {
 		...(diff.price !== undefined ? { price: diff.price } : {}),
 		...(diff.add_items !== undefined ? { add_items: diff.add_items } : {}),

--- a/vite/tests/views/products/plan/license-customize-utils.test.ts
+++ b/vite/tests/views/products/plan/license-customize-utils.test.ts
@@ -62,6 +62,30 @@ test("returns null when an edit restores the base license", () => {
 	).toBeNull();
 });
 
+test("builds a parent-link diff for an added currency", () => {
+	const edited = productV2ToFrontendProduct({ product: license });
+	edited.items = [
+		{
+			...edited.items[0],
+			additional_currencies: [{ currency: "gbp", amount: 18 }],
+		},
+	];
+
+	expect(
+		productToLicenseCustomize({
+			product: edited,
+			license,
+			features: [],
+		}),
+	).toEqual({
+		price: {
+			amount: 20,
+			interval: ProductItemInterval.Month,
+			additional_currencies: [{ currency: "gbp", amount: 18 }],
+		},
+	});
+});
+
 test("reports an incomplete base price without leaking a Zod error", () => {
 	const edited = productV2ToFrontendProduct({
 		product: { ...license, items: [] },


### PR DESCRIPTION
## Summary
- show added or removed catalog currencies in license save previews
- preserve migration-compatible comparisons for existing subscriber snapshots
- serialize currency-only license customizations through the dashboard and API

## Verification
- server and dashboard type checks
- 28 focused unit/frontend tests
- React Doctor: 100/100

The integration regression is included; its local run is blocked during setup by an invalid test secret before reaching the assertion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show currency changes in license plan previews and in the dashboard diff, and allow currency-only customizations to flow through the dashboard and API. Fixes missing visibility for added/removed `additional_currencies` on prices and item tiers.

- **Bug Fixes**
  - Detect and include `additional_currencies` changes in `diffPlanV1` (base price and item tiers) via `includeCurrencyListChanges`.
  - Thread currency diffs through preview/build/response and customize paths; dashboard plan diff now shows added/removed currency details.
  - Keep migration-safe comparisons for existing subscriber snapshots by opting into currency diffs only where needed.
  - Add focused unit and integration tests for currency previews and license customize utils.

<sup>Written for commit f69c2f0a64f0e7158b0ecc6c410e843713d4a588. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the plan preview system to surface catalog currency additions and removals as visible changes, in addition to price-amount edits it already tracked. The core mechanism is a new `includeCurrencyListChanges` flag on `diffPlanV1` that layers a strict `additionalCurrencyListsEqual` check on top of the existing migration-compatible `additionalCurrenciesCompatible` comparison, so callers that need a full diff can opt in without affecting snapshot-comparison paths used for migrations.

- **Bug fixes**: Introduce `additionalCurrencyListsEqual` and `itemCurrencyListsEqual` helpers and wire them into all preview/diff call sites (`diffPlanV1PreviewFields`, `getPlanResponse`, `buildPlanUpdatePreview`, `diffLicensePlanCustomize`, `productToLicenseCustomize`) via the new opt-in flag.
- **Bug fixes**: Update `customizePlanV1DiffsEqual` (used in `variantCustomizeChanged`) to also require full currency-list equality, so a currency-only change on a variant's customize no longer silently passes as "unchanged".
- **Improvements**: Add focused unit and integration tests covering the added-currency case for both the base price and per-item currency lists.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is additive — a new opt-in flag threads through all preview and customize-diff call sites, leaving migration-snapshot comparisons untouched.

All changed paths opt in to the stricter additionalCurrencyListsEqual check, and the pre-existing additionalCurrenciesCompatible logic used by migration snapshot comparisons is left intact. The customizePlanV1DiffsEqual update correctly expands variant-change detection. Unit tests cover the new currency-detection paths end-to-end; the integration test addition is structurally sound even though its local run is gated by a test-secret issue unrelated to the logic.

No files require special attention. The integration test in preview-parent-license-update.test.ts cannot yet run locally due to a test-secret setup issue noted in the PR, so its assertion remains unverified in CI.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/planV1Utils/diff/diffPlanV1.ts | Core diff engine: adds additionalCurrencyListsEqual, itemCurrencyListsEqual, and the includeCurrencyListChanges flag; existing additionalCurrenciesCompatible (used in pricesEqual/tiersEqual) is left intact for migration-safe comparisons. customizePlanV1DiffsEqual gains an explicit currency-list equality check. |
| shared/utils/planV1Utils/diff/diffPlanV1PreviewFields.ts | Both diffPlanV1ItemChanges and diffPlanV1PreviewFields now pass includeCurrencyListChanges: true, so currency-only changes appear in preview customize and price_change. |
| server/src/internal/licenses/actions/customize/toApiPlanLicenseWithCustomize.ts | diffLicensePlanCustomize now passes includeCurrencyListChanges: true; license API response will include currency-only customizations. |
| vite/src/views/products/plan/components/plan-licenses/licenseCustomizeUtils.ts | productToLicenseCustomize now detects currency-only edits and serializes them into the outgoing LicenseCustomize patch. |
| server/tests/integration/crud/plans/licenses/catalog-update/parent-plan/preview-parent-license-update.test.ts | Integration test expanded with a currency-only preview assertion; PR notes the test is locally blocked by an invalid test secret before reaching the assertion, so it cannot be validated in CI. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[diffPlanV1 called] --> B{includeCurrencyListChanges?}
    B -- false --> C[pricesEqual uses additionalCurrenciesCompatible\nonly changed amounts on shared currencies trigger diff]
    B -- true --> D[pricesEqual AND additionalCurrencyListsEqual\nany add/remove/change triggers diff]
    C --> E[itemsEqual uses itemPricesEqual\nwhich uses additionalCurrenciesCompatible]
    D --> F[itemsEqual OR itemCurrencyListsEqual\ndetects currency-list changes on items too]
    E --> G[Returns DiffedCustomizePlanV1]
    F --> G
    G --> H{Caller}
    H -- migration snapshot compare --> I[pricesEqual / additionalCurrenciesCompatible\nno flag needed]
    H -- preview / customize diff --> J[includeCurrencyListChanges: true\ndiffPlanV1PreviewFields\ngetApiPlanDiff\ndiffLicensePlanCustomize\nproductToLicenseCustomize\ngetPlanResponse]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[diffPlanV1 called] --> B{includeCurrencyListChanges?}
    B -- false --> C[pricesEqual uses additionalCurrenciesCompatible\nonly changed amounts on shared currencies trigger diff]
    B -- true --> D[pricesEqual AND additionalCurrencyListsEqual\nany add/remove/change triggers diff]
    C --> E[itemsEqual uses itemPricesEqual\nwhich uses additionalCurrenciesCompatible]
    D --> F[itemsEqual OR itemCurrencyListsEqual\ndetects currency-list changes on items too]
    E --> G[Returns DiffedCustomizePlanV1]
    F --> G
    G --> H{Caller}
    H -- migration snapshot compare --> I[pricesEqual / additionalCurrenciesCompatible\nno flag needed]
    H -- preview / customize diff --> J[includeCurrencyListChanges: true\ndiffPlanV1PreviewFields\ngetApiPlanDiff\ndiffLicensePlanCustomize\nproductToLicenseCustomize\ngetPlanResponse]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(licenses): 🐛 show currency edits in..."](https://github.com/useautumn/autumn/commit/dcf91f7c14edf2604568f8c60b2db70e77708d25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45593598)</sub>

<!-- /greptile_comment -->