### PR TITLE
fix(catalog): normalize missing product entitlements

### DIFF
--- a/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
@@ -65,7 +65,7 @@ export const getPlanResponse = async ({
 	// 1. Convert prices/entitlements to items
 	const rawItems = mapToProductItems({
 		prices: product.prices,
-		entitlements: product.entitlements,
+		entitlements: product.entitlements ?? [],
 		features: features,
 	});
 

--- a/server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts
@@ -179,7 +179,7 @@ export const getProductResponse = async ({
 	// 1. Get items with display
 	const rawItems = mapToProductItems({
 		prices: product.prices,
-		entitlements: product.entitlements,
+		entitlements: product.entitlements ?? [],
 		features: features,
 	});
 


### PR DESCRIPTION
Normalize missing product prices and entitlements at catalog response boundaries so incomplete historical products cannot crash preview/update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize missing product entitlements in catalog responses to prevent crashes when historical products have null/undefined entitlements. Set `product.entitlements` to `[]` in getPlanResponse and getProductResponse so preview/update flows don’t break.

<sup>Written for commit 3cea4dd5cd59620837066817b06999cdfd365525. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR guards `product.entitlements` with `?? []` in both `getPlanResponse` and `getProductResponse` so that historical products with missing entitlements no longer crash the catalog preview/update path. The fix is targeted and minimal, but the same null-safety treatment is not applied to `product.prices`.

- **Bug fixes** — `entitlements: product.entitlements ?? []` prevents crashes in `mapToProductItems` when the entitlements array is absent on incomplete historical products in both response utils.
- **Bug fixes (incomplete)** — `product.prices` is passed to `mapToProductItems` without a null-coalescing guard; if prices can also be absent on these historical products, `mapToProductItems`'s `for (const price of prices)` loop and `getProductProperties`'s `product.prices.some(...)` call will still throw.
</details>


<h3>Confidence Score: 3/5</h3>

The entitlements guard does fix one crash, but the `prices` field follows the same pattern and is left unguarded in both files, so the same category of crash can still happen via the prices path.

The fix addresses one half of what the PR description promises. `product.prices` is iterated unconditionally in `mapToProductItems` and called with `.some()` in `getProductProperties` — if a historical product has a null `prices` array (the same scenario that motivated the entitlements guard), both sites would still throw. Two files are affected and all three unguarded sites are on the active response path for catalog preview/update.

Both `getPlanResponse.ts` and `getProductResponse.ts` need a `?? []` guard on `product.prices` in the `mapToProductItems` call; `getProductResponse.ts` additionally needs it in the `product.prices.some(...)` expression inside `getProductProperties`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts | Adds `?? []` guard on `product.entitlements` before passing to `mapToProductItems`, preventing crashes when entitlements are missing on historical products. `product.prices` is not similarly guarded. |
| server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts | Same `?? []` guard applied to `product.entitlements` in `getProductResponse`. `product.prices` remains unguarded in both `mapToProductItems` call and `product.prices.some(...)` in `getProductProperties`. |


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant getPlanResponse_getProductResponse as getPlanResponse / getProductResponse
    participant mapToProductItems
    participant getProductProperties

    Caller->>getPlanResponse_getProductResponse: product (historical, may have null prices/entitlements)
    getPlanResponse_getProductResponse->>mapToProductItems: prices: product.prices (unguarded), entitlements: product.entitlements ?? []
    Note over mapToProductItems: Iterates entitlements ✅ (guarded)<br/>Iterates prices ⚠️ (unguarded — may crash)
    getPlanResponse_getProductResponse->>getProductProperties: product (getProductResponse only)
    Note over getProductProperties: product.prices.some(...) ⚠️ (unguarded — may crash)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant getPlanResponse_getProductResponse as getPlanResponse / getProductResponse
    participant mapToProductItems
    participant getProductProperties

    Caller->>getPlanResponse_getProductResponse: product (historical, may have null prices/entitlements)
    getPlanResponse_getProductResponse->>mapToProductItems: prices: product.prices (unguarded), entitlements: product.entitlements ?? []
    Note over mapToProductItems: Iterates entitlements ✅ (guarded)<br/>Iterates prices ⚠️ (unguarded — may crash)
    getPlanResponse_getProductResponse->>getProductProperties: product (getProductResponse only)
    Note over getProductProperties: product.prices.some(...) ⚠️ (unguarded — may crash)
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts`, line 155-158 ([link](https://github.com/useautumn/autumn/blob/3cea4dd5cd59620837066817b06999cdfd365525/server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts#L155-L158)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `product.prices.some(...)` inside `getProductProperties` is called unconditionally. If a historical product has a null `prices` field, this call throws before reaching `mapToProductItems`, making the entitlements guard irrelevant in that code path.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts
   Line: 155-158

   Comment:
   `product.prices.some(...)` inside `getProductProperties` is called unconditionally. If a historical product has a null `prices` field, this call throws before reaching `mapToProductItems`, making the entitlements guard irrelevant in that code path.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts:66-68
The PR description states it normalizes missing **prices** as well as entitlements, but `product.prices` is passed to `mapToProductItems` without a null-coalescing guard. Inside `mapToProductItems`, the very next loop is `for (const price of prices)` — if `prices` is `null` or `undefined` for the same class of incomplete historical products, the crash will still occur there.

```suggestion
	const rawItems = mapToProductItems({
		prices: product.prices ?? [],
		entitlements: product.entitlements ?? [],
```

### Issue 2 of 3
server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts:180-182
Same incomplete guard: `product.prices` is not null-coalesced before being passed to `mapToProductItems`. Additionally, `getProductProperties` (called just below) calls `product.prices.some(...)` unconditionally — a null `prices` field would throw there too, before even reaching `mapToProductItems`.

```suggestion
	const rawItems = mapToProductItems({
		prices: product.prices ?? [],
		entitlements: product.entitlements ?? [],
```

### Issue 3 of 3
server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts:155-158
`product.prices.some(...)` inside `getProductProperties` is called unconditionally. If a historical product has a null `prices` field, this call throws before reaching `mapToProductItems`, making the entitlements guard irrelevant in that code path.

```suggestion
		updateable: (product.prices ?? []).some(
			(p: Price) =>
				isPrepaidPrice(p) && p.config.interval !== BillingInterval.OneOff,
		),
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(catalog): normalize missing product ..."](https://github.com/useautumn/autumn/commit/3cea4dd5cd59620837066817b06999cdfd365525) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45744042)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->