### PR TITLE
Fix long-lived schedule checkout plan activation

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionExpired/handleStripeCheckoutSessionExpired.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionExpired/handleStripeCheckoutSessionExpired.ts
@@ -1,17 +1,15 @@
-import { CusProductStatus } from "@autumn/shared";
+import {
+	CheckoutStatus,
+	CusProductStatus,
+	type DeferredAutumnBillingPlanData,
+	MetadataType,
+} from "@autumn/shared";
 import type Stripe from "stripe";
 import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
+import { checkoutRepo } from "@/internal/checkouts";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
 import { MetadataService } from "@/internal/metadata/MetadataService";
 
-/**
- * checkout.session.expired handler — cleans up cusProduct rows that were
- * pre-inserted under the enable_plan_immediately flow but never got their
- * subscription linked because the customer abandoned the checkout.
- *
- * Identifies rows by stripe_checkout_session_id. Skips any row that has
- * subscription_ids populated (already completed via the success path).
- */
 export const handleStripeCheckoutSessionExpired = async ({
 	ctx,
 	event,
@@ -20,6 +18,10 @@ export const handleStripeCheckoutSessionExpired = async ({
 	event: Stripe.CheckoutSessionExpiredEvent;
 }) => {
 	const session = event.data.object;
+	const metadataId = session.metadata?.autumn_metadata_id;
+	const metadata = metadataId
+		? await MetadataService.get({ db: ctx.db, id: metadataId })
+		: null;
 
 	const cusProducts = await CusProductService.getByStripeCheckoutSessionId({
 		db: ctx.db,
@@ -28,13 +30,33 @@ export const handleStripeCheckoutSessionExpired = async ({
 		env: ctx.env,
 	});
 
+	const deferredData = metadata?.data as
+		| DeferredAutumnBillingPlanData
+		| undefined;
+	const longLivedCheckoutId = deferredData?.billingContext.longLivedCheckoutId;
+	const longLivedCheckout = longLivedCheckoutId
+		? await checkoutRepo.get({ db: ctx.db, id: longLivedCheckoutId })
+		: null;
+	const preserveProducts =
+		(metadata?.type === MetadataType.CheckoutSessionEnabledImmediately ||
+			metadata?.type ===
+				MetadataType.CheckoutSessionEnabledImmediatelyProcessing) &&
+		longLivedCheckout?.status === CheckoutStatus.Pending &&
+		longLivedCheckout.expires_at > Date.now() &&
+		cusProducts.length > 0;
+
+	if (preserveProducts) {
+		ctx.logger.info(
+			`[checkout.session.expired] Preserved ${cusProducts.length} cusProduct(s) for long-lived checkout ${longLivedCheckoutId}`,
+		);
+		return;
+	}
+
 	if (cusProducts.length === 0) {
-		// Try to clean up the metadata row even if no cusProduct ever got created
-		// (e.g. a deferred-flow checkout that expired).
-		if (session.metadata?.autumn_metadata_id) {
+		if (metadataId) {
 			await MetadataService.delete({
 				db: ctx.db,
-				id: session.metadata.autumn_metadata_id,
+				id: metadataId,
 			});
 		}
 		return;
@@ -43,7 +65,6 @@ export const handleStripeCheckoutSessionExpired = async ({
 	const now = Date.now();
 
 	for (const cusProduct of cusProducts) {
-		// If the success-path webhook already linked a subscription, leave it.
 		if ((cusProduct.subscription_ids ?? []).length > 0) continue;
 
 		await CusProductService.update({
@@ -56,10 +77,10 @@ export const handleStripeCheckoutSessionExpired = async ({
 		});
 	}
 
-	if (session.metadata?.autumn_metadata_id) {
+	if (metadataId) {
 		await MetadataService.delete({
 			db: ctx.db,
-			id: session.metadata.autumn_metadata_id,
+			id: metadataId,
 		});
 	}
 

--- a/server/src/internal/billing/v2/actions/attach/attach.ts
+++ b/server/src/internal/billing/v2/actions/attach/attach.ts
@@ -33,6 +33,7 @@ export async function attach({
 	params,
 	preview = false,
 	skipAutumnCheckout = false,
+	longLivedCheckoutId,
 
 	contextOverride,
 }: {
@@ -40,6 +41,7 @@ export async function attach({
 	params: AttachParamsV1;
 	preview?: boolean;
 	skipAutumnCheckout?: boolean;
+	longLivedCheckoutId?: string;
 
 	contextOverride?: BillingContextOverride;
 }): Promise<CreateAutumnCheckoutResult<AttachBillingContext>> {
@@ -66,6 +68,7 @@ export async function attach({
 		preview,
 		contextOverride,
 	});
+	billingContext.longLivedCheckoutId = longLivedCheckoutId;
 
 	logAttachContext({ ctx, billingContext });
 

--- a/server/src/internal/billing/v2/actions/createSchedule/createSchedule.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/createSchedule.ts
@@ -4,7 +4,7 @@ import type {
 	CreateScheduleParamsV0,
 	CreateScheduleResponse,
 } from "@autumn/shared";
-import { CheckoutAction } from "@autumn/shared";
+import { CheckoutAction, InternalError, ms } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { checkCheckoutSessionLock } from "@/internal/billing/v2/actions/locks/checkoutSessionLock/checkCheckoutSessionLock";
 import { checkoutSessionLock } from "@/internal/billing/v2/actions/locks/checkoutSessionLock/checkoutSessionLock";
@@ -12,6 +12,7 @@ import { createAutumnCheckout } from "@/internal/billing/v2/common/createAutumnC
 import { executeBillingPlan } from "@/internal/billing/v2/execute/executeBillingPlan";
 import { evaluateStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan";
 import { billingResultToResponse } from "@/internal/billing/v2/utils/billingResult/billingResultToResponse";
+import { checkoutRepo, setCheckoutCache } from "@/internal/checkouts";
 import { hashJson } from "@/utils/hash/hashJson";
 import { computeCreateSchedulePlan } from "./compute/computeCreateSchedulePlan";
 import {
@@ -21,6 +22,8 @@ import {
 } from "./errors/handleCreateScheduleErrors";
 import { setupCreateScheduleBillingContext } from "./setup/setupCreateScheduleBillingContext";
 import { persistCreateSchedule } from "./utils/persistCreateSchedule";
+
+const LONG_LIVED_CHECKOUT_EXPIRY_MS = ms.days(90);
 
 const buildPendingCreateScheduleResponse = ({
 	billingContext,
@@ -51,10 +54,12 @@ export const createSchedule = async ({
 	ctx,
 	params,
 	skipAutumnCheckout = false,
+	longLivedCheckoutId,
 }: {
 	ctx: AutumnContext;
 	params: CreateScheduleParamsV0;
 	skipAutumnCheckout?: boolean;
+	longLivedCheckoutId?: string;
 }): Promise<CreateScheduleResponse> => {
 	const checkoutReservation = !skipAutumnCheckout
 		? await checkoutSessionLock.get({ ctx, customerId: params.customer_id })
@@ -64,6 +69,7 @@ export const createSchedule = async ({
 		ctx,
 		params,
 	});
+	billingContext.longLivedCheckoutId = longLivedCheckoutId;
 
 	await handleCreateScheduleErrors({
 		billingContext,
@@ -89,6 +95,79 @@ export const createSchedule = async ({
 	};
 
 	handleCreateScheduleBillingPlanErrors({ ctx, billingContext, billingPlan });
+
+	if (
+		params.long_lived_checkout &&
+		billingContext.checkoutMode === "stripe_checkout" &&
+		!skipAutumnCheckout
+	) {
+		const { billingResult: checkoutBillingResult } = await createAutumnCheckout(
+			{
+				ctx,
+				action: CheckoutAction.CreateSchedule,
+				params,
+				billingContext,
+				billingPlan,
+				expiresInMs: LONG_LIVED_CHECKOUT_EXPIRY_MS,
+			},
+		);
+
+		const checkout = checkoutBillingResult?.autumn?.checkout;
+		if (!checkoutBillingResult || !checkout) {
+			throw new Error("createAutumnCheckout did not return a billing result");
+		}
+
+		if (!billingContext.enablePlanImmediately) {
+			return buildPendingCreateScheduleResponse({
+				billingContext,
+				billingResult: checkoutBillingResult,
+			});
+		}
+
+		billingContext.longLivedCheckoutId = checkout.id;
+		const billingResult = await executeBillingPlan({
+			ctx,
+			billingContext,
+			billingPlan,
+			onAutumnCommit: async ({ ctx: autumnCtx, stripeBillingResult }) => {
+				const updatedCheckout = await checkoutRepo.update({
+					db: autumnCtx.db,
+					id: checkout.id,
+					updates: {
+						response: billingResultToResponse({
+							billingContext,
+							billingResult: { stripe: stripeBillingResult },
+						}),
+					},
+				});
+				if (!updatedCheckout) {
+					throw new InternalError({
+						message: `Checkout ${checkout.id} disappeared during execution`,
+					});
+				}
+			},
+		});
+		const updatedCheckout = await checkoutRepo.get({
+			db: ctx.db,
+			id: checkout.id,
+		});
+		if (updatedCheckout) {
+			await setCheckoutCache({
+				checkoutId: checkout.id,
+				data: updatedCheckout,
+			}).catch((error) => {
+				ctx.logger.warn(`Failed to cache checkout ${checkout.id}: ${error}`);
+			});
+		}
+
+		return buildPendingCreateScheduleResponse({
+			billingContext,
+			billingResult: {
+				...billingResult,
+				autumn: checkoutBillingResult.autumn,
+			},
+		});
+	}
 
 	if (!skipAutumnCheckout) {
 		const cachedResult = await checkCheckoutSessionLock({

--- a/server/src/internal/billing/v2/common/createAutumnCheckout.ts
+++ b/server/src/internal/billing/v2/common/createAutumnCheckout.ts
@@ -19,12 +19,7 @@ export interface CreateAutumnCheckoutResult<T extends BillingContext> {
 	billingResult?: BillingResult;
 }
 
-/**
- * Creates an Autumn checkout session for customer confirmation.
- *
- * Used when checkoutMode === "autumn_checkout" (customer has payment method
- * but redirect_mode is "always", requiring user confirmation before billing).
- */
+/** Persists an Autumn-hosted checkout before billing executes. */
 export async function createAutumnCheckout<
 	T extends
 		| AttachBillingContext

--- a/server/src/internal/billing/v2/execute/executeBillingPlan.ts
+++ b/server/src/internal/billing/v2/execute/executeBillingPlan.ts
@@ -4,10 +4,12 @@ import type {
 	BillingResult,
 	StripeBillingPlanResult,
 } from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { checkoutSessionLock } from "@/internal/billing/v2/actions/locks/checkoutSessionLock/checkoutSessionLock";
 import { executeAutumnBillingPlan } from "@/internal/billing/v2/execute/executeAutumnBillingPlan";
 import { executeStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/execute/executeStripeBillingPlan";
+import { discardStripeCheckoutSession } from "@/internal/billing/v2/providers/stripe/utils/checkoutSessions/discardStripeCheckoutSession";
 import { sendBillingUpdatedWebhook } from "@/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook";
 import { billingPlanToSendProductsUpdated } from "@/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated";
 import { workflows } from "@/queue/workflows";
@@ -17,11 +19,19 @@ export const executeBillingPlan = async ({
 	billingContext,
 	billingPlan,
 	checkoutLockParamsHash,
+	onAutumnCommit,
 }: {
 	ctx: AutumnContext;
 	billingContext: BillingContext;
 	billingPlan: BillingPlan;
 	checkoutLockParamsHash?: string;
+	onAutumnCommit?: ({
+		ctx,
+		stripeBillingResult,
+	}: {
+		ctx: AutumnContext;
+		stripeBillingResult: StripeBillingPlanResult;
+	}) => Promise<void>;
 }): Promise<BillingResult> => {
 	const stripeBillingResult: StripeBillingPlanResult =
 		billingContext.skipBillingChanges
@@ -71,13 +81,44 @@ export const executeBillingPlan = async ({
 		};
 	}
 
-	await executeAutumnBillingPlan({
-		ctx,
-		autumnBillingPlan: billingPlan.autumn,
-		stripeInvoice: stripeBillingResult.stripeInvoice,
-		stripeInvoiceItems: stripeBillingResult.stripeInvoiceItems,
-		autumnInvoice: stripeBillingResult.autumnInvoice,
-	});
+	const executeAutumn = async (autumnCtx: AutumnContext) => {
+		await executeAutumnBillingPlan({
+			ctx: autumnCtx,
+			autumnBillingPlan: billingPlan.autumn,
+			stripeInvoice: stripeBillingResult.stripeInvoice,
+			stripeInvoiceItems: stripeBillingResult.stripeInvoiceItems,
+			autumnInvoice: stripeBillingResult.autumnInvoice,
+		});
+		await onAutumnCommit?.({
+			ctx: autumnCtx,
+			stripeBillingResult,
+		});
+	};
+
+	try {
+		if (onAutumnCommit) {
+			await ctx.db.transaction(async (tx) => {
+				await executeAutumn({
+					...ctx,
+					db: tx as unknown as DrizzleCli,
+				});
+			});
+		} else {
+			await executeAutumn(ctx);
+		}
+	} catch (error) {
+		if (onAutumnCommit && stripeBillingResult.stripeCheckoutSession) {
+			await discardStripeCheckoutSession({
+				ctx,
+				session: stripeBillingResult.stripeCheckoutSession,
+			}).catch((cleanupError) => {
+				ctx.logger.error(
+					`Failed to discard checkout session after rollback: ${cleanupError}`,
+				);
+			});
+		}
+		throw error;
+	}
 
 	// Queue webhooks after Autumn billing plan is executed
 	await billingPlanToSendProductsUpdated({

--- a/server/src/internal/billing/v2/providers/stripe/utils/checkoutSessions/discardStripeCheckoutSession.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/checkoutSessions/discardStripeCheckoutSession.ts
@@ -1,0 +1,21 @@
+import type Stripe from "stripe";
+import { createStripeCli } from "@/external/connect/createStripeCli";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { MetadataService } from "@/internal/metadata/MetadataService";
+
+export const discardStripeCheckoutSession = async ({
+	ctx,
+	session,
+}: {
+	ctx: AutumnContext;
+	session: Pick<Stripe.Checkout.Session, "id"> &
+		Partial<Pick<Stripe.Checkout.Session, "metadata" | "status">>;
+}) => {
+	if (!session.status || session.status === "open") {
+		const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
+		await stripeCli.checkout.sessions.expire(session.id);
+	}
+
+	const metadataId = session.metadata?.autumn_metadata_id;
+	if (metadataId) await MetadataService.delete({ db: ctx.db, id: metadataId });
+};

--- a/server/src/internal/billing/v2/utils/billingResult/billingResultToResponse.ts
+++ b/server/src/internal/billing/v2/utils/billingResult/billingResultToResponse.ts
@@ -2,13 +2,11 @@ import type { BillingContext, BillingResult } from "@autumn/shared";
 import {
 	type BillingResponse,
 	type Checkout,
-	CheckoutAction,
 	checkoutToUrl,
 	stripeToAtmnAmount,
 } from "@autumn/shared";
 
 const isLongLivedCheckout = (checkout: Checkout) =>
-	checkout.action === CheckoutAction.Attach &&
 	"long_lived_checkout" in checkout.params &&
 	checkout.params.long_lived_checkout === true;
 

--- a/server/src/internal/checkouts/handlers/handleStartLongLivedCheckout.ts
+++ b/server/src/internal/checkouts/handlers/handleStartLongLivedCheckout.ts
@@ -1,47 +1,60 @@
 import {
-	type AttachParamsV1,
 	AffectedResource,
-	CheckoutAction,
+	type AttachParamsV1,
+	type BillingResponse,
 	type Checkout,
+	CheckoutAction,
+	CheckoutCompletedError,
+	CheckoutExpiredError,
+	CheckoutStatus,
+	CheckoutUnavailableError,
+	type CreateScheduleParamsV0,
+	customerProducts,
+	type DeferredAutumnBillingPlanData,
 	ErrCode,
 	InternalError,
+	MetadataType,
 	RecaseError,
 	Scopes,
+	type StripeBillingPlanResult,
 } from "@autumn/shared";
 import { fromUnixTime, isFuture } from "date-fns";
+import { and, eq, inArray } from "drizzle-orm";
 import { StatusCodes } from "http-status-codes";
 import Stripe from "stripe";
+import type { DrizzleCli } from "@/db/initDrizzle";
 import { createStripeCli } from "@/external/connect/createStripeCli";
 import { createRoute } from "@/honoMiddlewares/routeHandler";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { billingActions } from "@/internal/billing/v2/actions";
+import { executeStripeCheckoutSessionAction } from "@/internal/billing/v2/providers/stripe/execute/executeStripeCheckoutSessionAction";
+import { discardStripeCheckoutSession } from "@/internal/billing/v2/providers/stripe/utils/checkoutSessions/discardStripeCheckoutSession";
 import { buildBillingLockKey } from "@/internal/billing/v2/utils/billingLock/buildBillingLockKey";
 import { billingResultToResponse } from "@/internal/billing/v2/utils/billingResult/billingResultToResponse";
+import { checkoutRepo } from "@/internal/checkouts";
+import { MetadataService } from "@/internal/metadata/MetadataService";
+import { getMetadataFromCheckoutSession } from "@/internal/metadata/metadataUtils";
 import { checkoutActions } from "../actions";
 
 const STRIPE_SESSION_ID_REGEX = /cs_(test|live)_[A-Za-z0-9]+/;
 
-const isLongLivedAttachCheckout = (checkout: Checkout) =>
-	checkout.action === CheckoutAction.Attach &&
+const isLongLivedCheckout = (checkout: Checkout) =>
 	"long_lived_checkout" in checkout.params &&
 	checkout.params.long_lived_checkout === true;
 
-const getActiveStripeCheckoutUrl = async ({
+const getStripeCheckoutSession = async ({
 	ctx,
 	url,
 }: {
 	ctx: AutumnContext;
 	url: string | null | undefined;
-}) => {
+}): Promise<Stripe.Checkout.Session | null> => {
 	const sessionId = url?.match(STRIPE_SESSION_ID_REGEX)?.[0];
 	if (!sessionId) return null;
 
 	try {
 		const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
-		const session = await stripeCli.checkout.sessions.retrieve(sessionId);
-		return session.status === "open" && isFuture(fromUnixTime(session.expires_at))
-			? session.url
-			: null;
+		return await stripeCli.checkout.sessions.retrieve(sessionId);
 	} catch (error) {
 		if (error instanceof Stripe.errors.StripeError) {
 			ctx.logger.warn(`Unable to retrieve checkout session ${sessionId}`);
@@ -49,6 +62,191 @@ const getActiveStripeCheckoutUrl = async ({
 		}
 		throw error;
 	}
+};
+
+const rotateEnabledCheckoutSession = async ({
+	ctx,
+	checkout,
+	session,
+}: {
+	ctx: AutumnContext;
+	checkout: Checkout;
+	session: Stripe.Checkout.Session;
+}): Promise<BillingResponse | null> => {
+	const metadata = await getMetadataFromCheckoutSession(session, ctx.db);
+	if (
+		metadata?.type === MetadataType.CheckoutSessionEnabledImmediatelyProcessing
+	) {
+		throw new RecaseError({
+			message: "Checkout rotation already in progress",
+			code: ErrCode.LockAlreadyExists,
+			statusCode: StatusCodes.LOCKED,
+		});
+	}
+	if (metadata?.type !== MetadataType.CheckoutSessionEnabledImmediately) {
+		return null;
+	}
+
+	const deferredData = metadata.data as DeferredAutumnBillingPlanData;
+	if (deferredData.billingContext.longLivedCheckoutId !== checkout.id) {
+		return null;
+	}
+
+	const checkoutSessionAction =
+		deferredData.billingPlan.stripe.checkoutSessionAction;
+	if (!checkoutSessionAction) return null;
+
+	const claimed = await MetadataService.claim({
+		db: ctx.db,
+		id: metadata.id,
+		fromType: MetadataType.CheckoutSessionEnabledImmediately,
+		toType: MetadataType.CheckoutSessionEnabledImmediatelyProcessing,
+	});
+	if (!claimed) {
+		throw new RecaseError({
+			message: "Checkout rotation already in progress",
+			code: ErrCode.LockAlreadyExists,
+			statusCode: StatusCodes.LOCKED,
+		});
+	}
+
+	let replacementSession: StripeBillingPlanResult["stripeCheckoutSession"];
+	try {
+		const stripeResult = await executeStripeCheckoutSessionAction({
+			ctx,
+			billingPlan: deferredData.billingPlan,
+			billingContext: deferredData.billingContext,
+			checkoutSessionAction,
+		});
+		replacementSession = stripeResult.stripeCheckoutSession;
+		if (!replacementSession) {
+			throw new InternalError({
+				message: "Long-lived checkout did not create a replacement session",
+			});
+		}
+		const activeReplacementSession = replacementSession;
+
+		const response = billingResultToResponse({
+			billingContext: deferredData.billingContext,
+			billingResult: { stripe: stripeResult },
+		});
+		const customerProductIds =
+			deferredData.billingPlan.autumn.insertCustomerProducts.map(
+				(customerProduct) => customerProduct.id,
+			);
+
+		await ctx.db.transaction(async (tx) => {
+			const txDb = tx as unknown as DrizzleCli;
+			const reboundProducts = await txDb
+				.update(customerProducts)
+				.set({ stripe_checkout_session_id: activeReplacementSession.id })
+				.where(
+					and(
+						inArray(customerProducts.id, customerProductIds),
+						eq(customerProducts.stripe_checkout_session_id, session.id),
+					),
+				)
+				.returning({ id: customerProducts.id });
+			if (reboundProducts.length !== customerProductIds.length) {
+				throw new InternalError({
+					message: "Long-lived checkout products changed during rotation",
+				});
+			}
+
+			await MetadataService.delete({ db: txDb, id: metadata.id });
+			const updatedCheckout = await checkoutRepo.update({
+				db: txDb,
+				id: checkout.id,
+				updates: { response },
+			});
+			if (!updatedCheckout) {
+				throw new InternalError({
+					message: `Checkout ${checkout.id} disappeared during rotation`,
+				});
+			}
+		});
+
+		return response;
+	} catch (error) {
+		let canRetry = !replacementSession;
+		if (replacementSession) {
+			canRetry = await discardStripeCheckoutSession({
+				ctx,
+				session: replacementSession,
+			})
+				.then(() => true)
+				.catch((cleanupError) => {
+					ctx.logger.error(
+						`Failed to discard replacement checkout session: ${cleanupError}`,
+					);
+					return false;
+				});
+		}
+		if (canRetry) {
+			await MetadataService.claim({
+				db: ctx.db,
+				id: metadata.id,
+				fromType: MetadataType.CheckoutSessionEnabledImmediatelyProcessing,
+				toType: MetadataType.CheckoutSessionEnabledImmediately,
+			});
+		}
+		throw error;
+	}
+};
+
+const startCheckout = async ({
+	ctx,
+	checkout,
+}: {
+	ctx: AutumnContext;
+	checkout: Checkout;
+}): Promise<BillingResponse> => {
+	if (checkout.action === CheckoutAction.Attach) {
+		const { billingContext, billingResult } = await billingActions.attach({
+			ctx,
+			params: {
+				...(checkout.params as AttachParamsV1),
+				long_lived_checkout: false,
+			},
+			preview: false,
+			skipAutumnCheckout: true,
+			longLivedCheckoutId: checkout.id,
+		});
+
+		if (!billingResult) {
+			throw new InternalError({
+				message: "Long-lived checkout attach did not return a billing result",
+			});
+		}
+
+		return billingResultToResponse({ billingContext, billingResult });
+	}
+
+	if (checkout.action === CheckoutAction.CreateSchedule) {
+		const result = await billingActions.createSchedule({
+			ctx,
+			params: {
+				...(checkout.params as CreateScheduleParamsV0),
+				long_lived_checkout: false,
+			},
+			skipAutumnCheckout: true,
+			longLivedCheckoutId: checkout.id,
+		});
+
+		return {
+			customer_id: result.customer_id,
+			entity_id: result.entity_id ?? undefined,
+			invoice: result.invoice,
+			payment_url: result.payment_url,
+			required_action: result.required_action,
+		};
+	}
+
+	throw new RecaseError({
+		message: "Unsupported long-lived checkout action",
+		code: ErrCode.InvalidRequest,
+		statusCode: StatusCodes.BAD_REQUEST,
+	});
 };
 
 export const handleStartLongLivedCheckout = createRoute({
@@ -73,42 +271,51 @@ export const handleStartLongLivedCheckout = createRoute({
 			: undefined,
 	handler: async (c) => {
 		const ctx = c.get("ctx");
-		const checkout = c.get("checkout");
+		const cachedCheckout = c.get("checkout");
+		const checkout = await checkoutRepo.get({
+			db: ctx.db,
+			id: cachedCheckout.id,
+		});
 
-		if (!isLongLivedAttachCheckout(checkout)) {
+		if (!checkout) throw new CheckoutUnavailableError();
+		if (checkout.status === CheckoutStatus.Completed) {
+			throw new CheckoutCompletedError();
+		}
+		if (
+			checkout.status === CheckoutStatus.Expired ||
+			checkout.expires_at < Date.now()
+		) {
+			throw new CheckoutExpiredError();
+		}
+
+		if (!isLongLivedCheckout(checkout)) {
 			throw new RecaseError({
-				message: "Long-lived checkout start only supports long-lived attach checkouts",
+				message: "Checkout is not long-lived",
 				code: ErrCode.InvalidRequest,
 				statusCode: StatusCodes.BAD_REQUEST,
 			});
 		}
 
-		const activeUrl = await getActiveStripeCheckoutUrl({
+		const session = await getStripeCheckoutSession({
 			ctx,
 			url: checkout.response?.payment_url,
 		});
-		if (activeUrl) return c.redirect(activeUrl, StatusCodes.SEE_OTHER);
-
-		const { billingContext, billingResult } = await billingActions.attach({
-			ctx,
-			params: {
-				...(checkout.params as AttachParamsV1),
-				long_lived_checkout: false,
-			},
-			preview: false,
-			skipAutumnCheckout: true,
-		});
-
-		if (!billingResult) {
-			throw new InternalError({
-				message: "billingResult not returned from long-lived checkout attach",
-			});
+		if (
+			session?.status === "open" &&
+			isFuture(fromUnixTime(session.expires_at)) &&
+			session.url
+		) {
+			return c.redirect(session.url, StatusCodes.SEE_OTHER);
 		}
 
-		const response = billingResultToResponse({ billingContext, billingResult });
+		const response =
+			(session &&
+				(await rotateEnabledCheckoutSession({ ctx, checkout, session }))) ||
+			(await startCheckout({ ctx, checkout }));
+
 		if (!response.payment_url) {
 			throw new InternalError({
-				message: "Long-lived checkout attach did not return a payment URL",
+				message: "Long-lived checkout did not return a payment URL",
 			});
 		}
 

--- a/server/tests/integration/billing/create-schedule/params/create-schedule-long-lived-checkout.test.ts
+++ b/server/tests/integration/billing/create-schedule/params/create-schedule-long-lived-checkout.test.ts
@@ -1,0 +1,374 @@
+// Contract — API/UI input: create_schedule accepts long_lived_checkout and returns a reusable /co/ URL.
+// Starting that URL creates a Stripe checkout and enables the immediate and scheduled products once.
+
+// Contract — expiry/retry: an expired child session preserves products and balances.
+// Reopening the same /co/ URL rotates the Stripe session without duplicating Autumn state.
+
+// Contract — completion/regression: the replacement session materializes one schedule.
+// A normal checkout session still expires its enable-plan-immediately products.
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	CheckoutStatus,
+	type CreateScheduleParamsV0Input,
+	CusProductStatus,
+	customers,
+	ms,
+	schedules,
+} from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { completeStripeCheckoutFormV2 as completeStripeCheckoutForm } from "@tests/utils/browserPool/completeStripeCheckoutFormV2";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import type Stripe from "stripe";
+import { handleStripeCheckoutSessionCompleted } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/handleStripeCheckoutSessionCompleted";
+import { handleStripeCheckoutSessionExpired } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionExpired/handleStripeCheckoutSessionExpired";
+import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
+import { checkoutRepo } from "@/internal/checkouts/repos/checkoutRepo";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
+
+const CHECKOUT_BASE_URL =
+	process.env.AUTUMN_TEST_BASE_URL ?? "http://localhost:8080";
+const STRIPE_SESSION_ID_REGEX = /cs_(test|live)_[A-Za-z0-9]+/;
+
+const getLongLivedCheckoutId = (paymentUrl: string | null | undefined) => {
+	const checkoutId = paymentUrl?.split("/co/")[1];
+	if (!checkoutId)
+		throw new Error(`Expected long-lived checkout URL: ${paymentUrl}`);
+	return checkoutId;
+};
+
+const getStripeSessionId = (url: string) => {
+	const sessionId = url.match(STRIPE_SESSION_ID_REGEX)?.[0];
+	if (!sessionId) throw new Error(`Expected Stripe checkout URL: ${url}`);
+	return sessionId;
+};
+
+const requestLongLivedCheckout = async (checkoutId: string) =>
+	await fetch(`${CHECKOUT_BASE_URL}/checkouts/${checkoutId}/start`, {
+		redirect: "manual",
+	});
+
+const startLongLivedCheckout = async (checkoutId: string) => {
+	const response = await requestLongLivedCheckout(checkoutId);
+	expect(response.status).toBe(303);
+	const location = response.headers.get("location");
+	expect(location).toContain("checkout.stripe.com");
+	return location!;
+};
+
+const expireCheckoutSession = async ({
+	ctx,
+	sessionId,
+}: {
+	ctx: Awaited<ReturnType<typeof initScenario>>["ctx"];
+	sessionId: string;
+}) => {
+	const session = await ctx.stripeCli.checkout.sessions.expire(sessionId);
+	const event = {
+		id: `evt_expired_${sessionId}`,
+		type: "checkout.session.expired",
+		data: { object: session },
+	} as unknown as Stripe.CheckoutSessionExpiredEvent;
+
+	await handleStripeCheckoutSessionExpired({
+		ctx: {
+			...ctx,
+			stripeCli: ctx.stripeCli,
+			stripeEvent: event,
+		} as StripeWebhookContext,
+		event,
+	});
+};
+
+const completeCheckoutSessionWebhook = async ({
+	ctx,
+	sessionId,
+}: {
+	ctx: Awaited<ReturnType<typeof initScenario>>["ctx"];
+	sessionId: string;
+}) => {
+	const session = await ctx.stripeCli.checkout.sessions.retrieve(sessionId);
+	const event = {
+		id: `evt_completed_${sessionId}`,
+		type: "checkout.session.completed",
+		data: { object: session },
+	} as unknown as Stripe.CheckoutSessionCompletedEvent;
+
+	await handleStripeCheckoutSessionCompleted({
+		ctx: {
+			...ctx,
+			stripeCli: ctx.stripeCli,
+			stripeEvent: event,
+		} as StripeWebhookContext,
+		event,
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("create-schedule long-lived checkout: preserves and rebinds enabled products across child expiry")}`,
+	async () => {
+		const customerId = `cs-long-lived-${crypto.randomUUID().slice(0, 8)}`;
+		const immediate = products.pro({
+			id: "immediate-enterprise-long-lived",
+			items: [items.monthlyMessages({ includedUsage: 10_000 })],
+		});
+		const future = products.pro({
+			id: "future-enterprise-long-lived",
+			items: [items.monthlyMessages({ includedUsage: 5_000 })],
+		});
+		const { autumnV1, autumnV2_1, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: true }),
+				s.products({ list: [immediate, future] }),
+			],
+			actions: [],
+		});
+		const customer = await ctx.db.query.customers.findFirst({
+			where: eq(customers.id, customerId),
+		});
+		const startsAt = Date.now();
+		const params: CreateScheduleParamsV0Input = {
+			customer_id: customerId,
+			billing_behavior: "none",
+			enable_plan_immediately: true,
+			long_lived_checkout: true,
+			phases: [
+				{ starts_at: startsAt, plans: [{ plan_id: immediate.id }] },
+				{
+					starts_at: startsAt + ms.days(30),
+					plans: [{ plan_id: future.id }],
+				},
+			],
+		};
+
+		const response = await autumnV1.billing.createSchedule(params);
+		expect(response.status).toBe("pending_payment");
+		expect(response.payment_url).toContain("/co/");
+		expect(response.payment_url).not.toContain("checkout.stripe.com");
+
+		const productsBeforeOpen = await CusProductService.list({
+			db: ctx.db,
+			internalCustomerId: customer!.internal_id,
+			inStatuses: [CusProductStatus.Active, CusProductStatus.Scheduled],
+		});
+		expect(productsBeforeOpen).toHaveLength(2);
+		expect(productsBeforeOpen).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					status: CusProductStatus.Active,
+					product: expect.objectContaining({ id: immediate.id }),
+				}),
+				expect.objectContaining({
+					status: CusProductStatus.Scheduled,
+					product: expect.objectContaining({ id: future.id }),
+				}),
+			]),
+		);
+
+		const checkoutId = getLongLivedCheckoutId(response.payment_url);
+		const checkout = await checkoutRepo.get({ db: ctx.db, id: checkoutId });
+		expect(checkout?.expires_at).toBe(checkout!.created_at + ms.days(90));
+
+		const firstStripeUrl = await startLongLivedCheckout(checkoutId);
+		const firstSessionId = getStripeSessionId(firstStripeUrl);
+		const productsBeforeExpiry = await CusProductService.list({
+			db: ctx.db,
+			internalCustomerId: customer!.internal_id,
+			inStatuses: [CusProductStatus.Active, CusProductStatus.Scheduled],
+		});
+		expect(productsBeforeExpiry).toEqual(productsBeforeOpen);
+		for (const product of productsBeforeExpiry) {
+			expect(product.stripe_checkout_session_id).toBe(firstSessionId);
+		}
+
+		const customerBeforeExpiry =
+			await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer: customerBeforeExpiry,
+			featureId: TestFeature.Messages,
+			remaining: 10_000,
+		});
+
+		await expireCheckoutSession({ ctx, sessionId: firstSessionId });
+
+		const productsAfterExpiry = await CusProductService.list({
+			db: ctx.db,
+			internalCustomerId: customer!.internal_id,
+			inStatuses: [CusProductStatus.Active, CusProductStatus.Scheduled],
+		});
+		for (const product of productsBeforeExpiry) {
+			expect(productsAfterExpiry).toContainEqual(
+				expect.objectContaining({ id: product.id }),
+			);
+		}
+		const customerAfterExpiry =
+			await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer: customerAfterExpiry,
+			featureId: TestFeature.Messages,
+			remaining: 10_000,
+		});
+
+		const rotationResponses = await Promise.all([
+			requestLongLivedCheckout(checkoutId),
+			requestLongLivedCheckout(checkoutId),
+		]);
+		expect(
+			rotationResponses.every(({ status }) => status === 303 || status === 423),
+		).toBe(true);
+		const replacementLocations = rotationResponses
+			.filter(({ status }) => status === 303)
+			.map((rotationResponse) => rotationResponse.headers.get("location")!);
+		expect(new Set(replacementLocations).size).toBe(1);
+		const replacementStripeUrl = replacementLocations[0]!;
+		const replacementSessionId = getStripeSessionId(replacementStripeUrl);
+		expect(replacementSessionId).not.toBe(firstSessionId);
+
+		const reboundProducts = await CusProductService.list({
+			db: ctx.db,
+			internalCustomerId: customer!.internal_id,
+			inStatuses: [CusProductStatus.Active, CusProductStatus.Scheduled],
+		});
+		expect(reboundProducts).toHaveLength(2);
+		expect(
+			reboundProducts.every(
+				(product) =>
+					product.stripe_checkout_session_id === replacementSessionId,
+			),
+		).toBe(true);
+
+		await completeStripeCheckoutForm({ url: replacementStripeUrl });
+		await completeCheckoutSessionWebhook({
+			ctx,
+			sessionId: replacementSessionId,
+		});
+
+		const createdSchedules = await ctx.db
+			.select()
+			.from(schedules)
+			.where(eq(schedules.internal_customer_id, customer!.internal_id));
+		expect(createdSchedules).toHaveLength(1);
+
+		const completedProducts = await CusProductService.list({
+			db: ctx.db,
+			internalCustomerId: customer!.internal_id,
+			inStatuses: [CusProductStatus.Active, CusProductStatus.Scheduled],
+		});
+		expect(completedProducts).toHaveLength(2);
+		expect(completedProducts[0]?.subscription_ids).not.toHaveLength(0);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("create-schedule long-lived checkout: parent expiry rolls back enabled products")}`,
+	async () => {
+		const customerId = `cs-parent-expiry-${crypto.randomUUID().slice(0, 8)}`;
+		const immediate = products.pro({
+			id: "create-schedule-parent-expiry-pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const future = products.pro({
+			id: "create-schedule-parent-expiry-growth",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+		const { autumnV1, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: true }),
+				s.products({ list: [immediate, future] }),
+			],
+			actions: [],
+		});
+		const customer = await ctx.db.query.customers.findFirst({
+			where: eq(customers.id, customerId),
+		});
+		const response = await autumnV1.billing.createSchedule({
+			customer_id: customerId,
+			enable_plan_immediately: true,
+			long_lived_checkout: true,
+			phases: [
+				{ starts_at: Date.now(), plans: [{ plan_id: immediate.id }] },
+				{
+					starts_at: Date.now() + ms.days(30),
+					plans: [{ plan_id: future.id }],
+				},
+			],
+		});
+		const checkoutId = getLongLivedCheckoutId(response.payment_url);
+		const stripeUrl = await startLongLivedCheckout(checkoutId);
+
+		await checkoutRepo.update({
+			db: ctx.db,
+			id: checkoutId,
+			updates: {
+				status: CheckoutStatus.Expired,
+				expires_at: Date.now() - 1,
+			},
+		});
+		await expireCheckoutSession({
+			ctx,
+			sessionId: getStripeSessionId(stripeUrl),
+		});
+
+		const productsAfterExpiry = await CusProductService.list({
+			db: ctx.db,
+			internalCustomerId: customer!.internal_id,
+			inStatuses: [CusProductStatus.Active, CusProductStatus.Scheduled],
+		});
+		expect(productsAfterExpiry).toHaveLength(0);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("create-schedule normal checkout: expired child still rolls back enabled products")}`,
+	async () => {
+		const customerId = `cs-normal-expiry-${crypto.randomUUID().slice(0, 8)}`;
+		const pro = products.pro({
+			id: "create-schedule-normal-expiry-pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const growth = products.pro({
+			id: "create-schedule-normal-expiry-growth",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+		const { autumnV1, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: true }),
+				s.products({ list: [pro, growth] }),
+			],
+			actions: [],
+		});
+		const customer = await ctx.db.query.customers.findFirst({
+			where: eq(customers.id, customerId),
+		});
+
+		const response = await autumnV1.billing.createSchedule({
+			customer_id: customerId,
+			enable_plan_immediately: true,
+			phases: [
+				{ starts_at: Date.now(), plans: [{ plan_id: pro.id }] },
+				{
+					starts_at: Date.now() + ms.days(30),
+					plans: [{ plan_id: growth.id }],
+				},
+			],
+		});
+		const sessionId = getStripeSessionId(response.payment_url!);
+		await expireCheckoutSession({ ctx, sessionId });
+
+		const productsAfterExpiry = await CusProductService.list({
+			db: ctx.db,
+			internalCustomerId: customer!.internal_id,
+			inStatuses: [CusProductStatus.Active, CusProductStatus.Scheduled],
+		});
+		expect(productsAfterExpiry).toHaveLength(0);
+	},
+);

--- a/shared/api/billing/createSchedule/createScheduleParamsV0.ts
+++ b/shared/api/billing/createSchedule/createScheduleParamsV0.ts
@@ -134,6 +134,10 @@ export const CreateScheduleParamsV0Schema = z
 			description:
 				"Additional parameters to pass into the creation of the Stripe checkout session.",
 		}),
+		long_lived_checkout: z.boolean().optional().meta({
+			description:
+				"If true, returns an Autumn-hosted checkout link that can create fresh Stripe checkout sessions when opened.",
+		}),
 		redirect_mode: RedirectModeSchema.default("if_required").meta({
 			description:
 				"Controls when to return a checkout URL for the immediate phase. 'always' forces a confirmation or checkout flow, 'if_required' only redirects when needed, and 'never' disables redirects.",

--- a/shared/models/billingModels/context/billingContext.ts
+++ b/shared/models/billingModels/context/billingContext.ts
@@ -112,6 +112,7 @@ export interface BillingContext {
 	// session is required. Mirrors invoice-mode enable_plan_immediately for the
 	// stripe_checkout flow.
 	enablePlanImmediately?: boolean;
+	longLivedCheckoutId?: string;
 	// When set, Autumn access starts at this time while billing may start later.
 	accessStartsAt?: number;
 	/** Identifies the Autumn action driving this billing context. Stamped onto Stripe

--- a/shared/models/otherModels/metadataTable.ts
+++ b/shared/models/otherModels/metadataTable.ts
@@ -11,6 +11,7 @@ export enum MetadataType {
 	CheckoutSessionV2 = "checkout_session_v2",
 	CheckoutSessionV2Processing = "checkout_session_v2_processing",
 	CheckoutSessionEnabledImmediately = "checkout_session_enabled_immediately",
+	CheckoutSessionEnabledImmediatelyProcessing = "checkout_session_enabled_immediately_processing",
 	SetupPaymentV2 = "setup_payment_v2",
 }
 

--- a/vite/src/components/forms/attach-v2/utils/buildAttachPreviewTotals.ts
+++ b/vite/src/components/forms/attach-v2/utils/buildAttachPreviewTotals.ts
@@ -1,4 +1,7 @@
-import type { AttachPreviewResponse } from "@autumn/shared";
+import type {
+	AttachPreviewResponse,
+	BillingPreviewResponse,
+} from "@autumn/shared";
 import { addMinutes, format, isAfter } from "date-fns";
 
 const FUTURE_START_TOLERANCE_MINUTES = 1;
@@ -67,7 +70,7 @@ export function buildAttachPreviewTotals({
 	startDate,
 	now = Date.now(),
 }: {
-	previewData: AttachPreviewResponse | null | undefined;
+	previewData: BillingPreviewResponse | null | undefined;
 	startDate: number | null;
 	now?: number;
 }): AttachPreviewTotal[] {

--- a/vite/src/components/forms/create-schedule/components/CreateScheduleAdvancedSection.tsx
+++ b/vite/src/components/forms/create-schedule/components/CreateScheduleAdvancedSection.tsx
@@ -4,29 +4,27 @@ import {
 	AdvancedSection,
 	ConfigRow,
 } from "@/components/forms/shared/advanced-section";
+import { useCreateScheduleFormContext } from "../context/CreateScheduleFormProvider";
 import {
 	canResetScheduleBillingCycle,
 	hasMultipleImmediateSchedulePlans,
 } from "../createScheduleFormSchema";
-import { useCreateScheduleFormContext } from "../context/CreateScheduleFormProvider";
 
 export function CreateScheduleAdvancedSection() {
 	const { form, formValues, preview } = useCreateScheduleFormContext();
 	const { billingBehavior, resetBillingCycle, enablePlanImmediately, phases } =
 		formValues;
-	const isCheckoutRedirect = preview?.redirect_to_checkout === true;
 
-	// Keep form state in sync with what the user can see: when the toggle hides
-	// (no checkout flow), reset the value so a stale `true` doesn't leak into
-	// the request body.
 	useEffect(() => {
-		if (!isCheckoutRedirect && enablePlanImmediately) {
+		if (!preview?.redirect_to_checkout && enablePlanImmediately) {
 			form.setFieldValue("enablePlanImmediately", false);
 		}
-	}, [isCheckoutRedirect, enablePlanImmediately, form]);
+	}, [preview?.redirect_to_checkout, enablePlanImmediately, form]);
 
 	const isProrate = billingBehavior !== "none";
-	const hasMultipleImmediatePlans = hasMultipleImmediateSchedulePlans({ phases });
+	const hasMultipleImmediatePlans = hasMultipleImmediateSchedulePlans({
+		phases,
+	});
 	const prorateDisabledReason = hasMultipleImmediatePlans
 		? "Not yet supported for multi attach"
 		: null;
@@ -80,20 +78,6 @@ export function CreateScheduleAdvancedSection() {
 					disabledReason: resetDisabledReason,
 				})}
 			/>
-			{isCheckoutRedirect && (
-				<ConfigRow
-					title="Enable Plan Immediately"
-					description="Activate the plan as soon as the checkout URL is generated, before the customer pays."
-					action={
-						<Switch
-							checked={enablePlanImmediately}
-							onCheckedChange={(checked) =>
-								form.setFieldValue("enablePlanImmediately", !!checked)
-							}
-						/>
-					}
-				/>
-			)}
 		</AdvancedSection>
 	);
 }

--- a/vite/src/components/forms/create-schedule/components/CreateScheduleSheetContent.tsx
+++ b/vite/src/components/forms/create-schedule/components/CreateScheduleSheetContent.tsx
@@ -112,7 +112,7 @@ function getConfirmLabel({
 		| undefined;
 }): string {
 	if (!preview) return "Create Schedule";
-	if (preview.redirect_to_checkout) return "Copy Checkout URL";
+	if (preview.redirect_to_checkout) return "Generate Checkout URL";
 	if (preview.total <= 0) return "Create Schedule";
 	return "Charge Customer";
 }
@@ -204,7 +204,11 @@ export function CreateScheduleReviewContent() {
 					<Button
 						variant="primary"
 						className="w-full"
-						onClick={() => handleSubmit()}
+						onClick={() =>
+							preview?.redirect_to_checkout
+								? setSheet({ type: "create-schedule-checkout-session" })
+								: handleSubmit()
+						}
 						isLoading={isPending}
 						disabled={isDisabled}
 					>

--- a/vite/src/components/forms/create-schedule/context/CreateScheduleFormProvider.tsx
+++ b/vite/src/components/forms/create-schedule/context/CreateScheduleFormProvider.tsx
@@ -87,6 +87,9 @@ interface CreateScheduleFormContextValue {
 		stripeId: string | undefined;
 		hostedInvoiceUrl: string | null | undefined;
 	}>;
+	handleCheckoutSubmit: (params?: { longLivedCheckout?: boolean }) => Promise<{
+		paymentUrl: string | null | undefined;
+	}>;
 	preview: AttachPreviewResponse | null | undefined;
 	previewQuery: { data: AttachPreviewResponse | null | undefined };
 	isPreviewLoading: boolean;
@@ -179,8 +182,9 @@ export function CreateScheduleFormProvider({
 		!hasActiveSubscription && immediatePlansPaidRecurring;
 
 	const editingPlanValue = editingPlan
-		? (formValues.phases[editingPlan.phaseIndex]?.plans[editingPlan.planIndex] ??
-			null)
+		? (formValues.phases[editingPlan.phaseIndex]?.plans[
+				editingPlan.planIndex
+			] ?? null)
 		: null;
 
 	const {
@@ -267,7 +271,7 @@ export function CreateScheduleFormProvider({
 		error: previewError,
 	} = useCreateSchedulePreview({ requestBody: previewRequestBody });
 
-	const { handleSubmit, handleInvoiceSubmit, isPending } =
+	const { handleSubmit, handleInvoiceSubmit, handleCheckoutSubmit, isPending } =
 		useCreateScheduleMutation({
 			customerId,
 			buildRequestBody,
@@ -303,6 +307,7 @@ export function CreateScheduleFormProvider({
 			isPending,
 			handleSubmit,
 			handleInvoiceSubmit,
+			handleCheckoutSubmit,
 			preview,
 			previewQuery,
 			isPreviewLoading,
@@ -334,6 +339,7 @@ export function CreateScheduleFormProvider({
 			isPending,
 			handleSubmit,
 			handleInvoiceSubmit,
+			handleCheckoutSubmit,
 			preview,
 			previewQuery,
 			isPreviewLoading,

--- a/vite/src/components/forms/create-schedule/createScheduleFormSchema.ts
+++ b/vite/src/components/forms/create-schedule/createScheduleFormSchema.ts
@@ -196,6 +196,7 @@ export const CreateScheduleFormSchema = z
 		billingBehavior: BillingBehaviorSchema.nullable(),
 		resetBillingCycle: z.boolean(),
 		enablePlanImmediately: z.boolean(),
+		longLivedCheckout: z.boolean(),
 	})
 	.refine(
 		(data) =>

--- a/vite/src/components/forms/create-schedule/hooks/useCreateScheduleForm.ts
+++ b/vite/src/components/forms/create-schedule/hooks/useCreateScheduleForm.ts
@@ -21,6 +21,7 @@ export function useCreateScheduleForm({
 		billingBehavior: null,
 		resetBillingCycle: false,
 		enablePlanImmediately: false,
+		longLivedCheckout: false,
 	};
 
 	const initialValuesRef = useRef<CreateScheduleForm>(defaultValues);

--- a/vite/src/components/forms/create-schedule/hooks/useCreateScheduleMutation.ts
+++ b/vite/src/components/forms/create-schedule/hooks/useCreateScheduleMutation.ts
@@ -61,10 +61,23 @@ export function useCreateScheduleMutation({
 		};
 	};
 
+	const handleCheckoutSubmit = async ({
+		longLivedCheckout,
+	}: {
+		longLivedCheckout?: boolean;
+	} = {}) => {
+		const result = await mutation.mutateAsync({
+			longLivedCheckout,
+			skipDefaultSuccess: true,
+		});
+		return { paymentUrl: result.data?.payment_url };
+	};
+
 	return {
 		mutation,
 		handleSubmit,
 		handleInvoiceSubmit,
+		handleCheckoutSubmit,
 		isPending: mutation.isPending,
 	};
 }

--- a/vite/src/components/forms/shared/GenerateCheckoutStage.tsx
+++ b/vite/src/components/forms/shared/GenerateCheckoutStage.tsx
@@ -1,11 +1,12 @@
-import type { AttachPreviewResponse } from "@autumn/shared";
+import type {
+	AttachPreviewResponse,
+	BillingPreviewResponse,
+} from "@autumn/shared";
 import { Button, Switch } from "@autumn/ui";
 import { ArrowLeft, CalendarCheckIcon, LinkIcon } from "@phosphor-icons/react";
-import { useStore } from "@tanstack/react-form";
 import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
-import { useAttachFormContext } from "@/components/forms/attach-v2/context/AttachFormProvider";
 import {
 	buildAttachPreviewTotals,
 	getAttachPreviewLineItems,
@@ -22,9 +23,20 @@ import { ConfigRow } from "./ConfigRow";
 import { PlanActivationSection } from "./SendInvoiceStage";
 import { UrlSuccessView } from "./UrlSuccessView";
 
-type PreviewData = AttachPreviewResponse | null | undefined;
+type PreviewData =
+	| AttachPreviewResponse
+	| BillingPreviewResponse
+	| null
+	| undefined;
 type GenerateCheckoutSubmitParams = {
 	longLivedCheckout?: boolean;
+};
+type ActivationControls = {
+	enablePlanImmediately: boolean;
+	onEnablePlanImmediatelyChange: (value: boolean) => void;
+	longLivedCheckout?: boolean;
+	onLongLivedCheckoutChange?: (value: boolean) => void;
+	showLongLivedCheckout?: boolean;
 };
 
 function usePreviewTotals({
@@ -53,6 +65,10 @@ function ActivationPreviewStage({
 	buttonIcon,
 	scheduledStartDate,
 	showLongLivedCheckout = false,
+	enablePlanImmediately,
+	onEnablePlanImmediatelyChange,
+	longLivedCheckout,
+	onLongLivedCheckoutChange,
 }: {
 	title: string;
 	description: string;
@@ -71,16 +87,7 @@ function ActivationPreviewStage({
 	buttonIcon: ReactNode;
 	scheduledStartDate?: number | null;
 	showLongLivedCheckout?: boolean;
-}) {
-	const { form } = useAttachFormContext();
-	const enablePlanImmediately = useStore(
-		form.store,
-		(state) => state.values.enablePlanImmediately,
-	);
-	const longLivedCheckout = useStore(
-		form.store,
-		(state) => state.values.longLivedCheckout,
-	);
+} & ActivationControls) {
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
 	const handleSubmit = async () => {
@@ -111,9 +118,7 @@ function ActivationPreviewStage({
 
 			<PlanActivationSection
 				enableImmediately={enablePlanImmediately}
-				setEnableImmediately={(value) =>
-					form.setFieldValue("enablePlanImmediately", value)
-				}
+				setEnableImmediately={onEnablePlanImmediatelyChange}
 				scheduledStartDate={scheduledStartDate}
 			/>
 
@@ -126,7 +131,7 @@ function ActivationPreviewStage({
 							<Switch
 								checked={!!longLivedCheckout}
 								onCheckedChange={(enabled) =>
-									form.setFieldValue("longLivedCheckout", !!enabled)
+									onLongLivedCheckoutChange?.(!!enabled)
 								}
 							/>
 						}
@@ -167,6 +172,10 @@ export function GenerateCheckoutStage({
 	currency,
 	totals,
 	showLongLivedCheckout = true,
+	enablePlanImmediately,
+	onEnablePlanImmediatelyChange,
+	longLivedCheckout,
+	onLongLivedCheckoutChange,
 }: {
 	productName?: string;
 	isPending: boolean;
@@ -182,8 +191,7 @@ export function GenerateCheckoutStage({
 		variant?: "primary" | "secondary";
 		badge?: string;
 	}[];
-	showLongLivedCheckout?: boolean;
-}) {
+} & ActivationControls) {
 	const [completedCheckoutUrl, setCompletedCheckoutUrl] = useState<
 		string | null
 	>(null);
@@ -232,6 +240,10 @@ export function GenerateCheckoutStage({
 			buttonLabel="Generate Checkout URL"
 			buttonIcon={<LinkIcon size={16} weight="bold" />}
 			showLongLivedCheckout={showLongLivedCheckout}
+			enablePlanImmediately={enablePlanImmediately}
+			onEnablePlanImmediatelyChange={onEnablePlanImmediatelyChange}
+			longLivedCheckout={longLivedCheckout}
+			onLongLivedCheckoutChange={onLongLivedCheckoutChange}
 		/>
 	);
 }
@@ -242,7 +254,7 @@ export function GenerateCheckoutStageWithPreview({
 	isPending,
 	onSubmit,
 	onBack,
-	showLongLivedCheckout,
+	...activationControls
 }: {
 	productName?: string;
 	previewQuery: {
@@ -253,8 +265,7 @@ export function GenerateCheckoutStageWithPreview({
 		paymentUrl: string | null | undefined;
 	}>;
 	onBack: () => void;
-	showLongLivedCheckout?: boolean;
-}) {
+} & ActivationControls) {
 	const previewData = previewQuery.data;
 	const totals = usePreviewTotals({ previewData });
 
@@ -267,7 +278,7 @@ export function GenerateCheckoutStageWithPreview({
 			lineItems={previewData?.line_items}
 			currency={previewData?.currency}
 			totals={totals}
-			showLongLivedCheckout={showLongLivedCheckout}
+			{...activationControls}
 		/>
 	);
 }
@@ -279,6 +290,8 @@ export function SchedulePlanStageWithPreview({
 	isPending,
 	onSubmit,
 	onBack,
+	enablePlanImmediately,
+	onEnablePlanImmediatelyChange,
 }: {
 	productName?: string;
 	startDate: number | null;
@@ -288,6 +301,8 @@ export function SchedulePlanStageWithPreview({
 	isPending: boolean;
 	onSubmit: () => void | Promise<void>;
 	onBack: () => void;
+	enablePlanImmediately: boolean;
+	onEnablePlanImmediatelyChange: (value: boolean) => void;
 }) {
 	const previewData = previewQuery.data;
 	const scheduledStartDate = getAttachScheduledStartDate({
@@ -320,6 +335,8 @@ export function SchedulePlanStageWithPreview({
 			buttonLabel="Schedule Plan"
 			buttonIcon={<CalendarCheckIcon size={16} weight="bold" />}
 			scheduledStartDate={scheduledStartDate}
+			enablePlanImmediately={enablePlanImmediately}
+			onEnablePlanImmediatelyChange={onEnablePlanImmediatelyChange}
 		/>
 	);
 }

--- a/vite/src/components/forms/shared/utils/applyCreateScheduleStageParams.ts
+++ b/vite/src/components/forms/shared/utils/applyCreateScheduleStageParams.ts
@@ -8,6 +8,7 @@ export function applyCreateScheduleStageParams({
 	finalizeInvoice,
 	invoiceTemplateId,
 	netTermsDays,
+	longLivedCheckout,
 }: BillingStageParams & {
 	requestBody: CreateScheduleParamsV0 | null;
 }): CreateScheduleParamsV0 | null {
@@ -28,10 +29,11 @@ export function applyCreateScheduleStageParams({
 		};
 	}
 
-	if (enableProductImmediately === undefined) return requestBody;
-
 	return {
 		...requestBody,
-		enable_plan_immediately: enableProductImmediately,
+		...(enableProductImmediately !== undefined
+			? { enable_plan_immediately: enableProductImmediately }
+			: {}),
+		...(longLivedCheckout ? { long_lived_checkout: true } : {}),
 	};
 }

--- a/vite/src/hooks/stores/useSheetStore.ts
+++ b/vite/src/hooks/stores/useSheetStore.ts
@@ -43,6 +43,7 @@ export type SheetType =
 	| "create-schedule"
 	| "create-schedule-review"
 	| "create-schedule-send-invoice"
+	| "create-schedule-checkout-session"
 	| null;
 
 // Store state interface

--- a/vite/src/views/customers2/components/sheets/AttachProductSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/AttachProductSheet.tsx
@@ -23,11 +23,11 @@ import {
 	getAttachPreviewLineItems,
 	isFutureStartDate,
 } from "@/components/forms/attach-v2/utils/buildAttachPreviewTotals";
+import { DisabledTooltipButton } from "@/components/forms/shared";
 import {
 	GenerateCheckoutStageWithPreview,
 	SchedulePlanStageWithPreview,
 } from "@/components/forms/shared/GenerateCheckoutStage";
-import { DisabledTooltipButton } from "@/components/forms/shared";
 import { SendInvoiceStageWithPreview } from "@/components/forms/shared/SendInvoiceStage";
 import { PreviewErrorDisplay } from "@/components/forms/update-subscription-v2/components/PreviewErrorDisplay";
 import {
@@ -436,6 +436,7 @@ function SendInvoiceContent() {
 
 function CheckoutSessionContent() {
 	const {
+		form,
 		product,
 		previewQuery,
 		isPending,
@@ -444,6 +445,14 @@ function CheckoutSessionContent() {
 	} = useAttachFormContext();
 	const { setSheet } = useSheetStore();
 	const itemId = useSheetStore((s) => s.itemId);
+	const enablePlanImmediately = useStore(
+		form.store,
+		(state) => state.values.enablePlanImmediately,
+	);
+	const longLivedCheckout = useStore(
+		form.store,
+		(state) => state.values.longLivedCheckout,
+	);
 
 	return (
 		<GenerateCheckoutStageWithPreview
@@ -453,12 +462,20 @@ function CheckoutSessionContent() {
 			onSubmit={handleCheckoutAttach}
 			onBack={() => setSheet({ type: "attach-review", itemId })}
 			showLongLivedCheckout={!additionalPlans.isMultiPlan}
+			enablePlanImmediately={enablePlanImmediately}
+			onEnablePlanImmediatelyChange={(value) =>
+				form.setFieldValue("enablePlanImmediately", value)
+			}
+			longLivedCheckout={longLivedCheckout}
+			onLongLivedCheckoutChange={(value) =>
+				form.setFieldValue("longLivedCheckout", value)
+			}
 		/>
 	);
 }
 
 function SchedulePlanContent() {
-	const { product, formValues, previewQuery, isPending, handleConfirm } =
+	const { form, product, formValues, previewQuery, isPending, handleConfirm } =
 		useAttachFormContext();
 	const { setSheet } = useSheetStore();
 	const itemId = useSheetStore((s) => s.itemId);
@@ -471,6 +488,10 @@ function SchedulePlanContent() {
 			isPending={isPending}
 			onSubmit={handleConfirm}
 			onBack={() => setSheet({ type: "attach-review", itemId })}
+			enablePlanImmediately={formValues.enablePlanImmediately}
+			onEnablePlanImmediatelyChange={(value) =>
+				form.setFieldValue("enablePlanImmediately", value)
+			}
 		/>
 	);
 }

--- a/vite/src/views/customers2/components/sheets/CreateScheduleSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/CreateScheduleSheet.tsx
@@ -10,6 +10,7 @@ import {
 	mapToProductItems,
 } from "@autumn/shared";
 import { Button } from "@autumn/ui";
+import { useStore } from "@tanstack/react-form";
 import { motion } from "motion/react";
 import { useMemo } from "react";
 import { toast } from "sonner";
@@ -32,6 +33,7 @@ import {
 	type CreateScheduleForm,
 	EMPTY_SCHEDULE_PLAN,
 } from "@/components/forms/create-schedule/createScheduleFormSchema";
+import { GenerateCheckoutStageWithPreview } from "@/components/forms/shared/GenerateCheckoutStage";
 import { SendInvoiceStageWithPreview } from "@/components/forms/shared/SendInvoiceStage";
 import {
 	STAGGER_CONTAINER,
@@ -179,6 +181,7 @@ export function buildInitialValues({
 				nowMs,
 			}),
 			enablePlanImmediately: false,
+			longLivedCheckout: false,
 		};
 	}
 
@@ -204,6 +207,7 @@ export function buildInitialValues({
 		billingBehavior: null,
 		resetBillingCycle: false,
 		enablePlanImmediately: false,
+		longLivedCheckout: false,
 	};
 }
 
@@ -355,6 +359,37 @@ function ScheduleSendInvoiceContent() {
 	);
 }
 
+function ScheduleCheckoutContent() {
+	const { form, previewQuery, isPending, handleCheckoutSubmit } =
+		useCreateScheduleFormContext();
+	const { setSheet } = useSheetStore();
+	const enablePlanImmediately = useStore(
+		form.store,
+		(state) => state.values.enablePlanImmediately,
+	);
+	const longLivedCheckout = useStore(
+		form.store,
+		(state) => state.values.longLivedCheckout,
+	);
+
+	return (
+		<GenerateCheckoutStageWithPreview
+			previewQuery={previewQuery}
+			isPending={isPending}
+			onSubmit={handleCheckoutSubmit}
+			onBack={() => setSheet({ type: "create-schedule-review" })}
+			enablePlanImmediately={enablePlanImmediately}
+			onEnablePlanImmediatelyChange={(value) =>
+				form.setFieldValue("enablePlanImmediately", value)
+			}
+			longLivedCheckout={longLivedCheckout}
+			onLongLivedCheckoutChange={(value) =>
+				form.setFieldValue("longLivedCheckout", value)
+			}
+		/>
+	);
+}
+
 function CreateScheduleSheetBody() {
 	const { editingPlan, editingPlanValue, handlePlanEditSave, setEditingPlan } =
 		useCreateScheduleFormContext();
@@ -375,6 +410,10 @@ function CreateScheduleSheetBody() {
 
 	if (sheetType === "create-schedule-send-invoice") {
 		return <ScheduleSendInvoiceContent />;
+	}
+
+	if (sheetType === "create-schedule-checkout-session") {
+		return <ScheduleCheckoutContent />;
 	}
 
 	if (sheetType === "create-schedule-review") {

--- a/vite/src/views/customers2/customer/CustomerSheets.tsx
+++ b/vite/src/views/customers2/customer/CustomerSheets.tsx
@@ -104,6 +104,7 @@ export function CustomerSheets() {
 			case "create-schedule":
 			case "create-schedule-review":
 			case "create-schedule-send-invoice":
+			case "create-schedule-checkout-session":
 				return <CreateScheduleSheet />;
 			default:
 				return null;

--- a/vite/tests/components/forms/create-schedule/hooks/build-create-schedule-request-body.test.ts
+++ b/vite/tests/components/forms/create-schedule/hooks/build-create-schedule-request-body.test.ts
@@ -7,6 +7,7 @@ import {
 	type SchedulePhase,
 } from "@/components/forms/create-schedule/createScheduleFormSchema";
 import { buildCreateScheduleRequestBody } from "@/components/forms/create-schedule/hooks/useCreateScheduleRequestBody";
+import { applyCreateScheduleStageParams } from "@/components/forms/shared/utils/applyCreateScheduleStageParams";
 import {
 	buildCustomize,
 	buildCustomizeBasePrice,
@@ -112,6 +113,34 @@ const schedulePhase = ({
 	startsAt,
 	persistedStartsAt,
 	plans: productIds.map(schedulePlan),
+});
+
+describe("applyCreateScheduleStageParams", () => {
+	const requestBody = buildCreateScheduleRequestBody({
+		customerId: "cus_1",
+		entityId: undefined,
+		phases: [schedulePhase({})],
+		products: [makeProduct({ id: "prod_1" })],
+		features,
+	});
+	if (!requestBody) throw new Error("Expected a valid create schedule body");
+
+	test("adds long-lived and immediate flags for checkout generation", () => {
+		const result = applyCreateScheduleStageParams({
+			requestBody,
+			enableProductImmediately: true,
+			longLivedCheckout: true,
+		});
+
+		expect(result?.enable_plan_immediately).toBe(true);
+		expect(result?.long_lived_checkout).toBe(true);
+	});
+
+	test("omits long-lived checkout unless explicitly enabled", () => {
+		const result = applyCreateScheduleStageParams({ requestBody });
+
+		expect(result?.long_lived_checkout).toBeUndefined();
+	});
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add long-lived checkout support to billing.create_schedule and expose the shared Attach checkout-generation UI
- materialize active and scheduled customer products before returning when enable_plan_immediately is selected
- preserve those products when a child Stripe checkout expires, then rotate and rebind a fresh session without duplicating plans or credits
- keep ordinary checkout expiry rollback behavior unchanged

## Regression coverage

- asserts the active and scheduled products exist before the reusable checkout link is opened
- expires the first child session and verifies product IDs and the 10k balance are preserved
- reopens the long-lived link, verifies the same products are rebound, completes checkout, and verifies one schedule is created
- verifies a normal expired checkout still removes immediately enabled products

## Verification

- server create-schedule integration: 2 passed, 26 assertions
- existing Attach long-lived integration: 2 passed, 16 assertions
- Create Schedule frontend tests: 47 passed, 98 assertions
- server and frontend typechecks passed
- Biome, ESLint, and git diff checks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds long‑lived checkout to `createSchedule` with safe immediate activation, atomic rotation, and parent-aware expiry. Enabled products are created once, preserved across child-session expiry, and rebound to a fresh session; parent or normal expiry still rolls them back.

- **New Features**
  - `createSchedule` accepts `long_lived_checkout` and returns an Autumn-hosted `/co/{id}` link (~90 days) that creates Stripe sessions on open.
  - With `enable_plan_immediately`, immediate and scheduled products are inserted once before returning; credits are available right away.
  - Long‑lived start now supports both Attach and Create Schedule: redirects to any still‑open session, or rotates and rebinds on demand.
  - Create Schedule reuses the shared checkout-generation UI with “Enable Plan Immediately,” “Long‑lived checkout,” and a “Generate Checkout URL” action.

- **Bug Fixes**
  - `checkout.session.expired` preserves products only when the parent long‑lived checkout is pending and unexpired; otherwise it rolls back and deletes metadata.
  - Rotation is concurrency‑safe via claimed metadata; rebinds happen in a single transaction, the checkout response is updated atomically, and any replacement session is discarded on failure.
  - Immediate execution for long‑lived schedules updates the stored checkout response within the same transaction, caches it, and discards the Stripe session on rollback; normal (non‑long‑lived) expiry is unchanged.

<sup>Written for commit 34e8741ebbe2f9e9871da70771992d2bbf75229b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds reusable checkout support to schedule creation and preserves enabled billing state while rotating expired child sessions.
- [API changes] Adds `long_lived_checkout` to the create-schedule request contract and supports reusable schedule checkout URLs.
- [Improvements] Shares checkout-generation UI and activation controls between Attach and Create Schedule.
- [Bug fixes] Materializes enabled products before returning and rebinds them to replacement Stripe sessions after child-session expiration.
- [Bug fixes] Keeps ordinary checkout expiration rollback behavior and adds integration and frontend regression coverage.
</details>

<h3>Confidence Score: 2/5</h3>

The PR should not merge until parent-expiry cleanup and the non-atomic retry and concurrency paths for schedule materialization and session rotation are addressed.

Long-lived checkout state can outlive an unusable parent, while failures or concurrent starts between separately persisted lifecycle steps can preserve unpaid entitlements, partially bind products, create duplicate payable sessions, or execute schedule materialization more than once.

server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionExpired/handleStripeCheckoutSessionExpired.ts, server/src/internal/checkouts/handlers/handleStartLongLivedCheckout.ts, server/src/internal/billing/v2/actions/createSchedule/createSchedule.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionExpired/handleStripeCheckoutSessionExpired.ts | Preserves enabled products for long-lived children, but does not verify the parent checkout is still valid. |
| server/src/internal/checkouts/handlers/handleStartLongLivedCheckout.ts | Adds schedule starts and replacement-session rotation, but concurrent and partial rotations can leave duplicate sessions or partially rebound products. |
| server/src/internal/billing/v2/actions/createSchedule/createSchedule.ts | Adds long-lived schedule creation and immediate materialization, with a retry window that can execute the billing plan twice. |
| shared/api/billing/createSchedule/createScheduleParamsV0.ts | Extends the public create-schedule schema with the optional long-lived checkout flag. |
| vite/src/components/forms/shared/GenerateCheckoutStage.tsx | Generalizes checkout-generation controls for use by both Attach and Create Schedule. |
| server/tests/integration/billing/create-schedule/params/create-schedule-long-lived-checkout.test.ts | Covers normal rotation and completion behavior but not parent expiry, concurrent rotation, or partial-failure retry paths. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant Autumn as Autumn Checkout
  participant Billing
  participant Stripe
  participant Webhook
  Client->>Billing: create_schedule(long_lived_checkout)
  Billing->>Autumn: Persist 90-day checkout
  Billing->>Billing: Materialize enabled products
  Client->>Autumn: Open reusable URL
  Autumn->>Stripe: Create child Checkout Session
  Stripe-->>Webhook: checkout.session.expired
  Webhook->>Billing: Preserve linked products
  Client->>Autumn: Reopen reusable URL
  Autumn->>Stripe: Create replacement session
  Autumn->>Billing: Rebind products
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionExpired/handleStripeCheckoutSessionExpired.ts:34-43
**Preserved products outlive checkout**

When a child session expires after its parent checkout has expired or been deleted, this condition treats the stored checkout ID as proof that the parent remains usable and returns without expiring the products, leaving unpaid active or scheduled entitlements granted indefinitely.

### Issue 2 of 4
server/src/internal/checkouts/handlers/handleStartLongLivedCheckout.ts:94-105
**Rotation leaves partially bound products**

When rotation fails after creating the replacement session or partway through this loop, products remain split between session IDs while the old metadata remains reusable. Completion then updates only the products bound to that session, and a retry creates another orphaned session from the old metadata.

### Issue 3 of 4
server/src/internal/billing/v2/actions/createSchedule/createSchedule.ts:122-133
**Schedule materialization repeats on retry**

When billing-plan execution succeeds but persisting the checkout response fails, the parent remains pending even though its products and credits were inserted. Starting it later executes the schedule plan again without an idempotency hash, producing duplicate billing state or a duplicate-identifier failure that leaves the reusable checkout unusable.

### Issue 4 of 4
server/src/internal/checkouts/handlers/handleStartLongLivedCheckout.ts:81-86
**Concurrent rotation creates duplicate sessions**

When the route lock falls open during Redis unavailability, concurrent starts both read the same expired session metadata and create replacement Stripe sessions here. Both sessions remain payable while the later product rebind wins, leaving the other replacement and its metadata orphaned.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): 🐛 preserve enabled plans ..."](https://github.com/useautumn/autumn/commit/b309ffdfca8a3fea073925ab9fede14427102873) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47080009)</sub>

> Greptile also left **4 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [Stripe Integration](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-stripe-integration.md)

<!-- /greptile_comment -->