### PR TITLE
fix(redis): preserve ioredis reconnect ownership

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   #   staging repo (autumn-staging) -> us-east-1
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix fix/dragonfly-resize-reconnect
 
 jobs:
   checks:

--- a/server/src/external/redis/initUtils/createRedisAvailability.ts
+++ b/server/src/external/redis/initUtils/createRedisAvailability.ts
@@ -7,7 +7,6 @@ import { waitForRedisReady } from "./redisWarmup.js";
 const REDIS_ERROR_LOG_INTERVAL_MS = 30_000;
 const REDIS_PROBE_INTERVAL_MS = 2_000;
 const REDIS_PROBE_TIMEOUT_MS = 1_000;
-const REDIS_STALE_RECONNECT_MS = 5_000;
 const REDIS_FAILURES_TO_DEGRADE = 5;
 const REDIS_SUCCESSES_TO_RECOVER = 3;
 const REDIS_LOOP_LAG_INCONCLUSIVE_MS = 500;
@@ -68,7 +67,6 @@ export const createRedisAvailability = ({
 	let consecutiveFailures = 0;
 	let consecutiveSuccesses = 0;
 	let consecutiveInconclusive = 0;
-	let reconnectStartedAt: number | null = null;
 	let lastEventLoopLagMs = 0;
 
 	const loopLagSampler = ((): { begin: () => void; end: () => number } => {
@@ -172,19 +170,6 @@ export const createRedisAvailability = ({
 		return redis.status === "ready" && pong === "PONG";
 	};
 
-	const reconnectRedis = async () => {
-		try {
-			redis.disconnect(false);
-			await withTimeout({
-				timeoutMs: REDIS_PROBE_TIMEOUT_MS,
-				fn: () => redis.connect(),
-			});
-			reconnectStartedAt = null;
-		} catch {
-			// Let the next probe decide whether we recovered.
-		}
-	};
-
 	const classifyPing = (pingOk: boolean): ProbeOutcome => {
 		if (pingOk) return "available";
 		return redis.status === "ready"
@@ -208,19 +193,12 @@ export const createRedisAvailability = ({
 			failedWhileReady && consecutiveFailures + 1 >= REDIS_FAILURES_TO_DEGRADE;
 
 		if (shouldReconnectReadyClient) {
-			await reconnectRedis();
-		} else if (redis.status !== "ready") {
-			if (redis.status === "connecting" || redis.status === "reconnecting") {
-				reconnectStartedAt ??= Date.now();
-				if (Date.now() - reconnectStartedAt < REDIS_STALE_RECONNECT_MS) {
-					return "connection_down";
-				}
-			}
-
-			await reconnectRedis();
+			// Let ioredis schedule recovery so its socket state remains authoritative.
+			redis.disconnect(true);
+			return "connection_down";
 		}
 
-		return classifyPing(await pingRedisClient().catch(() => false));
+		return classifyPing(false);
 	};
 
 	const probeAndClassify = async (): Promise<ProbeClassification> => {

--- a/server/src/external/redis/initUtils/createRedisAvailability.ts
+++ b/server/src/external/redis/initUtils/createRedisAvailability.ts
@@ -7,7 +7,6 @@ import { waitForRedisReady } from "./redisWarmup.js";
 const REDIS_ERROR_LOG_INTERVAL_MS = 30_000;
 const REDIS_PROBE_INTERVAL_MS = 2_000;
 const REDIS_PROBE_TIMEOUT_MS = 1_000;
-const REDIS_STALE_RECONNECT_MS = 5_000;
 const REDIS_FAILURES_TO_DEGRADE = 5;
 const REDIS_SUCCESSES_TO_RECOVER = 3;
 const REDIS_LOOP_LAG_INCONCLUSIVE_MS = 500;
@@ -60,6 +59,7 @@ export const createRedisAvailability = ({
 	getEventLoopLagMs?: () => number;
 	maxConsecutiveInconclusive?: number;
 }) => {
+	let probeRedis: Redis | null = null;
 	let redisAvailabilityState: RedisAvailabilityState = "degraded";
 	let redisMonitorInterval: ReturnType<typeof setInterval> | null = null;
 	let redisTickInFlight = false;
@@ -68,12 +68,30 @@ export const createRedisAvailability = ({
 	let consecutiveFailures = 0;
 	let consecutiveSuccesses = 0;
 	let consecutiveInconclusive = 0;
-	let reconnectStartedAt: number | null = null;
 	let lastEventLoopLagMs = 0;
 
-	const loopLagSampler = ((): { begin: () => void; end: () => number } => {
+	const getOrCreateProbeRedis = (): Redis => {
+		if (!hasConfig) return redis;
+		if (probeRedis) return probeRedis;
+
+		probeRedis = redis.duplicate();
+		if (probeRedis !== redis) probeRedis.on("error", () => {});
+		return probeRedis;
+	};
+
+	const getProbeRedisStatus = () => probeRedis?.status ?? "not_initialized";
+
+	const loopLagSampler = ((): {
+		begin: () => void;
+		end: () => number;
+		stop: () => void;
+	} => {
 		if (getEventLoopLagMs) {
-			return { begin: () => {}, end: () => getEventLoopLagMs() };
+			return {
+				begin: () => {},
+				end: () => getEventLoopLagMs(),
+				stop: () => {},
+			};
 		}
 
 		let histogram: ReturnType<typeof monitorEventLoopDelay> | null = null;
@@ -89,7 +107,7 @@ export const createRedisAvailability = ({
 				`[${logPrefix}] Event-loop delay monitor unavailable; lag-aware degrade suppression disabled`,
 				{ type: logType },
 			);
-			return { begin: () => {}, end: () => 0 };
+			return { begin: () => {}, end: () => 0, stop: () => {} };
 		}
 
 		const activeHistogram = histogram;
@@ -99,6 +117,7 @@ export const createRedisAvailability = ({
 				const maxMs = histogramMaxToMs(activeHistogram.max);
 				return Number.isFinite(maxMs) && maxMs > 0 ? maxMs : 0;
 			},
+			stop: () => activeHistogram.disable(),
 		};
 	})();
 
@@ -123,6 +142,7 @@ export const createRedisAvailability = ({
 				previousState,
 				state,
 				redisStatus: redis.status,
+				probeRedisStatus: getProbeRedisStatus(),
 				consecutiveFailures,
 				consecutiveSuccesses,
 				eventLoopLagMs: lastEventLoopLagMs,
@@ -155,72 +175,48 @@ export const createRedisAvailability = ({
 		logger.warn(`[${logPrefix}] Probe inconclusive under event-loop lag`, {
 			type: logType,
 			redisStatus: redis.status,
+			probeRedisStatus: getProbeRedisStatus(),
 			consecutiveFailures,
 			eventLoopLagMs: lastEventLoopLagMs,
 			loopLagThresholdMs: REDIS_LOOP_LAG_INCONCLUSIVE_MS,
 		});
 	};
 
-	const pingRedisClient = async () => {
-		if (redis.status !== "ready") return false;
+	const pingRedisClient = async (activeProbeRedis: Redis) => {
+		if (activeProbeRedis.status !== "ready") return false;
 
 		const pong = await withTimeout({
 			timeoutMs: REDIS_PROBE_TIMEOUT_MS,
-			fn: () => redis.ping(),
+			fn: () => activeProbeRedis.ping(),
 		});
 
-		return redis.status === "ready" && pong === "PONG";
+		return activeProbeRedis.status === "ready" && pong === "PONG";
 	};
 
-	const reconnectRedis = async () => {
-		try {
-			redis.disconnect(false);
-			await withTimeout({
-				timeoutMs: REDIS_PROBE_TIMEOUT_MS,
-				fn: () => redis.connect(),
-			});
-			reconnectStartedAt = null;
-		} catch {
-			// Let the next probe decide whether we recovered.
-		}
-	};
-
-	const classifyPing = (pingOk: boolean): ProbeOutcome => {
+	const classifyPing = ({
+		pingOk,
+		activeProbeRedis,
+	}: {
+		pingOk: boolean;
+		activeProbeRedis: Redis;
+	}): ProbeOutcome => {
 		if (pingOk) return "available";
-		return redis.status === "ready"
+		return activeProbeRedis.status === "ready"
 			? "unresponsive_while_ready"
 			: "connection_down";
 	};
 
 	const probeRedisAvailability = async (): Promise<ProbeOutcome> => {
 		if (!hasConfig) return "connection_down";
+		const activeProbeRedis = getOrCreateProbeRedis();
 
 		let pingOk = false;
 		try {
-			pingOk = await pingRedisClient();
+			pingOk = await pingRedisClient(activeProbeRedis);
 		} catch {
 			pingOk = false;
 		}
-		if (pingOk) return "available";
-
-		const failedWhileReady = redis.status === "ready";
-		const shouldReconnectReadyClient =
-			failedWhileReady && consecutiveFailures + 1 >= REDIS_FAILURES_TO_DEGRADE;
-
-		if (shouldReconnectReadyClient) {
-			await reconnectRedis();
-		} else if (redis.status !== "ready") {
-			if (redis.status === "connecting" || redis.status === "reconnecting") {
-				reconnectStartedAt ??= Date.now();
-				if (Date.now() - reconnectStartedAt < REDIS_STALE_RECONNECT_MS) {
-					return "connection_down";
-				}
-			}
-
-			await reconnectRedis();
-		}
-
-		return classifyPing(await pingRedisClient().catch(() => false));
+		return classifyPing({ pingOk, activeProbeRedis });
 	};
 
 	const probeAndClassify = async (): Promise<ProbeClassification> => {
@@ -260,9 +256,26 @@ export const createRedisAvailability = ({
 	return {
 		prime: async () => {
 			if (!hasConfig) return;
+			const activeProbeRedis = getOrCreateProbeRedis();
+			const readinessPromises: Promise<void>[] = [];
+
 			if (redis.status === "connecting" || redis.status === "reconnecting") {
-				await waitForRedisReady(redis, logPrefix).catch(() => undefined);
+				readinessPromises.push(
+					waitForRedisReady(redis, logPrefix).catch(() => undefined),
+				);
 			}
+			if (
+				activeProbeRedis !== redis &&
+				(activeProbeRedis.status === "connecting" ||
+					activeProbeRedis.status === "reconnecting")
+			) {
+				readinessPromises.push(
+					waitForRedisReady(activeProbeRedis, `${logPrefix}Probe`).catch(
+						() => undefined,
+					),
+				);
+			}
+			await Promise.all(readinessPromises);
 
 			const classification = await probeAndClassify();
 			consecutiveInconclusive = 0;
@@ -289,11 +302,19 @@ export const createRedisAvailability = ({
 			}, REDIS_PROBE_INTERVAL_MS);
 		},
 		stopMonitor: () => {
-			if (!redisMonitorInterval) return;
-			clearInterval(redisMonitorInterval);
-			redisMonitorInterval = null;
+			if (redisMonitorInterval) {
+				clearInterval(redisMonitorInterval);
+				redisMonitorInterval = null;
+			}
+			loopLagSampler.stop();
+			if (probeRedis && probeRedis !== redis && probeRedis.status !== "end") {
+				probeRedis.disconnect();
+			}
 		},
-		shouldUseRedis: () => hasConfig && redisAvailabilityState === "healthy",
+		shouldUseRedis: () =>
+			hasConfig &&
+			redis.status === "ready" &&
+			redisAvailabilityState === "healthy",
 		getRedisAvailability: (): RedisAvailabilitySnapshot => ({
 			configured: hasConfig,
 			state: redisAvailabilityState,

--- a/server/tests/integration/others/redis/create-redis-availability.test.ts
+++ b/server/tests/integration/others/redis/create-redis-availability.test.ts
@@ -1,4 +1,8 @@
+/** TDD regression: pre-fix the monitor cancels ioredis recovery after a provider-side close.
+ * Post-fix ioredis retains reconnect ownership and becomes ready when the endpoint returns. */
 import { describe, expect, test } from "bun:test";
+import net from "node:net";
+import { Redis } from "ioredis";
 import {
 	classifyProbe,
 	createRedisAvailability,
@@ -63,11 +67,96 @@ const waitUntil = async (check: () => boolean, timeoutMs: number) => {
 	throw new Error(`Condition not met within ${timeoutMs}ms`);
 };
 
+const startPingRedisServer = async ({ port = 0 }: { port?: number } = {}) => {
+	const sockets = new Set<net.Socket>();
+	const server = net.createServer((socket) => {
+		sockets.add(socket);
+		socket.on("close", () => sockets.delete(socket));
+		socket.on("data", () => socket.write("+PONG\r\n"));
+	});
+
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(port, "127.0.0.1", () => {
+			server.off("error", reject);
+			resolve();
+		});
+	});
+
+	const address = server.address();
+	if (!address || typeof address === "string") {
+		throw new Error("Failed to bind Redis test server");
+	}
+
+	return {
+		port: address.port,
+		stop: async () => {
+			for (const socket of sockets) socket.destroy();
+			await new Promise<void>((resolve, reject) => {
+				server.close((error) => (error ? reject(error) : resolve()));
+			});
+		},
+	};
+};
+
 describe("createRedisAvailability", () => {
+	test("recovers after the provider closes an established connection", async () => {
+		let endpoint = await startPingRedisServer();
+		const port = endpoint.port;
+		const redis = new Redis({
+			host: "127.0.0.1",
+			port,
+			connectTimeout: 250,
+			commandTimeout: 250,
+			disableClientInfo: true,
+			enableReadyCheck: false,
+			retryStrategy: () => 250,
+		});
+		redis.on("error", () => {});
+
+		const disconnectCalls: Array<boolean | undefined> = [];
+		const disconnect = redis.disconnect.bind(redis);
+		redis.disconnect = ((reconnect?: boolean) => {
+			disconnectCalls.push(reconnect);
+			disconnect(reconnect);
+		}) as Redis["disconnect"];
+
+		const availability = createRedisAvailability({
+			redis,
+			hasConfig: true,
+			logPrefix: "RedisV2",
+			logType: "redis_v2_availability_state_set",
+			getEventLoopLagMs: () => 0,
+		});
+
+		try {
+			await waitUntil(() => redis.status === "ready", 2_000);
+			await availability.prime();
+			expect(availability.shouldUseRedis()).toBe(true);
+
+			await endpoint.stop();
+			await waitUntil(() => redis.status === "reconnecting", 2_000);
+			await availability._runTickForTesting();
+
+			await new Promise((resolve) => setTimeout(resolve, 5_100));
+			await waitUntil(() => redis.status === "reconnecting", 2_000);
+			await availability._runTickForTesting();
+
+			endpoint = await startPingRedisServer({ port });
+			await waitUntil(() => redis.status === "ready", 2_000);
+
+			expect(disconnectCalls).not.toContain(false);
+			expect(await redis.ping()).toBe("PONG");
+		} finally {
+			redis.disconnect();
+			await endpoint.stop().catch(() => {});
+		}
+	}, 15_000);
+
 	test("does not start monitoring when Redis is not configured", () => {
 		const originalSetInterval = globalThis.setInterval;
 		let intervalCalls = 0;
-		globalThis.setInterval = ((handler: TimerHandler) => {
+		globalThis.setInterval = ((_handler: TimerHandler) => {
 			intervalCalls++;
 			return 0 as unknown as ReturnType<typeof setInterval>;
 		}) as unknown as typeof setInterval;
@@ -135,7 +224,7 @@ describe("createRedisAvailability", () => {
 		expect(availability.shouldUseRedis()).toBe(true);
 	});
 
-	test("reconnects after repeated probe failures while the client still reports ready", async () => {
+	test("asks ioredis to reconnect after repeated failures while still ready", async () => {
 		const redis = new FakeRedis();
 		const availability = createRedisAvailability({
 			redis: redis as never,
@@ -145,10 +234,11 @@ describe("createRedisAvailability", () => {
 		});
 
 		availability.startMonitor();
-		await waitUntil(() => redis.connectCalls > 0, 22_000);
+		await waitUntil(() => redis.disconnectCalls.includes(true), 22_000);
 		availability.stopMonitor();
 
-		expect(redis.disconnectCalls).toContain(false);
+		expect(redis.disconnectCalls).not.toContain(false);
+		expect(redis.connectCalls).toBe(0);
 	}, 30_000);
 });
 

--- a/server/tests/integration/others/redis/create-redis-availability.test.ts
+++ b/server/tests/integration/others/redis/create-redis-availability.test.ts
@@ -1,4 +1,14 @@
+/**
+ * Regression coverage for Redis monitor connection ownership.
+ *
+ * Before, the monitor eagerly opened its probe, warmed connections serially,
+ * and could disconnect the request client. The monitor now creates an isolated
+ * probe only when started, warms both clients concurrently, and leaves request
+ * reconnects to ioredis.
+ */
 import { describe, expect, test } from "bun:test";
+import net from "node:net";
+import { Redis } from "ioredis";
 import {
 	classifyProbe,
 	createRedisAvailability,
@@ -9,6 +19,7 @@ class FakeRedis {
 	status = "ready";
 	connectCalls = 0;
 	disconnectCalls: Array<boolean | undefined> = [];
+	duplicateCalls = 0;
 	pingCalls = 0;
 
 	async ping() {
@@ -29,12 +40,35 @@ class FakeRedis {
 		this.connectCalls++;
 		this.status = "ready";
 	}
+
+	duplicate(): FakeRedis {
+		this.duplicateCalls++;
+		return this;
+	}
+
+	on() {
+		return this;
+	}
 }
 
 class HealthyFakeRedis extends FakeRedis {
 	override async ping() {
 		this.pingCalls++;
 		return "PONG";
+	}
+}
+
+class BusyRequestRedis extends FakeRedis {
+	readonly probeRedis = new HealthyFakeRedis();
+
+	override async ping() {
+		this.pingCalls++;
+		return "NOPE";
+	}
+
+	override duplicate() {
+		this.duplicateCalls++;
+		return this.probeRedis;
 	}
 }
 
@@ -51,6 +85,15 @@ class ConnectingFakeRedis extends HealthyFakeRedis {
 	}
 }
 
+class DualConnectingRedis extends ConnectingFakeRedis {
+	readonly probeRedis = new ConnectingFakeRedis();
+
+	override duplicate() {
+		this.duplicateCalls++;
+		return this.probeRedis;
+	}
+}
+
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const waitUntil = async (check: () => boolean, timeoutMs: number) => {
@@ -63,11 +106,43 @@ const waitUntil = async (check: () => boolean, timeoutMs: number) => {
 	throw new Error(`Condition not met within ${timeoutMs}ms`);
 };
 
+const startPingRedisServer = async ({ port = 0 }: { port?: number } = {}) => {
+	const sockets = new Set<net.Socket>();
+	const server = net.createServer((socket) => {
+		sockets.add(socket);
+		socket.on("close", () => sockets.delete(socket));
+		socket.on("data", () => socket.write("+PONG\r\n"));
+	});
+
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(port, "127.0.0.1", () => {
+			server.off("error", reject);
+			resolve();
+		});
+	});
+
+	const address = server.address();
+	if (!address || typeof address === "string") {
+		throw new Error("Failed to bind Redis test server");
+	}
+
+	return {
+		port: address.port,
+		stop: async () => {
+			for (const socket of sockets) socket.destroy();
+			await new Promise<void>((resolve, reject) => {
+				server.close((error) => (error ? reject(error) : resolve()));
+			});
+		},
+	};
+};
+
 describe("createRedisAvailability", () => {
 	test("does not start monitoring when Redis is not configured", () => {
 		const originalSetInterval = globalThis.setInterval;
 		let intervalCalls = 0;
-		globalThis.setInterval = ((handler: TimerHandler) => {
+		globalThis.setInterval = ((_handler: TimerHandler) => {
 			intervalCalls++;
 			return 0 as unknown as ReturnType<typeof setInterval>;
 		}) as unknown as typeof setInterval;
@@ -100,6 +175,22 @@ describe("createRedisAvailability", () => {
 		});
 
 		expect(availability.shouldUseRedis()).toBe(false);
+	});
+
+	test("creates the probe connection only when monitoring begins", async () => {
+		const redis = new BusyRequestRedis();
+		const availability = createRedisAvailability({
+			redis: redis as never,
+			hasConfig: true,
+			logPrefix: "RedisV2",
+			logType: "redis_v2_availability_state_set",
+		});
+
+		expect(redis.duplicateCalls).toBe(0);
+
+		await availability.prime();
+
+		expect(redis.duplicateCalls).toBe(1);
 	});
 
 	test("primes healthy after a successful initial probe", async () => {
@@ -135,8 +226,8 @@ describe("createRedisAvailability", () => {
 		expect(availability.shouldUseRedis()).toBe(true);
 	});
 
-	test("reconnects after repeated probe failures while the client still reports ready", async () => {
-		const redis = new FakeRedis();
+	test("waits for the request and probe connections concurrently", async () => {
+		const redis = new DualConnectingRedis();
 		const availability = createRedisAvailability({
 			redis: redis as never,
 			hasConfig: true,
@@ -144,12 +235,95 @@ describe("createRedisAvailability", () => {
 			logType: "redis_v2_availability_state_set",
 		});
 
-		availability.startMonitor();
-		await waitUntil(() => redis.connectCalls > 0, 22_000);
-		availability.stopMonitor();
+		const primePromise = availability.prime();
+		await wait(0);
+		const requestWaitRegistered = redis.readyHandler !== undefined;
+		const probeWaitRegistered = redis.probeRedis.readyHandler !== undefined;
 
-		expect(redis.disconnectCalls).toContain(false);
-	}, 30_000);
+		redis.status = "ready";
+		redis.probeRedis.status = "ready";
+		redis.readyHandler?.();
+		redis.probeRedis.readyHandler?.();
+		await primePromise;
+
+		expect(requestWaitRegistered).toBe(true);
+		expect(probeWaitRegistered).toBe(true);
+		expect(availability.shouldUseRedis()).toBe(true);
+	});
+
+	test("isolates availability probes from the request connection", async () => {
+		const redis = new BusyRequestRedis();
+		const availability = createRedisAvailability({
+			redis: redis as never,
+			hasConfig: true,
+			logPrefix: "RedisV2",
+			logType: "redis_v2_availability_state_set",
+		});
+
+		await availability.prime();
+		for (let index = 0; index < 10; index++) {
+			await availability._runTickForTesting();
+		}
+
+		expect(availability.shouldUseRedis()).toBe(true);
+		expect(redis.pingCalls).toBe(0);
+		expect(redis.probeRedis.pingCalls).toBeGreaterThan(0);
+		expect(redis.disconnectCalls).toEqual([]);
+		expect(redis.connectCalls).toBe(0);
+	});
+
+	test("preserves ioredis reconnect ownership after the endpoint closes", async () => {
+		let endpoint = await startPingRedisServer();
+		const port = endpoint.port;
+		const redis = new Redis({
+			host: "127.0.0.1",
+			port,
+			connectTimeout: 250,
+			commandTimeout: 250,
+			disableClientInfo: true,
+			enableReadyCheck: false,
+			retryStrategy: () => 250,
+		});
+		redis.on("error", () => {});
+
+		const disconnectCalls: Array<boolean | undefined> = [];
+		const disconnect = redis.disconnect.bind(redis);
+		redis.disconnect = ((reconnect?: boolean) => {
+			disconnectCalls.push(reconnect);
+			disconnect(reconnect);
+		}) as Redis["disconnect"];
+
+		const availability = createRedisAvailability({
+			redis,
+			hasConfig: true,
+			logPrefix: "RedisV2",
+			logType: "redis_v2_availability_state_set",
+			getEventLoopLagMs: () => 0,
+		});
+
+		try {
+			await waitUntil(() => redis.status === "ready", 2_000);
+			await availability.prime();
+			expect(availability.shouldUseRedis()).toBe(true);
+
+			await endpoint.stop();
+			await waitUntil(() => redis.status === "reconnecting", 2_000);
+			await availability._runTickForTesting();
+
+			await wait(5_100);
+			await availability._runTickForTesting();
+
+			endpoint = await startPingRedisServer({ port });
+			await waitUntil(() => redis.status === "ready", 2_000);
+
+			expect(disconnectCalls).not.toContain(false);
+			expect(await redis.ping()).toBe("PONG");
+		} finally {
+			availability.stopMonitor();
+			redis.disconnect();
+			await endpoint.stop().catch(() => {});
+		}
+	}, 15_000);
 });
 
 class FlippableFakeRedis extends FakeRedis {


### PR DESCRIPTION
## Summary

- keep ioredis in control of reconnecting after a provider-side connection close
- use `disconnect(true)` only when repeated probe failures occur while the client still reports ready
- add a socket-level regression test covering endpoint loss beyond the old stale threshold and subsequent recovery

## Root cause

During an in-place Dragonfly resize, the provider can close an established connection. ioredis starts its normal reconnect loop, but the availability monitor previously treated a reconnect lasting more than five seconds as stale and called `disconnect(false)` followed by `connect()`. The explicit non-reconnecting disconnect could cancel the client-owned retry lifecycle and leave the process unable to recover when the endpoint returned.

## Impact

Redis-backed features can recover automatically after Dragonfly closes connections during a resize, without restarting the application process.

## Verification

- Redis availability integration suite: 21 passed, 0 failed
- focused reconnect regression using a real ioredis client and TCP endpoint: passed
- server typecheck: passed
- focused Biome check: passed
- `git diff --check`: passed

A real staging Dragonfly in-place resize remains the final provider-level validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps `ioredis` fully in charge of reconnects and isolates health checks on a duplicate client to prevent downtime during Dragonfly in-place resize. Also enables a staging deploy of this branch to validate recovery.

- **Bug Fixes**
  - Remove stale reconnect logic; never force reconnects or call `disconnect(false)`; let `ioredis` handle retries.
  - Run probes on `redis.duplicate()` created when monitoring starts; keep the request client untouched and warm both connections concurrently.
  - Only use Redis when it’s configured, `redis.status === "ready"`, and the state is healthy; add regression tests for provider-close recovery and probe isolation.

- **CI**
  - Add `fix/dragonfly-resize-reconnect` to `STAGING_DEPLOY_BRANCH_ALLOWLIST` to allow staging validation.

<sup>Written for commit 888961b9b4bbe61949ff0e3c7f2a575dc5b6bcb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR preserves automatic Redis recovery when a provider closes an active connection.
- **[Bug fixes]** Moves availability probes to an isolated duplicate Redis connection so monitoring cannot interrupt the request client's reconnect lifecycle.
- **[Bug fixes]** Removes the stale-reconnect override and requires the request client to be ready before Redis-backed features are used.
- **[Improvements]** Adds socket-level regression coverage for endpoint loss and recovery.
- **[Improvements]** Allows the fix branch to deploy to staging for provider-level validation.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/redis/initUtils/createRedisAvailability.ts | Isolates health probes on a duplicate connection, preserves request-client reconnect ownership, and cleans up monitor resources. |
| server/tests/integration/others/redis/create-redis-availability.test.ts | Adds unit and socket-level regression coverage for probe isolation, concurrent warmup, endpoint loss, and recovery. |
| .github/workflows/build.yml | Adds the PR branch to the temporary staging-deployment allowlist. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Monitor as Availability monitor
    participant Probe as Probe Redis client
    participant Request as Request Redis client
    participant Endpoint as Redis endpoint

    Monitor->>Probe: PING
    Probe->>Endpoint: PING
    Endpoint-->>Probe: PONG
    Endpoint--xRequest: Provider closes connection
    Request->>Request: ioredis owns retry lifecycle
    Monitor->>Probe: Continue availability probes
    Endpoint-->>Request: Endpoint becomes available
    Request->>Endpoint: Reconnect automatically
    Request-->>Monitor: Status ready
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge existing PR #2350 history"](https://github.com/useautumn/autumn/commit/888961b9b4bbe61949ff0e3c7f2a575dc5b6bcb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46272197)</sub>

<!-- /greptile_comment -->