### PR TITLE
fix(billing): show unavoidable schedule charges in preview

### DIFF
--- a/server/src/internal/billing/v2/actions/createSchedule/previewCreateSchedule.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/previewCreateSchedule.ts
@@ -7,6 +7,7 @@ import type {
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { evaluateStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan";
 import { billingPlanToAttachPreview } from "@/internal/billing/v2/utils/billingPlan/billingPlanToAttachPreview";
+import { computeAttachPreviewBillingPlan } from "@/internal/billing/v2/utils/billingPlan/preview/computeAttachPreviewBillingPlan";
 import { computeCreateSchedulePlan } from "./compute/computeCreateSchedulePlan";
 import {
 	handleCreateScheduleBillingPlanErrors,
@@ -54,13 +55,23 @@ export const previewCreateScheduleWithContext = async ({
 
 	handleCreateScheduleBillingPlanErrors({ ctx, billingContext, billingPlan });
 
+	const previewBillingPlan = await computeAttachPreviewBillingPlan({
+		ctx,
+		billingContext,
+		autumnBillingPlan,
+	});
+	const billingPlanWithPreview = {
+		...billingPlan,
+		preview: previewBillingPlan,
+	};
+
 	return {
 		billingContext,
-		billingPlan,
+		billingPlan: billingPlanWithPreview,
 		preview: await billingPlanToAttachPreview({
 			ctx,
 			billingContext,
-			billingPlan,
+			billingPlan: billingPlanWithPreview,
 		}),
 	};
 };

--- a/server/src/internal/billing/v2/compute/finalize/finalizeLineItems.ts
+++ b/server/src/internal/billing/v2/compute/finalize/finalizeLineItems.ts
@@ -37,6 +37,7 @@ export const finalizeLineItems = ({
 
 	if (
 		billingContext.requestedProrationBehavior === "none" &&
+		billingContext.stripeSubscription &&
 		!billingContext.anchorResetRefund?.noPartialRefund
 	) {
 		return [];

--- a/server/tests/integration/billing/create-schedule/backdate/create-schedule-backdate-preview.test.ts
+++ b/server/tests/integration/billing/create-schedule/backdate/create-schedule-backdate-preview.test.ts
@@ -28,13 +28,13 @@ import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
-import { addMonths } from "date-fns";
+import { addMonths, addYears } from "date-fns";
 import { createStripeCli } from "@/external/connect/createStripeCli";
-import { createAmountCoupon } from "../../utils/discounts/discountTestUtils";
 import {
 	expectResetAnchoredTo,
 	getCustomerProduct,
 } from "../../attach/params/start-date/utils";
+import { createAmountCoupon } from "../../utils/discounts/discountTestUtils";
 
 const previewCreateSchedule = async ({
 	autumnV1,
@@ -270,4 +270,76 @@ test.concurrent(
 		expect(response.status).toBe("created");
 		expect(response.invoice?.total).toBe(preview.total);
 	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("create-schedule backdate preview: no proration still shows the forced subscription invoice and tax")}`,
+	async () => {
+		const customerId = "create-schedule-backdate-preview-no-proration-tax";
+		const enterprise = products.base({
+			id: "enterprise",
+			items: [items.annualPrice({ price: 8_400 })],
+		});
+		const renewal = products.base({
+			id: "enterprise-renewal",
+			items: [items.annualPrice({ price: 13_500 })],
+		});
+
+		const { autumnV1, advancedTo } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					configOverrides: { automatic_tax: true },
+					taxRegistrations: ["AU"],
+				}),
+				s.customer({
+					testClock: false,
+					paymentMethod: "success",
+					stripeCustomerOverrides: {
+						address: {
+							country: "AU",
+							line1: "1 Test St",
+							city: "Sydney",
+							postal_code: "2000",
+							state: "NSW",
+						},
+					},
+				}),
+				s.products({ list: [enterprise, renewal] }),
+			],
+			actions: [],
+		});
+
+		const startsAt = advancedTo - ms.days(260);
+		const params: CreateScheduleParamsV0Input = {
+			customer_id: customerId,
+			billing_behavior: "none",
+			phases: [
+				{
+					starts_at: startsAt,
+					plans: [{ plan_id: enterprise.id }],
+				},
+				{
+					starts_at: addYears(startsAt, 1).getTime(),
+					plans: [{ plan_id: renewal.id }],
+				},
+			],
+		};
+
+		const preview = await previewCreateSchedule({ autumnV1, params });
+
+		expect(preview.subtotal).toBe(8_400);
+		expect(preview.line_items).toHaveLength(1);
+		expect(preview.tax?.status).toBe("complete");
+		expect(preview.tax?.total).toBeGreaterThan(0);
+		expect(preview.total).toBeCloseTo(
+			preview.subtotal + (preview.tax?.total ?? 0),
+			2,
+		);
+
+		const response = await autumnV1.billing.createSchedule(params);
+		expect(response.invoice?.status).toBe("paid");
+		expect(response.invoice?.total).toBeCloseTo(preview.total, 2);
+	},
+	300_000,
 );


### PR DESCRIPTION
## Summary

- preserve initial subscription invoice line items when `billing_behavior: none` is used without an existing Stripe subscription
- include automatic tax and invoice-credit enrichment in create-schedule previews
- add a regression covering a backdated annual schedule with a saved payment method

## Testing

- `create-schedule-backdate-preview.test.ts`: 4 passed
- `next-cycle-only.test.ts`: 6 passed
- `bun ts`
- Biome check on all touched files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix create-schedule previews to show unavoidable immediate charges and match the final invoice. Previews now keep initial subscription line items and include automatic tax and credits, even when `billing_behavior: "none"` is used without an existing Stripe subscription.

- **Bug Fixes**
  - Preserve initial subscription invoice line items when `billing_behavior: "none"` and no Stripe subscription exists.
  - Include automatic tax and invoice-credit enrichment in create-schedule previews.
  - Suppress proration line items only when `requestedProrationBehavior: "none"` and a Stripe subscription is present.

<sup>Written for commit 1bfc36cf91ddf9141adb4eb095a9ca8ed7c2c519. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes create-schedule previews include charges that cannot be suppressed. The main changes are:

- **Bug fixes:** Preserve initial subscription line items when `billing_behavior: "none"` is used without an existing Stripe subscription.
- **Improvements:** Add automatic tax and invoice-credit data to create-schedule previews.
- **Improvements:** Add a backdated annual schedule test with automatic tax and a saved payment method.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The new line-item condition matches the required initial-subscription charge behavior.
- The preview enrichment uses existing billing-plan fields and preview utilities.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/createSchedule/previewCreateSchedule.ts | Enriches create-schedule billing plans with tax and invoice-credit preview data before building the response. |
| server/src/internal/billing/v2/compute/finalize/finalizeLineItems.ts | Limits no-proration line-item suppression to customers with an existing Stripe subscription. |
| server/tests/integration/billing/create-schedule/backdate/create-schedule-backdate-preview.test.ts | Covers the initial annual charge, automatic tax, and final invoice total for a backdated schedule. |

<sub>Reviews (1): Last reviewed commit: ["fix(billing): 🐛 show unavoidable schedu..."](https://github.com/useautumn/autumn/commit/1bfc36cf91ddf9141adb4eb095a9ca8ed7c2c519) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45901089)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->