### PR TITLE
fix(catalog): normalize virtual license products

### DIFF
--- a/server/src/internal/catalog/actions/catalogPlanPreflight.ts
+++ b/server/src/internal/catalog/actions/catalogPlanPreflight.ts
@@ -33,6 +33,8 @@ const virtualProduct = ({
 		...(current ?? {}),
 		id,
 		version,
+		prices: current?.prices ?? [],
+		entitlements: current?.entitlements ?? [],
 		archived: archived ?? current?.archived ?? false,
 		internal_id:
 			current?.version === version

--- a/server/tests/integration/licenses/catalog-update/license-catalog-response.test.ts
+++ b/server/tests/integration/licenses/catalog-update/license-catalog-response.test.ts
@@ -3,11 +3,14 @@ import type {
 	CatalogPreviewUpdateResponse,
 	CheckResponseV3,
 } from "@autumn/shared";
+import { CatalogUpdateParamsSchema } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
+import defaultCtx from "@tests/utils/testInitUtils/createTestContext.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
+import { previewUpdateCatalog } from "@/internal/catalog/actions/previewUpdateCatalog/previewUpdateCatalog.js";
 import { listLicenseLinks, listLicensePools } from "../licenseTestUtils.js";
 
 const makeLicenseProduct = () => ({
@@ -63,6 +66,102 @@ test.concurrent(
 				{ plan_id: childId, licenses: [{ license_plan_id: parentId }] },
 			],
 		});
+	},
+);
+
+/** Fresh license plans must be complete FullProducts before customization. */
+test.concurrent(
+	`${chalk.yellowBright("licenses: catalog previews a customized same-batch license plan")}`,
+	async () => {
+		const suffix = Math.random().toString(36).slice(2, 9);
+		const seatId = `license_catalog_seat_${suffix}`;
+		const parentId = `license_catalog_parent_${suffix}`;
+		const standardId = `license_catalog_standard_${suffix}`;
+		const deepId = `license_catalog_deep_${suffix}`;
+		const creditsId = `license_catalog_credits_${suffix}`;
+
+		const params = CatalogUpdateParamsSchema.parse({
+			expand: ["plan_changes.plan"],
+			features: [
+				{
+					feature_id: standardId,
+					name: "Standard Search",
+					type: "metered",
+					consumable: true,
+				},
+				{
+					feature_id: deepId,
+					name: "Deep Search",
+					type: "metered",
+					consumable: true,
+				},
+				{
+					feature_id: creditsId,
+					name: "AI Credits",
+					type: "credit_system",
+					credit_schema: [
+						{ metered_feature_id: standardId, credit_cost: 1 },
+						{ metered_feature_id: deepId, credit_cost: 10 },
+					],
+				},
+			],
+			plans: [
+				{
+					plan_id: seatId,
+					version: 1,
+					name: "Team Seat",
+					licenses: [],
+					group: "",
+					add_on: false,
+					auto_enable: false,
+					items: [
+						{
+							feature_id: creditsId,
+							included: 600,
+							reset: { interval: "month" },
+						},
+					],
+					price: null,
+					free_trial: null,
+				},
+				{
+					plan_id: parentId,
+					version: 1,
+					name: "Team Quarterly",
+					licenses: [
+						{
+							license_plan_id: seatId,
+							included: 0,
+							prepaid_only: true,
+							customize: {
+								price: {
+									amount: 72,
+									interval: "quarter",
+									additional_currencies: [{ currency: "eur", amount: 72 }],
+								},
+							},
+						},
+					],
+					group: "",
+					add_on: false,
+					auto_enable: false,
+					price: null,
+					items: [],
+					free_trial: null,
+				},
+			],
+		});
+		const preview = await previewUpdateCatalog({ ctx: defaultCtx, params });
+
+		expect(preview.plan_changes).toHaveLength(2);
+		expect(preview.plan_changes[1]?.plan?.licenses).toEqual([
+			{
+				license_plan_id: seatId,
+				version: 1,
+				included: 0,
+				prepaid_only: true,
+			},
+		]);
 	},
 );
 


### PR DESCRIPTION
## Summary

- initialize virtual catalog products with empty price and entitlement collections
- prevent same-batch customized license previews from crashing before catalog writes
- add a regression matching the Mobbin Enterprise Seat catalog shape

## Verification

- confirmed red: `curPrices.filter` on the unfixed preview
- confirmed green: targeted integration regression
- `bunx tsgo --build --noEmit`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize virtual license products in catalog preflight by defaulting `prices` and `entitlements` to empty arrays. This prevents crashes when customizing same-batch license plan previews.

- **Bug Fixes**
  - Initialize virtual products with empty `prices` and `entitlements` in `catalogPlanPreflight.ts` to ensure complete product shape.
  - Fixed preview crash in same-batch customized license plans before catalog writes.
  - Added integration regression covering a Mobbin Enterprise Seat–style catalog and pinned license versions.

<sup>Written for commit 9afa34c495ba848e8731632073e8a2b09c74a19d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR completes virtual license products before same-batch customization. The main changes are:

- **Bug fixes:** Default missing price and entitlement collections to empty arrays.
- **Improvements:** Add coverage for previewing a customized same-batch license plan.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/catalog/actions/catalogPlanPreflight.ts | Initializes missing virtual-product collections while preserving collections from existing products. |
| server/tests/integration/licenses/catalog-update/license-catalog-response.test.ts | Adds coverage for a parent plan customizing a newly declared license plan in the same preview. |

<sub>Reviews (1): Last reviewed commit: ["fix(catalog): normalize virtual license ..."](https://github.com/useautumn/autumn/commit/9afa34c495ba848e8731632073e8a2b09c74a19d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46235803)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->