### PR TITLE
perf(customers): scope plan filters to organization

### DIFF
--- a/server/src/internal/customers/CusSearchService.ts
+++ b/server/src/internal/customers/CusSearchService.ts
@@ -64,26 +64,45 @@ const productFields = {
 	is_add_on: products.is_add_on,
 };
 
-const dashboardProductFilterToDrizzleSql = (
-	filter: DashboardProductVersionFilter,
-) =>
+const dashboardProductFilterToDrizzleSql = ({
+	filter,
+	orgId,
+	env,
+}: {
+	filter: DashboardProductVersionFilter;
+	orgId: string;
+	env: AppEnv;
+}) =>
 	and(
 		isCustomDashboardProductFilter(filter)
 			? and(
 					eq(customerProducts.product_id, filter.productId),
 					eq(customerProducts.is_custom, true),
 				)
-			: and(eq(products.id, filter.productId), eq(products.version, filter.version)),
+			: and(
+					eq(products.org_id, orgId),
+					eq(products.env, env),
+					eq(products.id, filter.productId),
+					eq(products.version, filter.version),
+				),
 	);
 
-const dashboardProductFilterToRawSql = (
-	filter: DashboardProductVersionFilter,
-) =>
+const dashboardProductFilterToRawSql = ({
+	filter,
+	orgId,
+	env,
+}: {
+	filter: DashboardProductVersionFilter;
+	orgId: string;
+	env: AppEnv;
+}) =>
 	isCustomDashboardProductFilter(filter)
 		? sql`(${customerProducts.product_id} = ${filter.productId} AND ${customerProducts.is_custom} = true)`
-		: sql`(${products.id} = ${filter.productId} AND ${products.version} = ${filter.version})`;
+		: sql`(${products.org_id} = ${orgId} AND ${products.env} = ${env} AND ${products.id} = ${filter.productId} AND ${products.version} = ${filter.version})`;
 
-const dashboardIntervalFilterToRawSql = (intervals: DashboardIntervalFilter[]) =>
+const dashboardIntervalFilterToRawSql = (
+	intervals: DashboardIntervalFilter[],
+) =>
 	sql`EXISTS (
 		SELECT 1
 		FROM customer_prices cpr_interval
@@ -195,7 +214,9 @@ export class CusSearchService {
 			// New product:version filtering
 			productVersionFilters.length > 0
 				? or(
-						...productVersionFilters.map(dashboardProductFilterToDrizzleSql),
+						...productVersionFilters.map((filter) =>
+							dashboardProductFilterToDrizzleSql({ filter, orgId, env }),
+						),
 					)
 				: undefined,
 			// Legacy product filtering (fallback)
@@ -1032,7 +1053,9 @@ const buildSearchPredicates = ({
 	const versionRaw =
 		productVersionFilters.length > 0
 			? sql`(${sql.join(
-					productVersionFilters.map(dashboardProductFilterToRawSql),
+					productVersionFilters.map((filter) =>
+						dashboardProductFilterToRawSql({ filter, orgId, env }),
+					),
 					sql` OR `,
 				)})`
 			: null;
@@ -1068,7 +1091,9 @@ const buildSearchPredicates = ({
 	const filtersDrizzle = and(
 		productVersionFilters.length > 0
 			? or(
-					...productVersionFilters.map(dashboardProductFilterToDrizzleSql),
+					...productVersionFilters.map((filter) =>
+						dashboardProductFilterToDrizzleSql({ filter, orgId, env }),
+					),
 				)
 			: undefined,
 		intervalFilters.length > 0

--- a/server/tests/unit/customers/dashboard-product-filter.test.ts
+++ b/server/tests/unit/customers/dashboard-product-filter.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { sql } from "drizzle-orm";
+import { AppEnv } from "@autumn/shared";
+import { type SQL, sql } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { CusSearchService } from "@/internal/customers/CusSearchService.js";
 import {
 	getCustomerListFilterSql,
 	parseDashboardVersionFilter,
@@ -56,5 +59,29 @@ describe("dashboard product filters", () => {
 		expect(normalized).toContain("p_dash.version = $4");
 		expect(normalized).toContain("cp_dash.is_custom = true");
 		expect(params).toEqual(["active", "past_due", "pro", 2, "pro"]);
+	});
+
+	/** Red: numbered plan search joined globally; green: products are scoped to the requesting org and environment. */
+	test("numbered plan cursor lookup scopes the product join", async () => {
+		let capturedQuery: ReturnType<PgDialect["sqlToQuery"]> | undefined;
+		const db = {
+			execute: async (query: SQL) => {
+				capturedQuery = dialect.sqlToQuery(query);
+				return [];
+			},
+		} as unknown as DrizzleCli;
+
+		await CusSearchService.resolveInternalIdsByCursor({
+			db,
+			orgId: "org_target",
+			env: AppEnv.Live,
+			search: "",
+			filters: { version: ["enterprise:1"] },
+			limit: 50,
+		});
+
+		const query = normalize(capturedQuery!.sql);
+		expect(query).toContain('"products"."org_id" =');
+		expect(query).toContain('"products"."env" =');
 	});
 });


### PR DESCRIPTION
## Summary
- scope numbered dashboard plan filters by organization and environment
- allow the existing `(org_id, env, id, version)` product index to serve customer lookup queries
- add regression coverage for the generated cursor query

## Context
Axiom traces for Resend showed `enterprise:1` customer filtering spending 40–67 seconds resolving customer IDs because the product lookup considered matching plan IDs across all organizations.

## Verification
- `bunx tsgo --build --noEmit`
- `./run.sh server/tests/unit/customers/dashboard-product-filter.test.ts` (4 passed)
- `bun test tests/unit/customers` (86 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope numbered dashboard plan filters to the requesting organization and environment so customer searches hit the existing `(org_id, env, id, version)` product index. Eliminates cross-org matches that caused 40–67s lookups and adds regression coverage for the cursor query.

<sup>Written for commit c36a8eb5670fd8538566e2a04c0e12e8006847aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR narrows numbered plan filtering to the requesting organization and environment. The main changes are:

- **Improvements:** Add organization and environment predicates to numbered product filters.
- **Bug fixes:** Prevent product lookup from considering matching plan IDs across organizations.
- **Improvements:** Add a cursor-query test for the generated scope predicates.
</details>

<h3>Confidence Score: 5/5</h3>

This looks mergeable after isolating the unit test from production config initialization.

- The query scope is applied consistently across the changed SQL builders.
- The new service import can start an S3-backed config store before the test runs.

server/tests/unit/customers/dashboard-product-filter.test.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/CusSearchService.ts | Scopes numbered product predicates by organization and environment in the Drizzle and raw SQL paths. |
| server/tests/unit/customers/dashboard-product-filter.test.ts | Adds cursor-query coverage but imports a service whose dependency chain starts production configuration during module loading. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/tests/unit/customers/dashboard-product-filter.test.ts:6
**Production Config Starts During Import**

Importing `CusSearchService` also loads `orgLimitsStore`, which creates and registers an S3-backed polling store during module evaluation. In unit-test environments without the required runtime configuration, that initialization can fail before this test reaches the mocked database call.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(customers): ⚡️ scope plan filters t..."](https://github.com/useautumn/autumn/commit/c36a8eb5670fd8538566e2a04c0e12e8006847aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46377910)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->