### PR TITLE
test(track): fix async tracking assertions

### DIFF
--- a/server/tests/unit/balances/track/batch-track-retry-dedup.test.ts
+++ b/server/tests/unit/balances/track/batch-track-retry-dedup.test.ts
@@ -141,7 +141,10 @@ describe("runBatchTrack — retry-dedup regression pin (cubic P1)", () => {
 	});
 
 	test("two requests with the same body produce DIFFERENT MessageDeduplicationId values per index (current accepted behavior — client retry duplicates)", async () => {
-		await runBatchTrack({ ctx: buildCtx({ requestId: "req_pin_first" }), body });
+		await runBatchTrack({
+			ctx: buildCtx({ requestId: "req_pin_first" }),
+			body,
+		});
 		const firstCall = mockState.queueCommands[0];
 		mockState.queueCommands = [];
 
@@ -200,7 +203,7 @@ describe("runBatchTrack — retry-dedup regression pin (cubic P1)", () => {
 		});
 	});
 
-	test("MessageGroupId is `${orgId}:${env}:${customerId}:${entityId ?? 'none'}` for each item", async () => {
+	test("MessageGroupId preserves the org, environment, customer, and entity routing prefix", async () => {
 		const ctx = buildCtx({ requestId: "req_pin_group" });
 
 		await runBatchTrack({ ctx, body });
@@ -208,10 +211,14 @@ describe("runBatchTrack — retry-dedup regression pin (cubic P1)", () => {
 		const entries = mockState.queueCommands[0]?.Entries ?? [];
 		expect(entries).toHaveLength(3);
 
-		expect(entries[0]?.MessageGroupId).toBe("org_pin:sandbox:cus_pin_a:none");
-		expect(entries[1]?.MessageGroupId).toBe(
+		expect(entries[0]?.MessageGroupId).toStartWith(
+			"org_pin:sandbox:cus_pin_a:none",
+		);
+		expect(entries[1]?.MessageGroupId).toStartWith(
 			"org_pin:sandbox:cus_pin_b:ent_pin_1",
 		);
-		expect(entries[2]?.MessageGroupId).toBe("org_pin:sandbox:cus_pin_c:none");
+		expect(entries[2]?.MessageGroupId).toStartWith(
+			"org_pin:sandbox:cus_pin_c:none",
+		);
 	});
 });

--- a/server/tests/unit/balances/track/handle-track-tokens.test.ts
+++ b/server/tests/unit/balances/track/handle-track-tokens.test.ts
@@ -1,16 +1,9 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
-	afterEach,
-	beforeEach,
-	describe,
-	expect,
-	mock,
-	test,
-} from "bun:test";
-import {
-	ApiVersion,
 	ApiVersionClass,
 	AppEnv,
 	FeatureType,
+	LATEST_VERSION,
 } from "@autumn/shared";
 import type { SQSClient } from "@aws-sdk/client-sqs";
 import { Hono } from "hono";
@@ -114,7 +107,7 @@ const createCtx = (): AutumnContext =>
 		id: "req_track_tokens_1",
 		org: { id: "org_123" },
 		env: AppEnv.Sandbox,
-		apiVersion: new ApiVersionClass(ApiVersion.V2_1),
+		apiVersion: new ApiVersionClass(LATEST_VERSION),
 		features: [{ id: "ai_credits", type: FeatureType.AiCreditSystem }],
 		extraLogs: {},
 		scopes: [],

--- a/server/tests/unit/balances/track/handle-track.test.ts
+++ b/server/tests/unit/balances/track/handle-track.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { ApiVersion, ApiVersionClass, AppEnv } from "@autumn/shared";
+import { ApiVersionClass, AppEnv, LATEST_VERSION } from "@autumn/shared";
 import type { SQSClient } from "@aws-sdk/client-sqs";
 import { Hono } from "hono";
 import type { AutumnContext, HonoEnv } from "@/honoUtils/HonoEnv.js";
@@ -20,7 +20,7 @@ const createCtx = (): AutumnContext =>
 		id: "req_track_1",
 		org: { id: "org_123" },
 		env: AppEnv.Sandbox,
-		apiVersion: new ApiVersionClass(ApiVersion.V2_1),
+		apiVersion: new ApiVersionClass(LATEST_VERSION),
 		features: [{ id: "messages" }],
 		extraLogs: {},
 		scopes: [],


### PR DESCRIPTION
## Summary
- exercise async track handlers with the latest API version
- keep retry-dedup routing assertions compatible with FIFO sharding

## Verification
- `bun test tests/unit/balances/track/handle-track.test.ts tests/unit/balances/track/handle-track-tokens.test.ts tests/unit/balances/track/batch-track-retry-dedup.test.ts`
- `bun ts`
- full unit suite: 1,868 passed; 5 unrelated existing RevenueCat/test-store failures

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update tracking unit tests to run against the latest API version and stabilize FIFO routing assertions for async handlers. This fixes flakiness and keeps retry/dedup behavior validated.

- **Bug Fixes**
  - Use `LATEST_VERSION` with `ApiVersionClass` from `@autumn/shared` in `handle-track` tests.
  - Relax `MessageGroupId` checks to `toStartWith` the org/env/customer/entity prefix, making them compatible with FIFO sharding.

<sup>Written for commit 9176956c74036229ac907cf2cfbf6d91e92fca6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates async tracking tests to match the current API and FIFO routing behavior.

- **Improvements:** Run handler tests with `LATEST_VERSION`.
- **Bug fixes:** Accept FIFO shard suffixes while checking the stable routing prefix.
- **Improvements:** Reformat one retry-dedup test call.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/tests/unit/balances/track/batch-track-retry-dedup.test.ts | Checks the stable FIFO routing prefix while allowing the production sharding suffix. |
| server/tests/unit/balances/track/handle-track-tokens.test.ts | Updates the token tracking context to use the latest supported API version. |
| server/tests/unit/balances/track/handle-track.test.ts | Updates the async tracking context to exercise the latest API validation path. |

<sub>Reviews (1): Last reviewed commit: ["test(track): fix async tracking assertio..."](https://github.com/useautumn/autumn/commit/9176956c74036229ac907cf2cfbf6d91e92fca6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46381334)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->