### PR TITLE
fix(catalog): normalize missing product prices

### DIFF
--- a/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
@@ -64,7 +64,7 @@ export const getPlanResponse = async ({
 }): Promise<ApiPlanV1> => {
 	// 1. Convert prices/entitlements to items
 	const rawItems = mapToProductItems({
-		prices: product.prices,
+		prices: product.prices ?? [],
 		entitlements: product.entitlements ?? [],
 		features: features,
 	});

--- a/server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts
@@ -152,7 +152,7 @@ const getProductProperties = ({
 		is_one_off: isOneOffProduct({ product }),
 		interval_group: largestInterval?.interval,
 		has_trial: hasFreeTrial,
-		updateable: product.prices.some(
+		updateable: (product.prices ?? []).some(
 			(p: Price) =>
 				isPrepaidPrice(p) && p.config.interval !== BillingInterval.OneOff,
 		),
@@ -178,7 +178,7 @@ export const getProductResponse = async ({
 }) => {
 	// 1. Get items with display
 	const rawItems = mapToProductItems({
-		prices: product.prices,
+		prices: product.prices ?? [],
 		entitlements: product.entitlements ?? [],
 		features: features,
 	});


### PR DESCRIPTION
Normalize missing product prices at catalog response boundaries so incomplete historical products cannot crash catalog analysis.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize missing product prices to empty arrays in product and plan response mappers to prevent crashes when products lack price data. This stabilizes catalog analysis for historical or incomplete products.

- **Bug Fixes**
  - Treat null/undefined `product.prices` as `[]` in `getProductResponse` and `getPlanResponse`.
  - Guard `updateable` check by iterating over `(product.prices ?? [])`.

<sup>Written for commit 2d4fb040ddcdaad66b7a6255bbcf9113da075454. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `?? []` null-coalescing guards for `product.prices` at catalog response boundaries to prevent crashes when incomplete historical products have missing price data.

- **[Bug fixes]** `getPlanResponse.ts`: guards `product.prices` before passing to `mapToProductItems`, preventing a crash when prices are absent on historical products.
- **[Bug fixes]** `getProductResponse.ts`: guards `product.prices` for both the `mapToProductItems` call and the `.some(isPrepaidPrice)` check, but the upstream `productToEffectivePrices` call on line 141 still spreads `product.prices` directly and is not covered by this fix.
</details>


<h3>Confidence Score: 3/5</h3>

The fix is partially effective — it closes some crash paths but leaves `productToEffectivePrices` in `getProductResponse` unguarded for the same null-prices scenario.

Three of the four `product.prices` access sites are guarded, but `productToEffectivePrices` (called inside `getProductProperties`) spreads `product.prices` directly. Any incomplete historical product that reaches `getProductResponse` will still throw a `TypeError` at that spread before the guarded `.some()` check is ever reached.

getProductResponse.ts — the `productToEffectivePrices` call on line 141 needs the same null guard treatment as the other three sites.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts | Adds `?? []` guard for `product.prices` before passing to `mapToProductItems` — safe and correct. |
| server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts | Adds `?? []` guards for `mapToProductItems` and `.some(...)`, but the call to `productToEffectivePrices` on line 141 spreads `product.prices` directly and remains unguarded — still crashable for null-prices products. |


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[FullProduct with null prices] --> B{getProductResponse}
    B --> C["mapToProductItems\n(product.prices ?? []) ✅"]
    B --> D["getProductProperties"]
    D --> E["productToEffectivePrices\n(...product.prices) ❌ unguarded"]
    D --> F["(product.prices ?? []).some(...) ✅"]
    B --> G["getAttachScenario"]

    H[FullProduct with null prices] --> I{getPlanResponse}
    I --> J["mapToProductItems\n(product.prices ?? []) ✅"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[FullProduct with null prices] --> B{getProductResponse}
    B --> C["mapToProductItems\n(product.prices ?? []) ✅"]
    B --> D["getProductProperties"]
    D --> E["productToEffectivePrices\n(...product.prices) ❌ unguarded"]
    D --> F["(product.prices ?? []).some(...) ✅"]
    B --> G["getAttachScenario"]

    H[FullProduct with null prices] --> I{getPlanResponse}
    I --> J["mapToProductItems\n(product.prices ?? []) ✅"]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts`, line 141 ([link](https://github.com/useautumn/autumn/blob/2d4fb040ddcdaad66b7a6255bbcf9113da075454/server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts#L141)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Incomplete null guard — `productToEffectivePrices` still spreads `product.prices` directly**

   The same "incomplete historical products" this PR targets will crash here. `productToEffectivePrices` (in `shared/utils/productUtils/convertProduct/productToEffectivePrices.ts`) is implemented as `[...product.prices, ...]`, so if `product.prices` is `null`/`undefined` at runtime it throws a `TypeError: null is not iterable`. The three `?? []` guards added in this PR protect `mapToProductItems` and `.some(...)` but leave this call unguarded.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts
   Line: 141

   Comment:
   **Incomplete null guard — `productToEffectivePrices` still spreads `product.prices` directly**

   The same "incomplete historical products" this PR targets will crash here. `productToEffectivePrices` (in `shared/utils/productUtils/convertProduct/productToEffectivePrices.ts`) is implemented as `[...product.prices, ...]`, so if `product.prices` is `null`/`undefined` at runtime it throws a `TypeError: null is not iterable`. The three `?? []` guards added in this PR protect `mapToProductItems` and `.some(...)` but leave this call unguarded.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts:141
**Incomplete null guard — `productToEffectivePrices` still spreads `product.prices` directly**

The same "incomplete historical products" this PR targets will crash here. `productToEffectivePrices` (in `shared/utils/productUtils/convertProduct/productToEffectivePrices.ts`) is implemented as `[...product.prices, ...]`, so if `product.prices` is `null`/`undefined` at runtime it throws a `TypeError: null is not iterable`. The three `?? []` guards added in this PR protect `mapToProductItems` and `.some(...)` but leave this call unguarded.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(catalog): normalize missing product ..."](https://github.com/useautumn/autumn/commit/2d4fb040ddcdaad66b7a6255bbcf9113da075454) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45758029)</sub>

<!-- /greptile_comment -->