### PR TITLE
Lazy load plan customer counts

### DIFF
--- a/vite/src/views/products/products/components/product-list/ProductListColumns.tsx
+++ b/vite/src/views/products/products/components/product-list/ProductListColumns.tsx
@@ -66,10 +66,7 @@ export const createProductListColumns = ({
 			return (
 				<div className="text-muted-foreground">
 					{isCountsLoading ? (
-						<Skeleton
-							aria-label="Loading customer count"
-							className="h-4 w-14"
-						/>
+						<Skeleton aria-label="Loading" className="h-4 w-14" />
 					) : (
 						<ProductCountsTooltip product={row.original} />
 					)}

--- a/vite/src/views/products/products/components/product-list/ProductListColumns.tsx
+++ b/vite/src/views/products/products/components/product-list/ProductListColumns.tsx
@@ -1,5 +1,5 @@
 import type { ProductV2 } from "@autumn/shared";
-import { MiniCopyButton } from "@autumn/ui";
+import { MiniCopyButton, Skeleton } from "@autumn/ui";
 import type { Row } from "@tanstack/react-table";
 import type { SandboxSummary } from "@/hooks/queries/useSandboxesQuery";
 import { formatUnixToDateTime } from "@/utils/formatUtils/formatDateUtils";
@@ -9,10 +9,12 @@ import { ProductNameCell } from "./ProductNameCell";
 
 export const createProductListColumns = ({
 	showGroup = false,
+	isCountsLoading = false,
 	onDeleteClick,
 	sandboxes = [],
 }: {
 	showGroup?: boolean;
+	isCountsLoading?: boolean;
 	onDeleteClick?: (product: ProductV2) => void;
 	sandboxes?: SandboxSummary[];
 } = {}) => [
@@ -63,7 +65,14 @@ export const createProductListColumns = ({
 		cell: ({ row }: { row: Row<ProductV2 & { active_count?: number }> }) => {
 			return (
 				<div className="text-muted-foreground">
-					<ProductCountsTooltip product={row.original} />
+					{isCountsLoading ? (
+						<Skeleton
+							aria-label="Loading customer count"
+							className="h-4 w-14"
+						/>
+					) : (
+						<ProductCountsTooltip product={row.original} />
+					)}
 				</div>
 			);
 		},

--- a/vite/src/views/products/products/components/product-list/ProductListTable.tsx
+++ b/vite/src/views/products/products/components/product-list/ProductListTable.tsx
@@ -139,10 +139,11 @@ export function ProductListTable() {
 		() =>
 			createProductListColumns({
 				showGroup: hasAnyGroup,
+				isCountsLoading,
 				onDeleteClick: handleDeleteClick,
 				sandboxes,
 			}),
-		[hasAnyGroup, handleDeleteClick, sandboxes],
+		[hasAnyGroup, isCountsLoading, handleDeleteClick, sandboxes],
 	);
 
 	const recurringBaseTable = useProductTable({
@@ -213,7 +214,6 @@ export function ProductListTable() {
 								table: recurringBaseTable,
 								numberOfColumns: columns.length,
 								enableSorting,
-								isLoading: isCountsLoading,
 								getRowHref,
 								getRowClassName: (product: ProductWithCounts) =>
 									product.base_id
@@ -241,7 +241,6 @@ export function ProductListTable() {
 									table: recurringAddOnTable,
 									numberOfColumns: columns.length,
 									enableSorting,
-									isLoading: isCountsLoading,
 									getRowHref,
 									rowClassName: "h-10",
 								}}
@@ -261,7 +260,6 @@ export function ProductListTable() {
 								table: oneTimeTable,
 								numberOfColumns: columns.length,
 								enableSorting,
-								isLoading: isCountsLoading,
 								getRowHref,
 								emptyStateText:
 									"One-time prices for top-ups or lifetime purchases",

--- a/vite/tests/views/products/products/product-list-lazy-counts.test.tsx
+++ b/vite/tests/views/products/products/product-list-lazy-counts.test.tsx
@@ -30,6 +30,7 @@ describe("product list customer count loading", () => {
 		const cell = renderCustomerCell({ isCountsLoading: true });
 
 		expect(cell.props.children.type).toBe(Skeleton);
+		expect(cell.props.children.props["aria-label"]).toBe("Loading");
 	});
 
 	test("shows the customer count tooltip after counts load", () => {

--- a/vite/tests/views/products/products/product-list-lazy-counts.test.tsx
+++ b/vite/tests/views/products/products/product-list-lazy-counts.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import type { ProductV2 } from "@autumn/shared";
+import { Skeleton } from "@autumn/ui";
+import type { ReactElement } from "react";
+import { createProductListColumns } from "@/views/products/products/components/product-list/ProductListColumns";
+import { ProductCountsTooltip } from "@/views/products/products/product-row-toolbar/ProductCountsTooltip";
+
+const product = { id: "pro" } as ProductV2;
+
+const renderCustomerCell = ({
+	isCountsLoading,
+}: {
+	isCountsLoading: boolean;
+}) => {
+	const customerColumn = createProductListColumns({ isCountsLoading }).find(
+		(column) => column.header === "Customers",
+	);
+
+	if (typeof customerColumn?.cell !== "function") {
+		throw new Error("Customers column cell is not renderable");
+	}
+
+	return customerColumn.cell({
+		row: { original: product },
+	} as never) as ReactElement<{ children: ReactElement }>;
+};
+
+describe("product list customer count loading", () => {
+	test("shows a skeleton in the Customers cell while counts load", () => {
+		const cell = renderCustomerCell({ isCountsLoading: true });
+
+		expect(cell.props.children.type).toBe(Skeleton);
+	});
+
+	test("shows the customer count tooltip after counts load", () => {
+		const cell = renderCustomerCell({ isCountsLoading: false });
+
+		expect(cell.props.children.type).toBe(ProductCountsTooltip);
+	});
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazy-loads customer counts in the product list. The “Customers” column now shows a `Skeleton` while counts fetch to reduce table flicker and improve perceived performance.

- New Features
  - Added `isCountsLoading` to `createProductListColumns`; renders `Skeleton` with aria-label "Loading" in the “Customers” cell while loading, otherwise shows `ProductCountsTooltip`.
  - Passed `isCountsLoading` from `ProductListTable` into column creation and removed table-level `isLoading` flags for product sections.
  - Added tests (`product-list-lazy-counts.test.tsx`) to verify skeleton vs tooltip rendering.

<sup>Written for commit 0182da38940751374c7aff8055e551901aba708b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the coarse-grained table-level loading skeleton (previously applied to all three product table sections via `isLoading: isCountsLoading`) with a per-cell skeleton rendered only in the "Customers" column while counts are fetching. Product names, IDs, groups, and created dates are now visible immediately; the customer count cell shows a `Skeleton` until counts resolve.

- **[Improvements]** `createProductListColumns` now accepts `isCountsLoading` and renders a `<Skeleton>` in the Customers cell during the fetch, keeping the rest of the table interactive immediately.
- **[Improvements]** Removed `isLoading` from all three `Table.Provider` configs, eliminating the full-table skeleton overlay that previously blocked all product data while counts loaded.
- **[Improvements]** New unit tests cover both states (skeleton while loading, tooltip after load).
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is well-scoped, improves perceived load time, and is covered by new unit tests.

The change is straightforward: loading state moves from the table level to a single column cell. Product data renders immediately; only the Customers count cell shows a skeleton. The new tests walk raw React element props which makes them brittle to future JSX restructuring, but this does not affect runtime behavior.

The test file (product-list-lazy-counts.test.tsx) would benefit from a more resilient assertion strategy, but no files have functional issues requiring attention before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/products/products/components/product-list/ProductListColumns.tsx | Adds `isCountsLoading` prop to `createProductListColumns`; swaps the Customers cell from always rendering `ProductCountsTooltip` to conditionally rendering a `Skeleton` while loading. |
| vite/src/views/products/products/components/product-list/ProductListTable.tsx | Passes `isCountsLoading` into `createProductListColumns` (and adds it to the dependency array), removing the table-level `isLoading` prop that previously blanketed all three table sections with skeleton rows. |
| vite/tests/views/products/products/product-list-lazy-counts.test.tsx | New unit tests covering the skeleton/tooltip toggle in the Customers cell; tests access `cell.props.children.type` directly which couples them to the exact JSX wrapper structure. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App as ProductListTable
    participant Q as useProductsQuery
    participant Cols as createProductListColumns
    participant Cell as Customers Cell

    App->>Q: fetch products + counts
    Q-->>App: "products (immediate), isCountsLoading=true"
    App->>Cols: "createProductListColumns({ isCountsLoading: true, ... })"
    Cols-->>Cell: render Skeleton aria-label Loading customer count

    Q-->>App: "counts resolved, isCountsLoading=false"
    App->>Cols: "createProductListColumns({ isCountsLoading: false, ... })"
    Cols-->>Cell: render ProductCountsTooltip product
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App as ProductListTable
    participant Q as useProductsQuery
    participant Cols as createProductListColumns
    participant Cell as Customers Cell

    App->>Q: fetch products + counts
    Q-->>App: "products (immediate), isCountsLoading=true"
    App->>Cols: "createProductListColumns({ isCountsLoading: true, ... })"
    Cols-->>Cell: render Skeleton aria-label Loading customer count

    Q-->>App: "counts resolved, isCountsLoading=false"
    App->>Cols: "createProductListColumns({ isCountsLoading: false, ... })"
    Cols-->>Cell: render ProductCountsTooltip product
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/tests/views/products/products/product-list-lazy-counts.test.tsx:32-38
**Brittle JSX-structure assertion**

Both tests access `cell.props.children.type` to reach inside the wrapping `<div>`. If the outer `<div className="text-muted-foreground">` is ever removed or an additional wrapper is added, the assertions will silently start asserting on the wrong element rather than failing with a clear message. A more resilient approach would be to use React Testing Library to render the element and query by `aria-label` (`"Loading customer count"`) for the skeleton case and by role/text for the tooltip case, rather than walking raw React element props.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Lazy load plan customer counts"](https://github.com/useautumn/autumn/commit/ff7547909df4f7ada99f3583ffd90a2fcfd38b1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45744513)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->