### PR TITLE
fix(catalog): normalize partial product relations

### DIFF
--- a/server/src/internal/catalog/actions/catalogMappings/catalogMappingUtils.ts
+++ b/server/src/internal/catalog/actions/catalogMappings/catalogMappingUtils.ts
@@ -156,8 +156,8 @@ export const buildProductMappingContext = ({
 	currency: string;
 }): ProductMappingContext => {
 	const rawItems = mapToProductItems({
-		prices: product.prices,
-		entitlements: product.entitlements,
+		prices: product.prices ?? [],
+		entitlements: product.entitlements ?? [],
 		features,
 	});
 	const sortedItems = sortProductItems(rawItems, features);
@@ -165,7 +165,7 @@ export const buildProductMappingContext = ({
 		product: { items: sortedItems } as any,
 	});
 	const basePrice = basePriceItem?.price_id
-		? product.prices.find((price) => price.id === basePriceItem.price_id)
+		? (product.prices ?? []).find((price) => price.id === basePriceItem.price_id)
 		: undefined;
 
 	const featureItems = productV2ToFeatureItems({
@@ -175,7 +175,7 @@ export const buildProductMappingContext = ({
 	const itemPrices = featureItems
 		.filter((item) => item.price_id && isFeaturePriceItem(item))
 		.map((item) => {
-			const price = product.prices.find((p) => p.id === item.price_id);
+			const price = (product.prices ?? []).find((p) => p.id === item.price_id);
 			const apiItem = productItemsToPlanItemsV1({
 				items: [item],
 				features,
@@ -246,6 +246,6 @@ export const productHasStripeProductId = ({
 	stripeProductId: string;
 }) =>
 	product.processor?.id === stripeProductId ||
-	product.prices.some(
+	(product.prices ?? []).some(
 		(price) => price.config.stripe_product_id === stripeProductId,
 	);

--- a/server/src/internal/catalog/actions/previewUpdateCatalog/previewUpdateCatalog.ts
+++ b/server/src/internal/catalog/actions/previewUpdateCatalog/previewUpdateCatalog.ts
@@ -44,7 +44,7 @@ const productUsesFeature = ({
 }) =>
 	(product.entitlements ?? []).some(
 		(entitlement) => entitlement.feature.id === featureId,
-	) || product.prices.some((price) => price.config?.feature_id === featureId);
+	) || (product.prices ?? []).some((price) => price.config?.feature_id === featureId);
 
 const productsForFeatureRemovalPreview = ({
 	featureId,

--- a/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
@@ -158,10 +158,10 @@ export const getPlanResponse = async ({
 		licenses: apiLicenses,
 		free_trial: freeTrial,
 
-		created_at: product.created_at,
-		env: product.env,
+		created_at: product.created_at ?? 0,
+		env: product.env ?? ctx?.env ?? "sandbox",
 		archived: product.archived,
-		base_variant_id: product.base_variant_id,
+		base_variant_id: product.base_variant_id ?? null,
 
 		config: product.config ?? { ignore_past_due: false },
 		billing_controls: billingControlsFromColumns(product),

--- a/server/src/internal/products/productV2Utils.ts
+++ b/server/src/internal/products/productV2Utils.ts
@@ -23,6 +23,8 @@ export const mapToProductItems = ({
 	allowFeatureMatch?: boolean;
 }): ProductItem[] => {
 	const items: ProductItem[] = [];
+	prices ??= [];
+	entitlements ??= [];
 
 	for (const ent of entitlements) {
 		const relatedPrice = getEntRelatedPrice(ent, prices, allowFeatureMatch);
@@ -60,16 +62,18 @@ export const mapToProductV2 = ({
 	features: Feature[];
 }): ProductV2 => {
 	const items: ProductItem[] = [];
+	const prices = product.prices ?? [];
+	const entitlements = product.entitlements ?? [];
 	// console.log("Prices:", product.prices);
 	// console.log("Entitlements:", product.entitlements);
 
-	for (const ent of product.entitlements) {
-		const relatedPrice = getEntRelatedPrice(ent, product.prices);
+	for (const ent of entitlements) {
+		const relatedPrice = getEntRelatedPrice(ent, prices);
 		items.push(toProductItem({ ent, price: relatedPrice }));
 	}
 
-	for (const price of product.prices) {
-		const relatedEnt = getPriceEntitlement(price, product.entitlements);
+	for (const price of prices) {
+		const relatedEnt = getPriceEntitlement(price, entitlements);
 
 		// console.log("Price:", price.id);
 		// console.log("Related ent:", relatedEnt);

--- a/shared/utils/productV2Utils/mapToProductV2.test.ts
+++ b/shared/utils/productV2Utils/mapToProductV2.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test";
+import { mapToProductItems } from "./mapToProductV2.js";
+
+// Legacy/customized products may omit relational arrays; mapping must remain total.
+test("mapToProductItems normalizes missing product relations", () => {
+	expect(
+		mapToProductItems({
+			prices: undefined as never,
+			entitlements: undefined as never,
+			features: [],
+		}),
+	).toEqual([]);
+});

--- a/shared/utils/productV2Utils/mapToProductV2.ts
+++ b/shared/utils/productV2Utils/mapToProductV2.ts
@@ -19,6 +19,8 @@ export const mapToProductItems = ({
 	features: Feature[];
 }): ProductItem[] => {
 	const items: ProductItem[] = [];
+	prices ??= [];
+	entitlements ??= [];
 
 	for (const ent of entitlements) {
 		// const relatedPrice = getEntRelatedPrice(ent, prices, allowFeatureMatch);


### PR DESCRIPTION
## Summary
- normalize missing price and entitlement arrays in shared/server product mappers
- keep catalog mapping and feature checks safe for partial legacy products
- normalize required plan response metadata during catalog preview

## Verification
- `bun test shared/utils/productV2Utils/mapToProductV2.test.ts`
- local Mobbin catalog preview advances past all validation errors to authentication

No Stripe writes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize catalog/product mapping to handle missing prices and entitlements, preventing crashes with partial legacy products. Also default plan response metadata so catalog preview proceeds without validation blockers.

- **Bug Fixes**
  - Treat undefined product.prices and product.entitlements as [] in mapping utilities.
  - Add null-safe lookups for prices/features in catalog mapping, preview checks, and Stripe product matching.
  - Default plan response fields: created_at=0, env from ctx or "sandbox", base_variant_id=null.
  - Add unit test to verify mapping with missing relations returns an empty item list.

<sup>Written for commit 72f16e1f95ff6bf0a178e29ee7afefd1d5c0ebc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes catalog mapping tolerate partial legacy products. The main changes are:

- **Bug fixes:** Default missing price and entitlement relations to empty arrays.
- **Bug fixes:** Guard catalog feature and Stripe product checks against missing prices.
- **API changes:** Fill required plan response metadata during catalog preview.
- **Improvements:** Add coverage for missing relations in `mapToProductItems`.
</details>

<h3>Confidence Score: 4/5</h3>

The shared full-product mapping path can still crash on the partial legacy products covered by this change.

- Server mapping and catalog checks consistently normalize missing relations.
- The shared `mapToProductV2` export still iterates missing relations directly.
- The new test covers only `mapToProductItems`.

shared/utils/productV2Utils/mapToProductV2.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/productV2Utils/mapToProductV2.ts | Normalizes relations in `mapToProductItems`, but leaves the full shared mapper unsafe for the same partial input. |
| server/src/internal/products/productV2Utils.ts | Normalizes missing relations in both server product mapping functions. |
| server/src/internal/catalog/actions/catalogMappings/catalogMappingUtils.ts | Guards item mapping, price lookup, and Stripe product matching against omitted relations. |
| server/src/internal/catalog/actions/previewUpdateCatalog/previewUpdateCatalog.ts | Makes feature-use checks tolerate products without prices. |
| server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts | Supplies required metadata when partial products are converted to plan responses. |
| shared/utils/productV2Utils/mapToProductV2.test.ts | Covers missing relations in the item mapper but not the full shared product mapper. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
shared/utils/productV2Utils/mapToProductV2.ts:22-23
**Full Mapper Still Throws**

This normalization only protects `mapToProductItems`. Shared callers that pass the same partial legacy product to `mapToProductV2` still reach direct iteration over `product.entitlements` and `product.prices`, so either missing relation causes a runtime error instead of producing a normalized product.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(catalog): normalize partial product ..."](https://github.com/useautumn/autumn/commit/72f16e1f95ff6bf0a178e29ee7afefd1d5c0ebc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45774562)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->