### PR TITLE
release: update atu limit count

### DIFF
--- a/server/src/internal/customers/actions/update/syncAutoTopupPurchaseLimitCounts.ts
+++ b/server/src/internal/customers/actions/update/syncAutoTopupPurchaseLimitCounts.ts
@@ -1,0 +1,95 @@
+import {
+	type AutoTopup,
+	type AutoTopupParams,
+	type Customer,
+	ErrCode,
+	RecaseError,
+	stripAutoTopupCountsForStorage,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { normalizeWindowCounter } from "@/internal/balances/autoTopUp/helpers/limits/autoTopupLimitWindowUtils.js";
+import { getOrCreateAutoTopupLimitState } from "@/internal/balances/autoTopUp/helpers/limits/getOrCreateAutoTopupLimitState.js";
+import { autoTopupLimitRepo } from "@/internal/balances/autoTopUp/repos";
+
+/**
+ * When customers.update includes `purchase_limit.count`, sync that value into
+ * `auto_topup_limit_states` and return auto_topups safe for JSONB storage
+ * (runtime `count` stripped).
+ *
+ * Omit `count` → leave the limit-state row unchanged.
+ * `count > limit` → 400.
+ * Stale/equal window → project a future `purchase_window_ends_at` so expand /
+ * preflight do not immediately normalize the written count back to 0.
+ * Active window → preserve `purchase_window_ends_at`.
+ */
+export const syncAutoTopupPurchaseLimitCounts = async ({
+	ctx,
+	customer,
+	autoTopups,
+}: {
+	ctx: AutumnContext;
+	customer: Customer;
+	autoTopups: AutoTopupParams[];
+}): Promise<AutoTopup[]> => {
+	const now = Date.now();
+	const customerId = customer.id || customer.internal_id;
+
+	for (const topup of autoTopups) {
+		const purchaseLimit = topup.purchase_limit;
+		const count = purchaseLimit?.count;
+		if (purchaseLimit == null || count === undefined) continue;
+
+		if (count > purchaseLimit.limit) {
+			throw new RecaseError({
+				message: `purchase_limit.count (${count}) cannot exceed purchase_limit.limit (${purchaseLimit.limit}) for feature ${topup.feature_id}`,
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		const state = await getOrCreateAutoTopupLimitState({
+			ctx,
+			internalCustomerId: customer.internal_id,
+			customerId,
+			featureId: topup.feature_id,
+			now,
+		});
+
+		const windowConfig = {
+			interval: purchaseLimit.interval,
+			interval_count: purchaseLimit.interval_count ?? 1,
+			limit: purchaseLimit.limit,
+		};
+
+		let purchaseWindowEndsAt = state.purchase_window_ends_at;
+		if (now >= purchaseWindowEndsAt) {
+			const normalized = normalizeWindowCounter({
+				now,
+				windowEndsAt: purchaseWindowEndsAt,
+				count: 0,
+				windowConfig,
+				from: purchaseWindowEndsAt,
+			});
+			if (!normalized) {
+				throw new RecaseError({
+					message: `Failed to initialize purchase limit window for feature ${topup.feature_id}`,
+					code: ErrCode.InvalidRequest,
+					statusCode: 400,
+				});
+			}
+			purchaseWindowEndsAt = normalized.windowEndsAt;
+		}
+
+		await autoTopupLimitRepo.updateById({
+			ctx,
+			id: state.id,
+			updates: {
+				purchase_count: count,
+				purchase_window_ends_at: purchaseWindowEndsAt,
+				updated_at: now,
+			},
+		});
+	}
+
+	return stripAutoTopupCountsForStorage(autoTopups) ?? [];
+};

--- a/server/src/internal/customers/actions/update/updateCustomer.ts
+++ b/server/src/internal/customers/actions/update/updateCustomer.ts
@@ -18,6 +18,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { triggerAutoTopUpsOnEnabled } from "@/internal/balances/autoTopUp/triggerAutoTopUpsOnEnabled";
 import { CusService } from "@/internal/customers/CusService";
 import { getApiCustomerByRollout } from "../getApiCustomerByRollout";
+import { syncAutoTopupPurchaseLimitCounts } from "./syncAutoTopupPurchaseLimitCounts";
 
 export const updateCustomer = async ({
 	ctx,
@@ -136,8 +137,14 @@ export const updateCustomer = async ({
 	// Prepare update data — only include defined billing control fields
 	const billingControlUpdates: Partial<Customer> = {};
 	if (billing_controls) {
-		if (billing_controls.auto_topups !== undefined)
-			billingControlUpdates.auto_topups = billing_controls.auto_topups;
+		if (billing_controls.auto_topups !== undefined) {
+			billingControlUpdates.auto_topups =
+				await syncAutoTopupPurchaseLimitCounts({
+					ctx,
+					customer: originalCustomer,
+					autoTopups: billing_controls.auto_topups,
+				});
+		}
 		if (billing_controls.spend_limits !== undefined)
 			billingControlUpdates.spend_limits = billing_controls.spend_limits;
 		if (billing_controls.usage_limits !== undefined)

--- a/server/src/internal/customers/cusUtils/initCustomer.ts
+++ b/server/src/internal/customers/cusUtils/initCustomer.ts
@@ -5,6 +5,7 @@ import {
 	type FullCustomer,
 	orgMultiCurrencyEnabled,
 	RecaseError,
+	stripAutoTopupCountsForStorage,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { generateId } from "@/utils/genUtils.js";
@@ -61,7 +62,9 @@ const initCustomer = ({
 		processors: customerData?.processors ?? null,
 		send_email_receipts: customerData?.send_email_receipts ?? false,
 		currency: customerData?.currency?.toLowerCase() || null,
-		auto_topups: customerData?.billing_controls?.auto_topups,
+		auto_topups: stripAutoTopupCountsForStorage(
+			customerData?.billing_controls?.auto_topups,
+		),
 		spend_limits: customerData?.billing_controls?.spend_limits,
 		usage_limits: customerData?.billing_controls?.usage_limits,
 		usage_alerts: customerData?.billing_controls?.usage_alerts,

--- a/server/tests/integration/crud/customers/auto-topup-purchase-limit-count.test.ts
+++ b/server/tests/integration/crud/customers/auto-topup-purchase-limit-count.test.ts
@@ -1,0 +1,360 @@
+/**
+ * TDD test for writable `purchase_limit.count` on customers.update.
+ *
+ * Contract under test:
+ *   New types/fields:
+ *     - billing_controls.auto_topups[].purchase_limit.count?: number (min 0)
+ *       on customer create/update params only
+ *     - next_reset_at / source remain response-only
+ *
+ *   New behaviors:
+ *     - count: N → writes auto_topup_limit_states.purchase_count = N
+ *       for (customer, feature_id)
+ *     - omit count → leave runtime state unchanged
+ *     - count > limit → 400
+ *     - purchase_limit with only count (no interval/limit) → 400
+ *     - count: 0 on active window → preserve purchase_window_ends_at
+ *     - count > 0 with stale/missing window → init future window so expand
+ *       does not project the written count back to 0
+ *     - count is stripped before JSONB write (never on customers.auto_topups)
+ *
+ *   Side effects:
+ *     - upserts/updates auto_topup_limit_states row
+ *     - still replaces customers.auto_topups config as today
+ *
+ * Pre-impl red: every assertion below fails because customers.update ignores
+ * count (zod strips it) and never touches auto_topup_limit_states.
+ * Post-impl green: sync helper writes purchase_count (+ window when needed)
+ * and strips count from JSONB storage.
+ *
+ * Note: this file avoids initScenario/Stripe — this cloud env has no
+ * STRIPE_SANDBOX_SECRET_KEY. Customer create/update + direct limit-state
+ * inserts are enough to cover the contract.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	ApiVersion,
+	AppEnv,
+	CustomerExpand,
+	ErrCode,
+	PurchaseLimitInterval,
+} from "@autumn/shared";
+import { makeAutoTopupConfig } from "@tests/integration/balances/auto-topup/utils/makeAutoTopupConfig";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import chalk from "chalk";
+import { initDrizzle } from "@/db/initDrizzle.js";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { autoTopupLimitRepo } from "@/internal/balances/autoTopUp/repos";
+import { CusService } from "@/internal/customers/CusService.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import { generateId } from "@/utils/genUtils.js";
+
+type ExpandedPurchaseLimit = {
+	interval: PurchaseLimitInterval | null;
+	interval_count: number | null;
+	limit: number | null;
+	count: number;
+	next_reset_at: number;
+};
+
+const createClients = async () => {
+	// Prefer TESTS_ORG when present; fall back so this file can run in the
+	// Cursor cloud VM where createTestContext fails without Stripe secrets
+	// (preload only builds the default ctx when TESTS_ORG is set).
+	const orgSlug = process.env.TESTS_ORG || "unit-test-org";
+	const orgSecretKey = process.env.UNIT_TEST_AUTUMN_SECRET_KEY;
+	if (!orgSecretKey) throw new Error("UNIT_TEST_AUTUMN_SECRET_KEY is required");
+
+	const { db } = initDrizzle();
+	const org = await OrgService.getBySlug({ db, slug: orgSlug });
+	if (!org) throw new Error(`Org ${orgSlug} not found`);
+
+	const ctx = {
+		db,
+		org,
+		env: AppEnv.Sandbox,
+	} as AutumnContext;
+
+	const autumn = new AutumnInt({
+		version: ApiVersion.V2_2,
+		secretKey: orgSecretKey,
+	});
+
+	return { autumn, ctx, org };
+};
+
+const ensureCustomer = async ({
+	autumn,
+	customerId,
+}: {
+	autumn: AutumnInt;
+	customerId: string;
+}) => {
+	try {
+		await autumn.customers.delete(customerId);
+	} catch {
+		// ignore missing
+	}
+
+	await autumn.customers.create({
+		id: customerId,
+		name: customerId,
+		email: `${customerId}@example.com`,
+	});
+};
+
+const getExpandedPurchaseLimit = async ({
+	autumn,
+	customerId,
+}: {
+	autumn: AutumnInt;
+	customerId: string;
+}) => {
+	const customer = await autumn.customers.get<ApiCustomerV5>(customerId, {
+		expand: [CustomerExpand.AutoTopupsPurchaseLimit],
+		skip_cache: "true",
+	});
+	return customer.billing_controls?.auto_topups?.[0]?.purchase_limit as
+		| ExpandedPurchaseLimit
+		| undefined;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("customers.update: purchase_limit.count writes runtime state")}`,
+	async () => {
+		const customerId = "atu-pl-count-write";
+		const { autumn, ctx, org } = await createClients();
+		await ensureCustomer({ autumn, customerId });
+
+		const customer = await CusService.get({
+			db: ctx.db,
+			idOrInternalId: customerId,
+			orgId: org.id,
+			env: ctx.env,
+		});
+		if (!customer) throw new Error("customer missing after create");
+
+		await autumn.customers.update(customerId, {
+			billing_controls: makeAutoTopupConfig({
+				threshold: 50,
+				quantity: 100,
+				purchaseLimit: { interval: PurchaseLimitInterval.Month, limit: 5 },
+			}),
+		});
+
+		const activeWindowEndsAt = Date.now() + 7 * 24 * 60 * 60 * 1000;
+		const now = Date.now();
+		await autoTopupLimitRepo.insert({
+			ctx,
+			data: {
+				id: generateId("atlim"),
+				internal_customer_id: customer.internal_id,
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				purchase_window_ends_at: activeWindowEndsAt,
+				purchase_count: 4,
+				attempt_window_ends_at: now,
+				attempt_count: 0,
+				failed_attempt_window_ends_at: now,
+				failed_attempt_count: 0,
+				updated_at: now,
+			},
+		});
+
+		// ── Contract 1: count: 0 resets purchase_count and preserves window ─
+		await autumn.customers.update(customerId, {
+			billing_controls: {
+				auto_topups: [
+					{
+						feature_id: TestFeature.Messages,
+						enabled: true,
+						threshold: 50,
+						quantity: 100,
+						purchase_limit: {
+							interval: PurchaseLimitInterval.Month,
+							interval_count: 1,
+							limit: 5,
+							count: 0,
+						},
+					},
+				],
+			},
+		});
+
+		const afterReset = await getExpandedPurchaseLimit({
+			autumn,
+			customerId,
+		});
+		expect(afterReset).toMatchObject({
+			interval: PurchaseLimitInterval.Month,
+			interval_count: 1,
+			limit: 5,
+			count: 0,
+		});
+		expect(afterReset?.next_reset_at).toBe(activeWindowEndsAt);
+
+		// ── Contract 2: omit count → leave runtime state unchanged ─────────
+		await autumn.customers.update(customerId, {
+			billing_controls: makeAutoTopupConfig({
+				threshold: 40,
+				quantity: 100,
+				purchaseLimit: { interval: PurchaseLimitInterval.Month, limit: 5 },
+			}),
+		});
+
+		const afterOmit = await getExpandedPurchaseLimit({
+			autumn,
+			customerId,
+		});
+		expect(afterOmit).toMatchObject({
+			count: 0,
+			next_reset_at: activeWindowEndsAt,
+		});
+
+		// ── Contract 3: count is not persisted on customers.auto_topups JSONB
+		const dbCustomer = await CusService.get({
+			db: ctx.db,
+			idOrInternalId: customerId,
+			orgId: org.id,
+			env: ctx.env,
+		});
+		const storedPurchaseLimit = dbCustomer?.auto_topups?.[0]?.purchase_limit as
+			| Record<string, unknown>
+			| undefined;
+		expect(storedPurchaseLimit).toEqual({
+			interval: PurchaseLimitInterval.Month,
+			interval_count: 1,
+			limit: 5,
+		});
+		expect(storedPurchaseLimit).not.toHaveProperty("count");
+
+		// ── Contract 4: count > limit → 400 ────────────────────────────────
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			func: async () =>
+				await autumn.customers.update(customerId, {
+					billing_controls: {
+						auto_topups: [
+							{
+								feature_id: TestFeature.Messages,
+								enabled: true,
+								threshold: 50,
+								quantity: 100,
+								purchase_limit: {
+									interval: PurchaseLimitInterval.Month,
+									interval_count: 1,
+									limit: 5,
+									count: 6,
+								},
+							},
+						],
+					},
+				}),
+		});
+
+		// ── Contract 5: purchase_limit with only count → 400 (zod) ─────────
+		await expectAutumnError({
+			func: async () =>
+				await autumn.customers.update(customerId, {
+					billing_controls: {
+						auto_topups: [
+							{
+								feature_id: TestFeature.Messages,
+								enabled: true,
+								threshold: 50,
+								quantity: 100,
+								purchase_limit: {
+									count: 0,
+								} as unknown as {
+									interval: PurchaseLimitInterval;
+									limit: number;
+									count: number;
+								},
+							},
+						],
+					},
+				}),
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("customers.update: purchase_limit.count re-inits stale window")}`,
+	async () => {
+		const customerId = "atu-pl-count-stale";
+		const { autumn, ctx, org } = await createClients();
+		await ensureCustomer({ autumn, customerId });
+
+		const customer = await CusService.get({
+			db: ctx.db,
+			idOrInternalId: customerId,
+			orgId: org.id,
+			env: ctx.env,
+		});
+		if (!customer) throw new Error("customer missing after create");
+
+		await autumn.customers.update(customerId, {
+			billing_controls: makeAutoTopupConfig({
+				threshold: 50,
+				quantity: 100,
+				purchaseLimit: { interval: PurchaseLimitInterval.Month, limit: 5 },
+			}),
+		});
+
+		const staleWindowEndsAt = Date.now() - 6 * 24 * 60 * 60 * 1000;
+		const now = Date.now();
+		await autoTopupLimitRepo.insert({
+			ctx,
+			data: {
+				id: generateId("atlim"),
+				internal_customer_id: customer.internal_id,
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				purchase_window_ends_at: staleWindowEndsAt,
+				purchase_count: 3,
+				attempt_window_ends_at: now,
+				attempt_count: 0,
+				failed_attempt_window_ends_at: now,
+				failed_attempt_count: 0,
+				updated_at: now,
+			},
+		});
+
+		// ── Contract 6: count > 0 on stale window → persist count + future window
+		await autumn.customers.update(customerId, {
+			billing_controls: {
+				auto_topups: [
+					{
+						feature_id: TestFeature.Messages,
+						enabled: true,
+						threshold: 50,
+						quantity: 100,
+						purchase_limit: {
+							interval: PurchaseLimitInterval.Month,
+							interval_count: 1,
+							limit: 5,
+							count: 2,
+						},
+					},
+				],
+			},
+		});
+
+		const expanded = await getExpandedPurchaseLimit({
+			autumn,
+			customerId,
+		});
+		expect(expanded).toMatchObject({
+			interval: PurchaseLimitInterval.Month,
+			interval_count: 1,
+			limit: 5,
+			count: 2,
+		});
+		expect(expanded?.next_reset_at).toBeGreaterThan(Date.now());
+		expect(expanded?.next_reset_at).not.toBe(staleWindowEndsAt);
+	},
+);

--- a/shared/models/cusModels/billingControls/customerBillingControls.ts
+++ b/shared/models/cusModels/billingControls/customerBillingControls.ts
@@ -33,58 +33,6 @@ export const BILLING_CONTROL_KEYS = [
 
 export type BillingControlKey = (typeof BILLING_CONTROL_KEYS)[number];
 
-export const pickBillingControlColumns = (
-	source: Partial<DbBillingControls> | null | undefined,
-): Partial<DbBillingControls> => {
-	if (!source) return {};
-
-	return Object.fromEntries(
-		BILLING_CONTROL_KEYS.flatMap((key) =>
-			source[key] === undefined ? [] : [[key, source[key]]],
-		),
-	) as Partial<DbBillingControls>;
-};
-
-export const billingControlsFromColumns = (
-	source: Partial<DbBillingControls> | null | undefined,
-): CustomerBillingControls => {
-	if (!source) return {};
-
-	return Object.fromEntries(
-		BILLING_CONTROL_KEYS.flatMap((key) =>
-			source[key] == null ? [] : [[key, source[key]]],
-		),
-	) as CustomerBillingControls;
-};
-
-/** Canonical form for change detection: skip_overage_billing false ≡ unset. */
-export const normalizeBillingControlsForCompare = (
-	billingControls: CustomerBillingControls | null | undefined,
-): CustomerBillingControls | undefined => {
-	if (!billingControls?.spend_limits) return billingControls ?? undefined;
-
-	return {
-		...billingControls,
-		spend_limits: billingControls.spend_limits.map((spendLimit) => {
-			if (spendLimit.skip_overage_billing === true) return spendLimit;
-			const { skip_overage_billing: _dropped, ...rest } = spendLimit;
-			return rest;
-		}),
-	};
-};
-
-export const mergeBillingControls = (
-	current: CustomerBillingControls | null | undefined,
-	patch: CustomerBillingControls | null | undefined,
-): CustomerBillingControls | undefined => {
-	if (!patch) return current ?? undefined;
-
-	return billingControlsFromColumns({
-		...(current ?? {}),
-		...pickBillingControlColumns(patch),
-	});
-};
-
 export const AutoTopupPurchaseLimitSchema = z.object({
 	interval: PurchaseLimitIntervalEnum.meta({
 		description: "The time interval for the purchase limit window.",
@@ -96,6 +44,19 @@ export const AutoTopupPurchaseLimitSchema = z.object({
 		description: "Maximum number of auto top-ups allowed within the interval.",
 	}),
 });
+
+/**
+ * Customer create/update params only. `count` is runtime state written to
+ * `auto_topup_limit_states` and must never be persisted on `customers.auto_topups`
+ * / `products.auto_topups` JSONB — strip via `stripAutoTopupCountsForStorage`.
+ */
+export const AutoTopupPurchaseLimitParamsSchema =
+	AutoTopupPurchaseLimitSchema.extend({
+		count: z.number().min(0).optional().meta({
+			description:
+				"Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.",
+		}),
+	});
 
 export const AutoTopupSchema = z.object({
 	feature_id: z.string().meta({
@@ -117,6 +78,13 @@ export const AutoTopupSchema = z.object({
 	invoice_mode: z.boolean().optional().meta({
 		description:
 			"When true, auto top-up creates a send_invoice invoice instead of auto-charging.",
+	}),
+});
+
+export const AutoTopupParamsSchema = AutoTopupSchema.extend({
+	purchase_limit: AutoTopupPurchaseLimitParamsSchema.optional().meta({
+		description:
+			"Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.",
 	}),
 });
 
@@ -199,8 +167,107 @@ export const DbBillingControlsSchema = z.object({
 	overage_allowed: z.array(DbOverageAllowedSchema).nullish(),
 });
 
+export type AutoTopupPurchaseLimit = z.infer<
+	typeof AutoTopupPurchaseLimitSchema
+>;
+export type AutoTopupPurchaseLimitParams = z.input<
+	typeof AutoTopupPurchaseLimitParamsSchema
+>;
+export type ExpandedPurchaseLimit = z.infer<typeof ExpandedPurchaseLimitSchema>;
+export type AutoTopup = z.infer<typeof AutoTopupSchema>;
+export type AutoTopupParams = z.input<typeof AutoTopupParamsSchema>;
+export type AutoTopupResponse = z.infer<typeof AutoTopupResponseSchema>;
+export type CustomerBillingControls = z.infer<
+	typeof CustomerBillingControlsSchema
+>;
+export type DbBillingControls = z.infer<typeof DbBillingControlsSchema>;
+
+/** Strip runtime `count` before persisting auto_topups JSONB. */
+export const stripAutoTopupCountsForStorage = (
+	autoTopups: AutoTopupParams[] | AutoTopup[] | null | undefined,
+): AutoTopup[] | null | undefined => {
+	if (autoTopups == null) return autoTopups;
+
+	return autoTopups.map((topup) =>
+		AutoTopupSchema.parse({
+			...topup,
+			purchase_limit: topup.purchase_limit
+				? {
+						interval: topup.purchase_limit.interval,
+						interval_count: topup.purchase_limit.interval_count ?? 1,
+						limit: topup.purchase_limit.limit,
+					}
+				: undefined,
+		}),
+	);
+};
+
+export const pickBillingControlColumns = (
+	source: Partial<DbBillingControls> | null | undefined,
+): Partial<DbBillingControls> => {
+	if (!source) return {};
+
+	const picked = Object.fromEntries(
+		BILLING_CONTROL_KEYS.flatMap((key) =>
+			source[key] === undefined ? [] : [[key, source[key]]],
+		),
+	) as Partial<DbBillingControls>;
+
+	if (picked.auto_topups !== undefined) {
+		picked.auto_topups = stripAutoTopupCountsForStorage(
+			picked.auto_topups as AutoTopupParams[] | null | undefined,
+		);
+	}
+
+	return picked;
+};
+
+export const billingControlsFromColumns = (
+	source: Partial<DbBillingControls> | null | undefined,
+): CustomerBillingControls => {
+	if (!source) return {};
+
+	return Object.fromEntries(
+		BILLING_CONTROL_KEYS.flatMap((key) =>
+			source[key] == null ? [] : [[key, source[key]]],
+		),
+	) as CustomerBillingControls;
+};
+
+/** Canonical form for change detection: skip_overage_billing false ≡ unset. */
+export const normalizeBillingControlsForCompare = (
+	billingControls: CustomerBillingControls | null | undefined,
+): CustomerBillingControls | undefined => {
+	if (!billingControls?.spend_limits) return billingControls ?? undefined;
+
+	return {
+		...billingControls,
+		spend_limits: billingControls.spend_limits.map((spendLimit) => {
+			if (spendLimit.skip_overage_billing === true) return spendLimit;
+			const { skip_overage_billing: _dropped, ...rest } = spendLimit;
+			return rest;
+		}),
+	};
+};
+
+export const mergeBillingControls = (
+	current: CustomerBillingControls | null | undefined,
+	patch: CustomerBillingControls | null | undefined,
+): CustomerBillingControls | undefined => {
+	if (!patch) return current ?? undefined;
+
+	return billingControlsFromColumns({
+		...(current ?? {}),
+		...pickBillingControlColumns(patch),
+	});
+};
+
 export const CustomerBillingControlsParamsSchema =
-	CustomerBillingControlsSchema.check((ctx) => {
+	CustomerBillingControlsSchema.extend({
+		auto_topups: z.array(AutoTopupParamsSchema).optional().meta({
+			description: "List of auto top-up configurations per feature.",
+		}),
+	}).check((ctx) => {
 		const billingControls = ctx.value;
 		const spendLimitFeatureIds = new Set<string>();
 
@@ -262,17 +329,6 @@ export const CustomerBillingControlsParamsSchema =
 			overageAllowedFeatureIds.add(overageAllowed.feature_id);
 		}
 	});
-
-export type AutoTopupPurchaseLimit = z.infer<
-	typeof AutoTopupPurchaseLimitSchema
->;
-export type ExpandedPurchaseLimit = z.infer<typeof ExpandedPurchaseLimitSchema>;
-export type AutoTopup = z.infer<typeof AutoTopupSchema>;
-export type AutoTopupResponse = z.infer<typeof AutoTopupResponseSchema>;
-export type CustomerBillingControls = z.infer<
-	typeof CustomerBillingControlsSchema
->;
-export type DbBillingControls = z.infer<typeof DbBillingControlsSchema>;
 
 export type CustomerBillingControlsParams = z.input<
 	typeof CustomerBillingControlsParamsSchema


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for setting `billing_controls.auto_topups[].purchase_limit.count` on `customers.update`, syncing the value to `auto_topup_limit_states` while stripping it from stored JSONB. Enforces `count <= limit` and handles stale windows so counts don’t reset immediately.

- **New Features**
  - Accepts `purchase_limit.count` in params-only schemas (`AutoTopupPurchaseLimitParams`, `AutoTopupParams`); not persisted in `customers.auto_topups`.
  - New sync step writes `purchase_count` to `auto_topup_limit_states`, preserves active `purchase_window_ends_at`, and re-inits a future window when stale.
  - `updateCustomer` now calls the sync and then stores auto top-ups via `stripAutoTopupCountsForStorage`.
  - Validation: `count > limit` returns 400; passing only `count` without `interval/limit` is rejected.
  - Added integration tests covering omit/persist behavior, window handling, and error cases.

<sup>Written for commit 00162e03b1e6e397c22f050ac155f4adf57b50c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes auto-top-up purchase counts writable through customer billing controls. The main changes are:

- **API changes:** Adds an optional `purchase_limit.count` request field.
- **Improvements:** Synchronizes update-time counts into auto-top-up limit state.
- **Bug fixes:** Removes runtime counts before storing auto-top-up JSONB.
- **Improvements:** Adds integration tests for count updates and stale windows.
</details>

<h3>Confidence Score: 4/5</h3>

Count synchronization can lose create-time input or leave limit state inconsistent with customer configuration.

- Customer creation accepts a count but discards it.
- Update-time state and configuration writes are not atomic.
- Duplicate features and interval changes can produce incorrect limit enforcement.

The customer initialization and auto-top-up count synchronization paths need fixes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/actions/update/syncAutoTopupPurchaseLimitCounts.ts | Adds count and window synchronization, but permits partial writes, duplicate-feature ambiguity, and stale boundaries after interval changes. |
| server/src/internal/customers/actions/update/updateCustomer.ts | Calls limit-state synchronization before storing the customer configuration without an enclosing transaction. |
| server/src/internal/customers/cusUtils/initCustomer.ts | Strips count for safe JSONB storage but loses the accepted create-time value. |
| shared/models/cusModels/billingControls/customerBillingControls.ts | Adds count to customer parameters and storage sanitization without limiting it to updates or rejecting duplicate auto-top-up features. |
| server/tests/integration/crud/customers/auto-topup-purchase-limit-count.test.ts | Covers update-time count behavior but not creation, duplicate features, interval changes, or failed multi-write operations. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as Customer API
    participant State as auto_topup_limit_states
    participant Customer as customers.auto_topups

    Client->>API: Send purchase_limit.count
    alt Create
        API->>API: Strip count
        API->>Customer: Store configuration
        Note over State: Count is not initialized
    else Update
        API->>State: Write count and window
        API->>Customer: Store configuration without count
        Note over State,Customer: Writes are not atomic
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
server/src/internal/customers/cusUtils/initCustomer.ts:65-67
**Create Count Is Discarded**

Customer creation now accepts `purchase_limit.count`, but this call strips the value without writing it to `auto_topup_limit_states`. Creating a customer with `count: 3` succeeds, yet the lazily created limit state starts at zero, so expanded responses and limit enforcement ignore the requested count.

### Issue 2 of 4
server/src/internal/customers/actions/update/updateCustomer.ts:141-146
**Limit State Commits Before Config**

This call writes each limit-state row before `CusService.update` persists the matching customer configuration, with no transaction covering both operations. If a later top-up fails validation or the customer update fails, the request returns an error after some counts have already changed, leaving billing enforcement out of sync with the stored configuration.

### Issue 3 of 4
server/src/internal/customers/actions/update/syncAutoTopupPurchaseLimitCounts.ts:37
**Duplicate Features Share One State**

The request schema allows multiple auto-top-ups with the same `feature_id`, so this loop updates the same unique limit-state row more than once while storing both configurations in the customer JSONB. With different counts or limits, the last entry silently wins for runtime state and downstream code receives two configurations backed by one ambiguous counter.

### Issue 4 of 4
server/src/internal/customers/actions/update/syncAutoTopupPurchaseLimitCounts.ts:64
**Changed Interval Keeps Old Window**

When an update changes the purchase-limit interval while the existing window is still active, this branch preserves an end time calculated from the old interval. For example, changing a monthly limit to weekly can leave the weekly counter active until the old monthly boundary, so auto-top-ups are limited over the wrong period.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #2356 from useautumn/..."](https://github.com/useautumn/autumn/commit/00162e03b1e6e397c22f050ac155f4adf57b50c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46393543)</sub>

> Greptile also left **4 inline comments** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->