### PR TITLE
fix(vite): restore admin hover without Option key

### DIFF
--- a/vite/src/components/general/AdminHover.tsx
+++ b/vite/src/components/general/AdminHover.tsx
@@ -1,51 +1,9 @@
 import { PreviewCard } from "@base-ui/react/preview-card";
 import { Check, Copy } from "lucide-react";
 import type React from "react";
-import { forwardRef, useState, useSyncExternalStore } from "react";
+import { forwardRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { useAdmin } from "@/views/admin/hooks/useAdmin";
-
-let isOptionKeyPressed = false;
-const optionKeyListeners = new Set<() => void>();
-
-const setOptionKeyPressed = (pressed: boolean) => {
-	if (pressed === isOptionKeyPressed) return;
-	isOptionKeyPressed = pressed;
-	for (const listener of optionKeyListeners) listener();
-};
-
-const syncOptionKeyPressed = (event: KeyboardEvent) => {
-	setOptionKeyPressed(event.altKey);
-};
-
-const resetOptionKeyPressed = () => setOptionKeyPressed(false);
-
-const subscribeToOptionKey = (listener: () => void) => {
-	optionKeyListeners.add(listener);
-	if (optionKeyListeners.size === 1 && typeof window !== "undefined") {
-		// Observe modifier state without cancelling or changing keyboard events.
-		window.addEventListener("keydown", syncOptionKeyPressed);
-		window.addEventListener("keyup", syncOptionKeyPressed);
-		window.addEventListener("blur", resetOptionKeyPressed);
-	}
-
-	return () => {
-		optionKeyListeners.delete(listener);
-		if (optionKeyListeners.size === 0 && typeof window !== "undefined") {
-			window.removeEventListener("keydown", syncOptionKeyPressed);
-			window.removeEventListener("keyup", syncOptionKeyPressed);
-			window.removeEventListener("blur", resetOptionKeyPressed);
-			resetOptionKeyPressed();
-		}
-	};
-};
-
-const useOptionKeyPressed = () =>
-	useSyncExternalStore(
-		subscribeToOptionKey,
-		() => isOptionKeyPressed,
-		() => false,
-	);
 
 export const AdminHover = forwardRef<
 	HTMLElement,
@@ -63,11 +21,8 @@ export const AdminHover = forwardRef<
 		_ref,
 	) => {
 		const { isAdmin, skipHover } = useAdmin();
-		const optionKeyPressed = useOptionKeyPressed();
 
-		if (!isAdmin || hide || skipHover || !optionKeyPressed) {
-			return <>{children}</>;
-		}
+		if (!isAdmin || hide || skipHover) return <>{children}</>;
 
 		return (
 			<PreviewCard.Root>


### PR DESCRIPTION
## Summary

- remove the global Option-key state and keyboard listeners from AdminHover
- restore admin preview cards on normal hover
- preserve the existing admin, hide, and skip-hover guards

## Verification

- bun -F @autumn/vite ts
- bunx biome check vite/src/components/general/AdminHover.tsx
- bunx react-doctor@latest --verbose --scope changed --base origin/main (89/100, no issues)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores admin preview cards to show on normal hover by removing the Option-key requirement and related global keyboard listeners. Keeps the existing admin, hide, and skip-hover guards intact.

<sup>Written for commit c12d330c7da24dd1acca43a4edbe329b36da339c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the Option/Alt-key requirement that was gating admin preview cards, restoring them to appear on normal hover. The change eliminates ~40 lines of global keyboard-listener infrastructure while preserving the `isAdmin`, `hide`, and `skipHover` guards.

- **[Bug fixes]** Drops the `useOptionKeyPressed` store and all associated `window` event listeners (`keydown`, `keyup`, `blur`) so the module no longer accumulates global state
- **[Bug fixes]** Simplifies the early-return guard from `!isAdmin || hide || skipHover || !optionKeyPressed` to `!isAdmin || hide || skipHover`, restoring hover-triggered preview cards for admin users
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a focused removal of the Option-key guard with no regressions to the admin/hide/skipHover checks.

The diff is a pure deletion of ~40 lines of global keyboard-listener infrastructure. All three existing access guards remain intact and the component's rendering logic is otherwise unchanged.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/general/AdminHover.tsx | Removes Option-key gating and cleans up ~40 lines of global keyboard listener state; guards preserved correctly |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AdminHover renders] --> B{isAdmin?}
    B -- No --> C[Return children only]
    B -- Yes --> D{hide?}
    D -- Yes --> C
    D -- No --> E{skipHover?}
    E -- Yes --> C
    E -- No --> F[Render PreviewCard with hover trigger]

    style F fill:#d4edda,stroke:#28a745
    style C fill:#f8d7da,stroke:#dc3545
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[AdminHover renders] --> B{isAdmin?}
    B -- No --> C[Return children only]
    B -- Yes --> D{hide?}
    D -- Yes --> C
    D -- No --> E{skipHover?}
    E -- Yes --> C
    E -- No --> F[Render PreviewCard with hover trigger]

    style F fill:#d4edda,stroke:#28a745
    style C fill:#f8d7da,stroke:#dc3545
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into hotfix/admin-ho..."](https://github.com/useautumn/autumn/commit/0354a8c009a19f030f90458e8c4bac8c73f5e5e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45679631)</sub>

<!-- /greptile_comment -->