### PR TITLE
fix(billing): restore JSON-safe license billing context

### DIFF
--- a/server/src/internal/billing/v2/compute/customerLicenseTransitions/applyCustomerLicenseTransitions.ts
+++ b/server/src/internal/billing/v2/compute/customerLicenseTransitions/applyCustomerLicenseTransitions.ts
@@ -51,17 +51,22 @@ export const applyCustomerLicenseTransitions = ({
 	for (const customerLicenseTransition of customerLicenseTransitions) {
 		const planLicenseId =
 			customerLicenseTransition.incomingCustomerLicense.planLicense?.id;
-		if (planLicenseId) {
-			customerLicenseBillingContext.projectedPlanLicenseIds.add(planLicenseId);
+		if (
+			planLicenseId &&
+			!customerLicenseBillingContext.projectedPlanLicenseIds.includes(
+				planLicenseId,
+			)
+		) {
+			customerLicenseBillingContext.projectedPlanLicenseIds.push(planLicenseId);
 		}
 		customerLicenseBillingContext.licenseBillingPriceRows.push(
 			...transitionLicenseBillingPriceRows({
 				licenseBillingPriceRows: persistedRows,
 				customerLicenseTransition,
 				assignedSeatCount:
-					customerLicenseBillingContext.assignedSeatCountByCustomerLicenseId.get(
-						customerLicenseTransition.outgoingCustomerLicense.id,
-					) ?? 0,
+					customerLicenseBillingContext.assignedSeatCountByCustomerLicenseId[
+						customerLicenseTransition.outgoingCustomerLicense.id
+					] ?? 0,
 			}),
 		);
 	}

--- a/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
@@ -21,6 +21,7 @@ import {
 	getPatchCustomerProducts,
 } from "@/internal/billing/v2/utils/billingPlan/customerProductPlanMutations";
 import { orgDisableStripeWrites } from "@/internal/orgs/orgUtils/convertOrgUtils";
+import { isStripeConnected } from "@/internal/orgs/orgUtils.js";
 import { checkStripeProductExists } from "@/internal/products/productUtils";
 import { applyStripeResourceReuseForProduct } from "@/internal/products/stripeResourceUtils/applyStripeResourceReuseForProduct";
 import { applyStripeReuseFromVariantFamilies } from "@/internal/products/stripeResourceUtils/applyStripeReuseFromVariantFamilies";
@@ -51,6 +52,9 @@ export const initStripeResourcesForProducts = async ({
 
 	if (env === AppEnv.Live) return;
 	if (orgDisableStripeWrites({ ctx, includeSandbox: true })) return;
+	// No Stripe account (e.g. fresh sandbox sub-orgs) — resources are
+	// created lazily once one is connected.
+	if (!isStripeConnected({ org, env })) return;
 
 	const batchProductUpdates = [];
 	for (const product of products) {

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptionItems/customerLicenseToStripeItemSpecs.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptionItems/customerLicenseToStripeItemSpecs.ts
@@ -27,8 +27,7 @@ export const customerLicenseToStripeItemSpecs = ({
 		billingContext.customerLicenseBillingContext?.licenseBillingPriceRows ?? []
 	).filter((row) => row.source.customerLicenseId === customerLicense.id);
 	const projectedPlanLicenseIds =
-		billingContext.customerLicenseBillingContext?.projectedPlanLicenseIds ??
-		new Set<string>();
+		billingContext.customerLicenseBillingContext?.projectedPlanLicenseIds ?? [];
 
 	// Desired state prices seats through the pool's (possibly repointed)
 	// definition — the read-time twin of the seat repoint executor.

--- a/server/src/internal/billing/v2/setup/customerLicenseBillingContext/setupCustomerLicenseBillingContext.ts
+++ b/server/src/internal/billing/v2/setup/customerLicenseBillingContext/setupCustomerLicenseBillingContext.ts
@@ -19,8 +19,8 @@ export const setupCustomerLicenseBillingContext = async ({
 	if (customerLicenses.length === 0) {
 		return {
 			licenseBillingPriceRows: [],
-			assignedSeatCountByCustomerLicenseId: new Map(),
-			projectedPlanLicenseIds: new Set(),
+			assignedSeatCountByCustomerLicenseId: {},
+			projectedPlanLicenseIds: [],
 		};
 	}
 
@@ -37,7 +37,7 @@ export const setupCustomerLicenseBillingContext = async ({
 				),
 			}),
 		]);
-	const assignedSeatCountByCustomerLicenseId = new Map(
+	const assignedSeatCountByCustomerLicenseId = Object.fromEntries(
 		customerLicenses.map((customerLicense) => [
 			customerLicense.id,
 			assignedSeatCountByLinkId.get(customerLicense.link_id) ?? 0,
@@ -47,6 +47,6 @@ export const setupCustomerLicenseBillingContext = async ({
 	return {
 		licenseBillingPriceRows,
 		assignedSeatCountByCustomerLicenseId,
-		projectedPlanLicenseIds: new Set(),
+		projectedPlanLicenseIds: [],
 	};
 };

--- a/server/src/internal/billing/v2/utils/lineItems/customerLicenseToLineItems.ts
+++ b/server/src/internal/billing/v2/utils/lineItems/customerLicenseToLineItems.ts
@@ -50,8 +50,7 @@ export const customerLicenseToLineItems = ({
 		billingContext.customerLicenseBillingContext?.licenseBillingPriceRows ?? []
 	).filter((row) => row.source.customerLicenseId === customerLicense.id);
 	const projectedPlanLicenseIds =
-		billingContext.customerLicenseBillingContext?.projectedPlanLicenseIds ??
-		new Set<string>();
+		billingContext.customerLicenseBillingContext?.projectedPlanLicenseIds ?? [];
 
 	// Seats bill through THIS side's definition: refunds get the outgoing
 	// pool's terms, charges the incoming — mirroring the repoint executor.

--- a/server/src/internal/billing/v2/utils/lineItems/resolveLicenseBillingRowsThroughDefinition.ts
+++ b/server/src/internal/billing/v2/utils/lineItems/resolveLicenseBillingRowsThroughDefinition.ts
@@ -1,7 +1,4 @@
-import {
-	type FullPlanLicense,
-	type LicenseBillingPriceRow,
-} from "@autumn/shared";
+import type { FullPlanLicense, LicenseBillingPriceRow } from "@autumn/shared";
 
 /** Selects projected rows for this definition, otherwise persisted rows. */
 export const resolveLicenseBillingRowsThroughDefinition = ({
@@ -11,11 +8,11 @@ export const resolveLicenseBillingRowsThroughDefinition = ({
 }: {
 	licenseBillingRows: LicenseBillingPriceRow[];
 	planLicense: FullPlanLicense;
-	projectedPlanLicenseIds: Set<string>;
+	projectedPlanLicenseIds: string[];
 }): LicenseBillingPriceRow[] => {
 	const projectedRows = licenseBillingRows.filter(
 		(row) => row.source.planLicenseId === planLicense.id,
 	);
-	if (projectedPlanLicenseIds.has(planLicense.id)) return projectedRows;
+	if (projectedPlanLicenseIds.includes(planLicense.id)) return projectedRows;
 	return licenseBillingRows.filter((row) => !row.source.planLicenseId);
 };

--- a/server/src/internal/features/FeatureService.ts
+++ b/server/src/internal/features/FeatureService.ts
@@ -123,13 +123,17 @@ export class FeatureService {
 				.returning();
 		}
 
+		// The row may have been deleted between read and update (e.g. async
+		// display generation racing an org/feature teardown).
+		if (updatedFeatures.length === 0) return null;
+
 		await clearOrgCache({
 			db,
 			orgId: updatedFeatures[0].org_id!,
 			env: updatedFeatures[0].env as AppEnv,
 		});
 
-		return updatedFeatures.length > 0 ? (updatedFeatures[0] as Feature) : null;
+		return updatedFeatures[0] as Feature;
 	}
 
 	static async insert({

--- a/server/src/internal/products/handlers/handleCopyEnvironment/handleCopyProducts.ts
+++ b/server/src/internal/products/handlers/handleCopyEnvironment/handleCopyProducts.ts
@@ -134,10 +134,13 @@ export const handleCopyProducts = async ({
 
 	await Promise.all(operations);
 
+	// inIds bypasses the products cache — the copy ops' invalidations land
+	// async, so a plain listFull can still see the pre-copy (empty) snapshot.
 	const copiedToProducts = await ProductService.listFull({
 		db,
 		orgId: toOrg.id,
 		env: toEnv,
+		inIds: fromProducts.map((product) => product.id),
 	});
 	await copyPlanLicenseLinks({
 		db,

--- a/server/src/queue/createWorkerContext.ts
+++ b/server/src/queue/createWorkerContext.ts
@@ -28,15 +28,18 @@ export const createWorkerContext = async ({
 	const { orgId, env, customerId, requestId } = payload;
 	if (!orgId || !env) return;
 
-	// Fetch org with features once for all items
-	const orgData = await OrgService.getWithFeatures({
-		db,
-		orgId,
-		env,
-	});
+	// Fetch org with features once for all items. A missing org means it was
+	// deleted after the job was queued (common in tests) — skip, don't fail.
+	let orgData: Awaited<ReturnType<typeof OrgService.getWithFeatures>> | null;
+	try {
+		orgData = await OrgService.getWithFeatures({ db, orgId, env });
+	} catch {
+		orgData = null;
+	}
 
 	if (!orgData) {
-		throw new Error(`Organization not found: ${orgId}, env: ${env}`);
+		logger.warn(`Org ${orgId} (${env}) not found — skipping queued job`);
+		return;
 	}
 
 	const { org, features } = orgData;

--- a/server/tests/integration/balances/track/basic/track-tokens.test.ts
+++ b/server/tests/integration/balances/track/basic/track-tokens.test.ts
@@ -9,6 +9,7 @@ import type {
 	TrackResponseV3,
 } from "@autumn/shared";
 import { ApiVersion, ErrCode, events, FeatureType } from "@autumn/shared";
+import { eventsDb } from "@tests/integration/balances/utils/events/getCustomerEvents.js";
 import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
@@ -19,7 +20,6 @@ import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { Decimal } from "decimal.js";
 import { and, desc, eq } from "drizzle-orm";
-import { db } from "@/db/initDrizzle.js";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
 import { getModelCreditCost } from "@/internal/features/aiCreditSystemUtils.js";
 import { getModelsDevPricing } from "@/internal/features/utils/getModelPricing.js";
@@ -205,7 +205,7 @@ test.concurrent(
 		const customer = (await autumnV2_2.customers.get(customerId, {
 			with_autumn_id: true,
 		})) as ApiCustomerV5 & { autumn_id?: string };
-		const eventRows = await db
+		const eventRows = await eventsDb()
 			.select({
 				created_at: events.created_at,
 				timestamp: events.timestamp,

--- a/server/tests/integration/balances/utils/events/getCustomerEvents.ts
+++ b/server/tests/integration/balances/utils/events/getCustomerEvents.ts
@@ -1,7 +1,12 @@
 import { ApiVersion } from "@autumn/shared";
+import { neonEventsDb } from "@server/db/initNeonEvents.js";
 import { AutumnInt } from "@server/external/autumn/autumnCli.js";
 import { EventService } from "@server/internal/api/events/EventService.js";
 import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+
+/** Events land in the split Neon events DB when configured; mirror the
+ * writer's resolution so asserts read where the server wrote. */
+export const eventsDb = () => neonEventsDb ?? ctx.db;
 
 export const getCustomerEvents = async ({
 	customerId,
@@ -15,7 +20,7 @@ export const getCustomerEvents = async ({
 	});
 
 	const events = await EventService.getByCustomerId({
-		db: ctx.db,
+		db: eventsDb(),
 		orgId: ctx.org.id,
 		internalCustomerId: customer.autumn_id ?? "",
 		env: ctx.env,

--- a/server/tests/integration/billing/update-subscription/custom-plan/update-paid-prepaid.test.ts
+++ b/server/tests/integration/billing/update-subscription/custom-plan/update-paid-prepaid.test.ts
@@ -31,914 +31,949 @@ import chalk from "chalk";
 // ═══════════════════════════════════════════════════════════════════════════════
 
 // Increase price per pack (same quantity)
-test.concurrent(`${chalk.yellowBright("prepaid: increase price per pack")}`, async () => {
-	const billingUnits = 100;
-	const oldPrice = 10;
+test.concurrent(
+	`${chalk.yellowBright("prepaid: increase price per pack")}`,
+	async () => {
+		const billingUnits = 100;
+		const oldPrice = 10;
 
-	const prepaidItem = items.prepaidMessages({
-		includedUsage: 0,
-		billingUnits,
-		price: oldPrice,
-	});
-	const priceItem = items.monthlyPrice({ price: 20 });
-	const pro = products.base({
-		id: "pro",
-		items: [prepaidItem, priceItem],
-	});
+		const prepaidItem = items.prepaidMessages({
+			includedUsage: 0,
+			billingUnits,
+			price: oldPrice,
+		});
+		const priceItem = items.monthlyPrice({ price: 20 });
+		const pro = products.base({
+			id: "pro",
+			items: [prepaidItem, priceItem],
+		});
 
-	const packs = 3;
-	const quantity = packs * billingUnits; // 300 units
+		const packs = 3;
+		const quantity = packs * billingUnits; // 300 units
 
-	const { customerId, autumnV1, ctx } = await initScenario({
-		customerId: "prepaid-price-up",
-		setup: [
-			s.customer({ paymentMethod: "success" }),
-			s.products({ list: [pro] }),
-		],
-		actions: [
-			s.attach({
-				productId: pro.id,
-				options: [{ feature_id: TestFeature.Messages, quantity }],
-			}),
-		],
-	});
+		const { customerId, autumnV1, ctx } = await initScenario({
+			customerId: "prepaid-price-up",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [
+				s.attach({
+					productId: pro.id,
+					options: [{ feature_id: TestFeature.Messages, quantity }],
+				}),
+			],
+		});
 
-	const messagesUsed = 50;
-	await autumnV1.track(
-		{
+		const messagesUsed = 50;
+		await autumnV1.track(
+			{
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value: messagesUsed,
+			},
+			{ timeout: 2000 },
+		);
+
+		// Increase price from $10 to $15 per pack
+		const newPrice = 15;
+		const newPrepaidItem = items.prepaidMessages({
+			includedUsage: 0,
+			billingUnits,
+			price: newPrice,
+		});
+
+		const updateParams = {
 			customer_id: customerId,
-			feature_id: TestFeature.Messages,
-			value: messagesUsed,
-		},
-		{ timeout: 2000 },
-	);
+			product_id: pro.id,
+			items: [newPrepaidItem, priceItem],
+			options: [{ feature_id: TestFeature.Messages, quantity }],
+		};
 
-	// Increase price from $10 to $15 per pack
-	const newPrice = 15;
-	const newPrepaidItem = items.prepaidMessages({
-		includedUsage: 0,
-		billingUnits,
-		price: newPrice,
-	});
+		const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
 
-	const updateParams = {
-		customer_id: customerId,
-		product_id: pro.id,
-		items: [newPrepaidItem, priceItem],
-		options: [{ feature_id: TestFeature.Messages, quantity }],
-	};
+		// Refund old: 3 * $10 = $30
+		// Charge new: 3 * $15 = $45
+		// Total: $45 - $30 = $15
+		expect(preview.total).toBe(packs * newPrice - packs * oldPrice);
 
-	const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
+		await autumnV1.subscriptions.update(updateParams);
 
-	// Refund old: 3 * $10 = $30
-	// Charge new: 3 * $15 = $45
-	// Total: $45 - $30 = $15
-	expect(preview.total).toBe(packs * newPrice - packs * oldPrice);
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
 
-	await autumnV1.subscriptions.update(updateParams);
+		// For prepaid: customer's included_usage = item's includedUsage + quantity
+		expectCustomerFeatureCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			includedUsage: quantity, // 0 + 300 = 300
+			balance: quantity - messagesUsed,
+			usage: messagesUsed,
+		});
 
-	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({
+			customer,
+			count: 2,
+			latestTotal: preview.total,
+		});
 
-	// For prepaid: customer's included_usage = item's includedUsage + quantity
-	expectCustomerFeatureCorrect({
-		customer,
-		featureId: TestFeature.Messages,
-		includedUsage: quantity, // 0 + 300 = 300
-		balance: quantity - messagesUsed,
-		usage: messagesUsed,
-	});
-
-	await expectCustomerInvoiceCorrect({
-		customer,
-		count: 2,
-		latestTotal: preview.total,
-	});
-
-	await expectSubToBeCorrect({
-		db: ctx.db,
-		customerId,
-		org: ctx.org,
-		env: ctx.env,
-	});
-});
+		await expectSubToBeCorrect({
+			db: ctx.db,
+			customerId,
+			org: ctx.org,
+			env: ctx.env,
+		});
+	},
+);
 
 // Decrease price per pack (same quantity)
-test.concurrent(`${chalk.yellowBright("prepaid: decrease price per pack")}`, async () => {
-	const billingUnits = 100;
-	const oldPrice = 20;
+test.concurrent(
+	`${chalk.yellowBright("prepaid: decrease price per pack")}`,
+	async () => {
+		const billingUnits = 100;
+		const oldPrice = 20;
 
-	const prepaidItem = items.prepaidMessages({
-		includedUsage: 0,
-		billingUnits,
-		price: oldPrice,
-	});
-	const priceItem = items.monthlyPrice({ price: 20 });
-	const pro = products.base({
-		id: "pro",
-		items: [prepaidItem, priceItem],
-	});
+		const prepaidItem = items.prepaidMessages({
+			includedUsage: 0,
+			billingUnits,
+			price: oldPrice,
+		});
+		const priceItem = items.monthlyPrice({ price: 20 });
+		const pro = products.base({
+			id: "pro",
+			items: [prepaidItem, priceItem],
+		});
 
-	const packs = 3;
-	const quantity = packs * billingUnits;
+		const packs = 3;
+		const quantity = packs * billingUnits;
 
-	const { customerId, autumnV1, ctx } = await initScenario({
-		customerId: "prepaid-price-down",
-		setup: [
-			s.customer({ paymentMethod: "success" }),
-			s.products({ list: [pro] }),
-		],
-		actions: [
-			s.attach({
-				productId: pro.id,
-				options: [{ feature_id: TestFeature.Messages, quantity }],
-			}),
-		],
-	});
+		const { customerId, autumnV1, ctx } = await initScenario({
+			customerId: "prepaid-price-down",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [
+				s.attach({
+					productId: pro.id,
+					options: [{ feature_id: TestFeature.Messages, quantity }],
+				}),
+			],
+		});
 
-	const messagesUsed = 50;
-	await autumnV1.track(
-		{
+		const messagesUsed = 50;
+		await autumnV1.track(
+			{
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value: messagesUsed,
+			},
+			{ timeout: 2000 },
+		);
+
+		// Decrease price from $20 to $10 per pack
+		const newPrice = 10;
+		const newPrepaidItem = items.prepaidMessages({
+			includedUsage: 0,
+			billingUnits,
+			price: newPrice,
+		});
+
+		const updateParams = {
 			customer_id: customerId,
-			feature_id: TestFeature.Messages,
-			value: messagesUsed,
-		},
-		{ timeout: 2000 },
-	);
+			product_id: pro.id,
+			items: [newPrepaidItem, priceItem],
+			options: [{ feature_id: TestFeature.Messages, quantity }],
+		};
 
-	// Decrease price from $20 to $10 per pack
-	const newPrice = 10;
-	const newPrepaidItem = items.prepaidMessages({
-		includedUsage: 0,
-		billingUnits,
-		price: newPrice,
-	});
+		const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
 
-	const updateParams = {
-		customer_id: customerId,
-		product_id: pro.id,
-		items: [newPrepaidItem, priceItem],
-		options: [{ feature_id: TestFeature.Messages, quantity }],
-	};
+		// Refund old: 3 * $20 = $60
+		// Charge new: 3 * $10 = $30
+		// Total: $30 - $60 = -$30 (credit)
+		expect(preview.total).toBe(packs * newPrice - packs * oldPrice);
 
-	const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
+		await autumnV1.subscriptions.update(updateParams);
 
-	// Refund old: 3 * $20 = $60
-	// Charge new: 3 * $10 = $30
-	// Total: $30 - $60 = -$30 (credit)
-	expect(preview.total).toBe(packs * newPrice - packs * oldPrice);
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
 
-	await autumnV1.subscriptions.update(updateParams);
+		expectCustomerFeatureCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			includedUsage: quantity, // 0 + 300 = 300
+			balance: quantity - messagesUsed,
+			usage: messagesUsed,
+		});
 
-	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({
+			customer,
+			count: 2,
+			latestTotal: preview.total,
+		});
 
-	expectCustomerFeatureCorrect({
-		customer,
-		featureId: TestFeature.Messages,
-		includedUsage: quantity, // 0 + 300 = 300
-		balance: quantity - messagesUsed,
-		usage: messagesUsed,
-	});
-
-	await expectCustomerInvoiceCorrect({
-		customer,
-		count: 2,
-		latestTotal: preview.total,
-	});
-
-	await expectSubToBeCorrect({
-		db: ctx.db,
-		customerId,
-		org: ctx.org,
-		env: ctx.env,
-	});
-});
+		await expectSubToBeCorrect({
+			db: ctx.db,
+			customerId,
+			org: ctx.org,
+			env: ctx.env,
+		});
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // BILLING UNITS CHANGES
 // ═══════════════════════════════════════════════════════════════════════════════
 
 // Decrease billing units (same quantity = more packs)
-test.concurrent(`${chalk.yellowBright("prepaid: decrease billing units (more packs)")}`, async () => {
-	const oldBillingUnits = 100;
-	const pricePerPack = 10;
+test.concurrent(
+	`${chalk.yellowBright("prepaid: decrease billing units (more packs)")}`,
+	async () => {
+		const oldBillingUnits = 100;
+		const pricePerPack = 10;
 
-	const prepaidItem = items.prepaidMessages({
-		includedUsage: 0,
-		billingUnits: oldBillingUnits,
-		price: pricePerPack,
-	});
-	const priceItem = items.monthlyPrice({ price: 20 });
-	const pro = products.base({
-		id: "pro",
-		items: [prepaidItem, priceItem],
-	});
+		const prepaidItem = items.prepaidMessages({
+			includedUsage: 0,
+			billingUnits: oldBillingUnits,
+			price: pricePerPack,
+		});
+		const priceItem = items.monthlyPrice({ price: 20 });
+		const pro = products.base({
+			id: "pro",
+			items: [prepaidItem, priceItem],
+		});
 
-	const quantity = 300; // 3 packs of 100
+		const quantity = 300; // 3 packs of 100
 
-	const { customerId, autumnV1, ctx } = await initScenario({
-		customerId: "prepaid-billing-units-down",
-		setup: [
-			s.customer({ paymentMethod: "success" }),
-			s.products({ list: [pro] }),
-		],
-		actions: [
-			s.attach({
-				productId: pro.id,
-				options: [{ feature_id: TestFeature.Messages, quantity }],
-			}),
-		],
-	});
+		const { customerId, autumnV1, ctx } = await initScenario({
+			customerId: "prepaid-billing-units-down",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [
+				s.attach({
+					productId: pro.id,
+					options: [{ feature_id: TestFeature.Messages, quantity }],
+				}),
+			],
+		});
 
-	const messagesUsed = 50;
-	await autumnV1.track(
-		{
+		const messagesUsed = 50;
+		await autumnV1.track(
+			{
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value: messagesUsed,
+			},
+			{ timeout: 2000 },
+		);
+
+		// Decrease billing units from 100 to 50 (300 units = 6 packs now)
+		const newBillingUnits = 50;
+		const newPrepaidItem = items.prepaidMessages({
+			includedUsage: 0,
+			billingUnits: newBillingUnits,
+			price: pricePerPack,
+		});
+
+		const updateParams = {
 			customer_id: customerId,
-			feature_id: TestFeature.Messages,
-			value: messagesUsed,
-		},
-		{ timeout: 2000 },
-	);
+			product_id: pro.id,
+			items: [newPrepaidItem, priceItem],
+			options: [{ feature_id: TestFeature.Messages, quantity }],
+		};
 
-	// Decrease billing units from 100 to 50 (300 units = 6 packs now)
-	const newBillingUnits = 50;
-	const newPrepaidItem = items.prepaidMessages({
-		includedUsage: 0,
-		billingUnits: newBillingUnits,
-		price: pricePerPack,
-	});
+		const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
 
-	const updateParams = {
-		customer_id: customerId,
-		product_id: pro.id,
-		items: [newPrepaidItem, priceItem],
-		options: [{ feature_id: TestFeature.Messages, quantity }],
-	};
+		// Old: 300 / 100 = 3 packs * $10 = $30
+		// New: 300 / 50 = 6 packs * $10 = $60
+		// Total: $60 - $30 = $30
+		const oldPacks = Math.ceil(quantity / oldBillingUnits);
+		const newPacks = Math.ceil(quantity / newBillingUnits);
+		expect(preview.total).toBe(
+			newPacks * pricePerPack - oldPacks * pricePerPack,
+		);
 
-	const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
+		await autumnV1.subscriptions.update(updateParams);
 
-	// Old: 300 / 100 = 3 packs * $10 = $30
-	// New: 300 / 50 = 6 packs * $10 = $60
-	// Total: $60 - $30 = $30
-	const oldPacks = Math.ceil(quantity / oldBillingUnits);
-	const newPacks = Math.ceil(quantity / newBillingUnits);
-	expect(preview.total).toBe(newPacks * pricePerPack - oldPacks * pricePerPack);
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
 
-	await autumnV1.subscriptions.update(updateParams);
+		expectCustomerFeatureCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			includedUsage: quantity, // 0 + 300 = 300
+			balance: quantity - messagesUsed,
+			usage: messagesUsed,
+		});
 
-	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({
+			customer,
+			count: 2,
+			latestTotal: preview.total,
+		});
 
-	expectCustomerFeatureCorrect({
-		customer,
-		featureId: TestFeature.Messages,
-		includedUsage: quantity, // 0 + 300 = 300
-		balance: quantity - messagesUsed,
-		usage: messagesUsed,
-	});
-
-	await expectCustomerInvoiceCorrect({
-		customer,
-		count: 2,
-		latestTotal: preview.total,
-	});
-
-	await expectSubToBeCorrect({
-		db: ctx.db,
-		customerId,
-		org: ctx.org,
-		env: ctx.env,
-	});
-});
+		await expectSubToBeCorrect({
+			db: ctx.db,
+			customerId,
+			org: ctx.org,
+			env: ctx.env,
+		});
+	},
+);
 
 // Increase billing units (same quantity = fewer packs)
-test.concurrent(`${chalk.yellowBright("prepaid: increase billing units (fewer packs)")}`, async () => {
-	const oldBillingUnits = 50;
-	const pricePerPack = 10;
+test.concurrent(
+	`${chalk.yellowBright("prepaid: increase billing units (fewer packs)")}`,
+	async () => {
+		const oldBillingUnits = 50;
+		const pricePerPack = 10;
 
-	const prepaidItem = items.prepaidMessages({
-		includedUsage: 0,
-		billingUnits: oldBillingUnits,
-		price: pricePerPack,
-	});
-	const priceItem = items.monthlyPrice({ price: 20 });
-	const pro = products.base({
-		id: "pro",
-		items: [prepaidItem, priceItem],
-	});
+		const prepaidItem = items.prepaidMessages({
+			includedUsage: 0,
+			billingUnits: oldBillingUnits,
+			price: pricePerPack,
+		});
+		const priceItem = items.monthlyPrice({ price: 20 });
+		const pro = products.base({
+			id: "pro",
+			items: [prepaidItem, priceItem],
+		});
 
-	const quantity = 300; // 6 packs of 50
+		const quantity = 300; // 6 packs of 50
 
-	const { customerId, autumnV1, ctx } = await initScenario({
-		customerId: "prepaid-billing-units-up",
-		setup: [
-			s.customer({ paymentMethod: "success" }),
-			s.products({ list: [pro] }),
-		],
-		actions: [
-			s.attach({
-				productId: pro.id,
-				options: [{ feature_id: TestFeature.Messages, quantity }],
-			}),
-		],
-	});
+		const { customerId, autumnV1, ctx } = await initScenario({
+			customerId: "prepaid-billing-units-up",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [
+				s.attach({
+					productId: pro.id,
+					options: [{ feature_id: TestFeature.Messages, quantity }],
+				}),
+			],
+		});
 
-	const messagesUsed = 50;
-	await autumnV1.track(
-		{
+		const messagesUsed = 50;
+		await autumnV1.track(
+			{
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value: messagesUsed,
+			},
+			{ timeout: 2000 },
+		);
+
+		// Increase billing units from 50 to 100 (300 units = 3 packs now)
+		const newBillingUnits = 100;
+		const newPrepaidItem = items.prepaidMessages({
+			includedUsage: 0,
+			billingUnits: newBillingUnits,
+			price: pricePerPack,
+		});
+
+		const updateParams = {
 			customer_id: customerId,
-			feature_id: TestFeature.Messages,
-			value: messagesUsed,
-		},
-		{ timeout: 2000 },
-	);
+			product_id: pro.id,
+			items: [newPrepaidItem, priceItem],
+			options: [{ feature_id: TestFeature.Messages, quantity }],
+		};
 
-	// Increase billing units from 50 to 100 (300 units = 3 packs now)
-	const newBillingUnits = 100;
-	const newPrepaidItem = items.prepaidMessages({
-		includedUsage: 0,
-		billingUnits: newBillingUnits,
-		price: pricePerPack,
-	});
+		const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
 
-	const updateParams = {
-		customer_id: customerId,
-		product_id: pro.id,
-		items: [newPrepaidItem, priceItem],
-		options: [{ feature_id: TestFeature.Messages, quantity }],
-	};
+		// Old: 300 / 50 = 6 packs * $10 = $60
+		// New: 300 / 100 = 3 packs * $10 = $30
+		// Total: $30 - $60 = -$30 (credit)
+		const oldPacks = Math.ceil(quantity / oldBillingUnits);
+		const newPacks = Math.ceil(quantity / newBillingUnits);
+		expect(preview.total).toBe(
+			newPacks * pricePerPack - oldPacks * pricePerPack,
+		);
 
-	const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
+		await autumnV1.subscriptions.update(updateParams);
 
-	// Old: 300 / 50 = 6 packs * $10 = $60
-	// New: 300 / 100 = 3 packs * $10 = $30
-	// Total: $30 - $60 = -$30 (credit)
-	const oldPacks = Math.ceil(quantity / oldBillingUnits);
-	const newPacks = Math.ceil(quantity / newBillingUnits);
-	expect(preview.total).toBe(newPacks * pricePerPack - oldPacks * pricePerPack);
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
 
-	await autumnV1.subscriptions.update(updateParams);
+		expectCustomerFeatureCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			includedUsage: quantity, // 0 + 300 = 300
+			balance: quantity - messagesUsed,
+			usage: messagesUsed,
+		});
 
-	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({
+			customer,
+			count: 2,
+			latestTotal: preview.total,
+		});
 
-	expectCustomerFeatureCorrect({
-		customer,
-		featureId: TestFeature.Messages,
-		includedUsage: quantity, // 0 + 300 = 300
-		balance: quantity - messagesUsed,
-		usage: messagesUsed,
-	});
-
-	await expectCustomerInvoiceCorrect({
-		customer,
-		count: 2,
-		latestTotal: preview.total,
-	});
-
-	await expectSubToBeCorrect({
-		db: ctx.db,
-		customerId,
-		org: ctx.org,
-		env: ctx.env,
-	});
-});
+		await expectSubToBeCorrect({
+			db: ctx.db,
+			customerId,
+			org: ctx.org,
+			env: ctx.env,
+		});
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // INCLUDED USAGE CHANGES
 // ═══════════════════════════════════════════════════════════════════════════════
 
 // Add included usage to prepaid feature
-test.concurrent(`${chalk.yellowBright("prepaid: add included usage")}`, async () => {
-	const billingUnits = 100;
-	const pricePerPack = 10;
+test.concurrent(
+	`${chalk.yellowBright("prepaid: add included usage")}`,
+	async () => {
+		const billingUnits = 100;
+		const pricePerPack = 10;
 
-	const prepaidItem = items.prepaidMessages({
-		includedUsage: 0,
-		billingUnits,
-		price: pricePerPack,
-	});
-	const priceItem = items.monthlyPrice({ price: 20 });
-	const pro = products.base({
-		id: "pro",
-		items: [prepaidItem, priceItem],
-	});
+		const prepaidItem = items.prepaidMessages({
+			includedUsage: 0,
+			billingUnits,
+			price: pricePerPack,
+		});
+		const priceItem = items.monthlyPrice({ price: 20 });
+		const pro = products.base({
+			id: "pro",
+			items: [prepaidItem, priceItem],
+		});
 
-	const packs = 2;
-	const quantity = packs * billingUnits; // 200 units
+		const packs = 2;
+		const quantity = packs * billingUnits; // 200 units
 
-	const { customerId, autumnV1, ctx } = await initScenario({
-		customerId: "prepaid-add-included",
-		setup: [
-			s.customer({ paymentMethod: "success" }),
-			s.products({ list: [pro] }),
-		],
-		actions: [
-			s.attach({
-				productId: pro.id,
-				options: [{ feature_id: TestFeature.Messages, quantity }],
-			}),
-		],
-	});
+		const { customerId, autumnV1, ctx } = await initScenario({
+			customerId: "prepaid-add-included",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [
+				s.attach({
+					productId: pro.id,
+					options: [{ feature_id: TestFeature.Messages, quantity }],
+				}),
+			],
+		});
 
-	const messagesUsed = 100;
-	await autumnV1.track(
-		{
+		const messagesUsed = 100;
+		await autumnV1.track(
+			{
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value: messagesUsed,
+			},
+			{ timeout: 2000 },
+		);
+
+		// Add 50 included usage (free units)
+		const includedUsage = 100;
+		const newPrepaidItem = items.prepaidMessages({
+			includedUsage,
+			billingUnits,
+			price: pricePerPack,
+		});
+
+		const updateParams = {
 			customer_id: customerId,
-			feature_id: TestFeature.Messages,
-			value: messagesUsed,
-		},
-		{ timeout: 2000 },
-	);
+			product_id: pro.id,
+			items: [newPrepaidItem, priceItem],
+		};
 
-	// Add 50 included usage (free units)
-	const includedUsage = 100;
-	const newPrepaidItem = items.prepaidMessages({
-		includedUsage,
-		billingUnits,
-		price: pricePerPack,
-	});
+		const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
 
-	const updateParams = {
-		customer_id: customerId,
-		product_id: pro.id,
-		items: [newPrepaidItem, priceItem],
-	};
+		// Adding included usage doesn't change prepaid charge (same packs)
+		expect(preview.total).toBe(-10);
 
-	const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
+		await autumnV1.subscriptions.update(updateParams);
 
-	// Adding included usage doesn't change prepaid charge (same packs)
-	expect(preview.total).toBe(-10);
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
 
-	await autumnV1.subscriptions.update(updateParams);
+		// Balance = includedUsage + quantity - messagesUsed = 50 + 200 - 100 = 150
+		// Customer's included_usage = item's includedUsage + quantity = 50 + 200 = 250
+		expectCustomerFeatureCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			includedUsage: quantity,
+			balance: quantity - messagesUsed,
+			usage: messagesUsed,
+		});
 
-	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({
+			customer,
+			count: 2,
+			latestTotal: preview.total,
+		});
 
-	// Balance = includedUsage + quantity - messagesUsed = 50 + 200 - 100 = 150
-	// Customer's included_usage = item's includedUsage + quantity = 50 + 200 = 250
-	expectCustomerFeatureCorrect({
-		customer,
-		featureId: TestFeature.Messages,
-		includedUsage: quantity,
-		balance: quantity - messagesUsed,
-		usage: messagesUsed,
-	});
-
-	await expectCustomerInvoiceCorrect({
-		customer,
-		count: 2,
-		latestTotal: preview.total,
-	});
-
-	await expectSubToBeCorrect({
-		db: ctx.db,
-		customerId,
-		org: ctx.org,
-		env: ctx.env,
-	});
-});
+		await expectSubToBeCorrect({
+			db: ctx.db,
+			customerId,
+			org: ctx.org,
+			env: ctx.env,
+		});
+	},
+);
 
 // Remove included usage from prepaid feature
-test.concurrent(`${chalk.yellowBright("prepaid: remove included usage")}`, async () => {
-	const billingUnits = 100;
-	const pricePerPack = 10;
-	const oldIncludedUsage = 100;
+test.concurrent(
+	`${chalk.yellowBright("prepaid: remove included usage")}`,
+	async () => {
+		const billingUnits = 100;
+		const pricePerPack = 10;
+		const oldIncludedUsage = 100;
 
-	const prepaidItem = items.prepaidMessages({
-		includedUsage: oldIncludedUsage,
-		billingUnits,
-		price: pricePerPack,
-	});
-	const priceItem = items.monthlyPrice({ price: 20 });
-	const pro = products.base({
-		id: "pro",
-		items: [prepaidItem, priceItem],
-	});
+		const prepaidItem = items.prepaidMessages({
+			includedUsage: oldIncludedUsage,
+			billingUnits,
+			price: pricePerPack,
+		});
+		const priceItem = items.monthlyPrice({ price: 20 });
+		const pro = products.base({
+			id: "pro",
+			items: [prepaidItem, priceItem],
+		});
 
-	const packs = 2;
-	const quantity = packs * billingUnits; // 200 units
+		const packs = 2;
+		const quantity = packs * billingUnits; // 200 units
 
-	const { customerId, autumnV1, ctx } = await initScenario({
-		customerId: "prepaid-remove-included",
-		setup: [
-			s.customer({ paymentMethod: "success" }),
-			s.products({ list: [pro] }),
-		],
-		actions: [
-			s.attach({
-				productId: pro.id,
-				options: [{ feature_id: TestFeature.Messages, quantity }],
-			}),
-		],
-	});
+		const { customerId, autumnV1, ctx } = await initScenario({
+			customerId: "prepaid-remove-included",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [
+				s.attach({
+					productId: pro.id,
+					options: [{ feature_id: TestFeature.Messages, quantity }],
+				}),
+			],
+		});
 
-	// Total balance = 100 (included) + 200 (prepaid) = 300
-	const messagesUsed = 150;
-	await autumnV1.track(
-		{
+		// Total balance = 100 (included) + 200 (prepaid) = 300
+		const messagesUsed = 150;
+		await autumnV1.track(
+			{
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value: messagesUsed,
+			},
+			{ timeout: 2000 },
+		);
+
+		// Remove included usage
+		const newPrepaidItem = items.prepaidMessages({
+			includedUsage: 0,
+			billingUnits,
+			price: pricePerPack,
+		});
+
+		const updateParams = {
 			customer_id: customerId,
-			feature_id: TestFeature.Messages,
-			value: messagesUsed,
-		},
-		{ timeout: 2000 },
-	);
+			product_id: pro.id,
+			items: [newPrepaidItem, priceItem],
+			options: [{ feature_id: TestFeature.Messages, quantity }],
+		};
 
-	// Remove included usage
-	const newPrepaidItem = items.prepaidMessages({
-		includedUsage: 0,
-		billingUnits,
-		price: pricePerPack,
-	});
+		const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
 
-	const updateParams = {
-		customer_id: customerId,
-		product_id: pro.id,
-		items: [newPrepaidItem, priceItem],
-		options: [{ feature_id: TestFeature.Messages, quantity }],
-	};
+		// Removing included usage doesn't change prepaid charge (same packs)
+		expect(preview.total).toBe(0);
 
-	const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
+		await autumnV1.subscriptions.update(updateParams);
 
-	// Removing included usage doesn't change prepaid charge (same packs)
-	expect(preview.total).toBe(0);
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
 
-	await autumnV1.subscriptions.update(updateParams);
+		// Balance = 0 (included) + 200 (prepaid) - 150 (used) = 50
+		// Customer's included_usage = 0 + 200 = 200
+		expectCustomerFeatureCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			includedUsage: quantity,
+			balance: quantity - messagesUsed,
+			usage: messagesUsed,
+		});
 
-	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({
+			customer,
+			count: 2,
+			latestTotal: preview.total,
+		});
 
-	// Balance = 0 (included) + 200 (prepaid) - 150 (used) = 50
-	// Customer's included_usage = 0 + 200 = 200
-	expectCustomerFeatureCorrect({
-		customer,
-		featureId: TestFeature.Messages,
-		includedUsage: quantity,
-		balance: quantity - messagesUsed,
-		usage: messagesUsed,
-	});
-
-	await expectCustomerInvoiceCorrect({
-		customer,
-		count: 2,
-		latestTotal: preview.total,
-	});
-
-	await expectSubToBeCorrect({
-		db: ctx.db,
-		customerId,
-		org: ctx.org,
-		env: ctx.env,
-	});
-});
+		await expectSubToBeCorrect({
+			db: ctx.db,
+			customerId,
+			org: ctx.org,
+			env: ctx.env,
+		});
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // COMBINED CHANGES
 // ═══════════════════════════════════════════════════════════════════════════════
 
 // Change price and billing units simultaneously
-test.concurrent(`${chalk.yellowBright("prepaid: change price and billing units")}`, async () => {
-	const oldBillingUnits = 100;
-	const oldPrice = 10;
+test.concurrent(
+	`${chalk.yellowBright("prepaid: change price and billing units")}`,
+	async () => {
+		const oldBillingUnits = 100;
+		const oldPrice = 10;
 
-	const prepaidItem = items.prepaidMessages({
-		includedUsage: 0,
-		billingUnits: oldBillingUnits,
-		price: oldPrice,
-	});
-	const priceItem = items.monthlyPrice({ price: 20 });
-	const pro = products.base({
-		id: "pro",
-		items: [prepaidItem, priceItem],
-	});
+		const prepaidItem = items.prepaidMessages({
+			includedUsage: 0,
+			billingUnits: oldBillingUnits,
+			price: oldPrice,
+		});
+		const priceItem = items.monthlyPrice({ price: 20 });
+		const pro = products.base({
+			id: "pro",
+			items: [prepaidItem, priceItem],
+		});
 
-	const quantity = 300; // 3 packs of 100
+		const quantity = 300; // 3 packs of 100
 
-	const { customerId, autumnV1, ctx } = await initScenario({
-		customerId: "prepaid-price-and-units",
-		setup: [
-			s.customer({ paymentMethod: "success" }),
-			s.products({ list: [pro] }),
-		],
-		actions: [
-			s.attach({
-				productId: pro.id,
-				options: [{ feature_id: TestFeature.Messages, quantity }],
-			}),
-		],
-	});
+		const { customerId, autumnV1, ctx } = await initScenario({
+			customerId: "prepaid-price-and-units",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [
+				s.attach({
+					productId: pro.id,
+					options: [{ feature_id: TestFeature.Messages, quantity }],
+				}),
+			],
+		});
 
-	const messagesUsed = 50;
-	await autumnV1.track(
-		{
+		const messagesUsed = 50;
+		await autumnV1.track(
+			{
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value: messagesUsed,
+			},
+			{ timeout: 2000 },
+		);
+
+		// Change: 100 units @ $10 -> 50 units @ $8
+		const newBillingUnits = 50;
+		const newPrice = 8;
+		const newPrepaidItem = items.prepaidMessages({
+			includedUsage: 0,
+			billingUnits: newBillingUnits,
+			price: newPrice,
+		});
+
+		const updateParams = {
 			customer_id: customerId,
-			feature_id: TestFeature.Messages,
-			value: messagesUsed,
-		},
-		{ timeout: 2000 },
-	);
+			product_id: pro.id,
+			items: [newPrepaidItem, priceItem],
+			options: [{ feature_id: TestFeature.Messages, quantity }],
+		};
 
-	// Change: 100 units @ $10 -> 50 units @ $8
-	const newBillingUnits = 50;
-	const newPrice = 8;
-	const newPrepaidItem = items.prepaidMessages({
-		includedUsage: 0,
-		billingUnits: newBillingUnits,
-		price: newPrice,
-	});
+		const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
 
-	const updateParams = {
-		customer_id: customerId,
-		product_id: pro.id,
-		items: [newPrepaidItem, priceItem],
-		options: [{ feature_id: TestFeature.Messages, quantity }],
-	};
+		// Old: 300 / 100 = 3 packs * $10 = $30
+		// New: 300 / 50 = 6 packs * $8 = $48
+		// Total: $48 - $30 = $18
+		const oldPacks = Math.ceil(quantity / oldBillingUnits);
+		const newPacks = Math.ceil(quantity / newBillingUnits);
+		expect(preview.total).toBe(newPacks * newPrice - oldPacks * oldPrice);
 
-	const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
+		await autumnV1.subscriptions.update(updateParams);
 
-	// Old: 300 / 100 = 3 packs * $10 = $30
-	// New: 300 / 50 = 6 packs * $8 = $48
-	// Total: $48 - $30 = $18
-	const oldPacks = Math.ceil(quantity / oldBillingUnits);
-	const newPacks = Math.ceil(quantity / newBillingUnits);
-	expect(preview.total).toBe(newPacks * newPrice - oldPacks * oldPrice);
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
 
-	await autumnV1.subscriptions.update(updateParams);
+		expectCustomerFeatureCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			includedUsage: quantity, // 0 + 300 = 300
+			balance: quantity - messagesUsed,
+			usage: messagesUsed,
+		});
 
-	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({
+			customer,
+			count: 2,
+			latestTotal: preview.total,
+		});
 
-	expectCustomerFeatureCorrect({
-		customer,
-		featureId: TestFeature.Messages,
-		includedUsage: quantity, // 0 + 300 = 300
-		balance: quantity - messagesUsed,
-		usage: messagesUsed,
-	});
-
-	await expectCustomerInvoiceCorrect({
-		customer,
-		count: 2,
-		latestTotal: preview.total,
-	});
-
-	await expectSubToBeCorrect({
-		db: ctx.db,
-		customerId,
-		org: ctx.org,
-		env: ctx.env,
-	});
-});
+		await expectSubToBeCorrect({
+			db: ctx.db,
+			customerId,
+			org: ctx.org,
+			env: ctx.env,
+		});
+	},
+);
 
 // Change all: price, billing units, and included usage
-test.concurrent(`${chalk.yellowBright("prepaid: change price, billing units, and included usage")}`, async () => {
-	const oldBillingUnits = 100;
-	const oldPrice = 10;
-	const oldIncludedUsage = 0;
+test.concurrent(
+	`${chalk.yellowBright("prepaid: change price, billing units, and included usage")}`,
+	async () => {
+		const oldBillingUnits = 100;
+		const oldPrice = 10;
+		const oldIncludedUsage = 0;
 
-	const prepaidItem = items.prepaidMessages({
-		includedUsage: oldIncludedUsage,
-		billingUnits: oldBillingUnits,
-		price: oldPrice,
-	});
-	const priceItem = items.monthlyPrice({ price: 20 });
-	const pro = products.base({
-		id: "pro",
-		items: [prepaidItem, priceItem],
-	});
+		const prepaidItem = items.prepaidMessages({
+			includedUsage: oldIncludedUsage,
+			billingUnits: oldBillingUnits,
+			price: oldPrice,
+		});
+		const priceItem = items.monthlyPrice({ price: 20 });
+		const pro = products.base({
+			id: "pro",
+			items: [prepaidItem, priceItem],
+		});
 
-	const quantity = 200; // 2 packs of 100
+		const quantity = 200; // 2 packs of 100
 
-	const { customerId, autumnV1, ctx } = await initScenario({
-		customerId: "prepaid-all-changes",
-		setup: [
-			s.customer({ paymentMethod: "success" }),
-			s.products({ list: [pro] }),
-		],
-		actions: [
-			s.attach({
-				productId: pro.id,
-				options: [{ feature_id: TestFeature.Messages, quantity }],
-			}),
-		],
-	});
+		const { customerId, autumnV1, ctx } = await initScenario({
+			customerId: "prepaid-all-changes",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [
+				s.attach({
+					productId: pro.id,
+					options: [{ feature_id: TestFeature.Messages, quantity }],
+				}),
+			],
+		});
 
-	const messagesUsed = 50;
-	await autumnV1.track(
-		{
+		const messagesUsed = 50;
+		await autumnV1.track(
+			{
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value: messagesUsed,
+			},
+			{ timeout: 2000 },
+		);
+
+		// Change everything: add 100 included, 50 units @ $5
+		const newBillingUnits = 50;
+		const newPrice = 5;
+		const newIncludedUsage = 100;
+		const newPrepaidItem = items.prepaidMessages({
+			includedUsage: newIncludedUsage,
+			billingUnits: newBillingUnits,
+			price: newPrice,
+		});
+
+		const updateParams = {
 			customer_id: customerId,
-			feature_id: TestFeature.Messages,
-			value: messagesUsed,
-		},
-		{ timeout: 2000 },
-	);
+			product_id: pro.id,
+			items: [newPrepaidItem, priceItem],
+			options: [{ feature_id: TestFeature.Messages, quantity }],
+		};
 
-	// Change everything: add 100 included, 50 units @ $5
-	const newBillingUnits = 50;
-	const newPrice = 5;
-	const newIncludedUsage = 100;
-	const newPrepaidItem = items.prepaidMessages({
-		includedUsage: newIncludedUsage,
-		billingUnits: newBillingUnits,
-		price: newPrice,
-	});
+		const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
 
-	const updateParams = {
-		customer_id: customerId,
-		product_id: pro.id,
-		items: [newPrepaidItem, priceItem],
-		options: [{ feature_id: TestFeature.Messages, quantity }],
-	};
+		// Old: 200 / 100 = 2 packs * $10 = $20
+		// New: 200 / 50 = 4 packs * $5 = $20
+		// Total: $20 - $20 = $0
+		const oldPacks = Math.ceil(quantity / oldBillingUnits);
+		const newPacks = Math.ceil((quantity - newIncludedUsage) / newBillingUnits);
+		expect(preview.total).toBe(newPacks * newPrice - oldPacks * oldPrice);
 
-	const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
+		await autumnV1.subscriptions.update(updateParams);
 
-	// Old: 200 / 100 = 2 packs * $10 = $20
-	// New: 200 / 50 = 4 packs * $5 = $20
-	// Total: $20 - $20 = $0
-	const oldPacks = Math.ceil(quantity / oldBillingUnits);
-	const newPacks = Math.ceil((quantity - newIncludedUsage) / newBillingUnits);
-	expect(preview.total).toBe(newPacks * newPrice - oldPacks * oldPrice);
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
 
-	await autumnV1.subscriptions.update(updateParams);
+		// Balance = quantity - messagesUsed = 200 - 50 = 150
+		// Customer's included_usage = quantity = 200
+		expectCustomerFeatureCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			includedUsage: quantity,
+			balance: quantity - messagesUsed,
+			usage: messagesUsed,
+		});
 
-	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({
+			customer,
+			count: 2,
+			latestTotal: preview.total,
+		});
 
-	// Balance = quantity - messagesUsed = 200 - 50 = 150
-	// Customer's included_usage = quantity = 200
-	expectCustomerFeatureCorrect({
-		customer,
-		featureId: TestFeature.Messages,
-		includedUsage: quantity,
-		balance: quantity - messagesUsed,
-		usage: messagesUsed,
-	});
-
-	await expectCustomerInvoiceCorrect({
-		customer,
-		count: 2,
-		latestTotal: preview.total,
-	});
-
-	await expectSubToBeCorrect({
-		db: ctx.db,
-		customerId,
-		org: ctx.org,
-		env: ctx.env,
-	});
-});
+		await expectSubToBeCorrect({
+			db: ctx.db,
+			customerId,
+			org: ctx.org,
+			env: ctx.env,
+		});
+	},
+);
 
 // Zero usage, change item config
-test.concurrent(`${chalk.yellowBright("prepaid: zero usage, change item config")}`, async () => {
-	const oldBillingUnits = 100;
-	const oldPrice = 10;
+test.concurrent(
+	`${chalk.yellowBright("prepaid: zero usage, change item config")}`,
+	async () => {
+		const oldBillingUnits = 100;
+		const oldPrice = 10;
 
-	const prepaidItem = items.prepaidMessages({
-		includedUsage: 0,
-		billingUnits: oldBillingUnits,
-		price: oldPrice,
-	});
-	const priceItem = items.monthlyPrice({ price: 20 });
-	const pro = products.base({
-		id: "pro",
-		items: [prepaidItem, priceItem],
-	});
+		const prepaidItem = items.prepaidMessages({
+			includedUsage: 0,
+			billingUnits: oldBillingUnits,
+			price: oldPrice,
+		});
+		const priceItem = items.monthlyPrice({ price: 20 });
+		const pro = products.base({
+			id: "pro",
+			items: [prepaidItem, priceItem],
+		});
 
-	const quantity = 200;
+		const quantity = 200;
 
-	const { customerId, autumnV1, ctx } = await initScenario({
-		customerId: "prepaid-zero-usage-item-change",
-		setup: [
-			s.customer({ paymentMethod: "success" }),
-			s.products({ list: [pro] }),
-		],
-		actions: [
-			s.attach({
-				productId: pro.id,
-				options: [{ feature_id: TestFeature.Messages, quantity }],
-			}),
-		],
-	});
+		const { customerId, autumnV1, ctx } = await initScenario({
+			customerId: "prepaid-zero-usage-item-change",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [
+				s.attach({
+					productId: pro.id,
+					options: [{ feature_id: TestFeature.Messages, quantity }],
+				}),
+			],
+		});
 
-	// No usage tracked
+		// No usage tracked
 
-	// Double the price
-	const newPrice = 20;
-	const newPrepaidItem = items.prepaidMessages({
-		includedUsage: 0,
-		billingUnits: oldBillingUnits,
-		price: newPrice,
-	});
+		// Double the price
+		const newPrice = 20;
+		const newPrepaidItem = items.prepaidMessages({
+			includedUsage: 0,
+			billingUnits: oldBillingUnits,
+			price: newPrice,
+		});
 
-	const updateParams = {
-		customer_id: customerId,
-		product_id: pro.id,
-		items: [newPrepaidItem, priceItem],
-		options: [{ feature_id: TestFeature.Messages, quantity }],
-	};
+		const updateParams = {
+			customer_id: customerId,
+			product_id: pro.id,
+			items: [newPrepaidItem, priceItem],
+			options: [{ feature_id: TestFeature.Messages, quantity }],
+		};
 
-	const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
+		const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
 
-	// Old: 2 packs * $10 = $20
-	// New: 2 packs * $20 = $40
-	// Total: $40 - $20 = $20
-	const packs = Math.ceil(quantity / oldBillingUnits);
-	expect(preview.total).toBe(packs * newPrice - packs * oldPrice);
+		// Old: 2 packs * $10 = $20
+		// New: 2 packs * $20 = $40
+		// Total: $40 - $20 = $20
+		const packs = Math.ceil(quantity / oldBillingUnits);
+		expect(preview.total).toBe(packs * newPrice - packs * oldPrice);
 
-	await autumnV1.subscriptions.update(updateParams);
+		await autumnV1.subscriptions.update(updateParams);
 
-	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
 
-	expectCustomerFeatureCorrect({
-		customer,
-		featureId: TestFeature.Messages,
-		includedUsage: quantity, // 0 + 200 = 200
-		balance: quantity,
-		usage: 0,
-	});
+		expectCustomerFeatureCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			includedUsage: quantity, // 0 + 200 = 200
+			balance: quantity,
+			usage: 0,
+		});
 
-	await expectCustomerInvoiceCorrect({
-		customer,
-		count: 2,
-		latestTotal: preview.total,
-	});
+		await expectCustomerInvoiceCorrect({
+			customer,
+			count: 2,
+			latestTotal: preview.total,
+		});
 
-	await expectSubToBeCorrect({
-		db: ctx.db,
-		customerId,
-		org: ctx.org,
-		env: ctx.env,
-	});
-});
+		await expectSubToBeCorrect({
+			db: ctx.db,
+			customerId,
+			org: ctx.org,
+			env: ctx.env,
+		});
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // FREE TO PAID: PREPAID ITEM WITH ZERO QUANTITY
 // ═══════════════════════════════════════════════════════════════════════════════
 
 // Update from free product to paid with prepaid item, passing 0 quantity
-test.concurrent(`${chalk.yellowBright("prepaid: free to paid with zero quantity")}`, async () => {
-	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
-	const free = products.base({ items: [messagesItem], id: "free" });
+test.concurrent(
+	`${chalk.yellowBright("prepaid: free to paid with zero quantity")}`,
+	async () => {
+		const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+		const free = products.base({ items: [messagesItem], id: "free" });
 
-	const { customerId, autumnV1, ctx } = await initScenario({
-		customerId: "free-to-prepaid-zero-qty",
-		setup: [
-			s.customer({ paymentMethod: "success" }),
-			s.products({ list: [free] }),
-		],
-		actions: [s.attach({ productId: free.id })],
-	});
+		const { customerId, autumnV1, ctx } = await initScenario({
+			customerId: "free-to-prepaid-zero-qty",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [free] }),
+			],
+			actions: [s.attach({ productId: free.id })],
+		});
 
-	// Track some usage on the free product
-	const messagesUsed = 30;
-	await autumnV1.track(
-		{
+		// Track some usage on the free product
+		const messagesUsed = 30;
+		await autumnV1.track(
+			{
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value: messagesUsed,
+			},
+			{ timeout: 2000 },
+		);
+
+		// Update to add prepaid messages item with 0 quantity
+		const billingUnits = 100;
+		const pricePerPack = 10;
+		const prepaidItem = items.prepaidMessages({
+			includedUsage: 0,
+			billingUnits,
+			price: pricePerPack,
+		});
+		const priceItem = items.monthlyPrice({ price: 20 });
+
+		const updateParams = {
 			customer_id: customerId,
-			feature_id: TestFeature.Messages,
-			value: messagesUsed,
-		},
-		{ timeout: 2000 },
-	);
+			product_id: free.id,
+			items: [prepaidItem, priceItem],
+			options: [{ feature_id: TestFeature.Messages, quantity: 0 }],
+		};
 
-	// Update to add prepaid messages item with 0 quantity
-	const billingUnits = 100;
-	const pricePerPack = 10;
-	const prepaidItem = items.prepaidMessages({
-		includedUsage: 0,
-		billingUnits,
-		price: pricePerPack,
-	});
-	const priceItem = items.monthlyPrice({ price: 20 });
+		const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
 
-	const updateParams = {
-		customer_id: customerId,
-		product_id: free.id,
-		items: [prepaidItem, priceItem],
-		options: [{ feature_id: TestFeature.Messages, quantity: 0 }],
-	};
+		// With 0 quantity, no packs are purchased
+		// Total = base price only = $20
+		expect(preview.total).toBe(priceItem.price);
 
-	const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
+		await autumnV1.subscriptions.update(updateParams);
 
-	// With 0 quantity, no packs are purchased
-	// Total = base price only = $20
-	expect(preview.total).toBe(priceItem.price);
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
 
-	await autumnV1.subscriptions.update(updateParams);
+		// With 0 quantity: includedUsage = 0, balance = 0 - messagesUsed (goes negative)
+		expectCustomerFeatureCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			includedUsage: 0, // 0 + 0 = 0
+			// Usage carries over with no floor, so the balance goes negative.
+			balance: 0 - messagesUsed,
+			usage: messagesUsed,
+		});
 
-	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({
+			customer,
+			count: 1, // Initial free invoice + update invoice
+			latestTotal: preview.total,
+		});
 
-	// With 0 quantity: includedUsage = 0, balance = 0 - messagesUsed (goes negative)
-	expectCustomerFeatureCorrect({
-		customer,
-		featureId: TestFeature.Messages,
-		includedUsage: 0, // 0 + 0 = 0
-		balance: Math.max(0, 0 - messagesUsed), // 0 - 30 = -30 (negative balance)
-		usage: 0,
-	});
-
-	await expectCustomerInvoiceCorrect({
-		customer,
-		count: 1, // Initial free invoice + update invoice
-		latestTotal: preview.total,
-	});
-
-	await expectSubToBeCorrect({
-		db: ctx.db,
-		customerId,
-		org: ctx.org,
-		env: ctx.env,
-	});
-});
+		await expectSubToBeCorrect({
+			db: ctx.db,
+			customerId,
+			org: ctx.org,
+			env: ctx.env,
+		});
+	},
+);

--- a/server/tests/integration/crud/plans/create-plan-basic.test.ts
+++ b/server/tests/integration/crud/plans/create-plan-basic.test.ts
@@ -355,7 +355,7 @@ test.concurrent(
 						billing_method: BillingMethod.UsageBased,
 						billing_units: 1000,
 						tiers: [
-							{ to: 100000, amount: 10 },
+							{ to: 200000, amount: 10 },
 							{ to: 500000, amount: 50 },
 							{ to: 1000000, amount: 40 },
 							{ to: TierInfinite, amount: 30 },
@@ -370,10 +370,6 @@ test.concurrent(
 						interval: BillingInterval.Month,
 						billing_method: BillingMethod.UsageBased,
 						billing_units: 1,
-					},
-					proration: {
-						on_increase: OnIncrease.ProrateImmediately,
-						on_decrease: OnDecrease.Prorate,
 					},
 				},
 			],
@@ -446,6 +442,7 @@ test.concurrent(
 			(i) => i.feature_id === TestFeature.Messages,
 		);
 		expect(meteredItem!.tiers).toHaveLength(4);
+		// V1.2 items expose tier bounds relative to included (200000 - 100000).
 		expect(meteredItem!.tiers![0]).toMatchObject({ to: 100000, amount: 10 });
 
 		const seatsItem = v1_2.items.find(

--- a/server/tests/integration/crud/plans/variants/interval-family.test.ts
+++ b/server/tests/integration/crud/plans/variants/interval-family.test.ts
@@ -21,7 +21,9 @@ import {
 	type ApiPlanV1,
 	ApiVersion,
 	BillingInterval,
+	type FullProduct,
 	ResetInterval,
+	resetIntvToEntIntv,
 	type UpdatePlanParamsV2Input,
 } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features";
@@ -31,11 +33,11 @@ import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 import { AutumnRpcCli } from "@/external/autumn/autumnRpcCli.js";
 import { ProductService } from "@/internal/products/ProductService.js";
+import { expectPreviewVariantsCorrect } from "./utils/expectVariantPreviewCorrect.js";
 import {
 	expectStripeResourcesCarriedToVariant,
 	expectVariantProductCorrect,
 } from "./utils/expectVariantProductCorrect.js";
-import { expectPreviewVariantsCorrect } from "./utils/expectVariantPreviewCorrect.js";
 import { readableVariantTestId } from "./utils/readableVariantTestId.js";
 import { createVariantPlan } from "./utils/variantTestPlanUtils.js";
 
@@ -181,22 +183,28 @@ const updateVariantInterval = async (
 };
 
 const getMsgAllowance = (full: any) =>
-	full.entitlements.find(
-		(e: any) => e.feature_id === TestFeature.Messages,
-	)?.allowance;
+	full.entitlements.find((e: any) => e.feature_id === TestFeature.Messages)
+		?.allowance;
 
 // Different intervals don't merge: a variant can carry more than one Messages
 // entitlement (one per interval) once the base propagates a new-interval item
 // alongside an existing one, so lookups here must disambiguate by interval.
-const getMsgAllowanceForInterval = (full: any, interval: ResetInterval) =>
-	full.entitlements.find(
-		(e: any) => e.feature_id === TestFeature.Messages && e.interval === interval,
+const getMsgAllowanceForInterval = (
+	full: FullProduct,
+	interval: ResetInterval,
+) => {
+	// One-off resets persist as lifetime entitlements.
+	const entInterval = resetIntvToEntIntv({ resetIntv: interval });
+	return full.entitlements.find(
+		(entitlement) =>
+			entitlement.feature_id === TestFeature.Messages &&
+			entitlement.interval === entInterval,
 	)?.allowance;
+};
 
 const getUsersAllowance = (full: any) =>
-	full.entitlements.find(
-		(e: any) => e.feature_id === TestFeature.Users,
-	)?.allowance;
+	full.entitlements.find((e: any) => e.feature_id === TestFeature.Users)
+		?.allowance;
 
 const getStripeProductId = (full: any) =>
 	full.prices.find((p: any) => p.config?.type === "fixed")?.config
@@ -213,10 +221,7 @@ test.concurrent(
 	`${chalk.yellowBright("interval-family create: 5 variants — all get base_internal_product_id, version=1, share stripe_product_id")}`,
 	async () => {
 		const cid = readableVariantTestId("if_create_family");
-		const { ctx, rpc, baseId } = await setupBase(
-			cid,
-			`iv_base_${cid}`,
-		);
+		const { ctx, rpc, baseId } = await setupBase(cid, `iv_base_${cid}`);
 
 		const variantIds = await create5Variants(rpc, baseId, cid);
 		const baseFull = await getFull(ctx, baseId);
@@ -322,7 +327,7 @@ test.concurrent(
 // 5. base disable_version cascades: no targeted variant versions,
 //    all patch in place regardless of their own customer status
 // ═════════════════════════════════════════════════════════════════
-	test.concurrent(
+test.concurrent(
 	`${chalk.yellowBright("interval-family propagate: base disable_version cascades — all 5 variants patch in place, none version")}`,
 	async () => {
 		const cid = readableVariantTestId("if_variant_customer");
@@ -522,12 +527,7 @@ test.concurrent(
 		const variantIds = await create5Variants(rpc, baseId, cid);
 
 		const err = await catchErr(() =>
-			createVariant(
-				rpc,
-				variantIds[0],
-				`iv_nested_${cid}`,
-				"Nested",
-			),
+			createVariant(rpc, variantIds[0], `iv_nested_${cid}`, "Nested"),
 		);
 
 		expect(err).not.toBeNull();
@@ -538,7 +538,7 @@ test.concurrent(
 // ═════════════════════════════════════════════════════════════════
 // 11. Stripe carry-forward — variant v2 retains stripe_price_id from v1
 // ═════════════════════════════════════════════════════════════════
-	test.concurrent(
+test.concurrent(
 	`${chalk.yellowBright("interval-family stripe: carry-forward — variant v2 retains stripe_price_id from v1 for unchanged prices")}`,
 	async () => {
 		const cid = readableVariantTestId("if_stripe_price");

--- a/server/tests/integration/crud/plans/variants/lifecycle.test.ts
+++ b/server/tests/integration/crud/plans/variants/lifecycle.test.ts
@@ -21,7 +21,6 @@
  */
 
 import { expect, test } from "bun:test";
-import { expectPreviewUpdatePlanCorrect } from "../previewUpdate/utils/expectPreviewUpdatePlanCorrect.js";
 import {
 	type ApiPlanV1,
 	ApiVersion,
@@ -36,6 +35,7 @@ import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 import { AutumnRpcCli } from "@/external/autumn/autumnRpcCli.js";
 import { ProductService } from "@/internal/products/ProductService.js";
+import { expectPreviewUpdatePlanCorrect } from "../previewUpdate/utils/expectPreviewUpdatePlanCorrect.js";
 import {
 	expectEntitlementAllowanceMatches,
 	expectStripeResourcesCarriedToVariant,
@@ -300,12 +300,14 @@ test.concurrent(
 );
 
 // ───────────────────────────────────────────────────────────────────
-// 6. preview_update rejects on variant
+// 6. preview_update supported on variant
+// (the cannot_preview_on_variant guard was removed when variant
+// previews shipped — previews on a variant now resolve normally)
 // ───────────────────────────────────────────────────────────────────
 test.concurrent(
-	`${chalk.yellowBright("variants preview_update: rejects on variant → 400 cannot_preview_on_variant")}`,
+	`${chalk.yellowBright("variants preview_update: supported on variant, previews its own changes")}`,
 	async () => {
-		const cid = readableVariantTestId("lc_preview_variant_err");
+		const cid = readableVariantTestId("lc_preview_variant_ok");
 		const base = baseProduct(`lc_base_${cid}`);
 
 		const { ctx } = await initScenario({
@@ -326,15 +328,13 @@ test.concurrent(
 			name: "Variant",
 		});
 
-		const err = await catchErr(() =>
-			rpc.post("/plans.preview_update", {
-				plan_id: variantId,
-				items: [monthlyItem(200)],
-			}),
-		);
+		const preview = (await rpc.post("/plans.preview_update", {
+			plan_id: variantId,
+			items: [monthlyItem(200)],
+		})) as { versionable: boolean };
 
-		expect(err).not.toBeNull();
-		expect(err?.code).toBe("cannot_preview_on_variant");
+		// Customer-less variant patches in place.
+		expect(preview.versionable).toBe(false);
 	},
 );
 
@@ -445,7 +445,10 @@ test.concurrent(
 
 		const { autumnV2_2, ctx } = await initScenario({
 			customerId: cid,
-			setup: [s.customer({ paymentMethod: "success" }), s.products({ list: [base] })],
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [base] }),
+			],
 			actions: [],
 		});
 

--- a/server/tests/integration/crud/plans/variants/reset-tier-ladder.test.ts
+++ b/server/tests/integration/crud/plans/variants/reset-tier-ladder.test.ts
@@ -30,10 +30,10 @@ import {
 	ResetInterval,
 } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
 import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
 import ctx from "@tests/utils/testInitUtils/createTestContext.js";
-import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
@@ -69,8 +69,14 @@ const createVariantRpc = async <T = ApiPlanV1>(
 		resetVariant,
 	});
 
-const previewUpdateRpc = async <T = PlanUpdatePreview>(planId: string, updates: Record<string, unknown>) =>
-	autumnRpc.rpc.call<T>({ method: "/plans.preview_update", body: { plan_id: planId, ...updates } });
+const previewUpdateRpc = async <T = PlanUpdatePreview>(
+	planId: string,
+	updates: Record<string, unknown>,
+) =>
+	autumnRpc.rpc.call<T>({
+		method: "/plans.preview_update",
+		body: { plan_id: planId, ...updates },
+	});
 
 const getPlanRpc = async (planId: string) =>
 	autumnRpc.plans.get<ApiPlanV1>(planId);
@@ -94,7 +100,10 @@ const prepaidCreditsItem = (amount: number) => ({
 
 const dashboardItem = { feature_id: TestFeature.Dashboard };
 
-const createBaseWithItems = async (id: string, itemDefs: Record<string, unknown>[]) => {
+const createBaseWithItems = async (
+	id: string,
+	itemDefs: Record<string, unknown>[],
+) => {
 	await cleanup(id);
 	await autumnRpc.plans.create<ApiPlanV1, CreatePlanParamsV2Input>({
 		plan_id: id,
@@ -109,404 +118,494 @@ const createBaseWithItems = async (id: string, itemDefs: Record<string, unknown>
 // 1. create_variant copies BOTH same-feature_id items — day + month preserved
 // ═══════════════════════════════════════════════════════════════════════════
 
-test.concurrent(`${chalk.yellowBright("reset-tier: create_variant copies BOTH same-feature_id day+month items")}`, async () => {
-	const baseId = readableVariantTestId("rt_copy");
-	const variantId = `${baseId}_variant`;
-	await createBaseWithItems(baseId, [
-		creditsItem(100, ResetInterval.Month),
-		creditsItem(50, ResetInterval.Day),
-	]);
+test.concurrent(
+	`${chalk.yellowBright("reset-tier: create_variant copies BOTH same-feature_id day+month items")}`,
+	async () => {
+		const baseId = readableVariantTestId("rt_copy");
+		const variantId = `${baseId}_variant`;
+		await createBaseWithItems(baseId, [
+			creditsItem(100, ResetInterval.Month),
+			creditsItem(50, ResetInterval.Day),
+		]);
 
-	await createVariantRpc(baseId, variantId, "Variant Copy");
+		await createVariantRpc(baseId, variantId, "Variant Copy");
 
-	const variant = await getPlanRpc(variantId);
-	const creditsItems = variant.items.filter((i) => i.feature_id === TestFeature.Credits);
-	expect(creditsItems.length).toBe(2);
+		const variant = await getPlanRpc(variantId);
+		const creditsItems = variant.items.filter(
+			(i) => i.feature_id === TestFeature.Credits,
+		);
+		expect(creditsItems.length).toBe(2);
 
-	const monthItem = creditsItems.find((i) => i.reset?.interval === ResetInterval.Month);
-	const dayItem = creditsItems.find((i) => i.reset?.interval === ResetInterval.Day);
-	expect(monthItem).toBeDefined();
-	expect(monthItem!.included).toBe(100);
-	expect(dayItem).toBeDefined();
-	expect(dayItem!.included).toBe(50);
-});
+		const monthItem = creditsItems.find(
+			(i) => i.reset?.interval === ResetInterval.Month,
+		);
+		const dayItem = creditsItems.find(
+			(i) => i.reset?.interval === ResetInterval.Day,
+		);
+		expect(monthItem).toBeDefined();
+		expect(monthItem!.included).toBe(100);
+		expect(dayItem).toBeDefined();
+		expect(dayItem!.included).toBe(50);
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════════════
 // 2. preview_update mutates only day-reset item — diff has ONE remove, ONE add
 // ═══════════════════════════════════════════════════════════════════════════
 
-test.concurrent(`${chalk.yellowBright("reset-tier: preview_update diff targets only day-reset item, month sibling untouched")}`, async () => {
-	const baseId = readableVariantTestId("rt_diff_day_month");
-	await createBaseWithItems(baseId, [
-		creditsItem(100, ResetInterval.Month),
-		creditsItem(50, ResetInterval.Day),
-	]);
-
-	const preview = await previewUpdateRpc(baseId, {
-		items: [
+test.concurrent(
+	`${chalk.yellowBright("reset-tier: preview_update diff targets only day-reset item, month sibling untouched")}`,
+	async () => {
+		const baseId = readableVariantTestId("rt_diff_day_month");
+		await createBaseWithItems(baseId, [
 			creditsItem(100, ResetInterval.Month),
-			creditsItem(200, ResetInterval.Day),
-		],
-	});
+			creditsItem(50, ResetInterval.Day),
+		]);
 
-	expect(preview.item_changes).toHaveLength(2);
-	expectPreviewItemChangeCorrect({
-		preview,
-		action: "deleted",
-		featureId: TestFeature.Credits,
-		item: { reset: { interval: ResetInterval.Day } },
-	});
-	expectPreviewItemChangeCorrect({
-		preview,
-		action: "created",
-		featureId: TestFeature.Credits,
-		item: { reset: { interval: ResetInterval.Day } },
-	});
+		const preview = await previewUpdateRpc(baseId, {
+			items: [
+				creditsItem(100, ResetInterval.Month),
+				creditsItem(200, ResetInterval.Day),
+			],
+		});
 
-	const removedMonth = preview.item_changes.some(
-		(change) =>
-			change.action === "deleted" &&
-			change.item.reset?.interval === ResetInterval.Month,
-	);
-	expect(removedMonth).toBe(false);
-});
+		expect(preview.item_changes).toHaveLength(2);
+		expectPreviewItemChangeCorrect({
+			preview,
+			action: "deleted",
+			featureId: TestFeature.Credits,
+			item: { reset: { interval: ResetInterval.Day } },
+		});
+		expectPreviewItemChangeCorrect({
+			preview,
+			action: "created",
+			featureId: TestFeature.Credits,
+			item: { reset: { interval: ResetInterval.Day } },
+		});
+
+		const removedMonth = preview.item_changes.some(
+			(change) =>
+				change.action === "deleted" &&
+				change.item.reset?.interval === ResetInterval.Month,
+		);
+		expect(removedMonth).toBe(false);
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════════════
 // 3. propagate day-only change — variant month byte-identical, day reflects new
 // ═══════════════════════════════════════════════════════════════════════════
 
-test.concurrent(`${chalk.yellowBright("reset-tier: propagate day-only change, month sibling byte-identical")}`, async () => {
-	const baseId = readableVariantTestId("rt_prop_day");
-	const variantId = `${baseId}_variant`;
-	await createBaseWithItems(baseId, [
-		creditsItem(100, ResetInterval.Month),
-		creditsItem(50, ResetInterval.Day),
-	]);
-	await createVariantRpc(baseId, variantId, "Variant Prop");
-
-	const variantBefore = await getPlanRpc(variantId);
-	const monthBefore = variantBefore.items.find(
-		(i) => i.feature_id === TestFeature.Credits && i.reset?.interval === ResetInterval.Month,
-	);
-
-	await autumnRpc.plans.update<ApiPlanV1>(baseId, {
-		items: [
+test.concurrent(
+	`${chalk.yellowBright("reset-tier: propagate day-only change, month sibling byte-identical")}`,
+	async () => {
+		const baseId = readableVariantTestId("rt_prop_day");
+		const variantId = `${baseId}_variant`;
+		await createBaseWithItems(baseId, [
 			creditsItem(100, ResetInterval.Month),
-			creditsItem(300, ResetInterval.Day),
-		],
-		update_variant_ids: [variantId],
-	});
+			creditsItem(50, ResetInterval.Day),
+		]);
+		await createVariantRpc(baseId, variantId, "Variant Prop");
 
-	const variantAfter = await getPlanRpc(variantId);
-	const monthAfter = variantAfter.items.find(
-		(i) => i.feature_id === TestFeature.Credits && i.reset?.interval === ResetInterval.Month,
-	);
-	const dayAfter = variantAfter.items.find(
-		(i) => i.feature_id === TestFeature.Credits && i.reset?.interval === ResetInterval.Day,
-	);
+		const variantBefore = await getPlanRpc(variantId);
+		const monthBefore = variantBefore.items.find(
+			(i) =>
+				i.feature_id === TestFeature.Credits &&
+				i.reset?.interval === ResetInterval.Month,
+		);
 
-	expect(monthAfter).toEqual(monthBefore);
-	expect(dayAfter!.included).toBe(300);
-});
+		await autumnRpc.plans.update<ApiPlanV1>(baseId, {
+			items: [
+				creditsItem(100, ResetInterval.Month),
+				creditsItem(300, ResetInterval.Day),
+			],
+			update_variant_ids: [variantId],
+		});
+
+		const variantAfter = await getPlanRpc(variantId);
+		const monthAfter = variantAfter.items.find(
+			(i) =>
+				i.feature_id === TestFeature.Credits &&
+				i.reset?.interval === ResetInterval.Month,
+		);
+		const dayAfter = variantAfter.items.find(
+			(i) =>
+				i.feature_id === TestFeature.Credits &&
+				i.reset?.interval === ResetInterval.Day,
+		);
+
+		expect(monthAfter).toEqual(monthBefore);
+		expect(dayAfter!.included).toBe(300);
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════════════
 // 4. credit-pack tier ladder — 4 priced variants, Dashboard propagated to all
 // ═══════════════════════════════════════════════════════════════════════════
 
-test.concurrent(`${chalk.yellowBright("reset-tier: tier ladder — 4 priced variants retain own price, Dashboard added")}`, async () => {
-	const baseId = readableVariantTestId("rt_ladder");
-	await createBaseWithItems(baseId, [prepaidCreditsItem(10)]);
+test.concurrent(
+	`${chalk.yellowBright("reset-tier: tier ladder — 4 priced variants retain own price, Dashboard added")}`,
+	async () => {
+		const baseId = readableVariantTestId("rt_ladder");
+		await createBaseWithItems(baseId, [prepaidCreditsItem(10)]);
 
-	const variantIds: string[] = [];
-	const prices = [10, 20, 30, 40];
-	for (let i = 0; i < 4; i++) {
-		const vid = `${baseId}_tier_${i + 1}`;
-		await createVariantRpc(baseId, vid, `Tier ${i + 1}`);
-		await autumnRpc.plans.update<ApiPlanV1>(vid, {
-			items: [prepaidCreditsItem(prices[i])],
+		const variantIds: string[] = [];
+		const prices = [10, 20, 30, 40];
+		for (let i = 0; i < 4; i++) {
+			const vid = `${baseId}_tier_${i + 1}`;
+			await createVariantRpc(baseId, vid, `Tier ${i + 1}`);
+			await autumnRpc.plans.update<ApiPlanV1>(vid, {
+				items: [prepaidCreditsItem(prices[i])],
+			});
+			variantIds.push(vid);
+		}
+
+		await autumnRpc.plans.update<ApiPlanV1>(baseId, {
+			items: [prepaidCreditsItem(10), dashboardItem],
+			update_variant_ids: variantIds,
 		});
-		variantIds.push(vid);
-	}
 
-	await autumnRpc.plans.update<ApiPlanV1>(baseId, {
-		items: [prepaidCreditsItem(10), dashboardItem],
-		update_variant_ids: variantIds,
-	});
+		for (let i = 0; i < 4; i++) {
+			const variant = await getPlanRpc(variantIds[i]);
+			const credits = variant.items.find(
+				(it) => it.feature_id === TestFeature.Credits,
+			);
+			const dashboard = variant.items.find(
+				(it) => it.feature_id === TestFeature.Dashboard,
+			);
 
-	for (let i = 0; i < 4; i++) {
-		const variant = await getPlanRpc(variantIds[i]);
-		const credits = variant.items.find((it) => it.feature_id === TestFeature.Credits);
-		const dashboard = variant.items.find((it) => it.feature_id === TestFeature.Dashboard);
+			expect(dashboard).toBeDefined();
+			expect(credits?.price?.amount).toBe(prices[i]);
+		}
 
-		expect(dashboard).toBeDefined();
-		expect(credits?.price?.amount).toBe(prices[i]);
-	}
-
-	await cleanup(baseId, ...variantIds);
-});
+		await cleanup(baseId, ...variantIds);
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════════════
 // 5. 21 variants → too_many_variants (400)
 // ═══════════════════════════════════════════════════════════════════════════
 
-test.concurrent(`${chalk.yellowBright("reset-tier: 21 variants in propagate → too_many_variants")}`, async () => {
-	const baseId = readableVariantTestId("rt_limit_21");
-	await createBaseWithItems(baseId, [creditsItem(100, ResetInterval.Month)]);
+test.concurrent(
+	`${chalk.yellowBright("reset-tier: 21 variants in propagate → too_many_variants")}`,
+	async () => {
+		const baseId = readableVariantTestId("rt_limit_21");
+		await createBaseWithItems(baseId, [creditsItem(100, ResetInterval.Month)]);
 
-	const variantIds: string[] = [];
-	for (let i = 0; i < 21; i++) {
-		const vid = `${baseId}_variant_${i}`;
-		await createVariantRpc(baseId, vid, `V${i}`);
-		variantIds.push(vid);
-	}
+		const variantIds: string[] = [];
+		for (let i = 0; i < 21; i++) {
+			const vid = `${baseId}_variant_${i}`;
+			await createVariantRpc(baseId, vid, `V${i}`);
+			variantIds.push(vid);
+		}
 
-	await expectAutumnError({
-		errCode: "too_many_variants",
-		func: async () => {
-			await autumnRpc.plans.update<ApiPlanV1>(baseId, {
-				items: [creditsItem(200, ResetInterval.Month)],
-				update_variant_ids: variantIds,
-			});
-		},
-	});
+		await expectAutumnError({
+			errCode: "too_many_variants",
+			func: async () => {
+				await autumnRpc.plans.update<ApiPlanV1>(baseId, {
+					items: [creditsItem(200, ResetInterval.Month)],
+					update_variant_ids: variantIds,
+				});
+			},
+		});
 
-	await cleanup(baseId, ...variantIds);
-});
+		await cleanup(baseId, ...variantIds);
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════════════
 // 6. 20 variants succeeds — boundary case
 // ═══════════════════════════════════════════════════════════════════════════
 
-test.concurrent(`${chalk.yellowBright("reset-tier: 20 variants in propagate succeeds (boundary)")}`, async () => {
-	const baseId = readableVariantTestId("rt_limit_20");
-	await createBaseWithItems(baseId, [creditsItem(100, ResetInterval.Month)]);
+test.concurrent(
+	`${chalk.yellowBright("reset-tier: 20 variants in propagate succeeds (boundary)")}`,
+	async () => {
+		const baseId = readableVariantTestId("rt_limit_20");
+		await createBaseWithItems(baseId, [creditsItem(100, ResetInterval.Month)]);
 
-	const variantIds: string[] = [];
-	for (let i = 0; i < 20; i++) {
-		const vid = `${baseId}_variant_${i}`;
-		await createVariantRpc(baseId, vid, `V${i}`);
-		variantIds.push(vid);
-	}
+		const variantIds: string[] = [];
+		for (let i = 0; i < 20; i++) {
+			const vid = `${baseId}_variant_${i}`;
+			await createVariantRpc(baseId, vid, `V${i}`);
+			variantIds.push(vid);
+		}
 
-	await autumnRpc.plans.update<ApiPlanV1>(baseId, {
-		items: [creditsItem(200, ResetInterval.Month)],
-		update_variant_ids: variantIds,
-	});
+		await autumnRpc.plans.update<ApiPlanV1>(baseId, {
+			items: [creditsItem(200, ResetInterval.Month)],
+			update_variant_ids: variantIds,
+		});
 
-	for (const vid of variantIds) {
-		const variant = await getPlanRpc(vid);
-		const credits = variant.items.find((it) => it.feature_id === TestFeature.Credits);
-		expect(credits?.included).toBe(200);
-	}
+		for (const vid of variantIds) {
+			const variant = await getPlanRpc(vid);
+			const credits = variant.items.find(
+				(it) => it.feature_id === TestFeature.Credits,
+			);
+			expect(credits?.included).toBe(200);
+		}
 
-	await cleanup(baseId, ...variantIds);
-});
+		await cleanup(baseId, ...variantIds);
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════════════
 // 7. day-reset survives versioning of both base and variant
 // ═══════════════════════════════════════════════════════════════════════════
 
-test.concurrent(`${chalk.yellowBright("reset-tier: day-reset survives versioning of both base and variant")}`, async () => {
-	const customerId = readableVariantTestId("rt_version_day");
-	const cust2 = readableVariantTestId("rt_version_day_c2");
-	const prefixedBaseId = `base_${customerId}`;
-	const variantId = `${prefixedBaseId}_variant`;
-	await deleteVariantTestCustomers({
-		client: autumnV1_2,
-		customerIds: [customerId, cust2],
-	});
-	await cleanup(variantId, prefixedBaseId);
+test.concurrent(
+	`${chalk.yellowBright("reset-tier: day-reset survives versioning of both base and variant")}`,
+	async () => {
+		const customerId = readableVariantTestId("rt_version_day");
+		const cust2 = readableVariantTestId("rt_version_day_c2");
+		const prefixedBaseId = `base_${customerId}`;
+		const variantId = `${prefixedBaseId}_variant`;
+		await deleteVariantTestCustomers({
+			client: autumnV1_2,
+			customerIds: [customerId, cust2],
+		});
+		await cleanup(variantId, prefixedBaseId);
 
-	const baseProd = products.base({
-		id: "base",
-		items: [
-			items.monthlyCredits({ includedUsage: 100 }),
-			{
-				feature_id: TestFeature.Credits,
-				included_usage: 50,
-				interval: ProductItemInterval.Day,
-				interval_count: 1,
-			} as any,
-		],
-	});
+		const baseProd = products.base({
+			id: "base",
+			items: [
+				items.monthlyCredits({ includedUsage: 100 }),
+				{
+					feature_id: TestFeature.Credits,
+					included_usage: 50,
+					interval: ProductItemInterval.Day,
+					interval_count: 1,
+				} as any,
+			],
+		});
 
-	const { autumnV1 } = await initScenario({
-		customerId,
-		setup: [
-			s.customer({ testClock: false }),
-			s.products({ list: [baseProd] }),
-		],
-		actions: [s.attach({ productId: "base" })],
-	});
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [baseProd] }),
+			],
+			actions: [s.attach({ productId: "base" })],
+		});
 
-	await createVariantRpc(prefixedBaseId, variantId, "Variant Versioned");
+		await createVariantRpc(prefixedBaseId, variantId, "Variant Versioned");
 
-	await autumnV1_2.createCustomer({ id: cust2, email: `${cust2}@test.com`, name: "C2" });
-	await autumnV1_2.attach({ customer_id: cust2, product_id: variantId } as any);
+		await autumnV1_2.createCustomer({
+			id: cust2,
+			email: `${cust2}@test.com`,
+			name: "C2",
+		});
+		await autumnV1_2.attach({
+			customer_id: cust2,
+			product_id: variantId,
+		} as any);
 
-	await autumnRpc.plans.update<ApiPlanV1>(prefixedBaseId, {
-		items: [
-			creditsItem(100, ResetInterval.Month),
-			creditsItem(300, ResetInterval.Day),
-		],
-		update_variant_ids: [variantId],
-	});
+		await autumnRpc.plans.update<ApiPlanV1>(prefixedBaseId, {
+			items: [
+				creditsItem(100, ResetInterval.Month),
+				creditsItem(300, ResetInterval.Day),
+			],
+			update_variant_ids: [variantId],
+		});
 
-	const baseAfter = await ProductService.getFull({ db, idOrInternalId: prefixedBaseId, orgId: org.id, env });
-	const variantAfter = await ProductService.getFull({ db, idOrInternalId: variantId, orgId: org.id, env });
+		const baseAfter = await ProductService.getFull({
+			db,
+			idOrInternalId: prefixedBaseId,
+			orgId: org.id,
+			env,
+		});
+		const variantAfter = await ProductService.getFull({
+			db,
+			idOrInternalId: variantId,
+			orgId: org.id,
+			env,
+		});
 
-	expect(baseAfter.version).toBe(2);
-	expect(variantAfter.version).toBe(2);
+		expect(baseAfter.version).toBe(2);
+		expect(variantAfter.version).toBe(2);
 
-	const basePlan = await getPlanRpc(prefixedBaseId);
-	const variantPlan = await getPlanRpc(variantId);
+		const basePlan = await getPlanRpc(prefixedBaseId);
+		const variantPlan = await getPlanRpc(variantId);
 
-	for (const plan of [basePlan, variantPlan]) {
-		const creditsItems = plan.items.filter((i) => i.feature_id === TestFeature.Credits);
-		expect(creditsItems.length).toBe(2);
-		const dayItem = creditsItems.find((i) => i.reset?.interval === ResetInterval.Day);
-		const monthItem = creditsItems.find((i) => i.reset?.interval === ResetInterval.Month);
-		expect(dayItem).toBeDefined();
-		expect(dayItem!.included).toBe(300);
-		expect(monthItem).toBeDefined();
-		expect(monthItem!.included).toBe(100);
-	}
+		for (const plan of [basePlan, variantPlan]) {
+			const creditsItems = plan.items.filter(
+				(i) => i.feature_id === TestFeature.Credits,
+			);
+			expect(creditsItems.length).toBe(2);
+			const dayItem = creditsItems.find(
+				(i) => i.reset?.interval === ResetInterval.Day,
+			);
+			const monthItem = creditsItems.find(
+				(i) => i.reset?.interval === ResetInterval.Month,
+			);
+			expect(dayItem).toBeDefined();
+			expect(dayItem!.included).toBe(300);
+			expect(monthItem).toBeDefined();
+			expect(monthItem!.included).toBe(100);
+		}
 
-	await cleanup(prefixedBaseId, variantId);
-});
+		await cleanup(prefixedBaseId, variantId);
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════════════
 // 8. hour-reset propagates — filter uses interval: "hour"
 // ═══════════════════════════════════════════════════════════════════════════
 
-test.concurrent(`${chalk.yellowBright("reset-tier: hour-reset propagates to variant")}`, async () => {
-	const baseId = readableVariantTestId("rt_hour");
-	const variantId = `${baseId}_variant`;
-	await createBaseWithItems(baseId, [
-		creditsItem(50, ResetInterval.Hour),
-	]);
+test.concurrent(
+	`${chalk.yellowBright("reset-tier: hour-reset propagates to variant")}`,
+	async () => {
+		const baseId = readableVariantTestId("rt_hour");
+		const variantId = `${baseId}_variant`;
+		await createBaseWithItems(baseId, [creditsItem(50, ResetInterval.Hour)]);
 
-	const preview = await previewUpdateRpc(baseId, {
-		items: [creditsItem(200, ResetInterval.Hour)],
-	});
+		const preview = await previewUpdateRpc(baseId, {
+			items: [creditsItem(200, ResetInterval.Hour)],
+		});
 
-	expectPreviewItemChangeCorrect({
-		preview,
-		action: "deleted",
-		featureId: TestFeature.Credits,
-		item: { reset: { interval: ResetInterval.Hour } },
-	});
+		expectPreviewItemChangeCorrect({
+			preview,
+			action: "deleted",
+			featureId: TestFeature.Credits,
+			item: { reset: { interval: ResetInterval.Hour } },
+		});
 
-	await createVariantRpc(baseId, variantId, "Variant Hour");
+		await createVariantRpc(baseId, variantId, "Variant Hour");
 
-	await autumnRpc.plans.update<ApiPlanV1>(baseId, {
-		items: [creditsItem(200, ResetInterval.Hour)],
-		update_variant_ids: [variantId],
-	});
+		await autumnRpc.plans.update<ApiPlanV1>(baseId, {
+			items: [creditsItem(200, ResetInterval.Hour)],
+			update_variant_ids: [variantId],
+		});
 
-	const variant = await getPlanRpc(variantId);
-	const hourItem = variant.items.find(
-		(i) => i.feature_id === TestFeature.Credits && i.reset?.interval === ResetInterval.Hour,
-	);
-	expect(hourItem).toBeDefined();
-	expect(hourItem!.included).toBe(200);
+		const variant = await getPlanRpc(variantId);
+		const hourItem = variant.items.find(
+			(i) =>
+				i.feature_id === TestFeature.Credits &&
+				i.reset?.interval === ResetInterval.Hour,
+		);
+		expect(hourItem).toBeDefined();
+		expect(hourItem!.included).toBe(200);
 
-	await cleanup(baseId, variantId);
-});
+		await cleanup(baseId, variantId);
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════════════
 // 9. Stripe price reuse on tier-ladder version-up — variant v2 retains stripe_price_id
 // ═══════════════════════════════════════════════════════════════════════════
 
-test.concurrent(`${chalk.yellowBright("reset-tier: Stripe price_id retained on variant version-up")}`, async () => {
-	const baseId = readableVariantTestId("rt_stripe_price");
-	const variantId = `${baseId}_variant`;
-	await createBaseWithItems(baseId, [prepaidCreditsItem(10)]);
-	await createVariantRpc(baseId, variantId, "Variant Stripe");
+test.concurrent(
+	`${chalk.yellowBright("reset-tier: Stripe price_id retained on variant version-up")}`,
+	async () => {
+		const baseId = readableVariantTestId("rt_stripe_price");
+		const variantId = `${baseId}_variant`;
+		await createBaseWithItems(baseId, [prepaidCreditsItem(10)]);
+		await createVariantRpc(baseId, variantId, "Variant Stripe");
 
-	const v1 = await ProductService.getFull({ db, idOrInternalId: variantId, orgId: org.id, env });
-	const v1Price = v1.prices.find(
-		(p: any) => p.config?.feature_id === TestFeature.Credits && p.config?.stripe_price_id,
-	);
-	expect(v1Price).toBeDefined();
-	const v1StripeId = (v1Price as any)?.config?.stripe_price_id;
-	expect(v1StripeId).toBeTruthy();
+		const v1 = await ProductService.getFull({
+			db,
+			idOrInternalId: variantId,
+			orgId: org.id,
+			env,
+		});
+		const v1Price = v1.prices.find(
+			(p: any) =>
+				p.config?.feature_id === TestFeature.Credits &&
+				p.config?.stripe_price_id,
+		);
+		expect(v1Price).toBeDefined();
+		const v1StripeId = (v1Price as any)?.config?.stripe_price_id;
+		expect(v1StripeId).toBeTruthy();
 
-	await autumnRpc.plans.update<ApiPlanV1>(baseId, {
-		items: [prepaidCreditsItem(10), dashboardItem],
-		update_variant_ids: [variantId],
-		force_version: true,
-	} as any);
+		await autumnRpc.plans.update<ApiPlanV1>(baseId, {
+			items: [prepaidCreditsItem(10), dashboardItem],
+			update_variant_ids: [variantId],
+			force_version: true,
+		} as any);
 
-	const v2 = await ProductService.getFull({ db, idOrInternalId: variantId, orgId: org.id, env });
-	expect(v2.version).toBe(2);
+		const v2 = await ProductService.getFull({
+			db,
+			idOrInternalId: variantId,
+			orgId: org.id,
+			env,
+		});
+		expect(v2.version).toBe(2);
 
-	const v2Price = v2.prices.find(
-		(p: any) => p.config?.feature_id === TestFeature.Credits && p.config?.stripe_price_id,
-	);
-	expect(v2Price).toBeDefined();
-	expect((v2Price as any)?.config?.stripe_price_id).toBe(v1StripeId);
+		const v2Price = v2.prices.find(
+			(p: any) =>
+				p.config?.feature_id === TestFeature.Credits &&
+				p.config?.stripe_price_id,
+		);
+		expect(v2Price).toBeDefined();
+		expect((v2Price as any)?.config?.stripe_price_id).toBe(v1StripeId);
 
-	await cleanup(baseId, variantId);
-});
+		await cleanup(baseId, variantId);
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════════════
 // 10. create_variant rejects archived source — 400 cannot_fork_archived_base
 // ═══════════════════════════════════════════════════════════════════════════
 
-test.concurrent(`${chalk.yellowBright("reset-tier: create_variant rejects archived base → cannot_fork_archived_base")}`, async () => {
-	const baseId = readableVariantTestId("rt_archived_err");
-	const variantId = `${baseId}_variant`;
-	await createBaseWithItems(baseId, [creditsItem(100, ResetInterval.Month)]);
+test.concurrent(
+	`${chalk.yellowBright("reset-tier: create_variant rejects archived base → cannot_fork_archived_base")}`,
+	async () => {
+		const baseId = readableVariantTestId("rt_archived_err");
+		const variantId = `${baseId}_variant`;
+		await createBaseWithItems(baseId, [creditsItem(100, ResetInterval.Month)]);
 
-	await autumnRpc.plans.update<ApiPlanV1>(baseId, { archived: true });
+		await autumnRpc.plans.update<ApiPlanV1>(baseId, { archived: true });
 
-	await expectAutumnError({
-		errCode: "cannot_fork_archived_base",
-		func: async () => {
-			await createVariantRpc(baseId, variantId, "Variant Archived");
-		},
-	});
+		await expectAutumnError({
+			errCode: "cannot_fork_archived_base",
+			func: async () => {
+				await createVariantRpc(baseId, variantId, "Variant Archived");
+			},
+		});
 
-	await cleanup(baseId);
-});
+		await cleanup(baseId);
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════════════
 // 11. create_variant rejects id collision — 409 product_id_already_exists
 // ═══════════════════════════════════════════════════════════════════════════
 
-test.concurrent(`${chalk.yellowBright("reset-tier: create_variant rejects id collision → product_id_already_exists")}`, async () => {
-	const baseId = readableVariantTestId("rt_collision_err");
-	await createBaseWithItems(baseId, [creditsItem(100, ResetInterval.Month)]);
+test.concurrent(
+	`${chalk.yellowBright("reset-tier: create_variant rejects id collision → product_id_already_exists")}`,
+	async () => {
+		const baseId = readableVariantTestId("rt_collision_err");
+		await createBaseWithItems(baseId, [creditsItem(100, ResetInterval.Month)]);
 
-	await expectAutumnError({
-		errCode: "product_id_already_exists",
-		func: async () => {
-			await createVariantRpc(baseId, baseId, "Self Collision", false);
-		},
-	});
+		await expectAutumnError({
+			errCode: "product_id_already_exists",
+			func: async () => {
+				await createVariantRpc(baseId, baseId, "Self Collision", false);
+			},
+		});
 
-	await cleanup(baseId);
-});
+		await cleanup(baseId);
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════════════
-// 12. preview_update rejects variant id — 400 cannot_preview_on_variant
+// 12. preview_update supported on variant id
+// (the cannot_preview_on_variant guard was removed when variant previews
+// shipped — previews on a variant now resolve normally)
 // ═══════════════════════════════════════════════════════════════════════════
 
-test.concurrent(`${chalk.yellowBright("reset-tier: preview_update rejects variant id → cannot_preview_on_variant")}`, async () => {
-	const baseId = readableVariantTestId("rt_preview_variant_err");
-	const variantId = `${baseId}_variant`;
-	await createBaseWithItems(baseId, [creditsItem(100, ResetInterval.Month)]);
-	await createVariantRpc(baseId, variantId, "Variant Preview");
+test.concurrent(
+	`${chalk.yellowBright("reset-tier: preview_update on variant id previews its own changes")}`,
+	async () => {
+		const baseId = readableVariantTestId("rt_preview_variant_ok");
+		const variantId = `${baseId}_variant`;
+		await createBaseWithItems(baseId, [creditsItem(100, ResetInterval.Month)]);
+		await createVariantRpc(baseId, variantId, "Variant Preview");
 
-	await expectAutumnError({
-		errCode: "cannot_preview_on_variant",
-		func: async () => {
-			await previewUpdateRpc(variantId, {
-				items: [creditsItem(200, ResetInterval.Month)],
-			});
-		},
-	});
+		// Customer-less variant patches in place.
+		const preview = await previewUpdateRpc(variantId, {
+			items: [creditsItem(200, ResetInterval.Month)],
+		});
+		expect(preview.versionable).toBe(false);
 
-	await cleanup(baseId, variantId);
-});
+		await cleanup(baseId, variantId);
+	},
+);

--- a/server/tests/integration/licenses/catalog-update/license-sandbox-copy.test.ts
+++ b/server/tests/integration/licenses/catalog-update/license-sandbox-copy.test.ts
@@ -283,9 +283,10 @@ describe("sandboxes.copy: copy plans + features between two sandbox sub-orgs", (
 
 		const links = copied!.licenses ?? [];
 		expect(links).toHaveLength(1);
+		// DB plan licenses carry internal ids; the public id is on the product.
 		expect(links[0]).toMatchObject({
-			license_plan_id: LICENSE_ID,
 			included: 3,
+			product: expect.objectContaining({ id: LICENSE_ID }),
 		});
 		const [storedLink] =
 			await planLicenseRepo.listCatalogByParentInternalProductIds({

--- a/server/tests/utils/cusProductUtils/resetTestUtils.ts
+++ b/server/tests/utils/cusProductUtils/resetTestUtils.ts
@@ -3,7 +3,6 @@ import {
 	cusProductsToCusEnts,
 	customerEntitlements,
 	type FullCustomer,
-	fullCustomerToCustomerEntitlements,
 } from "@autumn/shared";
 import { findCustomerEntitlement } from "@tests/balances/utils/findCustomerEntitlement.js";
 import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";

--- a/server/tests/utils/cusProductUtils/resetTestUtils.ts
+++ b/server/tests/utils/cusProductUtils/resetTestUtils.ts
@@ -1,4 +1,6 @@
 import {
+	CusProductStatus,
+	cusProductsToCusEnts,
 	customerEntitlements,
 	type FullCustomer,
 	fullCustomerToCustomerEntitlements,
@@ -213,9 +215,12 @@ export const expireAllCusEntsForReset = async ({
 		idOrInternalId: customerId,
 	});
 
-	const cusEnts = fullCustomerToCustomerEntitlements({
-		fullCustomer,
-		featureId,
+	// cusProductsToCusEnts skips the entity scoping filter — "ALL" here
+	// includes entity-scoped products' entitlements.
+	const cusEnts = cusProductsToCusEnts({
+		cusProducts: fullCustomer.customer_products,
+		featureIds: [featureId],
+		inStatuses: [CusProductStatus.Active, CusProductStatus.PastDue],
 	});
 
 	if (cusEnts.length === 0) {

--- a/shared/models/billingModels/context/customerLicenseBillingContext.ts
+++ b/shared/models/billingModels/context/customerLicenseBillingContext.ts
@@ -1,8 +1,7 @@
 import type { LicenseBillingPriceRow } from "../licenseBillingPriceRow.js";
 
-/** License billing state loaded once at setup (the facts that cost a DB
- * read); computes stay pure. Grows a sibling field per future fact.
- * JSON-safe only — deferred billing plans persist this to metadata JSONB. */
+/** License billing state loaded once; JSON-safe because deferred plans persist
+ * this context to metadata JSONB. */
 export type CustomerLicenseBillingContext = {
 	// Assigned seats' snapshot charges as (price × count), the free
 	// `included` seats already excluded.

--- a/shared/models/billingModels/context/customerLicenseBillingContext.ts
+++ b/shared/models/billingModels/context/customerLicenseBillingContext.ts
@@ -1,11 +1,12 @@
 import type { LicenseBillingPriceRow } from "../licenseBillingPriceRow.js";
 
 /** License billing state loaded once at setup (the facts that cost a DB
- * read); computes stay pure. Grows a sibling field per future fact. */
+ * read); computes stay pure. Grows a sibling field per future fact.
+ * JSON-safe only — deferred billing plans persist this to metadata JSONB. */
 export type CustomerLicenseBillingContext = {
 	// Assigned seats' snapshot charges as (price × count), the free
 	// `included` seats already excluded.
 	licenseBillingPriceRows: LicenseBillingPriceRow[];
-	assignedSeatCountByCustomerLicenseId: Map<string, number>;
-	projectedPlanLicenseIds: Set<string>;
+	assignedSeatCountByCustomerLicenseId: Record<string, number>;
+	projectedPlanLicenseIds: string[];
 };


### PR DESCRIPTION
## Summary

- restore the full dangling integration-fix commit, including the related changes that were no longer reachable from a branch
- serialize license billing context with plain records and arrays instead of Map and Set so deferred checkout JSONB round-trips preserve projected license IDs and assigned-seat counts
- retain the recovered sandbox Stripe guard, deleted-org and deleted-feature race handling, product-copy cache bypass, split events DB test lookup, and associated integration assertions

## Incident context

The production deployment contained the affected code path. The observed projectedPlanLicenseIds.has crash occurred once in a sandbox organization; no live-mode occurrences were found during the incident check.

## Verification

- bun -F @autumn/server ts
- focused Biome checks for the license billing hotfix files
- targeted stripe-checkout-license-quantity integration test was attempted, but the local test server was unavailable at localhost:8080, so the test stopped at setup with ConnectionRefused before reaching assertions

## Recovery provenance

Recovered dangling commit: b4331e347286393a4d3f5c62ab74036486fa8bf3
Applied hotfix commit: b140fed1c

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore JSON‑safe license billing context to stop sandbox checkout crashes and preserve projected license IDs and seat counts across JSONB round‑trips. Also reinstate missing guards and fixes around Stripe setup, deleted org/feature races, and product copy reads.

- **Bug Fixes**
  - Make customer license billing context JSON‑safe: Map/Set → plain objects/arrays. Update callers to use index access and `includes`/`push`; fix row resolution to use `includes`. Prevents the `projectedPlanLicenseIds.has` crash after JSON persistence.
  - Stripe: skip product resource initialization when no Stripe account is connected (e.g. fresh sandbox sub‑orgs) via `isStripeConnected`.
  - Queue worker: if the org was deleted after queuing, log a warning and skip the job instead of throwing.
  - Features: handle read→update races by returning null when no row was updated; clear cache only when an update happened.
  - Product copy: bypass the products cache by using `inIds` to reliably read copied products immediately after copy.
  - Tests/infra: read events from the split Neon events DB when configured; enable variant preview_update; update prepaid and variant tests (tier bounds, expectations, negative balances on zero‑quantity prepaid, license copy asserts).

<sup>Written for commit cacdd9cccfe971d98ecfef18755a39d41664077b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This hotfix restores a dangling integration commit and patches a production crash (`projectedPlanLicenseIds.has` TypeError) caused by `Map` and `Set` instances not surviving a JSONB round-trip in deferred checkout metadata.

- **[Bug fixes]** `CustomerLicenseBillingContext` fields changed from `Map`/`Set` to plain `Record`/`string[]` so the struct serialises cleanly to JSONB; all call-sites updated (`setupCustomerLicenseBillingContext`, `applyCustomerLicenseTransitions`, `resolveLicenseBillingRowsThroughDefinition`, and the two line-item helpers).
- **[Bug fixes]** `FeatureService.update` now returns `null` early when the DB update matches zero rows, preventing a crash when a feature is deleted between read and update; `createWorkerContext` logs a warning and skips gracefully when a queued job's org no longer exists; `initStripeResourcesForProducts` adds an `isStripeConnected` guard for fresh sandbox sub-orgs.
- **[Bug fixes]** `handleCopyProducts` passes `inIds` to the post-copy `listFull` call to bypass a stale cache snapshot; test event reads are routed through a new `eventsDb()` helper that mirrors the server's split-DB resolution.
</details>

<h3>Confidence Score: 4/5</h3>

The core billing fix is correct and well-scoped; the worker context change introduces a silent failure risk on transient DB errors.

The Map/Set → Record/array migration is consistent across all call-sites and the type definition, and the FeatureService race fix is straightforward. The one concern is in createWorkerContext.ts: the bare try/catch wrapping OrgService.getWithFeatures will absorb transient database errors as if the org were deleted, causing queued jobs to be silently skipped instead of retried. OrgService already exposes an allowNotFound option that would scope the graceful-skip to the not-found case only while letting real errors propagate.

server/src/queue/createWorkerContext.ts — the bare catch block should be replaced with the allowNotFound option on OrgService.getWithFeatures

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/models/billingModels/context/customerLicenseBillingContext.ts | Type definition updated from Map/Set to Record/string[] to make the struct JSON-safe for JSONB persistence; the change is the anchor for the entire hotfix |
| server/src/internal/billing/v2/setup/customerLicenseBillingContext/setupCustomerLicenseBillingContext.ts | Construction updated to use Object.fromEntries and [] instead of new Map/new Set, matching the updated type; logic is unchanged |
| server/src/internal/billing/v2/compute/customerLicenseTransitions/applyCustomerLicenseTransitions.ts | Switched from Set.add to array push with an includes-based dedup guard; semantics preserved, Map.get replaced with object index access |
| server/src/internal/billing/v2/utils/lineItems/resolveLicenseBillingRowsThroughDefinition.ts | Type updated from Set to string[], Set.has replaced with Array.includes; import style cleaned up to use type import |
| server/src/queue/createWorkerContext.ts | Deleted-org race condition now handled gracefully, but the bare try/catch swallows all exceptions including transient DB errors, risking silent job loss on infrastructure failures |
| server/src/internal/features/FeatureService.ts | Early return added before clearOrgCache when updatedFeatures is empty, fixing a latent crash (accessing index 0 of empty array) when a feature is deleted between read and update |
| server/src/internal/products/handlers/handleCopyEnvironment/handleCopyProducts.ts | inIds added to the post-copy ProductService.listFull call to bypass the cache and avoid reading a stale pre-copy snapshot |
| server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts | Added isStripeConnected guard to skip Stripe resource initialisation for fresh sandbox sub-orgs that have no Stripe account yet |
| server/tests/integration/balances/utils/events/getCustomerEvents.ts | Extracted eventsDb helper that resolves to the split Neon events DB when configured, so test assertions read from the same DB the server wrote to |
| server/tests/integration/licenses/catalog-update/license-sandbox-copy.test.ts | New integration test for sandbox copy of plan license links; directly exercises the action layer without a dev server |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Deferred checkout triggered] --> B[setupCustomerLicenseBillingContext]
    B --> C["Build context with\nRecord<string,number> + string[]"]
    C --> D[Persist context to JSONB metadata]
    D --> E[JSONB round-trip preserves plain objects]
    E --> F[applyCustomerLicenseTransitions]
    F --> G["projectedPlanLicenseIds.push + includes dedup"]
    G --> H[resolveLicenseBillingRowsThroughDefinition]
    H --> I["includes check → select projected or persisted rows"]
    I --> J[customerLicenseToLineItems / ToStripeItemSpecs]
    J --> K[Correct seat counts billed]

    style D fill:#f9f,stroke:#333
    style E fill:#f9f,stroke:#333
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Deferred checkout triggered] --> B[setupCustomerLicenseBillingContext]
    B --> C["Build context with\nRecord<string,number> + string[]"]
    C --> D[Persist context to JSONB metadata]
    D --> E[JSONB round-trip preserves plain objects]
    E --> F[applyCustomerLicenseTransitions]
    F --> G["projectedPlanLicenseIds.push + includes dedup"]
    G --> H[resolveLicenseBillingRowsThroughDefinition]
    H --> I["includes check → select projected or persisted rows"]
    I --> J[customerLicenseToLineItems / ToStripeItemSpecs]
    J --> K[Correct seat counts billed]

    style D fill:#f9f,stroke:#333
    style E fill:#f9f,stroke:#333
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/queue/createWorkerContext.ts:34-38
**Bare catch swallows transient DB errors**

The bare `try/catch` around `OrgService.getWithFeatures` treats every thrown exception — including database connection timeouts, network errors, or Drizzle query failures — identically to a deleted-org `RecaseError`. When a transient error fires, `orgData` is set to `null`, the job logs a warning, and returns silently. The queue never sees the error, so the job is not retried and the work is permanently dropped.

`OrgService.getWithFeatures` already has an `allowNotFound: true` option that returns `null` specifically for the not-found case while letting real errors propagate. Using that option keeps the intended graceful-skip behaviour for deleted orgs without silently discarding jobs on infrastructure failures.

```suggestion
	// Fetch org with features once for all items. A missing org means it was
	// deleted after the job was queued (common in tests) — skip, don't fail.
	const orgData = await OrgService.getWithFeatures({
		db,
		orgId,
		env,
		allowNotFound: true,
	});
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(billing): 🤖 clean recovered hotfi..."](https://github.com/useautumn/autumn/commit/cacdd9cccfe971d98ecfef18755a39d41664077b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45674154)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->