### PR TITLE
fix/dual checkout race

### DIFF
--- a/server/src/external/redis/redisUtils.ts
+++ b/server/src/external/redis/redisUtils.ts
@@ -2,12 +2,36 @@ import { ErrCode, RecaseError } from "@autumn/shared";
 import { tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
 import { redis } from "./initRedis.js";
 
-export const clearLock = async ({ lockKey }: { lockKey: string }) => {
-	await tryRedisWrite(() => redis.del(lockKey));
+/** With `token`, deletes only if this holder still owns the lock (expired-lease safety). */
+export const clearLock = async ({
+	lockKey,
+	token,
+}: {
+	lockKey: string;
+	token?: string;
+}) => {
+	if (!token) {
+		await tryRedisWrite(() => redis.del(lockKey));
+		return;
+	}
+
+	await tryRedisWrite(() =>
+		redis.eval(
+			`local value = redis.call("GET", KEYS[1])
+			if not value then return 0 end
+			local ok, lock = pcall(cjson.decode, value)
+			if not ok or lock.token ~= ARGV[1] then return 0 end
+			return redis.call("DEL", KEYS[1])`,
+			1,
+			lockKey,
+			token,
+		),
+	);
 };
 
 interface LockData {
 	errorMessage: string;
+	token?: string;
 }
 
 const DEFAULT_ERROR_MESSAGE =
@@ -22,10 +46,12 @@ export const acquireLock = async ({
 	lockKey,
 	ttlMs = 10000,
 	errorMessage = DEFAULT_ERROR_MESSAGE,
+	token,
 }: {
 	lockKey: string;
 	ttlMs?: number;
 	errorMessage?: string;
+	token?: string;
 }): Promise<boolean> => {
 	// If Redis not ready, allow operation to proceed
 	if (redis.status !== "ready") {
@@ -35,7 +61,7 @@ export const acquireLock = async ({
 	try {
 		// NX = only set if key doesn't exist, PX = set expiry in milliseconds
 		// Store as JSON for future extensibility
-		const lockData: LockData = { errorMessage };
+		const lockData: LockData = { errorMessage, token };
 		const result = await redis.set(
 			lockKey,
 			JSON.stringify(lockData),
@@ -85,11 +111,12 @@ export const withLock = async <T>({
 	errorMessage?: string;
 	fn: () => Promise<T>;
 }): Promise<T> => {
-	await acquireLock({ lockKey, ttlMs, errorMessage });
+	const token = crypto.randomUUID();
+	await acquireLock({ lockKey, ttlMs, errorMessage, token });
 
 	try {
 		return await fn();
 	} finally {
-		await clearLock({ lockKey });
+		await clearLock({ lockKey, token });
 	}
 };

--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts
@@ -12,6 +12,8 @@ import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/
 import { persistDeferredCreateSchedule } from "@/internal/billing/v2/actions/createSchedule/utils/persistDeferredCreateSchedule";
 import { addStripeSubscriptionScheduleIdToBillingPlan } from "@/internal/billing/v2/execute/addStripeSubscriptionScheduleIdToBillingPlan";
 import { executeAutumnBillingPlan } from "@/internal/billing/v2/execute/executeAutumnBillingPlan";
+import { buildBillingLockKey } from "@/internal/billing/v2/utils/billingLock/buildBillingLockKey";
+import { withBillingLock } from "@/internal/billing/v2/utils/billingLock/withBillingLock";
 import { logAutumnBillingPlan } from "@/internal/billing/v2/utils/logs/logAutumnBillingPlan";
 import { sendBillingUpdatedWebhook } from "@/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook";
 import { billingPlanToSendProductsUpdated } from "@/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated";
@@ -34,12 +36,29 @@ export const handleCheckoutSessionMetadataV2 = async ({
 		`[checkout.completed] Handling checkout session metadata V2: ${metadata.id}`,
 	);
 
-	await withClaimedCheckoutSessionMetadata({
-		ctx,
-		checkoutContext,
-		metadata,
-		execute: () =>
-			executeCheckoutSessionMetadataV2({ ctx, checkoutContext, metadata }),
+	const deferredData = metadata.data as DeferredAutumnBillingPlanData;
+	const customerId =
+		deferredData.billingContext.fullCustomer.id ??
+		deferredData.billingContext.fullCustomer.internal_id;
+
+	await withBillingLock({
+		lockKey: buildBillingLockKey({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			customerId,
+		}),
+		fn: () =>
+			withClaimedCheckoutSessionMetadata({
+				ctx,
+				checkoutContext,
+				metadata,
+				execute: () =>
+					executeCheckoutSessionMetadataV2({
+						ctx,
+						checkoutContext,
+						metadata,
+					}),
+			}),
 	});
 };
 

--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts
@@ -37,16 +37,15 @@ export const handleCheckoutSessionMetadataV2 = async ({
 	);
 
 	const deferredData = metadata.data as DeferredAutumnBillingPlanData;
-	const customerId =
-		deferredData.billingContext.fullCustomer.id ??
-		deferredData.billingContext.fullCustomer.internal_id;
+	const { id, internal_id } = deferredData.billingContext.fullCustomer;
 
 	await withBillingLock({
-		lockKey: buildBillingLockKey({
-			orgId: ctx.org.id,
-			env: ctx.env,
-			customerId,
-		}),
+		// Route locks key on whichever identifier the API caller passed — hold both.
+		lockKeys: [id, internal_id]
+			.filter((customerId): customerId is string => Boolean(customerId))
+			.map((customerId) =>
+				buildBillingLockKey({ orgId: ctx.org.id, env: ctx.env, customerId }),
+			),
 		fn: () =>
 			withClaimedCheckoutSessionMetadata({
 				ctx,

--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata.ts
@@ -58,7 +58,11 @@ export const withClaimedCheckoutSessionMetadata = async ({
 		throw error;
 	} finally {
 		if (lockCustomerId) {
-			await checkoutSessionLock.clear({ ctx, customerId: lockCustomerId });
+			await checkoutSessionLock.clearIfOwned({
+				ctx,
+				customerId: lockCustomerId,
+				checkoutSessionId: checkoutContext.stripeCheckoutSession.id,
+			});
 		}
 	}
 };

--- a/server/src/honoMiddlewares/routeHandler.ts
+++ b/server/src/honoMiddlewares/routeHandler.ts
@@ -292,6 +292,7 @@ export function createRoute<
 
 		// Acquire lock if lock config provided
 		let lockKey: string | null = null;
+		const lockToken = crypto.randomUUID();
 		if (opts.lock) {
 			lockKey = opts.lock.getKey(c);
 			if (lockKey) {
@@ -299,6 +300,7 @@ export function createRoute<
 					lockKey,
 					ttlMs: opts.lock.ttlMs,
 					errorMessage: opts.lock.errorMessage,
+					token: lockToken,
 				});
 			}
 		}
@@ -318,9 +320,9 @@ export function createRoute<
 				return await handler(c);
 			}
 		} finally {
-			// Always release lock
+			// Always release lock (only if this request still owns it)
 			if (lockKey) {
-				await clearLock({ lockKey });
+				await clearLock({ lockKey, token: lockToken });
 			}
 		}
 	};

--- a/server/src/internal/billing/v2/actions/attach/attach.ts
+++ b/server/src/internal/billing/v2/actions/attach/attach.ts
@@ -12,6 +12,7 @@ import { handleAttachV2Errors } from "@/internal/billing/v2/actions/attach/error
 import { logAttachContext } from "@/internal/billing/v2/actions/attach/logs/logAttachContext";
 import { setupAttachBillingContext } from "@/internal/billing/v2/actions/attach/setup/setupAttachBillingContext";
 import { checkCheckoutSessionLock } from "@/internal/billing/v2/actions/locks/checkoutSessionLock/checkCheckoutSessionLock";
+import { checkoutSessionLock } from "@/internal/billing/v2/actions/locks/checkoutSessionLock/checkoutSessionLock";
 import { executeBillingPlan } from "@/internal/billing/v2/execute/executeBillingPlan";
 import { evaluateStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan";
 import { logStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingPlan";
@@ -42,6 +43,14 @@ export async function attach({
 
 	contextOverride?: BillingContextOverride;
 }): Promise<CreateAutumnCheckoutResult<AttachBillingContext>> {
+	const checkoutReservation =
+		!preview && !skipAutumnCheckout
+			? await checkoutSessionLock.get({
+					ctx,
+					customerId: params.customer_id,
+				})
+			: undefined;
+
 	params = {
 		...params,
 		carry_over_usages: await resolveCarryOverUsagesParam({
@@ -139,6 +148,7 @@ export async function attach({
 			params: autumnCheckoutParams,
 			billingContext,
 			billingPlan,
+			existingLock: checkoutReservation,
 		});
 
 		if (cachedResult) return cachedResult;

--- a/server/src/internal/billing/v2/actions/locks/checkoutSessionLock/checkCheckoutSessionLock.ts
+++ b/server/src/internal/billing/v2/actions/locks/checkoutSessionLock/checkCheckoutSessionLock.ts
@@ -3,78 +3,79 @@ import { AppEnv, ErrCode, RecaseError } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import type { CreateAutumnCheckoutResult } from "@/internal/billing/v2/common/createAutumnCheckout";
 import { hashJson } from "@/utils/hash/hashJson";
-import { checkoutSessionLock } from "./checkoutSessionLock";
+import {
+	checkoutSessionLock,
+	type CheckoutSessionLockData,
+} from "./checkoutSessionLock";
 
-/**
- * Check the checkout session lock for a customer.
- *
- * - Same params + stripe_checkout → returns cached checkout result
- * - Different params + stripe_checkout → expires old session, returns null (proceed)
- * - Lock exists + non-checkout mode → throws 423
- * - No lock → returns null (proceed)
- */
+/** Reuses matching Checkout sessions and prevents a payable session from racing direct billing. */
 export const checkCheckoutSessionLock = async <T extends BillingContext>({
 	ctx,
 	params,
 	billingContext,
 	billingPlan,
+	existingLock,
 }: {
 	ctx: AutumnContext;
 	params: unknown;
 	billingContext: T;
 	billingPlan: BillingPlan;
+	existingLock?: CheckoutSessionLockData | null;
 }): Promise<CreateAutumnCheckoutResult<T> | null> => {
 	const customerId =
 		billingContext.fullCustomer.id ?? billingContext.fullCustomer.internal_id;
 	const paramsHash = hashJson({ value: params });
-	const existingLock = await checkoutSessionLock.get({ ctx, customerId });
-	if (!existingLock) return null;
+	const lock =
+		existingLock === undefined
+			? await checkoutSessionLock.get({ ctx, customerId })
+			: existingLock;
+	if (!lock) return null;
 
-	if (billingContext.checkoutMode === "stripe_checkout") {
-		if (existingLock.paramsHash === paramsHash) {
-			ctx.logger.info(
-				`Returning cached checkout session for customer ${customerId}`,
-			);
-			return {
-				billingContext,
-				billingPlan,
-				billingResult: {
-					stripe: {
-						deferred: true,
-						stripeCheckoutSession: {
-							id: existingLock.checkoutSessionId,
-							url: existingLock.checkoutSessionUrl,
-						},
+	if (lock.paramsHash === paramsHash) {
+		ctx.logger.info(
+			`Returning cached checkout session for customer ${customerId}`,
+		);
+		return {
+			billingContext,
+			billingPlan,
+			billingResult: {
+				stripe: {
+					deferred: true,
+					stripeCheckoutSession: {
+						id: lock.checkoutSessionId,
+						url: lock.checkoutSessionUrl,
 					},
 				},
-			};
-		}
+			},
+		};
+	}
 
+	if (billingContext.checkoutMode === "stripe_checkout") {
 		ctx.logger.info(
-			`Expiring old checkout session ${existingLock.checkoutSessionId} for customer ${customerId} (params changed)`,
+			`Expiring old checkout session ${lock.checkoutSessionId} for customer ${customerId} (params changed)`,
 		);
-		await checkoutSessionLock.expireAndClear({
+		await checkoutSessionLock.expireAndClearIfOwned({
 			ctx,
 			customerId,
-			checkoutSessionId: existingLock.checkoutSessionId,
+			checkoutSessionId: lock.checkoutSessionId,
 		});
 		return null;
 	}
 
 	if (ctx.env === AppEnv.Sandbox) {
 		ctx.logger.info(
-			`Sandbox: clearing checkout session lock for customer ${customerId} (session ${existingLock.checkoutSessionId}) to allow non-checkout billing action`,
+			`Sandbox: clearing checkout session lock for customer ${customerId} (session ${lock.checkoutSessionId}) to allow non-checkout billing action`,
 		);
-		await checkoutSessionLock.expireAndClear({
+		await checkoutSessionLock.expireAndClearIfOwned({
 			ctx,
 			customerId,
-			checkoutSessionId: existingLock.checkoutSessionId,
+			checkoutSessionId: lock.checkoutSessionId,
 		});
 		return null;
 	}
 
 	ctx.logger.info(
-		`Blocking non-checkout billing action for customer ${customerId} — checkout session ${existingLock.checkoutSessionId} still active`,
+		`Blocking non-checkout billing action for customer ${customerId} — checkout session ${lock.checkoutSessionId} still active`,
 	);
 	throw new RecaseError({
 		message: "A checkout session is already in progress for this customer",

--- a/server/src/internal/billing/v2/actions/locks/checkoutSessionLock/checkCheckoutSessionLock.ts
+++ b/server/src/internal/billing/v2/actions/locks/checkoutSessionLock/checkCheckoutSessionLock.ts
@@ -25,10 +25,10 @@ export const checkCheckoutSessionLock = async <T extends BillingContext>({
 	const customerId =
 		billingContext.fullCustomer.id ?? billingContext.fullCustomer.internal_id;
 	const paramsHash = hashJson({ value: params });
+	// Entry-time snapshot wins when present; a null snapshot (e.g. caller passed
+	// internal_id, reservation keyed on public id) falls back to the canonical key.
 	const lock =
-		existingLock === undefined
-			? await checkoutSessionLock.get({ ctx, customerId })
-			: existingLock;
+		existingLock ?? (await checkoutSessionLock.get({ ctx, customerId }));
 	if (!lock) return null;
 
 	if (lock.paramsHash === paramsHash) {

--- a/server/src/internal/billing/v2/actions/locks/checkoutSessionLock/checkoutSessionLock.ts
+++ b/server/src/internal/billing/v2/actions/locks/checkoutSessionLock/checkoutSessionLock.ts
@@ -1,13 +1,15 @@
 import { createStripeCli } from "@/external/connect/createStripeCli";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { getPrimaryRedis } from "@/external/redis/initRedis";
 import { CacheManager } from "@/utils/cacheUtils/CacheManager";
 
-const CHECKOUT_LOCK_TTL_SECONDS = 2 * 60;
+const FALLBACK_CHECKOUT_LOCK_TTL_SECONDS = 2 * 60;
 
 interface CheckoutSessionLockData {
 	paramsHash: string;
 	checkoutSessionUrl: string;
 	checkoutSessionId: string;
+	expiresAt?: number;
 }
 
 const buildKey = ({
@@ -45,32 +47,44 @@ const set = async ({
 	data: CheckoutSessionLockData;
 }): Promise<void> => {
 	try {
-		await CacheManager.setJson(
-			buildKey({ ctx, customerId }),
-			data,
-			CHECKOUT_LOCK_TTL_SECONDS,
-		);
+		const ttlSeconds = data.expiresAt
+			? Math.max(1, Math.ceil((data.expiresAt - Date.now()) / 1000))
+			: FALLBACK_CHECKOUT_LOCK_TTL_SECONDS;
+		await CacheManager.setJson(buildKey({ ctx, customerId }), data, ttlSeconds);
 	} catch (error) {
 		ctx.logger.error(`Failed to set checkout session lock: ${error}`);
 	}
 };
 
-const clear = async ({
+const clearIfOwned = async ({
 	ctx,
 	customerId,
+	checkoutSessionId,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
+	checkoutSessionId: string;
 }): Promise<void> => {
 	try {
-		await CacheManager.del(buildKey({ ctx, customerId }));
+		const redis = getPrimaryRedis();
+		if (redis.status !== "ready") return;
+		await redis.eval(
+			`local value = redis.call("GET", KEYS[1])
+			if not value then return 0 end
+			local lock = cjson.decode(value)
+			if lock.checkoutSessionId ~= ARGV[1] then return 0 end
+			return redis.call("DEL", KEYS[1])`,
+			1,
+			buildKey({ ctx, customerId }),
+			checkoutSessionId,
+		);
 	} catch (error) {
 		ctx.logger.error(`Failed to clear checkout session lock: ${error}`);
 	}
 };
 
-/** Expire the old Stripe Checkout session then delete the Redis lock. */
-const expireAndClear = async ({
+/** Expire the old Stripe Checkout session then clear its reservation. */
+const expireAndClearIfOwned = async ({
 	ctx,
 	customerId,
 	checkoutSessionId,
@@ -91,8 +105,13 @@ const expireAndClear = async ({
 		);
 	}
 
-	await clear({ ctx, customerId });
+	await clearIfOwned({ ctx, customerId, checkoutSessionId });
 };
 
-export const checkoutSessionLock = { get, set, clear, expireAndClear };
+export const checkoutSessionLock = {
+	get,
+	set,
+	clearIfOwned,
+	expireAndClearIfOwned,
+};
 export type { CheckoutSessionLockData };

--- a/server/src/internal/billing/v2/execute/executeBillingPlan.ts
+++ b/server/src/internal/billing/v2/execute/executeBillingPlan.ts
@@ -58,6 +58,10 @@ export const executeBillingPlan = async ({
 					checkoutSessionUrl:
 						stripeBillingResult.stripeCheckoutSession.url ?? "",
 					checkoutSessionId: stripeBillingResult.stripeCheckoutSession.id ?? "",
+					expiresAt:
+						"expires_at" in stripeBillingResult.stripeCheckoutSession
+							? stripeBillingResult.stripeCheckoutSession.expires_at * 1000
+							: undefined,
 				},
 			});
 		}

--- a/server/src/internal/billing/v2/utils/billingLock/withBillingLock.ts
+++ b/server/src/internal/billing/v2/utils/billingLock/withBillingLock.ts
@@ -1,0 +1,36 @@
+import { setTimeout as sleep } from "node:timers/promises";
+import { ErrCode, RecaseError } from "@autumn/shared";
+import { acquireLock, clearLock } from "@/external/redis/redisUtils";
+
+const BILLING_LOCK_TTL_MS = 120_000;
+const BILLING_LOCK_WAIT_MS = BILLING_LOCK_TTL_MS + 5_000;
+const BILLING_LOCK_RETRY_MS = 100;
+
+export const withBillingLock = async <T>({
+	lockKey,
+	fn,
+}: {
+	lockKey: string;
+	fn: () => Promise<T>;
+}): Promise<T> => {
+	const deadline = Date.now() + BILLING_LOCK_WAIT_MS;
+
+	while (true) {
+		try {
+			await acquireLock({ lockKey, ttlMs: BILLING_LOCK_TTL_MS });
+			break;
+		} catch (error) {
+			if (!isBillingLockConflict(error) || Date.now() >= deadline) throw error;
+			await sleep(BILLING_LOCK_RETRY_MS);
+		}
+	}
+
+	try {
+		return await fn();
+	} finally {
+		await clearLock({ lockKey });
+	}
+};
+
+const isBillingLockConflict = (error: unknown) =>
+	error instanceof RecaseError && error.code === ErrCode.LockAlreadyExists;

--- a/server/src/internal/billing/v2/utils/billingLock/withBillingLock.ts
+++ b/server/src/internal/billing/v2/utils/billingLock/withBillingLock.ts
@@ -6,29 +6,41 @@ const BILLING_LOCK_TTL_MS = 120_000;
 const BILLING_LOCK_WAIT_MS = BILLING_LOCK_TTL_MS + 5_000;
 const BILLING_LOCK_RETRY_MS = 100;
 
+/** Waits (bounded) for every key, runs fn, then releases only locks this call still owns. */
 export const withBillingLock = async <T>({
-	lockKey,
+	lockKeys,
 	fn,
 }: {
-	lockKey: string;
+	lockKeys: string[];
 	fn: () => Promise<T>;
 }): Promise<T> => {
+	const token = crypto.randomUUID();
+	// Sorted so concurrent multi-key holders acquire in the same order (no deadlock).
+	const sortedKeys = [...new Set(lockKeys)].sort();
 	const deadline = Date.now() + BILLING_LOCK_WAIT_MS;
-
-	while (true) {
-		try {
-			await acquireLock({ lockKey, ttlMs: BILLING_LOCK_TTL_MS });
-			break;
-		} catch (error) {
-			if (!isBillingLockConflict(error) || Date.now() >= deadline) throw error;
-			await sleep(BILLING_LOCK_RETRY_MS);
-		}
-	}
+	const heldKeys: string[] = [];
 
 	try {
+		for (const lockKey of sortedKeys) {
+			while (true) {
+				try {
+					await acquireLock({ lockKey, ttlMs: BILLING_LOCK_TTL_MS, token });
+					heldKeys.push(lockKey);
+					break;
+				} catch (error) {
+					if (!isBillingLockConflict(error) || Date.now() >= deadline) {
+						throw error;
+					}
+					await sleep(BILLING_LOCK_RETRY_MS);
+				}
+			}
+		}
+
 		return await fn();
 	} finally {
-		await clearLock({ lockKey });
+		for (const lockKey of heldKeys) {
+			await clearLock({ lockKey, token });
+		}
 	}
 };
 

--- a/server/tests/_temp/runable-dual-checkout-race.test.ts
+++ b/server/tests/_temp/runable-dual-checkout-race.test.ts
@@ -1,0 +1,174 @@
+/** Reproduces Runable's checkout-completion/direct-attach race; current code creates two paid Pro subscriptions.
+ * Green requires one active Pro product, one Stripe subscription, and one paid initial invoice. */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV3 } from "@autumn/shared";
+import {
+	createAmountCoupon,
+	createPromotionCode,
+} from "@tests/integration/billing/utils/discounts/discountTestUtils";
+import { completeStripeCheckoutFormV2 } from "@tests/utils/browserPool/completeStripeCheckoutFormV2";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { timeout } from "@tests/utils/genUtils";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { redis } from "@/external/redis/initRedis";
+import { CusService } from "@/internal/customers/CusService";
+
+const customerId = "runable-dual-checkout-race";
+
+const buildCheckoutLockKey = ({
+	orgId,
+	env,
+}: {
+	orgId: string;
+	env: string;
+}) => `checkout_lock:${orgId}:${env}:${customerId}`;
+
+const waitForCheckoutPaymentMethod = async ({
+	stripeCli,
+	stripeCustomerId,
+}: {
+	stripeCli: Parameters<typeof createAmountCoupon>[0]["stripeCli"];
+	stripeCustomerId: string;
+}) => {
+	const deadline = Date.now() + 30_000;
+	while (Date.now() < deadline) {
+		const methods = await stripeCli.paymentMethods.list({
+			customer: stripeCustomerId,
+			type: "card",
+			limit: 1,
+		});
+		if (methods.data.length > 0) return;
+		await timeout(200);
+	}
+	throw new Error("Checkout did not attach a payment method within 30 seconds");
+};
+
+test(
+	`${chalk.yellowBright("checkout race: completion overlapping a fresh attach creates only one subscription")}`,
+	async () => {
+		const basic = products.base({
+			id: "runable_basic",
+			isDefault: true,
+			items: [items.monthlyCredits({ includedUsage: 51_000 })],
+		});
+		const pro = products.base({
+			id: "runable_pro_25_monthly",
+			items: [
+				items.monthlyPrice({ price: 25 }),
+				items.monthlyCredits({ includedUsage: 51_000 }),
+			],
+		});
+
+		const { autumnV1, autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, withDefault: true }),
+				s.products({ list: [basic, pro] }),
+			],
+			actions: [],
+		});
+
+		const coupon = await createAmountCoupon({
+			stripeCli: ctx.stripeCli,
+			amountOffCents: 2_400,
+		});
+		const promotionCode = await createPromotionCode({
+			stripeCli: ctx.stripeCli,
+			coupon,
+			code: "RUN1-RACE-",
+		});
+		const attachParams = {
+			customer_id: customerId,
+			plan_id: pro.id,
+			redirect_mode: "if_required" as const,
+			discounts: [{ promotion_code: promotionCode.code }],
+			checkout_session_params: {
+				adaptive_pricing: { enabled: true },
+				billing_address_collection: "required" as const,
+			},
+			success_url: "https://example.com/?checkout_success=true",
+		};
+
+		const firstAttach = await autumnV2_2.billing.attach(attachParams, {
+			timeout: 0,
+		});
+		expect(firstAttach.payment_url).toContain("checkout.stripe.com");
+
+		const checkoutLockKey = buildCheckoutLockKey({
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		await redis.del(checkoutLockKey);
+
+		const secondAttach = await autumnV2_2.billing.attach(attachParams, {
+			timeout: 0,
+		});
+		expect(secondAttach.payment_url).toContain("checkout.stripe.com");
+		expect(secondAttach.payment_url).not.toBe(firstAttach.payment_url);
+
+		await timeout(121_000);
+		const customerBeforeCheckout = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const stripeCustomerIdBeforeCheckout =
+			customerBeforeCheckout.processor?.id ??
+			customerBeforeCheckout.processor?.processor_id;
+		expect(stripeCustomerIdBeforeCheckout).toBeDefined();
+
+		const checkoutCompletion = completeStripeCheckoutFormV2({
+			url: secondAttach.payment_url,
+			billingAddress: {
+				country: "US",
+				line1: "123 Main Street",
+				city: "New York",
+				state: "NY",
+				postal_code: "10001",
+			},
+		});
+		await waitForCheckoutPaymentMethod({
+			stripeCli: ctx.stripeCli,
+			stripeCustomerId: stripeCustomerIdBeforeCheckout!,
+		});
+
+		const thirdAttach = await autumnV2_2.billing.attach(attachParams, {
+			timeout: 0,
+		});
+		await checkoutCompletion;
+		expect(thirdAttach.payment_url).toBe(secondAttach.payment_url);
+		await timeout(12_000);
+
+		const [customer, fullCustomer] = await Promise.all([
+			autumnV1.customers.get<ApiCustomerV3>(customerId),
+			CusService.getFull({ ctx, idOrInternalId: customerId, withSubs: true }),
+		]);
+		const stripeCustomerId =
+			fullCustomer.processor?.id ?? fullCustomer.processor?.processor_id;
+		expect(stripeCustomerId).toBeDefined();
+
+		const stripeSubscriptions = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCustomerId!,
+			status: "all",
+		});
+		const activeProProducts = fullCustomer.customer_products.filter(
+			(product) => product.product.id === pro.id && product.status === "active",
+		);
+		const paidInitialInvoices = (customer.invoices ?? []).filter(
+			(invoice) => invoice.status === "paid" && invoice.total === 1,
+		);
+
+		expect({
+			activeProProducts: activeProProducts.length,
+			stripeSubscriptions: stripeSubscriptions.data.length,
+			paidInitialInvoices: paidInitialInvoices.length,
+		}).toEqual({
+			activeProProducts: 1,
+			stripeSubscriptions: 1,
+			paidInitialInvoices: 1,
+		});
+	},
+	300_000,
+);


### PR DESCRIPTION
## Problem

A Runable customer got two active subscriptions and was double-charged for the same plan. The production sequence (from Axiom + Stripe):

1. `billing.attach(pro)` → Stripe Checkout session A created.
2. 2m13s later, the same attach again → the Redis checkout reservation had already expired (2-minute TTL vs Stripe Checkout's ~24h lifetime), so a **second** Checkout session B was created.
3. The customer paid session B. Stripe created subscription #1 and saved the payment method.
4. While the `checkout.session.completed` webhook was still materializing the plan in Autumn (~11s), a third `billing.attach` arrived. It read stale customer state (still on the free plan), saw the newly saved payment method, chose **direct billing**, and created subscription #2.

Result: 2 active customer products, 2 Stripe subscriptions, 2 paid invoices.

Neither existing guard covers this overlap: the HTTP billing lock only serializes API requests (the webhook doesn't use it), and the checkout metadata claim only dedupes redelivery of the *same* session.

## Fix

No new locks or queues — the two existing Redis keys are made correct:

- **Checkout reservation (`checkout_lock:*`) lives as long as the session is payable.** TTL now derives from Stripe's `expires_at` instead of a fixed 2 minutes.
- **Attach snapshots the reservation at request entry**, before loading customer state. The webhook clearing Redis mid-request can no longer hide the pending checkout from an in-flight attach.
- **Same-params attach reuses the existing Checkout URL** even when a payment method now exists (previously reuse only applied in `stripe_checkout` mode — the exact gap the third attach fell through). Conflicting non-checkout attaches still get `423`.
- **Reservation cleanup is session-owned** (atomic Lua compare-and-delete), so a stale session completing late can't clear a newer session's reservation.
- **Checkout completion takes the same per-customer billing lock as `billing.attach`** (`withBillingLock`, bounded retry), so webhook materialization and API attaches serialize instead of interleaving.

## Test

`server/tests/_temp/runable-dual-checkout-race.test.ts` reproduces the exact production sequence (expired reservation → second session → completion racing a third attach). Red on the old code (2/2/2), green with this fix: the third attach returns the pending session's URL and exactly one product / subscription / invoice exists.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR serializes Checkout completion with billing attaches and keeps Checkout reservations for the payable session lifetime. The main changes are:

- **Bug fixes:** Reuse matching pending Checkout sessions across billing modes.
- **Bug fixes:** Derive reservation TTL from Stripe's session expiry.
- **Bug fixes:** Make reservation cleanup conditional on Checkout session ownership.
- **Improvements:** Add a shared customer billing lock around webhook materialization.
- **Improvements:** Add a test for the dual-checkout race.
</details>

<h3>Confidence Score: 4/5</h3>

The reservation snapshot and billing-lock ownership paths need fixes before merging.

- An alternate customer identifier can make attach miss an active reservation.
- A slow billing operation can delete a successor's lock and admit concurrent billing work.
- Session-owned Checkout cleanup and Stripe-derived reservation expiry otherwise match the intended race fix.

server/src/internal/billing/v2/actions/attach/attach.ts; server/src/internal/billing/v2/utils/billingLock/withBillingLock.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/attach/attach.ts | Snapshots pending Checkout state early, but the lookup can use a different customer identifier from reservation creation. |
| server/src/internal/billing/v2/utils/billingLock/withBillingLock.ts | Adds bounded lock acquisition, but release does not verify that the caller still owns the lease. |
| server/src/internal/billing/v2/actions/locks/checkoutSessionLock/checkoutSessionLock.ts | Adds Stripe-derived TTLs and atomic session-owned reservation cleanup. |
| server/src/internal/billing/v2/actions/locks/checkoutSessionLock/checkCheckoutSessionLock.ts | Reuses matching sessions across checkout modes and preserves the supplied reservation snapshot. |
| server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts | Runs Checkout materialization under the per-customer billing lock. |
| server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata.ts | Clears a reservation only when the completing session owns it. |
| server/src/internal/billing/v2/execute/executeBillingPlan.ts | Stores Stripe Checkout expiry in milliseconds with the reservation. |
| server/tests/_temp/runable-dual-checkout-race.test.ts | Covers Checkout completion racing a third attach, but not alternate customer identifiers or lease expiry during execution. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant A as Billing operation A
    participant R as Redis billing lock
    participant B as Billing operation B
    participant C as Billing operation C
    A->>R: Acquire lock with 120s TTL
    Note over A: Work continues beyond TTL
    R-->>R: Lock expires
    B->>R: Acquire replacement lock
    A->>R: Unconditional clearLock
    C->>R: Acquire while B is active
    Note over B,C: Customer billing runs concurrently
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant A as Billing operation A
    participant R as Redis billing lock
    participant B as Billing operation B
    participant C as Billing operation C
    A->>R: Acquire lock with 120s TTL
    Note over A: Work continues beyond TTL
    R-->>R: Lock expires
    B->>R: Acquire replacement lock
    A->>R: Unconditional clearLock
    C->>R: Acquire while B is active
    Note over B,C: Customer billing runs concurrently
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/billing/v2/actions/attach/attach.ts:46-51
**Snapshot Uses Noncanonical Customer Key**

The reservation is created with `fullCustomer.id ?? fullCustomer.internal_id`, but this snapshot uses the raw `params.customer_id`. When a caller supplies the customer's alternate accepted identifier, this lookup returns `null`; passing that value as `existingLock` prevents the later check from reading the canonical key, so the attach can miss a pending Checkout and proceed with direct billing.

### Issue 2 of 2
server/src/internal/billing/v2/utils/billingLock/withBillingLock.ts:31
**Expired Owner Deletes Successor Lock**

If billing work exceeds the 120-second lease, a waiting request can acquire the expired key while the first request is still running. The first request then unconditionally deletes the new owner's lock here, allowing another attach or webhook to run concurrently and recreate the duplicate-subscription race.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): 🐛 prevent duplicate check..."](https://github.com/useautumn/autumn/commit/b4ab8eb1531d7f265a744f0853b0aa5d156a99c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45982848)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->