### PR TITLE
Fix/editor bugs variants entity

### DIFF
--- a/server/src/internal/product/actions/updateProduct/validateVariantSettingsUpdate.ts
+++ b/server/src/internal/product/actions/updateProduct/validateVariantSettingsUpdate.ts
@@ -1,6 +1,7 @@
 import {
 	ErrCode,
 	type FullProduct,
+	ProductConfigSchema,
 	type ProductV2,
 	RecaseError,
 	type UpdateProductV2Params,
@@ -63,8 +64,15 @@ const normalizeVariantSettingValue = ({
 	// "" while a description-less plan stores null, which isn't a real change.
 	if (field === "description") return value || null;
 	if (field === "billing_controls") return canonicalizeBillingControls(value);
-	if (["config", "metadata"].includes(field)) {
-		return JSON.stringify(value ?? {});
+	// The read path defaults config through ProductConfigSchema (so the editor
+	// echoes back {ignore_past_due:false}) while the DB stores a bare {}. Parse
+	// both sides so those defaults line up and don't read as a change.
+	if (field === "config") {
+		const parsed = ProductConfigSchema.safeParse(value ?? {});
+		return JSON.stringify(sortDeep(parsed.success ? parsed.data : (value ?? {})));
+	}
+	if (field === "metadata") {
+		return JSON.stringify(sortDeep(value ?? {}));
 	}
 	return value;
 };

--- a/shared/utils/productV2Utils/compareProductUtils/compareItemUtils.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/compareItemUtils.ts
@@ -40,6 +40,7 @@ export const findSimilarItem = ({
 			(i) =>
 				isFeatureItem(i) &&
 				i.feature_id === item.feature_id &&
+				i.entity_feature_id == item.entity_feature_id &&
 				entIntervalsSame({
 					intervalA: {
 						interval: itemToEntInterval({ item: i }),
@@ -58,6 +59,7 @@ export const findSimilarItem = ({
 			(i) =>
 				isFeaturePriceItem(i) &&
 				i.feature_id === item.feature_id &&
+				i.entity_feature_id == item.entity_feature_id &&
 				intervalsSame({
 					intervalA: {
 						interval: itemToBillingInterval({ item: i }),

--- a/vite/src/views/products/plan/components/edit-plan-feature/AdvancedSettings.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/AdvancedSettings.tsx
@@ -7,6 +7,7 @@ import {
 	UsageModel,
 } from "@autumn/shared";
 import { SheetAccordion, SheetAccordionItem } from "@autumn/ui";
+import { useProduct } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import {
 	getFeatureCreditSystem,
@@ -22,6 +23,7 @@ import { UsageLimit } from "./advanced-settings/UsageLimit";
 export function AdvancedSettings() {
 	const { features } = useFeaturesQuery();
 	const { item } = useProductItemContext();
+	const { product } = useProduct();
 
 	if (!item) return null;
 
@@ -32,9 +34,12 @@ export function AdvancedSettings() {
 	// Determine what will show in Advanced section
 	const showUsageLimits = isPriced;
 	const showRollover = hasCreditSystem || usageType === FeatureUsageType.Single;
-	// Deprecated in favor of licenses. Only surface it for items that already
-	// have it set, so existing plans keep working.
-	const showEntityFeature = item.entity_feature_id != null;
+	// Deprecated in favor of licenses. Surface it whenever any item in the plan
+	// uses an entity feature, so all items in such plans keep working.
+	const showEntityFeature =
+		item.entity_feature_id != null ||
+		(product?.items?.some((planItem) => planItem?.entity_feature_id != null) ??
+			false);
 	// Proration shows for prepaid or continuous use features (not consumable + pay-per-use)
 	const showProration =
 		isPriced &&


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes editor/variant bugs to stop false “config updated” changes and correctly handle entity-feature items. Advanced Settings now shows the entity feature option when any plan item uses it.

- **Bug Fixes**
  - Normalize variant `config` with `ProductConfigSchema` and sort defaults to prevent spurious updates; also sort `metadata` before compare.
  - Match items by `entity_feature_id` in compare logic to correctly find similar items.
  - Show Entity Feature settings in Advanced Settings if any item in the plan uses an entity feature, not just the current item.

<sup>Written for commit aad6468addec58c25ceea5a167ebf5a4da208bb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adjusts product editing and comparison behavior for entity-scoped features. The main changes are:

- **Bug fixes:** Normalize product configuration defaults before variant-setting comparison.
- **Bug fixes:** Include entity feature IDs when matching feature and price items.
- **Improvements:** Show entity feature controls across plans that already use entity features.
- **Improvements:** Update the `ai` subproject revision.
</details>

<h3>Confidence Score: 4/5</h3>

The in-place item update path can lose existing IDs when an entity feature setting changes.

- `findSimilarItem` now rejects the existing item after an `entity_feature_id` edit.
- ID backfilling depends on that match, so the update can recreate and retire records instead of updating them.

shared/utils/productV2Utils/compareProductUtils/compareItemUtils.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/product/actions/updateProduct/validateVariantSettingsUpdate.ts | Applies schema defaults and stable key ordering when comparing product configuration. |
| shared/utils/productV2Utils/compareProductUtils/compareItemUtils.ts | Adds entity scope to similar-item matching, which can prevent ID backfilling when an existing item's entity setting changes. |
| vite/src/views/products/plan/components/edit-plan-feature/AdvancedSettings.tsx | Shows entity feature settings when any item in the current plan uses entity scope. |
| ai | Updates the pinned subproject revision. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
shared/utils/productV2Utils/compareProductUtils/compareItemUtils.ts:43
**Entity Change Drops Existing IDs**

When an existing item changes `entity_feature_id`, this predicate makes `findSimilarItem` return no match even though the feature and interval still identify the same edited item. `backfillExistingItemIds` then cannot retain its `entitlement_id`; the update path can treat it as a new row and retire the existing entitlement instead of updating it in place.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix entity feature ids"](https://github.com/useautumn/autumn/commit/aad6468addec58c25ceea5a167ebf5a4da208bb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46349768)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/autumn-org-2/github/useautumn/autumn/-/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))
- Context used - AGENTS.md ([source](https://app.greptile.com/autumn-org-2/github/useautumn/autumn/-/custom-context?memory=e38717a3-e8ad-4054-9219-102b893d3b3c))
- Context used - server/CLAUDE.md ([source](https://app.greptile.com/autumn-org-2/github/useautumn/autumn/-/custom-context?memory=7866843d-5d47-47cf-8270-b04b4f695fd8))
- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
</details>

<!-- /greptile_comment -->