### PR TITLE
fix(customers): preserve rate-limited recovery payload

### DIFF
--- a/server/src/honoMiddlewares/baseMiddleware.ts
+++ b/server/src/honoMiddlewares/baseMiddleware.ts
@@ -124,6 +124,7 @@ export const baseMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 		userId: undefined,
 		customerId,
 		entityId,
+		requestBody: body,
 		authType: AuthType.Unknown,
 		env: AppEnv.Sandbox, // maybe use app_env headers
 		scopes: [],

--- a/server/src/honoUtils/HonoEnv.ts
+++ b/server/src/honoUtils/HonoEnv.ts
@@ -31,6 +31,7 @@ export type RequestContext = {
 	oauthResource?: string;
 	customerId?: string;
 	entityId?: string;
+	requestBody?: unknown;
 
 	// Objects
 	db: DrizzleCli;

--- a/server/src/internal/customers/recovery/queueRateLimitedCustomerCreation.ts
+++ b/server/src/internal/customers/recovery/queueRateLimitedCustomerCreation.ts
@@ -27,7 +27,7 @@ export const queueRateLimitedCustomerCreation = async ({
 	const ctx = c.get("ctx");
 
 	try {
-		const body = await c.req.raw.clone().json();
+		const body = ctx.requestBody;
 		if (path === GET_OR_CREATE_PATH) {
 			const parsed = CreateCustomerParamsV1Schema.safeParse(body);
 			if (!parsed.success) return false;

--- a/server/tests/unit/customers/recovery/queue-rate-limited-customer-creation.test.ts
+++ b/server/tests/unit/customers/recovery/queue-rate-limited-customer-creation.test.ts
@@ -25,6 +25,7 @@ const { queueRateLimitedCustomerCreation } = await import(
 const buildApp = () => {
 	const app = new Hono<HonoEnv>();
 	app.use("*", async (c, next) => {
+		const requestBody = await c.req.json();
 		c.set("ctx", {
 			id: "req_rate_limited_123",
 			org: { id: "org_123" },
@@ -34,6 +35,7 @@ const buildApp = () => {
 			logger: {
 				error: mock(() => {}),
 			},
+			requestBody,
 		} as never);
 		await next();
 	});


### PR DESCRIPTION
Uses the request body already parsed by base middleware when queueing rate-limited customer creation recovery. Adds regression coverage for both customer creation routes.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Preserves parsed customer-creation payloads for rate-limit recovery.
- **[Bug fixes]** Stores the body parsed by base middleware in the shared request context and uses it when queueing rate-limited customer creation.
- **[API changes]** Extends `RequestContext` with an optional `requestBody` field.
- **[Improvements]** Adds regression coverage for both customer-creation routes.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the preserved payload correctly propagated to the rate-limit recovery path.

The request body is parsed once by base middleware, retained as a shared object reference, and preserved by downstream context updates before recovery validates and queues it.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/honoMiddlewares/baseMiddleware.ts | Stores the already-parsed request body in the per-request context for downstream recovery. |
| server/src/honoUtils/HonoEnv.ts | Adds the optional request-body value to the shared request-context type. |
| server/src/internal/customers/recovery/queueRateLimitedCustomerCreation.ts | Uses the preserved parsed payload instead of attempting to clone and reread the consumed request. |
| server/tests/unit/customers/recovery/queue-rate-limited-customer-creation.test.ts | Updates recovery tests to model base middleware parsing and context propagation. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant Base as Base middleware
  participant Limit as Rate-limit middleware
  participant Recovery as Customer recovery queue
  Client->>Base: Customer creation JSON
  Base->>Base: Parse request body
  Base->>Limit: Context containing requestBody
  Limit->>Recovery: Queue rate-limited creation
  Recovery->>Recovery: Validate preserved payload
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(customers): preserve rate-limited re..."](https://github.com/useautumn/autumn/commit/4cbd8541fa35d6a56fbcb25ebc70c65896130c33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46678993)</sub>

**Context used:**

- Knowledge Base — [Server API Routing: Request Lifecycle](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-api-routers.md)

<!-- /greptile_comment -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the parsed customer-creation payload and reuses it when queueing rate-limited recovery, avoiding failures from re-reading a consumed request stream. Adds regression tests for both customer-creation routes.

<sup>Written for commit 4cbd8541fa35d6a56fbcb25ebc70c65896130c33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

