### PR TITLE
Hotfix: allow negative auto-topup thresholds

### DIFF
--- a/shared/models/cusModels/billingControls/customerBillingControls.test.ts
+++ b/shared/models/cusModels/billingControls/customerBillingControls.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { AutoTopupSchema } from "./customerBillingControls";
+
+describe("AutoTopupSchema", () => {
+	test("allows a negative balance threshold", () => {
+		expect(
+			AutoTopupSchema.parse({
+				feature_id: "credits",
+				enabled: true,
+				threshold: -350_000,
+				quantity: 350_000,
+			}),
+		).toMatchObject({ threshold: -350_000 });
+	});
+});

--- a/shared/models/cusModels/billingControls/customerBillingControls.ts
+++ b/shared/models/cusModels/billingControls/customerBillingControls.ts
@@ -104,7 +104,7 @@ export const AutoTopupSchema = z.object({
 	enabled: z.boolean().default(false).meta({
 		description: "Whether auto top-up is enabled.",
 	}),
-	threshold: z.number().min(0).meta({
+	threshold: z.number().meta({
 		description:
 			"When the balance drops below this threshold, an auto top-up will be purchased.",
 	}),

--- a/vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx
@@ -161,7 +161,7 @@ export function BillingAutoTopupSheet() {
 			return null;
 		}
 		const parsedThreshold = Number.parseFloat(threshold);
-		if (Number.isNaN(parsedThreshold) || parsedThreshold < 0) {
+		if (Number.isNaN(parsedThreshold)) {
 			toast.error("Please enter a valid threshold");
 			return null;
 		}

--- a/vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts
+++ b/vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts
@@ -51,7 +51,7 @@ const requireNumber = (min: number, message: string) =>
 const AutoTopupFormSchema = z
 	.object({
 		feature_id: z.string().min(1, "Please select a feature"),
-		threshold: requireNumber(0, "Please enter a valid threshold"),
+		threshold: z.number({ message: "Please enter a valid threshold" }),
 		quantity: requireNumber(1, "Please enter a valid quantity"),
 		has_purchase_limit: z.boolean(),
 		purchase_limit_limit: z.number().nullable(),


### PR DESCRIPTION
## Summary
- allow negative auto-topup thresholds in the shared API schema
- remove the matching customer and plan UI validation
- cover negative thresholds with a schema regression test

## Validation
- `bun test shared/models/cusModels/billingControls/customerBillingControls.test.ts`
- `bunx biome check` on changed files
- React Doctor changed-file scan: no issues (92/100)
- server typecheck passes on `dev`; on `main` it is blocked by the existing `LanguageModelV4` / `LanguageModelV3` mismatch in `pricingAgentRouter.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow negative auto-topup balance thresholds end-to-end so teams can trigger top-ups when balances dip below zero. Updates the shared schema and removes blocking UI validation, with a regression test.

- **Bug Fixes**
  - Loosen `AutoTopupSchema.threshold` to `z.number()` (no min).
  - Remove non-negative validation in `BillingAutoTopupSheet` and relax `AutoTopupFormSchema` in `usePlanBillingControlForm`.
  - Add test to cover negative thresholds.

<sup>Written for commit a276dd80ba83a66ca0557a4bfc75e560eaa40415. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR allows auto-top-ups to trigger after a balance becomes negative. The main changes are:

- **API changes · Bug fixes:** Allow negative thresholds in the shared billing schema.
- **Bug fixes:** Remove non-negative checks from the customer and plan forms.
- **Improvements:** Add a schema test for negative thresholds.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The shared schema and both form paths now apply the intended threshold rule consistently.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/models/cusModels/billingControls/customerBillingControls.ts | Removes the minimum-zero constraint from the shared auto-top-up threshold. |
| shared/models/cusModels/billingControls/customerBillingControls.test.ts | Adds a focused test showing that a negative threshold passes schema validation. |
| vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx | Allows the customer form to submit a parsed negative threshold. |
| vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts | Removes the minimum-zero rule from plan form validation. |

<sub>Reviews (1): Last reviewed commit: ["fix(billing): allow negative auto-topup ..."](https://github.com/useautumn/autumn/commit/a276dd80ba83a66ca0557a4bfc75e560eaa40415) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46324012)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->