### PR TITLE
dev

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
@@ -25,7 +25,7 @@ import { checkStripeProductExists } from "@/internal/products/productUtils";
 import { applyStripeResourceReuseForProduct } from "@/internal/products/stripeResourceUtils/applyStripeResourceReuseForProduct";
 import { applyStripeReuseFromVariantFamilies } from "@/internal/products/stripeResourceUtils/applyStripeReuseFromVariantFamilies";
 import {
-	planLicenseToParentStripeInitProduct,
+	planLicenseToCustomStripeInitProduct,
 	planLicenseToStripeInitProduct,
 } from "./licenseStripeResourceUtils";
 
@@ -71,7 +71,7 @@ export const initStripeResourcesForProducts = async ({
 	const customLicenseProducts = products.flatMap((parentProduct) =>
 		(parentProduct.licenses ?? [])
 			.map((planLicense) =>
-				planLicenseToParentStripeInitProduct({ planLicense, parentProduct }),
+				planLicenseToCustomStripeInitProduct({ planLicense }),
 			)
 			.filter((licenseProduct) => licenseProduct !== null),
 	);
@@ -188,13 +188,12 @@ export const initStripeResourcesForBillingPlan = async ({
 		...insertCustomerProducts,
 		...fullCustomer.customer_products,
 	]) {
-		const parentProduct = cusProductToProduct({ cusProduct: customerProduct });
 		for (const customerLicense of customerProduct.customer_licenses ?? []) {
 			const planLicense = customerLicense.planLicense;
 			if (!planLicense) continue;
 			licenseProductsByDefinition.set(
 				customerLicense.plan_license_id ?? planLicense.product.internal_id,
-				planLicenseToStripeInitProduct({ planLicense, parentProduct }),
+				planLicenseToStripeInitProduct({ planLicense }),
 			);
 		}
 	}
@@ -202,23 +201,9 @@ export const initStripeResourcesForBillingPlan = async ({
 	for (const transition of autumnBillingPlan.customerLicenseTransitions ?? []) {
 		const planLicense = transition.incomingCustomerLicense.planLicense;
 		if (!planLicense) continue;
-		const parentCustomerProduct = [
-			...insertCustomerProducts,
-			...fullCustomer.customer_products,
-		].find(
-			(customerProduct) =>
-				customerProduct.id ===
-				transition.incomingCustomerLicense.parent_customer_product_id,
-		);
-		if (!parentCustomerProduct) continue;
 		licenseProductsByDefinition.set(
 			planLicense.id,
-			planLicenseToStripeInitProduct({
-				planLicense,
-				parentProduct: cusProductToProduct({
-					cusProduct: parentCustomerProduct,
-				}),
-			}),
+			planLicenseToStripeInitProduct({ planLicense }),
 		);
 	}
 	const licenseProducts = Array.from(licenseProductsByDefinition.values());

--- a/server/src/internal/billing/v2/providers/stripe/utils/common/licenseStripeResourceUtils.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/licenseStripeResourceUtils.ts
@@ -4,32 +4,24 @@ import {
 	planLicenseToCustomizedBasePrice,
 } from "@autumn/shared";
 
-export const planLicenseToParentStripeInitProduct = ({
+export const planLicenseToCustomStripeInitProduct = ({
 	planLicense,
-	parentProduct,
 }: {
 	planLicense: FullPlanLicense;
-	parentProduct: FullProduct;
 }): FullProduct | null => {
 	const customizedBasePrice = planLicenseToCustomizedBasePrice({ planLicense });
 
-	if (!customizedBasePrice || !parentProduct.processor?.id) {
-		return null;
-	}
+	if (!customizedBasePrice) return null;
 
 	return {
 		...planLicense.product,
-		processor: parentProduct.processor,
 		prices: [customizedBasePrice],
 	};
 };
 
 export const planLicenseToStripeInitProduct = ({
 	planLicense,
-	parentProduct,
 }: {
 	planLicense: FullPlanLicense;
-	parentProduct: FullProduct;
 }): FullProduct =>
-	planLicenseToParentStripeInitProduct({ planLicense, parentProduct }) ??
-	planLicense.product;
+	planLicenseToCustomStripeInitProduct({ planLicense }) ?? planLicense.product;

--- a/server/tests/integration/billing/stripe-webhooks/subscription-created/licenses/sub-created-parent-product-license-backsync.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/subscription-created/licenses/sub-created-parent-product-license-backsync.test.ts
@@ -1,5 +1,5 @@
-/** Contract: parent-customized fixed license prices use the parent Stripe Product.
- * Back-sync resolves product identity before price shape within shared products. */
+/** Contract: customized license prices use the license plan's Stripe Product.
+ * Back-sync resolves exact prices first, then unambiguous license price shapes. */
 import { expect, test } from "bun:test";
 import {
 	type ApiCustomerV5,
@@ -13,8 +13,8 @@ import {
 	expectProductActive,
 	expectProductNotPresent,
 } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
-import { getFullLicenseProduct } from "@tests/integration/licenses/catalog-update/utils/getFullLicenseProduct";
 import { createVariantPlan } from "@tests/integration/crud/plans/variants/utils/variantTestPlanUtils";
+import { getFullLicenseProduct } from "@tests/integration/licenses/catalog-update/utils/getFullLicenseProduct";
 import { expectCustomerLicenses } from "@tests/integration/licenses/utils/expectCustomerLicenses";
 import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
@@ -42,7 +42,7 @@ type Scenario = {
 const stripeProductId = ({ price }: { price: Stripe.Price }) =>
 	typeof price.product === "string" ? price.product : price.product.id;
 
-const expectCustomizedPriceUnderParent = async ({
+const expectCustomizedPriceUnderLicenseProduct = async ({
 	ctx,
 	parentPlanId,
 	licensePlanId,
@@ -51,40 +51,34 @@ const expectCustomizedPriceUnderParent = async ({
 	parentPlanId: string;
 	licensePlanId: string;
 }) => {
-	const [parent, customized] = await Promise.all([
-		ProductService.getFull({
-			db: ctx.db,
-			idOrInternalId: parentPlanId,
-			orgId: ctx.org.id,
-			env: ctx.env,
-		}),
-		getFullLicenseProduct({ ctx, parentPlanId, licensePlanId }),
-	]);
+	const customized = await getFullLicenseProduct({
+		ctx,
+		parentPlanId,
+		licensePlanId,
+	});
 	const price = productToBasePrice({
 		product: customized.fullLicenseProduct,
 	});
-	const parentStripeProductId = parent.processor?.id;
-	if (!parentStripeProductId) {
-		throw new Error(`Parent ${parentPlanId} has no Stripe product`);
+	const licenseStripeProductId = customized.fullLicenseProduct.processor?.id;
+	if (!licenseStripeProductId) {
+		throw new Error(`License ${licensePlanId} has no Stripe product`);
 	}
 
 	expect(customized.planLicense.customized).toBe(true);
 	expect(price?.is_custom).toBe(true);
-	expect(parentStripeProductId).toBeDefined();
-	expect(price?.config.stripe_product_id).toBe(parentStripeProductId);
+	expect(price?.config.stripe_product_id).toBe(licenseStripeProductId);
 	expect(price?.config.stripe_price_id).toBeDefined();
 
 	const stripePrice = await ctx.stripeCli.prices.retrieve(
 		price!.config.stripe_price_id!,
 	);
-	expect(stripeProductId({ price: stripePrice })).toBe(parentStripeProductId);
+	expect(stripeProductId({ price: stripePrice })).toBe(licenseStripeProductId);
 
 	return {
-		parent,
 		price: price!,
 		stripePrice,
 		stripePriceId: stripePrice.id,
-		stripeProductId: parentStripeProductId,
+		stripeProductId: licenseStripeProductId,
 	};
 };
 
@@ -168,7 +162,7 @@ const createLicenseSubscription = async ({
 		items: [{ price: stripePriceId, quantity: INITIAL_PAID_SEATS }],
 	});
 
-test(`${chalk.yellowBright("license back-sync: equal shapes under different parent products select by product")}`, async () => {
+test(`${chalk.yellowBright("license back-sync: equal shapes under one license product select by exact price")}`, async () => {
 	const customerId = "sub-license-parent-product-distinct";
 	const parentA = products.base({
 		id: `${customerId}-a`,
@@ -209,29 +203,24 @@ test(`${chalk.yellowBright("license back-sync: equal shapes under different pare
 	});
 
 	const [customA, customB] = await Promise.all([
-		expectCustomizedPriceUnderParent({
+		expectCustomizedPriceUnderLicenseProduct({
 			ctx: scenario.ctx,
 			parentPlanId: parentA.id,
 			licensePlanId: teamSeat.id,
 		}),
-		expectCustomizedPriceUnderParent({
+		expectCustomizedPriceUnderLicenseProduct({
 			ctx: scenario.ctx,
 			parentPlanId: parentB.id,
 			licensePlanId: teamSeat.id,
 		}),
 	]);
-	expect(customA.stripeProductId).not.toBe(customB.stripeProductId);
+	expect(customA.stripeProductId).toBe(customB.stripeProductId);
 	expect(customA.stripePriceId).not.toBe(customB.stripePriceId);
 
-	const externalPrice = await createStripeFixedPriceUnderProduct({
-		ctx: scenario.ctx,
-		stripeProductId: customB.stripeProductId,
-		unitAmount: 12 * 100,
-	});
 	const subscription = await createLicenseSubscription({
 		scenario,
 		customerId,
-		stripePriceId: externalPrice.id,
+		stripePriceId: customB.stripePriceId,
 	});
 	let customer = await waitForLicensePool({
 		scenario,
@@ -262,7 +251,7 @@ test(`${chalk.yellowBright("license back-sync: equal shapes under different pare
 	await expectProductActive({ customer, productId: parentB.id });
 });
 
-test(`${chalk.yellowBright("license back-sync: shared parent product selects by customized base shape")}`, async () => {
+test(`${chalk.yellowBright("license back-sync: shared license product selects by customized base shape")}`, async () => {
 	const customerId = "sub-license-parent-product-shared";
 	const pro = products.base({
 		id: `${customerId}-pro`,
@@ -329,12 +318,12 @@ test(`${chalk.yellowBright("license back-sync: shared parent product selects by 
 	});
 
 	const [monthly, annual] = await Promise.all([
-		expectCustomizedPriceUnderParent({
+		expectCustomizedPriceUnderLicenseProduct({
 			ctx: scenario.ctx,
 			parentPlanId: pro.id,
 			licensePlanId: teamSeat.id,
 		}),
-		expectCustomizedPriceUnderParent({
+		expectCustomizedPriceUnderLicenseProduct({
 			ctx: scenario.ctx,
 			parentPlanId: annualId,
 			licensePlanId: teamSeat.id,
@@ -412,7 +401,7 @@ test(`${chalk.yellowBright("license back-sync: parent and child sharing a produc
 		amount: 15,
 		interval: BillingInterval.Month,
 	});
-	const customized = await expectCustomizedPriceUnderParent({
+	const customized = await expectCustomizedPriceUnderLicenseProduct({
 		ctx: scenario.ctx,
 		parentPlanId: parent.id,
 		licensePlanId: teamSeat.id,

--- a/server/tests/integration/licenses/billing/attach/attach-license-parent-stripe-product.test.ts
+++ b/server/tests/integration/licenses/billing/attach/attach-license-parent-stripe-product.test.ts
@@ -1,11 +1,12 @@
-/** Contract: only custom fixed license prices inherit their parent Stripe Product.
- * Ordinary and feature-only links retain the shared child base price resources. */
+/** Contract: license prices always use the license plan's Stripe Product.
+ * This holds for custom attach/update prices and shared catalog resources. */
 import { expect, test } from "bun:test";
 import {
 	type AttachParamsV1Input,
 	BillingInterval,
 	type FullProduct,
 	productToBasePrice,
+	type UpdateSubscriptionV1ParamsInput,
 } from "@autumn/shared";
 import { getFullLicenseProduct } from "@tests/integration/licenses/catalog-update/utils/getFullLicenseProduct";
 import { expectLicenseDefinitionCorrect } from "@tests/integration/licenses/utils/expectLicenseDefinitionCorrect";
@@ -37,7 +38,7 @@ const expectLicenseProductStripeResourcesUnchanged = ({
 };
 
 test.concurrent(
-	`${chalk.yellowBright("license attach: custom base price is created under the parent Stripe product")}`,
+	`${chalk.yellowBright("license attach: custom base price stays under the license Stripe product")}`,
 	async () => {
 		const customerId = "attach-license-parent-stripe-product";
 		const parent = products.base({
@@ -77,10 +78,11 @@ test.concurrent(
 				env: scenario.ctx.env,
 			}),
 		]);
-		const parentStripeProductId = parentBefore.processor?.id;
-		if (!parentStripeProductId) {
-			throw new Error(`Parent ${parent.id} has no Stripe product`);
+		const licenseStripeProductId = childBefore.processor?.id;
+		if (!licenseStripeProductId) {
+			throw new Error(`License ${teamSeat.id} has no Stripe product`);
 		}
+		expect(parentBefore.processor?.id).not.toBe(licenseStripeProductId);
 
 		await scenario.autumnV2_3.billing.attach<AttachParamsV1Input>({
 			customer_id: customerId,
@@ -112,7 +114,103 @@ test.concurrent(
 				amount: 25,
 				interval: BillingInterval.Month,
 				isCustom: true,
-				stripeProductId: parentStripeProductId,
+				stripeProductId: licenseStripeProductId,
+			},
+		});
+
+		const childAfter = await ProductService.getFull({
+			db: scenario.ctx.db,
+			idOrInternalId: teamSeat.id,
+			orgId: scenario.ctx.org.id,
+			env: scenario.ctx.env,
+		});
+		expectLicenseProductStripeResourcesUnchanged({
+			before: childBefore,
+			after: childAfter,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license update: custom base price stays under the license Stripe product")}`,
+	async () => {
+		const customerId = "update-license-parent-stripe-product";
+		const parent = products.base({
+			id: `${customerId}-parent`,
+			items: [items.dashboard()],
+		});
+		const teamSeat = products.base({
+			id: `${customerId}-seat`,
+			items: [items.monthlyPrice({ price: 10 })],
+			group: `${customerId}-licenses`,
+		});
+		const scenario = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.products({ list: [parent, teamSeat] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: teamSeat.id,
+					included: 0,
+				}),
+				s.billing.attach({
+					productId: parent.id,
+					licenseQuantities: [{ licenseProductId: teamSeat.id, quantity: 2 }],
+				}),
+			],
+		});
+		const [parentBefore, childBefore] = await Promise.all([
+			ProductService.getFull({
+				db: scenario.ctx.db,
+				idOrInternalId: parent.id,
+				orgId: scenario.ctx.org.id,
+				env: scenario.ctx.env,
+			}),
+			ProductService.getFull({
+				db: scenario.ctx.db,
+				idOrInternalId: teamSeat.id,
+				orgId: scenario.ctx.org.id,
+				env: scenario.ctx.env,
+			}),
+		]);
+		const licenseStripeProductId = childBefore.processor?.id;
+		if (!licenseStripeProductId) {
+			throw new Error(`License ${teamSeat.id} has no Stripe product`);
+		}
+		expect(parentBefore.processor?.id).not.toBe(licenseStripeProductId);
+
+		await scenario.autumnV2_3.billing.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			plan_id: parent.id,
+			customize: {
+				upsert_licenses: [
+					{
+						license_plan_id: teamSeat.id,
+						customize: {
+							price: {
+								amount: 30,
+								interval: BillingInterval.Month,
+							},
+						},
+					},
+				],
+			},
+		});
+
+		await expectLicenseDefinitionCorrect({
+			ctx: scenario.ctx,
+			customerId,
+			parentPlanId: parent.id,
+			isCustom: true,
+			isCustomized: true,
+			basePrice: {
+				amount: 30,
+				interval: BillingInterval.Month,
+				isCustom: true,
+				stripeProductId: licenseStripeProductId,
 			},
 		});
 

--- a/trigger.config.ts
+++ b/trigger.config.ts
@@ -1,6 +1,5 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import {
-	additionalFiles,
 	additionalPackages,
 	aptGet,
 	syncEnvVars,
@@ -8,9 +7,8 @@ import {
 import { defineConfig } from "@trigger.dev/sdk/v3";
 import { fetchInfisicalSecretsFromEnv } from "./server/src/external/infisical/fetchInfisicalSecrets.js";
 
-// Derived from the root package.json workspaces so new workspace packages are
-// picked up automatically — the deploy image COPYs every workspace
-// package.json, and a missing one makes `bun install` fail against bun.lock.
+// Bun requires every configured workspace to contain a package.json, even
+// though Trigger bundles workspace code and only installs external packages.
 const rootPackageJson = JSON.parse(readFileSync("package.json", "utf-8")) as {
 	workspaces: string[] | { packages: string[] };
 };
@@ -29,15 +27,24 @@ const expandWorkspacePattern = (pattern: string): string[] => {
 		.map((entry) => `${baseDir}/${entry.name}`);
 };
 
-const workspacePackageJsonPaths = workspacePatterns
+const workspacePackageDirs = workspacePatterns
 	.flatMap(expandWorkspacePattern)
-	.map((dir) => `${dir}/package.json`)
-	.filter((path) => existsSync(path))
+	.filter((dir) => existsSync(`${dir}/package.json`))
 	.sort();
 
-const workspacePackageDirs = workspacePackageJsonPaths.map((path) =>
-	path.replace(/\/package\.json$/, ""),
-);
+const workspacePackageStubs = workspacePackageDirs.map((dir) => {
+	const packageJson = JSON.parse(
+		readFileSync(`${dir}/package.json`, "utf-8"),
+	) as { name?: string };
+	if (!packageJson.name) {
+		throw new Error(`Workspace package ${dir} is missing a name`);
+	}
+
+	return {
+		dir,
+		contents: JSON.stringify({ name: packageJson.name, private: true }),
+	};
+});
 
 export default defineConfig({
 	project: "proj_cwiutfmpdzfcshxevkok",
@@ -73,9 +80,6 @@ export default defineConfig({
 			"zod",
 		],
 		extensions: [
-			additionalFiles({
-				files: workspacePackageJsonPaths,
-			}),
 			{
 				name: "monorepo-workspace-manifests",
 				onBuildComplete: (context) => {
@@ -88,11 +92,7 @@ export default defineConfig({
 						image: {
 							instructions: [
 								"WORKDIR /app",
-								`RUN mkdir -p ${workspacePackageDirs.join(" ")} && chown -R bun:bun ${workspacePackageDirs.join(" ")}`,
-								...workspacePackageJsonPaths.map(
-									(path) => `COPY --chown=bun:bun ${path} ./${path}`,
-								),
-								"RUN chown -R bun:bun /app",
+								`RUN mkdir -p ${workspacePackageDirs.join(" ")} && ${workspacePackageStubs.map(({ dir, contents }) => `printf '${contents}' > ${dir}/package.json`).join(" && ")} && chown -R bun:bun /app`,
 							],
 						},
 					});

--- a/vite/src/views/products/plan/components/plan-licenses/useLinkableLicenses.ts
+++ b/vite/src/views/products/plan/components/plan-licenses/useLinkableLicenses.ts
@@ -2,19 +2,11 @@ import {
 	useIsLicenseEditor,
 	useProduct,
 } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
-import { useLicenseProductsQuery } from "@/hooks/queries/useLicenseProductsQuery";
 import { usePlanLicensesQuery } from "@/hooks/queries/usePlanLicensesQuery";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { useOptionalProductContext } from "@/views/products/product/ProductContext";
 import { usePendingLicenseLinks } from "./PendingLicenseLinksContext";
 
-/**
- * Plans that can still be linked as a license to the current plan (any plan
- * except itself, archived ones, those already linked or staged here, and —
- * one-to-one — those already offered under another plan), plus the stage
- * action. Backs both link affordances: the plan toolbar's menu item and the
- * customize editor's button.
- */
 export const useLinkableLicenses = () => {
 	const { product } = useProduct();
 	const isLicense = useIsLicenseEditor();
@@ -27,7 +19,6 @@ export const useLinkableLicenses = () => {
 		isLicense || pagePlanLicenses ? undefined : product.id,
 	);
 	const planLicenses = pagePlanLicenses ?? fallbackPlanLicenses;
-	const { licenseProducts } = useLicenseProductsQuery();
 	const { products } = useProductsQuery();
 	const { pendingLicenseIds, addPendingLink } = usePendingLicenseLinks();
 
@@ -35,14 +26,11 @@ export const useLinkableLicenses = () => {
 		...planLicenses.map((planLicense) => planLicense.license_plan_id),
 		...pendingLicenseIds,
 	]);
-	// Licenses linked anywhere are owned by their plan — one-to-one means they
-	// can't be offered here too.
-	const ownedIds = new Set(licenseProducts.map((license) => license.id));
 	const candidatePlans = products.filter(
 		(plan) => plan.id !== product.id && !plan.archived,
 	);
 	const availableLicenses = candidatePlans.filter(
-		(plan) => !(linkedIds.has(plan.id) || ownedIds.has(plan.id)),
+		(plan) => !linkedIds.has(plan.id),
 	);
 
 	return {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
License prices now always use the license plan’s Stripe Product (not the parent), removing ambiguity in back-sync and making attach/update customizations consistent.

- Refactors
  - Route custom and shared license base prices to the license plan’s Stripe Product; back-sync selects by exact price within that product.
  - Simplified Stripe init by removing parent-product dependency and using plan-license-only helpers (`planLicenseToCustomStripeInitProduct`, `planLicenseToStripeInitProduct`).
  - Updated tests to assert the new contract and added an update-customization test.
  - Trigger build: generate stub workspace `package.json` files during image build to satisfy Bun, remove copying of workspace manifests, and replace `additionalFiles` with a custom image step using `@trigger.dev` instructions.

<sup>Written for commit d81a6abfd2ec392dc349c6d15f4c265f2ec37ca3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes the Stripe Product ownership model for customized license prices: previously, customized prices were created under the **parent** product's Stripe Product; they now live under the **license** product's own Stripe Product. The `planLicenseToCustomStripeInitProduct` / `planLicenseToStripeInitProduct` helpers drop the `parentProduct` parameter entirely, and `trigger.config.ts` replaces `additionalFiles` copies of real `package.json`s with runtime-generated stubs.

- **[Bug fixes / Improvements]** `licenseStripeResourceUtils.ts` — removed `parentProduct` coupling; customized prices now reference the license's own Stripe Product, which also removes the guard that silently suppressed custom prices when the parent had no `processor.id`.
- **[Improvements]** `initStripeResourcesForProducts.ts` / `initStripeResourcesForBillingPlan` — call sites updated: `parentProduct` lookup and `cusProductToProduct` wrappers removed from license-transition handling, simplifying the billing plan initialisation path.
- **[Improvements]** `trigger.config.ts` — workspace `package.json` stubs are now generated with `printf` in a single Dockerfile `RUN` layer rather than individually `COPY`-ing real manifests, reducing image layer count and avoiding stale dependency lists in the deploy image.
</details>

<h3>Confidence Score: 4/5</h3>

The core billing change is intentional and well-tested; the trigger.config.ts refactor is straightforward with only a minor printf format-string edge case unreachable with valid npm package names.

The billing ownership model change is structural but thoroughly covered by updated integration tests, and the removed null-guard was itself a correctness concern. No logic paths are left untested.

trigger.config.ts — the printf stub-generation command embeds JSON content directly as a format string.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/common/licenseStripeResourceUtils.ts | Removes parentProduct coupling from both helpers; customized prices now spread the license product's own processor/Stripe Product instead of inheriting the parent's. |
| server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts | Call sites updated to match the new signatures; redundant parentCustomerProduct lookup removed from the license-transition loop. |
| trigger.config.ts | Replaces additionalFiles copies of workspace package.json with runtime-generated stubs. The printf format string is passed without a %s guard. |
| server/tests/integration/billing/stripe-webhooks/subscription-created/licenses/sub-created-parent-product-license-backsync.test.ts | Test contracts updated: same license product now yields the same Stripe Product ID across parent variants. |
| server/tests/integration/licenses/billing/attach/attach-license-parent-stripe-product.test.ts | Adds a new update-subscription test; both tests assert license Stripe Product is used and differs from the parent's. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
trigger.config.ts:43-46
`printf` treats its first argument as a format string, so any `%` character in `contents` would be misinterpreted as a format specifier. While npm package names cannot contain `%`, using `printf '%s'` with the content as a separate argument is the defensive idiom that avoids the risk entirely.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into dev"](https://github.com/useautumn/autumn/commit/65afdad62f17a332e7d90c294d1229258092e3e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45656745)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->