### PR TITLE
fix: register miscellaneous edge config in workers

### DIFF
--- a/server/src/workers.ts
+++ b/server/src/workers.ts
@@ -7,6 +7,7 @@ import {
 	startAllEdgeConfigPolling,
 	stopAllEdgeConfigPolling,
 } from "./internal/misc/edgeConfig/edgeConfigRegistry.js";
+import "./internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 import "./internal/misc/requestBlocks/requestBlockStore.js";
 import "./internal/misc/rollouts/rolloutConfigStore.js";
 import "./internal/misc/redisV2Cache/redisV2CacheStore.js";

--- a/server/tests/unit/edge-config/worker-edge-config-registration.test.ts
+++ b/server/tests/unit/edge-config/worker-edge-config-registration.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test";
+import path from "node:path";
+
+test("workers register miscellaneous edge config before polling starts", async () => {
+	const workersPath = path.resolve(import.meta.dir, "../../../src/workers.ts");
+	const workersSource = await Bun.file(workersPath).text();
+	const storeImport =
+		'import "./internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";';
+	const storeImportIndex = workersSource.indexOf(storeImport);
+	const pollingStartIndex = workersSource.indexOf(
+		"await startAllEdgeConfigPolling({ logger });",
+	);
+
+	expect(storeImportIndex).toBeGreaterThanOrEqual(0);
+	expect(pollingStartIndex).toBeGreaterThan(storeImportIndex);
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure workers register miscellaneous edge config before polling starts to prevent missing config on startup.

- **Bug Fixes**
  - Import the miscellaneous edge config store in `server/src/workers.ts` before `startAllEdgeConfigPolling`.
  - Add a unit test to assert registration happens before polling begins.

<sup>Written for commit 6c8f534e51f5932abcca9a93b52d4cd7f4e1557d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes worker-side registration of miscellaneous edge configuration.
- **[Bug fixes]** Imports the miscellaneous edge-config store during worker bootstrap so it is registered before polling starts.
- **[Improvements]** Adds a unit regression check for the worker bootstrap wiring.
</details>

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking opportunity to make the regression test verify runtime registration rather than source text.

The worker import executes the intended registration before polling, while the only accepted concern is that the new test can pass without observing the registry behavior it claims to protect.

server/tests/unit/edge-config/worker-edge-config-registration.test.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/workers.ts | Correctly adds the miscellaneous store’s side-effect import alongside the other worker edge-config registrations. |
| server/tests/unit/edge-config/worker-edge-config-registration.test.ts | Adds regression coverage, but source-string inspection does not verify that runtime registration occurs. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/tests/unit/edge-config/worker-edge-config-registration.test.ts:5-8
**Source text replaces behavior testing**

This test only searches `workers.ts` for literal strings, so it still passes when the imported module stops calling `registerEdgeConfig` or the matching text becomes non-executable. Verify the runtime registry behavior instead so the test protects workers from silently polling without the miscellaneous store.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: register miscellaneous edge config ..."](https://github.com/useautumn/autumn/commit/6c8f534e51f5932abcca9a93b52d4cd7f4e1557d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47039837)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)

<!-- /greptile_comment -->