### PR TITLE
feat: async update balance

### DIFF
--- a/server/src/external/autumn/autumnCli.ts
+++ b/server/src/external/autumn/autumnCli.ts
@@ -1192,8 +1192,11 @@ export class AutumnInt {
 			);
 			return data;
 		},
-		update: async (params: UpdateBalanceParamsV0) => {
-			const data = await this.post(`/balances/update`, params);
+		update: async (
+			params: UpdateBalanceParamsV0,
+			{ headers }: { headers?: Record<string, string> } = {},
+		) => {
+			const data = await this.post(`/balances/update`, params, headers);
 			return data;
 		},
 		delete: async (params: DeleteBalanceParamsV0) => {

--- a/server/src/honoMiddlewares/baseMiddleware.ts
+++ b/server/src/honoMiddlewares/baseMiddleware.ts
@@ -139,6 +139,9 @@ export const baseMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 		extraLogs: {},
 
 		testOptions: {
+			asyncBalanceUpdate:
+				process.env.NODE_ENV !== "production" &&
+				c.req.header("x-async-balance-update") === "true",
 			eventId: c.req.header("x-event-id"),
 			skipCacheDeletion: c.req.header("x-skip-cache-deletion") === "true",
 			skipWebhooks: c.req.header("x-skip-webhooks") === "true",

--- a/server/src/honoUtils/HonoEnv.ts
+++ b/server/src/honoUtils/HonoEnv.ts
@@ -92,6 +92,7 @@ export type RequestContext = {
 	orgRateLimitDegraded?: boolean;
 
 	testOptions?: {
+		asyncBalanceUpdate?: boolean;
 		skipCacheDeletion?: boolean;
 		skipWebhooks?: boolean;
 		/** Per-request sync-coalesce gate override (non-prod only); undefined

--- a/server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts
+++ b/server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts
@@ -150,7 +150,12 @@ export const updateBalanceV2 = async ({
 	params: UpdateBalanceParamsV0;
 	targetBalance?: number;
 }) => {
-	if (ASYNC_UPDATE_BALANCE_ORG_IDS.includes(ctx.org.id)) {
+	const asyncBalanceUpdateEnabled =
+		ASYNC_UPDATE_BALANCE_ORG_IDS.includes(ctx.org.id) ||
+		(process.env.NODE_ENV !== "production" &&
+			ctx.testOptions?.asyncBalanceUpdate);
+
+	if (asyncBalanceUpdateEnabled) {
 		return queueUpdateBalanceV2({ ctx, params, targetBalance });
 	}
 

--- a/server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts
+++ b/server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts
@@ -1,6 +1,13 @@
-import { notNullish, type UpdateBalanceParamsV0 } from "@autumn/shared";
+import {
+	ErrCode,
+	notNullish,
+	RecaseError,
+	type UpdateBalanceParamsV0,
+} from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.js";
+import { JobName } from "@/queue/JobName.js";
+import { addTaskToQueue } from "@/queue/queueUtils.js";
 import { buildCustomerEntitlementFilters } from "../../utils/buildCustomerEntitlementFilters.js";
 import { updateExpiresAtV2 } from "./updateExpiresAtV2.js";
 import { updateIncludedGrantV2 } from "./updateIncludedGrantV2.js";
@@ -8,8 +15,14 @@ import { updateNextResetAtV2 } from "./updateNextResetAtV2.js";
 import { updateRemainingV2 } from "./updateRemainingV2.js";
 import { updateUsageV2 } from "./updateUsageV2.js";
 
+const ASYNC_UPDATE_BALANCE_ORG_IDS: readonly string[] = [
+	"8x76vTcrXbKIn401yYObDynzqNsOKFrt",
+];
+const ASYNC_UPDATE_BALANCE_UNAVAILABLE_MESSAGE =
+	"Async balance update is not available right now";
+
 /** Update balance using the FullSubject cache path. */
-export const updateBalanceV2 = async ({
+export const runUpdateBalanceV2 = async ({
 	ctx,
 	params,
 	targetBalance,
@@ -78,4 +91,68 @@ export const updateBalanceV2 = async ({
 			customerEntitlementFilters,
 		});
 	}
+};
+
+const queueUpdateBalanceV2 = async ({
+	ctx,
+	params,
+	targetBalance,
+}: {
+	ctx: AutumnContext;
+	params: UpdateBalanceParamsV0;
+	targetBalance?: number;
+}) => {
+	const queueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
+	if (!queueUrl) {
+		throw new RecaseError({
+			message: ASYNC_UPDATE_BALANCE_UNAVAILABLE_MESSAGE,
+			code: ErrCode.InternalError,
+			statusCode: 503,
+		});
+	}
+
+	try {
+		await addTaskToQueue({
+			jobName: JobName.UpdateBalance,
+			queueUrl,
+			messageGroupId: `${ctx.org.id}:${ctx.env}:${params.customer_id}:${params.entity_id ?? "none"}`,
+			messageDeduplicationId: ctx.id,
+			payload: {
+				orgId: ctx.org.id,
+				env: ctx.env,
+				customerId: params.customer_id,
+				entityId: params.entity_id,
+				requestId: ctx.id,
+				params,
+				targetBalance,
+			},
+		});
+		// The worker owns invalidation; route refresh could flush pre-job cache state.
+		ctx.testOptions = { ...ctx.testOptions, skipCacheDeletion: true };
+	} catch (error) {
+		ctx.logger.error("[updateBalanceV2] Failed to enqueue async update", {
+			error,
+		});
+		throw new RecaseError({
+			message: ASYNC_UPDATE_BALANCE_UNAVAILABLE_MESSAGE,
+			code: ErrCode.InternalError,
+			statusCode: 503,
+		});
+	}
+};
+
+export const updateBalanceV2 = async ({
+	ctx,
+	params,
+	targetBalance,
+}: {
+	ctx: AutumnContext;
+	params: UpdateBalanceParamsV0;
+	targetBalance?: number;
+}) => {
+	if (ASYNC_UPDATE_BALANCE_ORG_IDS.includes(ctx.org.id)) {
+		return queueUpdateBalanceV2({ ctx, params, targetBalance });
+	}
+
+	return runUpdateBalanceV2({ ctx, params, targetBalance });
 };

--- a/server/src/queue/processMessage.ts
+++ b/server/src/queue/processMessage.ts
@@ -18,6 +18,7 @@ import { batchResetCustomerEntitlementsV2 } from "@/internal/balances/batchReset
 import { runInsertEventBatch } from "@/internal/balances/events/runInsertEventBatch.js";
 import { expireLock } from "@/internal/balances/finalizeLock/expireLock.js";
 import { runQueuedTrack } from "@/internal/balances/track/runQueuedTrack.js";
+import { runUpdateBalanceV2 } from "@/internal/balances/updateBalance/v2/updateBalanceV2.js";
 import { refreshEntityAggregateCache } from "@/internal/balances/utils/refreshEntityAggregate/index.js";
 import { syncItemV3 } from "@/internal/balances/utils/sync/syncItemV3.js";
 import { syncItemV4 } from "@/internal/balances/utils/sync/syncItemV4.js";
@@ -27,6 +28,7 @@ import { sendProductsUpdated } from "@/internal/billing/v2/workflows/sendProduct
 import { storeDeferredInvoiceLineItems } from "@/internal/billing/v2/workflows/storeDeferredInvoiceLineItems/storeDeferredInvoiceLineItems.js";
 import { storeInvoiceLineItems } from "@/internal/billing/v2/workflows/storeInvoiceLineItems/storeInvoiceLineItems.js";
 import { batchResetCustomerEntitlements } from "@/internal/customers/actions/resetCustomerEntitlements/batchResetCustomerEntitlements.js";
+import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
 import { replayFailedCustomerCreation } from "@/internal/customers/recovery/replayFailedCustomerCreation.js";
 import { runClearCreditSystemCacheTask } from "@/internal/features/featureActions/runClearCreditSystemCacheTask.js";
 import { generateFeatureDisplay } from "@/internal/features/workflows/generateFeatureDisplay.js";
@@ -71,13 +73,14 @@ export const shouldRetrySqsJobError = ({
 		// leave the message in SQS for redelivery, not swallow-and-ack.
 		case JobName.SyncCustomerDirty:
 		case JobName.Track:
+		case JobName.UpdateBalance:
 			return isTransientDbError({ error }) || isTransientRedisError({ error });
 		// Top-up shares the customer billing lock — retry instead of dropping the job
 		// when it collides with an attach or checkout materialization.
 		case JobName.AutoTopUp:
 			return (
 				error instanceof RecaseError && error.code === ErrCode.LockAlreadyExists
-      );
+			);
 		case JobName.StripeWebhookReplay:
 			return (
 				error instanceof StripeWebhookReplayInFlightError ||
@@ -157,11 +160,13 @@ export const processMessage = async ({
 		}
 
 		// Jobs below need worker context
+		const usesCustomerCache =
+			job.name === JobName.Track || job.name === JobName.UpdateBalance;
 		const ctx = await createWorkerContext({
 			db,
 			payload: job.data,
 			logger: workerLogger,
-			skipCache: job.name !== JobName.Track,
+			skipCache: !usesCustomerCache,
 		});
 		workerCtx = ctx;
 
@@ -288,6 +293,27 @@ export const processMessage = async ({
 				ctx,
 				body: job.data.body,
 				apiVersion: job.data.apiVersion,
+			});
+			return;
+		}
+
+		if (job.name === JobName.UpdateBalance) {
+			if (!ctx) {
+				workerLogger.error("No context found for update balance job");
+				return;
+			}
+
+			await runUpdateBalanceV2({
+				ctx,
+				params: job.data.params,
+				targetBalance: job.data.targetBalance,
+			});
+			await deleteCachedFullCustomer({
+				ctx,
+				customerId: job.data.customerId,
+				entityId: job.data.entityId,
+				source: "updateBalanceV2Worker",
+				flushBalances: false,
 			});
 			return;
 		}

--- a/server/src/queue/queueUtils.ts
+++ b/server/src/queue/queueUtils.ts
@@ -4,6 +4,7 @@ import type {
 	EventInsert,
 	Price,
 	TrackParams,
+	UpdateBalanceParamsV0,
 } from "@autumn/shared";
 import {
 	SendMessageBatchCommand,
@@ -81,6 +82,15 @@ export interface Payloads {
 		requestId: string;
 		apiVersion: ApiVersion;
 		body: TrackParams;
+	};
+	[JobName.UpdateBalance]: {
+		orgId: string;
+		env: AppEnv;
+		customerId: string;
+		entityId?: string;
+		requestId: string;
+		params: UpdateBalanceParamsV0;
+		targetBalance?: number;
 	};
 	[JobName.SyncCustomerDirty]: {
 		customerId: string;

--- a/server/tests/integration/balances/update/balance/update-balance-async.test.ts
+++ b/server/tests/integration/balances/update/balance/update-balance-async.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test";
+import type { ApiCustomer } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("async update: applies the balance update")}`,
+	async () => {
+		const product = products.base({
+			id: "base",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const { autumnV2, customerId } = await initScenario({
+			customerId: "async-update",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [product] }),
+			],
+			actions: [s.attach({ productId: product.id })],
+		});
+
+		const response = await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			current_balance: 40,
+		});
+		expect(response).toEqual({ success: true });
+
+		await timeout(5_000);
+
+		const customer = await autumnV2.customers.get<ApiCustomer>(customerId, {
+			skip_cache: "true",
+		});
+		expect(customer.balances[TestFeature.Messages].current_balance).toBe(40);
+	},
+);

--- a/server/tests/integration/balances/update/balance/update-balance-async.test.ts
+++ b/server/tests/integration/balances/update/balance/update-balance-async.test.ts
@@ -23,11 +23,14 @@ test.concurrent(
 			actions: [s.attach({ productId: product.id })],
 		});
 
-		const response = await autumnV2.balances.update({
-			customer_id: customerId,
-			feature_id: TestFeature.Messages,
-			current_balance: 40,
-		});
+		const response = await autumnV2.balances.update(
+			{
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				current_balance: 40,
+			},
+			{ headers: { "x-async-balance-update": "true" } },
+		);
 		expect(response).toEqual({ success: true });
 
 		await timeout(5_000);

--- a/server/tests/unit/balances/updateBalance/updateBalanceV2-async.test.ts
+++ b/server/tests/unit/balances/updateBalance/updateBalanceV2-async.test.ts
@@ -165,6 +165,17 @@ describe("updateBalanceV2 async routing", () => {
 		expect(ctx.testOptions?.skipCacheDeletion).toBeUndefined();
 	});
 
+	test("allows a non-production async balance update test option", async () => {
+		const ctx = createCtx();
+		ctx.testOptions = { asyncBalanceUpdate: true };
+
+		await updateBalanceV2({ ctx, params, targetBalance: 40 });
+
+		expect(state.queueCommands).toHaveLength(1);
+		expect(state.getFullSubjectCalls).toHaveLength(0);
+		expect(state.updateRemainingCalls).toHaveLength(0);
+	});
+
 	test("rejects before mutation when the async queue is unavailable", async () => {
 		process.env.TRACK_ASYNC_SQS_QUEUE_URL = undefined;
 

--- a/server/tests/unit/balances/updateBalance/updateBalanceV2-async.test.ts
+++ b/server/tests/unit/balances/updateBalance/updateBalanceV2-async.test.ts
@@ -1,0 +1,182 @@
+/** Org-scoped V2 balance updates enqueue exact jobs while other orgs retain synchronous execution.
+ * Enqueue delegates refresh to the worker; queue unavailability rejects before mutation. */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+	ApiVersionClass,
+	AppEnv,
+	LATEST_VERSION,
+	type UpdateBalanceParamsV0,
+} from "@autumn/shared";
+import type { SQSClient } from "@aws-sdk/client-sqs";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { getSqsClient } from "@/queue/initSqs.js";
+import { JobName } from "@/queue/JobName.js";
+
+const trackAsyncQueueUrl =
+	"https://sqs.eu-west-1.amazonaws.com/123456789012/track-async-dev.fifo";
+const asyncUpdateOrgId = "8x76vTcrXbKIn401yYObDynzqNsOKFrt";
+
+const state = {
+	queueCommands: [] as Record<string, unknown>[],
+	getFullSubjectCalls: [] as Record<string, unknown>[],
+	updateRemainingCalls: [] as Record<string, unknown>[],
+	originalSend: null as SQSClient["send"] | null,
+};
+
+mock.module(
+	"@/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.js",
+	() => ({
+		getOrSetCachedFullSubject: async (args: Record<string, unknown>) => {
+			state.getFullSubjectCalls.push(args);
+			return {
+				customerId: args.customerId,
+				entityId: args.entityId,
+			};
+		},
+	}),
+);
+
+mock.module(
+	"@/internal/balances/updateBalance/v2/updateRemainingV2.js",
+	() => ({
+		updateRemainingV2: async (args: Record<string, unknown>) => {
+			state.updateRemainingCalls.push(args);
+		},
+	}),
+);
+
+mock.module("@/internal/balances/updateBalance/v2/updateUsageV2.js", () => ({
+	updateUsageV2: async () => {},
+}));
+
+mock.module(
+	"@/internal/balances/updateBalance/v2/updateIncludedGrantV2.js",
+	() => ({ updateIncludedGrantV2: async () => {} }),
+);
+
+mock.module(
+	"@/internal/balances/updateBalance/v2/updateNextResetAtV2.js",
+	() => ({ updateNextResetAtV2: async () => {} }),
+);
+
+mock.module(
+	"@/internal/balances/updateBalance/v2/updateExpiresAtV2.js",
+	() => ({ updateExpiresAtV2: async () => {} }),
+);
+
+const { updateBalanceV2 } = await import(
+	// @ts-expect-error - Bun cache-busting query isolates module mocks.
+	"@/internal/balances/updateBalance/v2/updateBalanceV2.js?asyncUpdate"
+);
+
+const createCtx = ({ orgId = "org_123" }: { orgId?: string } = {}) =>
+	({
+		id: "req_update_balance_123",
+		org: { id: orgId, slug: "test-org" },
+		env: AppEnv.Sandbox,
+		customerId: "cus_123",
+		apiVersion: new ApiVersionClass(LATEST_VERSION),
+		features: [],
+		extraLogs: {},
+		scopes: [],
+		skipCache: false,
+		logger: {
+			warn: mock(() => {}),
+			info: mock(() => {}),
+			error: mock(() => {}),
+			debug: mock(() => {}),
+		},
+	}) as unknown as AutumnContext;
+
+const params = {
+	customer_id: "cus_123",
+	feature_id: "messages",
+	remaining: 40,
+} satisfies UpdateBalanceParamsV0;
+
+describe("updateBalanceV2 async routing", () => {
+	const originalQueueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
+
+	beforeEach(() => {
+		state.queueCommands = [];
+		state.getFullSubjectCalls = [];
+		state.updateRemainingCalls = [];
+		process.env.TRACK_ASYNC_SQS_QUEUE_URL = trackAsyncQueueUrl;
+
+		const sqsClient = getSqsClient({ queueUrl: trackAsyncQueueUrl });
+		state.originalSend = sqsClient.send.bind(sqsClient);
+		sqsClient.send = (async (command: { input: Record<string, unknown> }) => {
+			state.queueCommands.push(command.input);
+			return {};
+		}) as typeof sqsClient.send;
+	});
+
+	afterEach(() => {
+		if (state.originalSend) {
+			const sqsClient = getSqsClient({ queueUrl: trackAsyncQueueUrl });
+			sqsClient.send = state.originalSend;
+			state.originalSend = null;
+		}
+		process.env.TRACK_ASYNC_SQS_QUEUE_URL = originalQueueUrl;
+	});
+
+	test("enqueues configured async updates without running synchronous mutation helpers", async () => {
+		const ctx = createCtx({ orgId: asyncUpdateOrgId });
+
+		await updateBalanceV2({ ctx, params, targetBalance: 40 });
+
+		expect(state.queueCommands).toHaveLength(1);
+		expect(state.queueCommands[0]).toMatchObject({
+			QueueUrl: trackAsyncQueueUrl,
+			MessageGroupId: `${asyncUpdateOrgId}:sandbox:cus_123:none`,
+			MessageDeduplicationId: ctx.id,
+		});
+		const message = JSON.parse(
+			String(state.queueCommands[0].MessageBody),
+		) as Record<string, unknown>;
+		expect(message).toMatchObject({
+			name: JobName.UpdateBalance,
+			data: {
+				orgId: asyncUpdateOrgId,
+				env: AppEnv.Sandbox,
+				customerId: "cus_123",
+				requestId: ctx.id,
+				params,
+				targetBalance: 40,
+			},
+		});
+		expect(state.getFullSubjectCalls).toHaveLength(0);
+		expect(state.updateRemainingCalls).toHaveLength(0);
+		expect(ctx.testOptions?.skipCacheDeletion).toBe(true);
+	});
+
+	test("keeps other org updates synchronous", async () => {
+		const ctx = createCtx();
+		await updateBalanceV2({
+			ctx,
+			params,
+			targetBalance: 40,
+		});
+
+		expect(state.queueCommands).toHaveLength(0);
+		expect(state.getFullSubjectCalls).toHaveLength(1);
+		expect(state.updateRemainingCalls).toHaveLength(1);
+		expect(ctx.testOptions?.skipCacheDeletion).toBeUndefined();
+	});
+
+	test("rejects before mutation when the async queue is unavailable", async () => {
+		process.env.TRACK_ASYNC_SQS_QUEUE_URL = undefined;
+
+		await expect(
+			updateBalanceV2({
+				ctx: createCtx({ orgId: asyncUpdateOrgId }),
+				params,
+				targetBalance: 40,
+			}),
+		).rejects.toMatchObject({ statusCode: 503 });
+
+		expect(state.getFullSubjectCalls).toHaveLength(0);
+		expect(state.updateRemainingCalls).toHaveLength(0);
+	});
+});

--- a/server/tests/unit/queue/processMessage-update-balance.test.ts
+++ b/server/tests/unit/queue/processMessage-update-balance.test.ts
@@ -1,0 +1,166 @@
+/** Deferred update-balance jobs execute through the V2 core, then invalidate its cached subject.
+ * Transient database and Redis failures keep the SQS message available for retry. */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
+import type { Message } from "@aws-sdk/client-sqs";
+import { RedisUnavailableError } from "@/external/redis/utils/errors.js";
+import { JobName } from "@/queue/JobName.js";
+
+const state = {
+	createWorkerContextCalls: [] as Record<string, unknown>[],
+	getFullSubjectCalls: [] as Record<string, unknown>[],
+	updateRemainingCalls: [] as Record<string, unknown>[],
+	deleteCachedFullCustomerCalls: [] as Record<string, unknown>[],
+};
+
+mock.module("@/queue/createWorkerContext.js", () => ({
+	createWorkerContext: async (args: Record<string, unknown>) => {
+		state.createWorkerContextCalls.push(args);
+		return {
+			id: "req_123",
+			org: { id: "org_123", slug: "test-org" },
+			env: AppEnv.Sandbox,
+			customerId: "cus_123",
+			logger: {
+				error: mock(() => {}),
+				info: mock(() => {}),
+			},
+			extraLogs: {},
+		};
+	},
+}));
+
+mock.module(
+	"@/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.js",
+	() => ({
+		getOrSetCachedFullSubject: async (args: Record<string, unknown>) => {
+			state.getFullSubjectCalls.push(args);
+			return {
+				customerId: args.customerId,
+				entityId: args.entityId,
+			};
+		},
+	}),
+);
+
+mock.module(
+	"@/internal/balances/updateBalance/v2/updateRemainingV2.js",
+	() => ({
+		updateRemainingV2: async (args: Record<string, unknown>) => {
+			state.updateRemainingCalls.push(args);
+		},
+	}),
+);
+
+mock.module(
+	"@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js",
+	() => ({
+		deleteCachedFullCustomer: async (args: Record<string, unknown>) => {
+			state.deleteCachedFullCustomerCalls.push(args);
+		},
+	}),
+);
+
+mock.module("@/internal/balances/updateBalance/v2/updateUsageV2.js", () => ({
+	updateUsageV2: async () => {},
+}));
+
+mock.module(
+	"@/internal/balances/updateBalance/v2/updateIncludedGrantV2.js",
+	() => ({ updateIncludedGrantV2: async () => {} }),
+);
+
+mock.module(
+	"@/internal/balances/updateBalance/v2/updateNextResetAtV2.js",
+	() => ({ updateNextResetAtV2: async () => {} }),
+);
+
+mock.module(
+	"@/internal/balances/updateBalance/v2/updateExpiresAtV2.js",
+	() => ({ updateExpiresAtV2: async () => {} }),
+);
+
+const { processMessage, shouldRetrySqsJobError } = await import(
+	// @ts-expect-error - Bun cache-busting query isolates module mocks.
+	"@/queue/processMessage.js?updateBalance"
+);
+
+describe("processMessage update-balance jobs", () => {
+	beforeEach(() => {
+		state.createWorkerContextCalls = [];
+		state.getFullSubjectCalls = [];
+		state.updateRemainingCalls = [];
+		state.deleteCachedFullCustomerCalls = [];
+	});
+
+	test("creates a cache-capable worker context and executes the V2 update core", async () => {
+		const params = {
+			customer_id: "cus_123",
+			feature_id: "messages",
+			remaining: 40,
+		};
+		const payload = {
+			orgId: "org_123",
+			env: AppEnv.Sandbox,
+			customerId: "cus_123",
+			requestId: "req_123",
+			params,
+			targetBalance: 40,
+		};
+		const message = {
+			MessageId: "msg_123",
+			Body: JSON.stringify({
+				name: JobName.UpdateBalance,
+				data: payload,
+			}),
+		} satisfies Pick<Message, "MessageId" | "Body">;
+
+		await processMessage({ message: message as Message, db: {} as never });
+
+		expect(state.createWorkerContextCalls).toHaveLength(1);
+		expect(state.createWorkerContextCalls[0]).toMatchObject({
+			payload,
+			skipCache: false,
+		});
+		expect(state.getFullSubjectCalls).toHaveLength(1);
+		expect(state.getFullSubjectCalls[0]).toMatchObject({
+			customerId: "cus_123",
+			source: "handleUpdateBalance",
+		});
+		expect(state.updateRemainingCalls).toHaveLength(1);
+		expect(state.updateRemainingCalls[0]).toMatchObject({ params });
+		expect(state.deleteCachedFullCustomerCalls).toEqual([
+			{
+				ctx: expect.any(Object),
+				customerId: "cus_123",
+				entityId: undefined,
+				source: "updateBalanceV2Worker",
+				flushBalances: false,
+			},
+		]);
+	});
+
+	test("retries transient infrastructure failures", () => {
+		const transientDbError = Object.assign(new Error("connect timeout"), {
+			code: "CONNECT_TIMEOUT",
+		});
+		const transientRedisError = new RedisUnavailableError({
+			source: "updateBalanceV2",
+			reason: "timeout",
+		});
+
+		expect(
+			shouldRetrySqsJobError({
+				jobName: JobName.UpdateBalance,
+				error: transientDbError,
+			}),
+		).toBe(true);
+		expect(
+			shouldRetrySqsJobError({
+				jobName: JobName.UpdateBalance,
+				error: transientRedisError,
+			}),
+		).toBe(true);
+	});
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds asynchronous balance updates for selected orgs by queueing `UpdateBalance` jobs to SQS and processing them in the worker; adds a non-prod header to force async for testing. Improves reliability with retries and worker-owned cache invalidation.

- **New Features**
  - Routes `updateBalanceV2` to a FIFO SQS queue for allowlisted orgs or when `x-async-balance-update: true` is set in non-prod; falls back to sync otherwise.
  - Worker handles `JobName.UpdateBalance`: uses the customer cache, runs `runUpdateBalanceV2`, then calls `deleteCachedFullCustomer`; retries on transient DB/Redis errors.
  - Returns 503 if `TRACK_ASYNC_SQS_QUEUE_URL` is missing or enqueue fails; request path sets `skipCacheDeletion` so the worker owns invalidation; `autumnCli.balances.update` now accepts optional headers to enable test overrides.

<sup>Written for commit a7ea9935f2c17ae214cbfc92a98e60d192c8692b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces opt-in asynchronous balance updates through the existing SQS worker infrastructure.
- **[API changes]** Routes balance updates for an allowlisted organization to a FIFO queue while retaining synchronous behavior for other organizations.
- **[Improvements]** Adds worker-side balance processing, transient infrastructure retries, and post-processing cache invalidation.
- **[Improvements]** Adds a non-production request option and client header support for exercising the asynchronous path in integration tests.
- **[Improvements]** Adds unit and integration coverage for queue dispatch, synchronous fallback, worker processing, cache handling, and retry classification.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts | Splits the balance mutation core from routing and queues updates for the configured organization. |
| server/src/queue/processMessage.ts | Adds worker dispatch, cache-capable context creation, cache invalidation, and transient retry classification for balance-update jobs. |
| server/src/queue/queueUtils.ts | Defines the typed payload carried by asynchronous balance-update jobs. |
| server/src/honoMiddlewares/baseMiddleware.ts | Adds a non-production request option for exercising asynchronous balance updates. |
| server/src/external/autumn/autumnCli.ts | Allows internal test callers to provide headers when invoking the balance-update endpoint. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant API as Balance API
  participant SQS as FIFO SQS
  participant Worker
  participant Balance as Balance Store
  participant Cache

  Client->>API: Update balance
  alt Async-enabled organization
    API->>SQS: Enqueue UpdateBalance
    API-->>Client: success
    SQS->>Worker: Deliver job
    Worker->>Balance: Run updateBalanceV2 core
    Worker->>Cache: Invalidate customer cache
  else Other organization
    API->>Balance: Run updateBalanceV2 core
    API-->>Client: success
  end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["feat: async update balance"](https://github.com/useautumn/autumn/commit/a7ea9935f2c17ae214cbfc92a98e60d192c8692b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47630322)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Server API Routing: Request Lifecycle](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-api-routers.md)
- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)
- Knowledge Base — [External Integrations (non-Stripe)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-external-integrations.md)
</details>

<!-- /greptile_comment -->