### PR TITLE
Configure async track organizations

### DIFF
--- a/server/src/external/aws/s3/adminS3Config.ts
+++ b/server/src/external/aws/s3/adminS3Config.ts
@@ -23,6 +23,7 @@ export const ADMIN_FULL_SUBJECT_GATE_CONFIG_KEY =
 	"admin/full-subject-gate-config.json";
 export const ADMIN_ASYNC_BALANCE_UPDATE_CONFIG_KEY =
 	"admin/async-balance-update-config.json";
+export const ADMIN_ASYNC_TRACK_CONFIG_KEY = "admin/async-track-config.json";
 export const BLUE_GREEN_ACTIVE_SLOT_KEY = "admin/blue-green-active-slot.json";
 export const BLUE_GREEN_CRON_ACTIVE_SLOT_KEY =
 	"admin/blue-green-cron-active-slot.json";
@@ -117,6 +118,11 @@ export const getAdminEdgeConfigSources = () => ({
 			id: "async-balance-update",
 			label: "Async Balance Update",
 			key: ADMIN_ASYNC_BALANCE_UPDATE_CONFIG_KEY,
+		},
+		{
+			id: "async-track",
+			label: "Async Track",
+			key: ADMIN_ASYNC_TRACK_CONFIG_KEY,
 		},
 		{
 			id: "stripe-sync",

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -33,6 +33,7 @@ import "./internal/misc/batchReset/batchResetConfigStore.js";
 import "./internal/misc/resetJob/resetJobStore.js";
 import "./internal/misc/resetJobV2/resetJobV2Store.js";
 import "./internal/misc/asyncBalanceUpdate/asyncBalanceUpdateStore.js";
+import "./internal/misc/asyncTrack/asyncTrackStore.js";
 
 // Side-effect: configures trigger.dev SDK to use TRIGGER_SERVER_SECRET_KEY.
 import "./trigger/configureTrigger.js";

--- a/server/src/internal/admin/adminRouter.ts
+++ b/server/src/internal/admin/adminRouter.ts
@@ -14,6 +14,7 @@ import {
 	handleUpsertAdminOrgRedisConfig,
 } from "./handleAdminOrgRedisConfig";
 import { handleGetAdminAsyncBalanceUpdateConfig } from "./handleGetAdminAsyncBalanceUpdateConfig";
+import { handleGetAdminAsyncTrackConfig } from "./handleGetAdminAsyncTrackConfig";
 import { handleGetAdminBatchResetConfig } from "./handleGetAdminBatchResetConfig";
 import { handleGetAdminCustomerBlockConfig } from "./handleGetAdminCustomerBlockConfig";
 import { handleGetAdminEdgeConfigSources } from "./handleGetAdminEdgeConfigSources";
@@ -46,6 +47,7 @@ import {
 	handleUpdateSlackAdminTarget,
 } from "./handleSlackAdminChat";
 import { handleUpsertAdminAsyncBalanceUpdateConfig } from "./handleUpsertAdminAsyncBalanceUpdateConfig";
+import { handleUpsertAdminAsyncTrackConfig } from "./handleUpsertAdminAsyncTrackConfig";
 import { handleUpsertAdminBatchResetConfig } from "./handleUpsertAdminBatchResetConfig";
 import { handleUpsertAdminCustomerBlockConfig } from "./handleUpsertAdminCustomerBlockConfig";
 import { handleUpsertAdminFeatureFlagsConfig } from "./handleUpsertAdminFeatureFlagsConfig";
@@ -130,6 +132,11 @@ honoAdminRouter.get(
 honoAdminRouter.put(
 	"/async-balance-update-config",
 	...handleUpsertAdminAsyncBalanceUpdateConfig,
+);
+honoAdminRouter.get("/async-track-config", ...handleGetAdminAsyncTrackConfig);
+honoAdminRouter.put(
+	"/async-track-config",
+	...handleUpsertAdminAsyncTrackConfig,
 );
 honoAdminRouter.get(
 	"/full-subject-gate-config",

--- a/server/src/internal/admin/handleGetAdminAsyncTrackConfig.ts
+++ b/server/src/internal/admin/handleGetAdminAsyncTrackConfig.ts
@@ -1,0 +1,22 @@
+import { Scopes } from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import {
+	getAsyncTrackConfigFromSource,
+	getRuntimeAsyncTrackStatus,
+} from "@/internal/misc/asyncTrack/asyncTrackStore.js";
+
+export const handleGetAdminAsyncTrackConfig = createRoute({
+	scopes: [Scopes.Superuser],
+	handler: async (c) => {
+		const status = getRuntimeAsyncTrackStatus();
+		const config = await getAsyncTrackConfigFromSource();
+
+		return c.json({
+			...config,
+			configHealthy: status.healthy,
+			configConfigured: status.configured,
+			lastSuccessAt: status.lastSuccessAt ?? null,
+			error: status.error ?? null,
+		});
+	},
+});

--- a/server/src/internal/admin/handleUpsertAdminAsyncTrackConfig.ts
+++ b/server/src/internal/admin/handleUpsertAdminAsyncTrackConfig.ts
@@ -1,0 +1,13 @@
+import { Scopes } from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { AsyncTrackConfigSchema } from "@/internal/misc/asyncTrack/asyncTrackSchemas.js";
+import { updateFullAsyncTrackConfig } from "@/internal/misc/asyncTrack/asyncTrackStore.js";
+
+export const handleUpsertAdminAsyncTrackConfig = createRoute({
+	scopes: [Scopes.Superuser],
+	body: AsyncTrackConfigSchema,
+	handler: async (c) => {
+		await updateFullAsyncTrackConfig({ config: c.req.valid("json") });
+		return c.json({ success: true });
+	},
+});

--- a/server/src/internal/balances/handlers/handleTrack.ts
+++ b/server/src/internal/balances/handlers/handleTrack.ts
@@ -10,6 +10,7 @@ import { runAsyncTrack } from "@/internal/balances/track/runAsyncTrack.js";
 import { runTrackWithRollout } from "@/internal/balances/track/runTrackWithRollout.js";
 import { getTrackFeatureDeductionsForBody } from "@/internal/balances/track/utils/getFeatureDeductions.js";
 import { getQueuedTrackResponse } from "@/internal/balances/track/utils/getQueuedTrackResponse.js";
+import { isAsyncTrackEnabled } from "@/internal/misc/asyncTrack/asyncTrackStore.js";
 
 export const handleTrack = createRoute({
 	scopes: [Scopes.Balances.Write],
@@ -24,7 +25,10 @@ export const handleTrack = createRoute({
 		const ctx = c.get("ctx");
 		const featureDeductions = getTrackFeatureDeductionsForBody({ ctx, body });
 
-		if (body.async === true || ctx.org.slug === "firecrawl") {
+		if (
+			body.async === true ||
+			isAsyncTrackEnabled({ orgId: ctx.org.id, orgSlug: ctx.org.slug })
+		) {
 			await runAsyncTrack({ ctx, body });
 			return c.json(getQueuedTrackResponse({ ctx, body }), 202);
 		}

--- a/server/src/internal/misc/asyncTrack/asyncTrackSchemas.ts
+++ b/server/src/internal/misc/asyncTrack/asyncTrackSchemas.ts
@@ -1,0 +1,7 @@
+import { z } from "zod/v4";
+
+export const AsyncTrackConfigSchema = z.object({
+	enabledOrgIds: z.array(z.string()).default([]),
+});
+
+export type AsyncTrackConfig = z.infer<typeof AsyncTrackConfigSchema>;

--- a/server/src/internal/misc/asyncTrack/asyncTrackStore.ts
+++ b/server/src/internal/misc/asyncTrack/asyncTrackStore.ts
@@ -1,0 +1,47 @@
+import { ADMIN_ASYNC_TRACK_CONFIG_KEY } from "@/external/aws/s3/adminS3Config.js";
+import { registerEdgeConfig } from "@/internal/misc/edgeConfig/edgeConfigRegistry.js";
+import { createEdgeConfigStore } from "@/internal/misc/edgeConfig/edgeConfigStore.js";
+import {
+	type AsyncTrackConfig,
+	AsyncTrackConfigSchema,
+} from "./asyncTrackSchemas.js";
+
+const store = createEdgeConfigStore<AsyncTrackConfig>({
+	s3Key: ADMIN_ASYNC_TRACK_CONFIG_KEY,
+	schema: AsyncTrackConfigSchema,
+	defaultValue: () => AsyncTrackConfigSchema.parse({}),
+	retainOnError: true,
+});
+
+registerEdgeConfig({ store });
+
+export const isAsyncTrackEnabled = ({
+	orgId,
+	orgSlug,
+}: {
+	orgId: string;
+	orgSlug?: string;
+}): boolean => {
+	const enabled = store.get().enabledOrgIds;
+	return enabled.includes(orgId) || (!!orgSlug && enabled.includes(orgSlug));
+};
+
+export const getRuntimeAsyncTrackStatus = () => store.getStatus();
+
+export const getAsyncTrackConfigFromSource = async () => store.readFromSource();
+
+export const updateFullAsyncTrackConfig = async ({
+	config,
+}: {
+	config: AsyncTrackConfig;
+}) => {
+	await store.writeToSource({ config });
+};
+
+export const _setAsyncTrackConfigForTesting = ({
+	config,
+}: {
+	config: AsyncTrackConfig;
+}) => {
+	store._setRuntimeConfigForTesting(config);
+};

--- a/server/src/internal/misc/edgeConfig/edgeConfigStore.ts
+++ b/server/src/internal/misc/edgeConfig/edgeConfigStore.ts
@@ -53,12 +53,13 @@ const getEdgeConfigOverride = (): Record<string, unknown> | null => {
 
 /**
  * Factory that creates a typed, poll-based edge config backed by S3.
- * Fail-open: any S3 error resets the in-memory config to `defaultValue()`.
+ * Defaults to fail-open; stores may retain their last valid config on errors.
  */
 export const createEdgeConfigStore = <T>({
 	s3Key,
 	schema,
 	defaultValue,
+	retainOnError = false,
 	pollIntervalMs = process.env.NODE_ENV === "development"
 		? ms.seconds(1)
 		: ms.seconds(10),
@@ -67,6 +68,7 @@ export const createEdgeConfigStore = <T>({
 	s3Key: string;
 	schema: z.ZodType<T>;
 	defaultValue: () => T;
+	retainOnError?: boolean;
 	pollIntervalMs?: number;
 	s3Client?: S3Client;
 }) => {
@@ -223,7 +225,7 @@ export const createEdgeConfigStore = <T>({
 			const previouslyHealthy = runtimeStatus.healthy;
 			const sameError = runtimeStatus.error === errMsg;
 
-			runtimeConfig = defaultValue();
+			if (!retainOnError) runtimeConfig = defaultValue();
 			runtimeStatus = {
 				configured: true,
 				healthy: false,

--- a/server/tests/unit/balances/track/handle-track.test.ts
+++ b/server/tests/unit/balances/track/handle-track.test.ts
@@ -3,6 +3,7 @@ import { ApiVersionClass, AppEnv, LATEST_VERSION } from "@autumn/shared";
 import type { SQSClient } from "@aws-sdk/client-sqs";
 import { Hono } from "hono";
 import type { AutumnContext, HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { _setAsyncTrackConfigForTesting } from "@/internal/misc/asyncTrack/asyncTrackStore.js";
 import { getSqsClient } from "@/queue/initSqs.js";
 
 const trackAsyncQueueUrl =
@@ -15,10 +16,13 @@ const mockState = {
 
 import { handleTrack } from "@/internal/balances/handlers/handleTrack.js";
 
-const createCtx = ({ orgSlug = "test-org" } = {}): AutumnContext =>
+const createCtx = ({
+	orgId = "org_123",
+	orgSlug = "test-org",
+} = {}): AutumnContext =>
 	({
 		id: "req_track_1",
-		org: { id: "org_123", slug: orgSlug },
+		org: { id: orgId, slug: orgSlug },
 		env: AppEnv.Sandbox,
 		apiVersion: new ApiVersionClass(LATEST_VERSION),
 		features: [{ id: "messages" }],
@@ -48,6 +52,7 @@ describe("handleTrack", () => {
 
 	beforeEach(() => {
 		mockState.queueCommands = [];
+		_setAsyncTrackConfigForTesting({ config: { enabledOrgIds: [] } });
 		process.env.TRACK_ASYNC_SQS_QUEUE_URL = trackAsyncQueueUrl;
 		const sqsClient = getSqsClient({ queueUrl: trackAsyncQueueUrl });
 		mockState.originalSend = sqsClient.send.bind(sqsClient);
@@ -91,9 +96,13 @@ describe("handleTrack", () => {
 		});
 	});
 
-	test("returns 202 success for Firecrawl track", async () => {
+	test("returns 202 success for configured org slug", async () => {
+		_setAsyncTrackConfigForTesting({
+			config: { enabledOrgIds: ["configured-slug"] },
+		});
+
 		const response = await createApp({
-			ctx: createCtx({ orgSlug: "firecrawl" }),
+			ctx: createCtx({ orgSlug: "configured-slug" }),
 		}).request("/track", {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
@@ -110,6 +119,27 @@ describe("handleTrack", () => {
 			value: 1,
 			balance: null,
 		});
+		expect(mockState.queueCommands).toHaveLength(1);
+	});
+
+	test("returns 202 success for configured org ID", async () => {
+		_setAsyncTrackConfigForTesting({
+			config: { enabledOrgIds: ["org_async"] },
+		});
+
+		const response = await createApp({
+			ctx: createCtx({ orgId: "org_async" }),
+		}).request("/track", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				customer_id: "cus_123",
+				feature_id: "messages",
+				value: 1,
+			}),
+		});
+
+		expect(response.status).toBe(202);
 		expect(mockState.queueCommands).toHaveLength(1);
 	});
 });

--- a/server/tests/unit/edge-config/async-track-config.test.ts
+++ b/server/tests/unit/edge-config/async-track-config.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { AsyncTrackConfigSchema } from "@/internal/misc/asyncTrack/asyncTrackSchemas.js";
+import {
+	_setAsyncTrackConfigForTesting,
+	isAsyncTrackEnabled,
+} from "@/internal/misc/asyncTrack/asyncTrackStore.js";
+
+afterEach(() => {
+	_setAsyncTrackConfigForTesting({ config: { enabledOrgIds: [] } });
+});
+
+describe("async track config", () => {
+	test("defaults to no enabled orgs", () => {
+		expect(AsyncTrackConfigSchema.parse({}).enabledOrgIds).toEqual([]);
+	});
+
+	test("matches either org ID or slug", () => {
+		_setAsyncTrackConfigForTesting({
+			config: { enabledOrgIds: ["org_async", "configured-slug"] },
+		});
+
+		expect(isAsyncTrackEnabled({ orgId: "org_async" })).toBe(true);
+		expect(
+			isAsyncTrackEnabled({
+				orgId: "org_other",
+				orgSlug: "configured-slug",
+			}),
+		).toBe(true);
+		expect(isAsyncTrackEnabled({ orgId: "org_other" })).toBe(false);
+	});
+});

--- a/server/tests/unit/edge-config/edge-config-store.test.ts
+++ b/server/tests/unit/edge-config/edge-config-store.test.ts
@@ -248,6 +248,32 @@ describe("createEdgeConfigStore", () => {
 			expect(store.get().message).toBe("second");
 			expect(store.get().enabled).toBe(true);
 		});
+
+		test("retains cached config on refresh error when configured", async () => {
+			let callCount = 0;
+			const mockClient = createMockS3Client({
+				getResponse: () => {
+					if (callCount++ === 0) {
+						return makeBody({ enabled: true, message: "cached" });
+					}
+					throw new Error("NetworkingError");
+				},
+			});
+
+			store = createEdgeConfigStore<TestConfig>({
+				s3Key: "admin/test-config.json",
+				schema: TestConfigSchema,
+				defaultValue: defaultConfig,
+				retainOnError: true,
+				s3Client: mockClient,
+			});
+
+			await store.startPolling();
+			await store.refresh();
+
+			expect(store.get()).toEqual({ enabled: true, message: "cached" });
+			expect(store.getStatus().healthy).toBe(false);
+		});
 	});
 
 	describe("writeToSource", () => {

--- a/vite/src/views/admin/components/AsyncTrackDialog.tsx
+++ b/vite/src/views/admin/components/AsyncTrackDialog.tsx
@@ -1,0 +1,78 @@
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+	Skeleton,
+} from "@autumn/ui";
+import { useQuery } from "@tanstack/react-query";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import {
+	ASYNC_TRACK_DEFAULT_CONFIG,
+	ASYNC_TRACK_QUERY_KEY,
+	type AsyncTrackConfig,
+} from "./asyncTrackConfigTypes";
+import { EdgeConfigDialogBody } from "./EdgeConfigDialogBody";
+import { OrgAllowlistEdgeConfigForm } from "./OrgAllowlistEdgeConfigForm";
+
+export function AsyncTrackDialog({
+	open,
+	onOpenChange,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const axiosInstance = useAxiosInstance();
+	const configQuery = useQuery<AsyncTrackConfig>({
+		queryKey: ASYNC_TRACK_QUERY_KEY,
+		queryFn: async () => {
+			const { data } = await axiosInstance.get<AsyncTrackConfig>(
+				"/admin/async-track-config",
+			);
+			return { ...ASYNC_TRACK_DEFAULT_CONFIG, ...data };
+		},
+		enabled: open,
+	});
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-5xl bg-card">
+				<DialogHeader>
+					<DialogTitle className="text-balance">Async Track</DialogTitle>
+					<DialogDescription className="text-pretty">
+						Choose which orgs enqueue Track requests for background processing.
+					</DialogDescription>
+				</DialogHeader>
+
+				<EdgeConfigDialogBody
+					query={configQuery}
+					errorMessage="Failed to load async Track config"
+					skeleton={
+						<div className="grid gap-6 lg:grid-cols-[320px_1fr]">
+							<Skeleton className="h-64" />
+							<Skeleton className="h-64" />
+						</div>
+					}
+				>
+					{(config) => (
+						<OrgAllowlistEdgeConfigForm
+							key={config.lastSuccessAt ?? "never"}
+							config={config}
+							onClose={() => onOpenChange(false)}
+							endpoint="/admin/async-track-config"
+							queryKey={ASYNC_TRACK_QUERY_KEY}
+							successMessage="Async Track config saved"
+							errorMessage="Failed to save async Track config"
+							enabledDescription="Listed org IDs or slugs enqueue Track requests. Everyone else processes them synchronously."
+							emptyMessage="No orgs enabled — every Track request is processed synchronously unless it sets async."
+							missingConfigMessage="Async Track config is missing in S3, so no org is enabled by default."
+							healthyConfigMessage="Saved changes reach all servers within 10 seconds."
+							orgPlaceholder="Org ID or slug"
+						/>
+					)}
+				</EdgeConfigDialogBody>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/vite/src/views/admin/components/EdgeConfigTab.tsx
+++ b/vite/src/views/admin/components/EdgeConfigTab.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { AsyncBalanceUpdateDialog } from "./AsyncBalanceUpdateDialog";
+import { AsyncTrackDialog } from "./AsyncTrackDialog";
 import { CacheV2RampDialog } from "./CacheV2RampDialog";
 import { CustomerBlockDialog } from "./CustomerBlockDialog";
 import { EdgeConfigCard } from "./EdgeConfigCard";
@@ -108,6 +109,11 @@ export function EdgeConfigTab() {
 
 			<AsyncBalanceUpdateDialog
 				open={openConfig === "async-balance-update"}
+				onOpenChange={closeDialog}
+			/>
+
+			<AsyncTrackDialog
+				open={openConfig === "async-track"}
 				onOpenChange={closeDialog}
 			/>
 

--- a/vite/src/views/admin/components/asyncTrackConfigTypes.ts
+++ b/vite/src/views/admin/components/asyncTrackConfigTypes.ts
@@ -1,0 +1,15 @@
+import {
+	ORG_ALLOWLIST_DEFAULT_CONFIG,
+	type OrgAllowlistEdgeConfig,
+} from "./orgAllowlistEdgeConfigTypes";
+
+export type AsyncTrackConfig = OrgAllowlistEdgeConfig;
+
+export const ASYNC_TRACK_DEFAULT_CONFIG: AsyncTrackConfig = {
+	...ORG_ALLOWLIST_DEFAULT_CONFIG,
+};
+
+export const ASYNC_TRACK_QUERY_KEY = [
+	"admin-edge-config",
+	"async-track",
+] as const;

--- a/vite/src/views/admin/components/edgeConfigCards.ts
+++ b/vite/src/views/admin/components/edgeConfigCards.ts
@@ -28,6 +28,7 @@ export type EdgeConfigStatus = {
 export type EdgeConfigCardId =
 	| "feature-flags"
 	| "async-balance-update"
+	| "async-track"
 	| "request-block"
 	| "customer-block"
 	| "org-limits"
@@ -282,6 +283,24 @@ export const EDGE_CONFIG_SECTIONS: EdgeConfigSectionDef[] = [
 					"Enqueue balances.update calls for background processing by org.",
 				icon: Clock,
 				endpoint: "/admin/async-balance-update-config",
+				deriveStatus: (data) => {
+					const ids = asRecord(data).enabledOrgIds;
+					const count = Array.isArray(ids) ? ids.length : 0;
+
+					return count === 0
+						? { label: "No orgs enabled", tone: "neutral" }
+						: {
+								label: `${pluralize({ count, noun: "org" })} enabled`,
+								tone: "active",
+							};
+				},
+			},
+			{
+				id: "async-track",
+				title: "Async Track",
+				description: "Enqueue Track requests for background processing by org.",
+				icon: Waves,
+				endpoint: "/admin/async-track-config",
 				deriveStatus: (data) => {
 					const ids = asRecord(data).enabledOrgIds;
 					const count = Array.isArray(ids) ? ids.length : 0;


### PR DESCRIPTION
## Summary
- replace the Firecrawl hardcode with an S3-backed async-track organization allowlist
- match configured entries by organization ID or slug, with an empty default
- add superuser API routes and admin UI for managing the list

## Validation
- focused server unit tests: 5 passed
- server and Vite typechecks
- Biome and diff checks
- React Doctor: no changed-file issues

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables org-specific async Track processing via an S3-backed allowlist with admin endpoints and UI; replaces the Firecrawl special case. Adds safe config polling that retains the last-known allowlist on S3 errors.

- **New Features**
  - S3 edge config `admin/async-track-config.json` with `enabledOrgIds` (IDs or slugs), empty by default; retains last-known config on refresh errors.
  - Superuser API: `GET /admin/async-track-config` (config + runtime status) and `PUT /admin/async-track-config` (body: `AsyncTrackConfigSchema`).
  - Track handler queues when `async: true` or allowlisted via `isAsyncTrackEnabled({ orgId, orgSlug })`.
  - Admin UI: Edge Config tab adds an Async Track dialog to manage IDs/slugs with health/status indicators and a card showing enabled count.

<sup>Written for commit 6c535575f7bf0feefeef153bd2743fd037bc43df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Configures organization-specific asynchronous Track processing through an S3-backed allowlist.
- **[Improvements]** Adds ID-or-slug allowlist matching, retained runtime configuration during refresh failures, and focused edge-config and Track tests.
- **[API changes]** Adds superuser endpoints for reading and updating Async Track configuration.
- **[Improvements]** Adds an admin dialog and status card for managing the allowlist.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/misc/edgeConfig/edgeConfigStore.ts | Adds opt-in retention of the last valid runtime configuration when polling encounters an error. |
| server/src/internal/misc/asyncTrack/asyncTrackStore.ts | Defines and registers the S3-backed Async Track allowlist with ID-or-slug matching. |
| server/src/internal/balances/handlers/handleTrack.ts | Replaces the customer-specific asynchronous routing condition with the configured allowlist. |
| server/src/internal/admin/adminRouter.ts | Registers superuser endpoints for reading and updating Async Track configuration. |
| vite/src/views/admin/components/AsyncTrackDialog.tsx | Adds the administrative interface for viewing and editing the Async Track allowlist. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Admin as Superuser Admin
    participant API as Admin API
    participant S3 as S3 Edge Config
    participant Store as Async Track Store
    participant Track as Track Handler
    participant Queue as Async Track Queue
    Admin->>API: PUT /admin/async-track-config
    API->>S3: Write enabledOrgIds
    API->>Store: Update local runtime config
    Store->>S3: Poll configuration
    Track->>Store: Check org ID or slug
    alt Async requested or org allowlisted
        Track->>Queue: Enqueue Track request
        Track-->>Admin: 202 queued
    else Org not allowlisted
        Track->>Track: Process synchronously
    end
```
</details>

<sub>Reviews (4): Last reviewed commit: ["feat(track): configure async track organ..."](https://github.com/useautumn/autumn/commit/6c535575f7bf0feefeef153bd2743fd037bc43df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46614344)</sub>

<!-- /greptile_comment -->