### PR TITLE
add firelens config

### DIFF
--- a/firelens.conf
+++ b/firelens.conf
@@ -1,3 +1,9 @@
+[SERVICE]
+    # Flightcontrol prepends its own SERVICE block. The production AWS Fluent
+    # Bit image accepts an additional block and needs this file registered
+    # before the parser filter can use its built-in `json` parser.
+    Parsers_File /fluent-bit/etc/parsers.conf
+
 [FILTER]
     Name modify
     Match *
@@ -27,9 +33,40 @@
     Match *
     Add region ${AWS_REGION}
 
+[FILTER]
+    Name parser
+    Match *-firelens-*
+    Key_Name log
+    Parser json
+    Reserve_Data On
+    Preserve_Key Off
+
+[FILTER]
+    Name rewrite_tag
+    Match *-firelens-*
+    Rule $level ^(TRACE|DEBUG|INFO|WARN|ERROR|FATAL)$ axiom_express false
+    Emitter_Name axiom_express_emitter
+    Emitter_Storage.type memory
+    Emitter_Mem_Buf_Limit 10M
+
 [OUTPUT]
     Name http
-    Match *
+    Match axiom_express
+    Host us-east-1.aws.edge.axiom.co
+    Port 443
+    URI /v1/ingest/express
+    Format json
+    TLS On
+    json_date_key _time
+    json_date_format iso8601
+    Header Authorization Bearer ${AXIOM_TOKEN}
+    Header Content-Type application/json
+    retry_limit 5
+    net.dns.mode TCP
+
+[OUTPUT]
+    Name http
+    Match *-firelens-*
     Host us-east-1.aws.edge.axiom.co
     Port 443
     URI /v1/ingest/ecs


### PR DESCRIPTION
## Summary

- parse structured Pino JSON in Fluent Bit
- route application records to the Axiom `express` dataset
- keep unstructured runtime output in the `ecs` dataset
- bound FireLens re-emission buffering and retries

## Validation

- configuration is byte-for-byte identical to the previously validated FireLens configuration
- `git diff --check` passes
- PR changes only `firelens.conf`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes structured `pino` JSON logs through FireLens to Axiom `express`, while keeping unstructured runtime output in `ecs`. Adds parser and tag rewrite filters and caps buffering/retries for more reliable delivery.

- **New Features**
  - Add `[SERVICE]` with `Parsers_File` to enable the built-in `json` parser.
  - Parse the `log` field and preserve original data; rewrite tags by `level` to route app logs to Axiom `express`.
  - Send non-structured container output to `ecs`.
  - Configure HTTP outputs with TLS, ISO8601 `_time`, headers, TCP DNS; cap retries at 5 and set emitter memory buffer to 10MB.

<sup>Written for commit c19af8ce5085000dbca122c903b781b1c91388a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR routes structured application logs through FireLens into a separate Axiom dataset. The main changes are:

- **Improvements:** Register Fluent Bit's standard JSON parsers.
- **Improvements:** Parse Pino JSON and re-tag recognized application records.
- **Improvements:** Send structured records to `express` and runtime output to `ecs`.
- **Improvements:** Bound re-emission memory and HTTP retries.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The uppercase rewrite rule matches the repository's Pino level formatter.
- Structured and unstructured FireLens records retain distinct output paths.
- No blocking issues were found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| firelens.conf | Adds JSON parser registration, structured-record re-tagging, separate Axiom outputs, and bounded buffering and retries. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[FireLens record] --> B[Parse log field as JSON]
    B --> C{Recognized Pino level?}
    C -- Yes --> D[Re-tag as axiom_express]
    D --> E[Axiom express dataset]
    C -- No --> F[Keep FireLens tag]
    F --> G[Axiom ecs dataset]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["🤖 chore(logging): route structured logs..."](https://github.com/useautumn/autumn/commit/c19af8ce5085000dbca122c903b781b1c91388a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46395362)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->