### PR TITLE
fix: shard async track FIFO message groups

### DIFF
--- a/server/src/internal/balances/track/runAsyncTrack.ts
+++ b/server/src/internal/balances/track/runAsyncTrack.ts
@@ -1,5 +1,6 @@
 import { ErrCode, RecaseError, type TrackParams } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { getAsyncTrackMessageGroupId } from "./utils/getAsyncTrackMessageGroupId.js";
 import { queueTrack } from "./utils/queueTrack.js";
 
 const ASYNC_TRACK_UNAVAILABLE_MESSAGE =
@@ -23,11 +24,20 @@ export const runAsyncTrack = async ({
 			statusCode: 503,
 		});
 	}
+	const messageDeduplicationId = ctx.id;
 
 	const queued = await queueTrack({
 		ctx,
 		body,
 		queueUrl,
+		messageGroupId: getAsyncTrackMessageGroupId({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			customerId: body.customer_id,
+			entityId: body.entity_id,
+			messageDeduplicationId,
+		}),
+		messageDeduplicationId,
 		logFallback: false,
 		markQueuedForReplay: false,
 	});

--- a/server/src/internal/balances/track/runBatchTrack.ts
+++ b/server/src/internal/balances/track/runBatchTrack.ts
@@ -2,6 +2,7 @@ import { type BatchTrackParams, ErrCode, RecaseError } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { JobName } from "@/queue/JobName.js";
 import { addTasksToQueueBatch } from "@/queue/queueUtils.js";
+import { getAsyncTrackMessageGroupId } from "./utils/getAsyncTrackMessageGroupId.js";
 import { getTrackFeatureDeductionsForBody } from "./utils/getFeatureDeductions.js";
 
 const ASYNC_TRACK_UNAVAILABLE_MESSAGE =
@@ -31,19 +32,29 @@ export const runBatchTrack = async ({
 		getTrackFeatureDeductionsForBody({ ctx, body: item });
 	}
 
-	const entries = body.map((item, index) => ({
-		payload: {
-			orgId: ctx.org.id,
-			env: ctx.env,
-			customerId: item.customer_id,
-			entityId: item.entity_id,
-			requestId: ctx.id,
-			apiVersion: ctx.apiVersion.value,
-			body: item,
-		},
-		messageGroupId: `${ctx.org.id}:${ctx.env}:${item.customer_id}:${item.entity_id ?? "none"}`,
-		messageDeduplicationId: `${ctx.id}-${index}`,
-	}));
+	const entries = body.map((item, index) => {
+		const messageDeduplicationId = `${ctx.id}-${index}`;
+
+		return {
+			payload: {
+				orgId: ctx.org.id,
+				env: ctx.env,
+				customerId: item.customer_id,
+				entityId: item.entity_id,
+				requestId: ctx.id,
+				apiVersion: ctx.apiVersion.value,
+				body: item,
+			},
+			messageGroupId: getAsyncTrackMessageGroupId({
+				orgId: ctx.org.id,
+				env: ctx.env,
+				customerId: item.customer_id,
+				entityId: item.entity_id,
+				messageDeduplicationId,
+			}),
+			messageDeduplicationId,
+		};
+	});
 
 	const { successCount, failures } = await addTasksToQueueBatch({
 		jobName: JobName.Track,

--- a/server/src/internal/balances/track/utils/getAsyncTrackMessageGroupId.ts
+++ b/server/src/internal/balances/track/utils/getAsyncTrackMessageGroupId.ts
@@ -1,0 +1,22 @@
+import type { AppEnv } from "@autumn/shared";
+
+const ASYNC_TRACK_SHARD_COUNT = 8n;
+
+export const getAsyncTrackMessageGroupId = ({
+	orgId,
+	env,
+	customerId,
+	entityId,
+	messageDeduplicationId,
+}: {
+	orgId: string;
+	env: AppEnv;
+	customerId: string;
+	entityId?: string;
+	messageDeduplicationId: string;
+}) => {
+	const shard =
+		BigInt(Bun.hash(messageDeduplicationId)) % ASYNC_TRACK_SHARD_COUNT;
+
+	return `${orgId}:${env}:${customerId}:${entityId ?? "none"}:shard-${shard}`;
+};

--- a/server/src/internal/balances/track/utils/queueTrack.ts
+++ b/server/src/internal/balances/track/utils/queueTrack.ts
@@ -9,6 +9,7 @@ export const queueTrack = async ({
 	ctx,
 	body,
 	queueUrl,
+	messageGroupId,
 	messageDeduplicationId,
 	logFallback = true,
 	markQueuedForReplay = true,
@@ -16,6 +17,7 @@ export const queueTrack = async ({
 	ctx: AutumnContext;
 	body: TrackParams;
 	queueUrl?: string;
+	messageGroupId?: string;
 	messageDeduplicationId?: string;
 	logFallback?: boolean;
 	markQueuedForReplay?: boolean;
@@ -32,7 +34,9 @@ export const queueTrack = async ({
 		await addTaskToQueue({
 			jobName: JobName.Track,
 			queueUrl: resolvedQueueUrl,
-			messageGroupId: `${ctx.org.id}:${ctx.env}:${body.customer_id}:${body.entity_id ?? "none"}`,
+			messageGroupId:
+				messageGroupId ??
+				`${ctx.org.id}:${ctx.env}:${body.customer_id}:${body.entity_id ?? "none"}`,
 			messageDeduplicationId: messageDeduplicationId ?? ctx.id,
 			payload: {
 				orgId: ctx.org.id,

--- a/server/tests/unit/balances/track/runAsyncTrack.test.ts
+++ b/server/tests/unit/balances/track/runAsyncTrack.test.ts
@@ -75,9 +75,11 @@ describe("runAsyncTrack", () => {
 		expect(ctx.extraLogs.trackQueuedForReplay).toBeUndefined();
 		expect(mockState.queueCommands[0]).toMatchObject({
 			QueueUrl: trackAsyncQueueUrl,
-			MessageGroupId: "org_123:sandbox:cus_123:none",
 			MessageDeduplicationId: "req_async_1",
 		});
+		expect(mockState.queueCommands[0]?.MessageGroupId).toMatch(
+			/^org_123:sandbox:cus_123:none:shard-[0-7]$/,
+		);
 		expect(
 			JSON.parse(mockState.queueCommands[0]?.MessageBody as string),
 		).toMatchObject({
@@ -87,6 +89,19 @@ describe("runAsyncTrack", () => {
 				body,
 			},
 		});
+	});
+
+	test("uses a deterministic shard derived from the message deduplication ID", async () => {
+		const firstCtx = buildCtx();
+		const secondCtx = buildCtx();
+
+		await runAsyncTrack({ ctx: firstCtx, body });
+		await runAsyncTrack({ ctx: secondCtx, body });
+
+		expect(mockState.queueCommands).toHaveLength(2);
+		expect(mockState.queueCommands[0]?.MessageGroupId).toBe(
+			mockState.queueCommands[1]?.MessageGroupId,
+		);
 	});
 
 	test("throws 503 RecaseError when TRACK_ASYNC_SQS_QUEUE_URL is unset", async () => {

--- a/server/tests/unit/balances/track/runBatchTrack.test.ts
+++ b/server/tests/unit/balances/track/runBatchTrack.test.ts
@@ -139,19 +139,25 @@ describe("runBatchTrack", () => {
 		expect(mockState.queueCommands[0]?.Entries).toHaveLength(3);
 		expect(mockState.queueCommands[0]?.Entries?.[0]).toMatchObject({
 			Id: "0",
-			MessageGroupId: "org_123:sandbox:cus_123:none",
 			MessageDeduplicationId: "req_batch_1-0",
 		});
+		expect(mockState.queueCommands[0]?.Entries?.[0]?.MessageGroupId).toMatch(
+			/^org_123:sandbox:cus_123:none:shard-[0-7]$/,
+		);
 		expect(mockState.queueCommands[0]?.Entries?.[1]).toMatchObject({
 			Id: "1",
-			MessageGroupId: "org_123:sandbox:cus_123:ent_123",
 			MessageDeduplicationId: "req_batch_1-1",
 		});
+		expect(mockState.queueCommands[0]?.Entries?.[1]?.MessageGroupId).toMatch(
+			/^org_123:sandbox:cus_123:ent_123:shard-[0-7]$/,
+		);
 		expect(mockState.queueCommands[0]?.Entries?.[2]).toMatchObject({
 			Id: "2",
-			MessageGroupId: "org_123:sandbox:cus_456:none",
 			MessageDeduplicationId: "req_batch_1-2",
 		});
+		expect(mockState.queueCommands[0]?.Entries?.[2]?.MessageGroupId).toMatch(
+			/^org_123:sandbox:cus_456:none:shard-[0-7]$/,
+		);
 		expect(
 			JSON.parse(mockState.queueCommands[0]?.Entries?.[1]?.MessageBody ?? "{}"),
 		).toMatchObject({
@@ -314,17 +320,29 @@ describe("runBatchTrack", () => {
 		for (const command of mockState.queueCommands) {
 			expect(command.Entries).toHaveLength(10);
 		}
+		const shardIds = new Set(
+			mockState.queueCommands
+				.flatMap((command) => command.Entries ?? [])
+				.map((entry) => entry.MessageGroupId?.split(":").pop()),
+		);
+		expect(shardIds).toEqual(
+			new Set(Array.from({ length: 8 }, (_, index) => `shard-${index}`)),
+		);
 
 		expect(mockState.queueCommands[0]?.Entries?.[0]).toMatchObject({
 			Id: "0",
-			MessageGroupId: "org_123:sandbox:cus_0:none",
 			MessageDeduplicationId: "req_batch_1-0",
 		});
+		expect(mockState.queueCommands[0]?.Entries?.[0]?.MessageGroupId).toMatch(
+			/^org_123:sandbox:cus_0:none:shard-[0-7]$/,
+		);
 		expect(mockState.queueCommands[99]?.Entries?.[9]).toMatchObject({
 			Id: "9",
-			MessageGroupId: "org_123:sandbox:cus_999:none",
 			MessageDeduplicationId: "req_batch_1-999",
 		});
+		expect(mockState.queueCommands[99]?.Entries?.[9]?.MessageGroupId).toMatch(
+			/^org_123:sandbox:cus_999:none:shard-[0-7]$/,
+		);
 	});
 
 	test("rejects empty batch body at schema parse time", () => {


### PR DESCRIPTION
Shards async track FIFO message groups deterministically across eight lanes using the SQS deduplication ID. This applies only to the dedicated async track queue; the fail-open track queue keeps its existing customer/entity grouping.\n\nTests: server typecheck; 16 targeted async track, batch track, and queue track unit tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shard async track SQS FIFO message groups into 8 deterministic lanes using the message deduplication ID to reduce head-of-line blocking and improve throughput. Applies only to the dedicated async track queue; the fail-open queue keeps its existing customer/entity grouping.

- **Bug Fixes**
  - Added `getAsyncTrackMessageGroupId` to hash the dedupe ID into 8 shards; group ID format: `org:env:customer:entity:shard-[0-7]`.
  - Updated `runAsyncTrack` and `runBatchTrack` to set the new `messageGroupId`; `queueTrack` now accepts an optional `messageGroupId`.
  - Expanded unit tests to verify deterministic sharding and coverage across all 8 shards.

<sup>Written for commit 29d61609f8d773cf754d24d8766d1e5b3d61152a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR shards messages on the dedicated async track FIFO queue across eight lanes. The main changes are:

- **Improvements:** Derive an async message group from the SQS deduplication ID.
- **Improvements:** Apply the new grouping to single and batch async track requests.
- **Bug fixes:** Preserve customer and entity grouping for the separate fail-open queue.
- **Improvements:** Add tests for shard format, determinism, and distribution.
</details>

<h3>Confidence Score: 4/5</h3>

The async grouping path can reorder balance-affecting events for the same customer and entity.

- Request-specific shard keys split one ordering domain across independent FIFO groups.
- Single requests and entries within one batch can execute in a different order from enqueue order.
- The fail-open queue retains its previous grouping behavior.

server/src/internal/balances/track/utils/getAsyncTrackMessageGroupId.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/track/utils/getAsyncTrackMessageGroupId.ts | Adds eight-lane hashing based on each message ID, which removes customer and entity FIFO serialization. |
| server/src/internal/balances/track/runAsyncTrack.ts | Routes each dedicated async request using its request ID as the deduplication and shard input. |
| server/src/internal/balances/track/runBatchTrack.ts | Assigns each batch entry a separately hashed lane, allowing entries for one customer and entity to run out of array order. |
| server/src/internal/balances/track/utils/queueTrack.ts | Adds an optional message-group override while retaining the existing fallback for fail-open callers. |
| server/tests/unit/balances/track/runAsyncTrack.test.ts | Updates single-request tests to cover the sharded group format and deterministic hashing. |
| server/tests/unit/balances/track/runBatchTrack.test.ts | Updates batch tests to cover shard formatting and distribution across all eight lanes. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API
    participant A as FIFO shard A
    participant B as FIFO shard B
    participant Worker
    Client->>API: Event 1 for customer/entity
    API->>A: Group from request ID 1
    Client->>API: Event 2 for same customer/entity
    API->>B: Group from request ID 2
    B->>Worker: Event 2 may run first
    A->>Worker: Event 1 may run later
    Note over Worker: Balance operations observe reversed order
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/balances/track/utils/getAsyncTrackMessageGroupId.ts:18-19
**Customer Events Lose FIFO Order**

The shard depends on the per-message deduplication ID, so sequential events for the same customer and entity usually enter different SQS message groups. Workers can then process later requests—or later entries from one batch—before earlier ones, causing order-sensitive balance caps, rejections, and shared-balance deductions to observe the wrong state; the previous group key serialized these events.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🐛 fix(track): shard async FIFO message ..."](https://github.com/useautumn/autumn/commit/29d61609f8d773cf754d24d8766d1e5b3d61152a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46349505)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->