### PR TITLE
Fix undefined customer product query

### DIFF
--- a/vite/src/views/customers/customer/product/hooks/useCusProductQuery.tsx
+++ b/vite/src/views/customers/customer/product/hooks/useCusProductQuery.tsx
@@ -63,6 +63,7 @@ export const useCusProductQuery = () => {
 			stableStates.entity_id,
 		]),
 		queryFn: fetcher,
+		enabled: !!customer_id && !!product_id,
 	});
 
 	useEffect(() => {

--- a/vite/tests/views/customers/customer/product/hooks/use-cus-product-query.test.ts
+++ b/vite/tests/views/customers/customer/product/hooks/use-cus-product-query.test.ts
@@ -1,0 +1,72 @@
+/** Red: the inline editor fetched `/product/undefined`; green: route-dependent fetching waits for both IDs. */
+
+import { beforeEach, expect, mock, test } from "bun:test";
+
+const get = mock(async () => ({ data: {} }));
+let routeParams: { customer_id?: string; product_id?: string } = {};
+
+mock.module("react", () => ({
+	useEffect: () => undefined,
+	useMemo: (factory: () => unknown) => factory(),
+	useState: (initial: unknown) => [initial, () => undefined],
+}));
+
+mock.module("react-router", () => ({
+	useParams: () => routeParams,
+}));
+
+mock.module("nuqs", () => ({
+	parseAsInteger: {},
+	parseAsString: {},
+	useQueryStates: () => [{}],
+}));
+
+mock.module("@tanstack/react-query", () => ({
+	useQuery: (options: { enabled?: boolean; queryFn: () => unknown }) => {
+		if (options.enabled !== false) void options.queryFn();
+		return { data: undefined, isLoading: false, error: null, refetch: mock() };
+	},
+}));
+
+mock.module("@/hooks/common/useQueryKeyFactory", () => ({
+	useQueryKeyFactory: () => (key: unknown[]) => key,
+}));
+
+mock.module("@/services/useAxiosInstance", () => ({
+	useAxiosInstance: () => ({ get }),
+}));
+
+mock.module(
+	"@/views/customers/customer/product/hooks/useCusProductCache",
+	() => ({
+		useCusProductCache: () => ({ getCachedCusProduct: () => undefined }),
+	}),
+);
+
+const { useCusProductQuery } = await import(
+	"@/views/customers/customer/product/hooks/useCusProductQuery"
+);
+
+beforeEach(() => {
+	get.mockClear();
+	routeParams = {};
+});
+
+test("does not fetch a customer product without a product route parameter", () => {
+	routeParams = { customer_id: "cus_123" };
+
+	useCusProductQuery();
+
+	expect(get).not.toHaveBeenCalled();
+});
+
+test("fetches when both customer and product route parameters exist", () => {
+	routeParams = { customer_id: "cus_123", product_id: "pro_yearly" };
+
+	useCusProductQuery();
+
+	expect(get).toHaveBeenCalledWith(
+		"/customers/cus_123/product/pro_yearly",
+		expect.any(Object),
+	);
+});


### PR DESCRIPTION
## Summary
- prevent the customer-product query from running before both route parameters exist
- cover missing and valid product route parameters with a regression test

## Context
Opening the inline plan editor from a customer page mounts the shared breadcrumb without a `product_id` route parameter. The query previously requested `/customers/:customer_id/product/undefined`.

## Test plan
- `bun test tests/views/customers/customer/product/hooks/use-cus-product-query.test.ts`
- `tsc --noEmit` from `vite/`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the customer-product fetch from running until both `customer_id` and `product_id` exist, preventing calls to `/customers/:customer_id/product/undefined` when the inline editor opens from a customer page.

- **Bug Fixes**
  - Gated the query with `enabled: !!customer_id && !!product_id` in `useCusProductQuery`.
  - Added regression tests for missing and valid product route parameters.

<sup>Written for commit a154cfd845a7717d91e11f0d616c5c45efa58df3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents customer-product requests until both route parameters are available. The main changes are:

- **Bug fixes:** Guard the query with `customer_id` and `product_id`.
- **Improvements:** Test the missing-parameter and valid-parameter paths.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers/customer/product/hooks/useCusProductQuery.tsx | Disables the customer-product query while either required route parameter is absent. |
| vite/tests/views/customers/customer/product/hooks/use-cus-product-query.test.ts | Tests request suppression with a missing product ID and the expected request with both IDs. |

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): 🐛 guard customer produc..."](https://github.com/useautumn/autumn/commit/a154cfd845a7717d91e11f0d616c5c45efa58df3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45897444)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->