### PR TITLE
Fix blind message deletions

### DIFF
--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -50,6 +50,7 @@ const shouldIdleSelfKill = process.env.NODE_ENV !== "development";
 const MESSAGE_TIMEOUT_MS = 25_000;
 const SQS_RECEIVE_BATCH_LIMIT = 10;
 const QUEUE_CAPACITY_RETRY_MS = 1_000;
+const DELETE_RETRY_DELAYS_MS = [100, 250, 500] as const;
 
 type JobOverride = {
 	ack: "upfront" | "always-after-processing";
@@ -296,18 +297,44 @@ export const startPollingLoop = async ({
 		sqs: SQSClient;
 		toDelete: { Id: string; ReceiptHandle: string }[];
 	}) => {
-		if (toDelete.length === 0) return;
+		let pending = toDelete;
 
-		try {
-			await sqs.send(
-				new DeleteMessageBatchCommand({
-					QueueUrl: queueUrl,
-					Entries: toDelete,
-				}),
-			);
-		} catch (error) {
-			const message = error instanceof Error ? error.message : "Unknown error";
-			console.error(`${prefix} Batch delete failed: ${message}`);
+		for (let attempt = 0; pending.length > 0; attempt++) {
+			try {
+				const response = await sqs.send(
+					new DeleteMessageBatchCommand({
+						QueueUrl: queueUrl,
+						Entries: pending,
+					}),
+				);
+				const failed = response.Failed ?? [];
+				const senderFailures = failed.filter((failure) => failure.SenderFault);
+				if (senderFailures.length > 0) {
+					const message = `${prefix} SQS rejected ${senderFailures.length} message deletion(s): ${senderFailures.map((failure) => `${failure.Id}:${failure.Code}`).join(", ")}`;
+					console.error(message);
+					Sentry.captureMessage(message, "error");
+				}
+				const retryIds = new Set(
+					failed
+						.filter((failure) => !failure.SenderFault)
+						.map((failure) => failure.Id),
+				);
+				pending = pending.filter((entry) => retryIds.has(entry.Id));
+			} catch (error) {
+				const message =
+					error instanceof Error ? error.message : "Unknown error";
+				console.error(`${prefix} Batch delete failed: ${message}`);
+			}
+
+			const retryDelay = DELETE_RETRY_DELAYS_MS[attempt];
+			if (pending.length === 0 || retryDelay === undefined) break;
+			await new Promise((resolve) => setTimeout(resolve, retryDelay));
+		}
+
+		if (pending.length > 0) {
+			const message = `${prefix} Failed to delete ${pending.length} message(s) after ${DELETE_RETRY_DELAYS_MS.length + 1} attempts`;
+			console.error(message);
+			Sentry.captureMessage(message, "error");
 		}
 	};
 

--- a/server/tests/unit/queue/init-workers-delete-batch.test.ts
+++ b/server/tests/unit/queue/init-workers-delete-batch.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+	DeleteMessageBatchCommand,
+	type Message,
+	ReceiveMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+mock.module("@/queue/processMessage.js", () => ({
+	processMessage: mock(async () => {}),
+}));
+
+const { startPollingLoop } = await import("@/queue/initWorkers.js");
+
+const makeAbortError = () => {
+	const error = new Error("aborted") as Error & { name: string };
+	error.name = "AbortError";
+	return error;
+};
+
+/**
+ * A partial DeleteMessageBatch failure used to be ignored, so its successful job was redelivered.
+ * The worker must retry only failed acknowledgements and leave successful deletions alone.
+ */
+describe("SQS batch acknowledgement", () => {
+	test("retries only entries that SQS failed to delete", async () => {
+		const messages: Message[] = [
+			{
+				MessageId: "message-1",
+				ReceiptHandle: "receipt-1",
+				Body: JSON.stringify({ name: "test-job", data: {} }),
+			},
+			{
+				MessageId: "message-2",
+				ReceiptHandle: "receipt-2",
+				Body: JSON.stringify({ name: "test-job", data: {} }),
+			},
+		];
+		const deletedEntryBatches: Array<
+			Array<{ Id?: string; ReceiptHandle?: string }>
+		> = [];
+		let receiveCalls = 0;
+
+		const sqs = {
+			send: async (command: unknown) => {
+				if (command instanceof ReceiveMessageCommand) {
+					receiveCalls++;
+					if (receiveCalls === 1) return { Messages: messages };
+					throw makeAbortError();
+				}
+
+				if (command instanceof DeleteMessageBatchCommand) {
+					deletedEntryBatches.push(command.input.Entries ?? []);
+					if (deletedEntryBatches.length === 1) {
+						return {
+							Successful: [{ Id: "message-1" }],
+							Failed: [
+								{
+									Id: "message-2",
+									Code: "InternalError",
+									SenderFault: false,
+								},
+							],
+						};
+					}
+					return { Successful: [{ Id: "message-2" }], Failed: [] };
+				}
+
+				throw new Error("Unexpected SQS command");
+			},
+		};
+
+		await startPollingLoop({
+			db: {} as never,
+			queueId: "primary",
+			queueUrl: "https://sqs.eu-west-1.amazonaws.com/123/primary.fifo",
+			isFifo: true,
+			getSqsClientFn: () => sqs as never,
+			recreateSqsClientFn: () => sqs as never,
+			shouldPoll: () => true,
+		});
+
+		expect(deletedEntryBatches).toEqual([
+			[
+				{ Id: "message-1", ReceiptHandle: "receipt-1" },
+				{ Id: "message-2", ReceiptHandle: "receipt-2" },
+			],
+			[{ Id: "message-2", ReceiptHandle: "receipt-2" }],
+		]);
+	});
+
+	test("stops after four failed deletion attempts", async () => {
+		let deleteCalls = 0;
+		let receiveCalls = 0;
+		const sqs = {
+			send: async (command: unknown) => {
+				if (command instanceof ReceiveMessageCommand) {
+					receiveCalls++;
+					if (receiveCalls === 1) {
+						return {
+							Messages: [
+								{
+									MessageId: "message-1",
+									ReceiptHandle: "receipt-1",
+									Body: JSON.stringify({ name: "test-job", data: {} }),
+								},
+							],
+						};
+					}
+					throw makeAbortError();
+				}
+
+				if (command instanceof DeleteMessageBatchCommand) {
+					deleteCalls++;
+					return {
+						Failed: [
+							{
+								Id: "message-1",
+								Code: "InternalError",
+								SenderFault: false,
+							},
+						],
+					};
+				}
+
+				throw new Error("Unexpected SQS command");
+			},
+		};
+
+		await startPollingLoop({
+			db: {} as never,
+			queueId: "primary",
+			queueUrl: "https://sqs.eu-west-1.amazonaws.com/123/primary.fifo",
+			isFifo: true,
+			getSqsClientFn: () => sqs as never,
+			recreateSqsClientFn: () => sqs as never,
+			shouldPoll: () => true,
+		});
+
+		expect(deleteCalls).toBe(4);
+	});
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes blind SQS message deletions by handling partial batch failures correctly. Retries only failed deletions with short backoff to prevent redelivery and duplicate work.

- **Bug Fixes**
  - Retries only non-sender-fault failures from batch delete with 100/250/500ms delays (4 attempts total).
  - Skips re-deleting successful entries.
  - Logs and reports sender faults and final failures to `Sentry`.
  - Adds unit tests for selective retries and max-attempt behavior.

<sup>Written for commit bec9a5e24bbfdf5919092b2e2366485060220ded. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes partial SQS batch-delete handling so successfully processed jobs are acknowledged more reliably.
- **[Bug fixes]** Tracks failed batch-delete entries and retries only non-sender-fault failures with bounded backoff.
- **[Improvements]** Reports permanent sender faults and exhausted deletion retries through logs and Sentry.
- **[Improvements]** Adds unit coverage for selective retries and the four-attempt limit.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with bounded retries correctly preserving failed entries while excluding successful and permanent sender-fault results.

The changed deletion loop retains the full pending batch after request errors, narrows it to retryable failed IDs after partial responses, and terminates after the configured backoff sequence without introducing a concrete regression.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/queue/initWorkers.ts | Adds bounded, selective retries for partial and request-level SQS batch-delete failures while reporting permanent or exhausted failures. |
| server/tests/unit/queue/init-workers-delete-batch.test.ts | Verifies that only failed entries are retried and that repeated failures stop after four deletion attempts. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Processed SQS messages] --> B[DeleteMessageBatch]
  B --> C{Response}
  C -->|Successful entries| D[Remove from pending set]
  C -->|Sender faults| E[Log and report; do not retry]
  C -->|Retryable failures| F[Keep failed entries pending]
  C -->|Request error| G[Keep entire pending set]
  F --> H{Retry available?}
  G --> H
  H -->|Yes| I[Wait with bounded backoff]
  I --> B
  H -->|No| J[Log and report final failures]
  D --> K{Pending entries remain?}
  K -->|Yes| H
  K -->|No| L[Complete acknowledgement]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 retry failed SQS message deletio..."](https://github.com/useautumn/autumn/commit/bec9a5e24bbfdf5919092b2e2366485060220ded) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47551525)</sub>

**Context used:**

- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)

<!-- /greptile_comment -->