### PR TITLE
fix(sync): preserve shape-matched Stripe prices

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/sync/matchUtils/classifyItemMatch.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/sync/matchUtils/classifyItemMatch.ts
@@ -47,23 +47,18 @@ export const matchesOnBasePrice = (match: ItemMatch): boolean => {
 
 /* ── Composed classifiers: the role an item plays within its plan ────────── */
 
-const matchesMappedStripeProduct = (match: AutumnPriceMatch): boolean =>
-	"stripe_product_id" in match.matched_on &&
-	match.product.processor?.id === match.matched_on.stripe_product_id;
-
-/** Shape matches under the plan's mapped Stripe product select its catalog base. */
+/** Only a stored Stripe price identity selects the catalog base price. */
 export const isBasePriceMatch = (match: ItemMatch): match is AutumnPriceMatch =>
 	isAutumnPriceMatch(match) &&
 	matchesOnBasePrice(match) &&
-	(!matchesOnBasePriceShape(match) || matchesMappedStripeProduct(match));
+	!matchesOnBasePriceShape(match);
 
-/** Shape matches from another source preserve that Stripe price as custom. */
+/** Shape-only matches preserve the observed Stripe price as custom. */
 export const isCustomBaseMatch = (match: ItemMatch): boolean =>
 	isAutumnProductMatch(match) ||
 	(isAutumnPriceMatch(match) &&
 		matchesOnBasePrice(match) &&
-		matchesOnBasePriceShape(match) &&
-		!matchesMappedStripeProduct(match));
+		matchesOnBasePriceShape(match));
 
 /** Hit on one of the plan's feature prices — any price that isn't its base. */
 export const isFeaturePriceMatch = (

--- a/server/tests/integration/billing/stripe-webhooks/subscription-created/licenses/sub-created-mobbin-license-backsync.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/subscription-created/licenses/sub-created-mobbin-license-backsync.test.ts
@@ -1,0 +1,406 @@
+/** Parent-specific quarterly/yearly seat prices select their owning plan.
+ * Stripe quantities create and update the pool without replacing its definition. */
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV3,
+	type ApiCustomerV5,
+	type ApiEntityV2,
+	BillingInterval,
+} from "@autumn/shared";
+import { createExternalStripeSubscription } from "@tests/integration/billing/stripe-webhooks/utils/sharedStripeProductAutoSyncUtils";
+import { getProductStripeProductId } from "@tests/integration/billing/sync/utils/syncProductHelpers";
+import {
+	expectProductActive,
+	expectProductNotPresent,
+} from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { expectCustomerLicenses } from "@tests/integration/licenses/utils/expectCustomerLicenses";
+import { expectLicenseDefinitionCorrect } from "@tests/integration/licenses/utils/expectLicenseDefinitionCorrect";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { timeout } from "@tests/utils/genUtils";
+import ctx from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import { billingActions } from "@/internal/billing/v2/actions";
+import { subscriptionToSyncParams } from "@/internal/billing/v2/actions/sync/subscriptionToSyncParams";
+import { ProductService } from "@/internal/products/ProductService";
+
+const INCLUDED_SEATS = 0;
+const INITIAL_PAID_SEATS = 3;
+const UPDATED_PAID_SEATS = 4;
+const SEAT_CREDITS = 600;
+
+type AutumnV2_3 = Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+
+const waitForLicensePool = async ({
+	autumnV2_3,
+	customerId,
+	licensePlanId,
+	parentPlanId,
+	paidQuantity,
+	usage,
+}: {
+	autumnV2_3: AutumnV2_3;
+	customerId: string;
+	licensePlanId: string;
+	parentPlanId: string;
+	paidQuantity: number;
+	usage: number;
+}) => {
+	const deadline = Date.now() + 60_000;
+	let lastError: unknown;
+	while (Date.now() < deadline) {
+		try {
+			const customer =
+				await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+			expectCustomerLicenses({
+				customer,
+				count: 1,
+				licenses: [
+					{
+						license_plan_id: licensePlanId,
+						parent_plan_id: parentPlanId,
+						paid_quantity: paidQuantity,
+						granted: INCLUDED_SEATS + paidQuantity,
+						usage,
+						remaining: INCLUDED_SEATS + paidQuantity - usage,
+					},
+				],
+			});
+			return;
+		} catch (error) {
+			lastError = error;
+			await timeout(2_000);
+		}
+	}
+	throw lastError;
+};
+
+const setupSharedCustomizedLicense = async ({
+	customerId,
+}: {
+	customerId: string;
+}) => {
+	const teamQuarterly = products.base({
+		id: `${customerId}-team-quarterly`,
+		items: [items.dashboard()],
+	});
+	const teamYearly = products.base({
+		id: `${customerId}-team-yearly`,
+		items: [items.dashboard()],
+	});
+	const teamSeat = products.base({
+		id: `${customerId}-team-seat`,
+		items: [
+			items.monthlyPrice({ price: 10 }),
+			items.monthlyCredits({ includedUsage: SEAT_CREDITS }),
+		],
+		group: `${customerId}-licenses`,
+	});
+	const { autumnV1, autumnV2_2, autumnV2_3 } = await initScenario({
+		customerId,
+		ctx,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [teamQuarterly, teamYearly, teamSeat] }),
+		],
+		actions: [],
+	});
+
+	await autumnV2_2.post("/plans.update", {
+		plan_id: teamQuarterly.id,
+		licenses: [
+			{
+				license_plan_id: teamSeat.id,
+				included: INCLUDED_SEATS,
+				customize: {
+					price: { amount: 72, interval: BillingInterval.Quarter },
+				},
+			},
+		],
+	});
+	await autumnV2_2.post("/plans.update", {
+		plan_id: teamYearly.id,
+		licenses: [
+			{
+				license_plan_id: teamSeat.id,
+				included: INCLUDED_SEATS,
+				customize: {
+					price: { amount: 192, interval: BillingInterval.Year },
+				},
+			},
+		],
+	});
+
+	const teamSeatFull = await ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: teamSeat.id,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+	const stripeProductId = getProductStripeProductId({
+		fullProduct: teamSeatFull,
+	});
+	const [quarterlyStripePrice, yearlyStripePrice] = await Promise.all([
+		ctx.stripeCli.prices.create({
+			product: stripeProductId,
+			unit_amount: 72 * 100,
+			currency: "usd",
+			recurring: { interval: "month", interval_count: 3 },
+		}),
+		ctx.stripeCli.prices.create({
+			product: stripeProductId,
+			unit_amount: 192 * 100,
+			currency: "usd",
+			recurring: { interval: "year" },
+		}),
+	]);
+	expect(quarterlyStripePrice.id).not.toBe(yearlyStripePrice.id);
+	expect(quarterlyStripePrice.product).toBe(yearlyStripePrice.product);
+
+	return {
+		autumnV1,
+		autumnV2_3,
+		teamQuarterly,
+		teamYearly,
+		teamSeat,
+		quarterlyStripePriceId: quarterlyStripePrice.id,
+		yearlyStripePriceId: yearlyStripePrice.id,
+	};
+};
+
+const updateSubscriptionQuantity = async ({
+	subscription,
+	stripePriceId,
+	quantity,
+}: {
+	subscription: Stripe.Subscription;
+	stripePriceId: string;
+	quantity: number;
+}) => {
+	const item = subscription.items.data.find(
+		(candidate) => candidate.price.id === stripePriceId,
+	);
+	if (!item) throw new Error(`Subscription has no item for ${stripePriceId}`);
+	return ctx.stripeCli.subscriptions.update(subscription.id, {
+		items: [{ id: item.id, quantity }],
+		proration_behavior: "none",
+	});
+};
+
+const runBacksyncCase = async ({
+	customerId,
+	interval,
+}: {
+	customerId: string;
+	interval: BillingInterval.Quarter | BillingInterval.Year;
+}) => {
+	const family = await setupSharedCustomizedLicense({ customerId });
+	const isYearly = interval === BillingInterval.Year;
+	const parentPlan = isYearly ? family.teamYearly : family.teamQuarterly;
+	const otherParentPlan = isYearly ? family.teamQuarterly : family.teamYearly;
+	const stripePriceId = isYearly
+		? family.yearlyStripePriceId
+		: family.quarterlyStripePriceId;
+	const amount = isYearly ? 192 : 72;
+
+	const subscription = await createExternalStripeSubscription({
+		ctx,
+		customerId,
+		items: [{ price: stripePriceId, quantity: INITIAL_PAID_SEATS }],
+	});
+	await waitForLicensePool({
+		autumnV2_3: family.autumnV2_3,
+		customerId,
+		licensePlanId: family.teamSeat.id,
+		parentPlanId: parentPlan.id,
+		paidQuantity: INITIAL_PAID_SEATS,
+		usage: 0,
+	});
+	await timeout(2_000);
+	const proposal = await subscriptionToSyncParams({
+		ctx,
+		customerId,
+		subscription,
+	});
+	await billingActions.syncV2({
+		ctx,
+		params: proposal.params,
+		tags: ["mobbin-integration-test"],
+	});
+	await billingActions.syncV2({
+		ctx,
+		params: proposal.params,
+		tags: ["mobbin-integration-test"],
+	});
+	await waitForLicensePool({
+		autumnV2_3: family.autumnV2_3,
+		customerId,
+		licensePlanId: family.teamSeat.id,
+		parentPlanId: parentPlan.id,
+		paidQuantity: INITIAL_PAID_SEATS,
+		usage: 0,
+	});
+
+	const customer =
+		await family.autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductActive({ customer, productId: parentPlan.id });
+	await expectProductNotPresent({ customer, productId: otherParentPlan.id });
+	const definitionBefore = await expectLicenseDefinitionCorrect({
+		ctx,
+		customerId,
+		parentPlanId: parentPlan.id,
+		subscriptionId: subscription.id,
+		isCustom: false,
+		basePrice: { amount, interval },
+	});
+
+	const entityId = `${customerId}-member`;
+	await family.autumnV2_3.licenses.attach({
+		customer_id: customerId,
+		plan_id: family.teamSeat.id,
+		entities: [{ entity_id: entityId, name: "Member", feature_id: "users" }],
+	});
+	const entity = await family.autumnV2_3.entities.get<ApiEntityV2>(
+		customerId,
+		entityId,
+	);
+	expect(entity.balances.credits).toMatchObject({
+		remaining: SEAT_CREDITS,
+		usage: 0,
+	});
+	const workspace =
+		await family.autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+	expect(workspace.balances.credits).toBeUndefined();
+
+	await updateSubscriptionQuantity({
+		subscription,
+		stripePriceId,
+		quantity: UPDATED_PAID_SEATS,
+	});
+	await waitForLicensePool({
+		autumnV2_3: family.autumnV2_3,
+		customerId,
+		licensePlanId: family.teamSeat.id,
+		parentPlanId: parentPlan.id,
+		paidQuantity: UPDATED_PAID_SEATS,
+		usage: 1,
+	});
+	const definitionAfter = await expectLicenseDefinitionCorrect({
+		ctx,
+		customerId,
+		parentPlanId: parentPlan.id,
+		subscriptionId: subscription.id,
+		isCustom: false,
+		basePrice: { amount, interval },
+	});
+	expect(definitionAfter.id).toBe(definitionBefore.id);
+};
+
+test(`${chalk.yellowBright("Mobbin Team back-sync: quarterly price selects Team Quarterly and syncs seats")}`, async () => {
+	await runBacksyncCase({
+		customerId: "mobbin-team-quarterly-sync",
+		interval: BillingInterval.Quarter,
+	});
+});
+
+test(`${chalk.yellowBright("Mobbin Team back-sync: yearly price selects Team Yearly and syncs seats")}`, async () => {
+	await runBacksyncCase({
+		customerId: "mobbin-team-yearly-sync",
+		interval: BillingInterval.Year,
+	});
+});
+
+test(`${chalk.yellowBright("Mobbin Enterprise back-sync: Enterprise Seat never resolves to Team")}`, async () => {
+	const customerId = "mobbin-enterprise-seat-sync";
+	const team = products.base({
+		id: `${customerId}-team`,
+		items: [items.dashboard()],
+	});
+	const enterprise = products.base({
+		id: `${customerId}-enterprise`,
+		items: [items.dashboard()],
+	});
+	const teamSeat = products.base({
+		id: `${customerId}-team-seat`,
+		items: [items.monthlyCredits({ includedUsage: SEAT_CREDITS })],
+		group: `${customerId}-team-licenses`,
+	});
+	const enterpriseSeat = products.base({
+		id: `${customerId}-enterprise-seat`,
+		items: [items.monthlyCredits({ includedUsage: SEAT_CREDITS })],
+		group: `${customerId}-enterprise-licenses`,
+	});
+	const { autumnV1, autumnV2_2, autumnV2_3 } = await initScenario({
+		customerId,
+		ctx,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [team, enterprise, teamSeat, enterpriseSeat] }),
+		],
+		actions: [],
+	});
+
+	await autumnV2_2.post("/plans.update", {
+		plan_id: team.id,
+		licenses: [
+			{
+				license_plan_id: teamSeat.id,
+				included: 0,
+				customize: {
+					price: { amount: 192, interval: BillingInterval.Year },
+				},
+			},
+		],
+	});
+	await autumnV2_2.post("/plans.update", {
+		plan_id: enterprise.id,
+		licenses: [
+			{
+				license_plan_id: enterpriseSeat.id,
+				included: 0,
+				customize: {
+					price: { amount: 400, interval: BillingInterval.Year },
+				},
+			},
+		],
+	});
+	const enterpriseSeatFull = await ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: enterpriseSeat.id,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+	const stripePrice = await ctx.stripeCli.prices.create({
+		product: getProductStripeProductId({ fullProduct: enterpriseSeatFull }),
+		unit_amount: 400 * 100,
+		currency: "usd",
+		recurring: { interval: "year" },
+	});
+	const subscription = await createExternalStripeSubscription({
+		ctx,
+		customerId,
+		items: [{ price: stripePrice.id, quantity: 2 }],
+	});
+
+	await waitForLicensePool({
+		autumnV2_3,
+		customerId,
+		licensePlanId: enterpriseSeat.id,
+		parentPlanId: enterprise.id,
+		paidQuantity: 2,
+		usage: 0,
+	});
+	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductActive({ customer, productId: enterprise.id });
+	await expectProductNotPresent({ customer, productId: team.id });
+	await expectLicenseDefinitionCorrect({
+		ctx,
+		customerId,
+		parentPlanId: enterprise.id,
+		subscriptionId: subscription.id,
+		isCustom: false,
+		basePrice: { amount: 400, interval: BillingInterval.Year },
+	});
+});


### PR DESCRIPTION
## Summary

- preserve shape-matched Stripe base prices as custom prices with their observed Stripe price IDs
- keep exact stored Stripe price identities selecting catalog prices and versions
- cover Mobbin Team quarterly/yearly seat sync, 600 credits per assigned seat, quantity updates, repeated sync idempotency, and Enterprise seat isolation

## Tests

- `bunx tsgo --build --noEmit`
- `bun test tests/unit/billing/sync/stripe-sync-currency.test.ts`
- `./run.sh tests/integration/billing/sync/sync-multi-currency.test.ts`
- `./run.sh tests/integration/billing/sync/sync-plan-version.test.ts`
- `./run.sh tests/integration/billing/stripe-webhooks/subscription-created/licenses/sub-created-mobbin-license-backsync.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves shape-matched Stripe prices during sync by keeping them as custom prices with the observed Stripe price IDs, and only uses the catalog base price when an exact stored Stripe price identity exists. This fixes plan selection and seat syncing for Mobbin Team quarterly/yearly and keeps Enterprise seats isolated.

- **Bug Fixes**
  - Shape-only base price matches are now stored as custom prices with the observed Stripe price ID.
  - Catalog base price is selected only when a stored Stripe price identity is present.
  - Correctly selects Team Quarterly vs Yearly, updates seat quantities, ensures idempotent re-syncs, and prevents Enterprise Seat from resolving to Team.

<sup>Written for commit 7e5c4d0d89bf59ad9bdfb7b99ee51ee30ce45354. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR preserves shape-matched Stripe prices during subscription back-sync. The main changes are:

- **Bug fixes:** Classify shape-only base-price matches as custom prices.
- **Improvements:** Add quarterly and yearly shared-license back-sync tests.
- **Improvements:** Cover seat updates, repeated syncs, and plan isolation.
</details>

<h3>Confidence Score: 5/5</h3>

The change is mostly safe, but mapped-product shape matches may need to retain their catalog identity.

- Exact Stripe price identity matches remain unchanged.
- Shape matches from the plan's own mapped Stripe product now become custom prices.
- The added tests cover the intended shared-license workflows.

server/src/internal/billing/v2/providers/stripe/utils/sync/matchUtils/classifyItemMatch.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/sync/matchUtils/classifyItemMatch.ts | Changes base-price classification so every shape match is treated as a custom base, including matches from the plan's mapped Stripe product. |
| server/tests/integration/billing/stripe-webhooks/subscription-created/licenses/sub-created-mobbin-license-backsync.test.ts | Adds integration tests for quarterly, yearly, and cross-plan license back-sync behavior. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/billing/v2/providers/stripe/utils/sync/matchUtils/classifyItemMatch.ts:53
**Mapped Catalog Price Becomes Custom**

When an unknown Stripe price belongs to the plan's own mapped Stripe product and matches its catalog base shape, this condition now routes it to `isCustomBaseMatch`. That changes the plan base from a catalog match with an `autumn_price_id` to a generated customization, so back-sync can persist or provision a custom price even though the owning catalog price was identified.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sync): preserve shape-matched Stripe..."](https://github.com/useautumn/autumn/commit/7e5c4d0d89bf59ad9bdfb7b99ee51ee30ce45354) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46066867)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->