### PR TITLE
release

### DIFF
--- a/apps/docs/mintlify/api-reference/billing/attach.mdx
+++ b/apps/docs/mintlify/api-reference/billing/attach.mdx
@@ -506,7 +506,7 @@ A customer who has paid is locked to their currency: passing a different one, or
             </DynamicParamField>
 
             <DynamicParamField body="purchase_limit" type="object">
-              Optional rate limit to cap how often auto top-ups occur.
+              Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
               <Expandable title="properties">
                 <DynamicParamField body="interval" type="'hour' | 'day' | 'week' | 'month'" required>
                   The time interval for the purchase limit window.
@@ -518,6 +518,10 @@ A customer who has paid is locked to their currency: passing a different one, or
 
                 <DynamicParamField body="limit" type="number" required>
                   Maximum number of auto top-ups allowed within the interval.
+                </DynamicParamField>
+
+                <DynamicParamField body="count" type="number">
+                  Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                 </DynamicParamField>
 
               </Expandable>

--- a/apps/docs/mintlify/api-reference/billing/billingUpdate.mdx
+++ b/apps/docs/mintlify/api-reference/billing/billingUpdate.mdx
@@ -467,7 +467,7 @@ const response = await autumn.billing.update({
             </DynamicParamField>
 
             <DynamicParamField body="purchase_limit" type="object">
-              Optional rate limit to cap how often auto top-ups occur.
+              Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
               <Expandable title="properties">
                 <DynamicParamField body="interval" type="'hour' | 'day' | 'week' | 'month'" required>
                   The time interval for the purchase limit window.
@@ -479,6 +479,10 @@ const response = await autumn.billing.update({
 
                 <DynamicParamField body="limit" type="number" required>
                   Maximum number of auto top-ups allowed within the interval.
+                </DynamicParamField>
+
+                <DynamicParamField body="count" type="number">
+                  Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                 </DynamicParamField>
 
               </Expandable>

--- a/apps/docs/mintlify/api-reference/billing/createSchedule.mdx
+++ b/apps/docs/mintlify/api-reference/billing/createSchedule.mdx
@@ -459,7 +459,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                     </DynamicParamField>
 
                     <DynamicParamField body="purchase_limit" type="object">
-                      Optional rate limit to cap how often auto top-ups occur.
+                      Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                       <Expandable title="properties">
                         <DynamicParamField body="interval" type="'hour' | 'day' | 'week' | 'month'" required>
                           The time interval for the purchase limit window.
@@ -471,6 +471,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                         <DynamicParamField body="limit" type="number" required>
                           Maximum number of auto top-ups allowed within the interval.
+                        </DynamicParamField>
+
+                        <DynamicParamField body="count" type="number">
+                          Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                         </DynamicParamField>
 
                       </Expandable>

--- a/apps/docs/mintlify/api-reference/billing/import.mdx
+++ b/apps/docs/mintlify/api-reference/billing/import.mdx
@@ -982,7 +982,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                             </DynamicResponseField>
 
                             <DynamicResponseField name="purchase_limit" type="object">
-                              Optional rate limit to cap how often auto top-ups occur.
+                              Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                               <Expandable title="properties">
                                 <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                                   The time interval for the purchase limit window.
@@ -994,6 +994,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                                 <DynamicResponseField name="limit" type="number">
                                   Maximum number of auto top-ups allowed within the interval.
+                                </DynamicResponseField>
+
+                                <DynamicResponseField name="count" type="number">
+                                  Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                                 </DynamicResponseField>
 
                               </Expandable>
@@ -1917,7 +1921,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                             </DynamicResponseField>
 
                             <DynamicResponseField name="purchase_limit" type="object">
-                              Optional rate limit to cap how often auto top-ups occur.
+                              Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                               <Expandable title="properties">
                                 <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                                   The time interval for the purchase limit window.
@@ -1929,6 +1933,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                                 <DynamicResponseField name="limit" type="number">
                                   Maximum number of auto top-ups allowed within the interval.
+                                </DynamicResponseField>
+
+                                <DynamicResponseField name="count" type="number">
+                                  Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                                 </DynamicResponseField>
 
                               </Expandable>

--- a/apps/docs/mintlify/api-reference/billing/multiAttach.mdx
+++ b/apps/docs/mintlify/api-reference/billing/multiAttach.mdx
@@ -377,7 +377,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
             </DynamicParamField>
 
             <DynamicParamField body="purchase_limit" type="object">
-              Optional rate limit to cap how often auto top-ups occur.
+              Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
               <Expandable title="properties">
                 <DynamicParamField body="interval" type="'hour' | 'day' | 'week' | 'month'" required>
                   The time interval for the purchase limit window.
@@ -389,6 +389,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                 <DynamicParamField body="limit" type="number" required>
                   Maximum number of auto top-ups allowed within the interval.
+                </DynamicParamField>
+
+                <DynamicParamField body="count" type="number">
+                  Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                 </DynamicParamField>
 
               </Expandable>

--- a/apps/docs/mintlify/api-reference/billing/previewAttach.mdx
+++ b/apps/docs/mintlify/api-reference/billing/previewAttach.mdx
@@ -433,7 +433,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
             </DynamicParamField>
 
             <DynamicParamField body="purchase_limit" type="object">
-              Optional rate limit to cap how often auto top-ups occur.
+              Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
               <Expandable title="properties">
                 <DynamicParamField body="interval" type="'hour' | 'day' | 'week' | 'month'" required>
                   The time interval for the purchase limit window.
@@ -445,6 +445,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                 <DynamicParamField body="limit" type="number" required>
                   Maximum number of auto top-ups allowed within the interval.
+                </DynamicParamField>
+
+                <DynamicParamField body="count" type="number">
+                  Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                 </DynamicParamField>
 
               </Expandable>
@@ -1687,7 +1691,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                         </DynamicResponseField>
 
                         <DynamicResponseField name="purchase_limit" type="object">
-                          Optional rate limit to cap how often auto top-ups occur.
+                          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           <Expandable title="properties">
                             <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                               The time interval for the purchase limit window.
@@ -1699,6 +1703,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                             <DynamicResponseField name="limit" type="number">
                               Maximum number of auto top-ups allowed within the interval.
+                            </DynamicResponseField>
+
+                            <DynamicResponseField name="count" type="number">
+                              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             </DynamicResponseField>
 
                           </Expandable>
@@ -2600,7 +2608,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                         </DynamicResponseField>
 
                         <DynamicResponseField name="purchase_limit" type="object">
-                          Optional rate limit to cap how often auto top-ups occur.
+                          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           <Expandable title="properties">
                             <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                               The time interval for the purchase limit window.
@@ -2612,6 +2620,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                             <DynamicResponseField name="limit" type="number">
                               Maximum number of auto top-ups allowed within the interval.
+                            </DynamicResponseField>
+
+                            <DynamicResponseField name="count" type="number">
+                              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             </DynamicResponseField>
 
                           </Expandable>

--- a/apps/docs/mintlify/api-reference/billing/previewMultiAttach.mdx
+++ b/apps/docs/mintlify/api-reference/billing/previewMultiAttach.mdx
@@ -377,7 +377,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
             </DynamicParamField>
 
             <DynamicParamField body="purchase_limit" type="object">
-              Optional rate limit to cap how often auto top-ups occur.
+              Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
               <Expandable title="properties">
                 <DynamicParamField body="interval" type="'hour' | 'day' | 'week' | 'month'" required>
                   The time interval for the purchase limit window.
@@ -389,6 +389,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                 <DynamicParamField body="limit" type="number" required>
                   Maximum number of auto top-ups allowed within the interval.
+                </DynamicParamField>
+
+                <DynamicParamField body="count" type="number">
+                  Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                 </DynamicParamField>
 
               </Expandable>
@@ -1395,7 +1399,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                         </DynamicResponseField>
 
                         <DynamicResponseField name="purchase_limit" type="object">
-                          Optional rate limit to cap how often auto top-ups occur.
+                          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           <Expandable title="properties">
                             <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                               The time interval for the purchase limit window.
@@ -1407,6 +1411,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                             <DynamicResponseField name="limit" type="number">
                               Maximum number of auto top-ups allowed within the interval.
+                            </DynamicResponseField>
+
+                            <DynamicResponseField name="count" type="number">
+                              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             </DynamicResponseField>
 
                           </Expandable>
@@ -2308,7 +2316,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                         </DynamicResponseField>
 
                         <DynamicResponseField name="purchase_limit" type="object">
-                          Optional rate limit to cap how often auto top-ups occur.
+                          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           <Expandable title="properties">
                             <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                               The time interval for the purchase limit window.
@@ -2320,6 +2328,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                             <DynamicResponseField name="limit" type="number">
                               Maximum number of auto top-ups allowed within the interval.
+                            </DynamicResponseField>
+
+                            <DynamicResponseField name="count" type="number">
+                              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             </DynamicResponseField>
 
                           </Expandable>

--- a/apps/docs/mintlify/api-reference/billing/previewMultiUpdate.mdx
+++ b/apps/docs/mintlify/api-reference/billing/previewMultiUpdate.mdx
@@ -822,7 +822,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                             </DynamicResponseField>
 
                             <DynamicResponseField name="purchase_limit" type="object">
-                              Optional rate limit to cap how often auto top-ups occur.
+                              Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                               <Expandable title="properties">
                                 <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                                   The time interval for the purchase limit window.
@@ -834,6 +834,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                                 <DynamicResponseField name="limit" type="number">
                                   Maximum number of auto top-ups allowed within the interval.
+                                </DynamicResponseField>
+
+                                <DynamicResponseField name="count" type="number">
+                                  Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                                 </DynamicResponseField>
 
                               </Expandable>
@@ -1735,7 +1739,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                             </DynamicResponseField>
 
                             <DynamicResponseField name="purchase_limit" type="object">
-                              Optional rate limit to cap how often auto top-ups occur.
+                              Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                               <Expandable title="properties">
                                 <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                                   The time interval for the purchase limit window.
@@ -1747,6 +1751,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                                 <DynamicResponseField name="limit" type="number">
                                   Maximum number of auto top-ups allowed within the interval.
+                                </DynamicResponseField>
+
+                                <DynamicResponseField name="count" type="number">
+                                  Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                                 </DynamicResponseField>
 
                               </Expandable>

--- a/apps/docs/mintlify/api-reference/billing/previewUpdate.mdx
+++ b/apps/docs/mintlify/api-reference/billing/previewUpdate.mdx
@@ -433,7 +433,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
             </DynamicParamField>
 
             <DynamicParamField body="purchase_limit" type="object">
-              Optional rate limit to cap how often auto top-ups occur.
+              Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
               <Expandable title="properties">
                 <DynamicParamField body="interval" type="'hour' | 'day' | 'week' | 'month'" required>
                   The time interval for the purchase limit window.
@@ -445,6 +445,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                 <DynamicParamField body="limit" type="number" required>
                   Maximum number of auto top-ups allowed within the interval.
+                </DynamicParamField>
+
+                <DynamicParamField body="count" type="number">
+                  Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                 </DynamicParamField>
 
               </Expandable>
@@ -1630,7 +1634,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                         </DynamicResponseField>
 
                         <DynamicResponseField name="purchase_limit" type="object">
-                          Optional rate limit to cap how often auto top-ups occur.
+                          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           <Expandable title="properties">
                             <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                               The time interval for the purchase limit window.
@@ -1642,6 +1646,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                             <DynamicResponseField name="limit" type="number">
                               Maximum number of auto top-ups allowed within the interval.
+                            </DynamicResponseField>
+
+                            <DynamicResponseField name="count" type="number">
+                              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             </DynamicResponseField>
 
                           </Expandable>
@@ -2543,7 +2551,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                         </DynamicResponseField>
 
                         <DynamicResponseField name="purchase_limit" type="object">
-                          Optional rate limit to cap how often auto top-ups occur.
+                          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           <Expandable title="properties">
                             <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                               The time interval for the purchase limit window.
@@ -2555,6 +2563,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                             <DynamicResponseField name="limit" type="number">
                               Maximum number of auto top-ups allowed within the interval.
+                            </DynamicResponseField>
+
+                            <DynamicResponseField name="count" type="number">
+                              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             </DynamicResponseField>
 
                           </Expandable>

--- a/apps/docs/mintlify/api-reference/billing/setupPayment.mdx
+++ b/apps/docs/mintlify/api-reference/billing/setupPayment.mdx
@@ -433,7 +433,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
             </DynamicParamField>
 
             <DynamicParamField body="purchase_limit" type="object">
-              Optional rate limit to cap how often auto top-ups occur.
+              Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
               <Expandable title="properties">
                 <DynamicParamField body="interval" type="'hour' | 'day' | 'week' | 'month'" required>
                   The time interval for the purchase limit window.
@@ -445,6 +445,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                 <DynamicParamField body="limit" type="number" required>
                   Maximum number of auto top-ups allowed within the interval.
+                </DynamicParamField>
+
+                <DynamicParamField body="count" type="number">
+                  Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                 </DynamicParamField>
 
               </Expandable>

--- a/apps/docs/mintlify/api-reference/customers/getCustomer.mdx
+++ b/apps/docs/mintlify/api-reference/customers/getCustomer.mdx
@@ -801,7 +801,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                         </DynamicResponseField>
 
                         <DynamicResponseField name="purchase_limit" type="object">
-                          Optional rate limit to cap how often auto top-ups occur.
+                          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           <Expandable title="properties">
                             <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                               The time interval for the purchase limit window.
@@ -813,6 +813,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                             <DynamicResponseField name="limit" type="number">
                               Maximum number of auto top-ups allowed within the interval.
+                            </DynamicResponseField>
+
+                            <DynamicResponseField name="count" type="number">
+                              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             </DynamicResponseField>
 
                           </Expandable>
@@ -1736,7 +1740,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                         </DynamicResponseField>
 
                         <DynamicResponseField name="purchase_limit" type="object">
-                          Optional rate limit to cap how often auto top-ups occur.
+                          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           <Expandable title="properties">
                             <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                               The time interval for the purchase limit window.
@@ -1748,6 +1752,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                             <DynamicResponseField name="limit" type="number">
                               Maximum number of auto top-ups allowed within the interval.
+                            </DynamicResponseField>
+
+                            <DynamicResponseField name="count" type="number">
+                              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             </DynamicResponseField>
 
                           </Expandable>

--- a/apps/docs/mintlify/api-reference/customers/getOrCreateCustomer.mdx
+++ b/apps/docs/mintlify/api-reference/customers/getOrCreateCustomer.mdx
@@ -80,7 +80,7 @@ Pass `currency` to bill this customer in a currency other than your organization
         </DynamicParamField>
 
         <DynamicParamField body="purchase_limit" type="object">
-          Optional rate limit to cap how often auto top-ups occur.
+          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
           <Expandable title="properties">
             <DynamicParamField body="interval" type="'hour' | 'day' | 'week' | 'month'" required>
               The time interval for the purchase limit window.
@@ -92,6 +92,10 @@ Pass `currency` to bill this customer in a currency other than your organization
 
             <DynamicParamField body="limit" type="number" required>
               Maximum number of auto top-ups allowed within the interval.
+            </DynamicParamField>
+
+            <DynamicParamField body="count" type="number">
+              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
             </DynamicParamField>
 
           </Expandable>
@@ -1005,7 +1009,7 @@ Pass `currency` to bill this customer in a currency other than your organization
                         </DynamicResponseField>
 
                         <DynamicResponseField name="purchase_limit" type="object">
-                          Optional rate limit to cap how often auto top-ups occur.
+                          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           <Expandable title="properties">
                             <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                               The time interval for the purchase limit window.
@@ -1017,6 +1021,10 @@ Pass `currency` to bill this customer in a currency other than your organization
 
                             <DynamicResponseField name="limit" type="number">
                               Maximum number of auto top-ups allowed within the interval.
+                            </DynamicResponseField>
+
+                            <DynamicResponseField name="count" type="number">
+                              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             </DynamicResponseField>
 
                           </Expandable>
@@ -1940,7 +1948,7 @@ Pass `currency` to bill this customer in a currency other than your organization
                         </DynamicResponseField>
 
                         <DynamicResponseField name="purchase_limit" type="object">
-                          Optional rate limit to cap how often auto top-ups occur.
+                          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           <Expandable title="properties">
                             <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                               The time interval for the purchase limit window.
@@ -1952,6 +1960,10 @@ Pass `currency` to bill this customer in a currency other than your organization
 
                             <DynamicResponseField name="limit" type="number">
                               Maximum number of auto top-ups allowed within the interval.
+                            </DynamicResponseField>
+
+                            <DynamicResponseField name="count" type="number">
+                              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             </DynamicResponseField>
 
                           </Expandable>

--- a/apps/docs/mintlify/api-reference/customers/listCustomers.mdx
+++ b/apps/docs/mintlify/api-reference/customers/listCustomers.mdx
@@ -826,7 +826,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                             </DynamicResponseField>
 
                             <DynamicResponseField name="purchase_limit" type="object">
-                              Optional rate limit to cap how often auto top-ups occur.
+                              Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                               <Expandable title="properties">
                                 <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                                   The time interval for the purchase limit window.
@@ -838,6 +838,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                                 <DynamicResponseField name="limit" type="number">
                                   Maximum number of auto top-ups allowed within the interval.
+                                </DynamicResponseField>
+
+                                <DynamicResponseField name="count" type="number">
+                                  Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                                 </DynamicResponseField>
 
                               </Expandable>
@@ -1761,7 +1765,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                             </DynamicResponseField>
 
                             <DynamicResponseField name="purchase_limit" type="object">
-                              Optional rate limit to cap how often auto top-ups occur.
+                              Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                               <Expandable title="properties">
                                 <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                                   The time interval for the purchase limit window.
@@ -1773,6 +1777,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                                 <DynamicResponseField name="limit" type="number">
                                   Maximum number of auto top-ups allowed within the interval.
+                                </DynamicResponseField>
+
+                                <DynamicResponseField name="count" type="number">
+                                  Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                                 </DynamicResponseField>
 
                               </Expandable>

--- a/apps/docs/mintlify/api-reference/customers/updateCustomer.mdx
+++ b/apps/docs/mintlify/api-reference/customers/updateCustomer.mdx
@@ -64,7 +64,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
         </DynamicParamField>
 
         <DynamicParamField body="purchase_limit" type="object">
-          Optional rate limit to cap how often auto top-ups occur.
+          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
           <Expandable title="properties">
             <DynamicParamField body="interval" type="'hour' | 'day' | 'week' | 'month'" required>
               The time interval for the purchase limit window.
@@ -76,6 +76,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
             <DynamicParamField body="limit" type="number" required>
               Maximum number of auto top-ups allowed within the interval.
+            </DynamicParamField>
+
+            <DynamicParamField body="count" type="number">
+              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
             </DynamicParamField>
 
           </Expandable>
@@ -989,7 +993,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                         </DynamicResponseField>
 
                         <DynamicResponseField name="purchase_limit" type="object">
-                          Optional rate limit to cap how often auto top-ups occur.
+                          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           <Expandable title="properties">
                             <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                               The time interval for the purchase limit window.
@@ -1001,6 +1005,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                             <DynamicResponseField name="limit" type="number">
                               Maximum number of auto top-ups allowed within the interval.
+                            </DynamicResponseField>
+
+                            <DynamicResponseField name="count" type="number">
+                              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             </DynamicResponseField>
 
                           </Expandable>
@@ -1924,7 +1932,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                         </DynamicResponseField>
 
                         <DynamicResponseField name="purchase_limit" type="object">
-                          Optional rate limit to cap how often auto top-ups occur.
+                          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           <Expandable title="properties">
                             <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                               The time interval for the purchase limit window.
@@ -1936,6 +1944,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                             <DynamicResponseField name="limit" type="number">
                               Maximum number of auto top-ups allowed within the interval.
+                            </DynamicResponseField>
+
+                            <DynamicResponseField name="count" type="number">
+                              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             </DynamicResponseField>
 
                           </Expandable>

--- a/apps/docs/mintlify/api-reference/entities/createEntity.mdx
+++ b/apps/docs/mintlify/api-reference/entities/createEntity.mdx
@@ -181,7 +181,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
             </DynamicParamField>
 
             <DynamicParamField body="purchase_limit" type="object">
-              Optional rate limit to cap how often auto top-ups occur.
+              Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
               <Expandable title="properties">
                 <DynamicParamField body="interval" type="'hour' | 'day' | 'week' | 'month'" required>
                   The time interval for the purchase limit window.
@@ -193,6 +193,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                 <DynamicParamField body="limit" type="number" required>
                   Maximum number of auto top-ups allowed within the interval.
+                </DynamicParamField>
+
+                <DynamicParamField body="count" type="number">
+                  Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                 </DynamicParamField>
 
               </Expandable>
@@ -922,7 +926,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                         </DynamicResponseField>
 
                         <DynamicResponseField name="purchase_limit" type="object">
-                          Optional rate limit to cap how often auto top-ups occur.
+                          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           <Expandable title="properties">
                             <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                               The time interval for the purchase limit window.
@@ -934,6 +938,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                             <DynamicResponseField name="limit" type="number">
                               Maximum number of auto top-ups allowed within the interval.
+                            </DynamicResponseField>
+
+                            <DynamicResponseField name="count" type="number">
+                              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             </DynamicResponseField>
 
                           </Expandable>
@@ -1856,7 +1864,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                         </DynamicResponseField>
 
                         <DynamicResponseField name="purchase_limit" type="object">
-                          Optional rate limit to cap how often auto top-ups occur.
+                          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           <Expandable title="properties">
                             <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                               The time interval for the purchase limit window.
@@ -1868,6 +1876,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                             <DynamicResponseField name="limit" type="number">
                               Maximum number of auto top-ups allowed within the interval.
+                            </DynamicResponseField>
+
+                            <DynamicResponseField name="count" type="number">
+                              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             </DynamicResponseField>
 
                           </Expandable>

--- a/apps/docs/mintlify/api-reference/entities/getEntity.mdx
+++ b/apps/docs/mintlify/api-reference/entities/getEntity.mdx
@@ -610,7 +610,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                         </DynamicResponseField>
 
                         <DynamicResponseField name="purchase_limit" type="object">
-                          Optional rate limit to cap how often auto top-ups occur.
+                          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           <Expandable title="properties">
                             <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                               The time interval for the purchase limit window.
@@ -622,6 +622,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                             <DynamicResponseField name="limit" type="number">
                               Maximum number of auto top-ups allowed within the interval.
+                            </DynamicResponseField>
+
+                            <DynamicResponseField name="count" type="number">
+                              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             </DynamicResponseField>
 
                           </Expandable>
@@ -1544,7 +1548,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                         </DynamicResponseField>
 
                         <DynamicResponseField name="purchase_limit" type="object">
-                          Optional rate limit to cap how often auto top-ups occur.
+                          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           <Expandable title="properties">
                             <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                               The time interval for the purchase limit window.
@@ -1556,6 +1560,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                             <DynamicResponseField name="limit" type="number">
                               Maximum number of auto top-ups allowed within the interval.
+                            </DynamicResponseField>
+
+                            <DynamicResponseField name="count" type="number">
+                              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             </DynamicResponseField>
 
                           </Expandable>

--- a/apps/docs/mintlify/api-reference/entities/listEntities.mdx
+++ b/apps/docs/mintlify/api-reference/entities/listEntities.mdx
@@ -639,7 +639,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                             </DynamicResponseField>
 
                             <DynamicResponseField name="purchase_limit" type="object">
-                              Optional rate limit to cap how often auto top-ups occur.
+                              Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                               <Expandable title="properties">
                                 <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                                   The time interval for the purchase limit window.
@@ -651,6 +651,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                                 <DynamicResponseField name="limit" type="number">
                                   Maximum number of auto top-ups allowed within the interval.
+                                </DynamicResponseField>
+
+                                <DynamicResponseField name="count" type="number">
+                                  Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                                 </DynamicResponseField>
 
                               </Expandable>
@@ -1573,7 +1577,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                             </DynamicResponseField>
 
                             <DynamicResponseField name="purchase_limit" type="object">
-                              Optional rate limit to cap how often auto top-ups occur.
+                              Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                               <Expandable title="properties">
                                 <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                                   The time interval for the purchase limit window.
@@ -1585,6 +1589,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                                 <DynamicResponseField name="limit" type="number">
                                   Maximum number of auto top-ups allowed within the interval.
+                                </DynamicResponseField>
+
+                                <DynamicResponseField name="count" type="number">
+                                  Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                                 </DynamicResponseField>
 
                               </Expandable>

--- a/apps/docs/mintlify/api-reference/entities/updateEntity.mdx
+++ b/apps/docs/mintlify/api-reference/entities/updateEntity.mdx
@@ -712,7 +712,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                         </DynamicResponseField>
 
                         <DynamicResponseField name="purchase_limit" type="object">
-                          Optional rate limit to cap how often auto top-ups occur.
+                          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           <Expandable title="properties">
                             <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                               The time interval for the purchase limit window.
@@ -724,6 +724,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                             <DynamicResponseField name="limit" type="number">
                               Maximum number of auto top-ups allowed within the interval.
+                            </DynamicResponseField>
+
+                            <DynamicResponseField name="count" type="number">
+                              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             </DynamicResponseField>
 
                           </Expandable>
@@ -1646,7 +1650,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
                         </DynamicResponseField>
 
                         <DynamicResponseField name="purchase_limit" type="object">
-                          Optional rate limit to cap how often auto top-ups occur.
+                          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           <Expandable title="properties">
                             <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                               The time interval for the purchase limit window.
@@ -1658,6 +1662,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
                             <DynamicResponseField name="limit" type="number">
                               Maximum number of auto top-ups allowed within the interval.
+                            </DynamicResponseField>
+
+                            <DynamicResponseField name="count" type="number">
+                              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             </DynamicResponseField>
 
                           </Expandable>

--- a/apps/docs/mintlify/api-reference/plans/createPlan.mdx
+++ b/apps/docs/mintlify/api-reference/plans/createPlan.mdx
@@ -550,10 +550,6 @@ await autumn.plans.create({
 
     <DynamicParamField body="metadata" type="object" />
 
-    <DynamicParamField body="version" type="integer">
-      Pin the link to a specific version of the license plan. Omitted, an existing link keeps its pinned version and a new link resolves to the latest.
-    </DynamicParamField>
-
   </Expandable>
 </DynamicParamField>
 
@@ -612,7 +608,7 @@ await autumn.plans.create({
         </DynamicParamField>
 
         <DynamicParamField body="purchase_limit" type="object">
-          Optional rate limit to cap how often auto top-ups occur.
+          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
           <Expandable title="properties">
             <DynamicParamField body="interval" type="'hour' | 'day' | 'week' | 'month'" required>
               The time interval for the purchase limit window.
@@ -624,6 +620,10 @@ await autumn.plans.create({
 
             <DynamicParamField body="limit" type="number" required>
               Maximum number of auto top-ups allowed within the interval.
+            </DynamicParamField>
+
+            <DynamicParamField body="count" type="number">
+              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
             </DynamicParamField>
 
           </Expandable>
@@ -1301,7 +1301,7 @@ await autumn.plans.create({
                 </DynamicResponseField>
 
                 <DynamicResponseField name="purchase_limit" type="object">
-                  Optional rate limit to cap how often auto top-ups occur.
+                  Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                   <Expandable title="properties">
                     <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                       The time interval for the purchase limit window.
@@ -1313,6 +1313,10 @@ await autumn.plans.create({
 
                     <DynamicResponseField name="limit" type="number">
                       Maximum number of auto top-ups allowed within the interval.
+                    </DynamicResponseField>
+
+                    <DynamicResponseField name="count" type="number">
+                      Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                     </DynamicResponseField>
 
                   </Expandable>

--- a/apps/docs/mintlify/api-reference/plans/getPlan.mdx
+++ b/apps/docs/mintlify/api-reference/plans/getPlan.mdx
@@ -598,7 +598,7 @@ const plan = await autumn.plans.get({
                 </DynamicResponseField>
 
                 <DynamicResponseField name="purchase_limit" type="object">
-                  Optional rate limit to cap how often auto top-ups occur.
+                  Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                   <Expandable title="properties">
                     <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                       The time interval for the purchase limit window.
@@ -610,6 +610,10 @@ const plan = await autumn.plans.get({
 
                     <DynamicResponseField name="limit" type="number">
                       Maximum number of auto top-ups allowed within the interval.
+                    </DynamicResponseField>
+
+                    <DynamicResponseField name="count" type="number">
+                      Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                     </DynamicResponseField>
 
                   </Expandable>

--- a/apps/docs/mintlify/api-reference/plans/listPlans.mdx
+++ b/apps/docs/mintlify/api-reference/plans/listPlans.mdx
@@ -604,7 +604,7 @@ const plans = await autumn.plans.list({
                     </DynamicResponseField>
 
                     <DynamicResponseField name="purchase_limit" type="object">
-                      Optional rate limit to cap how often auto top-ups occur.
+                      Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                       <Expandable title="properties">
                         <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                           The time interval for the purchase limit window.
@@ -616,6 +616,10 @@ const plans = await autumn.plans.list({
 
                         <DynamicResponseField name="limit" type="number">
                           Maximum number of auto top-ups allowed within the interval.
+                        </DynamicResponseField>
+
+                        <DynamicResponseField name="count" type="number">
+                          Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                         </DynamicResponseField>
 
                       </Expandable>

--- a/apps/docs/mintlify/api-reference/plans/updatePlan.mdx
+++ b/apps/docs/mintlify/api-reference/plans/updatePlan.mdx
@@ -471,10 +471,6 @@ await autumn.plans.update({
 
     <DynamicParamField body="metadata" type="object" />
 
-    <DynamicParamField body="version" type="integer">
-      Pin the link to a specific version of the license plan. Omitted, an existing link keeps its pinned version and a new link resolves to the latest.
-    </DynamicParamField>
-
   </Expandable>
 </DynamicParamField>
 
@@ -533,7 +529,7 @@ await autumn.plans.update({
         </DynamicParamField>
 
         <DynamicParamField body="purchase_limit" type="object">
-          Optional rate limit to cap how often auto top-ups occur.
+          Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
           <Expandable title="properties">
             <DynamicParamField body="interval" type="'hour' | 'day' | 'week' | 'month'" required>
               The time interval for the purchase limit window.
@@ -545,6 +541,10 @@ await autumn.plans.update({
 
             <DynamicParamField body="limit" type="number" required>
               Maximum number of auto top-ups allowed within the interval.
+            </DynamicParamField>
+
+            <DynamicParamField body="count" type="number">
+              Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
             </DynamicParamField>
 
           </Expandable>
@@ -695,6 +695,16 @@ await autumn.plans.update({
 
 <DynamicParamField body="update_variant_ids" type="string[]">
   Variant plan IDs to apply this update to. Empty or omitted means no propagation.
+</DynamicParamField>
+
+<DynamicParamField body="update_license_parents" type="object[]">
+  Parent plan versions that should receive this license-plan update.
+  <Expandable title="properties">
+    <DynamicParamField body="plan_id" type="string" required />
+
+    <DynamicParamField body="version" type="integer" required />
+
+  </Expandable>
 </DynamicParamField>
 
 <DynamicParamField body="variants" type="object[]">
@@ -948,7 +958,7 @@ await autumn.plans.update({
                 </DynamicParamField>
 
                 <DynamicParamField body="purchase_limit" type="object">
-                  Optional rate limit to cap how often auto top-ups occur.
+                  Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                   <Expandable title="properties">
                     <DynamicParamField body="interval" type="'hour' | 'day' | 'week' | 'month'" required>
                       The time interval for the purchase limit window.
@@ -960,6 +970,10 @@ await autumn.plans.update({
 
                     <DynamicParamField body="limit" type="number" required>
                       Maximum number of auto top-ups allowed within the interval.
+                    </DynamicParamField>
+
+                    <DynamicParamField body="count" type="number">
+                      Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                     </DynamicParamField>
 
                   </Expandable>
@@ -1659,7 +1673,7 @@ await autumn.plans.update({
                 </DynamicResponseField>
 
                 <DynamicResponseField name="purchase_limit" type="object">
-                  Optional rate limit to cap how often auto top-ups occur.
+                  Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                   <Expandable title="properties">
                     <DynamicResponseField name="interval" type="'hour' | 'day' | 'week' | 'month'">
                       The time interval for the purchase limit window.
@@ -1671,6 +1685,10 @@ await autumn.plans.update({
 
                     <DynamicResponseField name="limit" type="number">
                       Maximum number of auto top-ups allowed within the interval.
+                    </DynamicResponseField>
+
+                    <DynamicResponseField name="count" type="number">
+                      Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                     </DynamicResponseField>
 
                   </Expandable>

--- a/apps/docs/mintlify/api/openapi.yml
+++ b/apps/docs/mintlify/api/openapi.yml
@@ -76,7 +76,6 @@ components:
                     description: Whether auto top-up is enabled.
                   threshold:
                     type: number
-                    minimum: 0
                     description: When the balance drops below this threshold, an auto top-up will be
                       purchased.
                   quantity:
@@ -103,10 +102,16 @@ components:
                         type: number
                         minimum: 1
                         description: Maximum number of auto top-ups allowed within the interval.
+                      count:
+                        type: number
+                        minimum: 0
+                        description: Set the current window's consumed auto top-up count. Omit to leave
+                          runtime state unchanged.
                     required:
                       - interval
                       - limit
-                    description: Optional rate limit to cap how often auto top-ups occur.
+                    description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                      to set the current window's consumed top-ups.
                   invoice_mode:
                     type: boolean
                     description: When true, auto top-up creates a send_invoice invoice instead of
@@ -339,7 +344,6 @@ components:
                     description: Whether auto top-up is enabled.
                   threshold:
                     type: number
-                    minimum: 0
                     description: When the balance drops below this threshold, an auto top-up will be
                       purchased.
                   quantity:
@@ -1996,7 +2000,6 @@ components:
                             description: Whether auto top-up is enabled.
                           threshold:
                             type: number
-                            minimum: 0
                             description: When the balance drops below this threshold, an auto top-up will be
                               purchased.
                           quantity:
@@ -2023,10 +2026,16 @@ components:
                                 type: number
                                 minimum: 1
                                 description: Maximum number of auto top-ups allowed within the interval.
+                              count:
+                                type: number
+                                minimum: 0
+                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                  runtime state unchanged.
                             required:
                               - interval
                               - limit
-                            description: Optional rate limit to cap how often auto top-ups occur.
+                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                              to set the current window's consumed top-ups.
                           invoice_mode:
                             type: boolean
                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -2197,7 +2206,6 @@ components:
                     description: Whether auto top-up is enabled.
                   threshold:
                     type: number
-                    minimum: 0
                     description: When the balance drops below this threshold, an auto top-up will be
                       purchased.
                   quantity:
@@ -2831,7 +2839,6 @@ paths:
                             description: Whether auto top-up is enabled.
                           threshold:
                             type: number
-                            minimum: 0
                             description: When the balance drops below this threshold, an auto top-up will be
                               purchased.
                           quantity:
@@ -2858,10 +2865,16 @@ paths:
                                 type: number
                                 minimum: 1
                                 description: Maximum number of auto top-ups allowed within the interval.
+                              count:
+                                type: number
+                                minimum: 0
+                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                  runtime state unchanged.
                             required:
                               - interval
                               - limit
-                            description: Optional rate limit to cap how often auto top-ups occur.
+                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                              to set the current window's consumed top-ups.
                           invoice_mode:
                             type: boolean
                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -3185,7 +3198,6 @@ paths:
                               description: Whether auto top-up is enabled.
                             threshold:
                               type: number
-                              minimum: 0
                               description: When the balance drops below this threshold, an auto top-up will be
                                 purchased.
                             quantity:
@@ -4261,7 +4273,6 @@ paths:
                                     description: Whether auto top-up is enabled.
                                   threshold:
                                     type: number
-                                    minimum: 0
                                     description: When the balance drops below this threshold, an auto top-up will be
                                       purchased.
                                   quantity:
@@ -5138,7 +5149,6 @@ paths:
                             description: Whether auto top-up is enabled.
                           threshold:
                             type: number
-                            minimum: 0
                             description: When the balance drops below this threshold, an auto top-up will be
                               purchased.
                           quantity:
@@ -5165,10 +5175,16 @@ paths:
                                 type: number
                                 minimum: 1
                                 description: Maximum number of auto top-ups allowed within the interval.
+                              count:
+                                type: number
+                                minimum: 0
+                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                  runtime state unchanged.
                             required:
                               - interval
                               - limit
-                            description: Optional rate limit to cap how often auto top-ups occur.
+                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                              to set the current window's consumed top-ups.
                           invoice_mode:
                             type: boolean
                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -5404,7 +5420,6 @@ paths:
                               description: Whether auto top-up is enabled.
                             threshold:
                               type: number
-                              minimum: 0
                               description: When the balance drops below this threshold, an auto top-up will be
                                 purchased.
                             quantity:
@@ -6851,7 +6866,6 @@ paths:
                             description: Whether auto top-up is enabled.
                           threshold:
                             type: number
-                            minimum: 0
                             description: When the balance drops below this threshold, an auto top-up will be
                               purchased.
                           quantity:
@@ -6878,10 +6892,16 @@ paths:
                                 type: number
                                 minimum: 1
                                 description: Maximum number of auto top-ups allowed within the interval.
+                              count:
+                                type: number
+                                minimum: 0
+                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                  runtime state unchanged.
                             required:
                               - interval
                               - limit
-                            description: Optional rate limit to cap how often auto top-ups occur.
+                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                              to set the current window's consumed top-ups.
                           invoice_mode:
                             type: boolean
                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -7843,7 +7863,6 @@ paths:
                                       description: Whether auto top-up is enabled.
                                     threshold:
                                       type: number
-                                      minimum: 0
                                       description: When the balance drops below this threshold, an auto top-up will be
                                         purchased.
                                     quantity:
@@ -7870,10 +7889,17 @@ paths:
                                           type: number
                                           minimum: 1
                                           description: Maximum number of auto top-ups allowed within the interval.
+                                        count:
+                                          type: number
+                                          minimum: 0
+                                          description: Set the current window's consumed auto top-up count. Omit to leave
+                                            runtime state unchanged.
                                       required:
                                         - interval
                                         - limit
-                                      description: Optional rate limit to cap how often auto top-ups occur.
+                                      description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                        to set the current window's consumed
+                                        top-ups.
                                     invoice_mode:
                                       type: boolean
                                       description: When true, auto top-up creates a send_invoice invoice instead of
@@ -8047,7 +8073,6 @@ paths:
                               description: Whether auto top-up is enabled.
                             threshold:
                               type: number
-                              minimum: 0
                               description: When the balance drops below this threshold, an auto top-up will be
                                 purchased.
                             quantity:
@@ -9173,7 +9198,6 @@ paths:
                                       description: Whether auto top-up is enabled.
                                     threshold:
                                       type: number
-                                      minimum: 0
                                       description: When the balance drops below this threshold, an auto top-up will be
                                         purchased.
                                     quantity:
@@ -9200,10 +9224,17 @@ paths:
                                           type: number
                                           minimum: 1
                                           description: Maximum number of auto top-ups allowed within the interval.
+                                        count:
+                                          type: number
+                                          minimum: 0
+                                          description: Set the current window's consumed auto top-up count. Omit to leave
+                                            runtime state unchanged.
                                       required:
                                         - interval
                                         - limit
-                                      description: Optional rate limit to cap how often auto top-ups occur.
+                                      description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                        to set the current window's consumed
+                                        top-ups.
                                     invoice_mode:
                                       type: boolean
                                       description: When true, auto top-up creates a send_invoice invoice instead of
@@ -9377,7 +9408,6 @@ paths:
                               description: Whether auto top-up is enabled.
                             threshold:
                               type: number
-                              minimum: 0
                               description: When the balance drops below this threshold, an auto top-up will be
                                 purchased.
                             quantity:
@@ -10482,7 +10512,6 @@ paths:
                                             description: Whether auto top-up is enabled.
                                           threshold:
                                             type: number
-                                            minimum: 0
                                             description: When the balance drops below this threshold, an auto top-up will be
                                               purchased.
                                           quantity:
@@ -10509,10 +10538,17 @@ paths:
                                                 type: number
                                                 minimum: 1
                                                 description: Maximum number of auto top-ups allowed within the interval.
+                                              count:
+                                                type: number
+                                                minimum: 0
+                                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                                  runtime state unchanged.
                                             required:
                                               - interval
                                               - limit
-                                            description: Optional rate limit to cap how often auto top-ups occur.
+                                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                              to set the current window's
+                                              consumed top-ups.
                                           invoice_mode:
                                             type: boolean
                                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -10687,7 +10723,6 @@ paths:
                                     description: Whether auto top-up is enabled.
                                   threshold:
                                     type: number
-                                    minimum: 0
                                     description: When the balance drops below this threshold, an auto top-up will be
                                       purchased.
                                   quantity:
@@ -11641,7 +11676,6 @@ paths:
                             description: Whether auto top-up is enabled.
                           threshold:
                             type: number
-                            minimum: 0
                             description: When the balance drops below this threshold, an auto top-up will be
                               purchased.
                           quantity:
@@ -11668,10 +11702,16 @@ paths:
                                 type: number
                                 minimum: 1
                                 description: Maximum number of auto top-ups allowed within the interval.
+                              count:
+                                type: number
+                                minimum: 0
+                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                  runtime state unchanged.
                             required:
                               - interval
                               - limit
-                            description: Optional rate limit to cap how often auto top-ups occur.
+                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                              to set the current window's consumed top-ups.
                           invoice_mode:
                             type: boolean
                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -12241,7 +12281,6 @@ paths:
                                       description: Whether auto top-up is enabled.
                                     threshold:
                                       type: number
-                                      minimum: 0
                                       description: When the balance drops below this threshold, an auto top-up will be
                                         purchased.
                                     quantity:
@@ -12268,10 +12307,17 @@ paths:
                                           type: number
                                           minimum: 1
                                           description: Maximum number of auto top-ups allowed within the interval.
+                                        count:
+                                          type: number
+                                          minimum: 0
+                                          description: Set the current window's consumed auto top-up count. Omit to leave
+                                            runtime state unchanged.
                                       required:
                                         - interval
                                         - limit
-                                      description: Optional rate limit to cap how often auto top-ups occur.
+                                      description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                        to set the current window's consumed
+                                        top-ups.
                                     invoice_mode:
                                       type: boolean
                                       description: When true, auto top-up creates a send_invoice invoice instead of
@@ -13226,7 +13272,6 @@ paths:
                                       description: Whether auto top-up is enabled.
                                     threshold:
                                       type: number
-                                      minimum: 0
                                       description: When the balance drops below this threshold, an auto top-up will be
                                         purchased.
                                     quantity:
@@ -13253,10 +13298,17 @@ paths:
                                           type: number
                                           minimum: 1
                                           description: Maximum number of auto top-ups allowed within the interval.
+                                        count:
+                                          type: number
+                                          minimum: 0
+                                          description: Set the current window's consumed auto top-up count. Omit to leave
+                                            runtime state unchanged.
                                       required:
                                         - interval
                                         - limit
-                                      description: Optional rate limit to cap how often auto top-ups occur.
+                                      description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                        to set the current window's consumed
+                                        top-ups.
                                     invoice_mode:
                                       type: boolean
                                       description: When true, auto top-up creates a send_invoice invoice instead of
@@ -13430,7 +13482,6 @@ paths:
                               description: Whether auto top-up is enabled.
                             threshold:
                               type: number
-                              minimum: 0
                               description: When the balance drops below this threshold, an auto top-up will be
                                 purchased.
                             quantity:
@@ -15422,7 +15473,6 @@ paths:
                                 description: Whether auto top-up is enabled.
                               threshold:
                                 type: number
-                                minimum: 0
                                 description: When the balance drops below this threshold, an auto top-up will be
                                   purchased.
                               quantity:
@@ -15449,10 +15499,16 @@ paths:
                                     type: number
                                     minimum: 1
                                     description: Maximum number of auto top-ups allowed within the interval.
+                                  count:
+                                    type: number
+                                    minimum: 0
+                                    description: Set the current window's consumed auto top-up count. Omit to leave
+                                      runtime state unchanged.
                                 required:
                                   - interval
                                   - limit
-                                description: Optional rate limit to cap how often auto top-ups occur.
+                                description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                  to set the current window's consumed top-ups.
                               invoice_mode:
                                 type: boolean
                                 description: When true, auto top-up creates a send_invoice invoice instead of
@@ -16867,7 +16923,6 @@ paths:
                                               description: Whether auto top-up is enabled.
                                             threshold:
                                               type: number
-                                              minimum: 0
                                               description: When the balance drops below this threshold, an auto top-up will be
                                                 purchased.
                                             quantity:
@@ -16894,10 +16949,17 @@ paths:
                                                   type: number
                                                   minimum: 1
                                                   description: Maximum number of auto top-ups allowed within the interval.
+                                                count:
+                                                  type: number
+                                                  minimum: 0
+                                                  description: Set the current window's consumed auto top-up count. Omit to leave
+                                                    runtime state unchanged.
                                               required:
                                                 - interval
                                                 - limit
-                                              description: Optional rate limit to cap how often auto top-ups occur.
+                                              description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                                to set the current window's
+                                                consumed top-ups.
                                             invoice_mode:
                                               type: boolean
                                               description: When true, auto top-up creates a send_invoice invoice instead of
@@ -17568,7 +17630,6 @@ paths:
                                             description: Whether auto top-up is enabled.
                                           threshold:
                                             type: number
-                                            minimum: 0
                                             description: When the balance drops below this threshold, an auto top-up will be
                                               purchased.
                                           quantity:
@@ -17595,10 +17656,17 @@ paths:
                                                 type: number
                                                 minimum: 1
                                                 description: Maximum number of auto top-ups allowed within the interval.
+                                              count:
+                                                type: number
+                                                minimum: 0
+                                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                                  runtime state unchanged.
                                             required:
                                               - interval
                                               - limit
-                                            description: Optional rate limit to cap how often auto top-ups occur.
+                                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                              to set the current window's
+                                              consumed top-ups.
                                           invoice_mode:
                                             type: boolean
                                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -19287,7 +19355,6 @@ paths:
                                 description: Whether auto top-up is enabled.
                               threshold:
                                 type: number
-                                minimum: 0
                                 description: When the balance drops below this threshold, an auto top-up will be
                                   purchased.
                               quantity:
@@ -19314,10 +19381,16 @@ paths:
                                     type: number
                                     minimum: 1
                                     description: Maximum number of auto top-ups allowed within the interval.
+                                  count:
+                                    type: number
+                                    minimum: 0
+                                    description: Set the current window's consumed auto top-up count. Omit to leave
+                                      runtime state unchanged.
                                 required:
                                   - interval
                                   - limit
-                                description: Optional rate limit to cap how often auto top-ups occur.
+                                description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                  to set the current window's consumed top-ups.
                               invoice_mode:
                                 type: boolean
                                 description: When true, auto top-up creates a send_invoice invoice instead of
@@ -22078,7 +22151,6 @@ paths:
                                 description: Whether auto top-up is enabled.
                               threshold:
                                 type: number
-                                minimum: 0
                                 description: When the balance drops below this threshold, an auto top-up will be
                                   purchased.
                               quantity:
@@ -22105,10 +22177,16 @@ paths:
                                     type: number
                                     minimum: 1
                                     description: Maximum number of auto top-ups allowed within the interval.
+                                  count:
+                                    type: number
+                                    minimum: 0
+                                    description: Set the current window's consumed auto top-up count. Omit to leave
+                                      runtime state unchanged.
                                 required:
                                   - interval
                                   - limit
-                                description: Optional rate limit to cap how often auto top-ups occur.
+                                description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                  to set the current window's consumed top-ups.
                               invoice_mode:
                                 type: boolean
                                 description: When true, auto top-up creates a send_invoice invoice instead of
@@ -23440,7 +23518,6 @@ paths:
                                 description: Whether auto top-up is enabled.
                               threshold:
                                 type: number
-                                minimum: 0
                                 description: When the balance drops below this threshold, an auto top-up will be
                                   purchased.
                               quantity:
@@ -23467,10 +23544,16 @@ paths:
                                     type: number
                                     minimum: 1
                                     description: Maximum number of auto top-ups allowed within the interval.
+                                  count:
+                                    type: number
+                                    minimum: 0
+                                    description: Set the current window's consumed auto top-up count. Omit to leave
+                                      runtime state unchanged.
                                 required:
                                   - interval
                                   - limit
-                                description: Optional rate limit to cap how often auto top-ups occur.
+                                description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                  to set the current window's consumed top-ups.
                               invoice_mode:
                                 type: boolean
                                 description: When true, auto top-up creates a send_invoice invoice instead of
@@ -25924,7 +26007,6 @@ paths:
                                 description: Whether auto top-up is enabled.
                               threshold:
                                 type: number
-                                minimum: 0
                                 description: When the balance drops below this threshold, an auto top-up will be
                                   purchased.
                               quantity:
@@ -25951,10 +26033,16 @@ paths:
                                     type: number
                                     minimum: 1
                                     description: Maximum number of auto top-ups allowed within the interval.
+                                  count:
+                                    type: number
+                                    minimum: 0
+                                    description: Set the current window's consumed auto top-up count. Omit to leave
+                                      runtime state unchanged.
                                 required:
                                   - interval
                                   - limit
-                                description: Optional rate limit to cap how often auto top-ups occur.
+                                description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                  to set the current window's consumed top-ups.
                               invoice_mode:
                                 type: boolean
                                 description: When true, auto top-up creates a send_invoice invoice instead of
@@ -28079,7 +28167,6 @@ paths:
                                         description: Whether auto top-up is enabled.
                                       threshold:
                                         type: number
-                                        minimum: 0
                                         description: When the balance drops below this threshold, an auto top-up will be
                                           purchased.
                                       quantity:
@@ -28856,7 +28943,6 @@ paths:
                                         description: Whether auto top-up is enabled.
                                       threshold:
                                         type: number
-                                        minimum: 0
                                         description: When the balance drops below this threshold, an auto top-up will be
                                           purchased.
                                       quantity:

--- a/firelens.conf
+++ b/firelens.conf
@@ -1,3 +1,9 @@
+[SERVICE]
+    # Flightcontrol prepends its own SERVICE block. The production AWS Fluent
+    # Bit image accepts an additional block and needs this file registered
+    # before the parser filter can use its built-in `json` parser.
+    Parsers_File /fluent-bit/etc/parsers.conf
+
 [FILTER]
     Name modify
     Match *
@@ -27,9 +33,40 @@
     Match *
     Add region ${AWS_REGION}
 
+[FILTER]
+    Name parser
+    Match *-firelens-*
+    Key_Name log
+    Parser json
+    Reserve_Data On
+    Preserve_Key Off
+
+[FILTER]
+    Name rewrite_tag
+    Match *-firelens-*
+    Rule $level ^(TRACE|DEBUG|INFO|WARN|ERROR|FATAL)$ axiom_express false
+    Emitter_Name axiom_express_emitter
+    Emitter_Storage.type memory
+    Emitter_Mem_Buf_Limit 10M
+
 [OUTPUT]
     Name http
-    Match *
+    Match axiom_express
+    Host us-east-1.aws.edge.axiom.co
+    Port 443
+    URI /v1/ingest/express
+    Format json
+    TLS On
+    json_date_key _time
+    json_date_format iso8601
+    Header Authorization Bearer ${AXIOM_TOKEN}
+    Header Content-Type application/json
+    retry_limit 5
+    net.dns.mode TCP
+
+[OUTPUT]
+    Name http
+    Match *-firelens-*
     Host us-east-1.aws.edge.axiom.co
     Port 443
     URI /v1/ingest/ecs

--- a/others/python-sdk/.speakeasy/gen.lock
+++ b/others/python-sdk/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: 05940b80-1ef8-40f4-9878-822fb2792070
 management:
-  docChecksum: c4956f53385cc66b5b4c481c15cb181c
+  docChecksum: f81a95ffb32713acb147693f47644f88
   docVersion: 2.3.0
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
   releaseVersion: 0.4.19
   configChecksum: b2caf9ea956e3c3c26e7f639fdd4ff2e
 persistentEdits:
-  generation_id: 8b1b6ff2-616b-4e09-9570-0eee9f8ef43a
-  pristine_commit_hash: 859aed428a688e93945dec33b8624806be19658b
-  pristine_tree_hash: b3ea4e12c87c5db00b362129ed6393b57ffbd44a
+  generation_id: 94db51d8-a3ad-4c1e-9b72-d54cf91ac359
+  pristine_commit_hash: 09700e90e0a61d65b07abe2fda558414bde70e99
+  pristine_tree_hash: c91210be739d76d006d83e040ad7f09e225c47bf
 features:
   python:
     additionalDependencies: 1.0.0
@@ -159,8 +159,8 @@ trackedFiles:
     pristine_git_object: 4b225a6a18f0583c0a5c0d0f770ef46cd12db337
   docs/models/attachautotopup.md:
     id: 15110f2cdb28
-    last_write_checksum: sha1:c9be4205d04d413b0d6d9c339111c7d792b49208
-    pristine_git_object: 17993b67ab2db059bb19591f51f3779ffe8d5546
+    last_write_checksum: sha1:fb7eb4673e19e5cbd55ea66a4dd85d20b766a3c3
+    pristine_git_object: d2ce35bcbdfd111c991acba79d36446b4f39950e
   docs/models/attachbaseprice.md:
     id: 9d6b5ae8c450
     last_write_checksum: sha1:136d86ac185da442a3e452cefaee5098f9fda771
@@ -363,8 +363,8 @@ trackedFiles:
     pristine_git_object: 925ea57b3dc4fb417c734ad9eeb3c161d2cfe68a
   docs/models/attachpurchaselimit.md:
     id: 1b8ea180aebf
-    last_write_checksum: sha1:1266d9d7e4acad6420d8656826d1d67c0c6dc3e5
-    pristine_git_object: 4976acf64da74f2b82dc3cf776fc9653ff8d1e94
+    last_write_checksum: sha1:2f17f6f2782455e0b21c4bfb4ce318f3644efaa1
+    pristine_git_object: f05d94fd768b7d182934fc7d2edab05b39678652
   docs/models/attachpurchaselimitinterval.md:
     id: 0a050968da92
     last_write_checksum: sha1:829e520883f075fdb853af6f4bd726c891239d95
@@ -663,8 +663,8 @@ trackedFiles:
     pristine_git_object: fe865ad29596f3a5c72a5ac55589086ae8b20064
   docs/models/billingupdateautotopup.md:
     id: 5b3d651d9246
-    last_write_checksum: sha1:6ffec6bca0b127ab2bce7af83dbc7f567a8750c6
-    pristine_git_object: 13c752e910ef8397fbad049040098047ff76f8c9
+    last_write_checksum: sha1:fa9f8653d5c58ce0e66ba3a44c2c24d662c03c5e
+    pristine_git_object: 8d434095c4b1dd27dee529a676544df57591f831
   docs/models/billingupdatebaseprice.md:
     id: c632c15479cf
     last_write_checksum: sha1:e76ef3c07fb0a53af8c4ae9981b07e379191fbd2
@@ -839,8 +839,8 @@ trackedFiles:
     pristine_git_object: 2fe315798c7425eea4b333ea5a3be11455a5e45d
   docs/models/billingupdatepurchaselimit.md:
     id: e8ab03617105
-    last_write_checksum: sha1:914aa71b58dfd8ce1df2d8b6eb5ee9832ad1b862
-    pristine_git_object: a1be7a56fba22870807e81d2a7a3f6e77cf58dcb
+    last_write_checksum: sha1:a53558e42bd7a34922b052fef8b4082037780b00
+    pristine_git_object: 14a94398d03db8e932e2ecebd316fc61e2a93bc7
   docs/models/billingupdatepurchaselimitinterval.md:
     id: ac34c00d2a69
     last_write_checksum: sha1:b95040a12884533e450cc65f29b7708e769fe597
@@ -1507,8 +1507,8 @@ trackedFiles:
     pristine_git_object: 18912b7d8ea75eb28d8c7b26b260cbe0b7b3e5ac
   docs/models/createplanautotopuprequest.md:
     id: 5b8c1f2c1e5e
-    last_write_checksum: sha1:a42a98ee8e83e237d26c7acdc9aafdc541ef517c
-    pristine_git_object: 7f2952912916622cc4c2c10254b69609fadf8e25
+    last_write_checksum: sha1:3d5eec21a14c5a8c1953a626a1f6cdf22aa1cfb7
+    pristine_git_object: ddcc38d3427e9c4386502784fb7eb934f9be1aef
   docs/models/createplanautotopupresponse.md:
     id: 95f17e3ab250
     last_write_checksum: sha1:bb0b532ed8193b821de82784146e057cf4c11088
@@ -1891,8 +1891,8 @@ trackedFiles:
     pristine_git_object: d0186ff49ec916df60ab6b1b6a767fd0894cde84
   docs/models/createplanpurchaselimitrequest.md:
     id: 071c769e81ec
-    last_write_checksum: sha1:dda3f921fbef9455bd18b263adf4eeda75338eb9
-    pristine_git_object: 8d777218a7e21f7ac54c4ad9d9d3cb0ce9300cf7
+    last_write_checksum: sha1:eab27cc21dd4a2f02c0648620ff4bbf7cc7c3d88
+    pristine_git_object: da8bf517a90de32afe03540dcea9b65ca00caa9d
   docs/models/createplanpurchaselimitresponse.md:
     id: 6c1246186aa6
     last_write_checksum: sha1:7b869cd5b84e9c84e31b6cbefe81eb35c2adb51c
@@ -1975,8 +1975,8 @@ trackedFiles:
     pristine_git_object: 6a253774e18e4e86bae8ce4a58269d0db49df4e5
   docs/models/createplanvariantdetailsautotopup.md:
     id: c984520c75ca
-    last_write_checksum: sha1:05612b5707e4599528357b6823bec8bfc71b70c1
-    pristine_git_object: bc5281cf86028f7dc0f00cc6adb5b399d39c53c2
+    last_write_checksum: sha1:6f76843c667c739300a7990807de3f33a2bd0779
+    pristine_git_object: 698ce80b6cf5b8677695a773ffa5a02be9a5540e
   docs/models/createplanvariantdetailsbillingcontrols.md:
     id: ae5beb6e1689
     last_write_checksum: sha1:57ee7a8210dbc93cdd5a9ef98a7ea7b2d0953c68
@@ -2023,8 +2023,8 @@ trackedFiles:
     pristine_git_object: 917de0238e95eaefae558f949050655ab15cd876
   docs/models/createplanvariantdetailspurchaselimit.md:
     id: c7aef1c5ade3
-    last_write_checksum: sha1:4fb7d33541cf232bbb13d9c4b2f36b3100c69df0
-    pristine_git_object: ea15306d0dbbf0c074d9669add6a1df6e449cd63
+    last_write_checksum: sha1:ac4e46903f3de9792d294648171d822b763175fd
+    pristine_git_object: f276f58047d94fae2d8910eff6fed2e9ad113d58
   docs/models/createplanvariantdetailspurchaselimitinterval.md:
     id: 087c419f9a82
     last_write_checksum: sha1:eee7a5787e37fe90c7867ca7aafa5e771ce7ac8e
@@ -2159,8 +2159,8 @@ trackedFiles:
     pristine_git_object: 115eb2fd82f0358d49f960ddca8e8f651fc8b33f
   docs/models/createscheduleautotopup2.md:
     id: 06f15100a5d2
-    last_write_checksum: sha1:a9ff84d7e6ae6cd7789dee8c3f02e52085f1eec8
-    pristine_git_object: 6dde81cc563717b7e615c442528defbb29e42c72
+    last_write_checksum: sha1:22d0b7ee3f4501b061f4b1138dcfa0b3b3226cf3
+    pristine_git_object: b8d533146470d265d8e521c62db91bc94f6a55ea
   docs/models/createschedulebaseprice2.md:
     id: 085a5cb811d8
     last_write_checksum: sha1:def7fa9dda15e1bc7f0275f1cff1a83a898da0a6
@@ -2299,8 +2299,8 @@ trackedFiles:
     pristine_git_object: 1e05140406e5b892611a0e99e19efe47887bdf90
   docs/models/createschedulepurchaselimit2.md:
     id: ba44df61a018
-    last_write_checksum: sha1:c7932a218fd8c1142f9eddd3ed60531209639ea8
-    pristine_git_object: 2684491f0d5971a475cd1fa511a4c32ecd40485a
+    last_write_checksum: sha1:c79e2274b3f06f779873e11f4396ffec2ec27d20
+    pristine_git_object: cce0a613efdf929fb21353d00b53858f2d88e91d
   docs/models/createschedulepurchaselimitinterval2.md:
     id: 710eceb9eac1
     last_write_checksum: sha1:6462a9c6fed4b22781eae8a1433fded5378ca1b5
@@ -2371,8 +2371,8 @@ trackedFiles:
     pristine_git_object: 322f87ce6357ae1918cd174de701fca6fc93bd77
   docs/models/customerdataautotopup.md:
     id: d37b23cdcc27
-    last_write_checksum: sha1:599e96167eead0ea87a6b3965819019ea4437f01
-    pristine_git_object: cf6e86760fcb5e8d9a375b62760578fc71f70d20
+    last_write_checksum: sha1:433e9c8b113eb943d47903cdded0b1954e598c8d
+    pristine_git_object: a5d99fd5517ed078f9dbfd8d2a61c0b52e866a53
   docs/models/customerdatabillingcontrols.md:
     id: 9a9f4fd47b8a
     last_write_checksum: sha1:5a4fbe5d38c490cca6cd4c41fd78725cacac86c6
@@ -2395,8 +2395,8 @@ trackedFiles:
     pristine_git_object: 4e59bfa9db3b3f1293ce0cda920140ea981b9e09
   docs/models/customerdatapurchaselimit.md:
     id: c415017a8c4d
-    last_write_checksum: sha1:5fbe7355e01e4dabb7743d839402502e3d60276d
-    pristine_git_object: f08f426d51c40b4642f63f55e8005de29868f9c9
+    last_write_checksum: sha1:754e8cccbf67011908c56579d574d104ea7e9f42
+    pristine_git_object: 4c66c61268b24daa0f61591d7bf7d1b07a3af5b0
   docs/models/customerdatapurchaselimitinterval.md:
     id: 2f2f6406b75e
     last_write_checksum: sha1:08a5e556685e524455fe6628ca03903bf26c4b50
@@ -3095,8 +3095,8 @@ trackedFiles:
     pristine_git_object: f5f28a920ccbcc244822b0994dcf89419eef72f7
   docs/models/getorcreatecustomerautotopup.md:
     id: 2beff692c107
-    last_write_checksum: sha1:980d9d480f667e5f75ee005128a4023488a139bd
-    pristine_git_object: 71910553ee8796a2dfbe5c63d62515ab63b0c395
+    last_write_checksum: sha1:b34a5b6887423474a02f17f6464386491cff0896
+    pristine_git_object: 6574c394f189b419b8f4be217084634cfdc8e05c
   docs/models/getorcreatecustomerbillingcontrols.md:
     id: c863934c5751
     last_write_checksum: sha1:2e5c116229b1061befedcba9938cb00ebf3b4d0c
@@ -3131,8 +3131,8 @@ trackedFiles:
     pristine_git_object: 63394b3bc1cc7c1670c5212a6b3d813c0b3b8ef1
   docs/models/getorcreatecustomerpurchaselimit.md:
     id: "425587326514"
-    last_write_checksum: sha1:d1d028dde2dcade9702ce1a70966f045baf49c74
-    pristine_git_object: 324803fdec501d444e3e929e13aa29cbff75b39d
+    last_write_checksum: sha1:337d4a049f4b9c0eed1fce47d7485ffdf571cfc5
+    pristine_git_object: 6750d5d3b725807dfad3ae61a657190173af537d
   docs/models/getorcreatecustomerpurchaselimitinterval.md:
     id: b8251af4ba20
     last_write_checksum: sha1:82af2be0dc953f3f71c37eea8be1f823f195cd76
@@ -3411,8 +3411,8 @@ trackedFiles:
     pristine_git_object: 91a6df1aba96e704ab4757be8aefafc3e228cd98
   docs/models/getplanvariantdetailsautotopup.md:
     id: 00dbb93a61e3
-    last_write_checksum: sha1:4ba39bc774344474c74537948402b7de6539a68b
-    pristine_git_object: 5ae0bb51165473bfeaa0f5cf2b5e899118129846
+    last_write_checksum: sha1:5fbc4ed00eb8049c9c6181517bde4921e8786014
+    pristine_git_object: fb229fe4e21894aaeca708018ee3cd0bda336e49
   docs/models/getplanvariantdetailsbillingcontrols.md:
     id: 1547325cf915
     last_write_checksum: sha1:e5ecdcceead9de4e368c8f3afe4838b6bf365f0c
@@ -3447,8 +3447,8 @@ trackedFiles:
     pristine_git_object: da6f6059e2dcd671ee16e5082bb6de10286880e8
   docs/models/getplanvariantdetailspurchaselimit.md:
     id: 755524a499a6
-    last_write_checksum: sha1:a31a17a34b17d42e7d0646f1756389c6f48cbac0
-    pristine_git_object: 772a730e464769cdb6238dbb68f414b818c541b4
+    last_write_checksum: sha1:efd9486cc077f47bc8562bb6396636d21601d8ea
+    pristine_git_object: 6c3293e65c6ae1d11fc1ce69308f16fd968f7745
   docs/models/getplanvariantdetailspurchaselimitinterval.md:
     id: 8b09af747476
     last_write_checksum: sha1:f0b33809106d249845b2b0957629bc18299808da
@@ -4347,8 +4347,8 @@ trackedFiles:
     pristine_git_object: b08aad360f30f4657b9ccb89ec95b7aa745acfba
   docs/models/listplansvariantdetailsautotopup.md:
     id: 20c33dc6e5ca
-    last_write_checksum: sha1:be638999b8c60289754d96b0e0a6f1bc0349bcdf
-    pristine_git_object: 94983a79195b5126e42d75377423cdf762ce66a0
+    last_write_checksum: sha1:bcf4b841e6399c02d3082460342f32aeb324448e
+    pristine_git_object: 339362f7c26ece090297b0b458a6d458ad189c43
   docs/models/listplansvariantdetailsbillingcontrols.md:
     id: f5477e249645
     last_write_checksum: sha1:fc56f310f7de1696d8780147cbf0e0c67306e46c
@@ -4383,8 +4383,8 @@ trackedFiles:
     pristine_git_object: 2ddce0ac83d7fea8823fe7e619c0b6b81544830a
   docs/models/listplansvariantdetailspurchaselimit.md:
     id: b631a937a083
-    last_write_checksum: sha1:8e5c403a8dafae0d2987c78783cb452234d91d25
-    pristine_git_object: d75739f14a5ec9173d1b76e3bc502093ccd321a0
+    last_write_checksum: sha1:e759fb7f6d414cd3e81cc1fe16fd3f31de75cbf0
+    pristine_git_object: 717cf18603cdbe6797541bf5696cc9092cf140c8
   docs/models/listplansvariantdetailspurchaselimitinterval.md:
     id: 55bcccf59241
     last_write_checksum: sha1:c2a4993f94ca705901d705eb9987aa490eeec120
@@ -4891,8 +4891,8 @@ trackedFiles:
     pristine_git_object: aef5b6c1bc30b6efa4eca01abcdc24c6e5cbd2dc
   docs/models/planvariantdetailsautotopup.md:
     id: 4ec4f15fa7c1
-    last_write_checksum: sha1:73355bfb2509464f6cc00e1534c15fed48585086
-    pristine_git_object: d23d7b5a6e28230d24a9884646cc040ac0c67c99
+    last_write_checksum: sha1:b9e4b49e925a3ed3e19545298fe4c6c0b2a6dfc8
+    pristine_git_object: a40cd869b27123408574fcfdb4a3661ec4f26b13
   docs/models/planvariantdetailsbillingcontrols.md:
     id: bded401054c6
     last_write_checksum: sha1:3fae1efce480f700b96060becaa2a93396c07a2d
@@ -4919,8 +4919,8 @@ trackedFiles:
     pristine_git_object: ced9f5af8e6be7355149cdf978cfab022958e1e9
   docs/models/planvariantdetailspurchaselimit.md:
     id: a9bb69a6fe6a
-    last_write_checksum: sha1:b75ba6a6dde3d65d901ae816977f69ff6721d25f
-    pristine_git_object: 91ee2745ab4bf483facb6c29644f9abe67b26e79
+    last_write_checksum: sha1:757ca9f7e750e346c024e2a8a88aaf905bddaf17
+    pristine_git_object: 9f8c602b2da21ce474f72acca12f90ed3436b0cf
   docs/models/planvariantdetailspurchaselimitinterval.md:
     id: 933acdf1458a
     last_write_checksum: sha1:fa74328ea572dde6724182eea1688f640f878b19
@@ -5051,8 +5051,8 @@ trackedFiles:
     pristine_git_object: 9d29579d60ad03509a0c3a9322beea8adc82f55a
   docs/models/previewattachautotopup.md:
     id: 65bde9ecb54d
-    last_write_checksum: sha1:2627dba7fd4fd1f3524ffaf9eb7f6987f7c72979
-    pristine_git_object: 9b49268d7642e604708a44d66adac9acf1e63720
+    last_write_checksum: sha1:daa89e8e7d748894416d06955635d6530cc9d3aa
+    pristine_git_object: 3d6896260bdb77f524c28642456435ff0b9ba957
   docs/models/previewattachbaseprice.md:
     id: 7c2843459273
     last_write_checksum: sha1:97d8c02b3aebcc3ec12ec4f7b8d0bff60042f056
@@ -5283,8 +5283,8 @@ trackedFiles:
     pristine_git_object: 1cc089658a20a07a4f3d3a449f7373cf36037a74
   docs/models/previewattachpurchaselimit.md:
     id: eaf96494549f
-    last_write_checksum: sha1:a5c47167f681c88878b8ee1f1b0d1fd7fc987a6d
-    pristine_git_object: 7adfbaead71c98d79abd0e74f96b50c312f0faf3
+    last_write_checksum: sha1:0fe5b8c585d412b5685b06bdb5d7345c65c4b2f0
+    pristine_git_object: d1e494fc2aa9e80d35c8203901f6b9c1636f05d1
   docs/models/previewattachpurchaselimitinterval.md:
     id: c151362a7be0
     last_write_checksum: sha1:74cfeae33a66c2ca173f550e9d745090fd8a88be
@@ -5807,8 +5807,8 @@ trackedFiles:
     pristine_git_object: db64b2ae127d3a36dd6ae6b7f58c3b22cfa3f1b6
   docs/models/previewupdateautotopup.md:
     id: cf7e5007afc5
-    last_write_checksum: sha1:452112047f7e01f0e2d0d89aec19f7e982199b81
-    pristine_git_object: 5c4ec762f6994de1fe6138c449c5cf8df9d89f64
+    last_write_checksum: sha1:0ec22052037019df1dee8ece7d9a9db636366201
+    pristine_git_object: f707b6720ed744efad086cf45149fa73d86a9bbd
   docs/models/previewupdatebaseprice.md:
     id: 7eea7a31d277
     last_write_checksum: sha1:3dabf1a24414b7e207019e974f6097c5bf45210f
@@ -6027,8 +6027,8 @@ trackedFiles:
     pristine_git_object: f09eb4baade271cd90673805ea85230e5fbc9c49
   docs/models/previewupdatepurchaselimit.md:
     id: 66a59b49f6c1
-    last_write_checksum: sha1:e34de5a2ef1bad2bcaf5e444da3ed4c2368e4921
-    pristine_git_object: ac502e3dab64b3e1496fcbe72178036490872393
+    last_write_checksum: sha1:4e4d1df2b51e23aba0dc3a1de6e0ca777e7db2d2
+    pristine_git_object: 1d794c8aad8191cb4f566f0daf194e38333dc015
   docs/models/previewupdatepurchaselimitinterval.md:
     id: 13adbd8dcb91
     last_write_checksum: sha1:0ba67c0c7c983475b49d49ebbecf8bc8364e11c8
@@ -6403,8 +6403,8 @@ trackedFiles:
     pristine_git_object: 53fc7933fee507da4b362252d0a4cfc577d17536
   docs/models/setuppaymentautotopup.md:
     id: f8823dfe9bb8
-    last_write_checksum: sha1:c1a7583624a45319cfba427d7b9c3044b3a81e6b
-    pristine_git_object: c97fc39d68c0a45d49dd6f338b967b4f2f0dcd67
+    last_write_checksum: sha1:89f949b4687280c1bf2f67b8ae1484db4f763021
+    pristine_git_object: 7f5424f6e9260c805d907ad5609e70027b4b0e5a
   docs/models/setuppaymentbaseprice.md:
     id: a123b4da0cd9
     last_write_checksum: sha1:8e848145fe4e5658f781d2b7bf8f335f45df7949
@@ -6575,8 +6575,8 @@ trackedFiles:
     pristine_git_object: b79cc25122d2f3e75b5504ac2ab52c1f1ff527cf
   docs/models/setuppaymentpurchaselimit.md:
     id: c48cf8871c7d
-    last_write_checksum: sha1:e79cc44eb67e609bbb1dfa2c2dabdf0226d82b4c
-    pristine_git_object: 088f8a4fab9aa814b52db52fd746052eae83267f
+    last_write_checksum: sha1:d797346c0c9e37932287987039d8268420e187ae
+    pristine_git_object: 6227468d8c0a52ee2c7b36d649a5a19cb4951c62
   docs/models/setuppaymentpurchaselimitinterval.md:
     id: 7865886ab45a
     last_write_checksum: sha1:16186c61933c15f0b1de65c62a101c21cf556563
@@ -6895,8 +6895,8 @@ trackedFiles:
     pristine_git_object: e2df03126ca9aa71027bcd8f9e8def06b4a6e612
   docs/models/updatecustomerautotopuprequest.md:
     id: 39142e7d45b0
-    last_write_checksum: sha1:604a27462c5217342eba9f56ee3f926148841a66
-    pristine_git_object: d576ca1d37b88d129169b9331e2ad509b395ed3f
+    last_write_checksum: sha1:5e4598d420a7dc0433b9c0418ae13ed7047819c6
+    pristine_git_object: b68764fa0895acb91cd9c833c2ab93b28064068b
   docs/models/updatecustomerautotopupresponse.md:
     id: c57d6aa94fbc
     last_write_checksum: sha1:4f153c173360fc6fcc8cbdb03e09e1da68924a09
@@ -7015,8 +7015,8 @@ trackedFiles:
     pristine_git_object: 8ecdcfc2e320fe3c2bfd6e923b01ed5a1788417c
   docs/models/updatecustomerpurchaselimitrequest.md:
     id: e0b5bae8abfe
-    last_write_checksum: sha1:10242d53f27a2a7d4a79da4896f4613149cee33d
-    pristine_git_object: 3be65ea39fee47ad7839606ec40c91548819e4b5
+    last_write_checksum: sha1:922d69ff13d7fb7858d48df2f078c608958e612d
+    pristine_git_object: 6d530408dce896b2b15eb814ae175b20da8317d6
   docs/models/updatecustomerpurchaselimitresponse1.md:
     id: accb82caac88
     last_write_checksum: sha1:3c2bf9fd114c8d1b206813c20568f607b8b57791
@@ -7351,8 +7351,8 @@ trackedFiles:
     pristine_git_object: ad36f93503838af401489616dfce1916dccb08f4
   docs/models/updateplanautotopuprequest.md:
     id: 728d617ae5eb
-    last_write_checksum: sha1:f5cb8ee53cebc6b16401faa7635b7d63ecd80234
-    pristine_git_object: a5e748d059d65a84c79d16736cb2a87e8550e72d
+    last_write_checksum: sha1:334ded4ea3a144b5d6bce2aa1d97e020ca42d5d8
+    pristine_git_object: ef5c3b4edb5abce2b0e3678feb7c3f725502fc76
   docs/models/updateplanautotopupresponse.md:
     id: 4fe573b999aa
     last_write_checksum: sha1:3aaeed8eed9cb2b1571f7eda2af99a1c8cb0f4ca
@@ -7739,8 +7739,8 @@ trackedFiles:
     pristine_git_object: cc9b07ca8c2ac1efd152d8ba6766a21940b73875
   docs/models/updateplanpurchaselimitrequest.md:
     id: 058893a720b3
-    last_write_checksum: sha1:c128844e4e0059c0bf75632cdb2d05226f5237c7
-    pristine_git_object: bec49bd4b4b021c30caefa5fd8095b5d7158c562
+    last_write_checksum: sha1:951867d0765f3cf713909bfe41652719fa6eb806
+    pristine_git_object: 54e83e8c18dbab2a886f3c5f039b0849027a7b6c
   docs/models/updateplanpurchaselimitresponse.md:
     id: 025600dee2ce
     last_write_checksum: sha1:be4ceea4313f227268f0000a24fb22b25dedb447
@@ -7823,8 +7823,8 @@ trackedFiles:
     pristine_git_object: b39d03627b6cbe2c35595f1b681f23fd30c1ee71
   docs/models/updateplanvariantdetailsautotopup.md:
     id: f66104927470
-    last_write_checksum: sha1:89c00bf1d4e4685bff349435fd2a109ad54380c8
-    pristine_git_object: 8f895b641858560dde6e168cd092548df6381040
+    last_write_checksum: sha1:b357ad2d82564b4d0af588c39fd7d8a3ef239123
+    pristine_git_object: e084c5697d128d10dbbdcaeea7d4ae00853100bd
   docs/models/updateplanvariantdetailsbillingcontrols.md:
     id: 99b1c1fbf647
     last_write_checksum: sha1:f6ce128f0ff39d91b4e4473289e240b64e1aa241
@@ -7871,8 +7871,8 @@ trackedFiles:
     pristine_git_object: eb32c3ad5079eb3852d69a1954f153e1ee745f3a
   docs/models/updateplanvariantdetailspurchaselimit.md:
     id: 22b1b43959b1
-    last_write_checksum: sha1:8d21a9d5159482abcf488b7c9f4cde1a142c9edf
-    pristine_git_object: 5188545d44c37b4ca6870578057fc3e15c82774b
+    last_write_checksum: sha1:dee286b8214d0208e152cb3696ddbcd555b53de6
+    pristine_git_object: 45cd6001907ceef6d84b236d59733bae77612a22
   docs/models/updateplanvariantdetailspurchaselimitinterval.md:
     id: 98af6395686b
     last_write_checksum: sha1:d13a16bcddca61b0849e29ec81d53d1cfbb6d7cc
@@ -7975,8 +7975,8 @@ trackedFiles:
     pristine_git_object: c885af85d97cba500333c381cb34b08840d5d7c6
   docs/models/variantautotopup.md:
     id: 88d5f637822a
-    last_write_checksum: sha1:eb0debe413221244d34df3d3a87a65b50123b480
-    pristine_git_object: d0ef4aeb7abae13d434b35ac7feec3fc00d44a19
+    last_write_checksum: sha1:dfe6aafebb85059dac5f3498374bb60c91996c7d
+    pristine_git_object: 0902bb8314c81bf9bed43ddce63f2e7c21139796
   docs/models/variantbaseprice.md:
     id: f24c0ca3e17f
     last_write_checksum: sha1:15243e2252c69a2c0fca2b6c156e831586de495f
@@ -8075,8 +8075,8 @@ trackedFiles:
     pristine_git_object: a1a72d6862a3facb180ccdfa7deab63822f0845d
   docs/models/variantpurchaselimit.md:
     id: 44a108b4dc23
-    last_write_checksum: sha1:2ad6c8d5115a9c8ed9524e895dff6f7c4fe0bd12
-    pristine_git_object: edd0f8c25af520bfcf5ac4759d1561961892fef7
+    last_write_checksum: sha1:c8eda2c641b5ef7d6e1647a6a8ecf7f59aeddb00
+    pristine_git_object: 1d9cfc8683fcee03fb56163196813e6c1b9da44f
   docs/models/variantpurchaselimitinterval.md:
     id: 7092bab14de4
     last_write_checksum: sha1:58ebc09fdb19add7c99836b73b687e686d07cd9c
@@ -8307,8 +8307,8 @@ trackedFiles:
     pristine_git_object: 46847dd0edc83a5f2c950765d7f4e3e3190ba2ed
   src/autumn_sdk/models/attachop.py:
     id: ebb59e06476c
-    last_write_checksum: sha1:40481bf405ad0b6cf8fcb37d21ee2d277484e80a
-    pristine_git_object: 53c94f0f20197c041873fca4ab861bc7bccc0b39
+    last_write_checksum: sha1:20ee6cf084b6f90792a00776c1047f3eaa5c1913
+    pristine_git_object: e5980dcd883d2c58b32ce2ee475dd17a9b463a6d
   src/autumn_sdk/models/balance.py:
     id: a6354d7c4b97
     last_write_checksum: sha1:b5ce91bd9a42de2332529dd64e83aa1154fd3d0e
@@ -8319,8 +8319,8 @@ trackedFiles:
     pristine_git_object: 104214260539e267dba373b7f140bea00456c518
   src/autumn_sdk/models/billingupdateop.py:
     id: a2f17c75cfd3
-    last_write_checksum: sha1:ff552cd8515f0b1fc35d592e368fc2b6b6bbd809
-    pristine_git_object: 146135ee44a89e2c3499bb8fe885834972d97962
+    last_write_checksum: sha1:2881d25ca2192e9cd7cdc5a8d2b57a2d63b0b044
+    pristine_git_object: 155564345faa8f16c69c30d67f04a430c12210cf
   src/autumn_sdk/models/checkop.py:
     id: 31c2f84723c6
     last_write_checksum: sha1:901e4f0ac685d3b1d551792d32fe913d0be2901e
@@ -8339,24 +8339,24 @@ trackedFiles:
     pristine_git_object: 496a076933b3e87f7a049a22543d43e13b34ae56
   src/autumn_sdk/models/createplanop.py:
     id: 077e6c7db2ad
-    last_write_checksum: sha1:02ff9452d46f2149d436b2fd41c9fe8b76d6cae2
-    pristine_git_object: 26f65bf3df476bc7f794227fa609f4e0ca4cef9a
+    last_write_checksum: sha1:094db93bae2948a9a67a75f1aa023809da38d9b5
+    pristine_git_object: 328e6ee0a9733df5419801d49fa1232c666055b0
   src/autumn_sdk/models/createreferralcodeop.py:
     id: 2f5f7b136c39
     last_write_checksum: sha1:9ef6a7e87ffd4cb0fb91f3592abb3b1ef51cb415
     pristine_git_object: fea4d1bb3875848e66502705e4cb818233ec3f5a
   src/autumn_sdk/models/createscheduleop.py:
     id: afb0cf1cf7f2
-    last_write_checksum: sha1:1a50c784e8c499e673702184d13c9648ce774abf
-    pristine_git_object: 0d261c93c0c67f74f3e9e21d69af2f3ea089aff1
+    last_write_checksum: sha1:b04db551595734ec117319fa4156c68c059d8a83
+    pristine_git_object: 23bdb2f0183a1a374bf37b71c35be731e7b10bc4
   src/autumn_sdk/models/customer.py:
     id: 8ed0174f7272
     last_write_checksum: sha1:30638da8b64e5ea23787fd1e50b8a051a2aa2031
     pristine_git_object: dc08d3cbe2bc9b9f99612301d8534c0663511bbd
   src/autumn_sdk/models/customerdata.py:
     id: 9d88118f2123
-    last_write_checksum: sha1:89e08ccf05d450a52f071d482c87c1bb5d2238a9
-    pristine_git_object: 880d031cf79b1de8074472ce67c51e13b821c070
+    last_write_checksum: sha1:c09c1cdb9013fb0c13f7ad6a5bc1c9412d01c4f5
+    pristine_git_object: 5e26531d3899ee4b78eb5a53ab19cd7d24c1b9d6
   src/autumn_sdk/models/customerexpand.py:
     id: 9d337d480baa
     last_write_checksum: sha1:ea31eb539b3854d917a7d8fe5685f730b8577a1f
@@ -8399,12 +8399,12 @@ trackedFiles:
     pristine_git_object: e5644620facf26204c3a512525886fed0054c447
   src/autumn_sdk/models/getorcreatecustomerop.py:
     id: acfac0d7be14
-    last_write_checksum: sha1:7e1ada1ef743598d6a348031e191bada46a47d97
-    pristine_git_object: 6c0acae13f607be68b72415882915f02a97df16e
+    last_write_checksum: sha1:e0791efc77a21f33d29522a5dc93be2c6f959256
+    pristine_git_object: 7a843b58495be022dc9efcda60f142b40ae060d4
   src/autumn_sdk/models/getplanop.py:
     id: 590fb77ac88d
-    last_write_checksum: sha1:f8a3baac7d3dd49ce7c573ca1533af1599f4d544
-    pristine_git_object: aa3169c8b82b012608caf6d61f68df5e9f61f29e
+    last_write_checksum: sha1:d5900ea3cf7c13f25bbe7125c42fe53dbd4b82c2
+    pristine_git_object: 5f3b4a9b114b33c33c190ed0cf063778a235819d
   src/autumn_sdk/models/getrevenuecatkeysop.py:
     id: 015155862a71
     last_write_checksum: sha1:6b3f88a48b721093562ec59db3f6dae2540fa139
@@ -8451,8 +8451,8 @@ trackedFiles:
     pristine_git_object: 82723c21210d8b89229a1683d8230c9372afce43
   src/autumn_sdk/models/listplansop.py:
     id: fdf892c403f4
-    last_write_checksum: sha1:13331888063ee99fa3f12d3d668f17b287c73178
-    pristine_git_object: 0f2b19fd6d340499a5a0e103d32d167f598db7e4
+    last_write_checksum: sha1:4de1c87862550f9a036ecae6ee774848dd76dcf8
+    pristine_git_object: f58d48fbff6f78eb85fc2567890f1a1d698e1a7a
   src/autumn_sdk/models/listrewardsop.py:
     id: de90eebc7e95
     last_write_checksum: sha1:270f334d9955ca547175b4c936ba0ac416002f20
@@ -8475,12 +8475,12 @@ trackedFiles:
     pristine_git_object: 79ac016f241d82916ccc1aab7c7e3a7e3fb9aef1
   src/autumn_sdk/models/plan.py:
     id: f85c4e07540d
-    last_write_checksum: sha1:f509e8d77e5c067ca337600c31047dceb28ec601
-    pristine_git_object: 883f3c3c7fc99d0a34f6c133c83277b5ac8a7f6b
+    last_write_checksum: sha1:52e039025172080ab9259118740982381ba818e0
+    pristine_git_object: 0ffd9b3918b2a6b47237579d608cd80a998fdb68
   src/autumn_sdk/models/previewattachop.py:
     id: 2b361be4bfa8
-    last_write_checksum: sha1:3f78e99797fcd65170eb9e72542ba8e8f9a89898
-    pristine_git_object: 8dd937dd8a86c2f3896fbf87b8fc1d81081c314f
+    last_write_checksum: sha1:3287d894a35f49d8dbc0ddf7dbdd49538696d6c0
+    pristine_git_object: 6a6f1ad73793a408b692e7ae86884fe94bc0b987
   src/autumn_sdk/models/previewmultiattachop.py:
     id: 963ffcd646a4
     last_write_checksum: sha1:13eae6db5aea44988a2cc6c1ee688fc53cc2dac0
@@ -8491,8 +8491,8 @@ trackedFiles:
     pristine_git_object: 85872f73a69aba31c8cbcd5da7f9f59b254dde49
   src/autumn_sdk/models/previewupdateop.py:
     id: 081d5f08508d
-    last_write_checksum: sha1:ba82a17b54dbd204f6bb2f77931dd7a6b19dbe8d
-    pristine_git_object: 25e80afc47fdc9f1cc8d8effc07f900a1c83ce39
+    last_write_checksum: sha1:ed38b9a691984414d264e40732ea31c045fc301a
+    pristine_git_object: 0054391992a70d0cdd8ecf81d169b8691b75d36a
   src/autumn_sdk/models/redeemreferralcodeop.py:
     id: 0abd7bfae718
     last_write_checksum: sha1:b1a584450f1f79e796dd755a9305dc30a07ed601
@@ -8519,8 +8519,8 @@ trackedFiles:
     pristine_git_object: aa686dd6f85ae1e27450392fcfe02527adfe8e61
   src/autumn_sdk/models/setuppaymentop.py:
     id: 603339ee67e3
-    last_write_checksum: sha1:edf22e8537f17f0309d4b685648cba918d83f724
-    pristine_git_object: 8762148494eb5d0b501a6310dcce0080e9d90970
+    last_write_checksum: sha1:155e6225117748c2dfb538a802a58d8e151f8e0d
+    pristine_git_object: 999805c95feb931dbab0adfac1c91807eb4d182f
   src/autumn_sdk/models/syncrevenuecatop.py:
     id: faddfbfd1214
     last_write_checksum: sha1:a2b90222b09b4ca95bc78d3573f5b17d4d50208b
@@ -8539,8 +8539,8 @@ trackedFiles:
     pristine_git_object: 7709cff4a867ccbb2022899e6a6751542d8f3fae
   src/autumn_sdk/models/updatecustomerop.py:
     id: 28b9d5b59bae
-    last_write_checksum: sha1:fb4e390d525214b69261761b657ac6c1134b75d2
-    pristine_git_object: 2f9f14dd4cc1794f86c9b17fbaae3dc038691456
+    last_write_checksum: sha1:b938fff71d98513e74d46e78275ac9a13e99d7f8
+    pristine_git_object: 85750af20855b999c70ace333181143ad833498c
   src/autumn_sdk/models/updateentityop.py:
     id: a49305af1e2e
     last_write_checksum: sha1:de10e55412a7a7b7dfb98c5e040353407eff2210
@@ -8551,8 +8551,8 @@ trackedFiles:
     pristine_git_object: daa78399b45fcaeda3fbe5843677a6900c520d4d
   src/autumn_sdk/models/updateplanop.py:
     id: 753ddf45ca40
-    last_write_checksum: sha1:4bbe574f656b2b417d3b659182adc9b78d07457f
-    pristine_git_object: 457409b47c81d10934c8fb6e84883e7cd444c86b
+    last_write_checksum: sha1:495149262bcac87ff868712a66b2ed92c711b8d6
+    pristine_git_object: 23ff21a47df57a32885e4679db18dc1f15e310e3
   src/autumn_sdk/plans.py:
     id: cf1ebabb687c
     last_write_checksum: sha1:ae4517b5e4c271794210ce03397eed27fa3a1646

--- a/others/python-sdk/src/autumn_sdk/models/attachop.py
+++ b/others/python-sdk/src/autumn_sdk/models/attachop.py
@@ -1127,7 +1127,7 @@ r"""The time interval for the purchase limit window."""
 
 
 class AttachPurchaseLimitTypedDict(TypedDict):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: AttachPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -1135,10 +1135,12 @@ class AttachPurchaseLimitTypedDict(TypedDict):
     r"""Maximum number of auto top-ups allowed within the interval."""
     interval_count: NotRequired[float]
     r"""Number of intervals in the purchase limit window."""
+    count: NotRequired[float]
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
 
 
 class AttachPurchaseLimit(BaseModel):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: AttachPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -1149,9 +1151,12 @@ class AttachPurchaseLimit(BaseModel):
     interval_count: Optional[float] = 1
     r"""Number of intervals in the purchase limit window."""
 
+    count: Optional[float] = None
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["interval_count"])
+        optional_fields = set(["interval_count", "count"])
         serialized = handler(self)
         m = {}
 
@@ -1176,7 +1181,7 @@ class AttachAutoTopupTypedDict(TypedDict):
     enabled: NotRequired[bool]
     r"""Whether auto top-up is enabled."""
     purchase_limit: NotRequired[AttachPurchaseLimitTypedDict]
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
     invoice_mode: NotRequired[bool]
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""
 
@@ -1195,7 +1200,7 @@ class AttachAutoTopup(BaseModel):
     r"""Whether auto top-up is enabled."""
 
     purchase_limit: Optional[AttachPurchaseLimit] = None
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     invoice_mode: Optional[bool] = None
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""

--- a/others/python-sdk/src/autumn_sdk/models/billingupdateop.py
+++ b/others/python-sdk/src/autumn_sdk/models/billingupdateop.py
@@ -1141,7 +1141,7 @@ r"""The time interval for the purchase limit window."""
 
 
 class BillingUpdatePurchaseLimitTypedDict(TypedDict):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: BillingUpdatePurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -1149,10 +1149,12 @@ class BillingUpdatePurchaseLimitTypedDict(TypedDict):
     r"""Maximum number of auto top-ups allowed within the interval."""
     interval_count: NotRequired[float]
     r"""Number of intervals in the purchase limit window."""
+    count: NotRequired[float]
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
 
 
 class BillingUpdatePurchaseLimit(BaseModel):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: BillingUpdatePurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -1163,9 +1165,12 @@ class BillingUpdatePurchaseLimit(BaseModel):
     interval_count: Optional[float] = 1
     r"""Number of intervals in the purchase limit window."""
 
+    count: Optional[float] = None
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["interval_count"])
+        optional_fields = set(["interval_count", "count"])
         serialized = handler(self)
         m = {}
 
@@ -1190,7 +1195,7 @@ class BillingUpdateAutoTopupTypedDict(TypedDict):
     enabled: NotRequired[bool]
     r"""Whether auto top-up is enabled."""
     purchase_limit: NotRequired[BillingUpdatePurchaseLimitTypedDict]
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
     invoice_mode: NotRequired[bool]
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""
 
@@ -1209,7 +1214,7 @@ class BillingUpdateAutoTopup(BaseModel):
     r"""Whether auto top-up is enabled."""
 
     purchase_limit: Optional[BillingUpdatePurchaseLimit] = None
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     invoice_mode: Optional[bool] = None
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""

--- a/others/python-sdk/src/autumn_sdk/models/createplanop.py
+++ b/others/python-sdk/src/autumn_sdk/models/createplanop.py
@@ -1158,8 +1158,6 @@ class CreatePlanLicenseTypedDict(TypedDict):
     prepaid_only: NotRequired[bool]
     customize: NotRequired[Nullable[CreatePlanLicenseCustomizeTypedDict]]
     metadata: NotRequired[Dict[str, Any]]
-    version: NotRequired[int]
-    r"""Pin the link to a specific version of the license plan. Omitted, an existing link keeps its pinned version and a new link resolves to the latest."""
 
 
 class CreatePlanLicense(BaseModel):
@@ -1173,14 +1171,9 @@ class CreatePlanLicense(BaseModel):
 
     metadata: Optional[Dict[str, Any]] = None
 
-    version: Optional[int] = None
-    r"""Pin the link to a specific version of the license plan. Omitted, an existing link keeps its pinned version and a new link resolves to the latest."""
-
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(
-            ["included", "prepaid_only", "customize", "metadata", "version"]
-        )
+        optional_fields = set(["included", "prepaid_only", "customize", "metadata"])
         nullable_fields = set(["customize"])
         serialized = handler(self)
         m = {}
@@ -1304,7 +1297,7 @@ r"""The time interval for the purchase limit window."""
 
 
 class CreatePlanPurchaseLimitRequestTypedDict(TypedDict):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: CreatePlanPurchaseLimitIntervalRequestBody
     r"""The time interval for the purchase limit window."""
@@ -1312,10 +1305,12 @@ class CreatePlanPurchaseLimitRequestTypedDict(TypedDict):
     r"""Maximum number of auto top-ups allowed within the interval."""
     interval_count: NotRequired[float]
     r"""Number of intervals in the purchase limit window."""
+    count: NotRequired[float]
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
 
 
 class CreatePlanPurchaseLimitRequest(BaseModel):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: CreatePlanPurchaseLimitIntervalRequestBody
     r"""The time interval for the purchase limit window."""
@@ -1326,9 +1321,12 @@ class CreatePlanPurchaseLimitRequest(BaseModel):
     interval_count: Optional[float] = 1
     r"""Number of intervals in the purchase limit window."""
 
+    count: Optional[float] = None
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["interval_count"])
+        optional_fields = set(["interval_count", "count"])
         serialized = handler(self)
         m = {}
 
@@ -1353,7 +1351,7 @@ class CreatePlanAutoTopupRequestTypedDict(TypedDict):
     enabled: NotRequired[bool]
     r"""Whether auto top-up is enabled."""
     purchase_limit: NotRequired[CreatePlanPurchaseLimitRequestTypedDict]
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
     invoice_mode: NotRequired[bool]
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""
 
@@ -1372,7 +1370,7 @@ class CreatePlanAutoTopupRequest(BaseModel):
     r"""Whether auto top-up is enabled."""
 
     purchase_limit: Optional[CreatePlanPurchaseLimitRequest] = None
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     invoice_mode: Optional[bool] = None
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""
@@ -3222,7 +3220,7 @@ r"""The time interval for the purchase limit window."""
 
 
 class CreatePlanVariantDetailsPurchaseLimitTypedDict(TypedDict):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: CreatePlanVariantDetailsPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -3230,10 +3228,12 @@ class CreatePlanVariantDetailsPurchaseLimitTypedDict(TypedDict):
     r"""Maximum number of auto top-ups allowed within the interval."""
     interval_count: NotRequired[float]
     r"""Number of intervals in the purchase limit window."""
+    count: NotRequired[float]
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
 
 
 class CreatePlanVariantDetailsPurchaseLimit(BaseModel):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: CreatePlanVariantDetailsPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -3244,9 +3244,12 @@ class CreatePlanVariantDetailsPurchaseLimit(BaseModel):
     interval_count: Optional[float] = 1
     r"""Number of intervals in the purchase limit window."""
 
+    count: Optional[float] = None
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["interval_count"])
+        optional_fields = set(["interval_count", "count"])
         serialized = handler(self)
         m = {}
 
@@ -3271,7 +3274,7 @@ class CreatePlanVariantDetailsAutoTopupTypedDict(TypedDict):
     enabled: NotRequired[bool]
     r"""Whether auto top-up is enabled."""
     purchase_limit: NotRequired[CreatePlanVariantDetailsPurchaseLimitTypedDict]
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
     invoice_mode: NotRequired[bool]
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""
 
@@ -3290,7 +3293,7 @@ class CreatePlanVariantDetailsAutoTopup(BaseModel):
     r"""Whether auto top-up is enabled."""
 
     purchase_limit: Optional[CreatePlanVariantDetailsPurchaseLimit] = None
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     invoice_mode: Optional[bool] = None
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""

--- a/others/python-sdk/src/autumn_sdk/models/createscheduleop.py
+++ b/others/python-sdk/src/autumn_sdk/models/createscheduleop.py
@@ -1148,7 +1148,7 @@ r"""The time interval for the purchase limit window."""
 
 
 class CreateSchedulePurchaseLimit2TypedDict(TypedDict):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: CreateSchedulePurchaseLimitInterval2
     r"""The time interval for the purchase limit window."""
@@ -1156,10 +1156,12 @@ class CreateSchedulePurchaseLimit2TypedDict(TypedDict):
     r"""Maximum number of auto top-ups allowed within the interval."""
     interval_count: NotRequired[float]
     r"""Number of intervals in the purchase limit window."""
+    count: NotRequired[float]
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
 
 
 class CreateSchedulePurchaseLimit2(BaseModel):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: CreateSchedulePurchaseLimitInterval2
     r"""The time interval for the purchase limit window."""
@@ -1170,9 +1172,12 @@ class CreateSchedulePurchaseLimit2(BaseModel):
     interval_count: Optional[float] = 1
     r"""Number of intervals in the purchase limit window."""
 
+    count: Optional[float] = None
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["interval_count"])
+        optional_fields = set(["interval_count", "count"])
         serialized = handler(self)
         m = {}
 
@@ -1197,7 +1202,7 @@ class CreateScheduleAutoTopup2TypedDict(TypedDict):
     enabled: NotRequired[bool]
     r"""Whether auto top-up is enabled."""
     purchase_limit: NotRequired[CreateSchedulePurchaseLimit2TypedDict]
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
     invoice_mode: NotRequired[bool]
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""
 
@@ -1216,7 +1221,7 @@ class CreateScheduleAutoTopup2(BaseModel):
     r"""Whether auto top-up is enabled."""
 
     purchase_limit: Optional[CreateSchedulePurchaseLimit2] = None
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     invoice_mode: Optional[bool] = None
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""

--- a/others/python-sdk/src/autumn_sdk/models/customerdata.py
+++ b/others/python-sdk/src/autumn_sdk/models/customerdata.py
@@ -24,7 +24,7 @@ r"""The time interval for the purchase limit window."""
 
 
 class CustomerDataPurchaseLimitTypedDict(TypedDict):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: CustomerDataPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -32,10 +32,12 @@ class CustomerDataPurchaseLimitTypedDict(TypedDict):
     r"""Maximum number of auto top-ups allowed within the interval."""
     interval_count: NotRequired[float]
     r"""Number of intervals in the purchase limit window."""
+    count: NotRequired[float]
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
 
 
 class CustomerDataPurchaseLimit(BaseModel):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: CustomerDataPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -46,9 +48,12 @@ class CustomerDataPurchaseLimit(BaseModel):
     interval_count: Optional[float] = 1
     r"""Number of intervals in the purchase limit window."""
 
+    count: Optional[float] = None
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["interval_count"])
+        optional_fields = set(["interval_count", "count"])
         serialized = handler(self)
         m = {}
 
@@ -73,7 +78,7 @@ class CustomerDataAutoTopupTypedDict(TypedDict):
     enabled: NotRequired[bool]
     r"""Whether auto top-up is enabled."""
     purchase_limit: NotRequired[CustomerDataPurchaseLimitTypedDict]
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
     invoice_mode: NotRequired[bool]
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""
 
@@ -92,7 +97,7 @@ class CustomerDataAutoTopup(BaseModel):
     r"""Whether auto top-up is enabled."""
 
     purchase_limit: Optional[CustomerDataPurchaseLimit] = None
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     invoice_mode: Optional[bool] = None
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""

--- a/others/python-sdk/src/autumn_sdk/models/getorcreatecustomerop.py
+++ b/others/python-sdk/src/autumn_sdk/models/getorcreatecustomerop.py
@@ -54,7 +54,7 @@ r"""The time interval for the purchase limit window."""
 
 
 class GetOrCreateCustomerPurchaseLimitTypedDict(TypedDict):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: GetOrCreateCustomerPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -62,10 +62,12 @@ class GetOrCreateCustomerPurchaseLimitTypedDict(TypedDict):
     r"""Maximum number of auto top-ups allowed within the interval."""
     interval_count: NotRequired[float]
     r"""Number of intervals in the purchase limit window."""
+    count: NotRequired[float]
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
 
 
 class GetOrCreateCustomerPurchaseLimit(BaseModel):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: GetOrCreateCustomerPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -76,9 +78,12 @@ class GetOrCreateCustomerPurchaseLimit(BaseModel):
     interval_count: Optional[float] = 1
     r"""Number of intervals in the purchase limit window."""
 
+    count: Optional[float] = None
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["interval_count"])
+        optional_fields = set(["interval_count", "count"])
         serialized = handler(self)
         m = {}
 
@@ -103,7 +108,7 @@ class GetOrCreateCustomerAutoTopupTypedDict(TypedDict):
     enabled: NotRequired[bool]
     r"""Whether auto top-up is enabled."""
     purchase_limit: NotRequired[GetOrCreateCustomerPurchaseLimitTypedDict]
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
     invoice_mode: NotRequired[bool]
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""
 
@@ -122,7 +127,7 @@ class GetOrCreateCustomerAutoTopup(BaseModel):
     r"""Whether auto top-up is enabled."""
 
     purchase_limit: Optional[GetOrCreateCustomerPurchaseLimit] = None
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     invoice_mode: Optional[bool] = None
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""

--- a/others/python-sdk/src/autumn_sdk/models/getplanop.py
+++ b/others/python-sdk/src/autumn_sdk/models/getplanop.py
@@ -1484,7 +1484,7 @@ r"""The time interval for the purchase limit window."""
 
 
 class GetPlanVariantDetailsPurchaseLimitTypedDict(TypedDict):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: GetPlanVariantDetailsPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -1492,10 +1492,12 @@ class GetPlanVariantDetailsPurchaseLimitTypedDict(TypedDict):
     r"""Maximum number of auto top-ups allowed within the interval."""
     interval_count: NotRequired[float]
     r"""Number of intervals in the purchase limit window."""
+    count: NotRequired[float]
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
 
 
 class GetPlanVariantDetailsPurchaseLimit(BaseModel):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: GetPlanVariantDetailsPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -1506,9 +1508,12 @@ class GetPlanVariantDetailsPurchaseLimit(BaseModel):
     interval_count: Optional[float] = 1
     r"""Number of intervals in the purchase limit window."""
 
+    count: Optional[float] = None
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["interval_count"])
+        optional_fields = set(["interval_count", "count"])
         serialized = handler(self)
         m = {}
 
@@ -1533,7 +1538,7 @@ class GetPlanVariantDetailsAutoTopupTypedDict(TypedDict):
     enabled: NotRequired[bool]
     r"""Whether auto top-up is enabled."""
     purchase_limit: NotRequired[GetPlanVariantDetailsPurchaseLimitTypedDict]
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
     invoice_mode: NotRequired[bool]
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""
 
@@ -1552,7 +1557,7 @@ class GetPlanVariantDetailsAutoTopup(BaseModel):
     r"""Whether auto top-up is enabled."""
 
     purchase_limit: Optional[GetPlanVariantDetailsPurchaseLimit] = None
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     invoice_mode: Optional[bool] = None
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""

--- a/others/python-sdk/src/autumn_sdk/models/listinvoicesop.py
+++ b/others/python-sdk/src/autumn_sdk/models/listinvoicesop.py
@@ -53,7 +53,7 @@ ListInvoicesStatus = Literal[
 ]
 
 
-ProcessorTypeRequest = Literal[
+ListInvoicesProcessorTypeRequest = Literal[
     "stripe",
     "revenuecat",
 ]
@@ -70,7 +70,7 @@ class ListInvoicesParamsTypedDict(TypedDict):
     r"""Filter invoices to a single entity by ID. Must be provided together with customer_id, since entity IDs are only unique per customer."""
     status: NotRequired[List[ListInvoicesStatus]]
     r"""Filter by invoice status (draft, open, paid, void, uncollectible)."""
-    processor_types: NotRequired[List[ProcessorTypeRequest]]
+    processor_types: NotRequired[List[ListInvoicesProcessorTypeRequest]]
     r"""Filter by billing processor (stripe, revenuecat). Invoices recorded before processor tracking count as stripe."""
 
 
@@ -90,7 +90,7 @@ class ListInvoicesParams(BaseModel):
     status: Optional[List[ListInvoicesStatus]] = None
     r"""Filter by invoice status (draft, open, paid, void, uncollectible)."""
 
-    processor_types: Optional[List[ProcessorTypeRequest]] = None
+    processor_types: Optional[List[ListInvoicesProcessorTypeRequest]] = None
     r"""Filter by billing processor (stripe, revenuecat). Invoices recorded before processor tracking count as stripe."""
 
     @model_serializer(mode="wrap")

--- a/others/python-sdk/src/autumn_sdk/models/listplansop.py
+++ b/others/python-sdk/src/autumn_sdk/models/listplansop.py
@@ -1450,7 +1450,7 @@ r"""The time interval for the purchase limit window."""
 
 
 class ListPlansVariantDetailsPurchaseLimitTypedDict(TypedDict):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: ListPlansVariantDetailsPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -1458,10 +1458,12 @@ class ListPlansVariantDetailsPurchaseLimitTypedDict(TypedDict):
     r"""Maximum number of auto top-ups allowed within the interval."""
     interval_count: NotRequired[float]
     r"""Number of intervals in the purchase limit window."""
+    count: NotRequired[float]
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
 
 
 class ListPlansVariantDetailsPurchaseLimit(BaseModel):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: ListPlansVariantDetailsPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -1472,9 +1474,12 @@ class ListPlansVariantDetailsPurchaseLimit(BaseModel):
     interval_count: Optional[float] = 1
     r"""Number of intervals in the purchase limit window."""
 
+    count: Optional[float] = None
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["interval_count"])
+        optional_fields = set(["interval_count", "count"])
         serialized = handler(self)
         m = {}
 
@@ -1499,7 +1504,7 @@ class ListPlansVariantDetailsAutoTopupTypedDict(TypedDict):
     enabled: NotRequired[bool]
     r"""Whether auto top-up is enabled."""
     purchase_limit: NotRequired[ListPlansVariantDetailsPurchaseLimitTypedDict]
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
     invoice_mode: NotRequired[bool]
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""
 
@@ -1518,7 +1523,7 @@ class ListPlansVariantDetailsAutoTopup(BaseModel):
     r"""Whether auto top-up is enabled."""
 
     purchase_limit: Optional[ListPlansVariantDetailsPurchaseLimit] = None
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     invoice_mode: Optional[bool] = None
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""

--- a/others/python-sdk/src/autumn_sdk/models/plan.py
+++ b/others/python-sdk/src/autumn_sdk/models/plan.py
@@ -1417,7 +1417,7 @@ r"""The time interval for the purchase limit window."""
 
 
 class PlanVariantDetailsPurchaseLimitTypedDict(TypedDict):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: PlanVariantDetailsPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -1425,10 +1425,12 @@ class PlanVariantDetailsPurchaseLimitTypedDict(TypedDict):
     r"""Maximum number of auto top-ups allowed within the interval."""
     interval_count: NotRequired[float]
     r"""Number of intervals in the purchase limit window."""
+    count: NotRequired[float]
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
 
 
 class PlanVariantDetailsPurchaseLimit(BaseModel):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: PlanVariantDetailsPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -1439,9 +1441,12 @@ class PlanVariantDetailsPurchaseLimit(BaseModel):
     interval_count: Optional[float] = 1
     r"""Number of intervals in the purchase limit window."""
 
+    count: Optional[float] = None
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["interval_count"])
+        optional_fields = set(["interval_count", "count"])
         serialized = handler(self)
         m = {}
 
@@ -1466,7 +1471,7 @@ class PlanVariantDetailsAutoTopupTypedDict(TypedDict):
     enabled: NotRequired[bool]
     r"""Whether auto top-up is enabled."""
     purchase_limit: NotRequired[PlanVariantDetailsPurchaseLimitTypedDict]
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
     invoice_mode: NotRequired[bool]
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""
 
@@ -1485,7 +1490,7 @@ class PlanVariantDetailsAutoTopup(BaseModel):
     r"""Whether auto top-up is enabled."""
 
     purchase_limit: Optional[PlanVariantDetailsPurchaseLimit] = None
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     invoice_mode: Optional[bool] = None
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""

--- a/others/python-sdk/src/autumn_sdk/models/previewattachop.py
+++ b/others/python-sdk/src/autumn_sdk/models/previewattachop.py
@@ -1142,7 +1142,7 @@ r"""The time interval for the purchase limit window."""
 
 
 class PreviewAttachPurchaseLimitTypedDict(TypedDict):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: PreviewAttachPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -1150,10 +1150,12 @@ class PreviewAttachPurchaseLimitTypedDict(TypedDict):
     r"""Maximum number of auto top-ups allowed within the interval."""
     interval_count: NotRequired[float]
     r"""Number of intervals in the purchase limit window."""
+    count: NotRequired[float]
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
 
 
 class PreviewAttachPurchaseLimit(BaseModel):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: PreviewAttachPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -1164,9 +1166,12 @@ class PreviewAttachPurchaseLimit(BaseModel):
     interval_count: Optional[float] = 1
     r"""Number of intervals in the purchase limit window."""
 
+    count: Optional[float] = None
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["interval_count"])
+        optional_fields = set(["interval_count", "count"])
         serialized = handler(self)
         m = {}
 
@@ -1191,7 +1196,7 @@ class PreviewAttachAutoTopupTypedDict(TypedDict):
     enabled: NotRequired[bool]
     r"""Whether auto top-up is enabled."""
     purchase_limit: NotRequired[PreviewAttachPurchaseLimitTypedDict]
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
     invoice_mode: NotRequired[bool]
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""
 
@@ -1210,7 +1215,7 @@ class PreviewAttachAutoTopup(BaseModel):
     r"""Whether auto top-up is enabled."""
 
     purchase_limit: Optional[PreviewAttachPurchaseLimit] = None
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     invoice_mode: Optional[bool] = None
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""

--- a/others/python-sdk/src/autumn_sdk/models/previewupdateop.py
+++ b/others/python-sdk/src/autumn_sdk/models/previewupdateop.py
@@ -1142,7 +1142,7 @@ r"""The time interval for the purchase limit window."""
 
 
 class PreviewUpdatePurchaseLimitTypedDict(TypedDict):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: PreviewUpdatePurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -1150,10 +1150,12 @@ class PreviewUpdatePurchaseLimitTypedDict(TypedDict):
     r"""Maximum number of auto top-ups allowed within the interval."""
     interval_count: NotRequired[float]
     r"""Number of intervals in the purchase limit window."""
+    count: NotRequired[float]
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
 
 
 class PreviewUpdatePurchaseLimit(BaseModel):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: PreviewUpdatePurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -1164,9 +1166,12 @@ class PreviewUpdatePurchaseLimit(BaseModel):
     interval_count: Optional[float] = 1
     r"""Number of intervals in the purchase limit window."""
 
+    count: Optional[float] = None
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["interval_count"])
+        optional_fields = set(["interval_count", "count"])
         serialized = handler(self)
         m = {}
 
@@ -1191,7 +1196,7 @@ class PreviewUpdateAutoTopupTypedDict(TypedDict):
     enabled: NotRequired[bool]
     r"""Whether auto top-up is enabled."""
     purchase_limit: NotRequired[PreviewUpdatePurchaseLimitTypedDict]
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
     invoice_mode: NotRequired[bool]
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""
 
@@ -1210,7 +1215,7 @@ class PreviewUpdateAutoTopup(BaseModel):
     r"""Whether auto top-up is enabled."""
 
     purchase_limit: Optional[PreviewUpdatePurchaseLimit] = None
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     invoice_mode: Optional[bool] = None
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""

--- a/others/python-sdk/src/autumn_sdk/models/setuppaymentop.py
+++ b/others/python-sdk/src/autumn_sdk/models/setuppaymentop.py
@@ -1138,7 +1138,7 @@ r"""The time interval for the purchase limit window."""
 
 
 class SetupPaymentPurchaseLimitTypedDict(TypedDict):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: SetupPaymentPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -1146,10 +1146,12 @@ class SetupPaymentPurchaseLimitTypedDict(TypedDict):
     r"""Maximum number of auto top-ups allowed within the interval."""
     interval_count: NotRequired[float]
     r"""Number of intervals in the purchase limit window."""
+    count: NotRequired[float]
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
 
 
 class SetupPaymentPurchaseLimit(BaseModel):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: SetupPaymentPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -1160,9 +1162,12 @@ class SetupPaymentPurchaseLimit(BaseModel):
     interval_count: Optional[float] = 1
     r"""Number of intervals in the purchase limit window."""
 
+    count: Optional[float] = None
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["interval_count"])
+        optional_fields = set(["interval_count", "count"])
         serialized = handler(self)
         m = {}
 
@@ -1187,7 +1192,7 @@ class SetupPaymentAutoTopupTypedDict(TypedDict):
     enabled: NotRequired[bool]
     r"""Whether auto top-up is enabled."""
     purchase_limit: NotRequired[SetupPaymentPurchaseLimitTypedDict]
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
     invoice_mode: NotRequired[bool]
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""
 
@@ -1206,7 +1211,7 @@ class SetupPaymentAutoTopup(BaseModel):
     r"""Whether auto top-up is enabled."""
 
     purchase_limit: Optional[SetupPaymentPurchaseLimit] = None
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     invoice_mode: Optional[bool] = None
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""

--- a/others/python-sdk/src/autumn_sdk/models/updatecustomerop.py
+++ b/others/python-sdk/src/autumn_sdk/models/updatecustomerop.py
@@ -56,7 +56,7 @@ r"""The time interval for the purchase limit window."""
 
 
 class UpdateCustomerPurchaseLimitRequestTypedDict(TypedDict):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: UpdateCustomerPurchaseLimitIntervalRequestBody
     r"""The time interval for the purchase limit window."""
@@ -64,10 +64,12 @@ class UpdateCustomerPurchaseLimitRequestTypedDict(TypedDict):
     r"""Maximum number of auto top-ups allowed within the interval."""
     interval_count: NotRequired[float]
     r"""Number of intervals in the purchase limit window."""
+    count: NotRequired[float]
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
 
 
 class UpdateCustomerPurchaseLimitRequest(BaseModel):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: UpdateCustomerPurchaseLimitIntervalRequestBody
     r"""The time interval for the purchase limit window."""
@@ -78,9 +80,12 @@ class UpdateCustomerPurchaseLimitRequest(BaseModel):
     interval_count: Optional[float] = 1
     r"""Number of intervals in the purchase limit window."""
 
+    count: Optional[float] = None
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["interval_count"])
+        optional_fields = set(["interval_count", "count"])
         serialized = handler(self)
         m = {}
 
@@ -105,7 +110,7 @@ class UpdateCustomerAutoTopupRequestTypedDict(TypedDict):
     enabled: NotRequired[bool]
     r"""Whether auto top-up is enabled."""
     purchase_limit: NotRequired[UpdateCustomerPurchaseLimitRequestTypedDict]
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
     invoice_mode: NotRequired[bool]
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""
 
@@ -124,7 +129,7 @@ class UpdateCustomerAutoTopupRequest(BaseModel):
     r"""Whether auto top-up is enabled."""
 
     purchase_limit: Optional[UpdateCustomerPurchaseLimitRequest] = None
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     invoice_mode: Optional[bool] = None
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""

--- a/others/python-sdk/src/autumn_sdk/models/updateplanop.py
+++ b/others/python-sdk/src/autumn_sdk/models/updateplanop.py
@@ -1158,8 +1158,6 @@ class UpdatePlanLicenseTypedDict(TypedDict):
     prepaid_only: NotRequired[bool]
     customize: NotRequired[Nullable[UpdatePlanLicenseCustomizeTypedDict]]
     metadata: NotRequired[Dict[str, Any]]
-    version: NotRequired[int]
-    r"""Pin the link to a specific version of the license plan. Omitted, an existing link keeps its pinned version and a new link resolves to the latest."""
 
 
 class UpdatePlanLicense(BaseModel):
@@ -1173,14 +1171,9 @@ class UpdatePlanLicense(BaseModel):
 
     metadata: Optional[Dict[str, Any]] = None
 
-    version: Optional[int] = None
-    r"""Pin the link to a specific version of the license plan. Omitted, an existing link keeps its pinned version and a new link resolves to the latest."""
-
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(
-            ["included", "prepaid_only", "customize", "metadata", "version"]
-        )
+        optional_fields = set(["included", "prepaid_only", "customize", "metadata"])
         nullable_fields = set(["customize"])
         serialized = handler(self)
         m = {}
@@ -1304,7 +1297,7 @@ r"""The time interval for the purchase limit window."""
 
 
 class UpdatePlanPurchaseLimitRequestTypedDict(TypedDict):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: UpdatePlanPurchaseLimitIntervalRequestBody
     r"""The time interval for the purchase limit window."""
@@ -1312,10 +1305,12 @@ class UpdatePlanPurchaseLimitRequestTypedDict(TypedDict):
     r"""Maximum number of auto top-ups allowed within the interval."""
     interval_count: NotRequired[float]
     r"""Number of intervals in the purchase limit window."""
+    count: NotRequired[float]
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
 
 
 class UpdatePlanPurchaseLimitRequest(BaseModel):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: UpdatePlanPurchaseLimitIntervalRequestBody
     r"""The time interval for the purchase limit window."""
@@ -1326,9 +1321,12 @@ class UpdatePlanPurchaseLimitRequest(BaseModel):
     interval_count: Optional[float] = 1
     r"""Number of intervals in the purchase limit window."""
 
+    count: Optional[float] = None
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["interval_count"])
+        optional_fields = set(["interval_count", "count"])
         serialized = handler(self)
         m = {}
 
@@ -1353,7 +1351,7 @@ class UpdatePlanAutoTopupRequestTypedDict(TypedDict):
     enabled: NotRequired[bool]
     r"""Whether auto top-up is enabled."""
     purchase_limit: NotRequired[UpdatePlanPurchaseLimitRequestTypedDict]
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
     invoice_mode: NotRequired[bool]
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""
 
@@ -1372,7 +1370,7 @@ class UpdatePlanAutoTopupRequest(BaseModel):
     r"""Whether auto top-up is enabled."""
 
     purchase_limit: Optional[UpdatePlanPurchaseLimitRequest] = None
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     invoice_mode: Optional[bool] = None
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""
@@ -1701,6 +1699,17 @@ class Migration(BaseModel):
                     m[k] = val
 
         return m
+
+
+class UpdateLicenseParentTypedDict(TypedDict):
+    plan_id: str
+    version: int
+
+
+class UpdateLicenseParent(BaseModel):
+    plan_id: str
+
+    version: int
 
 
 PriceVariantInterval = Literal[
@@ -2333,7 +2342,7 @@ r"""The time interval for the purchase limit window."""
 
 
 class VariantPurchaseLimitTypedDict(TypedDict):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: VariantPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -2341,10 +2350,12 @@ class VariantPurchaseLimitTypedDict(TypedDict):
     r"""Maximum number of auto top-ups allowed within the interval."""
     interval_count: NotRequired[float]
     r"""Number of intervals in the purchase limit window."""
+    count: NotRequired[float]
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
 
 
 class VariantPurchaseLimit(BaseModel):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: VariantPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -2355,9 +2366,12 @@ class VariantPurchaseLimit(BaseModel):
     interval_count: Optional[float] = 1
     r"""Number of intervals in the purchase limit window."""
 
+    count: Optional[float] = None
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["interval_count"])
+        optional_fields = set(["interval_count", "count"])
         serialized = handler(self)
         m = {}
 
@@ -2382,7 +2396,7 @@ class VariantAutoTopupTypedDict(TypedDict):
     enabled: NotRequired[bool]
     r"""Whether auto top-up is enabled."""
     purchase_limit: NotRequired[VariantPurchaseLimitTypedDict]
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
     invoice_mode: NotRequired[bool]
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""
 
@@ -2401,7 +2415,7 @@ class VariantAutoTopup(BaseModel):
     r"""Whether auto top-up is enabled."""
 
     purchase_limit: Optional[VariantPurchaseLimit] = None
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     invoice_mode: Optional[bool] = None
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""
@@ -2886,6 +2900,8 @@ class UpdatePlanParamsTypedDict(TypedDict):
     r"""Force versioning even when no customers exist. Mutually exclusive with disable_version."""
     update_variant_ids: NotRequired[List[str]]
     r"""Variant plan IDs to apply this update to. Empty or omitted means no propagation."""
+    update_license_parents: NotRequired[List[UpdateLicenseParentTypedDict]]
+    r"""Parent plan versions that should receive this license-plan update."""
     variants: NotRequired[List[VariantTypedDict]]
     r"""Additive variant updates for this base plan. Missing variants are created when name is provided."""
     is_default: NotRequired[bool]
@@ -2955,6 +2971,9 @@ class UpdatePlanParams(BaseModel):
     update_variant_ids: Optional[List[str]] = None
     r"""Variant plan IDs to apply this update to. Empty or omitted means no propagation."""
 
+    update_license_parents: Optional[List[UpdateLicenseParent]] = None
+    r"""Parent plan versions that should receive this license-plan update."""
+
     variants: Optional[List[Variant]] = None
     r"""Additive variant updates for this base plan. Missing variants are created when name is provided."""
 
@@ -2987,6 +3006,7 @@ class UpdatePlanParams(BaseModel):
                 "migration",
                 "force_version",
                 "update_variant_ids",
+                "update_license_parents",
                 "variants",
                 "is_default",
             ]
@@ -4447,7 +4467,7 @@ r"""The time interval for the purchase limit window."""
 
 
 class UpdatePlanVariantDetailsPurchaseLimitTypedDict(TypedDict):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: UpdatePlanVariantDetailsPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -4455,10 +4475,12 @@ class UpdatePlanVariantDetailsPurchaseLimitTypedDict(TypedDict):
     r"""Maximum number of auto top-ups allowed within the interval."""
     interval_count: NotRequired[float]
     r"""Number of intervals in the purchase limit window."""
+    count: NotRequired[float]
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
 
 
 class UpdatePlanVariantDetailsPurchaseLimit(BaseModel):
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     interval: UpdatePlanVariantDetailsPurchaseLimitInterval
     r"""The time interval for the purchase limit window."""
@@ -4469,9 +4491,12 @@ class UpdatePlanVariantDetailsPurchaseLimit(BaseModel):
     interval_count: Optional[float] = 1
     r"""Number of intervals in the purchase limit window."""
 
+    count: Optional[float] = None
+    r"""Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged."""
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["interval_count"])
+        optional_fields = set(["interval_count", "count"])
         serialized = handler(self)
         m = {}
 
@@ -4496,7 +4521,7 @@ class UpdatePlanVariantDetailsAutoTopupTypedDict(TypedDict):
     enabled: NotRequired[bool]
     r"""Whether auto top-up is enabled."""
     purchase_limit: NotRequired[UpdatePlanVariantDetailsPurchaseLimitTypedDict]
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
     invoice_mode: NotRequired[bool]
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""
 
@@ -4515,7 +4540,7 @@ class UpdatePlanVariantDetailsAutoTopup(BaseModel):
     r"""Whether auto top-up is enabled."""
 
     purchase_limit: Optional[UpdatePlanVariantDetailsPurchaseLimit] = None
-    r"""Optional rate limit to cap how often auto top-ups occur."""
+    r"""Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups."""
 
     invoice_mode: Optional[bool] = None
     r"""When true, auto top-up creates a send_invoice invoice instead of auto-charging."""

--- a/others/python-sdk/src/autumn_sdk/plans.py
+++ b/others/python-sdk/src/autumn_sdk/plans.py
@@ -789,6 +789,12 @@ class Plans(BaseSDK):
         migration: Optional[Union[models.Migration, models.MigrationTypedDict]] = None,
         force_version: Optional[bool] = None,
         update_variant_ids: Optional[List[str]] = None,
+        update_license_parents: Optional[
+            Union[
+                List[models.UpdateLicenseParent],
+                List[models.UpdateLicenseParentTypedDict],
+            ]
+        ] = None,
         variants: Optional[
             Union[List[models.Variant], List[models.VariantTypedDict]]
         ] = None,
@@ -827,6 +833,7 @@ class Plans(BaseSDK):
         :param migration:
         :param force_version: Force versioning even when no customers exist. Mutually exclusive with disable_version.
         :param update_variant_ids: Variant plan IDs to apply this update to. Empty or omitted means no propagation.
+        :param update_license_parents: Parent plan versions that should receive this license-plan update.
         :param variants: Additive variant updates for this base plan. Missing variants are created when name is provided.
         :param is_default: Whether this is the org's default plan. Cannot be true on a variant.
         :param retries: Override the default retry configuration for this method
@@ -880,6 +887,9 @@ class Plans(BaseSDK):
             migration=utils.get_pydantic_model(migration, Optional[models.Migration]),
             force_version=force_version,
             update_variant_ids=update_variant_ids,
+            update_license_parents=utils.get_pydantic_model(
+                update_license_parents, Optional[List[models.UpdateLicenseParent]]
+            ),
             variants=utils.get_pydantic_model(variants, Optional[List[models.Variant]]),
             is_default=is_default,
         )
@@ -997,6 +1007,12 @@ class Plans(BaseSDK):
         migration: Optional[Union[models.Migration, models.MigrationTypedDict]] = None,
         force_version: Optional[bool] = None,
         update_variant_ids: Optional[List[str]] = None,
+        update_license_parents: Optional[
+            Union[
+                List[models.UpdateLicenseParent],
+                List[models.UpdateLicenseParentTypedDict],
+            ]
+        ] = None,
         variants: Optional[
             Union[List[models.Variant], List[models.VariantTypedDict]]
         ] = None,
@@ -1035,6 +1051,7 @@ class Plans(BaseSDK):
         :param migration:
         :param force_version: Force versioning even when no customers exist. Mutually exclusive with disable_version.
         :param update_variant_ids: Variant plan IDs to apply this update to. Empty or omitted means no propagation.
+        :param update_license_parents: Parent plan versions that should receive this license-plan update.
         :param variants: Additive variant updates for this base plan. Missing variants are created when name is provided.
         :param is_default: Whether this is the org's default plan. Cannot be true on a variant.
         :param retries: Override the default retry configuration for this method
@@ -1088,6 +1105,9 @@ class Plans(BaseSDK):
             migration=utils.get_pydantic_model(migration, Optional[models.Migration]),
             force_version=force_version,
             update_variant_ids=update_variant_ids,
+            update_license_parents=utils.get_pydantic_model(
+                update_license_parents, Optional[List[models.UpdateLicenseParent]]
+            ),
             variants=utils.get_pydantic_model(variants, Optional[List[models.Variant]]),
             is_default=is_default,
         )

--- a/packages/autumn-js/src/generated/attachSchemas.ts
+++ b/packages/autumn-js/src/generated/attachSchemas.ts
@@ -326,6 +326,7 @@ export const attachPurchaseLimitOutboundSchema = z.object({
 	interval: z.string(),
 	interval_count: z.number(),
 	limit: z.number(),
+	count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const attachAutoTopupOutboundSchema = z.object({
@@ -803,6 +804,7 @@ export const attachPurchaseLimitSchema = z.object({
 	interval: attachPurchaseLimitIntervalSchema,
 	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 	limit: z.number(),
+	count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const attachAutoTopupSchema = z.object({

--- a/packages/autumn-js/src/generated/getOrCreateCustomerSchemas.ts
+++ b/packages/autumn-js/src/generated/getOrCreateCustomerSchemas.ts
@@ -32,6 +32,7 @@ export const getOrCreateCustomerPurchaseLimitOutboundSchema = z.object({
 	interval: z.string(),
 	interval_count: z.number(),
 	limit: z.number(),
+	count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const getOrCreateCustomerAutoTopupOutboundSchema = z.object({
@@ -157,6 +158,7 @@ export const getOrCreateCustomerPurchaseLimitSchema = z.object({
 	interval: getOrCreateCustomerPurchaseLimitIntervalSchema,
 	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 	limit: z.number(),
+	count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const getOrCreateCustomerAutoTopupSchema = z.object({

--- a/packages/autumn-js/src/generated/listPlansSchemas.ts
+++ b/packages/autumn-js/src/generated/listPlansSchemas.ts
@@ -325,6 +325,7 @@ export const listPlansVariantDetailsPurchaseLimitSchema = z.object({
 	interval: listPlansVariantDetailsPurchaseLimitIntervalSchema,
 	intervalCount: z.number(),
 	limit: z.number(),
+	count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const listPlansVariantDetailsAutoTopupSchema = z.object({

--- a/packages/autumn-js/src/generated/previewAttachSchemas.ts
+++ b/packages/autumn-js/src/generated/previewAttachSchemas.ts
@@ -439,6 +439,7 @@ export const previewAttachPurchaseLimitOutboundSchema = z.object({
 	interval: z.string(),
 	interval_count: z.number(),
 	limit: z.number(),
+	count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewAttachAutoTopupOutboundSchema = z.object({
@@ -951,6 +952,7 @@ export const previewAttachPurchaseLimitSchema = z.object({
 	interval: previewAttachPurchaseLimitIntervalSchema,
 	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 	limit: z.number(),
+	count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewAttachAutoTopupSchema = z.object({

--- a/packages/autumn-js/src/generated/previewUpdateSubscriptionSchemas.ts
+++ b/packages/autumn-js/src/generated/previewUpdateSubscriptionSchemas.ts
@@ -433,6 +433,7 @@ export const previewUpdatePurchaseLimitOutboundSchema = z.object({
 	interval: z.string(),
 	interval_count: z.number(),
 	limit: z.number(),
+	count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewUpdateAutoTopupOutboundSchema = z.object({
@@ -922,6 +923,7 @@ export const previewUpdatePurchaseLimitSchema = z.object({
 	interval: previewUpdatePurchaseLimitIntervalSchema,
 	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 	limit: z.number(),
+	count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewUpdateAutoTopupSchema = z.object({

--- a/packages/autumn-js/src/generated/setupPaymentSchemas.ts
+++ b/packages/autumn-js/src/generated/setupPaymentSchemas.ts
@@ -345,6 +345,7 @@ export const setupPaymentPurchaseLimitOutboundSchema = z.object({
 	interval: z.string(),
 	interval_count: z.number(),
 	limit: z.number(),
+	count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const setupPaymentAutoTopupOutboundSchema = z.object({
@@ -829,6 +830,7 @@ export const setupPaymentPurchaseLimitSchema = z.object({
 	interval: setupPaymentPurchaseLimitIntervalSchema,
 	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 	limit: z.number(),
+	count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const setupPaymentAutoTopupSchema = z.object({

--- a/packages/autumn-js/src/generated/updateSubscriptionSchemas.ts
+++ b/packages/autumn-js/src/generated/updateSubscriptionSchemas.ts
@@ -348,6 +348,7 @@ export const billingUpdatePurchaseLimitOutboundSchema = z.object({
 	interval: z.string(),
 	interval_count: z.number(),
 	limit: z.number(),
+	count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const billingUpdateAutoTopupOutboundSchema = z.object({
@@ -832,6 +833,7 @@ export const billingUpdatePurchaseLimitSchema = z.object({
 	interval: billingUpdatePurchaseLimitIntervalSchema,
 	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 	limit: z.number(),
+	count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const billingUpdateAutoTopupSchema = z.object({

--- a/packages/openapi/openapi-stripped.yml
+++ b/packages/openapi/openapi-stripped.yml
@@ -76,7 +76,6 @@ components:
                     description: Whether auto top-up is enabled.
                   threshold:
                     type: number
-                    minimum: 0
                     description: When the balance drops below this threshold, an auto top-up will be
                       purchased.
                   quantity:
@@ -103,10 +102,16 @@ components:
                         type: number
                         minimum: 1
                         description: Maximum number of auto top-ups allowed within the interval.
+                      count:
+                        type: number
+                        minimum: 0
+                        description: Set the current window's consumed auto top-up count. Omit to leave
+                          runtime state unchanged.
                     required:
                       - interval
                       - limit
-                    description: Optional rate limit to cap how often auto top-ups occur.
+                    description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                      to set the current window's consumed top-ups.
                   invoice_mode:
                     type: boolean
                     description: When true, auto top-up creates a send_invoice invoice instead of
@@ -339,7 +344,6 @@ components:
                     description: Whether auto top-up is enabled.
                   threshold:
                     type: number
-                    minimum: 0
                     description: When the balance drops below this threshold, an auto top-up will be
                       purchased.
                   quantity:
@@ -1996,7 +2000,6 @@ components:
                             description: Whether auto top-up is enabled.
                           threshold:
                             type: number
-                            minimum: 0
                             description: When the balance drops below this threshold, an auto top-up will be
                               purchased.
                           quantity:
@@ -2023,10 +2026,16 @@ components:
                                 type: number
                                 minimum: 1
                                 description: Maximum number of auto top-ups allowed within the interval.
+                              count:
+                                type: number
+                                minimum: 0
+                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                  runtime state unchanged.
                             required:
                               - interval
                               - limit
-                            description: Optional rate limit to cap how often auto top-ups occur.
+                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                              to set the current window's consumed top-ups.
                           invoice_mode:
                             type: boolean
                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -2197,7 +2206,6 @@ components:
                     description: Whether auto top-up is enabled.
                   threshold:
                     type: number
-                    minimum: 0
                     description: When the balance drops below this threshold, an auto top-up will be
                       purchased.
                   quantity:
@@ -2831,7 +2839,6 @@ paths:
                             description: Whether auto top-up is enabled.
                           threshold:
                             type: number
-                            minimum: 0
                             description: When the balance drops below this threshold, an auto top-up will be
                               purchased.
                           quantity:
@@ -2858,10 +2865,16 @@ paths:
                                 type: number
                                 minimum: 1
                                 description: Maximum number of auto top-ups allowed within the interval.
+                              count:
+                                type: number
+                                minimum: 0
+                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                  runtime state unchanged.
                             required:
                               - interval
                               - limit
-                            description: Optional rate limit to cap how often auto top-ups occur.
+                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                              to set the current window's consumed top-ups.
                           invoice_mode:
                             type: boolean
                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -3160,7 +3173,6 @@ paths:
                               description: Whether auto top-up is enabled.
                             threshold:
                               type: number
-                              minimum: 0
                               description: When the balance drops below this threshold, an auto top-up will be
                                 purchased.
                             quantity:
@@ -4217,7 +4229,6 @@ paths:
                                     description: Whether auto top-up is enabled.
                                   threshold:
                                     type: number
-                                    minimum: 0
                                     description: When the balance drops below this threshold, an auto top-up will be
                                       purchased.
                                   quantity:
@@ -5075,7 +5086,6 @@ paths:
                             description: Whether auto top-up is enabled.
                           threshold:
                             type: number
-                            minimum: 0
                             description: When the balance drops below this threshold, an auto top-up will be
                               purchased.
                           quantity:
@@ -5102,10 +5112,16 @@ paths:
                                 type: number
                                 minimum: 1
                                 description: Maximum number of auto top-ups allowed within the interval.
+                              count:
+                                type: number
+                                minimum: 0
+                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                  runtime state unchanged.
                             required:
                               - interval
                               - limit
-                            description: Optional rate limit to cap how often auto top-ups occur.
+                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                              to set the current window's consumed top-ups.
                           invoice_mode:
                             type: boolean
                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -5341,7 +5357,6 @@ paths:
                               description: Whether auto top-up is enabled.
                             threshold:
                               type: number
-                              minimum: 0
                               description: When the balance drops below this threshold, an auto top-up will be
                                 purchased.
                             quantity:
@@ -6741,7 +6756,6 @@ paths:
                             description: Whether auto top-up is enabled.
                           threshold:
                             type: number
-                            minimum: 0
                             description: When the balance drops below this threshold, an auto top-up will be
                               purchased.
                           quantity:
@@ -6768,10 +6782,16 @@ paths:
                                 type: number
                                 minimum: 1
                                 description: Maximum number of auto top-ups allowed within the interval.
+                              count:
+                                type: number
+                                minimum: 0
+                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                  runtime state unchanged.
                             required:
                               - interval
                               - limit
-                            description: Optional rate limit to cap how often auto top-ups occur.
+                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                              to set the current window's consumed top-ups.
                           invoice_mode:
                             type: boolean
                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -7733,7 +7753,6 @@ paths:
                                       description: Whether auto top-up is enabled.
                                     threshold:
                                       type: number
-                                      minimum: 0
                                       description: When the balance drops below this threshold, an auto top-up will be
                                         purchased.
                                     quantity:
@@ -7760,10 +7779,17 @@ paths:
                                           type: number
                                           minimum: 1
                                           description: Maximum number of auto top-ups allowed within the interval.
+                                        count:
+                                          type: number
+                                          minimum: 0
+                                          description: Set the current window's consumed auto top-up count. Omit to leave
+                                            runtime state unchanged.
                                       required:
                                         - interval
                                         - limit
-                                      description: Optional rate limit to cap how often auto top-ups occur.
+                                      description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                        to set the current window's consumed
+                                        top-ups.
                                     invoice_mode:
                                       type: boolean
                                       description: When true, auto top-up creates a send_invoice invoice instead of
@@ -7937,7 +7963,6 @@ paths:
                               description: Whether auto top-up is enabled.
                             threshold:
                               type: number
-                              minimum: 0
                               description: When the balance drops below this threshold, an auto top-up will be
                                 purchased.
                             quantity:
@@ -9017,7 +9042,6 @@ paths:
                                       description: Whether auto top-up is enabled.
                                     threshold:
                                       type: number
-                                      minimum: 0
                                       description: When the balance drops below this threshold, an auto top-up will be
                                         purchased.
                                     quantity:
@@ -9044,10 +9068,17 @@ paths:
                                           type: number
                                           minimum: 1
                                           description: Maximum number of auto top-ups allowed within the interval.
+                                        count:
+                                          type: number
+                                          minimum: 0
+                                          description: Set the current window's consumed auto top-up count. Omit to leave
+                                            runtime state unchanged.
                                       required:
                                         - interval
                                         - limit
-                                      description: Optional rate limit to cap how often auto top-ups occur.
+                                      description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                        to set the current window's consumed
+                                        top-ups.
                                     invoice_mode:
                                       type: boolean
                                       description: When true, auto top-up creates a send_invoice invoice instead of
@@ -9221,7 +9252,6 @@ paths:
                               description: Whether auto top-up is enabled.
                             threshold:
                               type: number
-                              minimum: 0
                               description: When the balance drops below this threshold, an auto top-up will be
                                 purchased.
                             quantity:
@@ -10307,7 +10337,6 @@ paths:
                                             description: Whether auto top-up is enabled.
                                           threshold:
                                             type: number
-                                            minimum: 0
                                             description: When the balance drops below this threshold, an auto top-up will be
                                               purchased.
                                           quantity:
@@ -10334,10 +10363,17 @@ paths:
                                                 type: number
                                                 minimum: 1
                                                 description: Maximum number of auto top-ups allowed within the interval.
+                                              count:
+                                                type: number
+                                                minimum: 0
+                                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                                  runtime state unchanged.
                                             required:
                                               - interval
                                               - limit
-                                            description: Optional rate limit to cap how often auto top-ups occur.
+                                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                              to set the current window's
+                                              consumed top-ups.
                                           invoice_mode:
                                             type: boolean
                                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -10512,7 +10548,6 @@ paths:
                                     description: Whether auto top-up is enabled.
                                   threshold:
                                     type: number
-                                    minimum: 0
                                     description: When the balance drops below this threshold, an auto top-up will be
                                       purchased.
                                   quantity:
@@ -11447,7 +11482,6 @@ paths:
                             description: Whether auto top-up is enabled.
                           threshold:
                             type: number
-                            minimum: 0
                             description: When the balance drops below this threshold, an auto top-up will be
                               purchased.
                           quantity:
@@ -11474,10 +11508,16 @@ paths:
                                 type: number
                                 minimum: 1
                                 description: Maximum number of auto top-ups allowed within the interval.
+                              count:
+                                type: number
+                                minimum: 0
+                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                  runtime state unchanged.
                             required:
                               - interval
                               - limit
-                            description: Optional rate limit to cap how often auto top-ups occur.
+                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                              to set the current window's consumed top-ups.
                           invoice_mode:
                             type: boolean
                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -12047,7 +12087,6 @@ paths:
                                       description: Whether auto top-up is enabled.
                                     threshold:
                                       type: number
-                                      minimum: 0
                                       description: When the balance drops below this threshold, an auto top-up will be
                                         purchased.
                                     quantity:
@@ -12074,10 +12113,17 @@ paths:
                                           type: number
                                           minimum: 1
                                           description: Maximum number of auto top-ups allowed within the interval.
+                                        count:
+                                          type: number
+                                          minimum: 0
+                                          description: Set the current window's consumed auto top-up count. Omit to leave
+                                            runtime state unchanged.
                                       required:
                                         - interval
                                         - limit
-                                      description: Optional rate limit to cap how often auto top-ups occur.
+                                      description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                        to set the current window's consumed
+                                        top-ups.
                                     invoice_mode:
                                       type: boolean
                                       description: When true, auto top-up creates a send_invoice invoice instead of
@@ -13032,7 +13078,6 @@ paths:
                                       description: Whether auto top-up is enabled.
                                     threshold:
                                       type: number
-                                      minimum: 0
                                       description: When the balance drops below this threshold, an auto top-up will be
                                         purchased.
                                     quantity:
@@ -13059,10 +13104,17 @@ paths:
                                           type: number
                                           minimum: 1
                                           description: Maximum number of auto top-ups allowed within the interval.
+                                        count:
+                                          type: number
+                                          minimum: 0
+                                          description: Set the current window's consumed auto top-up count. Omit to leave
+                                            runtime state unchanged.
                                       required:
                                         - interval
                                         - limit
-                                      description: Optional rate limit to cap how often auto top-ups occur.
+                                      description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                        to set the current window's consumed
+                                        top-ups.
                                     invoice_mode:
                                       type: boolean
                                       description: When true, auto top-up creates a send_invoice invoice instead of
@@ -13236,7 +13288,6 @@ paths:
                               description: Whether auto top-up is enabled.
                             threshold:
                               type: number
-                              minimum: 0
                               description: When the balance drops below this threshold, an auto top-up will be
                                 purchased.
                             quantity:
@@ -15060,7 +15111,6 @@ paths:
                                 description: Whether auto top-up is enabled.
                               threshold:
                                 type: number
-                                minimum: 0
                                 description: When the balance drops below this threshold, an auto top-up will be
                                   purchased.
                               quantity:
@@ -15087,10 +15137,16 @@ paths:
                                     type: number
                                     minimum: 1
                                     description: Maximum number of auto top-ups allowed within the interval.
+                                  count:
+                                    type: number
+                                    minimum: 0
+                                    description: Set the current window's consumed auto top-up count. Omit to leave
+                                      runtime state unchanged.
                                 required:
                                   - interval
                                   - limit
-                                description: Optional rate limit to cap how often auto top-ups occur.
+                                description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                  to set the current window's consumed top-ups.
                               invoice_mode:
                                 type: boolean
                                 description: When true, auto top-up creates a send_invoice invoice instead of
@@ -16481,7 +16537,6 @@ paths:
                                               description: Whether auto top-up is enabled.
                                             threshold:
                                               type: number
-                                              minimum: 0
                                               description: When the balance drops below this threshold, an auto top-up will be
                                                 purchased.
                                             quantity:
@@ -16508,10 +16563,17 @@ paths:
                                                   type: number
                                                   minimum: 1
                                                   description: Maximum number of auto top-ups allowed within the interval.
+                                                count:
+                                                  type: number
+                                                  minimum: 0
+                                                  description: Set the current window's consumed auto top-up count. Omit to leave
+                                                    runtime state unchanged.
                                               required:
                                                 - interval
                                                 - limit
-                                              description: Optional rate limit to cap how often auto top-ups occur.
+                                              description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                                to set the current window's
+                                                consumed top-ups.
                                             invoice_mode:
                                               type: boolean
                                               description: When true, auto top-up creates a send_invoice invoice instead of
@@ -17182,7 +17244,6 @@ paths:
                                             description: Whether auto top-up is enabled.
                                           threshold:
                                             type: number
-                                            minimum: 0
                                             description: When the balance drops below this threshold, an auto top-up will be
                                               purchased.
                                           quantity:
@@ -17209,10 +17270,17 @@ paths:
                                                 type: number
                                                 minimum: 1
                                                 description: Maximum number of auto top-ups allowed within the interval.
+                                              count:
+                                                type: number
+                                                minimum: 0
+                                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                                  runtime state unchanged.
                                             required:
                                               - interval
                                               - limit
-                                            description: Optional rate limit to cap how often auto top-ups occur.
+                                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                              to set the current window's
+                                              consumed top-ups.
                                           invoice_mode:
                                             type: boolean
                                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -18793,7 +18861,6 @@ paths:
                                 description: Whether auto top-up is enabled.
                               threshold:
                                 type: number
-                                minimum: 0
                                 description: When the balance drops below this threshold, an auto top-up will be
                                   purchased.
                               quantity:
@@ -18820,10 +18887,16 @@ paths:
                                     type: number
                                     minimum: 1
                                     description: Maximum number of auto top-ups allowed within the interval.
+                                  count:
+                                    type: number
+                                    minimum: 0
+                                    description: Set the current window's consumed auto top-up count. Omit to leave
+                                      runtime state unchanged.
                                 required:
                                   - interval
                                   - limit
-                                description: Optional rate limit to cap how often auto top-ups occur.
+                                description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                  to set the current window's consumed top-ups.
                               invoice_mode:
                                 type: boolean
                                 description: When true, auto top-up creates a send_invoice invoice instead of
@@ -21510,7 +21583,6 @@ paths:
                                 description: Whether auto top-up is enabled.
                               threshold:
                                 type: number
-                                minimum: 0
                                 description: When the balance drops below this threshold, an auto top-up will be
                                   purchased.
                               quantity:
@@ -21537,10 +21609,16 @@ paths:
                                     type: number
                                     minimum: 1
                                     description: Maximum number of auto top-ups allowed within the interval.
+                                  count:
+                                    type: number
+                                    minimum: 0
+                                    description: Set the current window's consumed auto top-up count. Omit to leave
+                                      runtime state unchanged.
                                 required:
                                   - interval
                                   - limit
-                                description: Optional rate limit to cap how often auto top-ups occur.
+                                description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                  to set the current window's consumed top-ups.
                               invoice_mode:
                                 type: boolean
                                 description: When true, auto top-up creates a send_invoice invoice instead of
@@ -22836,7 +22914,6 @@ paths:
                                 description: Whether auto top-up is enabled.
                               threshold:
                                 type: number
-                                minimum: 0
                                 description: When the balance drops below this threshold, an auto top-up will be
                                   purchased.
                               quantity:
@@ -22863,10 +22940,16 @@ paths:
                                     type: number
                                     minimum: 1
                                     description: Maximum number of auto top-ups allowed within the interval.
+                                  count:
+                                    type: number
+                                    minimum: 0
+                                    description: Set the current window's consumed auto top-up count. Omit to leave
+                                      runtime state unchanged.
                                 required:
                                   - interval
                                   - limit
-                                description: Optional rate limit to cap how often auto top-ups occur.
+                                description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                  to set the current window's consumed top-ups.
                               invoice_mode:
                                 type: boolean
                                 description: When true, auto top-up creates a send_invoice invoice instead of
@@ -25179,7 +25262,6 @@ paths:
                                 description: Whether auto top-up is enabled.
                               threshold:
                                 type: number
-                                minimum: 0
                                 description: When the balance drops below this threshold, an auto top-up will be
                                   purchased.
                               quantity:
@@ -25206,10 +25288,16 @@ paths:
                                     type: number
                                     minimum: 1
                                     description: Maximum number of auto top-ups allowed within the interval.
+                                  count:
+                                    type: number
+                                    minimum: 0
+                                    description: Set the current window's consumed auto top-up count. Omit to leave
+                                      runtime state unchanged.
                                 required:
                                   - interval
                                   - limit
-                                description: Optional rate limit to cap how often auto top-ups occur.
+                                description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                  to set the current window's consumed top-ups.
                               invoice_mode:
                                 type: boolean
                                 description: When true, auto top-up creates a send_invoice invoice instead of
@@ -27142,7 +27230,6 @@ paths:
                                         description: Whether auto top-up is enabled.
                                       threshold:
                                         type: number
-                                        minimum: 0
                                         description: When the balance drops below this threshold, an auto top-up will be
                                           purchased.
                                       quantity:
@@ -27919,7 +28006,6 @@ paths:
                                         description: Whether auto top-up is enabled.
                                       threshold:
                                         type: number
-                                        minimum: 0
                                         description: When the balance drops below this threshold, an auto top-up will be
                                           purchased.
                                       quantity:

--- a/packages/openapi/openapi.yml
+++ b/packages/openapi/openapi.yml
@@ -76,7 +76,6 @@ components:
                     description: Whether auto top-up is enabled.
                   threshold:
                     type: number
-                    minimum: 0
                     description: When the balance drops below this threshold, an auto top-up will be
                       purchased.
                   quantity:
@@ -103,10 +102,16 @@ components:
                         type: number
                         minimum: 1
                         description: Maximum number of auto top-ups allowed within the interval.
+                      count:
+                        type: number
+                        minimum: 0
+                        description: Set the current window's consumed auto top-up count. Omit to leave
+                          runtime state unchanged.
                     required:
                       - interval
                       - limit
-                    description: Optional rate limit to cap how often auto top-ups occur.
+                    description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                      to set the current window's consumed top-ups.
                   invoice_mode:
                     type: boolean
                     description: When true, auto top-up creates a send_invoice invoice instead of
@@ -339,7 +344,6 @@ components:
                     description: Whether auto top-up is enabled.
                   threshold:
                     type: number
-                    minimum: 0
                     description: When the balance drops below this threshold, an auto top-up will be
                       purchased.
                   quantity:
@@ -1995,7 +1999,6 @@ components:
                             description: Whether auto top-up is enabled.
                           threshold:
                             type: number
-                            minimum: 0
                             description: When the balance drops below this threshold, an auto top-up will be
                               purchased.
                           quantity:
@@ -2022,10 +2025,16 @@ components:
                                 type: number
                                 minimum: 1
                                 description: Maximum number of auto top-ups allowed within the interval.
+                              count:
+                                type: number
+                                minimum: 0
+                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                  runtime state unchanged.
                             required:
                               - interval
                               - limit
-                            description: Optional rate limit to cap how often auto top-ups occur.
+                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                              to set the current window's consumed top-ups.
                           invoice_mode:
                             type: boolean
                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -2196,7 +2205,6 @@ components:
                     description: Whether auto top-up is enabled.
                   threshold:
                     type: number
-                    minimum: 0
                     description: When the balance drops below this threshold, an auto top-up will be
                       purchased.
                   quantity:
@@ -2878,7 +2886,6 @@ paths:
                             description: Whether auto top-up is enabled.
                           threshold:
                             type: number
-                            minimum: 0
                             description: When the balance drops below this threshold, an auto top-up will be
                               purchased.
                           quantity:
@@ -2905,10 +2912,16 @@ paths:
                                 type: number
                                 minimum: 1
                                 description: Maximum number of auto top-ups allowed within the interval.
+                              count:
+                                type: number
+                                minimum: 0
+                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                  runtime state unchanged.
                             required:
                               - interval
                               - limit
-                            description: Optional rate limit to cap how often auto top-ups occur.
+                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                              to set the current window's consumed top-ups.
                           invoice_mode:
                             type: boolean
                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -3232,7 +3245,6 @@ paths:
                               description: Whether auto top-up is enabled.
                             threshold:
                               type: number
-                              minimum: 0
                               description: When the balance drops below this threshold, an auto top-up will be
                                 purchased.
                             quantity:
@@ -4285,7 +4297,6 @@ paths:
                                     description: Whether auto top-up is enabled.
                                   threshold:
                                     type: number
-                                    minimum: 0
                                     description: When the balance drops below this threshold, an auto top-up will be
                                       purchased.
                                   quantity:
@@ -5141,7 +5152,6 @@ paths:
                             description: Whether auto top-up is enabled.
                           threshold:
                             type: number
-                            minimum: 0
                             description: When the balance drops below this threshold, an auto top-up will be
                               purchased.
                           quantity:
@@ -5168,10 +5178,16 @@ paths:
                                 type: number
                                 minimum: 1
                                 description: Maximum number of auto top-ups allowed within the interval.
+                              count:
+                                type: number
+                                minimum: 0
+                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                  runtime state unchanged.
                             required:
                               - interval
                               - limit
-                            description: Optional rate limit to cap how often auto top-ups occur.
+                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                              to set the current window's consumed top-ups.
                           invoice_mode:
                             type: boolean
                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -5405,7 +5421,6 @@ paths:
                               description: Whether auto top-up is enabled.
                             threshold:
                               type: number
-                              minimum: 0
                               description: When the balance drops below this threshold, an auto top-up will be
                                 purchased.
                             quantity:
@@ -6875,7 +6890,6 @@ paths:
                             description: Whether auto top-up is enabled.
                           threshold:
                             type: number
-                            minimum: 0
                             description: When the balance drops below this threshold, an auto top-up will be
                               purchased.
                           quantity:
@@ -6902,10 +6916,16 @@ paths:
                                 type: number
                                 minimum: 1
                                 description: Maximum number of auto top-ups allowed within the interval.
+                              count:
+                                type: number
+                                minimum: 0
+                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                  runtime state unchanged.
                             required:
                               - interval
                               - limit
-                            description: Optional rate limit to cap how often auto top-ups occur.
+                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                              to set the current window's consumed top-ups.
                           invoice_mode:
                             type: boolean
                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -7865,7 +7885,6 @@ paths:
                                       description: Whether auto top-up is enabled.
                                     threshold:
                                       type: number
-                                      minimum: 0
                                       description: When the balance drops below this threshold, an auto top-up will be
                                         purchased.
                                     quantity:
@@ -7892,10 +7911,17 @@ paths:
                                           type: number
                                           minimum: 1
                                           description: Maximum number of auto top-ups allowed within the interval.
+                                        count:
+                                          type: number
+                                          minimum: 0
+                                          description: Set the current window's consumed auto top-up count. Omit to leave
+                                            runtime state unchanged.
                                       required:
                                         - interval
                                         - limit
-                                      description: Optional rate limit to cap how often auto top-ups occur.
+                                      description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                        to set the current window's consumed
+                                        top-ups.
                                     invoice_mode:
                                       type: boolean
                                       description: When true, auto top-up creates a send_invoice invoice instead of
@@ -8069,7 +8095,6 @@ paths:
                               description: Whether auto top-up is enabled.
                             threshold:
                               type: number
-                              minimum: 0
                               description: When the balance drops below this threshold, an auto top-up will be
                                 purchased.
                             quantity:
@@ -9177,7 +9202,6 @@ paths:
                                       description: Whether auto top-up is enabled.
                                     threshold:
                                       type: number
-                                      minimum: 0
                                       description: When the balance drops below this threshold, an auto top-up will be
                                         purchased.
                                     quantity:
@@ -9204,10 +9228,17 @@ paths:
                                           type: number
                                           minimum: 1
                                           description: Maximum number of auto top-ups allowed within the interval.
+                                        count:
+                                          type: number
+                                          minimum: 0
+                                          description: Set the current window's consumed auto top-up count. Omit to leave
+                                            runtime state unchanged.
                                       required:
                                         - interval
                                         - limit
-                                      description: Optional rate limit to cap how often auto top-ups occur.
+                                      description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                        to set the current window's consumed
+                                        top-ups.
                                     invoice_mode:
                                       type: boolean
                                       description: When true, auto top-up creates a send_invoice invoice instead of
@@ -9381,7 +9412,6 @@ paths:
                               description: Whether auto top-up is enabled.
                             threshold:
                               type: number
-                              minimum: 0
                               description: When the balance drops below this threshold, an auto top-up will be
                                 purchased.
                             quantity:
@@ -10468,7 +10498,6 @@ paths:
                                             description: Whether auto top-up is enabled.
                                           threshold:
                                             type: number
-                                            minimum: 0
                                             description: When the balance drops below this threshold, an auto top-up will be
                                               purchased.
                                           quantity:
@@ -10495,10 +10524,17 @@ paths:
                                                 type: number
                                                 minimum: 1
                                                 description: Maximum number of auto top-ups allowed within the interval.
+                                              count:
+                                                type: number
+                                                minimum: 0
+                                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                                  runtime state unchanged.
                                             required:
                                               - interval
                                               - limit
-                                            description: Optional rate limit to cap how often auto top-ups occur.
+                                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                              to set the current window's
+                                              consumed top-ups.
                                           invoice_mode:
                                             type: boolean
                                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -10673,7 +10709,6 @@ paths:
                                     description: Whether auto top-up is enabled.
                                   threshold:
                                     type: number
-                                    minimum: 0
                                     description: When the balance drops below this threshold, an auto top-up will be
                                       purchased.
                                   quantity:
@@ -11653,7 +11688,6 @@ paths:
                             description: Whether auto top-up is enabled.
                           threshold:
                             type: number
-                            minimum: 0
                             description: When the balance drops below this threshold, an auto top-up will be
                               purchased.
                           quantity:
@@ -11680,10 +11714,16 @@ paths:
                                 type: number
                                 minimum: 1
                                 description: Maximum number of auto top-ups allowed within the interval.
+                              count:
+                                type: number
+                                minimum: 0
+                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                  runtime state unchanged.
                             required:
                               - interval
                               - limit
-                            description: Optional rate limit to cap how often auto top-ups occur.
+                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                              to set the current window's consumed top-ups.
                           invoice_mode:
                             type: boolean
                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -12253,7 +12293,6 @@ paths:
                                       description: Whether auto top-up is enabled.
                                     threshold:
                                       type: number
-                                      minimum: 0
                                       description: When the balance drops below this threshold, an auto top-up will be
                                         purchased.
                                     quantity:
@@ -12280,10 +12319,17 @@ paths:
                                           type: number
                                           minimum: 1
                                           description: Maximum number of auto top-ups allowed within the interval.
+                                        count:
+                                          type: number
+                                          minimum: 0
+                                          description: Set the current window's consumed auto top-up count. Omit to leave
+                                            runtime state unchanged.
                                       required:
                                         - interval
                                         - limit
-                                      description: Optional rate limit to cap how often auto top-ups occur.
+                                      description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                        to set the current window's consumed
+                                        top-ups.
                                     invoice_mode:
                                       type: boolean
                                       description: When true, auto top-up creates a send_invoice invoice instead of
@@ -13236,7 +13282,6 @@ paths:
                                       description: Whether auto top-up is enabled.
                                     threshold:
                                       type: number
-                                      minimum: 0
                                       description: When the balance drops below this threshold, an auto top-up will be
                                         purchased.
                                     quantity:
@@ -13263,10 +13308,17 @@ paths:
                                           type: number
                                           minimum: 1
                                           description: Maximum number of auto top-ups allowed within the interval.
+                                        count:
+                                          type: number
+                                          minimum: 0
+                                          description: Set the current window's consumed auto top-up count. Omit to leave
+                                            runtime state unchanged.
                                       required:
                                         - interval
                                         - limit
-                                      description: Optional rate limit to cap how often auto top-ups occur.
+                                      description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                        to set the current window's consumed
+                                        top-ups.
                                     invoice_mode:
                                       type: boolean
                                       description: When true, auto top-up creates a send_invoice invoice instead of
@@ -13440,7 +13492,6 @@ paths:
                               description: Whether auto top-up is enabled.
                             threshold:
                               type: number
-                              minimum: 0
                               description: When the balance drops below this threshold, an auto top-up will be
                                 purchased.
                             quantity:
@@ -15584,7 +15635,6 @@ paths:
                                 description: Whether auto top-up is enabled.
                               threshold:
                                 type: number
-                                minimum: 0
                                 description: When the balance drops below this threshold, an auto top-up will be
                                   purchased.
                               quantity:
@@ -15611,10 +15661,16 @@ paths:
                                     type: number
                                     minimum: 1
                                     description: Maximum number of auto top-ups allowed within the interval.
+                                  count:
+                                    type: number
+                                    minimum: 0
+                                    description: Set the current window's consumed auto top-up count. Omit to leave
+                                      runtime state unchanged.
                                 required:
                                   - interval
                                   - limit
-                                description: Optional rate limit to cap how often auto top-ups occur.
+                                description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                  to set the current window's consumed top-ups.
                               invoice_mode:
                                 type: boolean
                                 description: When true, auto top-up creates a send_invoice invoice instead of
@@ -16383,7 +16439,7 @@ paths:
         @example
         ```typescript
         // Schedule a transition from a trial plan to a paid plan
-        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1784658936605,"plans":[{"planId":"trial_plan"}]},{"startsAt":1785868536605,"plans":[{"planId":"pro_plan"}]}] });
+        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1784744849888,"plans":[{"planId":"trial_plan"}]},{"startsAt":1785954449888,"plans":[{"planId":"pro_plan"}]}] });
         ```
 
         @param customerId - The ID of the customer to create the schedule for.
@@ -17016,7 +17072,6 @@ paths:
                                               description: Whether auto top-up is enabled.
                                             threshold:
                                               type: number
-                                              minimum: 0
                                               description: When the balance drops below this threshold, an auto top-up will be
                                                 purchased.
                                             quantity:
@@ -17043,10 +17098,17 @@ paths:
                                                   type: number
                                                   minimum: 1
                                                   description: Maximum number of auto top-ups allowed within the interval.
+                                                count:
+                                                  type: number
+                                                  minimum: 0
+                                                  description: Set the current window's consumed auto top-up count. Omit to leave
+                                                    runtime state unchanged.
                                               required:
                                                 - interval
                                                 - limit
-                                              description: Optional rate limit to cap how often auto top-ups occur.
+                                              description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                                to set the current window's
+                                                consumed top-ups.
                                             invoice_mode:
                                               type: boolean
                                               description: When true, auto top-up creates a send_invoice invoice instead of
@@ -17717,7 +17779,6 @@ paths:
                                             description: Whether auto top-up is enabled.
                                           threshold:
                                             type: number
-                                            minimum: 0
                                             description: When the balance drops below this threshold, an auto top-up will be
                                               purchased.
                                           quantity:
@@ -17744,10 +17805,17 @@ paths:
                                                 type: number
                                                 minimum: 1
                                                 description: Maximum number of auto top-ups allowed within the interval.
+                                              count:
+                                                type: number
+                                                minimum: 0
+                                                description: Set the current window's consumed auto top-up count. Omit to leave
+                                                  runtime state unchanged.
                                             required:
                                               - interval
                                               - limit
-                                            description: Optional rate limit to cap how often auto top-ups occur.
+                                            description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                              to set the current window's
+                                              consumed top-ups.
                                           invoice_mode:
                                             type: boolean
                                             description: When true, auto top-up creates a send_invoice invoice instead of
@@ -19469,7 +19537,6 @@ paths:
                                 description: Whether auto top-up is enabled.
                               threshold:
                                 type: number
-                                minimum: 0
                                 description: When the balance drops below this threshold, an auto top-up will be
                                   purchased.
                               quantity:
@@ -19496,10 +19563,16 @@ paths:
                                     type: number
                                     minimum: 1
                                     description: Maximum number of auto top-ups allowed within the interval.
+                                  count:
+                                    type: number
+                                    minimum: 0
+                                    description: Set the current window's consumed auto top-up count. Omit to leave
+                                      runtime state unchanged.
                                 required:
                                   - interval
                                   - limit
-                                description: Optional rate limit to cap how often auto top-ups occur.
+                                description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                  to set the current window's consumed top-ups.
                               invoice_mode:
                                 type: boolean
                                 description: When true, auto top-up creates a send_invoice invoice instead of
@@ -22300,7 +22373,6 @@ paths:
                                 description: Whether auto top-up is enabled.
                               threshold:
                                 type: number
-                                minimum: 0
                                 description: When the balance drops below this threshold, an auto top-up will be
                                   purchased.
                               quantity:
@@ -22327,10 +22399,16 @@ paths:
                                     type: number
                                     minimum: 1
                                     description: Maximum number of auto top-ups allowed within the interval.
+                                  count:
+                                    type: number
+                                    minimum: 0
+                                    description: Set the current window's consumed auto top-up count. Omit to leave
+                                      runtime state unchanged.
                                 required:
                                   - interval
                                   - limit
-                                description: Optional rate limit to cap how often auto top-ups occur.
+                                description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                  to set the current window's consumed top-ups.
                               invoice_mode:
                                 type: boolean
                                 description: When true, auto top-up creates a send_invoice invoice instead of
@@ -23702,7 +23780,6 @@ paths:
                                 description: Whether auto top-up is enabled.
                               threshold:
                                 type: number
-                                minimum: 0
                                 description: When the balance drops below this threshold, an auto top-up will be
                                   purchased.
                               quantity:
@@ -23729,10 +23806,16 @@ paths:
                                     type: number
                                     minimum: 1
                                     description: Maximum number of auto top-ups allowed within the interval.
+                                  count:
+                                    type: number
+                                    minimum: 0
+                                    description: Set the current window's consumed auto top-up count. Omit to leave
+                                      runtime state unchanged.
                                 required:
                                   - interval
                                   - limit
-                                description: Optional rate limit to cap how often auto top-ups occur.
+                                description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                  to set the current window's consumed top-ups.
                               invoice_mode:
                                 type: boolean
                                 description: When true, auto top-up creates a send_invoice invoice instead of
@@ -26051,7 +26134,6 @@ paths:
                                 description: Whether auto top-up is enabled.
                               threshold:
                                 type: number
-                                minimum: 0
                                 description: When the balance drops below this threshold, an auto top-up will be
                                   purchased.
                               quantity:
@@ -26078,10 +26160,16 @@ paths:
                                     type: number
                                     minimum: 1
                                     description: Maximum number of auto top-ups allowed within the interval.
+                                  count:
+                                    type: number
+                                    minimum: 0
+                                    description: Set the current window's consumed auto top-up count. Omit to leave
+                                      runtime state unchanged.
                                 required:
                                   - interval
                                   - limit
-                                description: Optional rate limit to cap how often auto top-ups occur.
+                                description: Optional rate limit to cap how often auto top-ups occur. Pass count
+                                  to set the current window's consumed top-ups.
                               invoice_mode:
                                 type: boolean
                                 description: When true, auto top-up creates a send_invoice invoice instead of
@@ -28055,7 +28143,6 @@ paths:
                                         description: Whether auto top-up is enabled.
                                       threshold:
                                         type: number
-                                        minimum: 0
                                         description: When the balance drops below this threshold, an auto top-up will be
                                           purchased.
                                       quantity:
@@ -28830,7 +28917,6 @@ paths:
                                         description: Whether auto top-up is enabled.
                                       threshold:
                                         type: number
-                                        minimum: 0
                                         description: When the balance drops below this threshold, an auto top-up will be
                                           purchased.
                                       quantity:

--- a/packages/sdk/.speakeasy/gen.lock
+++ b/packages/sdk/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: 7b300647-cd76-49e9-bf77-7d1bf5446d66
 management:
-  docChecksum: 71a990a383f0010c45f3682e189a82fe
+  docChecksum: 0ec6edf850540a933f6a79edc67f051b
   docVersion: 2.3.0
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
   releaseVersion: 0.10.18
   configChecksum: 751d545c3d03661781a8ccf68e83a1b6
 persistentEdits:
-  generation_id: 7eb7b0a9-789f-4600-b611-59c2d03309a1
-  pristine_commit_hash: 4b653836aa93ed9d2698ecf62585ef9140d8e93f
-  pristine_tree_hash: 3c55a0e4edb692b90fcc1a4930411f43b999764d
+  generation_id: 0d6ea8f3-6cb4-4f5b-96b0-c7a3cddcdbce
+  pristine_commit_hash: 6e27cace85dacb2a8c4f37e6f8a89151e63daef3
+  pristine_tree_hash: bd9de794c5b0304d44e2a94d235508aa94aacee7
 features:
   typescript:
     additionalDependencies: 0.1.0
@@ -182,8 +182,8 @@ trackedFiles:
     pristine_git_object: 92d058f3586e4370fe64fe61ab605c68df98539b
   docs/models/attach-auto-topup.md:
     id: f199077483db
-    last_write_checksum: sha1:10edc41e0abf9ca2554a1c120eb6898e30316061
-    pristine_git_object: 030383b8a163fa08385b084c5f4ec20b05f71665
+    last_write_checksum: sha1:fbc53a41a4e322a795aa4d153fb974c082e4c28e
+    pristine_git_object: 539db8c0564f63fa0cb456425379543418fb4c49
   docs/models/attach-base-price.md:
     id: f0987a200c0d
     last_write_checksum: sha1:0595dc42e9a153095daa7695ba01dd3f3335bf0a
@@ -390,8 +390,8 @@ trackedFiles:
     pristine_git_object: 7a4cd9d8a1f0695b36c5fa314fda9de65365867e
   docs/models/attach-purchase-limit.md:
     id: af964d969c78
-    last_write_checksum: sha1:2748c1abe894e046775c958fdf77cf44e736ec72
-    pristine_git_object: 020e9a9a2c8009c372a2edd1f17af89606abefe0
+    last_write_checksum: sha1:4341682d96cab477cc441ab297fdfb8d7cc89f85
+    pristine_git_object: 28f19435079e671d0d35c31d5bf859a1dd8c5df8
   docs/models/attach-redirect-mode.md:
     id: e3c87b6f489b
     last_write_checksum: sha1:822e38dbdafa354554ba2c73bededa06ec97c9a0
@@ -686,8 +686,8 @@ trackedFiles:
     pristine_git_object: 141e593599c2b1ba12c7149749a89d119e50c78a
   docs/models/billing-update-auto-topup.md:
     id: e8837f60d4f6
-    last_write_checksum: sha1:d9bb81d15d5b56a6aa5530ed0618d4c227ae204e
-    pristine_git_object: 234dc11db069fe4fd0fa130bcf1dd0311caff2bb
+    last_write_checksum: sha1:0c81a621a14bd2358dd6c96b30f01ff7f4c8c3c9
+    pristine_git_object: 5eea03ca83c09455b83e5b9821b89a1802fe34f3
   docs/models/billing-update-base-price.md:
     id: 7a3d2f48b101
     last_write_checksum: sha1:08dc49dbe42f6f1f8c7c6466d0a5fc38690ae1a6
@@ -866,8 +866,8 @@ trackedFiles:
     pristine_git_object: d7988287f09875b437308cc772473b23a1f64683
   docs/models/billing-update-purchase-limit.md:
     id: 9b70580f4662
-    last_write_checksum: sha1:9ffc9f99ab3e11294a5e0b42a7e3ada78c5668fc
-    pristine_git_object: 9fa0f09774d8f2b3646422500a15d9686e9077f4
+    last_write_checksum: sha1:61bf8866a9a4aa69fee017fff8944a0769bcfb1d
+    pristine_git_object: 5ce193bc80b822b69d0484b8a4828f3d7c9cdd57
   docs/models/billing-update-recalculate-balances.md:
     id: 8ead4615c410
     last_write_checksum: sha1:faeed44cbca8f10ff5e55213ce959bba7da80fa5
@@ -1530,8 +1530,8 @@ trackedFiles:
     pristine_git_object: 11bf4a9d74e75a895e27489a55444fbe76d6488e
   docs/models/create-plan-auto-topup-request.md:
     id: 4220992b4af0
-    last_write_checksum: sha1:58cd30fcf32cfeaf91057c9707e7f2a77c03268c
-    pristine_git_object: 54c7c845aa40965f29103a02c38fe1ce5d9c523a
+    last_write_checksum: sha1:15ea0b67158757f90aa76375cba09b18d10d609d
+    pristine_git_object: 94931759aecac4b2cf105fab14a19def4ab24eb2
   docs/models/create-plan-auto-topup-response.md:
     id: 729f2f97759f
     last_write_checksum: sha1:acd8933ae36be68ed16aecfc56b152aac2c41ee9
@@ -1914,8 +1914,8 @@ trackedFiles:
     pristine_git_object: ca1607781c10074ca0784aace3890e39717f358f
   docs/models/create-plan-purchase-limit-request.md:
     id: 89826591fd3e
-    last_write_checksum: sha1:e9f3a0ade7e33a18e5bb449f9a61e65abb85b403
-    pristine_git_object: b6cc304a9fdfc89387beea6d0b6260ee1ce85317
+    last_write_checksum: sha1:d14b15bb2754d227574f4231fda11e7e58032c43
+    pristine_git_object: 08d1f7580b255d0b1d3c16e7b530ea3ad46a6af1
   docs/models/create-plan-purchase-limit-response.md:
     id: 3f6d5600a425
     last_write_checksum: sha1:5acb9b88e680b4e63afcf41eb9e87c56fef2eb38
@@ -1994,8 +1994,8 @@ trackedFiles:
     pristine_git_object: 3d56ab7c38e3f8bcdc2bcf381759c5d2e64e3401
   docs/models/create-plan-variant-details-auto-topup.md:
     id: 47498d61f061
-    last_write_checksum: sha1:5d733417db67c0c98c73c136b5443303397be8e3
-    pristine_git_object: 25bc6d98737056b6975e2903a70fb960f6d12efb
+    last_write_checksum: sha1:db0bef949115236f0bc93d764eca609a0c8971f3
+    pristine_git_object: a3645b9f82b290d0e2d6ce8460b5d0323e4a282c
   docs/models/create-plan-variant-details-billing-controls.md:
     id: da06df4a7ee6
     last_write_checksum: sha1:805b0a46abbe809aa3bb58ca4d7e6f73aec45aa2
@@ -2046,8 +2046,8 @@ trackedFiles:
     pristine_git_object: b9d0c70eb15bea1107b9b0506452320526d16d9a
   docs/models/create-plan-variant-details-purchase-limit.md:
     id: ce32aa245fd1
-    last_write_checksum: sha1:ce0ddd47a2b6fb219a6c90cde7261f62403c361d
-    pristine_git_object: a5c02353db718ddf182533ae18ef42651a5d17b7
+    last_write_checksum: sha1:48f6098df0c72e426cd5d2d06f2bd8220defcac8
+    pristine_git_object: 508d35dc99f7338479e5fc4642766959254c7ce0
   docs/models/create-plan-variant-details-remove-item-billing-method.md:
     id: 2f9aabcb612f
     last_write_checksum: sha1:2be8fabed97356001281f1a8e52e677b099785ca
@@ -2182,8 +2182,8 @@ trackedFiles:
     pristine_git_object: 1509adb1d6cae175888e8052ce9b3e90ab756c96
   docs/models/create-schedule-auto-topup2.md:
     id: e67a209bf731
-    last_write_checksum: sha1:8a6ca1c592f983b741f2e92d4df5c89afeee9904
-    pristine_git_object: 063876dcb27b7737591e29d389f88214c8bc9862
+    last_write_checksum: sha1:247111e9a86f895628e790595722fcb208dce4f8
+    pristine_git_object: e86520ff22807d6cb3beb225f21e76d9821a78fd
   docs/models/create-schedule-base-price2.md:
     id: 56793b9353fd
     last_write_checksum: sha1:c345ab2b689f3c3460f361c8bfef6417530abecf
@@ -2326,8 +2326,8 @@ trackedFiles:
     pristine_git_object: aee3872ba68699ba1279fdb7ceef92be1f839377
   docs/models/create-schedule-purchase-limit2.md:
     id: 1216e233fbe7
-    last_write_checksum: sha1:51e8d257d0dbbc34a087e987a5e72b4a70fbf44e
-    pristine_git_object: 9f7c2bc413d5b5aa11d1a07d39d004f45f43b111
+    last_write_checksum: sha1:ce16339c8c5fa2610a4280bcea2b019200b0477a
+    pristine_git_object: 71e6710bf51218dd086ee0d6d02bbe97af6898d6
   docs/models/create-schedule-redirect-mode.md:
     id: 4414e1893b11
     last_write_checksum: sha1:a370027bd5e56f88c2223275e6131bfafacc6e44
@@ -2386,8 +2386,8 @@ trackedFiles:
     pristine_git_object: 240e81faccbe40b3977164f2a1df81eefa704cc5
   docs/models/customer-data-auto-topup.md:
     id: a9028229550e
-    last_write_checksum: sha1:97f734c3650a194091ce892a213014c746b124ed
-    pristine_git_object: 656aaaab7f348684ec056ef2ef997dd1bf6f7b20
+    last_write_checksum: sha1:462bd44b03e841f80699f9227557096123166a6f
+    pristine_git_object: c23728ad2717cf985aada4d24235993dc2f098aa
   docs/models/customer-data-billing-controls.md:
     id: ca09ea9a9d79
     last_write_checksum: sha1:c5e4f1df7c531adf0d73ee3b777f17524f49623b
@@ -2414,8 +2414,8 @@ trackedFiles:
     pristine_git_object: ddbb71ee6a29627e29d0d92640299bb671618c11
   docs/models/customer-data-purchase-limit.md:
     id: 52a86c6092c4
-    last_write_checksum: sha1:869703db26a5e1645575ed9992cfe8146c0925d7
-    pristine_git_object: 4e7adc776f479f261795c577d468142a330355e9
+    last_write_checksum: sha1:fae709851148f62f267f7dd06255675021c4ebe1
+    pristine_git_object: 7e8df701ff9c297a16ad3dce4fcc0cf50d058f40
   docs/models/customer-data-spend-limit.md:
     id: d6adb304f72d
     last_write_checksum: sha1:9732fa8bdcb1943408ed95c28b41fea452f22ab1
@@ -3118,8 +3118,8 @@ trackedFiles:
     pristine_git_object: 8f240bde6709a476ec744ba6216e1f0af24e113f
   docs/models/get-or-create-customer-auto-topup.md:
     id: "673761036094"
-    last_write_checksum: sha1:82829d5ba5755f620fd2e571c254d3ef6eadf82e
-    pristine_git_object: 8531f2bdc27ac9891b9bd369865f4cdbee359d73
+    last_write_checksum: sha1:ecdd5b284bfbedb11b470d382497a8bb209d4237
+    pristine_git_object: c31169ac6fb4b34d9e846684a0ff6c04d8d2cc6c
   docs/models/get-or-create-customer-billing-controls.md:
     id: e7ee10d9a50b
     last_write_checksum: sha1:ad80588d690231ca5f18a65682b1f1f2cbada54c
@@ -3158,8 +3158,8 @@ trackedFiles:
     pristine_git_object: 95783157c590556a4a603f88b326ec681d72d338
   docs/models/get-or-create-customer-purchase-limit.md:
     id: 409c503aeb70
-    last_write_checksum: sha1:e3687c4701b8de15825ca18f6c2cbb9b53e5d8b4
-    pristine_git_object: 7e2acbb5609dcc6998778dfcb03ab41fd0106700
+    last_write_checksum: sha1:078ed99a39fbb1b5c47e40890eab2c6b5dbe0f2c
+    pristine_git_object: 1f3aea58b35d99647fa2891de13b62e27c62be62
   docs/models/get-or-create-customer-spend-limit.md:
     id: 6bc905d17111
     last_write_checksum: sha1:c618c77388ffe370ac6d0ff6a51eb28bb09be0d4
@@ -3430,8 +3430,8 @@ trackedFiles:
     pristine_git_object: 54129a2c2a0703561c4ab35f8e60ab2252994e87
   docs/models/get-plan-variant-details-auto-topup.md:
     id: 96512e86d732
-    last_write_checksum: sha1:089f2a2051bc43467294798229e53591429f1ffd
-    pristine_git_object: dcd2bc82519a674511ac31ba8430316e8dc5b520
+    last_write_checksum: sha1:2f7908950021cbc569a30040d9bf233cb89fd537
+    pristine_git_object: b83e1657a50e5d02c9ff8fc008cff330a75619db
   docs/models/get-plan-variant-details-billing-controls.md:
     id: d43998bdec25
     last_write_checksum: sha1:3ad5bbbfcea35a7b55531167d9b443ef64c048b8
@@ -3470,8 +3470,8 @@ trackedFiles:
     pristine_git_object: 65ade8c40c69d89ed83c6d86e036418ef876f7f8
   docs/models/get-plan-variant-details-purchase-limit.md:
     id: fa2a6849af3e
-    last_write_checksum: sha1:2308fd5570f9e1f105c4e9b182b2ee00d700c912
-    pristine_git_object: dc18a58e553f0d0dfcd1682d6fc19a830dcad02a
+    last_write_checksum: sha1:05a769856eb8b6ef5b840ed0e45a6e92a2f6e4b0
+    pristine_git_object: 5737c24d68c4c80403f06ebcba92b7ec2fddf5f6
   docs/models/get-plan-variant-details-reset-interval.md:
     id: fd6c1816e3c3
     last_write_checksum: sha1:49bff5ee3f007b97342f3fda25f68934badeff6e
@@ -4362,8 +4362,8 @@ trackedFiles:
     pristine_git_object: 37f977d5325587be84a9196fad8a8b24422ccfc9
   docs/models/list-plans-variant-details-auto-topup.md:
     id: 512e7d204755
-    last_write_checksum: sha1:8c5b13e07a18f9ac18771394276561a3a74612ad
-    pristine_git_object: 95e55b8bd56f7690c8e6e105ea456d458abe6c8c
+    last_write_checksum: sha1:cebd75f0b0c6c7e8673baf9fe337b871a484887e
+    pristine_git_object: 144a60dcad2b909d6e372d2bc4e75bf874a25a40
   docs/models/list-plans-variant-details-billing-controls.md:
     id: b01a238f2194
     last_write_checksum: sha1:64620dd73d06f9d217ad0a223f0e31d7b07e0f92
@@ -4402,8 +4402,8 @@ trackedFiles:
     pristine_git_object: 9c8c5bed58c747077ae5cf8bd7a3a5522ef2b53d
   docs/models/list-plans-variant-details-purchase-limit.md:
     id: d834c9c2d7d1
-    last_write_checksum: sha1:5d1b4f429f2fb17f519aa905fbb7f382a35f94f4
-    pristine_git_object: dc942c9cd5f21bccc76a7912ca2ea91abc268bbc
+    last_write_checksum: sha1:ce8030c66c248627db6ac1cfb25f948349522f86
+    pristine_git_object: f04ae05ae2841895044de6c17f0befcc69c93d3b
   docs/models/list-plans-variant-details-reset-interval.md:
     id: e6025a763aa3
     last_write_checksum: sha1:ab1a97e311be254067fff8705cf18ec034d01851
@@ -4906,8 +4906,8 @@ trackedFiles:
     pristine_git_object: 91e2e12508c0f73d9ec8cc8e1f292281d21dd35d
   docs/models/plan-variant-details-auto-topup.md:
     id: 9b9cc6c8a012
-    last_write_checksum: sha1:15f55a24c55a1b22cc8dc38799f45d9af36f0a64
-    pristine_git_object: 331e4f9a3e023f287fc4e160d2744e4ecdab2744
+    last_write_checksum: sha1:62bb552ec3c11666b22dfed9162505ab23435f3b
+    pristine_git_object: 6a41d1cc88a0c85923e2ed230d28374f987f1e10
   docs/models/plan-variant-details-billing-controls.md:
     id: 0639706e276a
     last_write_checksum: sha1:ba4a907b80ee905296aa61db3185657d74fffa48
@@ -4938,8 +4938,8 @@ trackedFiles:
     pristine_git_object: e19fcc8797756448993708965cac3506a24b944c
   docs/models/plan-variant-details-purchase-limit.md:
     id: 18c5345423f1
-    last_write_checksum: sha1:fbe31130ab79cfb6376b9b51db6b8adbe44d3fdf
-    pristine_git_object: 1876f167bcf926588693fb848c54e47dd258202a
+    last_write_checksum: sha1:6702981c6a15db0d78ebf13a847c6b26bde28d9a
+    pristine_git_object: 7bd6830e5a56cac53d706cd7d42480360075ac5b
   docs/models/plan-variant-details-reset-interval.md:
     id: d92854106bdd
     last_write_checksum: sha1:a4a371045792bb04378dbecbbc468f262320936d
@@ -5062,8 +5062,8 @@ trackedFiles:
     pristine_git_object: 233439ea9e7483337c1974e355294de7350d5b24
   docs/models/preview-attach-auto-topup.md:
     id: 5c1a9152aa0f
-    last_write_checksum: sha1:fd363a77a28d2fedf5f1a899f061197cc2361826
-    pristine_git_object: f11fa75c5a1f0715c8c4b3699042f14a47e633f8
+    last_write_checksum: sha1:68eadc96d212d46d7e0730016537f33b86c1106b
+    pristine_git_object: 7dec4bd69311d6154c4d689b07960f7965226a37
   docs/models/preview-attach-base-price.md:
     id: c03a523d8cd0
     last_write_checksum: sha1:431c21f19b6c6a8b14d349f53935611ab3324a01
@@ -5298,8 +5298,8 @@ trackedFiles:
     pristine_git_object: 6a1f268957b8dec1015680d5828dcfbc11429c4f
   docs/models/preview-attach-purchase-limit.md:
     id: d03ba8e9c95f
-    last_write_checksum: sha1:84100d7ea5105cb94f5756e2bd3dffcd2936e649
-    pristine_git_object: 75b68d76f0bd1911e841ba1d905030276c7b7d09
+    last_write_checksum: sha1:455252af9abd470578a74a9115fd43d06bbe1deb
+    pristine_git_object: 74c463a4c17c4ad61e6b6c2290cf70d9e7a30077
   docs/models/preview-attach-redirect-mode.md:
     id: 09a67bc1b945
     last_write_checksum: sha1:3af045689583aa733d59cda58dbe2f7dbb52ad2c
@@ -5818,8 +5818,8 @@ trackedFiles:
     pristine_git_object: 2dfbb6d2767db7a27132c846b17b7dd83d30f668
   docs/models/preview-update-auto-topup.md:
     id: ce3863fb653f
-    last_write_checksum: sha1:2b74bcaa771787388deee5c1e887a96428f826e7
-    pristine_git_object: 3c12069fe7f79104540059d869d578e9fdfd166e
+    last_write_checksum: sha1:1a5821f0aa87bb8e89444144ed6f46184cab864f
+    pristine_git_object: 1fa274d7a1cc4cee500beb6ef20372c3d17d1d83
   docs/models/preview-update-base-price.md:
     id: 2da5e78ec0e0
     last_write_checksum: sha1:897365ce797986b84c8fc197e5173764ed8a7f8e
@@ -6042,8 +6042,8 @@ trackedFiles:
     pristine_git_object: 44581c88aa8b9c135e1e9457d0095849de0e04e0
   docs/models/preview-update-purchase-limit.md:
     id: 2425fb2db9d0
-    last_write_checksum: sha1:ddf8b4e6dde28d414e952a380759dc9afa0e8d8c
-    pristine_git_object: f0c578ec22a4735516d432ace00e9769033cf0fa
+    last_write_checksum: sha1:824abd986be1d08bf257442efd3c291e15a1a22c
+    pristine_git_object: 731515178301229f3e7a9966599c0317693e9244
   docs/models/preview-update-recalculate-balances.md:
     id: 8492e617571a
     last_write_checksum: sha1:b42eaaf40821a806f22d0a5be11a543d1ef12ce2
@@ -6422,8 +6422,8 @@ trackedFiles:
     pristine_git_object: 48d618e57811e63de01d8ee23b8926f7a6fd2b6a
   docs/models/setup-payment-auto-topup.md:
     id: 2439c659bd09
-    last_write_checksum: sha1:56c371a48fe179270b5bb9f45538e32b8b7ff131
-    pristine_git_object: 6ad9b3ec57408c2030e4e40938a004901fbab9f3
+    last_write_checksum: sha1:50e815c0b5cad1afe068a412cc0c7d5c11dfe0d2
+    pristine_git_object: 356f7afeddecdff8fc4de889f33df8f2b8c84696
   docs/models/setup-payment-base-price.md:
     id: 7379e4922abd
     last_write_checksum: sha1:8bd14fbd0c7058d285aed7feb8105c672c071bf6
@@ -6598,8 +6598,8 @@ trackedFiles:
     pristine_git_object: 5e4238dc6d5861f0b1a387d29faf4a8ee4d0663b
   docs/models/setup-payment-purchase-limit.md:
     id: dbdefd4815a2
-    last_write_checksum: sha1:636f2c215ba1dfb78ab8171d1a239956209d445f
-    pristine_git_object: 4e7e019e30b801b724068a6c4fcc04bb77a2ecee
+    last_write_checksum: sha1:5e226f710544fa34f1c74c68dd5f876f819f80ab
+    pristine_git_object: e0b4f75877f6eb45512c9c5f0bf5293849677512
   docs/models/setup-payment-remove-item-billing-method.md:
     id: 71080c21cd33
     last_write_checksum: sha1:784cbf9747dc8299617e342b91a9b75a392b4bd3
@@ -6914,8 +6914,8 @@ trackedFiles:
     pristine_git_object: 499e9e62b93f93e4774017a911c621b91407c3bb
   docs/models/update-customer-auto-topup-request.md:
     id: 9d975c2052ed
-    last_write_checksum: sha1:9c480fc958172d19f79d23c06eab743d9fadef0a
-    pristine_git_object: af2107e24d41ddaf7ee5d3b349fdf2fa84bbd5ce
+    last_write_checksum: sha1:7ce7ab5be0d39069778248aac2fa1e2b3d05c8e8
+    pristine_git_object: cbd2e82202476708c61b3a97d1c81b632f2c77c3
   docs/models/update-customer-auto-topup-response.md:
     id: 3c24a7d246cc
     last_write_checksum: sha1:335579c7f116e577885bb990a0fb822f23e36c19
@@ -7030,8 +7030,8 @@ trackedFiles:
     pristine_git_object: d8da2e158e5dd58bbce8592b7129ed52f11269d9
   docs/models/update-customer-purchase-limit-request.md:
     id: ae71fddbf2a5
-    last_write_checksum: sha1:8ad56d2a18ce89fd91461ffa51cf3aab0e3872c2
-    pristine_git_object: 94023a7f19ac6c8e9bb228f623eee1ff95dd41d8
+    last_write_checksum: sha1:190149ab65bade4cc03c17f7c2e6055c7fab8d3b
+    pristine_git_object: c712b48298e6f65ef95366d16c6b8f80efb327a1
   docs/models/update-customer-purchase-limit-response1.md:
     id: 4706d17e1852
     last_write_checksum: sha1:1a6e38a611106a213c9658d5461ba3f3c20d0d8b
@@ -7370,8 +7370,8 @@ trackedFiles:
     pristine_git_object: e67655ce96d6c0b48a0a6930027a0394b816136d
   docs/models/update-plan-auto-topup-request.md:
     id: b29b46295c91
-    last_write_checksum: sha1:0d3af0f345fffee42039e8f46512857dfb947e47
-    pristine_git_object: 1e2dfa302a60d3f00c49ea7ab9e37726837a0300
+    last_write_checksum: sha1:1aaf1abfae890a56b00e2d692422a43e2059de8b
+    pristine_git_object: 1e4060547b23bbf35b8d55b634fc77c381c59706
   docs/models/update-plan-auto-topup-response.md:
     id: ff840e2867e3
     last_write_checksum: sha1:33ad47af3f462bd8896bbb461e4be0e751c721f4
@@ -7758,8 +7758,8 @@ trackedFiles:
     pristine_git_object: af094163ac68f309ea6f201e9b73c8e97259d375
   docs/models/update-plan-purchase-limit-request.md:
     id: ba80a09b0b07
-    last_write_checksum: sha1:63deae9440dec30b9e2c3ba6b5369c7a12c501c5
-    pristine_git_object: 6232ea7446b1133e621cd61c6de147b97406270b
+    last_write_checksum: sha1:bd78d3837195e4870093e7031e65c2c6369c4907
+    pristine_git_object: 544444c28b5f53ec32e7a637dcda40b4ecda2501
   docs/models/update-plan-purchase-limit-response.md:
     id: b6e47d6bb20d
     last_write_checksum: sha1:cf7983205ce16ca91c186d7506f51e8bc7b51f40
@@ -7838,8 +7838,8 @@ trackedFiles:
     pristine_git_object: cd8e4d700c0809f7f4152d9e01370fe121e13072
   docs/models/update-plan-variant-details-auto-topup.md:
     id: 3a5cb6662734
-    last_write_checksum: sha1:cb74e759841471fab95c9fa3e4aa506589d634d6
-    pristine_git_object: fdd3620d4b65bcecb178442b0dae36d38ef2c88d
+    last_write_checksum: sha1:c525e5ca3e1bbda34152af28e410938274f410e5
+    pristine_git_object: 1fd5250157fd690031821a6b925ab03655ef5d54
   docs/models/update-plan-variant-details-billing-controls.md:
     id: 6bd23551de5b
     last_write_checksum: sha1:0c1084e33f9e783d346f3fa72281e5ba5ed49cb2
@@ -7890,8 +7890,8 @@ trackedFiles:
     pristine_git_object: a366e8f356f83e8bc2614e3af5234f5bc41bd920
   docs/models/update-plan-variant-details-purchase-limit.md:
     id: 5c81ee49b05f
-    last_write_checksum: sha1:451b8a6a1f4d2a666120f8c81d1a42977837bba5
-    pristine_git_object: 1711bb5992e3635420d7e0b6d25c577ae781f824
+    last_write_checksum: sha1:98e0e146548ef6f507e23a0e9219feaf7f11e6cf
+    pristine_git_object: 8430b42186b812cfb297f9b3ec2d529e16a349d2
   docs/models/update-plan-variant-details-remove-item-billing-method.md:
     id: f4ef80c199d0
     last_write_checksum: sha1:3d32672d4d9b687293d428b2c26526158e129521
@@ -7986,8 +7986,8 @@ trackedFiles:
     pristine_git_object: 5c01e5c61c113c0c64da177542b6c92b2eec5063
   docs/models/variant-auto-topup.md:
     id: dd1ea9ccb7ca
-    last_write_checksum: sha1:0a9ae7dfb6a4c6f9f024d531a713c74fe0f8931e
-    pristine_git_object: 588a9c80ed3148d23c18f3d1f0ceba662d5f85e0
+    last_write_checksum: sha1:cb4f58b70bdd86c098bf7c6836850335c6dc3af8
+    pristine_git_object: d82955c68f3f6b2a11298e32a4f2393153d2946d
   docs/models/variant-base-price.md:
     id: dd39d4ab9863
     last_write_checksum: sha1:4643589c5d598d1c6ae1f58a8ef4e96c41e3df28
@@ -8090,8 +8090,8 @@ trackedFiles:
     pristine_git_object: dab76692c62d7e6c36714388a117c3390a2efa0e
   docs/models/variant-purchase-limit.md:
     id: 10ee4817654f
-    last_write_checksum: sha1:664c1e99e70ab61e1260e870f7782ae1afe3ab8d
-    pristine_git_object: 4688cdcf3491d19a7607538a7b9e88c27f8220c9
+    last_write_checksum: sha1:a7aaa37a255059a0c83ce6630dde006b9d06b735
+    pristine_git_object: 8dee260dff48c7b586ac1dc8b07400322dca3d68
   docs/models/variant-remove-item-billing-method.md:
     id: c1266e029660
     last_write_checksum: sha1:dab8da784a21b3d6cffb3b896c91f5d2db9d32f5
@@ -8162,8 +8162,8 @@ trackedFiles:
     pristine_git_object: 0ebe5146cd24c153cb9b7655e4f502c09f7d4abd
   docs/sdks/billing/README.md:
     id: dc915331dd9d
-    last_write_checksum: sha1:e18608f4f5b7a89f75244ace2b8ba298b5b61d37
-    pristine_git_object: 4844a7988130db3043e83391c67699e271e5c1d7
+    last_write_checksum: sha1:3dea219afa1894bb7f76bbbc1d3a72dedf9e263c
+    pristine_git_object: c38269a07da01854067cc02172e21cb63aad9ab4
   docs/sdks/customers/README.md:
     id: 9332759cffc2
     last_write_checksum: sha1:9ef975ed7a810cead53f98391be01f8aafd67d7d
@@ -8266,8 +8266,8 @@ trackedFiles:
     pristine_git_object: c335cfcdd5ac114b1f647246236b69442ecbcdb2
   src/funcs/billing-create-schedule.ts:
     id: fd662bfcdc10
-    last_write_checksum: sha1:0cebbc53b564c55c42814869fd39162a3e3d4b61
-    pristine_git_object: 697e36debf9e783ace87421efd7c7b7bae5f6374
+    last_write_checksum: sha1:07837e3de85df705abcfdaba608bb155e38d3979
+    pristine_git_object: 4f6d0f58925596e2ad4f79562a59070e86b19d72
   src/funcs/billing-import.ts:
     id: ff582ad4629f
     last_write_checksum: sha1:673851739184e659789772519b9bc01485a21d79
@@ -8554,8 +8554,8 @@ trackedFiles:
     pristine_git_object: 3675cd4e8ad374d6b2865e2160e6ab8a606943c2
   src/models/attach-op.ts:
     id: 83ed65c26ab4
-    last_write_checksum: sha1:1c7c242660dcd37fc4d0bbcb8458bfeb89abe55e
-    pristine_git_object: 27af21b0c93c2f56d5c0ce9d973f7db9acc54107
+    last_write_checksum: sha1:ff0a94e9f6c29fd71703a9a455d3227009eb85b0
+    pristine_git_object: 932eab043933c084dab19dd83462f0ac1dec8f28
   src/models/autumn-default-error.ts:
     id: 2528aa7886eb
     last_write_checksum: sha1:4cce18f91be3262ada7d11dcd6326544e2341b58
@@ -8574,8 +8574,8 @@ trackedFiles:
     pristine_git_object: 16f66886fcadb22a9dc6d44137aea76959579d5c
   src/models/billing-update-op.ts:
     id: e7371769c7ca
-    last_write_checksum: sha1:49713a284065b0eb76345d85048833cf3668aa53
-    pristine_git_object: 4a3ed6d731d884eb263c2ad8bf0acedbc4ca4d94
+    last_write_checksum: sha1:4a82130233bdcdab80827abf46871b31c111afe9
+    pristine_git_object: 2566f4ee4305f072ac239321b073f4cb9edb7827
   src/models/check-op.ts:
     id: 42085bda016a
     last_write_checksum: sha1:b9a254aa82a4080ace1471a3241af7cef8954af8
@@ -8594,20 +8594,20 @@ trackedFiles:
     pristine_git_object: cc88593cb431fd33f22679a5eabae1eb9705c384
   src/models/create-plan-op.ts:
     id: e094d152f358
-    last_write_checksum: sha1:3c24b74cb1c394a3cfb3ffa03e93127ecf42e51b
-    pristine_git_object: 29eed14d9a678a0c23eeb2e0195e1d10f2c66267
+    last_write_checksum: sha1:8a3258ec202c073a718d8cbf87196953c4ede49e
+    pristine_git_object: 24f80cae278bf0095490e85766fd387f22dcc6df
   src/models/create-referral-code-op.ts:
     id: 745cd70e7a69
     last_write_checksum: sha1:01ce64d29c3bd84e0c9bf1e6a979e7e493f10d67
     pristine_git_object: d979198ac227f8e5731e5ca5e2e34b55d88da348
   src/models/create-schedule-op.ts:
     id: 68442c0abd75
-    last_write_checksum: sha1:4bfd2bebe7b862aa3f899e5f927a986a61ba34cd
-    pristine_git_object: 60019d0e9978f44819ebc48da8beb2aebde07e33
+    last_write_checksum: sha1:fa8e7d5c19015da04eeebca7c631b09dfa9f0186
+    pristine_git_object: ed42c4b86bb279cad475376fdfe03bd30b245bc4
   src/models/customer-data.ts:
     id: 04dac7ee392e
-    last_write_checksum: sha1:1b30a1e254d56693f3284443be6f349ffa4ec484
-    pristine_git_object: d7b53b00bc0218a248e5e7496d53e9558ce6d04c
+    last_write_checksum: sha1:39275a61f77a7323d604fc327f515b13525e5f8d
+    pristine_git_object: 85e02d59cd1a0382adab8093815facb8b170eb5e
   src/models/customer-expand.ts:
     id: 0792f23b0bc0
     last_write_checksum: sha1:0c9f3e2b934fcf8371c490ee4ca8cb9450c8db66
@@ -8654,12 +8654,12 @@ trackedFiles:
     pristine_git_object: 0097008c9b033d8069530b1b473a5a6f890b002e
   src/models/get-or-create-customer-op.ts:
     id: 46f8f65a57f2
-    last_write_checksum: sha1:e102121fa894e6394082fba700f095de7ee70fe4
-    pristine_git_object: 8bd7e9a076e3e57044bcb50baff6b24db7b503d2
+    last_write_checksum: sha1:b9082e3198c9ceb5e970247d156ca7367f83f3c4
+    pristine_git_object: de248bb3223837499ef0aad45ec21ecbf0d3a9f8
   src/models/get-plan-op.ts:
     id: 91c8f8dda7c8
-    last_write_checksum: sha1:91ff2a679af58b8ea4d5955f7936c8b32e076eb6
-    pristine_git_object: deed3d3a3234fea40e21a78a4f4342ae33d4dc47
+    last_write_checksum: sha1:21dc123819b9a7128a9e88c93d876bef747dcb92
+    pristine_git_object: bf5e1279f338aac5b7e9ee77744f4b1ac51e7dbe
   src/models/get-revenue-cat-keys-op.ts:
     id: 2d8e9e87f071
     last_write_checksum: sha1:e1c1f2eaf75a3db81b4800c63cbe2ea6e5b1fa56
@@ -8706,8 +8706,8 @@ trackedFiles:
     pristine_git_object: 006dc30d4ca20cfa16954578ac6dbf7b93f912e4
   src/models/list-plans-op.ts:
     id: 513cde894485
-    last_write_checksum: sha1:66917a089b45523f8fc4bab66dc13efe97a72513
-    pristine_git_object: 78221e2253ad64bd0aeaab5655bb8101cb006b43
+    last_write_checksum: sha1:435357f35e627b22f125798e227c3840e289cdab
+    pristine_git_object: 41c54675daefa730285d1b30c36d8597dc62e3b8
   src/models/list-rewards-op.ts:
     id: 1fa339fa50fb
     last_write_checksum: sha1:281da10de3dd1399ed63a3910db0cae7bb5aa7d9
@@ -8730,12 +8730,12 @@ trackedFiles:
     pristine_git_object: 4a9318890026bc6e67a8a5b65dc596ae7f25f855
   src/models/plan.ts:
     id: 9e9698a64fe7
-    last_write_checksum: sha1:916b9112944aeb7b21e0b452dfbde12ac4727f0d
-    pristine_git_object: 861af25dede9ad35d72ab1c3e9f81c17e9f3dad7
+    last_write_checksum: sha1:6e30f35b9f788e35b6df9b1dea708764b5f79357
+    pristine_git_object: 178af66132697f9fb1810a8e7c0d121b2e106122
   src/models/preview-attach-op.ts:
     id: 3efc6e3443a7
-    last_write_checksum: sha1:7d10d27a284e933c4ee3f660d30835f4d9abf544
-    pristine_git_object: 23b0f12466d2007bc84d32f2fab2227545905d4e
+    last_write_checksum: sha1:e6f6846714c4b38219e00bcd4558ecd749a12f45
+    pristine_git_object: b395a92c8537426f403b1ead01b44cf423e29ed5
   src/models/preview-multi-attach-op.ts:
     id: e4847dc281a6
     last_write_checksum: sha1:89ea23151299f10f8b45aaef20e6297145653422
@@ -8746,8 +8746,8 @@ trackedFiles:
     pristine_git_object: 8cc0bd0a02d8c594be41c3cda6e0c88e69428ef1
   src/models/preview-update-op.ts:
     id: fcbbbf3b22ac
-    last_write_checksum: sha1:0a0e87f79cdb66fdba29d99120ffe2dfe05196a8
-    pristine_git_object: 6e2a2d1cfbf2c5849117db14c73b786fec3c9bc2
+    last_write_checksum: sha1:0223f3a80876635299e21c8f008f4001a6e89304
+    pristine_git_object: 2ddf0ba99e7f88a01a3c4e4fcc2d138e393cb33c
   src/models/redeem-referral-code-op.ts:
     id: 511bf73dc4c6
     last_write_checksum: sha1:9ab6622018c82175ea98d2b26eadb4abf08f441a
@@ -8782,8 +8782,8 @@ trackedFiles:
     pristine_git_object: 3774cc1e9bbb80ac592990aa86f8d4a38ee51f29
   src/models/setup-payment-op.ts:
     id: 0e97e999ff3c
-    last_write_checksum: sha1:9208206c4bdbc1c944ceafbf5251d0e508270f0a
-    pristine_git_object: d806443282d3055ad5d25069b476396fddbd1a40
+    last_write_checksum: sha1:57b8367c897264b7103a54a613f8950a0298ce78
+    pristine_git_object: 65bab2b342c53a4230799f5137e4562d7ae00a40
   src/models/sync-revenue-cat-op.ts:
     id: bf3c25067f7c
     last_write_checksum: sha1:a5992af2f44badc20be2d55c8091ed4c22dfc903
@@ -8802,8 +8802,8 @@ trackedFiles:
     pristine_git_object: 8c47bb5b8cf5546e12fffaddcab36022c1f2ea4a
   src/models/update-customer-op.ts:
     id: 5d226d30d8e4
-    last_write_checksum: sha1:0f000a49837251f60bd105dccea642fdd0f1c8c4
-    pristine_git_object: 98437d4b30bbe7b25e8eebe2565d9c97425cf5d4
+    last_write_checksum: sha1:c982aacf8aaf8a25483df2073a757daa7522c67f
+    pristine_git_object: 2ea2f18148ef688db524c70fa3a155b092b7365e
   src/models/update-entity-op.ts:
     id: c3fdb6479f02
     last_write_checksum: sha1:0b11754f6c14f9d5c4c8c688cff3846dd3571782
@@ -8814,16 +8814,16 @@ trackedFiles:
     pristine_git_object: 1564c4312ff7944eaaaa5b8e8a80d4877b97f134
   src/models/update-plan-op.ts:
     id: 54b4f842d3b2
-    last_write_checksum: sha1:4f8eb3eaaa99aefbe7561272fb14792dc8558578
-    pristine_git_object: 924bb589f15ea3df572ea719ad4d823b2e3dbb4f
+    last_write_checksum: sha1:20d43f8b0c1f0d28b22a5485a40916480f26546b
+    pristine_git_object: 6f2a857f17ed2e6115c4031a15b3a603b266326c
   src/sdk/balances.ts:
     id: 9ad229cb9d64
     last_write_checksum: sha1:3e195bbaeea3a9bc5afd4095d92949f3cad0956e
     pristine_git_object: 571de419ea3321d79acec4bddbb46b1580007115
   src/sdk/billing.ts:
     id: 10905058c4ad
-    last_write_checksum: sha1:fff2f2678fca208ff60a73a737fd14688cbc23d5
-    pristine_git_object: 682bfa1f502e6bcdd5ea2251ddd7edbefb799440
+    last_write_checksum: sha1:49f676179292a5de7b824cecbb70ee967f6f905e
+    pristine_git_object: 8bf3abf77f0cc26be6779670ac2e9541514a826a
   src/sdk/customers.ts:
     id: d33e193e0c00
     last_write_checksum: sha1:9363c51bdf5a65a291f6ab33d70cf3742f5d3bbe

--- a/packages/sdk/.speakeasy/out.openapi.yaml
+++ b/packages/sdk/.speakeasy/out.openapi.yaml
@@ -74,7 +74,6 @@ components:
                     description: Whether auto top-up is enabled.
                   threshold:
                     type: number
-                    minimum: 0
                     description: When the balance drops below this threshold, an auto top-up will be purchased.
                   quantity:
                     type: number
@@ -100,10 +99,14 @@ components:
                         type: number
                         minimum: 1
                         description: Maximum number of auto top-ups allowed within the interval.
+                      count:
+                        type: number
+                        minimum: 0
+                        description: Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                     required:
                       - interval
                       - limit
-                    description: Optional rate limit to cap how often auto top-ups occur.
+                    description: Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                   invoice_mode:
                     type: boolean
                     description: When true, auto top-up creates a send_invoice invoice instead of auto-charging.
@@ -322,7 +325,6 @@ components:
                     description: Whether auto top-up is enabled.
                   threshold:
                     type: number
-                    minimum: 0
                     description: When the balance drops below this threshold, an auto top-up will be purchased.
                   quantity:
                     type: number
@@ -1865,7 +1867,6 @@ components:
                             description: Whether auto top-up is enabled.
                           threshold:
                             type: number
-                            minimum: 0
                             description: When the balance drops below this threshold, an auto top-up will be purchased.
                           quantity:
                             type: number
@@ -1891,10 +1892,14 @@ components:
                                 type: number
                                 minimum: 1
                                 description: Maximum number of auto top-ups allowed within the interval.
+                              count:
+                                type: number
+                                minimum: 0
+                                description: Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             required:
                               - interval
                               - limit
-                            description: Optional rate limit to cap how often auto top-ups occur.
+                            description: Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           invoice_mode:
                             type: boolean
                             description: When true, auto top-up creates a send_invoice invoice instead of auto-charging.
@@ -2048,7 +2053,6 @@ components:
                     description: Whether auto top-up is enabled.
                   threshold:
                     type: number
-                    minimum: 0
                     description: When the balance drops below this threshold, an auto top-up will be purchased.
                   quantity:
                     type: number
@@ -2684,7 +2688,6 @@ paths:
                             description: Whether auto top-up is enabled.
                           threshold:
                             type: number
-                            minimum: 0
                             description: When the balance drops below this threshold, an auto top-up will be purchased.
                           quantity:
                             type: number
@@ -2710,10 +2713,14 @@ paths:
                                 type: number
                                 minimum: 1
                                 description: Maximum number of auto top-ups allowed within the interval.
+                              count:
+                                type: number
+                                minimum: 0
+                                description: Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             required:
                               - interval
                               - limit
-                            description: Optional rate limit to cap how often auto top-ups occur.
+                            description: Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           invoice_mode:
                             type: boolean
                             description: When true, auto top-up creates a send_invoice invoice instead of auto-charging.
@@ -3011,7 +3018,6 @@ paths:
                               description: Whether auto top-up is enabled.
                             threshold:
                               type: number
-                              minimum: 0
                               description: When the balance drops below this threshold, an auto top-up will be purchased.
                             quantity:
                               type: number
@@ -4001,7 +4007,6 @@ paths:
                                     description: Whether auto top-up is enabled.
                                   threshold:
                                     type: number
-                                    minimum: 0
                                     description: When the balance drops below this threshold, an auto top-up will be purchased.
                                   quantity:
                                     type: number
@@ -4790,7 +4795,6 @@ paths:
                             description: Whether auto top-up is enabled.
                           threshold:
                             type: number
-                            minimum: 0
                             description: When the balance drops below this threshold, an auto top-up will be purchased.
                           quantity:
                             type: number
@@ -4816,10 +4820,14 @@ paths:
                                 type: number
                                 minimum: 1
                                 description: Maximum number of auto top-ups allowed within the interval.
+                              count:
+                                type: number
+                                minimum: 0
+                                description: Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             required:
                               - interval
                               - limit
-                            description: Optional rate limit to cap how often auto top-ups occur.
+                            description: Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           invoice_mode:
                             type: boolean
                             description: When true, auto top-up creates a send_invoice invoice instead of auto-charging.
@@ -5036,7 +5044,6 @@ paths:
                               description: Whether auto top-up is enabled.
                             threshold:
                               type: number
-                              minimum: 0
                               description: When the balance drops below this threshold, an auto top-up will be purchased.
                             quantity:
                               type: number
@@ -6391,7 +6398,6 @@ paths:
                             description: Whether auto top-up is enabled.
                           threshold:
                             type: number
-                            minimum: 0
                             description: When the balance drops below this threshold, an auto top-up will be purchased.
                           quantity:
                             type: number
@@ -6417,10 +6423,14 @@ paths:
                                 type: number
                                 minimum: 1
                                 description: Maximum number of auto top-ups allowed within the interval.
+                              count:
+                                type: number
+                                minimum: 0
+                                description: Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             required:
                               - interval
                               - limit
-                            description: Optional rate limit to cap how often auto top-ups occur.
+                            description: Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           invoice_mode:
                             type: boolean
                             description: When true, auto top-up creates a send_invoice invoice instead of auto-charging.
@@ -7292,7 +7302,6 @@ paths:
                                       description: Whether auto top-up is enabled.
                                     threshold:
                                       type: number
-                                      minimum: 0
                                       description: When the balance drops below this threshold, an auto top-up will be purchased.
                                     quantity:
                                       type: number
@@ -7318,10 +7327,14 @@ paths:
                                           type: number
                                           minimum: 1
                                           description: Maximum number of auto top-ups allowed within the interval.
+                                        count:
+                                          type: number
+                                          minimum: 0
+                                          description: Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                                       required:
                                         - interval
                                         - limit
-                                      description: Optional rate limit to cap how often auto top-ups occur.
+                                      description: Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                                     invoice_mode:
                                       type: boolean
                                       description: When true, auto top-up creates a send_invoice invoice instead of auto-charging.
@@ -7475,7 +7488,6 @@ paths:
                               description: Whether auto top-up is enabled.
                             threshold:
                               type: number
-                              minimum: 0
                               description: When the balance drops below this threshold, an auto top-up will be purchased.
                             quantity:
                               type: number
@@ -8486,7 +8498,6 @@ paths:
                                       description: Whether auto top-up is enabled.
                                     threshold:
                                       type: number
-                                      minimum: 0
                                       description: When the balance drops below this threshold, an auto top-up will be purchased.
                                     quantity:
                                       type: number
@@ -8512,10 +8523,14 @@ paths:
                                           type: number
                                           minimum: 1
                                           description: Maximum number of auto top-ups allowed within the interval.
+                                        count:
+                                          type: number
+                                          minimum: 0
+                                          description: Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                                       required:
                                         - interval
                                         - limit
-                                      description: Optional rate limit to cap how often auto top-ups occur.
+                                      description: Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                                     invoice_mode:
                                       type: boolean
                                       description: When true, auto top-up creates a send_invoice invoice instead of auto-charging.
@@ -8669,7 +8684,6 @@ paths:
                               description: Whether auto top-up is enabled.
                             threshold:
                               type: number
-                              minimum: 0
                               description: When the balance drops below this threshold, an auto top-up will be purchased.
                             quantity:
                               type: number
@@ -9650,7 +9664,6 @@ paths:
                                             description: Whether auto top-up is enabled.
                                           threshold:
                                             type: number
-                                            minimum: 0
                                             description: When the balance drops below this threshold, an auto top-up will be purchased.
                                           quantity:
                                             type: number
@@ -9676,10 +9689,14 @@ paths:
                                                 type: number
                                                 minimum: 1
                                                 description: Maximum number of auto top-ups allowed within the interval.
+                                              count:
+                                                type: number
+                                                minimum: 0
+                                                description: Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                                             required:
                                               - interval
                                               - limit
-                                            description: Optional rate limit to cap how often auto top-ups occur.
+                                            description: Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                                           invoice_mode:
                                             type: boolean
                                             description: When true, auto top-up creates a send_invoice invoice instead of auto-charging.
@@ -9833,7 +9850,6 @@ paths:
                                     description: Whether auto top-up is enabled.
                                   threshold:
                                     type: number
-                                    minimum: 0
                                     description: When the balance drops below this threshold, an auto top-up will be purchased.
                                   quantity:
                                     type: number
@@ -10736,7 +10752,6 @@ paths:
                             description: Whether auto top-up is enabled.
                           threshold:
                             type: number
-                            minimum: 0
                             description: When the balance drops below this threshold, an auto top-up will be purchased.
                           quantity:
                             type: number
@@ -10762,10 +10777,14 @@ paths:
                                 type: number
                                 minimum: 1
                                 description: Maximum number of auto top-ups allowed within the interval.
+                              count:
+                                type: number
+                                minimum: 0
+                                description: Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                             required:
                               - interval
                               - limit
-                            description: Optional rate limit to cap how often auto top-ups occur.
+                            description: Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                           invoice_mode:
                             type: boolean
                             description: When true, auto top-up creates a send_invoice invoice instead of auto-charging.
@@ -11281,7 +11300,6 @@ paths:
                                       description: Whether auto top-up is enabled.
                                     threshold:
                                       type: number
-                                      minimum: 0
                                       description: When the balance drops below this threshold, an auto top-up will be purchased.
                                     quantity:
                                       type: number
@@ -11307,10 +11325,14 @@ paths:
                                           type: number
                                           minimum: 1
                                           description: Maximum number of auto top-ups allowed within the interval.
+                                        count:
+                                          type: number
+                                          minimum: 0
+                                          description: Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                                       required:
                                         - interval
                                         - limit
-                                      description: Optional rate limit to cap how often auto top-ups occur.
+                                      description: Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                                     invoice_mode:
                                       type: boolean
                                       description: When true, auto top-up creates a send_invoice invoice instead of auto-charging.
@@ -12170,7 +12192,6 @@ paths:
                                       description: Whether auto top-up is enabled.
                                     threshold:
                                       type: number
-                                      minimum: 0
                                       description: When the balance drops below this threshold, an auto top-up will be purchased.
                                     quantity:
                                       type: number
@@ -12196,10 +12217,14 @@ paths:
                                           type: number
                                           minimum: 1
                                           description: Maximum number of auto top-ups allowed within the interval.
+                                        count:
+                                          type: number
+                                          minimum: 0
+                                          description: Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                                       required:
                                         - interval
                                         - limit
-                                      description: Optional rate limit to cap how often auto top-ups occur.
+                                      description: Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                                     invoice_mode:
                                       type: boolean
                                       description: When true, auto top-up creates a send_invoice invoice instead of auto-charging.
@@ -12353,7 +12378,6 @@ paths:
                               description: Whether auto top-up is enabled.
                             threshold:
                               type: number
-                              minimum: 0
                               description: When the balance drops below this threshold, an auto top-up will be purchased.
                             quantity:
                               type: number
@@ -14260,7 +14284,6 @@ paths:
                                 description: Whether auto top-up is enabled.
                               threshold:
                                 type: number
-                                minimum: 0
                                 description: When the balance drops below this threshold, an auto top-up will be purchased.
                               quantity:
                                 type: number
@@ -14286,10 +14309,14 @@ paths:
                                     type: number
                                     minimum: 1
                                     description: Maximum number of auto top-ups allowed within the interval.
+                                  count:
+                                    type: number
+                                    minimum: 0
+                                    description: Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                                 required:
                                   - interval
                                   - limit
-                                description: Optional rate limit to cap how often auto top-ups occur.
+                                description: Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                               invoice_mode:
                                 type: boolean
                                 description: When true, auto top-up creates a send_invoice invoice instead of auto-charging.
@@ -14959,7 +14986,7 @@ paths:
         @example
         ```typescript
         // Schedule a transition from a trial plan to a paid plan
-        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1784658936605,"plans":[{"planId":"trial_plan"}]},{"startsAt":1785868536605,"plans":[{"planId":"pro_plan"}]}] });
+        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1784744849888,"plans":[{"planId":"trial_plan"}]},{"startsAt":1785954449888,"plans":[{"planId":"pro_plan"}]}] });
         ```
 
         @param customerId - The ID of the customer to create the schedule for.
@@ -15523,7 +15550,6 @@ paths:
                                               description: Whether auto top-up is enabled.
                                             threshold:
                                               type: number
-                                              minimum: 0
                                               description: When the balance drops below this threshold, an auto top-up will be purchased.
                                             quantity:
                                               type: number
@@ -15549,10 +15575,14 @@ paths:
                                                   type: number
                                                   minimum: 1
                                                   description: Maximum number of auto top-ups allowed within the interval.
+                                                count:
+                                                  type: number
+                                                  minimum: 0
+                                                  description: Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                                               required:
                                                 - interval
                                                 - limit
-                                              description: Optional rate limit to cap how often auto top-ups occur.
+                                              description: Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                                             invoice_mode:
                                               type: boolean
                                               description: When true, auto top-up creates a send_invoice invoice instead of auto-charging.
@@ -16150,7 +16180,6 @@ paths:
                                             description: Whether auto top-up is enabled.
                                           threshold:
                                             type: number
-                                            minimum: 0
                                             description: When the balance drops below this threshold, an auto top-up will be purchased.
                                           quantity:
                                             type: number
@@ -16176,10 +16205,14 @@ paths:
                                                 type: number
                                                 minimum: 1
                                                 description: Maximum number of auto top-ups allowed within the interval.
+                                              count:
+                                                type: number
+                                                minimum: 0
+                                                description: Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                                             required:
                                               - interval
                                               - limit
-                                            description: Optional rate limit to cap how often auto top-ups occur.
+                                            description: Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                                           invoice_mode:
                                             type: boolean
                                             description: When true, auto top-up creates a send_invoice invoice instead of auto-charging.
@@ -17707,7 +17740,6 @@ paths:
                                 description: Whether auto top-up is enabled.
                               threshold:
                                 type: number
-                                minimum: 0
                                 description: When the balance drops below this threshold, an auto top-up will be purchased.
                               quantity:
                                 type: number
@@ -17733,10 +17765,14 @@ paths:
                                     type: number
                                     minimum: 1
                                     description: Maximum number of auto top-ups allowed within the interval.
+                                  count:
+                                    type: number
+                                    minimum: 0
+                                    description: Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                                 required:
                                   - interval
                                   - limit
-                                description: Optional rate limit to cap how often auto top-ups occur.
+                                description: Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                               invoice_mode:
                                 type: boolean
                                 description: When true, auto top-up creates a send_invoice invoice instead of auto-charging.
@@ -20245,7 +20281,6 @@ paths:
                                 description: Whether auto top-up is enabled.
                               threshold:
                                 type: number
-                                minimum: 0
                                 description: When the balance drops below this threshold, an auto top-up will be purchased.
                               quantity:
                                 type: number
@@ -20271,10 +20306,14 @@ paths:
                                     type: number
                                     minimum: 1
                                     description: Maximum number of auto top-ups allowed within the interval.
+                                  count:
+                                    type: number
+                                    minimum: 0
+                                    description: Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                                 required:
                                   - interval
                                   - limit
-                                description: Optional rate limit to cap how often auto top-ups occur.
+                                description: Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                               invoice_mode:
                                 type: boolean
                                 description: When true, auto top-up creates a send_invoice invoice instead of auto-charging.
@@ -21479,7 +21518,6 @@ paths:
                                 description: Whether auto top-up is enabled.
                               threshold:
                                 type: number
-                                minimum: 0
                                 description: When the balance drops below this threshold, an auto top-up will be purchased.
                               quantity:
                                 type: number
@@ -21505,10 +21543,14 @@ paths:
                                     type: number
                                     minimum: 1
                                     description: Maximum number of auto top-ups allowed within the interval.
+                                  count:
+                                    type: number
+                                    minimum: 0
+                                    description: Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                                 required:
                                   - interval
                                   - limit
-                                description: Optional rate limit to cap how often auto top-ups occur.
+                                description: Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                               invoice_mode:
                                 type: boolean
                                 description: When true, auto top-up creates a send_invoice invoice instead of auto-charging.
@@ -23625,7 +23667,6 @@ paths:
                                 description: Whether auto top-up is enabled.
                               threshold:
                                 type: number
-                                minimum: 0
                                 description: When the balance drops below this threshold, an auto top-up will be purchased.
                               quantity:
                                 type: number
@@ -23651,10 +23692,14 @@ paths:
                                     type: number
                                     minimum: 1
                                     description: Maximum number of auto top-ups allowed within the interval.
+                                  count:
+                                    type: number
+                                    minimum: 0
+                                    description: Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
                                 required:
                                   - interval
                                   - limit
-                                description: Optional rate limit to cap how often auto top-ups occur.
+                                description: Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
                               invoice_mode:
                                 type: boolean
                                 description: When true, auto top-up creates a send_invoice invoice instead of auto-charging.
@@ -25424,7 +25469,6 @@ paths:
                                         description: Whether auto top-up is enabled.
                                       threshold:
                                         type: number
-                                        minimum: 0
                                         description: When the balance drops below this threshold, an auto top-up will be purchased.
                                       quantity:
                                         type: number
@@ -26136,7 +26180,6 @@ paths:
                                         description: Whether auto top-up is enabled.
                                       threshold:
                                         type: number
-                                        minimum: 0
                                         description: When the balance drops below this threshold, an auto top-up will be purchased.
                                       quantity:
                                         type: number

--- a/packages/sdk/.speakeasy/workflow.lock
+++ b/packages/sdk/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.762.0
 sources:
     Autumn API:
         sourceNamespace: autumn-api
-        sourceRevisionDigest: sha256:325ae27cbf98a034119c393908994cfab84a49fb139c750fde78f22b7be35d51
-        sourceBlobDigest: sha256:5f8849ed7c0b99224fd21f105492b5af73f326093154cf1bbbe4d973bc438bc8
+        sourceRevisionDigest: sha256:55050d94598a33577d6469c69e6d7ce6791e2726c5396aad5be09c91f16fd7c2
+        sourceBlobDigest: sha256:6257e01399e67c966be550f74194330b0ca34153dbbdb7fb17c53b7036250069
         tags:
             - latest
             - 2.3.0
@@ -18,10 +18,10 @@ targets:
     autumn:
         source: Autumn API
         sourceNamespace: autumn-api
-        sourceRevisionDigest: sha256:325ae27cbf98a034119c393908994cfab84a49fb139c750fde78f22b7be35d51
-        sourceBlobDigest: sha256:5f8849ed7c0b99224fd21f105492b5af73f326093154cf1bbbe4d973bc438bc8
+        sourceRevisionDigest: sha256:55050d94598a33577d6469c69e6d7ce6791e2726c5396aad5be09c91f16fd7c2
+        sourceBlobDigest: sha256:6257e01399e67c966be550f74194330b0ca34153dbbdb7fb17c53b7036250069
         codeSamplesNamespace: autumn-api-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:23fe23d168121895ea5c8a9c2a5ea768ea5ff45a452ae4d40a5d6c06c4247468
+        codeSamplesRevisionDigest: sha256:f028d653180d5385753af8453e507b8eece20d519f067438c45bbb88025674ab
     autumn-python:
         source: Autumn API Stripped
         sourceNamespace: autumn-api-stripped

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -313,7 +313,7 @@ Use this endpoint to schedule future plan changes (e.g. switch from a trial plan
 @example
 ```typescript
 // Schedule a transition from a trial plan to a paid plan
-const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1784658936605,"plans":[{"planId":"trial_plan"}]},{"startsAt":1785868536605,"plans":[{"planId":"pro_plan"}]}] });
+const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1784744849888,"plans":[{"planId":"trial_plan"}]},{"startsAt":1785954449888,"plans":[{"planId":"pro_plan"}]}] });
 ```
 
 @param customerId - The ID of the customer to create the schedule for.
@@ -914,7 +914,7 @@ Use this endpoint to schedule future plan changes (e.g. switch from a trial plan
 @example
 ```typescript
 // Schedule a transition from a trial plan to a paid plan
-const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1784658936605,"plans":[{"planId":"trial_plan"}]},{"startsAt":1785868536605,"plans":[{"planId":"pro_plan"}]}] });
+const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1784744849888,"plans":[{"planId":"trial_plan"}]},{"startsAt":1785954449888,"plans":[{"planId":"pro_plan"}]}] });
 ```
 
 @param customerId - The ID of the customer to create the schedule for.

--- a/packages/sdk/src/funcs/billing-create-schedule.ts
+++ b/packages/sdk/src/funcs/billing-create-schedule.ts
@@ -34,7 +34,7 @@ import { Result } from "../types/fp.js";
  * @example
  * ```typescript
  * // Schedule a transition from a trial plan to a paid plan
- * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1784299196316,"plans":[{"planId":"trial_plan"}]},{"startsAt":1785508796316,"plans":[{"planId":"pro_plan"}]}] });
+ * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1784744849888,"plans":[{"planId":"trial_plan"}]},{"startsAt":1785954449888,"plans":[{"planId":"pro_plan"}]}] });
  * ```
  *
  * @param customerId - The ID of the customer to create the schedule for.

--- a/packages/sdk/src/funcs/plans-update.ts
+++ b/packages/sdk/src/funcs/plans-update.ts
@@ -79,6 +79,7 @@ import { Result } from "../types/fp.js";
  * @param allVersions - Apply the update diff to all versions of this plan. Mutually exclusive with disable_version. (optional)
  * @param forceVersion - Force versioning even when no customers exist. Mutually exclusive with disable_version. (optional)
  * @param updateVariantIds - Variant plan IDs to apply this update to. Empty or omitted means no propagation. (optional)
+ * @param updateLicenseParents - Parent plan versions that should receive this license-plan update. (optional)
  * @param variants - Additive variant updates for this base plan. Missing variants are created when name is provided. (optional)
  * @param isDefault - Whether this is the org's default plan. Cannot be true on a variant. (optional)
  *

--- a/packages/sdk/src/models/attach-op.ts
+++ b/packages/sdk/src/models/attach-op.ts
@@ -752,7 +752,7 @@ export type AttachPurchaseLimitInterval = ClosedEnum<
 >;
 
 /**
- * Optional rate limit to cap how often auto top-ups occur.
+ * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
  */
 export type AttachPurchaseLimit = {
   /**
@@ -767,6 +767,10 @@ export type AttachPurchaseLimit = {
    * Maximum number of auto top-ups allowed within the interval.
    */
   limit: number;
+  /**
+   * Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
+   */
+  count?: number | undefined;
 };
 
 export type AttachAutoTopup = {
@@ -787,7 +791,7 @@ export type AttachAutoTopup = {
    */
   quantity: number;
   /**
-   * Optional rate limit to cap how often auto top-ups occur.
+   * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
    */
   purchaseLimit?: AttachPurchaseLimit | undefined;
   /**
@@ -2602,6 +2606,7 @@ export type AttachPurchaseLimit$Outbound = {
   interval: string;
   interval_count: number;
   limit: number;
+  count?: number | undefined;
 };
 
 /** @internal */
@@ -2613,6 +2618,7 @@ export const AttachPurchaseLimit$outboundSchema: z.ZodMiniType<
     interval: AttachPurchaseLimitInterval$outboundSchema,
     intervalCount: z._default(z.number(), 1),
     limit: z.number(),
+    count: z.optional(z.number()),
   }),
   z.transform((v) => {
     return remap$(v, {

--- a/packages/sdk/src/models/billing-update-op.ts
+++ b/packages/sdk/src/models/billing-update-op.ts
@@ -768,7 +768,7 @@ export type BillingUpdatePurchaseLimitInterval = ClosedEnum<
 >;
 
 /**
- * Optional rate limit to cap how often auto top-ups occur.
+ * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
  */
 export type BillingUpdatePurchaseLimit = {
   /**
@@ -783,6 +783,10 @@ export type BillingUpdatePurchaseLimit = {
    * Maximum number of auto top-ups allowed within the interval.
    */
   limit: number;
+  /**
+   * Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
+   */
+  count?: number | undefined;
 };
 
 export type BillingUpdateAutoTopup = {
@@ -803,7 +807,7 @@ export type BillingUpdateAutoTopup = {
    */
   quantity: number;
   /**
-   * Optional rate limit to cap how often auto top-ups occur.
+   * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
    */
   purchaseLimit?: BillingUpdatePurchaseLimit | undefined;
   /**
@@ -2634,6 +2638,7 @@ export type BillingUpdatePurchaseLimit$Outbound = {
   interval: string;
   interval_count: number;
   limit: number;
+  count?: number | undefined;
 };
 
 /** @internal */
@@ -2645,6 +2650,7 @@ export const BillingUpdatePurchaseLimit$outboundSchema: z.ZodMiniType<
     interval: BillingUpdatePurchaseLimitInterval$outboundSchema,
     intervalCount: z._default(z.number(), 1),
     limit: z.number(),
+    count: z.optional(z.number()),
   }),
   z.transform((v) => {
     return remap$(v, {

--- a/packages/sdk/src/models/create-plan-op.ts
+++ b/packages/sdk/src/models/create-plan-op.ts
@@ -742,10 +742,6 @@ export type CreatePlanLicense = {
   prepaidOnly?: boolean | undefined;
   customize?: CreatePlanLicenseCustomize | null | undefined;
   metadata?: { [k: string]: any } | undefined;
-  /**
-   * Pin the link to a specific version of the license plan. Omitted, an existing link keeps its pinned version and a new link resolves to the latest.
-   */
-  version?: number | undefined;
 };
 
 /**
@@ -824,7 +820,7 @@ export type CreatePlanPurchaseLimitIntervalRequestBody = ClosedEnum<
 >;
 
 /**
- * Optional rate limit to cap how often auto top-ups occur.
+ * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
  */
 export type CreatePlanPurchaseLimitRequest = {
   /**
@@ -839,6 +835,10 @@ export type CreatePlanPurchaseLimitRequest = {
    * Maximum number of auto top-ups allowed within the interval.
    */
   limit: number;
+  /**
+   * Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
+   */
+  count?: number | undefined;
 };
 
 export type CreatePlanAutoTopupRequest = {
@@ -859,7 +859,7 @@ export type CreatePlanAutoTopupRequest = {
    */
   quantity: number;
   /**
-   * Optional rate limit to cap how often auto top-ups occur.
+   * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
    */
   purchaseLimit?: CreatePlanPurchaseLimitRequest | undefined;
   /**
@@ -1972,7 +1972,7 @@ export type CreatePlanVariantDetailsPurchaseLimitInterval = OpenEnum<
 >;
 
 /**
- * Optional rate limit to cap how often auto top-ups occur.
+ * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
  */
 export type CreatePlanVariantDetailsPurchaseLimit = {
   /**
@@ -1987,6 +1987,10 @@ export type CreatePlanVariantDetailsPurchaseLimit = {
    * Maximum number of auto top-ups allowed within the interval.
    */
   limit: number;
+  /**
+   * Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
+   */
+  count?: number | undefined;
 };
 
 export type CreatePlanVariantDetailsAutoTopup = {
@@ -2007,7 +2011,7 @@ export type CreatePlanVariantDetailsAutoTopup = {
    */
   quantity: number;
   /**
-   * Optional rate limit to cap how often auto top-ups occur.
+   * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
    */
   purchaseLimit?: CreatePlanVariantDetailsPurchaseLimit | undefined;
   /**
@@ -3567,7 +3571,6 @@ export type CreatePlanLicense$Outbound = {
   prepaid_only?: boolean | undefined;
   customize?: CreatePlanLicenseCustomize$Outbound | null | undefined;
   metadata?: { [k: string]: any } | undefined;
-  version?: number | undefined;
 };
 
 /** @internal */
@@ -3583,7 +3586,6 @@ export const CreatePlanLicense$outboundSchema: z.ZodMiniType<
       z.nullable(z.lazy(() => CreatePlanLicenseCustomize$outboundSchema)),
     ),
     metadata: z.optional(z.record(z.string(), z.any())),
-    version: z.optional(z.int()),
   }),
   z.transform((v) => {
     return remap$(v, {
@@ -3690,6 +3692,7 @@ export type CreatePlanPurchaseLimitRequest$Outbound = {
   interval: string;
   interval_count: number;
   limit: number;
+  count?: number | undefined;
 };
 
 /** @internal */
@@ -3701,6 +3704,7 @@ export const CreatePlanPurchaseLimitRequest$outboundSchema: z.ZodMiniType<
     interval: CreatePlanPurchaseLimitIntervalRequestBody$outboundSchema,
     intervalCount: z._default(z.number(), 1),
     limit: z.number(),
+    count: z.optional(z.number()),
   }),
   z.transform((v) => {
     return remap$(v, {
@@ -5104,6 +5108,7 @@ export const CreatePlanVariantDetailsPurchaseLimit$inboundSchema: z.ZodMiniType<
     interval: CreatePlanVariantDetailsPurchaseLimitInterval$inboundSchema,
     interval_count: z._default(types.number(), 1),
     limit: types.number(),
+    count: types.optional(types.number()),
   }),
   z.transform((v) => {
     return remap$(v, {

--- a/packages/sdk/src/models/create-schedule-op.ts
+++ b/packages/sdk/src/models/create-schedule-op.ts
@@ -767,7 +767,7 @@ export type CreateSchedulePurchaseLimitInterval2 = ClosedEnum<
 >;
 
 /**
- * Optional rate limit to cap how often auto top-ups occur.
+ * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
  */
 export type CreateSchedulePurchaseLimit2 = {
   /**
@@ -782,6 +782,10 @@ export type CreateSchedulePurchaseLimit2 = {
    * Maximum number of auto top-ups allowed within the interval.
    */
   limit: number;
+  /**
+   * Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
+   */
+  count?: number | undefined;
 };
 
 export type CreateScheduleAutoTopup2 = {
@@ -802,7 +806,7 @@ export type CreateScheduleAutoTopup2 = {
    */
   quantity: number;
   /**
-   * Optional rate limit to cap how often auto top-ups occur.
+   * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
    */
   purchaseLimit?: CreateSchedulePurchaseLimit2 | undefined;
   /**
@@ -2140,6 +2144,7 @@ export type CreateSchedulePurchaseLimit2$Outbound = {
   interval: string;
   interval_count: number;
   limit: number;
+  count?: number | undefined;
 };
 
 /** @internal */
@@ -2151,6 +2156,7 @@ export const CreateSchedulePurchaseLimit2$outboundSchema: z.ZodMiniType<
     interval: CreateSchedulePurchaseLimitInterval2$outboundSchema,
     intervalCount: z._default(z.number(), 1),
     limit: z.number(),
+    count: z.optional(z.number()),
   }),
   z.transform((v) => {
     return remap$(v, {

--- a/packages/sdk/src/models/customer-data.ts
+++ b/packages/sdk/src/models/customer-data.ts
@@ -24,7 +24,7 @@ export type CustomerDataPurchaseLimitInterval = ClosedEnum<
 >;
 
 /**
- * Optional rate limit to cap how often auto top-ups occur.
+ * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
  */
 export type CustomerDataPurchaseLimit = {
   /**
@@ -39,6 +39,10 @@ export type CustomerDataPurchaseLimit = {
    * Maximum number of auto top-ups allowed within the interval.
    */
   limit: number;
+  /**
+   * Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
+   */
+  count?: number | undefined;
 };
 
 export type CustomerDataAutoTopup = {
@@ -59,7 +63,7 @@ export type CustomerDataAutoTopup = {
    */
   quantity: number;
   /**
-   * Optional rate limit to cap how often auto top-ups occur.
+   * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
    */
   purchaseLimit?: CustomerDataPurchaseLimit | undefined;
   /**
@@ -301,6 +305,7 @@ export type CustomerDataPurchaseLimit$Outbound = {
   interval: string;
   interval_count: number;
   limit: number;
+  count?: number | undefined;
 };
 
 /** @internal */
@@ -312,6 +317,7 @@ export const CustomerDataPurchaseLimit$outboundSchema: z.ZodMiniType<
     interval: CustomerDataPurchaseLimitInterval$outboundSchema,
     intervalCount: z._default(z.number(), 1),
     limit: z.number(),
+    count: z.optional(z.number()),
   }),
   z.transform((v) => {
     return remap$(v, {

--- a/packages/sdk/src/models/get-or-create-customer-op.ts
+++ b/packages/sdk/src/models/get-or-create-customer-op.ts
@@ -32,7 +32,7 @@ export type GetOrCreateCustomerPurchaseLimitInterval = ClosedEnum<
 >;
 
 /**
- * Optional rate limit to cap how often auto top-ups occur.
+ * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
  */
 export type GetOrCreateCustomerPurchaseLimit = {
   /**
@@ -47,6 +47,10 @@ export type GetOrCreateCustomerPurchaseLimit = {
    * Maximum number of auto top-ups allowed within the interval.
    */
   limit: number;
+  /**
+   * Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
+   */
+  count?: number | undefined;
 };
 
 export type GetOrCreateCustomerAutoTopup = {
@@ -67,7 +71,7 @@ export type GetOrCreateCustomerAutoTopup = {
    */
   quantity: number;
   /**
-   * Optional rate limit to cap how often auto top-ups occur.
+   * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
    */
   purchaseLimit?: GetOrCreateCustomerPurchaseLimit | undefined;
   /**
@@ -314,6 +318,7 @@ export type GetOrCreateCustomerPurchaseLimit$Outbound = {
   interval: string;
   interval_count: number;
   limit: number;
+  count?: number | undefined;
 };
 
 /** @internal */
@@ -325,6 +330,7 @@ export const GetOrCreateCustomerPurchaseLimit$outboundSchema: z.ZodMiniType<
     interval: GetOrCreateCustomerPurchaseLimitInterval$outboundSchema,
     intervalCount: z._default(z.number(), 1),
     limit: z.number(),
+    count: z.optional(z.number()),
   }),
   z.transform((v) => {
     return remap$(v, {

--- a/packages/sdk/src/models/get-plan-op.ts
+++ b/packages/sdk/src/models/get-plan-op.ts
@@ -896,7 +896,7 @@ export type GetPlanVariantDetailsPurchaseLimitInterval = OpenEnum<
 >;
 
 /**
- * Optional rate limit to cap how often auto top-ups occur.
+ * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
  */
 export type GetPlanVariantDetailsPurchaseLimit = {
   /**
@@ -911,6 +911,10 @@ export type GetPlanVariantDetailsPurchaseLimit = {
    * Maximum number of auto top-ups allowed within the interval.
    */
   limit: number;
+  /**
+   * Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
+   */
+  count?: number | undefined;
 };
 
 export type GetPlanVariantDetailsAutoTopup = {
@@ -931,7 +935,7 @@ export type GetPlanVariantDetailsAutoTopup = {
    */
   quantity: number;
   /**
-   * Optional rate limit to cap how often auto top-ups occur.
+   * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
    */
   purchaseLimit?: GetPlanVariantDetailsPurchaseLimit | undefined;
   /**
@@ -2503,6 +2507,7 @@ export const GetPlanVariantDetailsPurchaseLimit$inboundSchema: z.ZodMiniType<
     interval: GetPlanVariantDetailsPurchaseLimitInterval$inboundSchema,
     interval_count: z._default(types.number(), 1),
     limit: types.number(),
+    count: types.optional(types.number()),
   }),
   z.transform((v) => {
     return remap$(v, {

--- a/packages/sdk/src/models/list-invoices-op.ts
+++ b/packages/sdk/src/models/list-invoices-op.ts
@@ -24,11 +24,13 @@ export const ListInvoicesStatus = {
 } as const;
 export type ListInvoicesStatus = ClosedEnum<typeof ListInvoicesStatus>;
 
-export const ProcessorTypeRequest = {
+export const ListInvoicesProcessorTypeRequest = {
   Stripe: "stripe",
   Revenuecat: "revenuecat",
 } as const;
-export type ProcessorTypeRequest = ClosedEnum<typeof ProcessorTypeRequest>;
+export type ListInvoicesProcessorTypeRequest = ClosedEnum<
+  typeof ListInvoicesProcessorTypeRequest
+>;
 
 export type ListInvoicesParams = {
   /**
@@ -54,7 +56,7 @@ export type ListInvoicesParams = {
   /**
    * Filter by billing processor (stripe, revenuecat). Invoices recorded before processor tracking count as stripe.
    */
-  processorTypes?: Array<ProcessorTypeRequest> | undefined;
+  processorTypes?: Array<ListInvoicesProcessorTypeRequest> | undefined;
 };
 
 /**
@@ -146,9 +148,9 @@ export const ListInvoicesStatus$outboundSchema: z.ZodMiniEnum<
 > = z.enum(ListInvoicesStatus);
 
 /** @internal */
-export const ProcessorTypeRequest$outboundSchema: z.ZodMiniEnum<
-  typeof ProcessorTypeRequest
-> = z.enum(ProcessorTypeRequest);
+export const ListInvoicesProcessorTypeRequest$outboundSchema: z.ZodMiniEnum<
+  typeof ListInvoicesProcessorTypeRequest
+> = z.enum(ListInvoicesProcessorTypeRequest);
 
 /** @internal */
 export type ListInvoicesParams$Outbound = {
@@ -171,7 +173,9 @@ export const ListInvoicesParams$outboundSchema: z.ZodMiniType<
     customerId: z.optional(z.string()),
     entityId: z.optional(z.string()),
     status: z.optional(z.array(ListInvoicesStatus$outboundSchema)),
-    processorTypes: z.optional(z.array(ProcessorTypeRequest$outboundSchema)),
+    processorTypes: z.optional(
+      z.array(ListInvoicesProcessorTypeRequest$outboundSchema),
+    ),
   }),
   z.transform((v) => {
     return remap$(v, {

--- a/packages/sdk/src/models/list-plans-op.ts
+++ b/packages/sdk/src/models/list-plans-op.ts
@@ -887,7 +887,7 @@ export type ListPlansVariantDetailsPurchaseLimitInterval = OpenEnum<
 >;
 
 /**
- * Optional rate limit to cap how often auto top-ups occur.
+ * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
  */
 export type ListPlansVariantDetailsPurchaseLimit = {
   /**
@@ -902,6 +902,10 @@ export type ListPlansVariantDetailsPurchaseLimit = {
    * Maximum number of auto top-ups allowed within the interval.
    */
   limit: number;
+  /**
+   * Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
+   */
+  count?: number | undefined;
 };
 
 export type ListPlansVariantDetailsAutoTopup = {
@@ -922,7 +926,7 @@ export type ListPlansVariantDetailsAutoTopup = {
    */
   quantity: number;
   /**
-   * Optional rate limit to cap how often auto top-ups occur.
+   * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
    */
   purchaseLimit?: ListPlansVariantDetailsPurchaseLimit | undefined;
   /**
@@ -2471,6 +2475,7 @@ export const ListPlansVariantDetailsPurchaseLimit$inboundSchema: z.ZodMiniType<
     interval: ListPlansVariantDetailsPurchaseLimitInterval$inboundSchema,
     interval_count: z._default(types.number(), 1),
     limit: types.number(),
+    count: types.optional(types.number()),
   }),
   z.transform((v) => {
     return remap$(v, {

--- a/packages/sdk/src/models/plan.ts
+++ b/packages/sdk/src/models/plan.ts
@@ -869,7 +869,7 @@ export type PlanVariantDetailsPurchaseLimitInterval = OpenEnum<
 >;
 
 /**
- * Optional rate limit to cap how often auto top-ups occur.
+ * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
  */
 export type PlanVariantDetailsPurchaseLimit = {
   /**
@@ -884,6 +884,10 @@ export type PlanVariantDetailsPurchaseLimit = {
    * Maximum number of auto top-ups allowed within the interval.
    */
   limit: number;
+  /**
+   * Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
+   */
+  count?: number | undefined;
 };
 
 export type PlanVariantDetailsAutoTopup = {
@@ -904,7 +908,7 @@ export type PlanVariantDetailsAutoTopup = {
    */
   quantity: number;
   /**
-   * Optional rate limit to cap how often auto top-ups occur.
+   * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
    */
   purchaseLimit?: PlanVariantDetailsPurchaseLimit | undefined;
   /**
@@ -2411,6 +2415,7 @@ export const PlanVariantDetailsPurchaseLimit$inboundSchema: z.ZodMiniType<
     interval: PlanVariantDetailsPurchaseLimitInterval$inboundSchema,
     interval_count: z._default(types.number(), 1),
     limit: types.number(),
+    count: types.optional(types.number()),
   }),
   z.transform((v) => {
     return remap$(v, {

--- a/packages/sdk/src/models/preview-attach-op.ts
+++ b/packages/sdk/src/models/preview-attach-op.ts
@@ -769,7 +769,7 @@ export type PreviewAttachPurchaseLimitInterval = ClosedEnum<
 >;
 
 /**
- * Optional rate limit to cap how often auto top-ups occur.
+ * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
  */
 export type PreviewAttachPurchaseLimit = {
   /**
@@ -784,6 +784,10 @@ export type PreviewAttachPurchaseLimit = {
    * Maximum number of auto top-ups allowed within the interval.
    */
   limit: number;
+  /**
+   * Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
+   */
+  count?: number | undefined;
 };
 
 export type PreviewAttachAutoTopup = {
@@ -804,7 +808,7 @@ export type PreviewAttachAutoTopup = {
    */
   quantity: number;
   /**
-   * Optional rate limit to cap how often auto top-ups occur.
+   * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
    */
   purchaseLimit?: PreviewAttachPurchaseLimit | undefined;
   /**
@@ -2963,6 +2967,7 @@ export type PreviewAttachPurchaseLimit$Outbound = {
   interval: string;
   interval_count: number;
   limit: number;
+  count?: number | undefined;
 };
 
 /** @internal */
@@ -2974,6 +2979,7 @@ export const PreviewAttachPurchaseLimit$outboundSchema: z.ZodMiniType<
     interval: PreviewAttachPurchaseLimitInterval$outboundSchema,
     intervalCount: z._default(z.number(), 1),
     limit: z.number(),
+    count: z.optional(z.number()),
   }),
   z.transform((v) => {
     return remap$(v, {

--- a/packages/sdk/src/models/preview-update-op.ts
+++ b/packages/sdk/src/models/preview-update-op.ts
@@ -769,7 +769,7 @@ export type PreviewUpdatePurchaseLimitInterval = ClosedEnum<
 >;
 
 /**
- * Optional rate limit to cap how often auto top-ups occur.
+ * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
  */
 export type PreviewUpdatePurchaseLimit = {
   /**
@@ -784,6 +784,10 @@ export type PreviewUpdatePurchaseLimit = {
    * Maximum number of auto top-ups allowed within the interval.
    */
   limit: number;
+  /**
+   * Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
+   */
+  count?: number | undefined;
 };
 
 export type PreviewUpdateAutoTopup = {
@@ -804,7 +808,7 @@ export type PreviewUpdateAutoTopup = {
    */
   quantity: number;
   /**
-   * Optional rate limit to cap how often auto top-ups occur.
+   * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
    */
   purchaseLimit?: PreviewUpdatePurchaseLimit | undefined;
   /**
@@ -2917,6 +2921,7 @@ export type PreviewUpdatePurchaseLimit$Outbound = {
   interval: string;
   interval_count: number;
   limit: number;
+  count?: number | undefined;
 };
 
 /** @internal */
@@ -2928,6 +2933,7 @@ export const PreviewUpdatePurchaseLimit$outboundSchema: z.ZodMiniType<
     interval: PreviewUpdatePurchaseLimitInterval$outboundSchema,
     intervalCount: z._default(z.number(), 1),
     limit: z.number(),
+    count: z.optional(z.number()),
   }),
   z.transform((v) => {
     return remap$(v, {

--- a/packages/sdk/src/models/setup-payment-op.ts
+++ b/packages/sdk/src/models/setup-payment-op.ts
@@ -767,7 +767,7 @@ export type SetupPaymentPurchaseLimitInterval = ClosedEnum<
 >;
 
 /**
- * Optional rate limit to cap how often auto top-ups occur.
+ * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
  */
 export type SetupPaymentPurchaseLimit = {
   /**
@@ -782,6 +782,10 @@ export type SetupPaymentPurchaseLimit = {
    * Maximum number of auto top-ups allowed within the interval.
    */
   limit: number;
+  /**
+   * Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
+   */
+  count?: number | undefined;
 };
 
 export type SetupPaymentAutoTopup = {
@@ -802,7 +806,7 @@ export type SetupPaymentAutoTopup = {
    */
   quantity: number;
   /**
-   * Optional rate limit to cap how often auto top-ups occur.
+   * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
    */
   purchaseLimit?: SetupPaymentPurchaseLimit | undefined;
   /**
@@ -2537,6 +2541,7 @@ export type SetupPaymentPurchaseLimit$Outbound = {
   interval: string;
   interval_count: number;
   limit: number;
+  count?: number | undefined;
 };
 
 /** @internal */
@@ -2548,6 +2553,7 @@ export const SetupPaymentPurchaseLimit$outboundSchema: z.ZodMiniType<
     interval: SetupPaymentPurchaseLimitInterval$outboundSchema,
     intervalCount: z._default(z.number(), 1),
     limit: z.number(),
+    count: z.optional(z.number()),
   }),
   z.transform((v) => {
     return remap$(v, {

--- a/packages/sdk/src/models/update-customer-op.ts
+++ b/packages/sdk/src/models/update-customer-op.ts
@@ -35,7 +35,7 @@ export type UpdateCustomerPurchaseLimitIntervalRequestBody = ClosedEnum<
 >;
 
 /**
- * Optional rate limit to cap how often auto top-ups occur.
+ * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
  */
 export type UpdateCustomerPurchaseLimitRequest = {
   /**
@@ -50,6 +50,10 @@ export type UpdateCustomerPurchaseLimitRequest = {
    * Maximum number of auto top-ups allowed within the interval.
    */
   limit: number;
+  /**
+   * Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
+   */
+  count?: number | undefined;
 };
 
 export type UpdateCustomerAutoTopupRequest = {
@@ -70,7 +74,7 @@ export type UpdateCustomerAutoTopupRequest = {
    */
   quantity: number;
   /**
-   * Optional rate limit to cap how often auto top-ups occur.
+   * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
    */
   purchaseLimit?: UpdateCustomerPurchaseLimitRequest | undefined;
   /**
@@ -1098,6 +1102,7 @@ export type UpdateCustomerPurchaseLimitRequest$Outbound = {
   interval: string;
   interval_count: number;
   limit: number;
+  count?: number | undefined;
 };
 
 /** @internal */
@@ -1109,6 +1114,7 @@ export const UpdateCustomerPurchaseLimitRequest$outboundSchema: z.ZodMiniType<
     interval: UpdateCustomerPurchaseLimitIntervalRequestBody$outboundSchema,
     intervalCount: z._default(z.number(), 1),
     limit: z.number(),
+    count: z.optional(z.number()),
   }),
   z.transform((v) => {
     return remap$(v, {

--- a/packages/sdk/src/models/update-plan-op.ts
+++ b/packages/sdk/src/models/update-plan-op.ts
@@ -742,10 +742,6 @@ export type UpdatePlanLicense = {
   prepaidOnly?: boolean | undefined;
   customize?: UpdatePlanLicenseCustomize | null | undefined;
   metadata?: { [k: string]: any } | undefined;
-  /**
-   * Pin the link to a specific version of the license plan. Omitted, an existing link keeps its pinned version and a new link resolves to the latest.
-   */
-  version?: number | undefined;
 };
 
 /**
@@ -824,7 +820,7 @@ export type UpdatePlanPurchaseLimitIntervalRequestBody = ClosedEnum<
 >;
 
 /**
- * Optional rate limit to cap how often auto top-ups occur.
+ * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
  */
 export type UpdatePlanPurchaseLimitRequest = {
   /**
@@ -839,6 +835,10 @@ export type UpdatePlanPurchaseLimitRequest = {
    * Maximum number of auto top-ups allowed within the interval.
    */
   limit: number;
+  /**
+   * Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
+   */
+  count?: number | undefined;
 };
 
 export type UpdatePlanAutoTopupRequest = {
@@ -859,7 +859,7 @@ export type UpdatePlanAutoTopupRequest = {
    */
   quantity: number;
   /**
-   * Optional rate limit to cap how often auto top-ups occur.
+   * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
    */
   purchaseLimit?: UpdatePlanPurchaseLimitRequest | undefined;
   /**
@@ -1032,6 +1032,11 @@ export type UpdatePlanBillingControlsRequest = {
 export type Migration = {
   draft?: boolean | undefined;
   includeCustom?: boolean | undefined;
+};
+
+export type UpdateLicenseParent = {
+  planId: string;
+  version: number;
 };
 
 /**
@@ -1472,7 +1477,7 @@ export type VariantPurchaseLimitInterval = ClosedEnum<
 >;
 
 /**
- * Optional rate limit to cap how often auto top-ups occur.
+ * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
  */
 export type VariantPurchaseLimit = {
   /**
@@ -1487,6 +1492,10 @@ export type VariantPurchaseLimit = {
    * Maximum number of auto top-ups allowed within the interval.
    */
   limit: number;
+  /**
+   * Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
+   */
+  count?: number | undefined;
 };
 
 export type VariantAutoTopup = {
@@ -1507,7 +1516,7 @@ export type VariantAutoTopup = {
    */
   quantity: number;
   /**
-   * Optional rate limit to cap how often auto top-ups occur.
+   * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
    */
   purchaseLimit?: VariantPurchaseLimit | undefined;
   /**
@@ -1806,6 +1815,10 @@ export type UpdatePlanParams = {
    * Variant plan IDs to apply this update to. Empty or omitted means no propagation.
    */
   updateVariantIds?: Array<string> | undefined;
+  /**
+   * Parent plan versions that should receive this license-plan update.
+   */
+  updateLicenseParents?: Array<UpdateLicenseParent> | undefined;
   /**
    * Additive variant updates for this base plan. Missing variants are created when name is provided.
    */
@@ -2703,7 +2716,7 @@ export type UpdatePlanVariantDetailsPurchaseLimitInterval = OpenEnum<
 >;
 
 /**
- * Optional rate limit to cap how often auto top-ups occur.
+ * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
  */
 export type UpdatePlanVariantDetailsPurchaseLimit = {
   /**
@@ -2718,6 +2731,10 @@ export type UpdatePlanVariantDetailsPurchaseLimit = {
    * Maximum number of auto top-ups allowed within the interval.
    */
   limit: number;
+  /**
+   * Set the current window's consumed auto top-up count. Omit to leave runtime state unchanged.
+   */
+  count?: number | undefined;
 };
 
 export type UpdatePlanVariantDetailsAutoTopup = {
@@ -2738,7 +2755,7 @@ export type UpdatePlanVariantDetailsAutoTopup = {
    */
   quantity: number;
   /**
-   * Optional rate limit to cap how often auto top-ups occur.
+   * Optional rate limit to cap how often auto top-ups occur. Pass count to set the current window's consumed top-ups.
    */
   purchaseLimit?: UpdatePlanVariantDetailsPurchaseLimit | undefined;
   /**
@@ -4298,7 +4315,6 @@ export type UpdatePlanLicense$Outbound = {
   prepaid_only?: boolean | undefined;
   customize?: UpdatePlanLicenseCustomize$Outbound | null | undefined;
   metadata?: { [k: string]: any } | undefined;
-  version?: number | undefined;
 };
 
 /** @internal */
@@ -4314,7 +4330,6 @@ export const UpdatePlanLicense$outboundSchema: z.ZodMiniType<
       z.nullable(z.lazy(() => UpdatePlanLicenseCustomize$outboundSchema)),
     ),
     metadata: z.optional(z.record(z.string(), z.any())),
-    version: z.optional(z.int()),
   }),
   z.transform((v) => {
     return remap$(v, {
@@ -4423,6 +4438,7 @@ export type UpdatePlanPurchaseLimitRequest$Outbound = {
   interval: string;
   interval_count: number;
   limit: number;
+  count?: number | undefined;
 };
 
 /** @internal */
@@ -4434,6 +4450,7 @@ export const UpdatePlanPurchaseLimitRequest$outboundSchema: z.ZodMiniType<
     interval: UpdatePlanPurchaseLimitIntervalRequestBody$outboundSchema,
     intervalCount: z._default(z.number(), 1),
     limit: z.number(),
+    count: z.optional(z.number()),
   }),
   z.transform((v) => {
     return remap$(v, {
@@ -4777,6 +4794,36 @@ export const Migration$outboundSchema: z.ZodMiniType<
 
 export function migrationToJSON(migration: Migration): string {
   return JSON.stringify(Migration$outboundSchema.parse(migration));
+}
+
+/** @internal */
+export type UpdateLicenseParent$Outbound = {
+  plan_id: string;
+  version: number;
+};
+
+/** @internal */
+export const UpdateLicenseParent$outboundSchema: z.ZodMiniType<
+  UpdateLicenseParent$Outbound,
+  UpdateLicenseParent
+> = z.pipe(
+  z.object({
+    planId: z.string(),
+    version: z.int(),
+  }),
+  z.transform((v) => {
+    return remap$(v, {
+      planId: "plan_id",
+    });
+  }),
+);
+
+export function updateLicenseParentToJSON(
+  updateLicenseParent: UpdateLicenseParent,
+): string {
+  return JSON.stringify(
+    UpdateLicenseParent$outboundSchema.parse(updateLicenseParent),
+  );
 }
 
 /** @internal */
@@ -5296,6 +5343,7 @@ export type VariantPurchaseLimit$Outbound = {
   interval: string;
   interval_count: number;
   limit: number;
+  count?: number | undefined;
 };
 
 /** @internal */
@@ -5307,6 +5355,7 @@ export const VariantPurchaseLimit$outboundSchema: z.ZodMiniType<
     interval: VariantPurchaseLimitInterval$outboundSchema,
     intervalCount: z._default(z.number(), 1),
     limit: z.number(),
+    count: z.optional(z.number()),
   }),
   z.transform((v) => {
     return remap$(v, {
@@ -5745,6 +5794,7 @@ export type UpdatePlanParams$Outbound = {
   migration?: Migration$Outbound | undefined;
   force_version?: boolean | undefined;
   update_variant_ids?: Array<string> | undefined;
+  update_license_parents?: Array<UpdateLicenseParent$Outbound> | undefined;
   variants?: Array<Variant$Outbound> | undefined;
   is_default?: boolean | undefined;
 };
@@ -5788,6 +5838,9 @@ export const UpdatePlanParams$outboundSchema: z.ZodMiniType<
     migration: z.optional(z.lazy(() => Migration$outboundSchema)),
     forceVersion: z.optional(z.boolean()),
     updateVariantIds: z.optional(z.array(z.string())),
+    updateLicenseParents: z.optional(
+      z.array(z.lazy(() => UpdateLicenseParent$outboundSchema)),
+    ),
     variants: z.optional(z.array(z.lazy(() => Variant$outboundSchema))),
     isDefault: z.optional(z.boolean()),
   }),
@@ -5805,6 +5858,7 @@ export const UpdatePlanParams$outboundSchema: z.ZodMiniType<
       allVersions: "all_versions",
       forceVersion: "force_version",
       updateVariantIds: "update_variant_ids",
+      updateLicenseParents: "update_license_parents",
       isDefault: "is_default",
     });
   }),
@@ -6837,6 +6891,7 @@ export const UpdatePlanVariantDetailsPurchaseLimit$inboundSchema: z.ZodMiniType<
     interval: UpdatePlanVariantDetailsPurchaseLimitInterval$inboundSchema,
     interval_count: z._default(types.number(), 1),
     limit: types.number(),
+    count: types.optional(types.number()),
   }),
   z.transform((v) => {
     return remap$(v, {

--- a/packages/sdk/src/sdk/billing.ts
+++ b/packages/sdk/src/sdk/billing.ts
@@ -93,7 +93,7 @@ export class Billing extends ClientSDK {
    * @example
    * ```typescript
    * // Schedule a transition from a trial plan to a paid plan
-   * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1784299196316,"plans":[{"planId":"trial_plan"}]},{"startsAt":1785508796316,"plans":[{"planId":"pro_plan"}]}] });
+   * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1784744849888,"plans":[{"planId":"trial_plan"}]},{"startsAt":1785954449888,"plans":[{"planId":"pro_plan"}]}] });
    * ```
    *
    * @param customerId - The ID of the customer to create the schedule for.

--- a/packages/sdk/src/sdk/plans.ts
+++ b/packages/sdk/src/sdk/plans.ts
@@ -217,6 +217,7 @@ export class Plans extends ClientSDK {
    * @param allVersions - Apply the update diff to all versions of this plan. Mutually exclusive with disable_version. (optional)
    * @param forceVersion - Force versioning even when no customers exist. Mutually exclusive with disable_version. (optional)
    * @param updateVariantIds - Variant plan IDs to apply this update to. Empty or omitted means no propagation. (optional)
+   * @param updateLicenseParents - Parent plan versions that should receive this license-plan update. (optional)
    * @param variants - Additive variant updates for this base plan. Missing variants are created when name is provided. (optional)
    * @param isDefault - Whether this is the org's default plan. Cannot be true on a variant. (optional)
    *


### PR DESCRIPTION
Release 22/07/2026

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional purchase_limit.count to auto top-up APIs and SDKs so you can set the current window’s consumed top-up count. Also routes structured logs through FireLens to Axiom for better observability.

- **New Features**
  - Auto top-up purchase limits: added `count` across OpenAPI, docs, `packages/sdk` (TS), `others/python-sdk`, and `@autumn-js`.
  - Plans: `plans.update` now supports `updateLicenseParents` to propagate license-plan updates.
  - Logging: new FireLens config parses JSON logs and sends them to Axiom Express.

- **Migration**
  - Plans: remove `version` from license link payloads in create/update; use `updateLicenseParents` when you need to propagate license-plan updates.

<sup>Written for commit e59416b86ca7ba4792d8bfb4881bd3dbe530b9b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR publishes updated API definitions, generated SDKs, documentation, and log routing. The main changes are:

- **API changes:** Adds license-parent propagation to plan updates.
- **API changes:** Adds runtime auto-top-up counts to purchase limits.
- **API changes:** Regenerates TypeScript and Python client models.
- **Improvements:** Routes structured Express logs through a dedicated Axiom stream.
- **Improvements:** Refreshes the generated API reference.
</details>

<h3>Confidence Score: 4/5</h3>

The generated TypeScript SDK has breaking export and request-model changes that need fixes before merging.

- Existing invoice enum imports can stop compiling.
- Existing license-version pins can stop compiling or be omitted from requests.
- The new license-parent field is serialized consistently with the updated wire shape.

packages/sdk/src/models/list-invoices-op.ts, packages/sdk/src/models/create-plan-op.ts, packages/sdk/src/models/update-plan-op.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/sdk/src/models/list-invoices-op.ts | Renames the exported invoice processor enum and its schema without compatibility aliases. |
| packages/sdk/src/models/create-plan-op.ts | Adds purchase-limit count support and removes license-version pinning from the public type and serializer. |
| packages/sdk/src/models/update-plan-op.ts | Adds license-parent propagation and purchase-limit counts while removing per-license version pinning. |
| others/python-sdk/src/autumn_sdk/plans.py | Passes the new license-parent update list through both Python plan-update methods. |
| packages/openapi/openapi.yml | Updates the public contract that drives the generated clients and documentation. |
| firelens.conf | Adds JSON parsing and routes recognized structured logs to a dedicated Axiom dataset. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/sdk/src/models/list-invoices-op.ts:27-33
**Public Enum Export Removed**

Existing TypeScript consumers that import `ProcessorTypeRequest` now fail to compile after upgrading, even though the processor-type values and request behavior are unchanged. Keep deprecated aliases for both `ProcessorTypeRequest` and `ProcessorTypeRequest$outboundSchema` so this generated naming change remains backward compatible.

### Issue 2 of 3
packages/sdk/src/models/create-plan-op.ts:744
**License Version Pin Removed**

Callers can no longer create a license link pinned to a specific plan version: typed object literals containing `license.version` fail to compile, while untyped inputs lose the field because it was also removed from the outbound schema. Preserve this optional field unless the endpoint now rejects version pinning.

### Issue 3 of 3
packages/sdk/src/models/update-plan-op.ts:744
**License Version Pin Removed**

Existing plan updates that pass `license.version` now fail TypeScript checking, and untyped callers silently omit the pin because the outbound Zod schema no longer serializes it. `updateLicenseParents` selects parent plans to update and does not preserve this per-license version-pin contract.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into dev"](https://github.com/useautumn/autumn/commit/9f4250f0f5d76fcde1c7e0afb1764de5e9628063) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46402368)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->