### PR TITLE
perf: cut getFullSubject and cursor list query costs

### DIFF
--- a/server/experiments/checkFullSubjectSqlStability.ts
+++ b/server/experiments/checkFullSubjectSqlStability.ts
@@ -1,0 +1,56 @@
+// Verifies getFullSubject emits identical SQL text regardless of how many
+// statuses / feature ids a caller passes — the precondition for reusing it as a
+// named prepared statement. Run: bun run experiments/checkFullSubjectSqlStability.ts
+import { AppEnv, CusProductStatus } from "@autumn/shared";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { getFullSubjectQuery } from "../src/internal/customers/repos/getFullSubject/getFullSubjectQuery.js";
+
+const dialect = new PgDialect();
+
+const compile = (inStatuses: CusProductStatus[]) =>
+	dialect.sqlToQuery(
+		getFullSubjectQuery({
+			orgId: "org_x",
+			env: AppEnv.Live,
+			customerId: "cus_x",
+			inStatuses,
+		}),
+	);
+
+const cases: Array<{ label: string; statuses: CusProductStatus[] }> = [
+	{ label: "1 status", statuses: [CusProductStatus.Active] },
+	{
+		label: "2 statuses",
+		statuses: [CusProductStatus.Active, CusProductStatus.PastDue],
+	},
+	{
+		label: "3 statuses",
+		statuses: [
+			CusProductStatus.Active,
+			CusProductStatus.PastDue,
+			CusProductStatus.Scheduled,
+		],
+	},
+];
+
+const compiled = cases.map(({ label, statuses }) => ({
+	label,
+	...compile(statuses),
+}));
+
+const [first, ...rest] = compiled;
+let stable = true;
+
+for (const other of rest) {
+	const same = other.sql === first.sql;
+	if (!same) stable = false;
+	console.log(
+		`${first.label} vs ${other.label}: text ${same ? "IDENTICAL" : "DIFFERS"} ` +
+			`(params ${first.params.length} vs ${other.params.length})`,
+	);
+}
+
+console.log(`\nSQL length: ${first.sql.length} chars`);
+console.log(`Placeholders: $1..$${first.params.length}`);
+console.log(stable ? "\nSTABLE — preparable" : "\nUNSTABLE — not preparable");
+process.exit(stable ? 0 : 1);

--- a/server/experiments/dumpFullSubjectSql.ts
+++ b/server/experiments/dumpFullSubjectSql.ts
@@ -1,0 +1,29 @@
+// Dump the getFullSubject SQL with params inlined, for EXPLAIN ANALYZE.
+// Run: bun run experiments/dumpFullSubjectSql.ts <orgId> <customerId>
+import { PgDialect } from "drizzle-orm/pg-core";
+import { AppEnv } from "@autumn/shared";
+import { getFullSubjectQuery } from "../src/internal/customers/repos/getFullSubject/getFullSubjectQuery.js";
+
+const [orgId, customerId] = process.argv.slice(2);
+
+const query = getFullSubjectQuery({
+	orgId,
+	env: AppEnv.Live,
+	customerId,
+});
+
+const { sql, params } = new PgDialect().sqlToQuery(query);
+
+const literal = (value: unknown): string => {
+	if (value === null || value === undefined) return "NULL";
+	if (typeof value === "number" || typeof value === "boolean") return `${value}`;
+	return `'${String(value).replace(/'/g, "''")}'`;
+};
+
+// $1..$n -> literals. Descending index order so $10 isn't clobbered by $1.
+let inlined = sql;
+for (let i = params.length; i >= 1; i--) {
+	inlined = inlined.replaceAll(`$${i}`, literal(params[i - 1]));
+}
+
+console.log(inlined);

--- a/server/experiments/maxQpsFullSubject.ts
+++ b/server/experiments/maxQpsFullSubject.ts
@@ -1,0 +1,123 @@
+// Max-QPS checker for getFullSubject, prepared vs unprepared.
+//
+//   ENV_FILE=.env infisical run --env=dev --recursive -- \
+//     bun experiments/maxQpsFullSubject.ts [secondsPerStep]
+//
+// Arms are interleaved at each concurrency step so CPU-credit throttling on a
+// burstable instance penalises both equally. Absolute QPS is only meaningful
+// relative to the box it ran on; the prepared/unprepared RATIO is the output
+// that transfers.
+import { AppEnv } from "@autumn/shared";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { PgDialect } from "drizzle-orm/pg-core";
+import pg from "pg";
+import { executePrepared } from "../src/db/executePrepared.js";
+import { getFullSubjectQuery } from "../src/internal/customers/repos/getFullSubject/getFullSubjectQuery.js";
+
+const SECONDS_PER_STEP = Number(process.argv[2]) || 5;
+const CONCURRENCIES = [1, 2, 4, 8, 16, 32];
+
+const url = process.env.DATABASE_URL;
+if (!url) throw new Error("DATABASE_URL not set");
+
+const dialect = new PgDialect();
+const pool = new pg.Pool({ connectionString: url, max: 40 });
+// The prepared arm runs through the real production helper, not a hand-rolled
+// pool.query, so this benchmarks the shipped code path.
+const db = drizzle({ client: pool }) as never;
+
+const { rows: subjects } = await pool.query<{ id: string; org_id: string }>(
+	`SELECT id, org_id FROM customers WHERE internal_id LIKE 'bench_%' ORDER BY id LIMIT 100`,
+);
+if (subjects.length === 0) {
+	throw new Error("No bench_ customers found — run seedBenchCustomers.ts first");
+}
+
+const compile = (orgId: string, customerId: string) =>
+	dialect.sqlToQuery(
+		getFullSubjectQuery({ orgId, env: AppEnv.Sandbox, customerId }),
+	);
+
+/** Confirms every subject compiles to the same SQL text — required to prepare. */
+const texts = new Set(subjects.map((s) => compile(s.org_id, s.id).sql));
+if (texts.size !== 1) {
+	throw new Error(`SQL text is not stable: ${texts.size} distinct variants`);
+}
+
+const percentile = (sorted: number[], p: number) =>
+	sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * p))] ?? 0;
+
+const runArm = async ({
+	prepared,
+	concurrency,
+}: {
+	prepared: boolean;
+	concurrency: number;
+}) => {
+	const deadline = Date.now() + SECONDS_PER_STEP * 1000;
+	const latencies: number[] = [];
+	let index = 0;
+	let errors = 0;
+
+	const worker = async () => {
+		while (Date.now() < deadline) {
+			const subject = subjects[index++ % subjects.length];
+			const query = getFullSubjectQuery({
+				orgId: subject.org_id,
+				env: AppEnv.Sandbox,
+				customerId: subject.id,
+			});
+			const start = performance.now();
+			try {
+				if (prepared) {
+					await executePrepared({ db, label: "getFullSubject", query });
+				} else {
+					const { sql: text, params } = dialect.sqlToQuery(query);
+					await pool.query({ text, values: params as unknown[] });
+				}
+				latencies.push(performance.now() - start);
+			} catch (error) {
+				errors++;
+				if (errors === 1) console.error("  first error:", error);
+			}
+		}
+	};
+
+	const startedAt = Date.now();
+	await Promise.all(Array.from({ length: concurrency }, worker));
+	const elapsedSeconds = (Date.now() - startedAt) / 1000;
+
+	latencies.sort((a, b) => a - b);
+	return {
+		qps: latencies.length / elapsedSeconds,
+		p50: percentile(latencies, 0.5),
+		p99: percentile(latencies, 0.99),
+		count: latencies.length,
+		errors,
+	};
+};
+
+console.log(
+	`subjects=${subjects.length}  sql=${[...texts][0].length} chars  ` +
+		`${SECONDS_PER_STEP}s/step\n`,
+);
+console.log(
+	"conc |        unprepared QPS  p50    p99 |          prepared QPS  p50    p99 | speedup",
+);
+console.log("-".repeat(104));
+
+for (const concurrency of CONCURRENCIES) {
+	// Interleave: cold arm first each step, so neither gets a cache advantage.
+	const plain = await runArm({ prepared: false, concurrency });
+	const prep = await runArm({ prepared: true, concurrency });
+
+	const speedup = plain.qps > 0 ? prep.qps / plain.qps : 0;
+	console.log(
+		`${String(concurrency).padStart(4)} | ` +
+			`${plain.qps.toFixed(1).padStart(20)} ${plain.p50.toFixed(1).padStart(6)} ${plain.p99.toFixed(1).padStart(6)} | ` +
+			`${prep.qps.toFixed(1).padStart(20)} ${prep.p50.toFixed(1).padStart(6)} ${prep.p99.toFixed(1).padStart(6)} | ` +
+			`${speedup.toFixed(2)}×${plain.errors + prep.errors > 0 ? `  (${plain.errors + prep.errors} errors)` : ""}`,
+	);
+}
+
+await pool.end();

--- a/server/experiments/seedBenchCustomers.ts
+++ b/server/experiments/seedBenchCustomers.ts
@@ -1,0 +1,148 @@
+// Seeds N fat customers on the dev DB by cloning a template customer, so the
+// planner sees prod-like row shapes. All rows use a `bench_` id prefix.
+//
+//   ENV_FILE=.env infisical run --env=dev --recursive -- \
+//     bun experiments/seedBenchCustomers.ts [count] [usageWindowsPerCustomer]
+//
+// Cleanup: bun experiments/seedBenchCustomers.ts --clean
+import pg from "pg";
+
+const TEMPLATE_CUSTOMER = "cus_3GXT6xOPn4Txwvpw5cfJA6pyJoG";
+const PREFIX = "bench_";
+
+const args = process.argv.slice(2);
+const clean = args.includes("--clean");
+const count = Number(args[0]) || 100;
+const windowsPerCustomer = Number(args[1]) || 4;
+
+const url = process.env.DATABASE_URL;
+if (!url) throw new Error("DATABASE_URL not set");
+
+const pool = new pg.Pool({ connectionString: url, max: 4 });
+
+const q = async (text: string, values: unknown[] = []) => {
+	const res = await pool.query(text, values);
+	return res.rowCount ?? 0;
+};
+
+/** Clone a row set, overriding columns via a jsonb patch. Column-agnostic. */
+const cloneSql = (table: string, patch: string, from: string) =>
+	`INSERT INTO ${table}
+	 SELECT (jsonb_populate_record(NULL::${table}, to_jsonb(t) || ${patch})).*
+	 FROM ${from}
+	 ON CONFLICT DO NOTHING`;
+
+const cleanup = async () => {
+	// Children first — FKs cascade on some paths but not all.
+	for (const [table, col] of [
+		["usage_windows", "internal_customer_id"],
+		["customer_prices", "id"],
+		["customer_entitlements", "id"],
+		["customer_products", "id"],
+		["customers", "internal_id"],
+	] as const) {
+		const n = await q(`DELETE FROM ${table} WHERE ${col} LIKE '${PREFIX}%'`);
+		console.log(`  deleted ${n} from ${table}`);
+	}
+};
+
+const seed = async () => {
+	const series = `generate_series(1, ${count}) i`;
+
+	console.log(`Cloning ${TEMPLATE_CUSTOMER} × ${count}...`);
+
+	const customers = await q(
+		cloneSql(
+			"customers",
+			`jsonb_build_object(
+				'internal_id', '${PREFIX}cus_'||i,
+				'id', '${PREFIX}'||i,
+				'name', 'Bench Customer '||i,
+				'email', 'bench+'||i||'@example.test')`,
+			`customers t, ${series} WHERE t.internal_id = '${TEMPLATE_CUSTOMER}'`,
+		),
+	);
+	console.log(`  customers: ${customers}`);
+
+	const products = await q(
+		cloneSql(
+			"customer_products",
+			`jsonb_build_object(
+				'id', '${PREFIX}cp_'||i||'_'||t.id,
+				'internal_customer_id', '${PREFIX}cus_'||i)`,
+			`customer_products t, ${series} WHERE t.internal_customer_id = '${TEMPLATE_CUSTOMER}'`,
+		),
+	);
+	console.log(`  customer_products: ${products}`);
+
+	const entitlements = await q(
+		cloneSql(
+			"customer_entitlements",
+			`jsonb_build_object(
+				'id', '${PREFIX}ce_'||i||'_'||t.id,
+				'internal_customer_id', '${PREFIX}cus_'||i,
+				'customer_product_id', CASE WHEN t.customer_product_id IS NULL THEN NULL
+					ELSE '${PREFIX}cp_'||i||'_'||t.customer_product_id END)`,
+			`customer_entitlements t, ${series} WHERE t.internal_customer_id = '${TEMPLATE_CUSTOMER}'`,
+		),
+	);
+	console.log(`  customer_entitlements: ${entitlements}`);
+
+	const prices = await q(
+		cloneSql(
+			"customer_prices",
+			`jsonb_build_object(
+				'id', '${PREFIX}cpr_'||i||'_'||t.id,
+				'customer_product_id', '${PREFIX}cp_'||i||'_'||t.customer_product_id)`,
+			`customer_prices t
+			 JOIN customer_products cp ON cp.id = t.customer_product_id
+			 , ${series}
+			 WHERE cp.internal_customer_id = '${TEMPLATE_CUSTOMER}'`,
+		),
+	);
+	console.log(`  customer_prices: ${prices}`);
+
+	// usage_windows has no template rows — synthesise from each customer's ents.
+	const windows = await q(
+		`INSERT INTO usage_windows (
+			id, internal_customer_id, internal_entity_id, feature_id,
+			internal_feature_id, filter_key, anchor_customer_entitlement_id,
+			window_start_at, window_end_at, usage, updated_at)
+		 SELECT '${PREFIX}uw_'||ce.id||'_'||w,
+		        ce.internal_customer_id,
+		        NULL,
+		        COALESCE(ce.feature_id, ce.internal_feature_id),
+		        ce.internal_feature_id,
+		        NULL,
+		        ce.id,
+		        (EXTRACT(EPOCH FROM now()) * 1000)::bigint - (w * 3600000),
+		        (EXTRACT(EPOCH FROM now()) * 1000)::bigint - ((w - 1) * 3600000),
+		        (w * 10)::numeric,
+		        (EXTRACT(EPOCH FROM now()) * 1000)::bigint
+		 FROM customer_entitlements ce, generate_series(1, ${windowsPerCustomer}) w
+		 WHERE ce.internal_customer_id LIKE '${PREFIX}%'
+		   AND ce.customer_product_id IS NOT NULL
+		 ON CONFLICT DO NOTHING`,
+	);
+	console.log(`  usage_windows: ${windows}`);
+};
+
+try {
+	if (clean) {
+		console.log("Cleaning bench rows...");
+		await cleanup();
+	} else {
+		await seed();
+		const { rows } = await pool.query(
+			`SELECT
+				(SELECT count(*) FROM customers WHERE internal_id LIKE '${PREFIX}%') AS customers,
+				(SELECT count(*) FROM customer_products WHERE id LIKE '${PREFIX}%') AS products,
+				(SELECT count(*) FROM customer_entitlements WHERE id LIKE '${PREFIX}%') AS entitlements,
+				(SELECT count(*) FROM customer_prices WHERE id LIKE '${PREFIX}%') AS prices,
+				(SELECT count(*) FROM usage_windows WHERE id LIKE '${PREFIX}%') AS usage_windows`,
+		);
+		console.log("\nTotals:", rows[0]);
+	}
+} finally {
+	await pool.end();
+}

--- a/server/experiments/verifyPreparedStatements.ts
+++ b/server/experiments/verifyPreparedStatements.ts
@@ -1,0 +1,77 @@
+// Proves executePrepared() creates a real server-side named prepared statement,
+// by pinning the pool to one connection and reading pg_prepared_statements.
+//
+//   ENV_FILE=.env infisical run --env=dev --recursive -- \
+//     bun experiments/verifyPreparedStatements.ts
+import { AppEnv } from "@autumn/shared";
+import { drizzle } from "drizzle-orm/node-postgres";
+import pg from "pg";
+import {
+	executePrepared,
+	preparedStatementNames,
+} from "../src/db/executePrepared.js";
+import { getFullSubjectQuery } from "../src/internal/customers/repos/getFullSubject/getFullSubjectQuery.js";
+
+const url = process.env.DATABASE_URL;
+if (!url) throw new Error("DATABASE_URL not set");
+
+// max:1 so every statement lands on the same backend we then inspect.
+const pool = new pg.Pool({ connectionString: url, max: 1 });
+const db = drizzle({ client: pool }) as never;
+
+const { rows: subjects } = await pool.query<{ id: string; org_id: string }>(
+	`SELECT id, org_id FROM customers WHERE internal_id LIKE 'bench_%' ORDER BY id LIMIT 3`,
+);
+if (subjects.length === 0) throw new Error("run seedBenchCustomers.ts first");
+
+const run = async (subject: { id: string; org_id: string }) => {
+	const started = performance.now();
+	const rows = await executePrepared({
+		db,
+		label: "getFullSubject",
+		query: getFullSubjectQuery({
+			orgId: subject.org_id,
+			env: AppEnv.Sandbox,
+			customerId: subject.id,
+		}),
+	});
+	return { ms: performance.now() - started, rows: rows.length };
+};
+
+// Postgres only considers a generic plan after 5 executions of a prepared
+// statement — until then it re-plans per call and we save parsing only. Run
+// well past that threshold so we can see whether it actually switches.
+console.log("Executing getFullSubject through executePrepared()...\n");
+for (let call = 1; call <= 12; call++) {
+	const subject = subjects[call % subjects.length];
+	const { ms, rows } = await run(subject);
+	console.log(
+		`  call ${String(call).padStart(2)} (${subject.id}): ${ms.toFixed(1)}ms, ${rows} row(s)`,
+	);
+}
+
+console.log("\nNames minted in-process:", preparedStatementNames());
+
+const { rows: serverSide } = await pool.query<{
+	name: string;
+	generic_plans: string;
+	custom_plans: string;
+	calls: string;
+}>(
+	`SELECT name, generic_plans, custom_plans, (generic_plans + custom_plans) AS calls
+	 FROM pg_prepared_statements ORDER BY name`,
+);
+
+console.log("\npg_prepared_statements on this backend:");
+if (serverSide.length === 0) {
+	console.log("  (none) — NOT prepared server-side");
+	process.exit(1);
+}
+for (const row of serverSide) {
+	console.log(
+		`  ${row.name}  calls=${row.calls}  generic=${row.generic_plans}  custom=${row.custom_plans}`,
+	);
+}
+
+console.log("\nPREPARED — statement is live on the server");
+await pool.end();

--- a/server/src/db/executePrepared.ts
+++ b/server/src/db/executePrepared.ts
@@ -1,0 +1,92 @@
+import { createHash } from "node:crypto";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import type { Pool } from "pg";
+import { logger } from "@/external/logtail/logtailUtils.js";
+import type { DrizzleCli } from "./initDrizzle.js";
+
+const dialect = new PgDialect();
+
+/** Kept under PgBouncer's `max_prepared_statements` (200) so the pooler tracks
+ *  every statement we mint rather than silently dropping the overflow. */
+const MAX_DISTINCT_STATEMENTS = 100;
+
+/** Statement name -> the exact SQL text it was first prepared with. node-postgres
+ *  caches by name per connection and a name bound to two different texts poisons
+ *  that connection, so we detect the collision here instead. */
+const preparedTexts = new Map<string, string>();
+
+let overflowWarned = false;
+
+const isEnabled = () => process.env.PREPARED_STATEMENTS_DISABLED !== "true";
+
+/** node-postgres pool behind a Drizzle client, or null for drivers without one. */
+const poolOf = (db: DrizzleCli): Pool | null =>
+	(db as unknown as { $client?: Pool }).$client ?? null;
+
+/** Stable, content-addressed statement name. Same SQL always yields the same
+ *  name across processes and restarts; edited SQL yields a new one. */
+const statementName = ({ label, text }: { label: string; text: string }) =>
+	`${label}_${createHash("sha1").update(text).digest("hex").slice(0, 16)}`;
+
+/**
+ * Executes a Drizzle SQL fragment as a server-side **named** prepared statement.
+ *
+ * Postgres plans a named statement once per connection and reuses that plan;
+ * node-postgres only sends a named Parse when `name` is supplied, so without
+ * this every execution re-plans from scratch and PgBouncer's
+ * `max_prepared_statements` never sees the statement at all.
+ *
+ * Callers must keep their SQL text invariant across executions: bind values as
+ * parameters, and use `sql.param(list)` for arrays so the text doesn't grow a
+ * placeholder per element. `experiments/checkFullSubjectSqlStability.ts` guards
+ * this for getFullSubject.
+ *
+ * Falls back to an unprepared execution rather than failing the request if the
+ * driver exposes no pool, the shape count overflows, or preparation is disabled.
+ */
+export const executePrepared = async <TRow = Record<string, unknown>>({
+	db,
+	query,
+	label,
+}: {
+	db: DrizzleCli;
+	/** Must compile to identical text on every call — only params may vary. */
+	query: SQL;
+	/** Short prefix identifying the call site, e.g. "getFullSubject". */
+	label: string;
+}): Promise<TRow[]> => {
+	const pool = poolOf(db);
+	if (!(pool && isEnabled())) return db.execute<TRow>(query);
+
+	const { sql: text, params } = dialect.sqlToQuery(query);
+	const name = statementName({ label, text });
+	const knownText = preparedTexts.get(name);
+
+	if (knownText === undefined) {
+		if (preparedTexts.size >= MAX_DISTINCT_STATEMENTS) {
+			if (!overflowWarned) {
+				overflowWarned = true;
+				logger.warn(
+					`[executePrepared] ${MAX_DISTINCT_STATEMENTS} distinct statements reached; ` +
+						"further shapes run unprepared. A query is likely emitting unstable SQL text.",
+					{ label },
+				);
+			}
+			return db.execute<TRow>(query);
+		}
+		preparedTexts.set(name, text);
+	} else if (knownText !== text) {
+		// Content-addressed names make this unreachable short of a SHA-1 collision;
+		// throwing beats poisoning every connection in the pool.
+		throw new Error(`[executePrepared] name collision for "${name}"`);
+	}
+
+	// Untyped on purpose: pg constrains its generic to QueryResultRow, which is
+	// narrower than the row shapes callers of db.execute() use.
+	const result = await pool.query({ name, text, values: params });
+	return result.rows as TRow[];
+};
+
+/** Statement names minted by this process — for diagnostics and tests. */
+export const preparedStatementNames = (): string[] => [...preparedTexts.keys()];

--- a/server/src/internal/customers/CusBatchService.ts
+++ b/server/src/internal/customers/CusBatchService.ts
@@ -360,6 +360,8 @@ export class CusBatchService {
 			withSubs: true,
 			withEntities: true,
 			includeInvoices: true,
+			// Only the dashboard renders products_page / products_total_count.
+			withProductsPage: true,
 			entitiesLimit,
 			limit: internalIds ? internalIds.length : limit,
 			cursor:

--- a/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
+++ b/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
@@ -44,6 +44,8 @@ export type CursorPaginatedFullCusQueryArgs = {
 	intervalFilters?: DashboardIntervalFilter[];
 	cusProductLimit: number;
 	customerId?: string;
+	/** Emit products_page / products_total_count. Dashboard only. */
+	withProductsPage?: boolean;
 };
 
 /**
@@ -72,13 +74,23 @@ export const getCursorPaginatedFullCusQuery = ({
 	intervalFilters,
 	cusProductLimit,
 	customerId,
+	withProductsPage = false,
 }: CursorPaginatedFullCusQueryArgs) => {
 	const cpStatusFilter = cpStatusInClause(inStatuses);
 
-	const productsSeedCte = customerProductsSeedCte({
-		inStatuses: RELEVANT_STATUSES,
-		limit: CUSTOMER_PRODUCTS_DEFAULT_LIMIT,
-	});
+	// products_page / products_total_count are only rendered by the dashboard.
+	// The public API path never reads them, and building them costs two extra
+	// CTEs over customer_products plus ~12MB of the response on a 500-row page.
+	const productsSeedCte = withProductsPage
+		? sql`, ${customerProductsSeedCte({
+				inStatuses: RELEVANT_STATUSES,
+				limit: CUSTOMER_PRODUCTS_DEFAULT_LIMIT,
+			})}`
+		: sql``;
+
+	const productsSeedSelect = withProductsPage
+		? sql`, ${customerProductsSeedSelect}`
+		: sql``;
 
 	const customerListFilterSql = getCustomerListFilterSql({
 		internalCustomerIds,
@@ -270,14 +282,14 @@ export const getCursorPaginatedFullCusQuery = ({
 			SELECT id, entitlement_id FROM ces_loose
 			UNION ALL
 			SELECT id, entitlement_id FROM ces_pooled
-		),
+		)
 		${productsSeedCte}
 		${entitiesCte}
 		${invoicesCte}
 		SELECT
 			(SELECT COALESCE(json_agg(row_json), '[]'::json) FROM cr) AS customers,
-			(SELECT COALESCE(json_object_agg(internal_customer_id, n), '{}'::json) FROM cp_counts) AS product_counts,
-			${customerProductsSeedSelect},
+			(SELECT COALESCE(json_object_agg(internal_customer_id, n), '{}'::json) FROM cp_counts) AS product_counts
+			${productsSeedSelect},
 			(SELECT COALESCE(json_agg(row_json), '[]'::json) FROM cps_ranked) AS customer_products,
 			(SELECT COALESCE(json_agg(row_json), '[]'::json) FROM ces_bound) AS customer_entitlements,
 			(SELECT COALESCE(json_agg(row_json ORDER BY id DESC), '[]'::json) FROM ces_loose) AS extra_customer_entitlements,

--- a/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
+++ b/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
@@ -292,14 +292,36 @@ export const getCursorPaginatedFullCusQuery = ({
 				JOIN entitlements e ON e.id = ce.entitlement_id
 				JOIN features f ON f.internal_id = e.internal_feature_id
 			) AS entitlements,
-			(SELECT COALESCE(json_agg(row_to_json(ro)), '[]'::json)
+			-- Rollovers and replaceables are gathered per cus_ent via a correlated
+			-- subquery, then flattened, rather than joined against ces_all directly.
+			-- A direct join lets the planner pick a merge join: pg_stats badly
+			-- underestimates n_distinct on customer_entitlements.customer_product_id,
+			-- so ces_all is estimated ~100x too large and one ordered scan of
+			-- rollovers looks cheaper than per-row probes. That scanned all 7.38M
+			-- rollover rows on every call (7.7s of an 8.3s query) to return zero.
+			-- Keeping the table access inside a scalar subquery removes the choice.
+			-- A plain CROSS JOIN LATERAL over the table is NOT sufficient — the
+			-- planner pulls it back up into the same join.
+			(SELECT COALESCE(json_agg(ro_row.value), '[]'::json)
 				FROM ces_all
-				JOIN rollovers ro ON ro.cus_ent_id = ces_all.id
-				WHERE ro.expires_at IS NULL OR ro.expires_at > EXTRACT(EPOCH FROM now()) * 1000
+				CROSS JOIN LATERAL json_array_elements(
+					COALESCE((
+						SELECT json_agg(row_to_json(ro))
+						FROM rollovers ro
+						WHERE ro.cus_ent_id = ces_all.id
+							AND (ro.expires_at IS NULL OR ro.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
+					), '[]'::json)
+				) AS ro_row(value)
 			) AS rollovers,
-			(SELECT COALESCE(json_agg(row_to_json(r)), '[]'::json)
+			(SELECT COALESCE(json_agg(rep_row.value), '[]'::json)
 				FROM ces_all
-				JOIN replaceables r ON r.cus_ent_id = ces_all.id
+				CROSS JOIN LATERAL json_array_elements(
+					COALESCE((
+						SELECT json_agg(row_to_json(r))
+						FROM replaceables r
+						WHERE r.cus_ent_id = ces_all.id
+					), '[]'::json)
+				) AS rep_row(value)
 			) AS replaceables,
 			(SELECT COALESCE(json_agg(row_to_json(ft)), '[]'::json)
 				FROM (SELECT DISTINCT free_trial_id FROM cps_ranked WHERE free_trial_id IS NOT NULL) cps

--- a/server/src/internal/customers/repos/getFullSubject/getEntityAggregateFragments.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getEntityAggregateFragments.ts
@@ -47,14 +47,11 @@ export const getEntityAggregateFragments = ({
 	statusFilter: SQL;
 	internalFeatureIds?: string[];
 }) => {
+	// Single array parameter, not one placeholder per id — keeps the SQL text
+	// stable across callers so the statement stays preparable.
 	const featureFilter =
 		internalFeatureIds && internalFeatureIds.length > 0
-			? sql`AND ce.internal_feature_id = ANY(ARRAY[${sql.join(
-					internalFeatureIds.map(
-						(internalFeatureId) => sql`${internalFeatureId}`,
-					),
-					sql`, `,
-				)}])`
+			? sql`AND ce.internal_feature_id = ANY(${sql.param(internalFeatureIds)}::text[])`
 			: sql``;
 
 	if (entityId) {

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
@@ -6,6 +6,7 @@ import {
 	normalizedToFullSubject,
 	type SubjectQueryRow,
 } from "@autumn/shared";
+import { executePrepared } from "@/db/executePrepared.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { checkPendingMigrationsForCustomer } from "@/internal/migrations/v2/lazy/checkPendingMigrationsForCustomer.js";
 import { lazyResetSubjectEntitlements } from "../../actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.js";
@@ -40,8 +41,10 @@ export async function getFullSubject({
 		env,
 		logger: ctx.logger,
 		queryFn: () =>
-			db.execute(
-				getFullSubjectQuery({
+			executePrepared({
+				db,
+				label: "getFullSubject",
+				query: getFullSubjectQuery({
 					orgId: org.id,
 					env,
 					customerId,
@@ -49,7 +52,7 @@ export async function getFullSubject({
 					inStatuses,
 					allowMissingEntity,
 				}),
-			),
+			}),
 	});
 
 	if (!result?.length) return undefined;
@@ -93,8 +96,10 @@ export async function getFullSubjectNormalized({
 		env,
 		logger: ctx.logger,
 		queryFn: () =>
-			db.execute(
-				getFullSubjectQuery({
+			executePrepared({
+				db,
+				label: "getFullSubject",
+				query: getFullSubjectQuery({
 					orgId: org.id,
 					env,
 					customerId,
@@ -102,7 +107,7 @@ export async function getFullSubjectNormalized({
 					inStatuses,
 					allowMissingEntity,
 				}),
-			),
+			}),
 	});
 
 	if (!result?.length) return undefined;

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts
@@ -196,6 +196,15 @@ export const getFullSubjectRowsQuery = ({
 					${effectiveRelevantStatusFirst} AS status_priority,
 					${hasCustomerPrices} AS has_customer_prices,
 					prod.is_add_on AS product_is_add_on,
+					-- Resolved once here and carried through cus_products so the
+					-- aggregate below doesn't repeat this LATERAL + join.
+					CASE WHEN pcl_early.id IS NULL THEN NULL ELSE to_jsonb(pcl_early) END
+						AS parent_customer_license,
+					CASE WHEN pcp_early.id IS NULL THEN NULL ELSE jsonb_build_object(
+						'status', pcp_early.status,
+						'subscription_ids', to_jsonb(pcp_early.subscription_ids),
+						'canceled_at', pcp_early.canceled_at
+					) END AS parent_customer_product,
 					cp.*
 				FROM customer_products cp
 				JOIN products prod
@@ -447,18 +456,11 @@ export const getFullSubjectRowsQuery = ({
 						- 'has_customer_prices'
 						- 'product_is_add_on'
 						- 'subject_rank'
-						-- Seat rows carry their pool + the parent's lifecycle snapshot
-						-- (fetched unfiltered: an expired parent is not in cus_products).
-						|| jsonb_build_object(
-							'parent_customer_license',
-							CASE WHEN pcl.id IS NULL THEN NULL ELSE to_jsonb(pcl) END,
-							'parent_customer_product',
-							CASE WHEN pcp_lifecycle.id IS NULL THEN NULL ELSE jsonb_build_object(
-								'status', pcp_lifecycle.status,
-								'subscription_ids', to_jsonb(pcp_lifecycle.subscription_ids),
-								'canceled_at', pcp_lifecycle.canceled_at
-							) END
-						)
+						-- parent_customer_license / parent_customer_product ride along
+						-- from all_cus_products (seat rows carry their pool and the
+						-- parent's unfiltered lifecycle snapshot), so they land in this
+						-- object via row_to_json. They used to be re-derived here by a
+						-- second copy of the same LATERAL + join.
 					)::json
 					ORDER BY
 						cp.subject_entity_priority ASC,
@@ -468,21 +470,6 @@ export const getFullSubjectRowsQuery = ({
 						cp.created_at DESC
 				) AS items
 			FROM cus_products cp
-			-- Links can match multiple pool rows (predecessors linger on expired
-			-- parents); seats inherit from the pool on the LIVE parent.
-			LEFT JOIN LATERAL (
-				SELECT pool.*
-				FROM customer_licenses pool
-				JOIN customer_products pool_parent
-					ON pool_parent.id = pool.parent_customer_product_id
-				WHERE cp.customer_license_link_id IS NOT NULL
-					AND pool.link_id = cp.customer_license_link_id
-				ORDER BY (pool_parent.status IN ('active', 'past_due', 'scheduled')) DESC,
-					pool.created_at DESC
-				LIMIT 1
-			) pcl ON true
-			LEFT JOIN customer_products pcp_lifecycle
-				ON pcp_lifecycle.id = pcl.parent_customer_product_id
 			GROUP BY cp.subject_key
 		),
 

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts
@@ -74,12 +74,13 @@ export const getFullSubjectRowsQuery = ({
 		inStatuses.length > 0
 			? ACTIVE_STATUSES.filter((status) => inStatuses.includes(status))
 			: ACTIVE_STATUSES;
+	// Status lists bind as a single array parameter rather than one placeholder
+	// per element. This keeps the generated SQL text identical regardless of how
+	// many statuses a caller passes, which is what lets the statement be reused
+	// as a named prepared statement instead of re-planned on every execution.
 	const entityAggregationStatusFilter =
 		entityAggregationStatuses.length > 0
-			? sql`AND cp.status = ANY(ARRAY[${sql.join(
-					entityAggregationStatuses.map((status) => sql`${status}`),
-					sql`, `,
-				)}])`
+			? sql`AND cp.status = ANY(${sql.param(entityAggregationStatuses)}::text[])`
 			: sql`AND FALSE`;
 
 	// Seats own no lifecycle: their raw status column lags until the seat-sync
@@ -87,16 +88,10 @@ export const getFullSubjectRowsQuery = ({
 	// parent's LIVE status (via pcp_early) instead of cp.status for those rows.
 	const effectiveStatusFilter =
 		inStatuses.length > 0
-			? sql`AND COALESCE(pcp_early.status, cp.status) = ANY(ARRAY[${sql.join(
-					inStatuses.map((status) => sql`${status}`),
-					sql`, `,
-				)}])`
+			? sql`AND COALESCE(pcp_early.status, cp.status) = ANY(${sql.param(inStatuses)}::text[])`
 			: sql``;
 
-	const effectiveRelevantStatusFirst = sql`CASE WHEN COALESCE(pcp_early.status, cp.status) = ANY(ARRAY[${sql.join(
-		RELEVANT_STATUSES.map((status) => sql`${status}`),
-		sql`, `,
-	)}]) THEN 0 ELSE 1 END`;
+	const effectiveRelevantStatusFirst = sql`CASE WHEN COALESCE(pcp_early.status, cp.status) = ANY(${sql.param(RELEVANT_STATUSES)}::text[]) THEN 0 ELSE 1 END`;
 
 	const hasCustomerPrices = sql`EXISTS (
 		SELECT 1

--- a/server/src/internal/orgs/orgUtils/cacheOrgWithFeatures.ts
+++ b/server/src/internal/orgs/orgUtils/cacheOrgWithFeatures.ts
@@ -1,0 +1,130 @@
+import { AppEnv } from "@autumn/shared";
+import type { DrizzleCli } from "@server/db/initDrizzle.js";
+import {
+	getConfiguredRegions,
+	getRegionalRedis,
+	redis,
+} from "@/external/redis/initRedis.js";
+import { tryRedisRead, tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
+import { OrgService } from "../OrgService.js";
+
+/** Short by design: org config changes are also pushed through clearOrgCache, so
+ *  this only has to bound the staleness window for anything that misses that. */
+export const ORG_WITH_FEATURES_CACHE_TTL_SECONDS = 60;
+
+type OrgWithFeatures = NonNullable<
+	Awaited<ReturnType<typeof OrgService.getWithFeatures>>
+>;
+
+export const buildOrgWithFeaturesCacheKey = ({
+	orgId,
+	env,
+}: {
+	orgId: string;
+	env: AppEnv;
+}) => `org_with_features:${orgId}:${env}`;
+
+export const getCachedOrgWithFeatures = async ({
+	orgId,
+	env,
+}: {
+	orgId: string;
+	env: AppEnv;
+}) => {
+	const cacheKey = buildOrgWithFeaturesCacheKey({ orgId, env });
+	const cached = await tryRedisRead(() => redis.get(cacheKey));
+
+	if (!cached) return null;
+
+	return JSON.parse(cached) as OrgWithFeatures;
+};
+
+export const setCachedOrgWithFeatures = async ({
+	orgId,
+	env,
+	data,
+	ttl = ORG_WITH_FEATURES_CACHE_TTL_SECONDS,
+}: {
+	orgId: string;
+	env: AppEnv;
+	data: OrgWithFeatures;
+	ttl?: number;
+}) => {
+	const cacheKey = buildOrgWithFeaturesCacheKey({ orgId, env });
+
+	await tryRedisWrite(() =>
+		redis.set(cacheKey, JSON.stringify(data), "EX", ttl),
+	);
+};
+
+export const clearOrgWithFeaturesCache = async ({
+	orgId,
+	env,
+	logger = console,
+}: {
+	orgId: string;
+	/** Omit to clear every env. */
+	env?: AppEnv;
+	logger?: Pick<Console, "error" | "warn">;
+}) => {
+	const envs = env ? [env] : [AppEnv.Live, AppEnv.Sandbox];
+
+	await Promise.all(
+		getConfiguredRegions().flatMap((region) =>
+			envs.map(async (targetEnv) => {
+				const regionalRedis = getRegionalRedis(region);
+
+				if (regionalRedis.status !== "ready") {
+					logger.warn(`[clearOrgWithFeaturesCache] ${region}: not_ready`);
+					return;
+				}
+
+				const deleted = await tryRedisWrite(
+					() =>
+						regionalRedis.del(
+							buildOrgWithFeaturesCacheKey({ orgId, env: targetEnv }),
+						),
+					regionalRedis,
+				);
+
+				if (deleted === null) {
+					logger.warn(`[clearOrgWithFeaturesCache] ${region}: delete_failed`);
+				}
+			}),
+		),
+	);
+};
+
+/**
+ * Read-through cache around `OrgService.getWithFeatures`.
+ *
+ * Queue workers call this once per message and async `balances.track` enqueues
+ * one message per API request, so the uncached path was running ~1,140 times a
+ * second against Postgres — 3.08M lookups in 45 minutes, 8.4% of database time —
+ * for a row that barely changes.
+ *
+ * `tryRedisRead`/`tryRedisWrite` fail open to null, so a Redis outage degrades
+ * to exactly the previous behaviour rather than erroring the job.
+ */
+export const getOrgWithFeaturesCached = async ({
+	db,
+	orgId,
+	env,
+	skipCache = false,
+}: {
+	db: DrizzleCli;
+	orgId: string;
+	env: AppEnv;
+	skipCache?: boolean;
+}): Promise<OrgWithFeatures | null> => {
+	if (!skipCache) {
+		const cached = await getCachedOrgWithFeatures({ orgId, env });
+		if (cached) return cached;
+	}
+
+	const fresh = await OrgService.getWithFeatures({ db, orgId, env });
+	if (!fresh) return null;
+
+	await setCachedOrgWithFeatures({ orgId, env, data: fresh });
+	return fresh;
+};

--- a/server/src/internal/orgs/orgUtils/clearOrgCache.ts
+++ b/server/src/internal/orgs/orgUtils/clearOrgCache.ts
@@ -2,6 +2,7 @@ import type { AppEnv } from "@autumn/shared";
 import type { DrizzleCli } from "@server/db/initDrizzle.js";
 import { clearSecretKeyCache } from "@/internal/dev/api-keys/cacheApiKeyUtils.js";
 import { OrgService } from "../OrgService.js";
+import { clearOrgWithFeaturesCache } from "./cacheOrgWithFeatures.js";
 
 export const clearOrgCache = async ({
 	db,
@@ -38,6 +39,10 @@ export const clearOrgCache = async ({
 				}),
 			),
 		);
+		// Workers read org config through a short-TTL cache; drop it here so a
+		// config change lands immediately rather than after the TTL.
+		await clearOrgWithFeaturesCache({ orgId, env, logger });
+
 		logger.info(`Cleared cache for org ${org.slug} (${orgId})`);
 	} catch (error) {
 		logger.error(`Failed to clear cache for org ${orgId}`);

--- a/server/src/queue/createWorkerContext.ts
+++ b/server/src/queue/createWorkerContext.ts
@@ -6,7 +6,7 @@ import { getCtxWithCustomerRedis } from "../external/redis/customerRedisRouting.
 import { resolveRedisV2 } from "../external/redis/resolveRedisV2.js";
 import type { AutumnContext } from "../honoUtils/HonoEnv.js";
 import { computeRolloutSnapshot } from "../internal/misc/rollouts/rolloutUtils.js";
-import { OrgService } from "../internal/orgs/OrgService.js";
+import { getOrgWithFeaturesCached } from "../internal/orgs/orgUtils/cacheOrgWithFeatures.js";
 import { generateId } from "../utils/genUtils.js";
 
 export const createWorkerContext = async ({
@@ -30,9 +30,12 @@ export const createWorkerContext = async ({
 
 	// Fetch org with features once for all items. A missing org means it was
 	// deleted after the job was queued (common in tests) — skip, don't fail.
-	let orgData: Awaited<ReturnType<typeof OrgService.getWithFeatures>> | null;
+	// Deliberately not gated on `skipCache` — that flag governs the customer
+	// cache (workers want fresh balances), whereas this is org config that
+	// changes rarely and is invalidated by clearOrgCache.
+	let orgData: Awaited<ReturnType<typeof getOrgWithFeaturesCached>>;
 	try {
-		orgData = await OrgService.getWithFeatures({ db, orgId, env });
+		orgData = await getOrgWithFeaturesCached({ db, orgId, env });
 	} catch {
 		orgData = null;
 	}

--- a/server/src/utils/workerUtils/createAutumnContext.ts
+++ b/server/src/utils/workerUtils/createAutumnContext.ts
@@ -12,7 +12,7 @@ import { getCtxWithCustomerRedis } from "@/external/redis/customerRedisRouting.j
 import { resolveRedisV2 } from "@/external/redis/resolveRedisV2.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
-import { OrgService } from "@/internal/orgs/OrgService.js";
+import { getOrgWithFeaturesCached } from "@/internal/orgs/orgUtils/cacheOrgWithFeatures.js";
 
 export const createWorkerAutumnContext = async ({
 	db,
@@ -28,7 +28,7 @@ export const createWorkerAutumnContext = async ({
 	workerId: string;
 }): Promise<AutumnContext> => {
 	// 1. Get org with features
-	const data = await OrgService.getWithFeatures({
+	const data = await getOrgWithFeaturesCached({
 		db,
 		orgId,
 		env,

--- a/shared/models/cusProductModels/cusEntModels/usageWindowTable.ts
+++ b/shared/models/cusProductModels/cusEntModels/usageWindowTable.ts
@@ -85,6 +85,13 @@ export const usageWindows = pgTable(
 		index("idx_usage_windows_internal_customer_id").on(
 			table.internal_customer_id,
 		),
+		// customers.internal_id is COLLATE "C" but this column is the database
+		// default, so joins resolve to "C" and the plain index above can never be
+		// used — it has 0 scans in prod. getFullSubject was sequentially scanning
+		// the whole table on every call as a result. See [[postgres-collation-index-trap]].
+		index("idx_usage_windows_internal_customer_id_c")
+			.on(sql`${table.internal_customer_id} COLLATE "C"`)
+			.concurrently(),
 		index("idx_uw_internal_feature_id")
 			.on(table.internal_feature_id)
 			.concurrently(),

--- a/shared/models/orgModels/orgTable.ts
+++ b/shared/models/orgModels/orgTable.ts
@@ -127,6 +127,20 @@ export const organizations = pgTable(
 			sql`${table.createdAt} DESC`,
 			sql`${table.id} DESC`,
 		),
+		// Stripe Connect webhooks resolve an org by external account id. Without
+		// these, the three OR'd ->> predicates in OrgService.getByAccountId force a
+		// seq scan; Postgres turns them into a BitmapOr instead. The table is only
+		// ~531 rows but its wide jsonb columns bloat it to ~37MB, so a scan cost
+		// ~20ms per webhook.
+		index("idx_orgs_test_connect_default_account")
+			.on(sql`(${table.test_stripe_connect}->>'default_account_id')`)
+			.concurrently(),
+		index("idx_orgs_test_connect_account")
+			.on(sql`(${table.test_stripe_connect}->>'account_id')`)
+			.concurrently(),
+		index("idx_orgs_live_connect_account")
+			.on(sql`(${table.live_stripe_connect}->>'account_id')`)
+			.concurrently(),
 		unique("organizations_test_pkey_key").on(table.test_pkey),
 		unique("organizations_live_pkey_key").on(table.live_pkey),
 	],


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reduce query planning and payload work for customer subject and cursor list queries by introducing named prepared statements, eliminating heavy joins/scans, and skipping dashboard-only data on API paths. Observed improvements include multi‑x throughput and a large drop in end‑to‑end latency for 500‑row dashboard pages.

- **New Features**
  - Added `executePrepared` to run Drizzle SQL as server-side named prepared statements and applied it to getFullSubject; array inputs bind via `sql.param` to keep SQL text stable.
  - Introduced a 60s Redis cache for org + features; invalidated via `clearOrgCache` and used in worker contexts to cut repeated DB reads.

- **Refactors**
  - Gated `products_page` and `products_total_count` behind `withProductsPage` (dashboard only) and set it in the dashboard batch service.
  - Reworked rollovers/replaceables in `cursorPaginatedFullCusQuery` to use per‑row scalar subqueries, preventing merge‑join full scans on large tables; carried seat parent lifecycle data from the early CTE instead of re-deriving it later.
  - Stabilized getFullSubject SQL by binding status/feature lists as a single array parameter.
  - Added indexes to remove hidden scan costs:
    - `usage_windows.internal_customer_id` with `"C"` collation to match `customers.internal_id`.
    - JSONB indexes for Stripe Connect account lookups on organizations.

<sup>Written for commit 26e2be8b066f9ad981ba3c45556d6e4f1aebb915. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR reduces database work across full-subject reads, customer pagination, and worker context creation:
- **[Improvements]** Executes full-subject reads as stable named prepared statements and changes list parameters to single PostgreSQL arrays.
- **[Improvements]** Reworks customer aggregation queries to avoid expensive rollover/replaceable scans, duplicate license joins, and unused dashboard product-page payloads.
- **[Improvements]** Adds a short-lived Redis cache for worker org-and-feature hydration with regional invalidation.
- **[Improvements]** Declares indexes for usage-window joins and Stripe Connect account lookups and adds performance experiment scripts.
</details>

<h3>Confidence Score: 2/5</h3>

The PR should not merge until the new indexes have a versioned migration and every feature-deletion path invalidates the worker org cache.

Deployed databases will not receive the declared indexes, and bulk feature deletion leaves workers consuming stale org feature data from the new cache for up to 60 seconds.

**Files Needing Attention:** shared/models/cusProductModels/cusEntModels/usageWindowTable.ts, shared/models/orgModels/orgTable.ts, shared/drizzle/, and server/src/internal/orgs/orgUtils/cacheOrgWithFeatures.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/db/executePrepared.ts | Adds content-addressed named prepared-statement execution with unprepared fallbacks and a bounded statement-shape registry. |
| server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts | Stabilizes array parameters and carries license-parent snapshots through the earlier customer-product CTE to remove duplicate joins. |
| server/src/internal/customers/cursorPaginatedFullCusQuery.ts | Makes dashboard product-page aggregation opt-in and replaces broad rollover/replaceable joins with correlated probes. |
| server/src/internal/orgs/orgUtils/cacheOrgWithFeatures.ts | Adds Redis read-through caching for worker org data, but existing bulk feature-deletion paths do not invalidate the new cache. |
| shared/models/cusProductModels/cusEntModels/usageWindowTable.ts | Declares a collation-compatible usage-window index, but no deployable database migration accompanies it. |
| shared/models/orgModels/orgTable.ts | Declares three Stripe Connect expression indexes, but no deployable database migration accompanies them. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Caller[Full-subject caller] --> StableSQL[Stable parameterized SQL]
  StableSQL --> Prepared[Named prepared statement]
  Prepared --> Postgres[(Postgres)]
  Cursor[Customer cursor query] --> Optional{Dashboard request?}
  Optional -->|Yes| ProductPage[Build product page CTEs]
  Optional -->|No| LeanResult[Skip product page CTEs]
  Worker[Queue worker] --> OrgCache{Org cache hit?}
  OrgCache -->|Yes| Context[Build worker context]
  OrgCache -->|No| OrgDB[Load org and features]
  OrgDB --> CacheWrite[Cache for 60 seconds]
  CacheWrite --> Context
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
shared/models/cusProductModels/cusEntModels/usageWindowTable.ts:88-91
**Indexes lack deployable migrations**

When this PR is deployed through the versioned migration workflow, these Drizzle-only declarations do not create the usage-window index or the three organization indexes, so production retains the sequential scans this change is intended to eliminate. Add the generated SQL migration and matching migration metadata for all four declarations.

### Issue 2 of 2
server/src/internal/orgs/orgUtils/cacheOrgWithFeatures.ts:118-121
**Feature deletions leave stale cache**

When `FeatureService.deleteByOrgId` or `safeDeleteByOrgId` removes an org's features, those existing mutation paths do not clear this new cache. Workers then continue building contexts from the deleted feature data for up to 60 seconds, causing queued entitlement and billing work to use stale org configuration. Invalidate this cache from those bulk-deletion paths.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(customers): ⚡️ build products\_page ..."](https://github.com/useautumn/autumn/commit/26e2be8b066f9ad981ba3c45556d6e4f1aebb915) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47660604)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)
- Knowledge Base — [Shared Database Schema](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/shared-db-schema.md)
- Knowledge Base — [External Integrations (non-Stripe)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-external-integrations.md)
</details>

<!-- /greptile_comment -->