### PR TITLE
fix: keep catalog push alive when deletion checks fail

### DIFF
--- a/packages/atmn/src/commands/push/push.ts
+++ b/packages/atmn/src/commands/push/push.ts
@@ -179,9 +179,19 @@ export async function checkFeatureDeleteInfo(
 	}
 
 	// Check API for product references
-	const response = await getFeatureDeletionInfo({ secretKey, featureId });
+	let response;
+	try {
+		response = await getFeatureDeletionInfo({ secretKey, featureId });
+	} catch {
+		return {
+			id: featureId,
+			canDelete: false,
+			reason: "deletion_check_failed",
+			featureType,
+		};
+	}
 
-	if (response && response.totalCount > 0) {
+		if (response && response.totalCount > 0) {
 		return {
 			id: featureId,
 			canDelete: false,
@@ -204,22 +214,27 @@ export async function checkFeatureDeleteInfo(
 // Check if a plan can be deleted
 async function checkPlanDeleteInfo(planId: string): Promise<PlanDeleteInfo> {
 	const secretKey = getSecretKey();
-	const response = await getPlanDeletionInfo({ secretKey, planId });
+	try {
+		const response = await getPlanDeletionInfo({ secretKey, planId });
 
-	if (response && response.totalCount > 0) {
+ 		if (response && response.totalCount > 0) {
+			return {
+				id: planId,
+				canDelete: false,
+				customerCount: response.totalCount,
+				firstCustomerName: response.customerName,
+			};
+		}
+
+		return { id: planId, canDelete: true, customerCount: 0 };
+	} catch {
 		return {
 			id: planId,
 			canDelete: false,
-			customerCount: response.totalCount,
-			firstCustomerName: response.customerName,
+			customerCount: 0,
+			deletionCheckFailed: true,
 		};
 	}
-
-	return {
-		id: planId,
-		canDelete: true,
-		customerCount: 0,
-	};
 }
 
 // Check if updating a plan will create a new version
@@ -572,6 +587,8 @@ function normalizePlanForCompare(
 			version:
 				license.version ?? licenseVersionFallbacks?.get(license.licensePlanId),
 			included: license.included ?? 0,
+			prepaidOnly: license.prepaidOnly ?? true,
+			customize: license.customize,
 		}));
 
 	return result;
@@ -644,6 +661,12 @@ function toApiCustomizePlan(customize: CustomizePlan): Record<string, unknown> {
 								...(customize.price.intervalCount !== undefined
 									? { interval_count: customize.price.intervalCount }
 									: {}),
+								...(customize.price.additionalCurrencies
+									? {
+											additional_currencies:
+												customize.price.additionalCurrencies,
+										}
+									: {}),
 							}
 						: null,
 				}
@@ -668,6 +691,15 @@ function toApiCustomizePlan(customize: CustomizePlan): Record<string, unknown> {
 						: null,
 				}
 			: {}),
+		...(customize.upsertLicenses !== undefined
+			? {
+					upsert_licenses: transformPlanToApi({
+						id: "license-customize",
+						name: "License customize",
+						licenses: customize.upsertLicenses,
+					}).licenses,
+				}
+			: {}),
 	};
 }
 
@@ -678,6 +710,7 @@ function toCatalogVariantParams(
 ): Record<string, unknown> {
 	return {
 		variant_plan_id: variant.id,
+		...(variant.version !== undefined ? { version: variant.version } : {}),
 		name: variant.name,
 		customize: toApiCustomizePlan(variant.customize ?? {}),
 		...(intent === "create_version" ? { force_version: true } : {}),

--- a/packages/atmn/src/commands/push/types.ts
+++ b/packages/atmn/src/commands/push/types.ts
@@ -8,7 +8,7 @@ import type { Feature, Plan } from "../../compose/models/index.js";
 export interface FeatureDeleteInfo {
 	id: string;
 	canDelete: boolean;
-	reason?: "credit_system" | "products";
+	reason?: "credit_system" | "products" | "deletion_check_failed";
 	referencingCreditSystems?: string[]; // IDs of credit systems using this feature
 	referencingProducts?: { name: string; count: number };
 	featureType?: "boolean" | "metered" | "credit_system"; // For sorting (delete credit systems first)
@@ -20,6 +20,7 @@ export interface PlanDeleteInfo {
 	canDelete: boolean;
 	customerCount: number;
 	firstCustomerName?: string;
+	deletionCheckFailed?: boolean;
 }
 
 // Plan update info

--- a/server/src/internal/billing/v2/actions/sync/subscriptionToSyncParams.ts
+++ b/server/src/internal/billing/v2/actions/sync/subscriptionToSyncParams.ts
@@ -43,6 +43,7 @@ const matchedPlanToSyncPlan = ({
 		: matchedPlan.customize;
 	return {
 		plan_id: matchedPlan.product.id,
+		version: matchedPlan.product.version,
 		quantity: matchedPlan.quantity,
 		customize,
 		expire_previous: true,

--- a/server/src/internal/catalog/actions/catalogPlanDependencies.ts
+++ b/server/src/internal/catalog/actions/catalogPlanDependencies.ts
@@ -8,6 +8,8 @@ import {
 const referenceKey = (id: string, version?: number) =>
 	version === undefined ? id : `${id}@${version}`;
 
+const targetId = (plan: CatalogPlanParams) => plan.new_plan_id ?? plan.plan_id;
+
 const dependenciesForPlan = (plan: CatalogPlanParams) =>
 	(plan.licenses ?? []).map((license) => ({
 		id: license.license_plan_id,
@@ -19,8 +21,8 @@ export const sortCatalogPlansByDependencies = (
 ): CatalogPlanParams[] => {
 	const byReference = new Map<string, CatalogPlanParams>();
 	for (const plan of plans) {
-		byReference.set(referenceKey(plan.plan_id, plan.version), plan);
-		const latestKey = plan.new_plan_id ?? plan.plan_id;
+		byReference.set(referenceKey(targetId(plan), plan.version), plan);
+		const latestKey = targetId(plan);
 		const latest = byReference.get(latestKey);
 		if (!latest || (plan.version ?? 0) > (latest.version ?? 0)) {
 			byReference.set(latestKey, plan);
@@ -31,7 +33,7 @@ export const sortCatalogPlansByDependencies = (
 	const visited = new Set<string>();
 	const sorted: CatalogPlanParams[] = [];
 	const visit = (plan: CatalogPlanParams) => {
-		const key = referenceKey(plan.plan_id, plan.version);
+		const key = referenceKey(targetId(plan), plan.version);
 		if (visiting.has(key)) {
 			throw new RecaseError({
 				message: "Plan dependency cycle detected.",
@@ -43,7 +45,7 @@ export const sortCatalogPlansByDependencies = (
 		visiting.add(key);
 		if (plan.version !== undefined && plan.version > 1) {
 			const previous = byReference.get(
-				referenceKey(plan.plan_id, plan.version - 1),
+				referenceKey(targetId(plan), plan.version - 1),
 			);
 			if (previous) visit(previous);
 		}
@@ -80,21 +82,22 @@ export const validateCatalogPlanVersionTargets = ({
 	}
 
 	for (const plan of sortCatalogPlansByDependencies(plans)) {
+		const id = targetId(plan);
 		if (
 			plan.version === undefined ||
-			existing.has(referenceKey(plan.plan_id, plan.version))
+			existing.has(referenceKey(id, plan.version))
 		) {
 			continue;
 		}
-		const expected = (latestById.get(plan.plan_id) ?? 0) + 1;
+		const expected = (latestById.get(id) ?? 0) + 1;
 		if (plan.version !== expected) {
 			throw new RecaseError({
-				message: `Plan ${plan.plan_id} version must be ${expected}, received ${plan.version}.`,
+				message: `Plan ${id} version must be ${expected}, received ${plan.version}.`,
 				code: ErrCode.InvalidRequest,
 				statusCode: 400,
 			});
 		}
-		existing.add(referenceKey(plan.plan_id, plan.version));
-		latestById.set(plan.plan_id, plan.version);
+		existing.add(referenceKey(id, plan.version));
+		latestById.set(id, plan.version);
 	}
 };

--- a/server/src/internal/catalog/actions/catalogPlanDependencies.ts
+++ b/server/src/internal/catalog/actions/catalogPlanDependencies.ts
@@ -1,4 +1,9 @@
-import { type CatalogPlanParams, ErrCode, RecaseError } from "@autumn/shared";
+import {
+	type CatalogPlanParams,
+	ErrCode,
+	type FullProduct,
+	RecaseError,
+} from "@autumn/shared";
 
 const referenceKey = (id: string, version?: number) =>
 	version === undefined ? id : `${id}@${version}`;
@@ -36,6 +41,12 @@ export const sortCatalogPlansByDependencies = (
 		}
 		if (visited.has(key)) return;
 		visiting.add(key);
+		if (plan.version !== undefined && plan.version > 1) {
+			const previous = byReference.get(
+				referenceKey(plan.plan_id, plan.version - 1),
+			);
+			if (previous) visit(previous);
+		}
 		for (const reference of dependenciesForPlan(plan)) {
 			const dependency =
 				byReference.get(referenceKey(reference.id, reference.version)) ??
@@ -48,4 +59,42 @@ export const sortCatalogPlansByDependencies = (
 	};
 	for (const plan of plans) visit(plan);
 	return sorted;
+};
+
+export const validateCatalogPlanVersionTargets = ({
+	plans,
+	products,
+}: {
+	plans: CatalogPlanParams[];
+	products: FullProduct[];
+}) => {
+	const existing = new Set(
+		products.map((product) => referenceKey(product.id, product.version)),
+	);
+	const latestById = new Map<string, number>();
+	for (const product of products) {
+		latestById.set(
+			product.id,
+			Math.max(latestById.get(product.id) ?? 0, product.version),
+		);
+	}
+
+	for (const plan of sortCatalogPlansByDependencies(plans)) {
+		if (
+			plan.version === undefined ||
+			existing.has(referenceKey(plan.plan_id, plan.version))
+		) {
+			continue;
+		}
+		const expected = (latestById.get(plan.plan_id) ?? 0) + 1;
+		if (plan.version !== expected) {
+			throw new RecaseError({
+				message: `Plan ${plan.plan_id} version must be ${expected}, received ${plan.version}.`,
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+		existing.add(referenceKey(plan.plan_id, plan.version));
+		latestById.set(plan.plan_id, plan.version);
+	}
 };

--- a/server/src/internal/catalog/actions/catalogPlanPreflight.ts
+++ b/server/src/internal/catalog/actions/catalogPlanPreflight.ts
@@ -74,7 +74,7 @@ const preflightCatalogLicenses = async ({
 				? previews[index]?.versionable
 					? (latest?.version ?? current.version) + 1
 					: current.version
-				: 1,
+				: (plan.version ?? 1),
 			archived: plan.archived,
 		});
 	});

--- a/server/src/internal/catalog/actions/catalogPlanPreflight.ts
+++ b/server/src/internal/catalog/actions/catalogPlanPreflight.ts
@@ -10,7 +10,10 @@ import {
 } from "@/internal/licenses/actions/links/syncPlanLicenses.js";
 import { previewAffectedLicenses } from "@/internal/product/actions/previewUpdatePlan/previewAffectedLicenses.js";
 import { ProductService } from "@/internal/products/ProductService.js";
-import { sortCatalogPlansByDependencies } from "./catalogPlanDependencies.js";
+import {
+	sortCatalogPlansByDependencies,
+	validateCatalogPlanVersionTargets,
+} from "./catalogPlanDependencies.js";
 
 const virtualProduct = ({
 	current,
@@ -50,6 +53,7 @@ const preflightCatalogLicenses = async ({
 		env: ctx.env,
 		returnAll: true,
 	});
+	validateCatalogPlanVersionTargets({ plans, products: persistedProducts });
 	const currentById = new Map<string, FullProduct>();
 	for (const product of persistedProducts) {
 		const current = currentById.get(product.id);

--- a/server/src/internal/catalog/actions/previewUpdateCatalog/previewCatalogPlanUpdate.ts
+++ b/server/src/internal/catalog/actions/previewUpdateCatalog/previewCatalogPlanUpdate.ts
@@ -26,7 +26,7 @@ const previewNewPlan = ({
 	const {
 		plan_id,
 		new_plan_id,
-		version: _version,
+		version,
 		variants: _variants,
 		include_versions: _includeVersions,
 		include_variants: _includeVariants,
@@ -43,7 +43,7 @@ const previewNewPlan = ({
 	});
 	const product = {
 		env: ctx.env,
-		version: 1,
+		version: version ?? 1,
 		created_at: Date.now(),
 		archived: false,
 		...resolved,

--- a/server/src/internal/catalog/actions/previewUpdateCatalog/previewUpdateCatalog.ts
+++ b/server/src/internal/catalog/actions/previewUpdateCatalog/previewUpdateCatalog.ts
@@ -42,7 +42,7 @@ const productUsesFeature = ({
 	product: FullProduct;
 	featureId: string;
 }) =>
-	product.entitlements.some(
+	(product.entitlements ?? []).some(
 		(entitlement) => entitlement.feature.id === featureId,
 	) || product.prices.some((price) => price.config?.feature_id === featureId);
 

--- a/server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts
+++ b/server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts
@@ -6,7 +6,6 @@ import {
 	type CreateProductV2Params,
 	dbToApiFeatureV1,
 	featureV1ToDbFeature,
-	ProductNotFoundError,
 	type UpdateProductV2Params,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
@@ -170,9 +169,6 @@ const upsertPlans = async ({
 							allowNotFound: true,
 						});
 			if (latest) {
-				if (version !== latest.version + 1) {
-					throw new ProductNotFoundError({ productId: plan_id, version });
-				}
 				const updates = apiPlan.map.paramsV1ToProductV2({
 					ctx,
 					currentFullProduct: latest,

--- a/server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts
+++ b/server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts
@@ -6,6 +6,7 @@ import {
 	type CreateProductV2Params,
 	dbToApiFeatureV1,
 	featureV1ToDbFeature,
+	ProductNotFoundError,
 	type UpdateProductV2Params,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
@@ -158,6 +159,35 @@ const upsertPlans = async ({
 
 		if (!current) {
 			const variantUpdates = variants ?? [];
+			const latest =
+				version === undefined
+					? null
+					: await ProductService.getFull({
+							db,
+							idOrInternalId: plan_id,
+							orgId: org.id,
+							env,
+							allowNotFound: true,
+						});
+			if (latest) {
+				if (version !== latest.version + 1) {
+					throw new ProductNotFoundError({ productId: plan_id, version });
+				}
+				const updates = apiPlan.map.paramsV1ToProductV2({
+					ctx,
+					currentFullProduct: latest,
+					params: { id: new_plan_id ?? plan_id, ...rest },
+				}) as UpdateProductV2Params;
+				await updateProduct({
+					ctx,
+					productId: plan_id,
+					query: { force_version: true },
+					updates,
+					initialFullProduct: latest,
+					variantUpdates,
+				});
+				continue;
+			}
 			const createParams = apiPlan.map.paramsV1ToProductV2({
 				ctx,
 				params: {

--- a/server/tests/integration/billing/sync/sync-plan-version.test.ts
+++ b/server/tests/integration/billing/sync/sync-plan-version.test.ts
@@ -1,0 +1,290 @@
+/** Exact Stripe Price IDs must select and persist the matching plan version. */
+
+import { expect, test } from "bun:test";
+import {
+	filterCustomerProductsByActiveStatuses,
+	filterCustomerProductsByStripeSubscriptionId,
+	findCustomerEntitlementByFeature,
+	isFixedPrice,
+	type SyncParamsV1,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import ctx from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { billingActions } from "@/internal/billing/v2/actions";
+import { subscriptionToSyncParams } from "@/internal/billing/v2/actions/sync/subscriptionToSyncParams";
+import { CusService } from "@/internal/customers/CusService";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
+import { ProductService } from "@/internal/products/ProductService";
+import { PriceService } from "@/internal/products/prices/PriceService";
+import {
+	createStripeFixedPriceUnderProduct,
+	createStripeSubscriptionSchedule,
+	getBaseStripePriceId,
+	getProductStripeProductId,
+	getStripeCustomerId,
+} from "./utils/syncProductHelpers";
+
+const setupVersionedPlan = async ({
+	planId,
+	customerId,
+}: {
+	planId: string;
+	customerId: string;
+}) => {
+	const plan = products.pro({
+		id: planId,
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+	const { autumnV2_2 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [plan], prefix: "" }),
+		],
+		actions: [],
+	});
+
+	await autumnV2_2.post("/catalog.update", {
+		plans: [
+			{
+				plan_id: planId,
+				name: plan.name,
+				force_version: true,
+				items: [
+					{
+						feature_id: TestFeature.Messages,
+						included: 200,
+						reset: { interval: "month" },
+					},
+				],
+			},
+		],
+	});
+
+	const [v1, v2] = await Promise.all(
+		[1, 2].map((version) =>
+			ProductService.getFull({
+				db: ctx.db,
+				orgId: ctx.org.id,
+				env: ctx.env,
+				idOrInternalId: planId,
+				version,
+			}),
+		),
+	);
+
+	const v1PriceId = getBaseStripePriceId({ fullProduct: v1 });
+	const v2BasePrice = v2.prices[0];
+	if (!v2BasePrice || !isFixedPrice(v2BasePrice)) {
+		throw new Error(`Expected a fixed v2 base price for ${planId}`);
+	}
+	const v2StripePrice = await createStripeFixedPriceUnderProduct({
+		ctx,
+		stripeProductId: getProductStripeProductId({ fullProduct: v2 }),
+		unitAmount: 2_000,
+	});
+	await PriceService.updateConfig({
+		db: ctx.db,
+		id: v2BasePrice.id,
+		config: {
+			...v2BasePrice.config,
+			stripe_price_id: v2StripePrice.id,
+		},
+	});
+
+	return { v1, v2, v1PriceId, v2PriceId: v2StripePrice.id };
+};
+
+const createSubscription = async ({
+	customerId,
+	priceId,
+}: {
+	customerId: string;
+	priceId: string;
+}) =>
+	ctx.stripeCli.subscriptions.create({
+		customer: await getStripeCustomerId({ ctx, customerId }),
+		items: [{ price: priceId }],
+	});
+
+const getPhases = ({ params }: { params: SyncParamsV1 }) => {
+	if (!params.phases) throw new Error("Expected sync phases");
+	return params.phases;
+};
+
+const expectLinkedVersion = async ({
+	customerId,
+	subscriptionId,
+	internalProductId,
+	expectedAllowance,
+}: {
+	customerId: string;
+	subscriptionId: string;
+	internalProductId: string;
+	expectedAllowance: number;
+}) => {
+	const customer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+		withEntities: true,
+		withSubs: true,
+	});
+	const linked = filterCustomerProductsByActiveStatuses({
+		customerProducts: filterCustomerProductsByStripeSubscriptionId({
+			customerProducts: customer.customer_products,
+			stripeSubscriptionId: subscriptionId,
+		}),
+	});
+	expect(linked).toHaveLength(1);
+	expect(linked[0]?.internal_product_id).toBe(internalProductId);
+	const messages = findCustomerEntitlementByFeature({
+		cusEnts: linked[0]?.customer_entitlements ?? [],
+		featureId: TestFeature.Messages,
+		errorOnNotFound: true,
+	});
+	expect(messages.entitlement.allowance).toBe(expectedAllowance);
+};
+
+test(`${chalk.yellowBright("billing.sync: exact Stripe Price selects plan version")}`, async () => {
+	const suffix = Math.random().toString(36).slice(2, 9);
+	const planId = `sync_price_version_${suffix}`;
+	const v1CustomerId = `sync-price-version-v1-${suffix}`;
+	const v2CustomerId = `sync-price-version-v2-${suffix}`;
+	const { v1, v2, v1PriceId, v2PriceId } = await setupVersionedPlan({
+		planId,
+		customerId: v1CustomerId,
+	});
+	await initScenario({
+		customerId: v2CustomerId,
+		setup: [s.customer({ paymentMethod: "success" })],
+		actions: [],
+	});
+	const allVersions = await ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		returnAll: true,
+	});
+
+	const v1Subscription = await createSubscription({
+		customerId: v1CustomerId,
+		priceId: v1PriceId,
+	});
+	const v1Proposal = await subscriptionToSyncParams({
+		ctx,
+		customerId: v1CustomerId,
+		subscription: v1Subscription,
+		fullProducts: allVersions,
+	});
+	expect(getPhases({ params: v1Proposal.params })[0]?.plans[0]).toMatchObject({
+		plan_id: planId,
+		version: 1,
+	});
+	await billingActions.syncV2({ ctx, params: v1Proposal.params });
+	await expectLinkedVersion({
+		customerId: v1CustomerId,
+		subscriptionId: v1Subscription.id,
+		internalProductId: v1.internal_id,
+		expectedAllowance: 100,
+	});
+
+	const v2Subscription = await createSubscription({
+		customerId: v2CustomerId,
+		priceId: v2PriceId,
+	});
+	const v2Proposal = await subscriptionToSyncParams({
+		ctx,
+		customerId: v2CustomerId,
+		subscription: v2Subscription,
+		fullProducts: allVersions,
+	});
+	expect(getPhases({ params: v2Proposal.params })[0]?.plans[0]).toMatchObject({
+		plan_id: planId,
+		version: 2,
+	});
+	await billingActions.syncV2({ ctx, params: v2Proposal.params });
+	await expectLinkedVersion({
+		customerId: v2CustomerId,
+		subscriptionId: v2Subscription.id,
+		internalProductId: v2.internal_id,
+		expectedAllowance: 200,
+	});
+
+	await billingActions.syncV2({ ctx, params: v2Proposal.params });
+	await expectLinkedVersion({
+		customerId: v2CustomerId,
+		subscriptionId: v2Subscription.id,
+		internalProductId: v2.internal_id,
+		expectedAllowance: 200,
+	});
+});
+
+test(`${chalk.yellowBright("billing.sync: schedule phases select exact plan versions")}`, async () => {
+	const suffix = Math.random().toString(36).slice(2, 9);
+	const planId = `sync_schedule_version_${suffix}`;
+	const customerId = `sync-schedule-version-${suffix}`;
+	const { v1, v2, v1PriceId, v2PriceId } = await setupVersionedPlan({
+		planId,
+		customerId,
+	});
+	const { subscription, schedule } = await createStripeSubscriptionSchedule({
+		ctx,
+		customerId,
+		phases: [
+			{ items: [{ price: v1PriceId }] },
+			{ items: [{ price: v2PriceId }] },
+		],
+	});
+	const allVersions = await ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		returnAll: true,
+	});
+	const proposal = await subscriptionToSyncParams({
+		ctx,
+		customerId,
+		subscription,
+		schedule,
+		fullProducts: allVersions,
+	});
+
+	const phases = getPhases({ params: proposal.params });
+	expect(phases).toHaveLength(2);
+	expect(phases[0]?.plans[0]).toMatchObject({
+		plan_id: planId,
+		version: 1,
+	});
+	expect(phases[1]?.plans[0]).toMatchObject({
+		plan_id: planId,
+		version: 2,
+	});
+
+	const result = await billingActions.syncV2({ ctx, params: proposal.params });
+	await expectLinkedVersion({
+		customerId,
+		subscriptionId: subscription.id,
+		internalProductId: v1.internal_id,
+		expectedAllowance: 100,
+	});
+	expect(result.scheduled_phases).toHaveLength(2);
+	const scheduledId =
+		result.scheduled_phases[result.scheduled_phases.length - 1]
+			?.customer_product_ids[0];
+	if (!scheduledId) throw new Error("Expected a scheduled customer product");
+	const scheduled = await CusProductService.getFull({
+		db: ctx.db,
+		id: scheduledId,
+	});
+	expect(scheduled?.internal_product_id).toBe(v2.internal_id);
+	const scheduledMessages = findCustomerEntitlementByFeature({
+		cusEnts: scheduled?.customer_entitlements ?? [],
+		featureId: TestFeature.Messages,
+		errorOnNotFound: true,
+	});
+	expect(scheduledMessages.entitlement.allowance).toBe(200);
+});

--- a/server/tests/integration/licenses/catalog-update/license-catalog-response.test.ts
+++ b/server/tests/integration/licenses/catalog-update/license-catalog-response.test.ts
@@ -117,14 +117,14 @@ test.concurrent(
 				name: "Parent",
 				licenses: [{ license_plan_id: childId, version: 2, included: 2 }],
 			},
-		];
+		].reverse();
 
 		const preview = (await autumnV2_2.post("/catalog.preview_update", {
 			expand: ["plan_changes.plan"],
 			plans,
 		})) as CatalogPreviewUpdateResponse;
 		expect(preview.plan_changes).toHaveLength(4);
-		expect(preview.plan_changes[3]?.plan?.licenses).toEqual([
+		expect(preview.plan_changes[0]?.plan?.licenses).toEqual([
 			{
 				license_plan_id: childId,
 				version: 2,
@@ -157,6 +157,14 @@ test.concurrent(
 				prepaid_only: true,
 			},
 		]);
+
+		for (const route of ["/catalog.preview_update", "/catalog.update"]) {
+			await expect(
+				autumnV2_2.post(route, {
+					plans: [{ plan_id: `${childId}_gap`, version: 2, name: "Gap" }],
+				}),
+			).rejects.toThrow("version must be 1, received 2");
+		}
 	},
 );
 

--- a/server/tests/integration/licenses/catalog-update/license-catalog-response.test.ts
+++ b/server/tests/integration/licenses/catalog-update/license-catalog-response.test.ts
@@ -66,6 +66,100 @@ test.concurrent(
 	},
 );
 
+/** Fresh explicit versions must resolve and persist same-batch pinned license versions. */
+test.concurrent(
+	`${chalk.yellowBright("licenses: catalog creates fresh explicit versions with pinned dependencies")}`,
+	async () => {
+		const suffix = Math.random().toString(36).slice(2, 9);
+		const { autumnV2_2 } = await initScenario({
+			customerId: `license-catalog-fresh-versions-${suffix}`,
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+		const parentId = `license_catalog_fresh_parent_${suffix}`;
+		const childId = `license_catalog_fresh_child_${suffix}`;
+		const plans = [
+			{
+				plan_id: childId,
+				version: 1,
+				name: "Child",
+				items: [
+					{
+						feature_id: TestFeature.Messages,
+						included: 10,
+						reset: { interval: "month" as const },
+					},
+				],
+				licenses: [],
+			},
+			{
+				plan_id: parentId,
+				version: 1,
+				name: "Parent",
+				licenses: [{ license_plan_id: childId, version: 1, included: 1 }],
+			},
+			{
+				plan_id: childId,
+				version: 2,
+				name: "Child",
+				items: [
+					{
+						feature_id: TestFeature.Messages,
+						included: 20,
+						reset: { interval: "month" as const },
+					},
+				],
+				licenses: [],
+			},
+			{
+				plan_id: parentId,
+				version: 2,
+				name: "Parent",
+				licenses: [{ license_plan_id: childId, version: 2, included: 2 }],
+			},
+		];
+
+		const preview = (await autumnV2_2.post("/catalog.preview_update", {
+			expand: ["plan_changes.plan"],
+			plans,
+		})) as CatalogPreviewUpdateResponse;
+		expect(preview.plan_changes).toHaveLength(4);
+		expect(preview.plan_changes[3]?.plan?.licenses).toEqual([
+			{
+				license_plan_id: childId,
+				version: 2,
+				included: 2,
+				prepaid_only: true,
+			},
+		]);
+
+		await autumnV2_2.post("/catalog.update", { plans });
+		const [parentV1, parentV2, childV1, childV2] = await Promise.all([
+			autumnV2_2.post("/plans.get", { plan_id: parentId, version: 1 }),
+			autumnV2_2.post("/plans.get", { plan_id: parentId, version: 2 }),
+			autumnV2_2.post("/plans.get", { plan_id: childId, version: 1 }),
+			autumnV2_2.post("/plans.get", { plan_id: childId, version: 2 }),
+		]);
+		expect([
+			parentV1.version,
+			parentV2.version,
+			childV1.version,
+			childV2.version,
+		]).toEqual([1, 2, 1, 2]);
+		expect(childV1.items[0]?.included).toBe(10);
+		expect(childV2.items[0]?.included).toBe(20);
+		expect(parentV1.licenses[0]?.version).toBe(1);
+		expect(parentV2.licenses).toEqual([
+			{
+				license_plan_id: childId,
+				version: 2,
+				included: 2,
+				prepaid_only: true,
+			},
+		]);
+	},
+);
+
 test.concurrent(
 	`${chalk.yellowBright("licenses: same-batch historical versioning resolves from the latest version")}`,
 	async () => {

--- a/server/tests/unit/catalog/catalog-plan-dependencies.test.ts
+++ b/server/tests/unit/catalog/catalog-plan-dependencies.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "bun:test";
 import type { CatalogPlanParams } from "@autumn/shared";
-import { sortCatalogPlansByDependencies } from "@/internal/catalog/actions/catalogPlanDependencies.js";
+import {
+	sortCatalogPlansByDependencies,
+	validateCatalogPlanVersionTargets,
+} from "@/internal/catalog/actions/catalogPlanDependencies.js";
 
 const plan = (
 	plan_id: string,
@@ -19,6 +22,15 @@ test.concurrent(
 
 		expect(
 			sorted.map(({ plan_id, version }) => `${plan_id}@${version ?? 0}`),
-		).toEqual(["child@2", "parent@0", "child@1"]);
+		).toEqual(["child@1", "child@2", "parent@0"]);
 	},
 );
+
+test.concurrent("fresh plans must start at version one", () => {
+	expect(() =>
+		validateCatalogPlanVersionTargets({
+			plans: [plan("fresh", 2)],
+			products: [],
+		}),
+	).toThrow("version must be 1, received 2");
+});

--- a/server/tests/unit/catalog/catalog-plan-dependencies.test.ts
+++ b/server/tests/unit/catalog/catalog-plan-dependencies.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import type { CatalogPlanParams } from "@autumn/shared";
+import type { CatalogPlanParams, FullProduct } from "@autumn/shared";
 import {
 	sortCatalogPlansByDependencies,
 	validateCatalogPlanVersionTargets,
@@ -9,7 +9,8 @@ const plan = (
 	plan_id: string,
 	version?: number,
 	licenses?: CatalogPlanParams["licenses"],
-): CatalogPlanParams => ({ plan_id, version, licenses });
+	new_plan_id?: string,
+): CatalogPlanParams => ({ plan_id, version, licenses, new_plan_id });
 
 test.concurrent(
 	"unpinned dependencies select the highest batch version",
@@ -33,4 +34,16 @@ test.concurrent("fresh plans must start at version one", () => {
 			products: [],
 		}),
 	).toThrow("version must be 1, received 2");
+});
+
+test.concurrent("renamed plans sequence versions under their target id", () => {
+	const plans = [
+		plan("legacy", 2, undefined, "current"),
+		plan("legacy", 3, undefined, "current"),
+	];
+	const products = [{ id: "current", version: 1 } as FullProduct];
+
+	expect(() =>
+		validateCatalogPlanVersionTargets({ plans, products }),
+	).not.toThrow();
 });


### PR DESCRIPTION
Prevents catalog preview/push from crashing on partially-deleted products with missing entitlements.

- feature deletion checks fail closed and defer deletion
- plan deletion checks fail closed and defer deletion
- catalog feature usage handles missing entitlements
- built local atmn package with `bun run build`

Validation: focused atmn push tests pass; full Autumn typecheck is currently blocked by pre-existing dependency/type errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps catalog preview/update/push running when deletion checks fail, and adds explicit plan versioning across catalog and billing sync. Stripe price mapping now pins the exact plan version, including schedule phases and renamed plans.

- **Bug Fixes**
  - Deletion checks fail closed and defer deletes; push/preview no longer crash and expose `deletion_check_failed` flags.
  - Catalog feature usage tolerates missing entitlements when checking references.
  - Billing sync preserves the matched plan version from Stripe Price IDs and subscription schedules.

- **New Features**
  - Support explicit plan versions in catalog preview/update and enforce sequential versioning (no gaps), including across renames (`new_plan_id`).
  - Order plan updates by dependencies and prior versions to pin same-batch license versions.
  - Push mapping improvements: support `variant.version`, `additional_currencies`, `customize.upsert_licenses`, and default license `prepaidOnly`.

<sup>Written for commit 222be1c078d2f231c561764e2b7a0c0ad6411d7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents `catalog.preview` and `catalog.push` from crashing when encountering partially-deleted products with missing entitlements, and adds first-class support for pushing explicit plan versions in a single batch.

- **Bug fixes**: Guards `product.entitlements` with `?? []` in `previewUpdateCatalog.ts` to prevent crashes on null entitlements; wraps `getFeatureDeletionInfo` and `getPlanDeletionInfo` API calls in try/catch so failures defer deletion rather than aborting the whole push.
- **Improvements**: Adds `validateCatalogPlanVersionTargets` to enforce sequential version numbering; extends the dependency sort to order earlier versions before later ones; adds a new `upsertPlans` branch to create versioned plans against an existing base; propagates `version` through billing sync params so Stripe price matching pins the correct plan version.
- **API changes**: `normalizePlanForCompare` now includes `prepaidOnly` and `customize` on licenses; `toApiCustomizePlan` forwards `additional_currencies`; `toCatalogVariantParams` forwards `version`.
</details>

<h3>Confidence Score: 3/5</h3>

Server-side changes are safe to merge; the client-side deletion guard in push.ts behaves differently from what the PR description promises.

The server-side catalog and billing changes are well-structured and covered by new integration and unit tests. The push.ts fix is incomplete: when the deletion-check API call fails, the code returns canDelete: false and sets deletionCheckFailed: true, but that flag is never read anywhere in the prompt generation or execution pipeline. Both the feature path and the plan path present 'Delete permanently' as the default action when a check fails, which is the opposite of conservative.

packages/atmn/src/commands/push/push.ts and packages/atmn/src/commands/push/prompts.ts — the deletionCheckFailed/deletion_check_failed path needs to either auto-skip or route to a prompt that defaults to Skip.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/atmn/src/commands/push/push.ts | Adds fail-closed error handling for deletion checks and new plan-normalization fields; the `deletionCheckFailed` guard is stored but never read, causing both feature and plan prompt routing to default to "Delete permanently" when a check fails. |
| packages/atmn/src/commands/push/types.ts | Adds `deletionCheckFailed?: boolean` to `PlanDeleteInfo` and a new `"deletion_check_failed"` reason to `FeatureDeleteInfo`; both additions are correct but the plan field is currently dead code. |
| server/src/internal/catalog/actions/catalogPlanDependencies.ts | Adds previous-version ordering to the dependency sort and a new `validateCatalogPlanVersionTargets` that enforces sequential version numbering for new plan versions; logic is correct and well-tested. |
| server/src/internal/catalog/actions/catalogPlanPreflight.ts | Calls `validateCatalogPlanVersionTargets` before virtual product construction and respects explicit version numbers on new plans; straightforward and correct. |
| server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts | Adds a new code path to create versioned plans against an existing base when the target version is absent; uses `force_version: true` and delegates to `updateProduct`, which is consistent with the existing versioning mechanism. |
| server/src/internal/catalog/actions/previewUpdateCatalog/previewUpdateCatalog.ts | Guards `product.entitlements` with `?? []` to prevent crashes on partially-deleted products; targeted one-line fix that addresses the stated bug. |
| server/src/internal/billing/v2/actions/sync/subscriptionToSyncParams.ts | Adds `version` to the sync plan params so that billing sync pins the exact matched product version; tested by the new integration test. |
| server/tests/integration/billing/sync/sync-plan-version.test.ts | New integration tests covering exact Stripe price → plan version selection for both single subscriptions and scheduled phases; comprehensive coverage of the sync version-pinning path. |
| server/tests/integration/licenses/catalog-update/license-catalog-response.test.ts | Adds tests for fresh explicit versioning with pinned license dependencies and version-gap rejection; correctly exercises the new `validateCatalogPlanVersionTargets` path. |
| server/tests/unit/catalog/catalog-plan-dependencies.test.ts | Updates expected sort order to `["child@1", "child@2", "parent@0"]` after the previous-version traversal change, and adds a unit test for gap-version rejection. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/atmn/src/commands/push/push.ts:230-237
**`deletionCheckFailed` flag is never read — fail-closed intent is not enforced**

When `getPlanDeletionInfo` throws, the catch block returns `canDelete: false, customerCount: 0, deletionCheckFailed: true`. Because `customerCount === 0`, `createPlanDeletePrompt` routes to `createPlanDeleteNoCustomersPrompt`, which presents **"Delete permanently"** as the default option. Nothing in `usePush.ts` (or anywhere else) reads `deletionCheckFailed` to override this behaviour, so if the user accepts the default the push will attempt to delete a plan whose customer status is genuinely unknown. The same pattern appears in `checkFeatureDeleteInfo`: `reason: "deletion_check_failed"` falls through `createFeatureDeletePrompt` to `createFeatureDeleteNoDepsPrompt`, again defaulting to "Delete permanently" as though the feature has no dependencies. Both cases contradict the PR's stated "fail closed and defer deletion" goal. At minimum the prompt should default to "Skip (keep as is)" when `deletionCheckFailed` is true; alternatively the failed-check entries could be excluded from `plansToDelete` / `featuresToDelete` entirely and silently deferred.

### Issue 2 of 2
packages/atmn/src/commands/push/push.ts:192-194
Extra indentation on the `if` statement — it is left over from the refactor and the surrounding code is at a single-tab indent level.

```suggestion
	}

	if (response && response.totalCount > 0) {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: keep catalog push alive when deleti..."](https://github.com/useautumn/autumn/commit/ecf6f0ffbf22c1bc1e87210391c73069f0f03db0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45708464)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->