### PR TITLE
docs: audit and correct documentation

### DIFF
--- a/apps/docs/api-reference-generator/balances/trackTokens.mdx
+++ b/apps/docs/api-reference-generator/balances/trackTokens.mdx
@@ -18,7 +18,7 @@ The `model_id` must use `provider/model` format, matching the provider and model
 <CodeGroup>
 
 ```typescript Anthropic
-await autumn.balances.trackTokens({
+await autumn.trackTokens({
   customerId: "cus_123",
   modelId: "anthropic/claude-opus-4-6",
   inputTokens: 1000,
@@ -27,7 +27,7 @@ await autumn.balances.trackTokens({
 ```
 
 ```typescript With cache + reasoning
-await autumn.balances.trackTokens({
+await autumn.trackTokens({
   customerId: "cus_123",
   modelId: "anthropic/claude-opus-4-6",
   inputTokens: 800,        // excludes the cached tokens below
@@ -39,7 +39,7 @@ await autumn.balances.trackTokens({
 ```
 
 ```typescript OpenRouter (nested path)
-await autumn.balances.trackTokens({
+await autumn.trackTokens({
   customerId: "cus_123",
   modelId: "openrouter/anthropic/claude-opus-4-6",
   inputTokens: 2000,
@@ -48,7 +48,7 @@ await autumn.balances.trackTokens({
 ```
 
 ```typescript With explicit feature
-await autumn.balances.trackTokens({
+await autumn.trackTokens({
   customerId: "cus_123",
   featureId: "ai_credits",
   modelId: "anthropic/claude-haiku-4-5",

--- a/apps/docs/api-reference-generator/core/batchTrack.mdx
+++ b/apps/docs/api-reference-generator/core/batchTrack.mdx
@@ -18,7 +18,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 <CodeGroup>
 
 ```typescript Batch many customers
-await autumn.balances.batchTrack([
+await autumn.batchTrack([
   { customerId: "cus_alice", featureId: "ai_messages", value: 1 },
   { customerId: "cus_bob",   featureId: "ai_messages", value: 1 },
   { customerId: "cus_carol", featureId: "ai_messages", value: 3 },
@@ -26,7 +26,7 @@ await autumn.balances.batchTrack([
 ```
 
 ```typescript Mixed features and entities
-await autumn.balances.batchTrack([
+await autumn.batchTrack([
   { customerId: "cus_123", featureId: "ai_messages", value: 5 },
   { customerId: "cus_123", featureId: "api_calls",   value: 12 },
   { customerId: "cus_123", featureId: "seats",       entityId: "team_a", value: 1 },

--- a/apps/docs/api-reference-generator/core/check.mdx
+++ b/apps/docs/api-reference-generator/core/check.mdx
@@ -25,7 +25,7 @@ if (!allowed) {
   // Show upgrade prompt or paywall
 }
 
-console.log(`You have ${balance.remaining} messages left`);
+console.log(`You have ${balance?.remaining ?? 0} messages left`);
 ```
 
 ```typescript Check and track atomically

--- a/apps/docs/api-reference-generator/core/track.mdx
+++ b/apps/docs/api-reference-generator/core/track.mdx
@@ -27,8 +27,9 @@ await autumn.track({
 await autumn.track({
   customerId: "cus_123",
   featureId: "api_calls",
-  value: 1,
-  idempotencyKey: "request_abc123" // Prevents duplicate tracking on retry
+  value: 1
+}, {
+  headers: { "Idempotency-Key": "request_abc123" }
 });
 ```
 

--- a/apps/docs/api-reference-generator/events/aggregateEvents.mdx
+++ b/apps/docs/api-reference-generator/events/aggregateEvents.mdx
@@ -27,7 +27,7 @@ await autumn.track({
 });
 ```
 
-You can then aggregate events grouped by any property using the `group_by` parameter:
+You can then aggregate events grouped by any property using the `groupBy` parameter:
 
 ```typescript
 const result = await autumn.events.aggregate({
@@ -64,9 +64,9 @@ const result = await autumn.events.aggregate({
 
 ## Response Format
 
-The response structure changes based on whether `group_by` is provided:
+The response structure changes based on whether `groupBy` is provided:
 
-### Without `group_by` (Flat Response)
+### Without `groupBy` (Flat Response)
 
 When no grouping is specified, `values` contains the aggregated sum for each feature:
 
@@ -88,9 +88,9 @@ When no grouping is specified, `values` contains the aggregated sum for each fea
 }
 ```
 
-### With `group_by` (Grouped Response)
+### With `groupBy` (Grouped Response)
 
-When grouping is specified, `values` contains the total sum while `grouped_values` breaks down values by group:
+When grouping is specified, `values` contains the total sum while `groupedValues` breaks down values by group:
 
 ```json
 {
@@ -100,7 +100,7 @@ When grouping is specified, `values` contains the total sum while `grouped_value
       "values": {
         "api_calls": 150
       },
-      "grouped_values": {
+      "groupedValues": {
         "api_calls": {
           "gpt-4": 100,
           "gpt-3.5": 50
@@ -115,5 +115,5 @@ When grouping is specified, `values` contains the total sum while `grouped_value
 ```
 
 <Note>
-  The `grouped_values` field is only present when `group_by` is provided in the request.
+  The `groupedValues` field is only present when `groupBy` is provided in the request.
 </Note>

--- a/apps/docs/api-reference-generator/keys/mintKey.mdx
+++ b/apps/docs/api-reference-generator/keys/mintKey.mdx
@@ -10,7 +10,7 @@ openapi: "openapi POST /v1/keys.mint"
 ### How it works
 
 1. Your backend calls `keys.mint` with your secret key to issue a token pair for a customer.
-2. Hand the **access token** to that customer's app. It can call `check`, `track`, `customers.get` and `entities.get` — always scoped to that customer, even if a different `customer_id` is sent.
+2. Hand the **access token** to that customer's app. It can call `check`, `track`, `customers.get`, `entities.get`, `events.list`, and `events.aggregate` — always scoped to that customer, even if a different `customer_id` is sent.
 3. Before the access token expires, the app calls [`keys.refresh`](/api-reference/keys/refreshKey) with its **refresh token** to rotate a fresh pair — no secret key required.
 
 <CodeGroup>

--- a/apps/docs/api-reference-generator/plans/deletePlan.mdx
+++ b/apps/docs/api-reference-generator/plans/deletePlan.mdx
@@ -10,7 +10,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 Deletes a plan or a specific version of a plan.
 
 <Warning>
-  Deleting a plan cannot be undone. Existing subscriptions to this plan will remain active until canceled.
+  Deleting a plan cannot be undone. Plans with any active or expired customers cannot be deleted.
 </Warning>
 
 ### Common Use Cases

--- a/apps/docs/api-reference-generator/plans/listPlans.mdx
+++ b/apps/docs/api-reference-generator/plans/listPlans.mdx
@@ -18,11 +18,11 @@ Lists all plans in the current environment.
 <CodeGroup>
 
 ```typescript List all plans
-const plans = await autumn.plans.list();
+const { list: plans } = await autumn.plans.list();
 ```
 
 ```typescript List plans with customer eligibility
-const plans = await autumn.plans.list({
+const { list: plans } = await autumn.plans.list({
   customerId: "cus_123"
 });
 
@@ -32,7 +32,7 @@ const plans = await autumn.plans.list({
 ```
 
 ```typescript Include archived plans
-const plans = await autumn.plans.list({
+const { list: plans } = await autumn.plans.list({
   includeArchived: true
 });
 ```

--- a/apps/docs/mintlify/api-reference/balances/check.mdx
+++ b/apps/docs/mintlify/api-reference/balances/check.mdx
@@ -16,7 +16,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 <CodeGroup>
 
 ```typescript Check feature access
-const { allowed, balance } = await autumn.balances.check({
+const { allowed, balance } = await autumn.check({
   customerId: "cus_123",
   featureId: "ai_messages"
 });
@@ -27,7 +27,7 @@ if (!allowed) {
 ```
 
 ```typescript Check and track atomically
-const { allowed } = await autumn.balances.check({
+const { allowed } = await autumn.check({
   customerId: "cus_123",
   featureId: "api_calls",
   requiredBalance: 1,
@@ -36,7 +36,7 @@ const { allowed } = await autumn.balances.check({
 ```
 
 ```typescript Get upgrade options when denied
-const { allowed, preview } = await autumn.balances.check({
+const { allowed, preview } = await autumn.check({
   customerId: "cus_123",
   featureId: "advanced_analytics",
   withPreview: true

--- a/apps/docs/mintlify/api-reference/balances/track.mdx
+++ b/apps/docs/mintlify/api-reference/balances/track.mdx
@@ -16,7 +16,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 <CodeGroup>
 
 ```typescript Track single usage
-await autumn.balances.track({
+await autumn.track({
   customerId: "cus_123",
   featureId: "ai_messages",
   value: 1
@@ -24,7 +24,7 @@ await autumn.balances.track({
 ```
 
 ```typescript Track with idempotency
-await autumn.balances.track({
+await autumn.track({
   customerId: "cus_123",
   featureId: "api_calls",
   value: 1,
@@ -33,7 +33,7 @@ await autumn.balances.track({
 ```
 
 ```typescript Credit balance (negative value)
-await autumn.balances.track({
+await autumn.track({
   customerId: "cus_123",
   featureId: "seats",
   value: -1 // Increases balance when removing a seat

--- a/apps/docs/mintlify/api-reference/balances/trackTokens.mdx
+++ b/apps/docs/mintlify/api-reference/balances/trackTokens.mdx
@@ -18,7 +18,7 @@ The `model_id` must use `provider/model` format, matching the provider and model
 <CodeGroup>
 
 ```typescript Anthropic
-await autumn.balances.trackTokens({
+await autumn.trackTokens({
   customerId: "cus_123",
   modelId: "anthropic/claude-opus-4-6",
   inputTokens: 1000,
@@ -27,7 +27,7 @@ await autumn.balances.trackTokens({
 ```
 
 ```typescript With cache + reasoning
-await autumn.balances.trackTokens({
+await autumn.trackTokens({
   customerId: "cus_123",
   modelId: "anthropic/claude-opus-4-6",
   inputTokens: 800,        // excludes the cached tokens below
@@ -39,7 +39,7 @@ await autumn.balances.trackTokens({
 ```
 
 ```typescript OpenRouter (nested path)
-await autumn.balances.trackTokens({
+await autumn.trackTokens({
   customerId: "cus_123",
   modelId: "openrouter/anthropic/claude-opus-4.6",
   inputTokens: 2000,
@@ -48,7 +48,7 @@ await autumn.balances.trackTokens({
 ```
 
 ```typescript With explicit feature
-await autumn.balances.trackTokens({
+await autumn.trackTokens({
   customerId: "cus_123",
   featureId: "ai_credits",
   modelId: "anthropic/claude-haiku-4-5",

--- a/apps/docs/mintlify/api-reference/core/batchTrack.mdx
+++ b/apps/docs/mintlify/api-reference/core/batchTrack.mdx
@@ -18,7 +18,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 <CodeGroup>
 
 ```typescript Batch many customers
-await autumn.balances.batchTrack([
+await autumn.batchTrack([
   { customerId: "cus_alice", featureId: "ai_messages", value: 1 },
   { customerId: "cus_bob",   featureId: "ai_messages", value: 1 },
   { customerId: "cus_carol", featureId: "ai_messages", value: 3 },
@@ -26,7 +26,7 @@ await autumn.balances.batchTrack([
 ```
 
 ```typescript Mixed features and entities
-await autumn.balances.batchTrack([
+await autumn.batchTrack([
   { customerId: "cus_123", featureId: "ai_messages", value: 5 },
   { customerId: "cus_123", featureId: "api_calls",   value: 12 },
   { customerId: "cus_123", featureId: "seats",       entityId: "team_a", value: 1 },

--- a/apps/docs/mintlify/api-reference/core/check.mdx
+++ b/apps/docs/mintlify/api-reference/core/check.mdx
@@ -25,7 +25,7 @@ if (!allowed) {
   // Show upgrade prompt or paywall
 }
 
-console.log(`You have ${balance.remaining} messages left`);
+console.log(`You have ${balance?.remaining ?? 0} messages left`);
 ```
 
 ```typescript Check and track atomically

--- a/apps/docs/mintlify/api-reference/core/track.mdx
+++ b/apps/docs/mintlify/api-reference/core/track.mdx
@@ -27,8 +27,9 @@ await autumn.track({
 await autumn.track({
   customerId: "cus_123",
   featureId: "api_calls",
-  value: 1,
-  idempotencyKey: "request_abc123" // Prevents duplicate tracking on retry
+  value: 1
+}, {
+  headers: { "Idempotency-Key": "request_abc123" }
 });
 ```
 

--- a/apps/docs/mintlify/api-reference/events/aggregateEvents.mdx
+++ b/apps/docs/mintlify/api-reference/events/aggregateEvents.mdx
@@ -27,7 +27,7 @@ await autumn.track({
 });
 ```
 
-You can then aggregate events grouped by any property using the `group_by` parameter:
+You can then aggregate events grouped by any property using the `groupBy` parameter:
 
 ```typescript
 const result = await autumn.events.aggregate({
@@ -64,9 +64,9 @@ const result = await autumn.events.aggregate({
 
 ## Response Format
 
-The response structure changes based on whether `group_by` is provided:
+The response structure changes based on whether `groupBy` is provided:
 
-### Without `group_by` (Flat Response)
+### Without `groupBy` (Flat Response)
 
 When no grouping is specified, `values` contains the aggregated sum for each feature:
 
@@ -88,9 +88,9 @@ When no grouping is specified, `values` contains the aggregated sum for each fea
 }
 ```
 
-### With `group_by` (Grouped Response)
+### With `groupBy` (Grouped Response)
 
-When grouping is specified, `values` contains the total sum while `grouped_values` breaks down values by group:
+When grouping is specified, `values` contains the total sum while `groupedValues` breaks down values by group:
 
 ```json
 {
@@ -100,7 +100,7 @@ When grouping is specified, `values` contains the total sum while `grouped_value
       "values": {
         "api_calls": 150
       },
-      "grouped_values": {
+      "groupedValues": {
         "api_calls": {
           "gpt-4": 100,
           "gpt-3.5": 50
@@ -115,7 +115,7 @@ When grouping is specified, `values` contains the total sum while `grouped_value
 ```
 
 <Note>
-  The `grouped_values` field is only present when `group_by` is provided in the request.
+  The `groupedValues` field is only present when `groupBy` is provided in the request.
 </Note>
 
 ### Body Parameters

--- a/apps/docs/mintlify/api-reference/keys/mintKey.mdx
+++ b/apps/docs/mintlify/api-reference/keys/mintKey.mdx
@@ -14,7 +14,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 ### How it works
 
 1. Your backend calls `keys.mint` with your secret key to issue a token pair for a customer.
-2. Hand the **access token** to that customer's app. It can call `check`, `track`, `customers.get` and `entities.get` — always scoped to that customer, even if a different `customer_id` is sent.
+2. Hand the **access token** to that customer's app. It can call `check`, `track`, `customers.get`, `entities.get`, `events.list`, and `events.aggregate` — always scoped to that customer, even if a different `customer_id` is sent.
 3. Before the access token expires, the app calls [`keys.refresh`](/api-reference/keys/refreshKey) with its **refresh token** to rotate a fresh pair — no secret key required.
 
 <CodeGroup>

--- a/apps/docs/mintlify/api-reference/plans/deletePlan.mdx
+++ b/apps/docs/mintlify/api-reference/plans/deletePlan.mdx
@@ -10,7 +10,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 Deletes a plan or a specific version of a plan.
 
 <Warning>
-  Deleting a plan cannot be undone. Existing subscriptions to this plan will remain active until canceled.
+  Deleting a plan cannot be undone. Plans with any active or expired customers cannot be deleted.
 </Warning>
 
 ### Common Use Cases

--- a/apps/docs/mintlify/api-reference/plans/listPlans.mdx
+++ b/apps/docs/mintlify/api-reference/plans/listPlans.mdx
@@ -18,11 +18,11 @@ Lists all plans in the current environment.
 <CodeGroup>
 
 ```typescript List all plans
-const plans = await autumn.plans.list();
+const { list: plans } = await autumn.plans.list();
 ```
 
 ```typescript List plans with customer eligibility
-const plans = await autumn.plans.list({
+const { list: plans } = await autumn.plans.list({
   customerId: "cus_123"
 });
 
@@ -32,7 +32,7 @@ const plans = await autumn.plans.list({
 ```
 
 ```typescript Include archived plans
-const plans = await autumn.plans.list({
+const { list: plans } = await autumn.plans.list({
   includeArchived: true
 });
 ```

--- a/apps/docs/mintlify/api-reference/platform.yaml
+++ b/apps/docs/mintlify/api-reference/platform.yaml
@@ -25,7 +25,7 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateOrganizationRequest'
       responses:
-        '201':
+        '200':
           description: Organization created successfully
           content:
             application/json:
@@ -279,13 +279,17 @@ components:
     CreateOrganizationResponse:
       type: object
       properties:
+        org_id:
+          type: string
+          description: Internal organization ID.
+        org_slug:
+          type: string
+          description: Organization slug, including its internal master organization suffix.
         test_secret_key:
           type: string
-          nullable: true
           description: Autumn test API key for the organization (if env is 'test' or 'both').
         live_secret_key:
           type: string
-          nullable: true
           description: Autumn live API key for the organization (if env is 'live' or 'both').
 
     GenerateOAuthURLRequest:

--- a/apps/docs/mintlify/api-reference/platform/oauth-url.mdx
+++ b/apps/docs/mintlify/api-reference/platform/oauth-url.mdx
@@ -15,9 +15,7 @@ After generating the OAuth URL:
 2. User authorizes their Stripe account
 3. Stripe redirects to Autumn's callback URL
 4. Autumn processes the authorization and redirects to your `redirect_url`
-5. Your `redirect_url` will receive query parameters:
-   - `success=true` or `success=false`
-   - `message=...` (if error occurred)
+5. Your `redirect_url` receives `success=true`, or an `error` parameter if the connection fails.
 
 <Note>
   OAuth state is stored in Upstash with a 10-minute expiry. The organization must have been created via the platform API before generating an OAuth URL.

--- a/apps/docs/mintlify/changelog/changelog.mdx
+++ b/apps/docs/mintlify/changelog/changelog.mdx
@@ -118,7 +118,7 @@ description: "Some new things we've shipped at Autumn HQ"
 
   ## Auto top-up failure webhook
 
-  Subscribe to the new [`billing.auto_topup.failed`](/api-reference/webhooks/billingAutoTopupFailed) webhook to react to auto top-up charges that don't go through — pause features, notify the customer, or fall back to manual top-up.
+  Subscribe to the new [`billing.auto_topup_failed`](/api-reference/webhooks/billingAutoTopupFailed) webhook to react to auto top-up charges that don't go through — pause features, notify the customer, or fall back to manual top-up.
 
   ## Expiring free recurring balances
 
@@ -882,8 +882,8 @@ We just released two new endpoints to retrieve usage data that your customers ha
 
 You can use this to display a billing event log, and a timeseries chart of usage data, so you can provide first-class billing observability out of the box!
 
-- **List Events**: [React hooks](/react/hooks/useListEvents) and [API reference](/api-reference/events/list-events)
-- **Aggregate Events**: [React hooks](/react/hooks/useAggregateEvents) and [API reference](/api-reference/events/aggregate-events)
+- **List Events**: [React hooks](/react/hooks/useListEvents) and [API reference](/api-reference/events/listEvents)
+- **Aggregate Events**: [React hooks](/react/hooks/useAggregateEvents) and [API reference](/api-reference/events/aggregateEvents)
 
 <br />
   <Frame style={{ width: "300px" }}>

--- a/apps/docs/mintlify/cli/commands.mdx
+++ b/apps/docs/mintlify/cli/commands.mdx
@@ -72,6 +72,10 @@ atmn push [options]
 | Flag | Description |
 |------|-------------|
 | `-y, --yes` | Auto-confirm all prompts |
+| `--all-versions` | Push every historical plan version in the config |
+| `--plan-intents <json>` | Headless map of plan/version IDs to update intents |
+| `--migration-drafts <json>` | Headless map selecting migration-draft creation |
+| `--variant-propagations <json>` | Headless map of base plans to variants to update |
 
 The CLI compares your local config with what's in Autumn and shows a summary of changes before applying. If plans with existing customers are modified, it will prompt about versioning.
 
@@ -86,6 +90,8 @@ atmn pull [options]
 | Flag | Description |
 |------|-------------|
 | `-f, --force` | Overwrite config instead of smart in-place update |
+| `--all-versions` | Pull every historical plan version |
+| `--no-declaration-file` | Skip generating `@useautumn-sdk.d.ts` |
 
 By default, `pull` does a smart in-place update -- it adds new features and plans, updates existing ones, and removes deleted ones while preserving your formatting. Use `--force` to overwrite the entire file.
 

--- a/apps/docs/mintlify/cli/config.mdx
+++ b/apps/docs/mintlify/cli/config.mdx
@@ -29,7 +29,7 @@ Features define what can be gated, metered, or billed in your app.
 </ParamField>
 
 <ParamField body="type" type="enum" required>
-  `"boolean"` | `"metered"` | `"credit_system"`
+  `"boolean"` | `"metered"` | `"credit_system"` | `"ai_credit_system"`
 </ParamField>
 
 <ParamField body="consumable" type="boolean">
@@ -127,7 +127,7 @@ Plans combine features with pricing to create your subscription tiers, add-ons, 
 <ParamField body="price" type="object">
   Base subscription price:
   - `amount: number` -- price amount (eg, `20` for $20)
-  - `interval: string` -- `"month"` | `"quarter"` | `"semi_annual"` | `"year"` | `"one_off"`
+  - `interval: string` -- `"week"` | `"month"` | `"quarter"` | `"semi_annual"` | `"year"` | `"one_off"`
   - `additionalCurrencies?: array` -- amounts in [other currencies](/documentation/concepts/plans#multiple-currencies), eg `[{ currency: 'eur', amount: 18 }]`
 </ParamField>
 
@@ -174,7 +174,7 @@ Plan items define what each plan includes -- usage limits, pricing, and billing 
 
 <ParamField body="reset" type="object">
   How often the included amount resets:
-  - `interval: string` -- `"hour"` | `"day"` | `"week"` | `"month"` | `"quarter"` | `"semi_annual"` | `"year"`
+  - `interval: string` -- `"one_off"` | `"minute"` | `"hour"` | `"day"` | `"week"` | `"month"` | `"quarter"` | `"semi_annual"` | `"year"`
   - `intervalCount: number` -- defaults to `1`
 </ParamField>
 
@@ -238,6 +238,7 @@ item({
       { to: 10000, amount: 0.008 },
       { to: 'inf', amount: 0.005 },
     ],
+    tierBehavior: 'graduated',
     billingMethod: 'usage_based',
     interval: 'month',
   },
@@ -252,6 +253,10 @@ item({
 
 <ParamField body="tiers" type="array">
   Tiered pricing. Each entry: `{ to: number | "inf", amount: number }`. Mutually exclusive with `amount`.
+</ParamField>
+
+<ParamField body="tierBehavior" type="enum">
+  Required with `tiers`: `"graduated"` | `"volume"`.
 </ParamField>
 
 <ParamField body="additionalCurrencies" type="array">

--- a/apps/docs/mintlify/documentation/concepts/balances.mdx
+++ b/apps/docs/mintlify/documentation/concepts/balances.mdx
@@ -23,8 +23,8 @@ Each balance has the following key fields:
 
 | Field | Description |
 |-------|-------------|
-| `included_usage` | The amount granted by the plan, or a purchased quantity |
-| `balance` | The remaining amount available |
+| `granted` | Total amount granted by included and prepaid quantities |
+| `remaining` | The remaining amount available |
 | `usage` | The amount that has been consumed |
 
 When you retrieve a customer, their balances will be included in the response. 
@@ -38,8 +38,9 @@ For the complete balance schema including reset configuration, overage settings,
 {
   "balances": {
     "messages": {
-      "granted_balance": 1000,
-      "current_balance": 750,
+      "feature_id": "messages",
+      "granted": 1000,
+      "remaining": 750,
       "usage": 250,
       "unlimited": false,
       "reset": {
@@ -89,15 +90,12 @@ When you track usage for a feature in a credit system, Autumn:
 For example, if you have a credit system with a credit cost of 2 credits per API request, and a customer uses 10 API requests, Autumn will deduct 20 credits from the balance.
 
 
-## Positive and Negative Balances
+## Allowance and Overage
 
-A balance can be positive or negative:
-
-- **Positive balance**: Customer has unused allowance remaining
-- **Negative balance**: Customer has used more than their allowance (only possible if [overage](/documentation/concepts/plan-items#priced-features) is enabled)
+A positive `remaining` value means the customer has unused allowance. `remaining` stops at zero; when overage is enabled, `usage` can exceed `granted`.
 
 <Note>
-Features can only have a negative balance if they have a usage-based price that allows overage. Otherwise, tracking stops when balance reaches 0.
+Without overage, tracking is capped when the remaining balance reaches zero.
 </Note>
 
 ## Balance Stacking
@@ -121,27 +119,33 @@ Each balance source is tracked separately in the `breakdown` array. This lets yo
 {
   "balances": {
     "messages": {
-      "included_usage": 700,
-      "balance": 700,
+      "granted": 700,
+      "remaining": 700,
       "usage": 0,
       "breakdown": [
         {
           "id": "ent_abc123",
-          "product_id": "pro",
-          "included_usage": 500,
-          "balance": 500,
+          "plan_id": "pro",
+          "included_grant": 500,
+          "prepaid_grant": 0,
+          "remaining": 500,
           "usage": 0,
-          "interval": "month",
-          "next_reset_at": 1745193600000
+          "reset": {
+            "interval": "month",
+            "resets_at": 1745193600000
+          }
         },
         {
           "id": "ent_def456",
-          "product_id": "top-up",
-          "included_usage": 200,
-          "balance": 200,
+          "plan_id": "top-up",
+          "included_grant": 0,
+          "prepaid_grant": 200,
+          "remaining": 200,
           "usage": 0,
-          "interval": "one_off",
-          "next_reset_at": null
+          "reset": {
+            "interval": "one_off",
+            "resets_at": null
+          }
         }
       ]
     }

--- a/apps/docs/mintlify/documentation/concepts/versioning.mdx
+++ b/apps/docs/mintlify/documentation/concepts/versioning.mdx
@@ -18,9 +18,9 @@ You can update products through the Autumn UI:
 1. Navigate to the [products page](https://app.useautumn.com/products)
 2. Select the product you want to modify
 3. Make your changes to the product items or properties
-4. Click "Update Product "
+4. Click "Update Plan"
 
-When you update a product, Autumn will create a new version of the product, and immediately apply this version to any new customers who purchase the product.
+When you update a product, Autumn will create a new version of the product, and immediately apply this version to any new customers who attach it.
 
 <Check>
   A new version will only be created if there are customers on the current
@@ -31,7 +31,7 @@ Existing customers will remain on the previous version (known as "grandfathering
 
 ## Migrating customers between product versions
 
-When you're ready, you can migrate customers to the latest verion of a product.
+When you're ready, you can migrate customers to the latest version of a product.
 
 1. Go to the [product details page](https://app.useautumn.com/products) of the product you want to migrate customers from
 2. On the right-hand side, you'll see a "Versions" section in the sidebar. Use the version history selector to find the version you want to migrate customers from
@@ -54,13 +54,13 @@ We have a customer, Mark, who has used 5 credits in the current month. We also h
 
 Here's what will happen to Mark:
 
-- Mark will be immediately have 15 credits available (20 in the new product minus 5 used)
+- Mark will immediately have 15 credits available (20 in the new product minus 5 used)
 - Mark was 5 credits under the limit in the old product, so has no line items added to his next invoice.
 - Mark will be charged 20 USD from his next billing cycle.
 
 Here's what will happen to Helly:
 
-- Helly will be immediately have 0 credits remaining (20 in the new product minus 20 used)
+- Helly will immediately have 0 credits remaining (20 in the new product minus 20 used)
 - Helly was 10 credits over the limit in the old product, so she'll have a 10 USD line item (10 credits \* 1 USD) added to her next invoice.
 - Any further credit usage will be charged at the new rate of 2 USD per credit.
 - Helly will be charged 20 USD from her next billing cycle.

--- a/apps/docs/mintlify/documentation/customers/balance-locking.mdx
+++ b/apps/docs/mintlify/documentation/customers/balance-locking.mdx
@@ -49,7 +49,7 @@ if (!response.allowed) {
 ```
 
 ```python Python
-response = await autumn.check(
+response = autumn.check(
     customer_id="user_123",
     feature_id="ai-tokens",
     required_balance=1000,
@@ -69,7 +69,7 @@ if not response.allowed:
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/check" \
+curl -X POST "https://api.useautumn.com/v1/balances.check" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -121,7 +121,7 @@ await autumn.balances.finalize({
 ```
 
 ```python Python
-await autumn.balances.finalize(
+autumn.balances.finalize(
     lock_id="completion_abc123",
     action="confirm",
 )
@@ -153,7 +153,7 @@ await autumn.balances.finalize({
 ```
 
 ```python Python
-await autumn.balances.finalize(
+autumn.balances.finalize(
     lock_id="completion_abc123",
     action="release",
 )
@@ -188,7 +188,7 @@ await autumn.balances.finalize({
 
 ```python Python
 # Reserved 1000 tokens, but only used 743
-await autumn.balances.finalize(
+autumn.balances.finalize(
     lock_id="completion_abc123",
     action="confirm",
     override_value=743,

--- a/apps/docs/mintlify/documentation/customers/billing-controls.mdx
+++ b/apps/docs/mintlify/documentation/customers/billing-controls.mdx
@@ -23,7 +23,7 @@ await autumn.customers.update({
 ```
 
 ```python Python
-await autumn.customers.update(
+autumn.customers.update(
     customer_id="user_123",
     billing_controls={
         "overage_allowed": [{"feature_id": "api_calls", "enabled": True}],
@@ -36,7 +36,7 @@ await autumn.customers.update(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers/update" \
+curl -X POST "https://api.useautumn.com/v1/customers.update" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -88,7 +88,7 @@ await autumn.customers.update({
 ```
 
 ```python Python
-await autumn.customers.update(
+autumn.customers.update(
     customer_id="user_123",
     billing_controls={
         "overage_allowed": [{
@@ -100,7 +100,7 @@ await autumn.customers.update(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers/update" \
+curl -X POST "https://api.useautumn.com/v1/customers.update" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -164,7 +164,7 @@ await autumn.customers.update({
 ```
 
 ```python Python
-await autumn.customers.update(
+autumn.customers.update(
     customer_id="user_123",
     billing_controls={
         "spend_limits": [{
@@ -177,7 +177,7 @@ await autumn.customers.update(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers/update" \
+curl -X POST "https://api.useautumn.com/v1/customers.update" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -241,7 +241,7 @@ await autumn.customers.update({
 ```
 
 ```python Python
-await autumn.customers.update(
+autumn.customers.update(
     customer_id="user_123",
     billing_controls={
         "usage_limits": [{
@@ -254,7 +254,7 @@ await autumn.customers.update(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers/update" \
+curl -X POST "https://api.useautumn.com/v1/customers.update" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -333,7 +333,7 @@ await autumn.customers.update({
 ```
 
 ```python Python
-await autumn.customers.update(
+autumn.customers.update(
     customer_id="user_123",
     billing_controls={
         "usage_alerts": [
@@ -357,7 +357,7 @@ await autumn.customers.update(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers/update" \
+curl -X POST "https://api.useautumn.com/v1/customers.update" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -425,7 +425,7 @@ await autumn.customers.update({
 ```
 
 ```python Python
-await autumn.customers.update(
+autumn.customers.update(
     customer_id="user_123",
     billing_controls={
         "auto_topups": [{
@@ -439,7 +439,7 @@ await autumn.customers.update(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers/update" \
+curl -X POST "https://api.useautumn.com/v1/customers.update" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -532,7 +532,7 @@ await autumn.entities.update({
 ```
 
 ```python Python
-await autumn.entities.update(
+autumn.entities.update(
     customer_id="org_123",
     entity_id="workspace_a",
     billing_controls={
@@ -561,7 +561,7 @@ await autumn.entities.update(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/entities/update" \
+curl -X POST "https://api.useautumn.com/v1/entities.update" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{

--- a/apps/docs/mintlify/documentation/customers/check.mdx
+++ b/apps/docs/mintlify/documentation/customers/check.mdx
@@ -12,7 +12,7 @@ The `check` method returns the `allowed` field in real-time to check if a custom
 The `allowed` field will return `true` for a given feature if:
 - The customer has an active plan with this feature
 - The customer has an active plan with a `credit_system` that grants this feature
-- The plan feature is <Badge>included</Badge> or <Badge>prepaid</Badge>, and the current balance is greater than the `required_balance` parameter
+- The plan feature is <Badge>included</Badge> or <Badge>prepaid</Badge>, and the current balance is at least the `required_balance` parameter
 - The plan feature is <Badge>usage-based</Badge>, and the user has not exceeded their max spend limit
 - The plan feature is <Badge>unlimited</Badge> or a <Badge>boolean</Badge> feature
 
@@ -50,7 +50,7 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_test_1234" });
 
-const response = await autumn.customers.check({
+const response = await autumn.check({
   customerId: "user_123",
   featureId: "messages",
 });
@@ -63,7 +63,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-response = await autumn.customers.check(
+response = autumn.check(
     customer_id="user_123",
     feature_id="messages",
 )
@@ -71,7 +71,7 @@ print(response.allowed)
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/check" \
+curl -X POST "https://api.useautumn.com/v1/balances.check" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -127,7 +127,7 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_test_1234" });
 
-const response = await autumn.customers.check({
+const response = await autumn.check({
   customerId: "user_123",
   featureId: "messages",
   requiredBalance: 3,
@@ -141,7 +141,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-response = await autumn.customers.check(
+response = autumn.check(
     customer_id="user_123",
     feature_id="messages",
     required_balance=3,
@@ -150,7 +150,7 @@ print(response.allowed)
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/check" \
+curl -X POST "https://api.useautumn.com/v1/balances.check" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -173,7 +173,7 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_test_1234" });
 
-const response = await autumn.customers.check({
+const response = await autumn.check({
   customerId: "user_123",
   featureId: "api_calls",
   requiredBalance: 3,
@@ -188,7 +188,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-response = await autumn.customers.check(
+response = autumn.check(
     customer_id="user_123",
     feature_id="api_calls",
     required_balance=3,
@@ -198,7 +198,7 @@ print(response.allowed)
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/check" \
+curl -X POST "https://api.useautumn.com/v1/balances.check" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -220,7 +220,7 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_test_1234" });
 
-await autumn.customers.track({
+await autumn.track({
   customerId: "user_123",
   featureId: "api_calls",
   value: -3,
@@ -232,7 +232,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-await autumn.customers.track(
+autumn.track(
     customer_id="user_123",
     feature_id="api_calls",
     value=-3,
@@ -240,7 +240,7 @@ await autumn.customers.track(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/track" \
+curl -X POST "https://api.useautumn.com/v1/balances.track" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -303,7 +303,7 @@ if (customer.flags?.["premiumDashboard"]) {
 ```
 
 ```python Python
-customer = await autumn.customers.get_or_create(
+customer = autumn.customers.get_or_create(
     customer_id="user_123",
     expand=["flags.feature"],
 )

--- a/apps/docs/mintlify/documentation/customers/creating-customers.mdx
+++ b/apps/docs/mintlify/documentation/customers/creating-customers.mdx
@@ -34,7 +34,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-customer = await autumn.customers.get_or_create(
+customer = autumn.customers.get_or_create(
     customer_id="user_123",
     name="John Doe",
     email="john@example.com",
@@ -42,7 +42,7 @@ customer = await autumn.customers.get_or_create(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers" \
+curl -X POST "https://api.useautumn.com/v1/customers.get_or_create" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -131,7 +131,7 @@ await autumn.customers.getOrCreate({
 ```
 
 ```python Python
-await autumn.customers.get_or_create(
+autumn.customers.get_or_create(
     customer_id="user_123",
     name="John Doe",
     email="john@example.com",
@@ -140,7 +140,7 @@ await autumn.customers.get_or_create(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers" \
+curl -X POST "https://api.useautumn.com/v1/customers.get_or_create" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -167,14 +167,14 @@ await autumn.customers.getOrCreate({
 ```
 
 ```python Python
-await autumn.customers.get_or_create(
+autumn.customers.get_or_create(
     customer_id="user_123",
     stripe_id="cus_abc123",
 )
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers" \
+curl -X POST "https://api.useautumn.com/v1/customers.get_or_create" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{

--- a/apps/docs/mintlify/documentation/customers/custom-plans.mdx
+++ b/apps/docs/mintlify/documentation/customers/custom-plans.mdx
@@ -17,7 +17,7 @@ Custom plans are useful when:
 ## Creating a custom plan via the dashboard
 
 1. Navigate to the [Customer details page](https://app.useautumn.com/customers) for the customer
-2. Click "Enable Product" (or click the existing product to modify it)
+2. Click "Enable Plan" (or click the existing product to modify it)
 3. Make changes to the product items before enabling:
    - Adjust feature allowances (e.g., increase included credits from 100 to 500)
    - Add or remove features

--- a/apps/docs/mintlify/documentation/customers/edge-cases.mdx
+++ b/apps/docs/mintlify/documentation/customers/edge-cases.mdx
@@ -55,21 +55,22 @@ If a recurring payment fails (e.g. card expired between billing cycles), the sub
 ```tsx React
 import { useCustomer } from "autumn-js/react";
 
-const { openBillingPortal } = useCustomer();
+const { openCustomerPortal } = useCustomer();
 
-<Button onClick={() => openBillingPortal({ returnUrl: window.location.href })} />
+<Button onClick={() => openCustomerPortal({ returnUrl: window.location.href })} />
 ```
 
 ```typescript Node.js
-const { data } = await autumn.billing.openCustomerPortal("user_123", {
+const data = await autumn.billing.openCustomerPortal({
+  customerId: "user_123",
   returnUrl: "https://your-app.com/billing",
 });
 // Redirect to data.url
 ```
 
 ```python Python
-response = await autumn.billing.open_customer_portal(
-    "user_123",
+response = autumn.billing.open_customer_portal(
+    customer_id="user_123",
     return_url="https://your-app.com/billing",
 )
 # Redirect to response.url
@@ -94,7 +95,7 @@ When an upgrade generates a proration invoice that fails to pay, Autumn automati
 
 ## Concurrent Requests
 
-Autumn uses distributed locking to prevent race conditions across billing operations. All mutating billing endpoints — `attach`, `multi_attach`, and `update_subscription` — share a per-customer lock. If two requests arrive simultaneously for the same customer, the second request receives a `429` response. This prevents duplicate subscriptions, double charges, or conflicting subscription updates.
+Autumn uses distributed locking to prevent race conditions across billing operations. Mutating billing endpoints including `billing.attach`, `billing.multi_attach`, and `billing.update` share a per-customer lock. If two requests arrive simultaneously for the same customer, the second request receives a `429` response. This prevents duplicate subscriptions, double charges, or conflicting subscription updates.
 
 The same lock is shared with auto top-ups, so a top-up triggered by usage can't race against a manual attach for the same customer.
 
@@ -103,9 +104,3 @@ The same lock is shared with auto top-ups, so a top-up triggered by usage can't 
 Stripe may deliver the same webhook event multiple times. Autumn deduplicates webhooks using a per-event idempotency key — if the same Stripe event ID is received more than once within a 5-minute window, the duplicate is acknowledged without reprocessing.
 
 Additionally, when Autumn initiates a subscription change (e.g. a cancellation or upgrade), it sets a short-lived lock on the subscription. This prevents the resulting Stripe webhook from re-processing the change that Autumn already applied, avoiding double-counting or conflicting state updates.
-
-## API Idempotency
-
-All API requests support an `Idempotency-Key` header. If the same key is sent within 24 hours, the duplicate request is rejected with a `409` response. This is useful when retrying requests after network failures — you won't accidentally attach the same plan twice.
-
-For event tracking (`track`), the `idempotency_key` field on the request body provides the same guarantee, backed by both a Redis check and a database-level unique constraint.

--- a/apps/docs/mintlify/documentation/customers/feature-entities.mdx
+++ b/apps/docs/mintlify/documentation/customers/feature-entities.mdx
@@ -31,18 +31,6 @@ This means if you create 2 entities for "seats", your usage of "seats" will be 2
 
 <CodeGroup>
 
-```tsx React
-import { useCustomer } from "autumn-js/react";
-
-const { createEntity } = useCustomer();
-
-await createEntity({
-  id: "user_abc",
-  name: "John Doe",
-  featureId: "seats",
-});
-```
-
 ```typescript TypeScript
 import { Autumn } from "autumn-js";
 
@@ -61,7 +49,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-await autumn.entities.create(
+autumn.entities.create(
     customer_id="org_123",
     entity_id="user_abc",
     feature_id="seats",
@@ -70,7 +58,7 @@ await autumn.entities.create(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/entities" \
+curl -X POST "https://api.useautumn.com/v1/entities.create" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -92,11 +80,14 @@ Just like with normal features, you can check feature access and track usage eve
 <CodeGroup>
 
 ```tsx React
-import { useEntity } from "autumn-js/react";
+import { useCustomer } from "autumn-js/react";
 
-const { check } = useEntity({ entityId: "user_abc" });
+const { check } = useCustomer();
 
-const { allowed } = check({ featureId: "ai-messages" });
+const { allowed } = check({
+  featureId: "ai-messages",
+  entityId: "user_abc",
+});
 
 if (allowed) {
   console.log("User has access to AI messages");
@@ -108,7 +99,7 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_test_1234" });
 
-const response = await autumn.customers.check({
+const response = await autumn.check({
   customerId: "org_123",
   featureId: "ai-messages",
   entityId: "user_abc",
@@ -122,7 +113,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-response = await autumn.customers.check(
+response = autumn.check(
     customer_id="org_123",
     feature_id="ai-messages",
     entity_id="user_abc",
@@ -131,7 +122,7 @@ print(response.allowed)
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/check" \
+curl -X POST "https://api.useautumn.com/v1/balances.check" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -147,20 +138,12 @@ curl -X POST "https://api.useautumn.com/v1/check" \
 
 <CodeGroup>
 
-```tsx React
-import { useEntity } from "autumn-js/react";
-
-const { track } = useEntity({ entityId: "user_abc" });
-
-await track({ featureId: "ai-messages", value: 10 });
-```
-
 ```typescript TypeScript
 import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_test_1234" });
 
-await autumn.customers.track({
+await autumn.track({
   customerId: "org_123",
   featureId: "ai-messages",
   entityId: "user_abc",
@@ -173,7 +156,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-await autumn.customers.track(
+autumn.track(
     customer_id="org_123",
     feature_id="ai-messages",
     entity_id="user_abc",
@@ -182,7 +165,7 @@ await autumn.customers.track(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/track" \
+curl -X POST "https://api.useautumn.com/v1/balances.track" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -195,25 +178,10 @@ curl -X POST "https://api.useautumn.com/v1/track" \
 
 </CodeGroup>
 
-#### Customer-level vs entity-level balances
-
-A customer-level balance is the total balance for the feature across all entities. Entity-level balances are the balance for a specific entity. You can check access and track usage events either at the customer-level or entity-level.
-
-<Info>
-**Example**
-
-You have a product that allows 500 credits per user per month. However, the credits are shared across all users in the account.
-
-You can create a feature entity for "seats" and then check access and send usage events at the top-level.
-
-</Info>
-
-To use top-level balances, just omit the `entityId` from your check request.
-
 <Note>
-  This will increment the usage counter for the top-level balance, and also
-  deduct from the first-created entity so that the sum of the the entity
-  balances is always the same as the top-level balance.
+  Customer-level checks and usage do not aggregate entity-level balances.
+  Include `entityId` for per-entity limits; model a separate customer-level
+  balance when usage should be shared.
 </Note>
 
 ## Deleting Entities
@@ -241,17 +209,17 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-await autumn.entities.delete(
+autumn.entities.delete(
     customer_id="org_123",
     entity_id="user_abc",
 )
 ```
 
 ```bash cURL
-curl -X DELETE "https://api.useautumn.com/v1/entities/user_abc" \
+curl -X POST "https://api.useautumn.com/v1/entities.delete" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
-  -d '{ "customer_id": "org_123" }'
+  -d '{ "customer_id": "org_123", "entity_id": "user_abc" }'
 ```
 
 </CodeGroup>

--- a/apps/docs/mintlify/documentation/customers/managing-balances.mdx
+++ b/apps/docs/mintlify/documentation/customers/managing-balances.mdx
@@ -24,7 +24,7 @@ To set or add to a feature's balance:
 
 ## Creating Standalone Balances (API)
 
-You can use the `/balances/create` endpoint to grant balances independent of any plan, for example to issue one-time promotional credits, referral rewards, or make manual customer adjustments.
+You can use the `balances.create` endpoint to grant balances independent of any plan, for example to issue one-time promotional credits, referral rewards, or make manual customer adjustments.
 
 You can also set expiration dates for promotional usage grants and configure reset intervals.
 
@@ -36,9 +36,9 @@ import { Autumn } from "autumn-js";
 const autumn = new Autumn({ secretKey: "am_sk_..." });
 
 await autumn.balances.create({
-  customer_id: "user_123",
-  feature_id: "credits",
-  granted_balance: 500,
+  customerId: "user_123",
+  featureId: "credits",
+  includedGrant: 500,
   reset: {
     interval: "one_off"
   }
@@ -46,14 +46,14 @@ await autumn.balances.create({
 ```
 
 ```python Python
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn(secret_key="am_sk_...")
 
 autumn.balances.create(
     customer_id="user_123",
     feature_id="credits",
-    granted_balance=500,
+    included_grant=500,
     reset={
         "interval": "one_off"
     }
@@ -61,13 +61,13 @@ autumn.balances.create(
 ```
 
 ```bash cURL
-curl -X POST https://api.useautumn.com/v1/balances/create \
+curl -X POST https://api.useautumn.com/v1/balances.create \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
     "customer_id": "user_123",
     "feature_id": "credits",
-    "granted_balance": 500,
+    "included_grant": 500,
     "reset": {
       "interval": "one_off"
     }
@@ -80,7 +80,7 @@ See the [Create Balance API reference](/api-reference/balances/createBalance) fo
 
 ## Updating Balances (API)
 
-Use the `/customers/{customer_id}/balances` endpoint to set balances for a customer.
+Use the `balances.update` endpoint to set a feature's remaining balance.
 
 <CodeGroup>
 
@@ -89,28 +89,33 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_..." });
 
-await autumn.customers.updateBalances("user_123", {
-  balances: [{ feature_id: "credits", balance: 750 }]
+await autumn.balances.update({
+  customerId: "user_123",
+  featureId: "credits",
+  remaining: 750,
 });
 ```
 
 ```python Python
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn(secret_key="am_sk_...")
 
-autumn.customers.update_balances(
-    "user_123",
-    balances=[{"feature_id": "credits", "balance": 750}]
+autumn.balances.update(
+    customer_id="user_123",
+    feature_id="credits",
+    remaining=750,
 )
 ```
 
 ```bash cURL
-curl -X POST https://api.useautumn.com/v1/customers/user_123/balances \
+curl -X POST https://api.useautumn.com/v1/balances.update \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
-    "balances": [{ "feature_id": "credits", "balance": 750 }]
+    "customer_id": "user_123",
+    "feature_id": "credits",
+    "remaining": 750
   }'
 ```
 
@@ -127,18 +132,20 @@ Retrieve all balances for a customer:
 <CodeGroup>
 
 ```typescript Node.js
-const customer = await autumn.customers.get("user_123");
+const customer = await autumn.customers.get({ customerId: "user_123" });
 console.log(customer.balances);
 ```
 
 ```python Python
-customer = autumn.customers.get("user_123")
+customer = autumn.customers.get(customer_id="user_123")
 print(customer.balances)
 ```
 
 ```bash cURL
-curl https://api.useautumn.com/v1/customers/user_123 \
-  -H "Authorization: Bearer am_sk_..."
+curl -X POST https://api.useautumn.com/v1/customers.get \
+  -H "Authorization: Bearer am_sk_..." \
+  -H "Content-Type: application/json" \
+  -d '{ "customer_id": "user_123" }'
 ```
 
 </CodeGroup>
@@ -153,8 +160,8 @@ Check access and get the current balance for a specific feature:
 
 ```typescript Node.js
 const result = await autumn.check({
-  customer_id: "user_123",
-  feature_id: "credits"
+  customerId: "user_123",
+  featureId: "credits"
 });
 
 console.log(result.allowed);
@@ -172,7 +179,7 @@ print(result.balance)
 ```
 
 ```bash cURL
-curl -X POST https://api.useautumn.com/v1/check \
+curl -X POST https://api.useautumn.com/v1/balances.check \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{

--- a/apps/docs/mintlify/documentation/customers/managing-customers.mdx
+++ b/apps/docs/mintlify/documentation/customers/managing-customers.mdx
@@ -80,7 +80,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-await autumn.customers.update(
+autumn.customers.update(
     customer_id="user_123",
     name="Mr New Name",
     email="newemail@example.com",
@@ -88,7 +88,7 @@ await autumn.customers.update(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers/update" \
+curl -X POST "https://api.useautumn.com/v1/customers.update" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{

--- a/apps/docs/mintlify/documentation/customers/payment-flow.mdx
+++ b/apps/docs/mintlify/documentation/customers/payment-flow.mdx
@@ -27,7 +27,7 @@ await attach({ planId: "pro" });
 ```
 
 ```python Python
-response = await autumn.billing.attach(
+response = autumn.billing.attach(
     customer_id="user_123",
     plan_id="pro",
 )
@@ -89,7 +89,7 @@ const preview = await previewAttach({ planId: "pro" });
 ```
 
 ```python Python
-preview = await autumn.billing.preview_attach(
+preview = autumn.billing.preview_attach(
     customer_id="user_123",
     plan_id="pro",
 )
@@ -165,7 +165,7 @@ const response = await attach({
 ```
 
 ```python Python
-response = await autumn.billing.attach(
+response = autumn.billing.attach(
     customer_id="user_123",
     plan_id="pro",
     redirect_mode="if_required",

--- a/apps/docs/mintlify/documentation/customers/subscription-lifecycle.mdx
+++ b/apps/docs/mintlify/documentation/customers/subscription-lifecycle.mdx
@@ -54,7 +54,7 @@ const response = await autumn.billing.update({
 ```
 
 ```python Python
-response = await autumn.billing.update(
+response = autumn.billing.update(
     customer_id="user_123",
     plan_id="pro",
     cancel_action="cancel_end_of_cycle",
@@ -102,7 +102,7 @@ const response = await autumn.billing.update({
 ```
 
 ```python Python
-response = await autumn.billing.update(
+response = autumn.billing.update(
     customer_id="user_123",
     plan_id="pro",
     cancel_action="cancel_immediately",
@@ -150,7 +150,7 @@ const response = await autumn.billing.update({
 ```
 
 ```python Python
-response = await autumn.billing.update(
+response = autumn.billing.update(
     customer_id="user_123",
     plan_id="pro",
     cancel_action="uncancel",
@@ -208,7 +208,7 @@ const response = await autumn.billing.update({
 ```python Python
 # Customer is on Pro with a scheduled downgrade to Basic.
 # Cancel the scheduled change and keep Pro.
-response = await autumn.billing.update(
+response = autumn.billing.update(
     customer_id="user_123",
     plan_id="pro",
     cancel_action="uncancel",
@@ -290,7 +290,7 @@ await attach({
 ```
 
 ```python Python
-response = await autumn.billing.attach(
+response = autumn.billing.attach(
     customer_id="user_123",
     plan_id="enterprise",
     carry_over_balances={
@@ -346,7 +346,7 @@ await attach({
 ```
 
 ```python Python
-response = await autumn.billing.attach(
+response = autumn.billing.attach(
     customer_id="user_123",
     plan_id="enterprise",
     carry_over_usages={

--- a/apps/docs/mintlify/documentation/customers/tracking-usage.mdx
+++ b/apps/docs/mintlify/documentation/customers/tracking-usage.mdx
@@ -28,7 +28,7 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_test_1234" });
 
-await autumn.customers.track({
+await autumn.track({
   customerId: "user_123",
   featureId: "ai-messages",
   value: 1,
@@ -40,7 +40,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-await autumn.customers.track(
+autumn.track(
     customer_id="user_123",
     feature_id="ai-messages",
     value=1,
@@ -48,7 +48,7 @@ await autumn.customers.track(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/track" \
+curl -X POST "https://api.useautumn.com/v1/balances.track" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -106,7 +106,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-await autumn.balances.update(
+autumn.balances.update(
     customer_id="user_123",
     feature_id="seats",
     usage=3,
@@ -114,7 +114,7 @@ await autumn.balances.update(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/balances/update" \
+curl -X POST "https://api.useautumn.com/v1/balances.update" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -142,10 +142,10 @@ The `modelId` must be in `provider/model` format, matching the provider and mode
 
 For providers with nested model paths (like OpenRouter), include the full path after the provider: `openrouter/anthropic/claude-opus-4.6`.
 
-Token counts are **exclusive pools**: `inputTokens` should exclude cached tokens (pass those as `cacheReadTokens` / `cacheWriteTokens`) and `outputTokens` should exclude reasoning tokens (pass those as `reasoningTokens`). Audio tokens go in `audioInputTokens` / `audioOutputTokens`. See the [API reference](/api-reference/balances/trackTokens) for the full parameter list.
+Token counts are **exclusive pools**: `inputTokens` should exclude cached tokens (pass those as `cacheReadTokens` / `cacheWriteTokens`) and `outputTokens` should exclude reasoning tokens (pass those as `reasoningTokens`). Audio tokens go in `audioInputTokens` / `audioOutputTokens`. See the [API reference](/api-reference/core/trackTokens) for the full parameter list.
 
 <Note>
-  `autumn.balances.trackTokens` requires an autumn-js release that includes
+  `autumn.trackTokens` requires an autumn-js release that includes
   the method. On older versions, call the REST endpoint directly — see the
   cURL tab below.
 </Note>
@@ -157,7 +157,7 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_test_1234" });
 
-await autumn.balances.trackTokens({
+await autumn.trackTokens({
   customerId: "user_123",
   modelId: "anthropic/claude-opus-4-6",
   inputTokens: 1000,
@@ -170,7 +170,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-await autumn.balances.track_tokens(
+autumn.track_tokens(
     customer_id="user_123",
     model_id="anthropic/claude-opus-4-6",
     input_tokens=1000,
@@ -245,7 +245,7 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_test_1234" });
 
-await autumn.customers.track({
+await autumn.track({
   customerId: "user_123",
   eventName: "blog_post_generation",
   value: 1,
@@ -257,7 +257,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-await autumn.customers.track(
+autumn.track(
     customer_id="user_123",
     event_name="blog_post_generation",
     value=1,
@@ -265,7 +265,7 @@ await autumn.customers.track(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/track" \
+curl -X POST "https://api.useautumn.com/v1/balances.track" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{

--- a/apps/docs/mintlify/documentation/customers/updating-subscriptions.mdx
+++ b/apps/docs/mintlify/documentation/customers/updating-subscriptions.mdx
@@ -74,7 +74,7 @@ await updateSubscription({
 ```
 
 ```python Python
-response = await autumn.billing.update(
+response = autumn.billing.update(
     customer_id="user_123",
     plan_id="team",
     feature_quantities=[
@@ -84,7 +84,7 @@ response = await autumn.billing.update(
 ```
 
 ```bash cURL
-curl -X POST 'https://api.useautumn.com/v1/billing/update' \
+curl -X POST 'https://api.useautumn.com/v1/billing.update' \
   -H 'Authorization: Bearer am_sk_...' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -138,7 +138,7 @@ await updateSubscription({
 
 ```python Python
 # Cancel at end of billing cycle
-await autumn.billing.update(
+autumn.billing.update(
     customer_id="user_123",
     plan_id="pro",
     cancel_action="cancel_end_of_cycle",
@@ -146,7 +146,7 @@ await autumn.billing.update(
 ```
 
 ```bash cURL
-curl -X POST 'https://api.useautumn.com/v1/billing/update' \
+curl -X POST 'https://api.useautumn.com/v1/billing.update' \
   -H 'Authorization: Bearer am_sk_...' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -206,7 +206,7 @@ await updateSubscription({
 ```
 
 ```python Python
-preview = await autumn.billing.preview_update(
+preview = autumn.billing.preview_update(
     customer_id="user_123",
     plan_id="team",
     feature_quantities=[
@@ -218,7 +218,7 @@ preview = await autumn.billing.preview_update(
 ```
 
 ```bash cURL
-curl -X POST 'https://api.useautumn.com/v1/billing/preview-update' \
+curl -X POST 'https://api.useautumn.com/v1/billing.preview_update' \
   -H 'Authorization: Bearer am_sk_...' \
   -H 'Content-Type: application/json' \
   -d '{

--- a/apps/docs/mintlify/documentation/customers/versioning.mdx
+++ b/apps/docs/mintlify/documentation/customers/versioning.mdx
@@ -10,9 +10,9 @@ You can update products through the Autumn UI:
 1. Navigate to the [products page](https://app.useautumn.com/products)
 2. Select the product you want to modify
 3. Make your changes to the product items or properties
-4. Click "Update Product "
+4. Click "Update Plan"
 
-When you update a product, Autumn will create a new version of the product, and immediately apply this version to any new customers who purchase the product.
+When you update a product, Autumn will create a new version of the product, and immediately apply this version to any new customers who attach it.
 
 <Check>
   A new version will only be created if there are customers on the current
@@ -23,7 +23,7 @@ Existing customers will remain on the previous version (known as "grandfathering
 
 ## Migrating customers between product versions
 
-When you're ready, you can migrate customers to the latest verion of a product.
+When you're ready, you can migrate customers to the latest version of a product.
 
 1. Go to the [product details page](https://app.useautumn.com/products) of the product you want to migrate customers from
 2. On the right-hand side, you'll see a "Versions" section in the sidebar. Use the version history selector to find the version you want to migrate customers from
@@ -46,13 +46,13 @@ We have a customer, Mark, who has used 5 credits in the current month. We also h
 
 Here's what will happen to Mark:
 
-- Mark will be immediately have 15 credits available (20 in the new product minus 5 used)
+- Mark will immediately have 15 credits available (20 in the new product minus 5 used)
 - Mark was 5 credits under the limit in the old product, so has no line items added to his next invoice.
 - Mark will be charged 20 USD from his next billing cycle.
 
 Here's what will happen to Helly:
 
-- Helly will be immediately have 0 credits remaining (20 in the new product minus 20 used)
+- Helly will immediately have 0 credits remaining (20 in the new product minus 20 used)
 - Helly was 10 credits over the limit in the old product, so she'll have a 10 USD line item (10 credits \* 1 USD) added to her next invoice.
 - Any further credit usage will be charged at the new rate of 2 USD per credit.
 - Helly will be charged 20 USD from her next billing cycle.

--- a/apps/docs/mintlify/documentation/external-providers/ai-sdk.mdx
+++ b/apps/docs/mintlify/documentation/external-providers/ai-sdk.mdx
@@ -106,7 +106,7 @@ const model = withAutumn({
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `autumn` | `Autumn` | Yes | Your Autumn SDK client instance |
+| `autumn` | `Autumn` | No | Autumn SDK client. If omitted, the wrapper uses `AUTUMN_API_KEY` or `AUTUMN_SECRET_KEY` |
 | `model` | `LanguageModelV3` | Yes | The AI SDK language model to wrap |
 | `customerId` | `string` | Yes | The Autumn customer ID to attribute usage to |
 | `providerId` | `string` | No | Override the provider prefix in the model name sent to Autumn. Falls back to the model's `provider` field |

--- a/apps/docs/mintlify/documentation/external-providers/openrouter.mdx
+++ b/apps/docs/mintlify/documentation/external-providers/openrouter.mdx
@@ -81,13 +81,13 @@ for await (const chunk of stream) {
 
 The wrapper normalizes OpenRouter's usage accounting into the exclusive token pools that [trackTokens](/api-reference/balances/trackTokens) expects: text input (excluding cached and audio tokens), text output (excluding reasoning tokens), cache reads, cache writes, audio input, and reasoning tokens. Each pool is billed at the model's published rate.
 
-The model is reported to Autumn as `openrouter/<slug>` (e.g. `openrouter/openai/gpt-4o`), using the resolved model from the response — so router aliases like `openrouter/auto` bill against the model that actually served the request. Autumn prices usage with OpenRouter's rates from [Models.dev](https://models.dev), and OpenRouter's own reported cost is attached to each event as the `openrouter_cost` property for reconciliation.
+The model is reported as `openrouter/<slug>` (for example, `openrouter/openai/gpt-4o`). The wrapper normally uses the requested model slug; for router aliases such as `openrouter/auto`, it uses the model that served the response. Autumn prices usage with OpenRouter's rates from [Models.dev](https://models.dev), and attaches OpenRouter's reported cost to the event as `openrouter_cost`.
 
 ## Options
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `autumn` | `Autumn` | Yes | Your Autumn SDK client instance |
+| `autumn` | `Autumn` | No | Autumn SDK client. If omitted, the wrapper uses `AUTUMN_API_KEY` or `AUTUMN_SECRET_KEY` |
 | `openRouter` | `OpenRouter` | Yes | The OpenRouter SDK client to wrap |
 | `customerId` | `string` | Yes | The Autumn customer ID to attribute usage to |
 | `featureId` | `string` | No | Target a specific AI credit system feature. Auto-detected if you only have one |

--- a/apps/docs/mintlify/documentation/external-providers/revenuecat.mdx
+++ b/apps/docs/mintlify/documentation/external-providers/revenuecat.mdx
@@ -3,7 +3,7 @@ title: "RevenueCat"
 description: "Integrate Autumn with RevenueCat for mobile app billing"
 ---
 
-RevenueCat integration allows you to use Autumn alongside RevenueCat for managing mobile app subscriptions and billing. This is a _read-only_ integration, which means that you will handle billing through RevenueCat. 
+RevenueCat integration allows you to use Autumn alongside RevenueCat for mobile app subscriptions. RevenueCat handles payment; Autumn mirrors purchases into plans and balances.
 
 Autumn will receive webhook updates from RevenueCat to update the customer's plan and features. You keep the benefits of RevenueCat's paywalls, AB testing and SDK.
 
@@ -16,44 +16,18 @@ Autumn will receive webhook updates from RevenueCat to update the customer's pla
     <Step>
     #### Connect RevenueCat to Autumn
     
-        To connect RevenueCat to Autumn, you'll need:
-        - A RevenueCat project ID
-        - A RevenueCat API key
-
-        To get your RevenueCat project ID, visit your RevenueCat dashboard and copy the project ID from the URL. e.g. `https://app.revenuecat.com/projects/1234567890/overview` will have a project ID of `1234567890`.
-
-        <Frame>
-          <img src="/assets/screenshots/revenuecat/project-id.png" alt="RevenueCat dashboard showing where to find your project ID" />
-        </Frame>
-
-        To get your RevenueCat API key, visit the API keys section on your dashboard, select "New secret API key", and select the following configuration:
-
-        - API Version: V2
-        - Charts metrics permissions: No access
-        - Customer information permissions: Read only
-        - Project configuration permissions: Read only
-
-        <Frame>
-            <img src="/assets/screenshots/revenuecat/api-key.png" alt="RevenueCat dashboard showing where to find your API key" />
-        </Frame>
-
-        Then, visit your Autumn dashboard, and in the "Developer > RevenueCat" section,
-        set up your RevenueCat project ID and API key.
-
-        <Frame>
-            <img src="/assets/screenshots/revenuecat/savekeys.png" alt="Autumn dashboard showing where to set up your RevenueCat project ID and API key" />
-        </Frame>
+        In the Autumn dashboard, open **Developer → RevenueCat**, choose **Connect via OAuth**, and select your RevenueCat project. Existing API-key integrations can migrate to OAuth from the same page.
     </Step>
 
     <Step>
-    #### Map your RevenueCat products to Autumn products
+    #### Sync or map products
 
-    When a RevenueCat product is purchased, define which Autumn product should be enabled for the customer. 
+    With OAuth, use **Sync Products** to create or rename matching RevenueCat products from your Autumn plans. Names sync; App Store and Google Play prices remain managed by those stores. Legacy API-key connections use **Map Products** to select which Autumn plan each RevenueCat product enables.
     
         <Warning>
         RevenueCat is managing billing, so any plan prices in Autumn will be ignored. 
         
-        Since RevenueCat does not support usage-based or quantity-based pricing, any Autumn plans with these price types will not display in the mapping screen for safety. 
+        Usage-based feature prices are excluded because RevenueCat cannot collect them at runtime. Prepaid feature prices are supported: map each RevenueCat SKU to the quantity it grants.
 
         </Warning>
 
@@ -69,24 +43,13 @@ Autumn will receive webhook updates from RevenueCat to update the customer's pla
     <Step>
     #### Set up the webhook integration
 
-        For Autumn to recieve updates from RevenueCat, you'll need to set up a webhook integration.
-
-        In RevenueCat, visit "Integrations > Webhooks", and click "Add new configuration". Use the following configuration:
-
-        - Webhook URL: paste this from the Autumn dashboard
-        - Authorization header value: paste this from the Autumn dashboard
-        - Environments: Depending on your Autumn environment, you are given two different URLs. This means you should also separate your RevenueCat webhooks for test and live environments.
-        - Events filter: All apps, all events.
-
-        <Frame>
-            <img src="/assets/screenshots/revenuecat/webhooks.png" alt="RevenueCat dashboard showing where to set up your webhook integration" />
-        </Frame>
+        In **Developer → RevenueCat**, click **Register webhook**. Autumn registers the RevenueCat webhook automatically. The dashboard also shows the URL and authorization value if you need to configure it manually.
     </Step>
 
     <Step>
     #### Integration
     
-        **You should not call Autumn's `attach()` or `checkout()` functions. Instead you should either use RevenueCat's SDK or RevenueCat's paywalls.**
+        **Do not call Autumn's `attach()` function for mobile purchases. Use RevenueCat's SDK or paywalls instead.**
         
         When the user pays via mobile, the plan will automatically sync into Autumn. Once you have purchased a product or an add-on, you may then continue using `check()` or `track()` to manage your features.
         
@@ -124,39 +87,26 @@ Autumn will receive webhook updates from RevenueCat to update the customer's pla
             ```typescript app/api/autumn/[...all]+api.ts
             // Expo also supports better-auth :)
             import { auth } from "@/lib/auth";
-            import { autumnHandler } from "autumn-js/backend";
+            import { autumnHandler } from "autumn-js/fetch";
 
-            export async function GET(request: Request, { all }: { all: string }) {
-                // Get the session from Better Auth
+            const handler = autumnHandler({
+              identify: async (request) => {
                 const session = await auth.api.getSession({ headers: request.headers });
-                if (!session?.user?.id) {
-                    return Response.json(
-                        { error: "Unauthorized - Please sign in" },
-                        { status: 401 },
-                    );
-                }
+                if (!session?.user?.id) return null;
 
-                // Extract user data from session
-                const customerId = session.user.id;
-                const customerData = {
+                return {
+                  customerId: session.user.id,
+                  customerData: {
                     name: session.user.name || "Unknown User",
                     email: session.user.email || "",
+                  },
                 };
+              },
+            });
 
-                const autumnResponse = await autumnHandler({
-                    request,
-                    customerId,
-                    customerData
-                });
-
-                return Response.json(autumnResponse.response, { status: autumnResponse.statusCode });
-            }
-
-            export const POST = GET;
-            export const PUT = GET;
-            export const DELETE = GET;
-            export const PATCH = GET;
-            export const OPTIONS = GET;
+            export const GET = handler;
+            export const POST = handler;
+            export const DELETE = handler;
             ```
         </CodeGroup>
 
@@ -228,12 +178,12 @@ Autumn will receive webhook updates from RevenueCat to update the customer's pla
 
         <CodeGroup>
             ```typescript check.ts
-            const { data } = await autumn.check({
-                customer_id: "user_or_org_id_from_auth",
-                feature_id: "pro",
+            const result = await autumn.check({
+                customerId: "user_or_org_id_from_auth",
+                featureId: "pro",
             });
 
-            if (data.allowed) {
+            if (result.allowed) {
                 // User has access to the feature
             } else {
                 // User does not have access to the feature
@@ -241,9 +191,9 @@ Autumn will receive webhook updates from RevenueCat to update the customer's pla
             ```
 
             ```typescript track.ts
-            const { data } = await autumn.track({
-                customer_id: "john_doe",
-                feature_id: "messages",
+            await autumn.track({
+                customerId: "john_doe",
+                featureId: "messages",
                 value: 1,
             });
 

--- a/apps/docs/mintlify/documentation/fail-open.mdx
+++ b/apps/docs/mintlify/documentation/fail-open.mdx
@@ -20,6 +20,7 @@ Fail-open is **enabled by default**. When Autumn is unreachable (network errors,
 | `check()` | `{ allowed: true }` | Users retain access to features |
 | `track()` | `{ value: 0, balance: null }` | Usage event is silently dropped |
 | `customers.getOrCreate()` | Sentinel customer with `id: null` | Returns a valid but empty customer object |
+| `entities.get()` | Sentinel entity with `id: null` | Returns a valid but empty entity object |
 
 <Warning>
 When fail-open triggers, the SDK logs a prominent error to your console so you're immediately aware of the issue.
@@ -67,7 +68,7 @@ const result = await autumn.check({
 });
 
 // Normal response: allowed is based on actual balance
-// Fail-open response: allowed is always true, customerId is ""
+// Fail-open response: allowed is always true, customerId is null
 ```
 
 When `customers.getOrCreate()` fails open, the returned customer will have `id: null`:
@@ -87,7 +88,7 @@ if (customer.id === null) {
 When fail-open triggers, you'll see this in your server logs:
 
 ```
-FATAL AUTUMN ERROR DETECTED; FAILING OPEN; LEARN MORE: https://docs.useautumn.com/docs/fail-open; STATUS PAGE: status.useautumn.com
+[Autumn] Request failed — failing open. Learn more: https://docs.useautumn.com/documentation/fail-open
   Operation: check | Status: 503 | Error: Server error
 ```
 

--- a/apps/docs/mintlify/documentation/getting-started/display-billing.mdx
+++ b/apps/docs/mintlify/documentation/getting-started/display-billing.mdx
@@ -80,7 +80,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-plans = await autumn.plans.list(customer_id="user_123")
+plans = autumn.plans.list(customer_id="user_123")
 
 for plan in plans.list:
     print(plan.name, plan.customer_eligibility.attach_action)
@@ -140,7 +140,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-response = await autumn.billing.attach(
+response = autumn.billing.attach(
     customer_id="user_123",
     plan_id="pro",
 )
@@ -148,7 +148,7 @@ response = await autumn.billing.attach(
 ```
 
 ```bash cURL
-curl -X POST 'https://api.useautumn.com/v1/attach' \
+curl -X POST 'https://api.useautumn.com/v1/billing.attach' \
   -H 'Authorization: Bearer am_sk_test_1234' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -196,7 +196,7 @@ from autumn_sdk import Autumn
 autumn = Autumn("am_sk_test_1234")
 
 # Cancel at end of billing cycle
-await autumn.billing.update(
+autumn.billing.update(
     customer_id="user_123",
     plan_id="pro",
     cancel_action="cancel_end_of_cycle",
@@ -204,7 +204,7 @@ await autumn.billing.update(
 ```
 
 ```bash cURL
-curl -X POST 'https://api.useautumn.com/v1/billing/update' \
+curl -X POST 'https://api.useautumn.com/v1/billing.update' \
   -H 'Authorization: Bearer am_sk_test_1234' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -272,7 +272,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-customer = await autumn.customers.get_or_create(
+customer = autumn.customers.get_or_create(
     customer_id="user_123"
 )
 
@@ -283,7 +283,7 @@ cancelling_sub = next(
 )
 
 if cancelling_sub:
-    await autumn.billing.update(
+    autumn.billing.update(
         customer_id="user_123",
         plan_id=cancelling_sub.plan_id,
         cancel_action="uncancel",
@@ -291,7 +291,7 @@ if cancelling_sub:
 ```
 
 ```bash cURL
-curl -X POST 'https://api.useautumn.com/v1/billing/update' \
+curl -X POST 'https://api.useautumn.com/v1/billing.update' \
   -H 'Authorization: Bearer am_sk_test_1234' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -344,7 +344,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-customer = await autumn.customers.get_or_create(
+customer = autumn.customers.get_or_create(
     customer_id="user_123"
 )
 
@@ -353,7 +353,7 @@ print([s.plan_id for s in active])
 ```
 
 ```bash cURL
-curl -X POST 'https://api.useautumn.com/v1/customers' \
+curl -X POST 'https://api.useautumn.com/v1/customers.get_or_create' \
   -H 'Authorization: Bearer am_sk_test_1234' \
   -H 'Content-Type: application/json' \
   -d '{ "customer_id": "user_123" }'
@@ -399,7 +399,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-customer = await autumn.customers.get_or_create(
+customer = autumn.customers.get_or_create(
     customer_id="user_123"
 )
 
@@ -408,7 +408,7 @@ print(f"{messages.remaining} / {messages.granted}")
 ```
 
 ```bash cURL
-curl -X POST 'https://api.useautumn.com/v1/customers' \
+curl -X POST 'https://api.useautumn.com/v1/customers.get_or_create' \
   -H 'Authorization: Bearer am_sk_test_1234' \
   -H 'Content-Type: application/json' \
   -d '{ "customer_id": "user_123" }'
@@ -458,7 +458,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-response = await autumn.billing.open_customer_portal(
+response = autumn.billing.open_customer_portal(
     customer_id="user_123",
     return_url="https://your-app.com/billing",
 )
@@ -513,7 +513,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-response = await autumn.events.aggregate(
+response = autumn.events.aggregate(
     customer_id="user_123",
     feature_id="messages",
     range="30d",

--- a/apps/docs/mintlify/documentation/getting-started/gating.mdx
+++ b/apps/docs/mintlify/documentation/getting-started/gating.mdx
@@ -50,7 +50,7 @@ autumn = Autumn('am_sk_42424242')
 
 async def main():
     # Check feature access
-    response = await autumn.check(
+    response = autumn.check(
         customer_id='user_or_org_id_from_auth',
         feature_id='messages',
         required_balance=1,
@@ -61,7 +61,7 @@ asyncio.run(main())
 
 ```bash cURL
 # Check feature access
-curl -X POST 'https://api.useautumn.com/v1/check' \
+curl -X POST 'https://api.useautumn.com/v1/balances.check' \
   -H 'Authorization: Bearer am_sk_42424242' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -132,7 +132,7 @@ autumn = Autumn('am_sk_42424242')
 
 # Then record 1 message used
 async def main():
-    await autumn.track(
+    autumn.track(
         customer_id='user_or_org_id_from_auth',
         feature_id='messages',
         value=1,
@@ -145,7 +145,7 @@ asyncio.run(main())
 # Your own function to send the chat message
 
 # Then record 1 message used
-curl -X POST 'https://api.useautumn.com/v1/track' \
+curl -X POST 'https://api.useautumn.com/v1/balances.track' \
   -H 'Authorization: Bearer am_sk_42424242' \
   -H 'Content-Type: application/json' \
   -d '{

--- a/apps/docs/mintlify/documentation/getting-started/setup.mdx
+++ b/apps/docs/mintlify/documentation/getting-started/setup.mdx
@@ -437,7 +437,7 @@ from autumn_sdk import Autumn
 autumn = Autumn('am_sk_42424242')
 
 async def main():
-    customer = await autumn.customers.get_or_create(
+    customer = autumn.customers.get_or_create(
         customer_id="user_or_org_id_from_auth",
         name="John Doe",
         email="john@example.com",
@@ -448,7 +448,7 @@ asyncio.run(main())
 
 ```bash cURL
 curl --request POST \
-  --url https://api.useautumn.com/v1/customers \
+  --url https://api.useautumn.com/v1/customers.get_or_create \
   --header 'Authorization: Bearer am_sk_42424242' \
   --header 'Content-Type: application/json' \
   --data '{
@@ -501,7 +501,7 @@ from autumn_sdk import Autumn
 autumn = Autumn('am_sk_42424242')
 
 async def main():
-  response = await autumn.billing.attach(
+  response = autumn.billing.attach(
       customer_id='user_or_org_id_from_auth',
       plan_id='pro',
       redirect_mode='always',
@@ -511,7 +511,7 @@ asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X POST 'https://api.useautumn.com/v1/attach' \
+curl -X POST 'https://api.useautumn.com/v1/billing.attach' \
 -H 'Authorization: Bearer am_sk_42424242' \
 -H 'Content-Type: application/json' \
 -d '{

--- a/apps/docs/mintlify/documentation/lakehouse/balance-semantics.mdx
+++ b/apps/docs/mintlify/documentation/lakehouse/balance-semantics.mdx
@@ -116,7 +116,7 @@ A ready-to-run query that applies all of this and reproduces the dashboard's ove
 
 ## Deduction order (why monthly drains before lifetime)
 
-When usage is recorded, Autumn deducts from entitlements **shortest-reset-interval-first** (a daily grant drains before a monthly, which drains before a lifetime/`one_off`), after a few higher-priority rules — entity-scoped before pooled when tracking an entity, unlimited first, prepaid before pay-per-use. This is why, when a customer has both a monthly grant and a lifetime grant for the same feature, the monthly empties first and overage lands on whichever pool is drained last. It matters for analytics because it determines **which** breakdown row shows the overage, not just the total.
+When usage is recorded, Autumn first prioritizes the tracked scope (entity-scoped before pooled when tracking an entity), boolean features, non-credit features, and unlimited grants. It then deducts **shortest-reset-interval-first** (a daily grant drains before a monthly, which drains before a lifetime/`one_off`). Among otherwise equal grants, main-plan items precede add-ons and prepaid precedes pay-per-use. This is why, when a customer has both a monthly grant and a lifetime grant for the same feature, the monthly empties first and overage lands on whichever pool is drained last. It matters for analytics because it determines **which** breakdown row shows the overage, not just the total.
 
 ## Footgun: `IS NULL` throws on these tables
 

--- a/apps/docs/mintlify/documentation/mcp.mdx
+++ b/apps/docs/mintlify/documentation/mcp.mdx
@@ -15,7 +15,8 @@ and log tools.
 Use Autumn MCP for this request.
 
 - Always start with autumn://docs/concepts to understand Autumn's data model.
-- Use autumn://docs/plan-management for pricing setup, plan creation, plan updates, and plan modeling.
+- Use autumn://docs/catalog for pricing setup and catalog changes.
+- Use autumn://docs/plan-management for detailed plan modeling.
 - Use autumn://docs/billing for attaching plans, updating subscriptions, cancellations, schedules, trials, and billing state changes.
 - Use autumn://docs/logs for API request logs, Stripe webhook timelines, customer request histories, and log analytics.
 - Use https://docs.useautumn.com/llms.txt to find product docs if the MCP resources do not answer something.
@@ -205,7 +206,8 @@ If your client does not support remote MCP servers directly:
 Autumn MCP exposes tools and resources. Ask your agent to read the relevant Autumn MCP resource before it acts:
 
 - Start with `autumn://docs/concepts` to understand Autumn's data model.
-- Use `autumn://docs/plan-management` for pricing setup, plan creation, and plan updates.
+- Use `autumn://docs/catalog` for pricing and catalog changes.
+- Use `autumn://docs/plan-management` for detailed plan modeling.
 - Use `autumn://docs/billing` for attaching plans, updating subscriptions, cancellations, schedules, trials, and billing state changes.
 - Use `autumn://docs/logs` for API request logs, Stripe webhook timelines, customer request histories, and log analytics.
 
@@ -214,6 +216,7 @@ Autumn MCP exposes tools and resources. Ask your agent to read the relevant Autu
 | Resource | Use for |
 | --- | --- |
 | `autumn://docs/concepts` | Autumn concepts and object relationships |
+| `autumn://docs/catalog` | Features, plans, and catalog updates |
 | `autumn://docs/plan-management` | Creating and updating pricing plans |
 | `autumn://docs/billing` | Billing actions and preview-first workflows |
 | `autumn://docs/logs` | Request logs, Stripe webhooks, and log analytics |

--- a/apps/docs/mintlify/documentation/modelling-pricing/add-ons.mdx
+++ b/apps/docs/mintlify/documentation/modelling-pricing/add-ons.mdx
@@ -104,9 +104,9 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_..." });
 
-const { data } = await autumn.checkout({
-  customer_id: "user_123",
-  plan_id: "storage_add_on",
+const data = await autumn.billing.attach({
+  customerId: "user_123",
+  planId: "storage_add_on",
 });
 ```
 
@@ -115,14 +115,14 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_...")
 
-response = await autumn.checkout(
+response = autumn.billing.attach(
     customer_id="user_123",
     plan_id="storage_add_on",
 )
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/checkout" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -136,11 +136,11 @@ curl -X POST "https://api.useautumn.com/v1/checkout" \
 For prepaid add-ons (like a credit top-up), pass the quantity:
 
 ```typescript TypeScript
-const { data } = await autumn.checkout({
-  customer_id: "user_123",
-  plan_id: "credit_top_up",
-  options: [{
-    feature_id: "credits",
+const data = await autumn.billing.attach({
+  customerId: "user_123",
+  planId: "credit_top_up",
+  featureQuantities: [{
+    featureId: "credits",
     quantity: 1000,
   }],
 });
@@ -153,26 +153,29 @@ Cancel an add-on using the same [cancel](/documentation/customers/subscription-l
 <CodeGroup>
 
 ```typescript TypeScript
-await autumn.cancel({
-  customer_id: "user_123",
-  plan_id: "storage_add_on",
+await autumn.billing.update({
+  customerId: "user_123",
+  planId: "storage_add_on",
+  cancelAction: "cancel_end_of_cycle",
 });
 ```
 
 ```python Python
-await autumn.cancel(
+autumn.billing.update(
     customer_id="user_123",
     plan_id="storage_add_on",
+    cancel_action="cancel_end_of_cycle",
 )
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/cancel" \
+curl -X POST "https://api.useautumn.com/v1/billing.update" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
     "customer_id": "user_123",
-    "plan_id": "storage_add_on"
+    "plan_id": "storage_add_on",
+    "cancel_action": "cancel_end_of_cycle"
   }'
 ```
 

--- a/apps/docs/mintlify/documentation/modelling-pricing/auto-top-ups.mdx
+++ b/apps/docs/mintlify/documentation/modelling-pricing/auto-top-ups.mdx
@@ -102,7 +102,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_...")
 
-await autumn.customers.update(
+autumn.customers.update(
     customer_id="user_123",
     billing_controls={
         "auto_topups": [{
@@ -116,7 +116,7 @@ await autumn.customers.update(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers/update" \
+curl -X POST "https://api.useautumn.com/v1/customers.update" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{

--- a/apps/docs/mintlify/documentation/modelling-pricing/credit-systems.mdx
+++ b/apps/docs/mintlify/documentation/modelling-pricing/credit-systems.mdx
@@ -110,7 +110,7 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_test_1234" });
 
-const response = await autumn.customers.check({
+const response = await autumn.check({
   customerId: "user_123",
   featureId: "premium_request",
   requiredBalance: 6,
@@ -124,7 +124,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-response = await autumn.customers.check(
+response = autumn.check(
     customer_id="user_123",
     feature_id="premium_request",
     required_balance=6,
@@ -133,7 +133,7 @@ print(response.allowed)
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/check" \
+curl -X POST "https://api.useautumn.com/v1/balances.check" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -184,7 +184,7 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_test_1234" });
 
-await autumn.customers.track({
+await autumn.track({
   customerId: "user_123",
   featureId: "premium_request",
   value: 6,
@@ -196,7 +196,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-await autumn.customers.track(
+autumn.track(
     customer_id="user_123",
     feature_id="premium_request",
     value=6,
@@ -204,7 +204,7 @@ await autumn.customers.track(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/track" \
+curl -X POST "https://api.useautumn.com/v1/balances.track" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -369,7 +369,7 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_test_1234" });
 
-await autumn.balances.trackTokens({
+await autumn.trackTokens({
   customerId: "user_123",
   modelId: "anthropic/claude-opus-4-5",
   inputTokens: 1500,
@@ -382,7 +382,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-await autumn.balances.track_tokens(
+autumn.track_tokens(
     customer_id="user_123",
     model_id="anthropic/claude-opus-4-5",
     input_tokens=1500,

--- a/apps/docs/mintlify/documentation/modelling-pricing/free-plans.mdx
+++ b/apps/docs/mintlify/documentation/modelling-pricing/free-plans.mdx
@@ -83,9 +83,9 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_..." });
 
-const { data } = await autumn.check({
-  customer_id: "user_123",
-  feature_id: "api_requests",
+const data = await autumn.check({
+  customerId: "user_123",
+  featureId: "api_requests",
 });
 
 if (!data.allowed) {
@@ -98,7 +98,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_...")
 
-response = await autumn.check(
+response = autumn.check(
     customer_id="user_123",
     feature_id="api_requests",
 )
@@ -108,7 +108,7 @@ if not response.allowed:
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/check" \
+curl -X POST "https://api.useautumn.com/v1/balances.check" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{

--- a/apps/docs/mintlify/documentation/modelling-pricing/one-off-purchases.mdx
+++ b/apps/docs/mintlify/documentation/modelling-pricing/one-off-purchases.mdx
@@ -71,7 +71,7 @@ One-off purchases don't create Stripe subscriptions. They generate a one-time in
 
 ## Purchasing a one-off plan
 
-For prepaid one-off plans, pass the desired `quantity` via the `options` array:
+For prepaid one-off plans, pass the desired total `quantity` via `featureQuantities`:
 
 <CodeGroup>
 
@@ -80,11 +80,11 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_..." });
 
-const { data } = await autumn.checkout({
-  customer_id: "user_123",
-  plan_id: "credit_top_up",
-  options: [{
-    feature_id: "credits",
+const data = await autumn.billing.attach({
+  customerId: "user_123",
+  planId: "credit_top_up",
+  featureQuantities: [{
+    featureId: "credits",
     quantity: 1000,
   }],
 });
@@ -95,10 +95,10 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_...")
 
-response = await autumn.checkout(
+response = autumn.billing.attach(
     customer_id="user_123",
     plan_id="credit_top_up",
-    options=[{
+    feature_quantities=[{
         "feature_id": "credits",
         "quantity": 1000,
     }],
@@ -106,13 +106,13 @@ response = await autumn.checkout(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/checkout" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
     "customer_id": "user_123",
     "plan_id": "credit_top_up",
-    "options": [{
+    "feature_quantities": [{
       "feature_id": "credits",
       "quantity": 1000
     }]

--- a/apps/docs/mintlify/documentation/modelling-pricing/per-unit-pricing.mdx
+++ b/apps/docs/mintlify/documentation/modelling-pricing/per-unit-pricing.mdx
@@ -83,7 +83,7 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_..." });
 
-const { data } = await autumn.billing.attach({
+const data = await autumn.billing.attach({
   customerId: "user_123",
   planId: "pro",
   featureQuantities: [{
@@ -98,7 +98,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_...")
 
-response = await autumn.billing.attach(
+response = autumn.billing.attach(
     customer_id="user_123",
     plan_id="pro",
     feature_quantities=[{
@@ -109,7 +109,7 @@ response = await autumn.billing.attach(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/billing/attach" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -143,15 +143,15 @@ const autumn = new Autumn({ secretKey: "am_sk_..." });
 
 // Add a seat
 await autumn.track({
-  customer_id: "user_123",
-  feature_id: "seats",
+  customerId: "user_123",
+  featureId: "seats",
   value: 1,
 });
 
 // Remove a seat
 await autumn.track({
-  customer_id: "user_123",
-  feature_id: "seats",
+  customerId: "user_123",
+  featureId: "seats",
   value: -1,
 });
 ```
@@ -162,14 +162,14 @@ from autumn_sdk import Autumn
 autumn = Autumn("am_sk_...")
 
 # Add a seat
-await autumn.track(
+autumn.track(
     customer_id="user_123",
     feature_id="seats",
     value=1,
 )
 
 # Remove a seat
-await autumn.track(
+autumn.track(
     customer_id="user_123",
     feature_id="seats",
     value=-1,
@@ -178,7 +178,7 @@ await autumn.track(
 
 ```bash cURL
 # Add a seat
-curl -X POST "https://api.useautumn.com/v1/track" \
+curl -X POST "https://api.useautumn.com/v1/balances.track" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -233,9 +233,9 @@ Before allowing a user to add a new seat, check if they have capacity:
 <CodeGroup>
 
 ```typescript TypeScript
-const { data } = await autumn.check({
-  customer_id: "user_123",
-  feature_id: "seats",
+const data = await autumn.check({
+  customerId: "user_123",
+  featureId: "seats",
 });
 
 if (!data.allowed) {
@@ -244,7 +244,7 @@ if (!data.allowed) {
 ```
 
 ```python Python
-response = await autumn.check(
+response = autumn.check(
     customer_id="user_123",
     feature_id="seats",
 )
@@ -254,7 +254,7 @@ if not response.allowed:
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/check" \
+curl -X POST "https://api.useautumn.com/v1/balances.check" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{

--- a/apps/docs/mintlify/documentation/modelling-pricing/prepaid-pricing.mdx
+++ b/apps/docs/mintlify/documentation/modelling-pricing/prepaid-pricing.mdx
@@ -112,7 +112,7 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_..." });
 
-const { data } = await autumn.billing.attach({
+const data = await autumn.billing.attach({
   customerId: "user_123",
   planId: "pro",
   featureQuantities: [
@@ -127,7 +127,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_...")
 
-response = await autumn.billing.attach(
+response = autumn.billing.attach(
     customer_id="user_123",
     plan_id="pro",
     feature_quantities=[
@@ -138,7 +138,7 @@ response = await autumn.billing.attach(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/billing/attach" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -171,7 +171,7 @@ await autumn.billing.update({
 ```
 
 ```python Python
-await autumn.billing.update(
+autumn.billing.update(
     customer_id="user_123",
     plan_id="pro",
     feature_quantities=[
@@ -182,7 +182,7 @@ await autumn.billing.update(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/billing/update" \
+curl -X POST "https://api.useautumn.com/v1/billing.update" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{

--- a/apps/docs/mintlify/documentation/modelling-pricing/proration.mdx
+++ b/apps/docs/mintlify/documentation/modelling-pricing/proration.mdx
@@ -127,7 +127,7 @@ autumn.billing.attach(
 ```
 
 ```bash cURL
-curl -X POST https://api.useautumn.com/v2/billing/attach \
+curl -X POST https://api.useautumn.com/v1/billing.attach \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{

--- a/apps/docs/mintlify/documentation/modelling-pricing/recurring.mdx
+++ b/apps/docs/mintlify/documentation/modelling-pricing/recurring.mdx
@@ -90,7 +90,7 @@ from autumn_sdk import Autumn
 autumn = Autumn("am_sk_...")
 
 async def main():
-    response = await autumn.billing.attach(
+    response = autumn.billing.attach(
         customer_id="user_123",
         plan_id="pro",
         redirect_mode="always",
@@ -102,7 +102,7 @@ asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/attach" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{

--- a/apps/docs/mintlify/documentation/modelling-pricing/rewards.mdx
+++ b/apps/docs/mintlify/documentation/modelling-pricing/rewards.mdx
@@ -94,7 +94,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-response = await autumn.referrals.create_code(
+response = autumn.referrals.create_code(
     customer_id="user_123",
     program_id="free-month",
 )
@@ -157,7 +157,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-response = await autumn.referrals.redeem_code(
+response = autumn.referrals.redeem_code(
     code="4EXWV1",
     customer_id="new_user_123",
 )

--- a/apps/docs/mintlify/documentation/modelling-pricing/rollovers.mdx
+++ b/apps/docs/mintlify/documentation/modelling-pricing/rollovers.mdx
@@ -81,32 +81,20 @@ At the end of each billing cycle, when a feature's balance resets:
 
 ## Viewing rollover balances
 
-Rollover balances appear in the `breakdown` array when you retrieve a customer's balances. Each rollover entry has its own expiry date:
+Rollover balances appear in the `rollovers` array. Each entry has its balance and expiry date:
 
 <Expandable title="customer balance with rollovers">
 ```json
 {
   "balances": {
     "credits": {
-      "included_usage": 1400,
-      "balance": 1400,
+      "granted": 1400,
+      "remaining": 1400,
       "usage": 0,
-      "breakdown": [
+      "rollovers": [
         {
-          "plan_id": "pro",
-          "included_usage": 1000,
-          "balance": 1000,
-          "usage": 0,
-          "interval": "month",
-          "next_reset_at": 1745193600000
-        },
-        {
-          "id": "roll_abc123",
-          "included_usage": 400,
           "balance": 400,
-          "usage": 0,
-          "interval": "one_off",
-          "expires_at": null
+          "expires_at": 1776729600000
         }
       ]
     }

--- a/apps/docs/mintlify/documentation/modelling-pricing/spend-limits.mdx
+++ b/apps/docs/mintlify/documentation/modelling-pricing/spend-limits.mdx
@@ -90,7 +90,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_...")
 
-await autumn.customers.update(
+autumn.customers.update(
     customer_id="user_123",
     billing_controls={
         "spend_limits": [{
@@ -103,7 +103,7 @@ await autumn.customers.update(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers/update" \
+curl -X POST "https://api.useautumn.com/v1/customers.update" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -153,7 +153,7 @@ await autumn.customers.update({
 ```
 
 ```python Python
-await autumn.customers.update(
+autumn.customers.update(
     customer_id="user_123",
     billing_controls={
         "spend_limits": [{
@@ -166,7 +166,7 @@ await autumn.customers.update(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers/update" \
+curl -X POST "https://api.useautumn.com/v1/customers.update" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -206,7 +206,7 @@ When a spend limit is configured, the `check` endpoint accounts for it in the `a
 <CodeGroup>
 
 ```typescript TypeScript
-const { data } = await autumn.check({
+const data = await autumn.check({
   customerId: "user_123",
   featureId: "api_calls",
 });
@@ -217,7 +217,7 @@ if (!data.allowed) {
 ```
 
 ```python Python
-response = await autumn.check(
+response = autumn.check(
     customer_id="user_123",
     feature_id="api_calls",
 )
@@ -227,7 +227,7 @@ if not response.allowed:
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/check" \
+curl -X POST "https://api.useautumn.com/v1/balances.check" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -299,7 +299,7 @@ await autumn.entities.update({
 ```
 
 ```python Python
-await autumn.entities.update(
+autumn.entities.update(
     customer_id="user_123",
     entity_id="workspace_a",
     billing_controls={
@@ -313,7 +313,7 @@ await autumn.entities.update(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/entities/update" \
+curl -X POST "https://api.useautumn.com/v1/entities.update" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -352,7 +352,7 @@ await autumn.customers.update({
 ```
 
 ```python Python
-await autumn.customers.update(
+autumn.customers.update(
     customer_id="user_123",
     billing_controls={
         "spend_limits": [{
@@ -364,7 +364,7 @@ await autumn.customers.update(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers/update" \
+curl -X POST "https://api.useautumn.com/v1/customers.update" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -443,7 +443,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_...")
 
-await autumn.customers.update(
+autumn.customers.update(
     customer_id="user_123",
     billing_controls={
         "usage_alerts": [{
@@ -458,7 +458,7 @@ await autumn.customers.update(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers/update" \
+curl -X POST "https://api.useautumn.com/v1/customers.update" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -497,7 +497,7 @@ await autumn.customers.update({
 ```
 
 ```python Python
-await autumn.customers.update(
+autumn.customers.update(
     customer_id="user_123",
     billing_controls={
         "usage_alerts": [{
@@ -512,7 +512,7 @@ await autumn.customers.update(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers/update" \
+curl -X POST "https://api.useautumn.com/v1/customers.update" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -588,7 +588,7 @@ await autumn.customers.update({
 ```
 
 ```python Python
-await autumn.customers.update(
+autumn.customers.update(
     customer_id="user_123",
     billing_controls={
         "usage_alerts": [
@@ -612,7 +612,7 @@ await autumn.customers.update(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers/update" \
+curl -X POST "https://api.useautumn.com/v1/customers.update" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{

--- a/apps/docs/mintlify/documentation/modelling-pricing/sub-entity-balances.mdx
+++ b/apps/docs/mintlify/documentation/modelling-pricing/sub-entity-balances.mdx
@@ -98,7 +98,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_...")
 
-await autumn.entities.create(
+autumn.entities.create(
     customer_id="org_123",
     entity_id="user_alice",
     feature_id="seats",
@@ -107,7 +107,7 @@ await autumn.entities.create(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/entities" \
+curl -X POST "https://api.useautumn.com/v1/entities.create" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -129,29 +129,29 @@ Pass the `entity_id` to `check` and `track` to operate on a specific entity's ba
 <CodeGroup>
 
 ```typescript TypeScript
-const { data } = await autumn.check({
-  customer_id: "org_123",
-  feature_id: "summaries",
-  entity_id: "user_alice",
+const data = await autumn.check({
+  customerId: "org_123",
+  featureId: "summaries",
+  entityId: "user_alice",
 });
 
 console.log(data.allowed);
-console.log(data.balance);
+console.log(data.balance?.remaining);
 ```
 
 ```python Python
-response = await autumn.check(
+response = autumn.check(
     customer_id="org_123",
     feature_id="summaries",
     entity_id="user_alice",
 )
 
 print(response.allowed)
-print(response.balance)
+print(response.balance.remaining)
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/check" \
+curl -X POST "https://api.useautumn.com/v1/balances.check" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -169,15 +169,15 @@ curl -X POST "https://api.useautumn.com/v1/check" \
 
 ```typescript TypeScript
 await autumn.track({
-  customer_id: "org_123",
-  feature_id: "summaries",
-  entity_id: "user_alice",
+  customerId: "org_123",
+  featureId: "summaries",
+  entityId: "user_alice",
   value: 1,
 });
 ```
 
 ```python Python
-await autumn.track(
+autumn.track(
     customer_id="org_123",
     feature_id="summaries",
     entity_id="user_alice",
@@ -186,7 +186,7 @@ await autumn.track(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/track" \
+curl -X POST "https://api.useautumn.com/v1/balances.track" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -199,15 +199,8 @@ curl -X POST "https://api.useautumn.com/v1/track" \
 
 </CodeGroup>
 
-## Customer-level vs entity-level
-
-| Level | How to use | Behavior |
-|-------|-----------|----------|
-| **Entity-level** | Pass `entity_id` in check/track | Checks/deducts from that entity's individual balance |
-| **Customer-level** | Omit `entity_id` | Returns the total balance across all entities |
-
 <Note>
-When tracking at the customer level (without `entity_id`), usage is deducted from the first-created entity to keep entity-level totals in sync with the customer-level total.
+Customer-level checks and usage do not aggregate entity-level balances. Include `entity_id` for a per-entity balance; model a separate customer-level balance when usage should be shared.
 </Note>
 
 ## Deleting entities
@@ -224,17 +217,17 @@ await autumn.entities.delete({
 ```
 
 ```python Python
-await autumn.entities.delete(
+autumn.entities.delete(
     customer_id="org_123",
     entity_id="user_alice",
 )
 ```
 
 ```bash cURL
-curl -X DELETE "https://api.useautumn.com/v1/entities/user_alice" \
+curl -X POST "https://api.useautumn.com/v1/entities.delete" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
-  -d '{ "customer_id": "org_123" }'
+  -d '{ "customer_id": "org_123", "entity_id": "user_alice" }'
 ```
 
 </CodeGroup>

--- a/apps/docs/mintlify/documentation/modelling-pricing/sub-entity-plans.mdx
+++ b/apps/docs/mintlify/documentation/modelling-pricing/sub-entity-plans.mdx
@@ -100,7 +100,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_...")
 
-await autumn.entities.create(
+autumn.entities.create(
     customer_id="org_123",
     entity_id="workspace_a",
     feature_id="workspaces",
@@ -109,7 +109,7 @@ await autumn.entities.create(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/entities" \
+curl -X POST "https://api.useautumn.com/v1/entities.create" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -135,7 +135,7 @@ const response = await autumn.billing.attach({
 ```
 
 ```python Python
-response = await autumn.billing.attach(
+response = autumn.billing.attach(
     customer_id="org_123",
     plan_id="workspace_pro",
     entity_id="workspace_a",
@@ -164,17 +164,17 @@ Pass the `entity_id` to scope `check` and `track` calls to a specific entity:
 <CodeGroup>
 
 ```typescript TypeScript
-const { data } = await autumn.check({
-  customer_id: "org_123",
-  feature_id: "requests",
-  entity_id: "workspace_a",
+const data = await autumn.check({
+  customerId: "org_123",
+  featureId: "requests",
+  entityId: "workspace_a",
 });
 
 console.log(data.allowed);
 ```
 
 ```python Python
-response = await autumn.check(
+response = autumn.check(
     customer_id="org_123",
     feature_id="requests",
     entity_id="workspace_a",
@@ -184,7 +184,7 @@ print(response.allowed)
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/check" \
+curl -X POST "https://api.useautumn.com/v1/balances.check" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -211,7 +211,7 @@ await autumn.billing.attach({
 ```
 
 ```python Python
-await autumn.billing.attach(
+autumn.billing.attach(
     customer_id="org_123",
     plan_id="workspace_pro",
     entity_id="workspace_a",
@@ -247,7 +247,7 @@ await autumn.billing.update({
 ```
 
 ```python Python
-await autumn.billing.update(
+autumn.billing.update(
     customer_id="org_123",
     plan_id="workspace_pro",
     entity_id="workspace_a",

--- a/apps/docs/mintlify/documentation/modelling-pricing/trials.mdx
+++ b/apps/docs/mintlify/documentation/modelling-pricing/trials.mdx
@@ -74,9 +74,9 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_..." });
 
-const { data } = await autumn.checkout({
-  customer_id: "user_123",
-  plan_id: "pro",
+const data = await autumn.billing.attach({
+  customerId: "user_123",
+  planId: "pro",
 });
 
 // Returns Stripe Checkout URL — customer adds card and starts trial
@@ -87,7 +87,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_...")
 
-response = await autumn.checkout(
+response = autumn.billing.attach(
     customer_id="user_123",
     plan_id="pro",
 )
@@ -95,7 +95,7 @@ response = await autumn.checkout(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/checkout" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -115,21 +115,21 @@ When `cardRequired` is `false`, no checkout is needed. You can attach the plan d
 <CodeGroup>
 
 ```typescript TypeScript
-const { data } = await autumn.attach({
-  customer_id: "user_123",
-  plan_id: "pro",
+const data = await autumn.billing.attach({
+  customerId: "user_123",
+  planId: "pro",
 });
 ```
 
 ```python Python
-response = await autumn.attach(
+response = autumn.billing.attach(
     customer_id="user_123",
     plan_id="pro",
 )
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/attach" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -157,7 +157,7 @@ The customer's subscription includes a `trial_ends_at` timestamp when a trial is
 <CodeGroup>
 
 ```typescript TypeScript
-const { data } = await autumn.customers.get("user_123");
+const data = await autumn.customers.get({ customerId: "user_123" });
 
 for (const sub of data.subscriptions) {
   if (sub.trialEndsAt) {
@@ -167,7 +167,7 @@ for (const sub of data.subscriptions) {
 ```
 
 ```python Python
-response = await autumn.customers.get("user_123")
+response = autumn.customers.get(customer_id="user_123")
 
 for sub in response.subscriptions:
     if sub.trial_ends_at:
@@ -194,8 +194,8 @@ To prevent trial abuse across multiple accounts, set a `fingerprint` when creati
 <CodeGroup>
 
 ```typescript TypeScript
-await autumn.customers.create({
-  id: "user_456",
+await autumn.customers.getOrCreate({
+  customerId: "user_456",
   name: "Jane Doe",
   email: "jane@example.com",
   fingerprint: "device_abc123",
@@ -203,8 +203,8 @@ await autumn.customers.create({
 ```
 
 ```python Python
-await autumn.customers.create(
-    id="user_456",
+autumn.customers.get_or_create(
+    customer_id="user_456",
     name="Jane Doe",
     email="jane@example.com",
     fingerprint="device_abc123",
@@ -212,11 +212,11 @@ await autumn.customers.create(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers" \
+curl -X POST "https://api.useautumn.com/v1/customers.get_or_create" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
-    "id": "user_456",
+    "customer_id": "user_456",
     "name": "Jane Doe",
     "email": "jane@example.com",
     "fingerprint": "device_abc123"
@@ -242,7 +242,7 @@ const customer = await autumn.customers.getOrCreate({
 ```
 
 ```python Python
-customer = await autumn.customers.get_or_create(
+customer = autumn.customers.get_or_create(
     customer_id="user_123",
     expand=["trials_used"],
 )
@@ -250,11 +250,11 @@ customer = await autumn.customers.get_or_create(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers" \
+curl -X POST "https://api.useautumn.com/v1/customers.get_or_create" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
-    "id": "user_123",
+    "customer_id": "user_123",
     "expand": ["trials_used"]
   }'
 ```
@@ -285,7 +285,7 @@ You can override any of these behaviors by passing `customize.freeTrial` on the 
 
 ## Overriding trial behavior
 
-You can override the default trial behavior on any `/attach` or `/update-subscription` call by passing `customize.freeTrial`:
+You can override the default trial behavior on `billing.attach` or `billing.update` by passing `customize.freeTrial`:
 
 <Tabs>
 <Tab title="Custom trial">
@@ -295,7 +295,7 @@ Pass a `freeTrial` object to start a trial with a custom duration. This **bypass
 <CodeGroup>
 
 ```typescript TypeScript
-await autumn.attach({
+await autumn.billing.attach({
   customerId: "user_123",
   planId: "pro",
   customize: {
@@ -309,7 +309,7 @@ await autumn.attach({
 ```
 
 ```python Python
-await autumn.attach(
+autumn.billing.attach(
     customer_id="user_123",
     plan_id="pro",
     customize={
@@ -323,7 +323,7 @@ await autumn.attach(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/attach" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -349,7 +349,7 @@ Pass `freeTrial: null` to skip the trial entirely and begin billing immediately 
 <CodeGroup>
 
 ```typescript TypeScript
-await autumn.attach({
+await autumn.billing.attach({
   customerId: "user_123",
   planId: "pro",
   customize: {
@@ -360,7 +360,7 @@ await autumn.attach({
 ```
 
 ```python Python
-await autumn.attach(
+autumn.billing.attach(
     customer_id="user_123",
     plan_id="pro",
     customize={"free_trial": None},
@@ -368,7 +368,7 @@ await autumn.attach(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/attach" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -380,19 +380,19 @@ curl -X POST "https://api.useautumn.com/v1/attach" \
 
 </CodeGroup>
 
-You can also pass `freeTrial: null` on `/update-subscription` to end an active trial early and start billing right away.
+You can also pass `freeTrial: null` to `billing.update` to end an active trial early and start billing right away.
 
 </Tab>
 <Tab title="Extend trial">
 
-To extend a trial, call `/update-subscription` with a new `customize.freeTrial`. The new trial duration is computed **from now** — it replaces the current trial end date rather than adding to it.
+To extend a trial, call `billing.update` with a new `customize.freeTrial`. The new trial duration is computed **from now** — it replaces the current trial end date rather than adding to it.
 
 <CodeGroup>
 
 ```typescript TypeScript
 // Customer is 5 days into a 14-day trial.
 // This gives them a fresh 14 days from now (not 14 + 9 remaining).
-await autumn.updateSubscription({
+await autumn.billing.update({
   customerId: "user_123",
   planId: "pro",
   customize: {
@@ -405,7 +405,7 @@ await autumn.updateSubscription({
 ```
 
 ```python Python
-await autumn.update_subscription(
+autumn.billing.update(
     customer_id="user_123",
     plan_id="pro",
     customize={
@@ -476,7 +476,7 @@ By default, feature usage during a trial carries over into the paid period. If y
 <CodeGroup>
 
 ```typescript TypeScript
-await autumn.attach({
+await autumn.billing.attach({
   customerId: "user_123",
   planId: "pro",
   transitionRules: {
@@ -486,7 +486,7 @@ await autumn.attach({
 ```
 
 ```python Python
-await autumn.attach(
+autumn.billing.attach(
     customer_id="user_123",
     plan_id="pro",
     transition_rules={
@@ -496,7 +496,7 @@ await autumn.attach(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/attach" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -511,6 +511,5 @@ curl -X POST "https://api.useautumn.com/v1/attach" \
 </CodeGroup>
 
 This sets the feature's reset cycle to begin when the trial ends rather than when the trial starts, so the customer gets a full fresh allowance once they start paying.
-
 
 

--- a/apps/docs/mintlify/documentation/modelling-pricing/usage-based-pricing.mdx
+++ b/apps/docs/mintlify/documentation/modelling-pricing/usage-based-pricing.mdx
@@ -86,8 +86,8 @@ import { Autumn } from "autumn-js";
 const autumn = new Autumn({ secretKey: "am_sk_..." });
 
 await autumn.track({
-  customer_id: "user_123",
-  feature_id: "notifications",
+  customerId: "user_123",
+  featureId: "notifications",
   value: 500,
 });
 ```
@@ -97,7 +97,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_...")
 
-await autumn.track(
+autumn.track(
     customer_id="user_123",
     feature_id="notifications",
     value=500,
@@ -105,7 +105,7 @@ await autumn.track(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/track" \
+curl -X POST "https://api.useautumn.com/v1/balances.track" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -124,27 +124,27 @@ Check if the customer can use the feature. For usage-based features with overage
 <CodeGroup>
 
 ```typescript TypeScript
-const { data } = await autumn.check({
-  customer_id: "user_123",
-  feature_id: "notifications",
+const data = await autumn.check({
+  customerId: "user_123",
+  featureId: "notifications",
 });
 
 console.log(data.allowed); // true (overage allowed)
-console.log(data.balance);
+console.log(data.balance?.remaining);
 ```
 
 ```python Python
-response = await autumn.check(
+response = autumn.check(
     customer_id="user_123",
     feature_id="notifications",
 )
 
 print(response.allowed)  # True (overage allowed)
-print(response.balance)
+print(response.balance.remaining)
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/check" \
+curl -X POST "https://api.useautumn.com/v1/balances.check" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{

--- a/apps/docs/mintlify/documentation/rate-limits.mdx
+++ b/apps/docs/mintlify/documentation/rate-limits.mdx
@@ -11,10 +11,15 @@ Autumn enforces rate limits to ensure reliable performance for all users. Limits
 |---|---|---|---|
 | **Check / Entitled / Get Customer** | 10,000 requests | 1 second | Per customer |
 | **Track / Usage / Balance updates** | 10,000 requests | 1 second | Per customer |
+| **Batch track** | 10 requests | 1 second | Per organization |
 | **Attach / Cancel / Billing operations** | 30 requests | 1 minute | Per customer |
 | **Events (list / aggregate / query)** | 5 requests | 1 second | Per customer |
-| **List Customers** | 5 requests | 1 second | Per organization |
+| **Get entity** | 50 requests | 1 second | Per customer |
+| **List customers / entities** | 50 requests | 1 second | Per organization on API v2.3 (5 on older versions) |
+| **Logs (search / query)** | 10 requests | 1 second | Per organization |
 | **All other endpoints** | 25 requests | 1 second | Per organization |
+
+Check, track, and entity-get traffic also has organization-wide caps of 240,000, 120,000, and 90,000 requests per minute respectively. When those caps are reached, `check` fails open and `track` is queued when possible; customer-establishment requests return `429`.
 
 ## Scopes
 
@@ -29,9 +34,9 @@ When a rate limit is exceeded, the API returns a `429 Too Many Requests` respons
 
 Under heavy load, customer-state endpoints (`/customers.get_or_create`, `/customers.get`, `/entities.get`) may briefly return a `503` with code `service_unavailable` and a `Retry-After` header (seconds). This is transient and unrelated to your request volume -- retry after the indicated delay. `check` and `track` are never shed this way (see [Fail-Open Defaults](/documentation/fail-open)).
 
-## Preview endpoints are not rate limited
+## Preview endpoints
 
-Preview endpoints like `/v1/attach/preview`, `/v1/billing.preview_attach`, and `/v1/billing.preview_update` are **not** subject to rate limits. You can call these freely to display pricing previews to your users.
+Preview endpoints such as `/v1/billing.preview_attach` and `/v1/billing.preview_update` use the general organization limit rather than the stricter 30-per-minute billing-operation limit.
 
 ## Requesting higher limits
 

--- a/apps/docs/mintlify/documentation/webhooks.mdx
+++ b/apps/docs/mintlify/documentation/webhooks.mdx
@@ -265,6 +265,8 @@ Fired when a customer crosses a configured usage alert threshold. Usage alerts l
 |---------------------|-------------|
 | `usage` | An absolute usage count was crossed |
 | `usage_percentage` | A percentage of the usage allowance was crossed |
+| `remaining` | An absolute remaining-balance threshold was crossed |
+| `remaining_percentage` | A percentage-of-remaining threshold was crossed |
 
 **Example payload:**
 

--- a/apps/docs/mintlify/examples/entity-balances.mdx
+++ b/apps/docs/mintlify/examples/entity-balances.mdx
@@ -64,7 +64,7 @@ When an organization signs up, create an Autumn customer.
 import { useCustomer } from "autumn-js/react";
 
 const App = () => {
-  const { customer } = useCustomer();
+  const { data: customer } = useCustomer();
 
   console.log("Autumn customer:", customer);
 
@@ -79,8 +79,8 @@ const autumn = new Autumn({
   secretKey: 'am_sk_42424242',
 });
 
-const { data, error } = await autumn.customers.create({
-  id: "org_123",
+const customer = await autumn.customers.getOrCreate({
+  customerId: "org_123",
   name: "Acme Corp",
   email: "admin@acme.com",
 });
@@ -88,13 +88,13 @@ const { data, error } = await autumn.customers.create({
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn('am_sk_42424242')
 
 async def main():
-    customer = await autumn.customers.create(
-        id="org_123",
+    customer = autumn.customers.get_or_create(
+        customer_id="org_123",
         name="Acme Corp",
         email="admin@acme.com",
     )
@@ -104,11 +104,11 @@ asyncio.run(main())
 
 ```bash cURL
 curl --request POST \
-  --url https://api.useautumn.com/v1/customers \
+  --url https://api.useautumn.com/v1/customers.get_or_create \
   --header 'Authorization: Bearer am_sk_42424242' \
   --header 'Content-Type: application/json' \
   --data '{
-    "id": "org_123",
+    "customer_id": "org_123",
     "name": "Acme Corp",
     "email": "admin@acme.com"
   }'
@@ -132,24 +132,25 @@ const autumn = new Autumn({
 });
 
 // Create entity for the initial admin user
-await autumn.entities.create("org_123", {
-  id: "user_admin",
+await autumn.entities.create({
+  customerId: "org_123",
+  entityId: "user_admin",
   name: "Admin User",
-  feature_id: "seats",
+  featureId: "seats",
 });
 ```
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_42424242")
 
 async def main():
     # Create entity for the initial admin user
-    await autumn.features.create_entity(
+    autumn.entities.create(
         customer_id="org_123",
-        id="user_admin",
+        entity_id="user_admin",
         name="Admin User",
         feature_id="seats",
     )
@@ -158,11 +159,12 @@ asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers/org_123/entities" \
+curl -X POST "https://api.useautumn.com/v1/entities.create" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
-    "id": "user_admin",
+    "customer_id": "org_123",
+    "entity_id": "user_admin",
     "name": "Admin User",
     "feature_id": "seats"
   }'
@@ -184,17 +186,16 @@ When the customer upgrades to Team, attach the plan. The checkout URL will show 
 <CodeGroup>
 
 ```jsx React
-import { useCustomer, CheckoutDialog } from "autumn-js/react";
+import { useCustomer } from "autumn-js/react";
 
 export default function UpgradeButton() {
-  const { checkout } = useCustomer();
+  const { attach } = useCustomer();
 
   return (
     <button
       onClick={async () => {
-        await checkout({
-          productId: "team",
-          dialog: CheckoutDialog,
+        await attach({
+          planId: "team",
         });
       }}
     >
@@ -211,29 +212,29 @@ const autumn = new Autumn({
   secretKey: 'am_sk_42424242',
 });
 
-const { data } = await autumn.checkout({
-  customer_id: "org_123",
-  product_id: "team",
+const data = await autumn.billing.attach({
+  customerId: "org_123",
+  planId: "team",
 });
 
-if (data.url) {
+if (data.paymentUrl) {
   // Redirect to Stripe checkout
 }
 ```
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_42424242")
 
 async def main():
-    response = await autumn.checkout(
+    response = autumn.billing.attach(
         customer_id="org_123",
-        product_id="team",
+        plan_id="team",
     )
     
-    if response.url:
+    if response.payment_url:
         # Redirect to Stripe checkout
         pass
 
@@ -241,12 +242,12 @@ asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/checkout" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
     "customer_id": "org_123",
-    "product_id": "team"
+    "plan_id": "team"
   }'
 ```
 
@@ -269,25 +270,29 @@ const autumn = new Autumn({
   secretKey: 'am_sk_42424242',
 });
 
-// Create entities for team members
-await autumn.entities.create("org_123", [
-  { id: "user_alice", name: "Alice Smith", feature_id: "seats" },
-  { id: "user_bob", name: "Bob Jones", feature_id: "seats" },
-  { id: "user_charlie", name: "Charlie Brown", feature_id: "seats" },
-]);
+await Promise.all([
+  ["user_alice", "Alice Smith"],
+  ["user_bob", "Bob Jones"],
+  ["user_charlie", "Charlie Brown"],
+].map(([entityId, name]) => autumn.entities.create({
+  customerId: "org_123",
+  entityId,
+  name,
+  featureId: "seats",
+})));
 ```
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_42424242")
 
 async def main():
     # Create entities for team members
-    await autumn.features.create_entity(
+    autumn.entities.create(
         customer_id="org_123",
-        id="user_alice",
+        entity_id="user_alice",
         name="Alice Smith",
         feature_id="seats",
     )
@@ -296,11 +301,12 @@ asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers/org_123/entities" \
+curl -X POST "https://api.useautumn.com/v1/entities.create" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
-    "id": "user_alice",
+    "customer_id": "org_123",
+    "entity_id": "user_alice",
     "name": "Alice Smith",
     "feature_id": "seats"
   }'
@@ -324,14 +330,16 @@ Before generating a meeting summary, check if that specific user has remaining b
 <CodeGroup>
 
 ```tsx React
-import { useEntity } from "autumn-js/react";
+import { useCustomer } from "autumn-js/react";
 
 function MeetingSummaryButton({ meetingId }: { meetingId: string }) {
-  // Pass the current user's entity ID
-  const { allowed, check } = useEntity("user_alice");
+  const { check } = useCustomer();
 
   const handleSummarize = async () => {
-    const { data } = await check({ featureId: "meeting_summaries" });
+    const data = check({
+      featureId: "meeting_summaries",
+      entityId: "user_alice",
+    });
 
     if (!data?.allowed) {
       alert("You've used all your meeting summaries this month");
@@ -354,28 +362,28 @@ const autumn = new Autumn({
 });
 
 // Check Alice's individual balance
-const { data } = await autumn.check({
-  customer_id: "org_123",
-  feature_id: "meeting_summaries",
-  entity_id: "user_alice",
+const data = await autumn.check({
+  customerId: "org_123",
+  featureId: "meeting_summaries",
+  entityId: "user_alice",
 });
 
 if (!data.allowed) {
   console.log("Alice has used all her meeting summaries");
 } else {
-  console.log(`Alice has ${data.balance} summaries remaining`);
+  console.log(`Alice has ${data.balance?.remaining} summaries remaining`);
 }
 ```
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_42424242")
 
 async def main():
     # Check Alice's individual balance
-    response = await autumn.check(
+    response = autumn.check(
         customer_id="org_123",
         feature_id="meeting_summaries",
         entity_id="user_alice",
@@ -384,13 +392,13 @@ async def main():
     if not response.allowed:
         print("Alice has used all her meeting summaries")
     else:
-        print(f"Alice has {response.balance} summaries remaining")
+        print(f"Alice has {response.balance.remaining} summaries remaining")
 
 asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/check" \
+curl -X POST "https://api.useautumn.com/v1/balances.check" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
@@ -402,21 +410,6 @@ curl -X POST "https://api.useautumn.com/v1/check" \
 
 </CodeGroup>
 
-<Expandable title="check response (entity-level)">
-```json
-{
-  "allowed": true,
-  "customer_id": "org_123",
-  "feature_id": "meeting_summaries",
-  "entity_id": "user_alice",
-  "balance": 47,
-  "usage": 3,
-  "included_usage": 50,
-  "unlimited": false
-}
-```
-</Expandable>
-
 </Step>
 
 <Step>
@@ -425,18 +418,6 @@ curl -X POST "https://api.useautumn.com/v1/check" \
 When a user generates a summary, track the usage against their entity.
 
 <CodeGroup>
-
-```tsx React
-import { useEntity } from "autumn-js/react";
-
-const { track } = useEntity("user_alice");
-
-// After generating a meeting summary
-await track({
-  featureId: "meeting_summaries",
-  value: 1,
-});
-```
 
 ```typescript Node.js
 import { Autumn } from "autumn-js";
@@ -447,22 +428,22 @@ const autumn = new Autumn({
 
 // Track usage for Alice
 await autumn.track({
-  customer_id: "org_123",
-  feature_id: "meeting_summaries",
-  entity_id: "user_alice",
+  customerId: "org_123",
+  featureId: "meeting_summaries",
+  entityId: "user_alice",
   value: 1,
 });
 ```
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_42424242")
 
 async def main():
     # Track usage for Alice
-    await autumn.track(
+    autumn.track(
         customer_id="org_123",
         feature_id="meeting_summaries",
         entity_id="user_alice",
@@ -473,7 +454,7 @@ asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/track" \
+curl -X POST "https://api.useautumn.com/v1/balances.track" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
@@ -485,77 +466,6 @@ curl -X POST "https://api.useautumn.com/v1/track" \
 ```
 
 </CodeGroup>
-
-</Step>
-
-<Step>
-#### Check Customer-level Balance (Optional)
-
-You can also check the total balance across all entities, useful for admin dashboards.
-
-<CodeGroup>
-
-```typescript Node.js
-import { Autumn } from "autumn-js";
-
-const autumn = new Autumn({
-  secretKey: 'am_sk_42424242',
-});
-
-// Check total balance across all users (omit entity_id)
-const { data } = await autumn.check({
-  customer_id: "org_123",
-  feature_id: "meeting_summaries",
-});
-
-// With 3 users at 50 each = 150 total
-console.log(`Team has ${data.balance} total summaries remaining`);
-```
-
-```python Python
-import asyncio
-from autumn import Autumn
-
-autumn = Autumn("am_sk_42424242")
-
-async def main():
-    # Check total balance across all users
-    response = await autumn.check(
-        customer_id="org_123",
-        feature_id="meeting_summaries",
-    )
-    
-    print(f"Team has {response.balance} total summaries remaining")
-
-asyncio.run(main())
-```
-
-```bash cURL
-curl -X POST "https://api.useautumn.com/v1/check" \
-  -H "Authorization: Bearer am_sk_42424242" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "customer_id": "org_123",
-    "feature_id": "meeting_summaries"
-  }'
-```
-
-</CodeGroup>
-
-<Expandable title="check response (customer-level)">
-```json
-{
-  "allowed": true,
-  "customer_id": "org_123",
-  "feature_id": "meeting_summaries",
-  "balance": 141,
-  "usage": 9,
-  "included_usage": 150,
-  "unlimited": false
-}
-```
-The total is the sum of all entity balances (3 users × 50 = 150 included).
-</Expandable>
 
 </Step>
 
@@ -576,25 +486,30 @@ const autumn = new Autumn({
 });
 
 // Remove Bob from the team
-await autumn.entities.delete("org_123", "user_bob");
+await autumn.entities.delete({
+  customerId: "org_123",
+  entityId: "user_bob",
+});
 ```
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_42424242")
 
 async def main():
     # Remove Bob from the team
-    await autumn.features.delete_entity("org_123", "user_bob")
+    autumn.entities.delete(customer_id="org_123", entity_id="user_bob")
 
 asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X DELETE "https://api.useautumn.com/v1/customers/org_123/entities/user_bob" \
-  -H "Authorization: Bearer am_sk_42424242"
+curl -X POST "https://api.useautumn.com/v1/entities.delete" \
+  -H "Authorization: Bearer am_sk_42424242" \
+  -H "Content-Type: application/json" \
+  -d '{ "customer_id": "org_123", "entity_id": "user_bob" }'
 ```
 
 </CodeGroup>
@@ -611,7 +526,6 @@ Deleting an entity automatically decrements the seat count. The customer's total
 | Level | Check/Track With | Use Case |
 |-------|------------------|----------|
 | **Entity-level** | `entity_id: "user_alice"` | Individual user limits, fair usage |
-| **Customer-level** | No `entity_id` | Admin dashboards, total consumption |
 
 Entity-level balances are ideal when you want to:
 - Ensure fair usage across team members

--- a/apps/docs/mintlify/examples/monetary-credits.mdx
+++ b/apps/docs/mintlify/examples/monetary-credits.mdx
@@ -118,7 +118,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-customer = await autumn.customers.get_or_create(
+customer = autumn.customers.get_or_create(
     customer_id="user_123",
     name="John Yeo",
     email="john@example.com",
@@ -126,7 +126,7 @@ customer = await autumn.customers.get_or_create(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers" \
+curl -X POST "https://api.useautumn.com/v1/customers.get_or_create" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -180,7 +180,7 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_test_1234" });
 
-const response = await autumn.customers.check({
+const response = await autumn.check({
   customerId: "user_123",
   featureId: "basic_messages",
   requiredBalance: 1,
@@ -197,7 +197,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-response = await autumn.customers.check(
+response = autumn.check(
     customer_id="user_123",
     feature_id="basic_messages",
     required_balance=1,
@@ -208,7 +208,7 @@ if not response.allowed:
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/check" \
+curl -X POST "https://api.useautumn.com/v1/balances.check" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -220,25 +220,6 @@ curl -X POST "https://api.useautumn.com/v1/check" \
 
 </CodeGroup>
 
-<Expandable title="check response">
-The credit system ID will be returned in the balance.
-```json
-{
-  "allowed": true,
-  "customerId": "user_123",
-  "requiredBalance": 0.01,
-  "balance": {
-    "featureId": "usd_credits",
-    "granted": 5,
-    "remaining": 5,
-    "usage": 0,
-    "unlimited": false,
-    "overageAllowed": false,
-    "nextResetAt": 1769110978704
-  }
-}
-```
-</Expandable>
 </Step>
 
 <Step>
@@ -253,7 +234,7 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_test_1234" });
 
-await autumn.customers.track({
+await autumn.track({
   customerId: "user_123",
   featureId: "basic_messages",
   value: 2,
@@ -265,7 +246,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-await autumn.customers.track(
+autumn.track(
     customer_id="user_123",
     feature_id="basic_messages",
     value=2,
@@ -273,7 +254,7 @@ await autumn.customers.track(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/track" \
+curl -X POST "https://api.useautumn.com/v1/balances.track" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -285,23 +266,6 @@ curl -X POST "https://api.useautumn.com/v1/track" \
 
 </CodeGroup>
 
-<Expandable title="track response">
-```json
-{
-  "customerId": "user_123",
-  "value": 2,
-  "balance": {
-    "featureId": "usd_credits",
-    "granted": 5,
-    "remaining": 4.98,
-    "usage": 0.02,
-    "unlimited": false,
-    "overageAllowed": false,
-    "nextResetAt": 1769110978704
-  }
-}
-```
-</Expandable>
 </Step>
 
 <Step>
@@ -344,7 +308,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-response = await autumn.billing.attach(
+response = autumn.billing.attach(
     customer_id="user_123",
     plan_id="pro",
 )
@@ -352,7 +316,7 @@ response = await autumn.billing.attach(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/attach" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -416,7 +380,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-response = await autumn.billing.attach(
+response = autumn.billing.attach(
     customer_id="user_123",
     plan_id="top_up",
     feature_quantities=[{
@@ -428,7 +392,7 @@ response = await autumn.billing.attach(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/attach" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{

--- a/apps/docs/mintlify/examples/pay-as-you-go-overages.mdx
+++ b/apps/docs/mintlify/examples/pay-as-you-go-overages.mdx
@@ -65,7 +65,7 @@ When your user signs up, create an Autumn customer. This will automatically assi
 import { useCustomer } from "autumn-js/react";
 
 const App = () => {
-  const { customer } = useCustomer();
+  const { data: customer } = useCustomer();
 
   console.log("Autumn customer:", customer);
 
@@ -80,8 +80,8 @@ const autumn = new Autumn({
   secretKey: 'am_sk_42424242',
 });
 
-const { data, error } = await autumn.customers.create({
-  id: "user_123",
+const customer = await autumn.customers.getOrCreate({
+  customerId: "user_123",
   name: "Jane Doe",
   email: "jane@example.com",
 });
@@ -89,13 +89,13 @@ const { data, error } = await autumn.customers.create({
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn('am_sk_42424242')
 
 async def main():
-    customer = await autumn.customers.create(
-        id="user_123",
+    customer = autumn.customers.get_or_create(
+        customer_id="user_123",
         name="Jane Doe",
         email="jane@example.com",
     )
@@ -105,11 +105,11 @@ asyncio.run(main())
 
 ```bash cURL
 curl --request POST \
-  --url https://api.useautumn.com/customers \
+  --url https://api.useautumn.com/v1/customers.get_or_create \
   --header 'Authorization: Bearer am_sk_42424242' \
   --header 'Content-Type: application/json' \
   --data '{
-    "id": "user_123",
+    "customer_id": "user_123",
     "name": "Jane Doe",
     "email": "jane@example.com"
   }'
@@ -132,7 +132,7 @@ export function SendNotification() {
   const { check } = useCustomer();
 
   const handleSendNotification = async () => {
-    const { data } = await check({ featureId: "notifications" });
+    const data = check({ featureId: "notifications" });
 
     if (!data?.allowed) {
       // User is over limit on Free plan
@@ -153,9 +153,9 @@ const autumn = new Autumn({
   secretKey: 'am_sk_42424242',
 });
 
-const { data } = await autumn.check({
-  customer_id: "user_123",
-  feature_id: "notifications",
+const data = await autumn.check({
+  customerId: "user_123",
+  featureId: "notifications",
 });
 
 if (!data.allowed) {
@@ -166,12 +166,12 @@ if (!data.allowed) {
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_42424242")
 
 async def main():
-    response = await autumn.check(
+    response = autumn.check(
         customer_id="user_123",
         feature_id="notifications",
     )
@@ -184,7 +184,7 @@ asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/check" \
+curl -X POST "https://api.useautumn.com/v1/balances.check" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
@@ -195,21 +195,6 @@ curl -X POST "https://api.useautumn.com/v1/check" \
 
 </CodeGroup>
 
-<Expandable title="check response (Free plan user)">
-```json
-{
-  "allowed": true,
-  "customer_id": "user_123",
-  "feature_id": "notifications",
-  "balance": 870,
-  "usage": 130,
-  "included_usage": 1000,
-  "unlimited": false,
-  "overage_allowed": false
-}
-```
-When `balance` reaches 0 and `overage_allowed` is `false`, the user will be blocked.
-</Expandable>
 
 </Step>
 
@@ -228,20 +213,20 @@ const autumn = new Autumn({
 });
 
 await autumn.track({
-  customer_id: "user_123",
-  feature_id: "notifications",
+  customerId: "user_123",
+  featureId: "notifications",
   value: 1,
 });
 ```
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_42424242")
 
 async def main():
-    await autumn.track(
+    autumn.track(
         customer_id="user_123",
         feature_id="notifications",
         value=1,
@@ -251,7 +236,7 @@ asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/track" \
+curl -X POST "https://api.useautumn.com/v1/balances.track" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
@@ -268,7 +253,7 @@ curl -X POST "https://api.useautumn.com/v1/track" \
 <Step>
 #### Switch to Pay-as-you-go
 
-When the user is approaching or has exceeded their limit, prompt them to switch to the Pay-as-you-go plan. Use `attach` with `setup_payment: true` to collect their card without charging upfront.
+When the user is approaching or has exceeded their limit, use `setupPayment` to collect their card and attach the Pay-as-you-go plan after setup.
 
 <Tip>
 You can retrieve the user's notification balance from the `check` or `customer` method, and use this to conditionally prompt them to add a payment method.
@@ -281,19 +266,14 @@ You can retrieve the user's notification balance from the `check` or `customer` 
 import { useCustomer } from "autumn-js/react";
 
 export default function EnableOveragesButton() {
-  const { attach } = useCustomer();
+  const { setupPayment } = useCustomer();
 
   return (
     <button
       onClick={async () => {
-        const { data } = await attach({
-          productId: "pay_as_you_go",
-          setupPayment: true,
+        await setupPayment({
+          planId: "pay_as_you_go",
         });
-
-        if (data?.url) {
-          window.location.href = data.url;
-        }
       }}
     >
       Enable Pay-as-you-go
@@ -309,11 +289,10 @@ const autumn = new Autumn({
   secretKey: 'am_sk_42424242',
 });
 
-const { data } = await autumn.attach({
-  customer_id: "user_123",
-  product_id: "pay_as_you_go",
-  setup_payment: true,
-  success_url: "https://your-app.com/settings",
+const data = await autumn.billing.setupPayment({
+  customerId: "user_123",
+  planId: "pay_as_you_go",
+  successUrl: "https://your-app.com/settings",
 });
 
 if (data.url) {
@@ -323,15 +302,14 @@ if (data.url) {
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_42424242")
 
 async def main():
-    response = await autumn.attach(
+    response = autumn.billing.setup_payment(
         customer_id="user_123",
-        product_id="pay_as_you_go",
-        setup_payment=True,
+        plan_id="pay_as_you_go",
         success_url="https://your-app.com/settings",
     )
     
@@ -343,13 +321,12 @@ asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/attach" \
+curl -X POST "https://api.useautumn.com/v1/billing.setup_payment" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
     "customer_id": "user_123",
-    "product_id": "pay_as_you_go",
-    "setup_payment": true,
+    "plan_id": "pay_as_you_go",
     "success_url": "https://your-app.com/settings"
   }'
 ```
@@ -367,21 +344,6 @@ Once the user completes the setup, they'll be switched from the Free plan to the
 
 After switching to Pay-as-you-go, the user's `check` response will show `overage_allowed: true`. They can continue using the feature beyond their included limit.
 
-<Expandable title="check response (Pay-as-you-go user)">
-```json
-{
-  "allowed": true,
-  "customer_id": "user_123",
-  "feature_id": "notifications",
-  "balance": -200,
-  "usage": 1200,
-  "included_usage": 1000,
-  "unlimited": false,
-  "overage_allowed": true
-}
-```
-The user has sent 1,200 notifications (200 over the limit). They will be billed $0.20 at the end of the billing period.
-</Expandable>
 
 </Step>
 </Steps>

--- a/apps/docs/mintlify/examples/per-seat.mdx
+++ b/apps/docs/mintlify/examples/per-seat.mdx
@@ -95,7 +95,7 @@ When your user signs up, create an Autumn customer. This will automatically assi
 import { useCustomer } from "autumn-js/react";
 
 const App = () => {
-  const { customer } = useCustomer();
+  const { data: customer } = useCustomer();
 
   console.log("Autumn customer:", customer);
 
@@ -110,8 +110,8 @@ const autumn = new Autumn({
   secretKey: 'am_sk_42424242',
 });
 
-const { data, error } = await autumn.customers.create({
-  id: "org_123",
+const customer = await autumn.customers.getOrCreate({
+  customerId: "org_123",
   name: "Acme Corp",
   email: "admin@acme.com",
 });
@@ -119,13 +119,13 @@ const { data, error } = await autumn.customers.create({
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn('am_sk_42424242')
 
 async def main():
-    customer = await autumn.customers.create(
-        id="org_123",
+    customer = autumn.customers.get_or_create(
+        customer_id="org_123",
         name="Acme Corp",
         email="admin@acme.com",
     )
@@ -135,11 +135,11 @@ asyncio.run(main())
 
 ```bash cURL
 curl --request POST \
-  --url https://api.useautumn.com/customers \
+  --url https://api.useautumn.com/v1/customers.get_or_create \
   --header 'Authorization: Bearer am_sk_42424242' \
   --header 'Content-Type: application/json' \
   --data '{
-    "id": "org_123",
+    "customer_id": "org_123",
     "name": "Acme Corp",
     "email": "admin@acme.com"
   }'
@@ -162,7 +162,7 @@ export function AddTeamMember() {
   const { check } = useCustomer();
 
   const handleAddMember = async () => {
-    const { data } = check({ featureId: "seats" });
+    const data = check({ featureId: "seats" });
 
     if (!data?.allowed) {
       // Prompt upgrade or purchase more seats
@@ -182,9 +182,9 @@ const autumn = new Autumn({
   secretKey: 'am_sk_42424242',
 });
 
-const { data } = await autumn.check({
-  customer_id: "org_123",
-  feature_id: "seats",
+const data = await autumn.check({
+  customerId: "org_123",
+  featureId: "seats",
 });
 
 if (!data.allowed) {
@@ -195,12 +195,12 @@ if (!data.allowed) {
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_42424242")
 
 async def main():
-    response = await autumn.check(
+    response = autumn.check(
         customer_id="org_123",
         feature_id="seats",
     )
@@ -213,7 +213,7 @@ asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/check" \
+curl -X POST "https://api.useautumn.com/v1/balances.check" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
@@ -224,26 +224,12 @@ curl -X POST "https://api.useautumn.com/v1/check" \
 
 </CodeGroup>
 
-<Expandable title="check response">
-```json
-{
-  "allowed": true,
-  "customer_id": "org_123",
-  "feature_id": "seats",
-  "balance": 1,
-  "usage": 2,
-  "included_usage": 3,
-  "unlimited": false,
-  "overage_allowed": false
-}
-```
-</Expandable>
 </Step>
 
 <Step>
 #### Track Seat Usage
 
-When team members are added, track seat usage. You can use the `track` endpoint to increment usage, or the `usage` endpoint to set the total directly.
+When team members are added, use `track` to increment usage or `balances.update` to set the total directly.
 
 Remember to track the usage for the initial user as well, after customer creation.
 
@@ -258,38 +244,38 @@ const autumn = new Autumn({
 
 // Increment by 1 when a seat is added
 await autumn.track({
-  customer_id: "org_123",
-  feature_id: "seats",
+  customerId: "org_123",
+  featureId: "seats",
   value: 1,
 });
 
 // Or set the total directly
-await autumn.usage({
-  customer_id: "org_123",
-  feature_id: "seats",
-  value: 2, // Total seats now in use
+await autumn.balances.update({
+  customerId: "org_123",
+  featureId: "seats",
+  usage: 2, // Total seats now in use
 });
 ```
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn('am_sk_42424242')
 
 async def main():
     # Increment by 1 when a seat is added
-    await autumn.track(
+    autumn.track(
         customer_id="org_123",
         feature_id="seats",
         value=1,
     )
     
     # Or set the total directly
-    await autumn.features.set_usage(
+    autumn.balances.update(
         customer_id="org_123",
         feature_id="seats",
-        value=2,  # Total seats now in use
+        usage=2,  # Total seats now in use
     )
 
 asyncio.run(main())
@@ -297,7 +283,7 @@ asyncio.run(main())
 
 ```bash cURL
 # Increment by 1
-curl -X POST "https://api.useautumn.com/v1/track" \
+curl -X POST "https://api.useautumn.com/v1/balances.track" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
@@ -307,13 +293,13 @@ curl -X POST "https://api.useautumn.com/v1/track" \
   }'
 
 # Or set total directly
-curl -X POST "https://api.useautumn.com/v1/usage" \
+curl -X POST "https://api.useautumn.com/v1/balances.update" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
     "customer_id": "org_123",
     "feature_id": "seats",
-    "value": 2
+    "usage": 2
   }'
 ```
 
@@ -328,30 +314,29 @@ Seat usage tracked on the Free tier will **carry over** when the customer upgrad
 <Step>
 #### Upgrade to Pro
 
-When the customer upgrades to Pro, use the `checkout` endpoint. If they need additional paid seats beyond the 5 included, pass the quantity in `options`.
+When the customer upgrades to Pro, attach the plan and pass their total seat quantity in `featureQuantities`.
 
 <Warning>
-The `quantity` in options represents the **additional paid seats only**, not total seats. Pro includes 5 seats, so if the customer wants 8 total seats, pass `quantity: 3`.
+The quantity includes the plan's included seats. If the customer wants 8 total seats, pass `quantity: 8`.
 </Warning>
 
 <CodeGroup>
 
 ```jsx React
-import { useCustomer, CheckoutDialog } from "autumn-js/react";
+import { useCustomer } from "autumn-js/react";
 
 export default function UpgradeButton() {
-  const { checkout } = useCustomer();
+  const { attach } = useCustomer();
 
   return (
     <button
       onClick={async () => {
         // Customer wants 8 total seats (5 included + 3 paid)
-        await checkout({
-          productId: "pro",
-          dialog: CheckoutDialog,
-          options: [{
+        await attach({
+          planId: "pro",
+          featureQuantities: [{
             featureId: "seats",
-            quantity: 3, // 3 paid seats beyond the 5 included
+            quantity: 8,
           }],
         });
       }}
@@ -370,38 +355,38 @@ const autumn = new Autumn({
 });
 
 // Customer wants 8 total seats (5 included + 3 paid)
-const { data } = await autumn.checkout({
-  customer_id: "org_123",
-  product_id: "pro",
-  options: [{
-    feature_id: "seats",
-    quantity: 3, // 3 paid seats beyond the 5 included
+const data = await autumn.billing.attach({
+  customerId: "org_123",
+  planId: "pro",
+  featureQuantities: [{
+    featureId: "seats",
+    quantity: 8,
   }],
 });
 
-if (data.url) {
+if (data.paymentUrl) {
   // Redirect to Stripe checkout
 }
 ```
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_42424242")
 
 async def main():
     # Customer wants 8 total seats (5 included + 3 paid)
-    response = await autumn.checkout(
+    response = autumn.billing.attach(
         customer_id="org_123",
-        product_id="pro",
-        options=[{
+        plan_id="pro",
+        feature_quantities=[{
             "feature_id": "seats",
-            "quantity": 3,  # 3 paid seats beyond the 5 included
+            "quantity": 8,
         }],
     )
     
-    if response.url:
+    if response.payment_url:
         # Redirect to Stripe checkout
         pass
 
@@ -409,15 +394,15 @@ asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/checkout" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
     "customer_id": "org_123",
-    "product_id": "pro",
-    "options": [{
+    "plan_id": "pro",
+    "feature_quantities": [{
       "feature_id": "seats",
-      "quantity": 3
+      "quantity": 8
     }]
   }'
 ```
@@ -425,7 +410,7 @@ curl -X POST "https://api.useautumn.com/v1/checkout" \
 </CodeGroup>
 
 <Tip>
-If the customer only needs the 5 included seats, pass `quantity: 0` or omit the options entirely.
+If the customer only needs the 5 included seats, pass `quantity: 5` or omit `featureQuantities`.
 </Tip>
 
 </Step>
@@ -438,27 +423,26 @@ How you update seat quantity depends on your billing model:
 <Tabs>
 <Tab title="Prepaid">
 
-For prepaid seats, use the `attach` endpoint with updated `options` to change the seat quantity. This will handle proration based on your configuration.
+For prepaid seats, use `billing.update` with the new total quantity. This handles proration based on your configuration.
 
 <CodeGroup>
 
 ```jsx React
-import { useCustomer, CheckoutDialog } from "autumn-js/react";
+import { useCustomer } from "autumn-js/react";
 
 export default function AddSeatsButton() {
-  const { checkout } = useCustomer();
+  const { updateSubscription } = useCustomer();
 
   return (
     <button
       onClick={async () => {
-        // Increase from 3 paid seats to 5 paid seats
+        // Increase from 8 total seats to 10 total seats
         // (8 total → 10 total)
-        await checkout({
-          productId: "pro",
-          dialog: CheckoutDialog,
-          options: [{
+        await updateSubscription({
+          planId: "pro",
+          featureQuantities: [{
             featureId: "seats",
-            quantity: 5, // New paid seat count
+            quantity: 10,
           }],
         });
       }}
@@ -476,31 +460,31 @@ const autumn = new Autumn({
   secretKey: 'am_sk_42424242',
 });
 
-// Increase from 3 paid seats to 5 paid seats (8 total → 10 total)
-const { data } = await autumn.attach({
-  customer_id: "org_123",
-  product_id: "pro",
-  options: [{
-    feature_id: "seats",
-    quantity: 5, // New paid seat count
+// Increase from 8 total seats to 10 total seats
+const data = await autumn.billing.update({
+  customerId: "org_123",
+  planId: "pro",
+  featureQuantities: [{
+    featureId: "seats",
+    quantity: 10,
   }],
 });
 ```
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_42424242")
 
 async def main():
-    # Increase from 3 paid seats to 5 paid seats (8 total → 10 total)
-    response = await autumn.attach(
+    # Increase from 8 total seats to 10 total seats
+    response = autumn.billing.update(
         customer_id="org_123",
-        product_id="pro",
-        options=[{
+        plan_id="pro",
+        feature_quantities=[{
             "feature_id": "seats",
-            "quantity": 5,  # New paid seat count
+            "quantity": 10,
         }],
     )
 
@@ -508,15 +492,15 @@ asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/attach" \
+curl -X POST "https://api.useautumn.com/v1/billing.update" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
     "customer_id": "org_123",
-    "product_id": "pro",
-    "options": [{
+    "plan_id": "pro",
+    "feature_quantities": [{
       "feature_id": "seats",
-      "quantity": 5
+      "quantity": 10
     }]
   }'
 ```
@@ -526,8 +510,8 @@ curl -X POST "https://api.useautumn.com/v1/attach" \
 <Info>
 **Prepaid quantity math:**
 - Pro includes 5 seats
-- Current: `quantity: 3` → 8 total seats (5 + 3)
-- Updated: `quantity: 5` → 10 total seats (5 + 5)
+- Current: `quantity: 8`
+- Updated: `quantity: 10`
 - Customer is charged prorated amount for 2 additional seats
 </Info>
 
@@ -547,38 +531,38 @@ const autumn = new Autumn({
 
 // When a new team member is added
 await autumn.track({
-  customer_id: "org_123",
-  feature_id: "seats",
+  customerId: "org_123",
+  featureId: "seats",
   value: 1,
 });
 
 // Or set the exact count
-await autumn.usage({
-  customer_id: "org_123",
-  feature_id: "seats",
-  value: 10, // Now using 10 seats total
+await autumn.balances.update({
+  customerId: "org_123",
+  featureId: "seats",
+  usage: 10, // Now using 10 seats total
 });
 ```
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn('am_sk_42424242')
 
 async def main():
     # When a new team member is added
-    await autumn.track(
+    autumn.track(
         customer_id="org_123",
         feature_id="seats",
         value=1,
     )
     
     # Or set the exact count
-    await autumn.features.set_usage(
+    autumn.balances.update(
         customer_id="org_123",
         feature_id="seats",
-        value=10,  # Now using 10 seats total
+        usage=10,  # Now using 10 seats total
     )
 
 asyncio.run(main())
@@ -586,7 +570,7 @@ asyncio.run(main())
 
 ```bash cURL
 # Increment when adding a seat
-curl -X POST "https://api.useautumn.com/v1/track" \
+curl -X POST "https://api.useautumn.com/v1/balances.track" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
@@ -596,13 +580,13 @@ curl -X POST "https://api.useautumn.com/v1/track" \
   }'
 
 # Or set the exact count
-curl -X POST "https://api.useautumn.com/v1/usage" \
+curl -X POST "https://api.useautumn.com/v1/balances.update" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
     "customer_id": "org_123",
     "feature_id": "seats",
-    "value": 10
+    "usage": 10
   }'
 ```
 
@@ -624,7 +608,7 @@ When team members leave, you'll want to decrease the seat count.
 <Tabs>
 <Tab title="Prepaid">
 
-Update the `options` with a lower quantity. Depending on your proration configuration, the customer may receive a credit.
+Update `featureQuantities` with the lower total quantity. Depending on your proration configuration, the customer may receive a credit.
 
 <CodeGroup>
 
@@ -635,31 +619,31 @@ const autumn = new Autumn({
   secretKey: 'am_sk_42424242',
 });
 
-// Decrease from 5 paid seats to 2 paid seats (10 total → 7 total)
-const { data } = await autumn.attach({
-  customer_id: "org_123",
-  product_id: "pro",
-  options: [{
-    feature_id: "seats",
-    quantity: 2, // New paid seat count
+// Decrease from 10 total seats to 7 total seats
+const data = await autumn.billing.update({
+  customerId: "org_123",
+  planId: "pro",
+  featureQuantities: [{
+    featureId: "seats",
+    quantity: 7,
   }],
 });
 ```
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_42424242")
 
 async def main():
-    # Decrease from 5 paid seats to 2 paid seats (10 total → 7 total)
-    response = await autumn.attach(
+    # Decrease from 10 total seats to 7 total seats
+    response = autumn.billing.update(
         customer_id="org_123",
-        product_id="pro",
-        options=[{
+        plan_id="pro",
+        feature_quantities=[{
             "feature_id": "seats",
-            "quantity": 2,  # New paid seat count
+            "quantity": 7,
         }],
     )
 
@@ -667,15 +651,15 @@ asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/attach" \
+curl -X POST "https://api.useautumn.com/v1/billing.update" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
     "customer_id": "org_123",
-    "product_id": "pro",
-    "options": [{
+    "plan_id": "pro",
+    "feature_quantities": [{
       "feature_id": "seats",
-      "quantity": 2
+      "quantity": 7
     }]
   }'
 ```
@@ -698,38 +682,38 @@ const autumn = new Autumn({
 
 // Decrement by 1 when a seat is removed
 await autumn.track({
-  customer_id: "org_123",
-  feature_id: "seats",
+  customerId: "org_123",
+  featureId: "seats",
   value: -1,
 });
 
 // Or set the new total
-await autumn.usage({
-  customer_id: "org_123",
-  feature_id: "seats",
-  value: 7, // Now using 7 seats
+await autumn.balances.update({
+  customerId: "org_123",
+  featureId: "seats",
+  usage: 7, // Now using 7 seats
 });
 ```
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn('am_sk_42424242')
 
 async def main():
     # Decrement by 1 when a seat is removed
-    await autumn.track(
+    autumn.track(
         customer_id="org_123",
         feature_id="seats",
         value=-1,
     )
     
     # Or set the new total
-    await autumn.features.set_usage(
+    autumn.balances.update(
         customer_id="org_123",
         feature_id="seats",
-        value=7,  # Now using 7 seats
+        usage=7,  # Now using 7 seats
     )
 
 asyncio.run(main())
@@ -737,7 +721,7 @@ asyncio.run(main())
 
 ```bash cURL
 # Decrement by 1
-curl -X POST "https://api.useautumn.com/v1/track" \
+curl -X POST "https://api.useautumn.com/v1/balances.track" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
@@ -747,13 +731,13 @@ curl -X POST "https://api.useautumn.com/v1/track" \
   }'
 
 # Or set new total
-curl -X POST "https://api.useautumn.com/v1/usage" \
+curl -X POST "https://api.useautumn.com/v1/balances.update" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
     "customer_id": "org_123",
     "feature_id": "seats",
-    "value": 7
+    "usage": 7
   }'
 ```
 
@@ -768,5 +752,5 @@ curl -X POST "https://api.useautumn.com/v1/usage" \
 
 | Billing Model | Add Seats | Remove Seats | When Billed |
 |---------------|-----------|--------------|-------------|
-| **Prepaid** | `attach` with new `quantity` | `attach` with lower `quantity` | Immediately (prorated) |
-| **Usage-based** | `track` or `usage` | `track` (negative) or `usage` | End of billing cycle |
+| **Prepaid** | `billing.update` with new `quantity` | `billing.update` with lower `quantity` | Immediately (prorated) |
+| **Usage-based** | `track` or `balances.update` | Negative `track` or `balances.update` | End of billing cycle |

--- a/apps/docs/mintlify/examples/prepaid.mdx
+++ b/apps/docs/mintlify/examples/prepaid.mdx
@@ -73,7 +73,7 @@ When your user signs up, create an Autumn customer. This will automatically assi
 import { useCustomer } from "autumn-js/react";
 
 const App = () => {
-  const { customer } = useCustomer();
+  const { data: customer } = useCustomer();
 
   console.log("Autumn customer:", customer);
 
@@ -88,8 +88,8 @@ const autumn = new Autumn({
   secretKey: 'am_sk_42424242',
 });
 
-const { data, error } = await autumn.customers.create({
-  id: "user_or_org_id_from_auth",
+const customer = await autumn.customers.getOrCreate({
+  customerId: "user_or_org_id_from_auth",
   name: "John Yeo",
   email: "john@example.com",
 });
@@ -97,13 +97,13 @@ const { data, error } = await autumn.customers.create({
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn('am_sk_42424242')
 
 async def main():
-    customer = await autumn.customers.create(
-        id="user_or_org_id_from_auth",
+    customer = autumn.customers.get_or_create(
+        customer_id="user_or_org_id_from_auth",
         name="John Yeo",
         email="john@example.com",
     )
@@ -113,11 +113,11 @@ asyncio.run(main())
 
 ```bash cURL
 curl --request POST \
-  --url https://api.useautumn.com/customers \
+  --url https://api.useautumn.com/v1/customers.get_or_create \
   --header 'Authorization: Bearer am_sk_42424242' \
   --header 'Content-Type: application/json' \
   --data '{
-    "id": "user_or_org_id_from_auth",
+    "customer_id": "user_or_org_id_from_auth",
     "name": "John Yeo",
     "email": "john@example.com"
   }'
@@ -140,9 +140,9 @@ export function CheckPremiumMessage() {
   const { check, refetch } = useCustomer();
 
   const handleCheckAccess = async () => {
-    const { data } = await check({ featureId: "messages" });
+    const { allowed } = check({ featureId: "messages" });
 
-    if (!data?.allowed) {
+    if (!allowed) {
       alert("You've run out of messages");
     } else {
       // proceed with sending message
@@ -159,9 +159,9 @@ const autumn = new Autumn({
   secretKey: 'am_sk_42424242',
 });
 
-const { data } = await autumn.check({
-  customer_id: "user_or_org_id_from_auth",
-  feature_id: "messages",
+const data = await autumn.check({
+  customerId: "user_or_org_id_from_auth",
+  featureId: "messages",
 });
 
 if (!data.allowed) {
@@ -172,12 +172,12 @@ if (!data.allowed) {
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_1234567890")
 
 async def main():
-    response = await autumn.check(
+    response = autumn.check(
         customer_id="user_or_org_id_from_auth",
         feature_id="messages",
     )
@@ -190,7 +190,7 @@ asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/check" \
+curl -X POST "https://api.useautumn.com/v1/balances.check" \
   -H "Authorization: Bearer am_sk_1234567890" \
   -H "Content-Type: application/json" \
   -d '{
@@ -201,24 +201,6 @@ curl -X POST "https://api.useautumn.com/v1/check" \
 
 </CodeGroup>
 
-<Expandable title="check response">
-```json
-{
-  "customer_id": "user_or_org_id_from_auth",
-  "feature_id": "messages",
-  "code": "feature_found",
-  "allowed": true,
-  "balance": 10,
-  "usage": 0,
-  "included_usage": 10,
-  "unlimited": false,
-  "interval": null,
-  "interval_count": 1,
-  "next_reset_at": 2803498203,
-  "overage_allowed": false
-}
-```
-</Expandable>
 </Step>
 
 <Step>
@@ -236,20 +218,20 @@ const autumn = new Autumn({
 });
 
 await autumn.track({
-  customer_id: "user_or_org_id_from_auth",
-  feature_id: "messages",
+  customerId: "user_or_org_id_from_auth",
+  featureId: "messages",
   value: 5,
 });
 ```
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_42424242")
 
 async def main():
-    await autumn.track(
+    autumn.track(
         customer_id="user_or_org_id_from_auth",
         feature_id="messages",
         value=5,
@@ -259,7 +241,7 @@ asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/track" \
+curl -X POST "https://api.useautumn.com/v1/balances.track" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
@@ -271,15 +253,6 @@ curl -X POST "https://api.useautumn.com/v1/track" \
 
 </CodeGroup>
 
-<Expandable title="track response">
-```json
-{
-  "code": "event_received",
-  "customer_id": "user_or_org_id_from_auth",
-  "feature_id": "messages"
-}
-```
-</Expandable>
 </Step>
 
 <Step>
@@ -290,18 +263,17 @@ When users run out of messages, they can purchase additional messages using our 
 <CodeGroup>
 
 ```jsx React
-import { useCustomer, CheckoutDialog } from "autumn-js/react";
+import { useCustomer } from "autumn-js/react";
 
 export default function TopUpButton() {
-  const { checkout } = useCustomer();
+  const { attach } = useCustomer();
 
   return (
     <button
       onClick={async () => {
-        await checkout({
-          productId: "top_up",
-          dialog: CheckoutDialog,
-          options: [{
+        await attach({
+          planId: "top_up",
+          featureQuantities: [{
             featureId: "messages",
             quantity: 200,
           }],
@@ -321,16 +293,16 @@ const autumn = new Autumn({
   secretKey: 'am_sk_42424242',
 });
 
-const { data } = await autumn.checkout({
-  customer_id: "user_or_org_id_from_auth",
-  product_id: "top_up",
-  options: [{
-    feature_id: "messages",
+const data = await autumn.billing.attach({
+  customerId: "user_or_org_id_from_auth",
+  planId: "top_up",
+  featureQuantities: [{
+    featureId: "messages",
     quantity: 200,
   }],
 });
 
-if (data.url) {
+if (data.paymentUrl) {
   // Redirect user to Stripe checkout URL
 } else {
   // Show purchase preview to user
@@ -339,21 +311,21 @@ if (data.url) {
 
 ```python Python
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_42424242")
 
 async def main():
-    response = await autumn.checkout(
+    response = autumn.billing.attach(
         customer_id="user_or_org_id_from_auth",
-        product_id="top-up",
-        options=[{
+        plan_id="top-up",
+        feature_quantities=[{
           "feature_id": "messages",
           "quantity": 200,
         }],
     )
     
-    if response.url:
+    if response.payment_url:
         # Redirect user to Stripe checkout URL
         pass
     else:
@@ -364,13 +336,13 @@ asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/checkout" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
     "customer_id": "user_or_org_id_from_auth",
-    "product_id": "top-up",
-    "options": [{
+    "plan_id": "top-up",
+    "feature_quantities": [{
       "feature_id": "messages",
       "quantity": 200
     }]
@@ -379,116 +351,37 @@ curl -X POST "https://api.useautumn.com/v1/checkout" \
 
 </CodeGroup>
 
-<Expandable title="checkout response">
-```json
-{
-  "customer_id": "user_or_org_id_from_auth",
-  "lines": [
-    {
-      "description": "Top-up - 200 premium messages",
-      "amount": 20,
-      "item": {
-        "type": "feature",
-        "feature_id": "premium-messages",
-        "feature_type": "prepaid",
-        "feature": {
-          "id": "premium-messages",
-          "name": "Premium messages",
-          "type": "metered",
-          "display": {
-            "singular": "premium message",
-            "plural": "premium messages"
-          }
-        },
-        "quantity": 200,
-        "price": 10,
-        "price_per": 100,
-        "display": {
-          "primary_text": "200 premium messages",
-          "secondary_text": "$10 per 100 messages"
-        }
-      }
-    }
-  ],
-  "product": {
-    "id": "top-up",
-    "name": "Top-up",
-    "group": null,
-    "env": "sandbox",
-    "is_add_on": false,
-    "is_default": false,
-    "archived": false,
-    "version": 1,
-    "created_at": 1766428038264,
-    "items": [
-      {
-        "type": "feature",
-        "feature_id": "premium-messages",
-        "feature_type": "prepaid",
-        "feature": {
-          "id": "premium-messages",
-          "name": "Premium messages",
-          "type": "metered",
-          "display": {
-            "singular": "premium message",
-            "plural": "premium messages"
-          }
-        },
-        "price": 10,
-        "price_per": 100,
-        "display": {
-          "primary_text": "$10 per 100 messages"
-        }
-      }
-    ],
-    "free_trial": null,
-    "base_variant_id": null,
-    "scenario": "attach",
-    "properties": {
-      "is_free": false,
-      "is_one_off": true,
-      "has_trial": false,
-      "updateable": false
-    }
-  },
-  "total": 20,
-  "currency": "usd",
-  "url": "https://checkout.stripe.com/c/pay/.......",
-  "has_prorations": false
-}
-```
-</Expandable>
 
 Once the customer completes the payment, they will have an additional 200 premium messages available to use.
 
 </Step>
 <Step>
 #### Displaying balances to the user
-You can display to the user by getting balances from the `customer` method. Under the `customer.features` record, you'll be able to retrieve a current balance, total granted, and a `breakdown` of their monthly vs top-up messages.
+The customer response exposes each feature balance under `balances`, including a `breakdown` of its monthly and top-up sources.
 
 <CodeGroup>
 
 ```jsx React [expandable]
 import { useCustomer } from "autumn-js/react";
 
-const { customer } = useCustomer();
+const { data: customer } = useCustomer();
 
-const messages = customer?.features?.messages;
+const messages = customer?.balances?.messages;
 
 // Get breakdown of monthly vs prepaid balances
 const monthlyBalance = messages?.breakdown?.find(
-  (b) => b.interval === "month"
+  (b) => b.reset?.interval === "month"
 );
 const prepaidBalance = messages?.breakdown?.find(
-  (b) => b.interval === "lifetime"
+  (b) => b.reset?.interval === "one_off"
 );
 
 // Display both balances to the user
 return (
   <div>
-    <p>Monthly: {monthlyBalance?.balance ?? 0} remaining</p>
-    <p>Prepaid: {prepaidBalance?.balance ?? 0} remaining</p>
-    <p>Total: {messages?.balance ?? 0} messages available</p>
+    <p>Monthly: {monthlyBalance?.remaining ?? 0} remaining</p>
+    <p>Prepaid: {prepaidBalance?.remaining ?? 0} remaining</p>
+    <p>Total: {messages?.remaining ?? 0} messages available</p>
   </div>
 );
 ```
@@ -500,100 +393,60 @@ const autumn = new Autumn({
   secretKey: 'am_sk_42424242',
 });
 
-const { data } = await autumn.customer({
-  customer_id: "user_or_org_id_from_auth",
+const data = await autumn.customers.get({
+  customerId: "user_or_org_id_from_auth",
 });
 
-const messages = data?.features?.messages;
+const messages = data.balances?.messages;
 
 // Extract monthly vs prepaid balances from the breakdown
 const monthlyBalance = messages?.breakdown?.find(
-  (b) => b.interval === "month"
+  (b) => b.reset?.interval === "month"
 );
 const prepaidBalance = messages?.breakdown?.find(
-  (b) => b.interval === "lifetime"
+  (b) => b.reset?.interval === "one_off"
 );
 
-console.log(`Monthly: ${monthlyBalance?.balance ?? 0} remaining`);
-console.log(`Prepaid: ${prepaidBalance?.balance ?? 0} remaining`);
-console.log(`Total: ${messages?.balance ?? 0} messages available`);
+console.log(`Monthly: ${monthlyBalance?.remaining ?? 0} remaining`);
+console.log(`Prepaid: ${prepaidBalance?.remaining ?? 0} remaining`);
+console.log(`Total: ${messages?.remaining ?? 0} messages available`);
 ```
 
 ```python Python [expandable]
 import asyncio
-from autumn import Autumn
+from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_42424242")
 
 async def main():
-    response = await autumn.customer(
+    response = autumn.customers.get(
         customer_id="user_or_org_id_from_auth",
     )
     
-    messages = response.features.get("messages", {})
-    breakdown = messages.get("breakdown", [])
+    messages = response.balances.get("messages")
+    breakdown = messages.breakdown if messages else []
     
     # Extract monthly vs prepaid balances
-    monthly = next((b for b in breakdown if b.get("interval") == "month"), None)
-    prepaid = next((b for b in breakdown if b.get("interval") == "lifetime"), None)
+    monthly = next((b for b in breakdown if b.reset and b.reset.interval == "month"), None)
+    prepaid = next((b for b in breakdown if b.reset and b.reset.interval == "one_off"), None)
     
-    print(f"Monthly: {monthly['balance'] if monthly else 0} remaining")
-    print(f"Prepaid: {prepaid['balance'] if prepaid else 0} remaining")
-    print(f"Total: {messages.get('balance', 0)} messages available")
+    print(f"Monthly: {monthly.remaining if monthly else 0} remaining")
+    print(f"Prepaid: {prepaid.remaining if prepaid else 0} remaining")
+    print(f"Total: {messages.remaining if messages else 0} messages available")
 
 asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X GET "https://api.useautumn.com/v1/customers/user_or_org_id_from_auth" \
+curl -X POST "https://api.useautumn.com/v1/customers.get" \
   -H "Authorization: Bearer am_sk_42424242" \
-  -H "Content-Type: application/json"
+  -H "Content-Type: application/json" \
+  -d '{ "customer_id": "user_or_org_id_from_auth" }'
 
-  # get features usage object from customer.features.[feature_id]
+  # Read the feature from customer.balances.[feature_id]
 ```
 
 </CodeGroup>
 
-<Expandable title="customer response">
-```json
-{
-"features": {
-    "messages": {
-      "id": "messages",
-      "type": "single_use",
-      "name": "Messages",
-      "interval": "multiple",
-      "interval_count": null,
-      "unlimited": false,
-      "balance": 205,
-      "usage": 5,
-      "included_usage": 210,
-      "next_reset_at": null,
-      "overage_allowed": false,
-      "breakdown": [
-        {
-          "interval": "month",
-          "interval_count": 1,
-          "balance": 5,
-          "usage": 5,
-          "included_usage": 10,
-          "next_reset_at": 1772191445539,
-          "overage_allowed": false
-        },
-        {
-          "interval": "lifetime",
-          "interval_count": 1,
-          "balance": 200,
-          "usage": 0,
-          "included_usage": 200,
-          "next_reset_at": null,
-          "overage_allowed": false
-        }
-      ]
-    }
-  },
-}
-```
-</Expandable>
 </Step>
 </Steps>

--- a/apps/docs/mintlify/examples/trial-card-not-required.mdx
+++ b/apps/docs/mintlify/examples/trial-card-not-required.mdx
@@ -82,14 +82,14 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-response = await autumn.billing.attach(
+response = autumn.billing.attach(
     customer_id="user_123",
     plan_id="pro",
 )
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/attach" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -140,7 +140,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-response = await autumn.billing.setup_payment(
+response = autumn.billing.setup_payment(
     customer_id="user_123",
     success_url="https://your-app.com/success",
 )
@@ -234,14 +234,14 @@ from autumn_sdk import Autumn
 autumn = Autumn("am_sk_test_1234")
 
 # Cancel the trial immediately
-await autumn.billing.update(
+autumn.billing.update(
     customer_id="user_123",
     plan_id="pro",
     cancel_action="cancel_immediately",
 )
 
 # Attach the plan again with a reward
-response = await autumn.billing.attach(
+response = autumn.billing.attach(
     customer_id="user_123",
     plan_id="pro",
     reward="early_end",
@@ -252,7 +252,7 @@ print("Trial ended early")
 
 ```bash cURL
 # Cancel the trial immediately
-curl -X POST "https://api.useautumn.com/v1/billing/update" \
+curl -X POST "https://api.useautumn.com/v1/billing.update" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -262,7 +262,7 @@ curl -X POST "https://api.useautumn.com/v1/billing/update" \
   }'
 
 # Attach the plan again with a reward
-curl -X POST "https://api.useautumn.com/v1/attach" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{

--- a/apps/docs/mintlify/examples/trial-card-required.mdx
+++ b/apps/docs/mintlify/examples/trial-card-required.mdx
@@ -72,7 +72,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-response = await autumn.billing.attach(
+response = autumn.billing.attach(
     customer_id="user_123",
     plan_id="pro",
 )
@@ -80,7 +80,7 @@ response = await autumn.billing.attach(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/attach" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -123,7 +123,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-response = await autumn.billing.attach(
+response = autumn.billing.attach(
     customer_id="user_123",
     plan_ids=["pro", "trial_fee"],
 )
@@ -131,7 +131,7 @@ response = await autumn.billing.attach(
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/attach" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -212,14 +212,14 @@ from autumn_sdk import Autumn
 autumn = Autumn("am_sk_test_1234")
 
 # Cancel the trial immediately
-await autumn.billing.update(
+autumn.billing.update(
     customer_id="user_123",
     plan_id="pro",
     cancel_action="cancel_immediately",
 )
 
 # Attach the plan again with a reward
-response = await autumn.billing.attach(
+response = autumn.billing.attach(
     customer_id="user_123",
     plan_id="pro",
     reward="early_end",
@@ -230,7 +230,7 @@ print("Trial ended early")
 
 ```bash cURL
 # Cancel the trial immediately
-curl -X POST "https://api.useautumn.com/v1/billing/update" \
+curl -X POST "https://api.useautumn.com/v1/billing.update" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -240,7 +240,7 @@ curl -X POST "https://api.useautumn.com/v1/billing/update" \
   }'
 
 # Attach the plan again with a reward
-curl -X POST "https://api.useautumn.com/v1/attach" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{
@@ -292,7 +292,7 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_test_1234")
 
-await autumn.billing.update(
+autumn.billing.update(
     customer_id="user_123",
     plan_id="pro",
     cancel_action="cancel_end_of_cycle",
@@ -302,7 +302,7 @@ print("Trial cancelled")
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/billing/update" \
+curl -X POST "https://api.useautumn.com/v1/billing.update" \
   -H "Authorization: Bearer am_sk_test_1234" \
   -H "Content-Type: application/json" \
   -d '{

--- a/apps/docs/mintlify/react/hooks/autumn-handler.mdx
+++ b/apps/docs/mintlify/react/hooks/autumn-handler.mdx
@@ -48,8 +48,8 @@ export const { GET, POST } = autumnHandler({
   Function that receives the incoming request and returns customer identification data.
   
   <Expandable title="AuthResult">
-    <ParamField body="customerId" type="string" required>
-      The unique identifier for the customer.
+    <ParamField body="customerId" type="string | null">
+      The unique identifier for the customer. Return `null` when the request is unauthenticated.
     </ParamField>
 
     <ParamField body="customerData" type="CustomerData">
@@ -68,8 +68,4 @@ export const { GET, POST } = autumnHandler({
 
 <ParamField body="pathPrefix" type="string">
   Path prefix for routes. Defaults to `/api/autumn`.
-</ParamField>
-
-<ParamField body="suppressLogs" type="boolean">
-  If true, suppresses console warnings and logs.
 </ParamField>

--- a/apps/docs/mintlify/react/hooks/autumn-provider.mdx
+++ b/apps/docs/mintlify/react/hooks/autumn-provider.mdx
@@ -44,10 +44,6 @@ export default function RootLayout({ children }) {
   Include credentials (cookies) in cross-origin requests. Defaults to true if `useBetterAuth` is true.
 </ParamField>
 
-<ParamField body="queryClient" type="QueryClient">
-  Custom TanStack Query client. Uses a default client if not provided.
-</ParamField>
-
-<ParamField body="suppressLogs" type="boolean">
-  If true, suppresses console warnings and logs.
+<ParamField body="headers" type="Record<string, string>">
+  Additional headers to include with every request to your backend.
 </ParamField>

--- a/apps/docs/mintlify/react/hooks/useAggregateEvents.mdx
+++ b/apps/docs/mintlify/react/hooks/useAggregateEvents.mdx
@@ -8,7 +8,7 @@ import LearnHooksTip from '/snippets/learn-hooks-tip.mdx';
 
 The `useAggregateEvents` hook provides access to usage analytics and reporting data. 
 
-It fetches data from the [/events/aggregate](/api-reference/events/aggregate-events) endpoint, that can be displayed in a chart (typically via a library like Recharts).
+It fetches data from the [`events.aggregate`](/api-reference/events/aggregateEvents) endpoint, which can be displayed in a chart (typically via a library like Recharts).
 
 <LearnHooksTip />
 
@@ -18,17 +18,20 @@ It fetches data from the [/events/aggregate](/api-reference/events/aggregate-eve
   The feature ID or array of feature IDs to query usage data for.
 </ParamField>
 
+<ParamField body="entityId" type="string">
+  Filter events to an entity.
+</ParamField>
+
 <ParamField body="groupBy" type="string">
-Aggregate data by an event properties paramater. This property is metadata passed in the event endpoint. Should be formatted as `properties.<event_property>`
+  Group by an event property (`properties.<name>`) or by `$customer_id`, `$entity_id`, or `$plan_id`.
 </ParamField>
 
 <ParamField body="range" type="string">
-  Time range for the analytics query. Available options: "24h", "7d", "30d", "90d", "last_cycle", "1bc", "3bc". "bc" refers to billing cycle. Defaults to "30d" if not provided.
-
+  `"24h"` | `"7d"` | `"30d"` | `"90d"` | `"last_cycle"` | `"1bc"` | `"3bc"`. Defaults to `"1bc"` when neither `range` nor `customRange` is provided.
 </ParamField>
 
 <ParamField body="binSize" type="string">
-  Granularity of the time bins for the data points. Available options: "day", "hour". Defaults to "day".
+  `"hour"` | `"day"` | `"week"` | `"month"`. Defaults to `"hour"` for a `24h` range and `"day"` otherwise.
 </ParamField>
 
 <ParamField body="customRange" type="object">
@@ -45,6 +48,14 @@ Aggregate data by an event properties paramater. This property is metadata passe
   </Expandable>
 </ParamField>
 
+<ParamField body="filterBy" type="Record<string, string>">
+  Filter events by up to five property values.
+</ParamField>
+
+<ParamField body="maxGroups" type="number">
+  Maximum distinct group values per time bin when using `groupBy`. Defaults to 9.
+</ParamField>
+
 <QueryOptionsParam />
 
 ## Returns
@@ -53,7 +64,8 @@ Aggregate data by an event properties paramater. This property is metadata passe
 
 Array of aggregated event data points for each time period. Each `AggregatedEventRow` includes:
 - `period`: Unix timestamp in milliseconds representing the start of the time period
-- Dynamic properties for each queried `featureId` with their usage amounts
+- `values`: Usage amounts keyed by feature ID
+- `groupedValues`: Values keyed by feature ID and group value when `groupBy` is used
 
 <Expandable title="list example">
 
@@ -61,14 +73,18 @@ Array of aggregated event data points for each time period. Each `AggregatedEven
 [
     {
         "period": 1765411200000,
-        "basic_messages": 3,
-        "premium_messages": 5
+        "values": {
+          "basic_messages": 3,
+          "premium_messages": 5
+        }
     },
     {
         "period": 1765497600000,
-        "basic_messages": 1,
-        "premium_messages": 2
-    },
+        "values": {
+          "basic_messages": 1,
+          "premium_messages": 2
+        }
+    }
 ]
 ```
 

--- a/apps/docs/mintlify/react/hooks/useCustomer.mdx
+++ b/apps/docs/mintlify/react/hooks/useCustomer.mdx
@@ -12,11 +12,11 @@ The `useCustomer` hook fetches customer data and provides billing actions like a
 ## Parameters
 
 <ParamField body="errorOnNotFound" type="boolean">
-  Whether to throw an error if the customer is not found. Defaults to `false`.
+  Whether to throw when the request cannot identify a customer. Defaults to `true`.
 </ParamField>
 
 <ParamField body="expand" type="CustomerExpand[]">
-  Array of additional data to include in the response. Options: `invoices`, `trials_used`, `rewards`, `entities`, `referrals`, `payment_method`, `subscriptions.plan`, `purchases.plan`, `balances.feature`.
+  Additional data to include. Options: `invoices`, `trials_used`, `rewards`, `entities`, `referrals`, `payment_method`, `subscriptions.plan`, `purchases.plan`, `balances.feature`, `flags.feature`, `billing_controls.auto_topups.purchase_limit`.
 </ParamField>
 
 <ParamField body="queryOptions" type="UseQueryOptions">
@@ -159,7 +159,7 @@ export default function SendMessageButton() {
 
 **Parameters**
 
-<ParamField body="featureId" type="string">
+<ParamField body="featureId" type="string" required>
   The ID of the feature to check access for.
 </ParamField>
 

--- a/apps/docs/mintlify/react/hooks/useListEvents.mdx
+++ b/apps/docs/mintlify/react/hooks/useListEvents.mdx
@@ -8,22 +8,26 @@ import LearnHooksTip from '/snippets/learn-hooks-tip.mdx';
 
 The `useListEvents` hook provides access to individual event records with pagination. 
 
-It fetches data from the [/events/list](/api-reference/events/list-events) endpoint, allowing you to display detailed event logs and histories.
+It fetches data from the [`events.list`](/api-reference/events/listEvents) endpoint, allowing you to display detailed event logs and histories.
 
 <LearnHooksTip />
 
 ## Parameters
 
-<ParamField body="featureId" type="string | string[]" required>
+<ParamField body="featureId" type="string | string[]">
   The feature ID or array of feature IDs to query events for.
 </ParamField>
 
-<ParamField body="offset" type="number">
-  Number of events to skip for pagination. Defaults to 0.
+<ParamField body="entityId" type="string">
+  Filter events to an entity.
+</ParamField>
+
+<ParamField body="startCursor" type="string">
+  Cursor at which to start pagination.
 </ParamField>
 
 <ParamField body="limit" type="number">
-  Maximum number of events to return per page. Defaults to 50.
+  Maximum number of events to return per page. Defaults to 100.
 </ParamField>
 
 <ParamField body="customRange" type="object">
@@ -53,6 +57,7 @@ Array of individual event records. Each event object includes:
 - `customerId`: The customer that recorded this event
 - `value`: The numeric value recorded with the event
 - `properties`: Metadata and custom properties for the event
+- `deductions`: Balance deductions caused by the event, or `null`
 
 <Expandable title="list example">
 
@@ -121,9 +126,8 @@ Function to navigate to the previous page of events. Only call when `hasPrevious
 
 ### `goToPage()`
 
-Function to jump to a specific page number. Accepts a page number (1-based) as parameter.
+Jump to an already visited page with `goToPage({ pageNum })`. Page numbers are 0-based.
 
 ### `resetPagination()`
 
 Function to reset pagination back to the first page.
-

--- a/apps/docs/mintlify/react/hooks/useListPlans.mdx
+++ b/apps/docs/mintlify/react/hooks/useListPlans.mdx
@@ -11,6 +11,18 @@ The `useListPlans` hook fetches all available plans configured in your Autumn da
 
 ## Parameters
 
+<ParamField body="customerId" type="string">
+  Return plan scenarios for a customer.
+</ParamField>
+
+<ParamField body="entityId" type="string">
+  Return plan scenarios for an entity.
+</ParamField>
+
+<ParamField body="includeArchived" type="boolean">
+  Include archived plans.
+</ParamField>
+
 <ParamField body="queryOptions" type="UseQueryOptions">
   Optional [TanStack Query options](https://tanstack.com/query/latest/docs/framework/react/reference/useQuery) to customize caching and refetching behavior.
 </ParamField>

--- a/apps/docs/mintlify/snippets/create-plans.mdx
+++ b/apps/docs/mintlify/snippets/create-plans.mdx
@@ -1,5 +1,5 @@
 <Tip>
-Browse our [Examples](/examples) for guides on setting up credit systems, top ups and other common pricing models.
+Browse our [Examples](/examples/monetary-credits) for guides on setting up credit systems, top ups and other common pricing models.
 </Tip>
 <Tabs>
 <Tab title="CLI">

--- a/apps/docs/mintlify/welcome.mdx
+++ b/apps/docs/mintlify/welcome.mdx
@@ -76,7 +76,7 @@ Your subscriptions live in Stripe. You're never locked in.
 <Accordion title="Do I need to call Autumn before every action?">
 For latency-sensitive operations, you may not want to make an `autumn.check()` network call before every action.
 
-You can either cache the Autumn customer data on your end, or use the `customer.products.updated` webhook to replicate Autumn state into your own system.
+You can either cache the Autumn customer data on your end, or use the `billing.updated` webhook to replicate plan changes into your own system.
 </Accordion>
 
 <Accordion title="What if Autumn goes down?">
@@ -104,7 +104,7 @@ For larger companies, we provide a forward-deployed service: dual-write to your 
 </Accordion>
 
 <Accordion title="Can you handle our event volume?">
-Autumn supports 10,000+ events per second per end customer. If you have specific throughput requirements, reach out and we'll walk through the architecture.
+The default track limit is 10,000 requests per second per customer, with an organization-wide cap. See [Rate Limits](/documentation/rate-limits), or contact us for higher throughput.
 </Accordion>
 
 </AccordionGroup>


### PR DESCRIPTION
## Summary

- audit the published documentation against the current TypeScript/Python SDKs, server routes, schemas, CLI, React hooks, and integrations
- make only factual copy corrections: SDK namespaces and signatures, RPC paths, request/response fields, hook behavior, pricing semantics, limits, and integration setup
- preserve existing wording and structure wherever it is still accurate

This intentionally contains no runtime changes, build-script changes, page deletions, or unrelated documentation cleanup.

## Validation

- `bun x --bun mint validate`
- `bun x --bun mint broken-links`
- JSON/YAML parse checks
- navigation-target and documented-route source checks
- `git diff --check origin/dev...HEAD`
