### PR TITLE
chore: force async

### DIFF
--- a/server/src/internal/balances/handlers/handleTrack.ts
+++ b/server/src/internal/balances/handlers/handleTrack.ts
@@ -24,7 +24,7 @@ export const handleTrack = createRoute({
 		const ctx = c.get("ctx");
 		const featureDeductions = getTrackFeatureDeductionsForBody({ ctx, body });
 
-		if (body.async === true) {
+		if (body.async === true || ctx.org.slug === "firecrawl") {
 			await runAsyncTrack({ ctx, body });
 			return c.json(getQueuedTrackResponse({ ctx, body }), 202);
 		}

--- a/server/tests/unit/balances/track/handle-track.test.ts
+++ b/server/tests/unit/balances/track/handle-track.test.ts
@@ -15,10 +15,10 @@ const mockState = {
 
 import { handleTrack } from "@/internal/balances/handlers/handleTrack.js";
 
-const createCtx = (): AutumnContext =>
+const createCtx = ({ orgSlug = "test-org" } = {}): AutumnContext =>
 	({
 		id: "req_track_1",
-		org: { id: "org_123" },
+		org: { id: "org_123", slug: orgSlug },
 		env: AppEnv.Sandbox,
 		apiVersion: new ApiVersionClass(LATEST_VERSION),
 		features: [{ id: "messages" }],
@@ -85,5 +85,23 @@ describe("handleTrack", () => {
 			QueueUrl: trackAsyncQueueUrl,
 			MessageDeduplicationId: "req_track_1",
 		});
+	});
+
+	test("returns 202 success for Firecrawl track", async () => {
+		const response = await createApp({
+			ctx: createCtx({ orgSlug: "firecrawl" }),
+		}).request("/track", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				customer_id: "cus_123",
+				feature_id: "messages",
+				value: 1,
+			}),
+		});
+
+		expect(response.status).toBe(202);
+		expect(await response.json()).toEqual({ success: true });
+		expect(mockState.queueCommands).toHaveLength(1);
 	});
 });


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Force async processing for `firecrawl` org in the track handler. Requests from this org are now queued and return 202, even if `body.async` is not set.

Added a unit test to verify 202 response and queue command for `firecrawl` requests.

<sup>Written for commit 19f90661c6c1531e076f7cd767b577adc670fe33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Forces Firecrawl tracking requests through the existing asynchronous processing path.
- **[Improvements, API changes]** Routes all requests from the Firecrawl organization through `runAsyncTrack`, returning an immediate `202 Accepted` response.
- **[Improvements]** Extends the unit-test context factory with configurable organization slugs and verifies Firecrawl requests enqueue tracking work.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The organization slug is available on authenticated request contexts, and the new condition reuses the established asynchronous tracking path while preserving its enqueue-failure handling.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/handlers/handleTrack.ts | Extends the existing async branch to force Firecrawl organization requests through queued tracking. |
| server/tests/unit/balances/track/handle-track.test.ts | Adds configurable organization slugs to the test context and covers Firecrawl's forced-async response and enqueue behavior. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant TrackHandler
    participant Queue
    participant Worker
    Client->>TrackHandler: POST /track (Firecrawl org)
    TrackHandler->>Queue: Enqueue track request
    TrackHandler-->>Client: "202 { success: true }"
    Queue->>Worker: Deliver queued track
    Worker->>Worker: Process usage asynchronously
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: force async"](https://github.com/useautumn/autumn/commit/7cbb6eb5f008f6de7a7f2b8e5d8703e812b43643) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46612885)</sub>

<!-- /greptile_comment -->