### PR TITLE
fix(catalog): normalize missing product entitlements

### DIFF
--- a/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
@@ -65,7 +65,7 @@ export const getPlanResponse = async ({
 	// 1. Convert prices/entitlements to items
 	const rawItems = mapToProductItems({
 		prices: product.prices,
-		entitlements: product.entitlements,
+		entitlements: product.entitlements ?? [],
 		features: features,
 	});
 

--- a/server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts
@@ -179,7 +179,7 @@ export const getProductResponse = async ({
 	// 1. Get items with display
 	const rawItems = mapToProductItems({
 		prices: product.prices,
-		entitlements: product.entitlements,
+		entitlements: product.entitlements ?? [],
 		features: features,
 	});
 


### PR DESCRIPTION
Normalize missing product prices and entitlements at catalog response boundaries so incomplete historical products cannot crash preview/update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize missing product entitlements in catalog responses to prevent crashes when previewing or updating historical products. Undefined entitlements are now treated as empty arrays in the plan and product response mappers.

<sup>Written for commit aa5ba5147659f9b2f6b2007cb9da178229424db9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds null-coalescing guards (`?? []`) on `product.entitlements` in the two catalog API response mappers (`getPlanResponse` and `getProductResponse`) to prevent runtime crashes when historical products are loaded without entitlements populated.

- **Bug fixes** — `getPlanResponse`: `product.entitlements ?? []` is passed to `mapToProductItems`, preventing a `TypeError` when iterating over `undefined` entitlements on historical products during catalog preview or update.
- **Bug fixes** — `getProductResponse`: the identical guard is added in the sibling mapper, closing the same crash path for the product-level API response.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — both changes are a one-line null-coalesce guard with no side effects on valid data.

The two changed functions are the only catalog response boundary mappers, and the guard is correct. Several other `mapToProductItems` call sites (e.g. `catalogMappingUtils.ts`, `invoiceMemoUtils.ts`) pass `product.entitlements` without the same guard, so the same crash can still surface via adjacent flows if those paths receive a historical product with missing entitlements.

server/src/internal/catalog/actions/catalogMappings/catalogMappingUtils.ts and the attach-preview helpers (getUpgradeProductPreview.ts, getNewProductPreview.ts, getDowngradeProductPreview.ts) pass entitlements without a null-coalesce guard.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts | Adds `?? []` fallback for `product.entitlements` before passing to `mapToProductItems`; safe and targeted fix. |
| server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts | Identical `?? []` guard added for the product-level response mapper; consistent with the plan mapper fix. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Catalog Preview / Update Request] --> B[setupPreviewCatalogContext]
    B --> C{Historical version?}
    C -- yes --> D[ProductService.getFull with version]
    C -- no --> E[ProductService.listFull cached]
    D --> F[FullProduct - entitlements may be undefined]
    E --> G[FullProduct - entitlements present]
    F --> H[getPlanResponse / getProductResponse]
    G --> H
    H --> I{entitlements null-coalesce}
    I -- before fix: undefined --> J[TypeError: Cannot iterate undefined]
    I -- after fix: empty array --> K[mapToProductItems - safe iteration]
    K --> L[API response returned]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Catalog Preview / Update Request] --> B[setupPreviewCatalogContext]
    B --> C{Historical version?}
    C -- yes --> D[ProductService.getFull with version]
    C -- no --> E[ProductService.listFull cached]
    D --> F[FullProduct - entitlements may be undefined]
    E --> G[FullProduct - entitlements present]
    F --> H[getPlanResponse / getProductResponse]
    G --> H
    H --> I{entitlements null-coalesce}
    I -- before fix: undefined --> J[TypeError: Cannot iterate undefined]
    I -- after fix: empty array --> K[mapToProductItems - safe iteration]
    K --> L[API response returned]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(catalog): normalize missing product ..."](https://github.com/useautumn/autumn/commit/aa5ba5147659f9b2f6b2007cb9da178229424db9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45744031)</sub>

<!-- /greptile_comment -->