### PR TITLE
feat(customers): queue failed customer creation

### DIFF
--- a/server/src/db/shed503OnTransientError.ts
+++ b/server/src/db/shed503OnTransientError.ts
@@ -7,10 +7,12 @@ export const shed503OnTransientError = async <T>({
 	ctx,
 	source,
 	run,
+	onTransientError,
 }: {
 	ctx: AutumnContext;
 	source: string;
 	run: () => T | Promise<T>;
+	onTransientError?: (error: unknown) => Promise<void>;
 }): Promise<T> => {
 	try {
 		return await run();
@@ -22,6 +24,14 @@ export const shed503OnTransientError = async <T>({
 			type: `${source}_fail_open`,
 			error,
 		});
+		try {
+			await onTransientError?.(error);
+		} catch (recoveryError) {
+			ctx.logger.error(
+				`[${source}] Failed to capture transient error for recovery`,
+				{ error: recoveryError },
+			);
+		}
 		throw new RecaseError({
 			message: "Service is temporarily unavailable, please retry shortly.",
 			code: "service_unavailable",

--- a/server/src/internal/customers/actions/createWithDefaults/createCustomerWithDefaults.ts
+++ b/server/src/internal/customers/actions/createWithDefaults/createCustomerWithDefaults.ts
@@ -9,6 +9,7 @@ import { executeStripeBillingPlan } from "@/internal/billing/v2/providers/stripe
 import { logStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingPlan.js";
 import { sendBillingUpdatedWebhook } from "@/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook.js";
 import { billingPlanToSendProductsUpdated } from "@/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated.js";
+import { setCustomerCreationRecoveryStage } from "@/internal/customers/recovery/customerCreationRecoveryStage.js";
 import { computeCreateCustomerPlan } from "./compute/computeCreateCustomerPlan.js";
 import { executeAutumnCreateCustomerPlan } from "./execute/executeAutumnCreateCustomerPlan.js";
 import { finalizeCreateCustomer } from "./finalizeCreateCustomer.js";
@@ -43,6 +44,8 @@ export const createCustomerWithDefaults = async ({
 	customerId: string | null;
 	customerData?: CustomerData;
 }): Promise<FullCustomer> => {
+	setCustomerCreationRecoveryStage({ ctx, stage: "pre_commit" });
+
 	// ============ Phase 1: Create Autumn customer ============
 
 	// 1. Setup
@@ -67,7 +70,10 @@ export const createCustomerWithDefaults = async ({
 	logAutumnPlanResult({ ctx, result: autumnResult });
 
 	// Early return if customer already existed or no paid products
-	if (autumnResult.type === "existing") return context.fullCustomer;
+	if (autumnResult.type === "existing") {
+		setCustomerCreationRecoveryStage({ ctx, stage: "completed" });
+		return context.fullCustomer;
+	}
 
 	// ============ Phase 2: Create stripe customer / attach paid defaults ============
 
@@ -94,14 +100,20 @@ export const createCustomerWithDefaults = async ({
 				customerProducts: context.fullCustomer.customer_products,
 			});
 
-		if (!shouldCreateStripeCustomer) return context.fullCustomer;
+		if (!shouldCreateStripeCustomer) {
+			setCustomerCreationRecoveryStage({ ctx, stage: "completed" });
+			return context.fullCustomer;
+		}
 
 		const billingContext = await setupCreateCustomerBillingContext({
 			ctx,
 			context,
 		});
 
-		if (!shouldAttachPaidDefaults) return context.fullCustomer;
+		if (!shouldAttachPaidDefaults) {
+			setCustomerCreationRecoveryStage({ ctx, stage: "completed" });
+			return context.fullCustomer;
+		}
 
 		// 5. Evaluate Stripe billing plan
 		const stripeBillingPlan = await evaluateStripeBillingPlan({
@@ -120,12 +132,14 @@ export const createCustomerWithDefaults = async ({
 		});
 
 		// 7. Finalize (link subscription back to Autumn)
-		return await finalizeCreateCustomer({
+		const fullCustomer = await finalizeCreateCustomer({
 			ctx,
 			context,
 			autumnBillingPlan,
 			stripeSubscription,
 		});
+		setCustomerCreationRecoveryStage({ ctx, stage: "completed" });
+		return fullCustomer;
 	} finally {
 		await billingPlanToSendProductsUpdated({
 			ctx,

--- a/server/src/internal/customers/actions/createWithDefaults/execute/executeAutumnCreateCustomerPlan.ts
+++ b/server/src/internal/customers/actions/createWithDefaults/execute/executeAutumnCreateCustomerPlan.ts
@@ -6,6 +6,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { executeAutumnBillingPlan } from "@/internal/billing/v2/execute/executeAutumnBillingPlan.js";
 import type { CreateCustomerContext } from "@/internal/customers/actions/createWithDefaults/createCustomerContext.js";
 import { syncAutoTopupPurchaseLimitCounts } from "@/internal/customers/actions/update/syncAutoTopupPurchaseLimitCounts.js";
+import { setCustomerCreationRecoveryStage } from "@/internal/customers/recovery/customerCreationRecoveryStage.js";
 import { captureOrgEvent } from "@/utils/posthog.js";
 import { CusService } from "../../../CusService.js";
 
@@ -70,6 +71,7 @@ export const executeAutumnCreateCustomerPlan = async ({
 			logger.info(
 				`Customer already exists, returning existing: ${fullCustomer.id || fullCustomer.email}`,
 			);
+			setCustomerCreationRecoveryStage({ ctx, stage: "existing" });
 			const existingCustomer = await CusService.getFull({
 				ctx,
 				idOrInternalId: fullCustomer.id || fullCustomer.internal_id,
@@ -87,6 +89,7 @@ export const executeAutumnCreateCustomerPlan = async ({
 		logger.info(
 			`Customer already exists (claimed or existing): ${fullCustomer.id || fullCustomer.internal_id}`,
 		);
+		setCustomerCreationRecoveryStage({ ctx, stage: "existing" });
 		const existingCustomer = await CusService.getFull({
 			ctx,
 			idOrInternalId: fullCustomer.internal_id,
@@ -97,6 +100,8 @@ export const executeAutumnCreateCustomerPlan = async ({
 		context.fullCustomer = existingCustomer;
 		return { type: "existing" };
 	}
+
+	setCustomerCreationRecoveryStage({ ctx, stage: "autumn_committed" });
 
 	if (ctx.authType === AuthType.SecretKey) {
 		await captureOrgEvent({

--- a/server/src/internal/customers/actions/getOrCreateApiCustomerByRollout.ts
+++ b/server/src/internal/customers/actions/getOrCreateApiCustomerByRollout.ts
@@ -2,6 +2,11 @@ import type { CheckParams, TrackParams } from "@autumn/shared";
 import { shed503OnTransientError } from "@/db/shed503OnTransientError.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getOrCreateCachedFullSubject } from "@/internal/customers/cache/fullSubject/index.js";
+import {
+	getCustomerCreationRecoveryStage,
+	setCustomerCreationRecoveryStage,
+} from "@/internal/customers/recovery/customerCreationRecoveryStage.js";
+import { queueFailedCustomerCreation } from "@/internal/customers/recovery/queueFailedCustomerCreation.js";
 import { isFullSubjectRolloutEnabled } from "@/internal/misc/rollouts/fullSubjectRolloutUtils.js";
 import { getApiCustomer } from "../cusUtils/apiCusUtils/getApiCustomer.js";
 import { getOrCreateCachedFullCustomer } from "../cusUtils/fullCustomerCacheUtils/getOrCreateCachedFullCustomer.js";
@@ -13,6 +18,7 @@ export const getOrCreateApiCustomerByRollout = async ({
 	params,
 	source,
 	withAutumnId,
+	enqueueRecoveryOnTransientFailure = true,
 }: {
 	ctx: AutumnContext;
 	params: Omit<TrackParams | CheckParams, "customer_id"> & {
@@ -20,7 +26,10 @@ export const getOrCreateApiCustomerByRollout = async ({
 	};
 	source?: string;
 	withAutumnId?: boolean;
+	enqueueRecoveryOnTransientFailure?: boolean;
 }) => {
+	setCustomerCreationRecoveryStage({ ctx, stage: "lookup" });
+
 	let fullSubject:
 		| Awaited<ReturnType<typeof getOrCreateCachedFullSubject>>
 		| undefined;
@@ -33,6 +42,17 @@ export const getOrCreateApiCustomerByRollout = async ({
 			ctx,
 			source: "get_or_create",
 			run: () => getOrCreateCachedFullSubject({ ctx, params, source }),
+			onTransientError: enqueueRecoveryOnTransientFailure
+				? async () => {
+						await queueFailedCustomerCreation({
+							ctx,
+							params,
+							source,
+							withAutumnId,
+							failureStage: getCustomerCreationRecoveryStage({ ctx }),
+						});
+					}
+				: undefined,
 		});
 	} else {
 		fullCustomer = await getOrCreateCachedFullCustomer({

--- a/server/src/internal/customers/recovery/customerCreationRecoveryStage.ts
+++ b/server/src/internal/customers/recovery/customerCreationRecoveryStage.ts
@@ -1,0 +1,34 @@
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type { CustomerCreationRecoveryStage } from "./customerCreationRecoveryTypes.js";
+
+const CUSTOMER_CREATION_RECOVERY_STAGE_KEY = "customerCreationRecoveryStage";
+
+const RECOVERY_STAGES = new Set<CustomerCreationRecoveryStage>([
+	"lookup",
+	"pre_commit",
+	"existing",
+	"autumn_committed",
+	"completed",
+]);
+
+export const setCustomerCreationRecoveryStage = ({
+	ctx,
+	stage,
+}: {
+	ctx: AutumnContext;
+	stage: CustomerCreationRecoveryStage;
+}) => {
+	ctx.extraLogs[CUSTOMER_CREATION_RECOVERY_STAGE_KEY] = stage;
+};
+
+export const getCustomerCreationRecoveryStage = ({
+	ctx,
+}: {
+	ctx: AutumnContext;
+}): CustomerCreationRecoveryStage => {
+	const stage = ctx.extraLogs[CUSTOMER_CREATION_RECOVERY_STAGE_KEY];
+	return typeof stage === "string" &&
+		RECOVERY_STAGES.has(stage as CustomerCreationRecoveryStage)
+		? (stage as CustomerCreationRecoveryStage)
+		: "lookup";
+};

--- a/server/src/internal/customers/recovery/customerCreationRecoveryTypes.ts
+++ b/server/src/internal/customers/recovery/customerCreationRecoveryTypes.ts
@@ -1,0 +1,33 @@
+import type {
+	ApiVersion,
+	AppEnv,
+	CheckParams,
+	TrackParams,
+} from "@autumn/shared";
+
+export type CustomerCreationRecoveryStage =
+	| "lookup"
+	| "pre_commit"
+	| "existing"
+	| "autumn_committed"
+	| "completed";
+
+export type CustomerCreationRecoveryParams = Omit<
+	TrackParams | CheckParams,
+	"customer_id"
+> & {
+	customer_id: string | null;
+};
+
+export interface CustomerCreationRecoveryPayload {
+	orgId: string;
+	env: AppEnv;
+	customerId?: string;
+	requestId: string;
+	apiVersion: ApiVersion;
+	params: CustomerCreationRecoveryParams;
+	source?: string;
+	withAutumnId?: boolean;
+	failureStage: CustomerCreationRecoveryStage;
+	failedAt: number;
+}

--- a/server/src/internal/customers/recovery/queueFailedCustomerCreation.ts
+++ b/server/src/internal/customers/recovery/queueFailedCustomerCreation.ts
@@ -1,0 +1,92 @@
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { JobName } from "@/queue/JobName.js";
+import { addTaskToQueue } from "@/queue/queueUtils.js";
+import type {
+	CustomerCreationRecoveryParams,
+	CustomerCreationRecoveryStage,
+} from "./customerCreationRecoveryTypes.js";
+
+export const CUSTOMER_CREATION_RECOVERY_MESSAGE_GROUP_ID =
+	"customer-creation-recovery";
+
+const getDeduplicationId = ({
+	ctx,
+	params,
+	withAutumnId,
+	failureStage,
+}: {
+	ctx: AutumnContext;
+	params: CustomerCreationRecoveryParams;
+	withAutumnId?: boolean;
+	failureStage: CustomerCreationRecoveryStage;
+}) =>
+	`customer-creation-${Bun.hash(
+		JSON.stringify({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			apiVersion: ctx.apiVersion.value,
+			params,
+			withAutumnId,
+			failureStage,
+		}),
+	).toString(16)}`;
+
+export const queueFailedCustomerCreation = async ({
+	ctx,
+	params,
+	source,
+	withAutumnId,
+	failureStage,
+}: {
+	ctx: AutumnContext;
+	params: CustomerCreationRecoveryParams;
+	source?: string;
+	withAutumnId?: boolean;
+	failureStage: CustomerCreationRecoveryStage;
+}): Promise<boolean> => {
+	const queueUrl = process.env.CUSTOMER_CREATION_RECOVERY_SQS_QUEUE_URL;
+	if (!queueUrl) {
+		ctx.logger.error(
+			"[customerCreationRecovery] Recovery queue URL is not configured",
+		);
+		return false;
+	}
+
+	try {
+		await addTaskToQueue({
+			jobName: JobName.CustomerCreationRecovery,
+			queueUrl,
+			messageGroupId: CUSTOMER_CREATION_RECOVERY_MESSAGE_GROUP_ID,
+			messageDeduplicationId: getDeduplicationId({
+				ctx,
+				params,
+				withAutumnId,
+				failureStage,
+			}),
+			generateDeduplicationId: false,
+			payload: {
+				orgId: ctx.org.id,
+				env: ctx.env,
+				customerId: params.customer_id ?? undefined,
+				requestId: ctx.id,
+				apiVersion: ctx.apiVersion.value,
+				params,
+				source,
+				withAutumnId,
+				failureStage,
+				failedAt: Date.now(),
+			},
+		});
+		ctx.extraLogs.customerCreationRecoveryQueued = {
+			failureStage,
+			queueUrl,
+		};
+		return true;
+	} catch (error) {
+		ctx.logger.error(
+			"[customerCreationRecovery] Failed to enqueue customer creation recovery",
+			{ error, failureStage },
+		);
+		return false;
+	}
+};

--- a/server/src/internal/customers/recovery/queueRateLimitedCustomerCreation.ts
+++ b/server/src/internal/customers/recovery/queueRateLimitedCustomerCreation.ts
@@ -1,0 +1,73 @@
+import {
+	CreateCustomerParamsV0Schema,
+	CreateCustomerParamsV1Schema,
+	CustomerDataSchema,
+} from "@autumn/shared";
+import type { Context } from "hono";
+import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { queueFailedCustomerCreation } from "./queueFailedCustomerCreation.js";
+
+const GET_OR_CREATE_PATH = "/v1/customers.get_or_create";
+const LEGACY_CREATE_PATH = "/v1/customers";
+
+const getWithAutumnIdFromQuery = ({ c }: { c: Context<HonoEnv> }) => {
+	const value = c.req.query("with_autumn_id");
+	return value === "true" || value === "1";
+};
+
+export const queueRateLimitedCustomerCreation = async ({
+	c,
+}: {
+	c: Context<HonoEnv>;
+}): Promise<boolean> => {
+	const path = c.req.path;
+	if (c.req.method !== "POST") return false;
+	if (path !== GET_OR_CREATE_PATH && path !== LEGACY_CREATE_PATH) return false;
+
+	const ctx = c.get("ctx");
+
+	try {
+		const body = await c.req.raw.clone().json();
+		if (path === GET_OR_CREATE_PATH) {
+			const parsed = CreateCustomerParamsV1Schema.safeParse(body);
+			if (!parsed.success) return false;
+			if (!parsed.data.customer_id && !parsed.data.email) return false;
+
+			return await queueFailedCustomerCreation({
+				ctx,
+				params: {
+					customer_id: parsed.data.customer_id,
+					customer_data: CustomerDataSchema.parse(parsed.data),
+					entity_id: parsed.data.entity_id,
+					entity_data: parsed.data.entity_data,
+				},
+				source: "rateLimit:customers.get_or_create",
+				withAutumnId: parsed.data.with_autumn_id,
+				failureStage: "lookup",
+			});
+		}
+
+		const parsed = CreateCustomerParamsV0Schema.safeParse(body);
+		if (!parsed.success) return false;
+		if (!parsed.data.id && !parsed.data.email) return false;
+
+		return await queueFailedCustomerCreation({
+			ctx,
+			params: {
+				customer_id: parsed.data.id,
+				customer_data: CustomerDataSchema.parse(parsed.data),
+				entity_id: parsed.data.entity_id,
+				entity_data: parsed.data.entity_data,
+			},
+			source: "rateLimit:customers",
+			withAutumnId: getWithAutumnIdFromQuery({ c }),
+			failureStage: "lookup",
+		});
+	} catch (error) {
+		ctx.logger.error(
+			"[customerCreationRecovery] Failed to capture rate-limited request",
+			{ error },
+		);
+		return false;
+	}
+};

--- a/server/src/internal/customers/recovery/replayFailedCustomerCreation.ts
+++ b/server/src/internal/customers/recovery/replayFailedCustomerCreation.ts
@@ -1,0 +1,41 @@
+import { ApiVersionClass } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { getOrCreateApiCustomerByRollout } from "@/internal/customers/actions/getOrCreateApiCustomerByRollout.js";
+import type { CustomerCreationRecoveryPayload } from "./customerCreationRecoveryTypes.js";
+
+export const replayFailedCustomerCreation = async ({
+	ctx,
+	payload,
+}: {
+	ctx: AutumnContext;
+	payload: CustomerCreationRecoveryPayload;
+}) => {
+	if (payload.failureStage === "autumn_committed") {
+		throw new Error(
+			`Customer creation recovery ${payload.requestId} requires manual billing review`,
+		);
+	}
+
+	ctx.apiVersion = new ApiVersionClass(payload.apiVersion);
+
+	await getOrCreateApiCustomerByRollout({
+		ctx,
+		params: payload.params,
+		source: "customerCreationRecovery",
+		withAutumnId: payload.withAutumnId,
+		enqueueRecoveryOnTransientFailure: false,
+	});
+
+	const outcome =
+		ctx.extraLogs.autumnPlanResult === "created" ? "created" : "fetched";
+	ctx.extraLogs.customerCreationRecoveryReplay = {
+		outcome,
+		sourceRequestId: payload.requestId,
+		failureStage: payload.failureStage,
+	};
+	ctx.logger.info("[customerCreationRecovery] Replay completed", {
+		outcome,
+		sourceRequestId: payload.requestId,
+		failureStage: payload.failureStage,
+	});
+};

--- a/server/src/internal/misc/jobQueues/jobQueueStore.ts
+++ b/server/src/internal/misc/jobQueues/jobQueueStore.ts
@@ -10,6 +10,7 @@ export const JOB_QUEUE_IDS = {
 	primary: "primary",
 	track: "track",
 	trackAsync: "trackAsync",
+	customerCreationRecovery: "customerCreationRecovery",
 } as const;
 
 export const KNOWN_JOB_QUEUES = [
@@ -31,6 +32,13 @@ export const KNOWN_JOB_QUEUES = [
 		label: "Track Async Queue",
 		description: "Customer-driven async / batch track ingest.",
 		defaultEnabled: true,
+	},
+	{
+		id: JOB_QUEUE_IDS.customerCreationRecovery,
+		label: "Customer Creation Recovery Queue",
+		description:
+			"Serialized replay queue for transient customer get-or-create failures.",
+		defaultEnabled: false,
 	},
 ] as const;
 

--- a/server/src/internal/misc/rateLimiter/rateLimitFactory.ts
+++ b/server/src/internal/misc/rateLimiter/rateLimitFactory.ts
@@ -4,6 +4,7 @@ import { rateLimiter } from "hono-rate-limiter";
 import { logger } from "@/external/logtail/logtailUtils.js";
 import { shouldUseRedis } from "@/external/redis/initRedis";
 import type { HonoEnv } from "@/honoUtils/HonoEnv";
+import { queueRateLimitedCustomerCreation } from "@/internal/customers/recovery/queueRateLimitedCustomerCreation.js";
 import {
 	isCheckFailOpenRoute,
 	RATE_LIMIT_CONFIGS,
@@ -93,6 +94,7 @@ export const rateLimitFactory = ({
 		warnOrgCapExceeded({ limitType: type, orgSlug: ctx?.org?.slug });
 
 		if (type === RateLimitType.CheckOrg && !isCheckFailOpenRoute(honoContext)) {
+			await queueRateLimitedCustomerCreation({ c: honoContext });
 			return c.json(
 				{
 					message: "Service is temporarily unavailable, please retry shortly.",

--- a/server/src/queue/JobName.ts
+++ b/server/src/queue/JobName.ts
@@ -22,6 +22,7 @@ export enum JobName {
 	RefreshEntityAggregate = "refresh-entity-aggregate",
 	InsertEventBatch = "insert-event-batch",
 	Track = "track",
+	CustomerCreationRecovery = "customer-creation-recovery",
 
 	ClearCreditSystemCustomerCache = "clear-credit-system-customer-cache",
 

--- a/server/src/queue/blueGreen/blueGreenReadinessChecks.ts
+++ b/server/src/queue/blueGreen/blueGreenReadinessChecks.ts
@@ -45,6 +45,7 @@ const getConfiguredQueueUrls = () =>
 		QUEUE_URL,
 		process.env.TRACK_SQS_QUEUE_URL,
 		process.env.TRACK_ASYNC_SQS_QUEUE_URL,
+		process.env.CUSTOMER_CREATION_RECOVERY_SQS_QUEUE_URL,
 	].filter((url): url is string => Boolean(url));
 
 export const getBlueGreenQueueUrls = ({
@@ -61,8 +62,7 @@ export const getBlueGreenQueueUrls = ({
 // the SDK falls back to (the queue URL's host).
 const sqsClientsByRegion = new Map<string, SQSClient>();
 const getSqsClientForQueue = (queueUrl: string): SQSClient => {
-	const region =
-		extractRegionFromQueueUrl({ queueUrl }) ?? DEFAULT_AWS_REGION;
+	const region = extractRegionFromQueueUrl({ queueUrl }) ?? DEFAULT_AWS_REGION;
 	const cached = sqsClientsByRegion.get(region);
 	if (cached) return cached;
 	const client = new SQSClient({ region });

--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -459,18 +459,26 @@ export const initWorkers = async ({
 	);
 	const pollingLoops = [];
 
-	for (const { queueId, queueUrl } of [
+	for (const { queueId, queueUrl, defaultEnabled } of [
 		{
 			queueId: JOB_QUEUE_IDS.primary,
 			queueUrl: QUEUE_URL,
+			defaultEnabled: true,
 		},
 		{
 			queueId: JOB_QUEUE_IDS.track,
 			queueUrl: process.env.TRACK_SQS_QUEUE_URL,
+			defaultEnabled: true,
 		},
 		{
 			queueId: JOB_QUEUE_IDS.trackAsync,
 			queueUrl: process.env.TRACK_ASYNC_SQS_QUEUE_URL,
+			defaultEnabled: true,
+		},
+		{
+			queueId: JOB_QUEUE_IDS.customerCreationRecovery,
+			queueUrl: process.env.CUSTOMER_CREATION_RECOVERY_SQS_QUEUE_URL,
+			defaultEnabled: false,
 		},
 	]) {
 		if (!queueUrl) continue;
@@ -483,7 +491,7 @@ export const initWorkers = async ({
 				getSqsClientFn: () => getSqsClient({ queueUrl }),
 				recreateSqsClientFn: () => recreateSqsClient({ queueUrl }),
 				shouldPoll: () =>
-					isJobQueueEnabled({ queue: queueId }) &&
+					isJobQueueEnabled({ queue: queueId, defaultEnabled }) &&
 					isActiveSlot({ serviceName: "workers" }),
 			}),
 		);

--- a/server/src/queue/processMessage.ts
+++ b/server/src/queue/processMessage.ts
@@ -20,6 +20,7 @@ import { sendProductsUpdated } from "@/internal/billing/v2/workflows/sendProduct
 import { storeDeferredInvoiceLineItems } from "@/internal/billing/v2/workflows/storeDeferredInvoiceLineItems/storeDeferredInvoiceLineItems.js";
 import { storeInvoiceLineItems } from "@/internal/billing/v2/workflows/storeInvoiceLineItems/storeInvoiceLineItems.js";
 import { batchResetCustomerEntitlements } from "@/internal/customers/actions/resetCustomerEntitlements/batchResetCustomerEntitlements.js";
+import { replayFailedCustomerCreation } from "@/internal/customers/recovery/replayFailedCustomerCreation.js";
 import { runClearCreditSystemCacheTask } from "@/internal/features/featureActions/runClearCreditSystemCacheTask.js";
 import { generateFeatureDisplay } from "@/internal/features/workflows/generateFeatureDisplay.js";
 import { runMigrationTask } from "@/internal/migrations/runMigrationTask.js";
@@ -53,6 +54,8 @@ export const shouldRetrySqsJobError = ({
 	error: unknown;
 }) => {
 	switch (jobName) {
+		case JobName.CustomerCreationRecovery:
+			return true;
 		case JobName.SyncBalanceBatchV3:
 		case JobName.SyncBalanceBatchV4:
 		case JobName.RefreshEntityAggregate:
@@ -143,6 +146,17 @@ export const processMessage = async ({
 				return;
 			}
 			await runMigrationTask({ ctx, payload: job.data });
+			return;
+		}
+
+		if (job.name === JobName.CustomerCreationRecovery) {
+			if (!ctx) {
+				throw new Error("No context found for customer creation recovery job");
+			}
+			await replayFailedCustomerCreation({
+				ctx,
+				payload: job.data,
+			});
 			return;
 		}
 

--- a/server/src/queue/queueUtils.ts
+++ b/server/src/queue/queueUtils.ts
@@ -11,6 +11,7 @@ import {
 	SendMessageCommand,
 } from "@aws-sdk/client-sqs";
 import { generateId } from "@server/utils/genUtils";
+import type { CustomerCreationRecoveryPayload } from "@/internal/customers/recovery/customerCreationRecoveryTypes.js";
 import type { ClearCreditSystemCachePayload } from "@/internal/features/featureActions/runClearCreditSystemCacheTask.js";
 import type { GenerateFeatureDisplayPayload } from "@/internal/features/workflows/generateFeatureDisplay.js";
 import { getSqsClient } from "./initSqs.js";
@@ -79,6 +80,7 @@ export interface Payloads {
 		apiVersion: ApiVersion;
 		body: TrackParams;
 	};
+	[JobName.CustomerCreationRecovery]: CustomerCreationRecoveryPayload;
 	[JobName.ClearCreditSystemCustomerCache]: ClearCreditSystemCachePayload;
 	[JobName.GenerateFeatureDisplay]: GenerateFeatureDisplayPayload;
 	[JobName.SendProductsUpdated]: SendProductsUpdatedPayload;

--- a/server/tests/unit/customers/recovery/get-or-create-recovery-capture.test.ts
+++ b/server/tests/unit/customers/recovery/get-or-create-recovery-capture.test.ts
@@ -1,0 +1,135 @@
+/**
+ * TDD contract for wiring customer get-or-create overload failures to recovery.
+ *
+ * Contract under test:
+ * - A transient FullSubject failure is still returned as the existing overload 503.
+ * - The validated request is captured once with the execution stage at failure.
+ * - Recovery workers can explicitly disable capture to prevent recursive enqueue.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ApiVersion, ApiVersionClass, AppEnv } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+const transientError = Object.assign(new Error("connect timeout"), {
+	code: "CONNECT_TIMEOUT",
+});
+
+const mockState = {
+	queueCalls: [] as Record<string, unknown>[],
+};
+
+mock.module("@/internal/misc/rollouts/fullSubjectRolloutUtils.js", () => ({
+	isFullSubjectRolloutEnabled: () => true,
+}));
+
+mock.module("@/internal/customers/cache/fullSubject/index.js", () => ({
+	getOrCreateCachedFullSubject: async () => {
+		throw transientError;
+	},
+}));
+
+mock.module(
+	"@/internal/customers/recovery/queueFailedCustomerCreation.js",
+	() => ({
+		queueFailedCustomerCreation: async (args: Record<string, unknown>) => {
+			mockState.queueCalls.push(args);
+			return true;
+		},
+	}),
+);
+
+mock.module(
+	"@/internal/customers/actions/ensureStripeCustomerFromCustomerData.js",
+	() => ({
+		ensureStripeCustomerFromCustomerData: async () => {},
+	}),
+);
+
+mock.module(
+	"@/internal/customers/cusUtils/apiCusUtils/getApiCustomer.js",
+	() => ({
+		getApiCustomer: () => ({ id: "legacy" }),
+	}),
+);
+
+mock.module(
+	"@/internal/customers/cusUtils/fullCustomerCacheUtils/getOrCreateCachedFullCustomer.js",
+	() => ({
+		getOrCreateCachedFullCustomer: async () => ({ id: "legacy" }),
+	}),
+);
+
+mock.module("@/internal/customers/cusUtils/getApiCustomerV2/index.js", () => ({
+	getApiCustomerV2: () => ({ id: "v2" }),
+}));
+
+const { getOrCreateApiCustomerByRollout } = await import(
+	// @ts-expect-error - Bun test cache-busting import query isolates module mocks.
+	"@/internal/customers/actions/getOrCreateApiCustomerByRollout.js?customerCreationCapture"
+);
+
+const buildContext = () =>
+	({
+		id: "req_customer_123",
+		org: { id: "org_123" },
+		env: AppEnv.Live,
+		apiVersion: new ApiVersionClass(ApiVersion.V2_1),
+		extraLogs: {},
+		logger: {
+			warn: mock(() => {}),
+			error: mock(() => {}),
+		},
+	}) as unknown as AutumnContext;
+
+const params = {
+	customer_id: "customer_123",
+	customer_data: { email: "customer@example.com" },
+};
+
+describe("getOrCreateApiCustomerByRollout recovery capture", () => {
+	beforeEach(() => {
+		mockState.queueCalls = [];
+	});
+
+	test("captures the validated request while preserving overload response semantics", async () => {
+		const ctx = buildContext();
+
+		await expect(
+			getOrCreateApiCustomerByRollout({
+				ctx,
+				params,
+				source: "handleGetOrCreateCustomerV2",
+				withAutumnId: true,
+			}),
+		).rejects.toMatchObject({
+			statusCode: 503,
+			data: { reason: "critical_db_saturated" },
+		});
+
+		expect(mockState.queueCalls).toEqual([
+			expect.objectContaining({
+				ctx,
+				params,
+				source: "handleGetOrCreateCustomerV2",
+				withAutumnId: true,
+				failureStage: "lookup",
+			}),
+		]);
+	});
+
+	test("does not recursively capture a recovery replay", async () => {
+		const ctx = buildContext();
+
+		await expect(
+			getOrCreateApiCustomerByRollout({
+				ctx,
+				params,
+				source: "customerCreationRecovery",
+				enqueueRecoveryOnTransientFailure: false,
+			}),
+		).rejects.toMatchObject({ statusCode: 503 });
+
+		expect(mockState.queueCalls).toHaveLength(0);
+	});
+});

--- a/server/tests/unit/customers/recovery/queue-failed-customer-creation.test.ts
+++ b/server/tests/unit/customers/recovery/queue-failed-customer-creation.test.ts
@@ -1,0 +1,163 @@
+/**
+ * TDD contract for durable customer get-or-create failure capture.
+ *
+ * Contract under test:
+ * - Transient failures are written to a dedicated FIFO queue without API credentials.
+ * - Payloads preserve org, environment, API version, normalized request, stage, and request ID.
+ * - Identical recovery requests share a deterministic deduplication ID.
+ * - Every message uses one global message group so replay has a hard concurrency ceiling of one.
+ * - Missing or unavailable recovery infrastructure never replaces the original API failure.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { ApiVersion, ApiVersionClass, AppEnv } from "@autumn/shared";
+import type { SQSClient } from "@aws-sdk/client-sqs";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import {
+	CUSTOMER_CREATION_RECOVERY_MESSAGE_GROUP_ID,
+	queueFailedCustomerCreation,
+} from "@/internal/customers/recovery/queueFailedCustomerCreation.js";
+import { getSqsClient } from "@/queue/initSqs.js";
+
+const recoveryQueueUrl =
+	"https://sqs.us-east-2.amazonaws.com/123456789012/customer-creation-recovery.fifo";
+
+const mockState = {
+	queueCommands: [] as Record<string, unknown>[],
+	originalSend: null as SQSClient["send"] | null,
+	shouldFailSend: false,
+};
+
+const buildContext = () =>
+	({
+		id: "req_customer_123",
+		org: { id: "org_123" },
+		env: AppEnv.Live,
+		apiVersion: new ApiVersionClass(ApiVersion.V2_1),
+		extraLogs: {},
+		logger: {
+			error: mock(() => {}),
+			warn: mock(() => {}),
+		},
+	}) as unknown as AutumnContext;
+
+const params = {
+	customer_id: "customer_123",
+	customer_data: {
+		email: "customer@example.com",
+		name: "Customer",
+	},
+	entity_id: "entity_123",
+	entity_data: {
+		name: "Entity",
+		feature_id: "seats",
+	},
+};
+
+describe("queueFailedCustomerCreation", () => {
+	const originalQueueUrl = process.env.CUSTOMER_CREATION_RECOVERY_SQS_QUEUE_URL;
+
+	beforeEach(() => {
+		mockState.queueCommands = [];
+		mockState.shouldFailSend = false;
+		process.env.CUSTOMER_CREATION_RECOVERY_SQS_QUEUE_URL = recoveryQueueUrl;
+
+		const sqsClient = getSqsClient({ queueUrl: recoveryQueueUrl });
+		mockState.originalSend = sqsClient.send.bind(sqsClient);
+		sqsClient.send = (async (command: { input: Record<string, unknown> }) => {
+			mockState.queueCommands.push(command.input);
+			if (mockState.shouldFailSend) throw new Error("SQS unavailable");
+			return {};
+		}) as typeof sqsClient.send;
+	});
+
+	afterEach(() => {
+		if (mockState.originalSend) {
+			getSqsClient({ queueUrl: recoveryQueueUrl }).send =
+				mockState.originalSend;
+		}
+		process.env.CUSTOMER_CREATION_RECOVERY_SQS_QUEUE_URL = originalQueueUrl;
+	});
+
+	test("stores a replayable, serialized request with deterministic ordering and deduplication", async () => {
+		const firstContext = buildContext();
+		const secondContext = buildContext();
+
+		const firstQueued = await queueFailedCustomerCreation({
+			ctx: firstContext,
+			params,
+			source: "handleGetOrCreateCustomerV2",
+			withAutumnId: true,
+			failureStage: "lookup",
+		});
+		const secondQueued = await queueFailedCustomerCreation({
+			ctx: secondContext,
+			params,
+			source: "handleGetOrCreateCustomerV2",
+			withAutumnId: true,
+			failureStage: "lookup",
+		});
+
+		expect(firstQueued).toBe(true);
+		expect(secondQueued).toBe(true);
+		expect(mockState.queueCommands).toHaveLength(2);
+		expect(mockState.queueCommands[0]).toMatchObject({
+			QueueUrl: recoveryQueueUrl,
+			MessageGroupId: CUSTOMER_CREATION_RECOVERY_MESSAGE_GROUP_ID,
+		});
+		expect(mockState.queueCommands[0]?.MessageDeduplicationId).toBe(
+			mockState.queueCommands[1]?.MessageDeduplicationId,
+		);
+
+		const queuedMessage = JSON.parse(
+			mockState.queueCommands[0]?.MessageBody as string,
+		);
+		expect(queuedMessage).toMatchObject({
+			name: "customer-creation-recovery",
+			data: {
+				orgId: "org_123",
+				env: AppEnv.Live,
+				customerId: "customer_123",
+				requestId: "req_customer_123",
+				apiVersion: ApiVersion.V2_1,
+				params,
+				source: "handleGetOrCreateCustomerV2",
+				withAutumnId: true,
+				failureStage: "lookup",
+			},
+		});
+		expect(JSON.stringify(queuedMessage)).not.toContain("apiKey");
+		expect(JSON.stringify(queuedMessage)).not.toContain("secretKey");
+	});
+
+	test("returns false without masking the request when the queue is not configured", async () => {
+		process.env.CUSTOMER_CREATION_RECOVERY_SQS_QUEUE_URL = undefined;
+		const ctx = buildContext();
+
+		const queued = await queueFailedCustomerCreation({
+			ctx,
+			params,
+			source: "handleGetOrCreateCustomerV2",
+			failureStage: "lookup",
+		});
+
+		expect(queued).toBe(false);
+		expect(mockState.queueCommands).toHaveLength(0);
+		expect(ctx.logger.error).toHaveBeenCalled();
+	});
+
+	test("returns false without throwing when SQS is unavailable", async () => {
+		mockState.shouldFailSend = true;
+		const ctx = buildContext();
+
+		const queued = await queueFailedCustomerCreation({
+			ctx,
+			params,
+			source: "handleGetOrCreateCustomerV2",
+			failureStage: "lookup",
+		});
+
+		expect(queued).toBe(false);
+		expect(ctx.logger.error).toHaveBeenCalled();
+	});
+});

--- a/server/tests/unit/customers/recovery/queue-rate-limited-customer-creation.test.ts
+++ b/server/tests/unit/customers/recovery/queue-rate-limited-customer-creation.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ApiVersion, ApiVersionClass, AppEnv } from "@autumn/shared";
+import { Hono } from "hono";
+import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
+
+const mockState = {
+	queueCalls: [] as Record<string, unknown>[],
+};
+
+mock.module(
+	"@/internal/customers/recovery/queueFailedCustomerCreation.js",
+	() => ({
+		queueFailedCustomerCreation: async (args: Record<string, unknown>) => {
+			mockState.queueCalls.push(args);
+			return true;
+		},
+	}),
+);
+
+const { queueRateLimitedCustomerCreation } = await import(
+	// @ts-expect-error - Bun test cache-busting import query isolates module mocks.
+	"@/internal/customers/recovery/queueRateLimitedCustomerCreation.js?rateLimitRecovery"
+);
+
+const buildApp = () => {
+	const app = new Hono<HonoEnv>();
+	app.use("*", async (c, next) => {
+		c.set("ctx", {
+			id: "req_rate_limited_123",
+			org: { id: "org_123" },
+			env: AppEnv.Live,
+			apiVersion: new ApiVersionClass(ApiVersion.V2_1),
+			extraLogs: {},
+			logger: {
+				error: mock(() => {}),
+			},
+		} as never);
+		await next();
+	});
+	app.post("*", async (c) =>
+		c.json({
+			queued: await queueRateLimitedCustomerCreation({ c }),
+		}),
+	);
+	return app;
+};
+
+describe("queueRateLimitedCustomerCreation", () => {
+	beforeEach(() => {
+		mockState.queueCalls = [];
+	});
+
+	test("captures a validated customers.get_or_create request", async () => {
+		const app = buildApp();
+		const response = await app.request(
+			"http://localhost/v1/customers.get_or_create",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					customer_id: "customer_123",
+					email: "customer@example.com",
+					entity_id: "entity_123",
+					entity_data: { name: "Workspace", feature_id: "seats" },
+					with_autumn_id: true,
+				}),
+			},
+		);
+
+		expect(await response.json()).toEqual({ queued: true });
+		expect(mockState.queueCalls).toEqual([
+			expect.objectContaining({
+				params: {
+					customer_id: "customer_123",
+					customer_data: {
+						email: "customer@example.com",
+					},
+					entity_id: "entity_123",
+					entity_data: { name: "Workspace", feature_id: "seats" },
+				},
+				source: "rateLimit:customers.get_or_create",
+				withAutumnId: true,
+				failureStage: "lookup",
+			}),
+		]);
+	});
+
+	test("captures a validated legacy customer create request", async () => {
+		const app = buildApp();
+		const response = await app.request(
+			"http://localhost/v1/customers?with_autumn_id=true",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					id: "customer_legacy",
+					email: "legacy@example.com",
+				}),
+			},
+		);
+
+		expect(await response.json()).toEqual({ queued: true });
+		expect(mockState.queueCalls).toEqual([
+			expect.objectContaining({
+				params: {
+					customer_id: "customer_legacy",
+					customer_data: {
+						email: "legacy@example.com",
+					},
+				},
+				source: "rateLimit:customers",
+				withAutumnId: true,
+				failureStage: "lookup",
+			}),
+		]);
+	});
+
+	test("does not queue invalid or unrelated requests", async () => {
+		const app = buildApp();
+		const invalidResponse = await app.request(
+			"http://localhost/v1/customers.get_or_create",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ customer_id: null }),
+			},
+		);
+		const fetchResponse = await app.request(
+			"http://localhost/v1/customers.get",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ customer_id: "customer_123" }),
+			},
+		);
+
+		expect(await invalidResponse.json()).toEqual({ queued: false });
+		expect(await fetchResponse.json()).toEqual({ queued: false });
+		expect(mockState.queueCalls).toHaveLength(0);
+	});
+});

--- a/server/tests/unit/customers/recovery/replay-failed-customer-creation.test.ts
+++ b/server/tests/unit/customers/recovery/replay-failed-customer-creation.test.ts
@@ -1,0 +1,125 @@
+/**
+ * TDD contract for customer creation recovery replay.
+ *
+ * Contract under test:
+ * - Safe failures replay the original normalized get-or-create operation.
+ * - Replays preserve the original API version and cannot enqueue themselves again.
+ * - Replays log whether they created or fetched the customer.
+ * - Failures after the Autumn commit stop for manual billing review.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ApiVersion, ApiVersionClass, AppEnv } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type { CustomerCreationRecoveryPayload } from "@/internal/customers/recovery/customerCreationRecoveryTypes.js";
+
+const mockState = {
+	getOrCreateCalls: [] as Record<string, unknown>[],
+	outcome: "created" as "created" | "existing" | undefined,
+};
+
+mock.module(
+	"@/internal/customers/actions/getOrCreateApiCustomerByRollout.js",
+	() => ({
+		getOrCreateApiCustomerByRollout: async (
+			args: Record<string, unknown> & { ctx: AutumnContext },
+		) => {
+			mockState.getOrCreateCalls.push(args);
+			if (mockState.outcome) {
+				args.ctx.extraLogs.autumnPlanResult = mockState.outcome;
+			}
+			return { id: "customer_123" };
+		},
+	}),
+);
+
+const { replayFailedCustomerCreation } = await import(
+	// @ts-expect-error - Bun test cache-busting import query isolates module mocks.
+	"@/internal/customers/recovery/replayFailedCustomerCreation.js?customerCreationRecovery"
+);
+
+const buildContext = () =>
+	({
+		org: { id: "org_123" },
+		env: AppEnv.Live,
+		apiVersion: new ApiVersionClass(ApiVersion.V0_2),
+		extraLogs: {},
+		logger: {
+			info: mock(() => {}),
+			error: mock(() => {}),
+		},
+	}) as unknown as AutumnContext;
+
+const buildPayload = (
+	failureStage: CustomerCreationRecoveryPayload["failureStage"] = "lookup",
+): CustomerCreationRecoveryPayload => ({
+	orgId: "org_123",
+	env: AppEnv.Live,
+	customerId: "customer_123",
+	requestId: "req_customer_123",
+	apiVersion: ApiVersion.V2_1,
+	params: {
+		customer_id: "customer_123",
+		customer_data: { email: "customer@example.com" },
+	},
+	source: "handleGetOrCreateCustomerV2",
+	withAutumnId: true,
+	failureStage,
+	failedAt: 1_785_000_000_000,
+});
+
+describe("replayFailedCustomerCreation", () => {
+	beforeEach(() => {
+		mockState.getOrCreateCalls = [];
+		mockState.outcome = "created";
+	});
+
+	test("replays a safe request with its original API semantics", async () => {
+		const ctx = buildContext();
+		const payload = buildPayload();
+
+		await replayFailedCustomerCreation({ ctx, payload });
+
+		expect(ctx.apiVersion.value).toBe(ApiVersion.V2_1);
+		expect(mockState.getOrCreateCalls).toEqual([
+			expect.objectContaining({
+				ctx,
+				params: payload.params,
+				source: "customerCreationRecovery",
+				withAutumnId: true,
+				enqueueRecoveryOnTransientFailure: false,
+			}),
+		]);
+		expect(ctx.extraLogs.customerCreationRecoveryReplay).toMatchObject({
+			outcome: "created",
+			sourceRequestId: "req_customer_123",
+		});
+	});
+
+	test("records a fetch when replay finds an existing customer", async () => {
+		mockState.outcome = undefined;
+		const ctx = buildContext();
+
+		await replayFailedCustomerCreation({
+			ctx,
+			payload: buildPayload("completed"),
+		});
+
+		expect(ctx.extraLogs.customerCreationRecoveryReplay).toMatchObject({
+			outcome: "fetched",
+		});
+	});
+
+	test("refuses automatic replay after the Autumn transaction committed", async () => {
+		const ctx = buildContext();
+
+		await expect(
+			replayFailedCustomerCreation({
+				ctx,
+				payload: buildPayload("autumn_committed"),
+			}),
+		).rejects.toThrow("requires manual billing review");
+
+		expect(mockState.getOrCreateCalls).toHaveLength(0);
+	});
+});

--- a/server/tests/unit/db/shed503OnTransientError.test.ts
+++ b/server/tests/unit/db/shed503OnTransientError.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, mock, test } from "bun:test";
+import { shed503OnTransientError } from "@/db/shed503OnTransientError.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+const buildContext = () =>
+	({
+		logger: {
+			warn: mock(() => {}),
+			error: mock(() => {}),
+		},
+	}) as unknown as AutumnContext;
+
+const transientError = Object.assign(new Error("connect timeout"), {
+	code: "CONNECT_TIMEOUT",
+});
+
+describe("shed503OnTransientError", () => {
+	test("runs transient failure capture before returning the overload 503", async () => {
+		const ctx = buildContext();
+		const onTransientError = mock(async () => {});
+
+		await expect(
+			shed503OnTransientError({
+				ctx,
+				source: "get_or_create",
+				run: () => {
+					throw transientError;
+				},
+				onTransientError,
+			}),
+		).rejects.toMatchObject({
+			statusCode: 503,
+			data: { reason: "critical_db_saturated" },
+		});
+
+		expect(onTransientError).toHaveBeenCalledWith(transientError);
+	});
+
+	test("does not let recovery queue failure replace the overload response", async () => {
+		const ctx = buildContext();
+
+		await expect(
+			shed503OnTransientError({
+				ctx,
+				source: "get_or_create",
+				run: () => {
+					throw transientError;
+				},
+				onTransientError: async () => {
+					throw new Error("SQS unavailable");
+				},
+			}),
+		).rejects.toMatchObject({
+			statusCode: 503,
+			data: { reason: "critical_db_saturated" },
+		});
+
+		expect(ctx.logger.error).toHaveBeenCalled();
+	});
+
+	test("does not capture non-transient application errors", async () => {
+		const ctx = buildContext();
+		const applicationError = new Error("invalid customer");
+		const onTransientError = mock(async () => {});
+
+		await expect(
+			shed503OnTransientError({
+				ctx,
+				source: "get_or_create",
+				run: () => {
+					throw applicationError;
+				},
+				onTransientError,
+			}),
+		).rejects.toBe(applicationError);
+
+		expect(onTransientError).not.toHaveBeenCalled();
+	});
+});

--- a/server/tests/unit/queue/processMessage.test.ts
+++ b/server/tests/unit/queue/processMessage.test.ts
@@ -4,6 +4,15 @@ import { JobName } from "@/queue/JobName.js";
 import { shouldRetrySqsJobError } from "@/queue/processMessage.js";
 
 describe("shouldRetrySqsJobError", () => {
+	test("keeps customer creation recovery failures for retry and DLQ redrive", () => {
+		expect(
+			shouldRetrySqsJobError({
+				jobName: JobName.CustomerCreationRecovery,
+				error: new Error("requires manual billing review"),
+			}),
+		).toBe(true);
+	});
+
 	test("retries track jobs on transient Redis errors", () => {
 		expect(
 			shouldRetrySqsJobError({


### PR DESCRIPTION
## Summary
- persist failed customer create and get-or-create requests to a dedicated FIFO recovery queue
- capture both pre-handler rate-limit shedding and transient database or Redis failures
- replay requests with original API semantics and globally serialized concurrency
- record whether replay created or fetched the customer
- send ambiguous post-commit billing cases through retry and DLQ for manual review

Infrastructure: https://github.com/useautumn/terraform/pull/62

## Validation
- 20 focused tests passed
- bun ts
- scoped Biome check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Queues failed customer creation and get-or-create requests to a serialized FIFO for automatic replay, capturing transient DB/Redis failures and rate-limited requests. Also strips noisy fields in FireLens to prevent Axiom schema overflow and skips no-op updates in `sync_balances_v2` to reduce writes.

- **New Features**
  - Capture validated `customers.get_or_create` and legacy `customers` create requests when rate-limited or on transient failures, and persist them to a FIFO queue with deterministic dedupe and a single message group for global serialization.
  - Track recovery stage (`lookup`, `pre_commit`, `existing`, `autumn_committed`, `completed`) and include it in queued payloads; failures after Autumn commit are retried/DLQ’d for manual billing review.
  - Add a `CustomerCreationRecovery` job that replays the original operation (preserves API version, avoids recursive enqueue) and records whether the replay created or fetched the customer.

- **Migration**
  - Configure `CUSTOMER_CREATION_RECOVERY_SQS_QUEUE_URL` and create the FIFO queue before deploy.
  - Enable the `customerCreationRecovery` job queue in Edge Config so workers start polling it.

<sup>Written for commit 15df07f39bac34b5aeed7664e232ee299b1207b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds durable, serialized recovery for customer creation failures.
- **[Improvements]** Captures transient database/Redis failures and rate-limited customer create/get-or-create requests in a dedicated FIFO queue.
- **[Improvements]** Tracks creation stages so pre-commit failures can be replayed while ambiguous post-commit billing cases are routed through retry and DLQ handling.
- **[Improvements]** Adds queue worker registration, readiness checks, feature-controlled polling, deterministic deduplication, and focused recovery tests.
- **[API changes]** Preserves the original API version, request parameters, and response semantics when replaying failed requests.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The recovery flow preserves request context, distinguishes safe replay from ambiguous post-commit billing work, serializes execution through FIFO, and keeps failed manual-review cases eligible for queue redrive.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/recovery/queueFailedCustomerCreation.ts | Adds deterministic FIFO enqueueing of replayable customer-creation requests without API credentials. |
| server/src/internal/customers/recovery/replayFailedCustomerCreation.ts | Replays safe failure stages with the original API version and rejects ambiguous post-commit cases for manual review. |
| server/src/internal/customers/actions/getOrCreateApiCustomerByRollout.ts | Captures transient failures from the FullSubject get-or-create path while preventing recursive recovery enqueueing. |
| server/src/internal/customers/actions/createWithDefaults/createCustomerWithDefaults.ts | Records customer-creation progress around Autumn and Stripe billing phases to support safe recovery decisions. |
| server/src/internal/misc/rateLimiter/rateLimitFactory.ts | Persists valid customer-creation requests shed by the organization rate limiter before returning the existing 503 response. |
| server/src/queue/processMessage.ts | Dispatches recovery jobs and preserves failures for SQS retry and DLQ redrive. |
| server/src/queue/initWorkers.ts | Adds opt-in polling for the dedicated recovery queue while retaining blue-green worker gating. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant API
  participant DBRedis as DB / Redis
  participant Recovery as Recovery FIFO
  participant Worker
  participant Stripe

  Client->>API: Create or get-or-create customer
  API->>DBRedis: Execute lookup and creation
  alt Successful request
    DBRedis-->>API: Customer
    API-->>Client: Original API response
  else Rate-limited or transient failure
    API->>Recovery: Enqueue request and failure stage
    API-->>Client: 503 Service unavailable
    Recovery->>Worker: Serialized replay
    alt Before Autumn commit
      Worker->>DBRedis: Replay original operation
      Worker->>Stripe: Apply required billing work
      Worker-->>Recovery: Acknowledge success
    else Autumn commit is ambiguous
      Worker-->>Recovery: Retry for DLQ/manual review
    end
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(customers): queue failed customer c..."](https://github.com/useautumn/autumn/commit/0e67c717763d420c55a76194c182dfdb0fe7775c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46640833)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)

<!-- /greptile_comment -->