### PR TITLE
feat: async update balance

### DIFF
--- a/server/tests/unit/queue/processMessage-update-balance.test.ts
+++ b/server/tests/unit/queue/processMessage-update-balance.test.ts
@@ -1,4 +1,4 @@
-/** Deferred update-balance jobs execute through the V2 core, then invalidate its cached subject.
+/** Deferred update-balance jobs execute through the V2 core without invalidating its cached subject.
  * Transient database and Redis failures keep the SQS message available for retry. */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -130,15 +130,7 @@ describe("processMessage update-balance jobs", () => {
 		});
 		expect(state.updateRemainingCalls).toHaveLength(1);
 		expect(state.updateRemainingCalls[0]).toMatchObject({ params });
-		expect(state.deleteCachedFullCustomerCalls).toEqual([
-			{
-				ctx: expect.any(Object),
-				customerId: "cus_123",
-				entityId: undefined,
-				source: "updateBalanceV2Worker",
-				flushBalances: false,
-			},
-		]);
+		expect(state.deleteCachedFullCustomerCalls).toEqual([]);
 	});
 
 	test("retries transient infrastructure failures", () => {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Deferred update-balance jobs now run through the V2 core without invalidating cached subjects. Updated unit test to expect no `deleteCachedFullCustomer` calls.

<sup>Written for commit e6235a9bde09b5fc170f4dfef6a5c8476ed471ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates the deferred balance-update worker test to reflect that successful jobs no longer invalidate the cached customer subject.
- **Improvements:** Revises the test description and cache-deletion assertion to expect no explicit invalidation after a successful balance update.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only aligns a focused unit-test expectation and description with the worker’s intended cache behavior.

The changed code modifies no production path and introduces no concrete test, build, security, or runtime failure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/tests/unit/queue/processMessage-update-balance.test.ts | Updates the success-path unit-test expectation and documentation to assert that deferred balance updates do not delete the cached customer subject. |

<sub>Reviews (1): Last reviewed commit: ["fix: unit tests"](https://github.com/useautumn/autumn/commit/e6235a9bde09b5fc170f4dfef6a5c8476ed471ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47645720)</sub>

<!-- /greptile_comment -->