### PR TITLE
fix(billing): allow dropped license pools to transition

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/errors/handleLicenseErrors/handleDroppedLicenseErrors.ts
+++ b/server/src/internal/billing/v2/actions/attach/errors/handleLicenseErrors/handleDroppedLicenseErrors.ts
@@ -11,9 +11,7 @@ const licensePlanIdOf = (customerLicense: FullCustomerLicense) =>
 	customerLicense.planLicense?.product.id ??
 	customerLicense.license_internal_product_id;
 
-/** Blocks an immediate switch that would strand active assignments: a used
- * outgoing pool must have a successor (same license plan, or a 1:1 group
- * match) on the incoming plan. */
+/** Blocks ambiguous active assignment mappings; dropped pools release in compute. */
 export const handleDroppedLicenseErrors = ({
 	billingContext,
 }: {
@@ -28,20 +26,18 @@ export const handleDroppedLicenseErrors = ({
 	});
 
 	for (const { outgoingCustomerLicense, reason, group } of unmatched) {
+		if (reason === "dropped") continue;
 		const used = customerLicenseToUsage({
 			customerLicense: outgoingCustomerLicense,
 		});
 		if (used === 0) continue;
 
 		const licensePlanId = licensePlanIdOf(outgoingCustomerLicense);
-		const conflict =
-			reason === "ambiguous"
-				? `the licenses in group "${group}" are not a 1:1 match on the incoming plan`
-				: "the incoming plan drops the license";
 		throw new RecaseError({
 			message:
 				`License changes conflict with active license assignments: ` +
-				`${used} assigned for ${licensePlanId}, but ${conflict}. Release licenses first.`,
+				`${used} assigned for ${licensePlanId}, but the licenses in group "${group}" ` +
+				"are not a 1:1 match on the incoming plan. Release licenses first.",
 			code: ErrCode.InvalidRequest,
 			statusCode: 400,
 		});


### PR DESCRIPTION
## Summary
- allow immediate transitions to drop license pools without blocking
- retain the guard for ambiguous active-license mappings

This unblocks Team → Pro transitions where the incoming plan intentionally removes the team seat pool. Unrelated local work remains stashed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow plan transitions that drop license pools by releasing active seat assignments during sync. This unblocks Team → Pro migrations while still blocking ambiguous 1:1 license mapping conflicts.

- **Bug Fixes**
  - Release active assignments from dropped pools during the immediate sync phase and execute them in `executeAutumnBillingPlan`.
  - Attach handler now skips dropped pools; only ambiguous group mappings block with a clear error.
  - Add `computeCustomerLicenseReleases` and integrate into `computeSyncImmediatePhase` and `computeSyncPlan`.
  - Implement atomic `licenseAssignmentRepo.releaseActiveAssignments` to clear assignments and restore pool `remaining`.
  - Extend `AutumnBillingPlan` with `releaseCustomerLicenseAssignments` (schema in `@autumn/shared`).
  - Add integration test to confirm Team → Pro removes inherited team seats and releases assignments.

<sup>Written for commit 28637a90a672daa44271adfbf2fe9c9296172bd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR allows billing transitions to release assignments from dropped license pools. The main changes are:

- **Bug fixes:** Allows dropped pools through immediate-transition validation.
- **Improvements:** Computes and executes assignment releases during subscription sync.
- **API changes:** Adds the assignment-release payload to the billing-plan schema.
- **Bug fixes:** Adds integration tests for Team-to-Pro sync transitions.
</details>

<h3>Confidence Score: 4/5</h3>

Immediate attach can leave assignments active after their license pool is dropped.

- The sync path creates and executes the required release action.
- The shared attach guard now allows the same transition without adding that action.
- Affected entities can retain stale assignments after the old product expires.

The dropped-license attach guard and immediate attach-plan computation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/attach/errors/handleLicenseErrors/handleDroppedLicenseErrors.ts | Allows dropped pools on immediate attach even though that planner does not create the new release action. |
| server/src/internal/billing/v2/actions/sync/compute/computeSyncImmediatePhase.ts | Collects assignment releases for pools dropped during immediate sync replacements. |
| server/src/internal/billing/v2/compute/customerLicenseTransitions/computeCustomerLicenseReleases.ts | Builds a release payload from outgoing pools with no successor. |
| server/src/internal/licenses/repos/licenseAssignmentRepo.ts | Adds a set-based operation to release active assignments and update released pool balances. |
| server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts | Executes the optional assignment-release action after license transitions. |
| shared/models/billingModels/plan/customerLicensePlan.ts | Defines the customer and pool identifiers required by an assignment release. |
| server/tests/integration/billing/sync/sync-dropped-license-inheritance.test.ts | Covers dropped-pool releases during sync but not the newly allowed immediate attach path. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Immediate plan transition] --> B{Transition path}
    B -->|Sync| C[Compute dropped-pool release]
    C --> D[Release active assignments]
    B -->|Attach| E[Allow dropped pool]
    E --> F[No release action created]
    F --> G[Old assignments remain active]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/billing/v2/actions/attach/errors/handleLicenseErrors/handleDroppedLicenseErrors.ts:29
**Attach Leaves Assignments Active**

An immediate attach that drops a pool with assigned seats now passes this guard, but only the sync planner creates `releaseCustomerLicenseAssignments`. The attach planner handles matched license transitions and has no release action for this unmatched pool, so the old product can expire while its entity assignments remain active.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): allow dropped license pool..."](https://github.com/useautumn/autumn/commit/965bf75d8153468e1180e95d8c7c80394986ca1a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46272203)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->