### PR TITLE
feat: archive successful request bodies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   #   staging repo (autumn-staging) -> us-east-1
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix feat/request-log-archive
 
 jobs:
   checks:

--- a/firelens.conf
+++ b/firelens.conf
@@ -44,6 +44,23 @@
 [FILTER]
     Name rewrite_tag
     Match *-firelens-*
+    Rule $log_destination ^request_log_archive$ request_log_archive false
+    Emitter_Name request_log_archive_emitter
+    Emitter_Storage.type memory
+    Emitter_Mem_Buf_Limit 10M
+
+[FILTER]
+    Name rewrite_tag
+    Match request_log_archive
+    Rule $region ^us-east-1$ request_log_archive_staging false
+    Rule $region ^us-east-2$ request_log_archive_prod false
+    Emitter_Name request_log_archive_region_emitter
+    Emitter_Storage.type memory
+    Emitter_Mem_Buf_Limit 10M
+
+[FILTER]
+    Name rewrite_tag
+    Match *-firelens-*
     Rule $level ^(TRACE|DEBUG|INFO|WARN|ERROR|FATAL)$ axiom_express false
     Emitter_Name axiom_express_emitter
     Emitter_Storage.type memory
@@ -71,6 +88,20 @@
     Header Content-Type application/json
     retry_limit 5
     net.dns.mode TCP
+
+[OUTPUT]
+    Name kinesis_firehose
+    Match request_log_archive_staging
+    Region us-east-1
+    Delivery_Stream tf-request-log-archive-staging-delivery
+    retry_limit 5
+
+[OUTPUT]
+    Name kinesis_firehose
+    Match request_log_archive_prod
+    Region us-east-2
+    Delivery_Stream tf-request-log-archive-prod-delivery
+    retry_limit 5
 
 [OUTPUT]
     Name http

--- a/server/src/honoMiddlewares/baseMiddleware.ts
+++ b/server/src/honoMiddlewares/baseMiddleware.ts
@@ -13,11 +13,9 @@ import { resolveRedisV2 } from "@/external/redis/resolveRedisV2.js";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { generateId } from "@/utils/genUtils.js";
 import { addRequestToLogs } from "@/utils/logging/addContextToLogs";
+import { redactRequestBody } from "./requestLogging/redactRequestBody.js";
 import { resolveCustomerId } from "./utils/resolveCustomerId.js";
 import { resolveEntityId } from "./utils/resolveEntityId.js";
-
-const SENSITIVE_REQUEST_BODY_KEYS = new Set(["connectionString"]);
-const REDACTED_REQUEST_BODY_VALUE = "[REDACTED]";
 
 const parseMockRevenueCatFixtures = (
 	raw: string | undefined,
@@ -33,23 +31,6 @@ const parseMockRevenueCatFixtures = (
 	} catch {
 		return {};
 	}
-};
-
-const redactSensitiveRequestBody = ({ body }: { body: unknown }): unknown => {
-	if (!body || typeof body !== "object") return body;
-
-	if (Array.isArray(body)) {
-		return body.map((item) => redactSensitiveRequestBody({ body: item }));
-	}
-
-	return Object.fromEntries(
-		Object.entries(body).map(([key, value]) => [
-			key,
-			SENSITIVE_REQUEST_BODY_KEYS.has(key)
-				? REDACTED_REQUEST_BODY_VALUE
-				: redactSensitiveRequestBody({ body: value }),
-		]),
-	);
 };
 
 /**
@@ -97,7 +78,7 @@ export const baseMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 			ip_address: c.req.header("x-forwarded-for"),
 			region: process.env.AWS_REGION,
 			query: c.req.query(),
-			body: redactSensitiveRequestBody({ body }),
+			body: redactRequestBody({ body }),
 
 			name: `${c.req.method} ${c.req.path}`,
 		},

--- a/server/src/honoMiddlewares/requestLogging/buildRequestResultRecords.ts
+++ b/server/src/honoMiddlewares/requestLogging/buildRequestResultRecords.ts
@@ -17,8 +17,6 @@ type RequestResultRecordParams = {
 type AxiomRequestResultRecord = {
 	statusCode: number;
 	durationMs: number;
-	responseBodyBytes: number;
-	responseArchiveRouted: boolean;
 	res: unknown;
 };
 
@@ -39,67 +37,8 @@ type ArchivedRequestResultRecord = {
 	response_body_bytes: number;
 };
 
-const RESPONSE_SUMMARY_KEYS = [
-	"allowed",
-	"code",
-	"status",
-	"success",
-	"id",
-	"customer_id",
-	"entity_id",
-] as const;
-
-const BALANCE_SUMMARY_KEYS = [
-	"granted",
-	"remaining",
-	"usage",
-	"unlimited",
-	"overage_allowed",
-	"next_reset_at",
-] as const;
-
 const serializeBody = ({ body }: { body: unknown }): string =>
 	JSON.stringify(body ?? null);
-
-const isSummaryValue = (value: unknown) =>
-	typeof value === "boolean" ||
-	typeof value === "number" ||
-	(typeof value === "string" && value.length <= 256);
-
-const buildResponseSummary = ({
-	responseBody,
-}: {
-	responseBody: unknown;
-}): Record<string, unknown> | null => {
-	if (
-		!responseBody ||
-		typeof responseBody !== "object" ||
-		Array.isArray(responseBody)
-	) {
-		return null;
-	}
-
-	const response = responseBody as Record<string, unknown>;
-	const summary = Object.fromEntries(
-		RESPONSE_SUMMARY_KEYS.flatMap((key) =>
-			isSummaryValue(response[key]) ? [[key, response[key]]] : [],
-		),
-	);
-	const balance = response.balance;
-	if (balance && typeof balance === "object" && !Array.isArray(balance)) {
-		const balanceRecord = balance as Record<string, unknown>;
-		const balanceSummary = Object.fromEntries(
-			BALANCE_SUMMARY_KEYS.flatMap((key) =>
-				isSummaryValue(balanceRecord[key]) ? [[key, balanceRecord[key]]] : [],
-			),
-		);
-		if (Object.keys(balanceSummary).length > 0) {
-			summary.balance = balanceSummary;
-		}
-	}
-
-	return Object.keys(summary).length > 0 ? summary : null;
-};
 
 export const buildRequestResultRecords = ({
 	requestId,
@@ -128,12 +67,7 @@ export const buildRequestResultRecords = ({
 		axiom: {
 			statusCode,
 			durationMs,
-			responseBodyBytes,
-			responseArchiveRouted,
-			res:
-				!isSuccess || !responseArchiveRouted
-					? (responseBody ?? null)
-					: buildResponseSummary({ responseBody }),
+			res: responseBody ?? null,
 		},
 		archive: responseArchiveRouted
 			? {

--- a/server/src/honoMiddlewares/requestLogging/buildRequestResultRecords.ts
+++ b/server/src/honoMiddlewares/requestLogging/buildRequestResultRecords.ts
@@ -12,7 +12,6 @@ type RequestResultRecordParams = {
 	durationMs: number;
 	responseBody: unknown;
 	archiveSuccessResponse: boolean;
-	includeSuccessBodyInAxiom: boolean;
 };
 
 type AxiomRequestResultRecord = {
@@ -20,7 +19,6 @@ type AxiomRequestResultRecord = {
 	durationMs: number;
 	responseBodyBytes: number;
 	responseArchiveRouted: boolean;
-	responseBodySampled: boolean;
 	res: unknown;
 };
 
@@ -117,7 +115,6 @@ export const buildRequestResultRecords = ({
 	durationMs,
 	responseBody,
 	archiveSuccessResponse,
-	includeSuccessBodyInAxiom,
 }: RequestResultRecordParams): {
 	axiom: AxiomRequestResultRecord;
 	archive: ArchivedRequestResultRecord | null;
@@ -126,8 +123,6 @@ export const buildRequestResultRecords = ({
 	const responseBodyBytes = Buffer.byteLength(serializedResponseBody);
 	const isSuccess = statusCode >= 200 && statusCode < 300;
 	const responseArchiveRouted = isSuccess && archiveSuccessResponse;
-	const responseBodySampled =
-		isSuccess && responseArchiveRouted && includeSuccessBodyInAxiom;
 
 	return {
 		axiom: {
@@ -135,9 +130,8 @@ export const buildRequestResultRecords = ({
 			durationMs,
 			responseBodyBytes,
 			responseArchiveRouted,
-			responseBodySampled,
 			res:
-				!isSuccess || !responseArchiveRouted || responseBodySampled
+				!isSuccess || !responseArchiveRouted
 					? (responseBody ?? null)
 					: buildResponseSummary({ responseBody }),
 		},

--- a/server/src/honoMiddlewares/requestLogging/buildRequestResultRecords.ts
+++ b/server/src/honoMiddlewares/requestLogging/buildRequestResultRecords.ts
@@ -1,0 +1,163 @@
+type RequestResultRecordParams = {
+	requestId: string;
+	requestMethod: string;
+	requestPath: string;
+	requestBody: unknown;
+	orgId: string | null;
+	customerId: string | null;
+	entityId: string | null;
+	environment: string;
+	eventTime: string;
+	statusCode: number;
+	durationMs: number;
+	responseBody: unknown;
+	archiveSuccessResponse: boolean;
+	includeSuccessBodyInAxiom: boolean;
+};
+
+type AxiomRequestResultRecord = {
+	statusCode: number;
+	durationMs: number;
+	responseBodyBytes: number;
+	responseArchiveRouted: boolean;
+	responseBodySampled: boolean;
+	res: unknown;
+};
+
+type ArchivedRequestResultRecord = {
+	log_destination: "request_log_archive";
+	event_time: string;
+	request_id: string;
+	request_method: string;
+	request_path: string;
+	status_code: number;
+	duration_ms: number;
+	org_id: string | null;
+	customer_id: string | null;
+	entity_id: string | null;
+	environment: string;
+	request_body: string;
+	response_body: string;
+	response_body_bytes: number;
+};
+
+const RESPONSE_SUMMARY_KEYS = [
+	"allowed",
+	"code",
+	"status",
+	"success",
+	"id",
+	"customer_id",
+	"entity_id",
+] as const;
+
+const BALANCE_SUMMARY_KEYS = [
+	"granted",
+	"remaining",
+	"usage",
+	"unlimited",
+	"overage_allowed",
+	"next_reset_at",
+] as const;
+
+const serializeBody = ({ body }: { body: unknown }): string =>
+	JSON.stringify(body ?? null);
+
+const isSummaryValue = (value: unknown) =>
+	typeof value === "boolean" ||
+	typeof value === "number" ||
+	(typeof value === "string" && value.length <= 256);
+
+const buildResponseSummary = ({
+	responseBody,
+}: {
+	responseBody: unknown;
+}): Record<string, unknown> | null => {
+	if (
+		!responseBody ||
+		typeof responseBody !== "object" ||
+		Array.isArray(responseBody)
+	) {
+		return null;
+	}
+
+	const response = responseBody as Record<string, unknown>;
+	const summary = Object.fromEntries(
+		RESPONSE_SUMMARY_KEYS.flatMap((key) =>
+			isSummaryValue(response[key]) ? [[key, response[key]]] : [],
+		),
+	);
+	const balance = response.balance;
+	if (balance && typeof balance === "object" && !Array.isArray(balance)) {
+		const balanceRecord = balance as Record<string, unknown>;
+		const balanceSummary = Object.fromEntries(
+			BALANCE_SUMMARY_KEYS.flatMap((key) =>
+				isSummaryValue(balanceRecord[key]) ? [[key, balanceRecord[key]]] : [],
+			),
+		);
+		if (Object.keys(balanceSummary).length > 0) {
+			summary.balance = balanceSummary;
+		}
+	}
+
+	return Object.keys(summary).length > 0 ? summary : null;
+};
+
+export const buildRequestResultRecords = ({
+	requestId,
+	requestMethod,
+	requestPath,
+	requestBody,
+	orgId,
+	customerId,
+	entityId,
+	environment,
+	eventTime,
+	statusCode,
+	durationMs,
+	responseBody,
+	archiveSuccessResponse,
+	includeSuccessBodyInAxiom,
+}: RequestResultRecordParams): {
+	axiom: AxiomRequestResultRecord;
+	archive: ArchivedRequestResultRecord | null;
+} => {
+	const serializedResponseBody = serializeBody({ body: responseBody });
+	const responseBodyBytes = Buffer.byteLength(serializedResponseBody);
+	const isSuccess = statusCode >= 200 && statusCode < 300;
+	const responseArchiveRouted = isSuccess && archiveSuccessResponse;
+	const responseBodySampled =
+		isSuccess && responseArchiveRouted && includeSuccessBodyInAxiom;
+
+	return {
+		axiom: {
+			statusCode,
+			durationMs,
+			responseBodyBytes,
+			responseArchiveRouted,
+			responseBodySampled,
+			res:
+				!isSuccess || !responseArchiveRouted || responseBodySampled
+					? (responseBody ?? null)
+					: buildResponseSummary({ responseBody }),
+		},
+		archive: responseArchiveRouted
+			? {
+					log_destination: "request_log_archive",
+					event_time: eventTime,
+					request_id: requestId,
+					request_method: requestMethod,
+					request_path: requestPath,
+					status_code: statusCode,
+					duration_ms: durationMs,
+					org_id: orgId,
+					customer_id: customerId,
+					entity_id: entityId,
+					environment,
+					request_body: serializeBody({ body: requestBody }),
+					response_body: serializedResponseBody,
+					response_body_bytes: responseBodyBytes,
+				}
+			: null,
+	};
+};

--- a/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
+++ b/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
@@ -1,25 +1,23 @@
 import chalk from "chalk";
 import type { Context } from "hono";
+import { logger as rootLogger } from "@/external/logtail/logtailUtils.js";
 import type { AutumnContext, HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { addExtrasToLogs } from "@/utils/logging/addContextToLogs";
 import { maskExtraLogs } from "@/utils/logging/maskExtraLogs.js";
+import { buildRequestResultRecords } from "./buildRequestResultRecords.js";
+import { redactRequestBody } from "./redactRequestBody.js";
 
-const HIGH_VOLUME_SUCCESS_ROUTES = new Set<string>([
-	// "/v1/balances.track",
-	// "/v1/balances.check",
-	// "/v1/check",
-	// "/v1/track",
-	// "/v1/customers.get_or_create",
-	// "/v1/entities.get",
-]);
-
-const SUCCESS_REQUEST_LOG_SAMPLE_RATE = Number.parseFloat(
-	process.env.AXIOM_SUCCESS_REQUEST_LOG_SAMPLE_RATE ?? "0",
+const SUCCESS_RESPONSE_BODY_SAMPLE_RATE = Number.parseFloat(
+	process.env.AXIOM_SUCCESS_RESPONSE_BODY_SAMPLE_RATE ?? "0",
 );
 
-const shouldSampleSuccessLog = () =>
-	SUCCESS_REQUEST_LOG_SAMPLE_RATE > 0 &&
-	Math.random() < Math.min(SUCCESS_REQUEST_LOG_SAMPLE_RATE, 1);
+const shouldSampleSuccessResponseBody = () =>
+	SUCCESS_RESPONSE_BODY_SAMPLE_RATE > 0 &&
+	Math.random() < Math.min(SUCCESS_RESPONSE_BODY_SAMPLE_RATE, 1);
+
+const isRequestLogArchiveDeployment = () =>
+	process.env.FLIGHTCONTROL === "true" &&
+	(process.env.FC_GIT_BRANCH === "dev" || process.env.FC_GIT_BRANCH === "main");
 
 export const logRequestResult = async ({
 	ctx,
@@ -42,12 +40,6 @@ export const logRequestResult = async ({
 		}
 
 		const isSuccess = statusCode >= 200 && statusCode < 300;
-		const isHighVolumeSuccess =
-			isSuccess && HIGH_VOLUME_SUCCESS_ROUTES.has(c.req.path);
-
-		if (isHighVolumeSuccess && !shouldSampleSuccessLog()) {
-			return;
-		}
 
 		ctx.logger = addExtrasToLogs({
 			logger: ctx.logger,
@@ -66,16 +58,36 @@ export const logRequestResult = async ({
 			}
 		}
 
+		const records = buildRequestResultRecords({
+			requestId: ctx.id,
+			requestMethod: c.req.method,
+			requestPath: c.req.path,
+			requestBody: redactRequestBody({ body: ctx.requestBody }),
+			orgId: ctx.org?.id ?? null,
+			customerId: ctx.customerId ?? null,
+			entityId: ctx.entityId ?? null,
+			environment: ctx.env,
+			eventTime: new Date(ctx.timestamp).toISOString(),
+			statusCode,
+			durationMs,
+			responseBody: finalResponseBody ?? null,
+			archiveSuccessResponse:
+				isSuccess &&
+				c.req.path.startsWith("/v1") &&
+				isRequestLogArchiveDeployment(),
+			includeSuccessBodyInAxiom: shouldSampleSuccessResponseBody(),
+		});
+
+		if (records.archive) {
+			rootLogger.info("request_log_archive", records.archive);
+		}
+
 		const log = isSuccess ? ctx.logger.info : ctx.logger.warn;
 		const statusColor = isSuccess ? chalk.green : chalk.yellow;
 
 		log(
 			`[${statusColor(statusCode)}] ${c.req.path} (${ctx.org?.slug}) ${durationMs}ms`,
-			{
-				statusCode,
-				durationMs,
-				res: finalResponseBody ?? null,
-			},
+			records.axiom,
 		);
 
 		if (

--- a/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
+++ b/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
@@ -7,14 +7,6 @@ import { maskExtraLogs } from "@/utils/logging/maskExtraLogs.js";
 import { buildRequestResultRecords } from "./buildRequestResultRecords.js";
 import { redactRequestBody } from "./redactRequestBody.js";
 
-const SUCCESS_RESPONSE_BODY_SAMPLE_RATE = Number.parseFloat(
-	process.env.AXIOM_SUCCESS_RESPONSE_BODY_SAMPLE_RATE ?? "0",
-);
-
-const shouldSampleSuccessResponseBody = () =>
-	SUCCESS_RESPONSE_BODY_SAMPLE_RATE > 0 &&
-	Math.random() < Math.min(SUCCESS_RESPONSE_BODY_SAMPLE_RATE, 1);
-
 const isRequestLogArchiveDeployment = () =>
 	process.env.FLIGHTCONTROL === "true" &&
 	(process.env.FC_GIT_BRANCH === "dev" || process.env.FC_GIT_BRANCH === "main");
@@ -75,7 +67,6 @@ export const logRequestResult = async ({
 				isSuccess &&
 				c.req.path.startsWith("/v1") &&
 				isRequestLogArchiveDeployment(),
-			includeSuccessBodyInAxiom: shouldSampleSuccessResponseBody(),
 		});
 
 		if (records.archive) {

--- a/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
+++ b/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
@@ -1,9 +1,9 @@
 import chalk from "chalk";
 import type { Context } from "hono";
-import { logger as rootLogger } from "@/external/logtail/logtailUtils.js";
 import type { AutumnContext, HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { addExtrasToLogs } from "@/utils/logging/addContextToLogs";
 import { maskExtraLogs } from "@/utils/logging/maskExtraLogs.js";
+import { writeFireLensRecord } from "@/utils/logging/writeFireLensRecord.js";
 import { buildRequestResultRecords } from "./buildRequestResultRecords.js";
 import { redactRequestBody } from "./redactRequestBody.js";
 
@@ -70,7 +70,7 @@ export const logRequestResult = async ({
 		});
 
 		if (records.archive) {
-			rootLogger.info("request_log_archive", records.archive);
+			writeFireLensRecord({ record: records.archive });
 		}
 
 		const log = isSuccess ? ctx.logger.info : ctx.logger.warn;

--- a/server/src/honoMiddlewares/requestLogging/redactRequestBody.ts
+++ b/server/src/honoMiddlewares/requestLogging/redactRequestBody.ts
@@ -1,0 +1,19 @@
+const SENSITIVE_REQUEST_BODY_KEYS = new Set(["connectionString"]);
+const REDACTED_REQUEST_BODY_VALUE = "[REDACTED]";
+
+export const redactRequestBody = ({ body }: { body: unknown }): unknown => {
+	if (!body || typeof body !== "object") return body;
+
+	if (Array.isArray(body)) {
+		return body.map((item) => redactRequestBody({ body: item }));
+	}
+
+	return Object.fromEntries(
+		Object.entries(body).map(([key, value]) => [
+			key,
+			SENSITIVE_REQUEST_BODY_KEYS.has(key)
+				? REDACTED_REQUEST_BODY_VALUE
+				: redactRequestBody({ body: value }),
+		]),
+	);
+};

--- a/server/src/utils/logging/writeFireLensRecord.ts
+++ b/server/src/utils/logging/writeFireLensRecord.ts
@@ -1,0 +1,13 @@
+type FireLensOutput = {
+	write: (chunk: string) => unknown;
+};
+
+export const writeFireLensRecord = ({
+	record,
+	output = process.stdout,
+}: {
+	record: unknown;
+	output?: FireLensOutput;
+}) => {
+	output.write(`${JSON.stringify(record)}\n`);
+};

--- a/server/tests/unit/logging/firelens-config.test.ts
+++ b/server/tests/unit/logging/firelens-config.test.ts
@@ -1,6 +1,7 @@
 /**
  * Contract: FireLens parses Pino's JSON envelope, sends structured records to
- * `express`, keeps console records in `ecs`, and bounds retries and re-emission.
+ * `express`, archives full request records in Firehose, keeps console records
+ * in `ecs`, and bounds retries and re-emission.
  */
 
 import { expect, test } from "bun:test";
@@ -21,6 +22,9 @@ test.concurrent(
 		expect(config).toContain("Parser json");
 		expect(config).toContain("Reserve_Data On");
 		expect(config).toContain(
+			"Rule $log_destination ^request_log_archive$ request_log_archive false",
+		);
+		expect(config).toContain(
 			"Rule $level ^(TRACE|DEBUG|INFO|WARN|ERROR|FATAL)$ axiom_express false",
 		);
 		expect(config).toContain("Emitter_Mem_Buf_Limit 10M");
@@ -29,7 +33,16 @@ test.concurrent(
 		);
 		expect(config).toContain("URI /v1/ingest/express");
 		expect(config).toContain("URI /v1/ingest/ecs");
-		expect(config.match(/retry_limit 5/g)).toHaveLength(2);
+		expect(config).toMatch(
+			/Name rewrite_tag\s+Match request_log_archive\s+Rule \$region \^us-east-1\$ request_log_archive_staging false\s+Rule \$region \^us-east-2\$ request_log_archive_prod false/,
+		);
+		expect(config).toMatch(
+			/Name kinesis_firehose\s+Match request_log_archive_staging\s+Region us-east-1\s+Delivery_Stream tf-request-log-archive-staging-delivery/,
+		);
+		expect(config).toMatch(
+			/Name kinesis_firehose\s+Match request_log_archive_prod\s+Region us-east-2\s+Delivery_Stream tf-request-log-archive-prod-delivery/,
+		);
+		expect(config.match(/retry_limit 5/g)).toHaveLength(4);
 		expect(config).not.toMatch(/\[OUTPUT\]\s+Name http\s+Match \*(?:\s|$)/);
 	},
 );

--- a/server/tests/unit/logging/firelensArchiveWriter.test.ts
+++ b/server/tests/unit/logging/firelensArchiveWriter.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { writeFireLensRecord } from "../../../src/utils/logging/writeFireLensRecord.js";
+
+test("writes archive records as a single raw JSON line", () => {
+	const chunks: string[] = [];
+
+	writeFireLensRecord({
+		record: {
+			log_destination: "request_log_archive",
+			request_id: "req_123",
+			response_body: '{"allowed":true}',
+		},
+		output: {
+			write: (chunk) => {
+				chunks.push(chunk);
+				return true;
+			},
+		},
+	});
+
+	expect(chunks).toEqual([
+		'{"log_destination":"request_log_archive","request_id":"req_123","response_body":"{\\"allowed\\":true}"}\n',
+	]);
+});

--- a/server/tests/unit/logging/requestResultRecords.test.ts
+++ b/server/tests/unit/logging/requestResultRecords.test.ts
@@ -15,7 +15,7 @@ const request = {
 };
 
 describe("buildRequestResultRecords", () => {
-	test("keeps a compact Axiom success record and archives the complete payload", () => {
+	test("keeps the existing Axiom success record and archives the complete payload", () => {
 		const records = buildRequestResultRecords({
 			...request,
 			statusCode: 200,
@@ -29,8 +29,6 @@ describe("buildRequestResultRecords", () => {
 		expect(records.axiom).toEqual({
 			statusCode: 200,
 			durationMs: 12,
-			responseBodyBytes: 44,
-			responseArchiveRouted: true,
 			res: {
 				allowed: true,
 				balance: { remaining: 999 },
@@ -63,12 +61,15 @@ describe("buildRequestResultRecords", () => {
 			responseBody,
 		});
 
-		expect(records.axiom.res).toEqual(responseBody);
-		expect(records.axiom.responseArchiveRouted).toBe(false);
+		expect(records.axiom).toEqual({
+			statusCode: 400,
+			durationMs: 9,
+			res: responseBody,
+		});
 		expect(records.archive).toBeNull();
 	});
 
-	test("keeps queryable response signals but drops high-cardinality success data", () => {
+	test("keeps the complete success response in Axiom while archiving it", () => {
 		const records = buildRequestResultRecords({
 			...request,
 			statusCode: 200,
@@ -88,13 +89,21 @@ describe("buildRequestResultRecords", () => {
 			},
 		});
 
-		expect(records.axiom.res).toEqual({
-			allowed: false,
-			code: "insufficient_balance",
-			balance: {
-				granted: 100,
-				remaining: 0,
-				usage: 100,
+		expect(records.axiom).toEqual({
+			statusCode: 200,
+			durationMs: 7,
+			res: {
+				allowed: false,
+				code: "insufficient_balance",
+				balance: {
+					granted: 100,
+					remaining: 0,
+					usage: 100,
+					breakdown: [{ id: "grant_1", remaining: 0 }],
+				},
+				balances: {
+					messages: { breakdown: [{ id: "grant_1", remaining: 0 }] },
+				},
 			},
 		});
 		expect(records.archive?.response_body).toContain('"breakdown"');
@@ -111,8 +120,11 @@ describe("buildRequestResultRecords", () => {
 			archiveSuccessResponse: false,
 		});
 
-		expect(records.axiom.res).toEqual(responseBody);
-		expect(records.axiom.responseArchiveRouted).toBe(false);
+		expect(records.axiom).toEqual({
+			statusCode: 200,
+			durationMs: 7,
+			res: responseBody,
+		});
 		expect(records.archive).toBeNull();
 	});
 });

--- a/server/tests/unit/logging/requestResultRecords.test.ts
+++ b/server/tests/unit/logging/requestResultRecords.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+import { buildRequestResultRecords } from "../../../src/honoMiddlewares/requestLogging/buildRequestResultRecords.js";
+
+const request = {
+	requestId: "req_123",
+	requestMethod: "POST",
+	requestPath: "/v1/balances.check",
+	requestBody: { customer_id: "cus_123", feature_id: "messages" },
+	orgId: "org_123",
+	customerId: "cus_123",
+	entityId: null,
+	environment: "live",
+	eventTime: "2026-07-27T12:00:00.000Z",
+	archiveSuccessResponse: true,
+};
+
+describe("buildRequestResultRecords", () => {
+	test("keeps a compact Axiom success record and archives the complete payload", () => {
+		const records = buildRequestResultRecords({
+			...request,
+			statusCode: 200,
+			durationMs: 12,
+			responseBody: {
+				allowed: true,
+				balance: { remaining: 999 },
+			},
+			includeSuccessBodyInAxiom: false,
+		});
+
+		expect(records.axiom).toEqual({
+			statusCode: 200,
+			durationMs: 12,
+			responseBodyBytes: 44,
+			responseArchiveRouted: true,
+			responseBodySampled: false,
+			res: {
+				allowed: true,
+				balance: { remaining: 999 },
+			},
+		});
+		expect(records.archive).toEqual({
+			log_destination: "request_log_archive",
+			event_time: "2026-07-27T12:00:00.000Z",
+			request_id: "req_123",
+			request_method: "POST",
+			request_path: "/v1/balances.check",
+			status_code: 200,
+			duration_ms: 12,
+			org_id: "org_123",
+			customer_id: "cus_123",
+			entity_id: null,
+			environment: "live",
+			request_body: '{"customer_id":"cus_123","feature_id":"messages"}',
+			response_body: '{"allowed":true,"balance":{"remaining":999}}',
+			response_body_bytes: 44,
+		});
+	});
+
+	test("keeps error bodies in Axiom and does not duplicate them into the archive", () => {
+		const responseBody = { code: "invalid_request", message: "No customer" };
+		const records = buildRequestResultRecords({
+			...request,
+			statusCode: 400,
+			durationMs: 9,
+			responseBody,
+			includeSuccessBodyInAxiom: false,
+		});
+
+		expect(records.axiom.res).toEqual(responseBody);
+		expect(records.axiom.responseArchiveRouted).toBe(false);
+		expect(records.archive).toBeNull();
+	});
+
+	test("can retain a sampled success body in both stores", () => {
+		const responseBody = { allowed: true };
+		const records = buildRequestResultRecords({
+			...request,
+			statusCode: 200,
+			durationMs: 7,
+			responseBody,
+			includeSuccessBodyInAxiom: true,
+		});
+
+		expect(records.axiom.res).toEqual(responseBody);
+		expect(records.axiom.responseBodySampled).toBe(true);
+		expect(records.archive?.response_body).toBe('{"allowed":true}');
+	});
+
+	test("keeps queryable response signals but drops high-cardinality success data", () => {
+		const records = buildRequestResultRecords({
+			...request,
+			statusCode: 200,
+			durationMs: 7,
+			responseBody: {
+				allowed: false,
+				code: "insufficient_balance",
+				balance: {
+					granted: 100,
+					remaining: 0,
+					usage: 100,
+					breakdown: [{ id: "grant_1", remaining: 0 }],
+				},
+				balances: {
+					messages: { breakdown: [{ id: "grant_1", remaining: 0 }] },
+				},
+			},
+			includeSuccessBodyInAxiom: false,
+		});
+
+		expect(records.axiom.res).toEqual({
+			allowed: false,
+			code: "insufficient_balance",
+			balance: {
+				granted: 100,
+				remaining: 0,
+				usage: 100,
+			},
+		});
+		expect(records.archive?.response_body).toContain('"breakdown"');
+		expect(records.archive?.response_body).toContain('"balances"');
+	});
+
+	test("keeps a success body in Axiom when the archive is unavailable", () => {
+		const responseBody = { allowed: true };
+		const records = buildRequestResultRecords({
+			...request,
+			statusCode: 200,
+			durationMs: 7,
+			responseBody,
+			archiveSuccessResponse: false,
+			includeSuccessBodyInAxiom: false,
+		});
+
+		expect(records.axiom.res).toEqual(responseBody);
+		expect(records.axiom.responseArchiveRouted).toBe(false);
+		expect(records.archive).toBeNull();
+	});
+});

--- a/server/tests/unit/logging/requestResultRecords.test.ts
+++ b/server/tests/unit/logging/requestResultRecords.test.ts
@@ -24,7 +24,6 @@ describe("buildRequestResultRecords", () => {
 				allowed: true,
 				balance: { remaining: 999 },
 			},
-			includeSuccessBodyInAxiom: false,
 		});
 
 		expect(records.axiom).toEqual({
@@ -32,7 +31,6 @@ describe("buildRequestResultRecords", () => {
 			durationMs: 12,
 			responseBodyBytes: 44,
 			responseArchiveRouted: true,
-			responseBodySampled: false,
 			res: {
 				allowed: true,
 				balance: { remaining: 999 },
@@ -63,27 +61,11 @@ describe("buildRequestResultRecords", () => {
 			statusCode: 400,
 			durationMs: 9,
 			responseBody,
-			includeSuccessBodyInAxiom: false,
 		});
 
 		expect(records.axiom.res).toEqual(responseBody);
 		expect(records.axiom.responseArchiveRouted).toBe(false);
 		expect(records.archive).toBeNull();
-	});
-
-	test("can retain a sampled success body in both stores", () => {
-		const responseBody = { allowed: true };
-		const records = buildRequestResultRecords({
-			...request,
-			statusCode: 200,
-			durationMs: 7,
-			responseBody,
-			includeSuccessBodyInAxiom: true,
-		});
-
-		expect(records.axiom.res).toEqual(responseBody);
-		expect(records.axiom.responseBodySampled).toBe(true);
-		expect(records.archive?.response_body).toBe('{"allowed":true}');
 	});
 
 	test("keeps queryable response signals but drops high-cardinality success data", () => {
@@ -104,7 +86,6 @@ describe("buildRequestResultRecords", () => {
 					messages: { breakdown: [{ id: "grant_1", remaining: 0 }] },
 				},
 			},
-			includeSuccessBodyInAxiom: false,
 		});
 
 		expect(records.axiom.res).toEqual({
@@ -128,7 +109,6 @@ describe("buildRequestResultRecords", () => {
 			durationMs: 7,
 			responseBody,
 			archiveSuccessResponse: false,
-			includeSuccessBodyInAxiom: false,
 		});
 
 		expect(records.axiom.res).toEqual(responseBody);


### PR DESCRIPTION
Routes complete successful API request and response bodies to the AWS archive while retaining compact queryable summaries and errors in Axiom.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Archives full successful API request/response bodies to AWS via FireLens and Kinesis Firehose, while keeping Axiom logs unchanged. Adds an S3-backed audit trail without changing current queryable logs.

- **New Features**
  - Added `buildRequestResultRecords` to emit two records: standard Axiom log and an optional archive with redacted request body, full response body, and size.
  - FireLens routes `log_destination: request_log_archive` to per-region Firehose streams (staging `us-east-1`, prod `us-east-2`); CI allowlist enables staging deploy for `feat/request-log-archive`.
  - Archive enabled for `/v1` routes on Flightcontrol `dev`/`main`; request bodies redacted via `redactRequestBody`; success-response sampling removed.

- **Bug Fixes**
  - Archive writes are additive: success bodies remain in Axiom and are also archived.
  - Archive records flow through FireLens by emitting raw JSON lines via `writeFireLensRecord`; updated `firelens.conf` and tests for tag/region routing.

<sup>Written for commit 4f395e347e5f19750fc9ef056502746547353cf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Archives successful `/v1` request and response payloads through FireLens while retaining the existing request-result logs.
- **Improvements:** Adds structured archive records, recursive request-body redaction, and raw JSON-line emission for FireLens.
- **Improvements:** Routes archive records to region-specific staging and production Kinesis Firehose streams.
- **Improvements:** Adds unit coverage for record construction, FireLens output, and regional routing.
- **API changes:** Enables archive routing for successful `/v1` requests on Flightcontrol `dev` and `main` deployments.
- **Improvements:** Adds the feature branch to the staging deployment allowlist.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/honoMiddlewares/requestLogging/buildRequestResultRecords.ts | Constructs the standard request-result record and an optional full archive record for successful responses. |
| server/src/honoMiddlewares/requestLogging/logRequestResult.ts | Enables archive emission for successful `/v1` requests in supported Flightcontrol deployments. |
| server/src/honoMiddlewares/requestLogging/redactRequestBody.ts | Extracts recursive request-body redaction into a reusable helper. |
| server/src/utils/logging/writeFireLensRecord.ts | Emits archive records to stdout as single-line JSON for FireLens ingestion. |
| firelens.conf | Routes archive-tagged records to region-specific Kinesis Firehose delivery streams. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Middleware as Hono request logging
    participant Axiom
    participant FireLens
    participant Firehose
    participant S3 as AWS archive

    Client->>Middleware: Successful /v1 request
    Middleware->>Middleware: Redact request body
    Middleware->>Middleware: Build Axiom and archive records
    Middleware->>Axiom: Emit request-result record
    Middleware->>FireLens: Write archive JSON line
    FireLens->>FireLens: Route by AWS region
    FireLens->>Firehose: Send archive record
    Firehose->>S3: Persist request and response bodies
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix: keep request archive writes additiv..."](https://github.com/useautumn/autumn/commit/4f395e347e5f19750fc9ef056502746547353cf1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47677411)</sub>

<!-- /greptile_comment -->