### PR TITLE
fix: cache backup url

### DIFF
--- a/server/src/cron.ts
+++ b/server/src/cron.ts
@@ -7,6 +7,7 @@ await warmupRegionalRedis();
 // Edge config modules self-register on import (cron reads redis-v2-cache
 // so resolveRedisV2 picks the right instance on each ctx build).
 await import("./internal/misc/redisV2Cache/redisV2CacheStore.js");
+await import("./internal/misc/mainRedisCache/mainRedisCacheStore.js");
 await import("./internal/misc/cacheV2Ramp/cacheV2RampStore.js");
 await import("./internal/misc/resetJob/resetJobStore.js");
 const { logger } = await import("./external/logtail/logtailUtils.js");

--- a/server/src/external/aws/s3/adminS3Config.ts
+++ b/server/src/external/aws/s3/adminS3Config.ts
@@ -10,6 +10,8 @@ export const ADMIN_RATE_LIMIT_REDIS_ALLOWLIST_CONFIG_KEY =
 	"admin/rate-limit-redis-allowlist-config.json";
 export const ADMIN_REDIS_V2_CACHE_CONFIG_KEY =
 	"admin/redis-v2-cache-config.json";
+export const ADMIN_MAIN_REDIS_CACHE_CONFIG_KEY =
+	"admin/main-redis-cache-config.json";
 export const ADMIN_CACHE_V2_RAMP_CONFIG_KEY = "admin/cache-v2-ramp-config.json";
 export const ADMIN_JOB_QUEUE_CONFIG_KEY = "admin/job-queue-config.json";
 export const ADMIN_BATCH_RESET_CONFIG_KEY = "admin/batch-reset-config.json";
@@ -67,6 +69,11 @@ export const getAdminEdgeConfigSources = () => ({
 			id: "redis-v2-cache",
 			label: "V2 Redis Instance",
 			key: ADMIN_REDIS_V2_CACHE_CONFIG_KEY,
+		},
+		{
+			id: "main-redis-cache",
+			label: "Main Redis Instance",
+			key: ADMIN_MAIN_REDIS_CACHE_CONFIG_KEY,
 		},
 		{
 			id: "cache-v2-ramp",

--- a/server/src/external/redis/initRedis.ts
+++ b/server/src/external/redis/initRedis.ts
@@ -1,11 +1,18 @@
 import "./initUtils/redisTypes.js";
 
 export {
+	createDisabledRedis,
 	createRedisClient,
 	createRedisConnection,
-	createDisabledRedis,
 } from "./initUtils/createRedisClient.js";
 export {
+	getRedisAvailability,
+	shouldUseRedis,
+	startRedisMonitor,
+	stopRedisMonitor,
+} from "./initUtils/redisAvailability.js";
+export {
+	getFallbackRedis,
 	getPrimaryRedis,
 	getRegionalRedis,
 	redis,
@@ -15,12 +22,6 @@ export {
 	getConfiguredRegions,
 	hasRedisConfig,
 } from "./initUtils/redisConfig.js";
-export {
-	getRedisAvailability,
-	shouldUseRedis,
-	startRedisMonitor,
-	stopRedisMonitor,
-} from "./initUtils/redisAvailability.js";
 export {
 	waitForRedisReady,
 	warmupRegionalRedis,

--- a/server/src/external/redis/initUtils/createRedisClient.ts
+++ b/server/src/external/redis/initUtils/createRedisClient.ts
@@ -22,11 +22,13 @@ const formatRedisEndpoint = ({ cacheUrl }: { cacheUrl: string }) => {
 export const createRedisClient = ({
 	cacheUrl,
 	region,
+	cacheCert = process.env.CACHE_CERT || null,
 	supportsUpstashShebang = false,
 	commandTimeout = REDIS_COMMAND_TIMEOUT_MS,
 }: {
 	cacheUrl: string;
 	region: string;
+	cacheCert?: string | null;
 	supportsUpstashShebang?: boolean;
 	commandTimeout?: number;
 }): Redis => {
@@ -37,7 +39,11 @@ export const createRedisClient = ({
 	const usesTls = cacheUrl.startsWith("rediss:");
 
 	const instance = new Redis(cacheUrl, {
-		tls: usesTls ? { lookup: redisDnsLookup } : undefined,
+		tls: cacheCert
+			? { ca: cacheCert }
+			: usesTls
+				? { lookup: redisDnsLookup }
+				: undefined,
 		family: 4,
 		keepAlive: 10000,
 		commandTimeout,

--- a/server/src/external/redis/initUtils/createRedisClient.ts
+++ b/server/src/external/redis/initUtils/createRedisClient.ts
@@ -1,6 +1,6 @@
 import { Redis } from "ioredis";
 import { instrumentRedis } from "../otel/instrumentRedis.js";
-import { cacheBackupUrl } from "./redisConfig.js";
+import { redisDnsLookup } from "./redisDnsLookup.js";
 import { registerRedisCommands } from "./registerRedisCommands.js";
 
 const REDIS_COMMAND_TIMEOUT_MS =
@@ -34,11 +34,10 @@ export const createRedisClient = ({
 		`[Redis] ${region}: connecting to ${formatRedisEndpoint({ cacheUrl })}`,
 	);
 
+	const usesTls = cacheUrl.startsWith("rediss:");
+
 	const instance = new Redis(cacheUrl, {
-		tls:
-			process.env.CACHE_CERT && !cacheBackupUrl
-				? { ca: process.env.CACHE_CERT }
-				: undefined,
+		tls: usesTls ? { lookup: redisDnsLookup } : undefined,
 		family: 4,
 		keepAlive: 10000,
 		commandTimeout,

--- a/server/src/external/redis/initUtils/redisClientRegistry.ts
+++ b/server/src/external/redis/initUtils/redisClientRegistry.ts
@@ -41,6 +41,7 @@ const fallbackRedis = !cacheBackupUrl
 		: createRedisClient({
 				cacheUrl: cacheBackupUrl,
 				region: `${currentRegion}:fallback`,
+				cacheCert: null,
 			});
 
 export const getFallbackRedis = (): Redis | null => fallbackRedis;

--- a/server/src/external/redis/initUtils/redisClientRegistry.ts
+++ b/server/src/external/redis/initUtils/redisClientRegistry.ts
@@ -1,6 +1,12 @@
 import type { Redis } from "ioredis";
+import { getActiveMainRedisInstance } from "@/internal/misc/mainRedisCache/mainRedisCacheStore.js";
+import {
+	createMainRedisRouter,
+	selectMainRedisClient,
+} from "../mainRedisRouting.js";
 import { createDisabledRedis, createRedisClient } from "./createRedisClient.js";
 import {
+	cacheBackupUrl,
 	currentRegion,
 	getCacheUrlForRegion,
 	hasRedisConfig,
@@ -8,17 +14,19 @@ import {
 	primaryCacheUrl,
 } from "./redisConfig.js";
 
-if (process.env.CACHE_BACKUP_URL?.trim()) {
+if (cacheBackupUrl) {
 	console.log(
-		`[Redis] Using CACHE_BACKUP_URL for all regions (primary region: ${currentRegion})`,
+		`[Redis] CACHE_BACKUP_URL configured as fallback (primary region: ${currentRegion})`,
 	);
 } else if (!hasRedisConfig) {
-	console.warn("[Redis] No Redis URL configured. Running in Postgres-only mode.");
+	console.warn(
+		"[Redis] No Redis URL configured. Running in Postgres-only mode.",
+	);
 } else if (primaryCacheUrl && getCacheUrlForRegion({ region: currentRegion })) {
 	console.log(`Using regional cache: ${currentRegion}`);
 }
 
-const primaryRedis =
+const localPrimaryRedis =
 	hasRedisConfig && primaryCacheUrl
 		? createRedisClient({
 				cacheUrl: primaryCacheUrl,
@@ -26,22 +34,36 @@ const primaryRedis =
 			})
 		: createDisabledRedis();
 
-/**
- * The active Redis instance. All consumer code imports this.
- * Normally points to the primary (current region).
- */
-export const redis: Redis = primaryRedis;
+const fallbackRedis = !cacheBackupUrl
+	? null
+	: cacheBackupUrl === primaryCacheUrl
+		? localPrimaryRedis
+		: createRedisClient({
+				cacheUrl: cacheBackupUrl,
+				region: `${currentRegion}:fallback`,
+			});
+
+export const getFallbackRedis = (): Redis | null => fallbackRedis;
 
 // Lazy-loaded regional Redis instances for cross-region sync
 const regionalRedisInstances: Map<string, Redis> = new Map();
+let lastLoggedInstance: string | null = null;
+let missingFallbackWarned = false;
 
-/** Get Redis instance for a specific region (lazy-loaded) */
-export const getRegionalRedis = (region: string): Redis => {
+export const getRegionalRedisForInstance = ({
+	region,
+	instance,
+}: {
+	region: string;
+	instance: "primary" | "fallback";
+}): Redis => {
+	if (instance === "fallback" && fallbackRedis) return fallbackRedis;
+
 	if (!hasRedisConfig) {
-		return primaryRedis;
+		return localPrimaryRedis;
 	}
 	if (region === currentRegion) {
-		return primaryRedis;
+		return localPrimaryRedis;
 	}
 
 	const cacheUrl = getCacheUrlForRegion({ region });
@@ -50,11 +72,11 @@ export const getRegionalRedis = (region: string): Redis => {
 		console.warn(
 			`No cache URL configured for region ${region}, falling back to primary`,
 		);
-		return primaryRedis;
+		return localPrimaryRedis;
 	}
 
 	if (cacheUrl === primaryCacheUrl) {
-		return primaryRedis;
+		return localPrimaryRedis;
 	}
 
 	let regionalInstance = regionalRedisInstances.get(region);
@@ -68,6 +90,35 @@ export const getRegionalRedis = (region: string): Redis => {
 
 	return regionalInstance;
 };
+
+/** Get the active Redis instance for a region. */
+export const getRegionalRedis = (region: string): Redis => {
+	const activeInstance = getActiveMainRedisInstance();
+	if (activeInstance !== lastLoggedInstance) {
+		console.log(`[Redis] Active main instance: ${activeInstance}`);
+		lastLoggedInstance = activeInstance;
+	}
+	if (
+		activeInstance === "fallback" &&
+		!fallbackRedis &&
+		!missingFallbackWarned
+	) {
+		console.warn(
+			"[Redis] Fallback selected without CACHE_BACKUP_URL; using primary",
+		);
+		missingFallbackWarned = true;
+	}
+
+	return selectMainRedisClient({
+		activeInstance,
+		primary: () => getRegionalRedisForInstance({ region, instance: "primary" }),
+		fallback: fallbackRedis,
+	});
+};
+
+export const redis: Redis = createMainRedisRouter({
+	resolve: () => getRegionalRedis(currentRegion),
+});
 
 /** Get the primary Redis instance (us-west-2) to avoid replication lag issues */
 export const getPrimaryRedis = () => getRegionalRedis(PRIMARY_REGION);

--- a/server/src/external/redis/initUtils/redisConfig.ts
+++ b/server/src/external/redis/initUtils/redisConfig.ts
@@ -10,29 +10,29 @@ export const currentRegion = process.env.AWS_REGION || REGION_US_WEST_2;
 
 export const cacheBackupUrl = process.env.CACHE_BACKUP_URL?.trim();
 
-// Map of region to cache URL. When CACHE_BACKUP_URL is set, all regions use it
-// (failover / single backup endpoint).
-const regionToCacheUrl: Record<string, string | undefined> = cacheBackupUrl
-	? {
-			[REGION_US_EAST_2]: cacheBackupUrl,
-			[REGION_US_WEST_2]: cacheBackupUrl,
-		}
-	: {
-			[REGION_US_EAST_2]: process.env.CACHE_URL_US_EAST,
-			[REGION_US_WEST_2]: process.env.CACHE_URL,
-		};
+// The backup is edge-selected unless it is the only configured Redis endpoint.
+const regionToCacheUrl: Record<string, string | undefined> = {
+	[REGION_US_EAST_2]: process.env.CACHE_URL_US_EAST,
+	[REGION_US_WEST_2]: process.env.CACHE_URL,
+};
+const hasPrimaryCacheUrls = Object.values(regionToCacheUrl).some(Boolean);
 
 export const primaryCacheUrl =
 	regionToCacheUrl[currentRegion] || process.env.CACHE_URL || cacheBackupUrl;
 
 export const hasRedisConfig = Boolean(primaryCacheUrl);
+
 /** Get all regions that have configured cache URLs */
 export const getConfiguredRegions = (): string[] => {
-	return ALL_REGIONS.filter((region) => regionToCacheUrl[region]);
+	const configured = ALL_REGIONS.filter((region) => regionToCacheUrl[region]);
+	return hasPrimaryCacheUrls || !cacheBackupUrl ? configured : [...ALL_REGIONS];
 };
 
 export const getCacheUrlForRegion = ({ region }: { region: string }) => {
-	return regionToCacheUrl[region];
+	return (
+		regionToCacheUrl[region] ||
+		(!hasPrimaryCacheUrls ? cacheBackupUrl : undefined)
+	);
 };
 
 export const PRIMARY_REGION = REGION_US_WEST_2;

--- a/server/src/external/redis/initUtils/redisDnsLookup.ts
+++ b/server/src/external/redis/initUtils/redisDnsLookup.ts
@@ -1,0 +1,56 @@
+import {
+	lookup as defaultLookup,
+	resolve4 as defaultResolve4,
+	type LookupAddress,
+	type LookupOptions,
+} from "node:dns";
+import type { LookupFunction } from "node:net";
+
+type LookupHost = (
+	hostname: string,
+	options: LookupOptions,
+	callback: (
+		error: NodeJS.ErrnoException | null,
+		address: string | LookupAddress[],
+		family: number,
+	) => void,
+) => void;
+
+type Resolve4Host = (
+	hostname: string,
+	callback: (error: NodeJS.ErrnoException | null, addresses: string[]) => void,
+) => void;
+
+export const createRedisDnsLookup = ({
+	lookupHost = defaultLookup as LookupHost,
+	resolve4Host = defaultResolve4,
+}: {
+	lookupHost?: LookupHost;
+	resolve4Host?: Resolve4Host;
+} = {}): LookupFunction => {
+	return (hostname, options, callback) => {
+		lookupHost(hostname, options, (lookupError, address, family) => {
+			if (!lookupError) {
+				callback(null, address, family);
+				return;
+			}
+
+			if (lookupError.code !== "ENOTFOUND" || options.all) {
+				callback(lookupError, "", family);
+				return;
+			}
+
+			resolve4Host(hostname, (resolveError, addresses) => {
+				const resolvedAddress = addresses?.[0];
+				if (resolveError || !resolvedAddress) {
+					callback(resolveError ?? lookupError, "", 4);
+					return;
+				}
+
+				callback(null, resolvedAddress, 4);
+			});
+		});
+	};
+};
+
+export const redisDnsLookup = createRedisDnsLookup();

--- a/server/src/external/redis/initUtils/redisWarmup.ts
+++ b/server/src/external/redis/initUtils/redisWarmup.ts
@@ -1,5 +1,8 @@
 import type { Redis } from "ioredis";
-import { getRegionalRedis } from "./redisClientRegistry.js";
+import {
+	getFallbackRedis,
+	getRegionalRedisForInstance,
+} from "./redisClientRegistry.js";
 import { getConfiguredRegions } from "./redisConfig.js";
 
 /** Wait for a Redis instance to be ready */
@@ -40,13 +43,25 @@ export const warmupRegionalRedis = async (): Promise<void> => {
 
 	const warmupPromises = regions.map(async (region) => {
 		try {
-			const instance = getRegionalRedis(region);
+			const instance = getRegionalRedisForInstance({
+				region,
+				instance: "primary",
+			});
 			await waitForRedisReady(instance, region);
 		} catch (error) {
 			console.error(`[Redis] ${region}: warmup failed -`, error);
 			// Don't throw - allow startup to continue even if one region fails
 		}
 	});
+
+	const fallback = getFallbackRedis();
+	if (fallback) {
+		warmupPromises.push(
+			waitForRedisReady(fallback, "fallback").catch((error) => {
+				console.error("[Redis] fallback: warmup failed -", error);
+			}),
+		);
+	}
 
 	await Promise.all(warmupPromises);
 

--- a/server/src/external/redis/mainRedisRouting.ts
+++ b/server/src/external/redis/mainRedisRouting.ts
@@ -1,0 +1,28 @@
+import type { Redis } from "ioredis";
+import type { MainRedisInstanceName } from "@/internal/misc/mainRedisCache/mainRedisCacheSchemas.js";
+
+export const selectMainRedisClient = ({
+	activeInstance,
+	primary,
+	fallback,
+}: {
+	activeInstance: MainRedisInstanceName;
+	primary: () => Redis;
+	fallback: Redis | null;
+}): Redis => (activeInstance === "fallback" && fallback ? fallback : primary());
+
+export const createMainRedisRouter = ({
+	resolve,
+}: {
+	resolve: () => Redis;
+}): Redis =>
+	new Proxy({} as Redis, {
+		get(_target, property) {
+			const redis = resolve();
+			const value = Reflect.get(redis, property, redis);
+			return typeof value === "function" ? value.bind(redis) : value;
+		},
+		set(_target, property, value) {
+			return Reflect.set(resolve(), property, value);
+		},
+	});

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -26,6 +26,7 @@ import "./internal/misc/customerBlocks/customerBlockStore.js";
 import "./internal/misc/edgeConfig/orgLimitsStore.js";
 import "./internal/misc/stripeSync/stripeSyncStore.js";
 import "./internal/misc/redisV2Cache/redisV2CacheStore.js";
+import "./internal/misc/mainRedisCache/mainRedisCacheStore.js";
 import "./internal/misc/cacheV2Ramp/cacheV2RampStore.js";
 import "./internal/misc/jobQueues/jobQueueStore.js";
 import "./internal/misc/batchReset/batchResetConfigStore.js";

--- a/server/src/internal/admin/adminRouter.ts
+++ b/server/src/internal/admin/adminRouter.ts
@@ -19,6 +19,7 @@ import { handleGetAdminEdgeConfigSources } from "./handleGetAdminEdgeConfigSourc
 import { handleGetAdminFeatureFlagsConfig } from "./handleGetAdminFeatureFlagsConfig";
 import { handleGetAdminFullSubjectGateConfig } from "./handleGetAdminFullSubjectGateConfig";
 import { handleGetAdminJobQueueConfig } from "./handleGetAdminJobQueueConfig";
+import { handleGetAdminMainRedisCacheConfig } from "./handleGetAdminMainRedisCacheConfig";
 import { handleGetAdminMiscellaneousEdgeConfig } from "./handleGetAdminMiscellaneousEdgeConfig";
 import { handleGetAdminOrgLimitsConfig } from "./handleGetAdminOrgLimitsConfig";
 import { handleGetAdminOrgRequestBlock } from "./handleGetAdminOrgRequestBlock";
@@ -47,6 +48,7 @@ import { handleUpsertAdminCustomerBlockConfig } from "./handleUpsertAdminCustome
 import { handleUpsertAdminFeatureFlagsConfig } from "./handleUpsertAdminFeatureFlagsConfig";
 import { handleUpsertAdminFullSubjectGateConfig } from "./handleUpsertAdminFullSubjectGateConfig";
 import { handleUpsertAdminJobQueueConfig } from "./handleUpsertAdminJobQueueConfig";
+import { handleUpsertAdminMainRedisCacheConfig } from "./handleUpsertAdminMainRedisCacheConfig";
 import { handleUpsertAdminMiscellaneousEdgeConfig } from "./handleUpsertAdminMiscellaneousEdgeConfig";
 import { handleUpsertAdminOrgLimitsConfig } from "./handleUpsertAdminOrgLimitsConfig";
 import { handleUpsertAdminOrgRequestBlock } from "./handleUpsertAdminOrgRequestBlock";
@@ -172,6 +174,14 @@ honoAdminRouter.get(
 honoAdminRouter.put(
 	"/redis-v2-cache-config",
 	...handleUpsertAdminRedisV2CacheConfig,
+);
+honoAdminRouter.get(
+	"/main-redis-cache-config",
+	...handleGetAdminMainRedisCacheConfig,
+);
+honoAdminRouter.put(
+	"/main-redis-cache-config",
+	...handleUpsertAdminMainRedisCacheConfig,
 );
 honoAdminRouter.get("/cache-v2-ramp", ...handleGetAdminCacheV2Ramp);
 honoAdminRouter.patch("/cache-v2-ramp", ...handleUpsertAdminCacheV2Ramp);

--- a/server/src/internal/admin/handleGetAdminMainRedisCacheConfig.ts
+++ b/server/src/internal/admin/handleGetAdminMainRedisCacheConfig.ts
@@ -1,0 +1,25 @@
+import { Scopes } from "@autumn/shared";
+import { getFallbackRedis } from "@/external/redis/initRedis.js";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import {
+	getActiveMainRedisInstance,
+	getMainRedisCacheStatus,
+} from "@/internal/misc/mainRedisCache/mainRedisCacheStore.js";
+
+export const handleGetAdminMainRedisCacheConfig = createRoute({
+	scopes: [Scopes.Superuser],
+	handler: async (c) => {
+		const status = getMainRedisCacheStatus();
+		const fallback = getFallbackRedis();
+
+		return c.json({
+			activeInstance: getActiveMainRedisInstance(),
+			fallbackConfigured: Boolean(fallback),
+			fallbackStatus: fallback?.status ?? "not_configured",
+			configHealthy: status.healthy,
+			configConfigured: status.configured,
+			lastSuccessAt: status.lastSuccessAt ?? null,
+			error: status.error ?? null,
+		});
+	},
+});

--- a/server/src/internal/admin/handleUpsertAdminMainRedisCacheConfig.ts
+++ b/server/src/internal/admin/handleUpsertAdminMainRedisCacheConfig.ts
@@ -1,0 +1,37 @@
+import { ErrCode, RecaseError, Scopes } from "@autumn/shared";
+import { getFallbackRedis } from "@/external/redis/initRedis.js";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { MainRedisCacheConfigSchema } from "@/internal/misc/mainRedisCache/mainRedisCacheSchemas.js";
+import { updateActiveMainRedisInstance } from "@/internal/misc/mainRedisCache/mainRedisCacheStore.js";
+
+export const handleUpsertAdminMainRedisCacheConfig = createRoute({
+	scopes: [Scopes.Superuser],
+	body: MainRedisCacheConfigSchema,
+	handler: async (c) => {
+		const { activeInstance } = c.req.valid("json");
+
+		if (activeInstance === "fallback") {
+			const fallback = getFallbackRedis();
+			if (!fallback || fallback.status !== "ready") {
+				throw new RecaseError({
+					message:
+						"CACHE_BACKUP_URL is not configured or its Redis client is not ready",
+					code: ErrCode.InvalidRequest,
+					statusCode: 503,
+				});
+			}
+
+			const pong = await fallback.ping().catch(() => null);
+			if (pong !== "PONG") {
+				throw new RecaseError({
+					message: "Fallback Redis did not respond to its readiness check",
+					code: ErrCode.InvalidRequest,
+					statusCode: 503,
+				});
+			}
+		}
+
+		await updateActiveMainRedisInstance({ activeInstance });
+		return c.json({ success: true, activeInstance });
+	},
+});

--- a/server/src/internal/misc/mainRedisCache/mainRedisCacheSchemas.ts
+++ b/server/src/internal/misc/mainRedisCache/mainRedisCacheSchemas.ts
@@ -1,0 +1,10 @@
+import { z } from "zod/v4";
+
+export const MainRedisInstanceName = z.enum(["primary", "fallback"]);
+export type MainRedisInstanceName = z.infer<typeof MainRedisInstanceName>;
+
+export const MainRedisCacheConfigSchema = z.object({
+	activeInstance: MainRedisInstanceName.default("primary"),
+});
+
+export type MainRedisCacheConfig = z.infer<typeof MainRedisCacheConfigSchema>;

--- a/server/src/internal/misc/mainRedisCache/mainRedisCacheStore.ts
+++ b/server/src/internal/misc/mainRedisCache/mainRedisCacheStore.ts
@@ -1,0 +1,39 @@
+import { ms } from "@autumn/shared";
+import { ADMIN_MAIN_REDIS_CACHE_CONFIG_KEY } from "@/external/aws/s3/adminS3Config.js";
+import { registerEdgeConfig } from "@/internal/misc/edgeConfig/edgeConfigRegistry.js";
+import { createEdgeConfigStore } from "@/internal/misc/edgeConfig/edgeConfigStore.js";
+import {
+	type MainRedisCacheConfig,
+	MainRedisCacheConfigSchema,
+	type MainRedisInstanceName,
+} from "./mainRedisCacheSchemas.js";
+
+const store = createEdgeConfigStore<MainRedisCacheConfig>({
+	s3Key: ADMIN_MAIN_REDIS_CACHE_CONFIG_KEY,
+	schema: MainRedisCacheConfigSchema,
+	defaultValue: () => ({ activeInstance: "primary" }),
+	pollIntervalMs: ms.seconds(10),
+});
+
+registerEdgeConfig({ store });
+
+export const getActiveMainRedisInstance = (): MainRedisInstanceName =>
+	store.get().activeInstance;
+
+export const getMainRedisCacheStatus = () => store.getStatus();
+
+export const updateActiveMainRedisInstance = async ({
+	activeInstance,
+}: {
+	activeInstance: MainRedisInstanceName;
+}) => {
+	await store.writeToSource({ config: { activeInstance } });
+};
+
+export const _setActiveMainRedisInstanceForTesting = ({
+	activeInstance,
+}: {
+	activeInstance: MainRedisInstanceName;
+}) => {
+	store._setRuntimeConfigForTesting({ activeInstance });
+};

--- a/server/src/workers.ts
+++ b/server/src/workers.ts
@@ -10,6 +10,7 @@ import {
 import "./internal/misc/requestBlocks/requestBlockStore.js";
 import "./internal/misc/rollouts/rolloutConfigStore.js";
 import "./internal/misc/redisV2Cache/redisV2CacheStore.js";
+import "./internal/misc/mainRedisCache/mainRedisCacheStore.js";
 import "./internal/misc/cacheV2Ramp/cacheV2RampStore.js";
 import "./internal/misc/jobQueues/jobQueueStore.js";
 import "./internal/misc/batchReset/batchResetConfigStore.js";

--- a/server/tests/unit/redis/main-redis-routing.test.ts
+++ b/server/tests/unit/redis/main-redis-routing.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import type { Redis } from "ioredis";
+import {
+	createMainRedisRouter,
+	selectMainRedisClient,
+} from "@/external/redis/mainRedisRouting.js";
+import { MainRedisCacheConfigSchema } from "@/internal/misc/mainRedisCache/mainRedisCacheSchemas.js";
+
+const asRedis = (value: object) => value as Redis;
+
+describe("main Redis routing", () => {
+	test("defaults edge config to primary", () => {
+		expect(MainRedisCacheConfigSchema.parse({})).toEqual({
+			activeInstance: "primary",
+		});
+	});
+
+	test("selects primary by default", () => {
+		const primary = asRedis({});
+		const fallback = asRedis({});
+
+		expect(
+			selectMainRedisClient({
+				activeInstance: "primary",
+				primary: () => primary,
+				fallback,
+			}),
+		).toBe(primary);
+	});
+
+	test("selects fallback when configured", () => {
+		const primary = asRedis({});
+		const fallback = asRedis({});
+
+		expect(
+			selectMainRedisClient({
+				activeInstance: "fallback",
+				primary: () => primary,
+				fallback,
+			}),
+		).toBe(fallback);
+	});
+
+	test("fails safely to primary when fallback is missing", () => {
+		const primary = asRedis({});
+
+		expect(
+			selectMainRedisClient({
+				activeInstance: "fallback",
+				primary: () => primary,
+				fallback: null,
+			}),
+		).toBe(primary);
+	});
+
+	test("routes auth and idempotency commands to the current client", async () => {
+		const primary = {
+			status: "ready",
+			name: "primary",
+			calls: [] as string[],
+			async get(key: string) {
+				this.calls.push(`get:${key}`);
+				return null;
+			},
+			async set(key: string) {
+				this.calls.push(`set:${key}`);
+				return "OK";
+			},
+			async del(key: string) {
+				this.calls.push(`del:${key}`);
+				return 1;
+			},
+		};
+		const fallback = {
+			status: "ready",
+			name: "fallback",
+			calls: [] as string[],
+			async get(key: string) {
+				this.calls.push(`get:${key}`);
+				return null;
+			},
+			async set(key: string) {
+				this.calls.push(`set:${key}`);
+				return "OK";
+			},
+			async del(key: string) {
+				this.calls.push(`del:${key}`);
+				return 1;
+			},
+		};
+		let active = primary;
+		const router = createMainRedisRouter({ resolve: () => asRedis(active) });
+
+		await router.get("secret_key:hash");
+		active = fallback;
+		await router.set("org:live:idempotency:hash", "1");
+		await router.del("org:live:idempotency:hash");
+
+		expect(primary.calls).toEqual(["get:secret_key:hash"]);
+		expect(fallback.calls).toEqual([
+			"set:org:live:idempotency:hash",
+			"del:org:live:idempotency:hash",
+		]);
+	});
+});

--- a/server/tests/unit/redis/redis-dns-lookup.test.ts
+++ b/server/tests/unit/redis/redis-dns-lookup.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import type { LookupOptions } from "node:dns";
+import { createRedisDnsLookup } from "@/external/redis/initUtils/redisDnsLookup.js";
+
+const options = { all: false, family: 4 } satisfies LookupOptions;
+
+describe("Redis DNS lookup", () => {
+	test("uses the system lookup result when available", async () => {
+		const lookup = createRedisDnsLookup({
+			lookupHost: (_hostname, _options, callback) => {
+				callback(null, "127.0.0.1", 4);
+			},
+			resolve4Host: () => {
+				throw new Error("resolve4 should not run");
+			},
+		});
+
+		const result = await new Promise<string>((resolve, reject) => {
+			lookup("redis.example.com", options, (error, address) => {
+				if (error) reject(error);
+				else resolve(String(address));
+			});
+		});
+
+		expect(result).toBe("127.0.0.1");
+	});
+
+	test("falls back to resolve4 after ENOTFOUND", async () => {
+		const lookup = createRedisDnsLookup({
+			lookupHost: (_hostname, _options, callback) => {
+				const error = new Error("not found") as NodeJS.ErrnoException;
+				error.code = "ENOTFOUND";
+				callback(error, "", 4);
+			},
+			resolve4Host: (_hostname, callback) => {
+				callback(null, ["192.0.2.1"]);
+			},
+		});
+
+		const result = await new Promise<string>((resolve, reject) => {
+			lookup("redis.example.com", options, (error, address) => {
+				if (error) reject(error);
+				else resolve(String(address));
+			});
+		});
+
+		expect(result).toBe("192.0.2.1");
+	});
+
+	test("preserves non-DNS lookup errors", async () => {
+		const expected = new Error("permission denied") as NodeJS.ErrnoException;
+		expected.code = "EACCES";
+		const lookup = createRedisDnsLookup({
+			lookupHost: (_hostname, _options, callback) => {
+				callback(expected, "", 4);
+			},
+			resolve4Host: () => {
+				throw new Error("resolve4 should not run");
+			},
+		});
+
+		const error = await new Promise<NodeJS.ErrnoException | null>((resolve) => {
+			lookup("redis.example.com", options, (lookupError) => {
+				resolve(lookupError);
+			});
+		});
+
+		expect(error).toBe(expected);
+	});
+});

--- a/vite/src/views/admin/components/EdgeConfigTab.tsx
+++ b/vite/src/views/admin/components/EdgeConfigTab.tsx
@@ -9,6 +9,7 @@ import { EdgeConfigDialog } from "./EdgeConfigDialog";
 import { FeatureFlagsDialog } from "./FeatureFlagsDialog";
 import { FullSubjectGateDialog } from "./FullSubjectGateDialog";
 import { JobQueuesDialog } from "./JobQueuesDialog";
+import { MainRedisCacheDialog } from "./MainRedisCacheDialog";
 import { MiscellaneousEdgeConfigDialog } from "./MiscellaneousEdgeConfigDialog";
 import { OrgLimitsDialog } from "./OrgLimitsDialog";
 import { RateLimitOverridesDialog } from "./RateLimitOverridesDialog";
@@ -42,6 +43,7 @@ export function EdgeConfigTab() {
 	const [batchResetOpen, setBatchResetOpen] = useState(false);
 	const [stripeSyncOpen, setStripeSyncOpen] = useState(false);
 	const [redisV2CacheOpen, setRedisV2CacheOpen] = useState(false);
+	const [mainRedisCacheOpen, setMainRedisCacheOpen] = useState(false);
 	const [cacheV2RampOpen, setCacheV2RampOpen] = useState(false);
 	const [miscellaneousOpen, setMiscellaneousOpen] = useState(false);
 	const [fullSubjectGateOpen, setFullSubjectGateOpen] = useState(false);
@@ -310,6 +312,25 @@ export function EdgeConfigTab() {
 				<div className="flex items-center justify-between border-t border-border p-4 last:border-b-0">
 					<div className="flex flex-col gap-0.5">
 						<div className="text-sm font-medium text-foreground">
+							Main Redis Instance
+						</div>
+						<div className="text-pretty text-xs text-tertiary-foreground">
+							Globally switch auth, idempotency, rate-limit, lock, and legacy
+							cache traffic between CACHE_URL and CACHE_BACKUP_URL.
+						</div>
+					</div>
+					<Button
+						variant="primary"
+						size="sm"
+						onClick={() => setMainRedisCacheOpen(true)}
+					>
+						Edit
+					</Button>
+				</div>
+
+				<div className="flex items-center justify-between border-t border-border p-4 last:border-b-0">
+					<div className="flex flex-col gap-0.5">
+						<div className="text-sm font-medium text-foreground">
 							Cache V2 Ramp
 						</div>
 						<div className="text-xs text-tertiary-foreground">
@@ -416,6 +437,11 @@ export function EdgeConfigTab() {
 			<RedisV2CacheDialog
 				open={redisV2CacheOpen}
 				onOpenChange={setRedisV2CacheOpen}
+			/>
+
+			<MainRedisCacheDialog
+				open={mainRedisCacheOpen}
+				onOpenChange={setMainRedisCacheOpen}
 			/>
 
 			<CacheV2RampDialog

--- a/vite/src/views/admin/components/MainRedisCacheDialog.tsx
+++ b/vite/src/views/admin/components/MainRedisCacheDialog.tsx
@@ -1,0 +1,259 @@
+import {
+	Alert,
+	AlertAction,
+	AlertDescription,
+	AlertTitle,
+	Badge,
+	Button,
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	Select,
+	SelectContent,
+	SelectGroup,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@autumn/ui";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useAppForm } from "@/hooks/form/form";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
+
+const INSTANCE_OPTIONS = [
+	{
+		value: "primary",
+		label: "Primary",
+		description: "Regional CACHE_URL endpoints",
+	},
+	{
+		value: "fallback",
+		label: "Fallback",
+		description: "Global CACHE_BACKUP_URL endpoint",
+	},
+] as const;
+
+type InstanceName = (typeof INSTANCE_OPTIONS)[number]["value"];
+
+type MainRedisCacheConfig = {
+	activeInstance: InstanceName;
+	fallbackConfigured: boolean;
+	fallbackStatus: string;
+	configHealthy: boolean;
+	configConfigured: boolean;
+	lastSuccessAt: string | null;
+	error: string | null;
+};
+
+const QUERY_KEY = ["admin-edge-config", "main-redis-cache"];
+
+function MainRedisCacheForm({
+	config,
+	onSaved,
+}: {
+	config: MainRedisCacheConfig;
+	onSaved: () => void;
+}) {
+	const axiosInstance = useAxiosInstance();
+	const queryClient = useQueryClient();
+	const saveMutation = useMutation({
+		mutationFn: async (activeInstance: InstanceName) => {
+			await axiosInstance.put("/admin/main-redis-cache-config", {
+				activeInstance,
+			});
+		},
+		onSuccess: async (_data, activeInstance) => {
+			await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+			toast.success(`Active main Redis set to "${activeInstance}"`);
+			onSaved();
+		},
+		onError: (error) => {
+			toast.error(getBackendErr(error, "Failed to switch main Redis"));
+		},
+	});
+	const form = useAppForm({
+		defaultValues: { activeInstance: config.activeInstance },
+		onSubmit: async ({ value }) => {
+			await saveMutation.mutateAsync(value.activeInstance);
+		},
+	});
+
+	return (
+		<>
+			<div className="flex flex-col gap-4">
+				<form.Field name="activeInstance">
+					{(field) => (
+						<div className="flex flex-col gap-2">
+							<div className="text-xs font-medium uppercase text-tertiary-foreground">
+								Active Instance
+							</div>
+							<Select
+								value={field.state.value}
+								onValueChange={(value) =>
+									field.handleChange(value as InstanceName)
+								}
+								items={INSTANCE_OPTIONS.map((option) => ({
+									value: option.value,
+									label: option.label,
+								}))}
+							>
+								<SelectTrigger>
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectGroup>
+										{INSTANCE_OPTIONS.map((option) => (
+											<SelectItem
+												key={option.value}
+												value={option.value}
+												disabled={
+													option.value === "fallback" &&
+													(!config.fallbackConfigured ||
+														config.fallbackStatus !== "ready")
+												}
+											>
+												<div className="flex flex-col">
+													<span className="text-sm text-foreground">
+														{option.label}
+													</span>
+													<span className="text-xs text-tertiary-foreground">
+														{option.description}
+													</span>
+												</div>
+											</SelectItem>
+										))}
+									</SelectGroup>
+								</SelectContent>
+							</Select>
+						</div>
+					)}
+				</form.Field>
+
+				<Alert>
+					<AlertTitle>Connection state is not copied</AlertTitle>
+					<AlertDescription>
+						The switch only reroutes commands. Use a synchronized fallback when
+						preserving existing locks and idempotency keys is required.
+					</AlertDescription>
+				</Alert>
+
+				<div className="flex flex-col gap-2 rounded-lg border border-border p-3 text-xs text-tertiary-foreground">
+					<div className="flex flex-wrap items-center gap-2">
+						<Badge variant="muted">
+							{config.configHealthy ? "Config healthy" : "Config unavailable"}
+						</Badge>
+						<Badge variant="muted">
+							Fallback:{" "}
+							{config.fallbackConfigured
+								? config.fallbackStatus
+								: "not configured"}
+						</Badge>
+						{config.lastSuccessAt && (
+							<span className="tabular-nums">
+								Last refresh: {new Date(config.lastSuccessAt).toLocaleString()}
+							</span>
+						)}
+					</div>
+					<div className="text-pretty">
+						{config.configConfigured === false
+							? "S3 main Redis config is not configured. Traffic defaults to primary."
+							: config.error ||
+								"Changes propagate to servers, workers, and cron within 10 seconds."}
+					</div>
+				</div>
+			</div>
+
+			<DialogFooter>
+				<Button variant="secondary" onClick={onSaved}>
+					Cancel
+				</Button>
+				<form.Subscribe
+					selector={(state) => ({
+						activeInstance: state.values.activeInstance,
+						isSubmitting: state.isSubmitting,
+					})}
+				>
+					{({ activeInstance, isSubmitting }) => (
+						<Button
+							variant="primary"
+							onClick={() => form.handleSubmit()}
+							isLoading={isSubmitting}
+							disabled={activeInstance === config.activeInstance}
+						>
+							Save
+						</Button>
+					)}
+				</form.Subscribe>
+			</DialogFooter>
+		</>
+	);
+}
+
+export function MainRedisCacheDialog({
+	open,
+	onOpenChange,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const axiosInstance = useAxiosInstance();
+	const configQuery = useQuery<MainRedisCacheConfig>({
+		queryKey: QUERY_KEY,
+		queryFn: async () => {
+			const { data } = await axiosInstance.get(
+				"/admin/main-redis-cache-config",
+			);
+			return data;
+		},
+		enabled: open,
+		refetchInterval: open ? 2_000 : false,
+	});
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-xl bg-card">
+				<DialogHeader>
+					<DialogTitle className="text-balance">
+						Main Redis Instance
+					</DialogTitle>
+					<DialogDescription className="text-pretty">
+						Globally route legacy cache, auth, idempotency, rate-limit, and lock
+						traffic between the primary and fallback Redis.
+					</DialogDescription>
+				</DialogHeader>
+
+				{configQuery.isLoading ? (
+					<div className="py-8 text-center text-sm text-tertiary-foreground">
+						Loading...
+					</div>
+				) : configQuery.isError ? (
+					<Alert variant="destructive">
+						<AlertTitle>Failed to load main Redis config</AlertTitle>
+						<AlertDescription>
+							{getBackendErr(configQuery.error, "Please try again")}
+						</AlertDescription>
+						<AlertAction>
+							<Button
+								variant="secondary"
+								size="sm"
+								onClick={() => configQuery.refetch()}
+							>
+								Retry
+							</Button>
+						</AlertAction>
+					</Alert>
+				) : configQuery.data ? (
+					<MainRedisCacheForm
+						key={`${configQuery.data.activeInstance}:${configQuery.data.lastSuccessAt ?? "never"}`}
+						config={configQuery.data}
+						onSaved={() => onOpenChange(false)}
+					/>
+				) : null}
+			</DialogContent>
+		</Dialog>
+	);
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds runtime routing between the primary and backup Redis endpoints.
- **[Bug fixes]** Treats `CACHE_BACKUP_URL` as a separately selectable fallback rather than replacing every regional endpoint.
- **[Improvements]** Adds S3-backed edge configuration, polling, warmup, readiness checks, DNS fallback behavior, and an admin control for selecting the active main Redis instance.
- **[API changes]** Adds superuser endpoints for reading and updating the active main Redis configuration.
</details>

<h3>Confidence Score: 4/5</h3>

This PR is not safe to merge until the fallback connection preserves CACHE_CERT for private-CA Redis endpoints.

The fallback client explicitly discards the configured Redis CA, preventing a private-CA backup endpoint from becoming ready or being selected during failover.

server/src/external/redis/initUtils/redisClientRegistry.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/redis/initUtils/createRedisClient.ts | Adds configurable TLS CA handling and DNS lookup fallback when creating Redis clients. |
| server/src/external/redis/initUtils/redisClientRegistry.ts | Introduces primary/fallback client routing, but explicitly removes CACHE_CERT from the fallback connection. |
| server/src/external/redis/mainRedisRouting.ts | Adds a proxy that resolves Redis commands against the currently selected client. |
| server/src/internal/misc/mainRedisCache/mainRedisCacheStore.ts | Adds the S3-backed edge-config store controlling the active main Redis instance. |
| server/src/internal/admin/handleUpsertAdminMainRedisCacheConfig.ts | Adds a superuser failover endpoint with fallback readiness and ping checks. |
| vite/src/views/admin/components/MainRedisCacheDialog.tsx | Adds an admin dialog for inspecting fallback health and changing the active Redis instance. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Admin[Admin Redis control] --> Config[S3 edge config]
  Config --> Pollers[Server, worker, and cron pollers]
  Pollers --> Router[Main Redis router]
  Router -->|primary| Primary[Regional CACHE_URL]
  Router -->|fallback| Fallback[Global CACHE_BACKUP_URL]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/external/redis/initUtils/redisClientRegistry.ts:44
**Fallback drops configured Redis CA**

When `CACHE_BACKUP_URL` uses TLS with a certificate signed by `CACHE_CERT`, passing `cacheCert: null` forces the fallback client to use the system trust store instead. The TLS handshake fails, so the client never becomes ready and the failover endpoint rejects switching to it with a 503.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: cache backup"](https://github.com/useautumn/autumn/commit/40f6bc18579a55147fe5bb52ff7d15d12e74c236) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46672840)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [External Integrations (non-Stripe)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-external-integrations.md)
- Knowledge Base — [Server API Routing: Request Lifecycle](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-api-routers.md)
- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)
</details>

<!-- /greptile_comment -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runtime routing between the regional Redis and the global backup at `CACHE_BACKUP_URL`, controlled by an S3-backed edge config and admin UI/API. Fixes the issue where the backup URL replaced all regions by making it an explicit, selectable fallback.

- **New Features**
  - Proxy-based router for the exported `redis` client that switches between primary and fallback at runtime without restarts.
  - S3 edge-config “Main Redis Instance” with 10s polling across servers/workers/cron, plus superuser GET/PUT endpoints and an admin dialog to inspect health and switch after readiness checks (includes `PING`).
  - Fallback warmup and health; new `redisDnsLookup` with `resolve4` fallback for TLS hosts and configurable `CACHE_CERT` for primary; unit tests for routing and DNS.

- **Bug Fixes**
  - `CACHE_BACKUP_URL` is now a selectable fallback instead of overriding all regional `CACHE_URL*`. If it’s the only Redis URL, it’s used across regions.
  - Safer startup and ops: regional and fallback warmup, readiness logs, and warnings when fallback is selected without a configured backup.

<sup>Written for commit 40f6bc18579a55147fe5bb52ff7d15d12e74c236. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

