### PR TITLE
fix(licenses): inherit assignment activity from parents

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/errors/handleLicenseErrors/handleDroppedLicenseErrors.ts
+++ b/server/src/internal/billing/v2/actions/attach/errors/handleLicenseErrors/handleDroppedLicenseErrors.ts
@@ -11,7 +11,7 @@ const licensePlanIdOf = (customerLicense: FullCustomerLicense) =>
 	customerLicense.planLicense?.product.id ??
 	customerLicense.license_internal_product_id;
 
-/** Blocks ambiguous active assignment mappings; dropped pools release in compute. */
+/** Blocks ambiguous mappings; dropped pools inherit their parent's lifecycle. */
 export const handleDroppedLicenseErrors = ({
 	billingContext,
 }: {

--- a/server/src/internal/licenses/repos/licenseAssignmentRepo.ts
+++ b/server/src/internal/licenses/repos/licenseAssignmentRepo.ts
@@ -13,6 +13,7 @@ import {
 	count,
 	desc,
 	eq,
+	exists,
 	inArray,
 	isNotNull,
 	isNull,
@@ -20,9 +21,16 @@ import {
 	or,
 	sql,
 } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 
 export type DbLicenseAssignment = DbCustomerProduct;
+
+const activeCustomerLicense = alias(
+	customerLicenses,
+	"active_customer_license",
+);
+const activeLicenseParent = alias(customerProducts, "active_license_parent");
 
 const assignmentConditions = () => [
 	isNotNull(customerProducts.customer_license_link_id),
@@ -76,7 +84,34 @@ const listAssignmentsWithEntityAndProductByCustomer = async ({
 					: []),
 				...assignmentConditions(),
 				...(activeOnly
-					? [inArray(customerProducts.status, ACTIVE_STATUSES)]
+					? [
+							inArray(customerProducts.status, ACTIVE_STATUSES),
+							exists(
+								db
+									.select({ id: activeCustomerLicense.id })
+									.from(activeCustomerLicense)
+									.innerJoin(
+										activeLicenseParent,
+										eq(
+											activeCustomerLicense.parent_customer_product_id,
+											activeLicenseParent.id,
+										),
+									)
+									.where(
+										and(
+											eq(
+												activeCustomerLicense.link_id,
+												customerProducts.customer_license_link_id,
+											),
+											eq(
+												activeCustomerLicense.internal_customer_id,
+												customerProducts.internal_customer_id,
+											),
+											inArray(activeLicenseParent.status, ACTIVE_STATUSES),
+										),
+									),
+							),
+						]
 					: []),
 				...(entityId ? [eq(entities.id, entityId)] : []),
 				...(licenseInternalProductId

--- a/server/tests/integration/licenses/billing/transitions/immediate-switch/attach-licenses-immediate-switch.test.ts
+++ b/server/tests/integration/licenses/billing/transitions/immediate-switch/attach-licenses-immediate-switch.test.ts
@@ -566,3 +566,118 @@ test.concurrent(
 		});
 	},
 );
+
+test.concurrent(
+	`${chalk.yellowBright("license transitions: dropped pools have no active assignments")}`,
+	async () => {
+		const customerId = "license-transition-dropped-pool";
+		const team = products.base({
+			id: "lic-dropped-team",
+			items: [items.dashboard()],
+		});
+		const pro = products.base({
+			id: "lic-dropped-pro",
+			items: [items.dashboard()],
+		});
+		const teamSeat = products.base({
+			id: "lic-dropped-team-seat",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const { autumnV2_3, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [team, pro, teamSeat] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: team.id,
+					licenseProductId: teamSeat.id,
+					included: 2,
+				}),
+				s.billing.attach({ productId: team.id }),
+				s.licenses.assign({
+					licenseProductId: teamSeat.id,
+					entityIndexes: [0, 1],
+				}),
+			],
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			redirect_mode: "if_required",
+		});
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		expectCustomerLicenses({ customer, licenses: [], count: 0 });
+		const access = await autumnV2_3.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Messages,
+		});
+		expect(access.allowed).toBe(false);
+		const assignments = await listLicenseAssignments({
+			autumn: autumnV2_3,
+			customerId,
+			licensePlanId: teamSeat.id,
+			active: true,
+		});
+		expect(assignments).toHaveLength(0);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("license transitions: matched pools keep assignments active")}`,
+	async () => {
+		const customerId = "license-transition-matched-pool";
+		const planA = products.base({
+			id: "lic-matched-plan-a",
+			items: [items.dashboard()],
+		});
+		const planB = products.base({
+			id: "lic-matched-plan-b",
+			items: [items.dashboard()],
+		});
+		const seat = products.base({
+			id: "lic-matched-seat",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const { autumnV2_3, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [planA, planB, seat] }),
+			],
+			actions: [
+				...[planA, planB].map((parent) =>
+					s.licenses.link({
+						parentProductId: parent.id,
+						licenseProductId: seat.id,
+						included: 2,
+					}),
+				),
+				s.billing.attach({ productId: planA.id }),
+				s.licenses.assign({
+					licenseProductId: seat.id,
+					entityIndexes: [0, 1],
+				}),
+			],
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: planB.id,
+			redirect_mode: "if_required",
+		});
+		const assignments = await listLicenseAssignments({
+			autumn: autumnV2_3,
+			customerId,
+			licensePlanId: seat.id,
+			active: true,
+		});
+		expect(assignments).toHaveLength(entities.length);
+	},
+);


### PR DESCRIPTION
## Summary
- treat a license assignment as active only when its stable pool link has an active parent
- preserve assignments carried across matched license successors
- cover dropped and matched pool transitions end to end

## Validation
- `bunx tsgo --build --noEmit`
- Biome on changed files
- dropped pool regression: pass
- matched successor control: pass
- ambiguous mapping guard: pass
- unused pool transition: pass