### PR TITLE
release

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/errors/handleLicenseErrors/handleDroppedLicenseErrors.ts
+++ b/server/src/internal/billing/v2/actions/attach/errors/handleLicenseErrors/handleDroppedLicenseErrors.ts
@@ -11,9 +11,7 @@ const licensePlanIdOf = (customerLicense: FullCustomerLicense) =>
 	customerLicense.planLicense?.product.id ??
 	customerLicense.license_internal_product_id;
 
-/** Blocks an immediate switch that would strand active assignments: a used
- * outgoing pool must have a successor (same license plan, or a 1:1 group
- * match) on the incoming plan. */
+/** Blocks ambiguous active assignment mappings; dropped pools release in compute. */
 export const handleDroppedLicenseErrors = ({
 	billingContext,
 }: {
@@ -28,20 +26,18 @@ export const handleDroppedLicenseErrors = ({
 	});
 
 	for (const { outgoingCustomerLicense, reason, group } of unmatched) {
+		if (reason === "dropped") continue;
 		const used = customerLicenseToUsage({
 			customerLicense: outgoingCustomerLicense,
 		});
 		if (used === 0) continue;
 
 		const licensePlanId = licensePlanIdOf(outgoingCustomerLicense);
-		const conflict =
-			reason === "ambiguous"
-				? `the licenses in group "${group}" are not a 1:1 match on the incoming plan`
-				: "the incoming plan drops the license";
 		throw new RecaseError({
 			message:
 				`License changes conflict with active license assignments: ` +
-				`${used} assigned for ${licensePlanId}, but ${conflict}. Release licenses first.`,
+				`${used} assigned for ${licensePlanId}, but the licenses in group "${group}" ` +
+				"are not a 1:1 match on the incoming plan. Release licenses first.",
 			code: ErrCode.InvalidRequest,
 			statusCode: 400,
 		});

--- a/server/src/internal/catalog/actions/catalogPlanPreflight.ts
+++ b/server/src/internal/catalog/actions/catalogPlanPreflight.ts
@@ -33,6 +33,8 @@ const virtualProduct = ({
 		...(current ?? {}),
 		id,
 		version,
+		prices: current?.prices ?? [],
+		entitlements: current?.entitlements ?? [],
 		archived: archived ?? current?.archived ?? false,
 		internal_id:
 			current?.version === version

--- a/server/tests/integration/licenses/catalog-update/license-catalog-response.test.ts
+++ b/server/tests/integration/licenses/catalog-update/license-catalog-response.test.ts
@@ -3,11 +3,14 @@ import type {
 	CatalogPreviewUpdateResponse,
 	CheckResponseV3,
 } from "@autumn/shared";
+import { CatalogUpdateParamsSchema } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
+import defaultCtx from "@tests/utils/testInitUtils/createTestContext.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
+import { previewUpdateCatalog } from "@/internal/catalog/actions/previewUpdateCatalog/previewUpdateCatalog.js";
 import { listLicenseLinks, listLicensePools } from "../licenseTestUtils.js";
 
 const makeLicenseProduct = () => ({
@@ -63,6 +66,102 @@ test.concurrent(
 				{ plan_id: childId, licenses: [{ license_plan_id: parentId }] },
 			],
 		});
+	},
+);
+
+/** Fresh license plans must be complete FullProducts before customization. */
+test.concurrent(
+	`${chalk.yellowBright("licenses: catalog previews a customized same-batch license plan")}`,
+	async () => {
+		const suffix = Math.random().toString(36).slice(2, 9);
+		const seatId = `license_catalog_seat_${suffix}`;
+		const parentId = `license_catalog_parent_${suffix}`;
+		const standardId = `license_catalog_standard_${suffix}`;
+		const deepId = `license_catalog_deep_${suffix}`;
+		const creditsId = `license_catalog_credits_${suffix}`;
+
+		const params = CatalogUpdateParamsSchema.parse({
+			expand: ["plan_changes.plan"],
+			features: [
+				{
+					feature_id: standardId,
+					name: "Standard Search",
+					type: "metered",
+					consumable: true,
+				},
+				{
+					feature_id: deepId,
+					name: "Deep Search",
+					type: "metered",
+					consumable: true,
+				},
+				{
+					feature_id: creditsId,
+					name: "AI Credits",
+					type: "credit_system",
+					credit_schema: [
+						{ metered_feature_id: standardId, credit_cost: 1 },
+						{ metered_feature_id: deepId, credit_cost: 10 },
+					],
+				},
+			],
+			plans: [
+				{
+					plan_id: seatId,
+					version: 1,
+					name: "Team Seat",
+					licenses: [],
+					group: "",
+					add_on: false,
+					auto_enable: false,
+					items: [
+						{
+							feature_id: creditsId,
+							included: 600,
+							reset: { interval: "month" },
+						},
+					],
+					price: null,
+					free_trial: null,
+				},
+				{
+					plan_id: parentId,
+					version: 1,
+					name: "Team Quarterly",
+					licenses: [
+						{
+							license_plan_id: seatId,
+							included: 0,
+							prepaid_only: true,
+							customize: {
+								price: {
+									amount: 72,
+									interval: "quarter",
+									additional_currencies: [{ currency: "eur", amount: 72 }],
+								},
+							},
+						},
+					],
+					group: "",
+					add_on: false,
+					auto_enable: false,
+					price: null,
+					items: [],
+					free_trial: null,
+				},
+			],
+		});
+		const preview = await previewUpdateCatalog({ ctx: defaultCtx, params });
+
+		expect(preview.plan_changes).toHaveLength(2);
+		expect(preview.plan_changes[1]?.plan?.licenses).toEqual([
+			{
+				license_plan_id: seatId,
+				version: 1,
+				included: 0,
+				prepaid_only: true,
+			},
+		]);
 	},
 );
 

--- a/vite/src/components/forms/shared/UrlSuccessView.tsx
+++ b/vite/src/components/forms/shared/UrlSuccessView.tsx
@@ -46,8 +46,8 @@ export function UrlSuccessView({
 				</Button>
 				<CopyButton
 					text={url}
-					className="w-full"
-					innerClassName="text-xs text-tertiary-foreground font-mono min-w-0 flex-1"
+					className="w-full [&>span]:min-w-0 [&>span]:max-w-full"
+					innerClassName="text-xs text-tertiary-foreground font-mono min-w-0 flex-1 text-left"
 				/>
 			</SheetFooter>
 		</>


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow dropped license pools during plan transitions, normalize virtual license products for previews, and fix long checkout URL truncation in the dashboard.

- Bug Fixes
  - Billing: Only block ambiguous active assignment mappings; dropped pools are released during compute to allow plan changes without manual cleanup.
  - Catalog: Ensure virtual products include default empty `prices` and `entitlements`, enabling customization of same-batch license plans in previews; added an integration test to cover this.
  - Dashboard: Constrain the Copy button wrapper so long checkout URLs are left-aligned and truncate at the end instead of hiding the start.

<sup>Written for commit 7d8f9753c0daf1302bcfe61de25fbc9555f73865. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adjusts license-plan previews and improves URL display behavior. The main changes are:

- **Bug fixes:** Allow dropped license pools to release assignments during computation.
- **Bug fixes:** Initialize required arrays on virtual catalog products.
- **Improvements:** Add coverage for customized same-batch license plans.
- **Improvements:** Improve long URL sizing and alignment in the success view.
</details>

<h3>Confidence Score: 4/5</h3>

The integration-test schema import should use the package entry point that exports it.

- The production changes have concrete handling for dropped pools and complete virtual-product shapes.
- The new test can fail to compile or load when the root shared barrel does not expose the imported schema.

server/tests/integration/licenses/catalog-update/license-catalog-response.test.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/attach/errors/handleLicenseErrors/handleDroppedLicenseErrors.ts | Skips active-assignment errors for intentionally dropped pools while retaining ambiguous-mapping checks. |
| server/src/internal/catalog/actions/catalogPlanPreflight.ts | Adds required empty price and entitlement arrays to fresh virtual products. |
| server/tests/integration/licenses/catalog-update/license-catalog-response.test.ts | Adds same-batch license customization coverage but may import the request schema from the wrong package entry point. |
| vite/src/components/forms/shared/UrlSuccessView.tsx | Adds width constraints and left alignment for long copyable URLs. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/tests/integration/licenses/catalog-update/license-catalog-response.test.ts:6
**Schema Missing From Root Barrel**

The server alias resolves `@autumn/shared` to `shared/index.ts`, while this schema is exposed through the `@autumn/shared/publicApiSchemas` subpath. If the root barrel does not re-export it through another chain, the integration-test target fails to type-check or load.

```suggestion
import { CatalogUpdateParamsSchema } from "@autumn/shared/publicApiSchemas";
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #2351 from useautumn/..."](https://github.com/useautumn/autumn/commit/7d8f9753c0daf1302bcfe61de25fbc9555f73865) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46273829)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->