### PR TITLE
fix/flim coupon issue

### DIFF
--- a/scripts/tw/helpers/preflight.ts
+++ b/scripts/tw/helpers/preflight.ts
@@ -62,7 +62,7 @@ const checkSecrets = (): PreflightProblem | undefined => {
 };
 
 const checkGit = (ref: string): PreflightProblem | undefined => {
-	const dirty = git("status", "--porcelain");
+	const dirty = git("status", "--porcelain", "--", ".", ":(exclude)ai");
 	if (dirty) {
 		return {
 			what: "uncommitted changes — workers clone origin/<ref>, so they won't see them",

--- a/server/src/external/stripe/coupons/resolvePromotionCode.ts
+++ b/server/src/external/stripe/coupons/resolvePromotionCode.ts
@@ -41,7 +41,7 @@ export const resolvePromotionCode = async ({
 			code,
 			active: true,
 			limit: 1,
-			expand: ["data.promotion.coupon"],
+			expand: ["data.promotion.coupon.applies_to"],
 		});
 
 		if (promos.data.length === 0) {
@@ -67,12 +67,9 @@ export const resolvePromotionCode = async ({
 		}
 
 		const minimumAmountsByCurrency = Object.fromEntries(
-			Object.entries(
-				promo.restrictions?.currency_options ?? {},
-			).map(([currency, option]) => [
-				currency.toLowerCase(),
-				option.minimum_amount,
-			]),
+			Object.entries(promo.restrictions?.currency_options ?? {}).map(
+				([currency, option]) => [currency.toLowerCase(), option.minimum_amount],
+			),
 		);
 
 		const hasCurrencyOptions = Object.keys(minimumAmountsByCurrency).length > 0;

--- a/server/src/internal/billing/v2/execute/executeAutumnActions/executeCustomerLicenseTransitions.ts
+++ b/server/src/internal/billing/v2/execute/executeAutumnActions/executeCustomerLicenseTransitions.ts
@@ -1,5 +1,6 @@
 import type { CustomerLicenseTransition } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { batchTransition } from "@/internal/billing/v2/actions/batchTransition/batchTransition";
 import { batchTransitionTask } from "@/internal/billing/v2/actions/batchTransition/tasks/batchTransitionTask";
 import { isSameRowTransition } from "@/internal/billing/v2/compute/customerLicenseTransitions/isSameRowTransition";
 import { customerLicenseRepo } from "@/internal/licenses/repos/customerLicenseRepo";
@@ -51,18 +52,24 @@ export const executeCustomerLicenseTransitions = async ({
 			});
 		}
 
-		await batchTransitionTask.trigger(
-			{
-				orgId: ctx.org.id,
-				env: ctx.env,
-				customerId: ctx.customerId,
-				transition,
-				executionScope: {
-					batchTransitionId: generateId("batch_transition"),
-					assignmentCutoffMs: Date.now(),
+		const executionScope = {
+			batchTransitionId: generateId("batch_transition"),
+			assignmentCutoffMs: Date.now(),
+		};
+
+		if (process.env.TW_WORKER_MODE === "1") {
+			await batchTransition({ ctx, transition, executionScope });
+		} else {
+			await batchTransitionTask.trigger(
+				{
+					orgId: ctx.org.id,
+					env: ctx.env,
+					customerId: ctx.customerId,
+					transition,
+					executionScope,
 				},
-			},
-			{ concurrencyKey: updates.linkId },
-		);
+				{ concurrencyKey: updates.linkId },
+			);
+		}
 	}
 };

--- a/server/src/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors.ts
+++ b/server/src/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors.ts
@@ -1,7 +1,36 @@
 import type { BillingContext, BillingPlan } from "@autumn/shared";
-import { ErrCode, InternalError } from "@autumn/shared";
+import { ErrCode, InternalError, RecaseError } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { validatePromotionCodeMinimums } from "@/internal/billing/v2/providers/stripe/errors/validatePromotionCodeMinimums";
+import { discountAppliesToLineItem } from "@/internal/billing/v2/providers/stripe/utils/discounts/discountAppliesToLineItem";
+
+const validatePromotionCodeProducts = ({
+	billingContext,
+	billingPlan,
+}: {
+	billingContext: BillingContext;
+	billingPlan: BillingPlan;
+}) => {
+	const lineItems = billingPlan.autumn.lineItems ?? [];
+	if (lineItems.length === 0) return;
+
+	const invalidPromotionCode = billingContext.stripeDiscounts?.find(
+		(discount) =>
+			!discount.id &&
+			discount.promotionCodeId &&
+			discount.source.coupon.applies_to?.products?.length &&
+			!lineItems.some((lineItem) =>
+				discountAppliesToLineItem({ discount, lineItem }),
+			),
+	);
+	if (!invalidPromotionCode) return;
+
+	throw new RecaseError({
+		message: "Promotion code does not apply to any products in this order.",
+		code: ErrCode.InvalidRequest,
+		statusCode: 400,
+	});
+};
 
 /**
  * Validates Stripe-specific billing context requirements before executing billing plan.
@@ -19,6 +48,7 @@ export const handleStripeBillingPlanErrors = ({
 	const { stripeSubscriptionSchedule } = billingContext;
 	const { subscriptionScheduleAction } = billingPlan.stripe;
 
+	validatePromotionCodeProducts({ billingContext, billingPlan });
 	validatePromotionCodeMinimums({ ctx, billingContext, billingPlan });
 
 	if (subscriptionScheduleAction?.type !== "update") return;

--- a/server/tests/integration/billing/attach/discounts/promotion-code-applies-to-validation.test.ts
+++ b/server/tests/integration/billing/attach/discounts/promotion-code-applies-to-validation.test.ts
@@ -1,0 +1,62 @@
+/**
+ * TDD test for promotion codes restricted to products outside the attach order.
+ *
+ * Red-failure mode (current behavior):
+ *  - Preview accepts the promo and displays a discount that Stripe will not apply.
+ *
+ * Green-success criteria (after fix):
+ *  - Preview rejects the promo before showing an inapplicable discount.
+ */
+
+import { test } from "bun:test";
+import { type AttachParamsV1Input, ErrCode } from "@autumn/shared";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import {
+	createPercentCoupon,
+	createPromotionCode,
+} from "../../utils/discounts/discountTestUtils.js";
+
+test.concurrent(
+	`${chalk.yellowBright("attach discount: rejects promo restricted to another product")}`,
+	async () => {
+		const customerId = "promo-applies-to-other-product";
+		const pro = products.pro({
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		const { autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [s.customer({}), s.products({ list: [pro] })],
+			actions: [],
+		});
+
+		const otherProduct = await ctx.stripeCli.products.create({
+			name: customerId,
+		});
+		const coupon = await createPercentCoupon({
+			stripeCli: ctx.stripeCli,
+			percentOff: 50,
+			appliesToProducts: [otherProduct.id],
+		});
+		const promotionCode = await createPromotionCode({
+			stripeCli: ctx.stripeCli,
+			coupon,
+			code: "OTHER_PRODUCT",
+		});
+		const params: AttachParamsV1Input = {
+			customer_id: customerId,
+			plan_id: pro.id,
+			discounts: [{ promotion_code: promotionCode.code }],
+		};
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			errMessage: "does not apply to any products in this order",
+			func: () => autumnV2_2.billing.previewAttach<AttachParamsV1Input>(params),
+		});
+	},
+);

--- a/server/tests/integration/external-psps/revenuecat/revenuecat-auto-topup-stripe.test.ts
+++ b/server/tests/integration/external-psps/revenuecat/revenuecat-auto-topup-stripe.test.ts
@@ -1,0 +1,236 @@
+/**
+ * RevenueCat subscription + Stripe-billed auto top-up.
+ *
+ * A customer with a Stripe customer + card on file purchases a subscription
+ * (monthly base price + one-off prepaid messages item) through RevenueCat.
+ * When the prepaid balance drops below the auto top-up threshold, the top-up
+ * should bill through Stripe even though the cus_product is RC-provisioned.
+ *
+ * Probes:
+ * - RC attach (no_billing_changes) creates the cusPrice for the one-off
+ *   prepaid item, so fullCustomerToAutoTopupObjects can find it.
+ * - Auto top-up executes a paid Stripe invoice for an RC cus_product whose
+ *   prices were never provisioned in Stripe.
+ * - The options.quantity bump lands on the RC cus_product.
+ * - A subsequent RC RENEWAL does not clobber the topped-up state.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	AppEnv,
+	CusProductStatus,
+	customers,
+	ProcessorType,
+} from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import { expectCustomerProductOptions } from "@tests/integration/utils/expectCustomerProductOptions";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { timeout } from "@tests/utils/genUtils";
+import ctx from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { RCMappingService } from "@/external/revenueCat/misc/RCMappingService";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
+import { OrgService } from "@/internal/orgs/OrgService";
+import { encryptData } from "@/utils/encryptUtils";
+import {
+	expectWebhookSuccess,
+	RevenueCatWebhookClient,
+} from "./utils/revenue-cat-webhook-client";
+
+const RC_WEBHOOK_SECRET = "test_rc_webhook_secret_auto_topup";
+
+/** Wait time for SQS auto top-up processing */
+const AUTO_TOPUP_WAIT_MS = 20000;
+
+const setupRevenueCatOrg = async () => {
+	if (
+		ctx.org.processor_configs?.revenuecat?.sandbox_webhook_secret !==
+		RC_WEBHOOK_SECRET
+	) {
+		await OrgService.update({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			updates: {
+				processor_configs: {
+					...ctx.org.processor_configs,
+					revenuecat: {
+						api_key: encryptData("mock_rc_api_key_live"),
+						sandbox_api_key: encryptData("mock_rc_api_key_sandbox"),
+						project_id: "mock_project_live",
+						sandbox_project_id: "mock_project_sandbox",
+						webhook_secret: RC_WEBHOOK_SECRET,
+						sandbox_webhook_secret: RC_WEBHOOK_SECRET,
+					},
+				},
+			},
+		});
+	}
+};
+
+test.concurrent(
+	`${chalk.yellowBright("revenuecat auto-topup: RC subscription tops up prepaid balance through Stripe")}`,
+	async () => {
+		const customerId = "rc-auto-topup-stripe-1";
+		const RC_SUB_SKU = "com.app.rc_auto_topup_sub_monthly";
+
+		// $20/month subscription carrying a one-off prepaid item ($10 / 100 messages)
+		const sub = products.pro({
+			id: "rc-topup-sub",
+			items: [
+				items.oneOffMessages({
+					includedUsage: 0,
+					billingUnits: 100,
+					price: 10,
+				}),
+			],
+		});
+
+		await setupRevenueCatOrg();
+
+		// Stripe customer + card on file, but NO Stripe products attached — the
+		// cross-processor guard only rejects non-RC cus_products with subscriptions.
+		const { autumnV2_1, ctx: scenarioCtx } = await initScenario({
+			customerId,
+			setup: [
+				s.deleteCustomer({ customerId }),
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.products({ list: [sub] }),
+			],
+			actions: [],
+		});
+
+		// Map the RC SKU to the sub, granting 500 messages (5 packs) on purchase.
+		await RCMappingService.upsert({
+			db: ctx.db,
+			data: {
+				org_id: ctx.org.id,
+				env: AppEnv.Sandbox,
+				autumn_product_id: sub.id,
+				revenuecat_product_ids: [RC_SUB_SKU],
+				feature_quantities: {
+					[RC_SUB_SKU]: [{ feature_id: TestFeature.Messages, quantity: 500 }],
+				},
+			},
+		});
+
+		const rcClient = new RevenueCatWebhookClient({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			webhookSecret: RC_WEBHOOK_SECRET,
+		});
+
+		expectWebhookSuccess(
+			await rcClient.initialPurchase({
+				productId: RC_SUB_SKU,
+				appUserId: customerId,
+				originalTransactionId: "rc_auto_topup_tx_001",
+				transactionId: "rc_auto_topup_tx_001",
+				price: 20,
+				purchasedAtMs: Date.now(),
+			}),
+		);
+
+		// ── 1. RC cus_product is active with the mapped prepaid grant ──────────
+		const dbCustomer = await ctx.db.query.customers.findFirst({
+			where: eq(customers.id, customerId),
+		});
+		const cusProducts = await CusProductService.list({
+			db: ctx.db,
+			internalCustomerId: dbCustomer!.internal_id,
+			inStatuses: [CusProductStatus.Active],
+		});
+		const rcCusProduct = cusProducts.find((cp) => cp.product.id === sub.id);
+		expect(rcCusProduct).toBeDefined();
+		expect(rcCusProduct!.processor?.type).toBe(ProcessorType.RevenueCat);
+
+		const before = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer: before,
+			featureId: TestFeature.Messages,
+			remaining: 500,
+		});
+
+		// ── 2. Enable auto top-up (threshold 20, quantity 100 = 1 pack) ────────
+		await autumnV2_1.customers.update(customerId, {
+			billing_controls: {
+				auto_topups: [
+					{
+						feature_id: TestFeature.Messages,
+						enabled: true,
+						threshold: 20,
+						quantity: 100,
+					},
+				],
+			},
+		});
+
+		// ── 3. Track below threshold → auto top-up should bill via Stripe ─────
+		await autumnV2_1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 490,
+		});
+
+		await timeout(AUTO_TOPUP_WAIT_MS);
+
+		// Balance: 500 - 490 + 100 = 110
+		const after = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer: after,
+			featureId: TestFeature.Messages,
+			remaining: 110,
+		});
+
+		// Latest invoice is the Stripe top-up: 1 pack × $10, paid.
+		// Count 2 = RC-recorded purchase invoice + Stripe top-up invoice.
+		await expectCustomerInvoiceCorrect({
+			customerId,
+			count: 2,
+			latestTotal: 10,
+			latestStatus: "paid",
+			latestInvoiceProductId: sub.id,
+		});
+
+		// Options: 5 initial packs + 1 topped-up pack = 6.
+		await expectCustomerProductOptions({
+			ctx: scenarioCtx,
+			customerId,
+			productId: sub.id,
+			featureId: TestFeature.Messages,
+			quantity: 6,
+		});
+
+		// ── 4. RC renewal must not clobber the topped-up state ─────────────────
+		expectWebhookSuccess(
+			await rcClient.renewal({
+				productId: RC_SUB_SKU,
+				appUserId: customerId,
+				originalTransactionId: "rc_auto_topup_tx_001",
+				transactionId: "rc_auto_topup_tx_002",
+				price: 20,
+				purchasedAtMs: Date.now(),
+			}),
+		);
+
+		const afterRenewal =
+			await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer: afterRenewal,
+			featureId: TestFeature.Messages,
+			remaining: 110,
+		});
+		await expectCustomerProductOptions({
+			ctx: scenarioCtx,
+			customerId,
+			productId: sub.id,
+			featureId: TestFeature.Messages,
+			quantity: 6,
+		});
+	},
+);


### PR DESCRIPTION
- **fix: 🐛 trigger in bun tw**
- **fix(billing): 🐛 reject promotion codes for unrelated products**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects Stripe promotion codes that don’t apply to any products in the order, and fixes batch transition triggering in `bun tw` worker mode. Adds integration tests for promo validation and a RevenueCat subscription with Stripe-billed auto top-up.

- **Bug Fixes**
  - Validate product scope for promotion codes: reject when `coupon.applies_to.products` doesn’t match any line items; update Stripe expand to `promotion.coupon.applies_to`; preview now fails fast with a 400.
  - Ensure batch transitions run in `TW_WORKER_MODE=1` by executing `batchTransition` inline; otherwise continue using the task trigger.

- **Tests**
  - Attach preview rejects a promotion code restricted to another product.
  - RevenueCat subscription triggers Stripe-billed auto top-up and preserves the topped-up state on renewal.

<sup>Written for commit d1aba73f743992bf79fccd3f99d2f1e883455e83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates billing and test-worker behavior:
- **Bug fixes:** Expands Stripe promotion-code coupon applicability and rejects codes restricted to products outside the billing plan.
- **Bug fixes:** Executes customer-license transitions inline in TW worker mode instead of scheduling nested Trigger.dev tasks.
- **Improvements:** Adds integration coverage for promotion-code product validation and RevenueCat-backed auto top-ups through Stripe.
- **Improvements:** Adjusts TW dirty-tree preflight handling for AI-related files.
</details>

<h3>Confidence Score: 4/5</h3>

The preflight pathspec should be anchored before merging because it can let workers silently test stale code when nested AI source files are modified.

The billing changes appear coherent, but the new dirty-tree exclusion can suppress tracked changes under `server/src/external/ai`, defeating the preflight guarantee that remote workers see the code being tested.

scripts/tw/helpers/preflight.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/tw/helpers/preflight.ts | Excludes `ai` from dirty-tree detection, but the unanchored pathspec can also hide modified runtime source in nested `ai` directories. |
| server/src/external/stripe/coupons/resolvePromotionCode.ts | Expands Stripe coupon product applicability so downstream billing validation can inspect it. |
| server/src/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors.ts | Adds early rejection of newly supplied promotion codes that match none of the order's Stripe products. |
| server/src/internal/billing/v2/execute/executeAutumnActions/executeCustomerLicenseTransitions.ts | Runs batch transitions inline in the isolated TW worker environment while retaining Trigger.dev dispatch elsewhere. |
| server/tests/integration/billing/attach/discounts/promotion-code-applies-to-validation.test.ts | Covers rejection of a promotion code restricted to an unrelated Stripe product. |
| server/tests/integration/external-psps/revenuecat/revenuecat-auto-topup-stripe.test.ts | Covers Stripe auto-top-up and renewal state preservation for a RevenueCat-provisioned customer product. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Resolve promotion code] --> B[Expand coupon applies_to]
  B --> C[Build Stripe billing context]
  C --> D[Compare applicable Stripe products with billing-plan line items]
  D -->|No matching product| E[Return InvalidRequest]
  D -->|At least one match| F[Continue billing plan]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
scripts/tw/helpers/preflight.ts:65
**Unanchored AI path exclusion**

When a developer modifies tracked source under a nested `ai` directory such as `server/src/external/ai/`, the unanchored `:(exclude)ai` pathspec hides those changes from preflight, causing workers to clone and test stale remote code instead of the local changes.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): 🐛 reject promotion codes ..."](https://github.com/useautumn/autumn/commit/d1aba73f743992bf79fccd3f99d2f1e883455e83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47071087)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [Stripe Integration](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-stripe-integration.md)

<!-- /greptile_comment -->