### PR TITLE
fix(dashboard): truncate long checkout URL from the start

### DIFF
--- a/vite/src/components/forms/shared/UrlSuccessView.tsx
+++ b/vite/src/components/forms/shared/UrlSuccessView.tsx
@@ -46,8 +46,8 @@ export function UrlSuccessView({
 				</Button>
 				<CopyButton
 					text={url}
-					className="w-full"
-					innerClassName="text-xs text-tertiary-foreground font-mono min-w-0 flex-1"
+					className="w-full [&>span]:min-w-0 [&>span]:max-w-full"
+					innerClassName="text-xs text-tertiary-foreground font-mono min-w-0 flex-1 text-left"
 				/>
 			</SheetFooter>
 		</>


### PR DESCRIPTION
## Problem

In the "Checkout URL Generated" view, the checkout URL was clipped on **both** ends — the start (`https://checkout.stripe.com/...`) was cut off, with no trailing ellipsis.

## Root cause

`CopyButton` already passes `truncate` and `min-w-0 flex-1`, so it looked like it should truncate.

The actual constraint is one layer up: `Button` wraps all children in a hardcoded `<span className="inline-flex items-center gap-2">` with no width limit. That wrapper sized itself to the full URL (~1777px), overflowed the 406px button, and — because the button is `justify-center` — got clipped symmetrically, hiding the start.

## Fix

Scoped entirely to the call site:

- `[&>span]:min-w-0 [&>span]:max-w-full` constrains the Button's child wrapper so the truncating child can shrink.
- `text-left` puts the ellipsis at the end instead of centering the text.

## Why not fix `Button` itself

An earlier revision added `min-w-0 max-w-full` to the wrapper in `packages/ui/.../button.tsx`. That works, but it changes every button in the app for one call site's problem, so it was dropped in favour of the call-site variant. Measured results are identical.

For the record, I also verified that the simpler options do **not** work — `min-w-0`, `overflow-hidden`, and both together on the button's own `className` all leave the wrapper at 1776.8px with the URL start still off-screen, because `overflow-hidden` hides the overflow without making the text truncate.

## Verification

Measured on the real component with `button.tsx` untouched:

| | before | after |
|---|---|---|
| wrapper span | 1776.8px | **390px** |
| URL span | 1754.8px | **368px** |
| truncating | no | **yes** |
| start visible | no | **yes** |

Renders as `https://checkout.stripe.com/c/pay/cs_test_a1J2Rpdm…`