### PR TITLE
Fix FireLens Axiom schema overflow

### DIFF
--- a/firelens.conf
+++ b/firelens.conf
@@ -49,6 +49,14 @@
     Emitter_Storage.type memory
     Emitter_Mem_Buf_Limit 10M
 
+[FILTER]
+    Name modify
+    Match axiom_express
+    Remove time
+    Remove region
+    Remove container_id
+    Remove container_name
+
 [OUTPUT]
     Name http
     Match axiom_express

--- a/server/tests/unit/logging/firelens-config.test.ts
+++ b/server/tests/unit/logging/firelens-config.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Contract: FireLens parses Pino's JSON envelope, sends structured records to
+ * `express`, keeps console records in `ecs`, and bounds retries and re-emission.
+ */
+
+import { expect, test } from "bun:test";
+import path from "node:path";
+
+test.concurrent(
+	"FireLens separates structured and console log datasets",
+	async () => {
+		const configPath = path.resolve(
+			import.meta.dir,
+			"../../../../firelens.conf",
+		);
+		const config = await Bun.file(configPath).text();
+
+		expect(config).toContain("Parsers_File /fluent-bit/etc/parsers.conf");
+		expect(config).not.toContain("[PARSER]");
+		expect(config).toContain("Key_Name log");
+		expect(config).toContain("Parser json");
+		expect(config).toContain("Reserve_Data On");
+		expect(config).toContain(
+			"Rule $level ^(TRACE|DEBUG|INFO|WARN|ERROR|FATAL)$ axiom_express false",
+		);
+		expect(config).toContain("Emitter_Mem_Buf_Limit 10M");
+		expect(config).toMatch(
+			/\[FILTER\]\s+Name modify\s+Match axiom_express\s+Remove time\s+Remove region\s+Remove container_id\s+Remove container_name/,
+		);
+		expect(config).toContain("URI /v1/ingest/express");
+		expect(config).toContain("URI /v1/ingest/ecs");
+		expect(config.match(/retry_limit 5/g)).toHaveLength(2);
+		expect(config).not.toMatch(/\[OUTPUT\]\s+Name http\s+Match \*(?:\s|$)/);
+	},
+);


### PR DESCRIPTION
## What changed

- Strip `time`, `region`, `container_id`, and `container_name` from records routed to Axiom `express`.
- Add a regression test for the FireLens parsing, routing, retry, and metadata-filter configuration.

## Why

The staging FireLens deployment started successfully, but Axiom rejected structured records with HTTP 400 because these four new transport fields would exceed the `express` dataset column limit. The filter is scoped to the `axiom_express` tag, so complete application fields such as `req`, `res`, `context`, and errors remain unchanged.

## Verification

- `bun test tests/unit/logging/firelens-config.test.ts`
- `bunx biome check server/tests/unit/logging/firelens-config.test.ts`
- Production Fluent Bit 1.9.10 image accepted the complete configuration with `--dry-run`
- Commit hook server typecheck passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Axiom 400 errors by removing time, region, container_id, and container_name from FireLens records sent to the `express` dataset to stay under column limits. Adds a regression test to verify parsing, routing, retry limits, and metadata filtering.

<sup>Written for commit 65b8b5a77416bd0eeb07324190cc81ed609f3424. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents Axiom schema overflow in the FireLens express route. The main changes are:

- **Bug fixes:** Remove four metadata fields from records routed to `axiom_express`.
- **Improvements:** Add a Bun test for parsing, routing, retries, metadata filtering, and output matching.
</details>

<h3>Confidence Score: 4/5</h3>

The express metadata filter can silently remove application data and needs a fix before merging.

- Parsed application fields share the same top-level names targeted by the new filter.
- Removing `time` can replace the original Pino event time with Fluent Bit's processing timestamp.
- The new test checks configuration text but does not exercise record collisions.

firelens.conf

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| firelens.conf | Adds an express-only metadata filter, but it can delete application fields after JSON parsing flattens the record. |
| server/tests/unit/logging/firelens-config.test.ts | Adds textual checks for the expected FireLens parser, routing, retry, filter, and output directives. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
firelens.conf:55-58
**Parsed Fields Lose Ownership**

The parser flattens Pino fields into the same record before this filter runs. A log such as `logger.info({ region: "eu-west-1" })` therefore loses its application-owned `region`; the same collision affects `container_id` and `container_name`, while removing Pino's `time` replaces the original event time with Fluent Bit's output timestamp.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: prevent FireLens Axiom schema overf..."](https://github.com/useautumn/autumn/commit/65b8b5a77416bd0eeb07324190cc81ed609f3424) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46409539)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->