### PR TITLE
Fix cyclic serialization after lazy reset

### DIFF
--- a/server/src/internal/customers/actions/resetCustomerEntitlements/applyResetResults.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlements/applyResetResults.ts
@@ -1,6 +1,8 @@
 import type {
 	FullCusEntWithProduct,
+	FullCusProduct,
 	FullCustomer,
+	FullCustomerEntitlement,
 	Rollover,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
@@ -13,29 +15,40 @@ export type RolloverClearingInfo = {
 	overwrites: Rollover[];
 };
 
-/** Find a cusEnt on the FullCustomer by ID, attaching the parent cusProduct.
- *  Uses Object.assign to preserve the original reference so in-place mutations
- *  (balance, rollovers, etc.) propagate back to the FullCustomer object. */
+/** Finds the stored entitlement and its parent without adding a back-reference.
+ * Mutations stay on the stored entitlement so FullCustomer remains serializable. */
 const findCusEnt = ({
 	fullCus,
 	cusEntId,
 }: {
 	fullCus: FullCustomer;
 	cusEntId: string;
-}): FullCusEntWithProduct | null => {
+}): {
+	customerEntitlement: FullCustomerEntitlement;
+	customerProduct: FullCusProduct | null;
+} | null => {
 	for (const cusProduct of fullCus.customer_products) {
 		for (const cusEnt of cusProduct.customer_entitlements) {
 			if (cusEnt.id === cusEntId)
-				return Object.assign(cusEnt, { customer_product: cusProduct });
+				return {
+					customerEntitlement: cusEnt,
+					customerProduct: cusProduct,
+				};
 		}
 	}
 	for (const cusEnt of fullCus.extra_customer_entitlements || []) {
 		if (cusEnt.id === cusEntId)
-			return Object.assign(cusEnt, { customer_product: null });
+			return {
+				customerEntitlement: cusEnt,
+				customerProduct: null,
+			};
 	}
 	for (const cusEnt of fullCus.pooled_customer_entitlements || []) {
 		if (cusEnt.id === cusEntId)
-			return Object.assign(cusEnt, { customer_product: null });
+			return {
+				customerEntitlement: cusEnt,
+				customerProduct: null,
+			};
 	}
 	return null;
 };
@@ -65,8 +78,9 @@ export const applyResetResults = async ({
 	const generalCtx = { ...ctx, db: ctx.dbGeneral };
 
 	for (const { cusEntId, result } of computed) {
-		const original = findCusEnt({ fullCus, cusEntId });
-		if (!original) continue;
+		const match = findCusEnt({ fullCus, cusEntId });
+		if (!match) continue;
+		const { customerEntitlement: original, customerProduct } = match;
 
 		const { updates } = result;
 		if (updates.balance !== null) original.balance = updates.balance;
@@ -85,7 +99,10 @@ export const applyResetResults = async ({
 				await RolloverService.clearExcessRollovers({
 					ctx: generalCtx,
 					newRows: result.rolloverInsert.rows,
-					fullCusEnt: original,
+					fullCusEnt: {
+						...original,
+						customer_product: customerProduct,
+					} satisfies FullCusEntWithProduct,
 				});
 			original.rollovers = rollovers;
 

--- a/server/tests/integration/billing/stripe-webhooks/subscription-deleted/subscription-deleted-expired-cache-serialization.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/subscription-deleted/subscription-deleted-expired-cache-serialization.test.ts
@@ -1,0 +1,87 @@
+/** Red: lazy reset makes the subscription.deleted expired-product cache payload cyclic.
+ * Green: reset preserves serializable product snapshots and the cache write succeeds. */
+
+import { expect, test } from "bun:test";
+import {
+	customerEntitlements,
+	findActiveCustomerProductById,
+	findCustomerEntitlementByFeature,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { CusService } from "@/internal/customers/CusService.js";
+import { customerProductActions } from "@/internal/customers/cusProducts/actions/index.js";
+
+test(`${chalk.yellowBright("sub.deleted: lazy reset keeps expired product cache serializable")}`, async () => {
+	const customerId = "sub-deleted-reset-cache-serialization";
+	const product = products.pro({
+		id: "sub-deleted-reset-cache-product",
+		items: [
+			items.monthlyMessages({ includedUsage: 100 }),
+			items.consumableWords(),
+		],
+	});
+	const { ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [product] }),
+		],
+		actions: [s.attach({ productId: product.id })],
+	});
+
+	const beforeReset = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+		skipReset: true,
+	});
+	const customerProductBeforeReset = findActiveCustomerProductById({
+		fullCus: beforeReset,
+		productId: product.id,
+	});
+	if (!customerProductBeforeReset)
+		throw new Error("Expected the attached customer product before reset");
+	const customerEntitlement = findCustomerEntitlementByFeature({
+		cusEnts: customerProductBeforeReset.customer_entitlements,
+		featureId: TestFeature.Messages,
+		errorOnNotFound: true,
+	});
+
+	await ctx.db
+		.update(customerEntitlements)
+		.set({ next_reset_at: Date.now() - 1_000 })
+		.where(eq(customerEntitlements.id, customerEntitlement.id));
+
+	const afterReset = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	const customerProduct = findActiveCustomerProductById({
+		fullCus: afterReset,
+		productId: product.id,
+	});
+	if (!customerProduct) {
+		throw new Error("Expected the attached customer product");
+	}
+	const resetCustomerEntitlement = findCustomerEntitlementByFeature({
+		cusEnts: customerProduct.customer_entitlements,
+		featureId: TestFeature.Messages,
+		errorOnNotFound: true,
+	});
+	expect(resetCustomerEntitlement?.next_reset_at).toBeGreaterThan(Date.now());
+
+	const stripeSubscriptionId = "sub_deleted_reset_cache_serialization";
+	await customerProductActions.expiredCache.set({
+		stripeSubscriptionId,
+		customerProducts: [customerProduct],
+	});
+
+	const cachedCustomerProducts = await customerProductActions.expiredCache.get({
+		stripeSubscriptionId,
+	});
+	expect(cachedCustomerProducts?.[0]?.id).toBe(customerProduct.id);
+});


### PR DESCRIPTION
## Summary

- keep FullCustomer lazy reset results acyclic
- preserve rollover clearing with a temporary parent-enriched entitlement view
- add subscription.deleted regression coverage for expired-product cache serialization

## Root cause

Lazy reset stored a customer product back-reference directly on its nested entitlement. That created a cycle which broke both customer.products.updated queue serialization and subscription.deleted expired-product caching.

## Testing

- regression test reproduced JSON.stringify cannot serialize cyclic structures before the fix and passes after it
- 1,962 server unit tests passed
- server typecheck passed
- Biome passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cyclic JSON serialization after lazy entitlement reset by removing product back-references on entitlements. Restores queue payloads and `subscription.deleted` expired-product cache writes.

- Bug Fixes
  - Avoids attaching `customer_product` on entitlements; keeps `FullCustomer` acyclic and serializable.
  - Preserves rollover clearing by passing a temporary parent-enriched entitlement to `RolloverService.clearExcessRollovers`.
  - Adds regression test to confirm `subscription.deleted` expired-product cache serializes and round-trips.

<sup>Written for commit 10b6f604dd1c9ab5fd3c0229484e784068eb7ac8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes cyclic serialization introduced by lazy entitlement resets.
- **Bug fixes:** Keeps stored `FullCustomer` entitlement graphs acyclic by returning the entitlement and parent product separately instead of attaching a persistent back-reference.
- **Improvements:** Supplies rollover clearing with a temporary parent-enriched entitlement view while preserving mutations on the stored entitlement.
- **Improvements:** Adds regression coverage for serializing and retrieving expired-product cache data after a lazy reset.
</details>

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge with no actionable defects identified.

The temporary parent-enriched entitlement is only read by rollover clearing, all reset mutations remain applied to the stored entitlement, and returned rollover state is explicitly written back without recreating the serialization cycle.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/actions/resetCustomerEntitlements/applyResetResults.ts | Removes the persistent entitlement-to-product back-reference while preserving reset updates and rollover clearing through a temporary enriched view. |
| server/tests/integration/billing/stripe-webhooks/subscription-deleted/subscription-deleted-expired-cache-serialization.test.ts | Adds regression coverage proving a lazily reset customer product can be serialized through the expired-product cache. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Customer as FullCustomer
    participant Reset as applyResetResults
    participant Rollover as RolloverService
    participant Cache as Expired Product Cache
    Reset->>Customer: Find stored entitlement and parent separately
    Reset->>Customer: Apply reset fields in place
    Reset->>Rollover: Pass temporary entitlement copy with parent
    Rollover-->>Reset: Return cleared rollovers
    Reset->>Customer: Store returned rollovers
    Customer->>Cache: Serialize acyclic product snapshot
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(stripe): 🐛 prevent cyclic reset ser..."](https://github.com/useautumn/autumn/commit/10b6f604dd1c9ab5fd3c0229484e784068eb7ac8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47671937)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->