### PR TITLE
Migrations: shared queue

### DIFF
--- a/server/src/external/autumn/autumnCli.ts
+++ b/server/src/external/autumn/autumnCli.ts
@@ -1123,6 +1123,7 @@ export class AutumnInt {
 			dry_run?: boolean;
 			only?: string[];
 			limit?: number;
+			/** @deprecated Migration concurrency is fleet-managed. */
 			concurrency?: number;
 			lazy_run?: boolean;
 			retry_item_statuses?: ("failed" | "skipped")[];

--- a/server/src/internal/migrations/v2/filters/customers/filterCustomers.ts
+++ b/server/src/internal/migrations/v2/filters/customers/filterCustomers.ts
@@ -76,6 +76,7 @@ export const filterCustomers = ({
 	includeProcessed,
 	batchSize,
 	limit,
+	afterInternalId,
 }: {
 	ctx: AutumnContext;
 	filter: CustomerFilter;
@@ -85,6 +86,7 @@ export const filterCustomers = ({
 	includeProcessed?: IncludeProcessed;
 	batchSize?: number;
 	limit?: number;
+	afterInternalId?: string;
 }): AsyncGenerator<CustomerRow[]> => {
 	const args = buildArgs({ ctx, filter, checkpoint, search, customerFilters });
 	const source = iterateOverFilterResults<CustomerRow>({
@@ -93,6 +95,7 @@ export const filterCustomers = ({
 			buildRowsSelect({ args, includeProcessed, limit, afterInternalId }),
 		batchSize:
 			limit === undefined ? batchSize : Math.min(batchSize ?? limit, limit),
+		afterInternalId,
 	});
 	return limit === undefined ? source : takeRows(source, limit);
 };

--- a/server/src/internal/migrations/v2/filters/iterateOverFilterResults.ts
+++ b/server/src/internal/migrations/v2/filters/iterateOverFilterResults.ts
@@ -13,12 +13,14 @@ export async function* iterateOverFilterResults<
 	db,
 	buildSelect,
 	batchSize = DEFAULT_BATCH_SIZE,
+	afterInternalId,
 }: {
 	db: { execute: (query: SQL) => Promise<unknown> };
 	buildSelect: (args: { limit: number; afterInternalId?: string }) => SQL;
 	batchSize?: number;
+	afterInternalId?: string;
 }): AsyncGenerator<TRow[]> {
-	let cursor: string | undefined;
+	let cursor = afterInternalId;
 	while (true) {
 		const query = buildSelect({ limit: batchSize, afterInternalId: cursor });
 		const rows = (await db.execute(query)) as unknown as TRow[];

--- a/server/src/internal/migrations/v2/filters/runFilter.ts
+++ b/server/src/internal/migrations/v2/filters/runFilter.ts
@@ -28,6 +28,9 @@ export const runFilter = async ({
 	dryRun,
 	kind,
 	controls,
+	includeCount = true,
+	afterInternalId,
+	batchSize,
 }: {
 	ctx: AutumnContext;
 	migration: MigrationRuntimeWithEventId;
@@ -35,9 +38,12 @@ export const runFilter = async ({
 	dryRun: boolean;
 	kind: RunScopeKind;
 	controls?: MigrationRunControls;
+	includeCount?: boolean;
+	afterInternalId?: string;
+	batchSize?: number;
 }): Promise<{
 	kind: RunScopeKind;
-	count: number;
+	count: number | null;
 	iterate: () => AsyncGenerator<RunScopeItem[]>;
 }> => {
 	if (kind !== "customer")
@@ -56,12 +62,14 @@ export const runFilter = async ({
 		controls,
 	});
 	const limit = controls?.limit ?? undefined;
-	const count = await countCustomers({
-		ctx,
-		filter,
-		checkpoint,
-		limit,
-	});
+	const count = includeCount
+		? await countCustomers({
+				ctx,
+				filter,
+				checkpoint,
+				limit,
+			})
+		: null;
 
 	ctx.logger.info("runFilter: customer scope resolved", {
 		data: {
@@ -94,6 +102,8 @@ export const runFilter = async ({
 			filter,
 			checkpoint,
 			limit,
+			afterInternalId,
+			batchSize,
 		})) {
 			yield batch.map(
 				(row): RunScopeItem => ({

--- a/server/src/internal/migrations/v2/handlers/handleRunMigration.ts
+++ b/server/src/internal/migrations/v2/handlers/handleRunMigration.ts
@@ -9,7 +9,7 @@ import { RETRYABLE_MIGRATION_ITEM_RUN_STATUSES } from "@/internal/migrations/v2/
 import { shouldRunMigrationInline } from "@/internal/migrations/v2/utils/shouldRunMigrationInline.js";
 import {
 	getMigrationTriggerOptions,
-	MIGRATION_CUSTOMER_CONCURRENCY,
+	MIGRATION_RUN_CUSTOMER_CONCURRENCY,
 } from "@/trigger/migrations/migrationTaskQueue.js";
 import {
 	executeRunMigration,
@@ -24,12 +24,14 @@ const RunMigrationBody = z.object({
 	dry_run: z.boolean().default(false),
 	limit: z.number().int().min(1).optional(),
 	only: z.array(z.string()).optional(),
+	/** Accepted for backward compatibility; migration concurrency is fleet-managed. */
 	concurrency: z
 		.number()
 		.int()
 		.min(1)
 		.max(LEGACY_MAX_REQUESTED_CONCURRENCY)
-		.optional(),
+		.optional()
+		.describe("Deprecated: migration concurrency is fleet-managed"),
 	retry_item_statuses: z
 		.array(z.enum(RETRYABLE_MIGRATION_ITEM_RUN_STATUSES))
 		.optional(),
@@ -146,7 +148,7 @@ export const handleRunMigration = createRoute({
 			migration_id: id,
 			dry_run: dryRun,
 			lazy_run: lazyRun,
-			concurrency: MIGRATION_CUSTOMER_CONCURRENCY,
+			concurrency: MIGRATION_RUN_CUSTOMER_CONCURRENCY,
 			run_id: migrationRunId,
 			trigger_run_id: triggerRunId,
 			public_access_token: publicAccessToken,

--- a/server/src/internal/migrations/v2/handlers/handleRunMigration.ts
+++ b/server/src/internal/migrations/v2/handlers/handleRunMigration.ts
@@ -1,4 +1,4 @@
-import { ErrCode, makeScopeChecker, RecaseError, Scopes } from "@autumn/shared";
+import { ErrCode, RecaseError, Scopes } from "@autumn/shared";
 import { auth } from "@trigger.dev/sdk/v3";
 import { z } from "zod/v4";
 import { createRoute } from "@/honoMiddlewares/routeHandler";
@@ -8,13 +8,16 @@ import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
 import { RETRYABLE_MIGRATION_ITEM_RUN_STATUSES } from "@/internal/migrations/v2/run/utils/retryItemStatuses.js";
 import { shouldRunMigrationInline } from "@/internal/migrations/v2/utils/shouldRunMigrationInline.js";
 import {
+	getMigrationTriggerOptions,
+	MIGRATION_CUSTOMER_CONCURRENCY,
+} from "@/trigger/migrations/migrationTaskQueue.js";
+import {
 	executeRunMigration,
 	type RunMigrationPayload,
 	runMigrationTask,
 } from "@/trigger/migrations/runMigrationTask.js";
 
-const MAX_CONCURRENCY = 5;
-const SUPERUSER_MAX_CONCURRENCY = 100;
+const LEGACY_MAX_REQUESTED_CONCURRENCY = 100;
 
 const RunMigrationBody = z.object({
 	id: z.string(),
@@ -25,29 +28,14 @@ const RunMigrationBody = z.object({
 		.number()
 		.int()
 		.min(1)
-		.max(SUPERUSER_MAX_CONCURRENCY)
+		.max(LEGACY_MAX_REQUESTED_CONCURRENCY)
 		.optional(),
 	retry_item_statuses: z
 		.array(z.enum(RETRYABLE_MIGRATION_ITEM_RUN_STATUSES))
 		.optional(),
-	/** When true, claim a lazy run alongside the background sweeper. Customers
-	 *  hit on the request path get migrated lazily via `runMigrationCustomerTask`
-	 *  before the sweeper reaches them. Background and lazy run on the same
-	 *  migration_run row — the claim is shared. */
+	/** Lazy runs share one run row with the sweeper and enqueue request-path customer work.
+	 * Targeted `only` is incompatible because lazy matching happens on customer reads. */
 	lazy_run: z.boolean().default(false),
-});
-
-const getRunMigrationTriggerOptions = ({
-	orgId,
-	migrationId,
-	isDev,
-}: {
-	orgId: string;
-	migrationId: string;
-	isDev: boolean;
-}) => ({
-	...(isDev ? { region: "eu-central-1" } : {}),
-	concurrencyKey: `${orgId}:${migrationId}`,
 });
 
 export const handleRunMigration = createRoute({
@@ -60,22 +48,9 @@ export const handleRunMigration = createRoute({
 			dry_run: dryRun,
 			limit,
 			only,
-			concurrency,
 			retry_item_statuses: retryItemStatuses,
 			lazy_run: lazyRun,
 		} = c.req.valid("json");
-
-		const { isSuperuser } = makeScopeChecker(ctx.scopes);
-		const maxConcurrency = isSuperuser
-			? SUPERUSER_MAX_CONCURRENCY
-			: MAX_CONCURRENCY;
-		if (concurrency !== undefined && concurrency > maxConcurrency) {
-			throw new RecaseError({
-				message: `Migration concurrency cannot exceed ${maxConcurrency}`,
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
-		}
 
 		const migration = await migrationRepo.find({ ctx, id });
 
@@ -119,7 +94,6 @@ export const handleRunMigration = createRoute({
 					controls: {
 						limit,
 						only,
-						concurrency,
 						retryItemStatuses,
 					},
 				};
@@ -129,11 +103,7 @@ export const handleRunMigration = createRoute({
 				}
 				const handle = await runMigrationTask.trigger(
 					payload,
-					getRunMigrationTriggerOptions({
-						orgId: ctx.org.id,
-						migrationId: id,
-						isDev,
-					}),
+					getMigrationTriggerOptions({ isDev }),
 				);
 				return { triggerRunId: handle.id };
 			},
@@ -176,7 +146,7 @@ export const handleRunMigration = createRoute({
 			migration_id: id,
 			dry_run: dryRun,
 			lazy_run: lazyRun,
-			concurrency,
+			concurrency: MIGRATION_CUSTOMER_CONCURRENCY,
 			run_id: migrationRunId,
 			trigger_run_id: triggerRunId,
 			public_access_token: publicAccessToken,

--- a/server/src/internal/migrations/v2/lazy/checkPendingMigrationsForCustomer.ts
+++ b/server/src/internal/migrations/v2/lazy/checkPendingMigrationsForCustomer.ts
@@ -80,8 +80,6 @@ export const checkPendingMigrationsForCustomer = async ({
 		};
 
 		if (shouldRunMigrationInline()) {
-			// Inline loses trigger.dev's concurrencyKey serialization; the
-			// server-side item-run claim is the real authority either way.
 			const inlineCtx = { ...ctx, insideTriggerTask: true };
 			void executeRunMigrationCustomer({
 				ctx: inlineCtx,
@@ -98,8 +96,6 @@ export const checkPendingMigrationsForCustomer = async ({
 			continue;
 		}
 
-		await runMigrationCustomerTask.trigger(payload, {
-			concurrencyKey: `${migration.internal_id}:${fullCustomer.internal_id}`,
-		});
+		await runMigrationCustomerTask.trigger(payload);
 	}
 };

--- a/server/src/internal/migrations/v2/lazy/checkPendingMigrationsForCustomer.ts
+++ b/server/src/internal/migrations/v2/lazy/checkPendingMigrationsForCustomer.ts
@@ -2,6 +2,7 @@ import type { FullCustomer, MigrationItemRunData } from "@autumn/shared";
 import { customerFilterMatchesFullCustomer } from "@autumn/shared/api/customers/utils/match/index.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { shouldRunMigrationInline } from "@/internal/migrations/v2/utils/shouldRunMigrationInline.js";
+import { MIGRATION_LAZY_TASK_PRIORITY_SECONDS } from "@/trigger/migrations/migrationTaskQueue.js";
 import {
 	executeRunMigrationCustomer,
 	runMigrationCustomerTask,
@@ -96,6 +97,8 @@ export const checkPendingMigrationsForCustomer = async ({
 			continue;
 		}
 
-		await runMigrationCustomerTask.trigger(payload);
+		await runMigrationCustomerTask.trigger(payload, {
+			priority: MIGRATION_LAZY_TASK_PRIORITY_SECONDS,
+		});
 	}
 };

--- a/server/src/internal/migrations/v2/run/orchestrators/iterateScope.ts
+++ b/server/src/internal/migrations/v2/run/orchestrators/iterateScope.ts
@@ -5,14 +5,18 @@ export type IterateScopeItemResult<T> =
 	| { status: "ok"; item: RunScopeItem; value: T }
 	| { status: "failed"; item: RunScopeItem; error: Error };
 
+export type IterateScopeCompletion = "exhausted" | "slice_complete" | "stopped";
+
 export type IterateScopeSummary<T> = {
 	processed: number;
 	succeeded: number;
 	failed: number;
 	results: IterateScopeItemResult<T>[];
+	completion: IterateScopeCompletion;
+	cursor: string | null;
 };
 
-/** Iterates scope items; a scheduler forces sequential execution and may yield between items.
+/** Iterates scope items; a scheduler forces sequential execution and ends between items.
  * Errors are collected by default or rethrown when `onError` is `throw`. */
 export const iterateScope = async <T>({
 	iterate,
@@ -20,19 +24,31 @@ export const iterateScope = async <T>({
 	onError = "continue",
 	concurrency = 1,
 	scheduler,
+	shouldStop,
 }: {
 	iterate: () => AsyncGenerator<RunScopeItem[]>;
 	perItem: (item: RunScopeItem) => Promise<T>;
 	onError?: "throw" | "continue";
 	concurrency?: number;
 	scheduler?: MigrationRunScheduler;
+	shouldStop?: () => boolean;
 }): Promise<IterateScopeSummary<T>> => {
 	const results: IterateScopeItemResult<T>[] = [];
 	let succeeded = 0;
 	let failed = 0;
 	const maxParallel = scheduler ? 1 : Math.max(1, Math.floor(concurrency));
-	let sliceStartedAtMs = scheduler?.now();
+	const sliceStartedAtMs = scheduler?.now();
 	let hasProcessedScheduledItem = false;
+	const summarize = (
+		completion: IterateScopeCompletion,
+	): IterateScopeSummary<T> => ({
+		processed: succeeded + failed,
+		succeeded,
+		failed,
+		results,
+		completion,
+		cursor: results[results.length - 1]?.item.internal_id ?? null,
+	});
 
 	const runItem = async (item: RunScopeItem) => {
 		try {
@@ -47,29 +63,23 @@ export const iterateScope = async <T>({
 		}
 	};
 
-	const completeScheduledSliceIfDue = async () => {
-		if (
-			!scheduler ||
-			!hasProcessedScheduledItem ||
-			sliceStartedAtMs === undefined ||
-			scheduler.now() - sliceStartedAtMs < scheduler.sliceDurationMs
-		) {
-			return;
-		}
-
-		await scheduler.onSliceComplete();
-		sliceStartedAtMs = scheduler.now();
-	};
+	const scheduledSliceIsComplete = () =>
+		scheduler !== undefined &&
+		hasProcessedScheduledItem &&
+		sliceStartedAtMs !== undefined &&
+		scheduler.now() - sliceStartedAtMs >= scheduler.sliceDurationMs;
 
 	if (maxParallel === 1) {
 		for await (const batch of iterate()) {
 			for (const item of batch) {
-				await completeScheduledSliceIfDue();
+				if (shouldStop?.()) return summarize("stopped");
+				if (scheduledSliceIsComplete()) return summarize("slice_complete");
 				await runItem(item);
 				hasProcessedScheduledItem = true;
+				if (shouldStop?.()) return summarize("stopped");
 			}
 		}
-		return { processed: succeeded + failed, succeeded, failed, results };
+		return summarize("exhausted");
 	}
 
 	const inflight = new Set<Promise<void>>();
@@ -82,13 +92,21 @@ export const iterateScope = async <T>({
 
 	for await (const batch of iterate()) {
 		for (const item of batch) {
+			if (shouldStop?.()) {
+				await Promise.all(inflight);
+				return summarize("stopped");
+			}
 			schedule(item);
 			if (inflight.size >= maxParallel) {
 				await Promise.race(inflight);
+				if (shouldStop?.()) {
+					await Promise.all(inflight);
+					return summarize("stopped");
+				}
 			}
 		}
 	}
 	await Promise.all(inflight);
 
-	return { processed: succeeded + failed, succeeded, failed, results };
+	return summarize(shouldStop?.() ? "stopped" : "exhausted");
 };

--- a/server/src/internal/migrations/v2/run/orchestrators/iterateScope.ts
+++ b/server/src/internal/migrations/v2/run/orchestrators/iterateScope.ts
@@ -1,3 +1,4 @@
+import type { MigrationRunScheduler } from "../types/migrationRunScheduler.js";
 import type { RunScopeItem } from "../types/runScope.js";
 
 export type IterateScopeItemResult<T> =
@@ -11,34 +12,27 @@ export type IterateScopeSummary<T> = {
 	results: IterateScopeItemResult<T>[];
 };
 
-/**
- * Generic iteration over any kind-tagged scope iterator. Calls `perItem`
- * for every item, collecting per-item results into a summary.
- *
- * `concurrency` (default 1): max parallel `perItem` invocations. The
- * iterator's batch boundaries are preserved — work for batch N starts
- * only after the source yields it, but within and across batches up to
- * `concurrency` items run concurrently via a sliding worker pool.
- *
- * On error: keeps going with `onError: "continue"` (default), or rethrows
- * the first error with `onError: "throw"`. Either way every visited
- * item shows up in `results` so callers see the full audit trail.
- */
+/** Iterates scope items; a scheduler forces sequential execution and may yield between items.
+ * Errors are collected by default or rethrown when `onError` is `throw`. */
 export const iterateScope = async <T>({
 	iterate,
 	perItem,
 	onError = "continue",
 	concurrency = 1,
+	scheduler,
 }: {
 	iterate: () => AsyncGenerator<RunScopeItem[]>;
 	perItem: (item: RunScopeItem) => Promise<T>;
 	onError?: "throw" | "continue";
 	concurrency?: number;
+	scheduler?: MigrationRunScheduler;
 }): Promise<IterateScopeSummary<T>> => {
 	const results: IterateScopeItemResult<T>[] = [];
 	let succeeded = 0;
 	let failed = 0;
-	const maxParallel = Math.max(1, Math.floor(concurrency));
+	const maxParallel = scheduler ? 1 : Math.max(1, Math.floor(concurrency));
+	let sliceStartedAtMs = scheduler?.now();
+	let hasProcessedScheduledItem = false;
 
 	const runItem = async (item: RunScopeItem) => {
 		try {
@@ -53,9 +47,27 @@ export const iterateScope = async <T>({
 		}
 	};
 
+	const completeScheduledSliceIfDue = async () => {
+		if (
+			!scheduler ||
+			!hasProcessedScheduledItem ||
+			sliceStartedAtMs === undefined ||
+			scheduler.now() - sliceStartedAtMs < scheduler.sliceDurationMs
+		) {
+			return;
+		}
+
+		await scheduler.onSliceComplete();
+		sliceStartedAtMs = scheduler.now();
+	};
+
 	if (maxParallel === 1) {
 		for await (const batch of iterate()) {
-			for (const item of batch) await runItem(item);
+			for (const item of batch) {
+				await completeScheduledSliceIfDue();
+				await runItem(item);
+				hasProcessedScheduledItem = true;
+			}
 		}
 		return { processed: succeeded + failed, succeeded, failed, results };
 	}

--- a/server/src/internal/migrations/v2/run/orchestrators/runScopeIteration.ts
+++ b/server/src/internal/migrations/v2/run/orchestrators/runScopeIteration.ts
@@ -12,6 +12,7 @@ import {
 	type MigrationRuntimeWithEventId,
 } from "../../types/migrationDefinition.js";
 import { migrateCustomer } from "../migrateCustomer/index.js";
+import type { MigrationRunScheduler } from "../types/migrationRunScheduler.js";
 import type { RunScopeItem, RunScopeKind } from "../types/runScope.js";
 import { isMigrationCancelRequested } from "../utils/migrationCancelToken.js";
 import { iterateScope } from "./iterateScope.js";
@@ -26,6 +27,7 @@ export const runScopeIteration = async ({
 	batch,
 	controls,
 	hooks,
+	scheduler,
 }: {
 	ctx: AutumnContext;
 	migration: MigrationRuntimeWithEventId;
@@ -35,6 +37,7 @@ export const runScopeIteration = async ({
 	batch?: MigrationBatchFn;
 	controls?: MigrationRunControls;
 	hooks?: MigrationHooks;
+	scheduler?: MigrationRunScheduler;
 }) => {
 	const { count, iterate } = await runFilter({
 		ctx,
@@ -67,7 +70,10 @@ export const runScopeIteration = async ({
 				`runMigration: per-item handler missing for kind "${item.kind}"`,
 			);
 
-		if (!cancelRequested && (await isMigrationCancelRequested({ migrationRunId })))
+		if (
+			!cancelRequested &&
+			(await isMigrationCancelRequested({ migrationRunId }))
+		)
 			cancelRequested = true;
 		if (cancelRequested) {
 			itemCtx.logger.info("run-migration: skipping item, cancel requested", {
@@ -117,6 +123,7 @@ export const runScopeIteration = async ({
 			iterate,
 			perItem: (item) => perItem({ item, itemCtx: ctx }),
 			concurrency: controls?.concurrency,
+			scheduler,
 		});
 	}
 
@@ -124,7 +131,7 @@ export const runScopeIteration = async ({
 		batch,
 		iterate,
 		kind,
-		controls,
+		controls: scheduler ? { ...controls, concurrency: 1 } : controls,
 		perItem,
 	});
 };

--- a/server/src/internal/migrations/v2/run/orchestrators/runScopeIteration.ts
+++ b/server/src/internal/migrations/v2/run/orchestrators/runScopeIteration.ts
@@ -28,6 +28,8 @@ export const runScopeIteration = async ({
 	controls,
 	hooks,
 	scheduler,
+	includeFilterCount,
+	afterInternalId,
 }: {
 	ctx: AutumnContext;
 	migration: MigrationRuntimeWithEventId;
@@ -38,6 +40,8 @@ export const runScopeIteration = async ({
 	controls?: MigrationRunControls;
 	hooks?: MigrationHooks;
 	scheduler?: MigrationRunScheduler;
+	includeFilterCount?: boolean;
+	afterInternalId?: string;
 }) => {
 	const { count, iterate } = await runFilter({
 		ctx,
@@ -46,6 +50,9 @@ export const runScopeIteration = async ({
 		dryRun,
 		kind,
 		controls,
+		includeCount: includeFilterCount,
+		afterInternalId,
+		batchSize: scheduler?.batchSize,
 	});
 	ctx.logger.info(`run-migration: iterating scope`, {
 		data: { kind, count, dryRun },
@@ -124,6 +131,7 @@ export const runScopeIteration = async ({
 			perItem: (item) => perItem({ item, itemCtx: ctx }),
 			concurrency: controls?.concurrency,
 			scheduler,
+			shouldStop: () => cancelRequested,
 		});
 	}
 

--- a/server/src/internal/migrations/v2/run/runMigration.ts
+++ b/server/src/internal/migrations/v2/run/runMigration.ts
@@ -17,6 +17,7 @@ import {
 import { runScopeIteration } from "./orchestrators/runScopeIteration.js";
 import { preProcessMigration } from "./preProcess/index.js";
 import { getRunScopes } from "./types/getRunScopes.js";
+import type { MigrationRunScheduler } from "./types/migrationRunScheduler.js";
 
 /** Top-level migration run: prepare -> per-scope filter+iterate -> per-item ops. */
 export const runMigration = async ({
@@ -28,6 +29,7 @@ export const runMigration = async ({
 	controls,
 	hooks,
 	plugins,
+	scheduler,
 }: {
 	ctx: AutumnContext;
 	migration: MigrationRuntime;
@@ -37,6 +39,7 @@ export const runMigration = async ({
 	controls?: MigrationRunControls;
 	hooks?: RunMigrationHooks;
 	plugins?: RunMigrationPlugin[];
+	scheduler?: MigrationRunScheduler;
 }): Promise<void> => {
 	const eventMigrationRunId = migrationRunId ?? generateId("mrun");
 	const migrationHooks = composeMigrationHooks({ hooks, plugins });
@@ -73,6 +76,7 @@ export const runMigration = async ({
 			batch,
 			controls,
 			hooks: migrationHooks,
+			scheduler,
 		});
 	}
 };

--- a/server/src/internal/migrations/v2/run/runMigration.ts
+++ b/server/src/internal/migrations/v2/run/runMigration.ts
@@ -12,12 +12,99 @@ import {
 import { prepare } from "../prepare/index.js";
 import {
 	type MigrationRuntime,
+	type MigrationRuntimeWithEventId,
 	withMigrationEventId,
 } from "../types/migrationDefinition.js";
+import type { IterateScopeCompletion } from "./orchestrators/iterateScope.js";
 import { runScopeIteration } from "./orchestrators/runScopeIteration.js";
 import { preProcessMigration } from "./preProcess/index.js";
 import { getRunScopes } from "./types/getRunScopes.js";
 import type { MigrationRunScheduler } from "./types/migrationRunScheduler.js";
+
+export type RunMigrationResult = {
+	processed: number;
+	completion: IterateScopeCompletion;
+	cursor: string | null;
+};
+
+export const prepareMigration = async ({
+	ctx,
+	migration,
+	dryRun,
+}: {
+	ctx: AutumnContext;
+	migration: MigrationRuntime;
+	dryRun: boolean;
+}): Promise<MigrationRuntimeWithEventId> => {
+	const migrationWithEventId = withMigrationEventId({
+		orgId: ctx.org.id,
+		env: ctx.env,
+		migration,
+	});
+	const guardedMigration = preProcessMigration(migrationWithEventId);
+	const { preparedState } = await prepare({
+		ctx,
+		migration: guardedMigration,
+		dryRun,
+	});
+
+	return {
+		...guardedMigration,
+		prepared_state: preparedState,
+	};
+};
+
+export const runPreparedMigration = async ({
+	ctx,
+	migration,
+	migrationRunId,
+	dryRun,
+	batch,
+	controls,
+	hooks,
+	scheduler,
+	includeFilterCount = true,
+	afterInternalId,
+}: {
+	ctx: AutumnContext;
+	migration: MigrationRuntimeWithEventId;
+	migrationRunId: string;
+	dryRun: boolean;
+	batch?: MigrationBatchFn;
+	controls?: MigrationRunControls;
+	hooks?: RunMigrationHooks;
+	scheduler?: MigrationRunScheduler;
+	includeFilterCount?: boolean;
+	afterInternalId?: string;
+}): Promise<RunMigrationResult> => {
+	let processed = 0;
+	let cursor: string | null = null;
+
+	for (const kind of getRunScopes({ migration })) {
+		const result = await runScopeIteration({
+			ctx,
+			migration,
+			migrationRunId,
+			dryRun,
+			kind,
+			batch,
+			controls,
+			hooks,
+			scheduler,
+			includeFilterCount,
+			afterInternalId,
+		});
+		if (!result) continue;
+		processed += result.processed;
+		cursor = result.cursor;
+
+		if ("completion" in result && result.completion !== "exhausted") {
+			return { processed, completion: result.completion, cursor };
+		}
+	}
+
+	return { processed, completion: "exhausted", cursor };
+};
 
 /** Top-level migration run: prepare -> per-scope filter+iterate -> per-item ops. */
 export const runMigration = async ({
@@ -40,45 +127,25 @@ export const runMigration = async ({
 	hooks?: RunMigrationHooks;
 	plugins?: RunMigrationPlugin[];
 	scheduler?: MigrationRunScheduler;
-}): Promise<void> => {
+}): Promise<RunMigrationResult> => {
 	const eventMigrationRunId = migrationRunId ?? generateId("mrun");
 	const migrationHooks = composeMigrationHooks({ hooks, plugins });
-	const migrationWithEventId = withMigrationEventId({
-		orgId: ctx.org.id,
-		env: ctx.env,
-		migration,
-	});
-
-	// Inject default guards (e.g. `custom: false` on version-bumping
-	// update_plan ops, both at the op-level plan_filter and at the
-	// migration.filter customer.plan level) so admin-customized
-	// customer_products are never touched. Has to run before `prepare`
-	// so the prepared state reflects the guarded filter.
-	const guardedMigration = preProcessMigration(migrationWithEventId);
-
-	const { preparedState } = await prepare({
+	const preparedMigration = await prepareMigration({
 		ctx,
-		migration: guardedMigration,
+		migration,
 		dryRun,
 	});
-	const preparedMigration = {
-		...guardedMigration,
-		prepared_state: preparedState,
-	};
 
-	for (const kind of getRunScopes({ migration: preparedMigration })) {
-		await runScopeIteration({
-			ctx,
-			migration: preparedMigration,
-			migrationRunId: eventMigrationRunId,
-			dryRun,
-			kind,
-			batch,
-			controls,
-			hooks: migrationHooks,
-			scheduler,
-		});
-	}
+	return runPreparedMigration({
+		ctx,
+		migration: preparedMigration,
+		migrationRunId: eventMigrationRunId,
+		dryRun,
+		batch,
+		controls,
+		hooks: migrationHooks,
+		scheduler,
+	});
 };
 
 export type { RunMigrationHooks, RunMigrationPlugin };

--- a/server/src/internal/migrations/v2/run/types/migrationRunScheduler.ts
+++ b/server/src/internal/migrations/v2/run/types/migrationRunScheduler.ts
@@ -1,5 +1,5 @@
 export type MigrationRunScheduler = {
+	batchSize: number;
 	sliceDurationMs: number;
 	now: () => number;
-	onSliceComplete: () => Promise<void>;
 };

--- a/server/src/internal/migrations/v2/run/types/migrationRunScheduler.ts
+++ b/server/src/internal/migrations/v2/run/types/migrationRunScheduler.ts
@@ -1,0 +1,5 @@
+export type MigrationRunScheduler = {
+	sliceDurationMs: number;
+	now: () => number;
+	onSliceComplete: () => Promise<void>;
+};

--- a/server/src/trigger/migrations/migrationTaskPayload.ts
+++ b/server/src/trigger/migrations/migrationTaskPayload.ts
@@ -1,0 +1,54 @@
+import { AppEnv } from "@autumn/shared";
+import { MigrationFilterSchema } from "@autumn/shared/api/migrations/filters/migrationFilter.js";
+import { OperationsSchema } from "@autumn/shared/api/migrations/operations/operations.js";
+import { z } from "zod/v4";
+import { PreparedStateSchema } from "@/internal/migrations/v2/prepare/types/index.js";
+import { RETRYABLE_MIGRATION_ITEM_RUN_STATUSES } from "@/internal/migrations/v2/run/utils/retryItemStatuses.js";
+
+const ControlsSchema = z
+	.object({
+		limit: z.number().int().min(1).optional(),
+		only: z.array(z.string()).optional(),
+		retryItemStatuses: z
+			.array(z.enum(RETRYABLE_MIGRATION_ITEM_RUN_STATUSES))
+			.optional(),
+	})
+	.optional();
+
+export const RunMigrationPayloadSchema = z.object({
+	orgId: z.string(),
+	env: z.enum(AppEnv),
+	migrationId: z.string(),
+	migrationRunId: z.string(),
+	dryRun: z.boolean().default(false),
+	lazyRun: z.boolean().default(false),
+	controls: ControlsSchema,
+});
+
+export type RunMigrationPayload = z.infer<typeof RunMigrationPayloadSchema>;
+
+export const PreparedMigrationSnapshotSchema = z.object({
+	internal_id: z.string(),
+	id: z.string(),
+	org_id: z.string(),
+	env: z.enum(AppEnv),
+	filter: MigrationFilterSchema.nullable(),
+	operations: OperationsSchema.nullable(),
+	prepared_state: PreparedStateSchema,
+	no_billing_changes: z.boolean().nullable(),
+	retry_failed: z.boolean(),
+	archived: z.boolean(),
+	created_at: z.number(),
+	updated_at: z.number().nullable(),
+	event_internal_id: z.string(),
+});
+
+export const RunMigrationChunkPayloadSchema = RunMigrationPayloadSchema.extend({
+	chunkIndex: z.number().int().min(0),
+	cursor: z.string().optional(),
+	migration: PreparedMigrationSnapshotSchema,
+});
+
+export type RunMigrationChunkPayload = z.infer<
+	typeof RunMigrationChunkPayloadSchema
+>;

--- a/server/src/trigger/migrations/migrationTaskQueue.ts
+++ b/server/src/trigger/migrations/migrationTaskQueue.ts
@@ -1,0 +1,64 @@
+import { queue, queues, wait } from "@trigger.dev/sdk/v3";
+import type { Logger } from "@/external/logtail/logtailUtils.js";
+import type { MigrationRunScheduler } from "@/internal/migrations/v2/run/types/migrationRunScheduler.js";
+
+export const MIGRATION_TASK_QUEUE_NAME = "migration-customer-work";
+export const MIGRATION_CUSTOMER_CONCURRENCY = 1;
+export const MIGRATION_SLICE_DURATION_MS = 10_000;
+export const MIGRATION_YIELD_SECONDS = 6;
+
+export const migrationTaskQueue = queue({
+	name: MIGRATION_TASK_QUEUE_NAME,
+	concurrencyLimit: MIGRATION_CUSTOMER_CONCURRENCY,
+});
+
+export const getMigrationTriggerOptions = ({ isDev }: { isDev: boolean }) =>
+	isDev ? { region: "eu-central-1" as const } : {};
+
+const getQueuedMigrationTaskCount = async () => {
+	const queueState = await queues.retrieve({
+		type: "custom",
+		name: MIGRATION_TASK_QUEUE_NAME,
+	});
+	return queueState.queued;
+};
+
+const checkpointMigrationTask = async () => {
+	await wait.for({ seconds: MIGRATION_YIELD_SECONDS });
+};
+
+export const createMigrationTaskScheduler = ({
+	logger,
+	getQueuedCount = getQueuedMigrationTaskCount,
+	checkpoint = checkpointMigrationTask,
+	now = Date.now,
+}: {
+	logger: Pick<Logger, "info" | "warn">;
+	getQueuedCount?: () => Promise<number>;
+	checkpoint?: () => Promise<void>;
+	now?: () => number;
+}): MigrationRunScheduler => ({
+	sliceDurationMs: MIGRATION_SLICE_DURATION_MS,
+	now,
+	onSliceComplete: async () => {
+		let queuedCount: number;
+		try {
+			queuedCount = await getQueuedCount();
+		} catch (error) {
+			logger.warn("run-migration: shared queue inspection failed, yielding", {
+				data: {
+					error: error instanceof Error ? error.message : String(error),
+				},
+			});
+			await checkpoint();
+			return;
+		}
+
+		if (queuedCount <= 0) return;
+
+		logger.info("run-migration: yielding shared queue", {
+			data: { queuedCount },
+		});
+		await checkpoint();
+	},
+});

--- a/server/src/trigger/migrations/migrationTaskQueue.ts
+++ b/server/src/trigger/migrations/migrationTaskQueue.ts
@@ -2,14 +2,18 @@ import { queue } from "@trigger.dev/sdk/v3";
 import type { MigrationRunScheduler } from "@/internal/migrations/v2/run/types/migrationRunScheduler.js";
 
 export const MIGRATION_TASK_QUEUE_NAME = "migration-customer-work";
-export const MIGRATION_CUSTOMER_CONCURRENCY = 1;
+export const MIGRATION_TASK_QUEUE_CONCURRENCY = 1;
+export const MIGRATION_RUN_CUSTOMER_CONCURRENCY = 1;
 export const MIGRATION_CHUNK_FETCH_SIZE = 100;
 export const MIGRATION_SLICE_DURATION_MS = 10_000;
+export const MIGRATION_CHUNK_MAX_DURATION_SECONDS = 15 * 60;
+export const MIGRATION_LAZY_TASK_PRIORITY_SECONDS = 5 * 60;
+// Interrupted item claims cannot yet be recovered safely without operator intent.
 export const MIGRATION_TASK_RETRY = { maxAttempts: 1 } as const;
 
 export const migrationTaskQueue = queue({
 	name: MIGRATION_TASK_QUEUE_NAME,
-	concurrencyLimit: MIGRATION_CUSTOMER_CONCURRENCY,
+	concurrencyLimit: MIGRATION_TASK_QUEUE_CONCURRENCY,
 });
 
 export const getMigrationTriggerOptions = ({ isDev }: { isDev: boolean }) =>

--- a/server/src/trigger/migrations/migrationTaskQueue.ts
+++ b/server/src/trigger/migrations/migrationTaskQueue.ts
@@ -1,11 +1,11 @@
-import { queue, queues, wait } from "@trigger.dev/sdk/v3";
-import type { Logger } from "@/external/logtail/logtailUtils.js";
+import { queue } from "@trigger.dev/sdk/v3";
 import type { MigrationRunScheduler } from "@/internal/migrations/v2/run/types/migrationRunScheduler.js";
 
 export const MIGRATION_TASK_QUEUE_NAME = "migration-customer-work";
 export const MIGRATION_CUSTOMER_CONCURRENCY = 1;
+export const MIGRATION_CHUNK_FETCH_SIZE = 100;
 export const MIGRATION_SLICE_DURATION_MS = 10_000;
-export const MIGRATION_YIELD_SECONDS = 6;
+export const MIGRATION_TASK_RETRY = { maxAttempts: 1 } as const;
 
 export const migrationTaskQueue = queue({
 	name: MIGRATION_TASK_QUEUE_NAME,
@@ -15,50 +15,12 @@ export const migrationTaskQueue = queue({
 export const getMigrationTriggerOptions = ({ isDev }: { isDev: boolean }) =>
 	isDev ? { region: "eu-central-1" as const } : {};
 
-const getQueuedMigrationTaskCount = async () => {
-	const queueState = await queues.retrieve({
-		type: "custom",
-		name: MIGRATION_TASK_QUEUE_NAME,
-	});
-	return queueState.queued;
-};
-
-const checkpointMigrationTask = async () => {
-	await wait.for({ seconds: MIGRATION_YIELD_SECONDS });
-};
-
-export const createMigrationTaskScheduler = ({
-	logger,
-	getQueuedCount = getQueuedMigrationTaskCount,
-	checkpoint = checkpointMigrationTask,
+export const createMigrationChunkScheduler = ({
 	now = Date.now,
 }: {
-	logger: Pick<Logger, "info" | "warn">;
-	getQueuedCount?: () => Promise<number>;
-	checkpoint?: () => Promise<void>;
 	now?: () => number;
-}): MigrationRunScheduler => ({
+} = {}): MigrationRunScheduler => ({
+	batchSize: MIGRATION_CHUNK_FETCH_SIZE,
 	sliceDurationMs: MIGRATION_SLICE_DURATION_MS,
 	now,
-	onSliceComplete: async () => {
-		let queuedCount: number;
-		try {
-			queuedCount = await getQueuedCount();
-		} catch (error) {
-			logger.warn("run-migration: shared queue inspection failed, yielding", {
-				data: {
-					error: error instanceof Error ? error.message : String(error),
-				},
-			});
-			await checkpoint();
-			return;
-		}
-
-		if (queuedCount <= 0) return;
-
-		logger.info("run-migration: yielding shared queue", {
-			data: { queuedCount },
-		});
-		await checkpoint();
-	},
 });

--- a/server/src/trigger/migrations/runMigrationChunkTask.ts
+++ b/server/src/trigger/migrations/runMigrationChunkTask.ts
@@ -1,0 +1,108 @@
+import { task } from "@trigger.dev/sdk/v3";
+import type { Logger } from "@/external/logtail/logtailUtils.js";
+import { warmupRegionalRedis } from "@/external/redis/initUtils/redisWarmup.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import {
+	type RunMigrationResult,
+	runPreparedMigration,
+} from "@/internal/migrations/v2/run/runMigration.js";
+import { isMigrationCancelRequested } from "@/internal/migrations/v2/run/utils/migrationCancelToken.js";
+import {
+	type RunMigrationChunkPayload,
+	RunMigrationChunkPayloadSchema,
+} from "@/trigger/migrations/migrationTaskPayload.js";
+import {
+	createMigrationChunkScheduler,
+	MIGRATION_CUSTOMER_CONCURRENCY,
+	MIGRATION_TASK_RETRY,
+	migrationTaskQueue,
+} from "@/trigger/migrations/migrationTaskQueue.js";
+import { createTriggerContext } from "@/trigger/utils/createTriggerContext.js";
+
+export const executeRunMigrationChunk = async ({
+	ctx,
+	logger,
+	payload,
+}: {
+	ctx: AutumnContext;
+	logger: Logger;
+	payload: RunMigrationChunkPayload;
+}): Promise<RunMigrationResult> => {
+	await warmupRegionalRedis().catch((error) => {
+		logger.warn("run-migration-chunk: redis warmup failed (continuing)", {
+			data: {
+				error: error instanceof Error ? error.message : String(error),
+			},
+		});
+	});
+
+	if (
+		await isMigrationCancelRequested({ migrationRunId: payload.migrationRunId })
+	) {
+		return {
+			processed: 0,
+			completion: "stopped",
+			cursor: payload.cursor ?? null,
+		};
+	}
+
+	if (
+		payload.migration.id !== payload.migrationId ||
+		payload.migration.org_id !== payload.orgId ||
+		payload.migration.env !== payload.env
+	) {
+		throw new Error("Migration chunk snapshot identity does not match payload");
+	}
+
+	logger.info("run-migration-chunk: starting", {
+		data: {
+			migrationRunId: payload.migrationRunId,
+			chunkIndex: payload.chunkIndex,
+			limit: payload.controls?.limit,
+		},
+	});
+
+	const result = await runPreparedMigration({
+		ctx,
+		migration: payload.migration,
+		migrationRunId: payload.migrationRunId,
+		dryRun: payload.dryRun,
+		controls: {
+			...(payload.controls ?? {}),
+			concurrency: MIGRATION_CUSTOMER_CONCURRENCY,
+			checkpointDryRun: true,
+		},
+		scheduler: createMigrationChunkScheduler(),
+		includeFilterCount: false,
+		afterInternalId: payload.cursor,
+	});
+
+	logger.info("run-migration-chunk: done", {
+		data: {
+			migrationRunId: payload.migrationRunId,
+			chunkIndex: payload.chunkIndex,
+			processed: result.processed,
+			completion: result.completion,
+		},
+	});
+
+	return result;
+};
+
+export const runMigrationChunkTask = task({
+	id: "run-migration-chunk",
+	queue: migrationTaskQueue,
+	retry: MIGRATION_TASK_RETRY,
+	machine: "medium-1x",
+	maxDuration: 86400,
+	run: async (rawPayload: unknown, { ctx: triggerCtx }) => {
+		const payload = RunMigrationChunkPayloadSchema.parse(rawPayload);
+		const { ctx, logger } = await createTriggerContext({
+			orgId: payload.orgId,
+			env: payload.env,
+			triggerCtx,
+		});
+
+		return executeRunMigrationChunk({ ctx, logger, payload });
+	},
+});

--- a/server/src/trigger/migrations/runMigrationChunkTask.ts
+++ b/server/src/trigger/migrations/runMigrationChunkTask.ts
@@ -13,7 +13,8 @@ import {
 } from "@/trigger/migrations/migrationTaskPayload.js";
 import {
 	createMigrationChunkScheduler,
-	MIGRATION_CUSTOMER_CONCURRENCY,
+	MIGRATION_CHUNK_MAX_DURATION_SECONDS,
+	MIGRATION_RUN_CUSTOMER_CONCURRENCY,
 	MIGRATION_TASK_RETRY,
 	migrationTaskQueue,
 } from "@/trigger/migrations/migrationTaskQueue.js";
@@ -69,7 +70,7 @@ export const executeRunMigrationChunk = async ({
 		dryRun: payload.dryRun,
 		controls: {
 			...(payload.controls ?? {}),
-			concurrency: MIGRATION_CUSTOMER_CONCURRENCY,
+			concurrency: MIGRATION_RUN_CUSTOMER_CONCURRENCY,
 			checkpointDryRun: true,
 		},
 		scheduler: createMigrationChunkScheduler(),
@@ -94,7 +95,7 @@ export const runMigrationChunkTask = task({
 	queue: migrationTaskQueue,
 	retry: MIGRATION_TASK_RETRY,
 	machine: "medium-1x",
-	maxDuration: 86400,
+	maxDuration: MIGRATION_CHUNK_MAX_DURATION_SECONDS,
 	run: async (rawPayload: unknown, { ctx: triggerCtx }) => {
 		const payload = RunMigrationChunkPayloadSchema.parse(rawPayload);
 		const { ctx, logger } = await createTriggerContext({

--- a/server/src/trigger/migrations/runMigrationCustomerTask.ts
+++ b/server/src/trigger/migrations/runMigrationCustomerTask.ts
@@ -9,6 +9,7 @@ import { withMigrationItemTracking } from "@/internal/migrations/v2/actions/migr
 import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
 import { migrateCustomer } from "@/internal/migrations/v2/run/migrateCustomer/index.js";
 import { isMigrationCancelRequested } from "@/internal/migrations/v2/run/utils/migrationCancelToken.js";
+import { migrationTaskQueue } from "@/trigger/migrations/migrationTaskQueue.js";
 import { createTriggerContext } from "@/trigger/utils/createTriggerContext.js";
 
 const LAZY_MIGRATION_CUSTOMER_LOCK_MAX_WAIT_MS = 2 * 60 * 1000;
@@ -112,17 +113,10 @@ export const executeRunMigrationCustomer = async ({
 	});
 };
 
-/**
- * Per-customer lazy migration task. Enqueued by `checkPendingMigrationsForCustomer`
- * on the customer-fetch path. Claims the `migration_item_runs` row, busts the
- * customer cache, then runs `migrateCustomer` under the existing tracking machinery.
- *
- * Trigger.dev's `concurrencyKey` (set at enqueue time) serializes parallel
- * requests for the same customer + migration; the server-side claim is the
- * real authority if another worker raced ahead.
- */
+/** Lazy customer work shares fleet capacity; the item claim remains the duplicate authority. */
 export const runMigrationCustomerTask = task({
 	id: "run-migration-customer",
+	queue: migrationTaskQueue,
 	maxDuration: 600,
 	run: async (rawPayload: unknown, { ctx: triggerCtx }) => {
 		const payload = PayloadSchema.parse(rawPayload);

--- a/server/src/trigger/migrations/runMigrationInChunks.ts
+++ b/server/src/trigger/migrations/runMigrationInChunks.ts
@@ -1,0 +1,63 @@
+import type { IterateScopeCompletion } from "@/internal/migrations/v2/run/orchestrators/iterateScope.js";
+
+export type MigrationChunkResult = {
+	processed: number;
+	completion: IterateScopeCompletion;
+	cursor: string | null;
+};
+
+export type MigrationChunkRunResult = {
+	processed: number;
+	chunks: number;
+	canceled: boolean;
+};
+
+export const runMigrationInChunks = async ({
+	limit,
+	isCancelRequested,
+	runChunk,
+}: {
+	limit?: number;
+	isCancelRequested: () => Promise<boolean>;
+	runChunk: (args: {
+		limit: number | undefined;
+		chunkIndex: number;
+		cursor: string | undefined;
+	}) => Promise<MigrationChunkResult>;
+}): Promise<MigrationChunkRunResult> => {
+	let processed = 0;
+	let chunks = 0;
+	let cursor: string | undefined;
+
+	while (limit === undefined || processed < limit) {
+		if (await isCancelRequested()) {
+			return { processed, chunks, canceled: true };
+		}
+
+		const remainingLimit =
+			limit === undefined ? undefined : Math.max(0, limit - processed);
+		const chunk = await runChunk({
+			limit: remainingLimit,
+			chunkIndex: chunks,
+			cursor,
+		});
+		chunks++;
+		processed += chunk.processed;
+
+		if (chunk.completion === "stopped") {
+			return { processed, chunks, canceled: true };
+		}
+		if (chunk.completion === "exhausted") break;
+		if (chunk.processed === 0) {
+			throw new Error("Migration chunk made no progress before continuation");
+		}
+		if (!chunk.cursor) {
+			throw new Error(
+				"Migration chunk did not return a cursor for continuation",
+			);
+		}
+		cursor = chunk.cursor;
+	}
+
+	return { processed, chunks, canceled: false };
+};

--- a/server/src/trigger/migrations/runMigrationTask.ts
+++ b/server/src/trigger/migrations/runMigrationTask.ts
@@ -13,7 +13,10 @@ import {
 	RunMigrationPayloadSchema,
 	type RunMigrationPayload as RunMigrationPayloadType,
 } from "@/trigger/migrations/migrationTaskPayload.js";
-import { MIGRATION_TASK_RETRY } from "@/trigger/migrations/migrationTaskQueue.js";
+import {
+	MIGRATION_RUN_CUSTOMER_CONCURRENCY,
+	MIGRATION_TASK_RETRY,
+} from "@/trigger/migrations/migrationTaskQueue.js";
 import {
 	executeRunMigrationChunk,
 	runMigrationChunkTask,
@@ -89,7 +92,7 @@ export const executeRunMigration = async ({
 					data: {
 						migrationRunId,
 						noBillingChanges: migration.no_billing_changes === true,
-						concurrency: 1,
+						concurrency: MIGRATION_RUN_CUSTOMER_CONCURRENCY,
 					},
 				});
 

--- a/server/src/trigger/migrations/runMigrationTask.ts
+++ b/server/src/trigger/migrations/runMigrationTask.ts
@@ -1,64 +1,52 @@
-import { AppEnv } from "@autumn/shared";
 import { task } from "@trigger.dev/sdk/v3";
-import { z } from "zod/v4";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
 import { warmupRegionalRedis } from "@/external/redis/initUtils/redisWarmup.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { withMigrationRunTracking } from "@/internal/migrations/v2/actions/migrationRun/index.js";
 import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
-import { runMigration } from "@/internal/migrations/v2/run/runMigration.js";
-import type { MigrationRunScheduler } from "@/internal/migrations/v2/run/types/migrationRunScheduler.js";
-import { RETRYABLE_MIGRATION_ITEM_RUN_STATUSES } from "@/internal/migrations/v2/run/utils/retryItemStatuses.js";
+import { prepareMigration } from "@/internal/migrations/v2/run/runMigration.js";
+import { isMigrationCancelRequested } from "@/internal/migrations/v2/run/utils/migrationCancelToken.js";
 import { clearOrgCache } from "@/internal/orgs/orgUtils/clearOrgCache.js";
 import {
-	createMigrationTaskScheduler,
-	MIGRATION_CUSTOMER_CONCURRENCY,
-	migrationTaskQueue,
-} from "@/trigger/migrations/migrationTaskQueue.js";
+	PreparedMigrationSnapshotSchema,
+	type RunMigrationChunkPayload,
+	RunMigrationPayloadSchema,
+	type RunMigrationPayload as RunMigrationPayloadType,
+} from "@/trigger/migrations/migrationTaskPayload.js";
+import { MIGRATION_TASK_RETRY } from "@/trigger/migrations/migrationTaskQueue.js";
+import {
+	executeRunMigrationChunk,
+	runMigrationChunkTask,
+} from "@/trigger/migrations/runMigrationChunkTask.js";
+import {
+	type MigrationChunkResult,
+	runMigrationInChunks,
+} from "@/trigger/migrations/runMigrationInChunks.js";
 import { createTriggerContext } from "@/trigger/utils/createTriggerContext.js";
 
-const ControlsSchema = z
-	.object({
-		limit: z.number().int().min(1).optional(),
-		only: z.array(z.string()).optional(),
-		retryItemStatuses: z
-			.array(z.enum(RETRYABLE_MIGRATION_ITEM_RUN_STATUSES))
-			.optional(),
-	})
-	.optional();
+export type RunMigrationPayload = RunMigrationPayloadType;
 
-const PayloadSchema = z.object({
-	orgId: z.string(),
-	env: z.enum(AppEnv),
-	migrationId: z.string(),
-	migrationRunId: z.string(),
-	dryRun: z.boolean().default(false),
-	lazyRun: z.boolean().default(false),
-	controls: ControlsSchema,
-});
-
-export type RunMigrationPayload = z.infer<typeof PayloadSchema>;
+export type RunMigrationChunkRunner = (
+	payload: RunMigrationChunkPayload,
+) => Promise<MigrationChunkResult>;
 
 /** Shared workload for the trigger.dev task and the local inline fallback. */
 export const executeRunMigration = async ({
 	ctx,
 	logger,
 	payload,
-	scheduler,
+	runChunk,
 }: {
 	ctx: AutumnContext;
 	logger: Logger;
 	payload: RunMigrationPayload;
-	scheduler?: MigrationRunScheduler;
+	runChunk?: RunMigrationChunkRunner;
 }) => {
 	const { orgId, env, migrationId, migrationRunId, dryRun, lazyRun, controls } =
 		payload;
 
-	// Trigger.dev tasks start with cold Redis connections — wait for
-	// readiness before touching the migration so cache invalidations
-	// (deleteCachedFullCustomer, invalidateSharedBalanceFields,
-	// invalidateCachedFullSubject) actually fire instead of being
-	// short-circuited by the `not_ready` availability gate.
+	// Trigger tasks start with cold Redis clients; warm them before preparation
+	// and cache work so availability checks do not short-circuit.
 	await warmupRegionalRedis().catch((error) => {
 		logger.warn("run-migration: redis warmup failed (continuing)", {
 			data: {
@@ -85,27 +73,45 @@ export const executeRunMigration = async ({
 			migrationRunId,
 			run: async () => {
 				const migration = await migrationRepo.find({ ctx, id: migrationId });
-
-				const effectiveControls = {
-					...(controls ?? {}),
-					concurrency: MIGRATION_CUSTOMER_CONCURRENCY,
-				};
+				const preparedMigration = await prepareMigration({
+					ctx,
+					migration,
+					dryRun,
+				});
+				const migrationSnapshot =
+					PreparedMigrationSnapshotSchema.parse(preparedMigration);
+				const executeChunk: RunMigrationChunkRunner =
+					runChunk ??
+					((chunkPayload) =>
+						executeRunMigrationChunk({ ctx, logger, payload: chunkPayload }));
 
 				logger.info("run-migration: resolved controls", {
 					data: {
 						migrationRunId,
 						noBillingChanges: migration.no_billing_changes === true,
-						concurrency: effectiveControls.concurrency,
+						concurrency: 1,
 					},
 				});
 
-				await runMigration({
-					ctx,
-					migration,
-					dryRun,
-					migrationRunId,
-					controls: effectiveControls,
-					scheduler,
+				const chunkRun = await runMigrationInChunks({
+					limit: controls?.limit,
+					isCancelRequested: () =>
+						isMigrationCancelRequested({ migrationRunId }),
+					runChunk: ({ limit, chunkIndex, cursor }) =>
+						executeChunk({
+							...payload,
+							chunkIndex,
+							cursor,
+							migration: migrationSnapshot,
+							controls: {
+								...(controls ?? {}),
+								...(limit === undefined ? {} : { limit }),
+							},
+						}),
+				});
+
+				logger.info("run-migration: chunks complete", {
+					data: { migrationRunId, ...chunkRun },
 				});
 			},
 		});
@@ -130,12 +136,12 @@ export const executeRunMigration = async ({
 
 export const runMigrationTask = task({
 	id: "run-migration",
-	queue: migrationTaskQueue,
+	retry: MIGRATION_TASK_RETRY,
 	machine: "medium-1x",
 	// Trigger.dev has no true "disable" — set very high to effectively remove the timeout.
 	maxDuration: 86400,
 	run: async (rawPayload: unknown, { ctx: triggerCtx }) => {
-		const payload = PayloadSchema.parse(rawPayload);
+		const payload = RunMigrationPayloadSchema.parse(rawPayload);
 
 		const { ctx, logger } = await createTriggerContext({
 			orgId: payload.orgId,
@@ -147,7 +153,13 @@ export const runMigrationTask = task({
 			ctx,
 			logger,
 			payload,
-			scheduler: createMigrationTaskScheduler({ logger }),
+			runChunk: (chunkPayload) =>
+				runMigrationChunkTask
+					.triggerAndWait(chunkPayload, {
+						idempotencyKey: `migration-chunk:${chunkPayload.migrationRunId}:${chunkPayload.chunkIndex}`,
+						idempotencyKeyTTL: "7d",
+					})
+					.unwrap(),
 		});
 	},
 });

--- a/server/src/trigger/migrations/runMigrationTask.ts
+++ b/server/src/trigger/migrations/runMigrationTask.ts
@@ -7,19 +7,20 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { withMigrationRunTracking } from "@/internal/migrations/v2/actions/migrationRun/index.js";
 import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
 import { runMigration } from "@/internal/migrations/v2/run/runMigration.js";
+import type { MigrationRunScheduler } from "@/internal/migrations/v2/run/types/migrationRunScheduler.js";
 import { RETRYABLE_MIGRATION_ITEM_RUN_STATUSES } from "@/internal/migrations/v2/run/utils/retryItemStatuses.js";
 import { clearOrgCache } from "@/internal/orgs/orgUtils/clearOrgCache.js";
+import {
+	createMigrationTaskScheduler,
+	MIGRATION_CUSTOMER_CONCURRENCY,
+	migrationTaskQueue,
+} from "@/trigger/migrations/migrationTaskQueue.js";
 import { createTriggerContext } from "@/trigger/utils/createTriggerContext.js";
-
-const DEFAULT_CONCURRENCY = 5;
-// Admin (superuser) runs may exceed the default cap — enforced in handleRunMigration.
-const MAX_CONCURRENCY = 100;
 
 const ControlsSchema = z
 	.object({
 		limit: z.number().int().min(1).optional(),
 		only: z.array(z.string()).optional(),
-		concurrency: z.number().int().min(1).max(MAX_CONCURRENCY).optional(),
 		retryItemStatuses: z
 			.array(z.enum(RETRYABLE_MIGRATION_ITEM_RUN_STATUSES))
 			.optional(),
@@ -38,19 +39,17 @@ const PayloadSchema = z.object({
 
 export type RunMigrationPayload = z.infer<typeof PayloadSchema>;
 
-export const runMigrationTaskQueue = {
-	concurrencyLimit: 1,
-};
-
 /** Shared workload for the trigger.dev task and the local inline fallback. */
 export const executeRunMigration = async ({
 	ctx,
 	logger,
 	payload,
+	scheduler,
 }: {
 	ctx: AutumnContext;
 	logger: Logger;
 	payload: RunMigrationPayload;
+	scheduler?: MigrationRunScheduler;
 }) => {
 	const { orgId, env, migrationId, migrationRunId, dryRun, lazyRun, controls } =
 		payload;
@@ -76,7 +75,6 @@ export const executeRunMigration = async ({
 			only: controls?.only,
 			onlyCount: controls?.only?.length,
 			limit: controls?.limit,
-			concurrency: controls?.concurrency,
 			retryItemStatuses: controls?.retryItemStatuses,
 		},
 	});
@@ -90,7 +88,7 @@ export const executeRunMigration = async ({
 
 				const effectiveControls = {
 					...(controls ?? {}),
-					concurrency: controls?.concurrency ?? DEFAULT_CONCURRENCY,
+					concurrency: MIGRATION_CUSTOMER_CONCURRENCY,
 				};
 
 				logger.info("run-migration: resolved controls", {
@@ -98,7 +96,6 @@ export const executeRunMigration = async ({
 						migrationRunId,
 						noBillingChanges: migration.no_billing_changes === true,
 						concurrency: effectiveControls.concurrency,
-						concurrencyExplicit: controls?.concurrency !== undefined,
 					},
 				});
 
@@ -108,6 +105,7 @@ export const executeRunMigration = async ({
 					dryRun,
 					migrationRunId,
 					controls: effectiveControls,
+					scheduler,
 				});
 			},
 		});
@@ -132,7 +130,7 @@ export const executeRunMigration = async ({
 
 export const runMigrationTask = task({
 	id: "run-migration",
-	queue: runMigrationTaskQueue,
+	queue: migrationTaskQueue,
 	machine: "medium-1x",
 	// Trigger.dev has no true "disable" — set very high to effectively remove the timeout.
 	maxDuration: 86400,
@@ -145,6 +143,11 @@ export const runMigrationTask = task({
 			triggerCtx,
 		});
 
-		await executeRunMigration({ ctx, logger, payload });
+		await executeRunMigration({
+			ctx,
+			logger,
+			payload,
+			scheduler: createMigrationTaskScheduler({ logger }),
+		});
 	},
 });

--- a/server/tests/integration/billing/migrations-v2/run-handler/run-handler-lazy-run-body.test.ts
+++ b/server/tests/integration/billing/migrations-v2/run-handler/run-handler-lazy-run-body.test.ts
@@ -12,6 +12,7 @@
  *     background-only shape (`lazy_run = false`).
  *   - The response echoes the requested `lazy_run` value alongside
  *     `dry_run` and `run_id`.
+ *   - Legacy concurrency input is accepted but effective concurrency is `1`.
  */
 
 import { expect, test } from "bun:test";
@@ -77,7 +78,7 @@ test.concurrent(
 
 		expect(response.migration_id).toBe(migration.id);
 		expect(response.lazy_run).toBe(true);
-		expect(response.concurrency).toBe(7);
+		expect(response.concurrency).toBe(1);
 
 		const updatedMigration = await migrationRepo.find({
 			ctx,

--- a/server/tests/unit/migrations-v2/filters/iterate-over-filter-results.test.ts
+++ b/server/tests/unit/migrations-v2/filters/iterate-over-filter-results.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { iterateOverFilterResults } from "@/internal/migrations/v2/filters/iterateOverFilterResults.js";
+
+test("filter iteration resumes after a cross-task customer cursor", async () => {
+	const cursors: Array<string | undefined> = [];
+	const responses = [
+		[{ internal_id: "customer_101" }, { internal_id: "customer_102" }],
+		[{ internal_id: "customer_103" }],
+	];
+	const rows: string[] = [];
+
+	const source = iterateOverFilterResults({
+		db: {
+			execute: async () => responses.shift() ?? [],
+		},
+		buildSelect: ({ afterInternalId }) => {
+			cursors.push(afterInternalId);
+			return sql`select 1`;
+		},
+		batchSize: 2,
+		afterInternalId: "customer_100",
+	});
+
+	for await (const batch of source) {
+		rows.push(...batch.map((row) => row.internal_id));
+	}
+
+	expect(cursors).toEqual(["customer_100", "customer_102"]);
+	expect(rows).toEqual(["customer_101", "customer_102", "customer_103"]);
+});

--- a/server/tests/unit/migrations-v2/scheduling/iterate-scope-scheduling.test.ts
+++ b/server/tests/unit/migrations-v2/scheduling/iterate-scope-scheduling.test.ts
@@ -1,0 +1,77 @@
+// Contract: scheduled migration scopes run one customer at a time and yield only between customers after a time slice.
+// A completed final customer must not cause an unnecessary yield.
+import { describe, expect, test } from "bun:test";
+import { iterateScope } from "@/internal/migrations/v2/run/orchestrators/iterateScope.js";
+import type { MigrationRunScheduler } from "@/internal/migrations/v2/run/types/migrationRunScheduler.js";
+import type { RunScopeItem } from "@/internal/migrations/v2/run/types/runScope.js";
+
+const customerItem = (id: string): RunScopeItem => ({
+	kind: "customer",
+	internal_id: `internal_${id}`,
+	id,
+});
+
+const iterateItems = (items: RunScopeItem[]) =>
+	async function* iterate(): AsyncGenerator<RunScopeItem[]> {
+		yield items;
+	};
+
+describe("iterateScope migration scheduling", () => {
+	test("forces sequential customer execution when a scheduler is present", async () => {
+		let active = 0;
+		let maxActive = 0;
+		const scheduler: MigrationRunScheduler = {
+			sliceDurationMs: Number.POSITIVE_INFINITY,
+			now: () => 0,
+			onSliceComplete: async () => {},
+		};
+
+		await iterateScope({
+			iterate: iterateItems([
+				customerItem("customer_1"),
+				customerItem("customer_2"),
+				customerItem("customer_3"),
+			]),
+			concurrency: 3,
+			scheduler,
+			perItem: async () => {
+				active++;
+				maxActive = Math.max(maxActive, active);
+				await Promise.resolve();
+				active--;
+				return undefined;
+			},
+		});
+
+		expect(maxActive).toBe(1);
+	});
+
+	test("yields between customers after the time slice without yielding after the final customer", async () => {
+		let nowMs = 0;
+		const events: string[] = [];
+		const scheduler: MigrationRunScheduler = {
+			sliceDurationMs: 10,
+			now: () => nowMs,
+			onSliceComplete: async () => {
+				events.push("yield");
+				nowMs += 5;
+			},
+		};
+
+		await iterateScope({
+			iterate: iterateItems([
+				customerItem("customer_1"),
+				customerItem("customer_2"),
+				customerItem("customer_3"),
+			]),
+			scheduler,
+			perItem: async (item) => {
+				events.push(item.id ?? item.internal_id);
+				nowMs += 6;
+				return undefined;
+			},
+		});
+
+		expect(events).toEqual(["customer_1", "customer_2", "yield", "customer_3"]);
+	});
+});

--- a/server/tests/unit/migrations-v2/scheduling/iterate-scope-scheduling.test.ts
+++ b/server/tests/unit/migrations-v2/scheduling/iterate-scope-scheduling.test.ts
@@ -1,5 +1,5 @@
-// Contract: scheduled migration scopes run one customer at a time and yield only between customers after a time slice.
-// A completed final customer must not cause an unnecessary yield.
+// Contract: scheduled scopes run one customer at a time and finish the task only between customers.
+// Exhausting the source on the final customer must not request an unnecessary continuation.
 import { describe, expect, test } from "bun:test";
 import { iterateScope } from "@/internal/migrations/v2/run/orchestrators/iterateScope.js";
 import type { MigrationRunScheduler } from "@/internal/migrations/v2/run/types/migrationRunScheduler.js";
@@ -21,9 +21,9 @@ describe("iterateScope migration scheduling", () => {
 		let active = 0;
 		let maxActive = 0;
 		const scheduler: MigrationRunScheduler = {
+			batchSize: 100,
 			sliceDurationMs: Number.POSITIVE_INFINITY,
 			now: () => 0,
-			onSliceComplete: async () => {},
 		};
 
 		await iterateScope({
@@ -46,19 +46,16 @@ describe("iterateScope migration scheduling", () => {
 		expect(maxActive).toBe(1);
 	});
 
-	test("yields between customers after the time slice without yielding after the final customer", async () => {
+	test("ends a slice between customers after the time budget", async () => {
 		let nowMs = 0;
 		const events: string[] = [];
 		const scheduler: MigrationRunScheduler = {
+			batchSize: 100,
 			sliceDurationMs: 10,
 			now: () => nowMs,
-			onSliceComplete: async () => {
-				events.push("yield");
-				nowMs += 5;
-			},
 		};
 
-		await iterateScope({
+		const summary = await iterateScope({
 			iterate: iterateItems([
 				customerItem("customer_1"),
 				customerItem("customer_2"),
@@ -72,6 +69,55 @@ describe("iterateScope migration scheduling", () => {
 			},
 		});
 
-		expect(events).toEqual(["customer_1", "customer_2", "yield", "customer_3"]);
+		expect(events).toEqual(["customer_1", "customer_2"]);
+		expect(summary.completion).toBe("slice_complete");
+		expect(summary.processed).toBe(2);
+		expect(summary.cursor).toBe("internal_customer_2");
+	});
+
+	test("reports exhaustion instead of continuing after the final customer", async () => {
+		let nowMs = 0;
+		const scheduler: MigrationRunScheduler = {
+			batchSize: 100,
+			sliceDurationMs: 10,
+			now: () => nowMs,
+		};
+
+		const summary = await iterateScope({
+			iterate: iterateItems([
+				customerItem("customer_1"),
+				customerItem("customer_2"),
+			]),
+			scheduler,
+			perItem: async () => {
+				nowMs += 6;
+				return undefined;
+			},
+		});
+
+		expect(summary.completion).toBe("exhausted");
+		expect(summary.processed).toBe(2);
+		expect(summary.cursor).toBe("internal_customer_2");
+	});
+
+	test("stops source consumption when the caller requests cancellation", async () => {
+		let stopRequested = false;
+		const processed: string[] = [];
+
+		const summary = await iterateScope({
+			iterate: iterateItems([
+				customerItem("customer_1"),
+				customerItem("customer_2"),
+			]),
+			shouldStop: () => stopRequested,
+			perItem: async (item) => {
+				processed.push(item.id ?? item.internal_id);
+				stopRequested = true;
+				return undefined;
+			},
+		});
+
+		expect(processed).toEqual(["customer_1"]);
+		expect(summary.completion).toBe("stopped");
 	});
 });

--- a/server/tests/unit/migrations-v2/scheduling/migration-task-scheduler.test.ts
+++ b/server/tests/unit/migrations-v2/scheduling/migration-task-scheduler.test.ts
@@ -1,18 +1,13 @@
-// Contract: all migration tasks share one queue; contention checkpoints, while an idle queue continues immediately.
-// Queue inspection failure is conservative and checkpoints rather than monopolising migration execution.
+// Contract: finite customer tasks share one queue; coordinators do not sleep while holding its only slot.
 import { describe, expect, test } from "bun:test";
 import {
-	createMigrationTaskScheduler,
+	createMigrationChunkScheduler,
 	getMigrationTriggerOptions,
+	MIGRATION_CHUNK_FETCH_SIZE,
 	MIGRATION_SLICE_DURATION_MS,
-	MIGRATION_YIELD_SECONDS,
+	MIGRATION_TASK_RETRY,
 	migrationTaskQueue,
 } from "@/trigger/migrations/migrationTaskQueue.js";
-
-const logger = {
-	info: () => {},
-	warn: () => {},
-};
 
 describe("migration task scheduler", () => {
 	test("defines one fleet-wide queue with a conservative initial limit", () => {
@@ -20,11 +15,13 @@ describe("migration task scheduler", () => {
 		expect(migrationTaskQueue.concurrencyLimit).toBe(1);
 	});
 
-	test("keeps the active slice longer than the checkpoint wait", () => {
-		expect(MIGRATION_YIELD_SECONDS).toBeGreaterThan(5);
-		expect(MIGRATION_SLICE_DURATION_MS).toBeGreaterThan(
-			MIGRATION_YIELD_SECONDS * 1000,
-		);
+	test("uses a bounded customer-work slice", () => {
+		expect(MIGRATION_SLICE_DURATION_MS).toBe(10_000);
+		expect(MIGRATION_CHUNK_FETCH_SIZE).toBe(100);
+	});
+
+	test("does not automatically retry checkpointed migration tasks", () => {
+		expect(MIGRATION_TASK_RETRY).toEqual({ maxAttempts: 1 });
 	});
 
 	test("does not partition migration runs into per-org queues", () => {
@@ -34,50 +31,11 @@ describe("migration task scheduler", () => {
 		});
 	});
 
-	test("continues without checkpointing when no other migration work is queued", async () => {
-		let checkpointCount = 0;
-		const scheduler = createMigrationTaskScheduler({
-			logger,
-			getQueuedCount: async () => 0,
-			checkpoint: async () => {
-				checkpointCount++;
-			},
-		});
+	test("creates a pure clock-based scheduler with no in-task wait", () => {
+		const scheduler = createMigrationChunkScheduler({ now: () => 123 });
 
-		await scheduler.onSliceComplete();
-
-		expect(checkpointCount).toBe(0);
-	});
-
-	test("checkpoints when another migration task is queued", async () => {
-		let checkpointCount = 0;
-		const scheduler = createMigrationTaskScheduler({
-			logger,
-			getQueuedCount: async () => 1,
-			checkpoint: async () => {
-				checkpointCount++;
-			},
-		});
-
-		await scheduler.onSliceComplete();
-
-		expect(checkpointCount).toBe(1);
-	});
-
-	test("checkpoints when queue inspection fails", async () => {
-		let checkpointCount = 0;
-		const scheduler = createMigrationTaskScheduler({
-			logger,
-			getQueuedCount: async () => {
-				throw new Error("queue unavailable");
-			},
-			checkpoint: async () => {
-				checkpointCount++;
-			},
-		});
-
-		await scheduler.onSliceComplete();
-
-		expect(checkpointCount).toBe(1);
+		expect(scheduler.sliceDurationMs).toBe(MIGRATION_SLICE_DURATION_MS);
+		expect(scheduler.batchSize).toBe(MIGRATION_CHUNK_FETCH_SIZE);
+		expect(scheduler.now()).toBe(123);
 	});
 });

--- a/server/tests/unit/migrations-v2/scheduling/migration-task-scheduler.test.ts
+++ b/server/tests/unit/migrations-v2/scheduling/migration-task-scheduler.test.ts
@@ -4,7 +4,11 @@ import {
 	createMigrationChunkScheduler,
 	getMigrationTriggerOptions,
 	MIGRATION_CHUNK_FETCH_SIZE,
+	MIGRATION_CHUNK_MAX_DURATION_SECONDS,
+	MIGRATION_LAZY_TASK_PRIORITY_SECONDS,
+	MIGRATION_RUN_CUSTOMER_CONCURRENCY,
 	MIGRATION_SLICE_DURATION_MS,
+	MIGRATION_TASK_QUEUE_CONCURRENCY,
 	MIGRATION_TASK_RETRY,
 	migrationTaskQueue,
 } from "@/trigger/migrations/migrationTaskQueue.js";
@@ -12,7 +16,15 @@ import {
 describe("migration task scheduler", () => {
 	test("defines one fleet-wide queue with a conservative initial limit", () => {
 		expect(migrationTaskQueue.name).toBe("migration-customer-work");
-		expect(migrationTaskQueue.concurrencyLimit).toBe(1);
+		expect(migrationTaskQueue.concurrencyLimit).toBe(
+			MIGRATION_TASK_QUEUE_CONCURRENCY,
+		);
+		expect(MIGRATION_TASK_QUEUE_CONCURRENCY).toBe(1);
+	});
+
+	test("keeps fleet and per-run concurrency independently tunable", () => {
+		expect(MIGRATION_TASK_QUEUE_CONCURRENCY).toBe(1);
+		expect(MIGRATION_RUN_CUSTOMER_CONCURRENCY).toBe(1);
 	});
 
 	test("uses a bounded customer-work slice", () => {
@@ -22,6 +34,13 @@ describe("migration task scheduler", () => {
 
 	test("does not automatically retry checkpointed migration tasks", () => {
 		expect(MIGRATION_TASK_RETRY).toEqual({ maxAttempts: 1 });
+	});
+
+	test("bounds a stuck chunk and prioritizes request-path customer work", () => {
+		expect(MIGRATION_CHUNK_MAX_DURATION_SECONDS).toBe(15 * 60);
+		expect(MIGRATION_LAZY_TASK_PRIORITY_SECONDS).toBeGreaterThan(
+			MIGRATION_SLICE_DURATION_MS / 1000,
+		);
 	});
 
 	test("does not partition migration runs into per-org queues", () => {

--- a/server/tests/unit/migrations-v2/scheduling/migration-task-scheduler.test.ts
+++ b/server/tests/unit/migrations-v2/scheduling/migration-task-scheduler.test.ts
@@ -1,0 +1,83 @@
+// Contract: all migration tasks share one queue; contention checkpoints, while an idle queue continues immediately.
+// Queue inspection failure is conservative and checkpoints rather than monopolising migration execution.
+import { describe, expect, test } from "bun:test";
+import {
+	createMigrationTaskScheduler,
+	getMigrationTriggerOptions,
+	MIGRATION_SLICE_DURATION_MS,
+	MIGRATION_YIELD_SECONDS,
+	migrationTaskQueue,
+} from "@/trigger/migrations/migrationTaskQueue.js";
+
+const logger = {
+	info: () => {},
+	warn: () => {},
+};
+
+describe("migration task scheduler", () => {
+	test("defines one fleet-wide queue with a conservative initial limit", () => {
+		expect(migrationTaskQueue.name).toBe("migration-customer-work");
+		expect(migrationTaskQueue.concurrencyLimit).toBe(1);
+	});
+
+	test("keeps the active slice longer than the checkpoint wait", () => {
+		expect(MIGRATION_YIELD_SECONDS).toBeGreaterThan(5);
+		expect(MIGRATION_SLICE_DURATION_MS).toBeGreaterThan(
+			MIGRATION_YIELD_SECONDS * 1000,
+		);
+	});
+
+	test("does not partition migration runs into per-org queues", () => {
+		expect(getMigrationTriggerOptions({ isDev: false })).toEqual({});
+		expect(getMigrationTriggerOptions({ isDev: true })).toEqual({
+			region: "eu-central-1",
+		});
+	});
+
+	test("continues without checkpointing when no other migration work is queued", async () => {
+		let checkpointCount = 0;
+		const scheduler = createMigrationTaskScheduler({
+			logger,
+			getQueuedCount: async () => 0,
+			checkpoint: async () => {
+				checkpointCount++;
+			},
+		});
+
+		await scheduler.onSliceComplete();
+
+		expect(checkpointCount).toBe(0);
+	});
+
+	test("checkpoints when another migration task is queued", async () => {
+		let checkpointCount = 0;
+		const scheduler = createMigrationTaskScheduler({
+			logger,
+			getQueuedCount: async () => 1,
+			checkpoint: async () => {
+				checkpointCount++;
+			},
+		});
+
+		await scheduler.onSliceComplete();
+
+		expect(checkpointCount).toBe(1);
+	});
+
+	test("checkpoints when queue inspection fails", async () => {
+		let checkpointCount = 0;
+		const scheduler = createMigrationTaskScheduler({
+			logger,
+			getQueuedCount: async () => {
+				throw new Error("queue unavailable");
+			},
+			checkpoint: async () => {
+				checkpointCount++;
+			},
+		});
+
+		await scheduler.onSliceComplete();
+
+		expect(checkpointCount).toBe(1);
+	});
+});

--- a/server/tests/unit/migrations-v2/scheduling/run-migration-in-chunks.test.ts
+++ b/server/tests/unit/migrations-v2/scheduling/run-migration-in-chunks.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Contract: a migration coordinator submits finite customer slices until the source is exhausted.
+ * Total limits and cancellation apply across slices, and zero-progress slices cannot spin forever.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
+import { RunMigrationChunkPayloadSchema } from "@/trigger/migrations/migrationTaskPayload.js";
+import { runMigrationInChunks } from "@/trigger/migrations/runMigrationInChunks.js";
+
+describe("runMigrationInChunks", () => {
+	test("requires a frozen prepared migration snapshot for every chunk", () => {
+		const migration = {
+			internal_id: "migration_internal_id",
+			id: "migration_id",
+			org_id: "org_id",
+			env: AppEnv.Sandbox,
+			filter: { customer: { customer_id: { $in: ["customer_1"] } } },
+			operations: {
+				customer: [{ type: "add_plan" as const, plan_id: "plan_id" }],
+			},
+			prepared_state: {},
+			no_billing_changes: true,
+			retry_failed: false,
+			archived: false,
+			created_at: 1,
+			updated_at: null,
+			event_internal_id: "migration_internal_id",
+		};
+
+		const result = RunMigrationChunkPayloadSchema.parse({
+			orgId: "org_id",
+			env: AppEnv.Sandbox,
+			migrationId: "migration_id",
+			migrationRunId: "migration_run_id",
+			dryRun: false,
+			lazyRun: false,
+			chunkIndex: 0,
+			migration,
+		});
+
+		expect(result.migration).toEqual(migration);
+		expect("preparedState" in result).toBe(false);
+	});
+
+	test("submits continuations until a chunk exhausts the source", async () => {
+		const completions = [
+			{
+				processed: 2,
+				completion: "slice_complete" as const,
+				cursor: "customer_2",
+			},
+			{
+				processed: 1,
+				completion: "slice_complete" as const,
+				cursor: "customer_3",
+			},
+			{ processed: 0, completion: "exhausted" as const, cursor: null },
+		];
+		const limits: Array<number | undefined> = [];
+		const cursors: Array<string | undefined> = [];
+
+		const result = await runMigrationInChunks({
+			isCancelRequested: async () => false,
+			runChunk: async ({ limit, cursor }) => {
+				limits.push(limit);
+				cursors.push(cursor);
+				const next = completions.shift();
+				if (!next) throw new Error("missing test completion");
+				return next;
+			},
+		});
+
+		expect(limits).toEqual([undefined, undefined, undefined]);
+		expect(cursors).toEqual([undefined, "customer_2", "customer_3"]);
+		expect(result).toEqual({ processed: 3, chunks: 3, canceled: false });
+	});
+
+	test("carries the remaining total limit into each continuation", async () => {
+		const limits: Array<number | undefined> = [];
+
+		const result = await runMigrationInChunks({
+			limit: 3,
+			isCancelRequested: async () => false,
+			runChunk: async ({ limit, chunkIndex }) => {
+				limits.push(limit);
+				return {
+					processed: limit === 3 ? 2 : 1,
+					completion: "slice_complete",
+					cursor: `customer_${chunkIndex + 1}`,
+				};
+			},
+		});
+
+		expect(limits).toEqual([3, 1]);
+		expect(result).toEqual({ processed: 3, chunks: 2, canceled: false });
+	});
+
+	test("does not submit another chunk after cancellation", async () => {
+		let chunkCount = 0;
+		let cancelChecks = 0;
+
+		const result = await runMigrationInChunks({
+			isCancelRequested: async () => {
+				cancelChecks++;
+				return cancelChecks > 1;
+			},
+			runChunk: async () => {
+				chunkCount++;
+				return {
+					processed: 2,
+					completion: "slice_complete",
+					cursor: "customer_2",
+				};
+			},
+		});
+
+		expect(chunkCount).toBe(1);
+		expect(result).toEqual({ processed: 2, chunks: 1, canceled: true });
+	});
+
+	test("honors cancellation detected inside a chunk", async () => {
+		const result = await runMigrationInChunks({
+			isCancelRequested: async () => false,
+			runChunk: async () => ({
+				processed: 1,
+				completion: "stopped",
+				cursor: "customer_1",
+			}),
+		});
+
+		expect(result).toEqual({ processed: 1, chunks: 1, canceled: true });
+	});
+
+	test("rejects a continuation that made no progress", async () => {
+		expect(
+			runMigrationInChunks({
+				isCancelRequested: async () => false,
+				runChunk: async () => ({
+					processed: 0,
+					completion: "slice_complete",
+					cursor: null,
+				}),
+			}),
+		).rejects.toThrow("made no progress");
+	});
+
+	test("rejects a continuation without a stable cursor", async () => {
+		expect(
+			runMigrationInChunks({
+				isCancelRequested: async () => false,
+				runChunk: async () => ({
+					processed: 1,
+					completion: "slice_complete",
+					cursor: null,
+				}),
+			}),
+		).rejects.toThrow("did not return a cursor");
+	});
+});

--- a/vite/src/hooks/queries/useMigrationsQuery.tsx
+++ b/vite/src/hooks/queries/useMigrationsQuery.tsx
@@ -103,7 +103,6 @@ export const useMigrationsQuery = () => {
 			dry_run?: boolean;
 			limit?: number;
 			only?: string[];
-			concurrency?: number;
 			lazy_run?: boolean;
 			retry_item_statuses?: RetryableMigrationItemRunStatus[];
 		}) => {
@@ -111,7 +110,7 @@ export const useMigrationsQuery = () => {
 				migration_id: string;
 				dry_run: boolean;
 				lazy_run: boolean;
-				concurrency?: number;
+				concurrency: number;
 				run_id: string;
 				trigger_run_id?: string;
 				public_access_token?: string;

--- a/vite/src/views/migrations/migration/hooks/buildRunMigrationRequest.ts
+++ b/vite/src/views/migrations/migration/hooks/buildRunMigrationRequest.ts
@@ -5,7 +5,6 @@ type BuildRunMigrationRequestParams = {
 	dryRun: boolean;
 	limit?: number;
 	only?: string[];
-	concurrency?: number;
 	retryItemStatuses?: RetryableMigrationItemRunStatus[];
 };
 
@@ -15,7 +14,6 @@ type RunMigrationRequest = {
 	lazy_run: false;
 	limit?: number;
 	only?: string[];
-	concurrency?: number;
 	retry_item_statuses?: RetryableMigrationItemRunStatus[];
 };
 
@@ -24,7 +22,6 @@ export const buildRunMigrationRequest = ({
 	dryRun,
 	limit,
 	only,
-	concurrency,
 	retryItemStatuses,
 }: BuildRunMigrationRequestParams): RunMigrationRequest => {
 	const request: RunMigrationRequest = {
@@ -35,7 +32,6 @@ export const buildRunMigrationRequest = ({
 
 	if (limit !== undefined) request.limit = limit;
 	if (only !== undefined) request.only = only;
-	if (concurrency !== undefined) request.concurrency = concurrency;
 
 	if (retryItemStatuses && retryItemStatuses.length > 0) {
 		request.retry_item_statuses = retryItemStatuses;

--- a/vite/src/views/migrations/migration/hooks/useRealtimeSubscriptions.ts
+++ b/vite/src/views/migrations/migration/hooks/useRealtimeSubscriptions.ts
@@ -40,13 +40,11 @@ export function useRealtimeSubscriptions({
 		dryRun,
 		limit,
 		only,
-		concurrency,
 		retryItemStatuses,
 	}: {
 		dryRun: boolean;
 		limit?: number;
 		only?: string[];
-		concurrency?: number;
 		retryItemStatuses?: RetryableMigrationItemRunStatus[];
 	}) => {
 		try {
@@ -56,7 +54,6 @@ export function useRealtimeSubscriptions({
 					dryRun,
 					limit,
 					only,
-					concurrency,
 					retryItemStatuses,
 				}),
 			);

--- a/vite/src/views/migrations/migration/live/MigrationLiveView.tsx
+++ b/vite/src/views/migrations/migration/live/MigrationLiveView.tsx
@@ -76,7 +76,6 @@ import {
 } from "@/utils/constants/customerListPagination";
 import { useEnv } from "@/utils/envUtils";
 import { pushPage } from "@/utils/genUtils";
-import { useAdmin } from "@/views/admin/hooks/useAdmin";
 import { useCustomerFilters } from "@/views/customers/hooks/useCustomerFilters";
 import { createCustomerListColumns } from "@/views/customers2/components/table/customer-list/CustomerListColumns";
 import { CustomerListFilterButton } from "@/views/customers2/components/table/customer-list/CustomerListFilterButton";
@@ -101,30 +100,10 @@ import {
 import { RealtimeRunWatcher } from "./RealtimeRunWatcher";
 import { useMigrationSheetStore } from "./useMigrationSheetStore";
 
-type AdminRunControls = {
+type MigrationRunControlsState = {
 	retryErrored: boolean;
 	retrySkipped: boolean;
-	concurrency: string;
 };
-
-const MIN_CONCURRENCY = 1;
-const MAX_CONCURRENCY = 5;
-const ADMIN_MAX_CONCURRENCY = 100;
-
-function parseConcurrency({
-	value,
-	maxConcurrency,
-}: {
-	value: string;
-	maxConcurrency: number;
-}): number | undefined {
-	const trimmed = value.trim();
-	if (trimmed === "") return undefined;
-	const parsed = Number(trimmed);
-	if (!Number.isInteger(parsed)) return undefined;
-	if (parsed < MIN_CONCURRENCY || parsed > maxConcurrency) return undefined;
-	return parsed;
-}
 
 type CustomerRow = MigrationPreviewCustomer & {
 	_event?: MigrationItemEvent;
@@ -135,7 +114,7 @@ type CustomerRow = MigrationPreviewCustomer & {
 function buildRetryItemStatuses({
 	retryErrored,
 	retrySkipped,
-}: Pick<AdminRunControls, "retryErrored" | "retrySkipped">) {
+}: Pick<MigrationRunControlsState, "retryErrored" | "retrySkipped">) {
 	const statuses: RetryableMigrationItemRunStatus[] = [];
 	if (retryErrored) statuses.push("failed");
 	if (retrySkipped) statuses.push("skipped");
@@ -292,10 +271,9 @@ export function MigrationLiveView({
 		parseAsBoolean.withDefault(false),
 	);
 	const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
-	const [runControls, setRunControls] = useState<AdminRunControls>({
+	const [runControls, setRunControls] = useState<MigrationRunControlsState>({
 		retryErrored: false,
 		retrySkipped: false,
-		concurrency: String(MAX_CONCURRENCY),
 	});
 	const [sample, setSample] = useState({
 		open: false,
@@ -306,20 +284,9 @@ export function MigrationLiveView({
 	});
 	const { cancelRun, isCanceling } = useMigrationsQuery();
 
-	const { isAdmin } = useAdmin();
-	const maxConcurrency = isAdmin ? ADMIN_MAX_CONCURRENCY : MAX_CONCURRENCY;
-
 	const resolvedRunControls = {
 		retryItemStatuses: buildRetryItemStatuses(runControls),
-		concurrency: parseConcurrency({
-			value: runControls.concurrency,
-			maxConcurrency,
-		}),
 	};
-	const invalidConcurrency =
-		runControls.concurrency.trim() !== "" &&
-		parseConcurrency({ value: runControls.concurrency, maxConcurrency }) ===
-			undefined;
 
 	const handleSearchChange = useCallback(
 		(e: React.ChangeEvent<HTMLInputElement>) => {
@@ -618,8 +585,6 @@ export function MigrationLiveView({
 						<MigrationRunControls
 							value={runControls}
 							onChange={setRunControls}
-							invalidConcurrency={invalidConcurrency}
-							maxConcurrency={maxConcurrency}
 							hasFailedItems={(progressCounts?.failed ?? 0) > 0}
 							hasSkippedItems={(progressCounts?.skipped ?? 0) > 0}
 						/>
@@ -633,7 +598,7 @@ export function MigrationLiveView({
 									triggerRun({ dryRun: false, ...resolvedRunControls });
 								}}
 								isLoading={isRunning}
-								disabled={isRunInProgress || invalidConcurrency}
+								disabled={isRunInProgress}
 							>
 								<PlayIcon size={14} weight="fill" />
 								Run
@@ -729,8 +694,6 @@ export function MigrationLiveView({
 							<MigrationRunControls
 								value={runControls}
 								onChange={setRunControls}
-								invalidConcurrency={invalidConcurrency}
-								maxConcurrency={maxConcurrency}
 								hasFailedItems={(progressCounts?.failed ?? 0) > 0}
 								hasSkippedItems={(progressCounts?.skipped ?? 0) > 0}
 							/>
@@ -742,7 +705,6 @@ export function MigrationLiveView({
 								isLoading={sample.running === "dry"}
 								disabled={
 									isRunInProgress ||
-									invalidConcurrency ||
 									sample.running !== null ||
 									(sample.mode === "limit"
 										? !sample.limit || Number(sample.limit) < 1
@@ -782,7 +744,6 @@ export function MigrationLiveView({
 								isLoading={sample.running === "live"}
 								disabled={
 									isRunInProgress ||
-									invalidConcurrency ||
 									sample.running !== null ||
 									(sample.mode === "limit"
 										? !sample.limit || Number(sample.limit) < 1
@@ -942,48 +903,19 @@ function ExecutionProgressBadge({
 function MigrationRunControls({
 	value,
 	onChange,
-	invalidConcurrency = false,
-	maxConcurrency = MAX_CONCURRENCY,
 	hasFailedItems = false,
 	hasSkippedItems = false,
 }: {
-	value: AdminRunControls;
-	onChange: (value: AdminRunControls) => void;
-	invalidConcurrency?: boolean;
-	maxConcurrency?: number;
+	value: MigrationRunControlsState;
+	onChange: (value: MigrationRunControlsState) => void;
 	hasFailedItems?: boolean;
 	hasSkippedItems?: boolean;
 }) {
+	if (!hasFailedItems && !hasSkippedItems) return null;
+
 	return (
 		<div className="flex flex-col gap-3">
 			<Separator />
-			<div className="flex items-center justify-between gap-4">
-				<div className="flex flex-col gap-0.5">
-					<span className="text-sm font-medium text-foreground">
-						Concurrency
-					</span>
-					<span className="text-xs text-tertiary-foreground">
-						Customers processed in parallel. Max {maxConcurrency}.
-					</span>
-				</div>
-				<Input
-					type="number"
-					min={MIN_CONCURRENCY}
-					max={maxConcurrency}
-					value={value.concurrency}
-					onChange={(e) => onChange({ ...value, concurrency: e.target.value })}
-					placeholder="Auto"
-					className={cn(
-						"w-20 text-sm",
-						invalidConcurrency && "border-red-500 focus-visible:ring-red-500",
-					)}
-				/>
-			</div>
-			{invalidConcurrency && (
-				<span className="text-xs text-red-500">
-					Concurrency must be between {MIN_CONCURRENCY} and {maxConcurrency}.
-				</span>
-			)}
 			{hasFailedItems && (
 				<div className="flex items-center justify-between gap-4">
 					<div className="flex flex-col gap-0.5">


### PR DESCRIPTION
## Summary

- put background and lazy migration tasks on one shared Trigger.dev queue
- process customers sequentially and yield between customers when another migration is waiting
- remove the dashboard's per-run concurrency control while treating legacy concurrency input as an effective value of 1

## Why

Migration concurrency was partitioned by organization or migration, then multiplied again inside each run. Overlapping organization migrations could therefore saturate the primary database. This change uses Trigger.dev's existing queue and checkpoint primitives instead of adding a Redis capacity controller or database schema.

## Validation

- `cd server && bun test --isolate tests/unit/migrations-v2` — 29 passed
- `cd server && bun ts`
- `cd vite && bun test tests/views/migrations/migration/build-run-migration-request.test.ts` — 2 passed
- `cd vite && bun ts`
- scoped Biome check
- `git diff --check`
- commit hooks: Knip plus server and Vite typechecks

## Remaining live verification

- exercise two competing organization migrations in deployed Trigger staging
- the secret-backed run-handler integration test was updated and typechecked, but was not run locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share migration fleet capacity across runs by moving customer work to a single shared `@trigger.dev` queue and coordinating background runs in time-sliced chunks. The coordinator submits finite slices, yields quickly, and ignores per-run concurrency.

- **New Features**
  - Single shared queue `migration-customer-work` with concurrency 1 for customer slices and lazy tasks; the coordinator runs off-queue.
  - Time-sliced execution: up to 100 customers or ~10s per slice, then yield; each chunk caps at 15m and does not auto-retry; lazy tasks are queued with higher priority.
  - Idempotent chunk continuations using a frozen prepared migration snapshot; cancellation is honored between slices.
  - Cursor-based continuation across chunks with `afterInternalId`; count queries are skipped during slices to reduce overhead.
  - Trigger options no longer partition by org; region set only in dev.

- **Migration**
  - Legacy `concurrency` input is accepted for compatibility but ignored; effective concurrency is 1.
  - Dashboard removes concurrency controls and no longer sends a value; API response returns `concurrency: 1`.

<sup>Written for commit 717e33b73d0687f5365201fe7b5bbc0e146bca5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves migration work onto shared fleet capacity. The main changes are:

- **Improvements:** Share one Trigger.dev queue across background and lazy migration tasks.
- **Improvements:** Process customers sequentially and checkpoint between customers during contention.
- **API changes:** Treat legacy concurrency input as an effective value of one.
- **Improvements:** Remove dashboard concurrency controls and add scheduling tests.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after confirming the new queue-state call matches the installed Trigger.dev SDK.

- The shared scheduling flow is internally consistent.
- The remaining item is a conditional SDK compatibility check rather than a demonstrated runtime bug.

server/src/trigger/migrations/migrationTaskQueue.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/trigger/migrations/migrationTaskQueue.ts | Adds the shared queue, queue-state inspection, and checkpoint scheduler. |
| server/src/trigger/migrations/runMigrationTask.ts | Moves background runs to the shared queue and fixes effective customer concurrency at one. |
| server/src/trigger/migrations/runMigrationCustomerTask.ts | Moves lazy customer work to the shared queue while retaining database item claims. |
| server/src/internal/migrations/v2/run/orchestrators/iterateScope.ts | Adds sequential, time-sliced customer iteration when a scheduler is present. |
| server/src/internal/migrations/v2/handlers/handleRunMigration.ts | Keeps legacy concurrency input compatible while reporting and applying concurrency one. |
| vite/src/views/migrations/migration/live/MigrationLiveView.tsx | Removes concurrency state, validation, and controls from the migration dashboard. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant API as Migration API
    participant Queue as Shared Queue
    participant Run as Background Run
    participant Lazy as Lazy Customer Task
    participant DB as Item Tracking

    API->>Queue: Enqueue migration run
    Queue->>Run: Start run
    loop Customers
        Run->>DB: Claim and process customer
        Run->>Queue: Check queued work after slice
        alt Work is waiting
            Run->>Queue: Checkpoint
            Queue->>Lazy: Process queued customer task
            Lazy->>DB: Claim and migrate customer
            Queue->>Run: Resume run
        else Queue is idle
            Run->>Run: Continue immediately
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant API as Migration API
    participant Queue as Shared Queue
    participant Run as Background Run
    participant Lazy as Lazy Customer Task
    participant DB as Item Tracking

    API->>Queue: Enqueue migration run
    Queue->>Run: Start run
    loop Customers
        Run->>DB: Claim and process customer
        Run->>Queue: Check queued work after slice
        alt Work is waiting
            Run->>Queue: Checkpoint
            Queue->>Lazy: Process queued customer task
            Lazy->>DB: Claim and migrate customer
            Queue->>Run: Resume run
        else Queue is idle
            Run->>Run: Continue immediately
        end
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/trigger/migrations/migrationTaskQueue.ts:19-24
**Queue State Shape May Break Build**

The new scheduler assumes `queues.retrieve()` accepts this custom-queue selector and returns a `queued` field. If the installed Trigger.dev SDK exposes a different selector or count field, the server typecheck fails and none of the migration tasks can deploy; this call needs to match the SDK version used by the server.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(migrations): share fleet capacity a..."](https://github.com/useautumn/autumn/commit/96909c3f9fdfad09c7059ff11d11632a8a212b45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46046942)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/autumn-org-2/github/useautumn/autumn/-/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))
- Context used - server/CLAUDE.md ([source](https://app.greptile.com/autumn-org-2/github/useautumn/autumn/-/custom-context?memory=7866843d-5d47-47cf-8270-b04b4f695fd8))
- Context used - AGENTS.md ([source](https://app.greptile.com/autumn-org-2/github/useautumn/autumn/-/custom-context?memory=e38717a3-e8ad-4054-9219-102b893d3b3c))
- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
</details>

<!-- /greptile_comment -->