### PR TITLE
feat(billing): add pooled balance flows

### DIFF
--- a/server/src/_luaScriptsV2/luaScriptsV2.ts
+++ b/server/src/_luaScriptsV2/luaScriptsV2.ts
@@ -55,7 +55,9 @@ import USAGE_WINDOW_CONTEXT_UTILS_V2 from "./fullSubjectDeduction/usageWindows/u
 import ROLL_USAGE_WINDOWS_MAIN from "./fullSubject/rollUsageWindows/rollUsageWindows.lua";
 import APPLY_FIELD_UPDATES from "./fullSubject/updateSubjectBalances/applyFieldUpdates.lua";
 import UPDATE_CONTEXT_UTILS from "./fullSubject/updateSubjectBalances/updateContextUtils.lua";
+import UPDATE_SUBJECT_BALANCE_BATCHES_MAIN from "./fullSubject/updateSubjectBalances/updateSubjectBalanceBatches.lua";
 import UPDATE_SUBJECT_BALANCES_MAIN from "./fullSubject/updateSubjectBalances/updateSubjectBalances.lua";
+import VALIDATE_SUBJECT_BALANCE_UPDATE from "./fullSubject/updateSubjectBalances/validateSubjectBalanceUpdate.lua";
 
 // ============================================================================
 // FULL CUSTOMER KEY BUILDER LUA (version interpolated from TS config)
@@ -247,6 +249,14 @@ ${UPDATE_CONTEXT_UTILS}
 ${APPLY_FIELD_UPDATES}
 ${UPDATE_AGGREGATED_BALANCES}
 ${UPDATE_SUBJECT_BALANCES_MAIN}`;
+
+/** Atomically applies guarded SubjectBalance updates across feature hashes. */
+export const UPDATE_SUBJECT_BALANCE_BATCHES_SCRIPT = `${LUA_UTILS}
+${UPDATE_CONTEXT_UTILS}
+${VALIDATE_SUBJECT_BALANCE_UPDATE}
+${APPLY_FIELD_UPDATES}
+${UPDATE_AGGREGATED_BALANCES}
+${UPDATE_SUBJECT_BALANCE_BATCHES_MAIN}`;
 
 /**
  * Lua script for atomically rolling usage-window counters in a per-feature

--- a/server/src/external/redis/initUtils/redisTypes.ts
+++ b/server/src/external/redis/initUtils/redisTypes.ts
@@ -92,6 +92,10 @@ declare module "ioredis" {
 			balanceKey: string,
 			paramsJson: string,
 		): Promise<string>;
+		updateSubjectBalanceBatches(
+			numberOfKeys: number,
+			...keysAndArgs: string[]
+		): Promise<string>;
 		rollUsageWindows(balanceKey: string, paramsJson: string): Promise<string>;
 		deleteFullCustomerCache(
 			cacheKey: string,

--- a/server/src/external/redis/initUtils/registerRedisCommands.ts
+++ b/server/src/external/redis/initUtils/registerRedisCommands.ts
@@ -34,6 +34,7 @@ import {
 	UPDATE_CUSTOMER_PRODUCT_V2_SCRIPT,
 	UPDATE_ENTITY_DATA_V2_SCRIPT,
 	UPDATE_ENTITY_IN_CUSTOMER_SCRIPT,
+	UPDATE_SUBJECT_BALANCE_BATCHES_SCRIPT,
 	UPDATE_SUBJECT_BALANCES_SCRIPT,
 	UPSERT_INVOICE_IN_CUSTOMER_SCRIPT,
 	UPSTASH_KEY_LOCKING_SHEBANG,
@@ -160,6 +161,10 @@ export const registerRedisCommands = ({
 	redisInstance.defineCommand("updateSubjectBalances", {
 		numberOfKeys: 1,
 		lua: prepareScript(UPDATE_SUBJECT_BALANCES_SCRIPT),
+	});
+
+	redisInstance.defineCommand("updateSubjectBalanceBatches", {
+		lua: prepareScript(UPDATE_SUBJECT_BALANCE_BATCHES_SCRIPT),
 	});
 
 	redisInstance.defineCommand("rollUsageWindows", {

--- a/server/src/internal/balances/recalculateBalance/reapplyUsageToCustomerEntitlements.ts
+++ b/server/src/internal/balances/recalculateBalance/reapplyUsageToCustomerEntitlements.ts
@@ -1,0 +1,132 @@
+import {
+	cusEntToStartingBalance,
+	type EntityBalance,
+	type FullCusEntWithFullCusProduct,
+} from "@autumn/shared";
+import { Decimal } from "decimal.js";
+import { deductFromCusEntsTypescript } from "@/internal/balances/track/deductUtils/deductFromCusEntsTypescript.js";
+import { isSyntheticPooledBalanceCustomerEntitlement } from "@/internal/billing/v2/pooledBalances/utils/pooledCustomerEntitlementClassification.js";
+import { getResetBalancesUpdate } from "@/internal/customers/cusProducts/cusEnts/groupByUtils.js";
+
+export type CustomerEntitlementGrantState =
+	| {
+			startingBalance: number;
+			adjustment: number;
+			entities?: undefined;
+	  }
+	| {
+			startingBalance?: undefined;
+			adjustment: number;
+			entities: Record<string, EntityBalance>;
+	  };
+
+export const getCustomerEntitlementGrantState = ({
+	customerEntitlement,
+}: {
+	customerEntitlement: FullCusEntWithFullCusProduct;
+}): CustomerEntitlementGrantState => {
+	const startingBalance = cusEntToStartingBalance({
+		cusEnt: customerEntitlement,
+	});
+	if (customerEntitlement.customer_product?.internal_entity_id) {
+		return {
+			startingBalance,
+			adjustment: 0,
+		};
+	}
+	if (
+		isSyntheticPooledBalanceCustomerEntitlement({
+			customerEntitlement,
+			customerProduct: customerEntitlement.customer_product,
+		})
+	) {
+		return {
+			startingBalance,
+			adjustment: customerEntitlement.adjustment ?? 0,
+		};
+	}
+
+	const resetUpdate = getResetBalancesUpdate({
+		cusEnt: customerEntitlement,
+		allowance: startingBalance ?? undefined,
+	});
+	if ("entities" in resetUpdate) {
+		return {
+			entities: resetUpdate.entities,
+			adjustment: 0,
+		};
+	}
+	return {
+		startingBalance: resetUpdate.balance,
+		adjustment: resetUpdate.adjustment,
+	};
+};
+
+export const reapplyUsageToCustomerEntitlements = ({
+	customerEntitlements,
+	usage,
+	targetEntityId,
+	getGrantState,
+}: {
+	customerEntitlements: FullCusEntWithFullCusProduct[];
+	usage: number;
+	targetEntityId?: string;
+	getGrantState: ({
+		customerEntitlement,
+	}: {
+		customerEntitlement: FullCusEntWithFullCusProduct;
+	}) => CustomerEntitlementGrantState;
+}): void => {
+	for (const customerEntitlement of customerEntitlements) {
+		const grantState = getGrantState({ customerEntitlement });
+		customerEntitlement.adjustment = grantState.adjustment;
+
+		if (grantState.entities !== undefined) {
+			customerEntitlement.entities = grantState.entities;
+			continue;
+		}
+
+		customerEntitlement.balance = new Decimal(grantState.startingBalance)
+			.plus(grantState.adjustment)
+			.toNumber();
+		customerEntitlement.additional_balance = 0;
+	}
+
+	const usesTopLevelEntityRows = customerEntitlements.every(
+		(customerEntitlement) =>
+			customerEntitlement.customer_product?.internal_entity_id != null,
+	);
+	const deductionCustomerEntitlements = usesTopLevelEntityRows
+		? customerEntitlements.map((customerEntitlement) => ({
+				...customerEntitlement,
+				entitlement: {
+					...customerEntitlement.entitlement,
+					entity_feature_id: null,
+				},
+			}))
+		: customerEntitlements;
+
+	deductFromCusEntsTypescript({
+		cusEnts: deductionCustomerEntitlements,
+		amountToDeduct: usage,
+		targetEntityId: usesTopLevelEntityRows ? undefined : targetEntityId,
+		allowOverage: true,
+	});
+
+	if (usesTopLevelEntityRows) {
+		const updatedById = new Map(
+			deductionCustomerEntitlements.map((customerEntitlement) => [
+				customerEntitlement.id,
+				customerEntitlement,
+			]),
+		);
+		for (const customerEntitlement of customerEntitlements) {
+			const updated = updatedById.get(customerEntitlement.id);
+			if (!updated) continue;
+			customerEntitlement.balance = updated.balance;
+			customerEntitlement.adjustment = updated.adjustment;
+			customerEntitlement.additional_balance = updated.additional_balance;
+			customerEntitlement.entities = updated.entities;
+		}
+	}
+};

--- a/server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts
+++ b/server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts
@@ -6,6 +6,7 @@ import type {
 import { tryCatch } from "@autumn/shared";
 import { sql } from "drizzle-orm";
 import { planetScaleTag } from "@/db/dbUtils.js";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import type { UsageWindowUpdate } from "../types/usageWindowUpdate.js";
 
@@ -39,6 +40,39 @@ export interface RolloverSyncEntry {
 	usage: number;
 	entities: Record<string, EntityRolloverBalance> | null;
 }
+
+export type FlushSubjectBalancesResult =
+	| "noop"
+	| "flushed"
+	| "conflict"
+	| "failed";
+
+export const writeSubjectBalancesToDb = async ({
+	db,
+	subjectBalances,
+	usageWindowUpdates = [],
+	queryName,
+}: {
+	db: DrizzleCli;
+	subjectBalances: SubjectBalance[];
+	usageWindowUpdates?: UsageWindowUpdate[];
+	queryName: string;
+}) => {
+	const entries = subjectBalances.map((subjectBalance) =>
+		subjectBalanceToSyncEntry({ subjectBalance }),
+	);
+	const rolloverEntries = subjectBalancesToRolloverEntries({ subjectBalances });
+
+	const result = await db.execute(
+		sql`SELECT * FROM sync_balances_v2(${JSON.stringify({
+			customer_entitlement_updates: entries,
+			rollover_updates: rolloverEntries,
+			usage_window_updates: usageWindowUpdates,
+		})}::jsonb) ${planetScaleTag({ query: queryName })}`,
+	);
+
+	return { result, entries, rolloverEntries };
+};
 
 export const subjectBalanceToSyncEntry = ({
 	subjectBalance,
@@ -86,46 +120,45 @@ export const flushSubjectBalancesToDb = async ({
 	subjectBalances,
 	usageWindowUpdates = [],
 	source,
+	db = ctx.db,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	subjectBalances: SubjectBalance[];
 	usageWindowUpdates?: UsageWindowUpdate[];
 	source: string;
-}): Promise<void> => {
-	if (subjectBalances.length === 0 && usageWindowUpdates.length === 0) return;
+	db?: DrizzleCli;
+}): Promise<FlushSubjectBalancesResult> => {
+	if (subjectBalances.length === 0 && usageWindowUpdates.length === 0) {
+		return "noop";
+	}
 
-	const { db, logger } = ctx;
-	const entries = subjectBalances.map((subjectBalance) =>
-		subjectBalanceToSyncEntry({ subjectBalance }),
-	);
-	const rolloverEntries = subjectBalancesToRolloverEntries({ subjectBalances });
-
-	const { error } = await tryCatch(
-		db.execute(
-			sql`SELECT * FROM sync_balances_v2(${JSON.stringify({
-				customer_entitlement_updates: entries,
-				rollover_updates: rolloverEntries,
-				usage_window_updates: usageWindowUpdates,
-			})}::jsonb) ${planetScaleTag({ query: "flushSubjectBalancesToDb" })}`,
-		),
+	const { logger } = ctx;
+	const { data, error } = await tryCatch(
+		writeSubjectBalancesToDb({
+			db,
+			subjectBalances,
+			usageWindowUpdates,
+			queryName: "flushSubjectBalancesToDb",
+		}),
 	);
 
 	if (!error) {
 		logger.info(
-			`[flushSubjectBalancesToDb] ${customerId}: flushed ${entries.length} balances, ${usageWindowUpdates.length} usage windows, source: ${source}`,
+			`[flushSubjectBalancesToDb] ${customerId}: flushed ${data.entries.length} balances, ${usageWindowUpdates.length} usage windows, source: ${source}`,
 		);
-		return;
+		return "flushed";
 	}
 
 	if (isSyncConflictError(error)) {
 		logger.warn(
 			`[flushSubjectBalancesToDb] ${customerId}: sync conflict during flush (Postgres ahead), source: ${source}, error: ${error.message}`,
 		);
-		return;
+		return "conflict";
 	}
 
 	logger.error(
 		`[flushSubjectBalancesToDb] ${customerId}: flush failed, unsynced balances lost, source: ${source}, error: ${error}`,
 	);
+	return "failed";
 };

--- a/server/src/internal/balances/utils/sync/withCustomerBalanceSyncLock.ts
+++ b/server/src/internal/balances/utils/sync/withCustomerBalanceSyncLock.ts
@@ -1,0 +1,84 @@
+import { customers } from "@autumn/shared";
+import { and, eq, or, sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+export type CustomerBalanceSyncDb = DrizzleCli;
+
+const CUSTOMER_BALANCE_SYNC_LOCK_TIMEOUT_MS = 10_000;
+
+const resolveInternalCustomerId = async ({
+	db,
+	ctx,
+	customerId,
+}: {
+	db: CustomerBalanceSyncDb;
+	ctx: AutumnContext;
+	customerId: string;
+}): Promise<string> => {
+	const customer = await db.query.customers.findFirst({
+		columns: { internal_id: true },
+		where: and(
+			or(eq(customers.id, customerId), eq(customers.internal_id, customerId)),
+			eq(customers.org_id, ctx.org.id),
+			eq(customers.env, ctx.env),
+		),
+	});
+
+	// A stale sync can outlive customer deletion. There is no remaining customer
+	// lifecycle to serialize with in that case, so retain the old no-op path.
+	return customer?.internal_id ?? customerId;
+};
+
+/**
+ * Serializes Redis-to-Postgres balance snapshots for one customer.
+ *
+ * The transaction-scoped advisory lock must be acquired before Redis is read
+ * and held through the matching Postgres write. That prevents a delayed sync
+ * worker from overwriting a newer lifecycle cutover with an older snapshot.
+ */
+export const withCustomerBalanceSyncLock = async <T>({
+	ctx,
+	customerId,
+	internalCustomerId,
+	callback,
+	onTransactionFailure,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	/** Pass this when the caller already has a verified customer record. */
+	internalCustomerId?: string;
+	callback: ({ db }: { db: CustomerBalanceSyncDb }) => Promise<T>;
+	onTransactionFailure?: ({ error }: { error: unknown }) => Promise<void>;
+}): Promise<T> => {
+	try {
+		return await ctx.db.transaction(async (transaction) => {
+			const db = transaction as unknown as CustomerBalanceSyncDb;
+			await db.execute(
+				sql.raw(
+					`SET LOCAL lock_timeout = ${CUSTOMER_BALANCE_SYNC_LOCK_TIMEOUT_MS}`,
+				),
+			);
+			const canonicalInternalCustomerId =
+				internalCustomerId ??
+				(await resolveInternalCustomerId({ db, ctx, customerId }));
+			const lockKey = `customer-balance-sync:${ctx.org.id}:${ctx.env}:${canonicalInternalCustomerId}`;
+			await db.execute(
+				sql`SELECT pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`,
+			);
+			return callback({ db });
+		});
+	} catch (error) {
+		if (onTransactionFailure) {
+			try {
+				await onTransactionFailure({ error });
+			} catch (failureHandlerError) {
+				throw new AggregateError(
+					[error, failureHandlerError],
+					"Customer balance-sync transaction and failure handler both failed.",
+				);
+			}
+		}
+		throw error;
+	}
+};

--- a/server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts
+++ b/server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts
@@ -7,6 +7,7 @@ import {
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { buildAutumnLineItems } from "@/internal/billing/v2/compute/computeAutumnUtils/buildAutumnLineItems";
 import { computeCustomerLicenseTransitions } from "@/internal/billing/v2/compute/customerLicenseTransitions/computeCustomerLicenseTransitions";
+import { computeAttachPooledBalancePlan } from "@/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalancePlan/computeAttachPooledBalancePlan.js";
 import { cusProductToExistingBalanceCarryOvers } from "@/internal/billing/v2/utils/handleCarryOvers/cusProductToExistingBalanceCarryOvers";
 import { cusProductToOneOffPrepaidCarryOvers } from "@/internal/billing/v2/utils/handleOneOffPrepaidCarryOvers/cusProductToOneOffPrepaidCarryOvers";
 import { computeAttachNewCustomerProduct } from "./computeAttachNewCustomerProduct";
@@ -101,6 +102,12 @@ export const computeAttachPlan = ({
 				})
 			: { allLineItems: [], updateCustomerEntitlements: [] };
 
+	const { customerProduct: preparedCustomerProduct, pooledBalancePlan } =
+		computeAttachPooledBalancePlan({
+			customerProduct: newCustomerProduct,
+			attachBillingContext,
+		});
+
 	// Lock the customer's currency on the first paid attach (only when they have
 	// none yet). Free attaches don't commit a currency. Applied conditionally at execute.
 	const {
@@ -120,10 +127,11 @@ export const computeAttachPlan = ({
 
 	let plan: AutumnBillingPlan = {
 		customerId: attachBillingContext.fullCustomer?.id ?? "",
-		insertCustomerProducts: [newCustomerProduct],
+		insertCustomerProducts: [preparedCustomerProduct],
 		lockCustomerCurrency,
 		updateCustomerProduct,
 		deleteCustomerProduct: scheduledCustomerProduct,
+		pooledBalancePlan,
 		customPrices,
 		customEntitlements: [
 			...(customEnts ?? []),

--- a/server/src/internal/billing/v2/actions/attachLicense/compute/computeAttachLicensePlan.ts
+++ b/server/src/internal/billing/v2/actions/attachLicense/compute/computeAttachLicensePlan.ts
@@ -3,13 +3,50 @@ import {
 	type Entity,
 	type FullCusProduct,
 	findFeatureById,
+	type UpsertPooledBalanceSourceSpec,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { initUpsertPooledBalanceSourceSpecs } from "@/internal/billing/v2/pooledBalances/compute/initUpsertPooledBalanceSourceSpec/initUpsertPooledBalanceSourceSpecs.js";
 import { initFullCustomerProductFromCustomerLicense } from "@/internal/billing/v2/utils/initFullCustomerProduct/initFullCustomerProductFromCustomerLicense.js";
 import { constructEntity } from "@/internal/entities/entityUtils/entityUtils.js";
 import type { AttachLicenseContext, AttachLicensePlan } from "../types.js";
 
 type LicenseAssignment = { entity: Entity; customerProduct: FullCusProduct };
+type PreparedLicenseAssignment = LicenseAssignment & {
+	upsertSourceSpecs: UpsertPooledBalanceSourceSpec[];
+};
+
+const prepareLicenseAssignment = ({
+	ctx,
+	context,
+	entity,
+	reusedCustomerProduct,
+}: {
+	ctx: AutumnContext;
+	context: AttachLicenseContext;
+	entity: Entity;
+	reusedCustomerProduct?: AttachLicenseContext["unusedAssignments"][number];
+}) => {
+	const initializedCustomerProduct = initFullCustomerProductFromCustomerLicense(
+		{
+			ctx,
+			fullCustomer: context.fullCustomer,
+			customerLicense: context.customerLicense,
+			internalEntityId: entity.internal_id,
+			resetCycleAnchor: context.resetCycleAnchorMs,
+			currentEpochMs: context.currentEpochMs,
+		},
+	);
+	const customerProduct: FullCusProduct =
+		reusedCustomerProduct ?? initializedCustomerProduct;
+
+	return initUpsertPooledBalanceSourceSpecs({
+		customerProduct,
+		resetPolicy: {
+			customerLicenseLinkId: context.customerLicense.link_id,
+		},
+	});
+};
 
 /** Entities that don't exist yet, constructed for the plan's insertEntities. */
 const computeNewEntities = ({
@@ -66,25 +103,26 @@ export const computeAttachLicensePlan = ({
 	const assignmentEntities = [...context.existingEntities, ...newEntities];
 
 	// Unused seats are re-pointed before any new seat is provisioned.
-	const reusedAssignments: LicenseAssignment[] = assignmentEntities
+	const reusedAssignments: PreparedLicenseAssignment[] = assignmentEntities
 		.slice(0, unusedAssignments.length)
-		.map((entity, index) => ({
-			entity,
-			customerProduct: unusedAssignments[index] as unknown as FullCusProduct,
-		}));
-	const insertedAssignments: LicenseAssignment[] = assignmentEntities
-		.slice(unusedAssignments.length)
-		.map((entity) => ({
-			entity,
-			customerProduct: initFullCustomerProductFromCustomerLicense({
+		.map((entity, index) => {
+			const prepared = prepareLicenseAssignment({
 				ctx,
-				fullCustomer,
-				customerLicense,
-				internalEntityId: entity.internal_id,
-				resetCycleAnchor: context.resetCycleAnchorMs,
-				currentEpochMs: context.currentEpochMs,
-			}),
-		}));
+				context,
+				entity,
+				reusedCustomerProduct: unusedAssignments[index],
+			});
+			return { entity, ...prepared };
+		});
+	const insertedAssignments: PreparedLicenseAssignment[] = assignmentEntities
+		.slice(unusedAssignments.length)
+		.map((entity) => {
+			const prepared = prepareLicenseAssignment({ ctx, context, entity });
+			return { entity, ...prepared };
+		});
+	const upsertSources = [...reusedAssignments, ...insertedAssignments].flatMap(
+		(assignment) => assignment.upsertSourceSpecs,
+	);
 
 	const billingPlan: AutumnBillingPlan = {
 		customerId: fullCustomer.id ?? fullCustomer.internal_id,
@@ -98,9 +136,11 @@ export const computeAttachLicensePlan = ({
 		customerLicenseUpdates: [
 			{
 				customerLicenseId: customerLicense.id,
-				remainingChange: -assignmentEntities.length,
+				remainingChange:
+					assignmentEntities.length === 0 ? 0 : -assignmentEntities.length,
 			},
 		],
+		pooledBalancePlan: { upsertSources },
 	};
 
 	return {

--- a/server/src/internal/billing/v2/actions/attachLicense/errors/handleAttachLicenseErrors.ts
+++ b/server/src/internal/billing/v2/actions/attachLicense/errors/handleAttachLicenseErrors.ts
@@ -7,7 +7,8 @@ export const handleAttachLicenseErrors = ({
 }: {
 	context: AttachLicenseContext;
 }) => {
-	const { customerLicense, entityParams, newEntityParams } = context;
+	const { customerLicense, entityParams, existingEntities, newEntityParams } =
+		context;
 
 	const duplicateEntityId = findDuplicate(
 		entityParams.map((entityParam) => entityParam.entity_id),
@@ -31,7 +32,9 @@ export const handleAttachLicenseErrors = ({
 		});
 	}
 
-	if (customerLicense.remaining < entityParams.length) {
+	const pendingAssignmentCount =
+		existingEntities.length + newEntityParams.length;
+	if (customerLicense.remaining < pendingAssignmentCount) {
 		throw new RecaseError({
 			message: "No available licenses for this plan.",
 			code: ErrCode.InvalidRequest,

--- a/server/src/internal/billing/v2/actions/attachLicense/setup/setupAttachLicenseContext.ts
+++ b/server/src/internal/billing/v2/actions/attachLicense/setup/setupAttachLicenseContext.ts
@@ -113,20 +113,34 @@ export const setupAttachLicenseContext = async ({
 
 	// The assignment's cycles anchor to the parent's billing state — same
 	// derivation as attach, minus any billing changes.
-	const [{ stripeSubscription, testClockFrozenTime }, unusedAssignments] =
-		await Promise.all([
-			setupStripeBillingContext({
-				ctx,
-				fullCustomer,
-				targetCustomerProduct: target.parentCustomerProduct,
-				createStripeCustomerIfMissing: false,
-			}),
-			licenseAssignmentRepo.listUnusedAssignmentsByLinkId({
-				db: ctx.db,
-				customerLicenseLinkId: target.customerLicense.link_id,
-				limit: params.entities.length,
-			}),
-		]);
+	const [
+		{ stripeSubscription, testClockFrozenTime },
+		unusedAssignments,
+		activeAssignments,
+	] = await Promise.all([
+		setupStripeBillingContext({
+			ctx,
+			fullCustomer,
+			targetCustomerProduct: target.parentCustomerProduct,
+			createStripeCustomerIfMissing: false,
+		}),
+		licenseAssignmentRepo.listUnusedAssignmentsByLinkId({
+			db: ctx.db,
+			customerLicenseLinkId: target.customerLicense.link_id,
+			limit: params.entities.length,
+		}),
+		licenseAssignmentRepo.listAssignmentsWithEntityAndProductByCustomer({
+			db: ctx.db,
+			internalCustomerId: fullCustomer.internal_id,
+			customerLicenseLinkId: target.customerLicense.link_id,
+		}),
+	]);
+	const assignedEntityIds = new Set(
+		activeAssignments.map((assignment) => assignment.entity_id),
+	);
+	const pendingEntityParams = params.entities.filter(
+		(entityParam) => !assignedEntityIds.has(entityParam.entity_id),
+	);
 	const currentEpochMs = testClockFrozenTime ?? Date.now();
 	const billingCycleAnchorMs = setupBillingCycleAnchor({
 		stripeSubscription,
@@ -146,6 +160,9 @@ export const setupAttachLicenseContext = async ({
 		resetCycleAnchorMs,
 		entityParams: params.entities,
 		unusedAssignments,
-		...splitRequestedEntities({ fullCustomer, entityParams: params.entities }),
+		...splitRequestedEntities({
+			fullCustomer,
+			entityParams: pendingEntityParams,
+		}),
 	};
 };

--- a/server/src/internal/billing/v2/actions/attachLicense/types.ts
+++ b/server/src/internal/billing/v2/actions/attachLicense/types.ts
@@ -1,7 +1,6 @@
 import type {
 	AttachLicenseEntityParams,
 	AutumnBillingPlan,
-	DbCustomerProduct,
 	Entity,
 	FullCusProduct,
 	FullCustomer,
@@ -23,7 +22,7 @@ export type AttachLicenseContext = {
 	newEntityParams: AttachLicenseEntityParams[];
 	// Released seats waiting in the pool, re-pointed before any new seat is
 	// provisioned. Fetched bounded by the request size.
-	unusedAssignments: DbCustomerProduct[];
+	unusedAssignments: FullCusProduct[];
 };
 
 export type AttachLicensePlan = {

--- a/server/src/internal/billing/v2/actions/common/immediateMultiProduct/computeImmediateMultiProductPlan.ts
+++ b/server/src/internal/billing/v2/actions/common/immediateMultiProduct/computeImmediateMultiProductPlan.ts
@@ -8,6 +8,7 @@ import { computeAttachNewCustomerProduct } from "@/internal/billing/v2/actions/a
 import { computeAttachTransitionUpdates } from "@/internal/billing/v2/actions/attach/compute/computeAttachTransitionUpdates";
 import { buildAutumnLineItems } from "@/internal/billing/v2/compute/computeAutumnUtils/buildAutumnLineItems";
 import { finalizeLineItems } from "@/internal/billing/v2/compute/finalize/finalizeLineItems";
+import { computeAttachPooledBalanceOps } from "@/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalanceOps.js";
 import { productContextToAttachBillingContext } from "@/internal/billing/v2/utils/billingContext/productContextToAttachBillingContext";
 import { cusProductToOneOffPrepaidCarryOvers } from "@/internal/billing/v2/utils/handleOneOffPrepaidCarryOvers/cusProductToOneOffPrepaidCarryOvers";
 
@@ -28,7 +29,7 @@ export const computeImmediateMultiProductPlan = ({
 		transitioningProductContext?.scheduledCustomerProduct;
 
 	let transitionContext: AttachBillingContext | undefined;
-	const insertCustomerProducts = billingContext.productContexts.map(
+	const rawInsertCustomerProducts = billingContext.productContexts.map(
 		(productContext) => {
 			const attachBillingContext = productContextToAttachBillingContext({
 				billingContext,
@@ -54,7 +55,7 @@ export const computeImmediateMultiProductPlan = ({
 
 	const { allLineItems, updateCustomerEntitlements } = buildAutumnLineItems({
 		ctx,
-		newCustomerProducts: insertCustomerProducts,
+		newCustomerProducts: rawInsertCustomerProducts,
 		deletedCustomerProduct,
 		billingContext,
 		includeArrearLineItems: deletedCustomerProduct !== undefined,
@@ -66,6 +67,22 @@ export const computeImmediateMultiProductPlan = ({
 				fullCustomer: billingContext.fullCustomer,
 			})
 		: { entitlements: [], customerEntitlements: [] };
+	const preparedPooledSources = rawInsertCustomerProducts.map(
+		(customerProduct, index) =>
+			computeAttachPooledBalanceOps({
+				customerProduct,
+				attachBillingContext: productContextToAttachBillingContext({
+					billingContext,
+					productContext: billingContext.productContexts[index],
+				}),
+			}),
+	);
+	const insertCustomerProducts = preparedPooledSources.map(
+		({ customerProduct }) => customerProduct,
+	);
+	const pooledBalanceOps = preparedPooledSources.flatMap(
+		({ pooledBalanceOps }) => pooledBalanceOps,
+	);
 
 	const billingPlan: AutumnBillingPlan = {
 		customerId:
@@ -73,6 +90,7 @@ export const computeImmediateMultiProductPlan = ({
 		insertCustomerProducts,
 		updateCustomerProduct,
 		deleteCustomerProduct: scheduledCustomerProduct,
+		pooledBalanceOps,
 		customPrices: billingContext.customPrices,
 		customEntitlements: [
 			...(billingContext.customEnts ?? []),

--- a/server/src/internal/billing/v2/actions/createSchedule/compute/computeCreateSchedulePlan.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/compute/computeCreateSchedulePlan.ts
@@ -71,6 +71,10 @@ export const computeCreateSchedulePlan = ({
 		insertCustomerProducts: allInsertCustomerProducts,
 		updateCustomerProducts: immediate.updateCustomerProducts,
 		deleteCustomerProducts: scheduled.deleteCustomerProducts,
+		pooledBalanceOps: [
+			...immediate.pooledBalanceOps,
+			...scheduled.pooledBalanceOps,
+		],
 		customPrices: billingContext.customPrices,
 		customEntitlements: [
 			...(billingContext.customEnts ?? []),

--- a/server/src/internal/billing/v2/actions/createSchedule/compute/computeImmediatePhaseCustomerProducts.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/compute/computeImmediatePhaseCustomerProducts.ts
@@ -2,10 +2,13 @@ import type {
 	AutumnBillingPlan,
 	CreateScheduleBillingContext,
 	FullCusProduct,
+	PooledBalanceOp,
 } from "@autumn/shared";
 import { CusProductStatus } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { computeAttachNewCustomerProduct } from "@/internal/billing/v2/actions/attach/compute/computeAttachNewCustomerProduct";
+import { computeAttachPooledBalanceOps } from "@/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalanceOps.js";
+import { customerProductToPooledBalanceRemovalOp } from "@/internal/billing/v2/pooledBalances/compute/customerProductToPooledBalanceRemovalOp.js";
 import { productContextToAttachBillingContext } from "@/internal/billing/v2/utils/billingContext/productContextToAttachBillingContext";
 import { applyScheduleTimingToCustomerProductPlan } from "@/internal/billing/v2/utils/billingPlan/customerProductPlanMutations";
 
@@ -41,8 +44,14 @@ const insertImmediateCustomerProducts = ({
 	billingContext: CreateScheduleBillingContext;
 	expiredCustomerProducts: FullCusProduct[];
 	nextPhaseStartsAt: number | undefined;
-}): FullCusProduct[] =>
-	billingContext.productContexts.map((productContext) => {
+}): {
+	insertCustomerProducts: FullCusProduct[];
+	pooledBalanceOps: PooledBalanceOp[];
+} => {
+	const insertCustomerProducts: FullCusProduct[] = [];
+	const pooledBalanceOps: PooledBalanceOp[] = [];
+
+	for (const productContext of billingContext.productContexts) {
 		const expiredSameProduct = expiredCustomerProducts.find(
 			(customerProduct) =>
 				customerProduct.product.id === productContext.fullProduct.id,
@@ -68,8 +77,17 @@ const insertImmediateCustomerProducts = ({
 			endedAt: nextPhaseStartsAt ?? null,
 		});
 
-		return newCustomerProduct;
-	});
+		const prepared = computeAttachPooledBalanceOps({
+			customerProduct: newCustomerProduct,
+			attachBillingContext,
+			removeCurrentSource: false,
+		});
+		insertCustomerProducts.push(prepared.customerProduct);
+		pooledBalanceOps.push(...prepared.pooledBalanceOps);
+	}
+
+	return { insertCustomerProducts, pooledBalanceOps };
+};
 
 /** Compute the immediate-phase customer product expirations and insertions. */
 export const computeImmediatePhaseCustomerProducts = ({
@@ -88,12 +106,25 @@ export const computeImmediatePhaseCustomerProducts = ({
 		currentEpochMs: billingContext.currentEpochMs,
 	});
 
-	const insertCustomerProducts = insertImmediateCustomerProducts({
+	const inserted = insertImmediateCustomerProducts({
 		ctx,
 		billingContext,
 		expiredCustomerProducts: currentRecurringCustomerProducts,
 		nextPhaseStartsAt,
 	});
+	const removalOperations = currentRecurringCustomerProducts.flatMap(
+		(customerProduct) => {
+			const operation = customerProductToPooledBalanceRemovalOp({
+				customerProduct,
+				effectiveAt: null,
+			});
+			return operation ? [operation] : [];
+		},
+	);
 
-	return { insertCustomerProducts, updateCustomerProducts };
+	return {
+		insertCustomerProducts: inserted.insertCustomerProducts,
+		updateCustomerProducts,
+		pooledBalanceOps: [...removalOperations, ...inserted.pooledBalanceOps],
+	};
 };

--- a/server/src/internal/billing/v2/actions/createSchedule/compute/computeScheduledCustomerProducts.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/compute/computeScheduledCustomerProducts.ts
@@ -1,8 +1,10 @@
 import type {
 	CreateScheduleBillingContext,
 	FullCusProduct,
+	PooledBalanceOp,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { computeAttachPooledBalanceOps } from "@/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalanceOps.js";
 import { initScheduledCustomerProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/initScheduledCustomerProduct";
 
 /** Build scheduled customer products to insert and existing ones to delete. */
@@ -18,6 +20,7 @@ export const computeScheduledCustomerProducts = ({
 	const insertCustomerProducts: FullCusProduct[] = [];
 	const customPrices = [];
 	const customEntitlements = [];
+	const pooledBalanceOps: PooledBalanceOp[] = [];
 	const scheduledPhases: { startsAt: number; customerProductIds: string[] }[] =
 		[];
 
@@ -42,8 +45,21 @@ export const computeScheduledCustomerProducts = ({
 					productContext.customPrices.length > 0 ||
 					productContext.customEntitlements.length > 0,
 			});
-			insertCustomerProducts.push(customerProduct);
-			phaseCustomerProductIds.push(customerProduct.id);
+			const prepared = computeAttachPooledBalanceOps({
+				customerProduct,
+				attachBillingContext: {
+					billingStartsAt: phaseContext.startsAt,
+					currentEpochMs: billingContext.currentEpochMs,
+					fullCustomer: billingContext.fullCustomer,
+					planTiming: "end_of_cycle",
+					requestedBillingCycleAnchor: undefined,
+					skipBillingChanges: billingContext.skipBillingChanges,
+				},
+				removeCurrentSource: false,
+			});
+			insertCustomerProducts.push(prepared.customerProduct);
+			pooledBalanceOps.push(...prepared.pooledBalanceOps);
+			phaseCustomerProductIds.push(prepared.customerProduct.id);
 			customPrices.push(...productContext.customPrices);
 			customEntitlements.push(...productContext.customEntitlements);
 		}
@@ -59,6 +75,7 @@ export const computeScheduledCustomerProducts = ({
 		deleteCustomerProducts: existingScheduledCustomerProducts,
 		customPrices,
 		customEntitlements,
+		pooledBalanceOps,
 		scheduledPhases,
 	};
 };

--- a/server/src/internal/billing/v2/actions/dfu/compute/computeFlashPlan.ts
+++ b/server/src/internal/billing/v2/actions/dfu/compute/computeFlashPlan.ts
@@ -3,15 +3,19 @@ import {
 	type AutumnBillingPlan,
 	BillingVersion,
 	CusProductStatus,
+	cusEntsToUsage,
 	cusProductToProcessorType,
 	type DfuFlashedPlan,
 	type FullCusProduct,
 	isProductPaidAndRecurring,
 	isResettingEntitlement,
 	nullish,
+	type PooledBalanceOp,
 	ProcessorType,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { computeAttachPooledBalanceOps } from "@/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalanceOps.js";
+import { customerProductToPooledBalanceRemovalOp } from "@/internal/billing/v2/pooledBalances/compute/customerProductToPooledBalanceRemovalOp.js";
 import { initFullCustomerProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/initFullCustomerProduct";
 import type {
 	FlashContext,
@@ -149,6 +153,7 @@ export const computeFlashPlan = ({
 	const { currentEpochMs, fullCustomer, params } = flashContext;
 	const insertCustomerProducts: FullCusProduct[] = [];
 	const updateCustomerProducts: CustomerProductUpdate[] = [];
+	const pooledBalanceOps: PooledBalanceOp[] = [];
 	const flashed: DfuFlashedPlan[] = [];
 
 	// Desired state per addressed scope, keyed by the scope's product internal ids.
@@ -198,12 +203,56 @@ export const computeFlashPlan = ({
 				flashContext,
 				planContext,
 			});
-		insertCustomerProducts.push(customerProduct);
+		const prepared = computeAttachPooledBalanceOps({
+			customerProduct,
+			attachBillingContext: {
+				billingStartsAt: customerProduct.starts_at,
+				currentEpochMs,
+				fullCustomer,
+				planTiming: "immediate",
+				requestedBillingCycleAnchor:
+					customerProduct.billing_cycle_anchor ?? undefined,
+				skipBillingChanges: true,
+			},
+			removeCurrentSource: false,
+		});
+		const flashedUsageBySourceEntitlementId = new Map(
+			customerProduct.customer_entitlements.map((customerEntitlement) => [
+				customerEntitlement.entitlement.id,
+				cusEntsToUsage({
+					cusEnts: [
+						{
+							...customerEntitlement,
+							customer_product: customerProduct,
+						},
+					],
+				}),
+			]),
+		);
+		const preparedPooledBalanceOps = prepared.pooledBalanceOps.map(
+			(operation) => {
+				if (operation.op !== "upsert_source") return operation;
+				const usage =
+					flashedUsageBySourceEntitlementId.get(
+						operation.sourceEntitlementId,
+					) ?? 0;
+				if (!Number.isFinite(usage) || usage <= 0) return operation;
+				return {
+					...operation,
+					usageReapply: {
+						amount: usage,
+						excludedSourceCustomerProductId: prepared.customerProduct.id,
+					},
+				};
+			},
+		);
+		insertCustomerProducts.push(prepared.customerProduct);
+		pooledBalanceOps.push(...preparedPooledBalanceOps);
 
 		flashed.push({
 			plan_id: planContext.plan.plan_id,
 			processor: planContext.processor ?? "stripe",
-			customer_product_id: customerProduct.id,
+			customer_product_id: prepared.customerProduct.id,
 			status: reportStatus,
 			skipped: false,
 			...(mismatchReason && { mismatch: true, reason: mismatchReason }),
@@ -241,6 +290,11 @@ export const computeFlashPlan = ({
 				canceled_at: currentEpochMs,
 			},
 		});
+		const removalOperation = customerProductToPooledBalanceRemovalOp({
+			customerProduct,
+			effectiveAt: null,
+		});
+		if (removalOperation) pooledBalanceOps.push(removalOperation);
 
 		flashed.push({
 			plan_id: customerProduct.product_id,
@@ -259,6 +313,7 @@ export const computeFlashPlan = ({
 				flashContext.fullCustomer.id ?? flashContext.fullCustomer.internal_id,
 			insertCustomerProducts,
 			updateCustomerProducts,
+			pooledBalanceOps,
 		},
 		flashed,
 	};

--- a/server/src/internal/billing/v2/actions/releaseLicense/compute/computeReleaseLicensePlan.ts
+++ b/server/src/internal/billing/v2/actions/releaseLicense/compute/computeReleaseLicensePlan.ts
@@ -1,4 +1,5 @@
 import type { AutumnBillingPlan } from "@autumn/shared";
+import { customerProductToPooledBalanceRemovalOp } from "@/internal/billing/v2/pooledBalances/compute/customerProductToPooledBalanceRemovalOp.js";
 import type { ReleaseLicenseContext, ReleaseLicensePlan } from "../types.js";
 import { computeCustomerLicenseRemainingChanges } from "./computeCustomerLicenseRemainingChanges.js";
 import { computeEntityCustomerProductUpdates } from "./computeEntityCustomerProductUpdates.js";
@@ -21,6 +22,13 @@ export const computeReleaseLicensePlan = ({
 			customerLicenseLinkIds: releases.map(
 				(release) => release.customerLicense.link_id,
 			),
+		}),
+		pooledBalanceOps: releases.flatMap(({ assignment }) => {
+			const operation = customerProductToPooledBalanceRemovalOp({
+				customerProduct: assignment,
+				effectiveAt: null,
+			});
+			return operation ? [operation] : [];
 		}),
 	};
 

--- a/server/src/internal/billing/v2/actions/sync/compute/computeSyncFuturePhases.ts
+++ b/server/src/internal/billing/v2/actions/sync/compute/computeSyncFuturePhases.ts
@@ -3,10 +3,13 @@ import {
 	CusProductStatus,
 	type Entitlement,
 	type FullCusProduct,
+	type PooledBalanceOp,
 	type Price,
 	type SyncBillingContext,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { computeAttachPooledBalanceOps } from "@/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalanceOps.js";
+import { customerProductToPooledBalanceRemovalOp } from "@/internal/billing/v2/pooledBalances/compute/customerProductToPooledBalanceRemovalOp.js";
 import { initScheduledCustomerProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/initScheduledCustomerProduct";
 
 export type ComputedSchedulePhase = {
@@ -24,6 +27,7 @@ export type FuturePhasesResult = {
 	updateCustomerProducts: CustomerProductUpdate[];
 	customPrices: Price[];
 	customEntitlements: Entitlement[];
+	pooledBalanceOps: PooledBalanceOp[];
 	scheduledPhases: ComputedSchedulePhase[];
 };
 
@@ -66,6 +70,7 @@ export const computeSyncFuturePhases = ({
 	const updateCustomerProducts: CustomerProductUpdate[] = [];
 	const customPrices: Price[] = [];
 	const customEntitlements: Entitlement[] = [];
+	const pooledBalanceOps: PooledBalanceOp[] = [];
 	const scheduledPhases: ComputedSchedulePhase[] = [];
 
 	for (const phaseContext of futurePhases) {
@@ -87,12 +92,30 @@ export const computeSyncFuturePhases = ({
 				subscriptionScheduleId: stripeSchedule?.id,
 				internalEntityId: productContext.entity?.internal_id,
 			});
-			insertCustomerProducts.push(cusProduct);
-			phaseIds.push(cusProduct.id);
+			const prepared = computeAttachPooledBalanceOps({
+				customerProduct: cusProduct,
+				attachBillingContext: {
+					billingStartsAt: phaseContext.startsAt,
+					currentEpochMs,
+					fullCustomer,
+					planTiming: "end_of_cycle",
+					requestedBillingCycleAnchor: undefined,
+					skipBillingChanges: true,
+				},
+				removeCurrentSource: false,
+			});
+			insertCustomerProducts.push(prepared.customerProduct);
+			pooledBalanceOps.push(...prepared.pooledBalanceOps);
+			phaseIds.push(prepared.customerProduct.id);
 			customPrices.push(...productContext.customPrices);
 			customEntitlements.push(...productContext.customEntitlements);
 
 			if (productContext.currentCustomerProduct) {
+				const removalOperation = customerProductToPooledBalanceRemovalOp({
+					customerProduct: productContext.currentCustomerProduct,
+					effectiveAt: null,
+				});
+				if (removalOperation) pooledBalanceOps.push(removalOperation);
 				updateCustomerProducts.push(
 					expireCustomerProduct({
 						customerProduct: productContext.currentCustomerProduct,
@@ -114,6 +137,7 @@ export const computeSyncFuturePhases = ({
 		updateCustomerProducts,
 		customPrices,
 		customEntitlements,
+		pooledBalanceOps,
 		scheduledPhases,
 	};
 };

--- a/server/src/internal/billing/v2/actions/sync/compute/computeSyncImmediatePhase.ts
+++ b/server/src/internal/billing/v2/actions/sync/compute/computeSyncImmediatePhase.ts
@@ -1,15 +1,17 @@
 import {
 	type AutumnBillingPlan,
-	type CustomerLicenseUpdate,
 	CusProductStatus,
+	type CustomerLicenseUpdate,
 	type Entitlement,
 	type FullCusProduct,
 	type InsertPlanLicenseSpec,
+	type PooledBalanceOp,
 	type Price,
 	type SyncBillingContext,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { computeCustomerLicenseQuantityChanges } from "@/internal/billing/v2/compute/computeCustomerLicenseQuantityChanges";
+import { computeAttachPooledBalanceOps } from "@/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalanceOps.js";
 import { resolveSyncExistingUsagesConfig } from "@/internal/billing/v2/utils/handleCarryOvers/resolveSyncExistingUsagesConfig";
 import { initImmediateSyncCustomerProduct } from "./initImmediateSyncCustomerProduct";
 
@@ -24,6 +26,7 @@ export type ImmediatePhaseResult = {
 	customEntitlements: Entitlement[];
 	insertPlanLicenses: InsertPlanLicenseSpec[];
 	customerLicenseUpdates: CustomerLicenseUpdate[];
+	pooledBalanceOps: PooledBalanceOp[];
 };
 
 const expireCustomerProduct = ({
@@ -72,6 +75,7 @@ export const computeSyncImmediatePhase = ({
 			customEntitlements: [],
 			insertPlanLicenses: [],
 			customerLicenseUpdates: [],
+			pooledBalanceOps: [],
 		};
 	}
 
@@ -81,6 +85,7 @@ export const computeSyncImmediatePhase = ({
 	const customEntitlements: Entitlement[] = [];
 	const insertPlanLicenses: InsertPlanLicenseSpec[] = [];
 	const customerLicenseUpdates: CustomerLicenseUpdate[] = [];
+	const pooledBalanceOps: PooledBalanceOp[] = [];
 
 	for (const productContext of immediatePhase.productContexts) {
 		const currentCustomerProduct = productContext.currentCustomerProduct;
@@ -115,7 +120,25 @@ export const computeSyncImmediatePhase = ({
 			existingUsagesConfig,
 		});
 
-		insertCustomerProducts.push(insertedCustomerProduct);
+		const {
+			customerProduct: preparedCustomerProduct,
+			pooledBalanceOps: computedPooledBalanceOps,
+		} = computeAttachPooledBalanceOps({
+			customerProduct: insertedCustomerProduct,
+			attachBillingContext: {
+				billingStartsAt: undefined,
+				currentCustomerProduct: productContext.currentCustomerProduct,
+				currentEpochMs,
+				fullCustomer,
+				planTiming: "immediate",
+				requestedBillingCycleAnchor:
+					insertedCustomerProduct.billing_cycle_anchor ?? undefined,
+				skipBillingChanges: true,
+			},
+		});
+
+		insertCustomerProducts.push(preparedCustomerProduct);
+		pooledBalanceOps.push(...computedPooledBalanceOps);
 		customPrices.push(...productContext.customPrices);
 		customEntitlements.push(...productContext.customEntitlements);
 		insertPlanLicenses.push(...(productContext.insertPlanLicenses ?? []));
@@ -137,5 +160,6 @@ export const computeSyncImmediatePhase = ({
 		customEntitlements,
 		insertPlanLicenses,
 		customerLicenseUpdates,
+		pooledBalanceOps,
 	};
 };

--- a/server/src/internal/billing/v2/actions/sync/compute/computeSyncPlan.ts
+++ b/server/src/internal/billing/v2/actions/sync/compute/computeSyncPlan.ts
@@ -74,6 +74,10 @@ export const computeSyncPlan = ({
 				? immediate.customerLicenseUpdates
 				: undefined,
 		lockCustomerCurrency: syncContextToCurrencyLock({ syncContext }),
+		pooledBalanceOps: [
+			...immediate.pooledBalanceOps,
+			...future.pooledBalanceOps,
+		],
 		upsertSubscription,
 	};
 

--- a/server/src/internal/billing/v2/actions/sync/scope/buildIncrementalSyncParams.ts
+++ b/server/src/internal/billing/v2/actions/sync/scope/buildIncrementalSyncParams.ts
@@ -69,15 +69,18 @@ const linkedAddOnInstances = ({
 			: !linkedProduct.internal_entity_id;
 	});
 
-/** Current API-side prepaid totals (packs × billing_units + allowance). */
-const linkedPrepaidFeatureTotals = ({
+/** Current API-side prepaid packs and totals (packs × billing_units + allowance). */
+const linkedPrepaidFeatureQuantities = ({
 	linkedProduct,
 	matchedPlan,
 }: {
 	linkedProduct: FullCusProduct;
 	matchedPlan: MatchedPlan;
-}): Map<string, number> => {
-	const totals = new Map<string, number>();
+}): Map<string, { purchasedPacks: number; total: number }> => {
+	const quantities = new Map<
+		string,
+		{ purchasedPacks: number; total: number }
+	>();
 	for (const price of matchedPlan.product.prices) {
 		if (!isPrepaidPrice(price)) continue;
 		const entitlement = priceToEnt({
@@ -92,9 +95,12 @@ const linkedPrepaidFeatureTotals = ({
 		const packs = option?.quantity ?? 0;
 		const billingUnits = price.config.billing_units ?? 1;
 		const allowance = entitlement.allowance ?? 0;
-		totals.set(entitlement.feature.id, packs * billingUnits + allowance);
+		quantities.set(entitlement.feature.id, {
+			purchasedPacks: packs,
+			total: packs * billingUnits + allowance,
+		});
 	}
-	return totals;
+	return quantities;
 };
 
 const prepaidQuantitiesDrifted = ({
@@ -106,17 +112,19 @@ const prepaidQuantitiesDrifted = ({
 	matchedPlan: MatchedPlan;
 	syncPlan: SyncPlanInstance;
 }): boolean => {
-	const currentTotals = linkedPrepaidFeatureTotals({
+	const currentQuantities = linkedPrepaidFeatureQuantities({
 		linkedProduct,
 		matchedPlan,
 	});
-	if (currentTotals.size === 0) return false;
+	if (currentQuantities.size === 0) return false;
 
-	for (const [featureId, currentTotal] of currentTotals) {
+	for (const [featureId, current] of currentQuantities) {
 		const desired = syncPlan.feature_quantities?.find(
 			(fq) => fq.feature_id === featureId,
 		);
-		if ((desired?.quantity ?? 0) !== currentTotal) return true;
+		const desiredQuantity = desired?.quantity ?? 0;
+		if (desiredQuantity === 0 && current.purchasedPacks === 0) continue;
+		if (desiredQuantity !== current.total) return true;
 	}
 	return false;
 };
@@ -184,6 +192,20 @@ export const buildIncrementalSyncParams = ({
 		// from the base item's Stripe quantity, never from prepaid items —
 		// prepaid pack counts live in syncPlan.feature_quantities instead).
 		if (matchedPlan.product.is_add_on === true) {
+			if (
+				!syncPlan.entity_id &&
+				linkedCustomerProducts.some(
+					(linkedProduct) =>
+						isCustomerProductAddOn(linkedProduct) &&
+						linkedProduct.product.id === syncPlan.plan_id &&
+						Boolean(linkedProduct.internal_entity_id),
+				)
+			) {
+				return {
+					shouldSync: false,
+					reason: "ambiguous_linked_targets",
+				};
+			}
 			const linkedInstances = linkedAddOnInstances({
 				linkedCustomerProducts,
 				syncPlan,
@@ -211,8 +233,23 @@ export const buildIncrementalSyncParams = ({
 			continue;
 		}
 
-		// Main plans re-sync only when the linked target's product id changed
-		// (upgrade/downgrade); prepaid drift is not checked for them here.
+		// Main plans re-sync when the linked product or version changes, or its
+		// prepaid quantities drift from Stripe.
+		if (
+			!syncPlan.entity_id &&
+			linkedCustomerProducts.some(
+				(linkedProduct) =>
+					!isCustomerProductAddOn(linkedProduct) &&
+					Boolean(linkedProduct.internal_entity_id) &&
+					(linkedProduct.product.group ?? "") ===
+						(matchedPlan.product.group ?? ""),
+			)
+		) {
+			return {
+				shouldSync: false,
+				reason: "ambiguous_linked_targets",
+			};
+		}
 		const target = matchedPlanToTargetGroupLink({ matchedPlan, syncPlan });
 		if (!target) {
 			return {
@@ -228,7 +265,8 @@ export const buildIncrementalSyncParams = ({
 		if (
 			!linkedProduct ||
 			linkedProduct.product.id !== target.productId ||
-			versionChanged
+			versionChanged ||
+			prepaidQuantitiesDrifted({ linkedProduct, matchedPlan, syncPlan })
 		) {
 			changedPlans.push(syncPlan);
 			continue;

--- a/server/src/internal/billing/v2/actions/sync/subscriptionToSyncParams.ts
+++ b/server/src/internal/billing/v2/actions/sync/subscriptionToSyncParams.ts
@@ -84,11 +84,18 @@ const stampEntityFromExistingLinks = ({
 	// product id → existing entity binding (only entity-scoped links).
 	// `entity_id` accepts either the public or internal entity id, so the
 	// internal id stored on the customer product is sufficient.
-	const entityIdByProductId = new Map<string, string>();
+	const entityIdByProductId = new Map<string, string | null>();
 	for (const customerProduct of linkedCustomerProducts) {
 		const productId = customerProduct.product?.id;
 		if (customerProduct.internal_entity_id && productId) {
-			entityIdByProductId.set(productId, customerProduct.internal_entity_id);
+			const existingEntityId = entityIdByProductId.get(productId);
+			entityIdByProductId.set(
+				productId,
+				existingEntityId === undefined ||
+					existingEntityId === customerProduct.internal_entity_id
+					? customerProduct.internal_entity_id
+					: null,
+			);
 		}
 	}
 

--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeCancelPlan.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeCancelPlan.ts
@@ -10,6 +10,13 @@ import {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { applyUncancelToPlan } from "@/internal/billing/v2/actions/updateSubscription/compute/cancel/applyUncancelToPlan";
+import { computeAttachPooledBalanceOps } from "@/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalanceOps.js";
+import {
+	customerProductToPooledBalanceOwnerRemovalOps,
+	customerProductToPooledBalanceOwnerRestoreOps,
+	customerProductToPooledBalanceRemovalOp,
+	customerProductToPooledBalanceRestoreOp,
+} from "@/internal/billing/v2/pooledBalances/compute/customerProductToPooledBalanceRemovalOp.js";
 import { applyCancelPlan } from "./applyCancelPlan";
 import { computeCancelLineItems } from "./computeCancelLineItems";
 import { computeCancelUpdates } from "./computeCancelUpdates";
@@ -129,6 +136,22 @@ const applyRevertTrialUnpause = ({
 	const canRestore = previousCusProduct?.status === CusProductStatus.Paused;
 
 	if (!canRestore) return plan;
+	const pooledRestore = computeAttachPooledBalanceOps({
+		customerProduct: {
+			...previousCusProduct,
+			status: CusProductStatus.Active,
+		},
+		attachBillingContext: {
+			billingStartsAt: billingContext.currentEpochMs,
+			currentCustomerProduct: previousCusProduct,
+			currentEpochMs: billingContext.currentEpochMs,
+			fullCustomer,
+			planTiming: "immediate",
+			requestedBillingCycleAnchor: billingContext.requestedBillingCycleAnchor,
+			skipBillingChanges: billingContext.skipBillingChanges,
+		},
+		removeCurrentSource: false,
+	});
 
 	return {
 		...plan,
@@ -138,6 +161,10 @@ const applyRevertTrialUnpause = ({
 				customerProduct: previousCusProduct,
 				updates: { status: CusProductStatus.Active },
 			},
+		],
+		pooledBalanceOps: [
+			...(plan.pooledBalanceOps ?? []),
+			...pooledRestore.pooledBalanceOps,
 		],
 	};
 };
@@ -161,10 +188,28 @@ export const computeCancelPlan = ({
 	if (!billingContext.cancelAction) return plan;
 
 	if (billingContext.cancelAction === "uncancel") {
-		return applyUncancelToPlan({
+		const uncancelledPlan = applyUncancelToPlan({
 			billingContext,
 			plan,
 		});
+		const expectedEffectiveAt = billingContext.customerProduct.ended_at;
+		if (typeof expectedEffectiveAt !== "number") return uncancelledPlan;
+		const pooledSourceRestore = customerProductToPooledBalanceRestoreOp({
+			customerProduct: billingContext.customerProduct,
+			expectedEffectiveAt,
+		});
+
+		return {
+			...uncancelledPlan,
+			pooledBalanceOps: [
+				...(uncancelledPlan.pooledBalanceOps ?? []),
+				...(pooledSourceRestore ? [pooledSourceRestore] : []),
+				...customerProductToPooledBalanceOwnerRestoreOps({
+					customerProduct: billingContext.customerProduct,
+					expectedEffectiveAt,
+				}),
+			],
+		};
 	}
 
 	if (
@@ -193,13 +238,33 @@ export const computeCancelPlan = ({
 	// Skip when cancelling a revert trial — the previous plan will be restored instead.
 	const isRevertTrialCancel =
 		billingContext.customerProduct.on_trial_end === "revert";
-	const defaultCustomerProduct = isRevertTrialCancel
+	const rawDefaultCustomerProduct = isRevertTrialCancel
 		? undefined
 		: computeDefaultCustomerProduct({
 				ctx,
 				billingContext,
 				endOfCycleMs,
 			});
+	const preparedDefault =
+		rawDefaultCustomerProduct &&
+		billingContext.cancelAction === "cancel_immediately"
+			? computeAttachPooledBalanceOps({
+					customerProduct: rawDefaultCustomerProduct,
+					attachBillingContext: {
+						billingStartsAt: billingContext.currentEpochMs,
+						currentCustomerProduct: billingContext.customerProduct,
+						currentEpochMs: billingContext.currentEpochMs,
+						fullCustomer: billingContext.fullCustomer,
+						planTiming: "immediate",
+						requestedBillingCycleAnchor:
+							billingContext.requestedBillingCycleAnchor,
+						skipBillingChanges: billingContext.skipBillingChanges,
+					},
+					removeCurrentSource: false,
+				})
+			: undefined;
+	const defaultCustomerProduct =
+		preparedDefault?.customerProduct ?? rawDefaultCustomerProduct;
 
 	ctx.logger.debug(
 		`[computeCancelPlan] default customer product: ${defaultCustomerProduct?.product.name}`,
@@ -224,8 +289,38 @@ export const computeCancelPlan = ({
 	});
 
 	// If this is a revert trial being cancelled, unpause the previous plan
-	return applyRevertTrialUnpause({
+	const finalPlan = applyRevertTrialUnpause({
 		billingContext,
 		plan: cancelledPlan,
 	});
+	const pooledSourceRemoval = customerProductToPooledBalanceRemovalOp({
+		customerProduct: billingContext.customerProduct,
+		effectiveAt:
+			billingContext.cancelAction === "cancel_end_of_cycle"
+				? endOfCycleMs
+				: null,
+	});
+	if (billingContext.cancelAction !== "cancel_end_of_cycle") {
+		return {
+			...finalPlan,
+			pooledBalanceOps: [
+				...(finalPlan.pooledBalanceOps ?? []),
+				...(preparedDefault?.pooledBalanceOps ?? []),
+				...(pooledSourceRemoval ? [pooledSourceRemoval] : []),
+			],
+		};
+	}
+
+	return {
+		...finalPlan,
+		pooledBalanceOps: [
+			...(finalPlan.pooledBalanceOps ?? []),
+			...(preparedDefault?.pooledBalanceOps ?? []),
+			...(pooledSourceRemoval ? [pooledSourceRemoval] : []),
+			...customerProductToPooledBalanceOwnerRemovalOps({
+				customerProduct: billingContext.customerProduct,
+				effectiveAt: endOfCycleMs,
+			}),
+		],
+	};
 };

--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/computeFieldUpdates.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/computeFieldUpdates.ts
@@ -1,11 +1,69 @@
 import type {
 	AutumnBillingPlan,
+	PooledBalanceOp,
+	UpdateSubscriptionBillingContext,
 	UpdateSubscriptionV1Params,
 } from "@autumn/shared";
+import { customerProductHasActiveStatus } from "@autumn/shared";
+import { computeAttachPooledBalanceOps } from "@/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalanceOps.js";
+import { customerProductToPooledBalanceRemovalOp } from "@/internal/billing/v2/pooledBalances/compute/customerProductToPooledBalanceRemovalOp.js";
 
 type CusProductFieldUpdates = NonNullable<
 	NonNullable<AutumnBillingPlan["updateCustomerProduct"]>["updates"]
 >;
+
+export const computeFieldUpdatePooledBalanceOps = ({
+	billingContext,
+	params,
+}: {
+	billingContext: UpdateSubscriptionBillingContext;
+	params: UpdateSubscriptionV1Params;
+}): PooledBalanceOp[] => {
+	const updatesStatus = params.status !== undefined;
+	const updatesSubscription = params.processor_subscription_id !== undefined;
+	if (!updatesStatus && !updatesSubscription) return [];
+
+	const currentCustomerProduct = billingContext.customerProduct;
+	const targetCustomerProduct = {
+		...currentCustomerProduct,
+		status: params.status ?? currentCustomerProduct.status,
+		subscription_ids:
+			params.processor_subscription_id === undefined
+				? currentCustomerProduct.subscription_ids
+				: params.processor_subscription_id
+					? [params.processor_subscription_id]
+					: [],
+	};
+	const clearsExistingSubscription =
+		params.processor_subscription_id === null &&
+		(currentCustomerProduct.subscription_ids?.length ?? 0) > 0;
+	if (
+		!customerProductHasActiveStatus(targetCustomerProduct) ||
+		clearsExistingSubscription
+	) {
+		const removal = customerProductToPooledBalanceRemovalOp({
+			customerProduct: currentCustomerProduct,
+			effectiveAt: null,
+		});
+		return removal ? [removal] : [];
+	}
+
+	const prepared = computeAttachPooledBalanceOps({
+		customerProduct: targetCustomerProduct,
+		attachBillingContext: {
+			billingStartsAt: billingContext.currentEpochMs,
+			currentCustomerProduct,
+			currentEpochMs: billingContext.currentEpochMs,
+			fullCustomer: billingContext.fullCustomer,
+			planTiming: "immediate",
+			requestedBillingCycleAnchor: billingContext.requestedBillingCycleAnchor,
+			skipBillingChanges: billingContext.skipBillingChanges,
+		},
+		removeCurrentSource: false,
+	});
+
+	return prepared.pooledBalanceOps;
+};
 
 export const computeFieldUpdates = ({
 	params,

--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/computeUpdateSubscriptionPlan.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/computeUpdateSubscriptionPlan.ts
@@ -16,7 +16,10 @@ import { computeUpdateLicenseQuantityPlan } from "@/internal/billing/v2/actions/
 import { computeUpdateQuantityPlan } from "@/internal/billing/v2/actions/updateSubscription/compute/updateQuantity/computeUpdateQuantityPlan";
 import { buildAutumnLineItems } from "@/internal/billing/v2/compute/computeAutumnUtils/buildAutumnLineItems";
 import { addStripeSubscriptionIdToBillingPlan } from "@/internal/billing/v2/execute/addStripeSubscriptionIdToBillingPlan";
-import { computeFieldUpdates } from "./computeFieldUpdates";
+import {
+	computeFieldUpdatePooledBalanceOps,
+	computeFieldUpdates,
+} from "./computeFieldUpdates";
 
 /**
  * Compute the subscription update plan
@@ -86,6 +89,31 @@ export const computeUpdateSubscriptionPlan = async ({
 			},
 		};
 	}
+	if (
+		!billingContext.cancelAction &&
+		plan.insertCustomerProducts.length === 0
+	) {
+		plan.pooledBalanceOps = [
+			...(plan.pooledBalanceOps ?? []),
+			...computeFieldUpdatePooledBalanceOps({ billingContext, params }),
+		];
+	}
+	const processorSubscriptionId = params.processor_subscription_id;
+	if (processorSubscriptionId) {
+		plan.pooledBalanceOps = plan.pooledBalanceOps?.map((operation) => {
+			if (
+				(operation.op !== "upsert_source" &&
+					operation.op !== "transfer_source") ||
+				operation.sourceCustomerProductId !==
+					billingContext.customerProduct.id ||
+				operation.stripeSubscriptionId === null
+			) {
+				return operation;
+			}
+
+			return { ...operation, stripeSubscriptionId: processorSubscriptionId };
+		});
+	}
 
 	// Apply cancel plan if cancelAction is set in context
 	plan = computeCancelPlan({ ctx, billingContext, plan });
@@ -101,11 +129,15 @@ export const computeUpdateSubscriptionPlan = async ({
 	// sub-id linkage in executeStripeSubscriptionAction never runs.
 	const existingSubscriptionId =
 		billingContext.customerProduct.subscription_ids?.[0];
+	const subscriptionIdForPlan =
+		params.processor_subscription_id !== undefined
+			? (params.processor_subscription_id ?? undefined)
+			: existingSubscriptionId;
 
-	if (billingContext.skipBillingChanges && existingSubscriptionId) {
+	if (billingContext.skipBillingChanges && subscriptionIdForPlan) {
 		addStripeSubscriptionIdToBillingPlan({
 			autumnBillingPlan: plan,
-			stripeSubscriptionId: existingSubscriptionId,
+			stripeSubscriptionId: subscriptionIdForPlan,
 		});
 	}
 

--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/customPlan/computeCustomPlan.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/customPlan/computeCustomPlan.ts
@@ -11,6 +11,7 @@ import { buildAutumnLineItems } from "@/internal/billing/v2/compute/computeAutum
 import { computePatchCustomerProductPlan } from "@/internal/billing/v2/compute/computePatchPlan";
 import { computeSchedulePhaseReplacements } from "@/internal/billing/v2/compute/computeSchedulePhaseReplacements";
 import { computeCustomerLicenseTransitions } from "@/internal/billing/v2/compute/customerLicenseTransitions/computeCustomerLicenseTransitions";
+import { computeAttachPooledBalanceOps } from "@/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalanceOps.js";
 import { applyOneOffPrepaidCarryOvers } from "@/internal/billing/v2/utils/handleOneOffPrepaidCarryOvers/applyOneOffPrepaidCarryOvers";
 
 export const computeCustomPlan = async ({
@@ -93,10 +94,23 @@ export const computeCustomPlan = async ({
 		fullCustomer,
 		customerProduct,
 	});
+	const { customerProduct: preparedCustomerProduct, pooledBalanceOps } =
+		computeAttachPooledBalanceOps({
+			customerProduct: newFullCustomerProduct,
+			attachBillingContext: {
+				currentCustomerProduct: customerProduct,
+				currentEpochMs: updateSubscriptionContext.currentEpochMs,
+				fullCustomer,
+				planTiming: isUpdatingScheduledProduct ? "end_of_cycle" : "immediate",
+				requestedBillingCycleAnchor:
+					updateSubscriptionContext.requestedBillingCycleAnchor,
+				skipBillingChanges: updateSubscriptionContext.skipBillingChanges,
+			},
+		});
 
 	return {
 		customerId: fullCustomer?.id ?? "",
-		insertCustomerProducts: [newFullCustomerProduct],
+		insertCustomerProducts: [preparedCustomerProduct],
 		updateCustomerProduct: isUpdatingScheduledProduct
 			? undefined
 			: {
@@ -110,7 +124,7 @@ export const computeCustomPlan = async ({
 			: deleteCustomerProduct,
 		schedulePhaseCustomerProductReplacements: computeSchedulePhaseReplacements({
 			oldCustomerProduct: customerProduct,
-			newCustomerProduct: newFullCustomerProduct,
+			newCustomerProduct: preparedCustomerProduct,
 		}),
 		customPrices,
 		customEntitlements: [
@@ -120,6 +134,7 @@ export const computeCustomPlan = async ({
 		customFreeTrial: trialContext?.customFreeTrial,
 		insertPlanLicenses: updateSubscriptionContext.insertPlanLicenses,
 		customerLicenseTransitions,
+		pooledBalanceOps,
 		lineItems: allLineItems,
 		insertCustomerEntitlements: oneOffPrepaidCarryOvers.customerEntitlements,
 	} satisfies AutumnBillingPlan;

--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/updateQuantity/computeUpdateQuantityPlan.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/updateQuantity/computeUpdateQuantityPlan.ts
@@ -4,6 +4,8 @@ import {
 	type UpdateSubscriptionBillingContext,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { computePooledQuantityUpdateOps } from "@/internal/billing/v2/pooledBalances/compute/computePooledQuantityUpdateOps.js";
+import { isPooledSourceCustomerEntitlement } from "@/internal/billing/v2/pooledBalances/utils/pooledCustomerEntitlementClassification.js";
 import { computeUpdateQuantityDetails } from "./computeUpdateQuantityDetails";
 
 export const computeUpdateQuantityPlan = ({
@@ -38,6 +40,10 @@ export const computeUpdateQuantityPlan = ({
 	const updatedOptions = quantityUpdateDetails.map(
 		(detail) => detail.updatedOptions,
 	);
+	const pooledBalanceOps = computePooledQuantityUpdateOps({
+		customerProduct,
+		updatedOptions,
+	});
 
 	return {
 		customerId: updateSubscriptionContext.fullCustomer?.id ?? "",
@@ -51,9 +57,16 @@ export const computeUpdateQuantityPlan = ({
 			},
 		},
 
-		updateCustomerEntitlements: quantityUpdateDetails.flatMap(
-			(detail) => detail.updateCustomerEntitlements,
-		),
+		updateCustomerEntitlements: quantityUpdateDetails
+			.flatMap((detail) => detail.updateCustomerEntitlements)
+			.filter(
+				(update) =>
+					!isPooledSourceCustomerEntitlement({
+						customerEntitlement: update.customerEntitlement,
+						customerProduct,
+					}),
+			),
+		pooledBalanceOps,
 
 		lineItems,
 	};

--- a/server/src/internal/billing/v2/compute/computePatchPlan/computePatchCustomerProductPlan.ts
+++ b/server/src/internal/billing/v2/compute/computePatchPlan/computePatchCustomerProductPlan.ts
@@ -2,16 +2,44 @@ import {
 	type AutumnBillingPlan,
 	CusProductStatus,
 	EntInterval,
+	type FullCustomerEntitlement,
 	getCycleEnd,
 	isBooleanEntitlement,
+	type PooledBalanceOp,
 	type UpdateSubscriptionBillingContext,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { buildAutumnLineItems } from "@/internal/billing/v2/compute/computeAutumnUtils/buildAutumnLineItems";
 import { computeSchedulePhaseReplacements } from "@/internal/billing/v2/compute/computeSchedulePhaseReplacements";
 import { computeCustomerLicenseTransitions } from "@/internal/billing/v2/compute/customerLicenseTransitions/computeCustomerLicenseTransitions";
+import { computeAttachPooledBalanceOps } from "@/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalanceOps.js";
+import { isPooledSourceCustomerEntitlement } from "@/internal/billing/v2/pooledBalances/utils/pooledCustomerEntitlementClassification.js";
 import { entitlementToResetCycleAnchor } from "@/internal/billing/v2/utils/initFullCustomerProduct/cycleAnchorUtils";
 import { initPatchCustomerProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/initPatchedCustomerProduct";
+
+export const computePatchPooledBalanceContributionRemovalOps = ({
+	customerProduct,
+	deleteCustomerEntitlements,
+}: {
+	customerProduct: UpdateSubscriptionBillingContext["customerProduct"];
+	deleteCustomerEntitlements: FullCustomerEntitlement[];
+}): PooledBalanceOp[] =>
+	customerProduct.status === CusProductStatus.Scheduled
+		? []
+		: deleteCustomerEntitlements
+				.filter((customerEntitlement) =>
+					isPooledSourceCustomerEntitlement({
+						customerEntitlement,
+						customerProduct,
+					}),
+				)
+				.map((customerEntitlement) => ({
+					op: "remove_contribution" as const,
+					internalCustomerId: customerProduct.internal_customer_id,
+					sourceCustomerProductId: customerProduct.id,
+					sourceEntitlementId: customerEntitlement.entitlement.id,
+					effectiveAt: null,
+				}));
 
 export const computePatchCustomerProductPlan = ({
 	ctx,
@@ -62,6 +90,75 @@ export const computePatchCustomerProductPlan = ({
 				includeArrearLineItems:
 					updateSubscriptionContext.chargeExistingOverages === true,
 			});
+	const pooledAttachBillingContext = {
+		currentCustomerProduct: patchContext.originalCustomerProduct,
+		currentEpochMs: updateSubscriptionContext.currentEpochMs,
+		fullCustomer,
+		planTiming: isUpdatingScheduledProduct
+			? ("end_of_cycle" as const)
+			: ("immediate" as const),
+		requestedBillingCycleAnchor:
+			updateSubscriptionContext.requestedBillingCycleAnchor,
+		skipBillingChanges: updateSubscriptionContext.skipBillingChanges,
+	};
+	let preparedCustomerProduct = finalCustomerProduct;
+	let patchInsertCustomerEntitlements = patchContext.insertCustomerEntitlements;
+	let pooledBalanceOps: PooledBalanceOp[] = [];
+
+	if (patchContext.mode === "new") {
+		const preparedPooledSource = computeAttachPooledBalanceOps({
+			customerProduct: finalCustomerProduct,
+			attachBillingContext: pooledAttachBillingContext,
+		});
+		preparedCustomerProduct = preparedPooledSource.customerProduct;
+		pooledBalanceOps = preparedPooledSource.pooledBalanceOps;
+	} else {
+		pooledBalanceOps = computePatchPooledBalanceContributionRemovalOps({
+			customerProduct: patchContext.originalCustomerProduct,
+			deleteCustomerEntitlements: patchContext.deleteCustomerEntitlements,
+		});
+
+		const insertedPooledCustomerEntitlements =
+			patchContext.insertCustomerEntitlements.filter((customerEntitlement) =>
+				isPooledSourceCustomerEntitlement({
+					customerEntitlement,
+					customerProduct: finalCustomerProduct,
+				}),
+			);
+		if (insertedPooledCustomerEntitlements.length > 0) {
+			const preparedInsertions = computeAttachPooledBalanceOps({
+				customerProduct: {
+					...finalCustomerProduct,
+					customer_entitlements: insertedPooledCustomerEntitlements,
+				},
+				attachBillingContext: pooledAttachBillingContext,
+				removeCurrentSource: false,
+			});
+			pooledBalanceOps.push(...preparedInsertions.pooledBalanceOps);
+			const preparedInsertionById = new Map(
+				preparedInsertions.customerProduct.customer_entitlements.map(
+					(customerEntitlement) => [
+						customerEntitlement.id,
+						customerEntitlement,
+					],
+				),
+			);
+			const prepareCustomerEntitlement = (
+				customerEntitlement: FullCustomerEntitlement,
+			) =>
+				preparedInsertionById.get(customerEntitlement.id) ??
+				customerEntitlement;
+			patchInsertCustomerEntitlements =
+				patchContext.insertCustomerEntitlements.map(prepareCustomerEntitlement);
+			preparedCustomerProduct = {
+				...finalCustomerProduct,
+				customer_entitlements: finalCustomerProduct.customer_entitlements.map(
+					prepareCustomerEntitlement,
+				),
+			};
+		}
+	}
+
 	const basePlan = {
 		customerId: fullCustomer?.id ?? "",
 		customPrices: patchContext.customPrices,
@@ -69,18 +166,19 @@ export const computePatchCustomerProductPlan = ({
 		customFreeTrial: trialContext?.customFreeTrial,
 		insertPlanLicenses: updateSubscriptionContext.insertPlanLicenses,
 		customerLicenseTransitions,
+		pooledBalanceOps,
 		lineItems: allLineItems,
 		insertCustomerEntitlements: oneOffPrepaidCarryOverCustomerEntitlements,
 		updateCustomerEntitlements: computeAnchorResetEntitlementUpdates({
 			updateSubscriptionContext,
-			finalCustomerProduct,
+			finalCustomerProduct: preparedCustomerProduct,
 		}),
 	} satisfies Partial<AutumnBillingPlan>;
 
 	if (patchContext.mode === "new") {
 		return {
 			...basePlan,
-			insertCustomerProducts: [finalCustomerProduct],
+			insertCustomerProducts: [preparedCustomerProduct],
 			updateCustomerProduct: isUpdatingScheduledProduct
 				? undefined
 				: {
@@ -98,7 +196,7 @@ export const computePatchCustomerProductPlan = ({
 			schedulePhaseCustomerProductReplacements:
 				computeSchedulePhaseReplacements({
 					oldCustomerProduct: patchContext.originalCustomerProduct,
-					newCustomerProduct: finalCustomerProduct,
+					newCustomerProduct: preparedCustomerProduct,
 				}),
 		} satisfies AutumnBillingPlan;
 	}
@@ -119,7 +217,7 @@ export const computePatchCustomerProductPlan = ({
 			{
 				customerProduct: patchContext.originalCustomerProduct,
 				insertCustomerPrices: patchContext.insertCustomerPrices,
-				insertCustomerEntitlements: patchContext.insertCustomerEntitlements,
+				insertCustomerEntitlements: patchInsertCustomerEntitlements,
 				deleteCustomerPrices: patchContext.deleteCustomerPrices,
 				deleteCustomerEntitlements: patchContext.deleteCustomerEntitlements,
 			},

--- a/server/src/internal/billing/v2/execute/addStripeSubscriptionIdToBillingPlan.ts
+++ b/server/src/internal/billing/v2/execute/addStripeSubscriptionIdToBillingPlan.ts
@@ -1,5 +1,4 @@
-import type { AutumnBillingPlan } from "@autumn/shared";
-import { cp } from "@autumn/shared";
+import { type AutumnBillingPlan, cp } from "@autumn/shared";
 import { getPatchedCustomerProductUpdates } from "@/internal/billing/v2/utils/billingPlan/customerProductPlanMutations.js";
 import { customerProductHasPaidLicenses } from "@/internal/billing/v2/utils/customerProductHasPaidLicenses.js";
 
@@ -15,6 +14,7 @@ export const addStripeSubscriptionIdToBillingPlan = ({
 	autumnBillingPlan: AutumnBillingPlan;
 	stripeSubscriptionId: string;
 }) => {
+	const linkedCustomerProductIds = new Set<string>();
 	for (const customerProduct of autumnBillingPlan.insertCustomerProducts) {
 		const { valid: isPaidRecurring } = cp(customerProduct).paid().recurring();
 
@@ -23,11 +23,42 @@ export const addStripeSubscriptionIdToBillingPlan = ({
 		}
 
 		customerProduct.subscription_ids = [stripeSubscriptionId];
+		linkedCustomerProductIds.add(customerProduct.id);
 	}
 
 	for (const update of getPatchedCustomerProductUpdates({
 		autumnBillingPlan,
 	})) {
 		update.updates.subscription_ids = [stripeSubscriptionId];
+		linkedCustomerProductIds.add(update.customerProduct.id);
+	}
+
+	for (const upsertSource of autumnBillingPlan.pooledBalancePlan
+		?.upsertSources ?? []) {
+		const { contribution } = upsertSource;
+		if (
+			!linkedCustomerProductIds.has(contribution.sourceCustomerProductId) ||
+			contribution.stripeSubscriptionId === null
+		) {
+			continue;
+		}
+
+		contribution.stripeSubscriptionId = stripeSubscriptionId;
+	}
+
+	for (const pooledBalanceOperation of autumnBillingPlan.pooledBalanceOps ??
+		[]) {
+		if (
+			(pooledBalanceOperation.op !== "upsert_source" &&
+				pooledBalanceOperation.op !== "transfer_source") ||
+			!linkedCustomerProductIds.has(
+				pooledBalanceOperation.sourceCustomerProductId,
+			) ||
+			pooledBalanceOperation.stripeSubscriptionId === null
+		) {
+			continue;
+		}
+
+		pooledBalanceOperation.stripeSubscriptionId = stripeSubscriptionId;
 	}
 };

--- a/server/src/internal/billing/v2/execute/addStripeSubscriptionScheduleIdToBillingPlan.ts
+++ b/server/src/internal/billing/v2/execute/addStripeSubscriptionScheduleIdToBillingPlan.ts
@@ -1,8 +1,5 @@
+import type { AutumnBillingPlan, StripeBillingPlan } from "@autumn/shared";
 import { CusProductStatus, cp } from "@autumn/shared";
-import type {
-	AutumnBillingPlan,
-	StripeBillingPlan,
-} from "@autumn/shared";
 import { getUpdateCustomerProducts } from "@/internal/billing/v2/utils/billingPlan/customerProductPlanMutations";
 
 export const addStripeSubscriptionScheduleIdToBillingPlan = ({

--- a/server/src/internal/billing/v2/execute/executeAutumnActions/executeCustomerLicenseTransitions.ts
+++ b/server/src/internal/billing/v2/execute/executeAutumnActions/executeCustomerLicenseTransitions.ts
@@ -1,56 +1,511 @@
-import type { CustomerLicenseTransition } from "@autumn/shared";
-import type { AutumnContext } from "@/honoUtils/HonoEnv";
-import { batchTransitionTask } from "@/internal/billing/v2/actions/batchTransition/tasks/batchTransitionTask";
-import { isSameRowTransition } from "@/internal/billing/v2/compute/customerLicenseTransitions/isSameRowTransition";
-import { customerLicenseRepo } from "@/internal/licenses/repos/customerLicenseRepo";
-import { generateId } from "@/utils/genUtils";
+import {
+	type CustomerLicenseTransition,
+	customerProductHasActiveStatus,
+	entsAreSame,
+	type FullCusProduct,
+	type InsertCustomerEntitlement,
+	InternalError,
+	type PooledBalanceOp,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { computeProductTransitions } from "@/internal/billing/v2/actions/batchTransition/compute/transitions/computeProductTransitions.js";
+import { batchTransitionTask } from "@/internal/billing/v2/actions/batchTransition/tasks/batchTransitionTask.js";
+import { isSameRowTransition } from "@/internal/billing/v2/compute/customerLicenseTransitions/isSameRowTransition.js";
+import { executePooledBalanceOps } from "@/internal/billing/v2/execute/executeAutumnActions/executePooledBalanceOps.js";
+import { initUpsertPooledBalanceSourceSpecs } from "@/internal/billing/v2/pooledBalances/compute/initUpsertPooledBalanceSourceSpec/initUpsertPooledBalanceSourceSpecs.js";
+import { pooledBalanceRepo } from "@/internal/billing/v2/pooledBalances/repos/pooledBalanceRepo.js";
+import { upsertSourceSpecToOp } from "@/internal/billing/v2/pooledBalances/utils/pooledBalancePlanToOps.js";
+import { initFullCustomerProductFromCustomerLicense } from "@/internal/billing/v2/utils/initFullCustomerProduct/initFullCustomerProductFromCustomerLicense.js";
+import { CusService } from "@/internal/customers/CusService.js";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService.js";
+import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
+import { customerLicenseRepo } from "@/internal/licenses/repos/customerLicenseRepo.js";
+import { generateId } from "@/utils/genUtils.js";
 
-/** Converges license pools and their assigned seat definitions.
- * Persists pre-existing successor pools during scheduled activation. */
-export const executeCustomerLicenseTransitions = async ({
+type TransitionCustomerEntitlement =
+	FullCusProduct["customer_entitlements"][number];
+
+type RestoreCustomerEntitlement = {
+	id: string;
+	target: InsertCustomerEntitlement;
+};
+
+export type PreparedPooledTargetCustomerEntitlementMutation =
+	| {
+			type: "insert";
+			target: InsertCustomerEntitlement;
+	  }
+	| {
+			type: "update";
+			id: string;
+			target: InsertCustomerEntitlement;
+	  };
+
+export type PreparedCustomerLicenseTransition = {
+	transition: CustomerLicenseTransition;
+	fullCustomerId: string;
+	operations: PooledBalanceOp[];
+	pooledTargetCustomerEntitlementMutations: PreparedPooledTargetCustomerEntitlementMutation[];
+	restoredCustomerEntitlements: RestoreCustomerEntitlement[];
+};
+
+const customerEntitlementToTarget = ({
+	customerEntitlement,
+	customerProductId,
+	id = customerEntitlement.id,
+}: {
+	customerEntitlement: TransitionCustomerEntitlement;
+	customerProductId: string;
+	id?: string;
+}): InsertCustomerEntitlement => ({
+	id,
+	customer_product_id: customerProductId,
+	entitlement_id: customerEntitlement.entitlement.id,
+	internal_customer_id: customerEntitlement.internal_customer_id,
+	internal_entity_id: customerEntitlement.internal_entity_id,
+	internal_feature_id: customerEntitlement.entitlement.internal_feature_id,
+	feature_id: customerEntitlement.entitlement.feature.id,
+	customer_id: customerEntitlement.customer_id,
+	created_at: customerEntitlement.created_at,
+	unlimited: customerEntitlement.unlimited,
+	balance: customerEntitlement.balance ?? 0,
+	additional_balance: customerEntitlement.additional_balance,
+	adjustment: customerEntitlement.adjustment,
+	entities: customerEntitlement.entities,
+	usage_allowed: customerEntitlement.usage_allowed,
+	separate_interval: customerEntitlement.separate_interval,
+	reset_cycle_anchor: customerEntitlement.reset_cycle_anchor,
+	next_reset_at: customerEntitlement.next_reset_at,
+	expires_at: customerEntitlement.expires_at,
+	cache_version: customerEntitlement.cache_version,
+	external_id: customerEntitlement.external_id,
+});
+
+const targetToUpdates = (target: InsertCustomerEntitlement) => {
+	const {
+		id: _id,
+		customer_product_id: _customerProductId,
+		created_at: _createdAt,
+		cache_version: _cacheVersion,
+		...updates
+	} = target;
+	return updates;
+};
+
+const findSourceCustomerEntitlement = ({
+	assignment,
+	targetCustomerEntitlement,
+	successorEntitlementIdByPreviousId,
+}: {
+	assignment: FullCusProduct;
+	targetCustomerEntitlement: TransitionCustomerEntitlement;
+	successorEntitlementIdByPreviousId: Map<string, string>;
+}) => {
+	const targetEntitlementId = targetCustomerEntitlement.entitlement.id;
+	const mappedCandidates = assignment.customer_entitlements.filter(
+		(customerEntitlement) =>
+			customerEntitlement.entitlement.id === targetEntitlementId ||
+			successorEntitlementIdByPreviousId.get(
+				customerEntitlement.entitlement.id,
+			) === targetEntitlementId,
+	);
+	if (mappedCandidates.length > 1) {
+		throw new InternalError({
+			message: `Customer entitlements for license assignment '${assignment.id}' cannot be matched unambiguously to '${targetEntitlementId}'.`,
+		});
+	}
+	if (mappedCandidates.length === 1) return mappedCandidates[0];
+
+	const matchingDefinitionCandidates = assignment.customer_entitlements.filter(
+		(customerEntitlement) =>
+			entsAreSame(
+				customerEntitlement.entitlement,
+				targetCustomerEntitlement.entitlement,
+			),
+	);
+	if (matchingDefinitionCandidates.length > 1) {
+		throw new InternalError({
+			message: `Customer entitlements for license assignment '${assignment.id}' cannot be matched unambiguously to the target definition '${targetEntitlementId}'.`,
+		});
+	}
+	return matchingDefinitionCandidates[0];
+};
+
+const executeTransitionRow = async ({
 	ctx,
-	customerLicenseTransitions,
+	transition,
 }: {
 	ctx: AutumnContext;
-	customerLicenseTransitions: CustomerLicenseTransition[] | undefined;
+	transition: CustomerLicenseTransition;
 }) => {
-	for (const transition of customerLicenseTransitions ?? []) {
-		const { incomingCustomerLicense, updates } = transition;
-		const planLicense = incomingCustomerLicense.planLicense;
-		if (!planLicense) continue;
+	const { incomingCustomerLicense, updates } = transition;
+	const planLicense = incomingCustomerLicense.planLicense;
+	if (!planLicense) return;
 
-		if (isSameRowTransition(transition)) {
-			await customerLicenseRepo.repointDefinition({
-				db: ctx.db,
-				customerLicenseId: incomingCustomerLicense.id,
-				planLicenseId: planLicense.id,
-				included: planLicense.included,
-				paidQuantity: updates.paidQuantity,
-			});
-			ctx.logger.info(
-				`[licenseTransitions] repointed pool ${incomingCustomerLicense.id} definition ${transition.outgoingCustomerLicense.plan_license_id} -> ${planLicense.id}`,
-				{
-					data: {
-						customerLicenseId: incomingCustomerLicense.id,
-						customerLicenseLinkId: updates.linkId,
-						fromPlanLicenseId:
-							transition.outgoingCustomerLicense.plan_license_id,
-						toPlanLicenseId: planLicense.id,
-						updates,
-					},
+	if (isSameRowTransition(transition)) {
+		await customerLicenseRepo.repointDefinition({
+			db: ctx.db,
+			customerLicenseId: incomingCustomerLicense.id,
+			planLicenseId: planLicense.id,
+			included: planLicense.included,
+			paidQuantity: updates.paidQuantity,
+		});
+		ctx.logger.info(
+			`[licenseTransitions] repointed pool ${incomingCustomerLicense.id} definition ${transition.outgoingCustomerLicense.plan_license_id} -> ${planLicense.id}`,
+			{
+				data: {
+					customerLicenseId: incomingCustomerLicense.id,
+					customerLicenseLinkId: updates.linkId,
+					fromPlanLicenseId: transition.outgoingCustomerLicense.plan_license_id,
+					toPlanLicenseId: planLicense.id,
+					updates,
 				},
+			},
+		);
+		return;
+	}
+
+	await customerLicenseRepo.carryCustomerLicenseState({
+		db: ctx.db,
+		customerLicenseId: incomingCustomerLicense.id,
+		linkId: updates.linkId,
+		granted: updates.granted,
+		remaining: updates.remaining,
+		paidQuantity: updates.paidQuantity,
+	});
+};
+
+const buildPooledTransitionOperations = async ({
+	ctx,
+	transition,
+	pendingCustomerProducts = [],
+}: {
+	ctx: AutumnContext;
+	transition: CustomerLicenseTransition;
+	pendingCustomerProducts?: FullCusProduct[];
+}): Promise<Omit<PreparedCustomerLicenseTransition, "transition">> => {
+	const { incomingCustomerLicense, outgoingCustomerLicense, updates } =
+		transition;
+	const planLicense = incomingCustomerLicense.planLicense;
+	if (!planLicense) {
+		return {
+			fullCustomerId: incomingCustomerLicense.internal_customer_id,
+			operations: [],
+			pooledTargetCustomerEntitlementMutations: [],
+			restoredCustomerEntitlements: [],
+		};
+	}
+
+	const [fullCustomer, customerProducts] = await Promise.all([
+		CusService.getFull({
+			ctx,
+			idOrInternalId: incomingCustomerLicense.internal_customer_id,
+			withEntities: true,
+		}),
+		CusProductService.list({
+			db: ctx.db,
+			internalCustomerId: incomingCustomerLicense.internal_customer_id,
+		}),
+	]);
+	const assignments = customerProducts.filter(
+		(customerProduct) =>
+			customerProduct.customer_license_link_id === updates.linkId &&
+			customerProduct.internal_entity_id !== null &&
+			customerProductHasActiveStatus(customerProduct),
+	);
+	if (assignments.length === 0) {
+		return {
+			fullCustomerId: fullCustomer.id ?? fullCustomer.internal_id,
+			operations: [],
+			pooledTargetCustomerEntitlementMutations: [],
+			restoredCustomerEntitlements: [],
+		};
+	}
+
+	const parentCustomerProduct = [
+		...customerProducts,
+		...pendingCustomerProducts,
+	].find(
+		(customerProduct) =>
+			customerProduct.id === incomingCustomerLicense.parent_customer_product_id,
+	);
+	if (!parentCustomerProduct) {
+		throw new InternalError({
+			message: `License transition parent '${incomingCustomerLicense.parent_customer_product_id}' was not found.`,
+		});
+	}
+
+	const contributions =
+		await pooledBalanceRepo.listContributionsBySourceCustomerProductIds({
+			db: ctx.db,
+			sourceCustomerProductIds: assignments.map(
+				(customerProduct) => customerProduct.id,
+			),
+		});
+	const pools = await pooledBalanceRepo.listByIds({
+		db: ctx.db,
+		pooledBalanceIds: [
+			...new Set(
+				contributions.map((contribution) => contribution.pooled_balance_id),
+			),
+		],
+	});
+	const poolById = new Map(pools.map((pool) => [pool.id, pool]));
+	const outgoingProduct = outgoingCustomerLicense.planLicense?.product;
+	const entitlementTransitions = outgoingProduct
+		? computeProductTransitions({
+				fromProduct: outgoingProduct,
+				toProduct: planLicense.product,
+			}).entitlementPrices.transitions
+		: [];
+	const successorEntitlementIdByPreviousId = new Map(
+		entitlementTransitions.map(
+			({ fromEntitlementPrice, toEntitlementPrice }) => [
+				fromEntitlementPrice.entitlement.id,
+				toEntitlementPrice.entitlement.id,
+			],
+		),
+	);
+	const operations: PooledBalanceOp[] = [];
+	const pooledTargetCustomerEntitlementMutations: PreparedPooledTargetCustomerEntitlementMutation[] =
+		[];
+	const restoredCustomerEntitlements: RestoreCustomerEntitlement[] = [];
+	const now = Date.now();
+	const resetCycleAnchor =
+		parentCustomerProduct.billing_cycle_anchor ??
+		parentCustomerProduct.created_at ??
+		now;
+
+	for (const assignment of assignments) {
+		const initializedTargetCustomerProduct = {
+			...initFullCustomerProductFromCustomerLicense({
+				ctx,
+				fullCustomer,
+				customerLicense: { ...incomingCustomerLicense, planLicense },
+				internalEntityId: assignment.internal_entity_id as string,
+				resetCycleAnchor,
+				currentEpochMs: now,
+			}),
+			id: assignment.id,
+		};
+		const { customerProduct: targetCustomerProduct, upsertSourceSpecs } =
+			initUpsertPooledBalanceSourceSpecs({
+				customerProduct: initializedTargetCustomerProduct,
+				resetPolicy: {
+					customerLicenseLinkId: transition.updates.linkId,
+				},
+			});
+		const targetOperations = upsertSourceSpecs.map(upsertSourceSpecToOp);
+		const sourceContributions = contributions.filter(
+			(contribution) =>
+				contribution.source_customer_product_id === assignment.id,
+		);
+		const unmatchedContributionIds = new Set(
+			sourceContributions.map((contribution) => contribution.id),
+		);
+
+		for (const targetOperation of targetOperations) {
+			const targetCustomerEntitlement =
+				targetCustomerProduct.customer_entitlements.find(
+					(candidate) =>
+						candidate.entitlement.id === targetOperation.sourceEntitlementId,
+				);
+			if (!targetCustomerEntitlement) {
+				throw new InternalError({
+					message: `Pooled target entitlement '${targetOperation.sourceEntitlementId}' was not found for license assignment '${assignment.id}'.`,
+				});
+			}
+			const sourceCustomerEntitlement = findSourceCustomerEntitlement({
+				assignment,
+				targetCustomerEntitlement,
+				successorEntitlementIdByPreviousId,
+			});
+			const target = customerEntitlementToTarget({
+				customerEntitlement: targetCustomerEntitlement,
+				customerProductId: assignment.id,
+				id: sourceCustomerEntitlement?.id,
+			});
+			if (!sourceCustomerEntitlement) {
+				pooledTargetCustomerEntitlementMutations.push({
+					type: "insert",
+					target,
+				});
+			} else if (
+				sourceCustomerEntitlement.entitlement.id !==
+				targetCustomerEntitlement.entitlement.id
+			) {
+				pooledTargetCustomerEntitlementMutations.push({
+					type: "update",
+					id: sourceCustomerEntitlement.id,
+					target,
+				});
+			}
+
+			let matchingContributions = sourceContributions.filter(
+				(contribution) =>
+					unmatchedContributionIds.has(contribution.id) &&
+					(successorEntitlementIdByPreviousId.get(
+						contribution.source_entitlement_id,
+					) ?? contribution.source_entitlement_id) ===
+						targetOperation.sourceEntitlementId,
 			);
-		} else {
-			await customerLicenseRepo.carryCustomerLicenseState({
-				db: ctx.db,
-				customerLicenseId: incomingCustomerLicense.id,
-				linkId: updates.linkId,
-				granted: updates.granted,
-				remaining: updates.remaining,
-				paidQuantity: updates.paidQuantity,
+			if (matchingContributions.length === 0) {
+				matchingContributions = sourceContributions.filter((contribution) => {
+					const pool = poolById.get(contribution.pooled_balance_id);
+					return (
+						unmatchedContributionIds.has(contribution.id) &&
+						pool?.internal_feature_id === targetOperation.internalFeatureId
+					);
+				});
+			}
+			if (matchingContributions.length > 1) {
+				throw new InternalError({
+					message: `Pooled sources for license assignment '${assignment.id}' cannot be matched unambiguously.`,
+				});
+			}
+
+			const contribution = matchingContributions[0];
+			if (!contribution) {
+				operations.push(targetOperation);
+				continue;
+			}
+			unmatchedContributionIds.delete(contribution.id);
+			operations.push({
+				...targetOperation,
+				op: "transfer_source",
+				contributionId: contribution.id,
+				expectedPooledBalanceId: contribution.pooled_balance_id,
 			});
 		}
 
+		for (const contribution of sourceContributions) {
+			if (!unmatchedContributionIds.has(contribution.id)) continue;
+			operations.push({
+				op: "remove_contribution",
+				internalCustomerId: assignment.internal_customer_id,
+				sourceCustomerProductId: assignment.id,
+				sourceEntitlementId: contribution.source_entitlement_id,
+				effectiveAt: null,
+			});
+		}
+
+		for (const customerEntitlement of assignment.customer_entitlements) {
+			const targetEntitlementId =
+				successorEntitlementIdByPreviousId.get(
+					customerEntitlement.entitlement.id,
+				) ?? customerEntitlement.entitlement.id;
+			const targetCustomerEntitlement =
+				targetCustomerProduct.customer_entitlements.find(
+					(candidate) => candidate.entitlement.id === targetEntitlementId,
+				);
+			if (!targetCustomerEntitlement?.entitlement.pooled) {
+				const wasPooled = sourceContributions.some(
+					(contribution) =>
+						contribution.source_entitlement_id ===
+						customerEntitlement.entitlement.id,
+				);
+				if (wasPooled && targetCustomerEntitlement) {
+					restoredCustomerEntitlements.push({
+						id: customerEntitlement.id,
+						target: customerEntitlementToTarget({
+							customerEntitlement: targetCustomerEntitlement,
+							customerProductId: assignment.id,
+							id: customerEntitlement.id,
+						}),
+					});
+				}
+			}
+		}
+	}
+
+	return {
+		fullCustomerId: fullCustomer.id ?? fullCustomer.internal_id,
+		operations,
+		pooledTargetCustomerEntitlementMutations,
+		restoredCustomerEntitlements,
+	};
+};
+
+export const prepareCustomerLicenseTransitions = async ({
+	ctx,
+	customerLicenseTransitions,
+	pendingCustomerProducts = [],
+}: {
+	ctx: AutumnContext;
+	customerLicenseTransitions: CustomerLicenseTransition[] | undefined;
+	pendingCustomerProducts?: FullCusProduct[];
+}): Promise<PreparedCustomerLicenseTransition[]> =>
+	Promise.all(
+		(customerLicenseTransitions ?? []).flatMap((transition) =>
+			transition.incomingCustomerLicense.planLicense
+				? [
+						buildPooledTransitionOperations({
+							ctx,
+							transition,
+							pendingCustomerProducts,
+						}).then((pooledTransition) => ({
+							transition,
+							...pooledTransition,
+						})),
+					]
+				: [],
+		),
+	);
+
+export const executePreparedCustomerLicenseTransitionRows = async ({
+	ctx,
+	preparedTransitions,
+}: {
+	ctx: AutumnContext;
+	preparedTransitions: PreparedCustomerLicenseTransition[];
+}) => {
+	for (const preparedTransition of preparedTransitions) {
+		await executeTransitionRow({
+			ctx,
+			transition: preparedTransition.transition,
+		});
+		for (const mutation of preparedTransition.pooledTargetCustomerEntitlementMutations) {
+			if (mutation.type === "insert") {
+				await CusEntService.insert({ ctx, data: [mutation.target] });
+				continue;
+			}
+			await CusEntService.update({
+				ctx,
+				id: mutation.id,
+				updates: targetToUpdates(mutation.target),
+				incrementCacheVersion: true,
+			});
+		}
+	}
+};
+
+export const restorePreparedCustomerLicenseEntitlements = async ({
+	ctx,
+	preparedTransitions,
+}: {
+	ctx: AutumnContext;
+	preparedTransitions: PreparedCustomerLicenseTransition[];
+}) => {
+	for (const { restoredCustomerEntitlements } of preparedTransitions) {
+		for (const restoration of restoredCustomerEntitlements) {
+			await CusEntService.update({
+				ctx,
+				id: restoration.id,
+				updates: targetToUpdates(restoration.target),
+				incrementCacheVersion: true,
+			});
+		}
+	}
+};
+
+export const triggerPreparedCustomerLicenseBatchTransitions = async ({
+	ctx,
+	preparedTransitions,
+}: {
+	ctx: AutumnContext;
+	preparedTransitions: PreparedCustomerLicenseTransition[];
+}) => {
+	for (const { transition } of preparedTransitions) {
 		await batchTransitionTask.trigger(
 			{
 				orgId: ctx.org.id,
@@ -62,7 +517,56 @@ export const executeCustomerLicenseTransitions = async ({
 					assignmentCutoffMs: Date.now(),
 				},
 			},
-			{ concurrencyKey: updates.linkId },
+			{ concurrencyKey: transition.updates.linkId },
 		);
 	}
+};
+
+/** Converges license pools synchronously, then dispatches assigned-seat transitions. */
+export const executeCustomerLicenseTransitions = async ({
+	ctx,
+	customerLicenseTransitions,
+	preparedTransitions: providedPreparedTransitions,
+}: {
+	ctx: AutumnContext;
+	customerLicenseTransitions: CustomerLicenseTransition[] | undefined;
+	preparedTransitions?: PreparedCustomerLicenseTransition[];
+}) => {
+	const preparedTransitions =
+		providedPreparedTransitions ??
+		(await prepareCustomerLicenseTransitions({
+			ctx,
+			customerLicenseTransitions,
+		}));
+	for (const preparedTransition of preparedTransitions) {
+		if (preparedTransition.operations.length > 0) {
+			await executePooledBalanceOps({
+				ctx,
+				customerId: preparedTransition.fullCustomerId,
+				pooledBalanceOps: preparedTransition.operations,
+				beforeDatabaseOperations: ({ db }) =>
+					executePreparedCustomerLicenseTransitionRows({
+						ctx: { ...ctx, db },
+						preparedTransitions: [preparedTransition],
+					}),
+				beforeRebalance: ({ db }) =>
+					restorePreparedCustomerLicenseEntitlements({
+						ctx: { ...ctx, db },
+						preparedTransitions: [preparedTransition],
+					}),
+			});
+			continue;
+		}
+
+		await executePreparedCustomerLicenseTransitionRows({
+			ctx,
+			preparedTransitions: [preparedTransition],
+		});
+	}
+	await triggerPreparedCustomerLicenseBatchTransitions({
+		ctx,
+		preparedTransitions,
+	});
+
+	return preparedTransitions.some(({ operations }) => operations.length > 0);
 };

--- a/server/src/internal/billing/v2/execute/executeAutumnActions/executePooledBalanceOps.ts
+++ b/server/src/internal/billing/v2/execute/executeAutumnActions/executePooledBalanceOps.ts
@@ -1,0 +1,1278 @@
+import {
+	AllowanceType,
+	type AutumnBillingPlan,
+	type DbPooledBalance,
+	type FullSubject,
+	findFeatureByInternalId,
+	InternalError,
+	orgToInStatuses,
+	type PooledBalanceOp,
+	type PooledBalancePlan,
+	type SubjectQueryRow,
+} from "@autumn/shared";
+import { Decimal } from "decimal.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import {
+	type CustomerBalanceSyncDb,
+	withCustomerBalanceSyncLock,
+} from "@/internal/balances/utils/sync/withCustomerBalanceSyncLock.js";
+import { computePooledBalanceLookup } from "@/internal/billing/v2/pooledBalances/compute/computePooledBalanceLookup.js";
+import {
+	computePooledBalanceRebalance,
+	computePooledBalanceUsageReapply,
+	type PooledBalanceRebalanceDelta,
+	type PooledBalanceUsageReapply,
+} from "@/internal/billing/v2/pooledBalances/compute/computePooledBalanceRebalance.js";
+import { computePooledContributionTransition } from "@/internal/billing/v2/pooledBalances/compute/computePooledContributionTransition.js";
+import { computePooledTransferGrantDeltas } from "@/internal/billing/v2/pooledBalances/compute/computePooledTransferGrantDeltas.js";
+import type { PooledBalanceCacheEffect } from "@/internal/billing/v2/pooledBalances/compute/pooledBalanceCacheEffects.js";
+import { applyPooledBalanceCacheCutover } from "@/internal/billing/v2/pooledBalances/execute/applyPooledBalanceCacheEffects.js";
+import {
+	type PooledBalanceDb,
+	pooledBalanceRepo,
+} from "@/internal/billing/v2/pooledBalances/repos/pooledBalanceRepo.js";
+import { assertSinglePoolSubscriptionOwner } from "@/internal/billing/v2/pooledBalances/utils/assertSinglePoolSubscriptionOwner.js";
+import { pooledBalancePlanToOps } from "@/internal/billing/v2/pooledBalances/utils/pooledBalancePlanToOps.js";
+import { getOrInitFullSubjectViewEpoch } from "@/internal/customers/cache/fullSubject/actions/invalidate/getOrInitFullSubjectViewEpoch.js";
+import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
+import {
+	getFullSubjectQuery,
+	resultToFullSubject,
+} from "@/internal/customers/repos/getFullSubject/index.js";
+import { generateId } from "@/utils/genUtils.js";
+
+type UpsertPooledBalanceSourceOp = Extract<
+	PooledBalanceOp,
+	{ op: "upsert_source" }
+>;
+type RemovePooledBalanceSourceOp = Extract<
+	PooledBalanceOp,
+	{ op: "remove_source" }
+>;
+type RemovePooledBalanceContributionOp = Extract<
+	PooledBalanceOp,
+	{ op: "remove_contribution" }
+>;
+type PooledBalanceRemovalOp =
+	| RemovePooledBalanceSourceOp
+	| RemovePooledBalanceContributionOp;
+type RestorePooledBalanceSourceOp = Extract<
+	PooledBalanceOp,
+	{ op: "restore_source" }
+>;
+export type TransferPooledBalanceSourceOp = Extract<
+	PooledBalanceOp,
+	{ op: "transfer_source" }
+>;
+type PooledBalanceOwnerTransitionOp = Extract<
+	PooledBalanceOp,
+	{ op: "stage_owner_removal" | "restore_owner" }
+>;
+
+export type PreparedPooledBalanceCacheCutover = Omit<
+	Parameters<typeof applyPooledBalanceCacheCutover>[0],
+	"ctx"
+>;
+
+export const applyPreparedPooledBalanceCacheCutover = async ({
+	ctx,
+	prepared,
+}: {
+	ctx: AutumnContext;
+	prepared: PreparedPooledBalanceCacheCutover;
+}) =>
+	withCustomerBalanceSyncLock({
+		ctx,
+		customerId: prepared.customerId,
+		internalCustomerId: prepared.fullSubject.internalCustomerId,
+		callback: ({ db }) =>
+			applyPooledBalanceCacheCutover({
+				ctx: { ...ctx, db },
+				...prepared,
+			}),
+		onTransactionFailure: () =>
+			deleteCachedFullCustomer({
+				ctx,
+				customerId: prepared.customerId,
+				source: "pooled-balance-cache-cutover-transaction-failure",
+				flushBalances: true,
+			}),
+	});
+
+export const getContributionUsageReapply = ({
+	featureId,
+	usageReapply,
+	previousContributionExists,
+	contributionDelta,
+}: {
+	featureId: string;
+	usageReapply?: UpsertPooledBalanceSourceOp["usageReapply"];
+	previousContributionExists: boolean;
+	contributionDelta: number;
+}): PooledBalanceUsageReapply | undefined => {
+	if (!usageReapply || (previousContributionExists && contributionDelta <= 0))
+		return undefined;
+	return { featureId, ...usageReapply };
+};
+
+export type PooledBalanceTransactionCallback = ({
+	db,
+}: {
+	db: CustomerBalanceSyncDb;
+}) => Promise<void>;
+
+const pooledBalanceToFeatureId = ({
+	ctx,
+	pool,
+}: {
+	ctx: AutumnContext;
+	pool: DbPooledBalance;
+}): string => {
+	return findFeatureByInternalId({
+		features: ctx.features,
+		internalId: pool.internal_feature_id,
+		errorOnNotFound: true,
+	}).id;
+};
+
+const pooledBalanceToCacheEffect = ({
+	ctx,
+	pool,
+	balanceDelta,
+	adjustmentDelta,
+}: {
+	ctx: AutumnContext;
+	pool: DbPooledBalance;
+	balanceDelta: number;
+	adjustmentDelta: number;
+}): PooledBalanceCacheEffect => ({
+	featureId: pooledBalanceToFeatureId({ ctx, pool }),
+	customerEntitlementId: pool.customer_entitlement_id,
+	balanceDelta,
+	adjustmentDelta,
+});
+
+const findOrCreatePooledBalance = async ({
+	db,
+	ctx,
+	customerId,
+	operation,
+	now,
+}: {
+	db: PooledBalanceDb;
+	ctx: AutumnContext;
+	customerId: string;
+	operation: UpsertPooledBalanceSourceOp | TransferPooledBalanceSourceOp;
+	now: number;
+}) => {
+	const lookup = computePooledBalanceLookup({ operation });
+	const existing = await pooledBalanceRepo.findByLookup({ db, lookup });
+	if (existing) return existing;
+
+	const entitlementId = generateId("ent");
+	const customerEntitlementId = generateId("cus_ent");
+
+	return pooledBalanceRepo.insertPoolGraph({
+		db,
+		entitlement: {
+			id: entitlementId,
+			created_at: now,
+			internal_feature_id: operation.internalFeatureId,
+			internal_product_id: null,
+			internal_reward_id: null,
+			is_custom: true,
+			allowance_type: AllowanceType.Fixed,
+			allowance: 0,
+			interval: operation.interval,
+			interval_count: operation.intervalCount,
+			carry_from_previous: false,
+			entity_feature_id: null,
+			pooled: true,
+			org_id: ctx.org.id,
+			feature_id: operation.featureId,
+			usage_limit: null,
+			expiry_duration: null,
+			expiry_length: null,
+			rollover: operation.rollover ?? null,
+		},
+		customerEntitlement: {
+			id: customerEntitlementId,
+			customer_product_id: null,
+			entitlement_id: entitlementId,
+			internal_customer_id: operation.internalCustomerId,
+			internal_entity_id: null,
+			internal_feature_id: operation.internalFeatureId,
+			unlimited: false,
+			balance: 0,
+			created_at: now,
+			reset_cycle_anchor: operation.resetCycleAnchor,
+			next_reset_at: operation.nextResetAt,
+			usage_allowed: false,
+			separate_interval: false,
+			adjustment: 0,
+			additional_balance: 0,
+			entities: null,
+			expires_at: null,
+			cache_version: 0,
+			customer_id: customerId,
+			feature_id: operation.featureId,
+			external_id: null,
+			expired: false,
+		},
+		pool: {
+			id: generateId("pooled_balance"),
+			org_id: ctx.org.id,
+			env: ctx.env,
+			...lookup,
+			customer_entitlement_id: customerEntitlementId,
+			last_applied_reset_at: null,
+			created_at: now,
+			updated_at: now,
+		},
+	});
+};
+
+const executeUpsertPooledBalanceSource = async ({
+	ctx,
+	customerId,
+	operation,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	operation: UpsertPooledBalanceSourceOp;
+}) => {
+	const cacheAdjustment = await ctx.db.transaction(async (transaction) => {
+		const db: PooledBalanceDb = transaction;
+		await pooledBalanceRepo.lockCustomer({
+			db,
+			internalCustomerId: operation.internalCustomerId,
+		});
+
+		const now = Date.now();
+		const pool = await findOrCreatePooledBalance({
+			db,
+			ctx,
+			customerId,
+			operation,
+			now,
+		});
+		if (operation.stripeSubscriptionId) {
+			assertSinglePoolSubscriptionOwner({
+				pooledBalanceId: pool.id,
+				poolContributions: await pooledBalanceRepo.listContributionsByPoolId({
+					db,
+					pooledBalanceId: pool.id,
+				}),
+				sourceCustomerProductId: operation.sourceCustomerProductId,
+				stripeSubscriptionId: operation.stripeSubscriptionId,
+			});
+		}
+
+		const previousContribution = await pooledBalanceRepo.findContribution({
+			db,
+			sourceCustomerProductId: operation.sourceCustomerProductId,
+			sourceEntitlementId: operation.sourceEntitlementId,
+		});
+		await pooledBalanceRepo.normalizeSourceCustomerEntitlement({
+			db,
+			sourceCustomerProductId: operation.sourceCustomerProductId,
+			sourceEntitlementId: operation.sourceEntitlementId,
+		});
+		if (
+			previousContribution &&
+			previousContribution.pooled_balance_id !== pool.id
+		) {
+			throw new InternalError({
+				message: `Pooled contribution '${previousContribution.id}' cannot move between pools without an explicit transfer.`,
+			});
+		}
+
+		const transition = computePooledContributionTransition({
+			previous: previousContribution
+				? {
+						currentCycleContribution: previousContribution.current_contribution,
+						nextCycleContribution: previousContribution.next_cycle_contribution,
+					}
+				: null,
+			desired: {
+				currentCycleContribution: operation.currentCycleContribution,
+				nextCycleContribution: operation.nextCycleContribution,
+			},
+		});
+
+		if (previousContribution) {
+			await pooledBalanceRepo.updateContribution({
+				db,
+				contributionId: previousContribution.id,
+				currentContribution: transition.next.currentCycleContribution,
+				nextCycleContribution: transition.next.nextCycleContribution,
+				owner: {
+					stripeSubscriptionId: operation.stripeSubscriptionId,
+					customerLicenseLinkId: operation.customerLicenseLinkId,
+				},
+				updatedAt: now,
+			});
+		} else {
+			await pooledBalanceRepo.insertContribution({
+				db,
+				contribution: {
+					id: generateId("pooled_contribution"),
+					pooled_balance_id: pool.id,
+					source_customer_product_id: operation.sourceCustomerProductId,
+					source_entitlement_id: operation.sourceEntitlementId,
+					stripe_subscription_id: operation.stripeSubscriptionId,
+					customer_license_link_id: operation.customerLicenseLinkId,
+					current_contribution: transition.next.currentCycleContribution,
+					next_cycle_contribution: transition.next.nextCycleContribution,
+					effective_at: null,
+					created_at: now,
+					updated_at: now,
+				},
+			});
+		}
+
+		await pooledBalanceRepo.incrementBalanceAndAdjustment({
+			db,
+			customerEntitlementId: pool.customer_entitlement_id,
+			delta: transition.contributionDelta,
+		});
+
+		return {
+			pool,
+			delta: transition.contributionDelta,
+			usageReapply: getContributionUsageReapply({
+				featureId: operation.featureId,
+				usageReapply: operation.usageReapply,
+				previousContributionExists: Boolean(previousContribution),
+				contributionDelta: transition.contributionDelta,
+			}),
+		};
+	});
+
+	if (cacheAdjustment.delta === 0 && !cacheAdjustment.usageReapply) {
+		return { affectedFeatureIds: [], cacheEffects: [], usageReapplies: [] };
+	}
+
+	return {
+		affectedFeatureIds: [operation.featureId],
+		cacheEffects:
+			cacheAdjustment.delta === 0
+				? []
+				: [
+						pooledBalanceToCacheEffect({
+							ctx,
+							pool: cacheAdjustment.pool,
+							balanceDelta: cacheAdjustment.delta,
+							adjustmentDelta: cacheAdjustment.delta,
+						}),
+					],
+		usageReapplies: cacheAdjustment.usageReapply
+			? [cacheAdjustment.usageReapply]
+			: [],
+	};
+};
+
+const executePooledBalanceTransferDatabaseUpdates = async ({
+	ctx,
+	customerId,
+	internalCustomerId,
+	operations,
+	afterDatabaseUpdates,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	internalCustomerId: string;
+	operations: TransferPooledBalanceSourceOp[];
+	afterDatabaseUpdates?: ({ db }: { db: PooledBalanceDb }) => Promise<void>;
+}) => {
+	const cacheAdjustments = await ctx.db.transaction(async (transaction) => {
+		const db: PooledBalanceDb = transaction;
+		await pooledBalanceRepo.lockCustomer({ db, internalCustomerId });
+		const adjustmentsByPoolId = new Map<
+			string,
+			{
+				pool: DbPooledBalance;
+				delta: number;
+				adjustmentDelta: number;
+			}
+		>();
+		const addAdjustment = ({
+			pool,
+			delta,
+			adjustmentDelta,
+		}: {
+			pool: DbPooledBalance;
+			delta: number;
+			adjustmentDelta: number;
+		}) => {
+			const previous = adjustmentsByPoolId.get(pool.id);
+			adjustmentsByPoolId.set(pool.id, {
+				pool,
+				delta: new Decimal(previous?.delta ?? 0).plus(delta).toNumber(),
+				adjustmentDelta: new Decimal(previous?.adjustmentDelta ?? 0)
+					.plus(adjustmentDelta)
+					.toNumber(),
+			});
+		};
+		type TransferRecord = {
+			operation: TransferPooledBalanceSourceOp;
+			contribution: NonNullable<
+				Awaited<ReturnType<typeof pooledBalanceRepo.findContributionById>>
+			>;
+			destinationPool: DbPooledBalance;
+		};
+		const transferRecords: TransferRecord[] = [];
+
+		for (const operation of operations) {
+			if (operation.internalCustomerId !== internalCustomerId) {
+				throw new InternalError({
+					message: `Pooled transfer '${operation.contributionId}' belongs to a different customer.`,
+				});
+			}
+
+			const now = Date.now();
+			const destinationPool = await findOrCreatePooledBalance({
+				db,
+				ctx,
+				customerId,
+				operation,
+				now,
+			});
+			const contribution = await pooledBalanceRepo.findContributionById({
+				db,
+				contributionId: operation.contributionId,
+			});
+			if (
+				!contribution ||
+				contribution.source_customer_product_id !==
+					operation.sourceCustomerProductId
+			) {
+				throw new InternalError({
+					message: `Pooled contribution '${operation.contributionId}' is missing or belongs to a different source.`,
+				});
+			}
+			transferRecords.push({ operation, contribution, destinationPool });
+		}
+
+		const previousPools = await pooledBalanceRepo.listByIds({
+			db,
+			pooledBalanceIds: [
+				...new Set(
+					transferRecords.map(
+						({ contribution }) => contribution.pooled_balance_id,
+					),
+				),
+			],
+		});
+		const previousPoolById = new Map(
+			previousPools.map((pool) => [pool.id, pool]),
+		);
+
+		for (const record of transferRecords) {
+			const { operation, contribution, destinationPool } = record;
+			const previousPool = previousPoolById.get(contribution.pooled_balance_id);
+			if (
+				!previousPool ||
+				previousPool.internal_customer_id !== internalCustomerId
+			) {
+				throw new InternalError({
+					message: `Pooled balance '${contribution.pooled_balance_id}' is missing or belongs to a different customer.`,
+				});
+			}
+
+			if (contribution.pooled_balance_id !== destinationPool.id) {
+				if (
+					contribution.pooled_balance_id !== operation.expectedPooledBalanceId
+				) {
+					throw new InternalError({
+						message: `Pooled contribution '${operation.contributionId}' moved from its expected source pool.`,
+					});
+				}
+			}
+			const poolById = new Map([
+				[previousPool.id, previousPool],
+				[destinationPool.id, destinationPool],
+			]);
+			for (const delta of computePooledTransferGrantDeltas({
+				previousPooledBalanceId: previousPool.id,
+				destinationPooledBalanceId: destinationPool.id,
+				previousContribution: contribution.current_contribution,
+				desiredContribution: operation.currentCycleContribution,
+			})) {
+				addAdjustment({
+					pool: poolById.get(delta.pooledBalanceId)!,
+					delta: delta.balanceDelta,
+					adjustmentDelta: delta.adjustmentDelta,
+				});
+			}
+			await pooledBalanceRepo.transferContribution({
+				db,
+				contributionId: contribution.id,
+				pooledBalanceId: destinationPool.id,
+				sourceEntitlementId: operation.sourceEntitlementId,
+				owner: {
+					stripeSubscriptionId: operation.stripeSubscriptionId,
+					customerLicenseLinkId: operation.customerLicenseLinkId,
+				},
+				currentContribution: operation.currentCycleContribution,
+				nextCycleContribution: operation.nextCycleContribution,
+				updatedAt: Date.now(),
+			});
+		}
+
+		for (const {
+			pool,
+			delta,
+			adjustmentDelta,
+		} of adjustmentsByPoolId.values()) {
+			await pooledBalanceRepo.incrementBalanceAndAdjustmentDeltas({
+				db,
+				customerEntitlementId: pool.customer_entitlement_id,
+				balanceDelta: delta,
+				adjustmentDelta,
+			});
+		}
+		await afterDatabaseUpdates?.({ db });
+		return [...adjustmentsByPoolId.values()];
+	});
+
+	return cacheAdjustments;
+};
+
+const executePooledBalanceTransfersWithLock = async ({
+	ctx,
+	customerId,
+	internalCustomerId,
+	operations,
+	afterDatabaseUpdates,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	internalCustomerId: string;
+	operations: TransferPooledBalanceSourceOp[];
+	afterDatabaseUpdates?: ({ db }: { db: PooledBalanceDb }) => Promise<void>;
+}) => {
+	const expectedSubjectViewEpoch = await getOrInitFullSubjectViewEpoch({
+		ctx,
+		customerId,
+	});
+	const adjustments = await executePooledBalanceTransferDatabaseUpdates({
+		ctx,
+		customerId,
+		internalCustomerId,
+		operations,
+		afterDatabaseUpdates,
+	});
+	const cacheEffects = adjustments.map(({ pool, delta, adjustmentDelta }) =>
+		pooledBalanceToCacheEffect({
+			ctx,
+			pool,
+			balanceDelta: delta,
+			adjustmentDelta,
+		}),
+	);
+	const featureIds = [
+		...new Set(cacheEffects.map(({ featureId }) => featureId)),
+	];
+	const rebalanceResult = await executePooledBalanceRebalance({
+		ctx,
+		customerId,
+		internalCustomerId,
+		featureIds,
+	});
+	const preparedCutover = rebalanceResult
+		? ({
+				customerId,
+				fullSubject: rebalanceResult.fullSubject,
+				featureIds,
+				rawEffects: cacheEffects,
+				expectedSubjectViewEpoch,
+				reverseOrder: ctx.org.config?.reverse_deduction_order,
+				inStatuses: rebalanceResult.inStatuses,
+			} satisfies PreparedPooledBalanceCacheCutover)
+		: undefined;
+
+	return { featureIds, preparedCutover };
+};
+
+export type ExecutePooledBalanceTransfersDependencies = {
+	withCustomerBalanceSyncLock: typeof withCustomerBalanceSyncLock;
+	executeWithLock: typeof executePooledBalanceTransfersWithLock;
+	applyCacheCutover: typeof applyPreparedPooledBalanceCacheCutover;
+};
+
+export const executePooledBalanceTransfersWithDependencies = async ({
+	ctx,
+	customerId,
+	internalCustomerId,
+	operations,
+	afterDatabaseUpdates,
+	dependencies = {
+		withCustomerBalanceSyncLock,
+		executeWithLock: executePooledBalanceTransfersWithLock,
+		applyCacheCutover: applyPreparedPooledBalanceCacheCutover,
+	},
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	internalCustomerId: string;
+	operations: TransferPooledBalanceSourceOp[];
+	afterDatabaseUpdates?: ({ db }: { db: PooledBalanceDb }) => Promise<void>;
+	dependencies?: ExecutePooledBalanceTransfersDependencies;
+}) => {
+	const { featureIds, preparedCutover } =
+		await dependencies.withCustomerBalanceSyncLock({
+			ctx,
+			customerId,
+			internalCustomerId,
+			callback: ({ db }) =>
+				dependencies.executeWithLock({
+					ctx: { ...ctx, db },
+					customerId,
+					internalCustomerId,
+					operations,
+					afterDatabaseUpdates,
+				}),
+		});
+	if (preparedCutover) {
+		await dependencies.applyCacheCutover({ ctx, prepared: preparedCutover });
+	}
+	return featureIds;
+};
+
+export const executePooledBalanceTransfers = async ({
+	ctx,
+	customerId,
+	internalCustomerId,
+	operations,
+	afterDatabaseUpdates,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	internalCustomerId: string;
+	operations: TransferPooledBalanceSourceOp[];
+	afterDatabaseUpdates?: ({ db }: { db: PooledBalanceDb }) => Promise<void>;
+}) =>
+	executePooledBalanceTransfersWithDependencies({
+		ctx,
+		customerId,
+		internalCustomerId,
+		operations,
+		afterDatabaseUpdates,
+	});
+
+const executeRemovePooledBalanceSources = async ({
+	ctx,
+	operations,
+}: {
+	ctx: AutumnContext;
+	operations: PooledBalanceRemovalOp[];
+}) => {
+	const affectedFeatureIds = new Set<string>();
+	const cacheEffects: PooledBalanceCacheEffect[] = [];
+	const operationsByInternalCustomerId = new Map<
+		string,
+		PooledBalanceRemovalOp[]
+	>();
+	for (const operation of operations) {
+		operationsByInternalCustomerId.set(operation.internalCustomerId, [
+			...(operationsByInternalCustomerId.get(operation.internalCustomerId) ??
+				[]),
+			operation,
+		]);
+	}
+
+	for (const [
+		internalCustomerId,
+		customerOperations,
+	] of operationsByInternalCustomerId) {
+		const cacheAdjustments = await ctx.db.transaction(async (transaction) => {
+			const db: PooledBalanceDb = transaction;
+			await pooledBalanceRepo.lockCustomer({ db, internalCustomerId });
+
+			const sourceRemovalByCustomerProductId = new Map(
+				customerOperations
+					.filter(
+						(operation): operation is RemovePooledBalanceSourceOp =>
+							operation.op === "remove_source",
+					)
+					.map((operation) => [operation.sourceCustomerProductId, operation]),
+			);
+			const contributionRemovalBySourceKey = new Map(
+				customerOperations
+					.filter(
+						(operation): operation is RemovePooledBalanceContributionOp =>
+							operation.op === "remove_contribution",
+					)
+					.map((operation) => [
+						`${operation.sourceCustomerProductId}:${operation.sourceEntitlementId}`,
+						operation,
+					]),
+			);
+			const contributions =
+				await pooledBalanceRepo.listContributionsBySourceCustomerProductIds({
+					db,
+					sourceCustomerProductIds: [
+						...new Set(
+							customerOperations.map(
+								(operation) => operation.sourceCustomerProductId,
+							),
+						),
+					],
+				});
+			const pools = await pooledBalanceRepo.listByIds({
+				db,
+				pooledBalanceIds: [
+					...new Set(
+						contributions.map((contribution) => contribution.pooled_balance_id),
+					),
+				],
+			});
+			const poolById = new Map(pools.map((pool) => [pool.id, pool]));
+			const adjustmentsByPoolId = new Map<
+				string,
+				{ pool: DbPooledBalance; delta: number }
+			>();
+			const now = Date.now();
+
+			for (const contribution of contributions) {
+				const operation =
+					contributionRemovalBySourceKey.get(
+						`${contribution.source_customer_product_id}:${contribution.source_entitlement_id}`,
+					) ??
+					sourceRemovalByCustomerProductId.get(
+						contribution.source_customer_product_id,
+					);
+				const pool = poolById.get(contribution.pooled_balance_id);
+				if (
+					!operation ||
+					!pool ||
+					pool.internal_customer_id !== internalCustomerId
+				) {
+					throw new InternalError({
+						message: `Pooled balance '${contribution.pooled_balance_id}' is missing or belongs to a different customer.`,
+					});
+				}
+
+				const transition = computePooledContributionTransition({
+					previous: {
+						currentCycleContribution: contribution.current_contribution,
+						nextCycleContribution: contribution.next_cycle_contribution,
+					},
+					desired: {
+						currentCycleContribution:
+							operation.effectiveAt === null
+								? 0
+								: contribution.current_contribution,
+						nextCycleContribution: 0,
+					},
+				});
+
+				await pooledBalanceRepo.updateContribution({
+					db,
+					contributionId: contribution.id,
+					currentContribution: transition.next.currentCycleContribution,
+					nextCycleContribution: transition.next.nextCycleContribution,
+					effectiveAt: operation.effectiveAt,
+					updatedAt: now,
+				});
+				const previousAdjustment = adjustmentsByPoolId.get(pool.id);
+				adjustmentsByPoolId.set(pool.id, {
+					pool,
+					delta:
+						(previousAdjustment?.delta ?? 0) + transition.contributionDelta,
+				});
+			}
+
+			for (const { pool, delta } of adjustmentsByPoolId.values()) {
+				await pooledBalanceRepo.incrementBalanceAndAdjustment({
+					db,
+					customerEntitlementId: pool.customer_entitlement_id,
+					delta,
+				});
+			}
+			return [...adjustmentsByPoolId.values()];
+		});
+
+		for (const { pool, delta } of cacheAdjustments) {
+			if (delta === 0) continue;
+			const cacheEffect = pooledBalanceToCacheEffect({
+				ctx,
+				pool,
+				balanceDelta: delta,
+				adjustmentDelta: delta,
+			});
+			cacheEffects.push(cacheEffect);
+			affectedFeatureIds.add(cacheEffect.featureId);
+		}
+	}
+
+	return { affectedFeatureIds: [...affectedFeatureIds], cacheEffects };
+};
+
+const applyPooledBalanceDeltasToFullSubject = ({
+	fullSubject,
+	deltas,
+}: {
+	fullSubject: FullSubject;
+	deltas: PooledBalanceRebalanceDelta[];
+}) => {
+	const deltaByCustomerEntitlementId = new Map<string, Decimal>();
+	for (const delta of deltas) {
+		deltaByCustomerEntitlementId.set(
+			delta.customerEntitlementId,
+			(
+				deltaByCustomerEntitlementId.get(delta.customerEntitlementId) ??
+				new Decimal(0)
+			).plus(delta.delta),
+		);
+	}
+
+	const customerEntitlements = [
+		...fullSubject.extra_customer_entitlements,
+		...fullSubject.customer_products.flatMap(
+			(customerProduct) => customerProduct.customer_entitlements,
+		),
+	];
+	for (const customerEntitlement of customerEntitlements) {
+		const delta = deltaByCustomerEntitlementId.get(customerEntitlement.id);
+		if (!delta) continue;
+		customerEntitlement.balance = new Decimal(customerEntitlement.balance ?? 0)
+			.plus(delta)
+			.toNumber();
+	}
+};
+
+const executePooledBalanceRebalance = async ({
+	ctx,
+	customerId,
+	internalCustomerId,
+	featureIds,
+	usageReapplies = [],
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	internalCustomerId: string;
+	featureIds: string[];
+	usageReapplies?: PooledBalanceUsageReapply[];
+}) => {
+	if (featureIds.length === 0) return null;
+
+	const result = await ctx.db.transaction(async (transaction) => {
+		const db: PooledBalanceDb = transaction;
+		await pooledBalanceRepo.lockCustomer({
+			db,
+			internalCustomerId,
+		});
+		const inStatuses = orgToInStatuses({ org: ctx.org });
+		const queryResult = await transaction.execute(
+			getFullSubjectQuery({
+				orgId: ctx.org.id,
+				env: ctx.env,
+				customerId,
+				inStatuses,
+			}),
+		);
+		const queryRows = (Array.isArray(queryResult)
+			? queryResult
+			: queryResult.rows) as unknown as SubjectQueryRow[];
+		const row = queryRows[0];
+		if (!row) {
+			throw new InternalError({
+				message: `Cannot load customer '${customerId}' for pooled balance rebalance.`,
+			});
+		}
+		const fullSubject = resultToFullSubject({ row });
+		if (fullSubject.internalCustomerId !== internalCustomerId) {
+			throw new InternalError({
+				message: `Pooled balance rebalance customer mismatch for '${customerId}'.`,
+			});
+		}
+		const fullSubjectAfterUsageReapply = structuredClone(fullSubject);
+		const usageReapplyDeltas = computePooledBalanceUsageReapply({
+			fullSubject: fullSubjectAfterUsageReapply,
+			usageReapplies,
+			reverseOrder: ctx.org.config?.reverse_deduction_order,
+			inStatuses,
+		});
+		applyPooledBalanceDeltasToFullSubject({
+			fullSubject: fullSubjectAfterUsageReapply,
+			deltas: usageReapplyDeltas,
+		});
+		const computedDeltas = computePooledBalanceRebalance({
+			fullSubject: fullSubjectAfterUsageReapply,
+			featureIds,
+			reverseOrder: ctx.org.config?.reverse_deduction_order,
+			inStatuses,
+		});
+		const deltasInLockOrder = [...usageReapplyDeltas, ...computedDeltas].sort(
+			(first, second) =>
+				first.customerEntitlementId.localeCompare(second.customerEntitlementId),
+		);
+
+		for (const delta of deltasInLockOrder) {
+			await pooledBalanceRepo.incrementBalanceAndAdjustmentDeltas({
+				db,
+				customerEntitlementId: delta.customerEntitlementId,
+				balanceDelta: delta.delta,
+				adjustmentDelta: 0,
+			});
+		}
+
+		return { usageReapplyDeltas, fullSubject, inStatuses };
+	});
+
+	return {
+		fullSubject: result.fullSubject,
+		inStatuses: result.inStatuses,
+		usageReapplyDeltas: result.usageReapplyDeltas,
+	};
+};
+
+const executePooledBalanceOwnerTransition = async ({
+	ctx,
+	operation,
+}: {
+	ctx: AutumnContext;
+	operation: PooledBalanceOwnerTransitionOp;
+}) => {
+	const effectiveAt =
+		operation.op === "stage_owner_removal"
+			? operation.effectiveAt
+			: operation.expectedEffectiveAt;
+	if (!Number.isFinite(effectiveAt)) {
+		throw new InternalError({
+			message: `Pooled balance owner transition requires a finite effective boundary.`,
+			data: { operation: operation.op, effectiveAt },
+		});
+	}
+
+	await ctx.db.transaction(async (transaction) => {
+		const db: PooledBalanceDb = transaction;
+		await pooledBalanceRepo.lockCustomer({
+			db,
+			internalCustomerId: operation.internalCustomerId,
+		});
+
+		const contributions = await pooledBalanceRepo.listContributionsByOwner({
+			db,
+			internalCustomerId: operation.internalCustomerId,
+			owner: { customerLicenseLinkId: operation.customerLicenseLinkId },
+		});
+		const now = Date.now();
+
+		for (const contribution of contributions) {
+			if (
+				operation.op === "restore_owner" &&
+				contribution.effective_at !== operation.expectedEffectiveAt
+			) {
+				continue;
+			}
+
+			await pooledBalanceRepo.updateContribution({
+				db,
+				contributionId: contribution.id,
+				currentContribution: contribution.current_contribution,
+				nextCycleContribution:
+					operation.op === "stage_owner_removal"
+						? 0
+						: contribution.current_contribution,
+				effectiveAt:
+					operation.op === "stage_owner_removal" ? operation.effectiveAt : null,
+				updatedAt: now,
+			});
+		}
+	});
+};
+
+const executeRestorePooledBalanceSource = async ({
+	ctx,
+	operation,
+}: {
+	ctx: AutumnContext;
+	operation: RestorePooledBalanceSourceOp;
+}) => {
+	if (!Number.isFinite(operation.expectedEffectiveAt)) {
+		throw new InternalError({
+			message: `Pooled balance source restore requires a finite effective boundary.`,
+			data: { expectedEffectiveAt: operation.expectedEffectiveAt },
+		});
+	}
+
+	await ctx.db.transaction(async (transaction) => {
+		const db: PooledBalanceDb = transaction;
+		await pooledBalanceRepo.lockCustomer({
+			db,
+			internalCustomerId: operation.internalCustomerId,
+		});
+		const contributions =
+			await pooledBalanceRepo.listContributionsBySourceCustomerProductIds({
+				db,
+				sourceCustomerProductIds: [operation.sourceCustomerProductId],
+			});
+		const now = Date.now();
+
+		for (const contribution of contributions) {
+			if (contribution.effective_at !== operation.expectedEffectiveAt) continue;
+
+			await pooledBalanceRepo.updateContribution({
+				db,
+				contributionId: contribution.id,
+				currentContribution: contribution.current_contribution,
+				nextCycleContribution: contribution.current_contribution,
+				effectiveAt: null,
+				updatedAt: now,
+			});
+		}
+	});
+};
+
+const executePooledBalanceOpsWithLock = async ({
+	ctx,
+	customerId,
+	pooledBalanceOps,
+	beforeDatabaseOperations,
+	beforeRebalance,
+	afterRebalance,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	pooledBalanceOps: AutumnBillingPlan["pooledBalanceOps"];
+	beforeDatabaseOperations?: PooledBalanceTransactionCallback;
+	beforeRebalance?: PooledBalanceTransactionCallback;
+	afterRebalance?: PooledBalanceTransactionCallback;
+}) => {
+	const operations = pooledBalanceOps ?? [];
+	if (operations.length === 0) {
+		await beforeDatabaseOperations?.({ db: ctx.db });
+		await beforeRebalance?.({ db: ctx.db });
+		await afterRebalance?.({ db: ctx.db });
+		return;
+	}
+	const expectedSubjectViewEpoch = await getOrInitFullSubjectViewEpoch({
+		ctx,
+		customerId,
+	});
+
+	const internalCustomerId = operations[0].internalCustomerId;
+	if (
+		operations.some(
+			(operation) => operation.internalCustomerId !== internalCustomerId,
+		)
+	) {
+		throw new InternalError({
+			message: `Pooled balance operations for customer '${customerId}' contain multiple internal customer IDs.`,
+		});
+	}
+
+	const affectedFeatureIds = new Set<string>();
+	const cacheEffects: PooledBalanceCacheEffect[] = [];
+	const usageReapplies: PooledBalanceUsageReapply[] = [];
+	await beforeDatabaseOperations?.({ db: ctx.db });
+	let operationIndex = 0;
+	while (operationIndex < operations.length) {
+		const operation = operations[operationIndex];
+		switch (operation.op) {
+			case "upsert_source": {
+				const result = await executeUpsertPooledBalanceSource({
+					ctx,
+					customerId,
+					operation,
+				});
+				for (const featureId of result.affectedFeatureIds) {
+					affectedFeatureIds.add(featureId);
+				}
+				cacheEffects.push(...result.cacheEffects);
+				usageReapplies.push(...result.usageReapplies);
+				operationIndex += 1;
+				continue;
+			}
+			case "stage_owner_removal":
+			case "restore_owner":
+				await executePooledBalanceOwnerTransition({ ctx, operation });
+				operationIndex += 1;
+				continue;
+			case "restore_source":
+				await executeRestorePooledBalanceSource({ ctx, operation });
+				operationIndex += 1;
+				continue;
+			case "transfer_source": {
+				const adjustments = await executePooledBalanceTransferDatabaseUpdates({
+					ctx,
+					customerId,
+					internalCustomerId: operation.internalCustomerId,
+					operations: [operation],
+				});
+				for (const { pool, delta, adjustmentDelta } of adjustments) {
+					if (delta === 0 && adjustmentDelta === 0) continue;
+					const cacheEffect = pooledBalanceToCacheEffect({
+						ctx,
+						pool,
+						balanceDelta: delta,
+						adjustmentDelta,
+					});
+					cacheEffects.push(cacheEffect);
+					affectedFeatureIds.add(cacheEffect.featureId);
+				}
+				operationIndex += 1;
+				continue;
+			}
+			case "remove_source":
+			case "remove_contribution":
+				break;
+		}
+
+		const removalOperations: PooledBalanceRemovalOp[] = [];
+		while (operationIndex < operations.length) {
+			const removalOperation = operations[operationIndex];
+			if (
+				removalOperation.op !== "remove_source" &&
+				removalOperation.op !== "remove_contribution"
+			) {
+				break;
+			}
+			removalOperations.push(removalOperation);
+			operationIndex += 1;
+		}
+		const removalResult = await executeRemovePooledBalanceSources({
+			ctx,
+			operations: removalOperations,
+		});
+		for (const featureId of removalResult.affectedFeatureIds) {
+			affectedFeatureIds.add(featureId);
+		}
+		cacheEffects.push(...removalResult.cacheEffects);
+	}
+
+	await beforeRebalance?.({ db: ctx.db });
+	if (affectedFeatureIds.size === 0) {
+		await afterRebalance?.({ db: ctx.db });
+		return;
+	}
+	const rebalanceResult = await executePooledBalanceRebalance({
+		ctx,
+		customerId,
+		internalCustomerId,
+		featureIds: [...affectedFeatureIds],
+		usageReapplies,
+	});
+	await afterRebalance?.({ db: ctx.db });
+	if (!rebalanceResult) return;
+	cacheEffects.push(
+		...rebalanceResult.usageReapplyDeltas.map(
+			({ customerEntitlementId, featureId, delta }) => ({
+				customerEntitlementId,
+				featureId,
+				balanceDelta: delta,
+				adjustmentDelta: 0,
+			}),
+		),
+	);
+	return {
+		customerId,
+		fullSubject: rebalanceResult.fullSubject,
+		featureIds: [...affectedFeatureIds],
+		rawEffects: cacheEffects,
+		expectedSubjectViewEpoch,
+		reverseOrder: ctx.org.config?.reverse_deduction_order,
+		inStatuses: rebalanceResult.inStatuses,
+	} satisfies PreparedPooledBalanceCacheCutover;
+};
+
+export type ExecutePooledBalanceOpsDependencies = {
+	withCustomerBalanceSyncLock: typeof withCustomerBalanceSyncLock;
+	executeWithLock: typeof executePooledBalanceOpsWithLock;
+	applyCacheCutover: typeof applyPreparedPooledBalanceCacheCutover;
+};
+
+export const executePooledBalanceOpsWithDependencies = async ({
+	ctx,
+	customerId,
+	pooledBalancePlan,
+	pooledBalanceOps,
+	balanceSyncDb,
+	beforeDatabaseOperations,
+	beforeRebalance,
+	afterRebalance,
+	dependencies = {
+		withCustomerBalanceSyncLock,
+		executeWithLock: executePooledBalanceOpsWithLock,
+		applyCacheCutover: applyPreparedPooledBalanceCacheCutover,
+	},
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	pooledBalancePlan?: PooledBalancePlan;
+	pooledBalanceOps?: AutumnBillingPlan["pooledBalanceOps"];
+	/** Existing customer balance-sync transaction. */
+	balanceSyncDb?: CustomerBalanceSyncDb;
+	beforeDatabaseOperations?: PooledBalanceTransactionCallback;
+	beforeRebalance?: PooledBalanceTransactionCallback;
+	afterRebalance?: PooledBalanceTransactionCallback;
+	dependencies?: ExecutePooledBalanceOpsDependencies;
+}) => {
+	const operations = [
+		...pooledBalancePlanToOps({ pooledBalancePlan }),
+		...(pooledBalanceOps ?? []),
+	];
+	if (
+		operations.length === 0 &&
+		!beforeDatabaseOperations &&
+		!beforeRebalance &&
+		!afterRebalance
+	)
+		return;
+
+	const executeWithLock = ({ db }: { db: CustomerBalanceSyncDb }) =>
+		dependencies.executeWithLock({
+			ctx: { ...ctx, db },
+			customerId,
+			pooledBalanceOps: operations,
+			beforeDatabaseOperations,
+			beforeRebalance,
+			afterRebalance,
+		});
+	if (balanceSyncDb) {
+		return executeWithLock({ db: balanceSyncDb });
+	}
+
+	const prepared = await dependencies.withCustomerBalanceSyncLock({
+		ctx,
+		customerId,
+		internalCustomerId: operations[0]?.internalCustomerId,
+		callback: executeWithLock,
+	});
+	if (!prepared) return;
+	await dependencies.applyCacheCutover({ ctx, prepared });
+};
+
+export const executePooledBalanceOps = async ({
+	ctx,
+	customerId,
+	pooledBalancePlan,
+	pooledBalanceOps,
+	balanceSyncDb,
+	beforeDatabaseOperations,
+	beforeRebalance,
+	afterRebalance,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	pooledBalancePlan?: PooledBalancePlan;
+	pooledBalanceOps?: AutumnBillingPlan["pooledBalanceOps"];
+	/** Existing customer balance-sync transaction. */
+	balanceSyncDb?: CustomerBalanceSyncDb;
+	beforeDatabaseOperations?: PooledBalanceTransactionCallback;
+	beforeRebalance?: PooledBalanceTransactionCallback;
+	afterRebalance?: PooledBalanceTransactionCallback;
+}) =>
+	executePooledBalanceOpsWithDependencies({
+		ctx,
+		customerId,
+		pooledBalancePlan,
+		pooledBalanceOps,
+		balanceSyncDb,
+		beforeDatabaseOperations,
+		beforeRebalance,
+		afterRebalance,
+	});

--- a/server/src/internal/billing/v2/execute/executeAutumnActions/executePooledPlanCustomerProductLifecycle.ts
+++ b/server/src/internal/billing/v2/execute/executeAutumnActions/executePooledPlanCustomerProductLifecycle.ts
@@ -1,0 +1,120 @@
+import type { AutumnBillingPlan } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { EntityService } from "@/internal/api/entities/EntityService.js";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService.js";
+import {
+	getDeleteCustomerProducts,
+	getUpdateCustomerProducts,
+} from "../../utils/billingPlan/customerProductPlanMutations.js";
+import { executeCustomerLicenseUpdates } from "./executeCustomerLicenseUpdates.js";
+import { executePatchCustomerProducts } from "./executePatchCustomerProducts.js";
+import {
+	executePooledBalanceOps,
+	type PooledBalanceTransactionCallback,
+} from "./executePooledBalanceOps.js";
+import { insertNewCusProducts } from "./insertNewCusProducts.js";
+
+export type ExecutePooledPlanCustomerProductLifecycleDependencies = {
+	executePooledBalanceOps: typeof executePooledBalanceOps;
+	patchCustomerProducts: typeof executePatchCustomerProducts;
+	insertNewCustomerProducts: typeof insertNewCusProducts;
+	insertEntities: typeof EntityService.insert;
+	executeCustomerLicenseUpdates: typeof executeCustomerLicenseUpdates;
+	updateCustomerProduct: (
+		args: Parameters<typeof CusProductService.update>[0],
+	) => Promise<unknown>;
+	deleteCustomerProduct: (
+		args: Parameters<typeof CusProductService.delete>[0],
+	) => Promise<unknown>;
+};
+
+export const executePooledPlanCustomerProductLifecycle = async ({
+	ctx,
+	autumnBillingPlan,
+	afterCustomerProductInserts,
+	beforeRebalance,
+	dependencies = {
+		executePooledBalanceOps,
+		patchCustomerProducts: executePatchCustomerProducts,
+		insertNewCustomerProducts: insertNewCusProducts,
+		insertEntities: EntityService.insert,
+		executeCustomerLicenseUpdates,
+		updateCustomerProduct: CusProductService.update,
+		deleteCustomerProduct: CusProductService.delete,
+	},
+}: {
+	ctx: AutumnContext;
+	autumnBillingPlan: AutumnBillingPlan;
+	afterCustomerProductInserts?: PooledBalanceTransactionCallback;
+	beforeRebalance?: PooledBalanceTransactionCallback;
+	dependencies?: ExecutePooledPlanCustomerProductLifecycleDependencies;
+}): Promise<boolean> => {
+	const { pooledBalancePlan, pooledBalanceOps } = autumnBillingPlan;
+	const hasPooledBalanceWork =
+		(pooledBalancePlan?.removeSources?.length ?? 0) > 0 ||
+		(pooledBalancePlan?.upsertSources?.length ?? 0) > 0 ||
+		(pooledBalanceOps?.length ?? 0) > 0;
+	if (!hasPooledBalanceWork) return false;
+
+	const updateCustomerProducts = getUpdateCustomerProducts({
+		autumnBillingPlan,
+	});
+	const deleteCustomerProducts = getDeleteCustomerProducts({
+		autumnBillingPlan,
+	});
+
+	await dependencies.executePooledBalanceOps({
+		ctx,
+		customerId: autumnBillingPlan.customerId,
+		pooledBalancePlan,
+		pooledBalanceOps,
+		beforeDatabaseOperations: async ({ db }) => {
+			const transactionContext = { ...ctx, db };
+			if (autumnBillingPlan.insertEntities?.length) {
+				await dependencies.insertEntities({
+					db,
+					data: autumnBillingPlan.insertEntities,
+				});
+			}
+			await dependencies.executeCustomerLicenseUpdates({
+				ctx: transactionContext,
+				customerLicenseUpdates: autumnBillingPlan.customerLicenseUpdates,
+			});
+			if (autumnBillingPlan.patchCustomerProducts) {
+				await dependencies.patchCustomerProducts({
+					ctx: transactionContext,
+					patchCustomerProducts: autumnBillingPlan.patchCustomerProducts,
+				});
+			}
+			await dependencies.insertNewCustomerProducts({
+				ctx: transactionContext,
+				newCusProducts: autumnBillingPlan.insertCustomerProducts,
+			});
+			await afterCustomerProductInserts?.({ db });
+		},
+		beforeRebalance: async ({ db }) => {
+			const transactionContext = { ...ctx, db };
+			for (const { customerProduct, updates } of updateCustomerProducts) {
+				if (!updates || Object.keys(updates).length === 0) continue;
+				await dependencies.updateCustomerProduct({
+					ctx: transactionContext,
+					cusProductId: customerProduct.id,
+					updates,
+				});
+			}
+
+			for (const deleteCustomerProduct of deleteCustomerProducts) {
+				ctx.logger.debug(
+					`[executeAutumnBillingPlan] deleting scheduled customer product: ${deleteCustomerProduct.product.id}`,
+				);
+				await dependencies.deleteCustomerProduct({
+					ctx: transactionContext,
+					cusProductId: deleteCustomerProduct.id,
+				});
+			}
+			await beforeRebalance?.({ db });
+		},
+	});
+
+	return true;
+};

--- a/server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts
+++ b/server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts
@@ -3,11 +3,18 @@ import type Stripe from "stripe";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { EntityService } from "@/internal/api/entities/EntityService";
 import { executeAutoTopupRebalance } from "@/internal/billing/v2/execute/executeAutumnActions/executeAutoTopupRebalance";
-import { executeCustomerLicenseTransitions } from "@/internal/billing/v2/execute/executeAutumnActions/executeCustomerLicenseTransitions";
+import {
+	executeCustomerLicenseTransitions,
+	executePreparedCustomerLicenseTransitionRows,
+	prepareCustomerLicenseTransitions,
+	restorePreparedCustomerLicenseEntitlements,
+	triggerPreparedCustomerLicenseBatchTransitions,
+} from "@/internal/billing/v2/execute/executeAutumnActions/executeCustomerLicenseTransitions";
 import { executeCustomerLicenseUpdates } from "@/internal/billing/v2/execute/executeAutumnActions/executeCustomerLicenseUpdates";
 import { executeInsertPlanLicenses } from "@/internal/billing/v2/execute/executeAutumnActions/executeInsertPlanLicenses";
 import { executeOneOffPurchaseRebalance } from "@/internal/billing/v2/execute/executeAutumnActions/executeOneOffPurchaseRebalance";
 import { executePatchCustomerProducts } from "@/internal/billing/v2/execute/executeAutumnActions/executePatchCustomerProducts";
+import { executePooledPlanCustomerProductLifecycle } from "@/internal/billing/v2/execute/executeAutumnActions/executePooledPlanCustomerProductLifecycle.js";
 import { insertNewCusProducts } from "@/internal/billing/v2/execute/executeAutumnActions/insertNewCusProducts";
 import { updateCustomerEntitlements } from "@/internal/billing/v2/execute/executeAutumnActions/updateCustomerEntitlements";
 import {
@@ -19,6 +26,7 @@ import { CusProductService } from "@/internal/customers/cusProducts/CusProductSe
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService";
 import { replaceScheduledPhaseCustomerProductIds } from "@/internal/customers/schedules/repos/replaceScheduledPhaseCustomerProductIds";
 import { invoiceActions } from "@/internal/invoices/actions";
+import { reconcileLicenseStateForCustomer } from "@/internal/licenses/actions/reconcile/reconcileLicenseState.js";
 import { EntitlementService } from "@/internal/products/entitlements/EntitlementService";
 import { FreeTrialService } from "@/internal/products/free-trials/FreeTrialService";
 import { PriceService } from "@/internal/products/prices/PriceService";
@@ -52,6 +60,38 @@ export const executeAutumnBillingPlan = async ({
 	const deleteCustomerProducts = getDeleteCustomerProducts({
 		autumnBillingPlan,
 	});
+	const preparedCustomerLicenseTransitions =
+		await prepareCustomerLicenseTransitions({
+			ctx,
+			customerLicenseTransitions: autumnBillingPlan.customerLicenseTransitions,
+			pendingCustomerProducts: insertCustomerProducts,
+		});
+	const customerLicensePooledBalanceOps =
+		preparedCustomerLicenseTransitions.flatMap(({ operations }) => operations);
+	const pooledAutumnBillingPlan =
+		customerLicensePooledBalanceOps.length > 0
+			? {
+					...autumnBillingPlan,
+					pooledBalanceOps: [
+						...(autumnBillingPlan.pooledBalanceOps ?? []),
+						...customerLicensePooledBalanceOps,
+					],
+				}
+			: autumnBillingPlan;
+	const hasPooledBalanceOps = Boolean(
+		pooledAutumnBillingPlan.pooledBalanceOps?.length ||
+			pooledAutumnBillingPlan.pooledBalancePlan?.removeSources?.length ||
+			pooledAutumnBillingPlan.pooledBalancePlan?.upsertSources?.length,
+	);
+	const executeCustomerLicenseTransitionsInPooledTransaction =
+		hasPooledBalanceOps && preparedCustomerLicenseTransitions.length > 0;
+	const shouldReconcileLicenseState =
+		(insertCustomerProducts?.length ?? 0) > 0 ||
+		updateCustomerProducts.length > 0 ||
+		deleteCustomerProducts.length > 0 ||
+		(autumnBillingPlan.patchCustomerProducts?.length ?? 0) > 0 ||
+		(autumnBillingPlan.customerLicenseUpdates?.length ?? 0) > 0 ||
+		(autumnBillingPlan.customerLicenseTransitions?.length ?? 0) > 0;
 
 	if (customEntitlements) {
 		await EntitlementService.insert({
@@ -86,7 +126,7 @@ export const executeAutumnBillingPlan = async ({
 		});
 	}
 
-	if (autumnBillingPlan.patchCustomerProducts) {
+	if (autumnBillingPlan.patchCustomerProducts && !hasPooledBalanceOps) {
 		// Custom prices/entitlements above must be inserted before customer rows can reference them.
 		// Patch execution only inserts/deletes customer_prices and customer_entitlements.
 		await executePatchCustomerProducts({
@@ -95,28 +135,63 @@ export const executeAutumnBillingPlan = async ({
 		});
 	}
 
-	await executeCustomerLicenseUpdates({
-		ctx,
-		customerLicenseUpdates: autumnBillingPlan.customerLicenseUpdates,
-	});
+	if (!hasPooledBalanceOps) {
+		await executeCustomerLicenseUpdates({
+			ctx,
+			customerLicenseUpdates: autumnBillingPlan.customerLicenseUpdates,
+		});
+	}
 
-	if (autumnBillingPlan.insertEntities?.length) {
+	if (!hasPooledBalanceOps && autumnBillingPlan.insertEntities?.length) {
 		await EntityService.insert({
 			db,
 			data: autumnBillingPlan.insertEntities,
 		});
 	}
 
-	// 2. Insert new customer products
-	await insertNewCusProducts({
-		ctx,
-		newCusProducts: insertCustomerProducts,
-	});
+	const customerProductLifecycleExecutedInPooledTransaction =
+		await executePooledPlanCustomerProductLifecycle({
+			ctx,
+			autumnBillingPlan: pooledAutumnBillingPlan,
+			afterCustomerProductInserts:
+				executeCustomerLicenseTransitionsInPooledTransaction
+					? ({ db }) =>
+							executePreparedCustomerLicenseTransitionRows({
+								ctx: { ...ctx, db },
+								preparedTransitions: preparedCustomerLicenseTransitions,
+							})
+					: undefined,
+			beforeRebalance: executeCustomerLicenseTransitionsInPooledTransaction
+				? ({ db }) =>
+						restorePreparedCustomerLicenseEntitlements({
+							ctx: { ...ctx, db },
+							preparedTransitions: preparedCustomerLicenseTransitions,
+						})
+				: undefined,
+		});
 
-	await executeCustomerLicenseTransitions({
-		ctx,
-		customerLicenseTransitions: autumnBillingPlan.customerLicenseTransitions,
-	});
+	if (!customerProductLifecycleExecutedInPooledTransaction) {
+		await insertNewCusProducts({
+			ctx,
+			newCusProducts: insertCustomerProducts,
+		});
+	}
+
+	// Successor pools now exist; adopted seats converge onto their definitions.
+	const executedPooledLicenseTransition =
+		customerLicensePooledBalanceOps.length > 0;
+	if (executeCustomerLicenseTransitionsInPooledTransaction) {
+		await triggerPreparedCustomerLicenseBatchTransitions({
+			ctx,
+			preparedTransitions: preparedCustomerLicenseTransitions,
+		});
+	} else {
+		await executeCustomerLicenseTransitions({
+			ctx,
+			customerLicenseTransitions: autumnBillingPlan.customerLicenseTransitions,
+			preparedTransitions: preparedCustomerLicenseTransitions,
+		});
+	}
 
 	await replaceScheduledPhaseCustomerProductIds({
 		ctx,
@@ -135,29 +210,33 @@ export const executeAutumnBillingPlan = async ({
 	}
 
 	// 3. Update customer product (DB only)
-	for (const { customerProduct, updates } of updateCustomerProducts) {
-		// Skip empty updates — drizzle throws "No values to set" on empty SET.
-		// This happens when the billing plan registers a customer product update
-		// entry (e.g. for intent=None discount-only flows) but there are no
-		// actual DB columns to change.
-		if (!updates || Object.keys(updates).length === 0) continue;
+	if (!customerProductLifecycleExecutedInPooledTransaction) {
+		for (const { customerProduct, updates } of updateCustomerProducts) {
+			// Skip empty updates — drizzle throws "No values to set" on empty SET.
+			// This happens when the billing plan registers a customer product update
+			// entry (e.g. for intent=None discount-only flows) but there are no
+			// actual DB columns to change.
+			if (!updates || Object.keys(updates).length === 0) continue;
 
-		await CusProductService.update({
-			ctx,
-			cusProductId: customerProduct.id,
-			updates: updates,
-		});
+			await CusProductService.update({
+				ctx,
+				cusProductId: customerProduct.id,
+				updates: updates,
+			});
+		}
 	}
 
 	// 4. Delete scheduled customer product (e.g., when updating while canceling)
-	for (const deleteCustomerProduct of deleteCustomerProducts) {
-		ctx.logger.debug(
-			`[executeAutumnBillingPlan] deleting scheduled customer product: ${deleteCustomerProduct.product.id}`,
-		);
-		await CusProductService.delete({
-			ctx,
-			cusProductId: deleteCustomerProduct.id,
-		});
+	if (!customerProductLifecycleExecutedInPooledTransaction) {
+		for (const deleteCustomerProduct of deleteCustomerProducts) {
+			ctx.logger.debug(
+				`[executeAutumnBillingPlan] deleting scheduled customer product: ${deleteCustomerProduct.product.id}`,
+			);
+			await CusProductService.delete({
+				ctx,
+				cusProductId: deleteCustomerProduct.id,
+			});
+		}
 	}
 
 	// 5. Update entitlement balances
@@ -182,6 +261,17 @@ export const executeAutumnBillingPlan = async ({
 			ctx,
 			customerId: autumnBillingPlan.customerId,
 			deltas: autumnBillingPlan.autoTopupRebalance.deltas,
+		});
+	}
+
+	if (shouldReconcileLicenseState) {
+		// Reconcile from current state so retries still converge an already-applied
+		// parent mutation; ordinary customers stop at the indexed presence check.
+		await reconcileLicenseStateForCustomer({
+			ctx,
+			idOrInternalId: autumnBillingPlan.customerId,
+			deleteCache: true,
+			flushBalances: hasPooledBalanceOps || executedPooledLicenseTransition,
 		});
 	}
 

--- a/server/src/internal/billing/v2/pooledBalances/compute/assertPooledContributionAmount.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/assertPooledContributionAmount.ts
@@ -1,0 +1,16 @@
+import { InternalError } from "@autumn/shared";
+
+export const assertPooledContributionAmount = ({
+	field,
+	value,
+}: {
+	field: "currentCycleContribution" | "nextCycleContribution" | "resetBalance";
+	value: number;
+}) => {
+	if (Number.isFinite(value) && value >= 0) return;
+
+	throw new InternalError({
+		message: `${field} must be finite and non-negative`,
+		data: { field, value },
+	});
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalanceOps.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalanceOps.ts
@@ -1,0 +1,19 @@
+import type { FullCusProduct, PooledBalanceOp } from "@autumn/shared";
+import { pooledBalancePlanToOps } from "@/internal/billing/v2/pooledBalances/utils/pooledBalancePlanToOps.js";
+import { computeAttachPooledBalancePlan } from "./computeAttachPooledBalancePlan/computeAttachPooledBalancePlan.js";
+
+// Legacy ops-shaped facade over computeAttachPooledBalancePlan; migrate callers to the plan form.
+export const computeAttachPooledBalanceOps = (
+	args: Parameters<typeof computeAttachPooledBalancePlan>[0],
+): {
+	customerProduct: FullCusProduct;
+	pooledBalanceOps: PooledBalanceOp[];
+} => {
+	const { customerProduct, pooledBalancePlan } =
+		computeAttachPooledBalancePlan(args);
+
+	return {
+		customerProduct,
+		pooledBalanceOps: pooledBalancePlanToOps({ pooledBalancePlan }),
+	};
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalancePlan/computeAttachPooledBalancePlan.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalancePlan/computeAttachPooledBalancePlan.ts
@@ -1,0 +1,149 @@
+import {
+	type AttachBillingContext,
+	customerProductHasActiveStatus,
+	type FullCusProduct,
+	type PooledBalancePlan,
+	type RemovePooledBalanceSource,
+	type UpsertPooledBalanceSourceSpec,
+} from "@autumn/shared";
+import { initUpsertPooledBalanceSourceSpecs } from "@/internal/billing/v2/pooledBalances/compute/initUpsertPooledBalanceSourceSpec/initUpsertPooledBalanceSourceSpecs.js";
+import { customerProductHasPooledSource } from "@/internal/billing/v2/pooledBalances/utils/pooledCustomerEntitlementClassification.js";
+import { initPooledResetPolicy } from "./initPooledResetPolicy.js";
+import { throwUnsupportedPooledAttach } from "./throwUnsupportedPooledAttach.js";
+
+type PooledAttachBillingContext = Pick<
+	AttachBillingContext,
+	| "billingStartsAt"
+	| "currentCustomerProduct"
+	| "currentEpochMs"
+	| "fullCustomer"
+	| "planTiming"
+	| "requestedBillingCycleAnchor"
+	| "skipBillingChanges"
+>;
+
+const computeRemoveSource = ({
+	removeCurrentSource,
+	planTiming,
+	currentCustomerProduct,
+}: {
+	removeCurrentSource: boolean;
+	planTiming: AttachBillingContext["planTiming"];
+	currentCustomerProduct?: FullCusProduct;
+}): RemovePooledBalanceSource | undefined => {
+	if (
+		planTiming !== "immediate" ||
+		!removeCurrentSource ||
+		!customerProductHasPooledSource(currentCustomerProduct)
+	) {
+		return undefined;
+	}
+
+	return {
+		internalCustomerId: currentCustomerProduct.internal_customer_id,
+		sourceCustomerProductId: currentCustomerProduct.id,
+		effectiveAt: null,
+	};
+};
+
+const newCustomerProductShouldContribute = ({
+	customerProduct,
+	currentEpochMs,
+}: {
+	customerProduct: FullCusProduct;
+	currentEpochMs: number;
+}) => {
+	const isActive = customerProductHasActiveStatus(customerProduct);
+	const effectiveStartsAt =
+		customerProduct.access_starts_at ?? customerProduct.starts_at;
+
+	if (isActive && effectiveStartsAt > currentEpochMs) {
+		return throwUnsupportedPooledAttach({
+			message:
+				"Pooled entity plan items cannot be scheduled or start in the future yet.",
+		});
+	}
+
+	if (customerProduct.free_trial_id || customerProduct.trial_ends_at) {
+		return throwUnsupportedPooledAttach({
+			message: "Pooled entity plan items do not support free trials yet.",
+		});
+	}
+
+	return isActive;
+};
+
+const computeUpsertSources = ({
+	customerProduct,
+	attachBillingContext,
+}: {
+	customerProduct: FullCusProduct;
+	attachBillingContext: PooledAttachBillingContext;
+}): {
+	customerProduct: FullCusProduct;
+	upsertSources: UpsertPooledBalanceSourceSpec[];
+} => {
+	if (!customerProductHasPooledSource(customerProduct)) {
+		return { customerProduct, upsertSources: [] };
+	}
+
+	const { currentCustomerProduct, currentEpochMs } = attachBillingContext;
+
+	const shouldContribute = newCustomerProductShouldContribute({
+		customerProduct,
+		currentEpochMs,
+	});
+
+	const resetPolicy = initPooledResetPolicy({
+		customerProduct,
+		attachBillingContext,
+		shouldContribute,
+	});
+
+	const { customerProduct: preparedCustomerProduct, upsertSourceSpecs } =
+		initUpsertPooledBalanceSourceSpecs({
+			customerProduct,
+			resetPolicy,
+			outgoingCustomerProduct: currentCustomerProduct,
+		});
+
+	return {
+		customerProduct: preparedCustomerProduct,
+		upsertSources: shouldContribute ? upsertSourceSpecs : [],
+	};
+};
+
+export const computeAttachPooledBalancePlan = ({
+	customerProduct,
+	attachBillingContext,
+	removeCurrentSource = true,
+}: {
+	customerProduct: FullCusProduct;
+	attachBillingContext: PooledAttachBillingContext;
+	removeCurrentSource?: boolean;
+}): {
+	customerProduct: FullCusProduct;
+	pooledBalancePlan: PooledBalancePlan;
+} => {
+	const { currentCustomerProduct } = attachBillingContext;
+
+	const removeSource = computeRemoveSource({
+		removeCurrentSource,
+		planTiming: attachBillingContext.planTiming,
+		currentCustomerProduct,
+	});
+
+	const { customerProduct: updatedCustomerProduct, upsertSources } =
+		computeUpsertSources({
+			customerProduct,
+			attachBillingContext,
+		});
+
+	return {
+		customerProduct: updatedCustomerProduct,
+		pooledBalancePlan: {
+			...(removeSource ? { removeSources: [removeSource] } : {}),
+			...(upsertSources.length > 0 ? { upsertSources } : {}),
+		},
+	};
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalancePlan/initPooledResetPolicy.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalancePlan/initPooledResetPolicy.ts
@@ -1,0 +1,94 @@
+import {
+	type AttachBillingContext,
+	cp,
+	type FullCusProduct,
+	isCustomerProductFree,
+} from "@autumn/shared";
+import type { PooledResetPolicy } from "@/internal/billing/v2/pooledBalances/utils/pooledResetPolicy.js";
+import { customerProductToPooledCustomerEntitlements } from "@/internal/customers/cusProducts/cusProductUtils/convertCusProduct.js";
+import { throwUnsupportedPooledAttach } from "./throwUnsupportedPooledAttach.js";
+
+type ResetPolicyBillingContext = Pick<
+	AttachBillingContext,
+	| "billingStartsAt"
+	| "currentCustomerProduct"
+	| "currentEpochMs"
+	| "fullCustomer"
+	| "requestedBillingCycleAnchor"
+	| "skipBillingChanges"
+>;
+
+// The only place a free-pool anchor is ever computed.
+const initFreePoolResetPolicy = ({
+	attachBillingContext,
+}: {
+	attachBillingContext: ResetPolicyBillingContext;
+}): PooledResetPolicy => {
+	const {
+		requestedBillingCycleAnchor,
+		billingStartsAt,
+		currentEpochMs,
+		fullCustomer,
+		currentCustomerProduct,
+	} = attachBillingContext;
+
+	const requestedResetCycleAnchor =
+		requestedBillingCycleAnchor === "now"
+			? currentEpochMs
+			: requestedBillingCycleAnchor;
+
+	const existingResetCycleAnchor = customerProductToPooledCustomerEntitlements({
+		customerProduct: currentCustomerProduct,
+	})[0]?.reset_cycle_anchor;
+
+	return {
+		lazy: {
+			anchor:
+				requestedResetCycleAnchor ??
+				billingStartsAt ??
+				existingResetCycleAnchor ??
+				fullCustomer.created_at,
+			now: currentEpochMs,
+		},
+	};
+};
+
+export const initPooledResetPolicy = ({
+	customerProduct,
+	attachBillingContext,
+	shouldContribute,
+}: {
+	customerProduct: FullCusProduct;
+	attachBillingContext: ResetPolicyBillingContext;
+	shouldContribute: boolean;
+}): PooledResetPolicy => {
+	if (isCustomerProductFree(customerProduct)) {
+		return initFreePoolResetPolicy({ attachBillingContext });
+	}
+
+	const { valid: isPaidRecurring } = cp(customerProduct).paid().recurring();
+	if (!isPaidRecurring) {
+		return throwUnsupportedPooledAttach({
+			message:
+				"Paid pooled entity plan items require a recurring subscription.",
+		});
+	}
+
+	const existingSubscriptionId = customerProduct.subscription_ids?.[0];
+	if (
+		shouldContribute &&
+		attachBillingContext.skipBillingChanges &&
+		!existingSubscriptionId
+	) {
+		return throwUnsupportedPooledAttach({
+			message:
+				"Paid pooled entity plan items require a billing subscription reset owner.",
+		});
+	}
+
+	return {
+		// A newly created Stripe subscription is linked into this policy by
+		// addStripeSubscriptionIdToBillingPlan before Autumn persistence runs.
+		stripeSubscriptionId: existingSubscriptionId ?? customerProduct.id,
+	};
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalancePlan/throwUnsupportedPooledAttach.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalancePlan/throwUnsupportedPooledAttach.ts
@@ -1,0 +1,13 @@
+import { ErrCode, RecaseError } from "@autumn/shared";
+
+export const throwUnsupportedPooledAttach = ({
+	message,
+}: {
+	message: string;
+}): never => {
+	throw new RecaseError({
+		message,
+		code: ErrCode.InvalidRequest,
+		statusCode: 400,
+	});
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/computePooledBalanceCacheCutover.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/computePooledBalanceCacheCutover.ts
@@ -1,0 +1,85 @@
+import type {
+	CusProductStatus,
+	FullCustomerEntitlement,
+	FullSubject,
+	SubjectBalance,
+} from "@autumn/shared";
+import { Decimal } from "decimal.js";
+import { computePooledBalanceRebalance } from "./computePooledBalanceRebalance.js";
+import {
+	coalescePooledBalanceCacheEffects,
+	type PooledBalanceCacheEffect,
+} from "./pooledBalanceCacheEffects.js";
+
+export const computePooledBalanceCacheCutover = ({
+	fullSubject,
+	featureIds,
+	rawEffects,
+	liveBalances,
+	reverseOrder,
+	inStatuses,
+}: {
+	fullSubject: FullSubject;
+	featureIds: string[];
+	rawEffects: PooledBalanceCacheEffect[];
+	liveBalances: SubjectBalance[];
+	reverseOrder?: boolean;
+	inStatuses?: CusProductStatus[];
+}): PooledBalanceCacheEffect[] => {
+	const liveBalanceById = new Map(
+		liveBalances.map((balance) => [balance.id, balance]),
+	);
+	const coalescedRawEffects = coalescePooledBalanceCacheEffects({
+		effects: rawEffects,
+	});
+	const rawEffectById = new Map(
+		coalescedRawEffects.map((effect) => [effect.customerEntitlementId, effect]),
+	);
+	const liveFullSubject = structuredClone(fullSubject);
+	const customerEntitlements: FullCustomerEntitlement[] = [
+		...liveFullSubject.extra_customer_entitlements,
+		...liveFullSubject.customer_products.flatMap(
+			(customerProduct) => customerProduct.customer_entitlements,
+		),
+	];
+
+	for (const customerEntitlement of customerEntitlements) {
+		const liveBalance = liveBalanceById.get(customerEntitlement.id);
+		if (!liveBalance) continue;
+
+		const rawEffect = rawEffectById.get(customerEntitlement.id);
+		customerEntitlement.balance = new Decimal(liveBalance.balance)
+			.plus(rawEffect?.balanceDelta ?? 0)
+			.toNumber();
+		customerEntitlement.adjustment = new Decimal(liveBalance.adjustment ?? 0)
+			.plus(rawEffect?.adjustmentDelta ?? 0)
+			.toNumber();
+		customerEntitlement.additional_balance = liveBalance.additional_balance;
+		customerEntitlement.entities = structuredClone(liveBalance.entities);
+		customerEntitlement.rollovers = structuredClone(liveBalance.rollovers);
+		customerEntitlement.replaceables = structuredClone(
+			liveBalance.replaceables,
+		);
+	}
+
+	const rebalanceEffects = computePooledBalanceRebalance({
+		fullSubject: liveFullSubject,
+		featureIds,
+		reverseOrder,
+		inStatuses,
+	}).map(({ featureId, customerEntitlementId, delta }) => ({
+		featureId,
+		customerEntitlementId,
+		balanceDelta: delta,
+		adjustmentDelta: 0,
+	}));
+
+	return coalescePooledBalanceCacheEffects({
+		effects: [...coalescedRawEffects, ...rebalanceEffects],
+	}).map((effect) => ({
+		...effect,
+		expectedBalance: liveBalanceById.get(effect.customerEntitlementId)?.balance,
+		expectedAdjustment: liveBalanceById.get(effect.customerEntitlementId)
+			?.adjustment,
+	}));
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/computePooledBalanceLookup.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/computePooledBalanceLookup.ts
@@ -1,0 +1,43 @@
+import {
+	EntInterval,
+	type PooledBalanceOp,
+	PooledBalanceResetMode,
+	rolloverToSignature,
+} from "@autumn/shared";
+
+type PoolSourceOperation = Extract<
+	PooledBalanceOp,
+	{ op: "upsert_source" | "transfer_source" }
+>;
+
+export const contributionOwnerToResetMode = ({
+	stripeSubscriptionId,
+}: {
+	stripeSubscriptionId: string | null;
+}) =>
+	stripeSubscriptionId
+		? PooledBalanceResetMode.Subscription
+		: PooledBalanceResetMode.Lazy;
+
+export const computePooledBalanceLookup = ({
+	operation,
+}: {
+	operation: PoolSourceOperation;
+}) => ({
+	internal_customer_id: operation.internalCustomerId,
+	internal_feature_id: operation.internalFeatureId,
+	interval: operation.interval,
+	interval_count: operation.intervalCount,
+	reset_cycle_anchor: operation.resetCycleAnchor,
+	// Lifetime pools never reset (null next_reset_at); a fixed mode keeps
+	// differently-owned lifetime grants coalescing into one pool.
+	reset_mode:
+		operation.interval === EntInterval.Lifetime
+			? PooledBalanceResetMode.Lazy
+			: contributionOwnerToResetMode({
+					stripeSubscriptionId: operation.stripeSubscriptionId,
+				}),
+	rollover_signature: rolloverToSignature({
+		rollover: operation.rollover,
+	}),
+});

--- a/server/src/internal/billing/v2/pooledBalances/compute/computePooledBalanceRebalance.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/computePooledBalanceRebalance.ts
@@ -1,0 +1,235 @@
+import {
+	type CusProductStatus,
+	cusEntsToUsage,
+	cusEntToRecalculateScopeKey,
+	type FullCusEntWithFullCusProduct,
+	type FullSubject,
+	fullSubjectToCustomerEntitlements,
+	isBooleanCusEnt,
+	isEntityScopedCusEnt,
+	isUnlimitedCusEnt,
+	RECALCULATE_CUSTOMER_SCOPE,
+} from "@autumn/shared";
+import { Decimal } from "decimal.js";
+import {
+	getCustomerEntitlementGrantState,
+	reapplyUsageToCustomerEntitlements,
+} from "@/internal/balances/recalculateBalance/reapplyUsageToCustomerEntitlements.js";
+import { isPooledSourceCustomerEntitlement } from "@/internal/billing/v2/pooledBalances/utils/pooledCustomerEntitlementClassification.js";
+
+export type PooledBalanceRebalanceDelta = {
+	customerEntitlementId: string;
+	featureId: string;
+	delta: number;
+};
+
+export type PooledBalanceUsageReapply = {
+	featureId: string;
+	amount: number;
+	excludedSourceCustomerProductId: string;
+};
+
+const isCustomerLevelNumericBalance = (
+	customerEntitlement: FullCusEntWithFullCusProduct,
+): boolean => {
+	// An entity-attached pooled row is only the normalized source record. Its
+	// grant lives on the synthetic customer-level pool entitlement, so putting
+	// the catalog allowance back here would double-mint the contribution.
+	if (
+		isPooledSourceCustomerEntitlement({
+			customerEntitlement,
+			customerProduct: customerEntitlement.customer_product,
+		})
+	) {
+		return false;
+	}
+	if (
+		cusEntToRecalculateScopeKey({ cusEnt: customerEntitlement }) !==
+		RECALCULATE_CUSTOMER_SCOPE
+	) {
+		return false;
+	}
+	if (isBooleanCusEnt({ cusEnt: customerEntitlement })) return false;
+	if (isUnlimitedCusEnt(customerEntitlement)) return false;
+	if (isEntityScopedCusEnt(customerEntitlement)) return false;
+	return true;
+};
+
+export const getPooledRebalanceCustomerEntitlements = ({
+	fullSubject,
+	featureId,
+	reverseOrder = false,
+	inStatuses,
+}: {
+	fullSubject: FullSubject;
+	featureId: string;
+	reverseOrder?: boolean;
+	inStatuses?: CusProductStatus[];
+}) =>
+	fullSubjectToCustomerEntitlements({
+		fullSubject,
+		featureIds: [featureId],
+		reverseOrder,
+		inStatuses,
+	}).filter(isCustomerLevelNumericBalance);
+
+const hasBalanceToRedistribute = ({
+	customerEntitlements,
+}: {
+	customerEntitlements: FullCusEntWithFullCusProduct[];
+}): boolean => {
+	let hasNegativeBalance = false;
+	let hasPositiveBalance = false;
+	for (const customerEntitlement of customerEntitlements) {
+		const balance = customerEntitlement.balance ?? 0;
+		if (balance < 0) hasNegativeBalance = true;
+		if (balance > 0) hasPositiveBalance = true;
+	}
+	return hasNegativeBalance && hasPositiveBalance;
+};
+
+const computeReappliedUsageDeltas = ({
+	featureId,
+	currentCustomerEntitlements,
+	usage,
+}: {
+	featureId: string;
+	currentCustomerEntitlements: FullCusEntWithFullCusProduct[];
+	usage: number;
+}): PooledBalanceRebalanceDelta[] => {
+	const rebalancedCustomerEntitlements = currentCustomerEntitlements.map(
+		(customerEntitlement) => structuredClone(customerEntitlement),
+	);
+	reapplyUsageToCustomerEntitlements({
+		customerEntitlements: rebalancedCustomerEntitlements,
+		usage,
+		getGrantState: getCustomerEntitlementGrantState,
+	});
+
+	const rebalancedById = new Map(
+		rebalancedCustomerEntitlements.map((customerEntitlement) => [
+			customerEntitlement.id,
+			customerEntitlement,
+		]),
+	);
+	const deltas: PooledBalanceRebalanceDelta[] = [];
+	for (const customerEntitlement of currentCustomerEntitlements) {
+		const rebalanced = rebalancedById.get(customerEntitlement.id);
+		if (!rebalanced) continue;
+
+		const delta = new Decimal(rebalanced.balance ?? 0)
+			.minus(customerEntitlement.balance ?? 0)
+			.toNumber();
+		if (delta === 0) continue;
+
+		deltas.push({
+			customerEntitlementId: customerEntitlement.id,
+			featureId,
+			delta,
+		});
+	}
+	return deltas;
+};
+
+export const computePooledBalanceUsageReapply = ({
+	fullSubject,
+	usageReapplies,
+	reverseOrder = false,
+	inStatuses,
+}: {
+	fullSubject: FullSubject;
+	usageReapplies: PooledBalanceUsageReapply[];
+	reverseOrder?: boolean;
+	inStatuses?: CusProductStatus[];
+}): PooledBalanceRebalanceDelta[] => {
+	const byFeatureId = new Map<
+		string,
+		{
+			amount: Decimal;
+			excludedSourceCustomerProductIds: Set<string>;
+		}
+	>();
+	for (const usageReapply of usageReapplies) {
+		if (usageReapply.amount <= 0) continue;
+		const current = byFeatureId.get(usageReapply.featureId) ?? {
+			amount: new Decimal(0),
+			excludedSourceCustomerProductIds: new Set<string>(),
+		};
+		current.amount = current.amount.plus(usageReapply.amount);
+		current.excludedSourceCustomerProductIds.add(
+			usageReapply.excludedSourceCustomerProductId,
+		);
+		byFeatureId.set(usageReapply.featureId, current);
+	}
+
+	const deltas: PooledBalanceRebalanceDelta[] = [];
+	for (const [featureId, reapply] of byFeatureId) {
+		const customerEntitlements = getPooledRebalanceCustomerEntitlements({
+			fullSubject,
+			featureId,
+			reverseOrder,
+			inStatuses,
+		}).filter(
+			(customerEntitlement) =>
+				!customerEntitlement.customer_product ||
+				!reapply.excludedSourceCustomerProductIds.has(
+					customerEntitlement.customer_product.id,
+				),
+		);
+		if (customerEntitlements.length === 0) continue;
+
+		const usage = reapply.amount
+			.plus(cusEntsToUsage({ cusEnts: customerEntitlements }))
+			.toNumber();
+		deltas.push(
+			...computeReappliedUsageDeltas({
+				featureId,
+				currentCustomerEntitlements: customerEntitlements,
+				usage,
+			}),
+		);
+	}
+	return deltas;
+};
+
+/** Reapplies recorded usage after a pooled grant changes, using Autumn's
+ * global entitlement ordering and returning balance-only deltas. */
+export const computePooledBalanceRebalance = ({
+	fullSubject,
+	featureIds,
+	reverseOrder = false,
+	inStatuses,
+}: {
+	fullSubject: FullSubject;
+	featureIds: string[];
+	reverseOrder?: boolean;
+	inStatuses?: CusProductStatus[];
+}): PooledBalanceRebalanceDelta[] => {
+	const deltas: PooledBalanceRebalanceDelta[] = [];
+
+	for (const featureId of new Set(featureIds)) {
+		const customerEntitlements = getPooledRebalanceCustomerEntitlements({
+			fullSubject,
+			featureId,
+			reverseOrder,
+			inStatuses,
+		});
+
+		if (
+			customerEntitlements.length < 2 ||
+			!hasBalanceToRedistribute({ customerEntitlements })
+		) {
+			continue;
+		}
+
+		deltas.push(
+			...computeReappliedUsageDeltas({
+				featureId,
+				currentCustomerEntitlements: customerEntitlements,
+				usage: cusEntsToUsage({ cusEnts: customerEntitlements }),
+			}),
+		);
+	}
+
+	return deltas;
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/computePooledBalanceReconciliation.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/computePooledBalanceReconciliation.ts
@@ -1,0 +1,108 @@
+import {
+	type CusProductStatus,
+	cusEntsToUsage,
+	type FullSubject,
+	type SubjectBalance,
+} from "@autumn/shared";
+import { Decimal } from "decimal.js";
+import {
+	getCustomerEntitlementGrantState,
+	reapplyUsageToCustomerEntitlements,
+} from "@/internal/balances/recalculateBalance/reapplyUsageToCustomerEntitlements.js";
+import { getPooledRebalanceCustomerEntitlements } from "./computePooledBalanceRebalance.js";
+
+export type PooledBalanceReconciliationUpdate = {
+	customerEntitlementId: string;
+	featureId: string;
+	balance: number;
+	adjustment: number;
+};
+
+/** Rebuilds affected balance distributions after live cache state has first
+ * been flushed to Postgres. Contribution totals supply synthetic pool grants;
+ * Autumn's normal deduction kernel reapplies the recorded usage. */
+export const computePooledBalanceReconciliation = ({
+	fullSubject,
+	featureIds,
+	pooledGrantByCustomerEntitlementId,
+	liveBalances = [],
+	reverseOrder = false,
+	inStatuses,
+}: {
+	fullSubject: FullSubject;
+	featureIds: string[];
+	pooledGrantByCustomerEntitlementId: ReadonlyMap<string, number>;
+	liveBalances?: SubjectBalance[];
+	reverseOrder?: boolean;
+	inStatuses?: CusProductStatus[];
+}): PooledBalanceReconciliationUpdate[] => {
+	const updates: PooledBalanceReconciliationUpdate[] = [];
+	const liveFullSubject = structuredClone(fullSubject);
+	const liveBalanceById = new Map(
+		liveBalances.map((liveBalance) => [liveBalance.id, liveBalance]),
+	);
+	for (const customerEntitlement of [
+		...liveFullSubject.extra_customer_entitlements,
+		...liveFullSubject.customer_products.flatMap(
+			(customerProduct) => customerProduct.customer_entitlements,
+		),
+	]) {
+		const liveBalance = liveBalanceById.get(customerEntitlement.id);
+		if (!liveBalance) continue;
+		customerEntitlement.balance = liveBalance.balance;
+		customerEntitlement.adjustment = liveBalance.adjustment;
+		customerEntitlement.additional_balance = liveBalance.additional_balance;
+		customerEntitlement.entities = structuredClone(liveBalance.entities);
+		customerEntitlement.rollovers = structuredClone(liveBalance.rollovers);
+		customerEntitlement.replaceables = structuredClone(
+			liveBalance.replaceables,
+		);
+	}
+
+	for (const featureId of new Set(featureIds)) {
+		const before = getPooledRebalanceCustomerEntitlements({
+			fullSubject: liveFullSubject,
+			featureId,
+			reverseOrder,
+			inStatuses,
+		});
+		if (before.length === 0) continue;
+
+		const usage = cusEntsToUsage({ cusEnts: before });
+		const after = before.map((customerEntitlement) => {
+			const clone = structuredClone(customerEntitlement);
+			const pooledGrant = pooledGrantByCustomerEntitlementId.get(clone.id);
+			if (pooledGrant !== undefined) clone.adjustment = pooledGrant;
+			return clone;
+		});
+		reapplyUsageToCustomerEntitlements({
+			customerEntitlements: after,
+			usage,
+			getGrantState: getCustomerEntitlementGrantState,
+		});
+
+		for (const customerEntitlement of after) {
+			const original = before.find(
+				(candidate) => candidate.id === customerEntitlement.id,
+			);
+			if (!original) continue;
+			const balance = customerEntitlement.balance ?? 0;
+			const adjustment = customerEntitlement.adjustment ?? 0;
+			if (
+				new Decimal(balance).equals(original.balance ?? 0) &&
+				new Decimal(adjustment).equals(original.adjustment ?? 0)
+			) {
+				continue;
+			}
+
+			updates.push({
+				customerEntitlementId: customerEntitlement.id,
+				featureId,
+				balance,
+				adjustment,
+			});
+		}
+	}
+
+	return updates;
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/computePooledContributionTransition.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/computePooledContributionTransition.ts
@@ -1,0 +1,53 @@
+import { Decimal } from "decimal.js";
+import { assertPooledContributionAmount } from "./assertPooledContributionAmount.js";
+
+export type PooledContributionAmounts = {
+	currentCycleContribution: number;
+	nextCycleContribution: number;
+};
+
+export type PooledContributionTransition = {
+	contributionDelta: number;
+	next: PooledContributionAmounts;
+};
+
+const assertPooledContributionAmounts = ({
+	amounts,
+}: {
+	amounts: PooledContributionAmounts;
+}) => {
+	assertPooledContributionAmount({
+		field: "currentCycleContribution",
+		value: amounts.currentCycleContribution,
+	});
+	assertPooledContributionAmount({
+		field: "nextCycleContribution",
+		value: amounts.nextCycleContribution,
+	});
+};
+
+export const computePooledContributionTransition = ({
+	previous,
+	desired,
+}: {
+	previous: PooledContributionAmounts | null;
+	desired: PooledContributionAmounts;
+}): PooledContributionTransition => {
+	if (previous) {
+		assertPooledContributionAmounts({ amounts: previous });
+	}
+	assertPooledContributionAmounts({ amounts: desired });
+
+	const previousCurrentContribution = previous?.currentCycleContribution ?? 0;
+	const contributionDelta = new Decimal(desired.currentCycleContribution)
+		.minus(previousCurrentContribution)
+		.toNumber();
+
+	return {
+		contributionDelta,
+		next: {
+			currentCycleContribution: desired.currentCycleContribution,
+			nextCycleContribution: desired.nextCycleContribution,
+		},
+	};
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/computePooledQuantityUpdateOps.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/computePooledQuantityUpdateOps.ts
@@ -1,0 +1,106 @@
+import {
+	BillingType,
+	customerPriceToCustomerEntitlement,
+	EntInterval,
+	type FeatureOptions,
+	type FullCusProduct,
+	getBillingType,
+	getStartingBalance,
+	InternalError,
+	type PooledBalanceOp,
+} from "@autumn/shared";
+import { isPooledSourceCustomerEntitlement } from "@/internal/billing/v2/pooledBalances/utils/pooledCustomerEntitlementClassification.js";
+
+export const computePooledQuantityUpdateOps = ({
+	customerProduct,
+	updatedOptions,
+}: {
+	customerProduct: FullCusProduct;
+	updatedOptions: FeatureOptions[];
+}): PooledBalanceOp[] => {
+	const operations: PooledBalanceOp[] = [];
+
+	for (const updatedOption of updatedOptions) {
+		const customerPrice = customerProduct.customer_prices.find(
+			(candidate) =>
+				candidate.price.config.internal_feature_id ===
+					updatedOption.internal_feature_id &&
+				getBillingType(candidate.price.config) === BillingType.UsageInAdvance,
+		);
+		if (!customerPrice) continue;
+
+		const customerEntitlement = customerPriceToCustomerEntitlement({
+			customerPrice,
+			customerEntitlements: customerProduct.customer_entitlements,
+			errorOnNotFound: true,
+		});
+		const { entitlement } = customerEntitlement;
+		if (
+			!isPooledSourceCustomerEntitlement({
+				customerEntitlement,
+				customerProduct,
+			})
+		)
+			continue;
+
+		const subscriptionId = customerProduct.subscription_ids?.[0];
+		if (!subscriptionId) {
+			throw new InternalError({
+				message: `Pooled prepaid source '${customerProduct.id}' is missing its subscription reset owner.`,
+			});
+		}
+		if (
+			typeof entitlement.allowance !== "number" ||
+			!entitlement.interval ||
+			(entitlement.interval !== EntInterval.Lifetime &&
+				(typeof customerEntitlement.reset_cycle_anchor !== "number" ||
+					typeof customerEntitlement.next_reset_at !== "number"))
+		) {
+			throw new InternalError({
+				message: `Pooled prepaid source '${customerProduct.id}' has incomplete reset metadata.`,
+			});
+		}
+
+		const currentCycleContribution = getStartingBalance({
+			entitlement,
+			options: updatedOption,
+			relatedPrice: customerPrice.price,
+			productQuantity: customerProduct.quantity,
+		});
+		const nextCycleContribution = getStartingBalance({
+			entitlement,
+			options: {
+				...updatedOption,
+				quantity: updatedOption.upcoming_quantity ?? updatedOption.quantity,
+			},
+			relatedPrice: customerPrice.price,
+			productQuantity: customerProduct.quantity,
+		});
+
+		operations.push({
+			op: "upsert_source",
+			internalCustomerId: customerProduct.internal_customer_id,
+			featureId: entitlement.feature.id,
+			internalFeatureId: entitlement.internal_feature_id,
+			interval: entitlement.interval,
+			intervalCount: entitlement.interval_count ?? 1,
+			resetCycleAnchor:
+				entitlement.interval === EntInterval.Lifetime
+					? null
+					: (customerEntitlement.reset_cycle_anchor ?? null),
+			nextResetAt:
+				entitlement.interval === EntInterval.Lifetime
+					? null
+					: (customerEntitlement.next_reset_at ?? null),
+			rollover: entitlement.rollover ?? null,
+			stripeSubscriptionId: subscriptionId,
+			customerLicenseLinkId: null,
+			sourceCustomerProductId: customerProduct.id,
+			sourceEntitlementId: entitlement.id,
+			currentCycleContribution,
+			nextCycleContribution,
+		});
+	}
+
+	return operations;
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/computePooledTransferGrantDeltas.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/computePooledTransferGrantDeltas.ts
@@ -1,0 +1,47 @@
+import { Decimal } from "decimal.js";
+
+export type PooledTransferGrantDelta = {
+	pooledBalanceId: string;
+	balanceDelta: number;
+	adjustmentDelta: number;
+};
+
+/** Moves only one contribution's grant between pools. Usage distribution is
+ * deliberately left to the shared pooled rebalance/global deduction kernel. */
+export const computePooledTransferGrantDeltas = ({
+	previousPooledBalanceId,
+	destinationPooledBalanceId,
+	previousContribution,
+	desiredContribution,
+}: {
+	previousPooledBalanceId: string;
+	destinationPooledBalanceId: string;
+	previousContribution: number;
+	desiredContribution: number;
+}): PooledTransferGrantDelta[] => {
+	if (previousPooledBalanceId === destinationPooledBalanceId) {
+		const delta = new Decimal(desiredContribution)
+			.minus(previousContribution)
+			.toNumber();
+		return [
+			{
+				pooledBalanceId: previousPooledBalanceId,
+				balanceDelta: delta,
+				adjustmentDelta: delta,
+			},
+		];
+	}
+
+	return [
+		{
+			pooledBalanceId: previousPooledBalanceId,
+			balanceDelta: new Decimal(previousContribution).negated().toNumber(),
+			adjustmentDelta: new Decimal(previousContribution).negated().toNumber(),
+		},
+		{
+			pooledBalanceId: destinationPooledBalanceId,
+			balanceDelta: desiredContribution,
+			adjustmentDelta: desiredContribution,
+		},
+	];
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/customerProductToPooledBalanceRemovalOp.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/customerProductToPooledBalanceRemovalOp.ts
@@ -1,0 +1,88 @@
+import { cp, type FullCusProduct, type PooledBalanceOp } from "@autumn/shared";
+import { customerProductHasPooledSource } from "@/internal/billing/v2/pooledBalances/utils/pooledCustomerEntitlementClassification.js";
+
+type StageOwnerRemovalOperation = Extract<
+	PooledBalanceOp,
+	{ op: "stage_owner_removal" }
+>;
+type RestoreOwnerOperation = Extract<PooledBalanceOp, { op: "restore_owner" }>;
+
+export const customerProductToPooledBalanceRemovalOp = ({
+	customerProduct,
+	effectiveAt,
+}: {
+	customerProduct: FullCusProduct;
+	effectiveAt: number | null;
+}): PooledBalanceOp | undefined => {
+	if (cp(customerProduct).scheduled().valid) return undefined;
+
+	if (!customerProductHasPooledSource(customerProduct)) return undefined;
+
+	return {
+		op: "remove_source",
+		internalCustomerId: customerProduct.internal_customer_id,
+		sourceCustomerProductId: customerProduct.id,
+		effectiveAt,
+	};
+};
+
+export const customerProductToPooledBalanceRestoreOp = ({
+	customerProduct,
+	expectedEffectiveAt,
+}: {
+	customerProduct: FullCusProduct;
+	expectedEffectiveAt: number;
+}): PooledBalanceOp | undefined => {
+	if (cp(customerProduct).scheduled().valid) return undefined;
+
+	if (!customerProductHasPooledSource(customerProduct)) return undefined;
+
+	return {
+		op: "restore_source",
+		internalCustomerId: customerProduct.internal_customer_id,
+		sourceCustomerProductId: customerProduct.id,
+		expectedEffectiveAt,
+	};
+};
+
+// A parent's license links: seat contributions are owned by the LINK, so
+// parent lifecycle events fan out to one op per link.
+const customerProductToLicenseLinkIds = (customerProduct: FullCusProduct) => [
+	...new Set(
+		(customerProduct.customer_licenses ?? []).map(
+			(customerLicense) => customerLicense.link_id,
+		),
+	),
+];
+
+export const customerProductToPooledBalanceOwnerRemovalOps = ({
+	customerProduct,
+	effectiveAt,
+}: {
+	customerProduct: FullCusProduct;
+	effectiveAt: number;
+}): StageOwnerRemovalOperation[] =>
+	customerProductToLicenseLinkIds(customerProduct).map(
+		(customerLicenseLinkId) => ({
+			op: "stage_owner_removal",
+			internalCustomerId: customerProduct.internal_customer_id,
+			customerLicenseLinkId,
+			effectiveAt,
+		}),
+	);
+
+export const customerProductToPooledBalanceOwnerRestoreOps = ({
+	customerProduct,
+	expectedEffectiveAt,
+}: {
+	customerProduct: FullCusProduct;
+	expectedEffectiveAt: number;
+}): RestoreOwnerOperation[] =>
+	customerProductToLicenseLinkIds(customerProduct).map(
+		(customerLicenseLinkId) => ({
+			op: "restore_owner",
+			internalCustomerId: customerProduct.internal_customer_id,
+			customerLicenseLinkId,
+			expectedEffectiveAt,
+		}),
+	);

--- a/server/src/internal/billing/v2/pooledBalances/compute/initUpsertPooledBalanceSourceSpec/computePooledUsageCarrySpec.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/initUpsertPooledBalanceSourceSpec/computePooledUsageCarrySpec.ts
@@ -1,0 +1,41 @@
+import {
+	cusEntsToUsage,
+	type FullCusEntWithFullCusProduct,
+	type FullCusProduct,
+	type PooledBalanceUsageReapply,
+} from "@autumn/shared";
+import { isPooledSourceCustomerEntitlement } from "@/internal/billing/v2/pooledBalances/utils/pooledCustomerEntitlementClassification.js";
+
+// Carries used units when the outgoing product granted the same feature NON-pooled.
+export const computePooledUsageCarrySpec = ({
+	customerEntitlement,
+	outgoingCustomerProduct,
+}: {
+	customerEntitlement: FullCusEntWithFullCusProduct;
+	outgoingCustomerProduct?: FullCusProduct;
+}): PooledBalanceUsageReapply | undefined => {
+	if (!outgoingCustomerProduct) return undefined;
+
+	const hasNonPooledSource = outgoingCustomerProduct.customer_entitlements.some(
+		(sourceCustomerEntitlement) =>
+			!isPooledSourceCustomerEntitlement({
+				customerEntitlement: sourceCustomerEntitlement,
+				customerProduct: outgoingCustomerProduct,
+			}) &&
+			sourceCustomerEntitlement.internal_feature_id ===
+				customerEntitlement.internal_feature_id,
+	);
+
+	if (!hasNonPooledSource) return undefined;
+
+	const amount = cusEntsToUsage({
+		cusEnts: [customerEntitlement],
+	});
+
+	if (!(amount > 0)) return undefined;
+
+	return {
+		amount,
+		excludedSourceCustomerProductId: outgoingCustomerProduct.id,
+	};
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/initUpsertPooledBalanceSourceSpec/initPooledContributionSpec.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/initUpsertPooledBalanceSourceSpec/initPooledContributionSpec.ts
@@ -1,0 +1,50 @@
+import {
+	cusEntToStartingBalance,
+	type FullCusEntWithFullCusProduct,
+	type FullCusProduct,
+	isFiniteNumber,
+	type PooledContributionSpec,
+} from "@autumn/shared";
+import {
+	type PooledResetPolicy,
+	pooledResetPolicyToContributionOwner,
+} from "@/internal/billing/v2/pooledBalances/utils/pooledResetPolicy.js";
+import { throwUnsupportedPooledEntitlement } from "./throwUnsupportedPooledEntitlement.js";
+
+export const initPooledContributionSpec = ({
+	customerProduct,
+	customerEntitlement,
+	resetPolicy,
+}: {
+	customerProduct: FullCusProduct;
+	customerEntitlement: FullCusEntWithFullCusProduct;
+	resetPolicy: PooledResetPolicy;
+}): PooledContributionSpec => {
+	const { entitlement } = customerEntitlement;
+
+	const currentCycleContribution = cusEntToStartingBalance({
+		cusEnt: customerEntitlement,
+	});
+	const nextCycleContribution = cusEntToStartingBalance({
+		cusEnt: customerEntitlement,
+		useUpcomingQuantity: true,
+	});
+	if (
+		!isFiniteNumber(currentCycleContribution) ||
+		currentCycleContribution < 0 ||
+		!isFiniteNumber(nextCycleContribution) ||
+		nextCycleContribution < 0
+	) {
+		return throwUnsupportedPooledEntitlement({
+			message: `Pooled feature '${entitlement.feature.id}' requires a finite, non-negative contribution grant.`,
+		});
+	}
+
+	return {
+		sourceCustomerProductId: customerProduct.id,
+		sourceEntitlementId: entitlement.id,
+		...pooledResetPolicyToContributionOwner({ resetPolicy }),
+		currentCycleContribution,
+		nextCycleContribution,
+	};
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/initUpsertPooledBalanceSourceSpec/initUpsertPooledBalanceSourceSpecs.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/initUpsertPooledBalanceSourceSpec/initUpsertPooledBalanceSourceSpecs.ts
@@ -1,0 +1,114 @@
+import {
+	type FullCusProduct,
+	isLifetimeEntitlement,
+	type UpsertPooledBalanceSourceSpec,
+} from "@autumn/shared";
+import { customerEntitlementToPooledIdentity } from "@/internal/billing/v2/pooledBalances/utils/customerEntitlementToPooledIdentity/customerEntitlementToPooledIdentity.js";
+import type { PooledResetPolicy } from "@/internal/billing/v2/pooledBalances/utils/pooledResetPolicy.js";
+import { customerProductToPooledCustomerEntitlements } from "@/internal/customers/cusProducts/cusProductUtils/convertCusProduct";
+import { computePooledUsageCarrySpec } from "./computePooledUsageCarrySpec.js";
+import { initPooledContributionSpec } from "./initPooledContributionSpec.js";
+import { resolvePoolResetSchedule } from "./resolvePoolResetSchedule.js";
+
+// The pool owns balances from here on; source cusEnts keep only reset metadata.
+const zeroPooledSourceCustomerEntitlements = ({
+	customerProduct,
+	upsertSourceSpecs,
+}: {
+	customerProduct: FullCusProduct;
+	upsertSourceSpecs: UpsertPooledBalanceSourceSpec[];
+}): FullCusProduct => {
+	const specByEntitlementId = new Map(
+		upsertSourceSpecs.map((spec) => [
+			spec.contribution.sourceEntitlementId,
+			spec,
+		]),
+	);
+
+	return {
+		...customerProduct,
+		customer_entitlements: customerProduct.customer_entitlements.map(
+			(customerEntitlement) => {
+				const spec = specByEntitlementId.get(
+					customerEntitlement.entitlement.id,
+				);
+				if (!spec) return customerEntitlement;
+
+				return {
+					...customerEntitlement,
+					balance: 0,
+					adjustment: 0,
+					additional_balance: 0,
+					entities: null,
+					reset_cycle_anchor: spec.pooledBalance.resetCycleAnchor,
+					next_reset_at: spec.pooledBalance.nextResetAt,
+				};
+			},
+		),
+	};
+};
+
+export const initUpsertPooledBalanceSourceSpecs = ({
+	customerProduct,
+	resetPolicy,
+	outgoingCustomerProduct,
+}: {
+	customerProduct: FullCusProduct;
+	resetPolicy: PooledResetPolicy;
+	outgoingCustomerProduct?: FullCusProduct;
+}): {
+	customerProduct: FullCusProduct;
+	upsertSourceSpecs: UpsertPooledBalanceSourceSpec[];
+} => {
+	const pooledCustomerEntitlements =
+		customerProductToPooledCustomerEntitlements({
+			customerProduct,
+		});
+
+	const upsertSourceSpecs = pooledCustomerEntitlements.map(
+		(customerEntitlement): UpsertPooledBalanceSourceSpec => {
+			const usageCarry = computePooledUsageCarrySpec({
+				customerEntitlement,
+				outgoingCustomerProduct,
+			});
+
+			// Row-derived identity; non-lifetime pools take their schedule from
+			// the attach policy instead of the row.
+			const rowIdentity = customerEntitlementToPooledIdentity({
+				customerEntitlement,
+			});
+			const pooledBalance = isLifetimeEntitlement({
+				entitlement: customerEntitlement.entitlement,
+			})
+				? rowIdentity
+				: {
+						...rowIdentity,
+						...resolvePoolResetSchedule({
+							resetPolicy,
+							customerEntitlement,
+							interval: rowIdentity.interval,
+							intervalCount: rowIdentity.intervalCount,
+						}),
+					};
+
+			return {
+				internalCustomerId: customerProduct.internal_customer_id,
+				pooledBalance,
+				contribution: initPooledContributionSpec({
+					customerProduct,
+					customerEntitlement,
+					resetPolicy,
+				}),
+				...(usageCarry ? { usageCarry } : {}),
+			};
+		},
+	);
+
+	return {
+		customerProduct: zeroPooledSourceCustomerEntitlements({
+			customerProduct,
+			upsertSourceSpecs,
+		}),
+		upsertSourceSpecs,
+	};
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/initUpsertPooledBalanceSourceSpec/resolvePoolResetSchedule.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/initUpsertPooledBalanceSourceSpec/resolvePoolResetSchedule.ts
@@ -1,0 +1,44 @@
+import {
+	type EntInterval,
+	type FullCusEntWithFullCusProduct,
+	getCycleEnd,
+	isFiniteNumber,
+} from "@autumn/shared";
+import type { PooledResetPolicy } from "@/internal/billing/v2/pooledBalances/utils/pooledResetPolicy.js";
+import { throwUnsupportedPooledEntitlement } from "./throwUnsupportedPooledEntitlement.js";
+
+// Free pools run on the policy's anchor; owned pools (subscription / license
+// parent) inherit the source row's schedule until their owner resets them.
+export const resolvePoolResetSchedule = ({
+	resetPolicy,
+	customerEntitlement,
+	interval,
+	intervalCount,
+}: {
+	resetPolicy: PooledResetPolicy;
+	customerEntitlement: FullCusEntWithFullCusProduct;
+	interval: EntInterval;
+	intervalCount: number;
+}): { resetCycleAnchor: number; nextResetAt: number } => {
+	if ("lazy" in resetPolicy) {
+		return {
+			resetCycleAnchor: resetPolicy.lazy.anchor,
+			nextResetAt: getCycleEnd({
+				anchor: resetPolicy.lazy.anchor,
+				interval,
+				intervalCount,
+				now: resetPolicy.lazy.now,
+			}),
+		};
+	}
+
+	const resetCycleAnchor = customerEntitlement.reset_cycle_anchor;
+	const nextResetAt = customerEntitlement.next_reset_at;
+	if (!isFiniteNumber(resetCycleAnchor) || !isFiniteNumber(nextResetAt)) {
+		return throwUnsupportedPooledEntitlement({
+			message: `Pooled feature '${customerEntitlement.entitlement.feature.id}' requires a reset anchor and next reset date.`,
+		});
+	}
+
+	return { resetCycleAnchor, nextResetAt };
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/initUpsertPooledBalanceSourceSpec/throwUnsupportedPooledEntitlement.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/initUpsertPooledBalanceSourceSpec/throwUnsupportedPooledEntitlement.ts
@@ -1,0 +1,13 @@
+import { ErrCode, RecaseError } from "@autumn/shared";
+
+export const throwUnsupportedPooledEntitlement = ({
+	message,
+}: {
+	message: string;
+}): never => {
+	throw new RecaseError({
+		message,
+		code: ErrCode.InvalidRequest,
+		statusCode: 400,
+	});
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/pooledBalanceCacheEffects.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/pooledBalanceCacheEffects.ts
@@ -1,0 +1,47 @@
+import { Decimal } from "decimal.js";
+
+export type PooledBalanceCacheEffect = {
+	featureId: string;
+	customerEntitlementId: string;
+	balanceDelta: number;
+	adjustmentDelta: number;
+	expectedBalance?: number;
+	expectedAdjustment?: number | null;
+};
+
+const effectKey = ({
+	featureId,
+	customerEntitlementId,
+}: Pick<PooledBalanceCacheEffect, "featureId" | "customerEntitlementId">) =>
+	`${featureId}\u0000${customerEntitlementId}`;
+
+export const coalescePooledBalanceCacheEffects = ({
+	effects,
+}: {
+	effects: PooledBalanceCacheEffect[];
+}): PooledBalanceCacheEffect[] => {
+	const effectsByKey = new Map<string, PooledBalanceCacheEffect>();
+
+	for (const effect of effects) {
+		const key = effectKey(effect);
+		const previous = effectsByKey.get(key);
+		effectsByKey.set(key, {
+			featureId: effect.featureId,
+			customerEntitlementId: effect.customerEntitlementId,
+			balanceDelta: new Decimal(previous?.balanceDelta ?? 0)
+				.plus(effect.balanceDelta)
+				.toNumber(),
+			adjustmentDelta: new Decimal(previous?.adjustmentDelta ?? 0)
+				.plus(effect.adjustmentDelta)
+				.toNumber(),
+			expectedBalance: effect.expectedBalance ?? previous?.expectedBalance,
+			expectedAdjustment:
+				effect.expectedAdjustment ?? previous?.expectedAdjustment,
+		});
+	}
+
+	return [...effectsByKey.values()].filter(
+		({ balanceDelta, adjustmentDelta }) =>
+			balanceDelta !== 0 || adjustmentDelta !== 0,
+	);
+};

--- a/server/src/internal/billing/v2/pooledBalances/execute/applyPooledBalanceCacheEffects.ts
+++ b/server/src/internal/billing/v2/pooledBalances/execute/applyPooledBalanceCacheEffects.ts
@@ -1,0 +1,532 @@
+import type {
+	CusProductStatus,
+	FullSubject,
+	SubjectBalance,
+} from "@autumn/shared";
+import { Decimal } from "decimal.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { writeSubjectBalancesToDb } from "@/internal/balances/utils/sync/flushSubjectBalancesToDb.js";
+import { computePooledBalanceCacheCutover } from "@/internal/billing/v2/pooledBalances/compute/computePooledBalanceCacheCutover.js";
+import { getPooledRebalanceCustomerEntitlements } from "@/internal/billing/v2/pooledBalances/compute/computePooledBalanceRebalance.js";
+import { computePooledBalanceReconciliation } from "@/internal/billing/v2/pooledBalances/compute/computePooledBalanceReconciliation.js";
+import type { PooledBalanceCacheEffect } from "@/internal/billing/v2/pooledBalances/compute/pooledBalanceCacheEffects.js";
+import { pooledBalanceRepo } from "@/internal/billing/v2/pooledBalances/repos/pooledBalanceRepo.js";
+import { isPooledSourceCustomerEntitlement } from "@/internal/billing/v2/pooledBalances/utils/pooledCustomerEntitlementClassification.js";
+import { getOrInitFullSubjectViewEpoch } from "@/internal/customers/cache/fullSubject/actions/invalidate/getOrInitFullSubjectViewEpoch.js";
+import { captureAndDeleteSharedBalanceFields } from "@/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.js";
+import { getCachedFeatureBalance } from "@/internal/customers/cache/fullSubject/balances/getCachedFeatureBalances.js";
+import { buildFullSubjectViewEpochKey } from "@/internal/customers/cache/fullSubject/builders/buildFullSubjectViewEpochKey.js";
+import { buildSharedFullSubjectBalanceKey } from "@/internal/customers/cache/fullSubject/builders/buildSharedFullSubjectBalanceKey.js";
+import { FULL_SUBJECT_CACHE_TTL_SECONDS } from "@/internal/customers/cache/fullSubject/config/fullSubjectCacheConfig.js";
+import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
+import {
+	deleteCachedFullCustomer,
+	deleteLegacyCachedFullCustomer,
+} from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
+import { tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
+
+type CacheBatchResult = {
+	conflict?: boolean;
+	cache_miss?: boolean;
+	epoch_mismatch?: boolean;
+	missing?: string[];
+	mismatched?: string[];
+	invalid?: string[];
+};
+
+type AtomicApplyResult =
+	| { kind: "applied" }
+	| { kind: "epoch_mismatch" }
+	| { kind: "conflict"; detail: CacheBatchResult }
+	| { kind: "missing"; reason: string };
+
+const MAX_CUTOVER_ATTEMPTS = 3;
+
+const invalidatePooledBalanceCaches = async ({
+	ctx,
+	customerId,
+	reason,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	reason: string;
+}) => {
+	ctx.logger.warn(
+		`[applyPooledBalanceCacheEffects] invalidating customer cache: ${reason}`,
+	);
+	await deleteCachedFullCustomer({
+		ctx,
+		customerId,
+		source: `applyPooledBalanceCacheEffects:${reason}`,
+		flushBalances: false,
+	});
+};
+
+const flushBalances = async ({
+	ctx,
+	balances,
+}: {
+	ctx: AutumnContext;
+	balances: SubjectBalance[];
+}) => {
+	if (balances.length === 0) return;
+	await writeSubjectBalancesToDb({
+		db: ctx.db,
+		subjectBalances: balances,
+		queryName: "applyPooledBalanceCacheEffects",
+	});
+};
+
+export const partitionSubjectBalancesByCacheVersion = ({
+	subjectBalances,
+	currentCustomerEntitlements,
+}: {
+	subjectBalances: SubjectBalance[];
+	currentCustomerEntitlements: Array<{
+		id: string;
+		cache_version?: number | null;
+	}>;
+}) => {
+	const currentCacheVersionById = new Map(
+		currentCustomerEntitlements.map((customerEntitlement) => [
+			customerEntitlement.id,
+			customerEntitlement.cache_version ?? 0,
+		]),
+	);
+	const syncable: SubjectBalance[] = [];
+	const stale: SubjectBalance[] = [];
+
+	for (const subjectBalance of subjectBalances) {
+		const currentCacheVersion = currentCacheVersionById.get(subjectBalance.id);
+		if (
+			currentCacheVersion === undefined ||
+			currentCacheVersion !== (subjectBalance.cache_version ?? 0)
+		) {
+			stale.push(subjectBalance);
+			continue;
+		}
+		syncable.push(subjectBalance);
+	}
+
+	return { stale, syncable };
+};
+
+export const partitionCapturedBalancesForPooledReconciliation = ({
+	subjectBalances,
+	currentCustomerEntitlements,
+	pooledSourceCustomerEntitlementIds,
+}: {
+	subjectBalances: SubjectBalance[];
+	currentCustomerEntitlements: Array<{
+		id: string;
+		cache_version?: number | null;
+	}>;
+	pooledSourceCustomerEntitlementIds: ReadonlySet<string>;
+}) => {
+	const { syncable, stale } = partitionSubjectBalancesByCacheVersion({
+		subjectBalances,
+		currentCustomerEntitlements,
+	});
+	return {
+		liveBalances: syncable,
+		balancesToFlush: syncable.filter(
+			(subjectBalance) =>
+				!pooledSourceCustomerEntitlementIds.has(subjectBalance.id),
+		),
+		stale,
+	};
+};
+
+const partitionCurrentSubjectBalances = async ({
+	ctx,
+	subjectBalances,
+}: {
+	ctx: AutumnContext;
+	subjectBalances: SubjectBalance[];
+}) => {
+	const currentCustomerEntitlements = await CusEntService.getByIds({
+		db: ctx.db,
+		ids: subjectBalances.map((subjectBalance) => subjectBalance.id),
+	});
+	return partitionSubjectBalancesByCacheVersion({
+		subjectBalances,
+		currentCustomerEntitlements,
+	});
+};
+
+const getPooledSourceCustomerEntitlementIds = ({
+	fullSubject,
+}: {
+	fullSubject: FullSubject;
+}) =>
+	new Set(
+		fullSubject.customer_products.flatMap((customerProduct) =>
+			customerProduct.customer_entitlements
+				.filter((customerEntitlement) =>
+					isPooledSourceCustomerEntitlement({
+						customerEntitlement,
+						customerProduct,
+					}),
+				)
+				.map((customerEntitlement) => customerEntitlement.id),
+		),
+	);
+
+const flushCapturedCurrentBalancesAndInvalidate = async ({
+	ctx,
+	customerId,
+	fullSubject,
+	reason,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	fullSubject: FullSubject;
+	reason: string;
+}) => {
+	const captured = await captureAndDeleteSharedBalanceFields({
+		ctx,
+		customerId,
+		failureMode: "strict",
+	});
+	if (captured) {
+		const pooledSourceCustomerEntitlementIds =
+			getPooledSourceCustomerEntitlementIds({ fullSubject });
+		const { syncable } = await partitionCurrentSubjectBalances({
+			ctx,
+			subjectBalances: captured.subjectBalances.filter(
+				(subjectBalance) =>
+					!pooledSourceCustomerEntitlementIds.has(subjectBalance.id),
+			),
+		});
+		await writeSubjectBalancesToDb({
+			db: ctx.db,
+			subjectBalances: syncable,
+			usageWindowUpdates: captured.usageWindowUpdates,
+			queryName: "flushCurrentPooledBalanceCutover",
+		});
+	}
+
+	await invalidatePooledBalanceCaches({ ctx, customerId, reason });
+};
+
+const applyFullSubjectEffects = async ({
+	ctx,
+	customerId,
+	featureIds,
+	effectsByFeatureId,
+	expectedSubjectViewEpoch,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	featureIds: string[];
+	effectsByFeatureId: ReadonlyMap<string, PooledBalanceCacheEffect[]>;
+	expectedSubjectViewEpoch: number;
+}): Promise<AtomicApplyResult> => {
+	const epochKey = buildFullSubjectViewEpochKey({
+		orgId: ctx.org.id,
+		env: ctx.env,
+		customerId,
+	});
+	const balanceKeys = featureIds.map((featureId) =>
+		buildSharedFullSubjectBalanceKey({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			customerId,
+			featureId,
+		}),
+	);
+	const resultJson = await tryRedisWrite(
+		() =>
+			ctx.redisV2.updateSubjectBalanceBatches(
+				balanceKeys.length + 1,
+				epochKey,
+				...balanceKeys,
+				JSON.stringify({
+					expected_subject_view_epoch: expectedSubjectViewEpoch,
+					ttl_seconds: FULL_SUBJECT_CACHE_TTL_SECONDS,
+					batches: featureIds.map((featureId) => ({
+						updates: (effectsByFeatureId.get(featureId) ?? []).map(
+							(effect) => ({
+								cus_ent_id: effect.customerEntitlementId,
+								balance_delta: effect.balanceDelta,
+								adjustment_delta: effect.adjustmentDelta,
+								expected_balance: effect.expectedBalance ?? null,
+								expected_adjustment: effect.expectedAdjustment ?? null,
+							}),
+						),
+					})),
+				}),
+			),
+		ctx.redisV2,
+	);
+	if (resultJson === null) {
+		return { kind: "missing", reason: "write_failed" };
+	}
+
+	let result: CacheBatchResult;
+	try {
+		result = JSON.parse(resultJson) as CacheBatchResult;
+	} catch {
+		return { kind: "missing", reason: "invalid_write_result" };
+	}
+	if (result.cache_miss) {
+		return { kind: "missing", reason: "hash_missing" };
+	}
+	if (result.epoch_mismatch) return { kind: "epoch_mismatch" };
+	if (result.conflict) return { kind: "conflict", detail: result };
+	return { kind: "applied" };
+};
+
+const reconcileCapturedBalances = async ({
+	ctx,
+	customerId,
+	fullSubject,
+	featureIds,
+	reverseOrder,
+	inStatuses,
+	reason,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	fullSubject: FullSubject;
+	featureIds: string[];
+	reverseOrder?: boolean;
+	inStatuses?: CusProductStatus[];
+	reason: string;
+}) => {
+	ctx.logger.warn(
+		`[applyPooledBalanceCacheEffects] reconciling captured balances: ${reason}`,
+	);
+	const captured = await captureAndDeleteSharedBalanceFields({
+		ctx,
+		customerId,
+		failureMode: "strict",
+	});
+
+	if (captured) {
+		const pooledSourceCustomerEntitlementIds =
+			getPooledSourceCustomerEntitlementIds({ fullSubject });
+		const currentCustomerEntitlements = await CusEntService.getByIds({
+			db: ctx.db,
+			ids: captured.subjectBalances.map((subjectBalance) => subjectBalance.id),
+		});
+		const { liveBalances, balancesToFlush } =
+			partitionCapturedBalancesForPooledReconciliation({
+				subjectBalances: captured.subjectBalances,
+				currentCustomerEntitlements,
+				pooledSourceCustomerEntitlementIds,
+			});
+		await writeSubjectBalancesToDb({
+			db: ctx.db,
+			subjectBalances: balancesToFlush,
+			usageWindowUpdates: captured.usageWindowUpdates,
+			queryName: "reconcileCapturedPooledBalances",
+		});
+
+		const internalFeatureIds = ctx.features
+			.filter((feature) => featureIds.includes(feature.id))
+			.map((feature) => feature.internal_id);
+		const pools = await pooledBalanceRepo.listByInternalCustomerAndFeatureIds({
+			db: ctx.db,
+			internalCustomerId: fullSubject.internalCustomerId,
+			internalFeatureIds,
+		});
+		const contributions = await pooledBalanceRepo.listContributionsByPoolIds({
+			db: ctx.db,
+			pooledBalanceIds: pools.map((pool) => pool.id),
+		});
+		const contributionTotalByPoolId = new Map<string, Decimal>();
+		for (const contribution of contributions) {
+			contributionTotalByPoolId.set(
+				contribution.pooled_balance_id,
+				(
+					contributionTotalByPoolId.get(contribution.pooled_balance_id) ??
+					new Decimal(0)
+				).plus(contribution.current_contribution),
+			);
+		}
+		const pooledGrantByCustomerEntitlementId = new Map(
+			pools.map((pool) => [
+				pool.customer_entitlement_id,
+				(contributionTotalByPoolId.get(pool.id) ?? new Decimal(0)).toNumber(),
+			]),
+		);
+		const updates = computePooledBalanceReconciliation({
+			fullSubject,
+			featureIds,
+			pooledGrantByCustomerEntitlementId,
+			liveBalances,
+			reverseOrder,
+			inStatuses,
+		}).sort((first, second) =>
+			first.customerEntitlementId.localeCompare(second.customerEntitlementId),
+		);
+		for (const update of updates) {
+			await pooledBalanceRepo.setBalanceAndAdjustment({
+				db: ctx.db,
+				customerEntitlementId: update.customerEntitlementId,
+				balance: update.balance,
+				adjustment: update.adjustment,
+			});
+		}
+	}
+
+	await invalidatePooledBalanceCaches({ ctx, customerId, reason });
+};
+
+export const applyPooledBalanceCacheCutover = async ({
+	ctx,
+	customerId,
+	fullSubject,
+	featureIds,
+	rawEffects,
+	expectedSubjectViewEpoch,
+	reverseOrder,
+	inStatuses,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	fullSubject: FullSubject;
+	featureIds: string[];
+	rawEffects: PooledBalanceCacheEffect[];
+	expectedSubjectViewEpoch: number;
+	reverseOrder?: boolean;
+	inStatuses?: CusProductStatus[];
+}): Promise<void> => {
+	const uniqueFeatureIds = [...new Set(featureIds)];
+	const customerEntitlementIdsByFeatureId = new Map(
+		uniqueFeatureIds.map((featureId) => [
+			featureId,
+			[
+				...new Set([
+					...getPooledRebalanceCustomerEntitlements({
+						fullSubject,
+						featureId,
+						reverseOrder,
+						inStatuses,
+					}).map(({ id }) => id),
+					...rawEffects
+						.filter((effect) => effect.featureId === featureId)
+						.map((effect) => effect.customerEntitlementId),
+				]),
+			],
+		]),
+	);
+	let expectedEpoch = expectedSubjectViewEpoch;
+	let failureReason = "cutover_conflict_exhausted";
+
+	for (let attempt = 0; attempt < MAX_CUTOVER_ATTEMPTS; attempt += 1) {
+		const liveBalancesByFeatureId = new Map<string, SubjectBalance[]>();
+		let readFailed = false;
+		for (const featureId of uniqueFeatureIds) {
+			const customerEntitlementIds =
+				customerEntitlementIdsByFeatureId.get(featureId) ?? [];
+			const liveBalanceOutcome = await getCachedFeatureBalance({
+				ctx,
+				customerId,
+				featureId,
+				customerEntitlementIds,
+				readMaster: true,
+			});
+			if (liveBalanceOutcome.kind !== "ok") {
+				failureReason = `cutover_read:${liveBalanceOutcome.reason}`;
+				readFailed = true;
+				break;
+			}
+			liveBalancesByFeatureId.set(featureId, liveBalanceOutcome.value.balances);
+		}
+		if (readFailed) break;
+
+		const effectsByFeatureId = new Map(
+			uniqueFeatureIds.map((featureId) => [
+				featureId,
+				computePooledBalanceCacheCutover({
+					fullSubject,
+					featureIds: [featureId],
+					rawEffects: rawEffects.filter(
+						(effect) => effect.featureId === featureId,
+					),
+					liveBalances: liveBalancesByFeatureId.get(featureId) ?? [],
+					reverseOrder,
+					inStatuses,
+				}),
+			]),
+		);
+		const result = await applyFullSubjectEffects({
+			ctx,
+			customerId,
+			featureIds: uniqueFeatureIds,
+			effectsByFeatureId,
+			expectedSubjectViewEpoch: expectedEpoch,
+		});
+		if (result.kind === "epoch_mismatch") {
+			failureReason = "cutover_epoch_mismatch";
+			expectedEpoch = await getOrInitFullSubjectViewEpoch({ ctx, customerId });
+			continue;
+		}
+		if (result.kind === "conflict") {
+			failureReason = `cutover_conflict:${JSON.stringify(result.detail)}`;
+			continue;
+		}
+		if (result.kind === "missing") {
+			failureReason = result.reason;
+			break;
+		}
+
+		const balancesToFlush: SubjectBalance[] = [];
+		let finalReadFailed = false;
+		for (const featureId of uniqueFeatureIds) {
+			const customerEntitlementIds =
+				customerEntitlementIdsByFeatureId.get(featureId) ?? [];
+			const finalBalanceOutcome = await getCachedFeatureBalance({
+				ctx,
+				customerId,
+				featureId,
+				customerEntitlementIds,
+				readMaster: true,
+			});
+			if (finalBalanceOutcome.kind !== "ok") {
+				failureReason = `cutover_final_read:${finalBalanceOutcome.reason}`;
+				finalReadFailed = true;
+				break;
+			}
+
+			balancesToFlush.push(...finalBalanceOutcome.value.balances);
+		}
+		if (finalReadFailed) break;
+
+		const { stale } = await partitionCurrentSubjectBalances({
+			ctx,
+			subjectBalances: balancesToFlush,
+		});
+		if (stale.length > 0) {
+			failureReason = `cutover_cache_version_mismatch:${stale
+				.map((subjectBalance) => subjectBalance.id)
+				.join(",")}`;
+			await flushCapturedCurrentBalancesAndInvalidate({
+				ctx,
+				customerId,
+				fullSubject,
+				reason: failureReason,
+			});
+			return;
+		}
+		await flushBalances({ ctx, balances: balancesToFlush });
+		await deleteLegacyCachedFullCustomer({
+			ctx,
+			customerId,
+			source: "applyPooledBalanceCacheCutover",
+		});
+		return;
+	}
+
+	await reconcileCapturedBalances({
+		ctx,
+		customerId,
+		fullSubject,
+		featureIds: uniqueFeatureIds,
+		reverseOrder,
+		inStatuses,
+		reason: failureReason,
+	});
+};

--- a/server/src/internal/billing/v2/pooledBalances/repos/pooledBalanceRepo.ts
+++ b/server/src/internal/billing/v2/pooledBalances/repos/pooledBalanceRepo.ts
@@ -1,0 +1,639 @@
+import {
+	customerEntitlements,
+	customers,
+	type DbCustomerEntitlement,
+	type DbPooledBalance,
+	type DbPooledBalanceContribution,
+	entitlements,
+	type InsertCustomerEntitlement,
+	type InsertPooledBalance,
+	type InsertPooledBalanceContribution,
+	InternalError,
+	pooledBalanceContributions,
+	pooledBalances,
+} from "@autumn/shared";
+import { and, eq, getTableColumns, inArray, isNull, sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+
+export type PooledBalanceDb = Pick<
+	DrizzleCli,
+	"query" | "select" | "insert" | "update" | "delete"
+>;
+
+export type PooledBalanceLookup = {
+	internal_customer_id: InsertPooledBalance["internal_customer_id"];
+	internal_feature_id: InsertPooledBalance["internal_feature_id"];
+	interval: InsertPooledBalance["interval"];
+	interval_count: number;
+	reset_cycle_anchor: number | null;
+	reset_mode: InsertPooledBalance["reset_mode"];
+	rollover_signature: string;
+};
+
+const lockCustomer = async ({
+	db,
+	internalCustomerId,
+}: {
+	db: PooledBalanceDb;
+	internalCustomerId: string;
+}) => {
+	const rows = await db
+		.select({ internalId: customers.internal_id })
+		.from(customers)
+		.where(eq(customers.internal_id, internalCustomerId))
+		.for("update");
+	if (rows.length > 0) return;
+
+	throw new InternalError({
+		message: `Cannot lock missing customer '${internalCustomerId}' for pooled balance update.`,
+	});
+};
+
+const findByLookup = async ({
+	db,
+	lookup,
+}: {
+	db: PooledBalanceDb;
+	lookup: PooledBalanceLookup;
+}): Promise<DbPooledBalance | undefined> =>
+	db.query.pooledBalances.findFirst({
+		where: and(
+			eq(pooledBalances.internal_customer_id, lookup.internal_customer_id),
+			eq(pooledBalances.internal_feature_id, lookup.internal_feature_id),
+			eq(pooledBalances.interval, lookup.interval),
+			eq(pooledBalances.interval_count, lookup.interval_count ?? 1),
+			lookup.reset_cycle_anchor === null
+				? isNull(pooledBalances.reset_cycle_anchor)
+				: eq(pooledBalances.reset_cycle_anchor, lookup.reset_cycle_anchor),
+			eq(pooledBalances.reset_mode, lookup.reset_mode),
+			eq(pooledBalances.rollover_signature, lookup.rollover_signature),
+		),
+	});
+
+const insertPoolGraph = async ({
+	db,
+	entitlement,
+	customerEntitlement,
+	pool,
+}: {
+	db: PooledBalanceDb;
+	entitlement: typeof entitlements.$inferInsert;
+	customerEntitlement: InsertCustomerEntitlement;
+	pool: InsertPooledBalance;
+}): Promise<DbPooledBalance> => {
+	await db.insert(entitlements).values(entitlement);
+	await db.insert(customerEntitlements).values(customerEntitlement);
+	const [insertedPool] = await db
+		.insert(pooledBalances)
+		.values(pool)
+		.returning();
+	if (insertedPool) return insertedPool;
+
+	throw new InternalError({
+		message: "Failed to insert pooled balance.",
+	});
+};
+
+const findContribution = async ({
+	db,
+	sourceCustomerProductId,
+	sourceEntitlementId,
+}: {
+	db: PooledBalanceDb;
+	sourceCustomerProductId: string;
+	sourceEntitlementId: string;
+}): Promise<DbPooledBalanceContribution | undefined> =>
+	db.query.pooledBalanceContributions.findFirst({
+		where: and(
+			eq(
+				pooledBalanceContributions.source_customer_product_id,
+				sourceCustomerProductId,
+			),
+			eq(pooledBalanceContributions.source_entitlement_id, sourceEntitlementId),
+		),
+	});
+
+const findContributionById = async ({
+	db,
+	contributionId,
+}: {
+	db: PooledBalanceDb;
+	contributionId: string;
+}): Promise<DbPooledBalanceContribution | undefined> =>
+	db.query.pooledBalanceContributions.findFirst({
+		where: eq(pooledBalanceContributions.id, contributionId),
+	});
+
+const listContributionsBySourceCustomerProduct = async ({
+	db,
+	sourceCustomerProductId,
+}: {
+	db: PooledBalanceDb;
+	sourceCustomerProductId: string;
+}): Promise<DbPooledBalanceContribution[]> =>
+	db.query.pooledBalanceContributions.findMany({
+		where: eq(
+			pooledBalanceContributions.source_customer_product_id,
+			sourceCustomerProductId,
+		),
+	});
+
+const listContributionsBySourceCustomerProductIds = async ({
+	db,
+	sourceCustomerProductIds,
+}: {
+	db: PooledBalanceDb;
+	sourceCustomerProductIds: string[];
+}): Promise<DbPooledBalanceContribution[]> => {
+	if (sourceCustomerProductIds.length === 0) return [];
+
+	return db.query.pooledBalanceContributions.findMany({
+		where: inArray(
+			pooledBalanceContributions.source_customer_product_id,
+			sourceCustomerProductIds,
+		),
+	});
+};
+
+const findById = async ({
+	db,
+	pooledBalanceId,
+}: {
+	db: PooledBalanceDb;
+	pooledBalanceId: string;
+}): Promise<DbPooledBalance | undefined> =>
+	db.query.pooledBalances.findFirst({
+		where: eq(pooledBalances.id, pooledBalanceId),
+	});
+
+const listByIds = async ({
+	db,
+	pooledBalanceIds,
+}: {
+	db: PooledBalanceDb;
+	pooledBalanceIds: string[];
+}): Promise<DbPooledBalance[]> => {
+	if (pooledBalanceIds.length === 0) return [];
+
+	return db.query.pooledBalances.findMany({
+		where: inArray(pooledBalances.id, pooledBalanceIds),
+	});
+};
+
+const listByInternalCustomerAndFeatureIds = async ({
+	db,
+	internalCustomerId,
+	internalFeatureIds,
+}: {
+	db: PooledBalanceDb;
+	internalCustomerId: string;
+	internalFeatureIds: string[];
+}): Promise<DbPooledBalance[]> => {
+	if (internalFeatureIds.length === 0) return [];
+
+	return db.query.pooledBalances.findMany({
+		where: and(
+			eq(pooledBalances.internal_customer_id, internalCustomerId),
+			inArray(pooledBalances.internal_feature_id, internalFeatureIds),
+		),
+	});
+};
+
+export type ContributionOwnerFilter =
+	| { stripeSubscriptionId: string }
+	| { customerLicenseLinkId: string };
+
+const contributionOwnerCondition = (owner: ContributionOwnerFilter) =>
+	"stripeSubscriptionId" in owner
+		? eq(
+				pooledBalanceContributions.stripe_subscription_id,
+				owner.stripeSubscriptionId,
+			)
+		: eq(
+				pooledBalanceContributions.customer_license_link_id,
+				owner.customerLicenseLinkId,
+			);
+
+const listByContributionOwner = async ({
+	db,
+	internalCustomerId,
+	owner,
+}: {
+	db: PooledBalanceDb;
+	internalCustomerId: string;
+	owner: ContributionOwnerFilter;
+}): Promise<DbPooledBalance[]> => {
+	const rows = await db
+		.select(getTableColumns(pooledBalances))
+		.from(pooledBalances)
+		.innerJoin(
+			pooledBalanceContributions,
+			eq(pooledBalanceContributions.pooled_balance_id, pooledBalances.id),
+		)
+		.where(
+			and(
+				eq(pooledBalances.internal_customer_id, internalCustomerId),
+				contributionOwnerCondition(owner),
+			),
+		);
+
+	return [...new Map(rows.map((pool) => [pool.id, pool])).values()];
+};
+
+const listContributionsByOwner = async ({
+	db,
+	internalCustomerId,
+	owner,
+}: {
+	db: PooledBalanceDb;
+	internalCustomerId: string;
+	owner: ContributionOwnerFilter;
+}): Promise<DbPooledBalanceContribution[]> =>
+	db
+		.select(getTableColumns(pooledBalanceContributions))
+		.from(pooledBalanceContributions)
+		.innerJoin(
+			pooledBalances,
+			eq(pooledBalanceContributions.pooled_balance_id, pooledBalances.id),
+		)
+		.where(
+			and(
+				eq(pooledBalances.internal_customer_id, internalCustomerId),
+				contributionOwnerCondition(owner),
+			),
+		);
+
+const findByCustomerEntitlementId = async ({
+	db,
+	customerEntitlementId,
+}: {
+	db: PooledBalanceDb;
+	customerEntitlementId: string;
+}): Promise<DbPooledBalance | undefined> =>
+	db.query.pooledBalances.findFirst({
+		where: eq(pooledBalances.customer_entitlement_id, customerEntitlementId),
+	});
+
+const findCustomerEntitlementById = async ({
+	db,
+	customerEntitlementId,
+}: {
+	db: PooledBalanceDb;
+	customerEntitlementId: string;
+}): Promise<DbCustomerEntitlement | undefined> =>
+	db.query.customerEntitlements.findFirst({
+		where: eq(customerEntitlements.id, customerEntitlementId),
+	});
+
+const listContributionsByPoolId = async ({
+	db,
+	pooledBalanceId,
+}: {
+	db: PooledBalanceDb;
+	pooledBalanceId: string;
+}): Promise<DbPooledBalanceContribution[]> =>
+	db.query.pooledBalanceContributions.findMany({
+		where: eq(pooledBalanceContributions.pooled_balance_id, pooledBalanceId),
+	});
+
+const listContributionsByPoolIds = async ({
+	db,
+	pooledBalanceIds,
+}: {
+	db: PooledBalanceDb;
+	pooledBalanceIds: string[];
+}): Promise<DbPooledBalanceContribution[]> => {
+	if (pooledBalanceIds.length === 0) return [];
+
+	return db.query.pooledBalanceContributions.findMany({
+		where: inArray(
+			pooledBalanceContributions.pooled_balance_id,
+			pooledBalanceIds,
+		),
+	});
+};
+
+const insertContribution = async ({
+	db,
+	contribution,
+}: {
+	db: PooledBalanceDb;
+	contribution: InsertPooledBalanceContribution;
+}) => {
+	await db.insert(pooledBalanceContributions).values(contribution);
+};
+
+const normalizeSourceCustomerEntitlement = async ({
+	db,
+	sourceCustomerProductId,
+	sourceEntitlementId,
+}: {
+	db: PooledBalanceDb;
+	sourceCustomerProductId: string;
+	sourceEntitlementId: string;
+}) => {
+	const rows = await db
+		.update(customerEntitlements)
+		.set({
+			balance: 0,
+			adjustment: 0,
+			additional_balance: 0,
+			entities: null,
+		})
+		.where(
+			and(
+				eq(customerEntitlements.customer_product_id, sourceCustomerProductId),
+				eq(customerEntitlements.entitlement_id, sourceEntitlementId),
+			),
+		)
+		.returning({ id: customerEntitlements.id });
+
+	if (rows.length > 0) return;
+	throw new InternalError({
+		message: `Pooled source entitlement '${sourceEntitlementId}' was not found on customer product '${sourceCustomerProductId}'.`,
+	});
+};
+
+const updateContribution = async ({
+	db,
+	contributionId,
+	currentContribution,
+	nextCycleContribution,
+	owner,
+	updatedAt,
+	effectiveAt,
+}: {
+	db: PooledBalanceDb;
+	contributionId: string;
+	currentContribution: number;
+	nextCycleContribution: number;
+	/** Both columns are rewritten together; null owner = free (lazy resets). */
+	owner?: {
+		stripeSubscriptionId: string | null;
+		customerLicenseLinkId: string | null;
+	};
+	updatedAt: number;
+	effectiveAt?: number | null;
+}) => {
+	await db
+		.update(pooledBalanceContributions)
+		.set({
+			current_contribution: currentContribution,
+			next_cycle_contribution: nextCycleContribution,
+			...(owner !== undefined
+				? {
+						stripe_subscription_id: owner.stripeSubscriptionId,
+						customer_license_link_id: owner.customerLicenseLinkId,
+					}
+				: {}),
+			...(effectiveAt !== undefined ? { effective_at: effectiveAt } : {}),
+			updated_at: updatedAt,
+		})
+		.where(eq(pooledBalanceContributions.id, contributionId));
+};
+
+const transferContribution = async ({
+	db,
+	contributionId,
+	pooledBalanceId,
+	sourceEntitlementId,
+	owner,
+	currentContribution,
+	nextCycleContribution,
+	updatedAt,
+}: {
+	db: PooledBalanceDb;
+	contributionId: string;
+	pooledBalanceId: string;
+	sourceEntitlementId: string;
+	owner: {
+		stripeSubscriptionId: string | null;
+		customerLicenseLinkId: string | null;
+	};
+	currentContribution: number;
+	nextCycleContribution: number;
+	updatedAt: number;
+}) => {
+	await db
+		.update(pooledBalanceContributions)
+		.set({
+			pooled_balance_id: pooledBalanceId,
+			source_entitlement_id: sourceEntitlementId,
+			stripe_subscription_id: owner.stripeSubscriptionId,
+			customer_license_link_id: owner.customerLicenseLinkId,
+			current_contribution: currentContribution,
+			next_cycle_contribution: nextCycleContribution,
+			effective_at: null,
+			updated_at: updatedAt,
+		})
+		.where(eq(pooledBalanceContributions.id, contributionId));
+};
+
+const incrementBalanceAndAdjustmentDeltas = async ({
+	db,
+	customerEntitlementId,
+	balanceDelta,
+	adjustmentDelta,
+}: {
+	db: PooledBalanceDb;
+	customerEntitlementId: string;
+	balanceDelta: number;
+	adjustmentDelta: number;
+}) => {
+	if (balanceDelta === 0 && adjustmentDelta === 0) return;
+
+	const rows = await db
+		.update(customerEntitlements)
+		.set({
+			balance: sql`${customerEntitlements.balance} + ${balanceDelta}`,
+			adjustment: sql`COALESCE(${customerEntitlements.adjustment}, 0) + ${adjustmentDelta}`,
+		})
+		.where(eq(customerEntitlements.id, customerEntitlementId))
+		.returning({ id: customerEntitlements.id });
+	if (rows.length > 0) return;
+
+	throw new InternalError({
+		message: `Pooled customer entitlement '${customerEntitlementId}' not found.`,
+	});
+};
+
+const setBalanceAndAdjustment = async ({
+	db,
+	customerEntitlementId,
+	balance,
+	adjustment,
+}: {
+	db: PooledBalanceDb;
+	customerEntitlementId: string;
+	balance: number;
+	adjustment: number;
+}) => {
+	const rows = await db
+		.update(customerEntitlements)
+		.set({ balance, adjustment })
+		.where(eq(customerEntitlements.id, customerEntitlementId))
+		.returning({ id: customerEntitlements.id });
+	if (rows.length > 0) return;
+
+	throw new InternalError({
+		message: `Pooled reconciliation customer entitlement '${customerEntitlementId}' not found.`,
+	});
+};
+
+const incrementBalanceAndAdjustment = async ({
+	db,
+	customerEntitlementId,
+	delta,
+}: {
+	db: PooledBalanceDb;
+	customerEntitlementId: string;
+	delta: number;
+}) =>
+	incrementBalanceAndAdjustmentDeltas({
+		db,
+		customerEntitlementId,
+		balanceDelta: delta,
+		adjustmentDelta: delta,
+	});
+
+const deleteGraphsByInternalCustomerIds = async ({
+	db,
+	internalCustomerIds,
+}: {
+	db: PooledBalanceDb;
+	internalCustomerIds: string[];
+}) => {
+	if (internalCustomerIds.length === 0) return;
+
+	const poolOwnedEntitlements = await db
+		.select({ entitlementId: customerEntitlements.entitlement_id })
+		.from(pooledBalances)
+		.innerJoin(
+			customerEntitlements,
+			eq(customerEntitlements.id, pooledBalances.customer_entitlement_id),
+		)
+		.where(inArray(pooledBalances.internal_customer_id, internalCustomerIds));
+	if (poolOwnedEntitlements.length === 0) return;
+
+	await db
+		.delete(pooledBalances)
+		.where(inArray(pooledBalances.internal_customer_id, internalCustomerIds));
+	await db.delete(entitlements).where(
+		inArray(
+			entitlements.id,
+			poolOwnedEntitlements.map(({ entitlementId }) => entitlementId),
+		),
+	);
+};
+
+const deleteGraphsByOrgId = async ({
+	db,
+	orgId,
+}: {
+	db: PooledBalanceDb;
+	orgId: string;
+}) => {
+	const rows = await db
+		.select({ internalCustomerId: pooledBalances.internal_customer_id })
+		.from(pooledBalances)
+		.where(eq(pooledBalances.org_id, orgId));
+
+	return deleteGraphsByInternalCustomerIds({
+		db,
+		internalCustomerIds: rows.map(
+			({ internalCustomerId }) => internalCustomerId,
+		),
+	});
+};
+
+const applyReset = async ({
+	db,
+	pool,
+	expectedNextResetAt,
+	nextResetAt,
+	balance,
+	adjustment,
+	contributions,
+	now,
+}: {
+	db: PooledBalanceDb;
+	pool: DbPooledBalance;
+	expectedNextResetAt: number;
+	nextResetAt: number;
+	balance: number;
+	adjustment: number;
+	contributions: Array<{
+		id: string;
+		currentCycleContribution: number;
+		nextCycleContribution: number;
+		effectiveAt?: number | null;
+	}>;
+	now: number;
+}): Promise<boolean> => {
+	const updatedCustomerEntitlements = await db
+		.update(customerEntitlements)
+		.set({
+			balance,
+			adjustment,
+			additional_balance: 0,
+			next_reset_at: nextResetAt,
+		})
+		.where(
+			and(
+				eq(customerEntitlements.id, pool.customer_entitlement_id),
+				eq(customerEntitlements.next_reset_at, expectedNextResetAt),
+			),
+		)
+		.returning({ id: customerEntitlements.id });
+	if (updatedCustomerEntitlements.length === 0) return false;
+
+	await db
+		.update(pooledBalances)
+		.set({
+			last_applied_reset_at: expectedNextResetAt,
+			updated_at: now,
+		})
+		.where(eq(pooledBalances.id, pool.id));
+
+	for (const contribution of contributions) {
+		await updateContribution({
+			db,
+			contributionId: contribution.id,
+			currentContribution: contribution.currentCycleContribution,
+			nextCycleContribution: contribution.nextCycleContribution,
+			effectiveAt: contribution.effectiveAt,
+			updatedAt: now,
+		});
+	}
+
+	return true;
+};
+
+export const pooledBalanceRepo = {
+	lockCustomer,
+	findByLookup,
+	insertPoolGraph,
+	findContribution,
+	findContributionById,
+	listContributionsBySourceCustomerProduct,
+	listContributionsBySourceCustomerProductIds,
+	findById,
+	listByIds,
+	listByInternalCustomerAndFeatureIds,
+	listByContributionOwner,
+	listContributionsByOwner,
+	findByCustomerEntitlementId,
+	findCustomerEntitlementById,
+	listContributionsByPoolId,
+	listContributionsByPoolIds,
+	insertContribution,
+	normalizeSourceCustomerEntitlement,
+	updateContribution,
+	transferContribution,
+	incrementBalanceAndAdjustment,
+	incrementBalanceAndAdjustmentDeltas,
+	setBalanceAndAdjustment,
+	deleteGraphsByInternalCustomerIds,
+	deleteGraphsByOrgId,
+	applyReset,
+};

--- a/server/src/internal/billing/v2/pooledBalances/utils/assertSinglePoolSubscriptionOwner.ts
+++ b/server/src/internal/billing/v2/pooledBalances/utils/assertSinglePoolSubscriptionOwner.ts
@@ -1,0 +1,33 @@
+import {
+	type DbPooledBalanceContribution,
+	InternalError,
+} from "@autumn/shared";
+
+// One pool = one renewal clock: a second subscription joining an existing
+// pool would double-roll every contribution on each sub's invoice.
+export const assertSinglePoolSubscriptionOwner = ({
+	pooledBalanceId,
+	poolContributions,
+	sourceCustomerProductId,
+	stripeSubscriptionId,
+}: {
+	pooledBalanceId: string;
+	poolContributions: Pick<
+		DbPooledBalanceContribution,
+		"source_customer_product_id" | "stripe_subscription_id"
+	>[];
+	sourceCustomerProductId: string;
+	stripeSubscriptionId: string;
+}) => {
+	const conflicting = poolContributions.find(
+		(contribution) =>
+			contribution.stripe_subscription_id &&
+			contribution.stripe_subscription_id !== stripeSubscriptionId &&
+			contribution.source_customer_product_id !== sourceCustomerProductId,
+	);
+	if (conflicting) {
+		throw new InternalError({
+			message: `Pooled balance '${pooledBalanceId}' is renewed by subscription '${conflicting.stripe_subscription_id}'; source '${sourceCustomerProductId}' on '${stripeSubscriptionId}' cannot join it.`,
+		});
+	}
+};

--- a/server/src/internal/billing/v2/pooledBalances/utils/customerEntitlementToPooledIdentity/customerEntitlementToPooledIdentity.ts
+++ b/server/src/internal/billing/v2/pooledBalances/utils/customerEntitlementToPooledIdentity/customerEntitlementToPooledIdentity.ts
@@ -1,0 +1,31 @@
+import {
+	EntInterval,
+	type FullCusEntWithFullCusProduct,
+	isLifetimeEntitlement,
+	type PooledBalanceIdentity,
+} from "@autumn/shared";
+
+/** The pool a source row feeds, derived entirely from the row. The reset
+ * schedule mirrors the row; attach-time policies may override it. */
+export const customerEntitlementToPooledIdentity = ({
+	customerEntitlement,
+}: {
+	customerEntitlement: FullCusEntWithFullCusProduct;
+}): PooledBalanceIdentity => {
+	const { entitlement } = customerEntitlement;
+	const isLifetime = isLifetimeEntitlement({ entitlement });
+
+	return {
+		featureId: entitlement.feature.id,
+		internalFeatureId: entitlement.internal_feature_id,
+		interval: entitlement.interval ?? EntInterval.Lifetime,
+		intervalCount: entitlement.interval_count ?? 1,
+		resetCycleAnchor: isLifetime
+			? null
+			: (customerEntitlement.reset_cycle_anchor ?? null),
+		nextResetAt: isLifetime
+			? null
+			: (customerEntitlement.next_reset_at ?? null),
+		rollover: entitlement.rollover ?? null,
+	};
+};

--- a/server/src/internal/billing/v2/pooledBalances/utils/pooledBalancePlanToOps.ts
+++ b/server/src/internal/billing/v2/pooledBalances/utils/pooledBalancePlanToOps.ts
@@ -1,0 +1,34 @@
+import type {
+	PooledBalanceOp,
+	PooledBalancePlan,
+	UpsertPooledBalanceSourceSpec,
+} from "@autumn/shared";
+
+export const upsertSourceSpecToOp = ({
+	internalCustomerId,
+	pooledBalance,
+	contribution,
+	usageCarry,
+}: UpsertPooledBalanceSourceSpec): Extract<
+	PooledBalanceOp,
+	{ op: "upsert_source" }
+> => ({
+	op: "upsert_source",
+	internalCustomerId,
+	...pooledBalance,
+	...contribution,
+	...(usageCarry ? { usageReapply: usageCarry } : {}),
+});
+
+// Removals precede upserts: sources leave the pool before new sources join.
+export const pooledBalancePlanToOps = ({
+	pooledBalancePlan,
+}: {
+	pooledBalancePlan?: PooledBalancePlan;
+}): PooledBalanceOp[] => [
+	...(pooledBalancePlan?.removeSources ?? []).map((removeSource) => ({
+		...removeSource,
+		op: "remove_source" as const,
+	})),
+	...(pooledBalancePlan?.upsertSources ?? []).map(upsertSourceSpecToOp),
+];

--- a/server/src/internal/billing/v2/pooledBalances/utils/pooledCustomerEntitlementClassification.ts
+++ b/server/src/internal/billing/v2/pooledBalances/utils/pooledCustomerEntitlementClassification.ts
@@ -1,0 +1,48 @@
+import type { FullCusProduct, FullCustomerEntitlement } from "@autumn/shared";
+
+type CustomerEntitlementWithPooledFlag = Pick<
+	FullCustomerEntitlement,
+	"entitlement"
+>;
+
+export const isPooledSourceCustomerEntitlement = ({
+	customerEntitlement,
+	customerProduct,
+}: {
+	customerEntitlement: CustomerEntitlementWithPooledFlag;
+	customerProduct: FullCusProduct | null | undefined;
+}): boolean =>
+	customerEntitlement.entitlement.pooled === true &&
+	Boolean(customerProduct?.internal_entity_id);
+
+export const isSyntheticPooledBalanceCustomerEntitlement = ({
+	customerEntitlement,
+	customerProduct,
+}: {
+	customerEntitlement: CustomerEntitlementWithPooledFlag;
+	customerProduct: FullCusProduct | null | undefined;
+}): boolean =>
+	customerEntitlement.entitlement.pooled === true && customerProduct === null;
+
+export const isManagedPooledCustomerEntitlement = (params: {
+	customerEntitlement: CustomerEntitlementWithPooledFlag;
+	customerProduct: FullCusProduct | null | undefined;
+}): boolean =>
+	isPooledSourceCustomerEntitlement(params) ||
+	isSyntheticPooledBalanceCustomerEntitlement(params);
+
+export const customerProductHasPooledSource = (
+	customerProduct?: FullCusProduct | null,
+): customerProduct is FullCusProduct => {
+	if (!customerProduct) return false;
+
+	return (
+		Boolean(customerProduct.internal_entity_id) &&
+		customerProduct.customer_entitlements.some((customerEntitlement) =>
+			isPooledSourceCustomerEntitlement({
+				customerEntitlement,
+				customerProduct,
+			}),
+		)
+	);
+};

--- a/server/src/internal/billing/v2/pooledBalances/utils/pooledResetPolicy.ts
+++ b/server/src/internal/billing/v2/pooledBalances/utils/pooledResetPolicy.ts
@@ -1,0 +1,24 @@
+/** Who renews a contribution: a Stripe subscription, a license parent
+ * product, or nobody (free — the pool lazily resets on its own anchor). */
+export type PooledResetPolicy =
+	| { stripeSubscriptionId: string }
+	| { customerLicenseLinkId: string }
+	| { lazy: { anchor: number; now: number } };
+
+export const pooledResetPolicyToContributionOwner = ({
+	resetPolicy,
+}: {
+	resetPolicy: PooledResetPolicy;
+}): {
+	stripeSubscriptionId: string | null;
+	customerLicenseLinkId: string | null;
+} => ({
+	stripeSubscriptionId:
+		"stripeSubscriptionId" in resetPolicy
+			? resetPolicy.stripeSubscriptionId
+			: null,
+	customerLicenseLinkId:
+		"customerLicenseLinkId" in resetPolicy
+			? resetPolicy.customerLicenseLinkId
+			: null,
+});

--- a/server/src/internal/billing/v2/utils/billingPlan/mergeAutumnBillingPlans.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/mergeAutumnBillingPlans.ts
@@ -1,4 +1,8 @@
-import type { AutumnBillingPlan } from "@autumn/shared";
+import type {
+	AutumnBillingPlan,
+	PooledBalanceOp,
+	PooledBalancePlan,
+} from "@autumn/shared";
 
 export const mergeAutumnBillingPlans = ({
 	base,
@@ -44,6 +48,12 @@ export const mergeAutumnBillingPlans = ({
 		incoming: incoming.schedulePhaseCustomerProductReplacements,
 		getKey: (replacement) => replacement.oldCustomerProductId,
 	}),
+	customerLicenseTransitions: mergeByKey({
+		base: base.customerLicenseTransitions,
+		incoming: incoming.customerLicenseTransitions,
+		getKey: (transition) =>
+			`${transition.outgoingCustomerLicense.id}:${transition.incomingCustomerLicense.id}`,
+	}),
 	customPrices: mergeById({
 		base: base.customPrices,
 		incoming: incoming.customPrices,
@@ -51,6 +61,14 @@ export const mergeAutumnBillingPlans = ({
 	customEntitlements: mergeById({
 		base: base.customEntitlements,
 		incoming: incoming.customEntitlements,
+	}),
+	pooledBalancePlan: mergePooledBalancePlan({
+		base: base.pooledBalancePlan,
+		incoming: incoming.pooledBalancePlan,
+	}),
+	pooledBalanceOps: mergePooledBalanceOps({
+		base: base.pooledBalanceOps,
+		incoming: incoming.pooledBalanceOps,
 	}),
 	customFreeTrial: incoming.customFreeTrial ?? base.customFreeTrial,
 	lineItems: mergeById({
@@ -126,6 +144,104 @@ const mergeByKey = <T>({
 	for (const item of incoming ?? []) itemByKey.set(getKey(item), item);
 
 	return Array.from(itemByKey.values());
+};
+
+const pooledBalanceOperationKey = (operation: PooledBalanceOp): string => {
+	switch (operation.op) {
+		case "upsert_source":
+			return `${operation.sourceCustomerProductId}:${operation.sourceEntitlementId}`;
+		case "remove_source":
+			return `${operation.sourceCustomerProductId}:remove`;
+		case "remove_contribution":
+			return `${operation.sourceCustomerProductId}:${operation.sourceEntitlementId}:remove`;
+		case "restore_source":
+			return `${operation.sourceCustomerProductId}:restore`;
+		case "transfer_source":
+			return `${operation.contributionId}:transfer`;
+		case "stage_owner_removal":
+		case "restore_owner":
+			return `owner:${operation.customerLicenseLinkId}`;
+	}
+};
+
+const keepLastOperationByKey = (
+	operations: PooledBalanceOp[],
+): PooledBalanceOp[] => {
+	const seen = new Set<string>();
+	const reversed: PooledBalanceOp[] = [];
+	for (let index = operations.length - 1; index >= 0; index -= 1) {
+		const operation = operations[index];
+		const key = pooledBalanceOperationKey(operation);
+		if (seen.has(key)) continue;
+		seen.add(key);
+		reversed.push(operation);
+	}
+	return reversed.reverse();
+};
+
+const mergePooledBalanceOps = ({
+	base,
+	incoming,
+}: {
+	base?: PooledBalanceOp[];
+	incoming?: PooledBalanceOp[];
+}): PooledBalanceOp[] | undefined => {
+	if (!base?.length && !incoming?.length) return undefined;
+
+	const uniqueIncoming = keepLastOperationByKey(incoming ?? []);
+	const incomingKeys = new Set(uniqueIncoming.map(pooledBalanceOperationKey));
+	const uniqueBase =
+		mergeByKey({
+			base,
+			incoming: [],
+			getKey: pooledBalanceOperationKey,
+		}) ?? [];
+	const remainingBase = uniqueBase.filter(
+		(operation) => !incomingKeys.has(pooledBalanceOperationKey(operation)),
+	);
+	return [...remainingBase, ...uniqueIncoming];
+};
+
+const mergeSourcesByKey = <Source>({
+	base,
+	incoming,
+	getKey,
+}: {
+	base?: Source[];
+	incoming?: Source[];
+	getKey: (source: Source) => string;
+}): Source[] | undefined => {
+	if (!base?.length && !incoming?.length) return undefined;
+	const merged = new Map<string, Source>();
+	for (const source of [...(base ?? []), ...(incoming ?? [])]) {
+		merged.set(getKey(source), source);
+	}
+	return [...merged.values()];
+};
+
+const mergePooledBalancePlan = ({
+	base,
+	incoming,
+}: {
+	base?: PooledBalancePlan;
+	incoming?: PooledBalancePlan;
+}): PooledBalancePlan | undefined => {
+	const removeSources = mergeSourcesByKey({
+		base: base?.removeSources,
+		incoming: incoming?.removeSources,
+		getKey: (source) => source.sourceCustomerProductId,
+	});
+	const upsertSources = mergeSourcesByKey({
+		base: base?.upsertSources,
+		incoming: incoming?.upsertSources,
+		getKey: (source) =>
+			`${source.contribution.sourceCustomerProductId}:${source.contribution.sourceEntitlementId}`,
+	});
+	if (!removeSources && !upsertSources) return undefined;
+	return {
+		...(removeSources ? { removeSources } : {}),
+		...(upsertSources ? { upsertSources } : {}),
+	};
 };
 
 type PatchCustomerProduct = NonNullable<

--- a/server/src/internal/billing/v2/utils/handleExistingUsages/cusProductToExistingUsages.ts
+++ b/server/src/internal/billing/v2/utils/handleExistingUsages/cusProductToExistingUsages.ts
@@ -10,6 +10,7 @@ import {
 	isUnlimitedCusEnt,
 } from "@autumn/shared";
 import { Decimal } from "decimal.js";
+import { isPooledSourceCustomerEntitlement } from "@/internal/billing/v2/pooledBalances/utils/pooledCustomerEntitlementClassification.js";
 
 export const cusProductToExistingUsages = ({
 	cusProduct,
@@ -37,6 +38,17 @@ export const cusProductToExistingUsages = ({
 	> = {};
 
 	for (const cusEnt of cusEnts) {
+		// Pooled source rows intentionally retain a zero balance while the shared
+		// loose entitlement owns runtime usage. Treating that zero as source usage
+		// would subtract the entire allowance again during a replacement.
+		if (
+			isPooledSourceCustomerEntitlement({
+				customerEntitlement: cusEnt,
+				customerProduct: cusProduct,
+			})
+		)
+			continue;
+
 		if (isBooleanCusEnt({ cusEnt })) continue;
 
 		if (isUnlimitedCusEnt(cusEnt)) continue;

--- a/server/src/internal/billing/v2/utils/initFullCustomerProduct/reapplyExistingUsagesToCustomerProduct.ts
+++ b/server/src/internal/billing/v2/utils/initFullCustomerProduct/reapplyExistingUsagesToCustomerProduct.ts
@@ -5,6 +5,7 @@ import {
 } from "@autumn/shared";
 import { cp } from "@utils/cusProductUtils/classifyCustomerProduct/cpBuilder";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { isPooledSourceCustomerEntitlement } from "@/internal/billing/v2/pooledBalances/utils/pooledCustomerEntitlementClassification.js";
 import { applyExistingUsages } from "@/internal/billing/v2/utils/handleExistingUsages/applyExistingUsages";
 import { cusProductToExistingUsages } from "@/internal/billing/v2/utils/handleExistingUsages/cusProductToExistingUsages";
 import { initCustomerEntitlementBalance } from "@/internal/billing/v2/utils/initFullCustomerProduct/initCustomerEntitlement/initCustomerEntitlementBalance";
@@ -22,9 +23,8 @@ export const reapplyExistingUsagesToCustomerProduct = async ({
 	fromCustomerProduct?: FullCusProduct;
 	customerProduct: FullCusProduct;
 }) => {
-	const { db } = ctx;
 	const { valid } = cp(customerProduct).main().recurring();
-	if (!valid) return;
+	if (!valid) return undefined;
 
 	const currentCustomerProduct =
 		fromCustomerProduct ??
@@ -33,7 +33,7 @@ export const reapplyExistingUsagesToCustomerProduct = async ({
 			customerProduct,
 		});
 
-	if (!currentCustomerProduct) return;
+	if (!currentCustomerProduct) return undefined;
 
 	// const featuresToCarryUsagesFor = customerProductToFeaturesToCarryUsagesFor({
 	// 	cusProduct: customerProduct,
@@ -72,6 +72,13 @@ export const reapplyExistingUsagesToCustomerProduct = async ({
 	});
 
 	for (const cusEnt of customerProduct.customer_entitlements) {
+		if (
+			isPooledSourceCustomerEntitlement({
+				customerEntitlement: cusEnt,
+				customerProduct,
+			})
+		)
+			continue;
 		await CusEntService.update({
 			ctx,
 			id: cusEnt.id,
@@ -81,4 +88,6 @@ export const reapplyExistingUsagesToCustomerProduct = async ({
 			},
 		});
 	}
+
+	return currentCustomerProduct;
 };

--- a/server/src/internal/billing/v2/utils/logs/logAutumnBillingPlan.ts
+++ b/server/src/internal/billing/v2/utils/logs/logAutumnBillingPlan.ts
@@ -64,6 +64,41 @@ export const logAutumnBillingPlan = ({
 						? `${plan.customEntitlements?.length} custom ent(s)`
 						: "none",
 
+				pooledBalancePlan:
+					[
+						...(plan.pooledBalancePlan?.removeSources ?? []).map(
+							(removeSource) =>
+								`${removeSource.sourceCustomerProductId}:remove${removeSource.effectiveAt ? `@${removeSource.effectiveAt}` : ""}`,
+						),
+						...(plan.pooledBalancePlan?.upsertSources ?? []).map(
+							(upsertSource) =>
+								`${upsertSource.contribution.sourceCustomerProductId}:${upsertSource.pooledBalance.featureId}=${upsertSource.contribution.currentCycleContribution}`,
+						),
+					].join(", ") || "none",
+
+				pooledBalanceOps:
+					plan.pooledBalanceOps
+						?.map((operation) => {
+							switch (operation.op) {
+								case "upsert_source":
+									return `${operation.sourceCustomerProductId}:${operation.featureId}=${operation.currentCycleContribution}`;
+								case "remove_source":
+									return `${operation.sourceCustomerProductId}:remove${operation.effectiveAt ? `@${operation.effectiveAt}` : ""}`;
+								case "remove_contribution":
+									return `${operation.sourceCustomerProductId}:${operation.sourceEntitlementId}:remove${operation.effectiveAt ? `@${operation.effectiveAt}` : ""}`;
+								case "restore_source":
+									return `${operation.sourceCustomerProductId}:restore@${operation.expectedEffectiveAt}`;
+								case "transfer_source":
+									return `${operation.sourceCustomerProductId}:${operation.featureId}=transfer:${operation.currentCycleContribution}`;
+								case "stage_owner_removal":
+									return `owner:${operation.customerLicenseLinkId}:stage@${operation.effectiveAt}`;
+								case "restore_owner":
+									return `owner:${operation.customerLicenseLinkId}:restore@${operation.expectedEffectiveAt}`;
+							}
+							return operation satisfies never;
+						})
+						.join(", ") || "none",
+
 				trialTransition: `${isTrialing ? "trialing" : "not trialing"} -> ${willBeTrialing ? "will trial" : "no trial"}`,
 
 				updateCustomerEntitlements:

--- a/server/src/internal/customers/actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.ts
@@ -11,6 +11,7 @@ import {
 	type ResetCusEntParam,
 	resetCusEnts,
 } from "@/internal/balances/utils/sql/client.js";
+import type { CustomerBalanceSyncDb } from "@/internal/balances/utils/sync/withCustomerBalanceSyncLock.js";
 import type { ProcessResetResult } from "../resetCustomerEntitlements/processReset.js";
 import { processReset } from "../resetCustomerEntitlements/processReset.js";
 import {
@@ -55,6 +56,9 @@ export const lazyResetSubjectEntitlements = async ({
 	ctx: AutumnContext;
 	fullSubject: FullSubject;
 	normalized?: NormalizedFullSubject;
+	/** Existing customer balance-sync transaction. Reserved for pooled resets,
+	 * which reuse this lock rather than trying to acquire it recursively. */
+	balanceSyncDb?: CustomerBalanceSyncDb;
 }): Promise<boolean> => {
 	if (getDbHealth() === PgHealth.Degraded) return false;
 

--- a/server/src/internal/customers/cache/fullSubject/actions/getCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/getCachedFullSubject.ts
@@ -6,6 +6,7 @@ import {
 import { isRedisMigrationCacheStale } from "@/external/redis/customerRedisRouting.js";
 import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type { CustomerBalanceSyncDb } from "@/internal/balances/utils/sync/withCustomerBalanceSyncLock.js";
 import { lazyResetSubjectEntitlements } from "@/internal/customers/actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.js";
 import { lazyResetSubjectUsageWindows } from "@/internal/customers/actions/resetUsageWindows/lazyResetSubjectUsageWindows.js";
 import { checkPendingMigrationsForCustomer } from "@/internal/migrations/v2/lazy/checkPendingMigrationsForCustomer.js";
@@ -37,12 +38,16 @@ export const getCachedFullSubject = async ({
 	entityId,
 	source,
 	staleWhileRevalidate = false,
+	balanceSyncDb,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	entityId?: string;
 	source?: string;
 	staleWhileRevalidate?: boolean;
+	/** Existing customer balance-sync transaction. Used by cache-miss rebuilds
+	 * so a due pooled reset does not wait on its own advisory lock. */
+	balanceSyncDb?: CustomerBalanceSyncDb;
 }): Promise<GetCachedFullSubjectResult> => {
 	const { org, env, logger, redisV2 } = ctx;
 	const subjectKey = buildFullSubjectKey({
@@ -264,7 +269,7 @@ export const getCachedFullSubject = async ({
 		});
 
 		const fullSubject = normalizedToFullSubject({ normalized });
-		await lazyResetSubjectEntitlements({ ctx, fullSubject });
+		await lazyResetSubjectEntitlements({ ctx, fullSubject, balanceSyncDb });
 		await lazyResetSubjectUsageWindows({ ctx, fullSubject, normalized });
 		await checkPendingMigrationsForCustomer({
 			ctx,

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateFullSubject.ts
@@ -1,11 +1,16 @@
 import type { Redis } from "ioredis";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { getRedisTargetsForCustomer } from "@/external/redis/customerRedisRouting.js";
+import { RedisUnavailableError } from "@/external/redis/utils/errors.js";
 import { tryRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { buildFullSubjectKey } from "../../builders/buildFullSubjectKey.js";
 import { buildFullSubjectViewEpochKey } from "../../builders/buildFullSubjectViewEpochKey.js";
 import { FULL_SUBJECT_EPOCH_TTL_SECONDS } from "../../config/fullSubjectCacheConfig.js";
-import { invalidateSharedBalanceFields } from "./invalidateSharedBalanceFields.js";
+import {
+	invalidateSharedBalanceFields,
+	type SharedBalanceCaptureMode,
+} from "./invalidateSharedBalanceFields.js";
 
 const invalidateCachedFullSubjectOnRedis = async ({
 	customerId,
@@ -14,6 +19,8 @@ const invalidateCachedFullSubjectOnRedis = async ({
 	source,
 	redisV2,
 	flushBalances,
+	balanceSyncDb,
+	balanceCaptureMode,
 }: {
 	customerId: string;
 	entityId?: string;
@@ -21,8 +28,16 @@ const invalidateCachedFullSubjectOnRedis = async ({
 	source?: string;
 	redisV2: Redis;
 	flushBalances?: boolean;
+	balanceSyncDb?: DrizzleCli;
+	balanceCaptureMode?: SharedBalanceCaptureMode;
 }): Promise<void> => {
 	if (redisV2.status !== "ready") {
+		if (balanceCaptureMode === "strict") {
+			throw new RedisUnavailableError({
+				source: "invalidateCachedFullSubject:not-ready",
+				reason: "not_ready",
+			});
+		}
 		const subjectLabel = entityId ? `${customerId}:${entityId}` : customerId;
 		ctx.logger.warn(
 			`[invalidateCachedFullSubject] redisV2 not_ready (status=${redisV2.status}), skipping subject: ${subjectLabel}, source: ${source}`,
@@ -35,6 +50,8 @@ const invalidateCachedFullSubjectOnRedis = async ({
 		customerId,
 		redisV2,
 		flushBalances,
+		balanceSyncDb,
+		balanceCaptureMode,
 	});
 
 	const { org, env, logger } = ctx;
@@ -78,12 +95,28 @@ const invalidateCachedFullSubjectOnRedis = async ({
 	}
 };
 
+export const shouldFlushSharedBalanceFields = ({
+	targetRedis,
+	authoritativeRedis,
+	flushBalances,
+	balanceCaptureMode,
+}: {
+	targetRedis: Redis;
+	authoritativeRedis: Redis;
+	flushBalances?: boolean;
+	balanceCaptureMode: SharedBalanceCaptureMode;
+}): boolean =>
+	targetRedis === authoritativeRedis &&
+	(Boolean(flushBalances) || balanceCaptureMode === "strict");
+
 export const invalidateCachedFullSubject = async ({
 	customerId,
 	entityId,
 	ctx,
 	source,
 	flushBalances,
+	balanceSyncDb,
+	balanceCaptureMode = "best_effort",
 }: {
 	customerId: string;
 	entityId?: string;
@@ -93,6 +126,10 @@ export const invalidateCachedFullSubject = async ({
 	 *  the caller has NOT just written balances to Postgres directly — the
 	 *  cached balances must still be the source of truth. */
 	flushBalances?: boolean;
+	balanceSyncDb?: DrizzleCli;
+	/** Fail closed when authoritative shared-balance capture is required before
+	 * a Postgres mutation. Secondary cache targets remain best-effort. */
+	balanceCaptureMode?: SharedBalanceCaptureMode;
 }): Promise<void> => {
 	if (!customerId) return;
 
@@ -107,7 +144,17 @@ export const invalidateCachedFullSubject = async ({
 				ctx,
 				source,
 				redisV2,
-				flushBalances,
+				// Only the authoritative cache may write a captured snapshot back
+				// to Postgres. Migration/secondary caches are deletion-only.
+				flushBalances: shouldFlushSharedBalanceFields({
+					targetRedis: redisV2,
+					authoritativeRedis: ctx.redisV2,
+					flushBalances,
+					balanceCaptureMode,
+				}),
+				balanceSyncDb: redisV2 === ctx.redisV2 ? balanceSyncDb : undefined,
+				balanceCaptureMode:
+					redisV2 === ctx.redisV2 ? balanceCaptureMode : "best_effort",
 			}),
 		),
 	);

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts
@@ -1,13 +1,27 @@
-import type { SubjectBalance, UsageWindow } from "@autumn/shared";
+import {
+	customerEntitlements,
+	customers,
+	features,
+	InternalError,
+	type SubjectBalance,
+	type UsageWindow,
+	usageWindows,
+} from "@autumn/shared";
+import { and, eq, or } from "drizzle-orm";
 import type { Redis } from "ioredis";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { RedisUnavailableError } from "@/external/redis/utils/errors.js";
+import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { flushSubjectBalancesToDb } from "@/internal/balances/utils/sync/flushSubjectBalancesToDb.js";
+import { writeSubjectBalancesToDb } from "@/internal/balances/utils/sync/flushSubjectBalancesToDb.js";
+import { withCustomerBalanceSyncLock } from "@/internal/balances/utils/sync/withCustomerBalanceSyncLock.js";
 import type { UsageWindowUpdate } from "@/internal/balances/utils/types/usageWindowUpdate.js";
 import { tryRedisRead, tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
 import { buildFullSubjectKey } from "../../builders/buildFullSubjectKey.js";
 import { buildSharedFullSubjectBalanceKey } from "../../builders/buildSharedFullSubjectBalanceKey.js";
 import {
 	AGGREGATED_BALANCE_FIELD,
+	SUBJECT_VIEW_EPOCH_FIELD,
 	USAGE_WINDOWS_FIELD,
 } from "../../config/fullSubjectCacheConfig.js";
 import type { CachedFullSubject } from "../../fullSubjectCacheModel.js";
@@ -18,13 +32,33 @@ import { sanitizeCachedSubjectBalance } from "../../sanitize/index.js";
 // ignoring callers' flushBalances opt-in.
 const FLUSH_BALANCES_ON_INVALIDATION = true;
 
+export type SharedBalanceCaptureMode = "best_effort" | "strict";
+
+const throwSharedBalanceCaptureFailure = ({
+	customerId,
+	stage,
+	error,
+}: {
+	customerId: string;
+	stage: string;
+	error?: unknown;
+}): never => {
+	throw new InternalError({
+		message: `Failed to capture shared FullSubject balances for '${customerId}' during ${stage}.`,
+		code: "shared_balance_capture_failed",
+		data: {
+			stage,
+			...(error instanceof Error ? { cause: error.message } : {}),
+		},
+	});
+};
+
 /**
  * Destructively reads (atomic read + HDEL) the shared balance hash fields for
  * a customer during structural invalidation, then flushes the values to
  * Postgres — an invalidation racing an un-synced deduction must not lose it.
- * No-op when the subject view is already gone — paired with HSET-on-write
- * semantics in setCachedFullSubject, stale fields are overwritten on the next
- * populate.
+ * No-op when the subject view is already gone; the next epoch's first cache
+ * populate replaces each stale feature hash before filling it.
  *
  * Must be called BEFORE the subject view key is deleted.
  */
@@ -33,6 +67,8 @@ export const invalidateSharedBalanceFields = async ({
 	customerId,
 	redisV2 = ctx.redisV2,
 	flushBalances = false,
+	balanceSyncDb,
+	balanceCaptureMode = "best_effort",
 }: {
 	ctx: AutumnContext;
 	customerId: string;
@@ -41,61 +77,87 @@ export const invalidateSharedBalanceFields = async ({
 	 *  safe when the caller has NOT just written balances to Postgres directly
 	 *  (the cached balances must still be the source of truth). */
 	flushBalances?: boolean;
+	/** Existing customer balance-sync transaction. Supplying this prevents a
+	 * nested advisory-lock wait when a broader invalidation owns the lock. */
+	balanceSyncDb?: DrizzleCli;
+	/** Strict capture is reserved for mutations whose Postgres write would be
+	 * corrupt if a live Redis-only deduction were mistaken for a cache miss. */
+	balanceCaptureMode?: SharedBalanceCaptureMode;
 }): Promise<void> => {
 	const { org, env } = ctx;
-	if (!customerId || redisV2.status !== "ready") return;
+	if (!customerId) return;
+	if (redisV2.status !== "ready") {
+		if (balanceCaptureMode === "strict") {
+			throw new RedisUnavailableError({
+				source: "captureSharedBalanceFields:not-ready",
+				reason: "not_ready",
+			});
+		}
+		return;
+	}
 
 	const subjectKey = buildFullSubjectKey({ orgId: org.id, env, customerId });
-
-	const cachedRaw = await tryRedisRead(() => redisV2.get(subjectKey), redisV2);
-	if (!cachedRaw) return;
-
 	if (!FLUSH_BALANCES_ON_INVALIDATION || !flushBalances) {
+		const cachedRaw = await tryRedisRead(
+			() => redisV2.get(subjectKey),
+			redisV2,
+		);
+		if (!cachedRaw) return;
 		await deleteFieldsFromManifest({ ctx, customerId, cachedRaw, redisV2 });
 		return;
 	}
 
-	await getDelFieldsFromManifest({ ctx, customerId, cachedRaw, redisV2 });
+	const captureAndFlush = async ({ db }: { db: DrizzleCli }) => {
+		const captured = await captureAndDeleteSharedBalanceFields({
+			ctx,
+			customerId,
+			redisV2,
+			failureMode: balanceCaptureMode,
+			resolveTargetsOnManifestMiss: () =>
+				resolveBalanceFieldTargetsFromDb({ ctx, customerId, db }),
+		});
+		if (!captured) return;
+		await writeSubjectBalancesToDb({
+			db,
+			subjectBalances: captured.subjectBalances,
+			usageWindowUpdates: captured.usageWindowUpdates,
+			queryName: "invalidateSharedBalanceFields",
+		});
+	};
+
+	if (balanceSyncDb) {
+		await captureAndFlush({ db: balanceSyncDb });
+		return;
+	}
+
+	await withCustomerBalanceSyncLock({
+		ctx,
+		customerId,
+		callback: captureAndFlush,
+	});
 };
 
-type BalanceFieldTargets = {
+export type BalanceFieldTargets = {
 	internalCustomerId: string;
 	featureIds: string[];
 	balanceKeys: string[];
 	customerEntitlementIdsByKey: string[][];
 };
 
-const manifestToBalanceFieldTargets = ({
+const buildBalanceFieldTargets = ({
 	ctx,
 	customerId,
-	cachedRaw,
+	internalCustomerId,
+	customerEntitlementIdsByFeatureId,
+	usageWindowFeatureIds,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
-	cachedRaw: string;
+	internalCustomerId: string;
+	customerEntitlementIdsByFeatureId: Record<string, string[]>;
+	usageWindowFeatureIds: string[];
 }): BalanceFieldTargets | null => {
-	const { org, env, logger } = ctx;
-
-	let manifest: CachedFullSubject;
-	try {
-		manifest = JSON.parse(cachedRaw) as CachedFullSubject;
-	} catch {
-		logger.warn(
-			`[invalidateSharedBalanceFields] Failed to parse subject view for ${customerId}, skipping field deletion`,
-		);
-		return null;
-	}
-
-	const { customerEntitlementIdsByFeatureId } = manifest;
-	if (!customerEntitlementIdsByFeatureId) return null;
-
-	// Capped features may have no entitlements, so their hashes only appear in
-	// usageWindowFeatureIds; union both so `_usage_windows` is covered too.
-	// Raw blob, no sanitize walker: cjson re-encodes empty arrays as {}, so
-	// array fields must be Array.isArray-guarded before spreading.
-	const usageWindowFeatureIds = Array.isArray(manifest.usageWindowFeatureIds)
-		? manifest.usageWindowFeatureIds
-		: [];
+	const { org, env } = ctx;
 	const featureIdSet = new Set([
 		...Object.keys(customerEntitlementIdsByFeatureId),
 		...usageWindowFeatureIds,
@@ -106,7 +168,6 @@ const manifestToBalanceFieldTargets = ({
 	const balanceKeys: string[] = [];
 	const customerEntitlementIdsByKey: string[][] = [];
 	for (const featureId of featureIdSet) {
-		const rawCusEntIds = customerEntitlementIdsByFeatureId[featureId];
 		featureIds.push(featureId);
 		balanceKeys.push(
 			buildSharedFullSubjectBalanceKey({
@@ -117,34 +178,173 @@ const manifestToBalanceFieldTargets = ({
 			}),
 		);
 		customerEntitlementIdsByKey.push(
-			Array.isArray(rawCusEntIds) ? rawCusEntIds : [],
+			customerEntitlementIdsByFeatureId[featureId] ?? [],
 		);
 	}
 
 	return {
-		internalCustomerId: manifest.internalCustomerId,
+		internalCustomerId,
 		featureIds,
 		balanceKeys,
 		customerEntitlementIdsByKey,
 	};
 };
 
-async function getDelFieldsFromManifest({
+const manifestToBalanceFieldTargets = ({
 	ctx,
 	customerId,
 	cachedRaw,
-	redisV2,
+	failureMode,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	cachedRaw: string;
-	redisV2: Redis;
-}) {
+	failureMode: SharedBalanceCaptureMode;
+}): BalanceFieldTargets | null => {
 	const { logger } = ctx;
 
-	const targets = manifestToBalanceFieldTargets({ ctx, customerId, cachedRaw });
-	if (!targets) return;
+	let manifest: CachedFullSubject;
+	try {
+		manifest = JSON.parse(cachedRaw) as CachedFullSubject;
+	} catch (error) {
+		if (failureMode === "strict") {
+			throwSharedBalanceCaptureFailure({
+				customerId,
+				stage: "manifest_parse",
+				error,
+			});
+		}
+		logger.warn(
+			`[invalidateSharedBalanceFields] Failed to parse subject view for ${customerId}, skipping field deletion`,
+		);
+		return null;
+	}
+
+	const { customerEntitlementIdsByFeatureId } = manifest;
+	if (
+		!customerEntitlementIdsByFeatureId ||
+		typeof manifest.internalCustomerId !== "string"
+	) {
+		if (failureMode === "strict") {
+			throwSharedBalanceCaptureFailure({
+				customerId,
+				stage: "manifest_shape",
+			});
+		}
+		return null;
+	}
+
+	// Capped features may have no entitlements, so their hashes only appear in
+	// usageWindowFeatureIds; union both so `_usage_windows` is covered too.
+	// Raw blob, no sanitize walker: cjson re-encodes empty arrays as {}, so
+	// array fields must be Array.isArray-guarded before spreading.
+	const usageWindowFeatureIds = Array.isArray(manifest.usageWindowFeatureIds)
+		? manifest.usageWindowFeatureIds
+		: [];
+	return buildBalanceFieldTargets({
+		ctx,
+		customerId,
+		internalCustomerId: manifest.internalCustomerId,
+		customerEntitlementIdsByFeatureId: Object.fromEntries(
+			Object.entries(customerEntitlementIdsByFeatureId).map(
+				([featureId, rawCustomerEntitlementIds]) => [
+					featureId,
+					Array.isArray(rawCustomerEntitlementIds)
+						? rawCustomerEntitlementIds
+						: [],
+				],
+			),
+		),
+		usageWindowFeatureIds,
+	});
+};
+
+const resolveBalanceFieldTargetsFromDb = async ({
+	ctx,
+	customerId,
+	db,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	db: DrizzleCli;
+}): Promise<BalanceFieldTargets | null> => {
+	const [customer] = await db
+		.select({ internalCustomerId: customers.internal_id })
+		.from(customers)
+		.where(
+			and(
+				or(eq(customers.id, customerId), eq(customers.internal_id, customerId)),
+				eq(customers.org_id, ctx.org.id),
+				eq(customers.env, ctx.env),
+			),
+		)
+		.limit(1);
+	if (!customer) return null;
+
+	const customerEntitlementRows = await db
+		.select({
+			id: customerEntitlements.id,
+			featureId: features.id,
+		})
+		.from(customerEntitlements)
+		.innerJoin(
+			features,
+			eq(customerEntitlements.internal_feature_id, features.internal_id),
+		)
+		.where(
+			eq(
+				customerEntitlements.internal_customer_id,
+				customer.internalCustomerId,
+			),
+		);
+	const usageWindowRows = await db
+		.select({ featureId: usageWindows.feature_id })
+		.from(usageWindows)
+		.where(eq(usageWindows.internal_customer_id, customer.internalCustomerId));
+
+	const customerEntitlementIdsByFeatureId: Record<string, string[]> = {};
+	for (const customerEntitlement of customerEntitlementRows) {
+		const existingIds =
+			customerEntitlementIdsByFeatureId[customerEntitlement.featureId] ?? [];
+		customerEntitlementIdsByFeatureId[customerEntitlement.featureId] = [
+			...existingIds,
+			customerEntitlement.id,
+		];
+	}
+
+	return buildBalanceFieldTargets({
+		ctx,
+		customerId,
+		internalCustomerId: customer.internalCustomerId,
+		customerEntitlementIdsByFeatureId,
+		usageWindowFeatureIds: [
+			...new Set(usageWindowRows.map(({ featureId }) => featureId)),
+		],
+	});
+};
+
+const captureAndDeleteFieldsFromTargets = async ({
+	ctx,
+	customerId,
+	redisV2,
+	failureMode,
+	targets,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	redisV2: Redis;
+	failureMode: SharedBalanceCaptureMode;
+	targets: BalanceFieldTargets;
+}): Promise<{
+	subjectBalances: SubjectBalance[];
+	usageWindowUpdates: UsageWindowUpdate[];
+} | null> => {
+	const { logger } = ctx;
+
 	const { balanceKeys, customerEntitlementIdsByKey } = targets;
+	if (balanceKeys.length === 0) {
+		return { subjectBalances: [], usageWindowUpdates: [] };
+	}
 
 	// `_usage_windows` is read+deleted alongside the cusEnt fields (last field
 	// per key) so window counters are flushed too, not just deleted.
@@ -153,22 +353,33 @@ async function getDelFieldsFromManifest({
 		USAGE_WINDOWS_FIELD,
 	]);
 
-	const resultRaw = await tryRedisWrite(
-		() =>
-			redisV2.getDelFullSubjectBalanceFields(
-				balanceKeys.length,
-				...balanceKeys,
-				JSON.stringify(fieldsByKey),
-				JSON.stringify([AGGREGATED_BALANCE_FIELD]),
-			),
-		redisV2,
-	);
+	const getDel = () =>
+		redisV2.getDelFullSubjectBalanceFields(
+			balanceKeys.length,
+			...balanceKeys,
+			JSON.stringify(fieldsByKey),
+			JSON.stringify([AGGREGATED_BALANCE_FIELD, SUBJECT_VIEW_EPOCH_FIELD]),
+		);
+	const resultRaw =
+		failureMode === "strict"
+			? await runRedisOp({
+					operation: getDel,
+					source: "captureSharedBalanceFields:getdel",
+					redisInstance: redisV2,
+				})
+			: await tryRedisWrite(getDel, redisV2);
 
 	if (resultRaw === null) {
+		if (failureMode === "strict") {
+			throwSharedBalanceCaptureFailure({
+				customerId,
+				stage: "getdel_result",
+			});
+		}
 		logger.warn(
 			`[invalidateSharedBalanceFields] ${customerId}: GETDEL failed, skipping flush`,
 		);
-		return;
+		return null;
 	}
 
 	const parsed = parseGetDelResult({
@@ -177,22 +388,78 @@ async function getDelFieldsFromManifest({
 		resultRaw,
 		targets,
 		fieldsByKey,
+		failureMode,
 	});
-	if (!parsed) return;
+	if (!parsed) return null;
 	const { subjectBalances, usageWindowUpdates } = parsed;
 
 	logger.info(
 		`[invalidateSharedBalanceFields] ${customerId}: GETDEL ${balanceKeys.length} balance keys, flushing ${subjectBalances.length} balances, ${usageWindowUpdates.length} usage windows`,
 	);
 
-	await flushSubjectBalancesToDb({
+	return { subjectBalances, usageWindowUpdates };
+};
+
+/** Atomically captures and removes the current FullSubject balance fields.
+ * The caller owns persistence/reconciliation and, when writing Postgres,
+ * must already hold the customer balance-sync lock. */
+export const captureAndDeleteSharedBalanceFields = async ({
+	ctx,
+	customerId,
+	redisV2 = ctx.redisV2,
+	failureMode = "best_effort",
+	resolveTargetsOnManifestMiss,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	redisV2?: Redis;
+	failureMode?: SharedBalanceCaptureMode;
+	resolveTargetsOnManifestMiss?: () => Promise<BalanceFieldTargets | null>;
+}): Promise<{
+	subjectBalances: SubjectBalance[];
+	usageWindowUpdates: UsageWindowUpdate[];
+} | null> => {
+	if (!customerId) return null;
+	if (redisV2.status !== "ready") {
+		if (failureMode === "strict") {
+			throw new RedisUnavailableError({
+				source: "captureSharedBalanceFields:not-ready",
+				reason: "not_ready",
+			});
+		}
+		return null;
+	}
+	const subjectKey = buildFullSubjectKey({
+		orgId: ctx.org.id,
+		env: ctx.env,
+		customerId,
+	});
+	const cachedRaw =
+		failureMode === "strict"
+			? await runRedisOp({
+					operation: () => redisV2.get(subjectKey),
+					source: "captureSharedBalanceFields:get",
+					redisInstance: redisV2,
+				})
+			: await tryRedisRead(() => redisV2.get(subjectKey), redisV2);
+	const targets =
+		cachedRaw === null
+			? await resolveTargetsOnManifestMiss?.()
+			: manifestToBalanceFieldTargets({
+					ctx,
+					customerId,
+					cachedRaw,
+					failureMode,
+				});
+	if (!targets) return null;
+	return captureAndDeleteFieldsFromTargets({
 		ctx,
 		customerId,
-		subjectBalances,
-		usageWindowUpdates,
-		source: "invalidateSharedBalanceFields",
+		redisV2,
+		failureMode,
+		targets,
 	});
-}
+};
 
 /** Legacy blind HDEL, kept as the FLUSH_BALANCES_ON_INVALIDATION=false path. */
 async function deleteFieldsFromManifest({
@@ -208,7 +475,12 @@ async function deleteFieldsFromManifest({
 }) {
 	const { logger } = ctx;
 
-	const targets = manifestToBalanceFieldTargets({ ctx, customerId, cachedRaw });
+	const targets = manifestToBalanceFieldTargets({
+		ctx,
+		customerId,
+		cachedRaw,
+		failureMode: "best_effort",
+	});
 	if (!targets) return;
 	const { balanceKeys, customerEntitlementIdsByKey } = targets;
 
@@ -219,6 +491,7 @@ async function deleteFieldsFromManifest({
 		const fieldsToDelete = [
 			...customerEntitlementIdsByKey[index],
 			AGGREGATED_BALANCE_FIELD,
+			SUBJECT_VIEW_EPOCH_FIELD,
 			USAGE_WINDOWS_FIELD,
 		];
 		pipeline.hdel(balanceKeys[index], ...fieldsToDelete);
@@ -239,12 +512,14 @@ function parseGetDelResult({
 	resultRaw,
 	targets,
 	fieldsByKey,
+	failureMode,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	resultRaw: string;
 	targets: BalanceFieldTargets;
 	fieldsByKey: string[][];
+	failureMode: SharedBalanceCaptureMode;
 }): {
 	subjectBalances: SubjectBalance[];
 	usageWindowUpdates: UsageWindowUpdate[];
@@ -255,12 +530,33 @@ function parseGetDelResult({
 	try {
 		valuesByKey = JSON.parse(resultRaw) as unknown[];
 	} catch (error) {
+		if (failureMode === "strict") {
+			throwSharedBalanceCaptureFailure({
+				customerId,
+				stage: "getdel_parse",
+				error,
+			});
+		}
 		logger.warn(
 			`[invalidateSharedBalanceFields] ${customerId}: failed to parse GETDEL result, skipping flush, error: ${error}`,
 		);
 		return null;
 	}
-	if (!Array.isArray(valuesByKey)) return null;
+	if (!Array.isArray(valuesByKey)) {
+		if (failureMode === "strict") {
+			throwSharedBalanceCaptureFailure({
+				customerId,
+				stage: "getdel_shape",
+			});
+		}
+		return null;
+	}
+	if (failureMode === "strict" && valuesByKey.length !== fieldsByKey.length) {
+		throwSharedBalanceCaptureFailure({
+			customerId,
+			stage: "getdel_key_count",
+		});
+	}
 
 	const subjectBalances: SubjectBalance[] = [];
 	const usageWindowUpdates: UsageWindowUpdate[] = [];
@@ -269,12 +565,27 @@ function parseGetDelResult({
 		const rawValues = valuesByKey[keyIndex];
 		// cjson encodes empty Lua tables as {}, so each per-key entry must be
 		// Array.isArray-guarded.
+		if (!Array.isArray(rawValues) && failureMode === "strict") {
+			throwSharedBalanceCaptureFailure({
+				customerId,
+				stage: "getdel_key_shape",
+			});
+		}
 		const values = Array.isArray(rawValues) ? (rawValues as unknown[]) : [];
 		const fields = fieldsByKey[keyIndex];
 
 		for (let fieldIndex = 0; fieldIndex < fields.length; fieldIndex++) {
 			const value = values[fieldIndex];
-			if (typeof value !== "string") continue;
+			if (value === null || value === undefined) continue;
+			if (typeof value !== "string") {
+				if (failureMode === "strict") {
+					throwSharedBalanceCaptureFailure({
+						customerId,
+						stage: "field_shape",
+					});
+				}
+				continue;
+			}
 
 			const isUsageWindowsField = fieldIndex === fields.length - 1;
 			try {
@@ -282,6 +593,9 @@ function parseGetDelResult({
 					// Empty/non-array snapshots mean no Redis rows to upsert; usage-window
 					// expiry and rolling are handled outside sync-back.
 					const parsedWindows = JSON.parse(value) as UsageWindow[];
+					if (!Array.isArray(parsedWindows) && failureMode === "strict") {
+						throw new Error("usage window snapshot is not an array");
+					}
 					usageWindowUpdates.push({
 						internal_customer_id: targets.internalCustomerId,
 						feature_id: targets.featureIds[keyIndex],
@@ -299,7 +613,14 @@ function parseGetDelResult({
 						}),
 					);
 				}
-			} catch {
+			} catch (error) {
+				if (failureMode === "strict") {
+					throwSharedBalanceCaptureFailure({
+						customerId,
+						stage: `field_parse:${fields[fieldIndex]}`,
+						error,
+					});
+				}
 				logger.warn(
 					`[invalidateSharedBalanceFields] ${customerId}: unparseable balance field ${fields[fieldIndex]}, dropping it from flush`,
 				);

--- a/server/src/internal/customers/cache/fullSubject/config/fullSubjectCacheConfig.ts
+++ b/server/src/internal/customers/cache/fullSubject/config/fullSubjectCacheConfig.ts
@@ -3,6 +3,7 @@ import { seconds } from "@autumn/shared";
 export const FULL_SUBJECT_CACHE_TTL_SECONDS = seconds.days(3);
 export const FULL_SUBJECT_EPOCH_TTL_SECONDS = seconds.days(5);
 export const AGGREGATED_BALANCE_FIELD = "_aggregated";
+export const SUBJECT_VIEW_EPOCH_FIELD = "_subject_view_epoch";
 // Customer-scoped usage-window counters for the capped feature, stored as a
 // reserved field in that feature's balance hash (JSON array of rows). The
 // rebuild writes it (even []) for armed caps; readers fail OPEN on a missing

--- a/server/src/internal/customers/cusProducts/cusProductUtils/convertCusProduct.ts
+++ b/server/src/internal/customers/cusProducts/cusProductUtils/convertCusProduct.ts
@@ -85,3 +85,13 @@ export const cusProductToCusEnt = ({
 
 	return undefined;
 };
+
+export const customerProductToPooledCustomerEntitlements = ({
+	customerProduct,
+}: {
+	customerProduct?: FullCusProduct;
+}): FullCusEntWithFullCusProduct[] =>
+	customerProduct?.customer_entitlements.map((customerEntitlement) => ({
+		...customerEntitlement,
+		customer_product: customerProduct,
+	})) ?? [];

--- a/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.ts
+++ b/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.ts
@@ -3,6 +3,7 @@ import {
 	getRegionalRedis,
 	redis,
 } from "@/external/redis/initRedis.js";
+import { withCustomerBalanceSyncLock } from "@/internal/balances/utils/sync/withCustomerBalanceSyncLock.js";
 import { invalidateCachedFullSubject } from "@/internal/customers/cache/fullSubject/index.js";
 import { buildPathIndexKey } from "@/internal/customers/cache/pathIndex/pathIndexConfig.js";
 import type { AutumnContext } from "../../../../honoUtils/HonoEnv.js";
@@ -13,24 +14,19 @@ import {
 } from "./fullCustomerCacheConfig.js";
 import { buildTestFullCustomerCacheGuardKey } from "./testFullCustomerCacheGuard.js";
 
-/**
- * Delete FullCustomer from Redis cache across ALL regions.
- * @param skipGuard - If true, skips setting the guard key. Default false (guard is set). Use skipGuard: true when deleting cache before a fresh Postgres read.
- */
-export const deleteCachedFullCustomer = async ({
+/** Delete only the legacy FullCustomer view across all regions. */
+export const deleteLegacyCachedFullCustomer = async ({
 	ctx,
 	customerId,
 	entityId,
 	source,
 	skipGuard = false,
-	flushBalances = false,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	entityId?: string;
 	source?: string;
 	skipGuard?: boolean;
-	flushBalances?: boolean;
 }): Promise<void> => {
 	const { org, env, logger } = ctx;
 
@@ -45,21 +41,10 @@ export const deleteCachedFullCustomer = async ({
 	const guardTimestamp = Date.now().toString();
 	const customerLabel = entityId ? `${customerId}:${entityId}` : customerId;
 
-	const invalidationPromises: Promise<void>[] = [
-		invalidateCachedFullSubject({
-			ctx,
-			customerId,
-			entityId,
-			source,
-			flushBalances,
-		}),
-	];
-
 	if (redis.status !== "ready") {
 		logger.warn(
 			`[deleteCachedFullCustomer] primary redis not_ready, skipping fullCustomer invalidation for ${customerLabel}`,
 		);
-		await Promise.all(invalidationPromises);
 		return;
 	}
 
@@ -109,5 +94,64 @@ export const deleteCachedFullCustomer = async ({
 		}
 	});
 
-	await Promise.all([...deletePromises, ...invalidationPromises]);
+	await Promise.all(deletePromises);
+};
+
+/**
+ * Delete FullCustomer and FullSubject cache views.
+ * @param skipGuard - If true, skips setting the legacy guard key. Default false.
+ */
+export const deleteCachedFullCustomer = async ({
+	ctx,
+	customerId,
+	entityId,
+	source,
+	skipGuard = false,
+	flushBalances = false,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	entityId?: string;
+	source?: string;
+	skipGuard?: boolean;
+	flushBalances?: boolean;
+}): Promise<void> => {
+	if (!customerId) return;
+
+	const invalidateAllViews = async ({
+		balanceSyncDb,
+	}: {
+		balanceSyncDb?: Parameters<
+			typeof invalidateCachedFullSubject
+		>[0]["balanceSyncDb"];
+	}) => {
+		await Promise.all([
+			invalidateCachedFullSubject({
+				ctx,
+				customerId,
+				entityId,
+				source,
+				flushBalances,
+				balanceSyncDb,
+			}),
+			deleteLegacyCachedFullCustomer({
+				ctx,
+				customerId,
+				entityId,
+				source,
+				skipGuard,
+			}),
+		]);
+	};
+
+	if (!flushBalances) {
+		await invalidateAllViews({});
+		return;
+	}
+
+	await withCustomerBalanceSyncLock({
+		ctx,
+		customerId,
+		callback: ({ db }) => invalidateAllViews({ balanceSyncDb: db }),
+	});
 };

--- a/server/src/internal/licenses/actions/reconcile/reconcileLicenseState.ts
+++ b/server/src/internal/licenses/actions/reconcile/reconcileLicenseState.ts
@@ -1,13 +1,75 @@
 import type { FullCustomer } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { withCustomerBalanceSyncLock } from "@/internal/balances/utils/sync/withCustomerBalanceSyncLock.js";
+import {
+	applyPreparedPooledBalanceCacheCutover,
+	executePooledBalanceOps,
+} from "@/internal/billing/v2/execute/executeAutumnActions/executePooledBalanceOps.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
 import { customerTouchesLicenses } from "../../repos/customerLicenseRepo/customerTouchesLicenses.js";
+import { licenseAssignmentRepo } from "../../repos/licenseAssignmentRepo.js";
 import { logLicenseAction } from "../logs/logLicenseAction.js";
 import { expireUnusedAssignments } from "./expireUnusedAssignments.js";
 import { reconcileCustomerLicenseBalances } from "./reconcileCustomerLicenseBalances/reconcileCustomerLicenseBalances.js";
 import { setupReconcileContext } from "./setupReconcileContext.js";
-import type { CustomerLicenseState } from "./types.js";
+import type { CustomerLicenseState, ReconcileContext } from "./types.js";
+
+const expireOrphanAssignments = async ({
+	ctx,
+	context,
+	customerId,
+	onPooledBalanceTransition,
+}: {
+	ctx: AutumnContext;
+	context: ReconcileContext;
+	customerId: string;
+	onPooledBalanceTransition?: () => void;
+}) => {
+	const validCustomerLicenseLinkIds = context.customerLicenses.map(
+		(customerLicense) => customerLicense.link_id,
+	);
+	const preparedCutover = await withCustomerBalanceSyncLock({
+		ctx,
+		customerId,
+		internalCustomerId: context.fullCustomer.internal_id,
+		callback: async ({ db }) => {
+			const orphanAssignments =
+				await licenseAssignmentRepo.listActiveOrphanAssignments({
+					db,
+					internalCustomerId: context.fullCustomer.internal_id,
+					validCustomerLicenseLinkIds,
+				});
+			if (orphanAssignments.length === 0) return undefined;
+
+			onPooledBalanceTransition?.();
+			return executePooledBalanceOps({
+				ctx: { ...ctx, db },
+				customerId,
+				balanceSyncDb: db,
+				pooledBalanceOps: orphanAssignments.map((assignment) => ({
+					op: "remove_source",
+					internalCustomerId: assignment.internal_customer_id,
+					sourceCustomerProductId: assignment.id,
+					effectiveAt: null,
+				})),
+				beforeRebalance: ({ db: operationDb }) =>
+					licenseAssignmentRepo.expireOrphanAssignments({
+						db: operationDb,
+						internalCustomerId: context.fullCustomer.internal_id,
+						validCustomerLicenseLinkIds,
+						endedAt: Date.now(),
+					}),
+			});
+		},
+	});
+	if (preparedCutover) {
+		await applyPreparedPooledBalanceCacheCutover({
+			ctx,
+			prepared: preparedCutover,
+		});
+	}
+};
 
 /**
  * Whole-customer license convergence: setup gathers bounded reads, balances
@@ -18,11 +80,15 @@ export const reconcileLicenseStateForCustomer = async ({
 	idOrInternalId,
 	fullCustomer,
 	deleteCache = false,
+	flushBalances = false,
+	onPooledBalanceTransition,
 }: {
 	ctx: AutumnContext;
 	idOrInternalId?: string;
 	fullCustomer?: FullCustomer;
 	deleteCache?: boolean;
+	flushBalances?: boolean;
+	onPooledBalanceTransition?: () => void;
 }): Promise<CustomerLicenseState | null> => {
 	if (!fullCustomer && !idOrInternalId) return null;
 
@@ -39,6 +105,7 @@ export const reconcileLicenseStateForCustomer = async ({
 			ctx,
 			idOrInternalId: idOrInternalId as string,
 		}));
+	let shouldFlushBalances = flushBalances;
 
 	try {
 		const context = await setupReconcileContext({
@@ -46,6 +113,15 @@ export const reconcileLicenseStateForCustomer = async ({
 			fullCustomer: customer,
 		});
 		await reconcileCustomerLicenseBalances({ ctx, context });
+		await expireOrphanAssignments({
+			ctx,
+			context,
+			customerId: customer.id ?? customer.internal_id,
+			onPooledBalanceTransition: () => {
+				shouldFlushBalances = true;
+				onPooledBalanceTransition?.();
+			},
+		});
 		await expireUnusedAssignments({ ctx, context });
 
 		logLicenseAction({
@@ -62,11 +138,12 @@ export const reconcileLicenseStateForCustomer = async ({
 			customerLicenses: context.customerLicenses,
 		};
 	} finally {
-		if (deleteCache && customer.id) {
+		if (deleteCache || shouldFlushBalances) {
 			await deleteCachedFullCustomer({
 				ctx,
-				customerId: customer.id,
+				customerId: customer.id ?? customer.internal_id,
 				source: "license.reconcile",
+				flushBalances: shouldFlushBalances,
 			});
 		}
 	}

--- a/server/src/internal/licenses/repos/licenseAssignmentRepo.ts
+++ b/server/src/internal/licenses/repos/licenseAssignmentRepo.ts
@@ -5,6 +5,7 @@ import {
 	customerProducts,
 	type DbCustomerProduct,
 	entities,
+	type FullCusProduct,
 	products,
 } from "@autumn/shared";
 import {
@@ -17,7 +18,6 @@ import {
 	isNotNull,
 	isNull,
 	notInArray,
-	or,
 	sql,
 } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
@@ -45,6 +45,7 @@ const listAssignmentsWithEntityAndProductByCustomer = async ({
 	entityId,
 	licenseInternalProductId,
 	parentCustomerProductId,
+	customerLicenseLinkId,
 	activeOnly = true,
 }: {
 	db: DrizzleCli;
@@ -52,6 +53,7 @@ const listAssignmentsWithEntityAndProductByCustomer = async ({
 	entityId?: string;
 	licenseInternalProductId?: string;
 	parentCustomerProductId?: string;
+	customerLicenseLinkId?: string;
 	activeOnly?: boolean;
 }) =>
 	await db
@@ -82,6 +84,14 @@ const listAssignmentsWithEntityAndProductByCustomer = async ({
 				...(licenseInternalProductId
 					? [eq(customerProducts.internal_product_id, licenseInternalProductId)]
 					: []),
+				...(customerLicenseLinkId
+					? [
+							eq(
+								customerProducts.customer_license_link_id,
+								customerLicenseLinkId,
+							),
+						]
+					: []),
 				...(parentCustomerProductId
 					? [
 							// Seats anchor by link; the pool row carries the parent.
@@ -111,16 +121,30 @@ const listUnusedAssignmentsByLinkId = async ({
 	db: DrizzleCli;
 	customerLicenseLinkId: string;
 	limit: number;
-}): Promise<DbLicenseAssignment[]> =>
-	await db.query.customerProducts.findMany({
+}): Promise<FullCusProduct[]> => {
+	const assignments = await db.query.customerProducts.findMany({
 		where: and(
 			eq(customerProducts.customer_license_link_id, customerLicenseLinkId),
 			isNull(customerProducts.internal_entity_id),
 			inArray(customerProducts.status, ACTIVE_STATUSES),
 		),
+		with: {
+			product: true,
+			customer_entitlements: {
+				with: {
+					entitlement: { with: { feature: true } },
+					replaceables: true,
+					rollovers: true,
+				},
+			},
+			customer_prices: { with: { price: true } },
+			free_trial: true,
+		},
 		orderBy: asc(customerProducts.released_at),
 		limit,
 	});
+	return assignments as FullCusProduct[];
+};
 
 const listActiveAssignmentsByInternalEntityId = async ({
 	db,
@@ -136,8 +160,32 @@ const listActiveAssignmentsByInternalEntityId = async ({
 		),
 	});
 
-/** Ends active seats anchored to no surviving pool link (unstamped or
- * dangling) — one set-based UPDATE per reconcile. */
+const listActiveOrphanAssignments = async ({
+	db,
+	internalCustomerId,
+	validCustomerLicenseLinkIds,
+}: {
+	db: DrizzleCli;
+	internalCustomerId: string;
+	validCustomerLicenseLinkIds: string[];
+}): Promise<DbLicenseAssignment[]> =>
+	await db.query.customerProducts.findMany({
+		where: and(
+			eq(customerProducts.internal_customer_id, internalCustomerId),
+			...activeAssignmentConditions(),
+			...(validCustomerLicenseLinkIds.length > 0
+				? [
+						notInArray(
+							customerProducts.customer_license_link_id,
+							validCustomerLicenseLinkIds,
+						),
+					]
+				: []),
+		),
+	});
+
+/** Ends active seats anchored to no surviving pool link — one set-based
+ * UPDATE per reconcile. An empty valid-link set means every active seat. */
 const expireOrphanAssignments = async ({
 	db,
 	internalCustomerId,
@@ -156,17 +204,14 @@ const expireOrphanAssignments = async ({
 			and(
 				eq(customerProducts.internal_customer_id, internalCustomerId),
 				...activeAssignmentConditions(),
-				or(
-					isNull(customerProducts.customer_license_link_id),
-					...(validCustomerLicenseLinkIds.length > 0
-						? [
-								notInArray(
-									customerProducts.customer_license_link_id,
-									validCustomerLicenseLinkIds,
-								),
-							]
-						: []),
-				),
+				...(validCustomerLicenseLinkIds.length > 0
+					? [
+							notInArray(
+								customerProducts.customer_license_link_id,
+								validCustomerLicenseLinkIds,
+							),
+						]
+					: []),
 			),
 		);
 };
@@ -273,6 +318,7 @@ const repointSeatPrices = async ({
 export const licenseAssignmentRepo = {
 	listAssignmentsWithEntityAndProductByCustomer,
 	listActiveAssignmentsByInternalEntityId,
+	listActiveOrphanAssignments,
 	listUnusedAssignmentsByLinkId,
 	expireOrphanAssignments,
 	expireUnusedAssignmentsByLinkIds,

--- a/shared/drizzle/0048_sour_dracula.sql
+++ b/shared/drizzle/0048_sour_dracula.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "pooled_balance_contributions" DROP CONSTRAINT "pooled_balance_contributions_reset_owner_type_valid";--> statement-breakpoint
+ALTER TABLE "pooled_balances" DROP CONSTRAINT "pooled_balances_reset_mode_valid";--> statement-breakpoint
+DROP INDEX CONCURRENTLY "idx_pooled_balance_contributions_reset_owner";--> statement-breakpoint
+ALTER TABLE "pooled_balance_contributions" ADD COLUMN "stripe_subscription_id" text;--> statement-breakpoint
+ALTER TABLE "pooled_balance_contributions" ADD COLUMN "customer_license_link_id" text;--> statement-breakpoint
+CREATE INDEX CONCURRENTLY "idx_pooled_balance_contributions_stripe_subscription" ON "pooled_balance_contributions" USING btree ("stripe_subscription_id","pooled_balance_id");--> statement-breakpoint
+CREATE INDEX CONCURRENTLY "idx_pooled_balance_contributions_license_link" ON "pooled_balance_contributions" USING btree ("customer_license_link_id","pooled_balance_id");--> statement-breakpoint
+ALTER TABLE "pooled_balance_contributions" DROP COLUMN "reset_owner_type";--> statement-breakpoint
+ALTER TABLE "pooled_balance_contributions" DROP COLUMN "reset_owner_id";--> statement-breakpoint
+ALTER TABLE "pooled_balance_contributions" ADD CONSTRAINT "pooled_balance_contributions_single_owner" CHECK ("pooled_balance_contributions"."stripe_subscription_id" IS NULL OR "pooled_balance_contributions"."customer_license_link_id" IS NULL);--> statement-breakpoint
+ALTER TABLE "pooled_balances" ADD CONSTRAINT "pooled_balances_reset_mode_valid" CHECK ("pooled_balances"."reset_mode" IN ('lazy', 'subscription'));

--- a/shared/drizzle/meta/0048_snapshot.json
+++ b/shared/drizzle/meta/0048_snapshot.json
@@ -1,0 +1,10309 @@
+{
+  "id": "d7e0ed0b-0e80-4d13-8928-6704d9f6295b",
+  "prevId": "b6e4ceac-e170-43eb-a918-a9222136a6e9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.actions": {
+      "name": "actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_actions_on_internal_entity_id": {
+          "name": "idx_actions_on_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "actions_org_id_fkey": {
+          "name": "actions_org_id_fkey",
+          "tableFrom": "actions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "actions_customer_id_fkey": {
+          "name": "actions_customer_id_fkey",
+          "tableFrom": "actions",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "actions_entity_id_fkey": {
+          "name": "actions_entity_id_fkey",
+          "tableFrom": "actions",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.agent_rules": {
+      "name": "agent_rules",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_rules": {
+          "name": "entity_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_rules": {
+          "name": "credit_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_rules_org_id_fkey": {
+          "name": "agent_rules_org_id_fkey",
+          "tableFrom": "agent_rules",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_org_id_fkey": {
+          "name": "api_keys_org_id_fkey",
+          "tableFrom": "api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_key": {
+          "name": "api_keys_hashed_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auto_topup_limit_states": {
+      "name": "auto_topup_limit_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_window_ends_at": {
+          "name": "purchase_window_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_count": {
+          "name": "purchase_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attempt_window_ends_at": {
+          "name": "attempt_window_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_attempt_window_ends_at": {
+          "name": "failed_attempt_window_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_attempt_count": {
+          "name": "failed_attempt_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failed_attempt_at": {
+          "name": "last_failed_attempt_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "auto_topup_limits_org_env_internal_customer_feature_unique": {
+          "name": "auto_topup_limits_org_env_internal_customer_feature_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auto_topup_limits_org_id_fkey": {
+          "name": "auto_topup_limits_org_id_fkey",
+          "tableFrom": "auto_topup_limit_states",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auto_topup_limits_internal_customer_id_fkey": {
+          "name": "auto_topup_limits_internal_customer_id_fkey",
+          "tableFrom": "auto_topup_limit_states",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_approvals": {
+      "name": "chat_approvals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_ts": {
+          "name": "message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_args": {
+          "name": "tool_args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview": {
+          "name": "preview",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_provider_user_id": {
+          "name": "decided_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_approvals_org_id_fkey": {
+          "name": "chat_approvals_org_id_fkey",
+          "tableFrom": "chat_approvals",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_installations": {
+      "name": "chat_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_env": {
+          "name": "default_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_api_key_id": {
+          "name": "sandbox_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_api_key": {
+          "name": "sandbox_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_api_key_id": {
+          "name": "live_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_api_key": {
+          "name": "live_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_provider_user_id": {
+          "name": "installed_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_installations_org_id_fkey": {
+          "name": "chat_installations_org_id_fkey",
+          "tableFrom": "chat_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_installations_org_provider_key": {
+          "name": "chat_installations_org_provider_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "provider"
+          ]
+        },
+        "chat_installations_provider_workspace_key": {
+          "name": "chat_installations_provider_workspace_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_oauth_credentials": {
+      "name": "chat_oauth_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_installation_id": {
+          "name": "chat_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_consent_id": {
+          "name": "oauth_consent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_oauth_credentials_installation_id_fkey": {
+          "name": "chat_oauth_credentials_installation_id_fkey",
+          "tableFrom": "chat_oauth_credentials",
+          "tableTo": "chat_installations",
+          "columnsFrom": [
+            "chat_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_oauth_credentials_org_id_fkey": {
+          "name": "chat_oauth_credentials_org_id_fkey",
+          "tableFrom": "chat_oauth_credentials",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_oauth_credentials_installation_org_env_user_key": {
+          "name": "chat_oauth_credentials_installation_org_env_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chat_installation_id",
+            "org_id",
+            "env",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_results": {
+      "name": "chat_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "leaf.chat_thread_contexts": {
+      "name": "chat_thread_contexts",
+      "schema": "leaf",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_installation_id": {
+          "name": "chat_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_identifier": {
+          "name": "target_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_provider_user_id": {
+          "name": "created_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_thread_contexts_thread_key": {
+          "name": "chat_thread_contexts_thread_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "channel_id",
+            "thread_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkouts": {
+      "name": "checkouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_version": {
+          "name": "params_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_checkouts_stripe_invoice_id": {
+          "name": "idx_checkouts_stripe_invoice_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leaf.cma_memory": {
+      "name": "cma_memory",
+      "schema": "leaf",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_store_id": {
+          "name": "memory_store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "cma_memory_org_id_env_pk": {
+          "name": "cma_memory_org_id_env_pk",
+          "columns": [
+            "org_id",
+            "env"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leaf.cma_sessions": {
+      "name": "cma_sessions",
+      "schema": "leaf",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "braintrust_parent": {
+          "name": "braintrust_parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "cma_sessions_org_id_env_thread_key_pk": {
+          "name": "cma_sessions_org_id_env_thread_key_pk",
+          "columns": [
+            "org_id",
+            "env",
+            "thread_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leaf.cma_vaults": {
+      "name": "cma_vaults",
+      "schema": "leaf",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_installation_id": {
+          "name": "chat_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vault_id": {
+          "name": "vault_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cma_vaults_installation_org_env_user_key": {
+          "name": "cma_vaults_installation_org_env_user_key",
+          "nullsNotDistinct": true,
+          "columns": [
+            "chat_installation_id",
+            "org_id",
+            "env",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_entitlements": {
+      "name": "customer_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_product_id": {
+          "name": "customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unlimited": {
+          "name": "unlimited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_cycle_anchor": {
+          "name": "reset_cycle_anchor",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reset_at": {
+          "name": "next_reset_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_allowed": {
+          "name": "usage_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "separate_interval": {
+          "name": "separate_interval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "adjustment": {
+          "name": "adjustment",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_balance": {
+          "name": "additional_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "entities": {
+          "name": "entities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_version": {
+          "name": "cache_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired": {
+          "name": "expired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_entitlements_product_id": {
+          "name": "idx_customer_entitlements_product_id",
+          "columns": [
+            {
+              "expression": "customer_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_customer_id": {
+          "name": "idx_customer_entitlements_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_customer_id_btree": {
+          "name": "idx_customer_entitlements_internal_customer_id_btree",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_entitlement_id": {
+          "name": "idx_customer_entitlements_entitlement_id",
+          "columns": [
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_feature_id_c": {
+          "name": "idx_customer_entitlements_internal_feature_id_c",
+          "columns": [
+            {
+              "expression": "\"internal_feature_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ce_internal_feature_id": {
+          "name": "idx_ce_internal_feature_id",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ce_customer_product_id_c": {
+          "name": "idx_ce_customer_product_id_c",
+          "columns": [
+            {
+              "expression": "\"customer_product_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ce_loose_next_reset": {
+          "name": "idx_ce_loose_next_reset",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"customer_product_id\" IS NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_nonnull_entity_by_id": {
+          "name": "idx_customer_entitlements_nonnull_entity_by_id",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"internal_entity_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_entity_id": {
+          "name": "idx_customer_entitlements_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        },
+        "idx_customer_entitlements_on_next_reset_at": {
+          "name": "idx_customer_entitlements_on_next_reset_at",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_separate_interval_reset": {
+          "name": "idx_customer_entitlements_separate_interval_reset",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"separate_interval\" = true AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_loose_customer_expires": {
+          "name": "idx_customer_entitlements_loose_customer_expires",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"customer_product_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_next_reset_not_expired": {
+          "name": "idx_customer_entitlements_next_reset_not_expired",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"expired\" IS NOT TRUE AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entitlements_internal_feature_id_fkey": {
+          "name": "entitlements_internal_feature_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_entitlements_internal_entity_id_fkey": {
+          "name": "customer_entitlements_internal_entity_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_entitlements_customer_product_id_fkey": {
+          "name": "customer_entitlements_customer_product_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "customer_entitlements_entitlement_id_fkey": {
+          "name": "customer_entitlements_entitlement_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "entitlements",
+          "columnsFrom": [
+            "entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_jwt_families": {
+      "name": "customer_jwt_families",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "refresh_kid": {
+          "name": "refresh_kid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "indefinite": {
+          "name": "indefinite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "customer_jwt_families_internal_customer_id_fkey": {
+          "name": "customer_jwt_families_internal_customer_id_fkey",
+          "tableFrom": "customer_jwt_families",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "customer_jwt_families_internal_customer_id_key": {
+          "name": "customer_jwt_families_internal_customer_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "internal_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_licenses": {
+      "name": "customer_licenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_customer_product_id": {
+          "name": "parent_customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_internal_product_id": {
+          "name": "license_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_license_id": {
+          "name": "plan_license_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted": {
+          "name": "granted",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "paid_quantity": {
+          "name": "paid_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "idx_customer_licenses_plan_license": {
+          "name": "idx_customer_licenses_plan_license",
+          "columns": [
+            {
+              "expression": "plan_license_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_customer_license": {
+          "name": "unique_customer_license",
+          "columns": [
+            {
+              "expression": "parent_customer_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "license_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_licenses_customer": {
+          "name": "idx_customer_licenses_customer",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_licenses_link": {
+          "name": "idx_customer_licenses_link",
+          "columns": [
+            {
+              "expression": "link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_licenses_customer_fkey": {
+          "name": "customer_licenses_customer_fkey",
+          "tableFrom": "customer_licenses",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_licenses_parent_customer_product_fkey": {
+          "name": "customer_licenses_parent_customer_product_fkey",
+          "tableFrom": "customer_licenses",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "parent_customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_licenses_license_product_fkey": {
+          "name": "customer_licenses_license_product_fkey",
+          "tableFrom": "customer_licenses",
+          "tableTo": "products",
+          "columnsFrom": [
+            "license_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_licenses_plan_license_fkey": {
+          "name": "customer_licenses_plan_license_fkey",
+          "tableFrom": "customer_licenses",
+          "tableTo": "plan_license",
+          "columnsFrom": [
+            "plan_license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_prices": {
+      "name": "customer_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_product_id": {
+          "name": "customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_prices_product_id": {
+          "name": "idx_customer_prices_product_id",
+          "columns": [
+            {
+              "expression": "customer_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_prices_price_id": {
+          "name": "idx_customer_prices_price_id",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_prices_internal_customer_id": {
+          "name": "idx_customer_prices_internal_customer_id",
+          "columns": [
+            {
+              "expression": "\"internal_customer_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_prices\".\"internal_customer_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cpr_customer_product_id_c": {
+          "name": "idx_cpr_customer_product_id_c",
+          "columns": [
+            {
+              "expression": "\"customer_product_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_prices_customer_product_id_fkey": {
+          "name": "customer_prices_customer_product_id_fkey",
+          "tableFrom": "customer_prices",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_prices_internal_customer_id_fkey": {
+          "name": "customer_prices_internal_customer_id_fkey",
+          "tableFrom": "customer_prices",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_prices_price_id_fkey": {
+          "name": "customer_prices_price_id_fkey",
+          "tableFrom": "customer_prices",
+          "tableTo": "prices",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_products": {
+      "name": "customer_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processor": {
+          "name": "processor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled": {
+          "name": "canceled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_starts_at": {
+          "name": "access_starts_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "free_trial_id": {
+          "name": "free_trial_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle_anchor": {
+          "name": "billing_cycle_anchor",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle_anchor_resets_at": {
+          "name": "billing_cycle_anchor_resets_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_method": {
+          "name": "collection_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'charge_automatically'"
+        },
+        "subscription_ids": {
+          "name": "subscription_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_ids": {
+          "name": "scheduled_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "customer_license_link_id": {
+          "name": "customer_license_link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_version": {
+          "name": "billing_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_version": {
+          "name": "api_version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_semver": {
+          "name": "api_semver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_customer_product_id": {
+          "name": "previous_customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_trial_end": {
+          "name": "on_trial_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_products_customer_status": {
+          "name": "idx_customer_products_customer_status",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_customer_status_created_at": {
+          "name": "idx_customer_products_customer_status_created_at",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_product_status": {
+          "name": "idx_customer_products_product_status",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_on_internal_entity_id": {
+          "name": "idx_customer_products_on_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_on_internal_product_id": {
+          "name": "idx_customer_products_on_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_subscription_ids": {
+          "name": "idx_customer_products_subscription_ids",
+          "columns": [
+            {
+              "expression": "subscription_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customer_products_scheduled_ids": {
+          "name": "idx_customer_products_scheduled_ids",
+          "columns": [
+            {
+              "expression": "scheduled_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customer_products_stripe_checkout_session_id": {
+          "name": "idx_customer_products_stripe_checkout_session_id",
+          "columns": [
+            {
+              "expression": "stripe_checkout_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_customer_license": {
+          "name": "idx_customer_products_customer_license",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_license_seat_order": {
+          "name": "idx_customer_products_license_seat_order",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_seat_sync": {
+          "name": "idx_customer_products_seat_sync",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_unused_seats": {
+          "name": "idx_customer_products_unused_seats",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "released_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL AND \"customer_products\".\"internal_entity_id\" IS NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_active_pool_assignment": {
+          "name": "unique_active_pool_assignment",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL AND \"customer_products\".\"internal_entity_id\" IS NOT NULL AND \"customer_products\".\"status\" IN ('active', 'past_due')",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_free_trial_id": {
+          "name": "idx_customer_products_free_trial_id",
+          "columns": [
+            {
+              "expression": "free_trial_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"free_trial_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_revenuecat_processor": {
+          "name": "idx_customer_products_revenuecat_processor",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"customer_products\".\"processor\" ->> 'type') = 'revenuecat'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_ended_at": {
+          "name": "idx_customer_products_ended_at",
+          "columns": [
+            {
+              "expression": "ended_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"status\" IN ('active', 'past_due') AND \"customer_products\".\"ended_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_trial_ends_at": {
+          "name": "idx_customer_products_trial_ends_at",
+          "columns": [
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"status\" IN ('active', 'past_due') AND \"customer_products\".\"trial_ends_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_product_id": {
+          "name": "idx_customer_products_product_id",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_products_free_trial_id_fkey": {
+          "name": "customer_products_free_trial_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "free_trials",
+          "columnsFrom": [
+            "free_trial_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "customer_products_internal_customer_id_fkey": {
+          "name": "customer_products_internal_customer_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "customer_products_internal_product_id_fkey": {
+          "name": "customer_products_internal_product_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "customer_products_internal_entity_id_fkey": {
+          "name": "customer_products_internal_entity_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processor": {
+          "name": "processor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processors": {
+          "name": "processors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "send_email_receipts": {
+          "name": "send_email_receipts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_topups": {
+          "name": "auto_topups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spend_limits": {
+          "name": "spend_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limits": {
+          "name": "usage_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_alerts": {
+          "name": "usage_alerts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overage_allowed": {
+          "name": "overage_allowed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "customers_email_null_id_unique": {
+          "name": "customers_email_null_id_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"customers\".\"id\" IS NULL AND \"customers\".\"email\" IS NOT NULL AND \"customers\".\"email\" != ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_org_env_fingerprint": {
+          "name": "idx_customers_org_env_fingerprint",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"fingerprint\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processor_id": {
+          "name": "idx_customers_processor_id",
+          "columns": [
+            {
+              "expression": "(\"processor\" ->> 'id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_composite": {
+          "name": "idx_customers_composite",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_org_env_internal_id": {
+          "name": "idx_customers_org_env_internal_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"internal_id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_email_trgm": {
+          "name": "idx_customers_email_trgm",
+          "columns": [
+            {
+              "expression": "\"email\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"email\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_name_trgm": {
+          "name": "idx_customers_name_trgm",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_id_trgm": {
+          "name": "idx_customers_id_trgm",
+          "columns": [
+            {
+              "expression": "\"id\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_org_id_env_created_at": {
+          "name": "idx_customers_org_id_env_created_at",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_cursor": {
+          "name": "idx_customers_cursor",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processors_revenuecat": {
+          "name": "idx_customers_processors_revenuecat",
+          "columns": [
+            {
+              "expression": "(\"processors\" ->> 'revenuecat')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processors_revenuecat_id": {
+          "name": "idx_customers_processors_revenuecat_id",
+          "columns": [
+            {
+              "expression": "(\"processors\" -> 'revenuecat' ->> 'id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processors_revenuecat_aliases": {
+          "name": "idx_customers_processors_revenuecat_aliases",
+          "columns": [
+            {
+              "expression": "(\"processors\" -> 'revenuecat' -> 'aliases')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_processors_vercel": {
+          "name": "idx_customers_processors_vercel",
+          "columns": [
+            {
+              "expression": "(\"processors\" ->> 'vercel')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customers_org_id_fkey": {
+          "name": "customers_org_id_fkey",
+          "tableFrom": "customers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cus_id_constraint": {
+          "name": "cus_id_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "id",
+            "env"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spend_limits": {
+          "name": "spend_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limits": {
+          "name": "usage_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_alerts": {
+          "name": "usage_alerts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overage_allowed": {
+          "name": "overage_allowed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_entities_internal_customer_id": {
+          "name": "idx_entities_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_internal_feature_id_c": {
+          "name": "idx_entities_internal_feature_id_c",
+          "columns": [
+            {
+              "expression": "\"internal_feature_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"entities\".\"internal_feature_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_internal_feature_id": {
+          "name": "idx_entities_internal_feature_id",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"entities\".\"internal_feature_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_customer_internal_desc": {
+          "name": "idx_entities_customer_internal_desc",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"internal_id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_org_env_id": {
+          "name": "idx_entities_org_env_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_cursor": {
+          "name": "idx_entities_cursor",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_customer_created_at": {
+          "name": "idx_entities_customer_created_at",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entities_internal_customer_id_fkey": {
+          "name": "entities_internal_customer_id_fkey",
+          "tableFrom": "entities",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entities_internal_feature_id_fkey": {
+          "name": "entities_internal_feature_id_fkey",
+          "tableFrom": "entities",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entities_org_id_fkey": {
+          "name": "entities_org_id_fkey",
+          "tableFrom": "entities",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entity_id_constraint": {
+          "name": "entity_id_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "env",
+            "internal_customer_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entitlements": {
+      "name": "entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_id": {
+          "name": "internal_reward_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "allowance_type": {
+          "name": "allowance_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowance": {
+          "name": "allowance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_count": {
+          "name": "interval_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "carry_from_previous": {
+          "name": "carry_from_previous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "entity_feature_id": {
+          "name": "entity_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "pooled": {
+          "name": "pooled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limit": {
+          "name": "usage_limit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_duration": {
+          "name": "expiry_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_length": {
+          "name": "expiry_length",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollover": {
+          "name": "rollover",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_entitlements_internal_product_id": {
+          "name": "idx_entitlements_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_reward_id": {
+          "name": "idx_entitlements_internal_reward_id",
+          "columns": [
+            {
+              "expression": "internal_reward_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_reward_feature": {
+          "name": "idx_entitlements_reward_feature",
+          "columns": [
+            {
+              "expression": "internal_reward_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_feature_id_c": {
+          "name": "idx_entitlements_internal_feature_id_c",
+          "columns": [
+            {
+              "expression": "\"internal_feature_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_feature_id": {
+          "name": "idx_entitlements_internal_feature_id",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_reward_id_c_partial": {
+          "name": "idx_entitlements_internal_reward_id_c_partial",
+          "columns": [
+            {
+              "expression": "\"internal_reward_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"entitlements\".\"internal_reward_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entitlements_internal_feature_id_fkey": {
+          "name": "entitlements_internal_feature_id_fkey",
+          "tableFrom": "entitlements",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entitlements_internal_product_id_fkey": {
+          "name": "entitlements_internal_product_id_fkey",
+          "tableFrom": "entitlements",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "entitlements_internal_reward_id_fkey": {
+          "name": "entitlements_internal_reward_id_fkey",
+          "tableFrom": "entitlements",
+          "tableTo": "rewards",
+          "columnsFrom": [
+            "internal_reward_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entitlements_id_key": {
+          "name": "entitlements_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_usage": {
+          "name": "set_usage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductions": {
+          "name": "deductions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_events_internal_customer_id": {
+          "name": "idx_events_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_internal_entity_id": {
+          "name": "idx_events_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_customer_non_usage_ts": {
+          "name": "idx_events_customer_non_usage_ts",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"timestamp\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"set_usage\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_timestamp": {
+          "name": "idx_events_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_internal_customer_id_fkey": {
+          "name": "events_internal_customer_id_fkey",
+          "tableFrom": "events",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_constraint": {
+          "name": "unique_event_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "env",
+            "customer_id",
+            "event_name",
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.features": {
+      "name": "features",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display": {
+          "name": "display",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_names": {
+          "name": "event_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "model_markups": {
+          "name": "model_markups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "stripe_meter": {
+          "name": "stripe_meter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        }
+      },
+      "indexes": {
+        "idx_features_composite": {
+          "name": "idx_features_composite",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "features_org_id_fkey": {
+          "name": "features_org_id_fkey",
+          "tableFrom": "features",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_id_constraint": {
+          "name": "feature_id_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "id",
+            "env"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.free_trials": {
+      "name": "free_trials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'day'"
+        },
+        "length": {
+          "name": "length",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unique_fingerprint": {
+          "name": "unique_fingerprint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "card_required": {
+          "name": "card_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "on_end": {
+          "name": "on_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_free_trials_internal_product_id": {
+          "name": "idx_free_trials_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "free_trials_internal_product_id_fkey": {
+          "name": "free_trials_internal_product_id_fkey",
+          "tableFrom": "free_trials",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leaf.harness_sessions": {
+      "name": "harness_sessions",
+      "schema": "leaf",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resume_state": {
+          "name": "resume_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "braintrust_parent": {
+          "name": "braintrust_parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "idx_harness_sessions_session_id": {
+          "name": "idx_harness_sessions_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "harness_sessions_org_id_env_thread_key_pk": {
+          "name": "harness_sessions_org_id_env_thread_key_pk",
+          "columns": [
+            "org_id",
+            "env",
+            "thread_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organizations_id_fk": {
+          "name": "invitation_organization_id_organizations_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.invoice_line_items": {
+      "name": "invoice_line_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_item_id": {
+          "name": "stripe_invoice_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_item_id": {
+          "name": "stripe_subscription_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_discountable": {
+          "name": "stripe_discountable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_after_discounts": {
+          "name": "amount_after_discounts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_quantity": {
+          "name": "stripe_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_quantity": {
+          "name": "total_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_quantity": {
+          "name": "paid_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_source": {
+          "name": "description_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_timing": {
+          "name": "billing_timing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prorated": {
+          "name": "prorated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_product_ids": {
+          "name": "customer_product_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customer_price_ids": {
+          "name": "customer_price_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customer_entitlement_ids": {
+          "name": "customer_entitlement_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_period_start": {
+          "name": "effective_period_start",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_period_end": {
+          "name": "effective_period_end",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discounts": {
+          "name": "discounts",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "idx_invoice_line_items_customer_product_ids": {
+          "name": "idx_invoice_line_items_customer_product_ids",
+          "columns": [
+            {
+              "expression": "customer_product_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_invoice_line_items_stripe_invoice_id": {
+          "name": "idx_invoice_line_items_stripe_invoice_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoice_line_items\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoice_line_items_invoice_id": {
+          "name": "idx_invoice_line_items_invoice_id",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoice_line_items\".\"invoice_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoice_line_items_stripe_invoice_item_id": {
+          "name": "idx_invoice_line_items_stripe_invoice_item_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoice_line_items\".\"stripe_invoice_item_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_line_items_invoice_id_fkey": {
+          "name": "invoice_line_items_invoice_id_fkey",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_line_items_stripe_id_unique": {
+          "name": "invoice_line_items_stripe_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_templates": {
+      "name": "invoice_templates",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footer": {
+          "name": "footer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "net_terms_days": {
+          "name": "net_terms_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_invoice_templates_org_id": {
+          "name": "idx_invoice_templates_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_templates_org_id_fkey": {
+          "name": "invoice_templates_org_id_fkey",
+          "tableFrom": "invoice_templates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_templates_id_unique": {
+          "name": "invoice_templates_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "product_ids": {
+          "name": "product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "internal_product_ids": {
+          "name": "internal_product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processor_type": {
+          "name": "processor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "hosted_invoice_url": {
+          "name": "hosted_invoice_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_amount": {
+          "name": "refunded_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "discounts": {
+          "name": "discounts",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "items": {
+          "name": "items",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "idx_invoices_customer_created": {
+          "name": "idx_invoices_customer_created",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_internal_entity_id": {
+          "name": "idx_invoices_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoices\".\"internal_entity_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_internal_customer_id_fkey": {
+          "name": "invoices_internal_customer_id_fkey",
+          "tableFrom": "invoices",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoices_internal_entity_id_fkey": {
+          "name": "invoices_internal_entity_id_fkey",
+          "tableFrom": "invoices",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_stripe_id_key": {
+          "name": "invoices_stripe_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.license_entitlements": {
+      "name": "license_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_license_id": {
+          "name": "plan_license_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "unique_license_entitlement": {
+          "name": "unique_license_entitlement",
+          "columns": [
+            {
+              "expression": "plan_license_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_license_entitlements_entitlement": {
+          "name": "idx_license_entitlements_entitlement",
+          "columns": [
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "license_entitlements_plan_license_fkey": {
+          "name": "license_entitlements_plan_license_fkey",
+          "tableFrom": "license_entitlements",
+          "tableTo": "plan_license",
+          "columnsFrom": [
+            "plan_license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "license_entitlements_entitlement_fkey": {
+          "name": "license_entitlements_entitlement_fkey",
+          "tableFrom": "license_entitlements",
+          "tableTo": "entitlements",
+          "columnsFrom": [
+            "entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.license_prices": {
+      "name": "license_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_license_id": {
+          "name": "plan_license_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "unique_license_price": {
+          "name": "unique_license_price",
+          "columns": [
+            {
+              "expression": "plan_license_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_license_prices_price": {
+          "name": "idx_license_prices_price",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "license_prices_plan_license_fkey": {
+          "name": "license_prices_plan_license_fkey",
+          "tableFrom": "license_prices",
+          "tableTo": "plan_license",
+          "columnsFrom": [
+            "plan_license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "license_prices_price_fkey": {
+          "name": "license_prices_price_fkey",
+          "tableFrom": "license_prices",
+          "tableTo": "prices",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organizations_id_fk": {
+          "name": "member_organization_id_organizations_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.metadata": {
+      "name": "metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_metadata_on_type_expires_at": {
+          "name": "idx_metadata_on_type_expires_at",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "metadata_expires_at_idx": {
+          "name": "metadata_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"metadata\".\"expires_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_errors": {
+      "name": "migration_errors",
+      "schema": "",
+      "columns": {
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "migration_job_id": {
+          "name": "migration_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "migration_customers_internal_customer_id_fkey": {
+          "name": "migration_customers_internal_customer_id_fkey",
+          "tableFrom": "migration_errors",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_customers_migration_job_id_fkey": {
+          "name": "migration_customers_migration_job_id_fkey",
+          "tableFrom": "migration_errors",
+          "tableTo": "migration_jobs",
+          "columnsFrom": [
+            "migration_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "migration_errors_pkey": {
+          "name": "migration_errors_pkey",
+          "columns": [
+            "internal_customer_id",
+            "migration_job_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_item_runs": {
+      "name": "migration_item_runs",
+      "schema": "",
+      "columns": {
+        "migration_item_run_id": {
+          "name": "migration_item_run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "migration_internal_id": {
+          "name": "migration_internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "migration_run_id": {
+          "name": "migration_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "item_kind": {
+          "name": "item_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_item_runs_live_unique": {
+          "name": "migration_item_runs_live_unique",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_item_runs\".\"dry_run\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_item_runs_live_c_idx": {
+          "name": "migration_item_runs_live_c_idx",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"item_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_item_runs\".\"dry_run\" = false",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_item_runs_dry_run_unique": {
+          "name": "migration_item_runs_dry_run_unique",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "migration_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_item_runs\".\"dry_run\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_item_runs_customer_recent_idx": {
+          "name": "migration_item_runs_customer_recent_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_item_runs\".\"item_kind\" = 'customer'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_jobs": {
+      "name": "migration_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_internal_product_id": {
+          "name": "from_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_internal_product_id": {
+          "name": "to_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_details": {
+          "name": "step_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "migration_jobs_from_internal_product_id_fkey": {
+          "name": "migration_jobs_from_internal_product_id_fkey",
+          "tableFrom": "migration_jobs",
+          "tableTo": "products",
+          "columnsFrom": [
+            "from_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_jobs_org_id_fkey": {
+          "name": "migration_jobs_org_id_fkey",
+          "tableFrom": "migration_jobs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_jobs_to_internal_product_id_fkey": {
+          "name": "migration_jobs_to_internal_product_id_fkey",
+          "tableFrom": "migration_jobs",
+          "tableTo": "products",
+          "columnsFrom": [
+            "to_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "migration_internal_id": {
+          "name": "migration_internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lazy_run": {
+          "name": "lazy_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trigger_run_id": {
+          "name": "trigger_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "only_ids": {
+          "name": "only_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_limit": {
+          "name": "target_limit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_per_migration_unique": {
+          "name": "migration_runs_active_per_migration_unique",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" IN ('queued', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_migration_internal_id_fkey": {
+          "name": "migration_runs_migration_internal_id_fkey",
+          "tableFrom": "migration_runs",
+          "tableTo": "migrations",
+          "columnsFrom": [
+            "migration_internal_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_runs_org_id_fkey": {
+          "name": "migration_runs_org_id_fkey",
+          "tableFrom": "migration_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migrations": {
+      "name": "migrations",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operations": {
+          "name": "operations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prepared_state": {
+          "name": "prepared_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_billing_changes": {
+          "name": "no_billing_changes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_failed": {
+          "name": "retry_failed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migrations_org_env_id_unique": {
+          "name": "migrations_org_env_id_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migrations_org_id_fkey": {
+          "name": "migrations_org_id_fkey",
+          "tableFrom": "migrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_consent_id": {
+          "name": "oauth_consent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_oauth_consent_id_oauth_consent_id_fk": {
+          "name": "oauth_access_token_oauth_consent_id_oauth_consent_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_consent",
+          "columnsFrom": [
+            "oauth_consent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_api_key_id": {
+          "name": "oauth_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_consent_id": {
+          "name": "oauth_consent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_oauth_consent_id_oauth_consent_id_fk": {
+          "name": "oauth_refresh_token_oauth_consent_id_oauth_consent_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_consent",
+          "columnsFrom": [
+            "oauth_consent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_currency": {
+          "name": "default_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'usd'"
+        },
+        "stripe_connected": {
+          "name": "stripe_connected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "stripe_config": {
+          "name": "stripe_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_stripe_connect": {
+          "name": "test_stripe_connect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "live_stripe_connect": {
+          "name": "live_stripe_connect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "processor_configs": {
+          "name": "processor_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_pkey": {
+          "name": "test_pkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_pkey": {
+          "name": "live_pkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "svix_config": {
+          "name": "svix_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "custom_buttons": {
+          "name": "custom_buttons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded": {
+          "name": "onboarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "deployed": {
+          "name": "deployed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_sandbox": {
+          "name": "is_sandbox",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sandbox_color": {
+          "name": "sandbox_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_icon": {
+          "name": "sandbox_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redis_config": {
+          "name": "redis_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_organizations_name_trgm": {
+          "name": "idx_organizations_name_trgm",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"organizations\".\"name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_organizations_slug_trgm": {
+          "name": "idx_organizations_slug_trgm",
+          "columns": [
+            {
+              "expression": "\"slug\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"organizations\".\"slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_organizations_created_at_id": {
+          "name": "idx_organizations_created_at_id",
+          "columns": [
+            {
+              "expression": "\"createdAt\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organizations_test_pkey_key": {
+          "name": "organizations_test_pkey_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_pkey"
+          ]
+        },
+        "organizations_live_pkey_key": {
+          "name": "organizations_live_pkey_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "live_pkey"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialId_idx": {
+          "name": "passkey_credentialId_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passkey_credential_id_unique": {
+          "name": "passkey_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.plan_license": {
+      "name": "plan_license",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_internal_product_id": {
+          "name": "parent_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_internal_product_id": {
+          "name": "license_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "included": {
+          "name": "included",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prepaid_only": {
+          "name": "prepaid_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "customized": {
+          "name": "customized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "unique_plan_license": {
+          "name": "unique_plan_license",
+          "columns": [
+            {
+              "expression": "parent_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "license_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"plan_license\".\"is_custom\" = false",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_plan_license_parent_product": {
+          "name": "idx_plan_license_parent_product",
+          "columns": [
+            {
+              "expression": "parent_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_plan_license_license": {
+          "name": "idx_plan_license_license",
+          "columns": [
+            {
+              "expression": "license_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plan_license_parent_product_fkey": {
+          "name": "plan_license_parent_product_fkey",
+          "tableFrom": "plan_license",
+          "tableTo": "products",
+          "columnsFrom": [
+            "parent_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_license_license_product_fkey": {
+          "name": "plan_license_license_product_fkey",
+          "tableFrom": "plan_license",
+          "tableTo": "products",
+          "columnsFrom": [
+            "license_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pooled_balance_contributions": {
+      "name": "pooled_balance_contributions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pooled_balance_id": {
+          "name": "pooled_balance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_customer_product_id": {
+          "name": "source_customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_entitlement_id": {
+          "name": "source_entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_license_link_id": {
+          "name": "customer_license_link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_contribution": {
+          "name": "current_contribution",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_cycle_contribution": {
+          "name": "next_cycle_contribution",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "idx_pooled_balance_contributions_pool": {
+          "name": "idx_pooled_balance_contributions_pool",
+          "columns": [
+            {
+              "expression": "pooled_balance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balance_contributions_source_entitlement": {
+          "name": "idx_pooled_balance_contributions_source_entitlement",
+          "columns": [
+            {
+              "expression": "source_entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balance_contributions_stripe_subscription": {
+          "name": "idx_pooled_balance_contributions_stripe_subscription",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pooled_balance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balance_contributions_license_link": {
+          "name": "idx_pooled_balance_contributions_license_link",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pooled_balance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pooled_balance_contributions_pool_fkey": {
+          "name": "pooled_balance_contributions_pool_fkey",
+          "tableFrom": "pooled_balance_contributions",
+          "tableTo": "pooled_balances",
+          "columnsFrom": [
+            "pooled_balance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pooled_balance_contributions_customer_product_fkey": {
+          "name": "pooled_balance_contributions_customer_product_fkey",
+          "tableFrom": "pooled_balance_contributions",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "source_customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pooled_balance_contributions_entitlement_fkey": {
+          "name": "pooled_balance_contributions_entitlement_fkey",
+          "tableFrom": "pooled_balance_contributions",
+          "tableTo": "entitlements",
+          "columnsFrom": [
+            "source_entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_pooled_balance_contribution": {
+          "name": "unique_pooled_balance_contribution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_customer_product_id",
+            "source_entitlement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pooled_balance_contributions_current_non_negative": {
+          "name": "pooled_balance_contributions_current_non_negative",
+          "value": "\"pooled_balance_contributions\".\"current_contribution\" >= 0"
+        },
+        "pooled_balance_contributions_next_non_negative": {
+          "name": "pooled_balance_contributions_next_non_negative",
+          "value": "\"pooled_balance_contributions\".\"next_cycle_contribution\" >= 0"
+        },
+        "pooled_balance_contributions_single_owner": {
+          "name": "pooled_balance_contributions_single_owner",
+          "value": "\"pooled_balance_contributions\".\"stripe_subscription_id\" IS NULL OR \"pooled_balance_contributions\".\"customer_license_link_id\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pooled_balances": {
+      "name": "pooled_balances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval_count": {
+          "name": "interval_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reset_cycle_anchor": {
+          "name": "reset_cycle_anchor",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_mode": {
+          "name": "reset_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollover_signature": {
+          "name": "rollover_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "customer_entitlement_id": {
+          "name": "customer_entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_applied_reset_at": {
+          "name": "last_applied_reset_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "idx_pooled_balances_org": {
+          "name": "idx_pooled_balances_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balances_reset_mode": {
+          "name": "idx_pooled_balances_reset_mode",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reset_mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balances_feature": {
+          "name": "idx_pooled_balances_feature",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pooled_balances_customer_fkey": {
+          "name": "pooled_balances_customer_fkey",
+          "tableFrom": "pooled_balances",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pooled_balances_feature_fkey": {
+          "name": "pooled_balances_feature_fkey",
+          "tableFrom": "pooled_balances",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "pooled_balances_customer_entitlement_fkey": {
+          "name": "pooled_balances_customer_entitlement_fkey",
+          "tableFrom": "pooled_balances",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "customer_entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_pooled_balance": {
+          "name": "unique_pooled_balance",
+          "nullsNotDistinct": true,
+          "columns": [
+            "internal_customer_id",
+            "internal_feature_id",
+            "interval",
+            "interval_count",
+            "reset_cycle_anchor",
+            "reset_mode",
+            "rollover_signature"
+          ]
+        },
+        "unique_pooled_balance_customer_entitlement": {
+          "name": "unique_pooled_balance_customer_entitlement",
+          "nullsNotDistinct": false,
+          "columns": [
+            "customer_entitlement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pooled_balances_interval_count_positive": {
+          "name": "pooled_balances_interval_count_positive",
+          "value": "\"pooled_balances\".\"interval_count\" > 0"
+        },
+        "pooled_balances_reset_mode_valid": {
+          "name": "pooled_balances_reset_mode_valid",
+          "value": "\"pooled_balances\".\"reset_mode\" IN ('lazy', 'subscription')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.prices": {
+      "name": "prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_type": {
+          "name": "billing_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier_behavior": {
+          "name": "tier_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "proration_config": {
+          "name": "proration_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        }
+      },
+      "indexes": {
+        "idx_prices_internal_product_id": {
+          "name": "idx_prices_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_entitlement_id": {
+          "name": "idx_prices_entitlement_id",
+          "columns": [
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prices_entitlement_id_fkey": {
+          "name": "prices_entitlement_id_fkey",
+          "tableFrom": "prices",
+          "tableTo": "entitlements",
+          "columnsFrom": [
+            "entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prices_internal_product_id_fkey": {
+          "name": "prices_internal_product_id_fkey",
+          "tableFrom": "prices",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "prices_id_key": {
+          "name": "prices_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_add_on": {
+          "name": "is_add_on",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "version": {
+          "name": "version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "processor": {
+          "name": "processor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "base_variant_id": {
+          "name": "base_variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_internal_product_id": {
+          "name": "base_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "auto_topups": {
+          "name": "auto_topups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spend_limits": {
+          "name": "spend_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limits": {
+          "name": "usage_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_alerts": {
+          "name": "usage_alerts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overage_allowed": {
+          "name": "overage_allowed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_products_org_env_id_version": {
+          "name": "idx_products_org_env_id_version",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_org_env_base_internal_product_id": {
+          "name": "idx_products_org_env_base_internal_product_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "base_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"products\".\"base_internal_product_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_org_id_fkey": {
+          "name": "products_org_id_fkey",
+          "tableFrom": "products",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_product": {
+          "name": "unique_product",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "id",
+            "env",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.referral_codes": {
+      "name": "referral_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_program_id": {
+          "name": "internal_reward_program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_referral_codes_internal_customer_id": {
+          "name": "idx_referral_codes_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "referral_codes_internal_customer_id_fkey": {
+          "name": "referral_codes_internal_customer_id_fkey",
+          "tableFrom": "referral_codes",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "referral_codes_internal_reward_program_id_fkey": {
+          "name": "referral_codes_internal_reward_program_id_fkey",
+          "tableFrom": "referral_codes",
+          "tableTo": "reward_programs",
+          "columnsFrom": [
+            "internal_reward_program_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "referral_codes_org_id_fkey": {
+          "name": "referral_codes_org_id_fkey",
+          "tableFrom": "referral_codes",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "referral_codes_pkey": {
+          "name": "referral_codes_pkey",
+          "columns": [
+            "code",
+            "org_id",
+            "env"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "referral_codes_id_key": {
+          "name": "referral_codes_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.replaceables": {
+      "name": "replaceables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cus_ent_id": {
+          "name": "cus_ent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_next_cycle": {
+          "name": "delete_next_cycle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_replaceables_cus_ent_id": {
+          "name": "idx_replaceables_cus_ent_id",
+          "columns": [
+            {
+              "expression": "cus_ent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "replaceables_cus_ent_id_fkey": {
+          "name": "replaceables_cus_ent_id_fkey",
+          "tableFrom": "replaceables",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "cus_ent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.revenuecat_mappings": {
+      "name": "revenuecat_mappings",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "autumn_product_id": {
+          "name": "autumn_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revenuecat_product_ids": {
+          "name": "revenuecat_product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "feature_quantities": {
+          "name": "feature_quantities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "revenuecat_mappings_org_id_fkey": {
+          "name": "revenuecat_mappings_org_id_fkey",
+          "tableFrom": "revenuecat_mappings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "revenuecat_mappings_pkey": {
+          "name": "revenuecat_mappings_pkey",
+          "columns": [
+            "org_id",
+            "env",
+            "autumn_product_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reward_programs": {
+      "name": "reward_programs",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_id": {
+          "name": "internal_reward_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_redemptions": {
+          "name": "max_redemptions",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unlimited_redemptions": {
+          "name": "unlimited_redemptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when": {
+          "name": "when",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'immediately'"
+        },
+        "product_ids": {
+          "name": "product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"\"}'"
+        },
+        "exclude_trial": {
+          "name": "exclude_trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reward_triggers_internal_reward_id_fkey": {
+          "name": "reward_triggers_internal_reward_id_fkey",
+          "tableFrom": "reward_programs",
+          "tableTo": "rewards",
+          "columnsFrom": [
+            "internal_reward_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reward_triggers_org_id_fkey": {
+          "name": "reward_triggers_org_id_fkey",
+          "tableFrom": "reward_programs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reward_redemptions": {
+      "name": "reward_redemptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered": {
+          "name": "triggered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_program_id": {
+          "name": "internal_reward_program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "redeemer_applied": {
+          "name": "redeemer_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "referral_code_id": {
+          "name": "referral_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_internal_id": {
+          "name": "reward_internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_code": {
+          "name": "promo_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_reward_redemptions_referral_code_id": {
+          "name": "idx_reward_redemptions_referral_code_id",
+          "columns": [
+            {
+              "expression": "referral_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reward_redemptions_reward_internal_id": {
+          "name": "idx_reward_redemptions_reward_internal_id",
+          "columns": [
+            {
+              "expression": "reward_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reward_redemptions_customer_reward": {
+          "name": "idx_reward_redemptions_customer_reward",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reward_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reward_redemptions_internal_customer_id_fkey": {
+          "name": "reward_redemptions_internal_customer_id_fkey",
+          "tableFrom": "reward_redemptions",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reward_redemptions_internal_reward_program_id_fkey": {
+          "name": "reward_redemptions_internal_reward_program_id_fkey",
+          "tableFrom": "reward_redemptions",
+          "tableTo": "reward_programs",
+          "columnsFrom": [
+            "internal_reward_program_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reward_redemptions_referral_code_id_fkey": {
+          "name": "reward_redemptions_referral_code_id_fkey",
+          "tableFrom": "reward_redemptions",
+          "tableTo": "referral_codes",
+          "columnsFrom": [
+            "referral_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards": {
+      "name": "rewards",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount_config": {
+          "name": "discount_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "free_product_config": {
+          "name": "free_product_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "free_product_id": {
+          "name": "free_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_codes": {
+          "name": "promo_codes",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_rewards_org_id_env": {
+          "name": "idx_rewards_org_id_env",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "coupons_org_id_fkey": {
+          "name": "coupons_org_id_fkey",
+          "tableFrom": "rewards",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rollovers": {
+      "name": "rollovers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cus_ent_id": {
+          "name": "cus_ent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "entities": {
+          "name": "entities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "idx_rollovers_cus_ent_id": {
+          "name": "idx_rollovers_cus_ent_id",
+          "columns": [
+            {
+              "expression": "cus_ent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rollovers_cus_ent_expires": {
+          "name": "idx_rollovers_cus_ent_expires",
+          "columns": [
+            {
+              "expression": "cus_ent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rollover_cus_ent_id_fkey": {
+          "name": "rollover_cus_ent_id_fkey",
+          "tableFrom": "rollovers",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "cus_ent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.phases": {
+      "name": "phases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_product_ids": {
+          "name": "customer_product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "phases_schedule_id_fkey": {
+          "name": "phases_schedule_id_fkey",
+          "tableFrom": "phases",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "phases_schedule_id_starts_at_key": {
+          "name": "phases_schedule_id_starts_at_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "schedule_id",
+            "starts_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "schedules_customer_scope_unique": {
+          "name": "schedules_customer_scope_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"internal_entity_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_entity_scope_unique": {
+          "name": "schedules_entity_scope_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"internal_entity_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_schedules_internal_customer_id": {
+          "name": "idx_schedules_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_schedules_internal_entity_id": {
+          "name": "idx_schedules_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_org_id_fkey": {
+          "name": "schedules_org_id_fkey",
+          "tableFrom": "schedules",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedules_internal_customer_id_fkey": {
+          "name": "schedules_internal_customer_id_fkey",
+          "tableFrom": "schedules",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedules_internal_entity_id_fkey": {
+          "name": "schedules_internal_entity_id_fkey",
+          "tableFrom": "schedules",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "leaf.slack_admin_threads": {
+      "name": "slack_admin_threads",
+      "schema": "leaf",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_installation_id": {
+          "name": "chat_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_identifier": {
+          "name": "target_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_provider_user_id": {
+          "name": "created_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_admin_threads_thread_key": {
+          "name": "slack_admin_threads_thread_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "channel_id",
+            "thread_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_schedule_id": {
+          "name": "stripe_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "usage_features": {
+          "name": "usage_features",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_org_id_fkey": {
+          "name": "subscriptions_org_id_fkey",
+          "tableFrom": "subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_id_key": {
+          "name": "subscriptions_stripe_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transition_rules": {
+      "name": "transition_rules",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "carry_over_usages": {
+          "name": "carry_over_usages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transition_rules_org_id_fkey": {
+          "name": "transition_rules_org_id_fkey",
+          "tableFrom": "transition_rules",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transition_rules_pkey": {
+          "name": "transition_rules_pkey",
+          "columns": [
+            "org_id",
+            "env"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_windows": {
+      "name": "usage_windows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter_key": {
+          "name": "filter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anchor_customer_entitlement_id": {
+          "name": "anchor_customer_entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage": {
+          "name": "usage",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_usage_windows_internal_customer_id": {
+          "name": "idx_usage_windows_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_uw_internal_feature_id": {
+          "name": "idx_uw_internal_feature_id",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_windows_customer_feature_scope": {
+          "name": "idx_usage_windows_customer_feature_scope",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "COALESCE(\"internal_entity_id\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "COALESCE(\"filter_key\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_windows_internal_customer_id_fkey": {
+          "name": "usage_windows_internal_customer_id_fkey",
+          "tableFrom": "usage_windows",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_windows_internal_entity_id_fkey": {
+          "name": "usage_windows_internal_entity_id_fkey",
+          "tableFrom": "usage_windows",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_windows_internal_feature_id_fkey": {
+          "name": "usage_windows_internal_feature_id_fkey",
+          "tableFrom": "usage_windows",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_windows_anchor_customer_entitlement_id_fkey": {
+          "name": "usage_windows_anchor_customer_entitlement_id_fkey",
+          "tableFrom": "usage_windows",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "anchor_customer_entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_name_trgm": {
+          "name": "idx_user_name_trgm",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user\".\"name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_user_email_trgm": {
+          "name": "idx_user_email_trgm",
+          "columns": [
+            {
+              "expression": "\"email\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user\".\"email\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_user_created_at_id": {
+          "name": "idx_user_created_at_id",
+          "columns": [
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_created_by_fkey": {
+          "name": "user_created_by_fkey",
+          "tableFrom": "user",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vercel_resources": {
+      "name": "vercel_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "vercel_resources_installation_name_unique_idx": {
+          "name": "vercel_resources_installation_name_unique_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status <> 'uninstalled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vercel_resources_org_id_fkey": {
+          "name": "vercel_resources_org_id_fkey",
+          "tableFrom": "vercel_resources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "leaf": "leaf"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/drizzle/meta/_journal.json
+++ b/shared/drizzle/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1784651067466,
       "tag": "0047_woozy_blackheart",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1784652947024,
+      "tag": "0048_sour_dracula",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/models/billingModels/plan/autumnBillingPlan.ts
+++ b/shared/models/billingModels/plan/autumnBillingPlan.ts
@@ -28,6 +28,10 @@ import {
 	CustomerLicenseUpdateSchema,
 	InsertPlanLicenseSpecSchema,
 } from "./customerLicensePlan";
+import {
+	PooledBalanceOpSchema,
+	PooledBalancePlanSchema,
+} from "./pooledBalancePlan";
 
 export const UpdateCustomerEntitlementSchema = z.object({
 	customerEntitlement: FullCustomerEntitlementSchema,
@@ -39,6 +43,7 @@ export const UpdateCustomerEntitlementSchema = z.object({
 			next_reset_at: z.number().optional(),
 			reset_cycle_anchor: z.number().nullable().optional(),
 			adjustment: z.number().optional(),
+			additional_balance: z.number().optional(),
 			entities: z.record(z.string(), EntityBalanceSchema).optional(),
 			balance: z.number().optional(),
 		})
@@ -119,6 +124,8 @@ export const AutumnBillingPlanSchema = z.object({
 	customerLicenseTransitions: z
 		.array(CustomerLicenseTransitionSchema)
 		.optional(),
+	pooledBalancePlan: PooledBalancePlanSchema.optional(),
+	pooledBalanceOps: z.array(PooledBalanceOpSchema).optional(),
 
 	lineItems: z.array(LineItemSchema).optional(),
 	customLineItems: z.array(CustomLineItemSchema).optional(),

--- a/shared/models/billingModels/plan/index.ts
+++ b/shared/models/billingModels/plan/index.ts
@@ -2,4 +2,5 @@ export * from "./autumnBillingPlan";
 export * from "./billingPlan";
 export * from "./billingResult";
 export * from "./customerLicensePlan";
+export * from "./pooledBalancePlan";
 export * from "./previewBillingPlan";

--- a/shared/models/billingModels/plan/pooledBalancePlan.ts
+++ b/shared/models/billingModels/plan/pooledBalancePlan.ts
@@ -1,0 +1,147 @@
+import { z } from "zod/v4";
+import { EntInterval } from "../../productModels/intervals/entitlementInterval.js";
+import { RolloverConfigSchema } from "../../productV2Models/productItemModels/productItemModels.js";
+
+const PooledBalanceSourceSchema = z.object({
+	internalCustomerId: z.string(),
+	sourceCustomerProductId: z.string(),
+});
+
+export const PooledBalanceUsageReapplySchema = z.object({
+	amount: z.number().positive(),
+	excludedSourceCustomerProductId: z.string(),
+});
+
+export const UpsertPooledBalanceSourceSchema = PooledBalanceSourceSchema.extend(
+	{
+		featureId: z.string(),
+		internalFeatureId: z.string(),
+		interval: z.nativeEnum(EntInterval),
+		intervalCount: z.number().int().positive(),
+		resetCycleAnchor: z.number().nullable(),
+		nextResetAt: z.number().nullable(),
+		rollover: RolloverConfigSchema.nullish().default(null),
+		stripeSubscriptionId: z.string().nullable(),
+		customerLicenseLinkId: z.string().nullable(),
+		sourceEntitlementId: z.string(),
+		currentCycleContribution: z.number().nonnegative(),
+		nextCycleContribution: z.number().nonnegative(),
+		usageReapply: PooledBalanceUsageReapplySchema.optional(),
+	},
+);
+
+export const UpsertPooledBalanceSourceOpSchema =
+	UpsertPooledBalanceSourceSchema.extend({
+		op: z.literal("upsert_source"),
+	});
+
+export const RemovePooledBalanceSourceSchema = PooledBalanceSourceSchema.extend(
+	{
+		effectiveAt: z.number().nullable(),
+	},
+);
+
+export const RemovePooledBalanceSourceOpSchema =
+	RemovePooledBalanceSourceSchema.extend({
+		op: z.literal("remove_source"),
+	});
+
+export const RemovePooledBalanceContributionOpSchema =
+	PooledBalanceSourceSchema.extend({
+		op: z.literal("remove_contribution"),
+		sourceEntitlementId: z.string(),
+		effectiveAt: z.number().nullable(),
+	});
+
+export const RestorePooledBalanceSourceOpSchema =
+	PooledBalanceSourceSchema.extend({
+		op: z.literal("restore_source"),
+		expectedEffectiveAt: z.number(),
+	});
+
+const PooledBalanceOwnerSchema = z.object({
+	internalCustomerId: z.string(),
+	customerLicenseLinkId: z.string(),
+});
+
+export const StagePooledBalanceOwnerRemovalOpSchema =
+	PooledBalanceOwnerSchema.extend({
+		op: z.literal("stage_owner_removal"),
+		effectiveAt: z.number(),
+	});
+
+export const RestorePooledBalanceOwnerOpSchema =
+	PooledBalanceOwnerSchema.extend({
+		op: z.literal("restore_owner"),
+		expectedEffectiveAt: z.number(),
+	});
+
+export const TransferPooledBalanceSourceOpSchema =
+	UpsertPooledBalanceSourceSchema.omit({
+		usageReapply: true,
+	}).extend({
+		op: z.literal("transfer_source"),
+		contributionId: z.string(),
+		expectedPooledBalanceId: z.string(),
+	});
+
+export const PooledBalanceIdentitySchema = z.object({
+	featureId: z.string(),
+	internalFeatureId: z.string(),
+	interval: z.enum(EntInterval),
+	intervalCount: z.number().int().positive(),
+	resetCycleAnchor: z.number().nullable(),
+	nextResetAt: z.number().nullable(),
+	rollover: RolloverConfigSchema.nullish().default(null),
+});
+
+export const PooledContributionSpecSchema = z.object({
+	sourceCustomerProductId: z.string(),
+	sourceEntitlementId: z.string(),
+	stripeSubscriptionId: z.string().nullable(),
+	customerLicenseLinkId: z.string().nullable(),
+	currentCycleContribution: z.number().nonnegative(),
+	nextCycleContribution: z.number().nonnegative(),
+});
+
+export const UpsertPooledBalanceSourceSpecSchema = z.object({
+	internalCustomerId: z.string(),
+	pooledBalance: PooledBalanceIdentitySchema,
+	contribution: PooledContributionSpecSchema,
+	usageCarry: PooledBalanceUsageReapplySchema.optional(),
+});
+
+export const PooledBalanceOpSchema = z.discriminatedUnion("op", [
+	UpsertPooledBalanceSourceOpSchema,
+	RemovePooledBalanceSourceOpSchema,
+	RemovePooledBalanceContributionOpSchema,
+	RestorePooledBalanceSourceOpSchema,
+	StagePooledBalanceOwnerRemovalOpSchema,
+	RestorePooledBalanceOwnerOpSchema,
+	TransferPooledBalanceSourceOpSchema,
+]);
+
+export type PooledBalanceOp = z.infer<typeof PooledBalanceOpSchema>;
+export type PooledBalanceUsageReapply = z.infer<
+	typeof PooledBalanceUsageReapplySchema
+>;
+
+export const PooledBalancePlanSchema = z.object({
+	removeSources: z.array(RemovePooledBalanceSourceSchema).optional(),
+	upsertSources: z.array(UpsertPooledBalanceSourceSpecSchema).optional(),
+});
+
+export type PooledBalancePlan = z.infer<typeof PooledBalancePlanSchema>;
+export type RemovePooledBalanceSource = z.infer<
+	typeof RemovePooledBalanceSourceSchema
+>;
+export type UpsertPooledBalanceSource = z.infer<
+	typeof UpsertPooledBalanceSourceSchema
+>;
+export type PooledBalanceIdentity = z.infer<typeof PooledBalanceIdentitySchema>;
+export type PooledContributionSpec = z.infer<
+	typeof PooledContributionSpecSchema
+>;
+export type UpsertPooledBalanceSourceSpec = z.infer<
+	typeof UpsertPooledBalanceSourceSpecSchema
+>;

--- a/shared/models/pooledBalanceModels/pooledBalanceTable.ts
+++ b/shared/models/pooledBalanceModels/pooledBalanceTable.ts
@@ -16,16 +16,9 @@ import { features } from "../featureModels/featureTable.js";
 import { entitlements } from "../productModels/entModels/entTable.js";
 import type { EntInterval } from "../productModels/intervals/entitlementInterval.js";
 
-export enum PooledBalanceResetOwnerType {
-	CustomerProduct = "customer_product",
-	Subscription = "subscription",
-	Free = "free",
-}
-
 export enum PooledBalanceResetMode {
 	Lazy = "lazy",
 	Subscription = "subscription",
-	Lifetime = "lifetime",
 }
 
 export const pooledBalances = pgTable(
@@ -82,7 +75,7 @@ export const pooledBalances = pgTable(
 		),
 		check(
 			"pooled_balances_reset_mode_valid",
-			sql`${table.reset_mode} IN ('lazy', 'subscription', 'lifetime')`,
+			sql`${table.reset_mode} IN ('lazy', 'subscription')`,
 		),
 		unique("unique_pooled_balance_customer_entitlement").on(
 			table.customer_entitlement_id,
@@ -104,8 +97,10 @@ export const pooledBalanceContributions = pgTable(
 		pooled_balance_id: text().notNull(),
 		source_customer_product_id: text().notNull(),
 		source_entitlement_id: text().notNull(),
-		reset_owner_type: text().$type<PooledBalanceResetOwnerType>().notNull(),
-		reset_owner_id: text().notNull(),
+		// Who renews this contribution: a Stripe subscription, a license link
+		// (customer_licenses.link_id), or neither (free — lazy anchor resets).
+		stripe_subscription_id: text(),
+		customer_license_link_id: text(),
 		current_contribution: numeric({ mode: "number" }).notNull().default(0),
 		next_cycle_contribution: numeric({ mode: "number" }).notNull().default(0),
 		effective_at: numeric({ mode: "number" }),
@@ -137,8 +132,8 @@ export const pooledBalanceContributions = pgTable(
 			sql`${table.next_cycle_contribution} >= 0`,
 		),
 		check(
-			"pooled_balance_contributions_reset_owner_type_valid",
-			sql`${table.reset_owner_type} IN ('customer_product', 'subscription', 'free')`,
+			"pooled_balance_contributions_single_owner",
+			sql`${table.stripe_subscription_id} IS NULL OR ${table.customer_license_link_id} IS NULL`,
 		),
 		unique("unique_pooled_balance_contribution").on(
 			table.source_customer_product_id,
@@ -150,8 +145,11 @@ export const pooledBalanceContributions = pgTable(
 		index("idx_pooled_balance_contributions_source_entitlement")
 			.on(table.source_entitlement_id)
 			.concurrently(),
-		index("idx_pooled_balance_contributions_reset_owner")
-			.on(table.reset_owner_type, table.reset_owner_id, table.pooled_balance_id)
+		index("idx_pooled_balance_contributions_stripe_subscription")
+			.on(table.stripe_subscription_id, table.pooled_balance_id)
+			.concurrently(),
+		index("idx_pooled_balance_contributions_license_link")
+			.on(table.customer_license_link_id, table.pooled_balance_id)
 			.concurrently(),
 	],
 );

--- a/shared/utils/cusEntUtils/balanceUtils/cusEntToStartingBalance.ts
+++ b/shared/utils/cusEntUtils/balanceUtils/cusEntToStartingBalance.ts
@@ -5,8 +5,10 @@ import { getStartingBalance } from "../getStartingBalance";
 
 export const cusEntToStartingBalance = ({
 	cusEnt,
+	useUpcomingQuantity = false,
 }: {
 	cusEnt: FullCusEntWithFullCusProduct;
+	useUpcomingQuantity?: boolean;
 }) => {
 	const cusPrice = cusEntToCusPrice({ cusEnt });
 	const price = cusPrice?.price;
@@ -14,10 +16,14 @@ export const cusEntToStartingBalance = ({
 		ent: cusEnt.entitlement,
 		options: cusEnt.customer_product?.options ?? [],
 	});
+	const effectiveOptions =
+		useUpcomingQuantity && options
+			? { ...options, quantity: options.upcoming_quantity ?? options.quantity }
+			: options;
 
 	return getStartingBalance({
 		entitlement: cusEnt.entitlement,
-		options,
+		options: effectiveOptions,
 		relatedPrice: price,
 		productQuantity: cusEnt.customer_product?.quantity ?? 1,
 	});

--- a/shared/utils/productUtils/entUtils/convertEnt/entitlementToRolloverSignature.ts
+++ b/shared/utils/productUtils/entUtils/convertEnt/entitlementToRolloverSignature.ts
@@ -1,0 +1,24 @@
+import type { Entitlement } from "@models/productModels/entModels/entModels";
+import type { RolloverConfig } from "@models/productV2Models/productItemModels/productItemModels";
+
+/** Field-by-field encoding matching rolloversAreSame's loose-null semantics. */
+export const rolloverToSignature = ({
+	rollover,
+}: {
+	rollover?: RolloverConfig | null;
+}): string => {
+	if (!rollover) return "none";
+
+	return JSON.stringify({
+		max: rollover.max ?? null,
+		max_percentage: rollover.max_percentage ?? null,
+		duration: rollover.duration ?? null,
+		length: rollover.length ?? null,
+	});
+};
+
+export const entitlementToRolloverSignature = ({
+	entitlement,
+}: {
+	entitlement: Entitlement;
+}): string => rolloverToSignature({ rollover: entitlement.rollover });

--- a/shared/utils/productUtils/entUtils/index.ts
+++ b/shared/utils/productUtils/entUtils/index.ts
@@ -1,5 +1,6 @@
 export * from "./classifyEntUtils.js";
 export * from "./compareEnt/entsAreSame.js";
+export * from "./convertEnt/entitlementToRolloverSignature.js";
 export * from "./enrichEntitlement.js";
 export * from "./findEntitlement/findEntitlementSuccessor.js";
 export * from "./formatEntUtils.js";

--- a/shared/utils/productUtils/priceUtils/convertPriceUtils.ts
+++ b/shared/utils/productUtils/priceUtils/convertPriceUtils.ts
@@ -2,8 +2,17 @@ import { InternalError } from "@api/errors/base/InternalError";
 import { BillingMethod } from "@api/products/components/billingMethod";
 import type { Feature } from "@models/featureModels/featureModels";
 import type { EntitlementWithFeature } from "@models/productModels/entModels/entModels";
-import type { UsagePriceConfig } from "@models/productModels/priceModels/priceConfig/usagePriceConfig";
-import { BillingType } from "@models/productModels/priceModels/priceEnums";
+import { FixedPriceConfigSchema } from "@models/productModels/priceModels/priceConfig/fixedPriceConfig";
+import {
+	type PriceCurrencyConfig,
+	type UsagePriceConfig,
+	UsagePriceConfigSchema,
+	type UsageTier,
+} from "@models/productModels/priceModels/priceConfig/usagePriceConfig";
+import {
+	BillingType,
+	PriceType,
+} from "@models/productModels/priceModels/priceEnums";
 import type { Price } from "@models/productModels/priceModels/priceModels";
 import {
 	OnDecrease,
@@ -15,8 +24,8 @@ import {
 	shouldProrate,
 	shouldSkipLineItems,
 } from "@utils/billingUtils";
-import { getBillingType } from "@utils/productUtils/priceUtils";
 import { priceToEnt } from "@utils/productUtils/convertProductUtils";
+import { getBillingType } from "@utils/productUtils/priceUtils";
 
 // Overload: errorOnNotFound = true → guaranteed Feature
 export function priceToFeature(params: {
@@ -115,3 +124,85 @@ export const priceToBillingMethod = ({
 
 	return undefined;
 };
+
+export enum PriceSignaturePrecision {
+	/** Every field pricesAreSame compares — same signature ⇔ same definition. */
+	Definition = "definition",
+	/** Feature, derived billing type, and billing cadence (findPriceSuccessor's key). */
+	BillingIdentity = "billing_identity",
+}
+
+// The final tier's `to` is ignored, mirroring tiersAreSame: "inf" and -1
+// both mean "no upper bound".
+const tiersToSignature = (tiers?: UsageTier[] | null) =>
+	(tiers ?? []).map((tier, index, allTiers) => [
+		index === allTiers.length - 1 ? null : tier.to,
+		tier.amount,
+		tier.flat_amount ?? 0,
+	]);
+
+const currenciesToSignature = (
+	currencies?: Record<string, PriceCurrencyConfig> | null,
+) =>
+	Object.keys(currencies ?? {})
+		.sort()
+		.map((currencyCode) => [
+			currencyCode,
+			currencies?.[currencyCode]?.amount ?? null,
+			tiersToSignature(currencies?.[currencyCode]?.usage_tiers),
+		]);
+
+const priceToDefinitionSignature = ({ price }: { price: Price }): string => {
+	if (price.config.type === PriceType.Fixed) {
+		const config = FixedPriceConfigSchema.parse(price.config);
+		return JSON.stringify({
+			type: config.type,
+			amount: config.amount,
+			interval: config.interval,
+			interval_count: config.interval_count ?? null,
+			base_currency: config.base_currency ?? null,
+			currencies: currenciesToSignature(config.currencies),
+		});
+	}
+
+	const config = UsagePriceConfigSchema.parse(price.config);
+	return JSON.stringify({
+		type: config.type,
+		bill_when: config.bill_when,
+		billing_units: config.billing_units ?? null,
+		should_prorate: config.should_prorate ?? null,
+		allocated_billing_behavior: config.allocated_billing_behavior ?? null,
+		interval: config.interval,
+		interval_count: config.interval_count ?? null,
+		feature_id: config.feature_id,
+		internal_feature_id: config.internal_feature_id,
+		usage_tiers: tiersToSignature(config.usage_tiers),
+		base_currency: config.base_currency ?? null,
+		currencies: currenciesToSignature(config.currencies),
+		on_increase: price.proration_config?.on_increase ?? null,
+		on_decrease: price.proration_config?.on_decrease ?? null,
+		tier_behavior: price.tier_behavior ?? null,
+	});
+};
+
+const priceToBillingIdentitySignature = ({ price }: { price: Price }): string =>
+	JSON.stringify({
+		feature_id: price.config.feature_id ?? null,
+		billing_type: getBillingType(price.config),
+		interval: price.config.interval ?? null,
+		interval_count: price.config.interval
+			? (price.config.interval_count ?? 1)
+			: null,
+	});
+
+/** Deterministic, field-by-field encoding of a price definition. */
+export const priceToSignature = ({
+	price,
+	precision,
+}: {
+	price: Price;
+	precision: PriceSignaturePrecision;
+}): string =>
+	precision === PriceSignaturePrecision.Definition
+		? priceToDefinitionSignature({ price })
+		: priceToBillingIdentitySignature({ price });

--- a/shared/utils/utils.ts
+++ b/shared/utils/utils.ts
@@ -9,6 +9,10 @@ export const nullish = <T>(
 export const notNullish = <T>(value: T | null | undefined): value is T =>
 	value !== null && value !== undefined;
 
+/** True only for real, finite numbers — rejects null/undefined, NaN, and ±Infinity. */
+export const isFiniteNumber = (value: unknown): value is number =>
+	Number.isFinite(value);
+
 export const idRegex = /^[a-zA-Z0-9_-]+$/;
 
 export const sumValues = (vals: number[]) => {


### PR DESCRIPTION
## Summary

- add pooled balance planning and execution to billing V2 attach, update, sync, schedule, DFU, and license flows
- introduce the structured `PooledBalancePlan` model and adapt pool identity to exclude pool-level entitlement and price IDs
- preserve and integrate the in-progress full-subject cache/balance-sync handoff, including atomic cache cutovers and live balance reapplication
- model contribution ownership with Stripe subscription or customer-license-link columns
- add a follow-up migration for the contribution owner schema

## Stack

- stacked on #2336
- base: `feat/pooled-balances-v2`

## Verification

- `bun -F @autumn/server ts`
- `bun -F @autumn/vite ts`
- changed TypeScript files pass Biome checks (two pre-existing warnings in `convertCusProduct.ts`)
- `bun db migrate:dry`
- commit hook: Knip + server TypeScript

Tests are intentionally left for the dedicated tests layer of the stack.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pooled balance support to Billing V2 so customer and license products can contribute to shared pools with safe cache/DB cutovers. All attach/sync/update/cancel/schedule/DFU and license flows now compute and execute pooled balance plans/ops.

- **New Features**
  - Added `PooledBalancePlan` and `pooledBalanceOps` to `AutumnBillingPlan` in `@autumn/shared`; included in plan logs and merging.
  - Implemented pooled balance engine (upsert/remove/transfer, quantity updates, cache cutover, reconciliation) with DB locking and atomic Redis cutovers.
  - Compute pooled plans/ops in attach, update (field/quantity), cancel/uncancel/pause/resume, sync (immediate/future), create schedule, DFU, and license attach/release.
  - Modeled contribution ownership by Stripe subscription or customer-license link; reset modes: subscription or lazy (free pool).
  - Rebalance usage across pooled/non-pooled grants and reapply live usage; prevents double-subscription owners and preserves rollover via signatures.
  - Added Redis Lua and commands for batched subject balance updates; integrated subject-balance write path and balance-sync lock.

- **Migration**
  - Run migration `0048_sour_dracula`: adds `stripe_subscription_id` and `customer_license_link_id` to pooled contributions; updates `reset_mode`; new indexes.
  - Registers new Redis command `updateSubjectBalanceBatches`; ensure Redis deployments load updated scripts.
  - No API shape changes required; deploy server and run DB migration before enabling pooled pools.

<sup>Written for commit acf71461994c279fca9b35b851992ce36f6575ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds pooled balances throughout the billing V2 lifecycle. The main changes are:

- **Improvements · API changes:** Structured pooled-balance plans and operations.
- **Improvements:** Pooled flows for attach, update, sync, schedules, DFU, and licenses.
- **Improvements:** Atomic cache cutovers, usage reapplication, and balance-sync locking.
- **API changes:** Subscription and license-link ownership for pooled contributions.
- **Bug fixes:** Idempotent license assignment accounting for existing entities.
</details>

<h3>Confidence Score: 2/5</h3>

The server build and balance durability paths need fixes before merging.

- The new Redis command imports Lua modules that are absent from the revision.
- A failed database flush can return normally after Redis balance fields were removed.
- Pooled-to-pooled replacements can omit consumed usage.
- Lifecycle writes can run before the customer-scoped pooled-operation lock.

luaScriptsV2.ts, flushSubjectBalancesToDb.ts, computePooledUsageCarrySpec.ts, and executePooledBalanceOps.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/_luaScriptsV2/luaScriptsV2.ts | Adds the batched balance-update script composition but imports missing Lua modules. |
| server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts | Adds explicit flush statuses but allows a failed durable write to return normally. |
| server/src/internal/balances/utils/sync/withCustomerBalanceSyncLock.ts | Adds a tenant- and customer-scoped advisory transaction lock for balance synchronization. |
| server/src/internal/billing/v2/pooledBalances/compute/initUpsertPooledBalanceSourceSpec/computePooledUsageCarrySpec.ts | Computes transition usage carry but excludes outgoing pooled sources. |
| server/src/internal/billing/v2/execute/executeAutumnActions/executePooledBalanceOps.ts | Adds pooled lifecycle execution, transfers, rebalancing, ownership transitions, and cache effects. |
| server/src/internal/billing/v2/pooledBalances/execute/applyPooledBalanceCacheEffects.ts | Adds guarded Redis cutovers, retries, reconciliation, and final database synchronization. |
| shared/models/billingModels/plan/pooledBalancePlan.ts | Defines the structured pooled-balance plan and operation schemas. |
| shared/drizzle/0048_sour_dracula.sql | Moves contribution ownership to Stripe subscription and customer-license-link columns. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Billing as Billing lifecycle
    participant DB as PostgreSQL
    participant Redis as Redis balances
    Billing->>DB: Apply product and pooled-source lifecycle
    Billing->>Redis: Apply guarded cache cutover
    Redis-->>Billing: Return live post-cutover balances
    Billing->>DB: Flush final balance snapshot
    alt Flush succeeds
        DB-->>Billing: Commit snapshot
    else Flush fails
        DB-->>Billing: Error
        Note over Billing,Redis: Redis fields may already be removed while the failure returns normally
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Billing as Billing lifecycle
    participant DB as PostgreSQL
    participant Redis as Redis balances
    Billing->>DB: Apply product and pooled-source lifecycle
    Billing->>Redis: Apply guarded cache cutover
    Redis-->>Billing: Return live post-cutover balances
    Billing->>DB: Flush final balance snapshot
    alt Flush succeeds
        DB-->>Billing: Commit snapshot
    else Flush fails
        DB-->>Billing: Error
        Note over Billing,Redis: Redis fields may already be removed while the failure returns normally
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
server/src/_luaScriptsV2/luaScriptsV2.ts:58-60
**Redis Script Modules Are Missing**

These imports resolve Lua files that are absent from the reviewed revision. Server builds fail during module resolution, so `updateSubjectBalanceBatches` cannot be registered or used.

### Issue 2 of 4
server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts:160-163
**Failed Flush Discards Balances**

When PostgreSQL returns a non-conflict error, this branch converts the failed durable write into a normal result. Invalidation and cutover callers can then continue after the authoritative Redis fields were captured or removed, permanently losing the unsynced usage instead of retaining or reconciling it.

### Issue 3 of 4
server/src/internal/billing/v2/pooledBalances/compute/initUpsertPooledBalanceSourceSpec/computePooledUsageCarrySpec.ts:19-27
**Pooled Replacement Drops Prior Usage**

Usage carry is created only when the outgoing feature has a non-pooled source entitlement. Replacing an already pooled product with another pooled product for the same feature therefore omits its consumed usage, allowing the destination grant to start without the prior deduction.

### Issue 4 of 4
server/src/internal/billing/v2/execute/executeAutumnActions/executePooledBalanceOps.ts:1071
**Lifecycle Writes Precede Customer Lock**

`beforeDatabaseOperations` runs before the pooled operation transactions acquire the customer lock. A concurrent pooled update can therefore interleave between these lifecycle writes and the contribution changes, leaving customer-product state and pooled grants based on different snapshots.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(billing): add pooled balance flows"](https://github.com/useautumn/autumn/commit/acf71461994c279fca9b35b851992ce36f6575ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46011793)</sub>

> Greptile also left **4 inline comments** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->