### PR TITLE
fix(catalog): normalize missing product prices

### DIFF
--- a/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
@@ -64,7 +64,7 @@ export const getPlanResponse = async ({
 }): Promise<ApiPlanV1> => {
 	// 1. Convert prices/entitlements to items
 	const rawItems = mapToProductItems({
-		prices: product.prices,
+		prices: product.prices ?? [],
 		entitlements: product.entitlements ?? [],
 		features: features,
 	});

--- a/server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts
@@ -152,7 +152,7 @@ const getProductProperties = ({
 		is_one_off: isOneOffProduct({ product }),
 		interval_group: largestInterval?.interval,
 		has_trial: hasFreeTrial,
-		updateable: product.prices.some(
+		updateable: (product.prices ?? []).some(
 			(p: Price) =>
 				isPrepaidPrice(p) && p.config.interval !== BillingInterval.OneOff,
 		),
@@ -178,7 +178,7 @@ export const getProductResponse = async ({
 }) => {
 	// 1. Get items with display
 	const rawItems = mapToProductItems({
-		prices: product.prices,
+		prices: product.prices ?? [],
 		entitlements: product.entitlements ?? [],
 		features: features,
 	});


### PR DESCRIPTION
Normalize missing product prices at catalog response boundaries so incomplete historical products cannot crash catalog analysis.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize product responses to treat missing `prices` as empty arrays. Prevents catalog analysis from crashing on historical products and keeps the `updateable` flag safe.

- **Bug Fixes**
  - Default `prices` to `[]` when mapping items in `getPlanResponse` and `getProductResponse`.
  - Guard `updateable` with `(product.prices ?? []).some(...)` to avoid undefined access.

<sup>Written for commit ad32b7c9b35523d515b1e8b32f6e14b9e43b85b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `?? []` null-coalescing guards at three call sites where `product.prices` is passed into `mapToProductItems` or iterated, preventing crashes when historical products have missing price arrays. The fix is applied consistently to both `getPlanResponse.ts` and `getProductResponse.ts`.

- **[Bug fixes]** `getPlanResponse.ts`: guards `product.prices` before `mapToProductItems`, preventing a runtime crash for historical products with no price data.
- **[Bug fixes]** `getProductResponse.ts`: guards `product.prices` in the `mapToProductItems` call and the `updateable` `.some()` check; however, the same null/undefined `product.prices` will still crash when `getProductProperties` calls `productToEffectivePrices({ product })`, which spreads `product.prices` directly without a guard.
</details>


<h3>Confidence Score: 3/5</h3>

The fix is incomplete — `getProductResponse` still has an unguarded spread of `product.prices` inside `productToEffectivePrices`, which will throw for the same historical products this PR intends to protect.

Two of the three guarded call sites are correct, but `getProductProperties` calls `productToEffectivePrices({ product })`, which spreads `product.prices` directly. A historical product with null prices will still crash at `is_free`/`is_one_off` computation in `getProductResponse`, making the catalog analysis fix only partially effective.

server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts — the `getProductProperties` function and its downstream call to `productToEffectivePrices` need the same null guard treatment.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts | Adds `?? []` null guard to `product.prices` before passing to `mapToProductItems`; the change is minimal and correct for this file. |
| server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts | Adds `?? []` guards to the `mapToProductItems` call and the `updateable` `.some()` check, but `getProductProperties` still calls `productToEffectivePrices({ product })` which spreads `product.prices` without a null guard — the same crash scenario is still reachable via `is_free`/`is_one_off` computation. |


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getProductResponse / getPlanResponse] --> B["mapToProductItems\n(product.prices ?? [] ✅ fixed)"]
    A --> C[getProductProperties]
    C --> D["updateable: (product.prices ?? []).some(...)\n✅ fixed"]
    C --> E["productToEffectivePrices({ product })\n...product.prices ❌ still unguarded"]
    E --> F["isFreeProduct / isOneOffProduct / getLargestInterval"]
    E --> G["TypeError if product.prices is null"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[getProductResponse / getPlanResponse] --> B["mapToProductItems\n(product.prices ?? [] ✅ fixed)"]
    A --> C[getProductProperties]
    C --> D["updateable: (product.prices ?? []).some(...)\n✅ fixed"]
    C --> E["productToEffectivePrices({ product })\n...product.prices ❌ still unguarded"]
    E --> F["isFreeProduct / isOneOffProduct / getLargestInterval"]
    E --> G["TypeError if product.prices is null"]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts`, line 141-158 ([link](https://github.com/useautumn/autumn/blob/ad32b7c9b35523d515b1e8b32f6e14b9e43b85b5/server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts#L141-L158)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`productToEffectivePrices` still spreads `product.prices` without a null guard**

   `getProductProperties` calls `productToEffectivePrices({ product })` on line 141, which does `[...product.prices, ...]` (spread of `product.prices`). For the same historical products this PR targets — where `product.prices` can be null/undefined — this will still throw a TypeError ("null is not iterable") before the `is_free`, `is_one_off`, `interval_group`, and `has_trial` properties can be computed. The three `?? []` guards added here and in `getPlanResponse.ts` do not cover this code path; `productToEffectivePrices` itself would need the same normalization.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts
   Line: 141-158

   Comment:
   **`productToEffectivePrices` still spreads `product.prices` without a null guard**

   `getProductProperties` calls `productToEffectivePrices({ product })` on line 141, which does `[...product.prices, ...]` (spread of `product.prices`). For the same historical products this PR targets — where `product.prices` can be null/undefined — this will still throw a TypeError ("null is not iterable") before the `is_free`, `is_one_off`, `interval_group`, and `has_trial` properties can be computed. The three `?? []` guards added here and in `getPlanResponse.ts` do not cover this code path; `productToEffectivePrices` itself would need the same normalization.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts:141-158
**`productToEffectivePrices` still spreads `product.prices` without a null guard**

`getProductProperties` calls `productToEffectivePrices({ product })` on line 141, which does `[...product.prices, ...]` (spread of `product.prices`). For the same historical products this PR targets — where `product.prices` can be null/undefined — this will still throw a TypeError ("null is not iterable") before the `is_free`, `is_one_off`, `interval_group`, and `has_trial` properties can be computed. The three `?? []` guards added here and in `getPlanResponse.ts` do not cover this code path; `productToEffectivePrices` itself would need the same normalization.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(catalog): normalize missing product ..."](https://github.com/useautumn/autumn/commit/ad32b7c9b35523d515b1e8b32f6e14b9e43b85b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45758023)</sub>

<!-- /greptile_comment -->