### PR TITLE
fix(catalog): tolerate incomplete product collections

### DIFF
--- a/server/src/internal/features/utils/updateFeatureUtils/getObjectsUsingFeature.ts
+++ b/server/src/internal/features/utils/updateFeatureUtils/getObjectsUsingFeature.ts
@@ -38,8 +38,8 @@ export const getObjectsUsingFeature = async ({
 		}),
 	]);
 
-	const allPrices = allProducts.flatMap((p) => p.prices);
-	const allEnts = allProducts.flatMap((p) => p.entitlements);
+	const allPrices = allProducts.flatMap((p) => p.prices ?? []);
+	const allEnts = allProducts.flatMap((p) => p.entitlements ?? []);
 	const creditSystems = getCreditSystemsFromFeature({
 		featureId: feature.id,
 		features: ctx.features,


### PR DESCRIPTION
Guard catalog feature discovery when historical products omit prices or entitlements. This prevents catalog preview/update from crashing and defers safely.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented crashes in catalog preview/update by tolerating products that omit `prices` or `entitlements` during feature discovery.

- **Bug Fixes**
  - Default to empty arrays when flattening product `prices` and `entitlements` (`p.prices ?? []`, `p.entitlements ?? []`) to avoid undefined access.

<sup>Written for commit b251dc39cbb516eb36099e4517a927be6c3fabfa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds `?? []` null-coalescing guards on `p.prices` and `p.entitlements` inside `getObjectsUsingFeature` so that historical products lacking those relations no longer crash the catalog feature-discovery path.

- **[Bug fixes]** `flatMap` on `p.prices` and `p.entitlements` previously threw a runtime error when either field was `null`/`undefined` on a historical product row; the null-coalescing fallback to `[]` defers safely instead.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a two-line defensive null-coalescing guard with no logic changes and no new failure modes.

The patch touches exactly one function, replaces straightforward flatMap calls with identical but null-safe equivalents, and cannot regress well-formed products (an empty array coalesces to itself). The FullProduct schema types prices and entitlements as required arrays, yet historical rows in the DB can deliver null/undefined for those relations — the guard is the correct minimal fix. No existing call sites or consumers are affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/features/utils/updateFeatureUtils/getObjectsUsingFeature.ts | Two-line defensive fix: adds ?? [] fallback when flattening prices and entitlements across all products, guarding against null/undefined on historical product records. |

<sub>Reviews (1): Last reviewed commit: ["fix(catalog): tolerate incomplete produc..."](https://github.com/useautumn/autumn/commit/b251dc39cbb516eb36099e4517a927be6c3fabfa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45739606)</sub>

<!-- /greptile_comment -->