### PR TITLE
feat(licenses): add batched transition queries

### DIFF
--- a/server/src/internal/billing/v2/actions/batchTransition/execute/sql/addCustomerBasePricesBatch.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/execute/sql/addCustomerBasePricesBatch.ts
@@ -1,0 +1,90 @@
+import { sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { AddBasePriceOperation } from "../../types/basePriceOperationTypes";
+import type { BatchMutationResult } from "../../types/types";
+import { activeStatusesSql, sqlList } from "./batchTransitionSqlUtils";
+
+export const addCustomerBasePricesBatch = async ({
+	db,
+	customerLicenseLinkId,
+	assignmentCutoffMs,
+	customerPriceIds,
+	operation,
+	batchSize,
+}: {
+	db: DrizzleCli;
+	customerLicenseLinkId: string;
+	assignmentCutoffMs: number;
+	customerPriceIds: string[];
+	operation: AddBasePriceOperation;
+	batchSize: number;
+}): Promise<BatchMutationResult> => {
+	if (operation.existingBasePriceIds.length === 0) {
+		throw new Error("Base price addition requires candidate IDs");
+	}
+	if (customerPriceIds.length !== batchSize) {
+		throw new Error("Base price addition requires one ID per row");
+	}
+
+	const [result] = await db.execute<BatchMutationResult>(sql`
+		WITH candidate_rows AS MATERIALIZED (
+			SELECT seat.id, seat.internal_customer_id, seat.created_at
+			FROM customer_products AS seat
+			WHERE seat.customer_license_link_id = ${customerLicenseLinkId}
+				AND seat.internal_entity_id IS NOT NULL
+				AND seat.status IN (${activeStatusesSql})
+				AND (seat.created_at IS NULL OR seat.created_at <= ${assignmentCutoffMs})
+				AND NOT EXISTS (
+					SELECT 1
+					FROM customer_prices AS existing
+					WHERE existing.customer_product_id = seat.id
+						AND existing.price_id IN (${sqlList({ values: operation.existingBasePriceIds })})
+				)
+			ORDER BY seat.created_at, seat.id
+			FOR UPDATE OF seat
+			LIMIT ${batchSize + 1}
+		),
+		target_rows AS MATERIALIZED (
+			SELECT
+				id,
+				internal_customer_id,
+				ROW_NUMBER() OVER (ORDER BY created_at, id) AS ordinal
+			FROM candidate_rows
+			LIMIT ${batchSize}
+		),
+		generated_ids AS MATERIALIZED (
+			SELECT generated.id, generated.ordinality
+			FROM JSONB_ARRAY_ELEMENTS_TEXT(${JSON.stringify(customerPriceIds)}::jsonb)
+				WITH ORDINALITY AS generated(id, ordinality)
+		),
+		inserted AS (
+			INSERT INTO customer_prices (
+				id,
+				created_at,
+				price_id,
+				internal_customer_id,
+				customer_product_id
+			)
+			SELECT
+				generated.id,
+				${assignmentCutoffMs},
+				${operation.toPrice.id},
+				target.internal_customer_id,
+				target.id
+			FROM target_rows AS target
+			INNER JOIN generated_ids AS generated
+				ON generated.ordinality = target.ordinal
+			ON CONFLICT (id) DO NOTHING
+			RETURNING 1
+		)
+		SELECT
+			(SELECT COUNT(*)::int FROM inserted) AS affected,
+			(
+				(SELECT COUNT(*) > ${batchSize} FROM candidate_rows)
+				OR
+				(SELECT COUNT(*) FROM inserted) < (SELECT COUNT(*) FROM target_rows)
+			) AS "hasMore"
+	`);
+
+	return result ?? { affected: 0, hasMore: false };
+};

--- a/server/src/internal/billing/v2/actions/batchTransition/execute/sql/addCustomerEntitlementsBatch.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/execute/sql/addCustomerEntitlementsBatch.ts
@@ -1,0 +1,121 @@
+import { sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { AddEntitlementPriceOperation } from "../../types/entitlementPriceOperationTypes";
+import type { BatchMutationResult } from "../../types/types";
+import { activeStatusesSql, sqlList } from "./batchTransitionSqlUtils";
+
+export const addCustomerEntitlementsBatch = async ({
+	db,
+	customerLicenseLinkId,
+	assignmentCutoffMs,
+	customerEntitlementIds,
+	operation,
+	batchSize,
+}: {
+	db: DrizzleCli;
+	customerLicenseLinkId: string;
+	assignmentCutoffMs: number;
+	customerEntitlementIds: string[];
+	operation: AddEntitlementPriceOperation;
+	batchSize: number;
+}): Promise<BatchMutationResult> => {
+	if (operation.existingEntitlementIds.length === 0) {
+		throw new Error("Customer entitlement addition requires candidate IDs");
+	}
+	if (customerEntitlementIds.length !== batchSize) {
+		throw new Error("Customer entitlement addition requires one ID per row");
+	}
+
+	const customerEntitlement = operation.customerEntitlement;
+	const [result] = await db.execute<BatchMutationResult>(sql`
+		WITH candidate_rows AS MATERIALIZED (
+			SELECT seat.id, seat.created_at
+			FROM customer_products AS seat
+			WHERE seat.customer_license_link_id = ${customerLicenseLinkId}
+				AND seat.status IN (${activeStatusesSql})
+				AND (seat.created_at IS NULL OR seat.created_at <= ${assignmentCutoffMs})
+				AND NOT EXISTS (
+					SELECT 1
+					FROM customer_entitlements AS existing
+					WHERE existing.customer_product_id = seat.id
+						AND existing.entitlement_id IN (${sqlList({ values: operation.existingEntitlementIds })})
+				)
+			ORDER BY seat.created_at, seat.id
+			FOR UPDATE OF seat
+			LIMIT ${batchSize + 1}
+		),
+		target_rows AS MATERIALIZED (
+			SELECT
+				id,
+				ROW_NUMBER() OVER (ORDER BY created_at, id) AS ordinal
+			FROM candidate_rows
+			LIMIT ${batchSize}
+		),
+		generated_ids AS MATERIALIZED (
+			SELECT generated.id, generated.ordinality
+			FROM JSONB_ARRAY_ELEMENTS_TEXT(${JSON.stringify(customerEntitlementIds)}::jsonb)
+				WITH ORDINALITY AS generated(id, ordinality)
+		),
+		inserted AS (
+			INSERT INTO customer_entitlements (
+				id,
+				customer_product_id,
+				entitlement_id,
+				internal_customer_id,
+				internal_entity_id,
+				internal_feature_id,
+				unlimited,
+				balance,
+				created_at,
+				reset_cycle_anchor,
+				next_reset_at,
+				usage_allowed,
+				separate_interval,
+				adjustment,
+				additional_balance,
+				entities,
+				expires_at,
+				cache_version,
+				customer_id,
+				feature_id,
+				external_id
+			)
+			SELECT
+				generated.id,
+				target.id,
+				${customerEntitlement.entitlement_id},
+				${customerEntitlement.internal_customer_id},
+				NULL,
+				${customerEntitlement.internal_feature_id},
+				${customerEntitlement.unlimited},
+				${customerEntitlement.balance},
+				${customerEntitlement.created_at},
+				${customerEntitlement.reset_cycle_anchor},
+				${customerEntitlement.next_reset_at},
+				${customerEntitlement.usage_allowed},
+				${customerEntitlement.separate_interval},
+				${customerEntitlement.adjustment},
+				${customerEntitlement.additional_balance},
+				${customerEntitlement.entities ? JSON.stringify(customerEntitlement.entities) : null}::jsonb,
+				${customerEntitlement.expires_at},
+				${customerEntitlement.cache_version},
+				${customerEntitlement.customer_id},
+				${customerEntitlement.feature_id},
+				${customerEntitlement.external_id}
+			FROM target_rows AS target
+			INNER JOIN generated_ids AS generated
+				ON generated.ordinality = target.ordinal
+			ON CONFLICT (id) DO NOTHING
+			RETURNING 1
+		)
+		SELECT
+			(SELECT COUNT(*)::int FROM inserted) AS affected,
+			(
+				(SELECT COUNT(*) > ${batchSize} FROM candidate_rows)
+				OR
+				(SELECT COUNT(*) FROM inserted) < (SELECT COUNT(*) FROM target_rows)
+			) AS "hasMore"
+	`);
+
+	return result ?? { affected: 0, hasMore: false };
+};

--- a/server/src/internal/billing/v2/actions/batchTransition/execute/sql/alignCustomerEntitlementCyclesBatch.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/execute/sql/alignCustomerEntitlementCyclesBatch.ts
@@ -1,0 +1,57 @@
+import { sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { CustomerEntitlementCycleOperation } from "../../types/customerEntitlementCycleOperationTypes";
+import type { BatchMutationResult } from "../../types/types";
+import { activeStatusesSql, sqlList } from "./batchTransitionSqlUtils";
+
+export const alignCustomerEntitlementCyclesBatch = async ({
+	db,
+	customerLicenseLinkId,
+	operation,
+	batchSize,
+}: {
+	db: DrizzleCli;
+	customerLicenseLinkId: string;
+	operation: CustomerEntitlementCycleOperation;
+	batchSize: number;
+}): Promise<BatchMutationResult> => {
+	const [result] = await db.execute<BatchMutationResult>(sql`
+		WITH candidate_rows AS MATERIALIZED (
+			SELECT customer_entitlement.ctid AS target_ctid
+			FROM customer_products AS seat
+			INNER JOIN customer_entitlements AS customer_entitlement
+				ON customer_entitlement.customer_product_id = seat.id
+			WHERE seat.customer_license_link_id = ${customerLicenseLinkId}
+				AND seat.internal_entity_id IS NOT NULL
+				AND seat.status IN (${activeStatusesSql})
+				AND customer_entitlement.entitlement_id IN (${sqlList({ values: operation.entitlementIds })})
+				AND (
+					customer_entitlement.reset_cycle_anchor IS DISTINCT FROM ${operation.resetCycleAnchor}
+					OR customer_entitlement.next_reset_at IS DISTINCT FROM ${operation.nextResetAt}
+				)
+			ORDER BY seat.created_at, seat.id, customer_entitlement.id
+			FOR UPDATE OF customer_entitlement
+			LIMIT ${batchSize + 1}
+		),
+		target_rows AS MATERIALIZED (
+			SELECT target_ctid
+			FROM candidate_rows
+			LIMIT ${batchSize}
+		),
+		updated AS (
+			UPDATE customer_entitlements AS customer_entitlement
+			SET
+				reset_cycle_anchor = ${operation.resetCycleAnchor},
+				next_reset_at = ${operation.nextResetAt},
+				cache_version = COALESCE(customer_entitlement.cache_version, 0) + 1
+			FROM target_rows
+			WHERE customer_entitlement.ctid = target_rows.target_ctid
+			RETURNING 1
+		)
+		SELECT
+			(SELECT COUNT(*)::int FROM updated) AS affected,
+			(SELECT COUNT(*) > ${batchSize} FROM candidate_rows) AS "hasMore"
+	`);
+
+	return result ?? { affected: 0, hasMore: false };
+};

--- a/server/src/internal/billing/v2/actions/batchTransition/execute/sql/batchTransitionSqlUtils.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/execute/sql/batchTransitionSqlUtils.ts
@@ -1,0 +1,10 @@
+import { ACTIVE_STATUSES } from "@autumn/shared";
+import { sql } from "drizzle-orm";
+
+export const sqlList = ({ values }: { values: string[] }) =>
+	sql.join(
+		values.map((value) => sql`${value}`),
+		sql`, `,
+	);
+
+export const activeStatusesSql = sqlList({ values: [...ACTIVE_STATUSES] });

--- a/server/src/internal/billing/v2/actions/batchTransition/execute/sql/deleteCustomerBasePricesBatch.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/execute/sql/deleteCustomerBasePricesBatch.ts
@@ -1,0 +1,49 @@
+import { sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { RemoveBasePriceOperation } from "../../types/basePriceOperationTypes";
+import type { BatchMutationResult } from "../../types/types";
+import { activeStatusesSql, sqlList } from "./batchTransitionSqlUtils";
+
+export const deleteCustomerBasePricesBatch = async ({
+	db,
+	customerLicenseLinkId,
+	operation,
+	batchSize,
+}: {
+	db: DrizzleCli;
+	customerLicenseLinkId: string;
+	operation: RemoveBasePriceOperation;
+	batchSize: number;
+}): Promise<BatchMutationResult> => {
+	const [result] = await db.execute<BatchMutationResult>(sql`
+		WITH candidate_rows AS MATERIALIZED (
+			SELECT customer_price.ctid AS target_ctid
+			FROM customer_products AS seat
+			INNER JOIN customer_prices AS customer_price
+				ON customer_price.customer_product_id = seat.id
+			WHERE seat.customer_license_link_id = ${customerLicenseLinkId}
+				AND seat.internal_entity_id IS NOT NULL
+				AND seat.status IN (${activeStatusesSql})
+				AND customer_price.price_id IN (${sqlList({ values: operation.fromPriceIds })})
+			ORDER BY seat.created_at, seat.id, customer_price.id
+			FOR UPDATE OF customer_price
+			LIMIT ${batchSize + 1}
+		),
+		target_rows AS MATERIALIZED (
+			SELECT target_ctid
+			FROM candidate_rows
+			LIMIT ${batchSize}
+		),
+		deleted AS (
+			DELETE FROM customer_prices AS customer_price
+			USING target_rows
+			WHERE customer_price.ctid = target_rows.target_ctid
+			RETURNING 1
+		)
+		SELECT
+			(SELECT COUNT(*)::int FROM deleted) AS affected,
+			(SELECT COUNT(*) > ${batchSize} FROM candidate_rows) AS "hasMore"
+	`);
+
+	return result ?? { affected: 0, hasMore: false };
+};

--- a/server/src/internal/billing/v2/actions/batchTransition/execute/sql/deleteCustomerEntitlementsBatch.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/execute/sql/deleteCustomerEntitlementsBatch.ts
@@ -1,0 +1,49 @@
+import { sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { RemoveEntitlementPriceOperation } from "../../types/entitlementPriceOperationTypes";
+import type { BatchMutationResult } from "../../types/types";
+import { activeStatusesSql, sqlList } from "./batchTransitionSqlUtils";
+
+export const deleteCustomerEntitlementsBatch = async ({
+	db,
+	customerLicenseLinkId,
+	operation,
+	batchSize,
+}: {
+	db: DrizzleCli;
+	customerLicenseLinkId: string;
+	operation: RemoveEntitlementPriceOperation;
+	batchSize: number;
+}): Promise<BatchMutationResult> => {
+	const [result] = await db.execute<BatchMutationResult>(sql`
+		WITH candidate_rows AS MATERIALIZED (
+			SELECT customer_entitlement.ctid AS target_ctid
+			FROM customer_products AS seat
+			INNER JOIN customer_entitlements AS customer_entitlement
+				ON customer_entitlement.customer_product_id = seat.id
+			WHERE seat.customer_license_link_id = ${customerLicenseLinkId}
+				AND seat.internal_entity_id IS NOT NULL
+				AND seat.status IN (${activeStatusesSql})
+				AND customer_entitlement.entitlement_id IN (${sqlList({ values: operation.fromEntitlementIds })})
+			ORDER BY seat.created_at, seat.id, customer_entitlement.id
+			FOR UPDATE OF customer_entitlement
+			LIMIT ${batchSize + 1}
+		),
+		target_rows AS MATERIALIZED (
+			SELECT target_ctid
+			FROM candidate_rows
+			LIMIT ${batchSize}
+		),
+		deleted AS (
+			DELETE FROM customer_entitlements AS customer_entitlement
+			USING target_rows
+			WHERE customer_entitlement.ctid = target_rows.target_ctid
+			RETURNING 1
+		)
+		SELECT
+			(SELECT COUNT(*)::int FROM deleted) AS affected,
+			(SELECT COUNT(*) > ${batchSize} FROM candidate_rows) AS "hasMore"
+	`);
+
+	return result ?? { affected: 0, hasMore: false };
+};

--- a/server/src/internal/billing/v2/actions/batchTransition/execute/sql/replaceCustomerBasePricesBatch.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/execute/sql/replaceCustomerBasePricesBatch.ts
@@ -1,0 +1,50 @@
+import { sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { ReplaceBasePriceOperation } from "../../types/basePriceOperationTypes";
+import type { BatchMutationResult } from "../../types/types";
+import { activeStatusesSql, sqlList } from "./batchTransitionSqlUtils";
+
+export const replaceCustomerBasePricesBatch = async ({
+	db,
+	customerLicenseLinkId,
+	operation,
+	batchSize,
+}: {
+	db: DrizzleCli;
+	customerLicenseLinkId: string;
+	operation: ReplaceBasePriceOperation;
+	batchSize: number;
+}): Promise<BatchMutationResult> => {
+	const [result] = await db.execute<BatchMutationResult>(sql`
+		WITH candidate_rows AS MATERIALIZED (
+			SELECT customer_price.ctid AS target_ctid
+			FROM customer_products AS seat
+			INNER JOIN customer_prices AS customer_price
+				ON customer_price.customer_product_id = seat.id
+			WHERE seat.customer_license_link_id = ${customerLicenseLinkId}
+				AND seat.internal_entity_id IS NOT NULL
+				AND seat.status IN (${activeStatusesSql})
+				AND customer_price.price_id IN (${sqlList({ values: operation.fromPriceIds })})
+			ORDER BY seat.created_at, seat.id, customer_price.id
+			FOR UPDATE OF customer_price
+			LIMIT ${batchSize + 1}
+		),
+		target_rows AS MATERIALIZED (
+			SELECT target_ctid
+			FROM candidate_rows
+			LIMIT ${batchSize}
+		),
+		updated AS (
+			UPDATE customer_prices AS customer_price
+			SET price_id = ${operation.toPrice.id}
+			FROM target_rows
+			WHERE customer_price.ctid = target_rows.target_ctid
+			RETURNING 1
+		)
+		SELECT
+			(SELECT COUNT(*)::int FROM updated) AS affected,
+			(SELECT COUNT(*) > ${batchSize} FROM candidate_rows) AS "hasMore"
+	`);
+
+	return result ?? { affected: 0, hasMore: false };
+};

--- a/server/src/internal/billing/v2/actions/batchTransition/execute/sql/replaceCustomerEntitlementsBatch.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/execute/sql/replaceCustomerEntitlementsBatch.ts
@@ -1,0 +1,72 @@
+import { type SQL, sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { ReplaceEntitlementPriceOperation } from "../../types/entitlementPriceOperationTypes";
+import type { BatchMutationResult } from "../../types/types";
+import { activeStatusesSql, sqlList } from "./batchTransitionSqlUtils";
+
+const balanceAssignment = (
+	operation: ReplaceEntitlementPriceOperation,
+): SQL => {
+	const patch = operation.customerEntitlementPatch.balance;
+	if (!patch) return sql``;
+	if (patch.type === "increment") {
+		return sql`, balance = customer_entitlement.balance + ${patch.amount}`;
+	}
+	return sql`, balance = ${patch.amount}`;
+};
+
+export const replaceCustomerEntitlementsBatch = async ({
+	db,
+	customerLicenseLinkId,
+	operation,
+	batchSize,
+}: {
+	db: DrizzleCli;
+	customerLicenseLinkId: string;
+	operation: ReplaceEntitlementPriceOperation;
+	batchSize: number;
+}): Promise<BatchMutationResult> => {
+	const targetEntitlement = operation.toEntitlementPrice.entitlement;
+	const unlimitedAssignment =
+		operation.customerEntitlementPatch.unlimited === undefined
+			? sql``
+			: sql`, unlimited = ${operation.customerEntitlementPatch.unlimited}`;
+	const [result] = await db.execute<BatchMutationResult>(sql`
+		WITH candidate_rows AS MATERIALIZED (
+			SELECT customer_entitlement.ctid AS target_ctid
+			FROM customer_products AS seat
+			INNER JOIN customer_entitlements AS customer_entitlement
+				ON customer_entitlement.customer_product_id = seat.id
+			WHERE seat.customer_license_link_id = ${customerLicenseLinkId}
+				AND seat.internal_entity_id IS NOT NULL
+				AND seat.status IN (${activeStatusesSql})
+				AND customer_entitlement.entitlement_id IN (${sqlList({ values: operation.fromEntitlementIds })})
+			ORDER BY seat.created_at, seat.id, customer_entitlement.id
+			FOR UPDATE OF customer_entitlement
+			LIMIT ${batchSize + 1}
+		),
+		target_rows AS MATERIALIZED (
+			SELECT target_ctid
+			FROM candidate_rows
+			LIMIT ${batchSize}
+		),
+		updated AS (
+			UPDATE customer_entitlements AS customer_entitlement
+			SET
+				entitlement_id = ${operation.toEntitlementId},
+				internal_feature_id = ${targetEntitlement.internal_feature_id},
+				feature_id = ${targetEntitlement.feature.id},
+				cache_version = COALESCE(customer_entitlement.cache_version, 0) + 1
+				${balanceAssignment(operation)}
+				${unlimitedAssignment}
+			FROM target_rows
+			WHERE customer_entitlement.ctid = target_rows.target_ctid
+			RETURNING 1
+		)
+		SELECT
+			(SELECT COUNT(*)::int FROM updated) AS affected,
+			(SELECT COUNT(*) > ${batchSize} FROM candidate_rows) AS "hasMore"
+	`);
+
+	return result ?? { affected: 0, hasMore: false };
+};

--- a/server/src/internal/billing/v2/actions/batchTransition/execute/sql/repointLicenseCustomerProductsBatch.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/execute/sql/repointLicenseCustomerProductsBatch.ts
@@ -1,0 +1,48 @@
+import { sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { CustomerProductTransition } from "../../compute/transitions/computeCustomerProductTransition";
+import type { BatchMutationResult } from "../../types/types";
+import { activeStatusesSql } from "./batchTransitionSqlUtils";
+
+export const repointLicenseCustomerProductsBatch = async ({
+	db,
+	customerLicenseLinkId,
+	transition,
+	batchSize,
+}: {
+	db: DrizzleCli;
+	customerLicenseLinkId: string;
+	transition: CustomerProductTransition;
+	batchSize: number;
+}): Promise<BatchMutationResult> => {
+	const [result] = await db.execute<BatchMutationResult>(sql`
+		WITH candidate_rows AS MATERIALIZED (
+			SELECT seat.ctid AS target_ctid
+			FROM customer_products AS seat
+			WHERE seat.customer_license_link_id = ${customerLicenseLinkId}
+				AND seat.internal_product_id = ${transition.fromInternalProductId}
+				AND seat.internal_entity_id IS NOT NULL
+				AND seat.status IN (${activeStatusesSql})
+			ORDER BY seat.created_at, seat.id
+			FOR UPDATE OF seat
+			LIMIT ${batchSize + 1}
+		),
+		target_rows AS MATERIALIZED (
+			SELECT target_ctid
+			FROM candidate_rows
+			LIMIT ${batchSize}
+		),
+		updated AS (
+			UPDATE customer_products AS seat
+			SET internal_product_id = ${transition.toInternalProductId}
+			FROM target_rows
+			WHERE seat.ctid = target_rows.target_ctid
+			RETURNING 1
+		)
+		SELECT
+			(SELECT COUNT(*)::int FROM updated) AS affected,
+			(SELECT COUNT(*) > ${batchSize} FROM candidate_rows) AS "hasMore"
+	`);
+
+	return result ?? { affected: 0, hasMore: false };
+};


### PR DESCRIPTION
## Summary
- add bounded batched SQL for customer-product repoints
- add entitlement insert, replace, and delete mutations
- add base-price insert, replace, and delete mutations
- constrain every mutation to the customer-license link and assignment cutoff

## Review focus
This child PR intentionally isolates the PostgreSQL mutation layer for infra review.

## Stack
- depends on https://github.com/useautumn/autumn/pull/2303
- parent stack begins at https://github.com/useautumn/autumn/pull/2295

## Verification
- server typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add batched SQL mutations for license transitions: repoint seats, add/replace/delete base prices and entitlements, and align entitlement cycles. Bounded, safe operations return affected counts and hasMore for iterative execution.

- **New Features**
  - Batched repoint of `customer_products` between internal products.
  - Batched add/replace/delete for customer base prices and entitlements; plus alignment of entitlement reset cycles.
  - Entitlement updates support balance increment/set and unlimited flag.
  - All mutations scoped to `customer_license_link_id`, active seats (`@autumn/shared`), and optional assignment cutoff; rows locked with FOR UPDATE.
  - Deterministic insert ID mapping via JSONB ordinality; each call returns {affected, hasMore}.

<sup>Written for commit 664da1cbc1c63da811839c4c4ce69455672bf713. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces the PostgreSQL mutation layer for batched license transitions, adding seven new SQL functions that INSERT, UPDATE, and DELETE `customer_prices` and `customer_entitlements` rows in bounded batches. All queries use ctid-based or ordinal-join patterns with `FOR UPDATE` row locking and a `LIMIT batchSize + 1` sentinel to signal continuation to the `executeBatchedMutation` loop.

- **[Improvements]** `repointLicenseCustomerProductsBatch` — bounded UPDATE that repoints `customer_products.internal_product_id` to a new product, constrained to the license link and active-status filter.
- **[Improvements]** Add/replace/delete mutations for `customer_prices` — three SQL functions covering the full base-price operation lifecycle with consistent `internal_entity_id IS NOT NULL` and `assignmentCutoffMs` guards.
- **[Improvements]** Add/replace/delete mutations for `customer_entitlements` — three SQL functions for the entitlement lifecycle; the replace variant builds dynamic SET fragments for optional `balance` and `unlimited` patches via drizzle `sql` tags.
</details>

<h3>Confidence Score: 3/5</h3>

Safe to merge after fixing the missing entity guard in addCustomerEntitlementsBatch; all other mutations are well-constructed.

Six of the eight files are consistent and correct. The add-entitlement query omits the `internal_entity_id IS NOT NULL` predicate that every peer mutation carries, meaning entitlements could be inserted onto customer-product rows that have not yet been assigned to a license entity. The rest of the SQL layer — locking strategy, hasMore sentinel, ordinal join for ID assignment, dynamic SET fragments — is solid.

server/src/internal/billing/v2/actions/batchTransition/execute/sql/addCustomerEntitlementsBatch.ts needs the missing entity-assignment guard added to its candidate_rows WHERE clause.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/batchTransition/execute/sql/addCustomerEntitlementsBatch.ts | Adds entitlements to customer products in batches; missing `internal_entity_id IS NOT NULL` guard that all peer mutations include, allowing unassigned seats to receive entitlements. |
| server/src/internal/billing/v2/actions/batchTransition/execute/sql/addCustomerBasePricesBatch.ts | Inserts new customer_prices rows for batch license transitions; guard checks, conflict handling, and hasMore logic all look correct. |
| server/src/internal/billing/v2/actions/batchTransition/execute/sql/replaceCustomerEntitlementsBatch.ts | Updates entitlement_id, feature metadata, and optional balance/unlimited fields; dynamic SQL fragments constructed safely via drizzle sql tags. |
| server/src/internal/billing/v2/actions/batchTransition/execute/sql/deleteCustomerEntitlementsBatch.ts | Deletes matching customer_entitlements rows using ctid-based batching; all guards present and consistent with peer files. |
| server/src/internal/billing/v2/actions/batchTransition/execute/sql/deleteCustomerBasePricesBatch.ts | Deletes customer_prices rows for removed base prices in batches; logic and guards are consistent with entitlement delete counterpart. |
| server/src/internal/billing/v2/actions/batchTransition/execute/sql/replaceCustomerBasePricesBatch.ts | Updates price_id on customer_prices rows for base-price swaps; straightforward and consistent with the entitlement replace file. |
| server/src/internal/billing/v2/actions/batchTransition/execute/sql/repointLicenseCustomerProductsBatch.ts | Repoints customer_products to a new internal_product_id in bounded batches; ctid approach and all predicates look correct. |
| server/src/internal/billing/v2/actions/batchTransition/execute/sql/batchTransitionSqlUtils.ts | Tiny utility file; sqlList correctly uses drizzle parameterization and activeStatusesSql is a safe module-level constant. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller as executeBatchedMutation
    participant SQL as Batch SQL Function
    participant PG as PostgreSQL

    Caller->>SQL: call(db, batchSize, operation)
    SQL->>PG: WITH candidate_rows AS MATERIALIZED (SELECT ... FOR UPDATE LIMIT batchSize+1)
    PG-->>SQL: locked candidate rows
    SQL->>PG: "target_rows = LIMIT batchSize"
    SQL->>PG: INSERT / UPDATE / DELETE
    PG-->>SQL: affected count + hasMore flag
    SQL-->>Caller: "BatchMutationResult { affected, hasMore }"

    alt "hasMore = true AND affected > 0"
        Caller->>SQL: call again (next batch)
    else "hasMore = false"
        Caller-->>Caller: return totalAffected
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller as executeBatchedMutation
    participant SQL as Batch SQL Function
    participant PG as PostgreSQL

    Caller->>SQL: call(db, batchSize, operation)
    SQL->>PG: WITH candidate_rows AS MATERIALIZED (SELECT ... FOR UPDATE LIMIT batchSize+1)
    PG-->>SQL: locked candidate rows
    SQL->>PG: "target_rows = LIMIT batchSize"
    SQL->>PG: INSERT / UPDATE / DELETE
    PG-->>SQL: affected count + hasMore flag
    SQL-->>Caller: "BatchMutationResult { affected, hasMore }"

    alt "hasMore = true AND affected > 0"
        Caller->>SQL: call again (next batch)
    else "hasMore = false"
        Caller-->>Caller: return totalAffected
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/billing/v2/actions/batchTransition/execute/sql/addCustomerEntitlementsBatch.ts:31-46
**Missing `internal_entity_id IS NOT NULL` guard**

Every other batch mutation in this PR — `addCustomerBasePricesBatch`, `deleteCustomerEntitlementsBatch`, `replaceCustomerEntitlementsBatch`, and both base-price variants — filters `AND seat.internal_entity_id IS NOT NULL` in the `candidate_rows` CTE. This query omits that predicate, so the entitlement-add can target customer-product rows that are not yet bound to any license entity. In practice this means entitlements may be inserted onto unassigned seats, causing them to carry entitlements they should never have received until an entity is assigned.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(licenses): 🎸 add batched transitio..."](https://github.com/useautumn/autumn/commit/63c054907657fcee33715dd8b78bca25478f6dba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45602304)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->