### PR TITLE
Fix batch reset rehydration concurrency

### DIFF
--- a/server/src/internal/customers/actions/resetCustomerEntitlements/batchResetCustomerEntitlements.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlements/batchResetCustomerEntitlements.ts
@@ -1,9 +1,13 @@
 import { CusProductStatus } from "@autumn/shared";
+import pLimit from "p-limit";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import type { BatchResetCusEntsPayload } from "@/queue/workflows.js";
 // import { isFullSubjectRolloutEnabled } from "@/internal/misc/rollouts/fullSubjectRolloutUtils.js";
 import { CusService } from "../../CusService.js";
 import { getFullSubject } from "../../repos/getFullSubject/getFullSubject.js";
+
+const CUSTOMER_REHYDRATION_CONCURRENCY = 5;
+const BATCH_SIZE = 100;
 
 /**
  * SQS worker handler: rehydrates each subject, which triggers lazy reset internally.
@@ -19,38 +23,40 @@ export const batchResetCustomerEntitlements = async ({
 
 	if (resets.length === 0) return;
 
-	const BATCH_SIZE = 100;
+	const limit = pLimit(CUSTOMER_REHYDRATION_CONCURRENCY);
 
 	for (let i = 0; i < resets.length; i += BATCH_SIZE) {
 		const batch = resets.slice(i, i + BATCH_SIZE);
 
 		await Promise.all(
-			batch.map(async (reset) => {
-				if (reset.internalEntityId || reset.entityId) {
-					await getFullSubject({
+			batch.map((reset) =>
+				limit(async () => {
+					if (reset.internalEntityId || reset.entityId) {
+						await getFullSubject({
+							ctx,
+							customerId: reset.internalCustomerId,
+							entityId: reset.internalEntityId ?? reset.entityId,
+							inStatuses: [CusProductStatus.Active, CusProductStatus.PastDue],
+						});
+						return;
+					}
+
+					await CusService.getFull({
 						ctx,
-						customerId: reset.internalCustomerId,
-						entityId: reset.internalEntityId ?? reset.entityId,
+						idOrInternalId: reset.internalCustomerId,
 						inStatuses: [CusProductStatus.Active, CusProductStatus.PastDue],
 					});
-					return;
-				}
 
-				await CusService.getFull({
-					ctx,
-					idOrInternalId: reset.internalCustomerId,
-					inStatuses: [CusProductStatus.Active, CusProductStatus.PastDue],
-				});
-
-				// V2 subject cache path: triggers lazyResetSubjectEntitlements
-				// if (isFullSubjectRolloutEnabled({ ctx })) {
-				// 	await getFullSubject({
-				// 		ctx,
-				// 		customerId: reset.internalCustomerId,
-				// 		inStatuses: [CusProductStatus.Active, CusProductStatus.PastDue],
-				// 	});
-				// }
-			}),
+					// V2 subject cache path: triggers lazyResetSubjectEntitlements
+					// if (isFullSubjectRolloutEnabled({ ctx })) {
+					// 	await getFullSubject({
+					// 		ctx,
+					// 		customerId: reset.internalCustomerId,
+					// 		inStatuses: [CusProductStatus.Active, CusProductStatus.PastDue],
+					// 	});
+					// }
+				}),
+			),
 		);
 	}
 };

--- a/server/tests/unit/customers/reset/batch-reset-customer-entitlements-concurrency.test.ts
+++ b/server/tests/unit/customers/reset/batch-reset-customer-entitlements-concurrency.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import type { FullCustomer } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { batchResetCustomerEntitlements } from "@/internal/customers/actions/resetCustomerEntitlements/batchResetCustomerEntitlements.js";
+import { CusService } from "@/internal/customers/CusService.js";
+
+describe("batchResetCustomerEntitlements", () => {
+	test("limits concurrent customer rehydrations to five", async () => {
+		let activeRehydrations = 0;
+		let maximumConcurrentRehydrations = 0;
+
+		const getFullSpy = spyOn(CusService, "getFull").mockImplementation(
+			async () => {
+				activeRehydrations++;
+				maximumConcurrentRehydrations = Math.max(
+					maximumConcurrentRehydrations,
+					activeRehydrations,
+				);
+
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				activeRehydrations--;
+				return {} as FullCustomer;
+			},
+		);
+
+		try {
+			await batchResetCustomerEntitlements({
+				ctx: {} as AutumnContext,
+				payload: {
+					orgId: "org_test",
+					env: "sandbox",
+					resets: Array.from({ length: 20 }, (_, index) => ({
+						internalCustomerId: `internal_customer_${index}`,
+						customerId: `customer_${index}`,
+						cusEntIds: [`customer_entitlement_${index}`],
+					})),
+				},
+			});
+
+			expect(getFullSpy).toHaveBeenCalledTimes(20);
+			expect(maximumConcurrentRehydrations).toBe(5);
+		} finally {
+			getFullSpy.mockRestore();
+		}
+	});
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound batch reset rehydration to 5 concurrent operations with `p-limit` to prevent overload in SQS batch processing. Added a unit test to verify the cap.

- **Bug Fixes**
  - Applied the 5-worker limit to both `CusService.getFull` and `getFullSubject`, scoped per handler run; test asserts max concurrency is 5 across 20 tasks.

<sup>Written for commit 0876125b903ded3f7bc354cb7ac846a8492e3b9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes an unbounded concurrency problem in the SQS batch-reset worker where up to 100 customer rehydrations could be fired simultaneously inside a single `Promise.all` call. It adds `pLimit` to cap concurrent rehydrations at 5 and ships a unit test that proves the limit holds.

- **[Bug fixes]** Wraps each rehydration task with a shared `pLimit(5)` limiter, so at most 5 `getFullSubject` / `CusService.getFull` calls run in parallel regardless of batch size.
- **[Improvements]** Promotes `BATCH_SIZE` and the new `CUSTOMER_REHYDRATION_CONCURRENCY` constant to module-level, making them easy to tune without digging into the function body.
- **[Improvements]** Adds a Bun unit test that injects a spy with an artificial 5 ms delay and asserts `maximumConcurrentRehydrations === 5` across 20 tasks.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted throttle on an async SQS worker with no behavioral change other than bounding parallelism, and the new unit test verifies the limit holds end-to-end.

The fix is small and self-contained: one pLimit wrapper around the existing rehydration calls, with the limiter correctly scoped per function invocation so different SQS handler calls do not share state. The outer batch loop was already sequential, so the shared limiter across batches has no surprising side effects. The accompanying test uses a spy with an artificial delay to deterministically verify that no more than 5 rehydrations run at once across 20 tasks.

No files require special attention. The test only exercises the CusService.getFull code path, but both rehydration branches are wrapped by the same limit() call so the concurrency guarantee applies equally to the entity path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/actions/resetCustomerEntitlements/batchResetCustomerEntitlements.ts | Introduces pLimit(5) to cap concurrent rehydrations; limit instance is correctly scoped per function invocation and shared across all batch iterations. |
| server/tests/unit/customers/reset/batch-reset-customer-entitlements-concurrency.test.ts | New Bun unit test verifying the concurrency limit via a spy with artificial delay; covers the customer path but not the entity (getFullSubject) path, which is also limited by the same pLimit wrapper. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[batchResetCustomerEntitlements called] --> B{resets.length === 0?}
    B -- Yes --> C[return early]
    B -- No --> D[Create pLimit limiter\nconcurrency = 5]
    D --> E[Slice next batch\nup to 100 resets]
    E --> F[Promise.all — batch.map with limit wrapper]
    F --> G{has entityId or\ninternalEntityId?}
    G -- Yes --> H[getFullSubject\nentity-level rehydration]
    G -- No --> I[CusService.getFull\ncustomer-level rehydration]
    H --> J[slot released back to pLimit]
    I --> J
    J --> K{more items\nin batch?}
    K -- Yes, slot free --> F
    K -- No, batch done --> L{more batches?}
    L -- Yes --> E
    L -- No --> M[Done]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: bound batch reset rehydration concu..."](https://github.com/useautumn/autumn/commit/2970fc638c00c2d2bebcbabebf1a39b2a11c945e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46562184)</sub>

<!-- /greptile_comment -->