### PR TITLE
fix: make license assignment idempotent

### DIFF
--- a/server/src/internal/billing/v2/actions/attachLicense/errors/handleAttachLicenseErrors.ts
+++ b/server/src/internal/billing/v2/actions/attachLicense/errors/handleAttachLicenseErrors.ts
@@ -31,7 +31,10 @@ export const handleAttachLicenseErrors = ({
 		});
 	}
 
-	if (customerLicense.remaining < entityParams.length) {
+	if (
+		customerLicense.remaining <
+		context.existingEntities.length + newEntityParams.length
+	) {
 		throw new RecaseError({
 			message: "No available licenses for this plan.",
 			code: ErrCode.InvalidRequest,

--- a/server/src/internal/billing/v2/actions/attachLicense/setup/setupAttachLicenseContext.ts
+++ b/server/src/internal/billing/v2/actions/attachLicense/setup/setupAttachLicenseContext.ts
@@ -110,6 +110,10 @@ export const setupAttachLicenseContext = async ({
 		fullCustomer,
 		licensePlanId: params.plan_id,
 	});
+	const entitySplit = splitRequestedEntities({
+		fullCustomer,
+		entityParams: params.entities,
+	});
 
 	// The assignment's cycles anchor to the parent's billing state — same
 	// derivation as attach, minus any billing changes.
@@ -127,6 +131,16 @@ export const setupAttachLicenseContext = async ({
 				limit: params.entities.length,
 			}),
 		]);
+	const activeAssignments =
+		await licenseAssignmentRepo.listAssignmentsWithEntityAndProductByCustomer({
+			db: ctx.db,
+			internalCustomerId: fullCustomer.internal_id,
+			licenseInternalProductId:
+				target.customerLicense.license_internal_product_id,
+		});
+	const assignedEntityIds = new Set(
+		activeAssignments.map((assignment) => assignment.entity_id),
+	);
 	const currentEpochMs = testClockFrozenTime ?? Date.now();
 	const billingCycleAnchorMs = setupBillingCycleAnchor({
 		stripeSubscription,
@@ -146,6 +160,9 @@ export const setupAttachLicenseContext = async ({
 		resetCycleAnchorMs,
 		entityParams: params.entities,
 		unusedAssignments,
-		...splitRequestedEntities({ fullCustomer, entityParams: params.entities }),
+		existingEntities: entitySplit.existingEntities.filter(
+			(entity) => !assignedEntityIds.has(entity.id),
+		),
+		newEntityParams: entitySplit.newEntityParams,
 	};
 };

--- a/server/tests/integration/licenses/billing/assignments/duplicate-license-attach.test.ts
+++ b/server/tests/integration/licenses/billing/assignments/duplicate-license-attach.test.ts
@@ -1,0 +1,47 @@
+/** Red: duplicate entities fail or consume capacity.
+ * Green: duplicate-only and mixed batches skip assigned entities with 200. */
+import { expect, test } from "bun:test";
+import type { ApiCustomerV5 } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { setupLicenseUpdateScenario } from "../update/setupLicenseUpdateScenario";
+
+test.each([
+	{ name: "duplicate-only", includeNew: false, usage: 1 },
+	{ name: "mixed duplicate and new", includeNew: true, usage: 2 },
+])("license-assign: $name returns 200", async ({ name, includeNew, usage }) => {
+	const customerId = `license-assign-${name.replaceAll(" ", "-")}`;
+	const { autumnV2_3, devSeat, assignSeats } = await setupLicenseUpdateScenario(
+		{
+			customerId,
+			idPrefix: customerId,
+			seatPrice: 20,
+			includedSeats: 1,
+			attachedSeats: 2,
+		},
+	);
+	await assignSeats({ count: 1 });
+
+	const response = await autumnV2_3.licenses.attach({
+		customer_id: customerId,
+		plan_id: devSeat.id,
+		entities: [
+			{ entity_id: `${customerId}-entity-1` },
+			...(includeNew
+				? [
+						{
+							entity_id: `${customerId}-entity-2`,
+							feature_id: TestFeature.Users,
+						},
+					]
+				: []),
+		],
+	});
+
+	expect(response).toEqual({ success: true });
+	const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+	expect(customer.licenses[0]).toMatchObject({
+		granted: 2,
+		usage,
+		remaining: 2 - usage,
+	});
+});


### PR DESCRIPTION
## Summary
- skip entities that already hold the requested license
- attach remaining new entities in mixed batches
- preserve license pool capacity for duplicate-only retries

## Verification
- duplicate-only retry returns 200 without consuming capacity
- mixed duplicate/new request returns 200 and assigns only the new entity
- existing paid-seat release/reuse lifecycle test passes
- bunx tsgo --build --noEmit
- Biome checks pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make license assignment idempotent under retries. We skip already-assigned entities across the same product, attach only new seats, and avoid consuming capacity on duplicate-only requests.

- **Bug Fixes**
  - Skip existing assignments by loading active assignments scoped to customer + product, then filter `existingEntities` before planning.
  - Check capacity against unassigned existing entities plus new entities only.
  - Add integration tests for duplicate-only and mixed duplicate/new batches (200 responses; granted/usage verified).

<sup>Written for commit a3407fec39fe2dd92d8ed79aa55536358c50b8fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Make license assignment retries idempotent for already assigned entities.
- **[Bug fixes]** Filter active assignments from duplicate-only and mixed attachment requests.
- **[Bug fixes]** Charge license capacity only for entities that still require an assignment.
- **[Improvements]** Add integration coverage for sequential duplicate-only and mixed duplicate/new retries.
</details>

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because concurrent retries can still fail with a unique-index violation when the Redis lock is unavailable or expires.

The changed filtering makes sequential retries idempotent, but setup and insertion are not enclosed in a database transaction and insertion does not handle the assignment uniqueness conflict; the application lock also permits execution when Redis is unavailable, leaving the previously reported concurrent race reachable.

**Files Needing Attention:** server/src/internal/billing/v2/actions/attachLicense/setup/setupAttachLicenseContext.ts, server/src/internal/billing/v2/actions/attachLicense/attachLicense.ts, server/src/external/redis/redisUtils.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/attachLicense/setup/setupAttachLicenseContext.ts | Loads active assignments and removes already licensed existing entities from the attachment plan. |
| server/src/internal/billing/v2/actions/attachLicense/errors/handleAttachLicenseErrors.ts | Updates capacity validation to count only existing and newly created entities that still need seats. |
| server/tests/integration/licenses/billing/assignments/duplicate-license-attach.test.ts | Covers duplicate-only and mixed duplicate/new sequential retry behavior. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant A as Attach request A
  participant B as Attach request B
  participant Redis
  participant DB
  A->>Redis: Acquire customer lock
  Redis-->>A: Acquired
  A->>DB: Read active assignments
  A->>DB: Insert missing assignment
  A->>Redis: Release lock
  B->>Redis: Acquire customer lock
  Redis-->>B: Acquired
  B->>DB: Re-read active assignments
  B-->>B: Skip existing assignment
  Note over A,B: If Redis is unavailable, both requests can pass through and race at insertion
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(licenses): 🐛 skip existing license ..."](https://github.com/useautumn/autumn/commit/a3407fec39fe2dd92d8ed79aa55536358c50b8fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47523510)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->