### PR TITLE
fix(cache): coalesce partial FullSubject hydrations

### DIFF
--- a/server/src/internal/customers/cache/fullSubject/actions/partial/getOrSetCachedPartialFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/partial/getOrSetCachedPartialFullSubject.ts
@@ -10,6 +10,92 @@ import { rehydrateWithLiveBalances } from "../rehydrateWithLiveBalances.js";
 import { setCachedFullSubject } from "../setCachedFullSubject/setCachedFullSubject.js";
 import { getCachedPartialFullSubject } from "./getCachedPartialFullSubject.js";
 
+const inFlightPartialFullSubjectHydrations = new WeakMap<
+	object,
+	Map<string, Promise<FullSubject>>
+>();
+
+const getPartialFullSubjectHydrationKey = ({
+	ctx,
+	customerId,
+	entityId,
+	featureIds,
+	subjectViewEpoch,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	entityId?: string;
+	featureIds: string[];
+	subjectViewEpoch: number;
+}): string =>
+	JSON.stringify({
+		orgId: ctx.org.id,
+		env: ctx.env,
+		customerId,
+		entityId,
+		featureIds: [...new Set(featureIds)].sort(),
+		subjectViewEpoch,
+	});
+
+const clearPartialFullSubjectHydration = ({
+	redis,
+	hydrationKey,
+	hydrationPromise,
+}: {
+	redis: object;
+	hydrationKey: string;
+	hydrationPromise: Promise<FullSubject>;
+}): void => {
+	const redisHydrations = inFlightPartialFullSubjectHydrations.get(redis);
+	if (redisHydrations?.get(hydrationKey) !== hydrationPromise) return;
+
+	redisHydrations.delete(hydrationKey);
+	if (redisHydrations.size === 0) {
+		inFlightPartialFullSubjectHydrations.delete(redis);
+	}
+};
+
+const runPartialFullSubjectHydrationSingleFlight = ({
+	ctx,
+	hydrationKey,
+	hydrate,
+}: {
+	ctx: AutumnContext;
+	hydrationKey: string;
+	hydrate: () => Promise<FullSubject>;
+}): Promise<FullSubject> => {
+	const redis = ctx.redisV2;
+	let redisHydrations = inFlightPartialFullSubjectHydrations.get(redis);
+
+	if (!redisHydrations) {
+		redisHydrations = new Map();
+		inFlightPartialFullSubjectHydrations.set(redis, redisHydrations);
+	}
+
+	const existingHydration = redisHydrations.get(hydrationKey);
+	if (existingHydration) return existingHydration;
+
+	const hydrationPromise = Promise.resolve().then(hydrate);
+	redisHydrations.set(hydrationKey, hydrationPromise);
+
+	void hydrationPromise.then(
+		() =>
+			clearPartialFullSubjectHydration({
+				redis,
+				hydrationKey,
+				hydrationPromise,
+			}),
+		() =>
+			clearPartialFullSubjectHydration({
+				redis,
+				hydrationKey,
+				hydrationPromise,
+			}),
+	);
+
+	return hydrationPromise;
+};
+
 export const getOrSetCachedPartialFullSubject = async ({
 	ctx,
 	customerId,
@@ -49,47 +135,63 @@ export const getOrSetCachedPartialFullSubject = async ({
 		}
 	}
 
-	logger.debug(
-		`[getOrSetCachedPartialFullSubject] Cache miss for ${customerId}${entityId ? `:${entityId}` : ""}, fetching from DB, source: ${source}`,
-	);
+	const hydrate = async (): Promise<FullSubject> => {
+		logger.debug(
+			`[getOrSetCachedPartialFullSubject] Cache miss for ${customerId}${entityId ? `:${entityId}` : ""}, fetching from DB, source: ${source}`,
+		);
 
-	const result = await getFullSubjectNormalized({
-		ctx,
-		customerId,
-		entityId,
-	});
-
-	if (!result) {
-		if (entityId) throw new EntityNotFoundError({ entityId });
-		throw new CustomerNotFoundError({ customerId });
-	}
-
-	const { normalized, fullSubject } = result;
-
-	if (useRedis) {
-		await setCachedFullSubject({
+		const result = await getFullSubjectNormalized({
 			ctx,
-			normalized,
-			fetchedSubjectViewEpoch,
+			customerId,
+			entityId,
 		});
 
-		// We just wrote the subject blob ourselves — skip re-reading it. Only
-		// the balance hashes need a fresh read to preserve any HSETNX-skipped
-		// in-flight Lua deduction patches. One RTT instead of two.
-		const withLiveBalances = await rehydrateWithLiveBalances({
-			ctx,
-			normalized,
-		});
-		if (withLiveBalances) {
-			return filterFullSubjectByFeatureIds({
-				fullSubject: withLiveBalances,
-				featureIds,
-			});
+		if (!result) {
+			if (entityId) throw new EntityNotFoundError({ entityId });
+			throw new CustomerNotFoundError({ customerId });
 		}
-	}
 
-	return filterFullSubjectByFeatureIds({
-		fullSubject,
-		featureIds,
+		const { normalized, fullSubject } = result;
+
+		if (useRedis) {
+			await setCachedFullSubject({
+				ctx,
+				normalized,
+				fetchedSubjectViewEpoch,
+			});
+
+			// We just wrote the subject blob ourselves — skip re-reading it. Only
+			// the balance hashes need a fresh read to preserve any HSETNX-skipped
+			// in-flight Lua deduction patches. One RTT instead of two.
+			const withLiveBalances = await rehydrateWithLiveBalances({
+				ctx,
+				normalized,
+			});
+			if (withLiveBalances) {
+				return filterFullSubjectByFeatureIds({
+					fullSubject: withLiveBalances,
+					featureIds,
+				});
+			}
+		}
+
+		return filterFullSubjectByFeatureIds({
+			fullSubject,
+			featureIds,
+		});
+	};
+
+	if (!useRedis) return hydrate();
+
+	return runPartialFullSubjectHydrationSingleFlight({
+		ctx,
+		hydrationKey: getPartialFullSubjectHydrationKey({
+			ctx,
+			customerId,
+			entityId,
+			featureIds,
+			subjectViewEpoch: fetchedSubjectViewEpoch,
+		}),
+		hydrate,
 	});
 };

--- a/server/tests/integration/balances/gate-failopen/gate-reject-failopen.test.ts
+++ b/server/tests/integration/balances/gate-failopen/gate-reject-failopen.test.ts
@@ -101,6 +101,10 @@ test.concurrent(
 		});
 
 		await invalidateCachedFullSubject({ ctx, customerId, source: "test" });
+		// This test deliberately exercises gate rejection. Identical cached
+		// partial reads now coalesce before reaching the gate, so bypass cache
+		// single-flight here to preserve the gate-specific test setup.
+		ctx.skipCache = true;
 
 		const results = await Promise.allSettled(
 			Array.from({ length: CONCURRENCY }, () =>

--- a/server/tests/integration/db/full-subject-cache/partial-full-subject-single-flight.test.ts
+++ b/server/tests/integration/db/full-subject-cache/partial-full-subject-single-flight.test.ts
@@ -1,0 +1,112 @@
+/**
+ * TDD regression for concurrent cold-cache checks hydrating the same partial
+ * FullSubject independently.
+ *
+ * Red-failure mode (before fix):
+ *  - Identical concurrent checks entered the FullSubject DB gate separately.
+ *  - Under a one-active/one-pending gate, excess requests failed open instead
+ *    of returning their real balance.
+ *
+ * Green-success criteria (after fix):
+ *  - Identical in-process checks share one cold-cache hydration.
+ *  - Every request returns real check data and the correct balance.
+ *  - The hydrated FullSubject is written to Redis.
+ */
+
+import { afterAll, expect, test } from "bun:test";
+import { ParsedCheckParamsSchema } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import { primeRedisV2Monitor } from "@/external/redis/initUtils/redisV2Availability.js";
+import { runCheckWithRollout } from "@/internal/balances/check/runCheckWithRollout.js";
+import {
+	getCachedFullSubject,
+	invalidateCachedFullSubject,
+} from "@/internal/customers/cache/fullSubject/index.js";
+import { _setFullSubjectGateConfigForTesting } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
+
+const CONCURRENCY = 8;
+
+_setFullSubjectGateConfigForTesting({
+	config: {
+		per_customer_limit: 1,
+		per_org_limit: 1,
+		max_wait_ms: 100,
+		per_customer_pending_max: 1,
+		per_org_pending_max: 1,
+	},
+});
+
+afterAll(() => {
+	_setFullSubjectGateConfigForTesting({ config: {} });
+});
+
+await primeRedisV2Monitor();
+
+test("identical concurrent cold-cache checks share one real hydration", async () => {
+	const customerId = "partial-full-subject-single-flight";
+	const freeProduct = products.base({
+		id: "partial-full-subject-single-flight-free",
+		items: [items.monthlyMessages({ includedUsage: 1000 })],
+	});
+
+	const { ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.deleteCustomer({ customerId }),
+			s.customer({ testClock: false }),
+			s.products({ list: [freeProduct] }),
+		],
+		actions: [s.attach({ productId: freeProduct.id })],
+	});
+
+	ctx.rolloutSnapshot = {
+		rolloutId: "v2-cache",
+		enabled: true,
+		percent: 100,
+		previousPercent: 100,
+		changedAt: 0,
+		customerBucket: 0,
+	};
+	ctx.customerId = customerId;
+
+	await invalidateCachedFullSubject({
+		ctx,
+		customerId,
+		source: "partial-full-subject-single-flight-test",
+	});
+
+	const body = ParsedCheckParamsSchema.parse({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+	});
+
+	const results = await Promise.all(
+		Array.from({ length: CONCURRENCY }, () =>
+			runCheckWithRollout({
+				ctx,
+				body,
+				requiredBalance: 1,
+			}),
+		),
+	);
+
+	for (const result of results) {
+		expect(result.checkData).not.toBeNull();
+		expect(result.response).toMatchObject({
+			allowed: true,
+			balance: {
+				remaining: 1000,
+			},
+		});
+	}
+
+	const cached = await getCachedFullSubject({
+		ctx,
+		customerId,
+		source: "partial-full-subject-single-flight-test:assert",
+	});
+	expect(cached.fullSubject).toBeDefined();
+});

--- a/server/tests/unit/full-subject-cache/get-or-set-cached-partial-full-subject-single-flight.test.ts
+++ b/server/tests/unit/full-subject-cache/get-or-set-cached-partial-full-subject-single-flight.test.ts
@@ -1,0 +1,344 @@
+/**
+ * TDD coverage for coalescing concurrent partial FullSubject cache misses.
+ *
+ * Red-failure mode (current behavior):
+ *  - Identical concurrent check reads each start their own DB hydration.
+ *
+ * Green-success criteria (after fix):
+ *  - One request hydrates while identical in-process readers await its result.
+ *  - Different feature sets and Redis instances remain isolated.
+ *  - A rejected hydration is removed so the next request can retry.
+ */
+
+import { expect, mock, test } from "bun:test";
+import { AppEnv, type FullSubject } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+const hydrationCounts = new Map<string, number>();
+const failuresRemaining = new Map<string, number>();
+const subjectViewEpochs = new Map<string, number>();
+
+const buildFullSubject = ({
+	customerId,
+	entityId,
+}: {
+	customerId: string;
+	entityId?: string;
+}): FullSubject =>
+	({
+		customer: {
+			id: customerId,
+			internal_id: `internal-${customerId}`,
+		},
+		entityId,
+		customer_products: [],
+		extra_customer_entitlements: [],
+		pooled_customer_entitlements: [],
+	}) as unknown as FullSubject;
+
+mock.module(
+	"@/internal/customers/cache/fullSubject/actions/partial/getCachedPartialFullSubject.js",
+	() => ({
+		getCachedPartialFullSubject: async ({
+			customerId,
+		}: {
+			customerId: string;
+		}) => ({
+			fullSubject: undefined,
+			subjectViewEpoch: subjectViewEpochs.get(customerId) ?? 0,
+		}),
+	}),
+);
+
+mock.module("@/internal/customers/repos/getFullSubject/index.js", () => ({
+	getFullSubjectNormalized: async ({
+		customerId,
+		entityId,
+	}: {
+		customerId: string;
+		entityId?: string;
+	}) => {
+		hydrationCounts.set(customerId, (hydrationCounts.get(customerId) ?? 0) + 1);
+		await new Promise((resolve) => setTimeout(resolve, 20));
+
+		const remainingFailures = failuresRemaining.get(customerId) ?? 0;
+		if (remainingFailures > 0) {
+			failuresRemaining.set(customerId, remainingFailures - 1);
+			throw new Error(`hydrate failed for ${customerId}`);
+		}
+
+		return {
+			normalized: {
+				customerId,
+				entityId,
+				customer_entitlements: [],
+			},
+			fullSubject: buildFullSubject({ customerId, entityId }),
+		};
+	},
+}));
+
+mock.module(
+	"@/internal/customers/cache/fullSubject/actions/setCachedFullSubject/setCachedFullSubject.js",
+	() => ({
+		setCachedFullSubject: async () => {},
+	}),
+);
+
+mock.module(
+	"@/internal/customers/cache/fullSubject/actions/rehydrateWithLiveBalances.js",
+	() => ({
+		rehydrateWithLiveBalances: async () => undefined,
+	}),
+);
+
+const { getOrSetCachedPartialFullSubject } = await import(
+	"@/internal/customers/cache/fullSubject/actions/partial/getOrSetCachedPartialFullSubject.js"
+);
+
+const buildContext = ({
+	redisV2,
+	orgId = "org-single-flight",
+	skipCache = false,
+}: {
+	redisV2: object;
+	orgId?: string;
+	skipCache?: boolean;
+}): AutumnContext =>
+	({
+		org: { id: orgId },
+		env: AppEnv.Live,
+		redisV2,
+		skipCache,
+		logger: {
+			debug: () => {},
+		},
+	}) as unknown as AutumnContext;
+
+test.concurrent(
+	"partial FullSubject cache miss: identical concurrent reads hydrate once",
+	async () => {
+		const customerId = "single-flight-identical";
+		const ctx = buildContext({ redisV2: {} });
+
+		const results = await Promise.all(
+			Array.from({ length: 10 }, () =>
+				getOrSetCachedPartialFullSubject({
+					ctx,
+					customerId,
+					featureIds: ["messages"],
+					source: "single-flight-test",
+				}),
+			),
+		);
+
+		expect(hydrationCounts.get(customerId)).toBe(1);
+		expect(
+			results.every((fullSubject) => fullSubject.customer.id === customerId),
+		).toBe(true);
+	},
+);
+
+test.concurrent(
+	"partial FullSubject cache miss: equivalent feature sets share a hydration",
+	async () => {
+		const customerId = "single-flight-canonical-feature-set";
+		const ctx = buildContext({ redisV2: {} });
+
+		await Promise.all([
+			getOrSetCachedPartialFullSubject({
+				ctx,
+				customerId,
+				featureIds: ["messages", "credits", "messages"],
+			}),
+			getOrSetCachedPartialFullSubject({
+				ctx,
+				customerId,
+				featureIds: ["credits", "messages"],
+			}),
+		]);
+
+		expect(hydrationCounts.get(customerId)).toBe(1);
+	},
+);
+
+test.concurrent(
+	"partial FullSubject cache miss: different feature sets do not share results",
+	async () => {
+		const customerId = "single-flight-feature-isolation";
+		const ctx = buildContext({ redisV2: {} });
+
+		await Promise.all([
+			getOrSetCachedPartialFullSubject({
+				ctx,
+				customerId,
+				featureIds: ["messages"],
+			}),
+			getOrSetCachedPartialFullSubject({
+				ctx,
+				customerId,
+				featureIds: ["credits"],
+			}),
+		]);
+
+		expect(hydrationCounts.get(customerId)).toBe(2);
+	},
+);
+
+test.concurrent(
+	"partial FullSubject cache miss: different entities do not share results",
+	async () => {
+		const customerId = "single-flight-entity-isolation";
+		const ctx = buildContext({ redisV2: {} });
+
+		await Promise.all([
+			getOrSetCachedPartialFullSubject({
+				ctx,
+				customerId,
+				entityId: "entity-a",
+				featureIds: ["messages"],
+			}),
+			getOrSetCachedPartialFullSubject({
+				ctx,
+				customerId,
+				entityId: "entity-b",
+				featureIds: ["messages"],
+			}),
+		]);
+
+		expect(hydrationCounts.get(customerId)).toBe(2);
+	},
+);
+
+test.concurrent(
+	"partial FullSubject cache miss: different orgs do not share results",
+	async () => {
+		const customerId = "single-flight-org-isolation";
+		const redisV2 = {};
+		const firstContext = buildContext({ redisV2, orgId: "org-a" });
+		const secondContext = buildContext({ redisV2, orgId: "org-b" });
+
+		await Promise.all([
+			getOrSetCachedPartialFullSubject({
+				ctx: firstContext,
+				customerId,
+				featureIds: ["messages"],
+			}),
+			getOrSetCachedPartialFullSubject({
+				ctx: secondContext,
+				customerId,
+				featureIds: ["messages"],
+			}),
+		]);
+
+		expect(hydrationCounts.get(customerId)).toBe(2);
+	},
+);
+
+test.concurrent(
+	"partial FullSubject cache miss: different Redis instances do not share results",
+	async () => {
+		const customerId = "single-flight-redis-isolation";
+		const firstContext = buildContext({ redisV2: {} });
+		const secondContext = buildContext({ redisV2: {} });
+
+		await Promise.all([
+			getOrSetCachedPartialFullSubject({
+				ctx: firstContext,
+				customerId,
+				featureIds: ["messages"],
+			}),
+			getOrSetCachedPartialFullSubject({
+				ctx: secondContext,
+				customerId,
+				featureIds: ["messages"],
+			}),
+		]);
+
+		expect(hydrationCounts.get(customerId)).toBe(2);
+	},
+);
+
+test.concurrent(
+	"partial FullSubject cache miss: a newer view epoch does not join stale hydration",
+	async () => {
+		const customerId = "single-flight-epoch-isolation";
+		const ctx = buildContext({ redisV2: {} });
+		subjectViewEpochs.set(customerId, 1);
+
+		const firstHydration = getOrSetCachedPartialFullSubject({
+			ctx,
+			customerId,
+			featureIds: ["messages"],
+		});
+		await Promise.resolve();
+
+		subjectViewEpochs.set(customerId, 2);
+		const secondHydration = getOrSetCachedPartialFullSubject({
+			ctx,
+			customerId,
+			featureIds: ["messages"],
+		});
+
+		await Promise.all([firstHydration, secondHydration]);
+		expect(hydrationCounts.get(customerId)).toBe(2);
+	},
+);
+
+test.concurrent(
+	"partial FullSubject cache miss: skipCache requests never share hydration",
+	async () => {
+		const customerId = "single-flight-skip-cache";
+		const ctx = buildContext({ redisV2: {}, skipCache: true });
+
+		await Promise.all([
+			getOrSetCachedPartialFullSubject({
+				ctx,
+				customerId,
+				featureIds: ["messages"],
+			}),
+			getOrSetCachedPartialFullSubject({
+				ctx,
+				customerId,
+				featureIds: ["messages"],
+			}),
+		]);
+
+		expect(hydrationCounts.get(customerId)).toBe(2);
+	},
+);
+
+test.concurrent(
+	"partial FullSubject cache miss: rejected flights are cleared for retry",
+	async () => {
+		const customerId = "single-flight-retry";
+		const ctx = buildContext({ redisV2: {} });
+		failuresRemaining.set(customerId, 1);
+
+		const firstWave = await Promise.allSettled([
+			getOrSetCachedPartialFullSubject({
+				ctx,
+				customerId,
+				featureIds: ["messages"],
+			}),
+			getOrSetCachedPartialFullSubject({
+				ctx,
+				customerId,
+				featureIds: ["messages"],
+			}),
+		]);
+
+		expect(firstWave.every((result) => result.status === "rejected")).toBe(
+			true,
+		);
+
+		const retry = await getOrSetCachedPartialFullSubject({
+			ctx,
+			customerId,
+			featureIds: ["messages"],
+		});
+
+		expect(retry.customer.id).toBe(customerId);
+		expect(hydrationCounts.get(customerId)).toBe(2);
+	},
+);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Coalesces concurrent partial FullSubject cache misses into a single hydration per Redis instance and key. Prevents duplicate DB work and fail-open behavior under the FullSubject DB gate while ensuring the hydrated result is cached.

- Bug Fixes
  - Added in-process single-flight for partial FullSubject hydrations keyed by org, env, customer, optional entity, sorted unique feature IDs, and view epoch.
  - Clears the in-flight entry on resolve or reject so retries work as expected.
  - Skips coalescing when `useRedis` is false or `ctx.skipCache` is true.
  - Preserves existing post-write path: write normalized subject, then rehydrate balances and filter once.
  - Tests: added unit coverage for coalescing, isolation (feature set/entity/org/Redis/epoch), retry after failure, and skipCache; added an integration test for shared hydration; updated the gate reject-failopen test to set `ctx.skipCache = true`.

<sup>Written for commit b2e81141e3fb37449e4fee9998ae7cede0f18993. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Coalesces identical in-process partial FullSubject cache misses while preserving isolation and retry behavior.
- **[Bug fixes]** Adds single-flight hydration keyed by Redis instance, organization, environment, subject, normalized feature set, and subject-view epoch.
- **[Improvements]** Clears completed or rejected flights so later cache misses can hydrate normally.
- **[Improvements]** Adds unit and integration coverage for coalescing, isolation, epoch changes, cache bypass, and retry behavior.
- **[Improvements]** Adjusts the gate fail-open test to bypass cache coalescing and retain its gate-specific coverage.
</details>

<h3>Confidence Score: 4/5</h3>

The pull request is safe to merge, with a non-blocking gap in coalescing during Redis-client transitions.

The single-flight implementation works for stable shared Redis clients, but a cache-ramp client replacement separates overlapping requests into different WeakMap entries and permits duplicate database hydration during that transition.

**Files Needing Attention:** server/src/internal/customers/cache/fullSubject/actions/partial/getOrSetCachedPartialFullSubject.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cache/fullSubject/actions/partial/getOrSetCachedPartialFullSubject.ts | Adds in-process single-flight coordination for identical cache misses, though replacing a Redis client divides active requests into separate flight maps. |
| server/tests/integration/db/full-subject-cache/partial-full-subject-single-flight.test.ts | Verifies concurrent cold-cache checks share hydration and return real balance data while populating Redis. |
| server/tests/unit/full-subject-cache/get-or-set-cached-partial-full-subject-single-flight.test.ts | Covers standard coalescing and isolation behavior but not Redis-client replacement during an active flight. |
| server/tests/integration/balances/gate-failopen/gate-reject-failopen.test.ts | Bypasses caching in the check case so the existing test continues to exercise gate rejection and fail-open behavior directly. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant A as Request A
  participant B as Request B
  participant Cache as Partial cache
  participant Flight as In-process single-flight
  participant DB as Database
  participant Redis as Redis
  A->>Cache: Read partial FullSubject
  B->>Cache: Read partial FullSubject
  Cache-->>A: Miss + epoch
  Cache-->>B: Miss + same epoch
  A->>Flight: Register hydration key
  Flight->>DB: Hydrate FullSubject
  B->>Flight: Join existing promise
  DB-->>Flight: FullSubject
  Flight->>Redis: Cache subject and balances
  Redis-->>Flight: Live balances
  Flight-->>A: Filtered FullSubject
  Flight-->>B: Same filtered FullSubject
  Flight->>Flight: Clear completed entry
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/customers/cache/fullSubject/actions/partial/getOrSetCachedPartialFullSubject.ts:67-68
**Redis rotation splits active flights**

When cache-ramp reconfiguration replaces the Redis client while a hydration is running, the WeakMap places requests before and after the replacement in separate flight maps even when they target the same backend and subject. Both requests then perform the database hydration, so the new coalescing protection does not prevent gate pressure during Redis-client transitions.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cache): coalesce partial FullSubject..."](https://github.com/useautumn/autumn/commit/b2e81141e3fb37449e4fee9998ae7cede0f18993) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47564359)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->