### PR TITLE
Fix scheduled product transfer to entities

### DIFF
--- a/server/src/internal/customers/handlers/handleTransferProduct/transferRelatedCustomerProducts.ts
+++ b/server/src/internal/customers/handlers/handleTransferProduct/transferRelatedCustomerProducts.ts
@@ -3,7 +3,11 @@ import {
 	type FullCusProduct,
 	type FullCustomer,
 	isCustomerProductScheduled,
+	schedulePhases,
+	schedules,
 } from "@autumn/shared";
+import { and, eq, inArray, isNull } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { nullish } from "@/utils/genUtils.js";
 import { CusProductService } from "../../cusProducts/CusProductService.js";
@@ -60,39 +64,31 @@ export const findTransferCustomerProduct = ({
 			cusProduct.product.id === productId,
 	);
 
-/**
- * Only like-for-like collides: an entity may hold an active and a scheduled
- * product in the same group at once, so a scheduled transfer is not blocked by
- * the target's active product (or vice versa).
- */
+/** Active and scheduled products in the same group do not collide. */
 export const findExistingTransferTargetProduct = ({
 	fullCustomer,
 	toEntity,
-	product,
 	transferringCustomerProducts,
 }: {
 	fullCustomer: FullCustomer;
 	toEntity: Entity | null;
-	product: TransferProduct;
 	transferringCustomerProducts: FullCusProduct[];
-}) => {
-	const transferringScheduledStates = new Set(
-		transferringCustomerProducts.map((cusProduct) =>
-			isCustomerProductScheduled(cusProduct),
-		),
-	);
-
-	return fullCustomer.customer_products.find(
+}) =>
+	fullCustomer.customer_products.find(
 		(cusProduct) =>
-			matchesTransferProduct({ cusProduct, product }) &&
-			transferringScheduledStates.has(
-				isCustomerProductScheduled(cusProduct),
+			transferringCustomerProducts.some(
+				(transferringCustomerProduct) =>
+					isCustomerProductScheduled(cusProduct) ===
+						isCustomerProductScheduled(transferringCustomerProduct) &&
+					matchesTransferProduct({
+						cusProduct,
+						product: transferringCustomerProduct.product,
+					}),
 			) &&
 			(toEntity
 				? cusProduct.internal_entity_id === toEntity.internal_id
 				: nullish(cusProduct.internal_entity_id)),
 	);
-};
 
 export const getTransferCustomerProducts = ({
 	fullCustomer,
@@ -114,40 +110,106 @@ export const getTransferCustomerProducts = ({
 			matchesTransferSource({ cusProduct, fromEntity }),
 	);
 
-export const transferRelatedCustomerProducts = async ({
+export const getTransferCustomerProductState = async ({
 	ctx,
 	fullCustomer,
 	fromEntity,
-	toEntity,
 	product,
 	customerProductId,
+	includeSchedule = true,
 }: {
 	ctx: AutumnContext;
 	fullCustomer: FullCustomer;
 	fromEntity: Entity | null;
-	toEntity: Entity | null;
 	product: TransferProduct;
 	customerProductId?: string | null;
+	includeSchedule?: boolean;
+}) => {
+	const selectedCustomerProducts = getTransferCustomerProducts({
+		fullCustomer,
+		fromEntity,
+		product,
+		customerProductId,
+	});
+	const selectedIds = selectedCustomerProducts.map(({ id }) => id);
+	const phases = includeSchedule
+		? await ctx.db
+				.select({
+					scheduleId: schedules.id,
+					customerProductIds: schedulePhases.customer_product_ids,
+				})
+				.from(schedules)
+				.innerJoin(schedulePhases, eq(schedulePhases.schedule_id, schedules.id))
+				.where(
+					and(
+						eq(schedules.org_id, ctx.org.id),
+						eq(schedules.env, ctx.env),
+						eq(schedules.internal_customer_id, fullCustomer.internal_id),
+						fromEntity
+							? eq(schedules.internal_entity_id, fromEntity.internal_id)
+							: isNull(schedules.internal_entity_id),
+					),
+				)
+		: [];
+	const selectedIdSet = new Set(selectedIds);
+	const scheduleIds = [
+		...new Set(
+			phases
+				.filter(({ customerProductIds }) =>
+					customerProductIds.some((id) => selectedIdSet.has(id)),
+				)
+				.map(({ scheduleId }) => scheduleId),
+		),
+	];
+	const scheduleIdSet = new Set(scheduleIds);
+	const customerProductIds = [
+		...new Set([
+			...selectedIds,
+			...phases
+				.filter(({ scheduleId }) => scheduleIdSet.has(scheduleId))
+				.flatMap(({ customerProductIds }) => customerProductIds),
+		]),
+	];
+	const customerProductIdSet = new Set(customerProductIds);
+
+	return {
+		customerProductIds,
+		customerProducts: fullCustomer.customer_products.filter(({ id }) =>
+			customerProductIdSet.has(id),
+		),
+		scheduleIds,
+	};
+};
+
+export const transferRelatedCustomerProducts = async ({
+	ctx,
+	toEntity,
+	customerProductIds,
+	scheduleIds,
+}: {
+	ctx: AutumnContext;
+	toEntity: Entity | null;
+	customerProductIds: string[];
+	scheduleIds: string[];
 }): Promise<TransferEntityUpdates> => {
 	const updates = {
 		entity_id: toEntity?.id ?? null,
 		internal_entity_id: toEntity?.internal_id ?? null,
 	};
+	await ctx.db.transaction(async (tx) => {
+		const txCtx = { ...ctx, db: tx as unknown as DrizzleCli };
 
-	await Promise.all(
-		getTransferCustomerProducts({
-			fullCustomer,
-			fromEntity,
-			product,
-			customerProductId,
-		}).map((cusProduct) =>
-			CusProductService.update({
-				ctx,
-				cusProductId: cusProduct.id,
-				updates,
-			}),
-		),
-	);
+		if (scheduleIds.length > 0) {
+			await txCtx.db
+				.update(schedules)
+				.set(updates)
+				.where(inArray(schedules.id, scheduleIds));
+		}
+
+		for (const cusProductId of customerProductIds) {
+			await CusProductService.update({ ctx: txCtx, cusProductId, updates });
+		}
+	});
 
 	return updates;
 };

--- a/server/src/internal/customers/handlers/handleTransferProductV2.ts
+++ b/server/src/internal/customers/handlers/handleTransferProductV2.ts
@@ -3,6 +3,7 @@ import {
 	AttachScenario,
 	CusProductAlreadyExistsError,
 	CusProductNotFoundError,
+	isCustomerProductScheduled,
 	RecaseError,
 	Scopes,
 } from "@autumn/shared";
@@ -17,7 +18,7 @@ import { handleDecreaseAndTransfer } from "./handleTransferProduct/handleDecreas
 import {
 	findExistingTransferTargetProduct,
 	findTransferCustomerProduct,
-	getTransferCustomerProducts,
+	getTransferCustomerProductState,
 	transferRelatedCustomerProducts,
 } from "./handleTransferProduct/transferRelatedCustomerProducts.js";
 
@@ -119,16 +120,19 @@ export const handleTransferProductV2 = createRoute({
 			});
 		}
 
+		const transferState = await getTransferCustomerProductState({
+			ctx,
+			fullCustomer: customer,
+			fromEntity,
+			product,
+			customerProductId: customer_product_id,
+			includeSchedule:
+				cusProduct.quantity <= 1 && !isCustomerProductScheduled(cusProduct),
+		});
 		const toCusProduct = findExistingTransferTargetProduct({
 			fullCustomer: customer,
 			toEntity,
-			product,
-			transferringCustomerProducts: getTransferCustomerProducts({
-				fullCustomer: customer,
-				fromEntity,
-				product,
-				customerProductId: customer_product_id,
-			}),
+			transferringCustomerProducts: transferState.customerProducts,
 		});
 
 		if (toCusProduct) {
@@ -150,11 +154,9 @@ export const handleTransferProductV2 = createRoute({
 		} else {
 			const updates = await transferRelatedCustomerProducts({
 				ctx,
-				fullCustomer: customer,
-				fromEntity,
 				toEntity,
-				product,
-				customerProductId: customer_product_id,
+				customerProductIds: transferState.customerProductIds,
+				scheduleIds: transferState.scheduleIds,
 			});
 
 			await addProductsUpdatedWebhookTask({

--- a/server/tests/integration/billing/transfer/transfer-scheduled-products.test.ts
+++ b/server/tests/integration/billing/transfer/transfer-scheduled-products.test.ts
@@ -1,11 +1,13 @@
 import { expect, test } from "bun:test";
-import { CusProductStatus } from "@autumn/shared";
+import { CusProductStatus, customerProducts, ms } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features";
 import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 import { CusService } from "@/internal/customers/CusService";
+import { getAllCustomerSchedules } from "@/internal/customers/cusUtils/getFullCustomerSchedule";
+import { generateId } from "@/utils/genUtils";
 
 const expectScopedProducts = async ({
 	ctx,
@@ -101,6 +103,114 @@ test.concurrent(
 			productIds: [pro.id, premium.id],
 			internalEntityId: targetEntity!.internal_id,
 		});
+	},
+	30000,
+);
+
+// Pre-fix: the UI request moved only the active phase and left the customer schedule behind.
+// Post-fix: every related phase and the persisted schedule move to the target entity.
+test.concurrent(
+	`${chalk.yellowBright("transfer: frontend request moves a three-phase schedule to an entity")}`,
+	async () => {
+		const customerId = "transfer-three-phase-schedule-to-entity";
+		const pro = products.pro({
+			id: "transfer-phase-one",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+		const premium = products.premium({
+			id: "transfer-phase-two",
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+		});
+		const growth = products.growth({
+			id: "transfer-phase-three",
+			items: [items.monthlyMessages({ includedUsage: 1500 })],
+		});
+
+		const { autumnV1, ctx, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, premium, growth] }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+			],
+			actions: [],
+		});
+
+		const now = Date.now();
+		await autumnV1.billing.createSchedule({
+			customer_id: customerId,
+			phases: [
+				{ starts_at: now, plans: [{ plan_id: pro.id }] },
+				{
+					starts_at: now + ms.days(30),
+					plans: [{ plan_id: premium.id }],
+				},
+				{
+					starts_at: now + ms.days(60),
+					plans: [{ plan_id: growth.id }],
+				},
+			],
+		});
+
+		const beforeTransfer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			withEntities: true,
+		});
+		const activeProduct = beforeTransfer.customer_products.find(
+			(customerProduct) => customerProduct.product.id === pro.id,
+		);
+		const targetEntity = beforeTransfer.entities.find(
+			(entity) => entity.id === entities[0].id,
+		);
+		expect(activeProduct).toBeDefined();
+		expect(targetEntity).toBeDefined();
+		const unrelatedCustomerProductId = generateId("cus_prod");
+		await ctx.db.insert(customerProducts).values({
+			id: unrelatedCustomerProductId,
+			internal_customer_id: beforeTransfer.internal_id,
+			internal_product_id: activeProduct!.internal_product_id,
+			product_id: pro.id,
+			status: CusProductStatus.Scheduled,
+			starts_at: now + ms.days(90),
+			created_at: now,
+		});
+
+		await autumnV1.post(`/customers/${customerId}/transfer`, {
+			customer_product_id: activeProduct!.id,
+			to_entity_id: targetEntity!.internal_id,
+			product_id: pro.id,
+		});
+
+		const afterTransfer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			withEntities: true,
+		});
+		const transferredProducts = afterTransfer.customer_products.filter(
+			(customerProduct) =>
+				customerProduct.id !== unrelatedCustomerProductId &&
+				[pro.id, premium.id, growth.id].includes(customerProduct.product.id),
+		);
+		expect(transferredProducts).toHaveLength(3);
+		expect(
+			transferredProducts.every(
+				(customerProduct) =>
+					customerProduct.internal_entity_id === targetEntity!.internal_id,
+			),
+		).toBe(true);
+		expect(
+			afterTransfer.customer_products.find(
+				({ id }) => id === unrelatedCustomerProductId,
+			)?.internal_entity_id,
+		).toBeNull();
+
+		const [schedule] = await getAllCustomerSchedules({
+			ctx,
+			internalCustomerId: afterTransfer.internal_id,
+		});
+		expect(schedule?.internal_entity_id).toBe(targetEntity!.internal_id);
+		expect(schedule?.phases).toHaveLength(3);
 	},
 	30000,
 );

--- a/server/tests/unit/customers/transfer-related-customer-products.test.ts
+++ b/server/tests/unit/customers/transfer-related-customer-products.test.ts
@@ -27,11 +27,13 @@ const createCustomerProduct = ({
 	productId = product.id,
 	internalEntityId = sourceEntity.internal_id,
 	status = CusProductStatus.Active,
+	group = product.group,
 }: {
 	id: string;
 	productId?: string;
 	internalEntityId?: string | null;
 	status?: CusProductStatus;
+	group?: string | null;
 }) =>
 	({
 		id,
@@ -40,7 +42,7 @@ const createCustomerProduct = ({
 		status,
 		product: {
 			id: productId,
-			group: product.group,
+			group,
 			is_add_on: product.is_add_on,
 		},
 	}) as FullCusProduct;
@@ -48,7 +50,11 @@ const createCustomerProduct = ({
 const fullCustomer = {
 	customer_products: [
 		createCustomerProduct({ id: "cus_prod_target" }),
-		createCustomerProduct({ id: "cus_prod_related" }),
+		createCustomerProduct({
+			id: "cus_prod_related",
+			status: CusProductStatus.Scheduled,
+		}),
+		createCustomerProduct({ id: "cus_prod_other_active" }),
 		createCustomerProduct({
 			id: "cus_prod_other_scope",
 			internalEntityId: "entity_internal_2",
@@ -91,6 +97,7 @@ describe("transfer customer product selection", () => {
 		expect(results.map((customerProduct) => customerProduct.id)).toEqual([
 			"cus_prod_target",
 			"cus_prod_related",
+			"cus_prod_other_active",
 		]);
 	});
 });
@@ -121,7 +128,6 @@ describe("transfer target collision", () => {
 				customer_products: [scheduledSource, activeAtTarget],
 			} as FullCustomer,
 			toEntity: targetEntity,
-			product,
 			transferringCustomerProducts: [scheduledSource],
 		});
 
@@ -134,7 +140,6 @@ describe("transfer target collision", () => {
 				customer_products: [scheduledSource, activeAtTarget, scheduledAtTarget],
 			} as FullCustomer,
 			toEntity: targetEntity,
-			product,
 			transferringCustomerProducts: [scheduledSource],
 		});
 
@@ -149,10 +154,35 @@ describe("transfer target collision", () => {
 				customer_products: [activeSource, scheduledAtTarget, activeAtTarget],
 			} as FullCustomer,
 			toEntity: targetEntity,
-			product,
 			transferringCustomerProducts: [activeSource],
 		});
 
 		expect(result?.id).toBe("cus_prod_target_active");
+	});
+
+	test("a cross-group scheduled successor collides at the target", () => {
+		const scheduledSuccessor = createCustomerProduct({
+			id: "cus_prod_successor",
+			productId: "premium",
+			group: "premium",
+			status: CusProductStatus.Scheduled,
+		});
+		const scheduledSuccessorAtTarget = createCustomerProduct({
+			id: "cus_prod_target_successor",
+			productId: "premium-target",
+			group: "premium",
+			internalEntityId: targetEntity.internal_id,
+			status: CusProductStatus.Scheduled,
+		});
+
+		const result = findExistingTransferTargetProduct({
+			fullCustomer: {
+				customer_products: [scheduledSuccessor, scheduledSuccessorAtTarget],
+			} as FullCustomer,
+			toEntity: targetEntity,
+			transferringCustomerProducts: [scheduledSuccessor],
+		});
+
+		expect(result?.id).toBe("cus_prod_target_successor");
 	});
 });


### PR DESCRIPTION
## Summary
- transfer scheduled successor products with the selected active product
- move the persisted schedule scope to the destination entity
- add frontend-shaped three-phase regression coverage

## Tests
- `bun test tests/unit/customers/transfer-related-customer-products.test.ts`
- `./run.sh tests/integration/billing/transfer/transfer-scheduled-products.test.ts`
- `bunx tsgo --build --noEmit`
- `bunx biome check` on changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes transfers so that when the frontend moves an active customer product, its scheduled successors and the persisted schedule move to the target entity. Tightens selection to schedule-phase membership and makes updates atomic to prevent mismatched scopes; adds a three‑phase regression test.

- **Bug Fixes**
  - Select only schedules whose phases include the selected product IDs; ignore unrelated same‑group products.
  - Detect target collisions by matching active vs scheduled state (including cross‑group successors).
  - Update schedules and related customer products in a single transaction to avoid partial moves.

<sup>Written for commit 334f9eecb98d51142b042f0739fa487ef5023ed7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves scheduled products and their persisted schedule with a transferred active product. The main changes are:

- **Bug fixes:** Include scheduled successor products in ID-targeted transfers.
- **Bug fixes:** Move matching persisted schedules to the destination entity.
- **Improvements:** Add unit and three-phase integration coverage for schedule transfers.
</details>

<h3>Confidence Score: 4/5</h3>

Schedule selection and transfer atomicity can leave products or schedules in the wrong entity scope.

- Product-group matching can include products from unrelated schedules.
- A valid cross-group successor can be omitted.
- A failed or concurrent transfer can persist mismatched schedule and product scopes.

server/src/internal/customers/handlers/handleTransferProduct/transferRelatedCustomerProducts.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/handlers/handleTransferProduct/transferRelatedCustomerProducts.ts | Adds scheduled-product selection and schedule movement, but group-based selection and separate writes can produce incorrect persisted scope. |
| server/tests/integration/billing/transfer/transfer-scheduled-products.test.ts | Adds a three-phase happy-path test that checks both product and schedule scope. |
| server/tests/unit/customers/transfer-related-customer-products.test.ts | Updates fixtures and expectations to include same-group scheduled products in targeted transfers. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Transfer selected active product] --> B[Select scheduled products by status and group]
    B --> C[Move schedules with overlapping phase IDs]
    C --> D[Update selected customer products in parallel]
    D -->|All updates succeed| E[Schedule and products share destination]
    D -->|Failure or concurrent transfer| F[Schedule and products have different scopes]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Transfer selected active product] --> B[Select scheduled products by status and group]
    B --> C[Move schedules with overlapping phase IDs]
    C --> D[Update selected customer products in parallel]
    D -->|All updates succeed| E[Schedule and products share destination]
    D -->|Failure or concurrent transfer| F[Schedule and products have different scopes]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
server/src/internal/customers/handlers/handleTransferProduct/transferRelatedCustomerProducts.ts:97-99
**Unrelated Schedules Move Together**

When the source scope contains another scheduled product in the selected product's group, this condition includes it even if it belongs to a separate schedule. Both that product and its persisted schedule can then move to the destination, because schedule membership is stored in `schedulePhases.customer_product_ids`, not inferred from product group.

### Issue 2 of 3
server/src/internal/customers/handlers/handleTransferProduct/transferRelatedCustomerProducts.ts:97-99
**Cross-Group Successors Stay Behind**

When a schedule changes to a product in another group, the scheduled phase fails `matchesTransferProduct` and is omitted from `customerProducts`. The active product and schedule move, but the later phase's customer product remains assigned to the source entity.

### Issue 3 of 3
server/src/internal/customers/handlers/handleTransferProduct/transferRelatedCustomerProducts.ts:130-154
**Transfer Writes Are Not Atomic**

The schedule is committed before the parallel customer-product updates. If one product update fails or two transfers interleave, the request can leave the schedule at one entity while some referenced phase products remain at another.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(customers): transfer scheduled produ..."](https://github.com/useautumn/autumn/commit/9beff9a7a0e8f7ed92377329b99f333340ae1525) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45908522)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->