### PR TITLE
release

### DIFF
--- a/others/python-sdk/uv.lock
+++ b/others/python-sdk/uv.lock
@@ -151,11 +151,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]

--- a/others/python-test/uv.lock
+++ b/others/python-test/uv.lock
@@ -25,7 +25,7 @@ wheels = [
 
 [[package]]
 name = "autumn-sdk"
-version = "1.0.0"
+version = "0.4.18"
 source = { editable = "../python-sdk" }
 dependencies = [
     { name = "httpcore" },
@@ -106,11 +106,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]

--- a/server/src/internal/catalog/actions/catalogPlanDependencies.ts
+++ b/server/src/internal/catalog/actions/catalogPlanDependencies.ts
@@ -8,6 +8,8 @@ import {
 const referenceKey = (id: string, version?: number) =>
 	version === undefined ? id : `${id}@${version}`;
 
+const targetId = (plan: CatalogPlanParams) => plan.new_plan_id ?? plan.plan_id;
+
 const dependenciesForPlan = (plan: CatalogPlanParams) =>
 	(plan.licenses ?? []).map((license) => license.license_plan_id);
 
@@ -16,8 +18,8 @@ export const sortCatalogPlansByDependencies = (
 ): CatalogPlanParams[] => {
 	const byReference = new Map<string, CatalogPlanParams>();
 	for (const plan of plans) {
-		byReference.set(referenceKey(plan.plan_id, plan.version), plan);
-		const latestKey = plan.new_plan_id ?? plan.plan_id;
+		byReference.set(referenceKey(targetId(plan), plan.version), plan);
+		const latestKey = targetId(plan);
 		const latest = byReference.get(latestKey);
 		if (!latest || (plan.version ?? 0) > (latest.version ?? 0)) {
 			byReference.set(latestKey, plan);
@@ -28,7 +30,7 @@ export const sortCatalogPlansByDependencies = (
 	const visited = new Set<string>();
 	const sorted: CatalogPlanParams[] = [];
 	const visit = (plan: CatalogPlanParams) => {
-		const key = referenceKey(plan.plan_id, plan.version);
+		const key = referenceKey(targetId(plan), plan.version);
 		if (visiting.has(key)) {
 			throw new RecaseError({
 				message: "Plan dependency cycle detected.",
@@ -40,7 +42,7 @@ export const sortCatalogPlansByDependencies = (
 		visiting.add(key);
 		if (plan.version !== undefined && plan.version > 1) {
 			const previous = byReference.get(
-				referenceKey(plan.plan_id, plan.version - 1),
+				referenceKey(targetId(plan), plan.version - 1),
 			);
 			if (previous) visit(previous);
 		}
@@ -75,21 +77,22 @@ export const validateCatalogPlanVersionTargets = ({
 	}
 
 	for (const plan of sortCatalogPlansByDependencies(plans)) {
+		const id = targetId(plan);
 		if (
 			plan.version === undefined ||
-			existing.has(referenceKey(plan.plan_id, plan.version))
+			existing.has(referenceKey(id, plan.version))
 		) {
 			continue;
 		}
-		const expected = (latestById.get(plan.plan_id) ?? 0) + 1;
+		const expected = (latestById.get(id) ?? 0) + 1;
 		if (plan.version !== expected) {
 			throw new RecaseError({
-				message: `Plan ${plan.plan_id} version must be ${expected}, received ${plan.version}.`,
+				message: `Plan ${id} version must be ${expected}, received ${plan.version}.`,
 				code: ErrCode.InvalidRequest,
 				statusCode: 400,
 			});
 		}
-		existing.add(referenceKey(plan.plan_id, plan.version));
-		latestById.set(plan.plan_id, plan.version);
+		existing.add(referenceKey(id, plan.version));
+		latestById.set(id, plan.version);
 	}
 };

--- a/server/src/internal/catalog/actions/previewUpdateCatalog/previewUpdateCatalog.ts
+++ b/server/src/internal/catalog/actions/previewUpdateCatalog/previewUpdateCatalog.ts
@@ -42,7 +42,7 @@ const productUsesFeature = ({
 	product: FullProduct;
 	featureId: string;
 }) =>
-	product.entitlements.some(
+	(product.entitlements ?? []).some(
 		(entitlement) => entitlement.feature.id === featureId,
 	) || product.prices.some((price) => price.config?.feature_id === featureId);
 

--- a/server/tests/unit/catalog/catalog-plan-dependencies.test.ts
+++ b/server/tests/unit/catalog/catalog-plan-dependencies.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import type { CatalogPlanParams } from "@autumn/shared";
+import type { CatalogPlanParams, FullProduct } from "@autumn/shared";
 import {
 	sortCatalogPlansByDependencies,
 	validateCatalogPlanVersionTargets,
@@ -9,7 +9,8 @@ const plan = (
 	plan_id: string,
 	version?: number,
 	licenses?: CatalogPlanParams["licenses"],
-): CatalogPlanParams => ({ plan_id, version, licenses });
+	new_plan_id?: string,
+): CatalogPlanParams => ({ plan_id, version, licenses, new_plan_id });
 
 test.concurrent(
 	"unpinned dependencies select the highest batch version",
@@ -33,4 +34,16 @@ test.concurrent("fresh plans must start at version one", () => {
 			products: [],
 		}),
 	).toThrow("version must be 1, received 2");
+});
+
+test.concurrent("renamed plans sequence versions under their target id", () => {
+	const plans = [
+		plan("legacy", 2, undefined, "current"),
+		plan("legacy", 3, undefined, "current"),
+	];
+	const products = [{ id: "current", version: 1 } as FullProduct];
+
+	expect(() =>
+		validateCatalogPlanVersionTargets({ plans, products }),
+	).not.toThrow();
 });


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes catalog plan versioning for renamed plans and prevents crashes when products lack entitlements. Also updates Python deps.

- **Bug Fixes**
  - Track renamed plan versions under their target id in sorting/validation to avoid invalid version errors during catalog sync.
  - Tolerate missing `product.entitlements` when checking feature usage.

- **Dependencies**
  - Bump `idna` to `3.15` in `others/python-sdk` and `others/python-test`.
  - Update `autumn-sdk` lock entry to `0.4.18` in tests.

<sup>Written for commit 3824b97c92f8cc55f3988eb113578e93218ed1ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes version-sequencing logic for renamed catalog plans and adds a defensive null-check for product entitlements. Both changes are targeted bug fixes with accompanying tests.

- **[Bug fixes]** `catalogPlanDependencies.ts`: Introduces a `targetId` helper (`new_plan_id ?? plan_id`) and applies it consistently to all `byReference` map keys, so versioned lookups (e.g. `"current@2"`) and previous-version chain traversal correctly resolve to the canonical plan ID rather than the old source ID when a plan is renamed.
- **[Bug fixes]** `previewUpdateCatalog.ts`: Guards `product.entitlements` with `?? []` before calling `.some()`, preventing a runtime crash when entitlements are absent on a `FullProduct`.
- **[Improvements]** New unit test covers the renamed-plan scenario end-to-end through `validateCatalogPlanVersionTargets`; lock files updated with an `idna` patch bump (3.11 → 3.15).
</details>

<h3>Confidence Score: 4/5</h3>

The TypeScript logic changes are correct and well-tested; the only open question is the autumn-sdk version going from 1.0.0 to 0.4.18 in the Python test lock file.

Both server-side fixes are narrow, well-reasoned, and backed by new unit tests that pass through the critical paths. The version drop in the Python test lock file (1.0.0 → 0.4.18) is unexplained from the diff alone — if unintentional it could affect consumers of the SDK, but it has no impact on server behavior.

others/python-test/uv.lock — confirm the autumn-sdk version change is deliberate.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/catalog/actions/catalogPlanDependencies.ts | Introduces targetId helper (new_plan_id ?? plan_id) and uses it consistently for all map keys, fixing version-sequencing logic for renamed plans. |
| server/src/internal/catalog/actions/previewUpdateCatalog/previewUpdateCatalog.ts | Defensive null-coalesce on product.entitlements prevents a runtime crash when entitlements is undefined. |
| server/tests/unit/catalog/catalog-plan-dependencies.test.ts | Adds new_plan_id to the plan factory and a new concurrent test validating that renamed plans sequence versions under their target ID. |
| others/python-sdk/uv.lock | Updates idna dependency from 3.11 to 3.15; routine patch bump. |
| others/python-test/uv.lock | Updates idna from 3.11 to 3.15 and reflects autumn-sdk version as 0.4.18 (previously 1.0.0) — worth confirming the version change is intentional. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["CatalogPlanParams\nplan_id, new_plan_id?, version"] --> B["targetId\nnew_plan_id ?? plan_id"]
    B --> C["byReference key\nid@version"]
    C --> D{version gt 1?}
    D -- Yes --> E["Lookup id@version-1"]
    E --> F["visit previous"]
    D -- No --> G["Resolve license deps"]
    F --> G
    G --> H["Sorted topological output"]
    H --> I["validateVersionTargets\nid = targetId"]
    I --> J{already exists?}
    J -- Yes --> K["Skip"]
    J -- No --> L["expected = latestById + 1"]
    L --> M{version matches?}
    M -- No --> N["Throw RecaseError"]
    M -- Yes --> O["Update existing and latestById"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["CatalogPlanParams\nplan_id, new_plan_id?, version"] --> B["targetId\nnew_plan_id ?? plan_id"]
    B --> C["byReference key\nid@version"]
    C --> D{version gt 1?}
    D -- Yes --> E["Lookup id@version-1"]
    E --> F["visit previous"]
    D -- No --> G["Resolve license deps"]
    F --> G
    G --> H["Sorted topological output"]
    H --> I["validateVersionTargets\nid = targetId"]
    I --> J{already exists?}
    J -- Yes --> K["Skip"]
    J -- No --> L["expected = latestById + 1"]
    L --> M{version matches?}
    M -- No --> N["Throw RecaseError"]
    M -- Yes --> O["Update existing and latestById"]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
others/python-test/uv.lock:27
**SDK version appears to decrease**

`autumn-sdk` version goes from `1.0.0` to `0.4.18` in this lock file. Since the version in an editable lock entry is derived from the package's own `pyproject.toml`, this means `others/python-sdk/pyproject.toml` now declares `0.4.18`. Given the PR is titled "release", was `1.0.0` an accidental forward-bump that is being corrected here, or is this an unintended downgrade?

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #2315 from useautumn/..."](https://github.com/useautumn/autumn/commit/3824b97c92f8cc55f3988eb113578e93218ed1ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45729786)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->