### PR TITLE
fix: avoid blocking customer recovery queue

### DIFF
--- a/server/src/internal/misc/rateLimiter/rateLimitFactory.ts
+++ b/server/src/internal/misc/rateLimiter/rateLimitFactory.ts
@@ -94,6 +94,8 @@ export const rateLimitFactory = ({
 		warnOrgCapExceeded({ limitType: type, orgSlug: ctx?.org?.slug });
 
 		if (type === RateLimitType.CheckOrg && !isCheckFailOpenRoute(honoContext)) {
+			// Clients fail open on this 429. Preserve valid customer creation
+			// requests for controlled, serialized replay after the incident.
 			await queueRateLimitedCustomerCreation({ c: honoContext });
 			c.header("Retry-After", undefined);
 			return c.json(

--- a/server/src/queue/processMessage.ts
+++ b/server/src/queue/processMessage.ts
@@ -55,7 +55,7 @@ export const shouldRetrySqsJobError = ({
 }) => {
 	switch (jobName) {
 		case JobName.CustomerCreationRecovery:
-			return true;
+			return isTransientDbError({ error }) || isTransientRedisError({ error });
 		case JobName.SyncBalanceBatchV3:
 		case JobName.SyncBalanceBatchV4:
 		case JobName.RefreshEntityAggregate:

--- a/server/tests/unit/queue/processMessage.test.ts
+++ b/server/tests/unit/queue/processMessage.test.ts
@@ -4,11 +4,34 @@ import { JobName } from "@/queue/JobName.js";
 import { shouldRetrySqsJobError } from "@/queue/processMessage.js";
 
 describe("shouldRetrySqsJobError", () => {
-	test("keeps customer creation recovery failures for retry and DLQ redrive", () => {
+	test("does not retry permanent customer creation recovery failures", () => {
 		expect(
 			shouldRetrySqsJobError({
 				jobName: JobName.CustomerCreationRecovery,
 				error: new Error("requires manual billing review"),
+			}),
+		).toBe(false);
+	});
+
+	test("retries customer creation recovery on transient database errors", () => {
+		expect(
+			shouldRetrySqsJobError({
+				jobName: JobName.CustomerCreationRecovery,
+				error: Object.assign(new Error("connect timeout"), {
+					code: "CONNECT_TIMEOUT",
+				}),
+			}),
+		).toBe(true);
+	});
+
+	test("retries customer creation recovery on transient Redis errors", () => {
+		expect(
+			shouldRetrySqsJobError({
+				jobName: JobName.CustomerCreationRecovery,
+				error: new RedisUnavailableError({
+					source: "customerCreationRecovery",
+					reason: "timeout",
+				}),
 			}),
 		).toBe(true);
 	});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stops requeueing permanent failures in customer creation recovery so the queue stays unblocked. Only transient database or Redis errors are retried.

- **Bug Fixes**
  - Updated `shouldRetrySqsJobError` for `JobName.CustomerCreationRecovery` to retry only on `isTransientDbError` or `isTransientRedisError`.
  - Added unit tests for non-retry on permanent errors and retry on transient DB/Redis errors.

<sup>Written for commit 2929483882edc99ff91d7a41fcd8e95941e131e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates customer-creation recovery behavior to prevent one permanent failure from blocking the serialized recovery queue.
- **Bug fixes:** Restricts recovery retries to errors classified as transient database or Redis failures.
- **Improvements:** Documents why rate-limited customer creation requests are queued for serialized replay.
- **Bug fixes:** Adds unit coverage for permanent, transient database, and transient Redis recovery failures.
</details>

<h3>Confidence Score: 2/5</h3>

The PR should not merge until wrapped transient failures remain retryable and committed recoveries retain a durable manual-review path.

The new classifier deletes full-subject recovery messages after transient failures are wrapped as RecaseError, and it also immediately deletes partially completed recoveries that explicitly require manual billing review rather than allowing DLQ redrive.

server/src/queue/processMessage.ts and server/tests/unit/queue/processMessage.test.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/queue/processMessage.ts | Narrows recovery retries but drops wrapped transient failures and removes DLQ redrive for committed recoveries requiring manual review. |
| server/src/internal/misc/rateLimiter/rateLimitFactory.ts | Adds explanatory comments around the existing enqueue-and-429 behavior without changing execution. |
| server/tests/unit/queue/processMessage.test.ts | Covers raw synthetic transient errors but not wrapped errors or the loss of DLQ handling for manual-review recoveries. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Rate-limited customer creation] --> B[Recovery SQS queue]
  B --> C[Replay customer creation]
  C --> D[Full-subject rollout path]
  D --> E{Dependency result}
  E -->|Success| F[Delete message]
  E -->|Transient DB or Redis error| G[shed503OnTransientError]
  G --> H[RecaseError]
  H --> I[Retry classifier]
  I -->|Currently classified permanent| J[Delete message and lose recovery]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/queue/processMessage.ts:58
**Wrapped transient errors are dropped**

When recovery uses the full-subject path, `shed503OnTransientError` converts transient database or Redis failures into `RecaseError`. Neither classifier here recognizes that wrapper, so the worker treats the failure as permanent and deletes the recovery message instead of retrying the customer creation.

### Issue 2 of 2
server/src/queue/processMessage.ts:58
**Manual-review failures bypass the DLQ**

When replay receives an `autumn_committed` recovery job, the handler throws the permanent “requires manual billing review” error. Classifying it as non-retryable makes the worker delete the message immediately, so the partially created customer receives neither further recovery attempts nor the previous DLQ redrive path for manual handling.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: avoid blocking customer recovery qu..."](https://github.com/useautumn/autumn/commit/2929483882edc99ff91d7a41fcd8e95941e131e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46729543)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)

<!-- /greptile_comment -->