### PR TITLE
feat: async update balance

### DIFF
--- a/server/src/external/aws/s3/adminS3Config.ts
+++ b/server/src/external/aws/s3/adminS3Config.ts
@@ -21,6 +21,8 @@ export const ADMIN_MISCELLANEOUS_EDGE_CONFIG_KEY =
 	"admin/miscellaneous-edge-config.json";
 export const ADMIN_FULL_SUBJECT_GATE_CONFIG_KEY =
 	"admin/full-subject-gate-config.json";
+export const ADMIN_ASYNC_BALANCE_UPDATE_CONFIG_KEY =
+	"admin/async-balance-update-config.json";
 export const BLUE_GREEN_ACTIVE_SLOT_KEY = "admin/blue-green-active-slot.json";
 export const BLUE_GREEN_CRON_ACTIVE_SLOT_KEY =
 	"admin/blue-green-cron-active-slot.json";
@@ -110,6 +112,11 @@ export const getAdminEdgeConfigSources = () => ({
 			id: "full-subject-gate",
 			label: "FullSubject Concurrency Gate",
 			key: ADMIN_FULL_SUBJECT_GATE_CONFIG_KEY,
+		},
+		{
+			id: "async-balance-update",
+			label: "Async Balance Update",
+			key: ADMIN_ASYNC_BALANCE_UPDATE_CONFIG_KEY,
 		},
 		{
 			id: "stripe-sync",

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -32,6 +32,7 @@ import "./internal/misc/jobQueues/jobQueueStore.js";
 import "./internal/misc/batchReset/batchResetConfigStore.js";
 import "./internal/misc/resetJob/resetJobStore.js";
 import "./internal/misc/resetJobV2/resetJobV2Store.js";
+import "./internal/misc/asyncBalanceUpdate/asyncBalanceUpdateStore.js";
 
 // Side-effect: configures trigger.dev SDK to use TRIGGER_SERVER_SECRET_KEY.
 import "./trigger/configureTrigger.js";

--- a/server/src/internal/admin/adminRouter.ts
+++ b/server/src/internal/admin/adminRouter.ts
@@ -13,6 +13,7 @@ import {
 	handleUpdateAdminOrgRedisPublicUrl,
 	handleUpsertAdminOrgRedisConfig,
 } from "./handleAdminOrgRedisConfig";
+import { handleGetAdminAsyncBalanceUpdateConfig } from "./handleGetAdminAsyncBalanceUpdateConfig";
 import { handleGetAdminBatchResetConfig } from "./handleGetAdminBatchResetConfig";
 import { handleGetAdminCustomerBlockConfig } from "./handleGetAdminCustomerBlockConfig";
 import { handleGetAdminEdgeConfigSources } from "./handleGetAdminEdgeConfigSources";
@@ -44,6 +45,7 @@ import {
 	handleGetSlackAdminInstall,
 	handleUpdateSlackAdminTarget,
 } from "./handleSlackAdminChat";
+import { handleUpsertAdminAsyncBalanceUpdateConfig } from "./handleUpsertAdminAsyncBalanceUpdateConfig";
 import { handleUpsertAdminBatchResetConfig } from "./handleUpsertAdminBatchResetConfig";
 import { handleUpsertAdminCustomerBlockConfig } from "./handleUpsertAdminCustomerBlockConfig";
 import { handleUpsertAdminFeatureFlagsConfig } from "./handleUpsertAdminFeatureFlagsConfig";
@@ -120,6 +122,14 @@ honoAdminRouter.get(
 honoAdminRouter.put(
 	"/miscellaneous-edge-config",
 	...handleUpsertAdminMiscellaneousEdgeConfig,
+);
+honoAdminRouter.get(
+	"/async-balance-update-config",
+	...handleGetAdminAsyncBalanceUpdateConfig,
+);
+honoAdminRouter.put(
+	"/async-balance-update-config",
+	...handleUpsertAdminAsyncBalanceUpdateConfig,
 );
 honoAdminRouter.get(
 	"/full-subject-gate-config",

--- a/server/src/internal/admin/handleGetAdminAsyncBalanceUpdateConfig.ts
+++ b/server/src/internal/admin/handleGetAdminAsyncBalanceUpdateConfig.ts
@@ -1,0 +1,22 @@
+import { Scopes } from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import {
+	getAsyncBalanceUpdateConfigFromSource,
+	getRuntimeAsyncBalanceUpdateConfigStatus,
+} from "@/internal/misc/asyncBalanceUpdate/asyncBalanceUpdateStore.js";
+
+export const handleGetAdminAsyncBalanceUpdateConfig = createRoute({
+	scopes: [Scopes.Superuser],
+	handler: async (c) => {
+		const status = getRuntimeAsyncBalanceUpdateConfigStatus();
+		const config = await getAsyncBalanceUpdateConfigFromSource();
+
+		return c.json({
+			...config,
+			configHealthy: status.healthy,
+			configConfigured: status.configured,
+			lastSuccessAt: status.lastSuccessAt ?? null,
+			error: status.error ?? null,
+		});
+	},
+});

--- a/server/src/internal/admin/handleUpsertAdminAsyncBalanceUpdateConfig.ts
+++ b/server/src/internal/admin/handleUpsertAdminAsyncBalanceUpdateConfig.ts
@@ -1,0 +1,16 @@
+import { Scopes } from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { AsyncBalanceUpdateConfigSchema } from "@/internal/misc/asyncBalanceUpdate/asyncBalanceUpdateSchemas.js";
+import { updateFullAsyncBalanceUpdateConfig } from "@/internal/misc/asyncBalanceUpdate/asyncBalanceUpdateStore.js";
+
+export const handleUpsertAdminAsyncBalanceUpdateConfig = createRoute({
+	scopes: [Scopes.Superuser],
+	body: AsyncBalanceUpdateConfigSchema,
+	handler: async (c) => {
+		const config = c.req.valid("json");
+
+		await updateFullAsyncBalanceUpdateConfig({ config });
+
+		return c.json({ success: true });
+	},
+});

--- a/server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts
+++ b/server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts
@@ -6,6 +6,7 @@ import {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.js";
+import { isAsyncBalanceUpdateEnabled } from "@/internal/misc/asyncBalanceUpdate/asyncBalanceUpdateStore.js";
 import { JobName } from "@/queue/JobName.js";
 import { addTaskToQueue } from "@/queue/queueUtils.js";
 import { buildCustomerEntitlementFilters } from "../../utils/buildCustomerEntitlementFilters.js";
@@ -15,9 +16,6 @@ import { updateNextResetAtV2 } from "./updateNextResetAtV2.js";
 import { updateRemainingV2 } from "./updateRemainingV2.js";
 import { updateUsageV2 } from "./updateUsageV2.js";
 
-const ASYNC_UPDATE_BALANCE_ORG_IDS: readonly string[] = [
-	"8x76vTcrXbKIn401yYObDynzqNsOKFrt",
-];
 const ASYNC_UPDATE_BALANCE_UNAVAILABLE_MESSAGE =
 	"Async balance update is not available right now";
 
@@ -151,7 +149,10 @@ export const updateBalanceV2 = async ({
 	targetBalance?: number;
 }) => {
 	const asyncBalanceUpdateEnabled =
-		ASYNC_UPDATE_BALANCE_ORG_IDS.includes(ctx.org.id) ||
+		isAsyncBalanceUpdateEnabled({
+			orgId: ctx.org.id,
+			orgSlug: ctx.org.slug,
+		}) ||
 		(process.env.NODE_ENV !== "production" &&
 			ctx.testOptions?.asyncBalanceUpdate);
 

--- a/server/src/internal/misc/asyncBalanceUpdate/asyncBalanceUpdateSchemas.ts
+++ b/server/src/internal/misc/asyncBalanceUpdate/asyncBalanceUpdateSchemas.ts
@@ -1,0 +1,9 @@
+import { z } from "zod/v4";
+
+export const AsyncBalanceUpdateConfigSchema = z.object({
+	enabledOrgIds: z.array(z.string()).default([]),
+});
+
+export type AsyncBalanceUpdateConfig = z.infer<
+	typeof AsyncBalanceUpdateConfigSchema
+>;

--- a/server/src/internal/misc/asyncBalanceUpdate/asyncBalanceUpdateStore.ts
+++ b/server/src/internal/misc/asyncBalanceUpdate/asyncBalanceUpdateStore.ts
@@ -1,0 +1,49 @@
+import { ADMIN_ASYNC_BALANCE_UPDATE_CONFIG_KEY } from "@/external/aws/s3/adminS3Config.js";
+import { registerEdgeConfig } from "@/internal/misc/edgeConfig/edgeConfigRegistry.js";
+import { createEdgeConfigStore } from "@/internal/misc/edgeConfig/edgeConfigStore.js";
+import {
+	type AsyncBalanceUpdateConfig,
+	AsyncBalanceUpdateConfigSchema,
+} from "./asyncBalanceUpdateSchemas.js";
+
+const store = createEdgeConfigStore<AsyncBalanceUpdateConfig>({
+	s3Key: ADMIN_ASYNC_BALANCE_UPDATE_CONFIG_KEY,
+	schema: AsyncBalanceUpdateConfigSchema,
+	defaultValue: () => AsyncBalanceUpdateConfigSchema.parse({}),
+});
+
+registerEdgeConfig({ store });
+
+export const isAsyncBalanceUpdateEnabled = ({
+	orgId,
+	orgSlug,
+}: {
+	orgId: string;
+	orgSlug?: string;
+}): boolean => {
+	const enabledOrgs = store.get().enabledOrgIds;
+	return (
+		enabledOrgs.includes(orgId) || (!!orgSlug && enabledOrgs.includes(orgSlug))
+	);
+};
+
+export const getRuntimeAsyncBalanceUpdateConfigStatus = () => store.getStatus();
+
+export const getAsyncBalanceUpdateConfigFromSource = async () =>
+	store.readFromSource();
+
+export const updateFullAsyncBalanceUpdateConfig = async ({
+	config,
+}: {
+	config: AsyncBalanceUpdateConfig;
+}) => {
+	await store.writeToSource({ config });
+};
+
+export const _setAsyncBalanceUpdateConfigForTesting = ({
+	config,
+}: {
+	config: AsyncBalanceUpdateConfig;
+}) => {
+	store._setRuntimeConfigForTesting(config);
+};

--- a/server/src/queue/processMessage.ts
+++ b/server/src/queue/processMessage.ts
@@ -28,7 +28,6 @@ import { sendProductsUpdated } from "@/internal/billing/v2/workflows/sendProduct
 import { storeDeferredInvoiceLineItems } from "@/internal/billing/v2/workflows/storeDeferredInvoiceLineItems/storeDeferredInvoiceLineItems.js";
 import { storeInvoiceLineItems } from "@/internal/billing/v2/workflows/storeInvoiceLineItems/storeInvoiceLineItems.js";
 import { batchResetCustomerEntitlements } from "@/internal/customers/actions/resetCustomerEntitlements/batchResetCustomerEntitlements.js";
-import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
 import { replayFailedCustomerCreation } from "@/internal/customers/recovery/replayFailedCustomerCreation.js";
 import { runClearCreditSystemCacheTask } from "@/internal/features/featureActions/runClearCreditSystemCacheTask.js";
 import { generateFeatureDisplay } from "@/internal/features/workflows/generateFeatureDisplay.js";
@@ -308,13 +307,7 @@ export const processMessage = async ({
 				params: job.data.params,
 				targetBalance: job.data.targetBalance,
 			});
-			await deleteCachedFullCustomer({
-				ctx,
-				customerId: job.data.customerId,
-				entityId: job.data.entityId,
-				source: "updateBalanceV2Worker",
-				flushBalances: false,
-			});
+
 			return;
 		}
 

--- a/server/src/workers.ts
+++ b/server/src/workers.ts
@@ -8,6 +8,7 @@ import {
 	stopAllEdgeConfigPolling,
 } from "./internal/misc/edgeConfig/edgeConfigRegistry.js";
 import "./internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
+import "./internal/misc/asyncBalanceUpdate/asyncBalanceUpdateStore.js";
 import "./internal/misc/requestBlocks/requestBlockStore.js";
 import "./internal/misc/rollouts/rolloutConfigStore.js";
 import "./internal/misc/redisV2Cache/redisV2CacheStore.js";

--- a/server/tests/unit/balances/updateBalance/asyncBalanceUpdateStore.test.ts
+++ b/server/tests/unit/balances/updateBalance/asyncBalanceUpdateStore.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { AsyncBalanceUpdateConfigSchema } from "@/internal/misc/asyncBalanceUpdate/asyncBalanceUpdateSchemas.js";
+import {
+	_setAsyncBalanceUpdateConfigForTesting,
+	isAsyncBalanceUpdateEnabled,
+} from "@/internal/misc/asyncBalanceUpdate/asyncBalanceUpdateStore.js";
+
+describe("async balance update edge config", () => {
+	afterEach(() => {
+		_setAsyncBalanceUpdateConfigForTesting({
+			config: AsyncBalanceUpdateConfigSchema.parse({}),
+		});
+	});
+
+	test("defaults to no enabled orgs", () => {
+		expect(AsyncBalanceUpdateConfigSchema.parse({})).toEqual({
+			enabledOrgIds: [],
+		});
+		expect(isAsyncBalanceUpdateEnabled({ orgId: "org_123" })).toBe(false);
+	});
+
+	test("enables listed org IDs and slugs", () => {
+		_setAsyncBalanceUpdateConfigForTesting({
+			config: { enabledOrgIds: ["org_123", "second-org"] },
+		});
+
+		expect(isAsyncBalanceUpdateEnabled({ orgId: "org_123" })).toBe(true);
+		expect(
+			isAsyncBalanceUpdateEnabled({
+				orgId: "org_456",
+				orgSlug: "second-org",
+			}),
+		).toBe(true);
+		expect(isAsyncBalanceUpdateEnabled({ orgId: "org_456" })).toBe(false);
+	});
+});

--- a/server/tests/unit/balances/updateBalance/updateBalanceV2-async.test.ts
+++ b/server/tests/unit/balances/updateBalance/updateBalanceV2-async.test.ts
@@ -10,12 +10,13 @@ import {
 } from "@autumn/shared";
 import type { SQSClient } from "@aws-sdk/client-sqs";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { AsyncBalanceUpdateConfigSchema } from "@/internal/misc/asyncBalanceUpdate/asyncBalanceUpdateSchemas.js";
+import { _setAsyncBalanceUpdateConfigForTesting } from "@/internal/misc/asyncBalanceUpdate/asyncBalanceUpdateStore.js";
 import { getSqsClient } from "@/queue/initSqs.js";
 import { JobName } from "@/queue/JobName.js";
 
 const trackAsyncQueueUrl =
 	"https://sqs.eu-west-1.amazonaws.com/123456789012/track-async-dev.fifo";
-const asyncUpdateOrgId = "8x76vTcrXbKIn401yYObDynzqNsOKFrt";
 
 const state = {
 	queueCommands: [] as Record<string, unknown>[],
@@ -70,10 +71,10 @@ const { updateBalanceV2 } = await import(
 	"@/internal/balances/updateBalance/v2/updateBalanceV2.js?asyncUpdate"
 );
 
-const createCtx = ({ orgId = "org_123" }: { orgId?: string } = {}) =>
+const createCtx = () =>
 	({
 		id: "req_update_balance_123",
-		org: { id: orgId, slug: "test-org" },
+		org: { id: "org_123", slug: "test-org" },
 		env: AppEnv.Sandbox,
 		customerId: "cus_123",
 		apiVersion: new ApiVersionClass(LATEST_VERSION),
@@ -102,6 +103,9 @@ describe("updateBalanceV2 async routing", () => {
 		state.queueCommands = [];
 		state.getFullSubjectCalls = [];
 		state.updateRemainingCalls = [];
+		_setAsyncBalanceUpdateConfigForTesting({
+			config: AsyncBalanceUpdateConfigSchema.parse({}),
+		});
 		process.env.TRACK_ASYNC_SQS_QUEUE_URL = trackAsyncQueueUrl;
 
 		const sqsClient = getSqsClient({ queueUrl: trackAsyncQueueUrl });
@@ -118,18 +122,24 @@ describe("updateBalanceV2 async routing", () => {
 			sqsClient.send = state.originalSend;
 			state.originalSend = null;
 		}
+		_setAsyncBalanceUpdateConfigForTesting({
+			config: AsyncBalanceUpdateConfigSchema.parse({}),
+		});
 		process.env.TRACK_ASYNC_SQS_QUEUE_URL = originalQueueUrl;
 	});
 
 	test("enqueues configured async updates without running synchronous mutation helpers", async () => {
-		const ctx = createCtx({ orgId: asyncUpdateOrgId });
+		_setAsyncBalanceUpdateConfigForTesting({
+			config: { enabledOrgIds: ["test-org"] },
+		});
+		const ctx = createCtx();
 
 		await updateBalanceV2({ ctx, params, targetBalance: 40 });
 
 		expect(state.queueCommands).toHaveLength(1);
 		expect(state.queueCommands[0]).toMatchObject({
 			QueueUrl: trackAsyncQueueUrl,
-			MessageGroupId: `${asyncUpdateOrgId}:sandbox:cus_123:none`,
+			MessageGroupId: "org_123:sandbox:cus_123:none",
 			MessageDeduplicationId: ctx.id,
 		});
 		const message = JSON.parse(
@@ -138,7 +148,7 @@ describe("updateBalanceV2 async routing", () => {
 		expect(message).toMatchObject({
 			name: JobName.UpdateBalance,
 			data: {
-				orgId: asyncUpdateOrgId,
+				orgId: "org_123",
 				env: AppEnv.Sandbox,
 				customerId: "cus_123",
 				requestId: ctx.id,
@@ -177,11 +187,14 @@ describe("updateBalanceV2 async routing", () => {
 	});
 
 	test("rejects before mutation when the async queue is unavailable", async () => {
+		_setAsyncBalanceUpdateConfigForTesting({
+			config: { enabledOrgIds: ["org_123"] },
+		});
 		process.env.TRACK_ASYNC_SQS_QUEUE_URL = undefined;
 
 		await expect(
 			updateBalanceV2({
-				ctx: createCtx({ orgId: asyncUpdateOrgId }),
+				ctx: createCtx(),
 				params,
 				targetBalance: 40,
 			}),

--- a/vite/src/views/admin/components/AsyncBalanceUpdateDialog.tsx
+++ b/vite/src/views/admin/components/AsyncBalanceUpdateDialog.tsx
@@ -1,0 +1,81 @@
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+	Skeleton,
+} from "@autumn/ui";
+import { useQuery } from "@tanstack/react-query";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import {
+	ASYNC_BALANCE_UPDATE_DEFAULT_CONFIG,
+	ASYNC_BALANCE_UPDATE_QUERY_KEY,
+	type AsyncBalanceUpdateConfig,
+} from "./asyncBalanceUpdateConfigTypes";
+import { EdgeConfigDialogBody } from "./EdgeConfigDialogBody";
+import { OrgAllowlistEdgeConfigForm } from "./OrgAllowlistEdgeConfigForm";
+
+export function AsyncBalanceUpdateDialog({
+	open,
+	onOpenChange,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const axiosInstance = useAxiosInstance();
+	const configQuery = useQuery<AsyncBalanceUpdateConfig>({
+		queryKey: ASYNC_BALANCE_UPDATE_QUERY_KEY,
+		queryFn: async () => {
+			const { data } = await axiosInstance.get<AsyncBalanceUpdateConfig>(
+				"/admin/async-balance-update-config",
+			);
+			return { ...ASYNC_BALANCE_UPDATE_DEFAULT_CONFIG, ...data };
+		},
+		enabled: open,
+	});
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-5xl bg-card">
+				<DialogHeader>
+					<DialogTitle className="text-balance">
+						Async Balance Updates
+					</DialogTitle>
+					<DialogDescription className="text-pretty">
+						Choose which orgs enqueue balances.update calls for background
+						processing.
+					</DialogDescription>
+				</DialogHeader>
+
+				<EdgeConfigDialogBody
+					query={configQuery}
+					errorMessage="Failed to load async balance update config"
+					skeleton={
+						<div className="grid gap-6 lg:grid-cols-[320px_1fr]">
+							<Skeleton className="h-64" />
+							<Skeleton className="h-64" />
+						</div>
+					}
+				>
+					{(config) => (
+						<OrgAllowlistEdgeConfigForm
+							key={config.lastSuccessAt ?? "never"}
+							config={config}
+							onClose={() => onOpenChange(false)}
+							endpoint="/admin/async-balance-update-config"
+							queryKey={ASYNC_BALANCE_UPDATE_QUERY_KEY}
+							successMessage="Async balance update config saved"
+							errorMessage="Failed to save async balance update config"
+							enabledDescription="Listed org IDs or slugs enqueue balance updates. Everyone else runs them synchronously."
+							emptyMessage="No orgs enabled — every balance update runs synchronously."
+							missingConfigMessage="Async balance update config is missing in S3, so updates stay synchronous for every org."
+							healthyConfigMessage="Saved changes reach all servers within 10 seconds."
+							orgPlaceholder="Org ID or slug"
+						/>
+					)}
+				</EdgeConfigDialogBody>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/vite/src/views/admin/components/EdgeConfigTab.tsx
+++ b/vite/src/views/admin/components/EdgeConfigTab.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { AsyncBalanceUpdateDialog } from "./AsyncBalanceUpdateDialog";
 import { CacheV2RampDialog } from "./CacheV2RampDialog";
 import { CustomerBlockDialog } from "./CustomerBlockDialog";
 import { EdgeConfigCard } from "./EdgeConfigCard";
@@ -102,6 +103,11 @@ export function EdgeConfigTab() {
 
 			<FeatureFlagsDialog
 				open={openConfig === "feature-flags"}
+				onOpenChange={closeDialog}
+			/>
+
+			<AsyncBalanceUpdateDialog
+				open={openConfig === "async-balance-update"}
 				onOpenChange={closeDialog}
 			/>
 

--- a/vite/src/views/admin/components/OrgAllowlistEdgeConfigForm.tsx
+++ b/vite/src/views/admin/components/OrgAllowlistEdgeConfigForm.tsx
@@ -1,0 +1,299 @@
+import { Badge, Button, DialogFooter, Input, Separator } from "@autumn/ui";
+import Editor from "@monaco-editor/react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
+import {
+	buildOrgAllowlistJsonText,
+	type OrgAllowlistEdgeConfig,
+} from "./orgAllowlistEdgeConfigTypes";
+
+type EditorState = {
+	config: OrgAllowlistEdgeConfig;
+	jsonText: string;
+	jsonError: string | null;
+};
+
+export const OrgAllowlistEdgeConfigForm = ({
+	config: loadedConfig,
+	onClose,
+	endpoint,
+	queryKey,
+	successMessage,
+	errorMessage,
+	enabledDescription,
+	emptyMessage,
+	missingConfigMessage,
+	healthyConfigMessage = "Saved changes reach all servers within 60 seconds.",
+	orgPlaceholder = "Org ID",
+}: {
+	config: OrgAllowlistEdgeConfig;
+	onClose: () => void;
+	endpoint: string;
+	queryKey: readonly unknown[];
+	successMessage: string;
+	errorMessage: string;
+	enabledDescription: string;
+	emptyMessage: string;
+	missingConfigMessage: string;
+	healthyConfigMessage?: string;
+	orgPlaceholder?: string;
+}) => {
+	const axiosInstance = useAxiosInstance();
+	const queryClient = useQueryClient();
+	const [editor, setEditor] = useState<EditorState>(() => ({
+		config: loadedConfig,
+		jsonText: buildOrgAllowlistJsonText({ config: loadedConfig }),
+		jsonError: null,
+	}));
+	const [newOrgId, setNewOrgId] = useState("");
+
+	const mutation = useMutation({
+		mutationFn: async (payload: unknown) => {
+			await axiosInstance.put(endpoint, payload);
+		},
+		onSuccess: async () => {
+			await queryClient.invalidateQueries({ queryKey });
+			toast.success(successMessage);
+			onClose();
+		},
+		onError: (error) => {
+			toast.error(getBackendErr(error, errorMessage));
+		},
+	});
+
+	const updateEnabledOrgIds = ({
+		update,
+	}: {
+		update: (current: string[]) => string[];
+	}) => {
+		setEditor((current) => {
+			const config = {
+				...current.config,
+				enabledOrgIds: update(current.config.enabledOrgIds),
+			};
+			return {
+				config,
+				jsonText: buildOrgAllowlistJsonText({ config }),
+				jsonError: null,
+			};
+		});
+	};
+
+	const handleJsonChange = (value: string | undefined) => {
+		const jsonText = value ?? "";
+		try {
+			const parsed = JSON.parse(jsonText) as { enabledOrgIds?: unknown };
+			const enabledOrgIds = parsed.enabledOrgIds ?? [];
+			if (
+				!Array.isArray(enabledOrgIds) ||
+				!enabledOrgIds.every((orgId) => typeof orgId === "string")
+			) {
+				throw new Error("enabledOrgIds must be an array of strings");
+			}
+			setEditor((current) => ({
+				config: {
+					...current.config,
+					enabledOrgIds,
+				},
+				jsonText,
+				jsonError: null,
+			}));
+		} catch (error) {
+			setEditor((current) => ({
+				...current,
+				jsonText,
+				jsonError:
+					error instanceof SyntaxError
+						? "Invalid JSON"
+						: error instanceof Error
+							? error.message
+							: "Invalid config",
+			}));
+		}
+	};
+
+	const addOrg = () => {
+		const orgId = newOrgId.trim();
+		if (!orgId) return;
+		if (editor.config.enabledOrgIds.includes(orgId)) {
+			toast.error("Org already in list");
+			return;
+		}
+
+		updateEnabledOrgIds({
+			update: (current) => [...current, orgId],
+		});
+		setNewOrgId("");
+	};
+
+	const removeOrg = ({ orgId }: { orgId: string }) => {
+		updateEnabledOrgIds({
+			update: (current) => current.filter((id) => id !== orgId),
+		});
+	};
+
+	const handleSave = async () => {
+		if (editor.jsonError) {
+			toast.error("Fix JSON errors before saving");
+			return;
+		}
+
+		let payload: unknown;
+		try {
+			payload = JSON.parse(editor.jsonText);
+		} catch {
+			toast.error("Invalid JSON");
+			return;
+		}
+
+		await mutation.mutateAsync(payload);
+	};
+
+	const sortedOrgIds = [...editor.config.enabledOrgIds].sort();
+	const statusMessage =
+		editor.config.configConfigured === false
+			? missingConfigMessage
+			: (editor.config.error ?? healthyConfigMessage);
+
+	return (
+		<>
+			<div className="grid gap-6 lg:grid-cols-[320px_1fr]">
+				<div className="flex flex-col gap-4">
+					<div className="flex flex-col gap-1">
+						<div className="text-xs font-medium uppercase text-tertiary-foreground">
+							Enabled orgs
+						</div>
+						<div className="text-pretty text-xs text-tertiary-foreground">
+							{enabledDescription}
+						</div>
+					</div>
+
+					<div className="rounded-lg border border-border p-3">
+						<div className="mb-3 flex gap-2">
+							<Input
+								placeholder={orgPlaceholder}
+								aria-label={orgPlaceholder}
+								value={newOrgId}
+								onChange={(event) => setNewOrgId(event.target.value)}
+								onKeyDown={(event) => {
+									if (event.key === "Enter") {
+										event.preventDefault();
+										addOrg();
+									}
+								}}
+							/>
+							<Button
+								variant="secondary"
+								size="sm"
+								onClick={addOrg}
+								disabled={!newOrgId.trim()}
+							>
+								Add
+							</Button>
+						</div>
+
+						<div className="flex flex-col gap-2 border-t border-border pt-3">
+							{sortedOrgIds.length === 0 && (
+								<div className="text-pretty text-xs italic text-tertiary-foreground">
+									{emptyMessage}
+								</div>
+							)}
+							{sortedOrgIds.map((orgId) => (
+								<div
+									key={orgId}
+									className="flex items-center justify-between gap-3 rounded-lg border border-border p-2"
+								>
+									<div className="truncate font-mono text-xs text-foreground">
+										{orgId}
+									</div>
+									<Button
+										variant="secondary"
+										size="sm"
+										onClick={() => removeOrg({ orgId })}
+									>
+										Remove
+									</Button>
+								</div>
+							))}
+						</div>
+					</div>
+
+					<div className="flex flex-col gap-3 text-xs text-tertiary-foreground">
+						<Separator />
+						<div className="flex flex-wrap items-center gap-2">
+							<Badge variant="muted">
+								{editor.config.configHealthy
+									? "Config healthy"
+									: "Config unavailable"}
+							</Badge>
+							{editor.config.lastSuccessAt && (
+								<span className="tabular-nums">
+									Last refresh:{" "}
+									{new Date(editor.config.lastSuccessAt).toLocaleString()}
+								</span>
+							)}
+						</div>
+						<p className="text-pretty">{statusMessage}</p>
+					</div>
+				</div>
+
+				<div className="flex flex-col gap-2">
+					<div className="flex flex-col gap-1">
+						<div className="text-xs font-medium uppercase text-tertiary-foreground">
+							Raw JSON
+						</div>
+						<div className="text-pretty text-xs text-tertiary-foreground">
+							Edits here and in the list stay in sync. This is what gets saved.
+						</div>
+					</div>
+					<div className="overflow-hidden rounded-md border border-border">
+						<Editor
+							height="420px"
+							language="json"
+							value={editor.jsonText}
+							onChange={handleJsonChange}
+							options={{
+								minimap: { enabled: false },
+								scrollBeyondLastLine: false,
+								fontSize: 12,
+								tabSize: 2,
+								wordWrap: "on",
+								formatOnPaste: true,
+								formatOnType: true,
+							}}
+							theme="vs-dark"
+						/>
+					</div>
+					{editor.jsonError && (
+						<div role="alert" className="text-xs text-destructive">
+							{editor.jsonError}
+						</div>
+					)}
+				</div>
+			</div>
+
+			{mutation.isError && (
+				<div role="alert" className="text-sm text-destructive">
+					{getBackendErr(mutation.error, errorMessage)}
+				</div>
+			)}
+
+			<DialogFooter>
+				<Button variant="secondary" onClick={onClose}>
+					Cancel
+				</Button>
+				<Button
+					variant="primary"
+					onClick={handleSave}
+					isLoading={mutation.isPending}
+					disabled={!!editor.jsonError}
+				>
+					Save
+				</Button>
+			</DialogFooter>
+		</>
+	);
+};

--- a/vite/src/views/admin/components/StripeSyncConfigForm.tsx
+++ b/vite/src/views/admin/components/StripeSyncConfigForm.tsx
@@ -1,244 +1,26 @@
-import { Badge, Button, DialogFooter, Input, Separator } from "@autumn/ui";
-import Editor from "@monaco-editor/react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
-import { toast } from "sonner";
-import { useAxiosInstance } from "@/services/useAxiosInstance";
-import { getBackendErr } from "@/utils/genUtils";
+import { OrgAllowlistEdgeConfigForm } from "./OrgAllowlistEdgeConfigForm";
 import {
-	buildStripeSyncJsonText,
-	getStripeSyncStatusMessage,
 	STRIPE_SYNC_QUERY_KEY,
 	type StripeSyncConfig,
 } from "./stripeSyncConfigTypes";
 
 export const StripeSyncConfigForm = ({
-	config: loadedConfig,
+	config,
 	onClose,
 }: {
 	config: StripeSyncConfig;
 	onClose: () => void;
-}) => {
-	const axiosInstance = useAxiosInstance();
-	const queryClient = useQueryClient();
-	const [config, setConfig] = useState<StripeSyncConfig>(loadedConfig);
-	const [jsonText, setJsonText] = useState(() =>
-		buildStripeSyncJsonText({ config: loadedConfig }),
-	);
-	const [jsonError, setJsonError] = useState<string | null>(null);
-	const [syncSource, setSyncSource] = useState<"form" | "json">("form");
-	const [newOrgId, setNewOrgId] = useState("");
-
-	const mutation = useMutation({
-		mutationFn: async (payload: unknown) => {
-			await axiosInstance.put("/admin/stripe-sync-config", payload);
-		},
-		onSuccess: async () => {
-			await queryClient.invalidateQueries({ queryKey: STRIPE_SYNC_QUERY_KEY });
-			toast.success("Stripe sync config saved");
-			onClose();
-		},
-		onError: (error) => {
-			toast.error(getBackendErr(error, "Failed to save stripe sync config"));
-		},
-	});
-
-	// Mirrors form edits into the JSON buffer; the buffer is what gets saved.
-	useEffect(() => {
-		if (syncSource !== "form") return;
-		setJsonText(buildStripeSyncJsonText({ config }));
-		setJsonError(null);
-	}, [config, syncSource]);
-
-	const sortedOrgIds = useMemo(
-		() => [...config.enabledOrgIds].sort(),
-		[config.enabledOrgIds],
-	);
-
-	const handleJsonChange = (value: string | undefined) => {
-		const text = value ?? "";
-		setJsonText(text);
-		setSyncSource("json");
-
-		try {
-			const parsed = JSON.parse(text) as { enabledOrgIds?: string[] };
-			setConfig((current) => ({
-				...current,
-				enabledOrgIds: parsed.enabledOrgIds ?? [],
-			}));
-			setJsonError(null);
-		} catch {
-			setJsonError("Invalid JSON");
-		}
-	};
-
-	const addOrg = () => {
-		const orgId = newOrgId.trim();
-		if (!orgId) return;
-		if (config.enabledOrgIds.includes(orgId)) {
-			toast.error("Org already in list");
-			return;
-		}
-
-		setSyncSource("form");
-		setConfig((current) => ({
-			...current,
-			enabledOrgIds: [...current.enabledOrgIds, orgId],
-		}));
-		setNewOrgId("");
-	};
-
-	const removeOrg = ({ orgId }: { orgId: string }) => {
-		setSyncSource("form");
-		setConfig((current) => ({
-			...current,
-			enabledOrgIds: current.enabledOrgIds.filter((id) => id !== orgId),
-		}));
-	};
-
-	const handleSave = async () => {
-		if (jsonError) {
-			toast.error("Fix JSON errors before saving");
-			return;
-		}
-
-		let payload: unknown;
-		try {
-			payload = JSON.parse(jsonText);
-		} catch {
-			toast.error("Invalid JSON");
-			return;
-		}
-
-		await mutation.mutateAsync(payload);
-	};
-
-	return (
-		<>
-			<div className="grid grid-cols-[320px_1fr] gap-6">
-				<div className="flex flex-col gap-4">
-					<div className="flex flex-col gap-1">
-						<div className="text-xs font-medium uppercase tracking-wide text-tertiary-foreground">
-							Enabled orgs
-						</div>
-						<div className="text-pretty text-xs text-tertiary-foreground">
-							Listed orgs get synced. Everyone else is off.
-						</div>
-					</div>
-
-					<div className="rounded-lg border border-border p-3">
-						<div className="mb-3 flex gap-2">
-							<Input
-								placeholder="Org ID or slug"
-								value={newOrgId}
-								onChange={(event) => setNewOrgId(event.target.value)}
-								onKeyDown={(event) => {
-									if (event.key === "Enter") addOrg();
-								}}
-							/>
-							<Button
-								variant="secondary"
-								size="sm"
-								onClick={addOrg}
-								disabled={!newOrgId.trim()}
-							>
-								Add
-							</Button>
-						</div>
-
-						<div className="flex flex-col gap-2 border-t border-border pt-3">
-							{sortedOrgIds.length === 0 && (
-								<div className="text-pretty text-xs italic text-tertiary-foreground">
-									No orgs enabled — sync is off everywhere.
-								</div>
-							)}
-							{sortedOrgIds.map((orgId) => (
-								<div
-									key={orgId}
-									className="flex items-center justify-between gap-3 rounded-lg border border-border p-2"
-								>
-									<div className="truncate font-mono text-xs text-foreground">
-										{orgId}
-									</div>
-									<Button
-										variant="secondary"
-										size="sm"
-										onClick={() => removeOrg({ orgId })}
-									>
-										Remove
-									</Button>
-								</div>
-							))}
-						</div>
-					</div>
-
-					<div className="flex flex-col gap-3 text-xs text-tertiary-foreground">
-						<Separator />
-						<div className="flex flex-wrap items-center gap-2">
-							<Badge variant="muted">
-								{config.configHealthy ? "Config healthy" : "Config unavailable"}
-							</Badge>
-							{config.lastSuccessAt && (
-								<span className="tabular-nums">
-									Last refresh:{" "}
-									{new Date(config.lastSuccessAt).toLocaleString()}
-								</span>
-							)}
-						</div>
-						<p className="text-pretty">
-							{getStripeSyncStatusMessage({ config })}
-						</p>
-					</div>
-				</div>
-
-				<div className="flex flex-col gap-2">
-					<div className="flex flex-col gap-1">
-						<div className="text-xs font-medium uppercase tracking-wide text-tertiary-foreground">
-							Raw JSON
-						</div>
-						<div className="text-pretty text-xs text-tertiary-foreground">
-							Edits here and in the list stay in sync. This is what gets saved.
-						</div>
-					</div>
-					<div className="overflow-hidden rounded-md border border-border">
-						<Editor
-							height="420px"
-							language="json"
-							value={jsonText}
-							onChange={handleJsonChange}
-							options={{
-								minimap: { enabled: false },
-								scrollBeyondLastLine: false,
-								fontSize: 12,
-								tabSize: 2,
-								wordWrap: "on",
-								formatOnPaste: true,
-								formatOnType: true,
-							}}
-							theme="vs-dark"
-						/>
-					</div>
-					{jsonError && (
-						<div role="alert" className="text-xs text-destructive">
-							{jsonError}
-						</div>
-					)}
-				</div>
-			</div>
-
-			<DialogFooter>
-				<Button variant="secondary" onClick={onClose}>
-					Cancel
-				</Button>
-				<Button
-					variant="primary"
-					onClick={handleSave}
-					isLoading={mutation.isPending}
-					disabled={!!jsonError}
-				>
-					Save
-				</Button>
-			</DialogFooter>
-		</>
-	);
-};
+}) => (
+	<OrgAllowlistEdgeConfigForm
+		config={config}
+		onClose={onClose}
+		endpoint="/admin/stripe-sync-config"
+		queryKey={STRIPE_SYNC_QUERY_KEY}
+		successMessage="Stripe sync config saved"
+		errorMessage="Failed to save stripe sync config"
+		enabledDescription="Listed orgs get synced. Everyone else is off."
+		emptyMessage="No orgs enabled — sync is off everywhere."
+		missingConfigMessage="Stripe sync config is missing in S3, so sync stays off for every org."
+		orgPlaceholder="Org ID or slug"
+	/>
+);

--- a/vite/src/views/admin/components/asyncBalanceUpdateConfigTypes.ts
+++ b/vite/src/views/admin/components/asyncBalanceUpdateConfigTypes.ts
@@ -1,0 +1,15 @@
+import {
+	ORG_ALLOWLIST_DEFAULT_CONFIG,
+	type OrgAllowlistEdgeConfig,
+} from "./orgAllowlistEdgeConfigTypes";
+
+export type AsyncBalanceUpdateConfig = OrgAllowlistEdgeConfig;
+
+export const ASYNC_BALANCE_UPDATE_DEFAULT_CONFIG: AsyncBalanceUpdateConfig = {
+	...ORG_ALLOWLIST_DEFAULT_CONFIG,
+};
+
+export const ASYNC_BALANCE_UPDATE_QUERY_KEY = [
+	"admin-edge-config",
+	"async-balance-update",
+] as const;

--- a/vite/src/views/admin/components/edgeConfigCards.ts
+++ b/vite/src/views/admin/components/edgeConfigCards.ts
@@ -27,6 +27,7 @@ export type EdgeConfigStatus = {
 
 export type EdgeConfigCardId =
 	| "feature-flags"
+	| "async-balance-update"
 	| "request-block"
 	| "customer-block"
 	| "org-limits"
@@ -274,6 +275,25 @@ export const EDGE_CONFIG_SECTIONS: EdgeConfigSectionDef[] = [
 		title: "Rollouts & Flags",
 		description: "Global gates and incremental feature enablement.",
 		cards: [
+			{
+				id: "async-balance-update",
+				title: "Async Balance Updates",
+				description:
+					"Enqueue balances.update calls for background processing by org.",
+				icon: Clock,
+				endpoint: "/admin/async-balance-update-config",
+				deriveStatus: (data) => {
+					const ids = asRecord(data).enabledOrgIds;
+					const count = Array.isArray(ids) ? ids.length : 0;
+
+					return count === 0
+						? { label: "No orgs enabled", tone: "neutral" }
+						: {
+								label: `${pluralize({ count, noun: "org" })} enabled`,
+								tone: "active",
+							};
+				},
+			},
 			{
 				id: "feature-flags",
 				title: "Feature Flags",

--- a/vite/src/views/admin/components/orgAllowlistEdgeConfigTypes.ts
+++ b/vite/src/views/admin/components/orgAllowlistEdgeConfigTypes.ts
@@ -1,0 +1,21 @@
+export type OrgAllowlistEdgeConfig = {
+	enabledOrgIds: string[];
+	configHealthy: boolean;
+	configConfigured: boolean;
+	lastSuccessAt: string | null;
+	error: string | null;
+};
+
+export const ORG_ALLOWLIST_DEFAULT_CONFIG: OrgAllowlistEdgeConfig = {
+	enabledOrgIds: [],
+	configHealthy: false,
+	configConfigured: false,
+	lastSuccessAt: null,
+	error: null,
+};
+
+export const buildOrgAllowlistJsonText = ({
+	config,
+}: {
+	config: OrgAllowlistEdgeConfig;
+}): string => JSON.stringify({ enabledOrgIds: config.enabledOrgIds }, null, 2);

--- a/vite/src/views/admin/components/stripeSyncConfigTypes.ts
+++ b/vite/src/views/admin/components/stripeSyncConfigTypes.ts
@@ -1,38 +1,15 @@
-export type StripeSyncConfig = {
-	enabledOrgIds: string[];
-	configHealthy: boolean;
-	configConfigured: boolean;
-	lastSuccessAt: string | null;
-	error: string | null;
-};
+import {
+	ORG_ALLOWLIST_DEFAULT_CONFIG,
+	type OrgAllowlistEdgeConfig,
+} from "./orgAllowlistEdgeConfigTypes";
+
+export type StripeSyncConfig = OrgAllowlistEdgeConfig;
 
 export const STRIPE_SYNC_DEFAULT_CONFIG: StripeSyncConfig = {
-	enabledOrgIds: [],
-	configHealthy: false,
-	configConfigured: false,
-	lastSuccessAt: null,
-	error: null,
+	...ORG_ALLOWLIST_DEFAULT_CONFIG,
 };
 
 export const STRIPE_SYNC_QUERY_KEY = [
 	"admin-edge-config",
 	"stripe-sync",
 ] as const;
-
-export const buildStripeSyncJsonText = ({
-	config,
-}: {
-	config: StripeSyncConfig;
-}): string => JSON.stringify({ enabledOrgIds: config.enabledOrgIds }, null, 2);
-
-export const getStripeSyncStatusMessage = ({
-	config,
-}: {
-	config: StripeSyncConfig;
-}) => {
-	if (config.configConfigured === false) {
-		return "Stripe sync config is missing in S3, so sync stays off for every org.";
-	}
-
-	return config.error ?? "Saved changes reach all servers within 60 seconds.";
-};


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an admin-controlled rollout for async balance updates and removes unnecessary cache clearing in the worker to reduce churn. Admins can allowlist orgs (ID or slug) to enqueue `balances.update` to the background queue; everyone else stays synchronous.

- **New Features**
  - New S3 edge config `admin/async-balance-update-config.json` with allowlisted orgs; defaults to off.
  - Server: GET/PUT `/admin/async-balance-update-config`, runtime store with health/status and polling.
  - `updateBalanceV2` uses `isAsyncBalanceUpdateEnabled(...)` (ID or slug) to enqueue to `SQS`; returns a clear error if the queue is unavailable.
  - Admin UI: “Async Balance Updates” dialog under Edge Config with list + raw JSON editor and live status.

- **Refactors**
  - Extracted reusable `OrgAllowlistEdgeConfigForm` and types; `StripeSyncConfigForm` now uses it to remove duplicate logic.
  - Registered the new store on server/worker startup and added it to admin edge config sources.
  - Removed full customer cache clearing in the async worker after `runUpdateBalance` to prevent unnecessary cache churn.

<sup>Written for commit dcccd0e91997976e2d744c172bf3d2c9c7c96a0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds an admin-managed rollout for routing selected organizations' balance updates through SQS.
- **[Improvements, API changes]** Adds S3-backed async-balance configuration, protected admin GET/PUT endpoints, runtime polling, and organization ID/slug matching.
- **[Improvements]** Routes allowlisted balance updates to the background queue and registers the configuration store in server and worker processes.
- **[Improvements]** Adds an admin dialog and reusable organization-allowlist editor shared with Stripe sync configuration.
- **[Improvements]** Adds unit coverage for configuration matching, queue routing, and unavailable-queue behavior.
</details>

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because deployments without a prepopulated S3 configuration still revert the organization previously using asynchronous balance updates to synchronous execution.

The current code removes the former hard-coded organization from async routing and initializes the replacement configuration with an empty allowlist, with no repository-backed seed or fallback preserving the existing rollout.

**Files Needing Attention:** server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts; server/src/internal/misc/asyncBalanceUpdate/asyncBalanceUpdateStore.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts | Replaces the hard-coded async organization gate with the new runtime edge-config lookup. |
| server/src/internal/misc/asyncBalanceUpdate/asyncBalanceUpdateStore.ts | Defines and registers the S3-backed organization allowlist used by balance-update routing. |
| server/src/queue/processMessage.ts | Updates post-processing behavior for queued balance-update jobs. |
| vite/src/views/admin/components/OrgAllowlistEdgeConfigForm.tsx | Introduces the reusable list and raw-JSON editor used by organization allowlist configurations. |
| vite/src/views/admin/components/AsyncBalanceUpdateDialog.tsx | Adds the admin interface for loading and updating async balance configuration. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Admin
  participant API as Admin API
  participant S3 as S3 Edge Config
  participant App as API Server
  participant SQS
  participant Worker

  Admin->>API: PUT async balance allowlist
  API->>S3: Persist configuration
  App->>S3: Poll configuration
  App->>App: Match organization ID or slug
  alt Organization is allowlisted
    App->>SQS: Enqueue UpdateBalance
    SQS->>Worker: Deliver job
    Worker->>Worker: Apply balance update
  else Organization is not allowlisted
    App->>App: Apply balance update synchronously
  end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: removed cache clear after runUpdate..."](https://github.com/useautumn/autumn/commit/dcccd0e91997976e2d744c172bf3d2c9c7c96a0a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47635934)</sub>

**Context used:**

- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)

<!-- /greptile_comment -->