### PR TITLE
feat: batch reset cron V2 (scan + SQS fan-out)

### DIFF
--- a/server/src/internal/balances/batchReset/batchResetCustomerEntitlementsV2.ts
+++ b/server/src/internal/balances/batchReset/batchResetCustomerEntitlementsV2.ts
@@ -52,14 +52,34 @@ export const batchResetCustomerEntitlementsV2 = async ({
 	});
 
 	await executeVerdictMutations({ db, verdictMutations });
-	await executeResetMutations({ db, resetMutations });
+	const { appliedCustomerEntitlementIds, staleSkippedCount } =
+		await executeResetMutations({ db, resetMutations });
+
+	if (staleSkippedCount > 0) {
+		// A concurrent reset (usually a lazy reset racing this worker) won —
+		// the guarded UPDATE skipped those rows instead of double-applying.
+		logger.info("[batchReset] stale mutations skipped", {
+			jobName: "reset-cus-ents-v2",
+			data: { staleSkippedCount },
+		});
+	}
+
+	const appliedResetMutations = resetMutations.filter(
+		({ customerEntitlementId }) =>
+			appliedCustomerEntitlementIds.has(customerEntitlementId),
+	);
 
 	// Postgres is authoritative now — drop the stale Redis state so the next
 	// read rehydrates instead of serving pre-reset balances.
 	await invalidateResetCaches({
 		resetGroups: classifiedBatchResetContext.resetGroups,
-		resetMutations,
+		resetMutations: appliedResetMutations,
 	});
 
-	return { ...classifiedBatchResetContext, verdictMutations, resetMutations };
+	return {
+		...classifiedBatchResetContext,
+		verdictMutations,
+		resetMutations,
+		appliedResetMutations,
+	};
 };

--- a/server/src/internal/balances/batchReset/compute/computeResets/computeResetMutation.ts
+++ b/server/src/internal/balances/batchReset/compute/computeResets/computeResetMutation.ts
@@ -11,6 +11,11 @@ export const computeResetMutation = async ({
 	ctx: AutumnContext;
 	customerEntitlement: ResetContextCustomerEntitlement;
 }): Promise<ResetMutation | null> => {
+	// Guaranteed non-null by the not_due classification; re-checked for the
+	// optimistic guard the execute UPDATE compares against.
+	const expectedNextResetAt = customerEntitlement.next_reset_at;
+	if (expectedNextResetAt == null) return null;
+
 	const result = await processReset({
 		ctx,
 		cusEnt: customerEntitlement,
@@ -22,6 +27,7 @@ export const computeResetMutation = async ({
 	if (newRollovers.length === 0) {
 		return {
 			customerEntitlementId: customerEntitlement.id,
+			expectedNextResetAt,
 			updates: result.updates,
 			rolloverInserts: [],
 			rolloverUpdates: [],
@@ -42,6 +48,7 @@ export const computeResetMutation = async ({
 
 	return {
 		customerEntitlementId: customerEntitlement.id,
+		expectedNextResetAt,
 		updates: result.updates,
 		rolloverInserts: newRollovers
 			.filter(({ id }) => !deletedRolloverIds.has(id))

--- a/server/src/internal/balances/batchReset/execute/executeResetMutations.ts
+++ b/server/src/internal/balances/batchReset/execute/executeResetMutations.ts
@@ -6,19 +6,28 @@ import { RolloverService } from "@/internal/customers/cusProducts/cusEnts/cusRol
 import { resetCronQueryTag } from "../resetCronQueryTag.js";
 import type { ResetMutation } from "../types.js";
 
+/**
+ * Applies the balance updates with an optimistic guard: a row only updates
+ * while its next_reset_at still matches what the mutation was computed from.
+ * A row that changed in between (a lazy reset racing the worker, or a
+ * duplicate delivery) is skipped. Returns the IDs that actually applied.
+ */
 const updateCustomerEntitlements = async ({
 	db,
 	resetMutations,
 }: {
 	db: DrizzleCli;
 	resetMutations: ResetMutation[];
-}) => {
-	const updates = resetMutations.map(({ customerEntitlementId, updates }) => ({
-		id: customerEntitlementId,
-		...updates,
-	}));
+}): Promise<Set<string>> => {
+	const updates = resetMutations.map(
+		({ customerEntitlementId, expectedNextResetAt, updates }) => ({
+			id: customerEntitlementId,
+			expected_next_reset_at: expectedNextResetAt,
+			...updates,
+		}),
+	);
 
-	await db.execute(sql`
+	const appliedRows = await db.execute<{ id: string }>(sql`
 		UPDATE ${customerEntitlements} AS customer_entitlement
 		SET
 			balance = COALESCE(reset_update.balance, customer_entitlement.balance),
@@ -32,6 +41,7 @@ const updateCustomerEntitlements = async ({
 			cache_version = COALESCE(customer_entitlement.cache_version, 0) + 1
 		FROM jsonb_to_recordset(${JSON.stringify(updates)}::jsonb) AS reset_update(
 			id text,
+			expected_next_reset_at numeric,
 			balance numeric,
 			additional_balance numeric,
 			adjustment numeric,
@@ -39,8 +49,12 @@ const updateCustomerEntitlements = async ({
 			next_reset_at numeric
 		)
 		WHERE customer_entitlement.id = reset_update.id
+			AND customer_entitlement.next_reset_at = reset_update.expected_next_reset_at
+		RETURNING customer_entitlement.id
 		${resetCronQueryTag("updateBalances")}
 	`);
+
+	return new Set(appliedRows.map((row) => row.id));
 };
 
 export const executeResetMutations = async ({
@@ -49,24 +63,40 @@ export const executeResetMutations = async ({
 }: {
 	db: DrizzleCli;
 	resetMutations: ResetMutation[];
-}) => {
-	if (resetMutations.length === 0) return;
+}): Promise<{
+	appliedCustomerEntitlementIds: Set<string>;
+	staleSkippedCount: number;
+}> => {
+	if (resetMutations.length === 0) {
+		return { appliedCustomerEntitlementIds: new Set(), staleSkippedCount: 0 };
+	}
 
-	const rolloverWrites = resetMutations.flatMap(
-		({ rolloverInserts, rolloverUpdates }) => [
-			...rolloverInserts,
-			...rolloverUpdates,
-		],
-	);
-	const rolloverDeleteIds = resetMutations.flatMap(
-		({ rolloverDeleteIds }) => rolloverDeleteIds,
-	);
+	let appliedCustomerEntitlementIds = new Set<string>();
 
 	await withStatementTimeout(db, async (transaction) => {
-		await updateCustomerEntitlements({
+		appliedCustomerEntitlementIds = await updateCustomerEntitlements({
 			db: transaction,
 			resetMutations,
 		});
+
+		// Rollover writes only for rows whose guarded UPDATE applied — a stale
+		// mutation's rollover would double-credit a row someone else already
+		// reset.
+		const appliedMutations = resetMutations.filter(
+			({ customerEntitlementId }) =>
+				appliedCustomerEntitlementIds.has(customerEntitlementId),
+		);
+
+		const rolloverWrites = appliedMutations.flatMap(
+			({ rolloverInserts, rolloverUpdates }) => [
+				...rolloverInserts,
+				...rolloverUpdates,
+			],
+		);
+		const rolloverDeleteIds = appliedMutations.flatMap(
+			({ rolloverDeleteIds }) => rolloverDeleteIds,
+		);
+
 		await RolloverService.upsert({
 			db: transaction,
 			rows: rolloverWrites,
@@ -78,4 +108,10 @@ export const executeResetMutations = async ({
 			queryTag: resetCronQueryTag("deleteRollovers"),
 		});
 	});
+
+	return {
+		appliedCustomerEntitlementIds,
+		staleSkippedCount:
+			resetMutations.length - appliedCustomerEntitlementIds.size,
+	};
 };

--- a/server/src/internal/balances/batchReset/types.ts
+++ b/server/src/internal/balances/batchReset/types.ts
@@ -33,6 +33,11 @@ export type ResetVerdict = {
 
 export type ResetMutation = {
 	customerEntitlementId: string;
+	/** next_reset_at the mutation was computed from. The execute UPDATE only
+	 * applies while the row still matches (optimistic guard), so a concurrent
+	 * duplicate — a lazy reset racing the worker, or an SQS redelivery —
+	 * no-ops instead of double-applying balances and rollovers. */
+	expectedNextResetAt: number;
 	updates: ResetUpdates;
 	rolloverInserts: Rollover[];
 	rolloverUpdates: Rollover[];

--- a/server/tests/integration/cron/batch-reset-v2/batch-reset-v2-race.test.ts
+++ b/server/tests/integration/cron/batch-reset-v2/batch-reset-v2-race.test.ts
@@ -1,0 +1,131 @@
+/**
+ * TDD test for the V2 batch reset optimistic guard.
+ *
+ * Contract under test:
+ *   Behaviors:
+ *     - a mutation computed BEFORE a concurrent reset committed (the lazy
+ *       reset racing the worker, or a duplicate delivery) is SKIPPED by the
+ *       guarded execute UPDATE: balance written by the winner survives,
+ *       next_reset_at is not pushed another cycle, and NO duplicate rollover
+ *       row is inserted
+ *     - the skip is reported (staleSkippedCount) and non-applied mutations
+ *       produce no rollover writes
+ *
+ * The race is simulated by running the worker's stages directly: hydrate +
+ * classify + compute, then committing a "lazy reset" (row update + rollover
+ * insert) before executeResetMutations runs with the now-stale mutations.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	customerEntitlements,
+	RolloverExpiryDurationType,
+} from "@autumn/shared";
+import { findCustomerEntitlement } from "@tests/balances/utils/findCustomerEntitlement.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expireCusEntForReset } from "@tests/utils/cusProductUtils/resetTestUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { eq, sql } from "drizzle-orm";
+import { logger } from "@/external/logtail/logtailUtils.js";
+import { classifyBatchResetContext } from "@/internal/balances/batchReset/compute/classifyBatchResetContext.js";
+import { computeResetMutations } from "@/internal/balances/batchReset/compute/computeResets/computeResetMutations.js";
+import { executeResetMutations } from "@/internal/balances/batchReset/execute/executeResetMutations.js";
+import { setupBatchResetContext } from "@/internal/balances/batchReset/setup/setupBatchResetContext.js";
+import {
+	fetchCustomerEntitlementRow,
+	fetchRollovers,
+} from "./batchResetV2TestUtils.js";
+
+const INCLUDED_USAGE = 100;
+
+test.concurrent(
+	`${chalk.yellowBright("batch-reset-v2 race: stale mutation is skipped after a concurrent reset wins")}`,
+	async () => {
+		const customerId = "batch-reset-v2-race-lazy-wins";
+		const plan = products.base({
+			id: "race-lazy-wins",
+			items: [
+				items.monthlyMessagesWithRollover({
+					includedUsage: INCLUDED_USAGE,
+					rolloverConfig: {
+						max: 1000,
+						length: 1,
+						duration: RolloverExpiryDurationType.Month,
+					},
+				}),
+			],
+		});
+
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+			actions: [s.attach({ productId: plan.id })],
+		});
+
+		const customerEntitlement = await findCustomerEntitlement({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+		expect(customerEntitlement).toBeDefined();
+
+		await expireCusEntForReset({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+			pastTimeMs: Date.now() - 1000,
+		});
+
+		// ── Worker stages 1-3: hydrate, classify, compute ────────────────
+		const batchResetContext = await setupBatchResetContext({
+			db: ctx.db,
+			logger,
+			payload: { customerEntitlementIds: [customerEntitlement!.id] },
+		});
+		const classified = classifyBatchResetContext({ batchResetContext });
+		const resetMutations = await computeResetMutations({
+			resetGroups: classified.resetGroups,
+		});
+		expect(resetMutations.length).toBe(1);
+		const computedNextResetAt = resetMutations[0].updates.next_reset_at;
+
+		// ── Concurrent "lazy reset" commits first: same reset target, its
+		// own rollover row, then some fresh usage (balance 95) ───────────
+		await ctx.db.execute(sql`
+			INSERT INTO rollovers (id, cus_ent_id, balance, usage, expires_at, entities)
+			VALUES ('roll_race_lazy_winner', ${customerEntitlement!.id}, 100, 0, null, '{}'::jsonb)
+		`);
+		await ctx.db
+			.update(customerEntitlements)
+			.set({ balance: 95, next_reset_at: computedNextResetAt })
+			.where(eq(customerEntitlements.id, customerEntitlement!.id));
+
+		// ── Worker stage 4: execute with the now-stale mutations ─────────
+		const { appliedCustomerEntitlementIds, staleSkippedCount } =
+			await executeResetMutations({ db: ctx.db, resetMutations });
+
+		// ── Contract: the stale mutation is skipped, not double-applied ──
+		expect(staleSkippedCount).toBe(1);
+		expect(appliedCustomerEntitlementIds.size).toBe(0);
+
+		const row = await fetchCustomerEntitlementRow({
+			db: ctx.db,
+			customerEntitlementId: customerEntitlement!.id,
+		});
+		// The winner's post-reset usage survives (no balance re-top).
+		expect(row.balance).toBe(95);
+		// next_reset_at not pushed another cycle forward.
+		expect(row.next_reset_at).toBe(computedNextResetAt);
+
+		// ── Contract: exactly ONE rollover row (the winner's) ────────────
+		const rolloverRows = await fetchRollovers({
+			db: ctx.db,
+			customerEntitlementId: customerEntitlement!.id,
+		});
+		expect(rolloverRows.length).toBe(1);
+		expect(rolloverRows[0].id).toBe("roll_race_lazy_winner");
+	},
+);


### PR DESCRIPTION
## Summary

Replaces the heavy V1 reset cron (3-branch UNION ALL scan, ~50s and 57M buffer hits per 1000 rows on prod) with a scan-and-fan-out architecture:

- **Scanner** (`runResetLoopV2`, own edge config `reset-job-v2`): single-table keyset sweep over overdue cusEnts (~35ms DB per 10k page), pages fanned to a dedicated SQS queue (`BATCH_RESET_SQS_QUEUE_URL`). Queue-depth backpressure (Gate A) + empty-queue sweep barrier (Gate B) prevent scan/worker overlap; both knobs live-tunable via the Batch Reset V2 admin dialog.
- **Worker** (`batchResetCustomerEntitlementsV2`, own SQS queue + job): bare-ID payloads, single-statement jsonb hydration, pure classification (not_due / past_due gate / product-not-active / should_expire / resets_via_invoice), batched reset + rollover mutations, batched subject-cache invalidation.
- **Optimistic guard**: execute UPDATE applies only while `next_reset_at` matches the computed-from value; rollover writes filtered to applied rows — a lazy reset racing the worker (or SQS redelivery) can no longer double-reset or double-credit rollovers.
- **Denormalization**: new `reset_by_invoice` column written lazily by worker verdicts + `expired` marking, so invoice-owned/expired rows exit the scan permanently. Migration `0047` adds the column + covering partial scan index (`CONCURRENTLY`; **prod apply is manual**).
- **Observability**: backlog gauge / page / sweep-completed events (fields under `data`) in the express dataset, PlanetScale query tags, dedicated `bun reset-v2 <staging|prod>` scanner entrypoint.

## Tests

- `tests/integration/cron/batch-reset-v2/` (registered in core-billing): scan eligibility + keyset pagination, worker basics (regular / multi-cycle catch-up / month-end boundary / legacy null-id entities / idempotent redelivery), skips (price-backed persists `reset_by_invoice`, past_due ± ignore, scheduled, expired, unlimited), rollovers (max / max_percentage / length>1 / Forever / exact multi-cycle clearing / clearing order / entity-scoped, all with expires_at assertions), cache invalidation, race (stale mutation skipped).
- Unit: scan gates (queue-depth backpressure), reset job V2 edge config.

## Outstanding

- ⚠️ Final integration run of the race test + full folder is pending — local dev server lost :8080 to a staging-connected server during the last verification window. 24/24 were green immediately before the guard commit; the guard itself is covered by the (not-yet-executed) race test. Run `bun test tests/integration/cron/batch-reset-v2/` once the dev stack is back.
- Prod rollout: apply migration 0047 manually (TablePlus, CONCURRENTLY), provision `BATCH_RESET_SQS_QUEUE_URL`, enable the batchReset job queue + reset-job-v2 edge config.
- V1 cron stays in place behind its own edge config for rollback; retire after parity confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an optimistic guard to Batch Reset V2 to prevent double resets and duplicate rollovers during races (lazy reset or duplicate SQS deliveries). Updates only apply if the row’s current `next_reset_at` matches the value the mutation was computed from; rollover writes and cache invalidation are limited to applied rows.

- **Bug Fixes**
  - Guarded UPDATE compares `expected_next_reset_at` with the current `next_reset_at`; returns applied IDs and a `staleSkippedCount`.
  - Rollover inserts/updates/deletes execute only for applied rows; cache invalidation uses the filtered set.
  - Logs skipped stale mutations to help spot races in prod.
  - Adds `expectedNextResetAt` to `ResetMutation`; updates compute/execute paths accordingly.
  - New race integration test ensures stale mutations are skipped and no duplicate rollover is created.

<sup>Written for commit b05171bb921cfd154fe46ee57736369dbce10ce7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds an optimistic execution guard and post-apply filtering to the batch-reset V2 pipeline.
- **Bug fixes, Improvements:** Captures each mutation's source `next_reset_at` and applies entitlement updates only while that timestamp still matches.
- **Bug fixes:** Restricts rollover writes and cache invalidation to entitlement updates returned by the guarded statement.
- **Improvements, API changes:** Returns applied entitlement IDs, stale-skip counts, and applied reset mutations for reporting and downstream handling.
- **Improvements:** Adds an integration test simulating a lazy reset winning before a stale worker mutation executes.
</details>

<h3>Confidence Score: 3/5</h3>

This PR should not merge until the optimistic guard also detects concurrent usage changes that leave next_reset_at unchanged.

The new guard prevents duplicate resets that advance next_reset_at, but a usage synchronization can alter reset inputs between computation and execution while still satisfying that guard, allowing stale balance and rollover mutations to commit.

server/src/internal/balances/batchReset/execute/executeResetMutations.ts and server/src/internal/balances/batchReset/compute/computeResets/computeResetMutation.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/batchReset/execute/executeResetMutations.ts | Adds guarded batched updates and filters rollover writes to returned IDs, but the guard misses concurrent usage changes to other reset inputs. |
| server/src/internal/balances/batchReset/compute/computeResets/computeResetMutation.ts | Captures next_reset_at for optimistic execution while continuing to compute resets from mutable balance and rollover snapshots. |
| server/src/internal/balances/batchReset/batchResetCustomerEntitlementsV2.ts | Logs stale skips and limits cache invalidation to successfully applied reset mutations. |
| server/src/internal/balances/batchReset/types.ts | Extends ResetMutation with the expected reset timestamp required by the execution guard. |
| server/tests/integration/cron/batch-reset-v2/batch-reset-v2-race.test.ts | Covers a concurrent reset that advances next_reset_at, but not concurrent usage that leaves the timestamp unchanged. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Worker as Batch-reset worker
  participant DB as PostgreSQL
  participant Usage as Usage synchronization
  participant Cache as Redis cache
  Worker->>DB: Hydrate entitlement and rollovers
  Worker->>Worker: Compute reset from snapshot
  Usage->>DB: Persist balance/rollover changes
  Worker->>DB: "UPDATE WHERE next_reset_at = expected"
  Note over Worker,DB: Guard still matches when usage did not change next_reset_at
  Worker->>DB: Apply computed rollover writes
  Worker->>Cache: Invalidate applied entitlement cache
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/balances/batchReset/execute/executeResetMutations.ts:52
**Guard misses concurrent usage state**

When usage synchronization changes balances, entities, or rollovers after reset computation without advancing `next_reset_at`, this guard still accepts the stale mutation, overwriting newly persisted usage or applying stale rollover writes and leaving the customer with an incorrect balance or rollover credit.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: optimistic guard on batch reset exe..."](https://github.com/useautumn/autumn/commit/b05171bb921cfd154fe46ee57736369dbce10ce7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47070747)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->