### PR TITLE
fix(billing): 🐛 reject promotion codes for unrelated products

### DIFF
--- a/server/src/external/stripe/coupons/resolvePromotionCode.ts
+++ b/server/src/external/stripe/coupons/resolvePromotionCode.ts
@@ -41,7 +41,7 @@ export const resolvePromotionCode = async ({
 			code,
 			active: true,
 			limit: 1,
-			expand: ["data.promotion.coupon"],
+			expand: ["data.promotion.coupon.applies_to"],
 		});
 
 		if (promos.data.length === 0) {
@@ -67,12 +67,9 @@ export const resolvePromotionCode = async ({
 		}
 
 		const minimumAmountsByCurrency = Object.fromEntries(
-			Object.entries(
-				promo.restrictions?.currency_options ?? {},
-			).map(([currency, option]) => [
-				currency.toLowerCase(),
-				option.minimum_amount,
-			]),
+			Object.entries(promo.restrictions?.currency_options ?? {}).map(
+				([currency, option]) => [currency.toLowerCase(), option.minimum_amount],
+			),
 		);
 
 		const hasCurrencyOptions = Object.keys(minimumAmountsByCurrency).length > 0;

--- a/server/src/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors.ts
+++ b/server/src/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors.ts
@@ -1,7 +1,36 @@
 import type { BillingContext, BillingPlan } from "@autumn/shared";
-import { ErrCode, InternalError } from "@autumn/shared";
+import { ErrCode, InternalError, RecaseError } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { validatePromotionCodeMinimums } from "@/internal/billing/v2/providers/stripe/errors/validatePromotionCodeMinimums";
+import { discountAppliesToLineItem } from "@/internal/billing/v2/providers/stripe/utils/discounts/discountAppliesToLineItem";
+
+const validatePromotionCodeProducts = ({
+	billingContext,
+	billingPlan,
+}: {
+	billingContext: BillingContext;
+	billingPlan: BillingPlan;
+}) => {
+	const lineItems = billingPlan.autumn.lineItems ?? [];
+	if (lineItems.length === 0) return;
+
+	const invalidPromotionCode = billingContext.stripeDiscounts?.find(
+		(discount) =>
+			!discount.id &&
+			discount.promotionCodeId &&
+			discount.source.coupon.applies_to?.products?.length &&
+			!lineItems.some((lineItem) =>
+				discountAppliesToLineItem({ discount, lineItem }),
+			),
+	);
+	if (!invalidPromotionCode) return;
+
+	throw new RecaseError({
+		message: "Promotion code does not apply to any products in this order.",
+		code: ErrCode.InvalidRequest,
+		statusCode: 400,
+	});
+};
 
 /**
  * Validates Stripe-specific billing context requirements before executing billing plan.
@@ -19,6 +48,7 @@ export const handleStripeBillingPlanErrors = ({
 	const { stripeSubscriptionSchedule } = billingContext;
 	const { subscriptionScheduleAction } = billingPlan.stripe;
 
+	validatePromotionCodeProducts({ billingContext, billingPlan });
 	validatePromotionCodeMinimums({ ctx, billingContext, billingPlan });
 
 	if (subscriptionScheduleAction?.type !== "update") return;

--- a/server/src/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors.ts
+++ b/server/src/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors.ts
@@ -1,8 +1,34 @@
 import type { BillingContext, BillingPlan } from "@autumn/shared";
-import { ErrCode, InternalError, RecaseError } from "@autumn/shared";
+import {
+	ErrCode,
+	InternalError,
+	isFixedPrice,
+	notNullish,
+	RecaseError,
+} from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { validatePromotionCodeMinimums } from "@/internal/billing/v2/providers/stripe/errors/validatePromotionCodeMinimums";
-import { discountAppliesToLineItem } from "@/internal/billing/v2/providers/stripe/utils/discounts/discountAppliesToLineItem";
+import { lineItemToStripeProductId } from "@/internal/billing/v2/providers/stripe/utils/invoiceLines/lineItemToStripeProductId";
+
+const getPlannedStripeProductIds = ({
+	billingPlan,
+}: {
+	billingPlan: BillingPlan;
+}) =>
+	new Set(
+		[
+			...(billingPlan.autumn.lineItems ?? []).map((lineItem) =>
+				lineItemToStripeProductId({ lineItem }),
+			),
+			...billingPlan.autumn.insertCustomerProducts.flatMap((customerProduct) =>
+				customerProduct.customer_prices.map(({ price }) =>
+					isFixedPrice(price)
+						? customerProduct.product.processor?.id
+						: price.config.stripe_product_id,
+				),
+			),
+		].filter(notNullish),
+	);
 
 const validatePromotionCodeProducts = ({
 	billingContext,
@@ -11,16 +37,16 @@ const validatePromotionCodeProducts = ({
 	billingContext: BillingContext;
 	billingPlan: BillingPlan;
 }) => {
-	const lineItems = billingPlan.autumn.lineItems ?? [];
-	if (lineItems.length === 0) return;
+	const plannedStripeProductIds = getPlannedStripeProductIds({ billingPlan });
+	if (plannedStripeProductIds.size === 0) return;
 
 	const invalidPromotionCode = billingContext.stripeDiscounts?.find(
 		(discount) =>
 			!discount.id &&
 			discount.promotionCodeId &&
 			discount.source.coupon.applies_to?.products?.length &&
-			!lineItems.some((lineItem) =>
-				discountAppliesToLineItem({ discount, lineItem }),
+			!discount.source.coupon.applies_to.products.some((productId) =>
+				plannedStripeProductIds.has(productId),
 			),
 	);
 	if (!invalidPromotionCode) return;

--- a/server/tests/integration/billing/attach/discounts/promotion-code-applies-to-validation.test.ts
+++ b/server/tests/integration/billing/attach/discounts/promotion-code-applies-to-validation.test.ts
@@ -60,3 +60,51 @@ test.concurrent(
 		});
 	},
 );
+
+test.concurrent(
+	`${chalk.yellowBright("attach discount: rejects unrelated promo for scheduled attach")}`,
+	async () => {
+		const customerId = "scheduled-promo-applies-to-other-product";
+		const pro = products.pro({
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+		const premium = products.premium({
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+		});
+
+		const { autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [s.billing.attach({ productId: pro.id })],
+		});
+
+		const otherProduct = await ctx.stripeCli.products.create({
+			name: customerId,
+		});
+		const coupon = await createPercentCoupon({
+			stripeCli: ctx.stripeCli,
+			percentOff: 50,
+			appliesToProducts: [otherProduct.id],
+		});
+		const promotionCode = await createPromotionCode({
+			stripeCli: ctx.stripeCli,
+			coupon,
+			code: "OTHER_SCHEDULED_PRODUCT",
+		});
+		const params: AttachParamsV1Input = {
+			customer_id: customerId,
+			plan_id: premium.id,
+			plan_schedule: "end_of_cycle",
+			discounts: [{ promotion_code: promotionCode.code }],
+		};
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			errMessage: "does not apply to any products in this order",
+			func: () => autumnV2_2.billing.previewAttach<AttachParamsV1Input>(params),
+		});
+	},
+);

--- a/server/tests/integration/billing/attach/discounts/promotion-code-applies-to-validation.test.ts
+++ b/server/tests/integration/billing/attach/discounts/promotion-code-applies-to-validation.test.ts
@@ -1,0 +1,62 @@
+/**
+ * TDD test for promotion codes restricted to products outside the attach order.
+ *
+ * Red-failure mode (current behavior):
+ *  - Preview accepts the promo and displays a discount that Stripe will not apply.
+ *
+ * Green-success criteria (after fix):
+ *  - Preview rejects the promo before showing an inapplicable discount.
+ */
+
+import { test } from "bun:test";
+import { type AttachParamsV1Input, ErrCode } from "@autumn/shared";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import {
+	createPercentCoupon,
+	createPromotionCode,
+} from "../../utils/discounts/discountTestUtils.js";
+
+test.concurrent(
+	`${chalk.yellowBright("attach discount: rejects promo restricted to another product")}`,
+	async () => {
+		const customerId = "promo-applies-to-other-product";
+		const pro = products.pro({
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		const { autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [s.customer({}), s.products({ list: [pro] })],
+			actions: [],
+		});
+
+		const otherProduct = await ctx.stripeCli.products.create({
+			name: customerId,
+		});
+		const coupon = await createPercentCoupon({
+			stripeCli: ctx.stripeCli,
+			percentOff: 50,
+			appliesToProducts: [otherProduct.id],
+		});
+		const promotionCode = await createPromotionCode({
+			stripeCli: ctx.stripeCli,
+			coupon,
+			code: "OTHER_PRODUCT",
+		});
+		const params: AttachParamsV1Input = {
+			customer_id: customerId,
+			plan_id: pro.id,
+			discounts: [{ promotion_code: promotionCode.code }],
+		};
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			errMessage: "does not apply to any products in this order",
+			func: () => autumnV2_2.billing.previewAttach<AttachParamsV1Input>(params),
+		});
+	},
+);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject promotion codes that don’t apply to any products in the order, including deferred/scheduled plans, so previews don’t show invalid discounts and Stripe doesn’t error.

- **Bug Fixes**
  - Validate promo codes against planned Stripe product IDs from immediate line items and inserted products; return `InvalidRequest` (400) when none match.
  - Apply the check to scheduled/no-proration flows that have no immediate line items.
  - Expand `promotion.coupon.applies_to` in `resolvePromotionCode` to read product restrictions.
  - Add integration tests for immediate attach and scheduled attach previews rejecting unrelated promos.

<sup>Written for commit 2a37bcb7c702bd76e16ce3f10294480538d98ef4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes promotion-code product validation in the Stripe billing pipeline.
- **Bug fixes:** Expands Stripe promotion-code coupon applicability metadata and rejects newly supplied codes that match none of the computed order line items.
- **Improvements:** Adds integration coverage for a promotion code restricted to an unrelated product.
</details>

<h3>Confidence Score: 3/5</h3>

This PR should not merge until product applicability is also enforced for billing operations with no computed immediate line items.

The new early return allows restricted promotion codes through scheduled, no-proration, and other valid operations whose plans intentionally contain no immediate Autumn line items.

server/src/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/coupons/resolvePromotionCode.ts | Expands the promotion code's nested coupon applicability metadata needed by downstream validation. |
| server/src/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors.ts | Adds the intended product restriction check, but empty-line-item billing flows bypass it completely. |
| server/tests/integration/billing/attach/discounts/promotion-code-applies-to-validation.test.ts | Covers immediate attach rejection but not deferred or no-immediate-line-item flows where validation is skipped. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Resolve promotion code] --> B[Expand coupon applies_to]
  B --> C[Build Stripe discount context]
  C --> D[Compute billing plan]
  D --> E{Autumn line items present?}
  E -->|Yes| F[Compare restricted products]
  F -->|No match| G[Return invalid request]
  F -->|Match| H[Continue billing]
  E -->|No| H
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors.ts:15
**Empty plans bypass product validation**

When a scheduled, no-proration, or other deferred billing operation produces no immediate Autumn line items, this return skips the promotion code's product restriction check, causing codes restricted to unrelated products to be accepted.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): 🐛 reject promotion codes ..."](https://github.com/useautumn/autumn/commit/e2d008648aca4aa98e5b66cc4de4ac627c822b36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47072217)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [Stripe Integration](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-stripe-integration.md)

<!-- /greptile_comment -->