### PR TITLE
feat: resets

### DIFF
--- a/server/src/internal/balances/batchReset/compute/classifyNoAction.ts
+++ b/server/src/internal/balances/batchReset/compute/classifyNoAction.ts
@@ -37,5 +37,20 @@ export const classifyNoAction = ({
 		};
 	}
 
+	// Parity with the lazy path (and the V1 cron): only Active and gated
+	// PastDue products reset. Scheduled/Trialing/Paused/etc. must not have
+	// their balances topped up or next_reset_at advanced. (Expired products
+	// are handled earlier by classifyShouldExpire.)
+	if (
+		customerProduct.status !== CusProductStatus.Active &&
+		customerProduct.status !== CusProductStatus.PastDue
+	) {
+		return {
+			kind: "no_action",
+			customerEntitlementId: customerEntitlement.id,
+			reason: "product_not_active",
+		};
+	}
+
 	return null;
 };

--- a/server/src/internal/balances/batchReset/types.ts
+++ b/server/src/internal/balances/batchReset/types.ts
@@ -27,7 +27,7 @@ export type ResetVerdict = {
 		| "clear_next_reset"
 		| "no_action";
 	customerEntitlementId: string;
-	reason?: "product_past_due" | "not_due";
+	reason?: "product_past_due" | "product_not_active" | "not_due";
 	unlimited?: boolean;
 };
 

--- a/server/tests/integration/cron/batch-reset-v2/batch-reset-v2-rollovers.test.ts
+++ b/server/tests/integration/cron/batch-reset-v2/batch-reset-v2-rollovers.test.ts
@@ -148,7 +148,7 @@ test.concurrent(
 test.concurrent(
 	`${chalk.yellowBright("batch-reset-v2 rollovers: max cap clamps the rolled-over balance")}`,
 	async () => {
-		const { ctx, customerEntitlement } = await initRolloverScenario({
+		const { ctx, customerEntitlement, pastTime } = await initRolloverScenario({
 			customerId: "batch-reset-v2-rollover-max-cap",
 			rolloverConfig: {
 				max: 50,
@@ -172,13 +172,15 @@ test.concurrent(
 			0,
 		);
 		expect(totalRollover).toBe(50);
+		// Clamping must not disturb the expiry of the surviving row.
+		expect(rolloverRows[0].expires_at).toBe(addMonths(pastTime, 1).getTime());
 	},
 );
 
 test.concurrent(
 	`${chalk.yellowBright("batch-reset-v2 rollovers: max_percentage clamps to pct of allowance")}`,
 	async () => {
-		const { ctx, customerEntitlement } = await initRolloverScenario({
+		const { ctx, customerEntitlement, pastTime } = await initRolloverScenario({
 			customerId: "batch-reset-v2-rollover-percentage",
 			rolloverConfig: {
 				max_percentage: 50,
@@ -202,6 +204,36 @@ test.concurrent(
 			0,
 		);
 		expect(totalRollover).toBe(50);
+		expect(rolloverRows[0].expires_at).toBe(addMonths(pastTime, 1).getTime());
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("batch-reset-v2 rollovers: multi-month length sets expires_at length months out")}`,
+	async () => {
+		const { ctx, customerEntitlement, pastTime } = await initRolloverScenario({
+			customerId: "batch-reset-v2-rollover-length-3",
+			rolloverConfig: {
+				max: 50,
+				length: 3,
+				duration: RolloverExpiryDurationType.Month,
+			},
+			trackValue: 70, // remaining 30 < max 50
+		});
+
+		await runBatchResetV2({
+			ctx,
+			customerEntitlementIds: [customerEntitlement.id],
+		});
+
+		const rolloverRows = await fetchRollovers({
+			db: ctx.db,
+			customerEntitlementId: customerEntitlement.id,
+		});
+		expect(rolloverRows.length).toBe(1);
+		expect(rolloverRows[0].balance).toBe(30);
+		// ── Contract: expiry = old next_reset_at + `length` months ──────
+		expect(rolloverRows[0].expires_at).toBe(addMonths(pastTime, 3).getTime());
 	},
 );
 
@@ -293,14 +325,101 @@ test.concurrent(
 			(total, rolloverRow) => total + (rolloverRow.balance ?? 0),
 			0,
 		);
-		expect(totalRollover).toBeLessThanOrEqual(ROLLOVER_MAX);
-		expect(totalRollover).toBeGreaterThan(0);
+		// ── Contract: EXACT clearing math — 300, 600→450, 750→450 ───────
+		expect(totalRollover).toBe(ROLLOVER_MAX);
+		expect(rolloverRows.length).toBeLessThanOrEqual(RESET_CYCLES);
+		// Forever duration: every surviving row keeps a null expiry.
+		for (const rolloverRow of rolloverRows) {
+			expect(rolloverRow.expires_at).toBeNull();
+		}
 
 		const row = await fetchCustomerEntitlementRow({
 			db: ctx.db,
 			customerEntitlementId: customerEntitlement!.id,
 		});
 		expect(row.balance).toBe(INCLUDED);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("batch-reset-v2 rollovers: max clearing trims the earliest-expiring row first")}`,
+	async () => {
+		const customerId = "batch-reset-v2-rollover-clearing-order";
+		const ROLLOVER_MAX = 150;
+
+		const plan = products.base({
+			id: "rollover-clearing-order",
+			items: [
+				items.monthlyMessagesWithRollover({
+					includedUsage: INCLUDED_USAGE,
+					rolloverConfig: {
+						max: ROLLOVER_MAX,
+						length: 1,
+						duration: RolloverExpiryDurationType.Month,
+					},
+				}),
+			],
+		});
+
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+			actions: [s.attach({ productId: plan.id })],
+		});
+
+		const customerEntitlement = await findCustomerEntitlement({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+		expect(customerEntitlement).toBeDefined();
+
+		// Cycle 1: rolls the full 100 with expiry = firstPastTime + 1 month.
+		const firstPastTime = Date.now() - 1000;
+		await expireCusEntForReset({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+			pastTimeMs: firstPastTime,
+		});
+		await runBatchResetV2({
+			ctx,
+			customerEntitlementIds: [customerEntitlement!.id],
+		});
+
+		// Cycle 2: rolls another 100 (total 200) → clearing must trim the 50
+		// excess from the EARLIEST-expiring row (cycle 1's), not cycle 2's.
+		const secondPastTime = Date.now() - 1000;
+		await expireCusEntForReset({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+			pastTimeMs: secondPastTime,
+		});
+		await runBatchResetV2({
+			ctx,
+			customerEntitlementIds: [customerEntitlement!.id],
+		});
+
+		const rolloverRows = await fetchRollovers({
+			db: ctx.db,
+			customerEntitlementId: customerEntitlement!.id,
+		});
+		expect(rolloverRows.length).toBe(2);
+
+		const sortedRows = [...rolloverRows].sort(
+			(a, b) => (a.expires_at ?? 0) - (b.expires_at ?? 0),
+		);
+		// ── Contract: earliest-expiring row trimmed to absorb the excess ─
+		expect(sortedRows[0].balance).toBe(50);
+		expect(sortedRows[0].expires_at).toBe(
+			addMonths(firstPastTime, 1).getTime(),
+		);
+		// ── Contract: newest row untouched, expiry from its own cycle ───
+		expect(sortedRows[1].balance).toBe(INCLUDED_USAGE);
+		expect(sortedRows[1].expires_at).toBe(
+			addMonths(secondPastTime, 1).getTime(),
+		);
 	},
 );
 
@@ -368,11 +487,12 @@ test.concurrent(
 			await new Promise((resolve) => setTimeout(resolve, 500));
 		}
 
+		const pastTime = Date.now() - 1000;
 		await expireCusEntForReset({
 			ctx,
 			customerId,
 			featureId: TestFeature.Messages,
-			pastTimeMs: Date.now() - 1000,
+			pastTimeMs: pastTime,
 		});
 		await runBatchResetV2({
 			ctx,
@@ -404,5 +524,7 @@ test.concurrent(
 			.map((entity) => entity.balance)
 			.sort((a, b) => a - b);
 		expect(rolloverBalances).toEqual([INCLUDED_USAGE - 40, INCLUDED_USAGE]);
+		// ── Contract: entity rollover carries the Month expiry too ──────
+		expect(rolloverRows[0].expires_at).toBe(addMonths(pastTime, 1).getTime());
 	},
 );

--- a/server/tests/integration/cron/batch-reset-v2/batch-reset-v2-skips.test.ts
+++ b/server/tests/integration/cron/batch-reset-v2/batch-reset-v2-skips.test.ts
@@ -37,6 +37,7 @@ import { getResetEligibleCustomerEntitlementsPage } from "@/internal/customers/c
 import {
 	fetchCustomerEntitlementRow,
 	runBatchResetV2,
+	waitForPostgresBalance,
 } from "./batchResetV2TestUtils.js";
 
 const INCLUDED_USAGE = 100;
@@ -221,6 +222,43 @@ test.concurrent(
 		});
 		expect(rowAfter.balance).toBe(INCLUDED_USAGE);
 		expect(rowAfter.next_reset_at!).toBeGreaterThan(Date.now());
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("batch-reset-v2 skips: scheduled product gets no_action verdict (lazy-path parity)")}`,
+	async () => {
+		const { ctx, customerEntitlement, pastTime } = await initPastDueScenario({
+			customerId: "batch-reset-v2-skip-scheduled",
+			ignorePastDue: false,
+			productStatus: CusProductStatus.Scheduled,
+		});
+		await waitForPostgresBalance({
+			db: ctx.db,
+			customerEntitlementId: customerEntitlement.id,
+			expectedBalance: INCLUDED_USAGE - 25,
+		});
+
+		const result = await runBatchResetV2({
+			ctx,
+			customerEntitlementIds: [customerEntitlement.id],
+		});
+
+		expect(result.resetMutations.length).toBe(0);
+		expect(result.verdicts).toEqual([
+			expect.objectContaining({
+				kind: "no_action",
+				reason: "product_not_active",
+				customerEntitlementId: customerEntitlement.id,
+			}),
+		]);
+
+		const rowAfter = await fetchCustomerEntitlementRow({
+			db: ctx.db,
+			customerEntitlementId: customerEntitlement.id,
+		});
+		expect(rowAfter.balance).toBe(INCLUDED_USAGE - 25);
+		expect(rowAfter.next_reset_at).toBe(pastTime);
 	},
 );
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Aligns batch-reset v2 with the v1/lazy path by skipping resets for non-active products and tightening rollover expiry/clearing rules. Adds a `no_action` verdict with reason `product_not_active` and expands tests to lock these contracts.

- **Bug Fixes**
  - Only `Active` and `PastDue` products reset; others return `no_action` with reason `product_not_active`.
  - Rollover clamping preserves the surviving row’s expiry.
  - Multi-month rollover length sets expiry to old `next_reset_at` + `length` months.
  - Max clearing trims the earliest-expiring rollover rows first; “forever” duration rows keep `null` expiry.
  - Entity-scoped rollovers reset per entity and carry the correct expiry.

<sup>Written for commit 33a87a9425fffbcc4f5a9e63a0ef455cde1afcb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds status-aware safeguards and broader rollover coverage to batch reset V2.
- [Bug fixes] Prevents scheduled, trialing, paused, and other non-active products from resetting balances or advancing `next_reset_at`.
- [API changes] Extends reset verdict reasons with `product_not_active`.
- [Improvements] Adds integration coverage for rollover expiry duration, cap clearing order, exact clearing math, forever rollovers, entity-scoped expiry, and scheduled-product skips.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the new reset guard matching the established Active and gated-PastDue semantics.

The classifier still expires products before applying the new status guard, correctly gates PastDue products through `ignore_past_due`, and now prevents all other non-active statuses from producing reset mutations.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/batchReset/compute/classifyNoAction.ts | Adds a status allowlist consistent with existing lazy and V1 reset behavior, while preserving gated PastDue resets. |
| server/src/internal/balances/batchReset/types.ts | Extends the typed no-action reason union for the new non-active-product verdict. |
| server/tests/integration/cron/batch-reset-v2/batch-reset-v2-skips.test.ts | Verifies scheduled products retain their balance and reset date and receive the new no-action reason. |
| server/tests/integration/cron/batch-reset-v2/batch-reset-v2-rollovers.test.ts | Strengthens rollover assertions for expiry calculation, cap enforcement, clearing order, and entity balances. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Reset candidate] --> B{Product expired?}
  B -- Yes --> C[Mark entitlement expired]
  B -- No --> D{Reset due?}
  D -- No --> E[No action: not_due]
  D -- Yes --> F{Past due and resets disabled?}
  F -- Yes --> G[No action: product_past_due]
  F -- No --> H{Active or allowed PastDue?}
  H -- No --> I[No action: product_not_active]
  H -- Yes --> J[Continue reset classification]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: reset cron"](https://github.com/useautumn/autumn/commit/33a87a9425fffbcc4f5a9e63a0ef455cde1afcb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47034379)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->