### PR TITLE
fix variant selector checkbox

### DIFF
--- a/vite/src/views/products/plan/versioning/PropagationTargetsStep.tsx
+++ b/vite/src/views/products/plan/versioning/PropagationTargetsStep.tsx
@@ -51,7 +51,7 @@ export function PropagationTargetsStep({
 					return (
 						<button
 							className={cn(
-								"flex items-center gap-3 rounded-xl bg-secondary/40 px-3 py-2.5 text-left ring-1 transition-colors",
+								"flex items-center gap-3 rounded-xl bg-secondary/40 px-3 py-2.5 text-left ring-1 transition-colors cursor-pointer",
 								checked
 									? "ring-primary"
 									: "ring-transparent hover:bg-secondary/60",
@@ -60,7 +60,7 @@ export function PropagationTargetsStep({
 							onClick={() => onToggle(target.id)}
 							type="button"
 						>
-							<Checkbox checked={checked} />
+							<Checkbox checked={checked} className="pointer-events-none" />
 							<div className="flex min-w-0 flex-1 items-baseline gap-2">
 								<span className="text-sm font-medium text-foreground">
 									{target.name}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the variant selector checkbox so clicking anywhere on the row toggles selection reliably. Adds a pointer cursor to the row and disables pointer events on the Checkbox to prevent missed or double clicks.

<sup>Written for commit e682f2339dc24f28cb380fbe1143455b5ca2c1f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes propagation target rows respond consistently to pointer input. The main changes are:

- **Bug fixes:** Routes checkbox clicks to the enclosing target-row toggle.
- **Improvements:** Shows a pointer cursor over selectable target rows.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The checkbox is a controlled indicator, while the enclosing button owns the toggle action.
- No blocking issues were found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/versioning/PropagationTargetsStep.tsx | Adds a pointer cursor to target rows and directs checkbox pointer events to the enclosing toggle button. |

<sub>Reviews (1): Last reviewed commit: ["fix variant selector checkbox"](https://github.com/useautumn/autumn/commit/e682f2339dc24f28cb380fbe1143455b5ca2c1f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46366068)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->