### PR TITLE
route Axiom logs through FireLens

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   #   staging repo (autumn-staging) -> us-east-1
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix feat/firelens-log-transport
 
 jobs:
   checks:

--- a/server/.env.example
+++ b/server/.env.example
@@ -56,6 +56,8 @@ RESEND_DOMAIN=
 # AXIOM
 # This will send pino and Open Telemetry logs to https://axiom.co/
 AXIOM_TOKEN=
+# firelens activates only in ECS; other runtimes retain the direct transport.
+AXIOM_LOG_TRANSPORT=direct
 
 # SVIX
 # This will enable webhooks using Svix: https://www.svix.com

--- a/server/src/utils/logging/initLogger.ts
+++ b/server/src/utils/logging/initLogger.ts
@@ -163,15 +163,22 @@ const createConsoleJsonStream = () =>
  */
 export type InitLoggerOptions = {
 	mode?: "default" | "dual";
+	transport?: "direct" | "firelens";
 };
 
 export const initLogger = (options: InitLoggerOptions = {}) => {
-	const { mode = "default" } = options;
+	const { mode = "default", transport } = options;
 
 	const streams: pino.StreamEntry[] = [];
 	const isDev = process.env.NODE_ENV === "development";
 	const isTest = process.env.NODE_ENV === "test";
 	const isDevOrTest = isDev || isTest;
+	const configuredTransport =
+		transport ??
+		(process.env.AXIOM_LOG_TRANSPORT === "firelens" ? "firelens" : "direct");
+	const isRunningInEcs = Boolean(process.env.ECS_CONTAINER_METADATA_URI_V4);
+	const shouldUseFirelens =
+		configuredTransport === "firelens" && !isDevOrTest && isRunningInEcs;
 
 	if (mode === "dual") {
 		streams.push({
@@ -181,9 +188,11 @@ export const initLogger = (options: InitLoggerOptions = {}) => {
 						trailingNewline: false,
 						useConsoleLog: true,
 					})
-				: createConsoleJsonStream(),
+				: shouldUseFirelens
+					? process.stdout
+					: createConsoleJsonStream(),
 		});
-		if (process.env.AXIOM_TOKEN) {
+		if (!shouldUseFirelens && process.env.AXIOM_TOKEN) {
 			streams.push({
 				level: "info",
 				stream: pino.transport({
@@ -204,7 +213,12 @@ export const initLogger = (options: InitLoggerOptions = {}) => {
 			});
 		}
 
-		if (process.env.AXIOM_TOKEN) {
+		if (shouldUseFirelens) {
+			streams.push({
+				level: "info",
+				stream: process.stdout,
+			});
+		} else if (process.env.AXIOM_TOKEN) {
 			streams.push({
 				level: "info",
 				stream: pino.transport({

--- a/server/tests/unit/logging/firelens-config.test.ts
+++ b/server/tests/unit/logging/firelens-config.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Contract: FireLens parses Pino's JSON envelope, sends structured records to
+ * `express`, keeps console records in `ecs`, and bounds retries and re-emission.
+ */
+
+import { expect, test } from "bun:test";
+import path from "node:path";
+
+test.concurrent(
+	"FireLens separates structured and console log datasets",
+	async () => {
+		const configPath = path.resolve(
+			import.meta.dir,
+			"../../../../firelens.conf",
+		);
+		const config = await Bun.file(configPath).text();
+
+		expect(config).toContain("Parsers_File /fluent-bit/etc/parsers.conf");
+		expect(config).not.toContain("[PARSER]");
+		expect(config).toContain("Key_Name log");
+		expect(config).toContain("Parser json");
+		expect(config).toContain("Reserve_Data On");
+		expect(config).toContain(
+			"Rule $level ^(TRACE|DEBUG|INFO|WARN|ERROR|FATAL)$ axiom_express false",
+		);
+		expect(config).toContain("Emitter_Mem_Buf_Limit 10M");
+		expect(config).toContain("URI /v1/ingest/express");
+		expect(config).toContain("URI /v1/ingest/ecs");
+		expect(config.match(/retry_limit 5/g)).toHaveLength(2);
+		expect(config).not.toMatch(/\[OUTPUT\]\s+Name http\s+Match \*(?:\s|$)/);
+	},
+);

--- a/server/tests/unit/logging/init-logger-transport.test.ts
+++ b/server/tests/unit/logging/init-logger-transport.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Contract: FireLens mode writes complete Pino JSON to stdout without creating
+ * an Axiom transport, while direct mode retains the existing Axiom transport.
+ */
+
+import { expect, spyOn, test } from "bun:test";
+import { Writable } from "node:stream";
+import pino from "pino";
+import { initLogger } from "@/utils/logging/initLogger.js";
+
+test("logger selects FireLens without changing structured records", () => {
+	const previousNodeEnv = process.env.NODE_ENV;
+	const previousAxiomToken = process.env.AXIOM_TOKEN;
+	const previousLogTransport = process.env.AXIOM_LOG_TRANSPORT;
+	const previousEcsMetadataUri = process.env.ECS_CONTAINER_METADATA_URI_V4;
+	const stdoutChunks: string[] = [];
+	const directChunks: string[] = [];
+	const directStream = new Writable({
+		write(chunk, _encoding, callback) {
+			directChunks.push(chunk.toString());
+			callback();
+		},
+	});
+	const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(
+		(chunk: string | Uint8Array) => {
+			stdoutChunks.push(chunk.toString());
+			return true;
+		},
+	);
+	const transportSpy = spyOn(pino, "transport").mockReturnValue(
+		directStream as ReturnType<typeof pino.transport>,
+	);
+
+	try {
+		process.env.NODE_ENV = "production";
+		process.env.AXIOM_TOKEN = "test-token";
+		process.env.AXIOM_LOG_TRANSPORT = "firelens";
+		process.env.ECS_CONTAINER_METADATA_URI_V4 = "http://169.254.170.2/v4/test";
+
+		const firelensLogger = initLogger();
+		const responseBody = {
+			customer_id: "customer_123",
+			balances: {
+				messages: {
+					remaining: 42,
+				},
+			},
+		};
+
+		firelensLogger.info(
+			{
+				req: {
+					id: "request_123",
+					name: "balances.track",
+					url: "/v1/balances.track",
+				},
+				context: {
+					org_id: "org_123",
+					env: "production",
+				},
+				res: responseBody,
+				statusCode: 200,
+				durationMs: 12,
+			},
+			"Request completed",
+		);
+
+		expect(transportSpy).not.toHaveBeenCalled();
+		expect(stdoutChunks).toHaveLength(1);
+
+		const firelensRecord = JSON.parse(stdoutChunks[0] ?? "{}");
+		expect(firelensRecord).toMatchObject({
+			level: "INFO",
+			msg: "Request completed",
+			req: {
+				id: "request_123",
+				name: "balances.track",
+				url: "/v1/balances.track",
+			},
+			context: {
+				org_id: "org_123",
+				env: "production",
+			},
+			res: responseBody,
+			statusCode: 200,
+			durationMs: 12,
+		});
+
+		process.env.AXIOM_LOG_TRANSPORT = "direct";
+		const directLogger = initLogger();
+		directLogger.info({ req: { id: "request_456" } }, "Direct request");
+
+		expect(transportSpy).toHaveBeenCalledTimes(1);
+		expect(directChunks.join("")).toContain("request_456");
+
+		process.env.AXIOM_LOG_TRANSPORT = "firelens";
+		delete process.env.ECS_CONTAINER_METADATA_URI_V4;
+		initLogger();
+		expect(transportSpy).toHaveBeenCalledTimes(2);
+	} finally {
+		stdoutSpy.mockRestore();
+		transportSpy.mockRestore();
+		restoreEnvironmentVariable({
+			name: "NODE_ENV",
+			previousValue: previousNodeEnv,
+		});
+		restoreEnvironmentVariable({
+			name: "AXIOM_TOKEN",
+			previousValue: previousAxiomToken,
+		});
+		restoreEnvironmentVariable({
+			name: "AXIOM_LOG_TRANSPORT",
+			previousValue: previousLogTransport,
+		});
+		restoreEnvironmentVariable({
+			name: "ECS_CONTAINER_METADATA_URI_V4",
+			previousValue: previousEcsMetadataUri,
+		});
+	}
+});
+
+const restoreEnvironmentVariable = ({
+	name,
+	previousValue,
+}: {
+	name: string;
+	previousValue: string | undefined;
+}) => {
+	if (previousValue === undefined) {
+		delete process.env[name];
+		return;
+	}
+
+	process.env[name] = previousValue;
+};


### PR DESCRIPTION
## Summary by cubic
Route application logs through FireLens to Axiom in ECS, with an ECS-aware auto-switch and a direct Axiom transport as fallback. Adds Fluent Bit config and tests; dev/test behavior is unchanged.

- **New Features**
  - Fluent Bit config to parse `json`, send structured records to Axiom express, and console records to ecs; TLS on, retry_limit 5.
  - Logger supports `transport: "direct" | "firelens"` via `AXIOM_LOG_TRANSPORT`; auto-enables FireLens only in production ECS.
  - Keeps direct Axiom transport when not in ECS or in dev/test; maintains dual mode.
  - Added unit tests for FireLens config and transport selection.
  - Updated `.env.example`; CI allowlist includes `feat/firelens-log-transport`.

- **Migration**
  - In ECS, set `AXIOM_LOG_TRANSPORT=firelens` and ensure the FireLens/Fluent Bit sidecar is enabled.
  - No changes needed for local dev/test; default remains `direct`.

<sup>Written for commit adbb124a93cd3c21fb7cc00c8d5f4a873ed73f7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR routes structured application logs through FireLens while keeping direct Axiom delivery as a fallback. The main changes are:

- **Improvements:** Select FireLens only in configured production ECS environments.
- **Improvements:** Parse and route structured Pino records to the Axiom `express` dataset.
- **Improvements:** Route unmatched container records to the Axiom `ecs` dataset.
- **Improvements:** Add unit tests for logger selection and FireLens configuration.
- **Improvements:** Allow the feature branch to deploy to staging.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- FireLens activation is limited to configured production ECS environments.
- Other environments retain the existing direct Axiom path.
- The Pino level formatter matches the FireLens rewrite rule.
- No blocking issues were found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| firelens.conf | Adds the parser, tag rewriting, bounded emitter, and separate Axiom outputs for structured and container records. |
| server/src/utils/logging/initLogger.ts | Adds explicit and environment-driven transport selection with direct delivery as the non-ECS fallback. |
| server/tests/unit/logging/firelens-config.test.ts | Checks the main parser, routing, output, and retry settings in the FireLens configuration. |
| server/tests/unit/logging/init-logger-transport.test.ts | Covers FireLens output, direct transport, structured record preservation, and the non-ECS fallback. |
| server/.env.example | Documents direct Axiom delivery as the default transport. |
| .github/workflows/build.yml | Adds the feature branch to the staging deployment allowlist. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Pino logger] --> B{FireLens configured and running in production ECS?}
    B -- No --> C[Direct Axiom transport]
    B -- Yes --> D[Container stdout]
    D --> E[FireLens JSON parser]
    E --> F{Recognized Pino level?}
    F -- Yes --> G[Retag as axiom_express]
    G --> H[Axiom express dataset]
    F -- No --> I[Keep FireLens tag]
    I --> J[Axiom ecs dataset]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["route Axiom logs through FireLens"](https://github.com/useautumn/autumn/commit/adbb124a93cd3c21fb7cc00c8d5f4a873ed73f7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46381992)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/autumn-org-2/github/useautumn/autumn/-/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))
- Context used - AGENTS.md ([source](https://app.greptile.com/autumn-org-2/github/useautumn/autumn/-/custom-context?memory=e38717a3-e8ad-4054-9219-102b893d3b3c))
- Context used - server/CLAUDE.md ([source](https://app.greptile.com/autumn-org-2/github/useautumn/autumn/-/custom-context?memory=7866843d-5d47-47cf-8270-b04b4f695fd8))
- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
</details>

<!-- /greptile_comment -->