### PR TITLE
Disable lazy dashboard migration runs

### DIFF
--- a/vite/src/views/migrations/migration/hooks/buildRunMigrationRequest.ts
+++ b/vite/src/views/migrations/migration/hooks/buildRunMigrationRequest.ts
@@ -1,0 +1,47 @@
+import type { RetryableMigrationItemRunStatus } from "@/hooks/queries/useMigrationsQuery";
+
+type BuildRunMigrationRequestParams = {
+	migrationId: string;
+	dryRun: boolean;
+	limit?: number;
+	only?: string[];
+	concurrency?: number;
+	retryItemStatuses?: RetryableMigrationItemRunStatus[];
+};
+
+type RunMigrationRequest = {
+	id: string;
+	dry_run: boolean;
+	lazy_run: false;
+	limit?: number;
+	only?: string[];
+	concurrency?: number;
+	retry_item_statuses?: RetryableMigrationItemRunStatus[];
+};
+
+export const buildRunMigrationRequest = ({
+	migrationId,
+	dryRun,
+	limit,
+	only,
+	concurrency,
+	retryItemStatuses,
+}: BuildRunMigrationRequestParams): RunMigrationRequest => {
+	const request: RunMigrationRequest = {
+		id: migrationId,
+		dry_run: dryRun,
+		lazy_run: false,
+	};
+
+	if (limit !== undefined) request.limit = limit;
+	if (only !== undefined) request.only = only;
+	if (concurrency !== undefined) request.concurrency = concurrency;
+
+	if (retryItemStatuses && retryItemStatuses.length > 0) {
+		request.retry_item_statuses = retryItemStatuses;
+	} else if (only && only.length > 0) {
+		request.retry_item_statuses = ["failed"];
+	}
+
+	return request;
+};

--- a/vite/src/views/migrations/migration/hooks/useRealtimeSubscriptions.ts
+++ b/vite/src/views/migrations/migration/hooks/useRealtimeSubscriptions.ts
@@ -6,6 +6,7 @@ import {
 	useMigrationsQuery,
 } from "@/hooks/queries/useMigrationsQuery";
 import { getBackendErr } from "@/utils/genUtils";
+import { buildRunMigrationRequest } from "./buildRunMigrationRequest";
 import type { RealtimeRunSubscription } from "./useMigrationRunRealtime";
 
 const SETTLE_WINDOW_MS = 15000;
@@ -39,33 +40,26 @@ export function useRealtimeSubscriptions({
 		dryRun,
 		limit,
 		only,
-		lazyRun,
 		concurrency,
 		retryItemStatuses,
 	}: {
 		dryRun: boolean;
 		limit?: number;
 		only?: string[];
-		lazyRun?: boolean;
 		concurrency?: number;
 		retryItemStatuses?: RetryableMigrationItemRunStatus[];
 	}) => {
 		try {
-			const isTargetedRun = only !== undefined && only.length > 0;
-			const retryStatuses =
-				retryItemStatuses && retryItemStatuses.length > 0
-					? retryItemStatuses
-					: undefined;
-			const result = await runMigration({
-				id: migrationId,
-				dry_run: dryRun,
-				limit,
-				only,
-				lazy_run: isTargetedRun ? false : (lazyRun ?? true),
-				concurrency,
-				retry_item_statuses:
-					retryStatuses ?? (isTargetedRun ? ["failed"] : undefined),
-			});
+			const result = await runMigration(
+				buildRunMigrationRequest({
+					migrationId,
+					dryRun,
+					limit,
+					only,
+					concurrency,
+					retryItemStatuses,
+				}),
+			);
 			if (result.trigger_run_id && result.public_access_token) {
 				setSubscriptions((prev) => [
 					...prev,

--- a/vite/src/views/migrations/migration/live/MigrationLiveView.tsx
+++ b/vite/src/views/migrations/migration/live/MigrationLiveView.tsx
@@ -102,7 +102,6 @@ import { RealtimeRunWatcher } from "./RealtimeRunWatcher";
 import { useMigrationSheetStore } from "./useMigrationSheetStore";
 
 type AdminRunControls = {
-	lazyRun: boolean;
 	retryErrored: boolean;
 	retrySkipped: boolean;
 	concurrency: string;
@@ -294,7 +293,6 @@ export function MigrationLiveView({
 	);
 	const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
 	const [runControls, setRunControls] = useState<AdminRunControls>({
-		lazyRun: true,
 		retryErrored: false,
 		retrySkipped: false,
 		concurrency: String(MAX_CONCURRENCY),
@@ -312,7 +310,6 @@ export function MigrationLiveView({
 	const maxConcurrency = isAdmin ? ADMIN_MAX_CONCURRENCY : MAX_CONCURRENCY;
 
 	const resolvedRunControls = {
-		lazyRun: runControls.lazyRun,
 		retryItemStatuses: buildRetryItemStatuses(runControls),
 		concurrency: parseConcurrency({
 			value: runControls.concurrency,
@@ -734,7 +731,6 @@ export function MigrationLiveView({
 								onChange={setRunControls}
 								invalidConcurrency={invalidConcurrency}
 								maxConcurrency={maxConcurrency}
-								lazyDisabled={sample.mode === "select"}
 								hasFailedItems={(progressCounts?.failed ?? 0) > 0}
 								hasSkippedItems={(progressCounts?.skipped ?? 0) > 0}
 							/>
@@ -948,7 +944,6 @@ function MigrationRunControls({
 	onChange,
 	invalidConcurrency = false,
 	maxConcurrency = MAX_CONCURRENCY,
-	lazyDisabled = false,
 	hasFailedItems = false,
 	hasSkippedItems = false,
 }: {
@@ -956,33 +951,12 @@ function MigrationRunControls({
 	onChange: (value: AdminRunControls) => void;
 	invalidConcurrency?: boolean;
 	maxConcurrency?: number;
-	lazyDisabled?: boolean;
 	hasFailedItems?: boolean;
 	hasSkippedItems?: boolean;
 }) {
 	return (
 		<div className="flex flex-col gap-3">
 			<Separator />
-			<div
-				className={cn(
-					"flex items-center justify-between gap-4",
-					lazyDisabled && "opacity-50",
-				)}
-			>
-				<div className="flex flex-col gap-0.5">
-					<span className="text-sm font-medium text-foreground">Lazy run</span>
-					<span className="text-xs text-tertiary-foreground">
-						Remaining customers migrate when queried.
-					</span>
-				</div>
-				<Switch
-					checked={value.lazyRun && !lazyDisabled}
-					disabled={lazyDisabled}
-					onCheckedChange={(checked) =>
-						onChange({ ...value, lazyRun: checked === true })
-					}
-				/>
-			</div>
 			<div className="flex items-center justify-between gap-4">
 				<div className="flex flex-col gap-0.5">
 					<span className="text-sm font-medium text-foreground">

--- a/vite/tests/views/migrations/migration/build-run-migration-request.test.ts
+++ b/vite/tests/views/migrations/migration/build-run-migration-request.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { buildRunMigrationRequest } from "@/views/migrations/migration/hooks/buildRunMigrationRequest";
+
+describe("buildRunMigrationRequest", () => {
+	test("disables lazy execution for full migration runs", () => {
+		expect(
+			buildRunMigrationRequest({
+				migrationId: "disable-lazy-runs",
+				dryRun: false,
+			}),
+		).toEqual({
+			id: "disable-lazy-runs",
+			dry_run: false,
+			lazy_run: false,
+		});
+	});
+
+	test("keeps targeted-run retry defaults without enabling lazy execution", () => {
+		expect(
+			buildRunMigrationRequest({
+				migrationId: "disable-lazy-runs",
+				dryRun: false,
+				only: ["customer_1"],
+			}),
+		).toEqual({
+			id: "disable-lazy-runs",
+			dry_run: false,
+			only: ["customer_1"],
+			lazy_run: false,
+			retry_item_statuses: ["failed"],
+		});
+	});
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable lazy execution for migrations started from the dashboard. All runs now execute immediately (lazy_run: false), and the lazy toggle is removed from the UI.

- Bug Fixes
  - Route all run requests through buildRunMigrationRequest, which always sets lazy_run: false and keeps targeted-run retry defaults (retry_item_statuses: ["failed"] when only is set).
  - Remove the lazy run toggle and related props from MigrationLiveView.
  - Simplify useRealtimeSubscriptions to use the request builder; drop the lazyRun param.
  - Add tests covering full and targeted runs to confirm lazy_run is disabled.

<sup>Written for commit ac4965760d1ebafb5414944f99a439f5403b1732. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the "lazy run" toggle from the migration dashboard UI and enforces `lazy_run: false` on every migration request sent from the frontend. The request-building logic is extracted into a dedicated `buildRunMigrationRequest` helper with unit tests.

- **[Bug fixes / Improvements]** Always sends `lazy_run: false` in migration run requests — previously non-targeted runs defaulted `lazy_run` to `true`, meaning customers could be migrated lazily on-query without an explicit run; this change ensures all dashboard-triggered runs execute eagerly.
- **[Improvements]** Extracts request construction into `buildRunMigrationRequest`, making the logic independently testable and removing duplicated inline logic from `useRealtimeSubscriptions`.
- **[Improvements]** Cleans up the `AdminRunControls` type, the `MigrationRunControls` component, and the `triggerRun` signature by removing all `lazyRun`-related props and state.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a focused removal of the lazy-run opt-in, and the refactored request builder preserves all existing retry and targeting logic exactly.

The diff is small and mechanical: the `lazy_run: false` literal is now enforced in the type system, the `retry_item_statuses` defaulting logic is unchanged, and the UI cleanup is complete with no dangling references. Unit tests confirm both the full-run and targeted-run paths.

No files require special attention. The test file could benefit from a case covering explicitly supplied `retryItemStatuses`, but this is not a blocker.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/migrations/migration/hooks/buildRunMigrationRequest.ts | New helper that always sets `lazy_run: false`; `retry_item_statuses` defaulting logic correctly mirrors the old inline behaviour. |
| vite/src/views/migrations/migration/hooks/useRealtimeSubscriptions.ts | Removes `lazyRun` from the `triggerRun` signature and delegates to `buildRunMigrationRequest`; no behavioural change beyond disabling lazy runs. |
| vite/src/views/migrations/migration/live/MigrationLiveView.tsx | Removes the lazy-run toggle UI element, its state, and the `lazyDisabled` prop from `MigrationRunControls`; cleanup is complete and consistent. |
| vite/tests/views/migrations/migration/build-run-migration-request.test.ts | Covers the two primary paths (full run, targeted run); missing a case for explicitly supplied `retryItemStatuses` overriding the `only`-based default. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as MigrationLiveView
    participant Hook as useRealtimeSubscriptions
    participant Builder as buildRunMigrationRequest
    participant API as runMigration (API)

    UI->>Hook: "triggerRun({ dryRun, limit, only, concurrency, retryItemStatuses })"
    Hook->>Builder: buildRunMigrationRequest(params)
    Note over Builder: Always sets lazy_run: false<br/>Defaults retry_item_statuses to ["failed"]<br/>when only[] is non-empty
    Builder-->>Hook: "RunMigrationRequest { id, dry_run, lazy_run: false, ... }"
    Hook->>API: runMigration(request)
    API-->>Hook: "{ trigger_run_id, public_access_token, run_id }"
    Hook-->>UI: subscription added + toast shown
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as MigrationLiveView
    participant Hook as useRealtimeSubscriptions
    participant Builder as buildRunMigrationRequest
    participant API as runMigration (API)

    UI->>Hook: "triggerRun({ dryRun, limit, only, concurrency, retryItemStatuses })"
    Hook->>Builder: buildRunMigrationRequest(params)
    Note over Builder: Always sets lazy_run: false<br/>Defaults retry_item_statuses to ["failed"]<br/>when only[] is non-empty
    Builder-->>Hook: "RunMigrationRequest { id, dry_run, lazy_run: false, ... }"
    Hook->>API: runMigration(request)
    API-->>Hook: "{ trigger_run_id, public_access_token, run_id }"
    Hook-->>UI: subscription added + toast shown
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(migrations): disable lazy dashboard ..."](https://github.com/useautumn/autumn/commit/ac4965760d1ebafb5414944f99a439f5403b1732) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45597538)</sub>

<!-- /greptile_comment -->