### PR TITLE
test(track): prove async=true does not insert events before queue processing

### DIFF
--- a/scripts/dw/helpers/env-files.ts
+++ b/scripts/dw/helpers/env-files.ts
@@ -119,6 +119,7 @@ export function writeEnvLocalFiles(entry: RegistryEntry): void {
 		serverEnv.CACHE_V2_DRAGONFLY_URL = redisUrl;
 		serverEnv.SQS_QUEUE_URL_V2 = `http://localhost:${elasticMqPort}/000000000000/autumn.fifo`;
 		serverEnv.TRACK_SQS_QUEUE_URL = `http://localhost:${elasticMqPort}/000000000000/autumn-track.fifo`;
+		serverEnv.TRACK_ASYNC_SQS_QUEUE_URL = `http://localhost:${elasticMqPort}/000000000000/autumn-track-async.fifo`;
 	}
 	if (existsSync(portlessCa)) {
 		serverEnv.NODE_EXTRA_CA_CERTS = portlessCa;

--- a/scripts/setup/elasticmq.conf
+++ b/scripts/setup/elasticmq.conf
@@ -25,4 +25,8 @@ queues {
     fifo = true
     contentBasedDeduplication = true
   }
+  "autumn-track-async.fifo" {
+    fifo = true
+    contentBasedDeduplication = true
+  }
 }

--- a/scripts/setup/writeAgentEnv.ts
+++ b/scripts/setup/writeAgentEnv.ts
@@ -62,6 +62,8 @@ REDIS_URL=redis://localhost:6379
 
 # ElasticMQ (local SQS, per-agent isolated queue)
 SQS_QUEUE_URL_V2=http://localhost:9324/000000000000/autumn.fifo
+TRACK_SQS_QUEUE_URL=http://localhost:9324/000000000000/autumn-track.fifo
+TRACK_ASYNC_SQS_QUEUE_URL=http://localhost:9324/000000000000/autumn-track-async.fifo
 AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=x
 AWS_SECRET_ACCESS_KEY=x

--- a/server/tests/integration/balances/track/async/track-async-no-instant-event.test.ts
+++ b/server/tests/integration/balances/track/async/track-async-no-instant-event.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Characterization / regression: async=true track must NOT insert an event
+ * (or mutate balance) on the request path before the track queue worker runs.
+ *
+ * Context: we are seeing production events with empty/null deductions and
+ * wanted to rule out "async track inserts the event optimistically before
+ * processing".
+ *
+ * Expected (current) behavior:
+ *  - POST /track async=true → 202 { success: true }
+ *  - Immediately after: zero persisted events for the customer, balance unchanged
+ *  - After worker + event batch flush: one event WITH deductions, balance reduced
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	events,
+	type TrackParams,
+} from "@autumn/shared";
+import {
+	eventsDb,
+	getCustomerEvents,
+} from "@tests/integration/balances/utils/events/getCustomerEvents.js";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { Decimal } from "decimal.js";
+import { and, desc, eq } from "drizzle-orm";
+
+const EVENT_BATCH_WAIT_MS = 4000;
+const TRACK_VALUE = 7;
+const INCLUDED_USAGE = 100;
+
+test.concurrent(
+	`${chalk.yellowBright("track-async: async=true does not insert an event before the track queue processes")}`,
+	async () => {
+		const customerId = `track-async-no-instant-event-${Date.now()}`;
+		const free = products.base({
+			id: "free",
+			items: [items.monthlyMessages({ includedUsage: INCLUDED_USAGE })],
+		});
+
+		const { autumnV1, autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [free] }),
+			],
+			actions: [s.attach({ productId: free.id })],
+		});
+
+		const before = (await autumnV2_2.customers.get(
+			customerId,
+		)) as ApiCustomerV5;
+		expectBalanceCorrect({
+			customer: before,
+			featureId: TestFeature.Messages,
+			remaining: INCLUDED_USAGE,
+			usage: 0,
+			planId: free.id,
+		});
+
+		const trackParams = {
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: TRACK_VALUE,
+			async: true,
+		} satisfies TrackParams;
+
+		// Use raw fetch so we can assert HTTP 202 (AutumnInt.track swallows status).
+		const response = await fetch(`${autumnV1["baseUrl"]}/track`, {
+			method: "POST",
+			headers: autumnV1["headers"],
+			body: JSON.stringify(trackParams),
+		});
+
+		expect(response.status).toBe(202);
+		expect(await response.json()).toEqual({ success: true });
+
+		// ---- Immediate assertions: request path must not have written an event
+		// or deducted balance. No sleep — this is the whole point of the test.
+		const eventsImmediately = await getCustomerEvents({ customerId });
+		expect(eventsImmediately).toHaveLength(0);
+
+		const immediatelyAfter = (await autumnV2_2.customers.get(
+			customerId,
+		)) as ApiCustomerV5;
+		expectBalanceCorrect({
+			customer: immediatelyAfter,
+			featureId: TestFeature.Messages,
+			remaining: INCLUDED_USAGE,
+			usage: 0,
+			planId: free.id,
+		});
+
+		// ---- Eventually the track worker + event batcher should land the event
+		// with deductions and apply the balance mutation.
+		await timeout(EVENT_BATCH_WAIT_MS);
+
+		const customer = (await autumnV2_2.customers.get(customerId, {
+			with_autumn_id: true,
+		})) as ApiCustomerV5 & { autumn_id?: string };
+		const internalCustomerId = customer.autumn_id;
+		expect(internalCustomerId).toBeDefined();
+
+		const eventRows = await eventsDb()
+			.select({
+				id: events.id,
+				event_name: events.event_name,
+				value: events.value,
+				deductions: events.deductions,
+			})
+			.from(events)
+			.where(
+				and(
+					eq(events.org_id, ctx.org.id),
+					eq(events.env, ctx.env),
+					eq(events.internal_customer_id, internalCustomerId as string),
+				),
+			)
+			.orderBy(desc(events.created_at))
+			.limit(5);
+
+		expect(eventRows.length).toBeGreaterThan(0);
+		const latest = eventRows[0];
+		expect(latest.value).toBe(TRACK_VALUE);
+		expect(latest.event_name).toBe(TestFeature.Messages);
+		expect(latest.deductions).not.toBeNull();
+		expect(latest.deductions ?? []).toHaveLength(1);
+		expect(latest.deductions?.[0]?.feature_id).toBe(TestFeature.Messages);
+		expect(latest.deductions?.[0]?.value).toBe(TRACK_VALUE);
+
+		const afterWorker = (await autumnV2_2.customers.get(
+			customerId,
+		)) as ApiCustomerV5;
+		expectBalanceCorrect({
+			customer: afterWorker,
+			featureId: TestFeature.Messages,
+			remaining: new Decimal(INCLUDED_USAGE).sub(TRACK_VALUE).toNumber(),
+			usage: TRACK_VALUE,
+			planId: free.id,
+		});
+	},
+);

--- a/server/tests/integration/balances/track/async/track-async-no-instant-event.test.ts
+++ b/server/tests/integration/balances/track/async/track-async-no-instant-event.test.ts
@@ -4,12 +4,19 @@
  *
  * Context: we are seeing production events with empty/null deductions and
  * wanted to rule out "async track inserts the event optimistically before
- * processing".
+ * processing". Live check confirmed request-path insert does NOT happen;
+ * empty deductions still appear *after* the worker when there is nothing to
+ * deduct (e.g. no entitlements) — same as sync track. See also
+ * track-unlimited-cusEnt-attribution for another empty-deductions path.
  *
- * Expected (current) behavior:
+ * Expected (current) behavior with an attached metered plan:
  *  - POST /track async=true → 202 { success: true }
  *  - Immediately after: zero persisted events for the customer, balance unchanged
  *  - After worker + event batch flush: one event WITH deductions, balance reduced
+ *
+ * Companion unit proof (no Stripe needed):
+ *  server/tests/unit/balances/track/handle-track.test.ts
+ *  "async=true queues only — does not insert/batch an event on the request path"
  */
 
 import { expect, test } from "bun:test";

--- a/server/tests/unit/balances/track/handle-track.test.ts
+++ b/server/tests/unit/balances/track/handle-track.test.ts
@@ -1,8 +1,10 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { ApiVersion, ApiVersionClass, AppEnv } from "@autumn/shared";
 import type { SQSClient } from "@aws-sdk/client-sqs";
 import { Hono } from "hono";
 import type { AutumnContext, HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { EventService } from "@/internal/api/events/EventService.js";
+import { globalEventBatchingManager } from "@/internal/balances/events/EventBatchingManager.js";
 import { getSqsClient } from "@/queue/initSqs.js";
 
 const trackAsyncQueueUrl =
@@ -85,5 +87,32 @@ describe("handleTrack", () => {
 			QueueUrl: trackAsyncQueueUrl,
 			MessageDeduplicationId: "req_track_1",
 		});
+	});
+
+	test("async=true queues only — does not insert/batch an event on the request path", async () => {
+		const addEventSpy = spyOn(globalEventBatchingManager, "addEvent");
+		const insertSpy = spyOn(EventService, "insert");
+
+		try {
+			const response = await createApp({ ctx: createCtx() }).request("/track", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					customer_id: "cus_123",
+					feature_id: "messages",
+					value: 7,
+					async: true,
+				}),
+			});
+
+			expect(response.status).toBe(202);
+			expect(await response.json()).toEqual({ success: true });
+			expect(mockState.queueCommands).toHaveLength(1);
+			expect(addEventSpy).not.toHaveBeenCalled();
+			expect(insertSpy).not.toHaveBeenCalled();
+		} finally {
+			addEventSpy.mockRestore();
+			insertSpy.mockRestore();
+		}
 	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds an integration characterization test for `track` with `async: true`: **no event / no balance mutation immediately after 202**, then after the worker + batcher an event should land **with deductions**.
- Extends `handleTrack` unit coverage to spy on `EventBatchingManager.addEvent` and `EventService.insert` — async request path only queues SQS.
- Wires `TRACK_ASYNC_SQS_QUEUE_URL` / `autumn-track-async.fifo` into local agent ElasticMQ + `writeAgentEnv` / `dw` env helpers.

## Findings (ran locally)
1. **No optimistic insert.** Unit test green; live probe also saw `events_immediate=0` after `202`.
2. **Empty deductions are not caused by async insert timing.** After the worker ran (and also for sync track), a customer with **no entitlements** still got an event with `deductions = null` / empty `internal_product_id`. Same symptom as the existing unlimited-cusEnt attribution path.

## Test plan
- [x] `bunx tsgo --build --noEmit` in `server/`
- [x] `bun test server/tests/unit/balances/track/handle-track.test.ts` — 2 pass
- [ ] Full integration file needs Stripe-linked test org (`initScenario` attach); not runnable in this cloud env without `STRIPE_SANDBOX_SECRET_KEY`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1784737642386509?thread_ts=1784737642.386509&cid=C0BCAQQK0KS)

<div><a href="https://cursor.com/agents/bc-685507ed-2801-5c5f-99f0-3e401ad002be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-685507ed-2801-5c5f-99f0-3e401ad002be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds integration and unit tests proving `track` with `async: true` only queues SQS (returns 202) and does not insert or batch events on the request path; the event is created with deductions and the balance updates only after the worker runs. Wires `TRACK_SQS_QUEUE_URL`, `TRACK_ASYNC_SQS_QUEUE_URL`, and the `autumn-track-async.fifo` queue into local ElasticMQ and env helpers for local and VM testing.

<sup>Written for commit 92657e7754f5162ea567dbf9ff8adc809b2dbff6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

