### PR TITLE
Fix auto top-up purchase limit state synchronization

### DIFF
--- a/server/src/internal/customers/actions/createWithDefaults/createCustomerContext.ts
+++ b/server/src/internal/customers/actions/createWithDefaults/createCustomerContext.ts
@@ -1,4 +1,5 @@
 import type {
+	AutoTopupParams,
 	BillingContext,
 	FullCustomer,
 	FullProduct,
@@ -12,6 +13,7 @@ export interface CreateCustomerContextFree {
 	trialContext?: TrialContext;
 	hasPaidProducts: boolean;
 	billingContext?: BillingContext;
+	autoTopups?: AutoTopupParams[];
 }
 
 export type CreateCustomerContext = CreateCustomerContextFree;

--- a/server/src/internal/customers/actions/createWithDefaults/execute/executeAutumnCreateCustomerPlan.ts
+++ b/server/src/internal/customers/actions/createWithDefaults/execute/executeAutumnCreateCustomerPlan.ts
@@ -5,6 +5,7 @@ import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { executeAutumnBillingPlan } from "@/internal/billing/v2/execute/executeAutumnBillingPlan.js";
 import type { CreateCustomerContext } from "@/internal/customers/actions/createWithDefaults/createCustomerContext.js";
+import { syncAutoTopupPurchaseLimitCounts } from "@/internal/customers/actions/update/syncAutoTopupPurchaseLimitCounts.js";
 import { captureOrgEvent } from "@/utils/posthog.js";
 import { CusService } from "../../../CusService.js";
 
@@ -50,6 +51,12 @@ export const executeAutumnCreateCustomerPlan = async ({
 				wasUpdate = true;
 				return;
 			}
+
+			await syncAutoTopupPurchaseLimitCounts({
+				ctx: { ...ctx, db: txDb },
+				customer: fullCustomer,
+				autoTopups: context.autoTopups ?? [],
+			});
 
 			await executeAutumnBillingPlan({
 				ctx: { ...ctx, db: txDb },

--- a/server/src/internal/customers/actions/createWithDefaults/setup/setupCreateCustomer.ts
+++ b/server/src/internal/customers/actions/createWithDefaults/setup/setupCreateCustomer.ts
@@ -52,5 +52,6 @@ export const setupCreateCustomer = async ({
 		currentEpochMs,
 		trialContext,
 		hasPaidProducts,
+		autoTopups: customerData?.billing_controls?.auto_topups,
 	};
 };

--- a/server/src/internal/customers/actions/update/syncAutoTopupPurchaseLimitCounts.ts
+++ b/server/src/internal/customers/actions/update/syncAutoTopupPurchaseLimitCounts.ts
@@ -11,6 +11,26 @@ import { normalizeWindowCounter } from "@/internal/balances/autoTopUp/helpers/li
 import { getOrCreateAutoTopupLimitState } from "@/internal/balances/autoTopUp/helpers/limits/getOrCreateAutoTopupLimitState.js";
 import { autoTopupLimitRepo } from "@/internal/balances/autoTopUp/repos";
 
+export const validateAutoTopupPurchaseLimitCounts = ({
+	autoTopups,
+}: {
+	autoTopups: AutoTopupParams[];
+}) => {
+	for (const topup of autoTopups) {
+		const purchaseLimit = topup.purchase_limit;
+		const count = purchaseLimit?.count;
+		if (purchaseLimit == null || count === undefined) continue;
+
+		if (count > purchaseLimit.limit) {
+			throw new RecaseError({
+				message: `purchase_limit.count (${count}) cannot exceed purchase_limit.limit (${purchaseLimit.limit}) for feature ${topup.feature_id}`,
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+	}
+};
+
 /**
  * When customers.update includes `purchase_limit.count`, sync that value into
  * `auto_topup_limit_states` and return auto_topups safe for JSONB storage
@@ -31,6 +51,8 @@ export const syncAutoTopupPurchaseLimitCounts = async ({
 	customer: Customer;
 	autoTopups: AutoTopupParams[];
 }): Promise<AutoTopup[]> => {
+	validateAutoTopupPurchaseLimitCounts({ autoTopups });
+
 	const now = Date.now();
 	const customerId = customer.id || customer.internal_id;
 
@@ -38,14 +60,6 @@ export const syncAutoTopupPurchaseLimitCounts = async ({
 		const purchaseLimit = topup.purchase_limit;
 		const count = purchaseLimit?.count;
 		if (purchaseLimit == null || count === undefined) continue;
-
-		if (count > purchaseLimit.limit) {
-			throw new RecaseError({
-				message: `purchase_limit.count (${count}) cannot exceed purchase_limit.limit (${purchaseLimit.limit}) for feature ${topup.feature_id}`,
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
-		}
 
 		const state = await getOrCreateAutoTopupLimitState({
 			ctx,
@@ -61,14 +75,22 @@ export const syncAutoTopupPurchaseLimitCounts = async ({
 			limit: purchaseLimit.limit,
 		};
 
+		const previousPurchaseLimit = customer.auto_topups?.find(
+			(existingTopup) => existingTopup.feature_id === topup.feature_id,
+		)?.purchase_limit;
+		const intervalChanged =
+			previousPurchaseLimit?.interval !== purchaseLimit.interval ||
+			(previousPurchaseLimit?.interval_count ?? 1) !==
+				(purchaseLimit.interval_count ?? 1);
+
 		let purchaseWindowEndsAt = state.purchase_window_ends_at;
-		if (now >= purchaseWindowEndsAt) {
+		if (intervalChanged || now >= purchaseWindowEndsAt) {
 			const normalized = normalizeWindowCounter({
 				now,
-				windowEndsAt: purchaseWindowEndsAt,
+				windowEndsAt: intervalChanged ? now : purchaseWindowEndsAt,
 				count: 0,
 				windowConfig,
-				from: purchaseWindowEndsAt,
+				from: intervalChanged ? now : purchaseWindowEndsAt,
 			});
 			if (!normalized) {
 				throw new RecaseError({

--- a/server/src/internal/customers/actions/update/updateCustomer.ts
+++ b/server/src/internal/customers/actions/update/updateCustomer.ts
@@ -6,9 +6,11 @@ import {
 	ProcessorType,
 	RecaseError,
 	shouldForwardCustomerMetadata,
+	stripAutoTopupCountsForStorage,
 	type UpdateCustomerParamsV1,
 } from "@autumn/shared";
 import type Stripe from "stripe";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { createStripeCli } from "@/external/connect/createStripeCli";
 import {
 	autumnToStripeCustomerMetadata,
@@ -18,7 +20,10 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { triggerAutoTopUpsOnEnabled } from "@/internal/balances/autoTopUp/triggerAutoTopUpsOnEnabled";
 import { CusService } from "@/internal/customers/CusService";
 import { getApiCustomerByRollout } from "../getApiCustomerByRollout";
-import { syncAutoTopupPurchaseLimitCounts } from "./syncAutoTopupPurchaseLimitCounts";
+import {
+	syncAutoTopupPurchaseLimitCounts,
+	validateAutoTopupPurchaseLimitCounts,
+} from "./syncAutoTopupPurchaseLimitCounts";
 
 export const updateCustomer = async ({
 	ctx,
@@ -49,6 +54,10 @@ export const updateCustomer = async ({
 	if (!originalCustomer) {
 		throw new CustomerNotFoundError({ customerId });
 	}
+
+	validateAutoTopupPurchaseLimitCounts({
+		autoTopups: billing_controls?.auto_topups ?? [],
+	});
 
 	if (newCustomerId === null) {
 		throw new RecaseError({
@@ -139,11 +148,7 @@ export const updateCustomer = async ({
 	if (billing_controls) {
 		if (billing_controls.auto_topups !== undefined) {
 			billingControlUpdates.auto_topups =
-				await syncAutoTopupPurchaseLimitCounts({
-					ctx,
-					customer: originalCustomer,
-					autoTopups: billing_controls.auto_topups,
-				});
+				stripAutoTopupCountsForStorage(billing_controls.auto_topups) ?? [];
 		}
 		if (billing_controls.spend_limits !== undefined)
 			billingControlUpdates.spend_limits = billing_controls.spend_limits;
@@ -188,10 +193,22 @@ export const updateCustomer = async ({
 		delete updateData.id;
 	}
 
-	await CusService.update({
-		ctx,
-		idOrInternalId: originalCustomer.id || originalCustomer.internal_id,
-		update: updateData,
+	await db.transaction(async (tx) => {
+		const txCtx = { ...ctx, db: tx as unknown as DrizzleCli };
+
+		if (billing_controls?.auto_topups !== undefined) {
+			await syncAutoTopupPurchaseLimitCounts({
+				ctx: txCtx,
+				customer: originalCustomer,
+				autoTopups: billing_controls.auto_topups,
+			});
+		}
+
+		await CusService.update({
+			ctx: txCtx,
+			idOrInternalId: originalCustomer.id || originalCustomer.internal_id,
+			update: updateData,
+		});
 	});
 
 	ctx.skipCache = true;

--- a/server/tests/integration/crud/customers/auto-topup-purchase-limit-count.test.ts
+++ b/server/tests/integration/crud/customers/auto-topup-purchase-limit-count.test.ts
@@ -358,3 +358,211 @@ test.concurrent(
 		expect(expanded?.next_reset_at).not.toBe(staleWindowEndsAt);
 	},
 );
+
+test.concurrent(
+	`${chalk.yellowBright("customers.create: purchase_limit.count writes runtime state")}`,
+	async () => {
+		const customerId = "atu-pl-count-create";
+		const { autumn } = await createClients();
+
+		try {
+			await autumn.customers.delete(customerId);
+		} catch {
+			// ignore missing
+		}
+
+		await autumn.customers.create({
+			id: customerId,
+			name: customerId,
+			email: `${customerId}@example.com`,
+			billing_controls: {
+				auto_topups: [
+					{
+						feature_id: TestFeature.Messages,
+						enabled: true,
+						threshold: 50,
+						quantity: 100,
+						purchase_limit: {
+							interval: PurchaseLimitInterval.Month,
+							limit: 5,
+							count: 3,
+						},
+					},
+				],
+			},
+		});
+
+		const expanded = await getExpandedPurchaseLimit({ autumn, customerId });
+		expect(expanded).toMatchObject({
+			interval: PurchaseLimitInterval.Month,
+			limit: 5,
+			count: 3,
+		});
+		expect(expanded?.next_reset_at).toBeGreaterThan(Date.now());
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("customers.update: rejected counts do not partially commit")}`,
+	async () => {
+		const customerId = "atu-pl-count-atomic";
+		const { autumn } = await createClients();
+		await ensureCustomer({ autumn, customerId });
+
+		await autumn.customers.update(customerId, {
+			billing_controls: {
+				auto_topups: [
+					{
+						feature_id: TestFeature.Messages,
+						enabled: true,
+						threshold: 50,
+						quantity: 100,
+						purchase_limit: {
+							interval: PurchaseLimitInterval.Month,
+							limit: 5,
+							count: 1,
+						},
+					},
+				],
+			},
+		});
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			func: async () =>
+				await autumn.customers.update(customerId, {
+					billing_controls: {
+						auto_topups: [
+							{
+								feature_id: TestFeature.Messages,
+								enabled: true,
+								threshold: 50,
+								quantity: 100,
+								purchase_limit: {
+									interval: PurchaseLimitInterval.Month,
+									limit: 5,
+									count: 2,
+								},
+							},
+							{
+								feature_id: TestFeature.Credits,
+								enabled: true,
+								threshold: 50,
+								quantity: 100,
+								purchase_limit: {
+									interval: PurchaseLimitInterval.Month,
+									limit: 5,
+									count: 6,
+								},
+							},
+						],
+					},
+				}),
+		});
+
+		const expanded = await getExpandedPurchaseLimit({ autumn, customerId });
+		expect(expanded?.count).toEqual(1);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("customers.update: interval changes reset the purchase window")}`,
+	async () => {
+		const customerId = "atu-pl-count-interval";
+		const { autumn, ctx, org } = await createClients();
+		await ensureCustomer({ autumn, customerId });
+
+		await autumn.customers.update(customerId, {
+			billing_controls: makeAutoTopupConfig({
+				threshold: 50,
+				quantity: 100,
+				purchaseLimit: { interval: PurchaseLimitInterval.Month, limit: 5 },
+			}),
+		});
+
+		const customer = await CusService.get({
+			db: ctx.db,
+			idOrInternalId: customerId,
+			orgId: org.id,
+			env: ctx.env,
+		});
+		if (!customer) throw new Error("customer missing after create");
+
+		const now = Date.now();
+		const monthlyWindowEndsAt = now + 25 * 24 * 60 * 60 * 1000;
+		await autoTopupLimitRepo.insert({
+			ctx,
+			data: {
+				id: generateId("atlim"),
+				internal_customer_id: customer.internal_id,
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				purchase_window_ends_at: monthlyWindowEndsAt,
+				purchase_count: 1,
+				attempt_window_ends_at: now,
+				attempt_count: 0,
+				failed_attempt_window_ends_at: now,
+				failed_attempt_count: 0,
+				updated_at: now,
+			},
+		});
+
+		await autumn.customers.update(customerId, {
+			billing_controls: {
+				auto_topups: [
+					{
+						feature_id: TestFeature.Messages,
+						enabled: true,
+						threshold: 50,
+						quantity: 100,
+						purchase_limit: {
+							interval: PurchaseLimitInterval.Week,
+							limit: 5,
+							count: 1,
+						},
+					},
+				],
+			},
+		});
+
+		const expanded = await getExpandedPurchaseLimit({ autumn, customerId });
+		expect(expanded?.next_reset_at).toBeGreaterThan(
+			Date.now() + 6 * 24 * 60 * 60 * 1000,
+		);
+		expect(expanded?.next_reset_at).toBeLessThan(
+			Date.now() + 8 * 24 * 60 * 60 * 1000,
+		);
+		expect(expanded?.next_reset_at).not.toEqual(monthlyWindowEndsAt);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("customers.update: duplicate auto top-up features are rejected")}`,
+	async () => {
+		const customerId = "atu-pl-count-duplicate";
+		const { autumn } = await createClients();
+		await ensureCustomer({ autumn, customerId });
+
+		await expectAutumnError({
+			func: async () =>
+				await autumn.customers.update(customerId, {
+					billing_controls: {
+						auto_topups: [
+							{
+								feature_id: TestFeature.Messages,
+								enabled: true,
+								threshold: 50,
+								quantity: 100,
+							},
+							{
+								feature_id: TestFeature.Messages,
+								enabled: true,
+								threshold: 25,
+								quantity: 50,
+							},
+						],
+					},
+				}),
+		});
+	},
+);

--- a/shared/models/cusModels/billingControls/customerBillingControls.ts
+++ b/shared/models/cusModels/billingControls/customerBillingControls.ts
@@ -269,6 +269,24 @@ export const CustomerBillingControlsParamsSchema =
 		}),
 	}).check((ctx) => {
 		const billingControls = ctx.value;
+		const autoTopupFeatureIds = new Set<string>();
+
+		for (const [index, autoTopup] of (
+			billingControls.auto_topups ?? []
+		).entries()) {
+			if (autoTopupFeatureIds.has(autoTopup.feature_id)) {
+				ctx.issues.push({
+					code: "custom",
+					message: "Only one auto top-up entry is allowed per feature_id",
+					input: autoTopup.feature_id,
+					path: ["auto_topups", index, "feature_id"],
+				});
+				return;
+			}
+
+			autoTopupFeatureIds.add(autoTopup.feature_id);
+		}
+
 		const spendLimitFeatureIds = new Set<string>();
 
 		for (const [index, spendLimit] of (


### PR DESCRIPTION
Resolves the review feedback from #2365 by keeping customer auto top-up configuration and runtime purchase-limit state consistent.

- Persists supplied purchase counts during customer creation in the same transaction as the customer row.
- Makes customer updates atomic across the JSONB configuration and `auto_topup_limit_states`, with full count validation before mutation.
- Rejects duplicate auto top-ups for the same feature and starts a new window when the configured interval changes.
- Adds regression coverage for create, rollback, duplicate-feature, and interval-change behavior.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/23c32836-6cb2-46af-b4cb-613e1e17304d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-037" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/23c32836-6cb2-46af-b4cb-613e1e17304d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-037&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-037"><img alt="SCO-037" src="https://capy.ai/api/badge/thread.svg?label=SCO-037"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistencies between customer auto top-up config and runtime purchase-limit state and makes updates atomic. Addresses Linear SCO-037.

- **Bug Fixes**
  - Sync `purchase_limit.count` on customers.create within the same transaction.
  - Validate `count <= limit` up front; reject with 400 before any mutation.
  - Make customers.update atomic by wrapping JSONB updates and limit-state writes in one DB transaction; store counts only in runtime state (JSON config omits count).
  - Reset the purchase window when the interval or interval_count changes.
  - Reject duplicate auto top-ups for the same `feature_id`.
  - Add integration tests for create, atomic rollbacks, interval changes, and duplicate-feature cases.

<sup>Written for commit c156714360e1c8c1f6f30ae6dc532a802121ad54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR synchronizes auto top-up configuration with runtime purchase-limit state. The main changes are:

- **Bug fixes:** Persist supplied purchase counts during customer creation.
- **Bug fixes:** Update customer configuration and runtime limit state in one transaction.
- **Improvements:** Validate all counts before mutation and reject duplicate feature entries.
- **Improvements:** Start a new purchase window when its configured interval changes.
- **Improvements:** Add tests for creation, rollback, duplicate features, and interval changes.
</details>

<h3>Confidence Score: 4/5</h3>

The customer-claim creation path can silently discard a supplied purchase count.

- New-customer creation and normal updates keep configuration and runtime state atomic.
- Claiming an existing customer returns before the new count synchronization runs.
- The request can succeed even though the supplied runtime count was not applied.

server/src/internal/customers/actions/createWithDefaults/execute/executeAutumnCreateCustomerPlan.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/actions/createWithDefaults/execute/executeAutumnCreateCustomerPlan.ts | Adds creation-time count synchronization, but the existing-customer claim branch returns before it runs. |
| server/src/internal/customers/actions/update/syncAutoTopupPurchaseLimitCounts.ts | Adds full count validation and resets the purchase window when its interval changes. |
| server/src/internal/customers/actions/update/updateCustomer.ts | Moves runtime count synchronization and customer configuration updates into one transaction. |
| shared/models/cusModels/billingControls/customerBillingControls.ts | Rejects duplicate auto top-up entries for the same feature. |
| server/tests/integration/crud/customers/auto-topup-purchase-limit-count.test.ts | Covers normal creation, rollback, interval changes, and duplicate features, but not creation through the customer-claim path. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Create customer request] --> B[Build customer configuration]
    B --> C[Insert or claim by email]
    C -->|New customer| D[Sync purchase count]
    D --> E[Execute billing plan]
    C -->|Existing customer claimed| F[Return before synchronization]
    F --> G[Supplied count is lost]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/customers/actions/createWithDefaults/execute/executeAutumnCreateCustomerPlan.ts:55-59
**Claimed Customer Count Is Dropped**

When `insertOrClaimEmail` returns `wasUpdate: true`, the preceding branch returns before this synchronization runs. A create request that claims an existing customer by email therefore stores the auto top-up configuration without `count` but never writes that count to `auto_topup_limit_states`, so the request succeeds while silently losing the supplied purchase count.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix auto topup purchase limit state sync..."](https://github.com/useautumn/autumn/commit/c156714360e1c8c1f6f30ae6dc532a802121ad54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46400333)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->