### PR TITLE
fix(dashboard): default plan schedule preview to immediate

### DIFF
--- a/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
@@ -162,8 +162,8 @@ export function buildAttachRequestBody({
 
 	if (startDate && !trialEnabled) {
 		body.starts_at = startDate;
-	} else if (planSchedule) {
-		body.plan_schedule = planSchedule;
+	} else {
+		body.plan_schedule = planSchedule ?? "immediate";
 	}
 
 	if (endDate) {

--- a/vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts
+++ b/vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts
@@ -220,6 +220,17 @@ describe("buildAttachRequestBody — starts_at handling", () => {
 		],
 	});
 
+	/** Pre-fix omitted the selected default; post-fix sends "immediate" to keep the preview aligned with the UI. */
+	test("defaults plan_schedule to immediate", () => {
+		const result = buildAttachRequestBody({
+			...baseParams,
+			product,
+			prepaidOptions: {},
+		});
+
+		expect(result?.plan_schedule).toBe("immediate");
+	});
+
 	test("sends starts_at instead of silently falling back to plan_schedule", () => {
 		const startDate = addDays(Date.now(), 1).getTime();
 


### PR DESCRIPTION
## Summary

- serialize the attach form’s visible immediate schedule default in preview requests
- preserve explicit end-of-cycle and future start-date behavior
- add regression coverage for the initial unset form state

## Testing

- `bun run ts` in `vite/`
- `bun test tests/components/forms/attach-v2` (51 pass)
- targeted ESLint
- React Doctor changed-scope scan (100/100)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaults the attach form’s plan schedule in preview requests to "immediate" when unset, so the preview matches the UI and avoids hidden fallbacks.

- **Bug Fixes**
  - Always send `plan_schedule: "immediate"` when no start date and no explicit schedule are provided.
  - Keep `starts_at`, end-of-cycle, and future start-date behavior unchanged, with a regression test for the default state.

<sup>Written for commit fd73affd0fbc2ec5255b583b5170837648e18619. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR aligns attach request serialization with the schedule shown by the form. The main changes are:

- **Bug fixes:** Send `plan_schedule: "immediate"` for the initial unset form state.
- **Improvements:** Keep explicit end-of-cycle and future start-date behavior unchanged.
- **Improvements:** Add a test for the default schedule request body.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- Preview and submission share the same request body, so the serialized default remains consistent.
- The new test covers the form state addressed by this change.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts | Serializes the form's visible immediate default while preserving explicit schedules and applicable start dates. |
| vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts | Adds focused coverage for the initially unset schedule state. |

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): 🐛 default plan schedule..."](https://github.com/useautumn/autumn/commit/fd73affd0fbc2ec5255b583b5170837648e18619) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46236717)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/autumn-org-2/github/useautumn/autumn/-/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))
- Context used - AGENTS.md ([source](https://app.greptile.com/autumn-org-2/github/useautumn/autumn/-/custom-context?memory=e38717a3-e8ad-4054-9219-102b893d3b3c))
- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
</details>

<!-- /greptile_comment -->