### PR TITLE
fix(dashboard): preserve base price when reselecting paid plan

### DIFF
--- a/vite/src/views/products/plan/components/edit-plan-details/PlanTypeSection.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-details/PlanTypeSection.tsx
@@ -8,6 +8,7 @@ import { CoinsIcon } from "@phosphor-icons/react";
 import { IncludedUsageIcon } from "@/components/v2/icons/AutumnIcons";
 import { useProduct } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 import { SheetSection } from "@/components/v2/sheets/InlineSheet";
+import { selectPaidPlanType } from "@/views/products/plan/utils/selectPaidPlanType";
 
 export const PlanTypeSection = () => {
 	const { product, setProduct } = useProduct();
@@ -48,17 +49,7 @@ export const PlanTypeSection = () => {
 					<div className="flex w-full items-center gap-4">
 						<PanelButton
 							isSelected={planType === "paid"}
-							onClick={async () => {
-								setProduct({
-									...product,
-									planType: "paid",
-									basePriceType: "usage",
-									is_default: false,
-									items: product.items.filter(
-										(item: ProductItem) => !isPriceItem(item),
-									),
-								});
-							}}
+							onClick={() => setProduct(selectPaidPlanType({ product }))}
 							icon={<CoinsIcon size={16} color="currentColor" />}
 						/>
 						<div className="flex-1">

--- a/vite/src/views/products/plan/utils/selectPaidPlanType.ts
+++ b/vite/src/views/products/plan/utils/selectPaidPlanType.ts
@@ -1,0 +1,20 @@
+import {
+	type FrontendProduct,
+	isPriceItem,
+	productV2ToPlanType,
+} from "@autumn/shared";
+
+export const selectPaidPlanType = ({
+	product,
+}: {
+	product: FrontendProduct;
+}): FrontendProduct =>
+	productV2ToPlanType({ product }) === "paid"
+		? product
+		: {
+				...product,
+				planType: "paid",
+				basePriceType: "usage",
+				is_default: false,
+				items: product.items.filter((item) => !isPriceItem(item)),
+			};

--- a/vite/tests/views/products/plan/plan-type-section.test.ts
+++ b/vite/tests/views/products/plan/plan-type-section.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import type { FrontendProduct, ProductItem } from "@autumn/shared";
+import { buildUpdateSubscriptionCustomizationParams } from "@/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody";
+import { selectPaidPlanType } from "@/views/products/plan/utils/selectPaidPlanType";
+
+describe("paid plan type selection", () => {
+	test("preserves the existing base price and feature items", () => {
+		const items = [
+			{ price: 3_000, interval: "year", interval_count: 1 },
+			{ feature_id: "AI_CREDITS", included_usage: 10_000 },
+		] as ProductItem[];
+		const product = {
+			id: "pro_yearly",
+			name: "Pro Yearly",
+			planType: "paid",
+			basePriceType: "recurring",
+			items,
+		} as FrontendProduct;
+
+		const selectedProduct = selectPaidPlanType({ product });
+		const request = buildUpdateSubscriptionCustomizationParams({
+			items: selectedProduct.items,
+			addLicenses: null,
+		});
+
+		expect(request.items).toEqual(items);
+	});
+});


### PR DESCRIPTION
## Summary

- make selecting an already-paid plan a no-op
- preserve the existing paid transition for non-paid plans
- cover the serialized update request so its base price and feature items cannot regress

## Verification

- bun test tests/ (328 passed)
- bun run ts
- React Doctor changed-files scan (100/100)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where reselecting the Paid plan in the plan editor could wipe the base price or feature items. Selecting Paid on an already-paid plan is now a no-op; switching from a non-paid plan to Paid still applies the expected defaults.

- **Bug Fixes**
  - Preserve existing base price and feature items when Paid is reselected.
  - Keep non-paid → Paid transition behavior; added a unit test to ensure the serialized update request remains intact.

<sup>Written for commit 747eafdd56978c5d2555f68b1d13f638767242a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR preserves paid-plan pricing when the paid option is selected again. The main changes are:

- **Bug fixes:** Treat an already-paid plan selection as a no-op.
- **Improvements:** Move paid-plan selection logic into a typed utility.
- **Improvements:** Add a test covering preserved price and feature items in the update request.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/components/edit-plan-details/PlanTypeSection.tsx | Uses the new helper when the paid plan option is selected. |
| vite/src/views/products/plan/utils/selectPaidPlanType.ts | Preserves an existing paid product and retains the previous free-to-paid transition. |
| vite/tests/views/products/plan/plan-type-section.test.ts | Tests that paid-plan price and feature items survive update-request serialization. |

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): 🐛 preserve base price w..."](https://github.com/useautumn/autumn/commit/747eafdd56978c5d2555f68b1d13f638767242a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45921924)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->