### PR TITLE
fix: reduce track idempotency TTL to one day

### DIFF
--- a/server/src/internal/balances/track/v3/trackIdempotencyKey.ts
+++ b/server/src/internal/balances/track/v3/trackIdempotencyKey.ts
@@ -1,7 +1,7 @@
 import { ms } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 
-export const TRACK_V3_IDEMPOTENCY_TTL_MS = ms.days(2);
+export const TRACK_V3_IDEMPOTENCY_TTL_MS = ms.days(1);
 
 export const getTrackIdempotencyKey = ({ ctx }: { ctx: AutumnContext }) =>
 	`track:${ctx.id}`;

--- a/server/tests/integration/balances/track/track-v3-idempotency.test.ts
+++ b/server/tests/integration/balances/track/track-v3-idempotency.test.ts
@@ -1,11 +1,14 @@
 import { expect, test } from "bun:test";
-import { ApiVersion, ApiVersionClass, ErrCode } from "@autumn/shared";
+import { ApiVersion, ApiVersionClass, ErrCode, ms } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import ctx from "@tests/utils/testInitUtils/createTestContext.js";
 import { Decimal } from "decimal.js";
 import { getTrackFeatureDeductionsForBody } from "@/internal/balances/track/utils/getFeatureDeductions.js";
-import { getRedisTrackFeatureIdempotencyKey } from "@/internal/balances/track/v3/trackIdempotencyKey.js";
 import { runTrackV3 } from "@/internal/balances/track/v3/runTrackV3.js";
+import {
+	getRedisTrackFeatureIdempotencyKey,
+	TRACK_V3_IDEMPOTENCY_TTL_MS,
+} from "@/internal/balances/track/v3/trackIdempotencyKey.js";
 import { buildCustomerMeteredScenario } from "../../db/full-subject/utils/fullSubjectScenarioBuilders.js";
 import { withInsertedScenario } from "../../db/full-subject/utils/withInsertedScenario.js";
 
@@ -67,6 +70,9 @@ test("track-v3 idempotency is atomic for single-feature requests", async () => {
 				featureId: TestFeature.Messages,
 			});
 			expect(await ctx.redisV2.exists(redisKey)).toBe(1);
+			const ttlMs = await ctx.redisV2.pttl(redisKey);
+			expect(ttlMs).toBeGreaterThan(ms.hours(23));
+			expect(ttlMs).toBeLessThanOrEqual(TRACK_V3_IDEMPOTENCY_TTL_MS);
 		},
 	});
 });

--- a/server/tests/unit/balances/track-v3/trackIdempotencyKey.test.ts
+++ b/server/tests/unit/balances/track-v3/trackIdempotencyKey.test.ts
@@ -1,6 +1,13 @@
 import { expect, test } from "bun:test";
-import { AppEnv } from "@autumn/shared";
-import { getTrackIdempotencyKey } from "@/internal/balances/track/v3/trackIdempotencyKey.js";
+import { AppEnv, ms } from "@autumn/shared";
+import {
+	getTrackIdempotencyKey,
+	TRACK_V3_IDEMPOTENCY_TTL_MS,
+} from "@/internal/balances/track/v3/trackIdempotencyKey.js";
+
+test("track v3 idempotency keys expire after one day", () => {
+	expect(TRACK_V3_IDEMPOTENCY_TTL_MS).toBe(ms.days(1));
+});
 
 test("getTrackIdempotencyKey uses the request id", () => {
 	expect(


### PR DESCRIPTION
Reduces V3 track idempotency-key retention from two days to one day. Adds unit and integration coverage verifying the resulting Redis TTL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce V3 track idempotency-key TTL from two days to one day to lower Redis retention while keeping duplicate protection. Add unit and integration tests that assert the Redis TTL is >23 hours and <= the configured one-day TTL.

<sup>Written for commit 32a152cfeb7c99b1217488a524d0184fb3ff883e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Shortens V3 track idempotency-key retention and verifies the applied Redis expiry.
- [Bug fixes] Reduces the V3 track idempotency TTL from two days to one day.
- [Improvements] Adds unit coverage for the one-day TTL constant.
- [Improvements] Adds integration coverage confirming that Redis applies the expected TTL.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with the shortened TTL correctly propagated to the existing Redis expiry path and covered by integration testing.

The production change only adjusts the existing millisecond TTL constant, while the Redis write continues to apply that value as a PX expiry and the integration test verifies the resulting remaining lifetime.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/track/v3/trackIdempotencyKey.ts | Changes the V3 track idempotency-key retention constant from two days to one day. |
| server/tests/integration/balances/track/track-v3-idempotency.test.ts | Verifies that the generated Redis idempotency key has a remaining TTL between 23 and 24 hours. |
| server/tests/unit/balances/track-v3/trackIdempotencyKey.test.ts | Adds a direct assertion that the exported idempotency TTL is one day. |

<sub>Reviews (1): Last reviewed commit: ["fix: reduce track idempotency TTL to one..."](https://github.com/useautumn/autumn/commit/32a152cfeb7c99b1217488a524d0184fb3ff883e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47062485)</sub>

<!-- /greptile_comment -->