### PR TITLE
feat(billing): implement pooled balance attach flow

### DIFF
--- a/.plans/pooled-balances/balance-sync-correctness.md
+++ b/.plans/pooled-balances/balance-sync-correctness.md
@@ -1,0 +1,160 @@
+# Pooled balance sync correctness
+
+## Status
+
+Deferred. This functionality must return before pooled balances are production-ready.
+
+## Required outcome
+
+Prevent an older Redis balance snapshot from overwriting newer pooled state in Postgres.
+
+Redis can contain usage deductions not yet flushed to Postgres, while pooled billing directly changes Postgres grants and balances. Those sources need a serialized handoff.
+
+## Race to prevent
+
+1. Redis contains the latest usage-adjusted balance.
+2. A sync worker reads it and pauses before writing Postgres.
+3. Pooled billing writes a newer grant/balance to Postgres.
+4. The delayed worker writes its older snapshot.
+5. The pooled transition is lost.
+
+Structural cache invalidation has the related risk of deleting Redis-only usage before it is flushed.
+
+## withCustomerBalanceSyncLock
+
+### Purpose
+
+Serialize operations transferring or reconciling Redis/Postgres balance state for one customer.
+
+### Reference behavior
+
+The helper:
+
+1. opened a Postgres transaction;
+2. resolved canonical internal customer ID when necessary;
+3. built a lock key from organization, environment, and internal customer ID;
+4. acquired a transaction-scoped Postgres advisory lock;
+5. ran the callback with that transaction handle;
+6. committed or rolled back;
+7. released the lock when the transaction ended.
+
+It used a local ten-second timeout so unexpectedly long holders failed rather than waiting indefinitely.
+
+### Invariant
+
+Acquire the lock before reading a Redis snapshot and hold it until the related Postgres write completes. Locking only the write permits Redis to change between read and lock acquisition.
+
+It protects against:
+
+- delayed Redis-to-Postgres sync overwriting pooled rebalance;
+- concurrent structural transitions using different snapshots;
+- invalidation deleting Redis-only deductions during persistence;
+- resets, billing transitions, and balance flushes interleaving.
+
+Scope is organization, environment, and internal customer. Different customers remain concurrent.
+
+## balanceSyncDb
+
+balanceSyncDb was the transaction handle from an already-acquired customer balance-sync lock, not another database.
+
+It allowed nested work to reuse the outer transaction instead of:
+
+- opening another transaction;
+- acquiring the same advisory lock again;
+- waiting on itself;
+- committing independently.
+
+When supplied, inner work had to use it for every related Postgres read/write, leave transaction ownership to the caller, and return post-commit cache work to the outer owner.
+
+The billing rework should not carry this parameter through every helper. Prefer one top-level balance-transition boundary. Before deleting the concept, confirm resets, invalidation, webhooks, and license transitions never enter pooled execution while already holding the same lock.
+
+## Post-commit cache cutover
+
+### Purpose
+
+Make Redis reflect a committed pooled transition without losing usage arriving concurrently.
+
+Redis cannot join a Postgres transaction. Mutating it before commit can expose state that later rolls back, so cache mutation happens only after Postgres succeeds.
+
+### Precise optimistic strategy
+
+Inside the transaction, prepare a cutover result containing:
+
+- customer and affected feature IDs;
+- rebalanced subject view;
+- balance/adjustment deltas by customer entitlement;
+- expected subject-view epoch;
+- relevant statuses and deduction order.
+
+After commit:
+
+1. Read live Redis balances for affected features from the primary.
+2. Combine live values with committed grant effects.
+3. Recompute distribution against live usage.
+4. Send all affected updates to one atomic Redis operation.
+5. Check expected subject epoch and expected balances.
+6. If they match, apply deltas atomically and refresh TTLs.
+7. Flush resulting Redis balances to Postgres so stores converge.
+
+The epoch prevents applying effects to a structurally different customer view. Expected values prevent overwriting deductions made after the original read.
+
+### Conflict or cache-miss fallback
+
+On epoch change, balance change, missing Redis data, or atomic-write failure:
+
+1. Atomically capture and delete the customer’s shared Redis balance fields.
+2. Compare captured cache_version values with current customer entitlements.
+3. Discard stale snapshots.
+4. Flush valid non-source balances and usage windows to Postgres.
+5. Exclude pooled source entitlements because synthetic pools own their spendable grants.
+6. Reload pool graphs/contributions from Postgres.
+7. Reconcile grants with captured live usage.
+8. Persist reconciled state.
+9. Invalidate subject cache so the next read rebuilds from converged Postgres.
+
+Plain cache deletion is unsafe: it can discard deductions not yet in Postgres and restore spent credits on rebuild.
+
+### Simpler acceptable first strategy
+
+A slower initial implementation is acceptable:
+
+1. Acquire the customer balance-sync lock.
+2. Atomically capture/delete relevant Redis balance fields.
+3. Flush valid Redis-only balances and usage windows.
+4. Apply pooled lifecycle/rebalance in the same Postgres transaction.
+5. Commit.
+6. Invalidate subject cache.
+7. Rebuild Redis from Postgres on next read.
+
+It must honor cache versions and never flush a pooled source row’s zero/stale balance over synthetic pool state.
+
+## Required boundary
+
+1. Acquire per-customer balance-sync lock.
+2. Capture/flush Redis-only state required by the strategy.
+3. In one Postgres transaction, apply related product, source, contribution, pool, and rebalance writes.
+4. Commit Postgres.
+5. Apply post-commit cutover or invalidate for rebuild.
+
+## Acceptance criteria
+
+- A Redis snapshot read before a pooled transition cannot overwrite it afterward.
+- A deduction arriving during transition is neither lost nor applied twice.
+- Failed Postgres transaction exposes no uncommitted Redis state.
+- Cache conflicts reconcile/invalidate instead of blindly applying stale deltas.
+- Cache deletion never drops Redis-only usage.
+- Different customers remain concurrent.
+- Nested callers correctly reuse the locked transaction or are removed.
+
+## Tests
+
+- delayed Redis sync versus contribution update;
+- concurrent deduction versus pooled attach;
+- concurrent deduction versus source removal;
+- subject epoch change between commit and cutover;
+- cache-version mismatch during reconciliation;
+- Redis cache miss during cutover;
+- Redis write failure after Postgres commit;
+- Postgres rollback leaves Redis unchanged;
+- nested operation does not reacquire its own lock;
+- two customers do not block each other.

--- a/.plans/pooled-balances/billing-flow-coverage.md
+++ b/.plans/pooled-balances/billing-flow-coverage.md
@@ -1,0 +1,786 @@
+# Pooled balance billing-flow coverage
+
+## Status and purpose
+
+This is the parity contract for rebuilding pooled-balance billing flows from scratch.
+
+- Reference implementation: feat/pooled-balances-billing-v2 at 7ef9bf086.
+- Clean implementation branch: feat/pooled-balances-billing-rework.
+- Scope: billing actions under server/src/internal/billing/v2, plus reset, cache, and balance-sync boundaries those actions depend on.
+- Goal: preserve every valid business case without preserving the reference execution architecture.
+
+The reference branch is evidence of intended behavior, not the target design. It mixed reads, computation, locks, transactions, and writes inside execution. Some paths were only scaffolded and had no callers or tests.
+
+Status labels used below:
+
+- Implemented: the reference emitted and executed a pooled mutation.
+- Partial: code existed, but a lifecycle or integration boundary was incomplete.
+- Unsupported: the reference intentionally rejected the case.
+- Deferred: required for production correctness but explicitly left for later.
+- Audit required: observed behavior must be confirmed rather than copied blindly.
+
+## Target architecture
+
+Every action retains the normal V2 pipeline:
+
+~~~text
+setup
+  -> load customer, pools, contributions, owners, and balance state
+compute
+  -> produce the complete AutumnBillingPlan with explicit pooled writes
+evaluate / execute Stripe
+  -> resolve processor resources and IDs
+execute Autumn
+  -> mechanically apply already-computed writes
+~~~
+
+Required rules:
+
+1. Setup performs every database read needed to decide pooled writes.
+2. Compute is deterministic and performs no database reads.
+3. Stripe evaluation may replace temporary owner IDs with real Stripe IDs.
+4. Autumn execution does not rediscover contributions, choose pools, calculate deltas, or reload a FullSubject to rebalance.
+5. executeAutumnBillingPlan stays one cohesive path. Pooled execution is one ordinary optional step, not a separate product/license lifecycle.
+6. executeCustomerLicenseTransitions runs normally. Its pooled effects are prepared in setup/compute and included in the main pooled plan.
+7. Pooled execution owns at most one transaction. Leaf executors open no nested transactions or locks.
+8. One plan belongs to one internalCustomerId. Pooled execution does not group or iterate across customers.
+9. Execution applies explicit inserts, updates, and deltas in stable order.
+10. Cache/balance-sync correctness, documented in [balance-sync-correctness.md](./balance-sync-correctness.md), must return before production rollout.
+
+## Domain model
+
+### Source customer product
+
+A source is an entity-attached customer product with at least one entitlement whose definition has pooled: true.
+
+The source is not the shared balance. Its pooled source customer-entitlement rows retain lifecycle/reset metadata, but spendable fields are normalized:
+
+- balance = 0
+- adjustment = 0
+- additional_balance = 0
+- entities = null
+
+A customer-level product with a pooled definition is not a source.
+
+### Pool
+
+A pooled_balances row identifies a shared grant for one customer and feature/reset configuration. It points to one synthetic customer-level customer_entitlements row, which is the spendable balance used for deductions.
+
+Pool identity is:
+
+~~~text
+internal_customer_id
++ internal_feature_id
++ interval
++ interval_count
++ reset_cycle_anchor
++ reset_mode
++ rollover_signature
+~~~
+
+It excludes product, price, entitlement, entity, source product, and next_reset_at. Lifetime pools use null anchor/next reset and lazy reset mode.
+
+### Contribution
+
+A pooled_balance_contributions row connects one source entitlement to one pool. Stable source identity is source_customer_product_id plus source_entitlement_id.
+
+It stores:
+
+- current_contribution: grant currently minted into the pool.
+- next_cycle_contribution: grant to mint after the next owner reset.
+- effective_at: staged removal boundary, or null.
+- stripe_subscription_id: paid recurring reset owner.
+- customer_license_link_id: assigned-seat reset owner.
+- neither owner: free/lazy contribution.
+
+The pool has no entitlement_id or price_id identity. source_entitlement_id remains on the contribution because one product can contribute several pooled features and a patch may remove only one.
+
+Whole-source removal affects all contributions under a source product. Single-contribution removal affects one source product plus entitlement. Reference removals zeroed or staged rows; they did not delete them.
+
+## Cross-cutting invariants
+
+### Classification and amounts
+
+1. A pooled source requires pooled: true and an entity-attached product.
+2. The synthetic pooled entitlement has no customer product.
+3. Source and synthetic rows are managed rows, not ordinary independent grants.
+4. Contributions are finite and non-negative.
+5. Current contribution uses current quantity.
+6. Next contribution uses upcoming_quantity when present, otherwise current quantity.
+7. Product quantity, allowance, billing units, and options use the canonical starting-balance calculation.
+8. One-off prepaid prices remain manual top-ups until pooled top-up semantics are explicitly designed.
+9. Boolean, unlimited, or entity-allocated semantics cannot silently become a finite contribution.
+
+### Reset ownership
+
+Free sources use lazy reset. Reference anchor priority was requested anchor, billing start, outgoing pooled-source anchor, then customer creation time.
+
+Paid recurring sources require a Stripe subscription owner. A new customer-product ID may be a temporary compute token, but Stripe execution replaces it before Autumn persistence. Under skipBillingChanges, an active paid source without an existing/supplied subscription is invalid.
+
+License assignments use customer_license.link_id as reset owner and inherit the parent reset cycle.
+
+A non-lifetime subscription-owned pool cannot contain contributions renewed by different subscriptions. The reference validated this during execution; the rebuild validates it during compute from setup data.
+
+License and free contributions both used lazy reset mode. Confirm whether they may coalesce when every identity field matches.
+
+### Balance and adjustment accounting
+
+For an upsert or immediate removal:
+
+~~~text
+contribution_delta = desired_current - previous_current
+pool.balance       += contribution_delta
+pool.adjustment    += contribution_delta
+~~~
+
+Changing adjustment with grant preserves recorded usage.
+
+For scheduled removal:
+
+~~~text
+current_contribution     remains unchanged
+next_cycle_contribution  becomes 0
+effective_at             becomes cycle end
+pool delta               is 0 now
+~~~
+
+A restore only applies when effective_at equals the expected cancellation boundary, preventing an old uncancel from reviving newer state.
+
+A transfer removes prior current contribution/adjustment from the old pool, adds desired current contribution/adjustment to the destination, moves the existing row, and checks its source identity and expected old pool.
+
+### Usage carry and rebalance
+
+Usage carry preserves known consumption when moving from a non-pooled grant or importing a flashed balance. Rebalance redistributes total feature usage across eligible customer-level numeric entitlements in Autumn deduction order.
+
+Required behavior:
+
+- Exclude normalized source rows.
+- Include synthetic pools and ordinary customer-level numeric entitlements.
+- Exclude boolean, unlimited, entity-scoped, and non-customer-scope rows.
+- Respect reverse_deduction_order and status rules.
+- Preserve total usage; only distribution changes.
+- Exclude the outgoing/source product from usage carry to prevent double deduction.
+- Reference reapplied usage for a new contribution or positive increase, not a non-positive existing update.
+- Rebalance changes balance only; grant deltas change balance and adjustment.
+
+Setup loads every eligible entitlement for affected features. Compute emits exact rebalance deltas. Execute never recomputes them.
+
+### Plan composition
+
+Reference named fields were removeSources, removeContributions, restoreSources, stageOwnerRemovals, restoreOwners, transferSources, and upsertSources. This is clearer than a discriminated operation list, but the entries still forced execution-time reads.
+
+The rebuild should keep readable named fields while making contents execution-ready, separating:
+
+- pool graphs to insert;
+- source entitlement normalizations;
+- contribution inserts;
+- exact contribution updates/transfers;
+- pooled entitlement grant deltas;
+- rebalance balance deltas;
+- affected features for cache handling.
+
+No executor should require a pool lookup, contribution lookup, FullSubject load, or business calculation.
+
+Reference merge keys were source product for whole-source changes, source product plus entitlement for contribution changes, license link for owner changes, and contribution ID for transfers. Later values won. The rebuild also rejects contradictory final writes.
+
+## Required setup context
+
+Each action loads only pooled state it can affect:
+
+- canonical public/internal customer IDs;
+- current, outgoing, incoming, scheduled, and assignment products;
+- pooled source rows and definitions;
+- pools for affected features and their synthetic entitlements;
+- contributions for affected sources, pools, subscriptions, or license links;
+- eligible customer-level numeric entitlements;
+- balances, adjustments, cache versions, and reset metadata;
+- status filters and deduction order;
+- known Stripe IDs and anchors;
+- license parents, links, seats, unused assignments, and definition transitions;
+- one captured current timestamp.
+
+Prefer one joined PooledBalanceBillingContext over repository reads scattered across compute helpers.
+
+## Flow coverage
+
+### A. Attach an entity plan
+
+Reference: Implemented, with unsupported cases and missing cache/concurrency protection.
+
+#### A1. Non-pooled attach
+
+- Customer-level plans and entity plans without pooled entitlements follow existing attach behavior.
+- Emit no pool graph, contribution, normalization, or rebalance writes.
+
+#### A2. First immediate pooled source
+
+- Initialize the incoming customer product normally.
+- Calculate one contribution per pooled entitlement.
+- Resolve free, subscription, or license reset policy.
+- Reuse a matching pool from setup or compute a new graph.
+- Normalize source entitlements.
+- Insert/upsert contributions.
+- Add current grants to the synthetic entitlement.
+- Rebalance affected features.
+
+A missing pool requires one custom pooled entitlement definition, one synthetic customer entitlement, one pooled balance row, and contribution rows.
+
+#### A3. Immediate replacement
+
+- Remove every outgoing source contribution immediately.
+- Upsert every incoming pooled contribution.
+- Expire/insert products through normal attach behavior.
+- Net grant deltas before rebalance.
+- If the outgoing same-feature grant was non-pooled, carry recorded usage.
+
+#### A4. Add another entity to an existing pool
+
+- Reuse only when every identity field matches.
+- Add a contribution keyed by the new source product and entitlement.
+- Increase balance and adjustment by its current contribution.
+- Reject a conflicting Stripe owner.
+
+#### A5. Idempotency
+
+- Existing contribution for the same source identity is updated, not duplicated.
+- Delta uses stored current contribution from setup.
+- A contribution pointing to another pool requires explicit transfer.
+- Concurrent creation must be conflict-safe, not an unguarded find-then-insert.
+
+#### A6. Inactive and scheduled products
+
+- Scheduled/inactive products mint no grant now.
+- They may have prepared source rows, but activation later adds the contribution.
+- The reference prepared scheduled rows but did not complete standalone activation: Partial.
+
+#### A7. Unsupported cases
+
+Reference returned 400 for:
+
+- active pooled entity product starting in the future;
+- pooled source with free trial or trial end;
+- paid pooled product that is not paid recurring;
+- active paid source under skipBillingChanges without subscription owner;
+- non-finite or negative contribution;
+- resetting paid/license source with incomplete reset dates.
+
+Keep these rejections until each has an explicit lifecycle design.
+
+#### A8. Processor safety
+
+- Preview computes the same plan but writes nothing.
+- Stripe failure leaves no Autumn pooled state.
+- Actual subscription ID reaches product and contribution owner before persistence.
+
+### B. Immediate multi-product attach
+
+Reference: Implemented.
+
+- Prepare every product independently.
+- Merge pooled writes into one Autumn plan.
+- Aggregate products affecting the same pool deterministically.
+- Keep one internal customer.
+- Preserve normal license transitions.
+
+### C. Create schedule
+
+Reference: Partial because activation/reset integration was incomplete.
+
+#### C1. Immediate phase
+
+- Expire selected current recurring products.
+- Immediately remove all their pooled sources.
+- Prepare every immediate product.
+- Do not remove outgoing sources again inside per-product preparation.
+- Merge removals/upserts once.
+
+#### C2. Future phases
+
+- Insert scheduled products with start/end and schedule linkage.
+- Mint no contribution while inactive.
+- Do not remove the active source merely because a future phase exists.
+- At activation, atomically remove outgoing and add incoming contributions.
+
+The activation behavior was not completed in the reference.
+
+#### C3. Schedule replacement
+
+- Delete/replace old scheduled products normally.
+- Never-active products need no pooled removal.
+- A contribution unexpectedly attached to a scheduled product is an invariant violation.
+
+### D. Update subscription
+
+#### D1. Recurring prepaid quantity
+
+Reference: Implemented.
+
+- Exclude one-off prepaid prices.
+- Compute current/upcoming options normally.
+- Suppress ordinary direct balance updates for pooled source rows.
+- Recompute current and next contributions.
+- Preserve identity/reset metadata.
+- Require subscription owner and complete reset data.
+- Apply contribution delta to balance/adjustment, then rebalance.
+- Non-pooled siblings update normally.
+
+#### D2. Manual top-up
+
+Reference: no pooled-specific behavior.
+
+- Keep the existing one-off purchase flow.
+- Do not rewrite recurring contributions.
+- Design credit ownership, expiry, and reset before pooled top-ups.
+
+#### D2a. Update license quantity
+
+Reference: no direct pooled-source mutation; license transition machinery handled definition changes.
+
+- Changing the number of available seats changes customer-license granted/remaining state, not the contribution of an already assigned seat.
+- Existing assigned-seat contributions remain unchanged when only availability changes.
+- Adding or releasing an actual assignment is covered by the attach/release license flows.
+- If the license product definition changes at the same time, use the customer-license definition transition coverage below.
+- Existing validation must prevent a quantity reduction from silently orphaning assignments.
+
+#### D3. Status or processor subscription ID
+
+Reference: Implemented.
+
+- No pooled plan when neither field changes.
+- Inactive target status removes source immediately.
+- Explicitly clearing an existing subscription removes source immediately.
+- Active owned target re-upserts without removing first.
+- Supplied processor ID patches contribution owners and product subscription IDs.
+- Skip this extra plan when cancellation/replacement already owns lifecycle.
+
+#### D4. Custom expire-and-insert
+
+Reference: Implemented.
+
+- Prepare new custom product like attach.
+- Remove old/add new source for active update.
+- Preserve price, entitlement, usage carry, line item, schedule, and license behavior.
+- Replacing a scheduled row does not mutate an active pool.
+
+#### D5. Patch in place
+
+Reference: Implemented.
+
+- Deleting one pooled entitlement removes only that contribution.
+- Adding one prepares only that entitlement.
+- Normalize inserted source rows.
+- Scheduled products have no active contribution to remove.
+- Leave unchanged siblings untouched.
+- “New row” mode uses expire-and-insert.
+- Same-row license transitions compare pristine original and final patched products.
+- Anchor reset updates use the prepared product.
+
+#### D6. Immediate cancellation
+
+Reference: Implemented.
+
+- Remove canceled source immediately.
+- Prepare an immediate default pooled product without removing twice.
+- Remove invalidated add-on sources only if active.
+- Keep normal refund/Stripe behavior.
+
+#### D7. End-of-cycle cancellation
+
+Reference: staging Implemented; reset application Partial.
+
+- Keep current contribution until boundary.
+- Set next contribution to zero and effective_at to cycle end.
+- Do not change current pool balance.
+- Stage every seat contribution owned by license links on the parent.
+- Scheduled default contributes only on activation.
+- Reset/transition processing applies staged removal exactly once; reference did not wire this consumer.
+
+#### D8. Uncancel
+
+Reference: restoration Implemented, dependent on reset lifecycle.
+
+- Restore only rows matching exact prior ended_at boundary.
+- Restore license-owned rows by link with same comparison.
+- Set next back to current and clear effective_at.
+- Do not change current pool balance.
+- Non-finite ended_at means no restore attempt.
+
+#### D9. Cancel before billing starts
+
+Reference: Implemented.
+
+- Delete a scheduled/future-start product with schedule and no live subscription.
+- It never contributed, so remove nothing.
+- If this uncancels the current product in the same group, its contribution remains.
+
+#### D10. Revert-trial cancellation
+
+Reference: Implemented, although creating pooled trials was Unsupported.
+
+- Do not create a default.
+- Unpause the previous product.
+- Re-upsert its active sources.
+- Remove canceled product source if present.
+
+#### D11. Billing-cycle anchor reset
+
+Reference: Partial.
+
+- Preserve ordinary reset metadata and line items.
+- Keep source and synthetic reset data consistent.
+- Changed non-lifetime anchor changes pool identity and may require transfer.
+- Add an explicit decision/test rather than silently mutating identity.
+
+### E. Stripe sync
+
+Reference: immediate replacement and detection scope Implemented; future phases/concurrency Partial.
+
+#### E1. Immediate replacement
+
+- Same product with only license quantity drift updates license state without recreating parent source.
+- Otherwise initialize from Stripe.
+- Apply configured usage carry before pooled preparation.
+- Remove old source, add new source, expire old product.
+- Existing Stripe ID is required as reset owner.
+
+#### E2. Prepaid drift detection
+
+- Compare Stripe-derived totals with linked product prepaid state.
+- Desired zero with zero purchased packs is not drift solely because catalog allowance is nonzero.
+- Detect main and add-on drift.
+- Replace with usage carry instead of directly overwriting source.
+
+#### E3. Entity scope
+
+- Preserve existing entity binding in generated sync params.
+- Reject/skip ambiguous mappings.
+- Never create customer-level duplicate for an entity-linked source.
+- Infer removed add-ons only when Stripe detection has no unmatched items.
+
+#### E4. Future phases
+
+Required behavior:
+
+- create inactive scheduled rows;
+- preserve current source until its real boundary;
+- transition sources during activation.
+
+Audit required: reference sometimes expired and removed currentCustomerProduct while computing a future phase. Do not copy unless semantics prove it is obsolete now.
+
+### F. DFU / flash
+
+Reference: Implemented.
+
+- Skip desired plan already represented by an active product.
+- Build imported product with source status, processor, anchor, and balances.
+- Prepare pooled sources as immediate attach.
+- Convert imported used units into usage carry before normalization.
+- Exclude flashed source while applying usage.
+- Expire omitted active products only in payload-addressed customer/entity scopes.
+- Remove sources for products expired by reconciliation.
+- Leave non-addressed scopes untouched.
+- Preserve mismatch reporting while enforcing reset-owner validation.
+
+### G. Attach license seats
+
+Reference: Implemented with execution/concurrency caveats.
+
+- Resolve exactly one assignable parent/license pair.
+- Reject missing, ambiguous, or archived target.
+- Ignore entities already assigned under the link.
+- Reuse released assignments before inserting new rows.
+- Repoint reused rows and clear released_at.
+- Insert missing entities before products.
+- Initialize assignment from licensed definition.
+- Anchor resets to parent cycle.
+- Add one contribution per pooled assignment entitlement, owned by license link.
+- Normalize source rows.
+- Decrement remaining by newly assigned seats only.
+- Keep one customer and one Autumn plan.
+
+### H. Release license seats
+
+Reference: Implemented.
+
+- Mark assignment released normally.
+- Immediately remove all its pooled contributions.
+- Increment license remaining.
+- Aggregate multiple releases in one customer plan.
+
+### I. Customer-license definition transition
+
+Reference: broad functional coverage, architecturally Partial.
+
+The reference performed setup and compute inside executeCustomerLicenseTransitions. Move all of this earlier.
+
+For every active assigned seat:
+
+1. Initialize target assignment from incoming definition while retaining product ID and entity.
+2. Match definitions through product transition map, then semantic equality.
+3. Reject ambiguous entitlement/contribution matches.
+4. Insert contribution when target pooled entitlement has no match.
+5. Transfer existing contribution when definition or pool identity changes.
+6. Verify expected old pool before transfer.
+7. Remove unmatched old pooled contributions.
+8. Insert missing target source rows.
+9. Repoint existing rows when definition changes.
+10. Restore ordinary balance/reset fields when pooled becomes non-pooled.
+11. Apply customer-license row transition normally.
+12. Trigger background seat transition only after synchronous commit.
+
+Required redesign:
+
+- Setup loads seats, pool graphs, contributions, parent, and transition map.
+- Compute emits license changes, source-row writes, transfers/removals/upserts, and exact deltas.
+- Main pooled execution applies them once.
+- executeCustomerLicenseTransitions only applies normal prepared license changes.
+- Batch dispatch remains post-commit.
+
+### J. License-parent cancellation and restoration
+
+Reference: staging Implemented; reset integration Partial.
+
+- End-of-cycle parent cancellation stages every contribution owned by each license link.
+- Uncancel restores only matching boundaries.
+- Immediate parent cancellation transitions/removes seat contributions even though seats are separate products.
+- Parent replacement preserving a link transfers/repoints ownership rather than stranding seats.
+- Add end-to-end tests across parent, seat, pool, and reset state.
+
+## Execution order
+
+Reference order was roughly:
+
+1. custom definitions;
+2. plan-license definitions;
+3. direct entitlement inserts/patches;
+4. license quantity updates;
+5. entities;
+6. new products;
+7. pooled mutations;
+8. customer-license transitions;
+9. schedule replacements;
+10. product updates/deletes;
+11. ordinary entitlement updates/rebalances;
+12. subscription/invoice persistence.
+
+The rebuild preserves dependencies without a second lifecycle path:
+
+- source products/rows exist before contribution inserts;
+- removals are computed from setup state before outgoing mutation/deletion;
+- related normal and pooled writes commit atomically where practical;
+- normal product/license execution is never skipped because pooled writes exist;
+- absent pooled plan is a no-op;
+- background dispatch happens post-commit.
+
+Stable pooled write order:
+
+1. insert missing synthetic entitlement/pool graphs;
+2. normalize source rows;
+3. insert/update/transfer/stage/restore contributions;
+4. apply aggregated grant deltas;
+5. apply precomputed usage-carry/rebalance deltas in stable entitlement-ID order;
+6. commit;
+7. perform cache cutover/invalidation.
+
+## Reference gaps
+
+### Pool resets
+
+Reference: Partial / effectively unimplemented.
+
+The repository exposed applyReset, owner lookups, next contributions, effective boundaries, and last_applied_reset_at, but no production caller applied pooled resets. The rebuild needs:
+
+- lazy reset for free pools;
+- subscription renewal reset by Stripe owner;
+- license-parent reset by license link;
+- current becoming next contribution;
+- staged removal becoming zero at boundary;
+- rollover and balance/adjustment reset;
+- expected-next-reset compare-and-set;
+- idempotency for duplicate webhooks/concurrent checks;
+- cache cutover after reset.
+
+Attach/cancel can come first, but scheduled cancellation is incomplete until this exists.
+
+### Cache and stale sync
+
+Reference: Deferred.
+
+The old branch documented and partly implemented a customer-scoped sync lock, reusable transaction handle, and post-commit cache cutover. See [balance-sync-correctness.md](./balance-sync-correctness.md).
+
+### Pool garbage collection
+
+Reference: not implemented.
+
+Zeroed contributions and empty pools remained. Decide whether history is permanent or cleanup is needed. Cleanup cannot break uncancel, auditability, or delayed reset processing.
+
+### Automated tests
+
+Reference: not implemented.
+
+The reference commit added no pooled billing integration tests. Every case below is new required coverage.
+
+## Test and acceptance matrix
+
+### Attach
+
+- PB-A01: first free entity source creates graph, normalized source, contribution, and balance.
+- PB-A02: first paid source uses real post-Stripe subscription owner.
+- PB-A03: second entity with identical identity joins existing pool.
+- PB-A04: identity difference creates a distinct pool.
+- PB-A05: repeated upsert does not duplicate contribution or grant.
+- PB-A06: immediate replacement removes old and adds new in one result.
+- PB-A07: non-pooled to pooled preserves usage.
+- PB-A08: pooled to non-pooled does not infer usage from normalized zero.
+- PB-A09: conflicting Stripe owner is rejected.
+- PB-A10: customer-level pooled definition is not a source.
+- PB-A11: future active start is rejected.
+- PB-A12: free trial is rejected.
+- PB-A13: paid non-recurring source is rejected.
+- PB-A14: missing reset owner under skip-billing is rejected.
+- PB-A15: negative, infinite, or NaN contribution is rejected.
+- PB-A16: preview and Stripe failure write nothing.
+
+### Multi-attach and schedules
+
+- PB-S01: multiple immediate products aggregate correctly.
+- PB-S02: immediate schedule phase removes all outgoing and adds all incoming once.
+- PB-S03: future scheduled product mints no grant.
+- PB-S04: activation atomically transitions source.
+- PB-S05: deleting never-active schedule changes no balance.
+- PB-S06: future phase creation does not remove current source early.
+
+### Subscription updates
+
+- PB-U01: quantity increase applies exact grant delta.
+- PB-U02: quantity decrease preserves usage.
+- PB-U03: upcoming quantity changes next but not current grant.
+- PB-U04: one-off prepaid is excluded.
+- PB-U05: non-pooled sibling updates normally.
+- PB-U06: inactive status removes source.
+- PB-U07: clearing subscription removes source.
+- PB-U08: changing subscription reassigns owner without duplicate grant.
+- PB-U09: custom replacement transitions sources.
+- PB-U10: patch deletion removes selected contribution only.
+- PB-U11: patch insertion adds and normalizes selected source only.
+- PB-U12: scheduled patch removes no nonexistent active grant.
+- PB-U13: immediate cancel removes now and prepares default correctly.
+- PB-U14: end-of-cycle cancel stages without current balance change.
+- PB-U15: uncancel restores exact boundary only.
+- PB-U16: cancel-before-start has no pool mutation.
+- PB-U17: revert-trial cancellation restores prior source.
+- PB-U18: anchor reset keeps identity consistent or explicitly transfers.
+
+### Sync and DFU
+
+- PB-Y01: immediate sync replacement carries usage and transitions source.
+- PB-Y02: license-only drift leaves parent contribution unchanged.
+- PB-Y03: main/add-on prepaid drift is detected.
+- PB-Y04: entity binding is preserved.
+- PB-Y05: ambiguous entities do not create customer-level duplicate.
+- PB-Y06: unmatched Stripe items do not cause false removal.
+- PB-Y07: future sync phase does not remove current source early.
+- PB-F01: flashed unused grant imports full contribution.
+- PB-F02: flashed used grant reapplies imported usage once.
+- PB-F03: already-active target is skipped.
+- PB-F04: omitted product expires only in addressed scope and removes source.
+- PB-F05: non-addressed scope remains untouched.
+
+### Licenses
+
+- PB-L01: new seat creates owned contributions and decrements remaining.
+- PB-L02: reused seat repoints without duplicate contribution.
+- PB-L03: duplicate entity request is idempotent.
+- PB-L04: release removes source and increments remaining.
+- PB-L05: license definition adds pooled entitlement.
+- PB-L06: definition removes one pooled entitlement.
+- PB-L07: identity change transfers contribution.
+- PB-L08: pooled to non-pooled restores ordinary source balance.
+- PB-L09: ambiguous matching fails before writes.
+- PB-L10: stale expected pool fails transfer before writes.
+- PB-L11: parent end-of-cycle cancel stages every owned seat.
+- PB-L12: parent uncancel restores matching staged seats.
+- PB-L13: batch workflow dispatches only after commit.
+
+### Accounting, reset, and concurrency
+
+- PB-R01: grant delta changes balance/adjustment; rebalance changes balance only.
+- PB-R02: total usage is invariant through rebalance.
+- PB-R03: normal and reverse deduction order distribute correctly.
+- PB-R04: source/boolean/unlimited/entity rows are excluded.
+- PB-R05: free lazy reset applies next contributions once.
+- PB-R06: subscription renewal resets only owned pools.
+- PB-R07: license reset applies only owned contributions.
+- PB-R08: staged removal becomes zero at boundary.
+- PB-R09: duplicate reset is a compare-and-set no-op.
+- PB-C01: concurrent creation yields one pool and one contribution per source.
+- PB-C02: concurrent attach/quantity update loses no delta.
+- PB-C03: stale transfer fails expected-pool check.
+- PB-C04: rollback leaves all related Autumn state unchanged.
+- PB-C05: stale Redis cannot overwrite pooled transition.
+- PB-C06: concurrent usage is neither lost nor duplicated.
+- PB-C07: different customers do not block each other.
+
+## Recommended implementation sequence
+
+### Phase 1: attach setup and plan types
+
+- Add joined pool setup context.
+- Define execution-ready named plan fields.
+- Implement pure identity, contribution, delta, normalization, usage carry, and rebalance helpers.
+- Support first attach, joining an existing pool, and immediate replacement.
+- Preserve unsupported errors.
+
+### Phase 2: mechanical executor
+
+- Apply explicit graph, contribution, and entitlement writes.
+- Use one transaction and no nested executor transactions.
+- Call once from cohesive executeAutumnBillingPlan.
+- Keep normal product/license execution unconditional.
+
+### Phase 3: attach variants
+
+- Immediate multi-product.
+- Schedule immediate phase.
+- Scheduled preparation, explicitly tracking activation if out of scope.
+
+### Phase 4: subscription mutations
+
+- Quantity/upcoming quantity.
+- Field changes.
+- Custom replacement and patch.
+- Immediate cancel, staged cancel, uncancel, and revert trial.
+- Anchor reset/transfer decision.
+
+### Phase 5: reconciliation
+
+- Sync immediate/future.
+- DFU/flash.
+- Entity scope and usage carry.
+
+### Phase 6: licenses
+
+- Attach/reuse/release seat.
+- Move transition setup/compute out of execution.
+- Add/remove/transfer and pooled-to-non-pooled restoration.
+- Parent owner staging/restoration.
+
+### Phase 7: reset and cache correctness
+
+- Implement free/subscription/license resets.
+- Restore balance-sync serialization and post-commit cache strategy.
+- Add race tests.
+
+## Definition of done
+
+- Every applicable matrix case is green.
+- Every reference behavior is preserved or deliberately changed here.
+- Every Audit required item has a recorded decision.
+- Setup owns reads, compute owns decisions, execute owns writes.
+- executeAutumnBillingPlan has one lifecycle path.
+- License transitions are not prepared inside execution.
+- No leaf pooled executor opens a transaction or lock.
+- Scheduled cancellation has a real reset consumer.
+- Cache/balance-sync correctness is restored.
+- Preview, Stripe failure, and DB rollback are side-effect safe.
+- Logs expose pool/source IDs and deltas without runtime recomputation.

--- a/scripts/testScripts/getDescribeAtCursor.ts
+++ b/scripts/testScripts/getDescribeAtCursor.ts
@@ -9,9 +9,16 @@ const lines = content.split("\n");
 const MULTILINE_LOOKAHEAD = 5;
 
 const escapeRegex = (raw: string) => raw.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const templateToRegex = (raw: string) =>
+	raw
+		.split(/\$\{.*?\}/)
+		.map(escapeRegex)
+		.join(".*");
 
 const CHALK_PATTERN =
 	/(?:describe|test(?:\.concurrent)?)\s*\(\s*`\$\{chalk\.\w+\(["'](.*?)["']\)\}`/;
+const CHALK_TEMPLATE_PATTERN =
+	/(?:describe|test(?:\.concurrent)?)\s*\(\s*`\$\{chalk\.\w+\(`([\s\S]*?)`\)\}`/;
 const BLOCK_NAME = String.raw`(?:describe|test(?:\.concurrent)?|Eval(?:<[^>]+>)?)`;
 const SIMPLE_PATTERN = new RegExp(`${BLOCK_NAME}\\s*\\(\\s*["'\`](.*?)["'\`]`);
 const OPEN_PATTERN = new RegExp(`${BLOCK_NAME}\\s*\\(\\s*$`);
@@ -21,6 +28,12 @@ const OPEN_PATTERN = new RegExp(`${BLOCK_NAME}\\s*\\(\\s*$`);
 // next line(s) — `test.concurrent(\n\t\`${chalk.yellowBright("name")}\`,` — are matched.
 for (let i = lineNum - 1; i >= 0; i--) {
 	const line = lines[i];
+
+	const chalkTemplateMatch = line.match(CHALK_TEMPLATE_PATTERN);
+	if (chalkTemplateMatch) {
+		console.log(templateToRegex(chalkTemplateMatch[1]));
+		process.exit(0);
+	}
 
 	const chalkMatch = line.match(CHALK_PATTERN);
 	if (chalkMatch) {
@@ -38,6 +51,11 @@ for (let i = lineNum - 1; i >= 0; i--) {
 		const joined = lines
 			.slice(i, Math.min(lines.length, i + 1 + MULTILINE_LOOKAHEAD))
 			.join("\n");
+		const chalkTemplateMulti = joined.match(CHALK_TEMPLATE_PATTERN);
+		if (chalkTemplateMulti) {
+			console.log(templateToRegex(chalkTemplateMulti[1]));
+			process.exit(0);
+		}
 		const chalkMulti = joined.match(CHALK_PATTERN);
 		if (chalkMulti) {
 			console.log(escapeRegex(chalkMulti[1]));

--- a/server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts
+++ b/server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts
@@ -7,6 +7,7 @@ import {
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { buildAutumnLineItems } from "@/internal/billing/v2/compute/computeAutumnUtils/buildAutumnLineItems";
 import { computeCustomerLicenseTransitions } from "@/internal/billing/v2/compute/customerLicenseTransitions/computeCustomerLicenseTransitions";
+import { computeAttachPooledBalancePlan } from "@/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalancePlan";
 import { cusProductToExistingBalanceCarryOvers } from "@/internal/billing/v2/utils/handleCarryOvers/cusProductToExistingBalanceCarryOvers";
 import { cusProductToOneOffPrepaidCarryOvers } from "@/internal/billing/v2/utils/handleOneOffPrepaidCarryOvers/cusProductToOneOffPrepaidCarryOvers";
 import { computeAttachNewCustomerProduct } from "./computeAttachNewCustomerProduct";
@@ -101,6 +102,13 @@ export const computeAttachPlan = ({
 				})
 			: { allLineItems: [], updateCustomerEntitlements: [] };
 
+	const { customerProduct: preparedNewCustomerProduct, pooledBalancePlan } =
+		computeAttachPooledBalancePlan({
+			ctx,
+			attachBillingContext,
+			newCustomerProduct,
+		});
+
 	// Lock the customer's currency on the first paid attach (only when they have
 	// none yet). Free attaches don't commit a currency. Applied conditionally at execute.
 	const {
@@ -120,7 +128,7 @@ export const computeAttachPlan = ({
 
 	let plan: AutumnBillingPlan = {
 		customerId: attachBillingContext.fullCustomer?.id ?? "",
-		insertCustomerProducts: [newCustomerProduct],
+		insertCustomerProducts: [preparedNewCustomerProduct],
 		lockCustomerCurrency,
 		updateCustomerProduct,
 		deleteCustomerProduct: scheduledCustomerProduct,
@@ -139,6 +147,7 @@ export const computeAttachPlan = ({
 			...oneOffPrepaidCarryOvers.customerEntitlements,
 		],
 		updateCustomerEntitlements,
+		pooledBalancePlan,
 		oneOffPurchaseRebalance,
 	};
 

--- a/server/src/internal/billing/v2/execute/addStripeSubscriptionIdToBillingPlan.ts
+++ b/server/src/internal/billing/v2/execute/addStripeSubscriptionIdToBillingPlan.ts
@@ -1,6 +1,7 @@
 import type { AutumnBillingPlan } from "@autumn/shared";
-import { cp } from "@autumn/shared";
+import { cp, PooledBalanceResetMode } from "@autumn/shared";
 import { getPatchedCustomerProductUpdates } from "@/internal/billing/v2/utils/billingPlan/customerProductPlanMutations.js";
+import { getChangedPooledBalances } from "@/internal/billing/v2/utils/billingPlan/pooledBalancePlan.js";
 import { customerProductHasPaidLicenses } from "@/internal/billing/v2/utils/customerProductHasPaidLicenses.js";
 
 /**
@@ -29,5 +30,14 @@ export const addStripeSubscriptionIdToBillingPlan = ({
 		autumnBillingPlan,
 	})) {
 		update.updates.subscription_ids = [stripeSubscriptionId];
+	}
+
+	for (const pooledCustomerEntitlement of getChangedPooledBalances({
+		autumnBillingPlan,
+	})) {
+		const pooledBalance = pooledCustomerEntitlement.pooled_balance;
+		if (pooledBalance?.reset_mode === PooledBalanceResetMode.Subscription) {
+			pooledBalance.stripe_subscription_id = stripeSubscriptionId;
+		}
 	}
 };

--- a/server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts
+++ b/server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts
@@ -10,6 +10,7 @@ import { executeOneOffPurchaseRebalance } from "@/internal/billing/v2/execute/ex
 import { executePatchCustomerProducts } from "@/internal/billing/v2/execute/executeAutumnActions/executePatchCustomerProducts";
 import { insertNewCusProducts } from "@/internal/billing/v2/execute/executeAutumnActions/insertNewCusProducts";
 import { updateCustomerEntitlements } from "@/internal/billing/v2/execute/executeAutumnActions/updateCustomerEntitlements";
+import { executePooledBalancePlan } from "@/internal/billing/v2/pooledBalances/execute/executePooledBalancePlan";
 import {
 	getDeleteCustomerProducts,
 	getUpdateCustomerProducts,
@@ -111,6 +112,11 @@ export const executeAutumnBillingPlan = async ({
 	await insertNewCusProducts({
 		ctx,
 		newCusProducts: insertCustomerProducts,
+	});
+
+	await executePooledBalancePlan({
+		ctx,
+		pooledBalancePlan: autumnBillingPlan.pooledBalancePlan,
 	});
 
 	await executeCustomerLicenseTransitions({

--- a/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/applyIncomingPooledBalanceSources.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/applyIncomingPooledBalanceSources.ts
@@ -1,0 +1,91 @@
+import {
+	customerProductHasActiveStatus,
+	type FullCusProduct,
+	filterCustomerEntitlementsByPooledBalanceSource,
+	isCustomerProductEntityScoped,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import type { PooledBalanceComputeContext } from "../types/pooledBalanceComputeTypes";
+import { addToInsertPoolContributions } from "../utils/pooledBalancePlanUtils";
+import { computePooledBalanceContributionAmounts } from "./computePooledBalanceContributionAmounts";
+import { computePooledBalanceLifecycle } from "./computePooledBalanceLifecycle";
+import { initCustomerEntitlementPooledIdentity } from "./initCustomerEntitlementPooledIdentity";
+import { initPooledBalanceContribution } from "./initPooledBalanceContribution";
+import { normalizePooledBalanceContributionCustomerEntitlement } from "./normalizePooledBalanceContributionCustomerEntitlement";
+import { upsertPooledBalance } from "./upsertPooledBalance";
+
+export const applyIncomingPooledBalanceSources = ({
+	ctx,
+	computeContext,
+	customerProduct,
+	stripeSubscriptionId,
+	customerCreatedAt,
+	now,
+}: {
+	ctx: AutumnContext;
+	computeContext: PooledBalanceComputeContext;
+	customerProduct: FullCusProduct;
+	stripeSubscriptionId?: string;
+	customerCreatedAt: number;
+	now: number;
+}) => {
+	if (
+		!isCustomerProductEntityScoped(customerProduct) ||
+		!customerProductHasActiveStatus(customerProduct)
+	) {
+		return;
+	}
+
+	const contributionCustomerEntitlements =
+		filterCustomerEntitlementsByPooledBalanceSource({
+			customerEntitlements: customerProduct.customer_entitlements,
+		});
+
+	for (const contributionCustomerEntitlement of contributionCustomerEntitlements) {
+		const lifecycle = computePooledBalanceLifecycle({
+			computeContext,
+			customerEntitlement: contributionCustomerEntitlement,
+			customerProduct,
+			stripeSubscriptionId,
+			customerCreatedAt,
+			now,
+		});
+
+		const identity = initCustomerEntitlementPooledIdentity({
+			customerEntitlement: contributionCustomerEntitlement,
+			lifecycle,
+		});
+
+		const contributionAmounts = computePooledBalanceContributionAmounts({
+			contributionCustomerEntitlement,
+			customerProduct,
+		});
+
+		const pooledCustomerEntitlement = upsertPooledBalance({
+			ctx,
+			computeContext,
+			contributionCustomerEntitlement,
+			customerProduct,
+			identity,
+			contributionAmounts,
+			nextResetAt: lifecycle.nextResetAt,
+			now,
+		});
+
+		const contribution = initPooledBalanceContribution({
+			pooledCustomerEntitlement,
+			contributionCustomerEntitlement,
+			customerProduct,
+			contributionAmounts,
+			now,
+		});
+
+		addToInsertPoolContributions({
+			pooledBalancePlan: computeContext.plan,
+			contribution,
+		});
+		normalizePooledBalanceContributionCustomerEntitlement({
+			contributionCustomerEntitlement,
+		});
+	}
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/computePooledBalanceContributionAmounts.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/computePooledBalanceContributionAmounts.ts
@@ -1,0 +1,30 @@
+import {
+	addCusProductToCusEnt,
+	cusEntToStartingBalance,
+	type FullCusProduct,
+	type FullCustomerEntitlement,
+} from "@autumn/shared";
+import type { PooledBalanceContributionAmounts } from "../types/pooledBalanceComputeTypes";
+
+export const computePooledBalanceContributionAmounts = ({
+	contributionCustomerEntitlement,
+	customerProduct,
+}: {
+	contributionCustomerEntitlement: FullCustomerEntitlement;
+	customerProduct: FullCusProduct;
+}): PooledBalanceContributionAmounts => {
+	const customerEntitlementWithProduct = addCusProductToCusEnt({
+		cusEnt: contributionCustomerEntitlement,
+		cusProduct: customerProduct,
+	});
+
+	return {
+		currentContribution: cusEntToStartingBalance({
+			cusEnt: customerEntitlementWithProduct,
+		}),
+		nextCycleContribution: cusEntToStartingBalance({
+			cusEnt: customerEntitlementWithProduct,
+			useUpcomingQuantity: true,
+		}),
+	};
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/computePooledBalanceLifecycle.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/computePooledBalanceLifecycle.ts
@@ -1,0 +1,214 @@
+import {
+	EntInterval,
+	type FullCusProduct,
+	type FullCustomerEntitlement,
+	getCycleEnd,
+	InternalError,
+	isCustomerProductFree,
+	isCustomerProductPaidRecurring,
+	PooledBalanceResetMode,
+} from "@autumn/shared";
+import type {
+	PooledBalanceComputeContext,
+	PooledBalanceLifecycle,
+} from "../types/pooledBalanceComputeTypes";
+import { initCustomerEntitlementPooledIdentity } from "./initCustomerEntitlementPooledIdentity";
+
+const getResetMode = ({
+	customerProduct,
+	interval,
+}: {
+	customerProduct: FullCusProduct;
+	interval: EntInterval;
+}) => {
+	if (interval === EntInterval.Lifetime) {
+		return PooledBalanceResetMode.Lifetime;
+	}
+	if (customerProduct.customer_license_link_id) {
+		return PooledBalanceResetMode.Lazy;
+	}
+	if (isCustomerProductFree(customerProduct)) {
+		return PooledBalanceResetMode.Lazy;
+	}
+	if (isCustomerProductPaidRecurring(customerProduct)) {
+		return PooledBalanceResetMode.Subscription;
+	}
+
+	throw new InternalError({
+		message: "Paid pooled entitlements must belong to a recurring product.",
+	});
+};
+
+const findExistingPoolResetCycleAnchor = ({
+	computeContext,
+	customerEntitlement,
+	resetMode,
+	stripeSubscriptionId,
+	customerLicenseLinkId,
+}: {
+	computeContext: PooledBalanceComputeContext;
+	customerEntitlement: FullCustomerEntitlement;
+	resetMode: PooledBalanceResetMode;
+	stripeSubscriptionId: string | null;
+	customerLicenseLinkId: string | null;
+}) => {
+	const sourceIdentity = initCustomerEntitlementPooledIdentity({
+		customerEntitlement,
+		lifecycle: {
+			resetCycleAnchor: null,
+			resetMode,
+			stripeSubscriptionId,
+			customerLicenseLinkId,
+		},
+	});
+
+	return computeContext.pooledCustomerEntitlements.find(
+		({ pooled_balance }) =>
+			pooled_balance.internal_feature_id === sourceIdentity.internalFeatureId &&
+			pooled_balance.interval === sourceIdentity.interval &&
+			pooled_balance.interval_count === sourceIdentity.intervalCount &&
+			pooled_balance.reset_mode === resetMode &&
+			pooled_balance.stripe_subscription_id === stripeSubscriptionId &&
+			pooled_balance.customer_license_link_id === customerLicenseLinkId &&
+			pooled_balance.rollover_signature === sourceIdentity.rolloverSignature,
+	)?.pooled_balance.reset_cycle_anchor;
+};
+
+const getPooledBalanceLifecycleIds = ({
+	customerProduct,
+	resetMode,
+	stripeSubscriptionId,
+}: {
+	customerProduct: FullCusProduct;
+	resetMode: PooledBalanceResetMode;
+	stripeSubscriptionId?: string;
+}): Pick<
+	PooledBalanceLifecycle,
+	"stripeSubscriptionId" | "customerLicenseLinkId"
+> => {
+	if (resetMode === PooledBalanceResetMode.Lifetime) {
+		return {
+			stripeSubscriptionId: null,
+			customerLicenseLinkId: null,
+		};
+	}
+
+	if (customerProduct.customer_license_link_id) {
+		return {
+			stripeSubscriptionId: null,
+			customerLicenseLinkId: customerProduct.customer_license_link_id,
+		};
+	}
+
+	if (resetMode === PooledBalanceResetMode.Subscription) {
+		return {
+			stripeSubscriptionId:
+				stripeSubscriptionId ??
+				customerProduct.subscription_ids?.[0] ??
+				customerProduct.id,
+			customerLicenseLinkId: null,
+		};
+	}
+
+	return {
+		stripeSubscriptionId: null,
+		customerLicenseLinkId: null,
+	};
+};
+
+const resolveResetCycleAnchor = ({
+	computeContext,
+	customerEntitlement,
+	resetMode,
+	stripeSubscriptionId,
+	customerLicenseLinkId,
+	customerCreatedAt,
+}: {
+	computeContext: PooledBalanceComputeContext;
+	customerEntitlement: FullCustomerEntitlement;
+	resetMode: PooledBalanceResetMode;
+	stripeSubscriptionId: string | null;
+	customerLicenseLinkId: string | null;
+	customerCreatedAt: number;
+}) => {
+	if (resetMode === PooledBalanceResetMode.Lifetime) return null;
+	const existingResetCycleAnchor = findExistingPoolResetCycleAnchor({
+		computeContext,
+		customerEntitlement,
+		resetMode,
+		stripeSubscriptionId,
+		customerLicenseLinkId,
+	});
+	if (existingResetCycleAnchor !== undefined) {
+		return existingResetCycleAnchor;
+	}
+
+	if (
+		resetMode === PooledBalanceResetMode.Subscription ||
+		customerLicenseLinkId
+	) {
+		return customerEntitlement.reset_cycle_anchor ?? null;
+	}
+
+	return customerCreatedAt;
+};
+
+export const computePooledBalanceLifecycle = ({
+	computeContext,
+	customerEntitlement,
+	customerProduct,
+	stripeSubscriptionId: existingStripeSubscriptionId,
+	customerCreatedAt,
+	now,
+}: {
+	computeContext: PooledBalanceComputeContext;
+	customerEntitlement: FullCustomerEntitlement;
+	customerProduct: FullCusProduct;
+	stripeSubscriptionId?: string;
+	customerCreatedAt: number;
+	now: number;
+}): PooledBalanceLifecycle => {
+	const interval =
+		customerEntitlement.entitlement.interval ?? EntInterval.Lifetime;
+
+	const resetMode = getResetMode({ customerProduct, interval });
+	const { stripeSubscriptionId, customerLicenseLinkId } =
+		getPooledBalanceLifecycleIds({
+			customerProduct,
+			resetMode,
+			stripeSubscriptionId: existingStripeSubscriptionId,
+		});
+	const resetCycleAnchor = resolveResetCycleAnchor({
+		computeContext,
+		customerEntitlement,
+		resetMode,
+		stripeSubscriptionId,
+		customerLicenseLinkId,
+		customerCreatedAt,
+	});
+
+	if (
+		resetMode !== PooledBalanceResetMode.Lifetime &&
+		resetCycleAnchor === null
+	) {
+		throw new InternalError({
+			message: `Pooled entitlement '${customerEntitlement.id}' is missing its reset cycle anchor.`,
+		});
+	}
+
+	return {
+		resetMode,
+		resetCycleAnchor,
+		stripeSubscriptionId,
+		customerLicenseLinkId,
+		nextResetAt:
+			resetMode === PooledBalanceResetMode.Lifetime
+				? null
+				: getCycleEnd({
+						anchor: resetCycleAnchor ?? "now",
+						interval,
+						intervalCount: customerEntitlement.entitlement.interval_count ?? 1,
+						now,
+					}),
+	};
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/initCustomerEntitlementPooledIdentity.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/initCustomerEntitlementPooledIdentity.ts
@@ -1,0 +1,33 @@
+import {
+	EntInterval,
+	type FullCustomerEntitlement,
+	type PooledBalanceIdentity,
+} from "@autumn/shared";
+import type { PooledBalanceLifecycle } from "../types/pooledBalanceComputeTypes";
+
+type PooledBalanceIdentityLifecycle = Pick<
+	PooledBalanceLifecycle,
+	| "resetCycleAnchor"
+	| "resetMode"
+	| "stripeSubscriptionId"
+	| "customerLicenseLinkId"
+>;
+
+export const initCustomerEntitlementPooledIdentity = ({
+	customerEntitlement,
+	lifecycle,
+}: {
+	customerEntitlement: FullCustomerEntitlement;
+	lifecycle: PooledBalanceIdentityLifecycle;
+}): PooledBalanceIdentity => ({
+	internalFeatureId: customerEntitlement.internal_feature_id,
+	interval: customerEntitlement.entitlement.interval ?? EntInterval.Lifetime,
+	intervalCount: customerEntitlement.entitlement.interval_count ?? 1,
+	resetCycleAnchor: lifecycle.resetCycleAnchor,
+	resetMode: lifecycle.resetMode,
+	stripeSubscriptionId: lifecycle.stripeSubscriptionId,
+	customerLicenseLinkId: lifecycle.customerLicenseLinkId,
+	rolloverSignature: customerEntitlement.entitlement.rollover
+		? JSON.stringify(customerEntitlement.entitlement.rollover)
+		: "none",
+});

--- a/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/initPooledBalanceContribution.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/initPooledBalanceContribution.ts
@@ -1,0 +1,34 @@
+import type {
+	FullCusProduct,
+	FullCustomerEntitlement,
+	InsertPooledBalanceContribution,
+} from "@autumn/shared";
+import { generateId } from "@/utils/genUtils";
+import type {
+	MutablePooledCustomerEntitlement,
+	PooledBalanceContributionAmounts,
+} from "../types/pooledBalanceComputeTypes";
+
+export const initPooledBalanceContribution = ({
+	pooledCustomerEntitlement,
+	contributionCustomerEntitlement,
+	customerProduct,
+	contributionAmounts,
+	now,
+}: {
+	pooledCustomerEntitlement: MutablePooledCustomerEntitlement;
+	contributionCustomerEntitlement: FullCustomerEntitlement;
+	customerProduct: FullCusProduct;
+	contributionAmounts: PooledBalanceContributionAmounts;
+	now: number;
+}): InsertPooledBalanceContribution => ({
+	id: generateId("pool_contribution"),
+	pooled_balance_id: pooledCustomerEntitlement.pooled_balance.id,
+	source_customer_product_id: customerProduct.id,
+	source_customer_entitlement_id: contributionCustomerEntitlement.id,
+	current_contribution: contributionAmounts.currentContribution,
+	next_cycle_contribution: contributionAmounts.nextCycleContribution,
+	effective_at: null,
+	created_at: now,
+	updated_at: now,
+});

--- a/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/initPooledBalanceGraph.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/initPooledBalanceGraph.ts
@@ -1,0 +1,83 @@
+import type {
+	FullCusProduct,
+	FullCustomerEntitlement,
+	PooledBalanceIdentity,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { generateId } from "@/utils/genUtils";
+import type { MutablePooledCustomerEntitlement } from "../types/pooledBalanceComputeTypes";
+
+export const initPooledBalanceGraph = ({
+	ctx,
+	contributionCustomerEntitlement,
+	customerProduct,
+	identity,
+	balanceDelta,
+	granted,
+	nextResetAt,
+	now,
+}: {
+	ctx: AutumnContext;
+	contributionCustomerEntitlement: FullCustomerEntitlement;
+	customerProduct: FullCusProduct;
+	identity: PooledBalanceIdentity;
+	balanceDelta: number;
+	granted: number;
+	nextResetAt: number | null;
+	now: number;
+}): MutablePooledCustomerEntitlement => {
+	const entitlementId = generateId("ent");
+	const customerEntitlementId = generateId("cus_ent");
+
+	return {
+		...structuredClone(contributionCustomerEntitlement),
+		id: customerEntitlementId,
+		entitlement_id: entitlementId,
+		entitlement: {
+			...structuredClone(contributionCustomerEntitlement.entitlement),
+			id: entitlementId,
+			created_at: now,
+			internal_product_id: null,
+			internal_reward_id: null,
+			is_custom: true,
+			allowance: 0,
+			org_id: ctx.org.id,
+			feature_id: contributionCustomerEntitlement.entitlement.feature.id,
+			pooled: true,
+		},
+		customer_product_id: null,
+		internal_entity_id: null,
+		created_at: now,
+		balance: balanceDelta,
+		adjustment: 0,
+		additional_balance: 0,
+		entities: null,
+		reset_cycle_anchor: identity.resetCycleAnchor,
+		next_reset_at: nextResetAt,
+		cache_version: 0,
+		external_id: null,
+		is_pooled_balance: true,
+		replaceables: [],
+		rollovers: [],
+		pooled_balance_contribution: undefined,
+		pooled_balance: {
+			id: generateId("pool"),
+			org_id: ctx.org.id,
+			env: ctx.env,
+			internal_customer_id: customerProduct.internal_customer_id,
+			internal_feature_id: identity.internalFeatureId,
+			granted,
+			interval: identity.interval,
+			interval_count: identity.intervalCount,
+			reset_cycle_anchor: identity.resetCycleAnchor,
+			reset_mode: identity.resetMode,
+			stripe_subscription_id: identity.stripeSubscriptionId,
+			customer_license_link_id: identity.customerLicenseLinkId,
+			rollover_signature: identity.rolloverSignature,
+			customer_entitlement_id: customerEntitlementId,
+			last_applied_reset_at: null,
+			created_at: now,
+			updated_at: now,
+		},
+	};
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/normalizePooledBalanceContributionCustomerEntitlement.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/normalizePooledBalanceContributionCustomerEntitlement.ts
@@ -1,0 +1,12 @@
+import type { FullCustomerEntitlement } from "@autumn/shared";
+
+export const normalizePooledBalanceContributionCustomerEntitlement = ({
+	contributionCustomerEntitlement,
+}: {
+	contributionCustomerEntitlement: FullCustomerEntitlement;
+}) => {
+	contributionCustomerEntitlement.balance = 0;
+	contributionCustomerEntitlement.adjustment = 0;
+	contributionCustomerEntitlement.additional_balance = 0;
+	contributionCustomerEntitlement.entities = null;
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/upsertPooledBalance.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/upsertPooledBalance.ts
@@ -1,0 +1,84 @@
+import {
+	addSafe,
+	type FullCusProduct,
+	type FullCustomerEntitlement,
+	type PooledBalanceIdentity,
+	pooledBalanceIdentityToKey,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { addInsertedPooledBalanceToComputeContext } from "../context/pooledBalanceComputeContextUtils";
+import type {
+	MutablePooledCustomerEntitlement,
+	PooledBalanceComputeContext,
+	PooledBalanceContributionAmounts,
+} from "../types/pooledBalanceComputeTypes";
+import { addToUpdatePoolBalances } from "../utils/pooledBalancePlanUtils";
+import { initPooledBalanceGraph } from "./initPooledBalanceGraph";
+
+export const upsertPooledBalance = ({
+	ctx,
+	computeContext,
+	contributionCustomerEntitlement,
+	customerProduct,
+	identity,
+	contributionAmounts,
+	nextResetAt,
+	now,
+}: {
+	ctx: AutumnContext;
+	computeContext: PooledBalanceComputeContext;
+	contributionCustomerEntitlement: FullCustomerEntitlement;
+	customerProduct: FullCusProduct;
+	identity: PooledBalanceIdentity;
+	contributionAmounts: PooledBalanceContributionAmounts;
+	nextResetAt: number | null;
+	now: number;
+}): MutablePooledCustomerEntitlement => {
+	const existingPooledCustomerEntitlement =
+		computeContext.pooledCustomerEntitlementByIdentity.get(
+			pooledBalanceIdentityToKey({ identity }),
+		);
+
+	const balanceDelta =
+		existingPooledCustomerEntitlement &&
+		computeContext.pooledBalanceIdsWithRemovedContributions.has(
+			existingPooledCustomerEntitlement.pooled_balance.id,
+		)
+			? contributionAmounts.currentContribution
+			: (contributionCustomerEntitlement.balance ?? 0);
+
+	if (!existingPooledCustomerEntitlement) {
+		const insertedPooledCustomerEntitlement = initPooledBalanceGraph({
+			ctx,
+			contributionCustomerEntitlement,
+			customerProduct,
+			identity,
+			balanceDelta,
+			granted: contributionAmounts.currentContribution,
+			nextResetAt,
+			now,
+		});
+
+		addInsertedPooledBalanceToComputeContext({
+			computeContext,
+			pooledCustomerEntitlement: insertedPooledCustomerEntitlement,
+		});
+
+		return insertedPooledCustomerEntitlement;
+	}
+
+	addToUpdatePoolBalances({
+		pooledBalancePlan: computeContext.plan,
+		pooledCustomerEntitlement: existingPooledCustomerEntitlement,
+		balance: addSafe({
+			left: existingPooledCustomerEntitlement.balance,
+			right: balanceDelta,
+		}),
+		granted: addSafe({
+			left: existingPooledCustomerEntitlement.pooled_balance.granted,
+			right: contributionAmounts.currentContribution,
+		}),
+	});
+
+	return existingPooledCustomerEntitlement;
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/applyOutgoingPooledBalanceSources/applyOutgoingPooledBalanceSources.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/applyOutgoingPooledBalanceSources/applyOutgoingPooledBalanceSources.ts
@@ -1,0 +1,66 @@
+import {
+	type FullCusProduct,
+	filterCustomerEntitlementsByPooledBalanceSource,
+	InternalError,
+	isCustomerProductEntityScoped,
+	subtractSafe,
+} from "@autumn/shared";
+import type { PooledBalanceComputeContext } from "../types/pooledBalanceComputeTypes";
+import {
+	addToDeletePoolContributions,
+	addToUpdatePoolBalances,
+} from "../utils/pooledBalancePlanUtils";
+
+export const applyOutgoingPooledBalanceSources = ({
+	computeContext,
+	customerProduct,
+}: {
+	computeContext: PooledBalanceComputeContext;
+	customerProduct?: FullCusProduct;
+}) => {
+	if (!customerProduct || !isCustomerProductEntityScoped(customerProduct))
+		return;
+
+	const contributionCustomerEntitlements =
+		filterCustomerEntitlementsByPooledBalanceSource({
+			customerEntitlements: customerProduct.customer_entitlements,
+		});
+
+	for (const contributionCustomerEntitlement of contributionCustomerEntitlements) {
+		const contribution =
+			contributionCustomerEntitlement.pooled_balance_contribution;
+		if (!contribution) continue;
+
+		const pooledCustomerEntitlement =
+			computeContext.pooledCustomerEntitlementByPoolId.get(
+				contribution.pooled_balance_id,
+			);
+		if (!pooledCustomerEntitlement) {
+			throw new InternalError({
+				message: `Pooled balance '${contribution.pooled_balance_id}' was not hydrated for outgoing contribution '${contribution.id}'.`,
+			});
+		}
+
+		addToUpdatePoolBalances({
+			pooledBalancePlan: computeContext.plan,
+			pooledCustomerEntitlement,
+			balance: subtractSafe({
+				left: pooledCustomerEntitlement.balance,
+				right: contribution.current_contribution,
+			}),
+			granted: subtractSafe({
+				left: pooledCustomerEntitlement.pooled_balance.granted,
+				right: contribution.current_contribution,
+			}),
+		});
+
+		computeContext.pooledBalanceIdsWithRemovedContributions.add(
+			contribution.pooled_balance_id,
+		);
+
+		addToDeletePoolContributions({
+			pooledBalancePlan: computeContext.plan,
+			contribution,
+		});
+	}
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalancePlan.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/computeAttachPooledBalancePlan.ts
@@ -1,0 +1,52 @@
+import type {
+	AttachBillingContext,
+	FullCusProduct,
+	PooledBalancePlan,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { applyIncomingPooledBalanceSources } from "./applyIncomingPooledBalanceSources/applyIncomingPooledBalanceSources";
+import { applyOutgoingPooledBalanceSources } from "./applyOutgoingPooledBalanceSources/applyOutgoingPooledBalanceSources";
+import { finalizePooledBalanceComputeContext } from "./context/finalizePooledBalanceComputeContext";
+import { setupPooledBalanceComputeContext } from "./context/setupPooledBalanceComputeContext";
+
+export const computeAttachPooledBalancePlan = ({
+	ctx,
+	attachBillingContext,
+	newCustomerProduct,
+}: {
+	ctx: AutumnContext;
+	attachBillingContext: AttachBillingContext;
+	newCustomerProduct: FullCusProduct;
+}): {
+	customerProduct: FullCusProduct;
+	pooledBalancePlan?: PooledBalancePlan;
+} => {
+	const customerProduct = structuredClone(newCustomerProduct);
+	if (attachBillingContext.planTiming !== "immediate") {
+		return { customerProduct };
+	}
+
+	const computeContext = setupPooledBalanceComputeContext({
+		pooledCustomerEntitlements:
+			attachBillingContext.fullCustomer.pooled_customer_entitlements ?? [],
+	});
+
+	applyOutgoingPooledBalanceSources({
+		computeContext,
+		customerProduct: attachBillingContext.currentCustomerProduct,
+	});
+
+	applyIncomingPooledBalanceSources({
+		ctx,
+		computeContext,
+		customerProduct,
+		stripeSubscriptionId: attachBillingContext.stripeSubscription?.id,
+		customerCreatedAt: attachBillingContext.fullCustomer.created_at,
+		now: attachBillingContext.currentEpochMs,
+	});
+
+	return {
+		customerProduct,
+		pooledBalancePlan: finalizePooledBalanceComputeContext({ computeContext }),
+	};
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/context/finalizePooledBalanceComputeContext.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/context/finalizePooledBalanceComputeContext.ts
@@ -1,0 +1,15 @@
+import type { PooledBalancePlan } from "@autumn/shared";
+import { pooledBalancePlanHasChanges } from "@/internal/billing/v2/utils/billingPlan/pooledBalancePlan";
+import type { PooledBalanceComputeContext } from "../types/pooledBalanceComputeTypes";
+
+export const finalizePooledBalanceComputeContext = ({
+	computeContext,
+}: {
+	computeContext: PooledBalanceComputeContext;
+}): PooledBalancePlan | undefined => {
+	return pooledBalancePlanHasChanges({
+		pooledBalancePlan: computeContext.plan,
+	})
+		? computeContext.plan
+		: undefined;
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/context/pooledBalanceComputeContextUtils.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/context/pooledBalanceComputeContextUtils.ts
@@ -1,0 +1,30 @@
+import {
+	pooledBalanceIdentityToKey,
+	pooledBalanceToPooledBalanceIdentity,
+} from "@autumn/shared";
+import type {
+	MutablePooledCustomerEntitlement,
+	PooledBalanceComputeContext,
+} from "../types/pooledBalanceComputeTypes";
+
+export const addInsertedPooledBalanceToComputeContext = ({
+	computeContext,
+	pooledCustomerEntitlement,
+}: {
+	computeContext: PooledBalanceComputeContext;
+	pooledCustomerEntitlement: MutablePooledCustomerEntitlement;
+}) => {
+	const pooledBalance = pooledCustomerEntitlement.pooled_balance;
+	computeContext.pooledCustomerEntitlements.push(pooledCustomerEntitlement);
+	computeContext.pooledCustomerEntitlementByPoolId.set(
+		pooledBalance.id,
+		pooledCustomerEntitlement,
+	);
+	computeContext.pooledCustomerEntitlementByIdentity.set(
+		pooledBalanceIdentityToKey({
+			identity: pooledBalanceToPooledBalanceIdentity({ pooledBalance }),
+		}),
+		pooledCustomerEntitlement,
+	);
+	computeContext.plan.insertPoolBalances.push(pooledCustomerEntitlement);
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/context/setupPooledBalanceComputeContext.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/context/setupPooledBalanceComputeContext.ts
@@ -1,0 +1,59 @@
+import {
+	type FullCustomerEntitlement,
+	InternalError,
+	pooledBalanceIdentityToKey,
+	pooledBalanceToPooledBalanceIdentity,
+} from "@autumn/shared";
+import { emptyPooledBalancePlan } from "@/internal/billing/v2/utils/billingPlan/pooledBalancePlan";
+import type {
+	MutablePooledCustomerEntitlement,
+	PooledBalanceComputeContext,
+} from "../types/pooledBalanceComputeTypes";
+
+const clonePooledCustomerEntitlements = ({
+	customerEntitlements,
+}: {
+	customerEntitlements: FullCustomerEntitlement[];
+}): MutablePooledCustomerEntitlement[] =>
+	customerEntitlements.map((customerEntitlement) => {
+		const clonedCustomerEntitlement = structuredClone(customerEntitlement);
+		if (!clonedCustomerEntitlement.pooled_balance) {
+			throw new InternalError({
+				message: `Synthetic pooled customer entitlement '${clonedCustomerEntitlement.id}' is missing its pooled balance.`,
+			});
+		}
+
+		return clonedCustomerEntitlement as MutablePooledCustomerEntitlement;
+	});
+
+export const setupPooledBalanceComputeContext = ({
+	pooledCustomerEntitlements: inputPooledCustomerEntitlements,
+}: {
+	pooledCustomerEntitlements: FullCustomerEntitlement[];
+}): PooledBalanceComputeContext => {
+	const pooledCustomerEntitlements = clonePooledCustomerEntitlements({
+		customerEntitlements: inputPooledCustomerEntitlements,
+	});
+
+	return {
+		plan: emptyPooledBalancePlan(),
+		pooledCustomerEntitlements,
+		pooledCustomerEntitlementByPoolId: new Map(
+			pooledCustomerEntitlements.map((customerEntitlement) => [
+				customerEntitlement.pooled_balance.id,
+				customerEntitlement,
+			]),
+		),
+		pooledCustomerEntitlementByIdentity: new Map(
+			pooledCustomerEntitlements.map((customerEntitlement) => [
+				pooledBalanceIdentityToKey({
+					identity: pooledBalanceToPooledBalanceIdentity({
+						pooledBalance: customerEntitlement.pooled_balance,
+					}),
+				}),
+				customerEntitlement,
+			]),
+		),
+		pooledBalanceIdsWithRemovedContributions: new Set(),
+	};
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/types/pooledBalanceComputeTypes.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/types/pooledBalanceComputeTypes.ts
@@ -1,0 +1,38 @@
+import type {
+	FullCustomerEntitlement,
+	PooledBalanceIdentity,
+	PooledBalancePlan,
+} from "@autumn/shared";
+
+export type MutablePooledCustomerEntitlement = FullCustomerEntitlement & {
+	pooled_balance: NonNullable<FullCustomerEntitlement["pooled_balance"]>;
+};
+
+export type PooledBalanceComputeContext = {
+	plan: PooledBalancePlan;
+	pooledCustomerEntitlements: MutablePooledCustomerEntitlement[];
+	pooledCustomerEntitlementByPoolId: Map<
+		string,
+		MutablePooledCustomerEntitlement
+	>;
+	pooledCustomerEntitlementByIdentity: Map<
+		string,
+		MutablePooledCustomerEntitlement
+	>;
+	pooledBalanceIdsWithRemovedContributions: Set<string>;
+};
+
+export type PooledBalanceLifecycle = Pick<
+	PooledBalanceIdentity,
+	| "resetCycleAnchor"
+	| "resetMode"
+	| "stripeSubscriptionId"
+	| "customerLicenseLinkId"
+> & {
+	nextResetAt: number | null;
+};
+
+export type PooledBalanceContributionAmounts = {
+	currentContribution: number;
+	nextCycleContribution: number;
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/utils/pooledBalancePlanUtils.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/utils/pooledBalancePlanUtils.ts
@@ -1,0 +1,59 @@
+import type {
+  DbPooledBalanceContribution,
+  InsertPooledBalanceContribution,
+  PooledBalancePlan,
+} from "@autumn/shared";
+import type { MutablePooledCustomerEntitlement } from "../types/pooledBalanceComputeTypes";
+
+export const addToUpdatePoolBalances = ({
+  pooledBalancePlan,
+  pooledCustomerEntitlement,
+  balance,
+  granted,
+}: {
+  pooledBalancePlan: PooledBalancePlan;
+  pooledCustomerEntitlement: MutablePooledCustomerEntitlement;
+  balance: number;
+  granted: number;
+}) => {
+  pooledCustomerEntitlement.balance = balance;
+  pooledCustomerEntitlement.pooled_balance.granted = granted;
+
+  const isInsertedInPlan = pooledBalancePlan.insertPoolBalances.some(
+    (insertedPooledCustomerEntitlement) =>
+      insertedPooledCustomerEntitlement.id === pooledCustomerEntitlement.id,
+  );
+  if (isInsertedInPlan) return;
+
+  const existingUpdateIndex = pooledBalancePlan.updatePoolBalances.findIndex(
+    (updatedPooledCustomerEntitlement) =>
+      updatedPooledCustomerEntitlement.id === pooledCustomerEntitlement.id,
+  );
+  if (existingUpdateIndex === -1) {
+    pooledBalancePlan.updatePoolBalances.push(pooledCustomerEntitlement);
+    return;
+  }
+
+  pooledBalancePlan.updatePoolBalances[existingUpdateIndex] =
+    pooledCustomerEntitlement;
+};
+
+export const addToInsertPoolContributions = ({
+  pooledBalancePlan,
+  contribution,
+}: {
+  pooledBalancePlan: PooledBalancePlan;
+  contribution: InsertPooledBalanceContribution;
+}) => {
+  pooledBalancePlan.insertPoolContributions.push(contribution);
+};
+
+export const addToDeletePoolContributions = ({
+  pooledBalancePlan,
+  contribution,
+}: {
+  pooledBalancePlan: PooledBalancePlan;
+  contribution: DbPooledBalanceContribution;
+}) => {
+  pooledBalancePlan.deletePoolContributions.push(contribution);
+};

--- a/server/src/internal/billing/v2/pooledBalances/execute/executePooledBalancePlan.ts
+++ b/server/src/internal/billing/v2/pooledBalances/execute/executePooledBalancePlan.ts
@@ -1,0 +1,118 @@
+import {
+	customerEntitlements,
+	entitlements,
+	type InsertCustomerEntitlement,
+	type InsertDbEntitlement,
+	InternalError,
+	type PooledBalancePlan,
+	pooledBalanceContributions,
+	pooledBalances,
+} from "@autumn/shared";
+import { eq, inArray, sql } from "drizzle-orm";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { pooledBalancePlanHasChanges } from "@/internal/billing/v2/utils/billingPlan/pooledBalancePlan";
+
+/** Persists a fully computed pooled-balance plan without reading or recomputing state. */
+export const executePooledBalancePlan = async ({
+	ctx,
+	pooledBalancePlan,
+}: {
+	ctx: AutumnContext;
+	pooledBalancePlan?: PooledBalancePlan;
+}) => {
+	if (
+		!pooledBalancePlan ||
+		!pooledBalancePlanHasChanges({ pooledBalancePlan })
+	) {
+		return;
+	}
+
+	await ctx.db.transaction(async (tx) => {
+		for (const fullCustomerEntitlement of pooledBalancePlan.insertPoolBalances) {
+			const {
+				entitlement: fullEntitlement,
+				replaceables: _replaceables,
+				rollovers: _rollovers,
+				pooled_balance: pooledBalance,
+				pooled_balance_contribution: _pooledBalanceContribution,
+				...customerEntitlement
+			} = fullCustomerEntitlement;
+
+			if (!pooledBalance) {
+				throw new InternalError({
+					message: `Synthetic customer entitlement '${customerEntitlement.id}' is missing its pooled balance.`,
+				});
+			}
+
+			const { feature: _feature, ...entitlement } = fullEntitlement;
+			await tx.insert(entitlements).values(entitlement as InsertDbEntitlement);
+			await tx
+				.insert(customerEntitlements)
+				.values(customerEntitlement as InsertCustomerEntitlement);
+			await tx.insert(pooledBalances).values(pooledBalance);
+		}
+
+		for (const fullCustomerEntitlement of pooledBalancePlan.updatePoolBalances) {
+			const pooledBalance = fullCustomerEntitlement.pooled_balance;
+			if (!pooledBalance) {
+				throw new InternalError({
+					message: `Synthetic customer entitlement '${fullCustomerEntitlement.id}' is missing its pooled balance.`,
+				});
+			}
+
+			await tx
+				.update(customerEntitlements)
+				.set({
+					balance: fullCustomerEntitlement.balance ?? 0,
+					adjustment: fullCustomerEntitlement.adjustment ?? 0,
+					additional_balance: fullCustomerEntitlement.additional_balance ?? 0,
+					entities: fullCustomerEntitlement.entities ?? null,
+					reset_cycle_anchor:
+						fullCustomerEntitlement.reset_cycle_anchor ?? null,
+					next_reset_at: fullCustomerEntitlement.next_reset_at,
+					cache_version: sql`${customerEntitlements.cache_version} + 1`,
+				})
+				.where(eq(customerEntitlements.id, fullCustomerEntitlement.id));
+
+			await tx
+				.update(pooledBalances)
+				.set({
+					granted: pooledBalance.granted,
+					reset_cycle_anchor: pooledBalance.reset_cycle_anchor,
+					stripe_subscription_id: pooledBalance.stripe_subscription_id,
+					customer_license_link_id: pooledBalance.customer_license_link_id,
+					last_applied_reset_at: pooledBalance.last_applied_reset_at,
+					updated_at: Date.now(),
+				})
+				.where(eq(pooledBalances.id, pooledBalance.id));
+		}
+
+		if (pooledBalancePlan.insertPoolContributions.length > 0) {
+			await tx
+				.insert(pooledBalanceContributions)
+				.values(pooledBalancePlan.insertPoolContributions);
+		}
+
+		for (const contribution of pooledBalancePlan.updatePoolContributions) {
+			await tx
+				.update(pooledBalanceContributions)
+				.set({
+					pooled_balance_id: contribution.pooled_balance_id,
+					current_contribution: contribution.current_contribution,
+					next_cycle_contribution: contribution.next_cycle_contribution,
+					effective_at: contribution.effective_at,
+					updated_at: contribution.updated_at,
+				})
+				.where(eq(pooledBalanceContributions.id, contribution.id));
+		}
+
+		const contributionIds = pooledBalancePlan.deletePoolContributions.map(
+			(contribution) => contribution.id,
+		);
+		if (contributionIds.length > 0) {
+			await tx
+				.delete(pooledBalanceContributions)
+				.where(inArray(pooledBalanceContributions.id, contributionIds));
+		}
+	});
+};

--- a/server/src/internal/billing/v2/utils/billingPlan/mergeAutumnBillingPlans.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/mergeAutumnBillingPlans.ts
@@ -75,6 +75,40 @@ export const mergeAutumnBillingPlans = ({
 		incoming: incoming.updateCustomerEntitlements,
 		getKey: (update) => update.customerEntitlement.id,
 	}),
+	pooledBalancePlan:
+		base.pooledBalancePlan || incoming.pooledBalancePlan
+			? {
+					insertPoolBalances:
+						mergeByKey({
+							base: base.pooledBalancePlan?.insertPoolBalances,
+							incoming: incoming.pooledBalancePlan?.insertPoolBalances,
+							getKey: (pooledCustomerEntitlement) =>
+								pooledCustomerEntitlement.id,
+						}) ?? [],
+					updatePoolBalances:
+						mergeByKey({
+							base: base.pooledBalancePlan?.updatePoolBalances,
+							incoming: incoming.pooledBalancePlan?.updatePoolBalances,
+							getKey: (pooledCustomerEntitlement) =>
+								pooledCustomerEntitlement.id,
+						}) ?? [],
+					insertPoolContributions:
+						mergeById({
+							base: base.pooledBalancePlan?.insertPoolContributions,
+							incoming: incoming.pooledBalancePlan?.insertPoolContributions,
+						}) ?? [],
+					updatePoolContributions:
+						mergeById({
+							base: base.pooledBalancePlan?.updatePoolContributions,
+							incoming: incoming.pooledBalancePlan?.updatePoolContributions,
+						}) ?? [],
+					deletePoolContributions:
+						mergeById({
+							base: base.pooledBalancePlan?.deletePoolContributions,
+							incoming: incoming.pooledBalancePlan?.deletePoolContributions,
+						}) ?? [],
+				}
+			: undefined,
 	autoTopupRebalance:
 		base.autoTopupRebalance || incoming.autoTopupRebalance
 			? {

--- a/server/src/internal/billing/v2/utils/billingPlan/pooledBalancePlan.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/pooledBalancePlan.ts
@@ -1,0 +1,32 @@
+import type { AutumnBillingPlan, PooledBalancePlan } from "@autumn/shared";
+
+export const emptyPooledBalancePlan = (): PooledBalancePlan => ({
+	insertPoolBalances: [],
+	updatePoolBalances: [],
+	insertPoolContributions: [],
+	updatePoolContributions: [],
+	deletePoolContributions: [],
+});
+
+export const pooledBalancePlanHasChanges = ({
+	pooledBalancePlan,
+}: {
+	pooledBalancePlan?: PooledBalancePlan;
+}) =>
+	Boolean(
+		pooledBalancePlan &&
+			(pooledBalancePlan.insertPoolBalances.length > 0 ||
+				pooledBalancePlan.updatePoolBalances.length > 0 ||
+				pooledBalancePlan.insertPoolContributions.length > 0 ||
+				pooledBalancePlan.updatePoolContributions.length > 0 ||
+				pooledBalancePlan.deletePoolContributions.length > 0),
+	);
+
+export const getChangedPooledBalances = ({
+	autumnBillingPlan,
+}: {
+	autumnBillingPlan: AutumnBillingPlan;
+}) => [
+	...(autumnBillingPlan.pooledBalancePlan?.insertPoolBalances ?? []),
+	...(autumnBillingPlan.pooledBalancePlan?.updatePoolBalances ?? []),
+];

--- a/server/src/internal/customers/CusService.ts
+++ b/server/src/internal/customers/CusService.ts
@@ -62,6 +62,7 @@ import {
 	getCustomerProductsPageQuery,
 } from "./getCustomerProductsPageQuery.js";
 import { getFullCusQuery, hasCustomerListFilters } from "./getFullCusQuery.js";
+import { hydrateFullCustomerPooledBalances } from "./pooledBalances/hydrateFullCustomerPooledBalances.js";
 import {
 	type FlattenedCustomerRow,
 	reassembleFlattenedCustomer,
@@ -280,6 +281,12 @@ export class CusService {
 						fullCustomer: fullCus,
 					});
 				}
+
+				await hydrateFullCustomerPooledBalances({
+					ctx,
+					fullCustomer: fullCus,
+					internalEntityId: entityId ? fullCus.entity?.internal_id : null,
+				});
 
 				return fullCus;
 			},

--- a/server/src/internal/customers/actions/resetCustomerEntitlementsV2/getResettableCustomerEntitlements.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlementsV2/getResettableCustomerEntitlements.ts
@@ -1,8 +1,8 @@
 import {
-	cusEntToCusPrice,
 	CusProductStatus,
-	isCustomerEntitlementPrepaidWithSeparateResetInterval,
+	cusEntToCusPrice,
 	type FullCusEntWithFullCusProduct,
+	isCustomerEntitlementPrepaidWithSeparateResetInterval,
 } from "@autumn/shared";
 
 /**
@@ -27,6 +27,10 @@ export const getResettableCustomerEntitlements = ({
 
 	for (const cusEnt of customerEntitlements) {
 		if (!cusEnt.next_reset_at || cusEnt.next_reset_at >= now) continue;
+		// Pooled sources are normalized to zero and synthetic pools have their
+		// own reset-owner lifecycle. Neither may use the ordinary cusEnt reset.
+		if (cusEnt.is_pooled_balance || cusEnt.entitlement.pooled === true)
+			continue;
 
 		const cusProduct = cusEnt.customer_product;
 		if (cusProduct?.status === CusProductStatus.PastDue) {

--- a/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
+++ b/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
@@ -215,6 +215,7 @@ export const getCursorPaginatedFullCusQuery = ({
 				FROM customer_entitlements ce
 				WHERE ce.internal_customer_id = cr.internal_id
 					AND ce.customer_product_id IS NULL
+					AND ce.is_pooled_balance = false
 					AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
 				ORDER BY ce.id DESC
 				LIMIT 30

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -391,6 +391,7 @@ const buildExtraEntitlementsCTE = () => {
         FROM customer_entitlements ce
         WHERE ce.internal_customer_id = (SELECT internal_id FROM customer_record)
           AND ce.customer_product_id IS NULL
+		  AND ce.is_pooled_balance = false
           AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
         ORDER BY ce.id DESC
         LIMIT 30
@@ -744,6 +745,7 @@ export const getPaginatedFullCusQuery = ({
       FROM customer_entitlements ce
       WHERE ce.internal_customer_id = cr.internal_id
         AND ce.customer_product_id IS NULL
+		AND ce.is_pooled_balance = false
         AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
       ORDER BY ce.id DESC
       LIMIT 30

--- a/server/src/internal/customers/pooledBalances/hydrateFullCustomerPooledBalances.ts
+++ b/server/src/internal/customers/pooledBalances/hydrateFullCustomerPooledBalances.ts
@@ -1,0 +1,42 @@
+import type { FullCustomer } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { pooledBalancesRepo } from "./repos/pooledBalancesRepo";
+
+export const hydrateFullCustomerPooledBalances = async ({
+	ctx,
+	fullCustomer,
+	internalEntityId,
+}: {
+	ctx: AutumnContext;
+	fullCustomer: FullCustomer;
+	/** Null selects customer-level sources; a string selects one entity. */
+	internalEntityId: string | null | undefined;
+}): Promise<void> => {
+	const [pooledCustomerEntitlements, contributions] = await Promise.all([
+		pooledBalancesRepo.listPooledCustomerEntitlements({
+			db: ctx.db,
+			internalCustomerId: fullCustomer.internal_id,
+		}),
+		pooledBalancesRepo.listScopedPooledBalanceContributions({
+			db: ctx.db,
+			internalCustomerId: fullCustomer.internal_id,
+			internalEntityId,
+		}),
+	]);
+
+	const contributionByCustomerEntitlementId = new Map(
+		contributions.map((contribution) => [
+			contribution.source_customer_entitlement_id,
+			contribution,
+		]),
+	);
+
+	for (const customerProduct of fullCustomer.customer_products) {
+		for (const customerEntitlement of customerProduct.customer_entitlements) {
+			customerEntitlement.pooled_balance_contribution =
+				contributionByCustomerEntitlementId.get(customerEntitlement.id);
+		}
+	}
+
+	fullCustomer.pooled_customer_entitlements = pooledCustomerEntitlements;
+};

--- a/server/src/internal/customers/pooledBalances/repos/listPooledCustomerEntitlements.ts
+++ b/server/src/internal/customers/pooledBalances/repos/listPooledCustomerEntitlements.ts
@@ -1,0 +1,45 @@
+import {
+	type FullCustomerEntitlement,
+	InternalError,
+	pooledBalances,
+} from "@autumn/shared";
+import { desc, eq } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle";
+
+const POOLED_CUSTOMER_ENTITLEMENT_LIMIT = 100;
+
+export const listPooledCustomerEntitlements = async ({
+	db,
+	internalCustomerId,
+}: {
+	db: DrizzleCli;
+	internalCustomerId: string;
+}): Promise<FullCustomerEntitlement[]> => {
+	const rows = await db.query.pooledBalances.findMany({
+		where: eq(pooledBalances.internal_customer_id, internalCustomerId),
+		with: {
+			customer_entitlement: {
+				with: {
+					entitlement: { with: { feature: true } },
+					replaceables: true,
+					rollovers: true,
+				},
+			},
+		},
+		orderBy: desc(pooledBalances.created_at),
+		limit: POOLED_CUSTOMER_ENTITLEMENT_LIMIT,
+	});
+
+	return rows.map(({ customer_entitlement: customerEntitlement, ...pool }) => {
+		if (!customerEntitlement?.entitlement) {
+			throw new InternalError({
+				message: `Pooled balance '${pool.id}' is missing its customer entitlement graph.`,
+			});
+		}
+
+		return {
+			...(customerEntitlement as FullCustomerEntitlement),
+			pooled_balance: pool,
+		};
+	});
+};

--- a/server/src/internal/customers/pooledBalances/repos/listScopedPooledBalanceContributions.ts
+++ b/server/src/internal/customers/pooledBalances/repos/listScopedPooledBalanceContributions.ts
@@ -1,0 +1,51 @@
+import {
+	customerEntitlements,
+	customerProducts,
+	pooledBalanceContributions,
+} from "@autumn/shared";
+import { and, desc, eq, getTableColumns, isNull } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle";
+
+const POOLED_BALANCE_CONTRIBUTION_LIMIT = 100;
+
+export const listScopedPooledBalanceContributions = async ({
+	db,
+	internalCustomerId,
+	internalEntityId,
+}: {
+	db: DrizzleCli;
+	internalCustomerId: string;
+	/** Undefined means an entity was requested but could not be resolved. */
+	internalEntityId: string | null | undefined;
+}) => {
+	if (internalEntityId === undefined) return [];
+
+	return db
+		.select(getTableColumns(pooledBalanceContributions))
+		.from(pooledBalanceContributions)
+		.innerJoin(
+			customerEntitlements,
+			eq(
+				customerEntitlements.id,
+				pooledBalanceContributions.source_customer_entitlement_id,
+			),
+		)
+		.innerJoin(
+			customerProducts,
+			eq(
+				customerProducts.id,
+				pooledBalanceContributions.source_customer_product_id,
+			),
+		)
+		.where(
+			and(
+				eq(customerProducts.internal_customer_id, internalCustomerId),
+				eq(customerEntitlements.customer_product_id, customerProducts.id),
+				internalEntityId === null
+					? isNull(customerProducts.internal_entity_id)
+					: eq(customerProducts.internal_entity_id, internalEntityId),
+			),
+		)
+		.orderBy(desc(pooledBalanceContributions.created_at))
+		.limit(POOLED_BALANCE_CONTRIBUTION_LIMIT);
+};

--- a/server/src/internal/customers/pooledBalances/repos/pooledBalancesRepo.ts
+++ b/server/src/internal/customers/pooledBalances/repos/pooledBalancesRepo.ts
@@ -1,0 +1,7 @@
+import { listPooledCustomerEntitlements } from "./listPooledCustomerEntitlements";
+import { listScopedPooledBalanceContributions } from "./listScopedPooledBalanceContributions";
+
+export const pooledBalancesRepo = {
+	listPooledCustomerEntitlements,
+	listScopedPooledBalanceContributions,
+};

--- a/server/src/internal/customers/repos/getFullSubject/getEntityAggregateFragments.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getEntityAggregateFragments.ts
@@ -207,6 +207,7 @@ export const getEntityAggregateFragments = ({
 				BOOL_OR(ce.usage_allowed) AS usage_allowed
 			FROM entity_level_cus_ents ce
 			JOIN entitlements ent ON ce.entitlement_id = ent.id
+			WHERE ent.pooled IS NOT TRUE
 			GROUP BY ce.internal_feature_id, ce.internal_customer_id
 		),
 

--- a/server/src/internal/customers/repos/getFullSubject/getEntityOptionsAggregateFragments.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getEntityOptionsAggregateFragments.ts
@@ -55,8 +55,8 @@ export const getEntityOptionsAggregateFragments = () => {
 					cpr.created_at DESC
 				LIMIT 1
 			) prepaid_price ON true
-			WHERE
-				(
+			WHERE ent.pooled IS NOT TRUE
+				AND (
 					eor.option_internal_feature_id IS NOT NULL
 					AND ce.internal_feature_id = eor.option_internal_feature_id
 				)

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts
@@ -250,20 +250,31 @@ export const getFullSubjectRowsQuery = ({
 						THEN 0
 						ELSE 1
 					END AS subject_entity_priority,
-					ce.*
+					ce.*,
+					CASE
+						WHEN pb.id IS NULL THEN NULL
+						ELSE row_to_json(pb)
+					END AS pooled_balance
 				FROM customer_entitlements ce
+				LEFT JOIN pooled_balances pb
+					ON pb.customer_entitlement_id = ce.id
 				WHERE ce.internal_customer_id = sr.internal_customer_id
 					AND ce.customer_product_id IS NULL
-					AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
 					AND (
-						ce.balance != 0
-						OR ce.unlimited IS TRUE
-						OR EXISTS (
-							SELECT 1
-							FROM entitlements e
-							JOIN features f ON f.internal_id = e.internal_feature_id
-							WHERE e.id = ce.entitlement_id
-								AND f.type = 'boolean'
+						ce.is_pooled_balance IS TRUE
+						OR (
+							(ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
+							AND (
+								ce.balance != 0
+								OR ce.unlimited IS TRUE
+								OR EXISTS (
+									SELECT 1
+									FROM entitlements e
+									JOIN features f ON f.internal_id = e.internal_feature_id
+									WHERE e.id = ce.entitlement_id
+										AND f.type = 'boolean'
+								)
+							)
 						)
 					)
 					${customerEntitlementSubjectPredicate}

--- a/server/src/internal/customers/repos/getFullSubject/subjectQueryRowToNormalized.ts
+++ b/server/src/internal/customers/repos/getFullSubject/subjectQueryRowToNormalized.ts
@@ -162,12 +162,18 @@ export const subjectQueryRowToNormalized = ({
 	};
 
 	const partitionCustomerEntitlement = (
-		customerEntitlement: DbCustomerEntitlement,
+		customerEntitlement: SubjectQueryRow["customer_entitlements"][number],
 	) => {
 		const catalogEntitlement = entitlementsByEntitlementId.get(
 			customerEntitlement.entitlement_id,
 		);
 		if (!catalogEntitlement) return;
+		if (
+			catalogEntitlement.pooled === true &&
+			!customerEntitlement.is_pooled_balance
+		) {
+			return;
+		}
 
 		if (catalogEntitlement.feature.type === FeatureType.Boolean) {
 			const newPriority = getFlagPriority(customerEntitlement);
@@ -206,6 +212,7 @@ export const subjectQueryRowToNormalized = ({
 				adjustment: customerEntitlement.adjustment ?? 0,
 				additional_balance: customerEntitlement.additional_balance ?? 0,
 				cache_version: customerEntitlement.cache_version ?? 0,
+				pooled_balance: customerEntitlement.pooled_balance ?? undefined,
 				entities: customerEntitlement.entities ?? null,
 				entitlement: catalogEntitlement as EntitlementWithFeature,
 				replaceables: replaceablesByCusEntId.get(customerEntitlement.id) ?? [],

--- a/server/tests/integration/billing/pooled-balances/pooled-balance-attach-flow.test.ts
+++ b/server/tests/integration/billing/pooled-balances/pooled-balance-attach-flow.test.ts
@@ -1,0 +1,255 @@
+/**
+ * TDD contract for free-monthly, lifetime, and paid-monthly pooled balances
+ * created and removed by the attach flow.
+ *
+ * Contract under test:
+ *   New types/fields:
+ *     - customer_entitlements.is_pooled_balance identifies synthetic pool rows.
+ *     - pooled_balances.granted materializes the sum of current contributions.
+ *     - contributions are keyed by source_customer_entitlement_id while retaining source_customer_product_id.
+ *   New behaviors:
+ *     - Compatible pooled entitlements attached to entities coalesce into one synthetic balance.
+ *     - Free monthly pools reset lazily without a Stripe subscription identity.
+ *     - Lifetime pools do not reset.
+ *     - Paid monthly pools reset with their Stripe subscription billing cycle.
+ *     - Source customer entitlements are normalized and omitted from public balances.
+ *     - An immediate outgoing customer product subtracts its contribution from the pool and deletes its contribution row.
+ *   Side effects:
+ *     - Attach inserts/updates the synthetic customer entitlement and inserts contribution rows.
+ *     - Replacement updates the synthetic customer entitlement and deletes the outgoing contribution.
+ *
+ * Pre-implementation red: attach creates ordinary entity balances but no pooled graph.
+ * Post-implementation green: the pooled graph and API balance agree for attach and removal.
+ */
+
+import { test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	type AttachParamsV1Input,
+	EntInterval,
+	PooledBalanceResetMode,
+} from "@autumn/shared";
+import { expectNoStripeSubscription } from "@tests/integration/billing/utils/expectNoStripeSubscription.js";
+import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect/index.js";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { expectPooledBalanceCorrect } from "./utils/expectPooledBalanceCorrect.js";
+import { getPooledSourceCustomerProduct } from "./utils/getPooledBalanceDbState.js";
+
+const POOLED_GRANT = 500;
+
+type PooledAttachCase = {
+	id: string;
+	interval: EntInterval;
+	paid: boolean;
+	resetMode: PooledBalanceResetMode;
+};
+
+const runPooledAttachCase = async ({
+	pooledAttachCase,
+}: {
+	pooledAttachCase: PooledAttachCase;
+}) => {
+	const pooledItem = {
+		...(pooledAttachCase.interval === EntInterval.Lifetime
+			? items.lifetimeMessages({ includedUsage: POOLED_GRANT })
+			: items.monthlyMessages({ includedUsage: POOLED_GRANT })),
+		pooled: true,
+	};
+	const pooledPlan = pooledAttachCase.paid
+		? products.pro({
+				id: `pooled-${pooledAttachCase.id}`,
+				items: [pooledItem],
+			})
+		: products.base({
+				id: `pooled-${pooledAttachCase.id}`,
+				items: [pooledItem],
+			});
+	const privatePlan = products.base({
+		id: `private-${pooledAttachCase.id}`,
+		items: [
+			pooledAttachCase.interval === EntInterval.Lifetime
+				? items.lifetimeMessages({ includedUsage: 250 })
+				: items.monthlyMessages({ includedUsage: 250 }),
+		],
+	});
+	const customerId = `pooled-attach-${pooledAttachCase.id}`;
+	const { entities, autumnV2_2, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({
+				testClock: false,
+				...(pooledAttachCase.paid ? { paymentMethod: "success" as const } : {}),
+			}),
+			s.entities({ count: 3, featureId: TestFeature.Users }),
+			s.products({ list: [pooledPlan, privatePlan] }),
+		],
+		actions: [
+			s.billing.attach({ productId: pooledPlan.id, entityIndex: 0 }),
+			s.billing.attach({ productId: pooledPlan.id, entityIndex: 1 }),
+			s.track({
+				featureId: TestFeature.Messages,
+				value: 700,
+				entityIndex: 2,
+				timeout: 2000,
+			}),
+		],
+	});
+
+	const lifecycleExpectation = {
+		interval: pooledAttachCase.interval,
+		nextResetAt:
+			pooledAttachCase.resetMode === PooledBalanceResetMode.Lifetime
+				? null
+				: ("present" as const),
+		resetCycleAnchor:
+			pooledAttachCase.resetMode === PooledBalanceResetMode.Lifetime
+				? null
+				: ("present" as const),
+		resetMode: pooledAttachCase.resetMode,
+		stripeSubscriptionId:
+			pooledAttachCase.resetMode === PooledBalanceResetMode.Subscription
+				? ("stripe_subscription" as const)
+				: null,
+	};
+	const before = await expectPooledBalanceCorrect({
+		db: ctx.db,
+		customerId,
+		pool: {
+			balance: POOLED_GRANT * 2 - 700,
+			adjustment: 0,
+			cacheVersion: 1,
+			granted: POOLED_GRANT * 2,
+			...lifecycleExpectation,
+		},
+		contributions: {
+			count: 2,
+			currentContribution: POOLED_GRANT,
+			nextCycleContribution: POOLED_GRANT,
+		},
+		sources: { count: 2, balance: 0, adjustment: 0 },
+	});
+	const pooledCustomerEntitlement = before.poolCustomerEntitlements[0];
+	const outgoingCustomerProduct = getPooledSourceCustomerProduct({
+		state: before,
+		productId: pooledPlan.id,
+		entityId: entities[0].id,
+	});
+
+	const customerBeforeRemoval = await autumnV2_2.customers.get<ApiCustomerV5>(
+		customerId,
+		{
+			skip_cache: "true",
+		},
+	);
+	expectBalanceCorrect({
+		customer: customerBeforeRemoval,
+		featureId: TestFeature.Messages,
+		granted: POOLED_GRANT * 2,
+		includedGrant: POOLED_GRANT * 2,
+		remaining: POOLED_GRANT * 2 - 700,
+		usage: 700,
+		breakdownCount: 1,
+		breakdownId: pooledCustomerEntitlement.id,
+	});
+
+	await autumnV2_2.billing.attach<AttachParamsV1Input>({
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		plan_id: privatePlan.id,
+		plan_schedule: "immediate",
+	});
+
+	await expectPooledBalanceCorrect({
+		db: ctx.db,
+		customerId,
+		pool: {
+			balance: -200,
+			adjustment: 0,
+			cacheVersion: 2,
+			granted: POOLED_GRANT,
+			...lifecycleExpectation,
+		},
+		contributions: {
+			count: 1,
+			currentContribution: POOLED_GRANT,
+			nextCycleContribution: POOLED_GRANT,
+			excludedSourceCustomerProductIds: [outgoingCustomerProduct.id],
+		},
+		sources: { count: 2, balance: 0, adjustment: 0 },
+	});
+
+	const customerAfterRemoval = await autumnV2_2.customers.get<ApiCustomerV5>(
+		customerId,
+		{
+			skip_cache: "true",
+		},
+	);
+	expectBalanceCorrect({
+		customer: customerAfterRemoval,
+		featureId: TestFeature.Messages,
+		granted: POOLED_GRANT + 250,
+		includedGrant: POOLED_GRANT,
+		remaining: 250,
+		usage: 700,
+		breakdownCount: 1,
+		breakdownId: pooledCustomerEntitlement.id,
+	});
+
+	if (pooledAttachCase.paid) {
+		await expectStripeSubscriptionCorrect({ ctx, customerId });
+	} else {
+		await expectNoStripeSubscription({
+			db: ctx.db,
+			customerId,
+			org: ctx.org,
+			env: ctx.env,
+		});
+	}
+};
+
+test.concurrent(
+	`${chalk.yellowBright("pooled attach: free-monthly coalesces and removes an outgoing source")}`,
+	async () => {
+		await runPooledAttachCase({
+			pooledAttachCase: {
+				id: "free-monthly",
+				interval: EntInterval.Month,
+				paid: false,
+				resetMode: PooledBalanceResetMode.Lazy,
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("pooled attach: lifetime coalesces and removes an outgoing source")}`,
+	async () => {
+		await runPooledAttachCase({
+			pooledAttachCase: {
+				id: "lifetime",
+				interval: EntInterval.Lifetime,
+				paid: false,
+				resetMode: PooledBalanceResetMode.Lifetime,
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("pooled attach: paid-monthly coalesces and removes an outgoing source")}`,
+	async () => {
+		await runPooledAttachCase({
+			pooledAttachCase: {
+				id: "paid-monthly",
+				interval: EntInterval.Month,
+				paid: true,
+				resetMode: PooledBalanceResetMode.Subscription,
+			},
+		});
+	},
+);

--- a/server/tests/integration/billing/pooled-balances/utils/expectPooledBalanceCorrect.ts
+++ b/server/tests/integration/billing/pooled-balances/utils/expectPooledBalanceCorrect.ts
@@ -1,0 +1,151 @@
+import { expect } from "bun:test";
+import type { EntInterval, PooledBalanceResetMode } from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { getPooledBalanceDbState } from "./getPooledBalanceDbState.js";
+
+type PoolExpectation = {
+	count?: number;
+	balance: number;
+	adjustment: number;
+	cacheVersion?: number;
+	granted: number;
+	interval: EntInterval;
+	nextResetAt: "present" | null;
+	resetCycleAnchor: "present" | null;
+	resetMode: PooledBalanceResetMode;
+	stripeSubscriptionId: "stripe_subscription" | null;
+};
+
+type ContributionExpectation = {
+	count: number;
+	currentContribution?: number;
+	nextCycleContribution?: number;
+	excludedSourceCustomerProductIds?: string[];
+};
+
+type SourceExpectation = {
+	count: number;
+	balance?: number;
+	adjustment?: number;
+};
+
+export const expectPooledBalanceCorrect = async ({
+	db,
+	customerId,
+	pool,
+	contributions,
+	sources,
+}: {
+	db: DrizzleCli;
+	customerId: string;
+	pool: PoolExpectation;
+	contributions: ContributionExpectation;
+	sources: SourceExpectation;
+}) => {
+	const state = await getPooledBalanceDbState({ db, customerId });
+	const poolCount = pool.count ?? 1;
+
+	expect(state.pools).toHaveLength(poolCount);
+	expect(state.poolCustomerEntitlements).toHaveLength(poolCount);
+	for (const pooledCustomerEntitlement of state.poolCustomerEntitlements) {
+		expect(pooledCustomerEntitlement).toMatchObject({
+			is_pooled_balance: true,
+			customer_product_id: null,
+			balance: pool.balance,
+			adjustment: pool.adjustment,
+			...(pool.cacheVersion === undefined
+				? {}
+				: { cache_version: pool.cacheVersion }),
+		});
+		if (pool.nextResetAt === "present") {
+			expect(pooledCustomerEntitlement.next_reset_at).not.toBeNull();
+		} else {
+			expect(pooledCustomerEntitlement.next_reset_at).toBeNull();
+		}
+	}
+
+	for (const pooledBalance of state.pools) {
+		expect(pooledBalance).toMatchObject({
+			granted: pool.granted,
+			interval: pool.interval,
+			reset_mode: pool.resetMode,
+			customer_license_link_id: null,
+		});
+		if (pool.resetCycleAnchor === "present") {
+			expect(pooledBalance.reset_cycle_anchor).not.toBeNull();
+		} else {
+			expect(pooledBalance.reset_cycle_anchor).toBeNull();
+		}
+		if (pool.stripeSubscriptionId === "stripe_subscription") {
+			expect(pooledBalance.stripe_subscription_id).toMatch(/^sub_/);
+		} else {
+			expect(pooledBalance.stripe_subscription_id).toBeNull();
+		}
+	}
+
+	expect(state.contributions).toHaveLength(contributions.count);
+	for (const contribution of state.contributions) {
+		expect(contribution).toMatchObject({
+			...(contributions.currentContribution === undefined
+				? {}
+				: {
+						current_contribution: contributions.currentContribution,
+					}),
+			...(contributions.nextCycleContribution === undefined
+				? {}
+				: {
+						next_cycle_contribution: contributions.nextCycleContribution,
+					}),
+		});
+
+		const sourceCustomerProduct = state.sourceCustomerProducts.find(
+			(customerProduct) =>
+				customerProduct.id === contribution.source_customer_product_id,
+		);
+		const sourceCustomerEntitlement =
+			sourceCustomerProduct?.customer_entitlements.find(
+				(customerEntitlement) =>
+					customerEntitlement.id ===
+					contribution.source_customer_entitlement_id,
+			);
+		expect(sourceCustomerProduct).toBeDefined();
+		expect(sourceCustomerEntitlement).toBeDefined();
+		expect(sourceCustomerEntitlement?.customer_product_id).toBe(
+			contribution.source_customer_product_id,
+		);
+		expect(
+			state.pools.some(
+				(candidate) => candidate.id === contribution.pooled_balance_id,
+			),
+		).toBe(true);
+	}
+
+	for (const sourceCustomerProductId of contributions.excludedSourceCustomerProductIds ??
+		[]) {
+		expect(
+			state.contributions.some(
+				(contribution) =>
+					contribution.source_customer_product_id === sourceCustomerProductId,
+			),
+		).toBe(false);
+	}
+
+	const pooledSourceCustomerEntitlements = state.sourceCustomerProducts.flatMap(
+		(customerProduct) =>
+			customerProduct.customer_entitlements.filter(
+				(customerEntitlement) => customerEntitlement.entitlement.pooled,
+			),
+	);
+	expect(pooledSourceCustomerEntitlements).toHaveLength(sources.count);
+	for (const sourceCustomerEntitlement of pooledSourceCustomerEntitlements) {
+		expect(sourceCustomerEntitlement).toMatchObject({
+			is_pooled_balance: false,
+			...(sources.balance === undefined ? {} : { balance: sources.balance }),
+			...(sources.adjustment === undefined
+				? {}
+				: { adjustment: sources.adjustment }),
+		});
+	}
+
+	return state;
+};

--- a/server/tests/integration/billing/pooled-balances/utils/getPooledBalanceDbState.ts
+++ b/server/tests/integration/billing/pooled-balances/utils/getPooledBalanceDbState.ts
@@ -1,0 +1,85 @@
+import {
+	customerEntitlements,
+	customerProducts,
+	customers,
+	pooledBalanceContributions,
+	pooledBalances,
+} from "@autumn/shared";
+import { eq, inArray } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+
+export const getPooledBalanceDbState = async ({
+	db,
+	customerId,
+}: {
+	db: DrizzleCli;
+	customerId: string;
+}) => {
+	const customer = await db.query.customers.findFirst({
+		where: eq(customers.id, customerId),
+	});
+	if (!customer) throw new Error(`Customer '${customerId}' not found`);
+
+	const [pools, sourceCustomerProducts] = await Promise.all([
+		db.query.pooledBalances.findMany({
+			where: eq(pooledBalances.internal_customer_id, customer.internal_id),
+		}),
+		db.query.customerProducts.findMany({
+			where: eq(customerProducts.internal_customer_id, customer.internal_id),
+			with: {
+				customer_entitlements: { with: { entitlement: true } },
+			},
+		}),
+	]);
+
+	const poolCustomerEntitlements = pools.length
+		? await db.query.customerEntitlements.findMany({
+				where: inArray(
+					customerEntitlements.id,
+					pools.map((pool) => pool.customer_entitlement_id),
+				),
+			})
+		: [];
+	const contributions = pools.length
+		? await db.query.pooledBalanceContributions.findMany({
+				where: inArray(
+					pooledBalanceContributions.pooled_balance_id,
+					pools.map((pool) => pool.id),
+				),
+			})
+		: [];
+
+	return {
+		contributions,
+		poolCustomerEntitlements,
+		pools,
+		sourceCustomerProducts,
+	};
+};
+
+export type PooledBalanceDbState = Awaited<
+	ReturnType<typeof getPooledBalanceDbState>
+>;
+
+export const getPooledSourceCustomerProduct = ({
+	state,
+	productId,
+	entityId,
+}: {
+	state: PooledBalanceDbState;
+	productId: string;
+	entityId: string;
+}) => {
+	const customerProduct = state.sourceCustomerProducts.find(
+		(candidate) =>
+			candidate.product_id === productId && candidate.entity_id === entityId,
+	);
+
+	if (!customerProduct) {
+		throw new Error(
+			`Pooled source customer product '${productId}' was not found for entity '${entityId}'.`,
+		);
+	}
+
+	return customerProduct;
+};

--- a/server/tests/integration/db/full-subject/utils/fullSubjectScenarioBuilders.ts
+++ b/server/tests/integration/db/full-subject/utils/fullSubjectScenarioBuilders.ts
@@ -348,6 +348,7 @@ const buildCustomerEntitlement = ({
 	next_reset_at: now + 30 * 24 * 60 * 60 * 1000,
 	usage_allowed: false,
 	separate_interval: false,
+	is_pooled_balance: false,
 	reset_cycle_anchor: null,
 	adjustment: 0,
 	additional_balance: 0,

--- a/server/tests/integration/utils/expectBalanceCorrect.ts
+++ b/server/tests/integration/utils/expectBalanceCorrect.ts
@@ -29,6 +29,7 @@ export const expectBalanceCorrect = ({
 	customer,
 	featureId,
 	granted,
+	includedGrant,
 	remaining,
 	planId,
 	usage,
@@ -37,10 +38,13 @@ export const expectBalanceCorrect = ({
 	breakdown,
 	rollovers,
 	positiveRolloverCount,
+	breakdownCount,
+	breakdownId,
 }: {
 	customer: ApiCustomerV5 | ApiEntityV2;
 	featureId: string;
 	granted?: number;
+	includedGrant?: number;
 	remaining?: number;
 	planId?: string | null;
 	usage?: number;
@@ -50,12 +54,20 @@ export const expectBalanceCorrect = ({
 	/** Expected rollovers in order (oldest first). Only specified fields are checked. */
 	rollovers?: Partial<ApiBalanceRollover>[];
 	positiveRolloverCount?: number;
+	breakdownCount?: number;
+	breakdownId?: string;
 }) => {
 	const balance = customer.balances[featureId];
 	expect(balance).toBeDefined();
 
 	if (typeof granted !== "undefined") {
 		expect(roundTo8Dp(balance.granted)).toBe(roundTo8Dp(granted));
+	}
+
+	if (typeof includedGrant !== "undefined") {
+		expect(roundTo8Dp(balance.breakdown?.[0]?.included_grant ?? 0)).toBe(
+			roundTo8Dp(includedGrant),
+		);
 	}
 
 	if (typeof remaining !== "undefined") {
@@ -124,5 +136,13 @@ export const expectBalanceCorrect = ({
 		expect(actual.filter((item) => item.balance > 0).length).toBe(
 			positiveRolloverCount,
 		);
+	}
+
+	if (typeof breakdownCount !== "undefined") {
+		expect(balance.breakdown).toHaveLength(breakdownCount);
+	}
+
+	if (typeof breakdownId !== "undefined") {
+		expect(balance.breakdown?.[0]?.id).toBe(breakdownId);
 	}
 };

--- a/shared/db/schema.ts
+++ b/shared/db/schema.ts
@@ -76,6 +76,10 @@ import { organizations } from "../models/orgModels/orgTable.js";
 import { transitionRules } from "../models/orgModels/transitionRules/transitionRulesTable.js";
 import { metadata } from "../models/otherModels/metadataTable.js";
 import {
+	pooledBalanceContributionsRelations,
+	pooledBalancesRelations,
+} from "../models/pooledBalanceModels/pooledBalanceRelations.js";
+import {
 	pooledBalanceContributions,
 	pooledBalances,
 } from "../models/pooledBalanceModels/pooledBalanceTable.js";
@@ -197,7 +201,9 @@ export {
 	planLicenses,
 	planLicenseRelations,
 	pooledBalanceContributions,
+	pooledBalanceContributionsRelations,
 	pooledBalances,
+	pooledBalancesRelations,
 	passkey,
 	// Relations
 	organizationsRelations,

--- a/shared/drizzle/0047_next_avengers.sql
+++ b/shared/drizzle/0047_next_avengers.sql
@@ -2,18 +2,15 @@ CREATE TABLE "pooled_balance_contributions" (
 	"id" text PRIMARY KEY NOT NULL,
 	"pooled_balance_id" text NOT NULL,
 	"source_customer_product_id" text NOT NULL,
-	"source_entitlement_id" text NOT NULL,
-	"reset_owner_type" text NOT NULL,
-	"reset_owner_id" text NOT NULL,
+	"source_customer_entitlement_id" text NOT NULL,
 	"current_contribution" numeric DEFAULT 0 NOT NULL,
 	"next_cycle_contribution" numeric DEFAULT 0 NOT NULL,
 	"effective_at" numeric,
 	"created_at" numeric DEFAULT ROUND(date_part('epoch', NOW()) * 1000)::BIGINT NOT NULL,
 	"updated_at" numeric DEFAULT ROUND(date_part('epoch', NOW()) * 1000)::BIGINT NOT NULL,
-	CONSTRAINT "unique_pooled_balance_contribution" UNIQUE("source_customer_product_id","source_entitlement_id"),
+	CONSTRAINT "unique_pooled_balance_contribution" UNIQUE("source_customer_entitlement_id"),
 	CONSTRAINT "pooled_balance_contributions_current_non_negative" CHECK ("pooled_balance_contributions"."current_contribution" >= 0),
-	CONSTRAINT "pooled_balance_contributions_next_non_negative" CHECK ("pooled_balance_contributions"."next_cycle_contribution" >= 0),
-	CONSTRAINT "pooled_balance_contributions_reset_owner_type_valid" CHECK ("pooled_balance_contributions"."reset_owner_type" IN ('customer_product', 'subscription', 'free'))
+	CONSTRAINT "pooled_balance_contributions_next_non_negative" CHECK ("pooled_balance_contributions"."next_cycle_contribution" >= 0)
 );
 --> statement-breakpoint
 CREATE TABLE "pooled_balances" (
@@ -22,31 +19,49 @@ CREATE TABLE "pooled_balances" (
 	"env" text NOT NULL,
 	"internal_customer_id" text NOT NULL,
 	"internal_feature_id" text NOT NULL,
+	"granted" numeric DEFAULT 0 NOT NULL,
 	"interval" text NOT NULL,
 	"interval_count" numeric DEFAULT 1 NOT NULL,
 	"reset_cycle_anchor" numeric,
 	"reset_mode" text NOT NULL,
+	"stripe_subscription_id" text,
+	"customer_license_link_id" text,
 	"rollover_signature" text DEFAULT 'none' NOT NULL,
 	"customer_entitlement_id" text NOT NULL,
 	"last_applied_reset_at" numeric,
 	"created_at" numeric DEFAULT ROUND(date_part('epoch', NOW()) * 1000)::BIGINT NOT NULL,
 	"updated_at" numeric DEFAULT ROUND(date_part('epoch', NOW()) * 1000)::BIGINT NOT NULL,
-	CONSTRAINT "unique_pooled_balance" UNIQUE NULLS NOT DISTINCT("internal_customer_id","internal_feature_id","interval","interval_count","reset_cycle_anchor","reset_mode","rollover_signature"),
+	CONSTRAINT "unique_pooled_balance" UNIQUE NULLS NOT DISTINCT("internal_customer_id","internal_feature_id","interval","interval_count","reset_cycle_anchor","reset_mode","stripe_subscription_id","customer_license_link_id","rollover_signature"),
 	CONSTRAINT "unique_pooled_balance_customer_entitlement" UNIQUE("customer_entitlement_id"),
 	CONSTRAINT "pooled_balances_interval_count_positive" CHECK ("pooled_balances"."interval_count" > 0),
-	CONSTRAINT "pooled_balances_reset_mode_valid" CHECK ("pooled_balances"."reset_mode" IN ('lazy', 'subscription', 'lifetime'))
+	CONSTRAINT "pooled_balances_granted_non_negative" CHECK ("pooled_balances"."granted" >= 0),
+	CONSTRAINT "pooled_balances_reset_mode_valid" CHECK ("pooled_balances"."reset_mode" IN ('lazy', 'subscription', 'lifetime')),
+	CONSTRAINT "pooled_balances_lifecycle_ids_valid" CHECK ((
+				"pooled_balances"."reset_mode" = 'subscription'
+				AND "pooled_balances"."stripe_subscription_id" IS NOT NULL
+				AND "pooled_balances"."customer_license_link_id" IS NULL
+			) OR (
+				"pooled_balances"."reset_mode" = 'lazy'
+				AND "pooled_balances"."stripe_subscription_id" IS NULL
+			) OR (
+				"pooled_balances"."reset_mode" = 'lifetime'
+				AND "pooled_balances"."stripe_subscription_id" IS NULL
+				AND "pooled_balances"."customer_license_link_id" IS NULL
+			))
 );
 --> statement-breakpoint
+ALTER TABLE "customer_entitlements" ADD COLUMN "is_pooled_balance" boolean DEFAULT false NOT NULL;--> statement-breakpoint
 ALTER TABLE "entitlements" ADD COLUMN "pooled" boolean DEFAULT false NOT NULL;--> statement-breakpoint
 ALTER TABLE "pooled_balance_contributions" ADD CONSTRAINT "pooled_balance_contributions_pool_fkey" FOREIGN KEY ("pooled_balance_id") REFERENCES "public"."pooled_balances"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "pooled_balance_contributions" ADD CONSTRAINT "pooled_balance_contributions_customer_product_fkey" FOREIGN KEY ("source_customer_product_id") REFERENCES "public"."customer_products"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "pooled_balance_contributions" ADD CONSTRAINT "pooled_balance_contributions_entitlement_fkey" FOREIGN KEY ("source_entitlement_id") REFERENCES "public"."entitlements"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pooled_balance_contributions" ADD CONSTRAINT "pooled_balance_contributions_customer_product_fkey" FOREIGN KEY ("source_customer_product_id") REFERENCES "public"."customer_products"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pooled_balance_contributions" ADD CONSTRAINT "pooled_balance_contributions_customer_entitlement_fkey" FOREIGN KEY ("source_customer_entitlement_id") REFERENCES "public"."customer_entitlements"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "pooled_balances" ADD CONSTRAINT "pooled_balances_customer_fkey" FOREIGN KEY ("internal_customer_id") REFERENCES "public"."customers"("internal_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "pooled_balances" ADD CONSTRAINT "pooled_balances_feature_fkey" FOREIGN KEY ("internal_feature_id") REFERENCES "public"."features"("internal_id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "pooled_balances" ADD CONSTRAINT "pooled_balances_customer_entitlement_fkey" FOREIGN KEY ("customer_entitlement_id") REFERENCES "public"."customer_entitlements"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX CONCURRENTLY "idx_pooled_balance_contributions_pool" ON "pooled_balance_contributions" USING btree ("pooled_balance_id");--> statement-breakpoint
-CREATE INDEX CONCURRENTLY "idx_pooled_balance_contributions_source_entitlement" ON "pooled_balance_contributions" USING btree ("source_entitlement_id");--> statement-breakpoint
-CREATE INDEX CONCURRENTLY "idx_pooled_balance_contributions_reset_owner" ON "pooled_balance_contributions" USING btree ("reset_owner_type","reset_owner_id","pooled_balance_id");--> statement-breakpoint
+CREATE INDEX CONCURRENTLY "idx_pooled_balance_contributions_source_customer_entitlement" ON "pooled_balance_contributions" USING btree ("source_customer_entitlement_id");--> statement-breakpoint
 CREATE INDEX CONCURRENTLY "idx_pooled_balances_org" ON "pooled_balances" USING btree ("org_id");--> statement-breakpoint
 CREATE INDEX CONCURRENTLY "idx_pooled_balances_reset_mode" ON "pooled_balances" USING btree ("internal_customer_id","reset_mode");--> statement-breakpoint
-CREATE INDEX CONCURRENTLY "idx_pooled_balances_feature" ON "pooled_balances" USING btree ("internal_feature_id");
+CREATE INDEX CONCURRENTLY "idx_pooled_balances_feature" ON "pooled_balances" USING btree ("internal_feature_id");--> statement-breakpoint
+CREATE INDEX CONCURRENTLY "idx_pooled_balances_stripe_subscription" ON "pooled_balances" USING btree ("internal_customer_id","stripe_subscription_id") WHERE "pooled_balances"."stripe_subscription_id" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX CONCURRENTLY "idx_pooled_balances_customer_license" ON "pooled_balances" USING btree ("internal_customer_id","customer_license_link_id") WHERE "pooled_balances"."customer_license_link_id" IS NOT NULL;

--- a/shared/drizzle/meta/0047_snapshot.json
+++ b/shared/drizzle/meta/0047_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "b6e4ceac-e170-43eb-a918-a9222136a6e9",
+  "id": "0f8ff78e-c90d-4e74-81fb-8e0866c3c2aa",
   "prevId": "c3041e96-b8d2-4e62-b2b1-430e4d6c8989",
   "version": "7",
   "dialect": "postgresql",
@@ -1576,6 +1576,13 @@
           "notNull": true,
           "default": false
         },
+        "is_pooled_balance": {
+          "name": "is_pooled_balance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
         "adjustment": {
           "name": "adjustment",
           "type": "numeric",
@@ -2359,7 +2366,7 @@
           "columnsTo": [
             "id"
           ],
-          "onDelete": "no action",
+          "onDelete": "cascade",
           "onUpdate": "no action"
         }
       },
@@ -2928,7 +2935,7 @@
           "columnsTo": [
             "id"
           ],
-          "onDelete": "no action",
+          "onDelete": "cascade",
           "onUpdate": "no action"
         },
         "customer_products_internal_customer_id_fkey": {
@@ -7540,20 +7547,8 @@
           "primaryKey": false,
           "notNull": true
         },
-        "source_entitlement_id": {
-          "name": "source_entitlement_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reset_owner_type": {
-          "name": "reset_owner_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reset_owner_id": {
-          "name": "reset_owner_id",
+        "source_customer_entitlement_id": {
+          "name": "source_customer_entitlement_id",
           "type": "text",
           "primaryKey": false,
           "notNull": true
@@ -7609,38 +7604,11 @@
           "method": "btree",
           "with": {}
         },
-        "idx_pooled_balance_contributions_source_entitlement": {
-          "name": "idx_pooled_balance_contributions_source_entitlement",
+        "idx_pooled_balance_contributions_source_customer_entitlement": {
+          "name": "idx_pooled_balance_contributions_source_customer_entitlement",
           "columns": [
             {
-              "expression": "source_entitlement_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_pooled_balance_contributions_reset_owner": {
-          "name": "idx_pooled_balance_contributions_reset_owner",
-          "columns": [
-            {
-              "expression": "reset_owner_type",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "reset_owner_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "pooled_balance_id",
+              "expression": "source_customer_entitlement_id",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -7679,12 +7647,12 @@
           "onDelete": "no action",
           "onUpdate": "no action"
         },
-        "pooled_balance_contributions_entitlement_fkey": {
-          "name": "pooled_balance_contributions_entitlement_fkey",
+        "pooled_balance_contributions_customer_entitlement_fkey": {
+          "name": "pooled_balance_contributions_customer_entitlement_fkey",
           "tableFrom": "pooled_balance_contributions",
-          "tableTo": "entitlements",
+          "tableTo": "customer_entitlements",
           "columnsFrom": [
-            "source_entitlement_id"
+            "source_customer_entitlement_id"
           ],
           "columnsTo": [
             "id"
@@ -7699,8 +7667,7 @@
           "name": "unique_pooled_balance_contribution",
           "nullsNotDistinct": false,
           "columns": [
-            "source_customer_product_id",
-            "source_entitlement_id"
+            "source_customer_entitlement_id"
           ]
         }
       },
@@ -7713,10 +7680,6 @@
         "pooled_balance_contributions_next_non_negative": {
           "name": "pooled_balance_contributions_next_non_negative",
           "value": "\"pooled_balance_contributions\".\"next_cycle_contribution\" >= 0"
-        },
-        "pooled_balance_contributions_reset_owner_type_valid": {
-          "name": "pooled_balance_contributions_reset_owner_type_valid",
-          "value": "\"pooled_balance_contributions\".\"reset_owner_type\" IN ('customer_product', 'subscription', 'free')"
         }
       },
       "isRLSEnabled": false
@@ -7755,6 +7718,13 @@
           "primaryKey": false,
           "notNull": true
         },
+        "granted": {
+          "name": "granted",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
         "interval": {
           "name": "interval",
           "type": "text",
@@ -7779,6 +7749,18 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_license_link_id": {
+          "name": "customer_license_link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
         },
         "rollover_signature": {
           "name": "rollover_signature",
@@ -7865,6 +7847,50 @@
           "concurrently": true,
           "method": "btree",
           "with": {}
+        },
+        "idx_pooled_balances_stripe_subscription": {
+          "name": "idx_pooled_balances_stripe_subscription",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pooled_balances\".\"stripe_subscription_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balances_customer_license": {
+          "name": "idx_pooled_balances_customer_license",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pooled_balances\".\"customer_license_link_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {
@@ -7920,6 +7946,8 @@
             "interval_count",
             "reset_cycle_anchor",
             "reset_mode",
+            "stripe_subscription_id",
+            "customer_license_link_id",
             "rollover_signature"
           ]
         },
@@ -7937,9 +7965,17 @@
           "name": "pooled_balances_interval_count_positive",
           "value": "\"pooled_balances\".\"interval_count\" > 0"
         },
+        "pooled_balances_granted_non_negative": {
+          "name": "pooled_balances_granted_non_negative",
+          "value": "\"pooled_balances\".\"granted\" >= 0"
+        },
         "pooled_balances_reset_mode_valid": {
           "name": "pooled_balances_reset_mode_valid",
           "value": "\"pooled_balances\".\"reset_mode\" IN ('lazy', 'subscription', 'lifetime')"
+        },
+        "pooled_balances_lifecycle_ids_valid": {
+          "name": "pooled_balances_lifecycle_ids_valid",
+          "value": "(\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'subscription'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NOT NULL\n\t\t\t\tAND \"pooled_balances\".\"customer_license_link_id\" IS NULL\n\t\t\t) OR (\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'lazy'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NULL\n\t\t\t) OR (\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'lifetime'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NULL\n\t\t\t\tAND \"pooled_balances\".\"customer_license_link_id\" IS NULL\n\t\t\t)"
         }
       },
       "isRLSEnabled": false

--- a/shared/drizzle/meta/_journal.json
+++ b/shared/drizzle/meta/_journal.json
@@ -334,8 +334,8 @@
     {
       "idx": 47,
       "version": "7",
-      "when": 1784651067466,
-      "tag": "0047_woozy_blackheart",
+      "when": 1784665621208,
+      "tag": "0047_next_avengers",
       "breakpoints": true
     }
   ]

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -76,6 +76,7 @@ export * from "./models/licenseModels/fullCustomerLicense";
 export * from "./models/licenseModels/fullPlanLicenseModel";
 export * from "./models/licenseModels/licenseModels";
 export * from "./models/licenseModels/licenseTable";
+export * from "./models/pooledBalanceModels/pooledBalanceIdentity";
 export * from "./models/pooledBalanceModels/pooledBalanceTable";
 // Processor Models
 export * from "./models/processorModels/processorModels";

--- a/shared/models/billingModels/plan/autumnBillingPlan.ts
+++ b/shared/models/billingModels/plan/autumnBillingPlan.ts
@@ -28,6 +28,7 @@ import {
 	CustomerLicenseUpdateSchema,
 	InsertPlanLicenseSpecSchema,
 } from "./customerLicensePlan";
+import { PooledBalancePlanSchema } from "./pooledBalancePlan";
 
 export const UpdateCustomerEntitlementSchema = z.object({
 	customerEntitlement: FullCustomerEntitlementSchema,
@@ -130,6 +131,7 @@ export const AutumnBillingPlanSchema = z.object({
 	updateCustomerEntitlements: z
 		.array(UpdateCustomerEntitlementSchema)
 		.optional(),
+	pooledBalancePlan: PooledBalancePlanSchema.optional(),
 
 	/**
 	 * Pre-computed auto top-up rebalance deltas. The compute step sizes paydown + prepaid

--- a/shared/models/billingModels/plan/index.ts
+++ b/shared/models/billingModels/plan/index.ts
@@ -2,4 +2,5 @@ export * from "./autumnBillingPlan";
 export * from "./billingPlan";
 export * from "./billingResult";
 export * from "./customerLicensePlan";
+export * from "./pooledBalancePlan";
 export * from "./previewBillingPlan";

--- a/shared/models/billingModels/plan/pooledBalancePlan.ts
+++ b/shared/models/billingModels/plan/pooledBalancePlan.ts
@@ -1,0 +1,16 @@
+import { z } from "zod/v4";
+import type { FullCustomerEntitlement } from "../../cusProductModels/cusEntModels/cusEntModels.js";
+import type {
+	DbPooledBalanceContribution,
+	InsertPooledBalanceContribution,
+} from "../../pooledBalanceModels/pooledBalanceTable.js";
+
+export const PooledBalancePlanSchema = z.object({
+	insertPoolBalances: z.array(z.custom<FullCustomerEntitlement>()),
+	updatePoolBalances: z.array(z.custom<FullCustomerEntitlement>()),
+	insertPoolContributions: z.array(z.custom<InsertPooledBalanceContribution>()),
+	updatePoolContributions: z.array(z.custom<DbPooledBalanceContribution>()),
+	deletePoolContributions: z.array(z.custom<DbPooledBalanceContribution>()),
+});
+
+export type PooledBalancePlan = z.infer<typeof PooledBalancePlanSchema>;

--- a/shared/models/cusModels/fullCusModel.ts
+++ b/shared/models/cusModels/fullCusModel.ts
@@ -1,7 +1,10 @@
 import { ProductSchema } from "@models/productModels/productModels.js";
 import { z } from "zod/v4";
 import type { CustomerProductsPage } from "../../api/customers/cusPlans/listCustomerProductsParams.js";
-import type { FullCustomerEntitlement } from "../cusProductModels/cusEntModels/cusEntModels.js";
+import {
+	type FullCustomerEntitlement,
+	FullCustomerEntitlementSchema,
+} from "../cusProductModels/cusEntModels/cusEntModels.js";
 import {
 	CusProductSchema,
 	type FullCusProduct,
@@ -66,6 +69,9 @@ export const FullCustomerSchema = CustomerSchema.extend({
 	// hole-filling via `normalizeFromSchema`) tolerant of entries written
 	// before this field existed. Empty array also matches the SQL default.
 	migration_item_runs: z.array(MigrationItemRunSchema).optional(),
+	pooled_customer_entitlements: z
+		.array(FullCustomerEntitlementSchema)
+		.default([]),
 });
 
 export type FullCustomerSchedule = Schedule & { phases: SchedulePhase[] };
@@ -87,6 +93,8 @@ export type FullCustomer = Customer & {
 	extra_customer_entitlements: FullCustomerEntitlement[];
 	schedule?: FullCustomerSchedule;
 	migration_item_runs?: MigrationItemRunData[];
+	/** Hydrated by customer/subject readers; optional for legacy cached objects. */
+	pooled_customer_entitlements?: FullCustomerEntitlement[];
 };
 
 export const CustomerWithProductsSchema = CustomerSchema.extend({

--- a/shared/models/cusModels/fullSubject/normalizedFullSubjectModel.ts
+++ b/shared/models/cusModels/fullSubject/normalizedFullSubjectModel.ts
@@ -22,6 +22,7 @@ import type { DbCustomerProduct } from "../../cusProductModels/cusProductTable.j
 import type { DbCustomerLicense } from "../../licenseModels/customerLicenseTable.js";
 import type { FullCustomerLicense } from "../../licenseModels/fullCustomerLicense.js";
 import type { MigrationItemRunData } from "../../migrationV2Models/migrationItemRunSchema.js";
+import type { DbPooledBalance } from "../../pooledBalanceModels/pooledBalanceTable.js";
 import type { EntitlementWithFeature } from "../../productModels/entModels/entModels.js";
 import type { DbFreeTrial } from "../../productModels/freeTrialModels/freeTrialTable.js";
 import type { DbPrice } from "../../productModels/priceModels/priceTable.js";
@@ -89,6 +90,8 @@ export type SubjectBalance = {
 	additional_balance: number;
 	usage_allowed: boolean | null;
 	separate_interval: boolean;
+	is_pooled_balance?: boolean;
+	pooled_balance?: DbPooledBalance;
 	reset_cycle_anchor: number | null;
 	next_reset_at: number | null;
 	expires_at: number | null;

--- a/shared/models/cusModels/fullSubject/subjectQueryRow.ts
+++ b/shared/models/cusModels/fullSubject/subjectQueryRow.ts
@@ -9,6 +9,7 @@ import type { DbFeature } from "../../featureModels/featureTable.js";
 import type { DbCustomerLicense } from "../../licenseModels/customerLicenseTable.js";
 import type { DbPlanLicense } from "../../licenseModels/planLicenseTable.js";
 import type { MigrationItemRunData } from "../../migrationV2Models/migrationItemRunSchema.js";
+import type { DbPooledBalance } from "../../pooledBalanceModels/pooledBalanceTable.js";
 import type { DbEntitlement } from "../../productModels/entModels/entTable.js";
 import type { DbFreeTrial } from "../../productModels/freeTrialModels/freeTrialTable.js";
 import type { DbPrice } from "../../productModels/priceModels/priceTable.js";
@@ -21,6 +22,10 @@ import type { Invoice } from "../invoiceModels/invoiceModels.js";
 
 type EntitlementWithFeatureRow = DbEntitlement & {
 	feature: DbFeature;
+};
+
+type SubjectCustomerEntitlementRow = DbCustomerEntitlement & {
+	pooled_balance?: DbPooledBalance | null;
 };
 
 /** One customer license bundle: the row, its effective plan license
@@ -49,10 +54,10 @@ export type CustomerProductRow = DbCustomerProduct & {
 export type SubjectQueryRow = {
 	customer: DbCustomer;
 	customer_products: CustomerProductRow[];
-	customer_entitlements: DbCustomerEntitlement[];
+	customer_entitlements: SubjectCustomerEntitlementRow[];
 	customer_prices: DbCustomerPrice[];
 	customer_licenses: SubjectCustomerLicenseRow[];
-	extra_customer_entitlements: DbCustomerEntitlement[];
+	extra_customer_entitlements: SubjectCustomerEntitlementRow[];
 	replaceables: Replaceable[];
 	rollovers: DbRollover[];
 	usage_windows: DbUsageWindow[];

--- a/shared/models/cusProductModels/cusEntModels/cusEntModels.ts
+++ b/shared/models/cusProductModels/cusEntModels/cusEntModels.ts
@@ -1,4 +1,8 @@
 import { z } from "zod/v4";
+import type {
+	DbPooledBalance,
+	DbPooledBalanceContribution,
+} from "../../pooledBalanceModels/pooledBalanceTable.js";
 import { EntitlementWithFeatureSchema } from "../../productModels/entModels/entModels.js";
 import { EntInterval } from "../../productModels/intervals/entitlementInterval.js";
 import { ReplaceableSchema } from "./replaceableSchema.js";
@@ -39,6 +43,9 @@ export const CustomerEntitlementSchema = z.object({
 
 	usage_allowed: z.boolean().nullable(),
 	separate_interval: z.boolean().default(false),
+	// Optional at the model boundary for legacy cached objects. The DB column is
+	// non-null and defaults to false.
+	is_pooled_balance: z.boolean().optional(),
 	reset_cycle_anchor: z.number().nullable().optional(),
 	next_reset_at: z.number().nullable(),
 	adjustment: z.number().nullish().default(0),
@@ -57,6 +64,10 @@ export const FullCustomerEntitlementSchema = CustomerEntitlementSchema.extend({
 	entitlement: EntitlementWithFeatureSchema,
 	replaceables: z.array(ReplaceableSchema),
 	rollovers: z.array(RolloverSchema),
+	pooled_balance: z.custom<DbPooledBalance>().optional(),
+	pooled_balance_contribution: z
+		.custom<DbPooledBalanceContribution>()
+		.optional(),
 });
 
 export type CustomerEntitlementFilters = z.infer<

--- a/shared/models/cusProductModels/cusEntModels/cusEntRelations.ts
+++ b/shared/models/cusProductModels/cusEntModels/cusEntRelations.ts
@@ -1,6 +1,7 @@
 import { relations } from "drizzle-orm";
 import { customers } from "../../cusModels/cusTable.js";
 import { features } from "../../featureModels/featureTable.js";
+import { pooledBalanceContributions } from "../../pooledBalanceModels/pooledBalanceTable.js";
 import { entitlements } from "../../productModels/entModels/entTable.js";
 import { customerProducts } from "../cusProductTable.js";
 import { customerEntitlements } from "./cusEntTable.js";
@@ -28,5 +29,10 @@ export const customerEntitlementsRelations = relations(
 		}),
 		replaceables: many(replaceables),
 		rollovers: many(rollovers),
+		pooled_balance_contribution: one(pooledBalanceContributions, {
+			fields: [customerEntitlements.id],
+			references: [pooledBalanceContributions.source_customer_entitlement_id],
+			relationName: "sourceCustomerEntitlementContribution",
+		}),
 	}),
 );

--- a/shared/models/cusProductModels/cusEntModels/cusEntTable.ts
+++ b/shared/models/cusProductModels/cusEntModels/cusEntTable.ts
@@ -33,6 +33,7 @@ export const customerEntitlements = pgTable(
 		next_reset_at: numeric({ mode: "number" }),
 		usage_allowed: boolean("usage_allowed").default(false),
 		separate_interval: boolean("separate_interval").notNull().default(false),
+		is_pooled_balance: boolean("is_pooled_balance").notNull().default(false),
 
 		// Adjustment is how much balance changes. Eg. balance goes from 100 -> 200, adjustment is +100 (will deprecate soon)
 		adjustment: numeric({ mode: "number" }),

--- a/shared/models/pooledBalanceModels/pooledBalanceIdentity.ts
+++ b/shared/models/pooledBalanceModels/pooledBalanceIdentity.ts
@@ -1,0 +1,13 @@
+import type { EntInterval } from "../productModels/intervals/entitlementInterval.js";
+import type { PooledBalanceResetMode } from "./pooledBalanceTable.js";
+
+export type PooledBalanceIdentity = {
+	internalFeatureId: string;
+	interval: EntInterval;
+	intervalCount: number;
+	resetCycleAnchor: number | null;
+	resetMode: PooledBalanceResetMode;
+	stripeSubscriptionId: string | null;
+	customerLicenseLinkId: string | null;
+	rolloverSignature: string;
+};

--- a/shared/models/pooledBalanceModels/pooledBalanceRelations.ts
+++ b/shared/models/pooledBalanceModels/pooledBalanceRelations.ts
@@ -1,0 +1,28 @@
+import { relations } from "drizzle-orm";
+import { customerEntitlements } from "../cusProductModels/cusEntModels/cusEntTable.js";
+import {
+	pooledBalanceContributions,
+	pooledBalances,
+} from "./pooledBalanceTable.js";
+
+export const pooledBalancesRelations = relations(pooledBalances, ({ one }) => ({
+	customer_entitlement: one(customerEntitlements, {
+		fields: [pooledBalances.customer_entitlement_id],
+		references: [customerEntitlements.id],
+	}),
+}));
+
+export const pooledBalanceContributionsRelations = relations(
+	pooledBalanceContributions,
+	({ one }) => ({
+		pooled_balance: one(pooledBalances, {
+			fields: [pooledBalanceContributions.pooled_balance_id],
+			references: [pooledBalances.id],
+		}),
+		source_customer_entitlement: one(customerEntitlements, {
+			fields: [pooledBalanceContributions.source_customer_entitlement_id],
+			references: [customerEntitlements.id],
+			relationName: "sourceCustomerEntitlementContribution",
+		}),
+	}),
+);

--- a/shared/models/pooledBalanceModels/pooledBalanceTable.ts
+++ b/shared/models/pooledBalanceModels/pooledBalanceTable.ts
@@ -13,14 +13,7 @@ import { customers } from "../cusModels/cusTable.js";
 import { customerEntitlements } from "../cusProductModels/cusEntModels/cusEntTable.js";
 import { customerProducts } from "../cusProductModels/cusProductTable.js";
 import { features } from "../featureModels/featureTable.js";
-import { entitlements } from "../productModels/entModels/entTable.js";
 import type { EntInterval } from "../productModels/intervals/entitlementInterval.js";
-
-export enum PooledBalanceResetOwnerType {
-	CustomerProduct = "customer_product",
-	Subscription = "subscription",
-	Free = "free",
-}
 
 export enum PooledBalanceResetMode {
 	Lazy = "lazy",
@@ -36,12 +29,15 @@ export const pooledBalances = pgTable(
 		env: text().notNull(),
 		internal_customer_id: text().notNull(),
 		internal_feature_id: text().notNull(),
+		granted: numeric({ mode: "number" }).notNull().default(0),
 
 		interval: text().$type<EntInterval>().notNull(),
 		interval_count: numeric({ mode: "number" }).notNull().default(1),
 
 		reset_cycle_anchor: numeric({ mode: "number" }),
 		reset_mode: text().$type<PooledBalanceResetMode>().notNull(),
+		stripe_subscription_id: text(),
+		customer_license_link_id: text(),
 		rollover_signature: text().notNull().default("none"),
 		customer_entitlement_id: text().notNull(),
 		last_applied_reset_at: numeric({ mode: "number" }),
@@ -73,6 +69,8 @@ export const pooledBalances = pgTable(
 				table.interval_count,
 				table.reset_cycle_anchor,
 				table.reset_mode,
+				table.stripe_subscription_id,
+				table.customer_license_link_id,
 				table.rollover_signature,
 			)
 			.nullsNotDistinct(),
@@ -80,9 +78,25 @@ export const pooledBalances = pgTable(
 			"pooled_balances_interval_count_positive",
 			sql`${table.interval_count} > 0`,
 		),
+		check("pooled_balances_granted_non_negative", sql`${table.granted} >= 0`),
 		check(
 			"pooled_balances_reset_mode_valid",
 			sql`${table.reset_mode} IN ('lazy', 'subscription', 'lifetime')`,
+		),
+		check(
+			"pooled_balances_lifecycle_ids_valid",
+			sql`(
+				${table.reset_mode} = 'subscription'
+				AND ${table.stripe_subscription_id} IS NOT NULL
+				AND ${table.customer_license_link_id} IS NULL
+			) OR (
+				${table.reset_mode} = 'lazy'
+				AND ${table.stripe_subscription_id} IS NULL
+			) OR (
+				${table.reset_mode} = 'lifetime'
+				AND ${table.stripe_subscription_id} IS NULL
+				AND ${table.customer_license_link_id} IS NULL
+			)`,
 		),
 		unique("unique_pooled_balance_customer_entitlement").on(
 			table.customer_entitlement_id,
@@ -94,6 +108,14 @@ export const pooledBalances = pgTable(
 		index("idx_pooled_balances_feature")
 			.on(table.internal_feature_id)
 			.concurrently(),
+		index("idx_pooled_balances_stripe_subscription")
+			.on(table.internal_customer_id, table.stripe_subscription_id)
+			.where(sql`${table.stripe_subscription_id} IS NOT NULL`)
+			.concurrently(),
+		index("idx_pooled_balances_customer_license")
+			.on(table.internal_customer_id, table.customer_license_link_id)
+			.where(sql`${table.customer_license_link_id} IS NOT NULL`)
+			.concurrently(),
 	],
 );
 
@@ -103,9 +125,7 @@ export const pooledBalanceContributions = pgTable(
 		id: text().primaryKey().notNull(),
 		pooled_balance_id: text().notNull(),
 		source_customer_product_id: text().notNull(),
-		source_entitlement_id: text().notNull(),
-		reset_owner_type: text().$type<PooledBalanceResetOwnerType>().notNull(),
-		reset_owner_id: text().notNull(),
+		source_customer_entitlement_id: text().notNull(),
 		current_contribution: numeric({ mode: "number" }).notNull().default(0),
 		next_cycle_contribution: numeric({ mode: "number" }).notNull().default(0),
 		effective_at: numeric({ mode: "number" }),
@@ -122,12 +142,12 @@ export const pooledBalanceContributions = pgTable(
 			columns: [table.source_customer_product_id],
 			foreignColumns: [customerProducts.id],
 			name: "pooled_balance_contributions_customer_product_fkey",
-		}).onDelete("no action"),
+		}).onDelete("cascade"),
 		foreignKey({
-			columns: [table.source_entitlement_id],
-			foreignColumns: [entitlements.id],
-			name: "pooled_balance_contributions_entitlement_fkey",
-		}).onDelete("no action"),
+			columns: [table.source_customer_entitlement_id],
+			foreignColumns: [customerEntitlements.id],
+			name: "pooled_balance_contributions_customer_entitlement_fkey",
+		}).onDelete("cascade"),
 		check(
 			"pooled_balance_contributions_current_non_negative",
 			sql`${table.current_contribution} >= 0`,
@@ -136,22 +156,14 @@ export const pooledBalanceContributions = pgTable(
 			"pooled_balance_contributions_next_non_negative",
 			sql`${table.next_cycle_contribution} >= 0`,
 		),
-		check(
-			"pooled_balance_contributions_reset_owner_type_valid",
-			sql`${table.reset_owner_type} IN ('customer_product', 'subscription', 'free')`,
-		),
 		unique("unique_pooled_balance_contribution").on(
-			table.source_customer_product_id,
-			table.source_entitlement_id,
+			table.source_customer_entitlement_id,
 		),
 		index("idx_pooled_balance_contributions_pool")
 			.on(table.pooled_balance_id)
 			.concurrently(),
-		index("idx_pooled_balance_contributions_source_entitlement")
-			.on(table.source_entitlement_id)
-			.concurrently(),
-		index("idx_pooled_balance_contributions_reset_owner")
-			.on(table.reset_owner_type, table.reset_owner_id, table.pooled_balance_id)
+		index("idx_pooled_balance_contributions_source_customer_entitlement")
+			.on(table.source_customer_entitlement_id)
 			.concurrently(),
 	],
 );

--- a/shared/utils/common/index.ts
+++ b/shared/utils/common/index.ts
@@ -1,2 +1,3 @@
 export * from "./formatUtils/index";
+export * from "./mathUtils";
 export * from "./unixUtils";

--- a/shared/utils/common/mathUtils.ts
+++ b/shared/utils/common/mathUtils.ts
@@ -1,0 +1,19 @@
+import { Decimal } from "decimal.js";
+
+/** Adds decimal values without floating-point drift. Nullish values are zero. */
+export const addSafe = ({
+	left,
+	right,
+}: {
+	left: number | null | undefined;
+	right: number | null | undefined;
+}) => new Decimal(left ?? 0).plus(right ?? 0).toNumber();
+
+/** Subtracts decimal values without floating-point drift. Nullish values are zero. */
+export const subtractSafe = ({
+	left,
+	right,
+}: {
+	left: number | null | undefined;
+	right: number | null | undefined;
+}) => new Decimal(left ?? 0).minus(right ?? 0).toNumber();

--- a/shared/utils/cusEntUtils/balanceUtils/cusEntToStartingBalance.ts
+++ b/shared/utils/cusEntUtils/balanceUtils/cusEntToStartingBalance.ts
@@ -5,15 +5,26 @@ import { getStartingBalance } from "../getStartingBalance";
 
 export const cusEntToStartingBalance = ({
 	cusEnt,
+	useUpcomingQuantity = false,
 }: {
 	cusEnt: FullCusEntWithFullCusProduct;
+	useUpcomingQuantity?: boolean;
 }) => {
 	const cusPrice = cusEntToCusPrice({ cusEnt });
 	const price = cusPrice?.price;
-	const options = entToOptions({
+	const customerProductOptions = entToOptions({
 		ent: cusEnt.entitlement,
 		options: cusEnt.customer_product?.options ?? [],
 	});
+	const options =
+		useUpcomingQuantity && customerProductOptions
+			? {
+					...customerProductOptions,
+					quantity:
+						customerProductOptions.upcoming_quantity ??
+						customerProductOptions.quantity,
+				}
+			: customerProductOptions;
 
 	return getStartingBalance({
 		entitlement: cusEnt.entitlement,

--- a/shared/utils/cusEntUtils/balanceUtils/grantedBalanceUtils/cusEntsToAllowance.ts
+++ b/shared/utils/cusEntUtils/balanceUtils/grantedBalanceUtils/cusEntsToAllowance.ts
@@ -33,7 +33,8 @@ export const cusEntsToAllowance = ({
 			entityId,
 		});
 
-		const grantedBalance = cusEnt.entitlement.allowance || 0;
+		const grantedBalance =
+			cusEnt.pooled_balance?.granted ?? cusEnt.entitlement.allowance ?? 0;
 
 		const total = new Decimal(grantedBalance)
 			.mul(cusEnt.customer_product?.quantity ?? 1)

--- a/shared/utils/cusEntUtils/classifyCusEnt/isPooledBalanceCustomerEntitlement.ts
+++ b/shared/utils/cusEntUtils/classifyCusEnt/isPooledBalanceCustomerEntitlement.ts
@@ -1,0 +1,15 @@
+import type { FullCustomerEntitlement } from "../../../models/cusProductModels/cusEntModels/cusEntModels.js";
+
+export const isSyntheticPooledBalanceCustomerEntitlement = ({
+	customerEntitlement,
+}: {
+	customerEntitlement: FullCustomerEntitlement;
+}) => customerEntitlement.is_pooled_balance === true;
+
+export const isPooledBalanceSourceCustomerEntitlement = ({
+	customerEntitlement,
+}: {
+	customerEntitlement: FullCustomerEntitlement;
+}) =>
+	customerEntitlement.entitlement.pooled === true &&
+	!isSyntheticPooledBalanceCustomerEntitlement({ customerEntitlement });

--- a/shared/utils/cusEntUtils/filterCustomerEntitlements/filterCustomerEntitlementsByPooledBalanceSource.ts
+++ b/shared/utils/cusEntUtils/filterCustomerEntitlements/filterCustomerEntitlementsByPooledBalanceSource.ts
@@ -1,0 +1,13 @@
+import type { FullCustomerEntitlement } from "../../../models/cusProductModels/cusEntModels/cusEntModels.js";
+import { isPooledBalanceSourceCustomerEntitlement } from "../classifyCusEnt/isPooledBalanceCustomerEntitlement.js";
+
+export const filterCustomerEntitlementsByPooledBalanceSource = <
+	T extends FullCustomerEntitlement,
+>({
+	customerEntitlements,
+}: {
+	customerEntitlements: T[];
+}): T[] =>
+	customerEntitlements.filter((customerEntitlement) =>
+		isPooledBalanceSourceCustomerEntitlement({ customerEntitlement }),
+	);

--- a/shared/utils/cusEntUtils/index.ts
+++ b/shared/utils/cusEntUtils/index.ts
@@ -26,6 +26,7 @@ export * from "./balanceUtils/rollovers/cusEntsToRolloverUsage";
 export * from "./balanceUtils/rollovers/cusEntsToRolloverUsage";
 export * from "./classifyCusEnt/cusEntsHaveUnlimited";
 export * from "./classifyCusEnt/cusEntsHaveUsageAllowed";
+export * from "./classifyCusEnt/isPooledBalanceCustomerEntitlement";
 // Classify utils
 export * from "./classifyCusEntUtils";
 // Convert utils barrel
@@ -46,6 +47,7 @@ export * from "./convertCusEntUtils/resolveSpendLimitOverageLimit";
 // Core utils
 export * from "./cusEntUtils";
 export * from "./filterCusEntUtils";
+export * from "./filterCustomerEntitlements/filterCustomerEntitlementsByPooledBalanceSource";
 export * from "./findCustomerEntitlement/findCustomerEntitlementByFeature";
 // Find utils
 export * from "./findCustomerEntitlement/findCustomerEntitlementById";

--- a/shared/utils/cusUtils/fullCusUtils/fullCustomerToCustomerEntitlements.ts
+++ b/shared/utils/cusUtils/fullCusUtils/fullCustomerToCustomerEntitlements.ts
@@ -48,6 +48,13 @@ export const fullCustomerToCustomerEntitlements = ({
 		});
 	}
 
+	for (const cusEnt of fullCustomer.pooled_customer_entitlements ?? []) {
+		cusEnts.push({
+			...cusEnt,
+			customer_product: null,
+		});
+	}
+
 	if (featureId) {
 		cusEnts = cusEnts.filter(
 			(cusEnt) => cusEnt.entitlement.feature.id === featureId,

--- a/shared/utils/fullSubjectUtils/normalizedToFullSubject.ts
+++ b/shared/utils/fullSubjectUtils/normalizedToFullSubject.ts
@@ -65,6 +65,8 @@ const subjectBalanceToFullCustomerEntitlement = ({
 		additional_balance: subjectBalance.additional_balance,
 		usage_allowed: subjectBalance.usage_allowed,
 		separate_interval: subjectBalance.separate_interval,
+		is_pooled_balance: subjectBalance.is_pooled_balance,
+		pooled_balance: subjectBalance.pooled_balance,
 		reset_cycle_anchor: subjectBalance.reset_cycle_anchor,
 		next_reset_at: subjectBalance.next_reset_at,
 		adjustment: subjectBalance.adjustment,

--- a/shared/utils/index.ts
+++ b/shared/utils/index.ts
@@ -39,6 +39,7 @@ export * from "./planV1Utils/diff/applyDiff";
 // Plan V1 diff/apply utils
 export * from "./planV1Utils/diff/diffPlanV1";
 export * from "./planV1Utils/diff/diffPlanV1PreviewFields";
+export * from "./pooledBalanceUtils/index";
 export * from "./productUtils/classifyProduct/classifyProductUtils";
 export * from "./productUtils/classifyProduct/hasMissingStripeResourcesForProduct";
 export * from "./productUtils/classifyProduct/isProductPaidAndRecurring";

--- a/shared/utils/pooledBalanceUtils/convertPooledBalance/pooledBalanceIdentityToKey.ts
+++ b/shared/utils/pooledBalanceUtils/convertPooledBalance/pooledBalanceIdentityToKey.ts
@@ -1,0 +1,17 @@
+import type { PooledBalanceIdentity } from "../../../models/pooledBalanceModels/pooledBalanceIdentity.js";
+
+export const pooledBalanceIdentityToKey = ({
+	identity,
+}: {
+	identity: PooledBalanceIdentity;
+}) =>
+	JSON.stringify([
+		identity.internalFeatureId,
+		identity.interval,
+		identity.intervalCount,
+		identity.resetCycleAnchor,
+		identity.resetMode,
+		identity.stripeSubscriptionId,
+		identity.customerLicenseLinkId,
+		identity.rolloverSignature,
+	]);

--- a/shared/utils/pooledBalanceUtils/convertPooledBalance/pooledBalanceToPooledBalanceIdentity.ts
+++ b/shared/utils/pooledBalanceUtils/convertPooledBalance/pooledBalanceToPooledBalanceIdentity.ts
@@ -1,0 +1,17 @@
+import type { PooledBalanceIdentity } from "../../../models/pooledBalanceModels/pooledBalanceIdentity.js";
+import type { DbPooledBalance } from "../../../models/pooledBalanceModels/pooledBalanceTable.js";
+
+export const pooledBalanceToPooledBalanceIdentity = ({
+	pooledBalance,
+}: {
+	pooledBalance: DbPooledBalance;
+}): PooledBalanceIdentity => ({
+	internalFeatureId: pooledBalance.internal_feature_id,
+	interval: pooledBalance.interval,
+	intervalCount: pooledBalance.interval_count,
+	resetCycleAnchor: pooledBalance.reset_cycle_anchor,
+	resetMode: pooledBalance.reset_mode,
+	stripeSubscriptionId: pooledBalance.stripe_subscription_id,
+	customerLicenseLinkId: pooledBalance.customer_license_link_id,
+	rolloverSignature: pooledBalance.rollover_signature,
+});

--- a/shared/utils/pooledBalanceUtils/index.ts
+++ b/shared/utils/pooledBalanceUtils/index.ts
@@ -1,0 +1,2 @@
+export * from "./convertPooledBalance/pooledBalanceIdentityToKey.js";
+export * from "./convertPooledBalance/pooledBalanceToPooledBalanceIdentity.js";

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
@@ -10,6 +10,7 @@ import {
 	getRolloverFields,
 	isFreeCustomerEntitlement,
 	isPrepaidCustomerEntitlement,
+	isSyntheticPooledBalanceCustomerEntitlement,
 	nullish,
 } from "@autumn/shared";
 import {
@@ -582,14 +583,18 @@ export const CustomerBalanceTableColumns = ({
 			const isSubRow = row.depth > 0;
 
 			if (isSubRow) {
+				const isPooledBalance = isSyntheticPooledBalanceCustomerEntitlement({
+					customerEntitlement: ent,
+				});
 				const { productName, intervalLabel, entityName } =
 					getCustomerBalanceSourceParts({ balance: ent, entities });
+				const sourceName = isPooledBalance ? "Pooled" : productName;
 				const hasPlan = !!ent.customer_product;
 				const metaParts = [intervalLabel, entityName]
 					.filter(Boolean)
 					.join(" · ");
 
-				if (!hasPlan) {
+				if (!hasPlan && !isPooledBalance) {
 					return (
 						<div className="flex items-center gap-2 min-w-0">
 							<BalanceBillingIcon balance={ent} />
@@ -618,7 +623,7 @@ export const CustomerBalanceTableColumns = ({
 								})}
 							>
 								<span className="text-foreground text-xs font-medium truncate">
-									{productName}
+									{sourceName}
 								</span>
 							</AdminHover>
 						</div>

--- a/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
@@ -23,6 +23,7 @@ import {
 	createFeaturesMap,
 	deduplicateEntitlements,
 	flattenCustomerEntitlements,
+	flattenStandaloneCustomerEntitlements,
 	processNonBooleanEntitlements,
 } from "./customerFeatureUsageUtils";
 
@@ -64,26 +65,28 @@ export function CustomerFeatureUsageTable() {
 		// Add extra entitlements (loose entitlements not tied to a product)
 		// Customer level: show ALL loose entitlements (customer can access entity-scoped balances at top level)
 		// Entity level: show ONLY that entity's loose entitlements
-		const extraEnts: FullCusEntWithFullCusProduct[] = (
-			customer?.extra_customer_entitlements || []
-		)
-			.filter((ent: FullCustomerEntitlement) => {
-				// If no entity selected (customer level), show ALL loose entitlements
-				if (!selectedEntity) {
-					return true;
-				}
-				// If entity selected, show ONLY that entity's loose entitlements
-				return ent.internal_entity_id === selectedEntity.internal_id;
-			})
-			.map((ent: FullCustomerEntitlement) => ({
-				...ent,
-				customer_product: null,
-			}));
+		const visibleExtraEntitlements = (
+			customer?.extra_customer_entitlements ?? []
+		).filter((ent: FullCustomerEntitlement) => {
+			// If no entity selected (customer level), show ALL loose entitlements
+			if (!selectedEntity) {
+				return true;
+			}
+			// If entity selected, show ONLY that entity's loose entitlements
+			return ent.internal_entity_id === selectedEntity.internal_id;
+		});
+		const extraEnts = flattenStandaloneCustomerEntitlements({
+			customerEntitlements: visibleExtraEntitlements,
+		});
+		const pooledEnts = flattenStandaloneCustomerEntitlements({
+			customerEntitlements: customer?.pooled_customer_entitlements ?? [],
+		});
 
-		return [...productEnts, ...extraEnts];
+		return [...productEnts, ...extraEnts, ...pooledEnts];
 	}, [
 		filteredCustomerProducts,
 		customer?.extra_customer_entitlements,
+		customer?.pooled_customer_entitlements,
 		selectedEntity,
 	]);
 

--- a/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageTableFilters.ts
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageTableFilters.ts
@@ -1,6 +1,7 @@
 import {
 	CusProductStatus,
 	type FullCusEntWithFullCusProduct,
+	isPooledBalanceSourceCustomerEntitlement,
 } from "@autumn/shared";
 
 export function filterCustomerFeatureUsage({
@@ -12,6 +13,13 @@ export function filterCustomerFeatureUsage({
 }): FullCusEntWithFullCusProduct[] {
 	return entitlements
 		.filter((ent: FullCusEntWithFullCusProduct) => {
+			if (
+				isPooledBalanceSourceCustomerEntitlement({
+					customerEntitlement: ent,
+				})
+			) {
+				return false;
+			}
 			if (showExpired) {
 				return true;
 			}

--- a/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageUtils.ts
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageUtils.ts
@@ -24,6 +24,17 @@ export function flattenCustomerEntitlements({
 	);
 }
 
+export function flattenStandaloneCustomerEntitlements({
+	customerEntitlements,
+}: {
+	customerEntitlements: FullCustomerEntitlement[];
+}): FullCusEntWithFullCusProduct[] {
+	return customerEntitlements.map((customerEntitlement) => ({
+		...customerEntitlement,
+		customer_product: null,
+	}));
+}
+
 /**
  * Creates a features lookup map
  */

--- a/vite/tests/views/customers2/customer-feature-usage.test.ts
+++ b/vite/tests/views/customers2/customer-feature-usage.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import {
+	CusProductStatus,
+	type FullCusEntWithFullCusProduct,
+	type FullCustomerEntitlement,
+} from "@autumn/shared";
+import { filterCustomerFeatureUsage } from "@/views/customers2/components/table/customer-feature-usage/customerFeatureUsageTableFilters";
+import { flattenStandaloneCustomerEntitlements } from "@/views/customers2/components/table/customer-feature-usage/customerFeatureUsageUtils";
+
+const buildCustomerEntitlement = ({
+	id,
+	pooled,
+	isPooledBalance = false,
+}: {
+	id: string;
+	pooled: boolean;
+	isPooledBalance?: boolean;
+}) =>
+	({
+		id,
+		created_at: 0,
+		is_pooled_balance: isPooledBalance,
+		entitlement: {
+			pooled,
+			feature: { id: "messages" },
+		},
+		customer_product: {
+			status: CusProductStatus.Active,
+		},
+	}) as FullCusEntWithFullCusProduct;
+
+describe("customer feature usage pooled balances", () => {
+	test("shows the synthetic pool and hides its contribution sources", () => {
+		const ordinary = buildCustomerEntitlement({
+			id: "ordinary",
+			pooled: false,
+		});
+		const contributionSource = buildCustomerEntitlement({
+			id: "source",
+			pooled: true,
+		});
+		const syntheticPool = buildCustomerEntitlement({
+			id: "pool",
+			pooled: true,
+			isPooledBalance: true,
+		});
+
+		const filtered = filterCustomerFeatureUsage({
+			entitlements: [ordinary, contributionSource, syntheticPool],
+			showExpired: false,
+		});
+
+		expect(filtered.map(({ id }) => id)).toEqual(["ordinary", "pool"]);
+	});
+
+	test("flattens hydrated pooled entitlements as standalone balances", () => {
+		const pooledCustomerEntitlement = buildCustomerEntitlement({
+			id: "pool",
+			pooled: true,
+			isPooledBalance: true,
+		});
+
+		const [flattened] = flattenStandaloneCustomerEntitlements({
+			customerEntitlements: [
+				pooledCustomerEntitlement as FullCustomerEntitlement,
+			],
+		});
+
+		expect(flattened.id).toBe("pool");
+		expect(flattened.is_pooled_balance).toBe(true);
+		expect(flattened.customer_product).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

- compute and execute pooled balance contributions during attach
- hydrate synthetic pooled balances through customer and full-subject responses
- expose pooled balances in the dashboard while hiding contribution entitlements
- cover free monthly, lifetime, paid monthly, and outgoing-source cases

## Validation

- Knip
- server TypeScript build
- Vite TypeScript build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the pooled balance attach flow: creates pools, computes contributions, and persists them during attach. Surfaces synthetic pooled balances in APIs and the dashboard while hiding contribution sources, covering free monthly, lifetime, and paid monthly lifecycles with Stripe-linked resets where needed.

- **New Features**
  - Adds pooled balance planning to attach: `computeAttachPooledBalancePlan` → merged into `AutumnBillingPlan` → `executePooledBalancePlan`.
  - Hydrates synthetic pools in `CusService` and subject queries; excludes pooled sources from resets/aggregates; propagates Stripe subscription IDs when `PooledBalanceResetMode.Subscription`.
  - Schema updates: `customer_entitlements.is_pooled_balance`, `pooled_balances.granted`, contributions keyed by `source_customer_entitlement_id`, and cascade FKs.
  - Dashboard: shows a “Pooled” row and hides contribution entitlements; filters out pooled sources in feature usage.
  - Test coverage: integration tests for attach and pooled lifecycles; UI unit tests for feature usage filtering.

- **Migration**
  - Run migration `0047_next_avengers`.
  - No backfill required (new fields have safe defaults); deploy server and dashboard together.

<sup>Written for commit f2882597c51ee33bcae97575e294250386033b42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds pooled balances to the entity-product attach flow. The main changes are:

- **Improvements:** Computes and persists pooled grants and source contributions.
- **API changes:** Hydrates synthetic pools into customer and subject responses.
- **Improvements:** Shows pooled balances in the dashboard while hiding source entitlements.
- **API changes:** Adds pooled-balance tables, relations, plan models, and shared exports.
- **Bug fixes:** Covers free monthly, lifetime, paid monthly, usage, and replacement flows.
</details>

<h3>Confidence Score: 2/5</h3>

Concurrent attaches can lose grants, and pooled failures can leave a paid product partially committed.

- Absolute pool updates can overwrite another attach.
- Pool creation and contribution insertion are not conflict-safe.
- The pooled transaction does not include preceding product writes.
- Repository limits can produce incomplete pool and contribution graphs.

Pooled execution, lifecycle computation, and pooled repository loaders.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/pooledBalances/execute/executePooledBalancePlan.ts | Adds transactional pooled persistence, but absolute snapshot updates race and the transaction excludes surrounding attach writes. |
| server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts | Runs pooled persistence after source-product insertion without a shared transaction. |
| server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/applyIncomingPooledBalanceSources.ts | Computes incoming contributions and normalizes sources, but always plans contribution inserts. |
| server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/computePooledBalanceLifecycle.ts | Computes pool lifecycle ownership but can use a customer-product ID as a subscription owner. |
| server/src/internal/customers/pooledBalances/repos/listPooledCustomerEntitlements.ts | Loads synthetic pooled entitlements but silently truncates the pool graph. |
| server/src/internal/customers/pooledBalances/repos/listScopedPooledBalanceContributions.ts | Loads scoped contributions but silently truncates the ownership graph. |
| shared/models/pooledBalanceModels/pooledBalanceTable.ts | Adds lifecycle and identity constraints that expose unhandled concurrent and repeated insert paths. |

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant A as Attach request
    participant S as Stripe
    participant E as Autumn executor
    participant P as Pooled transaction
    participant DB as PostgreSQL

    A->>S: Apply subscription changes
    S-->>A: Success
    A->>E: Execute Autumn plan
    E->>DB: Commit product and entitlement writes
    E->>P: Execute pooled plan
    P->>DB: Insert or update pool and contributions
    alt pooled write succeeds
        DB-->>P: Commit
        P-->>E: Success
    else conflict or stale update
        DB-->>P: Error or overwritten balance
        P-->>E: Roll back pooled writes
        Note over E,DB: Earlier product and Stripe state remains committed
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant A as Attach request
    participant S as Stripe
    participant E as Autumn executor
    participant P as Pooled transaction
    participant DB as PostgreSQL

    A->>S: Apply subscription changes
    S-->>A: Success
    A->>E: Execute Autumn plan
    E->>DB: Commit product and entitlement writes
    E->>P: Execute pooled plan
    P->>DB: Insert or update pool and contributions
    alt pooled write succeeds
        DB-->>P: Commit
        P-->>E: Success
    else conflict or stale update
        DB-->>P: Error or overwritten balance
        P-->>E: Roll back pooled writes
        Note over E,DB: Earlier product and Stripe state remains committed
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 6 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 6
server/src/internal/billing/v2/pooledBalances/execute/executePooledBalancePlan.ts:55-88
**Concurrent Updates Lose Grants**

Two attaches can compute absolute `balance` and `granted` values from the same customer snapshot. The second transaction then overwrites the first transaction's update while both contributions remain, so the persisted grant no longer equals the contribution total.

### Issue 2 of 6
server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts:114-120
**Pooled Failure Cannot Roll Back Attach**

The source product is inserted before `executePooledBalancePlan` opens its separate transaction. If a pooled insert or update fails, only pooled writes roll back while the product, preceding entitlements, and completed Stripe operation remain, exposing an active product with no matching pooled grant.

### Issue 3 of 6
server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/applyIncomingPooledBalanceSources.ts:83-86
**Existing Contributions Are Reinserted**

Every incoming source becomes an insert even when its `source_customer_entitlement_id` already owns a contribution and was not removed as outgoing. An idempotent attach or retry then violates the contribution uniqueness constraint instead of updating or retaining the existing row.

### Issue 4 of 6
server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/computePooledBalanceLifecycle.ts:103-111
**Product ID Becomes Subscription Owner**

When a paid recurring attach has no supplied or existing subscription ID, this fallback stores the customer-product ID as `stripe_subscription_id`. The database accepts the non-null value, but renewal and ownership logic later treats it as a real Stripe subscription, so the pool cannot be reconciled against its actual billing lifecycle.

### Issue 5 of 6
server/src/internal/customers/pooledBalances/repos/listPooledCustomerEntitlements.ts:30
**Pool Graph Stops At 100**

A customer with more than 100 pool identities receives a silently truncated pool graph. Omitted pools disappear from hydrated responses and attach computation can treat an existing identity as absent, leading to an incorrect insert plan or a uniqueness failure.

### Issue 6 of 6
server/src/internal/customers/pooledBalances/repos/listScopedPooledBalanceContributions.ts:49
**Contribution Graph Stops At 100**

An entity or customer with more than 100 source contributions is hydrated with an incomplete ownership graph. Omitted source entitlements lack `pooled_balance_contribution`, so later replacement logic can fail to remove their grants and leave the shared balance overstated.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(billing): 🎸 implement pooled balan..."](https://github.com/useautumn/autumn/commit/f2882597c51ee33bcae97575e294250386033b42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46097474)</sub>

> Greptile also left **6 inline comments** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->