### PR TITLE
fix(catalog): normalize partial product relations

### DIFF
--- a/server/src/internal/catalog/actions/catalogMappings/catalogMappingUtils.ts
+++ b/server/src/internal/catalog/actions/catalogMappings/catalogMappingUtils.ts
@@ -156,8 +156,8 @@ export const buildProductMappingContext = ({
 	currency: string;
 }): ProductMappingContext => {
 	const rawItems = mapToProductItems({
-		prices: product.prices,
-		entitlements: product.entitlements,
+		prices: product.prices ?? [],
+		entitlements: product.entitlements ?? [],
 		features,
 	});
 	const sortedItems = sortProductItems(rawItems, features);
@@ -165,7 +165,7 @@ export const buildProductMappingContext = ({
 		product: { items: sortedItems } as any,
 	});
 	const basePrice = basePriceItem?.price_id
-		? product.prices.find((price) => price.id === basePriceItem.price_id)
+		? (product.prices ?? []).find((price) => price.id === basePriceItem.price_id)
 		: undefined;
 
 	const featureItems = productV2ToFeatureItems({
@@ -175,7 +175,7 @@ export const buildProductMappingContext = ({
 	const itemPrices = featureItems
 		.filter((item) => item.price_id && isFeaturePriceItem(item))
 		.map((item) => {
-			const price = product.prices.find((p) => p.id === item.price_id);
+			const price = (product.prices ?? []).find((p) => p.id === item.price_id);
 			const apiItem = productItemsToPlanItemsV1({
 				items: [item],
 				features,
@@ -246,6 +246,6 @@ export const productHasStripeProductId = ({
 	stripeProductId: string;
 }) =>
 	product.processor?.id === stripeProductId ||
-	product.prices.some(
+	(product.prices ?? []).some(
 		(price) => price.config.stripe_product_id === stripeProductId,
 	);

--- a/server/src/internal/catalog/actions/previewUpdateCatalog/previewUpdateCatalog.ts
+++ b/server/src/internal/catalog/actions/previewUpdateCatalog/previewUpdateCatalog.ts
@@ -44,7 +44,7 @@ const productUsesFeature = ({
 }) =>
 	(product.entitlements ?? []).some(
 		(entitlement) => entitlement.feature.id === featureId,
-	) || product.prices.some((price) => price.config?.feature_id === featureId);
+	) || (product.prices ?? []).some((price) => price.config?.feature_id === featureId);
 
 const productsForFeatureRemovalPreview = ({
 	featureId,

--- a/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
@@ -158,10 +158,10 @@ export const getPlanResponse = async ({
 		licenses: apiLicenses,
 		free_trial: freeTrial,
 
-		created_at: product.created_at,
-		env: product.env,
+		created_at: product.created_at ?? 0,
+		env: product.env ?? ctx?.env ?? "sandbox",
 		archived: product.archived,
-		base_variant_id: product.base_variant_id,
+		base_variant_id: product.base_variant_id ?? null,
 
 		config: product.config ?? { ignore_past_due: false },
 		billing_controls: billingControlsFromColumns(product),

--- a/server/src/internal/products/productV2Utils.ts
+++ b/server/src/internal/products/productV2Utils.ts
@@ -23,6 +23,8 @@ export const mapToProductItems = ({
 	allowFeatureMatch?: boolean;
 }): ProductItem[] => {
 	const items: ProductItem[] = [];
+	prices ??= [];
+	entitlements ??= [];
 
 	for (const ent of entitlements) {
 		const relatedPrice = getEntRelatedPrice(ent, prices, allowFeatureMatch);
@@ -60,16 +62,18 @@ export const mapToProductV2 = ({
 	features: Feature[];
 }): ProductV2 => {
 	const items: ProductItem[] = [];
+	const prices = product.prices ?? [];
+	const entitlements = product.entitlements ?? [];
 	// console.log("Prices:", product.prices);
 	// console.log("Entitlements:", product.entitlements);
 
-	for (const ent of product.entitlements) {
-		const relatedPrice = getEntRelatedPrice(ent, product.prices);
+	for (const ent of entitlements) {
+		const relatedPrice = getEntRelatedPrice(ent, prices);
 		items.push(toProductItem({ ent, price: relatedPrice }));
 	}
 
-	for (const price of product.prices) {
-		const relatedEnt = getPriceEntitlement(price, product.entitlements);
+	for (const price of prices) {
+		const relatedEnt = getPriceEntitlement(price, entitlements);
 
 		// console.log("Price:", price.id);
 		// console.log("Related ent:", relatedEnt);

--- a/shared/utils/productV2Utils/mapToProductV2.test.ts
+++ b/shared/utils/productV2Utils/mapToProductV2.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test";
+import { mapToProductItems } from "./mapToProductV2.js";
+
+// Legacy/customized products may omit relational arrays; mapping must remain total.
+test("mapToProductItems normalizes missing product relations", () => {
+	expect(
+		mapToProductItems({
+			prices: undefined as never,
+			entitlements: undefined as never,
+			features: [],
+		}),
+	).toEqual([]);
+});

--- a/shared/utils/productV2Utils/mapToProductV2.ts
+++ b/shared/utils/productV2Utils/mapToProductV2.ts
@@ -19,6 +19,8 @@ export const mapToProductItems = ({
 	features: Feature[];
 }): ProductItem[] => {
 	const items: ProductItem[] = [];
+	prices ??= [];
+	entitlements ??= [];
 
 	for (const ent of entitlements) {
 		// const relatedPrice = getEntRelatedPrice(ent, prices, allowFeatureMatch);


### PR DESCRIPTION
## Summary
- normalize missing price and entitlement arrays in shared/server product mappers
- keep catalog mapping and feature checks safe for partial legacy products
- normalize required plan response metadata during catalog preview

## Verification
- `bun test shared/utils/productV2Utils/mapToProductV2.test.ts`
- local Mobbin catalog preview advances past all validation errors to authentication

No Stripe writes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize missing product relations (prices and entitlements) so partial/legacy products don’t break catalog mapping or preview. Also normalize plan response defaults to avoid null/undefined issues.

- **Bug Fixes**
  - Default `prices` and `entitlements` to `[]` in `mapToProductItems`, `mapToProductV2`, and catalog helpers.
  - Guard feature/price lookups in catalog mapping and preview (`productUsesFeature`, price searches).
  - Normalize plan response fields: `created_at` to `0`, `env` to `ctx.env` or `"sandbox"`, `base_variant_id` to `null`.
  - Add unit test to verify mapping works when relations are missing.

<sup>Written for commit 7755cb35bf9280bd723b16eb865b9a9c32ff2a9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes catalog handling safer for partial legacy products. The main changes are:

- **Bug fixes:** Normalize missing price and entitlement arrays in shared and server mappers.
- **Bug fixes:** Keep catalog mapping and feature checks safe when product relations are absent.
- **API changes:** Fill required plan metadata during catalog preview.
- **Improvements:** Add a test for products with missing relation arrays.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/catalog/actions/catalogMappings/catalogMappingUtils.ts | Normalizes absent product relations during catalog mapping and Stripe product checks. |
| server/src/internal/catalog/actions/previewUpdateCatalog/previewUpdateCatalog.ts | Handles missing prices while checking whether products use a feature. |
| server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts | Adds schema-compatible defaults for required plan response metadata. |
| server/src/internal/products/productV2Utils.ts | Normalizes missing prices and entitlements in server-side product mapping. |
| shared/utils/productV2Utils/mapToProductV2.ts | Normalizes missing relations in the shared product-item mapper. |
| shared/utils/productV2Utils/mapToProductV2.test.ts | Tests mapping when both relational arrays are omitted. |

<sub>Reviews (1): Last reviewed commit: ["fix(catalog): normalize partial product ..."](https://github.com/useautumn/autumn/commit/7755cb35bf9280bd723b16eb865b9a9c32ff2a9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45774547)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->