### PR TITLE
fix(auth): deduplicate OAuth organization list

### DIFF
--- a/server/src/internal/auth/handleListAuthOrganizations.ts
+++ b/server/src/internal/auth/handleListAuthOrganizations.ts
@@ -20,7 +20,7 @@ export const handleListAuthOrganizations = async (c: Context) => {
 	}
 
 	const orgs = await db
-		.select({
+		.selectDistinct({
 			id: organizations.id,
 			name: organizations.name,
 			slug: organizations.slug,

--- a/server/tests/integration/auth/list-organizations-deduplicates-memberships.test.ts
+++ b/server/tests/integration/auth/list-organizations-deduplicates-memberships.test.ts
@@ -1,0 +1,43 @@
+/**
+ * TDD test for duplicate organizations in the OAuth consent selector.
+ * Red returns one organization per membership; green returns each organization once.
+ */
+
+import { expect, test } from "bun:test";
+import { member } from "@autumn/shared";
+import defaultCtx from "@tests/utils/testInitUtils/createTestContext.js";
+import {
+	createDashboardSession,
+	dashboardGet,
+} from "@tests/utils/testInitUtils/dashboardSession.js";
+import { initDrizzle } from "@/db/initDrizzle.js";
+import { generateId } from "@/utils/genUtils.js";
+
+const { db } = initDrizzle();
+
+test("organization list deduplicates multiple memberships for the same organization", async () => {
+	const session = await createDashboardSession(defaultCtx);
+
+	try {
+		await db.insert(member).values({
+			id: generateId("mem"),
+			organizationId: defaultCtx.org.id,
+			userId: session.userId,
+			role: "owner",
+			createdAt: new Date(),
+		});
+
+		const response = await dashboardGet<Array<{ id: string }>>(
+			defaultCtx,
+			session,
+			"/api/auth/organization/list",
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.data.filter((org) => org.id === defaultCtx.org.id)).toHaveLength(
+			1,
+		);
+	} finally {
+		await session.cleanup();
+	}
+});


### PR DESCRIPTION
## Summary

- return each organization once when duplicate membership rows exist
- add integration coverage for the OAuth organization-list response

## Red / green

- red: duplicate memberships returned the same organization twice
- green: the organization list returns one matching organization

## Test plan

- `bunx tsgo --build --noEmit`
- `AUTUMN_TEST_BASE_URL=http://localhost:8081 ./run.sh /absolute/path/to/list-organizations-deduplicates-memberships.test.ts`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes duplicate organizations from the OAuth organization list. The main changes are:

- **Bug fixes:** Select distinct organization rows when duplicate memberships exist.
- **Improvements:** Add an integration test for the duplicate-membership case.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The distinct projection includes the organization ID, so separate organizations cannot be collapsed.
- The ordered columns are included in the projection and remain valid with PostgreSQL distinct semantics.
- The test reaches the changed route and generated memberships are removed when session cleanup deletes the user.
- No blocking issues were found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/auth/handleListAuthOrganizations.ts | Uses a distinct organization projection to collapse duplicate rows from the membership join. |
| server/tests/integration/auth/list-organizations-deduplicates-memberships.test.ts | Adds integration coverage that creates two memberships and verifies one organization is returned. |

<sub>Reviews (1): Last reviewed commit: ["fix(auth): 🐛 deduplicate OAuth organiza..."](https://github.com/useautumn/autumn/commit/1b55620049c2df9299022d4176ddabad53abac34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46237158)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->