### PR TITLE
fix(dashboard): show and update license changes

### DIFF
--- a/vite/src/components/forms/shared/plan-items/LicenseQuantityControl.tsx
+++ b/vite/src/components/forms/shared/plan-items/LicenseQuantityControl.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
 import type { UseAttachForm } from "@/components/forms/attach-v2/hooks/useAttachForm";
+import type { UseUpdateSubscriptionForm } from "@/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionForm";
 import { QuantityEditControl } from "./QuantityEditControl";
 
 export interface LicenseQuantityEditor {
-	form: UseAttachForm;
+	form: UseAttachForm | UseUpdateSubscriptionForm;
 	quantities: Record<string, number | undefined>;
 }
 

--- a/vite/src/components/forms/update-subscription-v2/components/EditPlanSection.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/EditPlanSection.tsx
@@ -20,7 +20,7 @@ export function EditPlanSection() {
 	} = useUpdateSubscriptionFormContext();
 
 	const { customerProduct } = formContext;
-	const { prepaidOptions } = formValues;
+	const { licenseQuantities, prepaidOptions } = formValues;
 	const isCustomized =
 		formValues.items !== null || formValues.addLicenses !== null;
 	const hasCustomizations = isCustomized || isVersionReady;
@@ -117,6 +117,7 @@ export function EditPlanSection() {
 				form={form}
 				showDiff={hasCustomizations}
 				addLicenses={formValues.addLicenses}
+				licenseQuantityEditor={{ form, quantities: licenseQuantities }}
 				currency={currency}
 				onEditPlan={handleEditPlan}
 				priceChange={priceChange}

--- a/vite/src/components/forms/update-subscription-v2/context/UpdateSubscriptionFormProvider.tsx
+++ b/vite/src/components/forms/update-subscription-v2/context/UpdateSubscriptionFormProvider.tsx
@@ -29,6 +29,10 @@ import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useProductVersionQuery } from "@/hooks/queries/useProductVersionQuery";
 import type { PrepaidItemWithFeature } from "@/hooks/stores/useProductStore";
 import { useHasBillingChanges } from "@/hooks/stores/useProductStore";
+import {
+	clampLicenseQuantitiesToIncluded,
+	convertLicenseQuantitiesToParams,
+} from "@/utils/billing/licenseQuantityUtils";
 import { useHasSubscriptionChanges } from "../hooks/useHasSubscriptionChanges";
 import {
 	type UseTrialStateReturn,
@@ -180,6 +184,7 @@ export function UpdateSubscriptionFormProvider({
 
 	const defaultValues = form.options.defaultValues;
 	const initialPrepaidOptions = defaultValues?.prepaidOptions ?? {};
+	const initialLicenseQuantities = defaultValues?.licenseQuantities ?? {};
 	const initialBillingBehavior = defaultValues?.billingBehavior ?? null;
 
 	const productWithFormItems = useMemo((): FrontendProduct | undefined => {
@@ -287,12 +292,19 @@ export function UpdateSubscriptionFormProvider({
 	});
 
 	const hasPrepaidQuantityChanges = changedPrepaidOptions !== undefined;
+	const hasLicenseQuantityChanges = Boolean(
+		convertLicenseQuantitiesToParams({
+			licenseQuantities: formValues.licenseQuantities,
+			initialLicenseQuantities,
+		}),
+	);
 	const isVersionLoading = isVersionChanged && !isVersionReady;
 	const hasNoBillingChanges =
 		normalizedFormValues.noBillingChanges ||
 		(hasChanges &&
 			!hasBillingChanges &&
 			!hasPrepaidQuantityChanges &&
+			!hasLicenseQuantityChanges &&
 			!isVersionLoading &&
 			!normalizedFormValues.resetBillingCycle);
 
@@ -368,6 +380,13 @@ export function UpdateSubscriptionFormProvider({
 
 			if (editedAddLicenses) {
 				form.setFieldValue("addLicenses", editedAddLicenses);
+				form.setFieldValue(
+					"licenseQuantities",
+					clampLicenseQuantitiesToIncluded({
+						licenseQuantities: form.store.state.values.licenseQuantities,
+						upsertLicenses: editedAddLicenses,
+					}),
+				);
 			}
 
 			setShowPlanEditor(false);

--- a/vite/src/components/forms/update-subscription-v2/hooks/useHasSubscriptionChanges.ts
+++ b/vite/src/components/forms/update-subscription-v2/hooks/useHasSubscriptionChanges.ts
@@ -12,6 +12,10 @@ import {
 } from "@autumn/shared";
 import { useMemo } from "react";
 import type { PrepaidItemWithFeature } from "@/hooks/stores/useProductStore";
+import {
+	convertLicenseQuantitiesToParams,
+	customerLicensesToQuantityTotals,
+} from "@/utils/billing/licenseQuantityUtils";
 import type { UpdateSubscriptionForm } from "../updateSubscriptionFormSchema";
 
 type PrepaidChangeItem = {
@@ -67,6 +71,16 @@ export function useHasSubscriptionChanges({
 		if (formValues.resetBillingCycle) return true;
 		if (formValues.noBillingChanges) return true;
 		if (formValues.addLicenses !== null) return true;
+		if (
+			convertLicenseQuantitiesToParams({
+				licenseQuantities: formValues.licenseQuantities,
+				initialLicenseQuantities: customerLicensesToQuantityTotals({
+					customerLicenses: customerProduct.customer_licenses ?? [],
+				}),
+			})
+		) {
+			return true;
+		}
 
 		if (formValues.discounts?.length > 0) return true;
 
@@ -133,6 +147,7 @@ export function useHasSubscriptionChanges({
 		formValues.version,
 		formValues.items,
 		formValues.addLicenses,
+		formValues.licenseQuantities,
 		formValues.prepaidOptions,
 		initialPrepaidOptions,
 		prepaidItems,

--- a/vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionForm.ts
+++ b/vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionForm.ts
@@ -5,6 +5,7 @@ import {
 } from "@autumn/shared";
 import { useMemo } from "react";
 import { useAppForm } from "@/hooks/form/form";
+import { customerLicensesToQuantityTotals } from "@/utils/billing/licenseQuantityUtils";
 import { backendToDisplayQuantity } from "@/utils/billing/prepaidQuantityUtils";
 import type { UpdateSubscriptionFormContext } from "../context/UpdateSubscriptionFormProvider";
 import {
@@ -30,6 +31,13 @@ export function useUpdateSubscriptionForm({
 			}),
 		[customerProduct.options, prepaidItems],
 	);
+	const initialLicenseQuantities = useMemo(
+		() =>
+			customerLicensesToQuantityTotals({
+				customerLicenses: customerProduct.customer_licenses ?? [],
+			}),
+		[customerProduct.customer_licenses],
+	);
 
 	const isTrialing = isCustomerProductTrialing(customerProduct);
 	const remainingTrialDays = isTrialing
@@ -43,6 +51,7 @@ export function useUpdateSubscriptionForm({
 	return useAppForm({
 		defaultValues: {
 			prepaidOptions: initialPrepaidOptions,
+			licenseQuantities: initialLicenseQuantities,
 			trialLength: remainingTrialDays,
 			trialDuration: FreeTrialDuration.Day,
 			trialCardRequired,

--- a/vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody.ts
+++ b/vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody.ts
@@ -7,6 +7,7 @@ import type {
 import { ProductItemFeatureType } from "@autumn/shared";
 import { useCallback, useMemo } from "react";
 import { normalizeBillingRequestItems } from "@/components/forms/shared/utils/normalizeBillingRequestItems";
+import { convertLicenseQuantitiesToParams } from "@/utils/billing/licenseQuantityUtils";
 import type { UpdateSubscriptionFormContext } from "../context/UpdateSubscriptionFormProvider";
 import { getFreeTrial } from "../utils/getFreeTrial";
 import type { UseUpdateSubscriptionForm } from "./useUpdateSubscriptionForm";
@@ -109,12 +110,23 @@ export function buildUpdateSubscriptionOptions({
 export function buildUpdateSubscriptionCustomizationParams({
 	items,
 	addLicenses,
+	licenseQuantities,
+	initialLicenseQuantities,
 }: {
 	items: ProductItem[] | null;
 	addLicenses: CustomizePlanLicense[] | null;
-}): Pick<UpdateSubscriptionV0Params, "items" | "upsert_licenses"> {
+	licenseQuantities: Record<string, number | undefined>;
+	initialLicenseQuantities: Record<string, number | undefined>;
+}): Pick<
+	UpdateSubscriptionV0Params,
+	"items" | "license_quantities" | "upsert_licenses"
+> {
 	return {
 		items: normalizeBillingRequestItems({ items }),
+		license_quantities: convertLicenseQuantitiesToParams({
+			licenseQuantities,
+			initialLicenseQuantities,
+		}),
 		upsert_licenses: addLicenses ?? undefined,
 	};
 }
@@ -135,6 +147,10 @@ export function useUpdateSubscriptionRequestBody({
 		() => form.options.defaultValues?.prepaidOptions ?? {},
 		[form.options.defaultValues?.prepaidOptions],
 	);
+	const initialLicenseQuantities = useMemo(
+		() => form.options.defaultValues?.licenseQuantities ?? {},
+		[form.options.defaultValues?.licenseQuantities],
+	);
 	const initialBackendQuantities = useMemo(
 		() =>
 			customerProduct.options.reduce(
@@ -154,6 +170,7 @@ export function useUpdateSubscriptionRequestBody({
 		const formValues = form.store.state.values;
 		const {
 			prepaidOptions,
+			licenseQuantities,
 			trialLength,
 			trialDuration,
 			removeTrial,
@@ -220,7 +237,12 @@ export function useUpdateSubscriptionRequestBody({
 			...base,
 			options: options.length > 0 ? options : undefined,
 			free_trial: freeTrial,
-			...buildUpdateSubscriptionCustomizationParams({ items, addLicenses }),
+			...buildUpdateSubscriptionCustomizationParams({
+				items,
+				addLicenses,
+				licenseQuantities,
+				initialLicenseQuantities,
+			}),
 			version: version !== initialVersion ? version : undefined,
 			billing_behavior: billingBehavior || undefined,
 			billing_cycle_anchor: resetBillingCycle ? "now" : undefined,
@@ -238,6 +260,7 @@ export function useUpdateSubscriptionRequestBody({
 		currentPrepaidItems,
 		initialPrepaidOptions,
 		initialBackendQuantities,
+		initialLicenseQuantities,
 	]);
 
 	return { buildRequestBody };

--- a/vite/src/components/forms/update-subscription-v2/updateSubscriptionFormSchema.ts
+++ b/vite/src/components/forms/update-subscription-v2/updateSubscriptionFormSchema.ts
@@ -12,6 +12,7 @@ import { RefundBehaviorSchema } from "@/components/forms/update-subscription-v2/
 
 export const UpdateSubscriptionFormSchema = z.object({
 	prepaidOptions: z.record(z.string(), z.number().nonnegative().optional()),
+	licenseQuantities: z.record(z.string(), z.number().nonnegative().optional()),
 
 	trialLength: z.number().positive().nullable(),
 	trialDuration: z.enum(FreeTrialDuration),

--- a/vite/src/utils/billing/licenseQuantityUtils.ts
+++ b/vite/src/utils/billing/licenseQuantityUtils.ts
@@ -1,7 +1,23 @@
 import type {
 	CustomizePlanLicense,
+	FullCustomerLicense,
 	LicenseQuantityParams,
 } from "@autumn/shared";
+
+export function customerLicensesToQuantityTotals({
+	customerLicenses,
+}: {
+	customerLicenses: FullCustomerLicense[];
+}): Record<string, number> {
+	const quantities: Record<string, number> = {};
+
+	for (const customerLicense of customerLicenses) {
+		const licensePlanId = customerLicense.planLicense?.product.id;
+		if (licensePlanId) quantities[licensePlanId] = customerLicense.granted;
+	}
+
+	return quantities;
+}
 
 /**
  * Converts staged license seat totals into license_quantities params.
@@ -9,13 +25,20 @@ import type {
  */
 export function convertLicenseQuantitiesToParams({
 	licenseQuantities,
+	initialLicenseQuantities = {},
 }: {
 	licenseQuantities: Record<string, number | undefined>;
+	initialLicenseQuantities?: Record<string, number | undefined>;
 }): LicenseQuantityParams[] | undefined {
 	const params: LicenseQuantityParams[] = [];
 
 	for (const [licensePlanId, quantity] of Object.entries(licenseQuantities)) {
-		if (quantity === undefined) continue;
+		if (
+			quantity === undefined ||
+			quantity === initialLicenseQuantities[licensePlanId]
+		) {
+			continue;
+		}
 		params.push({ license_plan_id: licensePlanId, quantity });
 	}
 

--- a/vite/src/views/products/plan/versioning/MigrateTargetsStep.tsx
+++ b/vite/src/views/products/plan/versioning/MigrateTargetsStep.tsx
@@ -1,10 +1,13 @@
 import type {
+	Feature,
 	PlanUpdatePreview,
 	PlanUpdatePreviewItemChange,
+	PlanUpdatePreviewLicenseChange,
 	PlanUpdatePreviewVariantConflict,
 } from "@autumn/shared";
 import { UsersIcon, WarningIcon } from "@phosphor-icons/react";
 import { ItemChangeList } from "@/components/v2/ItemChangeList";
+import { LicenseChangeList } from "./LicenseChangeList";
 import {
 	previousAttributesToSettingChanges,
 	type SettingChange,
@@ -16,6 +19,7 @@ export type MigrateTargetRow = {
 	isCurrent: boolean;
 	isNew: boolean;
 	itemChanges: PlanUpdatePreviewItemChange[];
+	licenseChanges: PlanUpdatePreviewLicenseChange[];
 	hasPriceChange: boolean;
 	settingChanges: SettingChange[];
 	customerCount: number;
@@ -54,6 +58,7 @@ export function buildMigrateTargets({
 			isCurrent: !baseCreatesNewVersion,
 			isNew: baseCreatesNewVersion,
 			itemChanges: preview.item_changes ?? [],
+			licenseChanges: preview.license_changes ?? [],
 			hasPriceChange: preview.price_change !== undefined,
 			settingChanges: previousAttributesToSettingChanges(
 				preview.previous_attributes,
@@ -67,6 +72,7 @@ export function buildMigrateTargets({
 					isCurrent: false,
 					isNew: false,
 					itemChanges: version.item_changes ?? [],
+					licenseChanges: [],
 					hasPriceChange: version.price_change !== undefined,
 					settingChanges: previousAttributesToSettingChanges(
 						version.previous_attributes,
@@ -109,6 +115,7 @@ export function buildMigrateTargets({
 					isCurrent: isLatest && !createsNewVersion,
 					isNew: createsNewVersion,
 					itemChanges: entry.item_changes ?? [],
+					licenseChanges: [],
 					hasPriceChange: entry.price_change !== undefined,
 					settingChanges: previousAttributesToSettingChanges(
 						entry.previous_attributes,
@@ -164,15 +171,18 @@ function VersionStatusBadges({
 function VersionBody({
 	row,
 	showSettings,
+	features,
 }: {
 	row: MigrateTargetRow;
 	showSettings: boolean;
+	features?: Feature[];
 }) {
 	// Settings (config, billing controls, …) are a global metadata patch shared by
 	// every version, so the mixed-change view surfaces them once above the targets.
 	const settingChanges = showSettings ? row.settingChanges : [];
 	const hasChanges =
 		row.itemChanges.length > 0 ||
+		row.licenseChanges.length > 0 ||
 		row.hasPriceChange ||
 		settingChanges.length > 0;
 	return (
@@ -180,6 +190,7 @@ function VersionBody({
 			{row.itemChanges.length > 0 && (
 				<ItemChangeList itemChanges={row.itemChanges} />
 			)}
+			<LicenseChangeList changes={row.licenseChanges} features={features} />
 			{row.hasPriceChange && (
 				<span className="text-tertiary-foreground text-xs">
 					Base price change
@@ -212,10 +223,12 @@ export function MigrateTargetsStep({
 	targets,
 	showCustomers = true,
 	showSettings = true,
+	features,
 }: {
 	targets: MigrateTarget[];
 	showCustomers?: boolean;
 	showSettings?: boolean;
+	features?: Feature[];
 }) {
 	if (targets.length === 0) {
 		return (
@@ -247,7 +260,11 @@ export function MigrateTargetsStep({
 							</div>
 						</div>
 						{singleRow ? (
-							<VersionBody row={target.rows[0]} showSettings={showSettings} />
+							<VersionBody
+								row={target.rows[0]}
+								showSettings={showSettings}
+								features={features}
+							/>
 						) : (
 							<div className="flex flex-col gap-2">
 								{target.rows.map((row) => (
@@ -256,7 +273,11 @@ export function MigrateTargetsStep({
 											row={row}
 											showCustomers={showCustomers}
 										/>
-										<VersionBody row={row} showSettings={showSettings} />
+										<VersionBody
+											row={row}
+											showSettings={showSettings}
+											features={features}
+										/>
 									</div>
 								))}
 							</div>

--- a/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
+++ b/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
@@ -684,6 +684,7 @@ export default function PlanChangeDialog({
 															</div>
 														)}
 														<MigrateTargetsStep
+															features={features}
 															showCustomers={migrateNeeded}
 															showSettings={false}
 															targets={migrateTargets}

--- a/vite/tests/components/forms/update-subscription-v2/hooks/build-update-subscription-customization-params.test.ts
+++ b/vite/tests/components/forms/update-subscription-v2/hooks/build-update-subscription-customization-params.test.ts
@@ -15,8 +15,14 @@ describe("buildUpdateSubscriptionCustomizationParams", () => {
 			buildUpdateSubscriptionCustomizationParams({
 				items: null,
 				addLicenses,
+				licenseQuantities: {},
+				initialLicenseQuantities: {},
 			}),
-		).toEqual({ items: undefined, upsert_licenses: addLicenses });
+		).toEqual({
+			items: undefined,
+			license_quantities: undefined,
+			upsert_licenses: addLicenses,
+		});
 	});
 
 	test("omits untouched license patches", () => {
@@ -24,7 +30,28 @@ describe("buildUpdateSubscriptionCustomizationParams", () => {
 			buildUpdateSubscriptionCustomizationParams({
 				items: null,
 				addLicenses: null,
+				licenseQuantities: { team_seat: 2 },
+				initialLicenseQuantities: { team_seat: 2 },
 			}),
-		).toEqual({ items: undefined, upsert_licenses: undefined });
+		).toEqual({
+			items: undefined,
+			license_quantities: undefined,
+			upsert_licenses: undefined,
+		});
+	});
+
+	test("serializes only changed license seat totals", () => {
+		expect(
+			buildUpdateSubscriptionCustomizationParams({
+				items: null,
+				addLicenses: null,
+				licenseQuantities: { team_seat: 4, support_seat: 1 },
+				initialLicenseQuantities: { team_seat: 2, support_seat: 1 },
+			}),
+		).toEqual({
+			items: undefined,
+			license_quantities: [{ license_plan_id: "team_seat", quantity: 4 }],
+			upsert_licenses: undefined,
+		});
 	});
 });

--- a/vite/tests/utils/billing/license-quantity-utils.test.ts
+++ b/vite/tests/utils/billing/license-quantity-utils.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import type { FullCustomerLicense } from "@autumn/shared";
+import { customerLicensesToQuantityTotals } from "@/utils/billing/licenseQuantityUtils";
+
+describe("customerLicensesToQuantityTotals", () => {
+	test("uses current granted totals keyed by license plan id", () => {
+		const customerLicenses = [
+			{
+				granted: 3,
+				planLicense: { product: { id: "team_seat" } },
+			},
+			{ granted: 2, planLicense: null },
+		] as FullCustomerLicense[];
+
+		expect(customerLicensesToQuantityTotals({ customerLicenses })).toEqual({
+			team_seat: 3,
+		});
+	});
+});

--- a/vite/tests/views/products/plan/versioning/build-migrate-targets.test.ts
+++ b/vite/tests/views/products/plan/versioning/build-migrate-targets.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+import type {
+	PlanUpdatePreview,
+	PlanUpdatePreviewLicenseChange,
+} from "@autumn/shared";
+import { buildMigrateTargets } from "@/views/products/plan/versioning/MigrateTargetsStep";
+
+test("carries base plan license changes into the review target", () => {
+	const licenseChange = {
+		license_plan_id: "team_seat",
+		action: "update",
+	} as PlanUpdatePreviewLicenseChange;
+	const preview = {
+		plan_id: "team",
+		has_customers: true,
+		customer_count: 1,
+		license_changes: [licenseChange],
+		variants: [],
+		other_versions: [],
+	} as PlanUpdatePreview;
+
+	const targets = buildMigrateTargets({
+		preview,
+		selectedVariantIds: [],
+		versionChoice: "new",
+		currentVersion: 1,
+		baseName: "Team Quarterly",
+	});
+
+	expect(targets[0].rows[0].licenseChanges).toEqual([licenseChange]);
+});


### PR DESCRIPTION
## Summary

- allow existing license seat totals to be edited in subscription updates
- send only changed license quantities and include them in change detection
- show license changes in the plan migration review

## Validation

- bun run ts
- 5 focused Bun tests across update-subscription, license quantity, and migration review
- React Doctor: 83/100 with one pre-existing only-export-components warning

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables editing existing license seat totals during subscription updates and shows license changes in the migration review. Only changed quantities are sent and counted as changes to avoid no-op updates.

- New Features
  - Add license quantity controls to Update Subscription, initialized from current customer licenses and clamped when adding licenses.
  - Send `license_quantities` only when totals change; unchanged values are omitted.
  - Include license quantity changes in change detection and “no billing changes” logic.
  - Show license changes in migration review (`MigrateTargetsStep`) via `LicenseChangeList`, including base plan changes.
  - Add focused tests for request params, utils, and migration targets.

<sup>Written for commit 9e5c2023a3e7667775c0bce18d8278e39c7439b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the update-subscription form to support editing existing license seat totals and wires those changes into the plan migration review dialog. The implementation sends only changed quantities to the API and gates billing-change detection on them.

- **[Bug fixes, Improvements]** `licenseQuantities` field added to the update-subscription form schema and initialized from current `customer_licenses`; only changed values are serialised as `license_quantities` params, with clamping applied when a plan editor save reduces the included seats below the staged quantity.
- **[Improvements]** `useHasSubscriptionChanges` and `hasNoBillingChanges` in the provider are both updated to recognise license quantity diffs, so the billing-change banner and preview behave correctly.
- **[Improvements]** `LicenseChangeList` component is surfaced in `MigrateTargetsStep` to show license changes in the plan migration review; `features` is threaded down from `PlanChangeDialog` to support future label resolution.
</details>

<h3>Confidence Score: 4/5</h3>

The core diff-only serialisation and form wiring are correct; one function that builds the initial quantity baseline may silently discard data if a customer holds more than one license row per product ID.

The change-detection logic and request-body construction are well-tested and follow existing patterns. The one concern is customerLicensesToQuantityTotals, which overwrites rather than accumulates when two FullCustomerLicense entries share the same planLicense.product.id. If that situation can arise in production data, the form would initialise with the wrong baseline, breaking change detection and potentially sending an incorrect quantity to the API.

vite/src/utils/billing/licenseQuantityUtils.ts — confirm the data model guarantees at most one FullCustomerLicense per product ID, or add accumulation logic.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/utils/billing/licenseQuantityUtils.ts | New utility functions for converting customer licenses to quantity maps and diffing them; last-write-wins overwrite in customerLicensesToQuantityTotals may produce incorrect baselines if a customer holds multiple licenses for the same product ID |
| vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody.ts | Adds licenseQuantities / initialLicenseQuantities threading into buildUpdateSubscriptionCustomizationParams; diff-only serialization is correct and memoized safely |
| vite/src/components/forms/update-subscription-v2/hooks/useHasSubscriptionChanges.ts | License quantity changes are correctly wired into change detection; dependency array is complete |
| vite/src/components/forms/update-subscription-v2/context/UpdateSubscriptionFormProvider.tsx | hasLicenseQuantityChanges added to hasNoBillingChanges guard; clampLicenseQuantitiesToIncluded called correctly after plan editor save |
| vite/src/views/products/plan/versioning/MigrateTargetsStep.tsx | licenseChanges field added to MigrateTargetRow and propagated through buildMigrateTargets; non-base rows default to empty array correctly |
| vite/src/views/products/plan/versioning/LicenseChangeList.tsx | New component renders license changes in the migration review; displays raw license_plan_id instead of a resolved human-readable name |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/utils/billing/licenseQuantityUtils.ts:14-16
**Last-write-wins when multiple licenses share a product ID**

If a customer can have more than one `FullCustomerLicense` entry with the same `planLicense.product.id` (e.g. two rows both keyed to `"team_seat"`), each iteration silently overwrites the previous value. The form would be initialised with whichever entry happens to be last in the array, making the change-detection baseline incorrect and potentially sending a wrong `license_quantities` payload to the backend.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): 🐛 show and update licen..."](https://github.com/useautumn/autumn/commit/9e5c2023a3e7667775c0bce18d8278e39c7439b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45611724)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->