### PR TITLE
chore: ratelimit statuscode

### DIFF
--- a/server/src/internal/misc/rateLimiter/rateLimitConfigs.ts
+++ b/server/src/internal/misc/rateLimiter/rateLimitConfigs.ts
@@ -190,8 +190,8 @@ export type RateLimitConfig = {
 	windowMs: number;
 	notInRedis: boolean;
 	scope: RateLimitScope;
-	// "degrade" = over-limit requests fail open (check -> allow, track -> SQS
-	// queue) instead of 429, so the cap sheds DB load without losing events.
+	// "degrade" preserves check/track traffic through fallback paths.
+	// Establish routes still reject with 429.
 	overLimit?: "reject" | "degrade";
 };
 

--- a/server/src/internal/misc/rateLimiter/rateLimitFactory.ts
+++ b/server/src/internal/misc/rateLimiter/rateLimitFactory.ts
@@ -82,8 +82,8 @@ export const rateLimitFactory = ({
 		return resolveRateLimit({ config, apiVersion }).limit;
 	};
 
-	// Over-limit "degrade": fail open instead of 429 — check routes get the
-	// allow-fallback via the ctx flag; establish routes shed a retryable 503.
+	// Check routes fail open; establish routes reject with a standard 429.
+	// Track routes use the degradation flag to preserve events through SQS.
 	const degradeHandler = async (
 		c: Context,
 		next: Next,
@@ -93,13 +93,14 @@ export const rateLimitFactory = ({
 		warnOrgCapExceeded({ limitType: type, orgSlug: ctx?.org?.slug });
 
 		if (type === RateLimitType.CheckOrg && !isCheckFailOpenRoute(honoContext)) {
+			c.header("Retry-After", undefined);
 			return c.json(
 				{
-					message: "Service is temporarily unavailable, please retry shortly.",
-					code: "service_unavailable",
+					message: "Rate limit exceeded.",
+					code: "rate_limit_exceeded",
 					env: ctx?.env,
 				},
-				503,
+				429,
 			);
 		}
 

--- a/server/tests/unit/rate-limits/rate-limit-factory.test.ts
+++ b/server/tests/unit/rate-limits/rate-limit-factory.test.ts
@@ -1,4 +1,6 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 
 const mockState = {
 	shouldUseRedis: false,
@@ -59,6 +61,46 @@ describe("rateLimitFactory", () => {
 		expect(mockState.warnings).toEqual([
 			"[rate-limit] Redis unavailable; bypassing distributed rate limiting",
 		]);
+	});
+
+	test("returns 429 without Retry-After for an over-limit establish route", async () => {
+		const app = new Hono<HonoEnv>();
+		const middleware = rateLimitFactory({
+			type: RateLimitType.CheckOrg,
+			config: {
+				name: "test-check-org",
+				limit: 1,
+				windowMs: 60_000,
+				notInRedis: true,
+				scope: RateLimitScope.Org,
+				overLimit: "degrade",
+			},
+		});
+
+		app.use("*", async (c, next) => {
+			c.set("ctx", {
+				env: "live",
+				org: { id: "org_123", slug: "test-org" },
+			} as never);
+			return middleware(c as never, next);
+		});
+		app.post("/v1/customers", (c) => c.json({ success: true }));
+
+		const firstResponse = await app.request("/v1/customers", {
+			method: "POST",
+		});
+		const limitedResponse = await app.request("/v1/customers", {
+			method: "POST",
+		});
+
+		expect(firstResponse.status).toBe(200);
+		expect(limitedResponse.status).toBe(429);
+		expect(limitedResponse.headers.get("Retry-After")).toBeNull();
+		expect(await limitedResponse.json()).toEqual({
+			message: "Rate limit exceeded.",
+			code: "rate_limit_exceeded",
+			env: "live",
+		});
 	});
 });
 

--- a/vite/src/views/admin/components/RateLimitOverrideOrgCard.tsx
+++ b/vite/src/views/admin/components/RateLimitOverrideOrgCard.tsx
@@ -1,0 +1,71 @@
+import {
+	Badge,
+	Button,
+	Card,
+	CardAction,
+	CardContent,
+	CardHeader,
+	CardTitle,
+	Separator,
+} from "@autumn/ui";
+import { Fragment } from "react";
+
+export type RateLimitOverrideEntry = {
+	type: string;
+	limit: number;
+	defaultLimit: number | undefined;
+};
+
+export function RateLimitOverrideOrgCard({
+	orgId,
+	entries,
+	onRemove,
+}: {
+	orgId: string;
+	entries: RateLimitOverrideEntry[];
+	onRemove: ({ orgId, type }: { orgId: string; type: string }) => void;
+}) {
+	const countLabel = entries.length === 1 ? "limit" : "limits";
+
+	return (
+		<Card className="gap-0 py-0">
+			<CardHeader className="border-b py-3">
+				<CardTitle className="truncate font-mono text-xs">{orgId}</CardTitle>
+				<CardAction>
+					<Badge variant="muted">
+						{entries.length} {countLabel}
+					</Badge>
+				</CardAction>
+			</CardHeader>
+			<CardContent>
+				{entries.map((entry, index) => (
+					<Fragment key={entry.type}>
+						{index > 0 && <Separator />}
+						<div className="flex items-center justify-between gap-3 py-2">
+							<div className="min-w-0">
+								<div className="truncate font-mono text-[11px] text-muted-foreground">
+									{entry.type}
+								</div>
+								<div className="text-xs tabular-nums text-muted-foreground">
+									limit: {entry.limit}
+									{entry.defaultLimit !== undefined && (
+										<span className="ml-1 text-tertiary-foreground">
+											(default {entry.defaultLimit})
+										</span>
+									)}
+								</div>
+							</div>
+							<Button
+								variant="secondary"
+								size="sm"
+								onClick={() => onRemove({ orgId, type: entry.type })}
+							>
+								Remove
+							</Button>
+						</div>
+					</Fragment>
+				))}
+			</CardContent>
+		</Card>
+	);
+}

--- a/vite/src/views/admin/components/RateLimitOverridesDialog.tsx
+++ b/vite/src/views/admin/components/RateLimitOverridesDialog.tsx
@@ -8,6 +8,7 @@ import {
 	DialogHeader,
 	DialogTitle,
 	Input,
+	ScrollArea,
 	Select,
 	SelectContent,
 	SelectItem,
@@ -19,6 +20,10 @@ import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
+import {
+	type RateLimitOverrideEntry,
+	RateLimitOverrideOrgCard,
+} from "./RateLimitOverrideOrgCard";
 
 type RateLimitDefault = {
 	limit: number;
@@ -52,34 +57,36 @@ const getEditableConfig = ({
 	orgs: config.orgs,
 });
 
-type EntryRow = {
+type OrgEntryGroup = {
 	orgId: string;
-	type: string;
-	limit: number;
-	defaultLimit: number | undefined;
+	entries: RateLimitOverrideEntry[];
 };
 
-const getEntryRows = ({
+const getOrgEntryGroups = ({
 	config,
 }: {
 	config: RateLimitOverridesConfig;
-}): EntryRow[] => {
-	const rows: EntryRow[] = [];
-	for (const [orgId, entry] of Object.entries(config.orgs)) {
-		for (const [type, limit] of Object.entries(entry.limits ?? {})) {
-			rows.push({
-				orgId,
+}): OrgEntryGroup[] => {
+	const groups: OrgEntryGroup[] = [];
+	const orgs = Object.entries(config.orgs);
+	orgs.sort(([leftOrgId], [rightOrgId]) => leftOrgId.localeCompare(rightOrgId));
+
+	for (const [orgId, entry] of orgs) {
+		const limits = Object.entries(entry.limits ?? {});
+		limits.sort(([leftType], [rightType]) => leftType.localeCompare(rightType));
+
+		const entries: RateLimitOverrideEntry[] = [];
+		for (const [type, limit] of limits) {
+			entries.push({
 				type,
 				limit,
 				defaultLimit: config.defaults[type]?.limit,
 			});
 		}
+		if (entries.length > 0) groups.push({ orgId, entries });
 	}
-	return rows.sort((a, b) =>
-		a.orgId === b.orgId
-			? a.type.localeCompare(b.type)
-			: a.orgId.localeCompare(b.orgId),
-	);
+
+	return groups;
 };
 
 export function RateLimitOverridesDialog({
@@ -144,7 +151,7 @@ export function RateLimitOverridesDialog({
 		setJsonError(null);
 	}, [config, syncSource]);
 
-	const entryRows = useMemo(() => getEntryRows({ config }), [config]);
+	const orgEntryGroups = useMemo(() => getOrgEntryGroups({ config }), [config]);
 	const rateLimitTypes = useMemo(
 		() => Object.keys(config.defaults).sort(),
 		[config.defaults],
@@ -232,7 +239,7 @@ export function RateLimitOverridesDialog({
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="max-w-5xl bg-card">
+			<DialogContent className="max-h-[calc(100dvh-2rem)] max-w-5xl grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden bg-card">
 				<DialogHeader>
 					<DialogTitle>Rate Limit Overrides</DialogTitle>
 					<DialogDescription>
@@ -242,171 +249,146 @@ export function RateLimitOverridesDialog({
 					</DialogDescription>
 				</DialogHeader>
 
-				{loading ? (
-					<div className="py-8 text-center text-sm text-tertiary-foreground">
-						Loading...
-					</div>
-				) : (
-					<div className="grid grid-cols-[360px_1fr] gap-6">
-						<div className="flex flex-col gap-4">
-							<div className="text-xs font-medium uppercase tracking-wide text-tertiary-foreground">
-								Override Entries
-							</div>
-
-							<div className="rounded-lg border border-border p-3">
-								<div className="mb-3 flex flex-col gap-2">
-									<Input
-										placeholder="Org ID or slug (e.g. mintlify)"
-										value={newOrgId}
-										onChange={(event) => setNewOrgId(event.target.value)}
-									/>
-									<Select
-										value={newType}
-										onValueChange={(value: string) => setNewType(value)}
-									>
-										<SelectTrigger className="h-9 w-full">
-											<SelectValue placeholder="Rate limit type..." />
-										</SelectTrigger>
-										<SelectContent>
-											{rateLimitTypes.map((type) => (
-												<SelectItem key={type} value={type}>
-													<span className="font-mono text-xs">{type}</span>
-													{config.defaults[type] && (
-														<span className="ml-2 text-[11px] text-tertiary-foreground">
-															(default {config.defaults[type].limit}/
-															{config.defaults[type].windowMs}ms)
-														</span>
-													)}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
-									<Input
-										placeholder="Limit (e.g. 200)"
-										type="number"
-										min={0}
-										value={newLimit}
-										onChange={(event) => setNewLimit(event.target.value)}
-									/>
-									<Button
-										variant="secondary"
-										size="sm"
-										onClick={addEntry}
-										disabled={
-											!newOrgId.trim() ||
-											!newType ||
-											!newLimit.trim() ||
-											Number.isNaN(Number.parseInt(newLimit, 10)) ||
-											Number.parseInt(newLimit, 10) < 0
-										}
-									>
-										Add override
-									</Button>
+				<ScrollArea className="min-h-0">
+					{loading ? (
+						<div className="py-8 text-center text-sm text-tertiary-foreground">
+							Loading...
+						</div>
+					) : (
+						<div className="grid grid-cols-[360px_1fr] gap-6 pr-3">
+							<div className="flex flex-col gap-4">
+								<div className="text-xs font-medium uppercase tracking-wide text-tertiary-foreground">
+									Override Entries
 								</div>
 
-								<div className="flex flex-col gap-2 border-t border-border pt-3">
-									{entryRows.length === 0 ? (
-										<div className="text-xs italic text-tertiary-foreground">
-											No overrides — all orgs use the hardcoded defaults.
-										</div>
-									) : (
-										entryRows.map((entry) => (
-											<div
-												key={`${entry.orgId}|${entry.type}`}
-												className="flex items-start justify-between gap-3 rounded-lg border border-border p-2"
-											>
-												<div className="min-w-0 flex-1">
-													<div className="truncate font-mono text-xs text-foreground">
-														{entry.orgId}
-													</div>
-													<div className="truncate font-mono text-[11px] text-muted-foreground">
-														{entry.type}
-													</div>
-													<div className="text-xs text-muted-foreground">
-														limit: {entry.limit}
-														{entry.defaultLimit !== undefined && (
-															<span className="ml-1 text-tertiary-foreground">
-																(default {entry.defaultLimit})
+								<div className="rounded-lg border border-border p-3">
+									<div className="mb-3 flex flex-col gap-2">
+										<Input
+											placeholder="Org ID or slug (e.g. mintlify)"
+											value={newOrgId}
+											onChange={(event) => setNewOrgId(event.target.value)}
+										/>
+										<Select
+											value={newType}
+											onValueChange={(value: string) => setNewType(value)}
+										>
+											<SelectTrigger className="h-9 w-full">
+												<SelectValue placeholder="Rate limit type..." />
+											</SelectTrigger>
+											<SelectContent>
+												{rateLimitTypes.map((type) => (
+													<SelectItem key={type} value={type}>
+														<span className="font-mono text-xs">{type}</span>
+														{config.defaults[type] && (
+															<span className="ml-2 text-[11px] text-tertiary-foreground">
+																(default {config.defaults[type].limit}/
+																{config.defaults[type].windowMs}ms)
 															</span>
 														)}
-													</div>
-												</div>
-												<Button
-													variant="secondary"
-													size="sm"
-													onClick={() =>
-														removeEntry({
-															orgId: entry.orgId,
-															type: entry.type,
-														})
-													}
-												>
-													Remove
-												</Button>
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+										<Input
+											placeholder="Limit (e.g. 200)"
+											type="number"
+											min={0}
+											value={newLimit}
+											onChange={(event) => setNewLimit(event.target.value)}
+										/>
+										<Button
+											variant="secondary"
+											size="sm"
+											onClick={addEntry}
+											disabled={
+												!newOrgId.trim() ||
+												!newType ||
+												!newLimit.trim() ||
+												Number.isNaN(Number.parseInt(newLimit, 10)) ||
+												Number.parseInt(newLimit, 10) < 0
+											}
+										>
+											Add override
+										</Button>
+									</div>
+
+									<div className="flex flex-col gap-2 border-t border-border pt-3">
+										{orgEntryGroups.length === 0 ? (
+											<div className="text-xs italic text-tertiary-foreground">
+												No overrides — all orgs use the hardcoded defaults.
 											</div>
-										))
-									)}
+										) : (
+											orgEntryGroups.map(({ orgId, entries }) => (
+												<RateLimitOverrideOrgCard
+													key={orgId}
+													orgId={orgId}
+													entries={entries}
+													onRemove={removeEntry}
+												/>
+											))
+										)}
+									</div>
+								</div>
+
+								<div className="rounded-lg border border-border p-3 text-xs text-tertiary-foreground">
+									<div className="mb-2 flex items-center gap-2">
+										<Badge
+											variant="muted"
+											className={
+												config.configHealthy
+													? "border-emerald-200 bg-emerald-50 text-emerald-700"
+													: "border-amber-200 bg-amber-50 text-amber-700"
+											}
+										>
+											{config.configHealthy
+												? "Config healthy"
+												: "Config unavailable"}
+										</Badge>
+										{config.lastSuccessAt && (
+											<span>
+												Last refresh:{" "}
+												{new Date(config.lastSuccessAt).toLocaleString()}
+											</span>
+										)}
+									</div>
+									<div>
+										{config.configConfigured === false
+											? "S3 rate-limit overrides config is not configured."
+											: config.error ||
+												"Overrides take effect on the next request after polling refresh (10s)."}
+									</div>
 								</div>
 							</div>
 
-							<div className="rounded-lg border border-border p-3 text-xs text-tertiary-foreground">
-								<div className="mb-2 flex items-center gap-2">
-									<Badge
-										variant="muted"
-										className={
-											config.configHealthy
-												? "border-emerald-200 bg-emerald-50 text-emerald-700"
-												: "border-amber-200 bg-amber-50 text-amber-700"
-										}
-									>
-										{config.configHealthy
-											? "Config healthy"
-											: "Config unavailable"}
-									</Badge>
-									{config.lastSuccessAt && (
-										<span>
-											Last refresh:{" "}
-											{new Date(config.lastSuccessAt).toLocaleString()}
-										</span>
-									)}
+							<div className="flex flex-col gap-2">
+								<div className="text-xs font-medium uppercase tracking-wide text-tertiary-foreground">
+									Raw JSON
 								</div>
-								<div>
-									{config.configConfigured === false
-										? "S3 rate-limit overrides config is not configured."
-										: config.error ||
-											"Overrides take effect on the next request after polling refresh (10s)."}
+								<div className="overflow-hidden rounded-md border border-border">
+									<Editor
+										height="420px"
+										language="json"
+										value={jsonText}
+										onChange={handleJsonChange}
+										options={{
+											minimap: { enabled: false },
+											scrollBeyondLastLine: false,
+											fontSize: 12,
+											tabSize: 2,
+											wordWrap: "on",
+											formatOnPaste: true,
+											formatOnType: true,
+										}}
+										theme="vs-dark"
+									/>
 								</div>
+								{jsonError && (
+									<div className="text-xs text-red-500">{jsonError}</div>
+								)}
 							</div>
 						</div>
-
-						<div className="flex flex-col gap-2">
-							<div className="text-xs font-medium uppercase tracking-wide text-tertiary-foreground">
-								Raw JSON
-							</div>
-							<div className="overflow-hidden rounded-md border border-border">
-								<Editor
-									height="420px"
-									language="json"
-									value={jsonText}
-									onChange={handleJsonChange}
-									options={{
-										minimap: { enabled: false },
-										scrollBeyondLastLine: false,
-										fontSize: 12,
-										tabSize: 2,
-										wordWrap: "on",
-										formatOnPaste: true,
-										formatOnType: true,
-									}}
-									theme="vs-dark"
-								/>
-							</div>
-							{jsonError && (
-								<div className="text-xs text-red-500">{jsonError}</div>
-							)}
-						</div>
-					</div>
-				)}
+					)}
+				</ScrollArea>
 
 				<DialogFooter>
 					<Button variant="secondary" onClick={() => onOpenChange(false)}>


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Return 429 without Retry-After for over‑limit establish routes, and simplify the admin overrides UI by grouping entries per org.

- **Bug Fixes**
  - Establish routes now return 429 with {message: "Rate limit exceeded", code: "rate_limit_exceeded"} when over limit (no Retry-After).
  - Check routes still fail open; track routes preserve events via the degradation flag.
  - Added unit test covering the 429 response and headers.

- **Refactors**
  - Reworked admin “Rate Limit Overrides” dialog: entries are grouped by org with a new `RateLimitOverrideOrgCard` component.
  - Added scrolling and constrained dialog height for large configs; minor copy and layout cleanups.
  - Kept raw JSON editor; improved type selection display using defaults from `@autumn/ui` components.

<sup>Written for commit 435a07f97982302d2a896f7b9b1ccb5f89888a19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR standardizes degraded establish-route rate-limit responses and improves the admin override dialog.
- **[Bug fixes, API changes]** Changes over-limit establish responses from `503 service_unavailable` to `429 rate_limit_exceeded` and removes `Retry-After`.
- **[Improvements]** Adds unit coverage for the new status, body, and header behavior.
- **[Improvements]** Groups override entries into per-organization cards and makes the dialog body scroll within the viewport.
</details>

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only a non-blocking stale comment about the previous 503 behavior needing correction.

The changed runtime behavior is explicitly covered by a focused unit test; the only retained issue is conflicting documentation within the rate-limit configuration.

server/src/internal/misc/rateLimiter/rateLimitConfigs.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/misc/rateLimiter/rateLimitConfigs.ts | Updates the degradation contract documentation, but leaves an earlier comment describing the old 503 behavior. |
| server/src/internal/misc/rateLimiter/rateLimitFactory.ts | Changes degraded establish-route responses to a standard 429 payload without Retry-After. |
| server/tests/unit/rate-limits/rate-limit-factory.test.ts | Adds focused coverage for the changed establish-route response contract. |
| vite/src/views/admin/components/RateLimitOverrideOrgCard.tsx | Introduces a reusable grouped card for displaying and removing an organization’s overrides. |
| vite/src/views/admin/components/RateLimitOverridesDialog.tsx | Groups overrides by organization and constrains the dialog body with a scroll area. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/misc/rateLimiter/rateLimitConfigs.ts:194-195
**Conflicting degraded-route documentation**

The updated comment says establish routes reject with 429, while the route-classification comment near `CHECK_FAIL_OPEN_PATTERNS` still says they shed a 503. Keeping both descriptions in sync avoids misleading future changes to this rate-limit branch.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into chore/ratelimit..."](https://github.com/useautumn/autumn/commit/cc6eee07fa8f6fe9a401b20fe909eda711c02078) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46686483)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->