### PR TITLE
Fix worker idle recycling across queues

### DIFF
--- a/server/experiments/explainResetCount.ts
+++ b/server/experiments/explainResetCount.ts
@@ -10,17 +10,11 @@ const { buildCountResetEligibleQuery, countResetEligibleCustomerEntitlements } =
 		"../src/internal/customers/cusProducts/cusEnts/repos/countResetEligibleCustomerEntitlements"
 	);
 
-// Benchmarks the backlog-gauge count (countResetEligibleCustomerEntitlements)
-// that the V2 reset cron logs every few minutes — verifies the capped count
-// stays cheap against a large overdue backlog.
-//
-// Run with:
-//   bun run experiments/explainResetCount.ts
-// Options (env vars):
-//   RESET_COUNT_CAP=1000000   count cap (default 1,000,000, same as the cron)
+// Benchmarks the diagnostic capped count; the runtime reset gauge does not use it.
+// Run with `bun run experiments/explainResetCount.ts`; RESET_COUNT_CAP defaults to 10k.
 
 const main = async () => {
-	const cap = Number(process.env.RESET_COUNT_CAP ?? 1_000_000);
+	const cap = Number(process.env.RESET_COUNT_CAP ?? 10_000);
 	const dueBefore = Date.now();
 	const { db } = initDrizzle();
 

--- a/server/src/internal/balances/batchReset/logs/logResetBacklogGauge.ts
+++ b/server/src/internal/balances/batchReset/logs/logResetBacklogGauge.ts
@@ -1,15 +1,10 @@
 import type { CronContext } from "@/cron/utils/CronContext.js";
 import type { ResetScanCursor } from "@/internal/customers/cusProducts/cusEnts/repos/getResetEligibleCustomerEntitlementsPage.js";
-import { customerEntitlementsRepo } from "@/internal/customers/cusProducts/cusEnts/repos/index.js";
 import { getBatchResetQueueDepth } from "../concurrency/getBatchResetQueueDepth.js";
 
-// Cap keeps the count cheap against a large backlog ("at least N").
-const BACKLOG_COUNT_CAP = 1_000_000;
-
 /**
- * Periodic status event for Axiom: how many customer entitlements are
- * overdue-eligible right now, current queue depth, and how far behind "now"
- * the scan position is.
+ * Periodic status event for Axiom: current queue depth and how far behind
+ * "now" the scan position is.
  */
 export const logResetBacklogGauge = async ({
 	ctx,
@@ -20,20 +15,11 @@ export const logResetBacklogGauge = async ({
 	cursor: ResetScanCursor | null;
 	sweepScanned: number;
 }) => {
-	const [backlog, queueDepth] = await Promise.all([
-		customerEntitlementsRepo.countResetEligibleCustomerEntitlements({
-			db: ctx.db,
-			dueBefore: Date.now(),
-			cap: BACKLOG_COUNT_CAP,
-		}),
-		getBatchResetQueueDepth().catch(() => null),
-	]);
+	const queueDepth = await getBatchResetQueueDepth().catch(() => null);
 
 	ctx.logger.info("[reset-cus-ents-v2] backlog gauge", {
 		jobName: "reset-cus-ents-v2",
 		data: {
-			overdueEligibleCount: backlog.count,
-			overdueCountCapped: backlog.capped,
 			queueVisible: queueDepth?.visible ?? null,
 			queueInFlight: queueDepth?.inFlight ?? null,
 			sweepScanned,

--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -33,6 +33,10 @@ import {
 import { getSqsClient, QUEUE_URL, recreateSqsClient } from "./initSqs.js";
 import { JobName } from "./JobName.js";
 import { processMessage, type SqsJob } from "./processMessage.js";
+import {
+	createWorkerActivityTracker,
+	type WorkerActivityTracker,
+} from "./workerActivityTracker.js";
 
 // ============ Shared State ============
 let isRunning = true;
@@ -42,8 +46,7 @@ export const getAbortControllerCountForTesting = () => abortControllers.size;
 // Process recycling — exit after processing this many messages to prevent memory leaks
 const MAX_MESSAGES_BEFORE_RECYCLE = 50_000;
 
-// Idle self-kill — exit if worker processes 0 messages for this many consecutive intervals
-const IDLE_SELF_KILL_THRESHOLD = 5; // ~5 min of 0 messages (5 * 60s)
+const IDLE_SELF_KILL_MS = ms.minutes(5);
 const shouldIdleSelfKill = process.env.NODE_ENV !== "development";
 
 // Per-message processing timeout — must be under VisibilityTimeout (30s)
@@ -117,6 +120,9 @@ export const startPollingLoop = async ({
 	recreateSqsClientFn,
 	shouldPoll = () => true,
 	visibilityTimeoutSeconds = 30,
+	workerActivity = createWorkerActivityTracker({
+		idleAfterMs: IDLE_SELF_KILL_MS,
+	}),
 }: {
 	db: DrizzleCli;
 	queueId: string;
@@ -129,6 +135,7 @@ export const startPollingLoop = async ({
 	 * a message redelivered mid-processing means two workers mutating the same
 	 * rows concurrently. */
 	visibilityTimeoutSeconds?: number;
+	workerActivity?: WorkerActivityTracker;
 }) => {
 	// Per-loop state
 	let messagesProcessed = 0;
@@ -198,15 +205,10 @@ export const startPollingLoop = async ({
 		if (messagesProcessed === 0) {
 			consecutiveZeroMessageIntervals++;
 
-			if (
-				shouldIdleSelfKill &&
-				consecutiveZeroMessageIntervals >= IDLE_SELF_KILL_THRESHOLD &&
-				totalMessagesProcessed > 0 &&
-				activeMigrationJobs === 0 &&
-				process.env.NODE_ENV !== "development"
-			) {
+			const idleStatus = workerActivity.getIdleStatus();
+			if (shouldIdleSelfKill && idleStatus.shouldRecycle) {
 				console.log(
-					`${prefix} Idle self-kill: 0 messages for ${consecutiveZeroMessageIntervals} intervals after processing ${totalMessagesProcessed} total. Exiting for cluster respawn.`,
+					`[SQS Worker ${process.pid}] Idle self-kill: no messages received across any queue for ${Math.floor(idleStatus.idleForMs / 60_000)} minutes after receiving ${idleStatus.totalMessagesReceived} total. Exiting for cluster respawn.`,
 				);
 				process.exit(0);
 			}
@@ -413,6 +415,7 @@ export const startPollingLoop = async ({
 
 	while (isRunning) {
 		let capacityLease: QueueCapacityLease | null = null;
+		let batchWorkStarted = false;
 		try {
 			if (!shouldPoll()) {
 				consecutiveEmptyPolls = 0;
@@ -442,6 +445,11 @@ export const startPollingLoop = async ({
 			);
 
 			const messages = response.Messages ?? [];
+			if (messages.length > 0) {
+				workerActivity.recordMessagesReceived({ count: messages.length });
+				workerActivity.startWork();
+				batchWorkStarted = true;
+			}
 			const leasedMessages = await capacityLease.assign(messages);
 
 			if (messages.length > 0) {
@@ -458,6 +466,7 @@ export const startPollingLoop = async ({
 					const override = getJobOverride(job.name);
 					if (override?.dispatch === "background" && !capacityLease.isLimited) {
 						activeMigrationJobs++;
+						workerActivity.startWork();
 						handleSingleMessage({ sqs, message, db })
 							.catch((error) => {
 								console.error(
@@ -466,7 +475,10 @@ export const startPollingLoop = async ({
 								);
 								Sentry.captureException(error);
 							})
-							.finally(() => activeMigrationJobs--);
+							.finally(() => {
+								activeMigrationJobs--;
+								workerActivity.finishWork();
+							});
 					} else {
 						regularMessages.push({
 							message,
@@ -510,6 +522,7 @@ export const startPollingLoop = async ({
 			if (newClient) sqs = newClient;
 			else if ((error as { name?: string }).name === "AbortError") break;
 		} finally {
+			if (batchWorkStarted) workerActivity.finishWork();
 			await capacityLease?.release();
 		}
 	}
@@ -565,6 +578,9 @@ export const initWorkers = async ({
 		`[Worker ${process.pid}] ${queueImplementation} worker ready in ${startupDurationMs}ms`,
 	);
 	const pollingLoops = [];
+	const workerActivity = createWorkerActivityTracker({
+		idleAfterMs: IDLE_SELF_KILL_MS,
+	});
 
 	for (const {
 		queueId,
@@ -622,6 +638,7 @@ export const initWorkers = async ({
 					isJobQueueEnabled({ queue: queueId, defaultEnabled }) &&
 					isActiveSlot({ serviceName: "workers" }),
 				visibilityTimeoutSeconds,
+				workerActivity,
 			}),
 		);
 	}

--- a/server/src/queue/workerActivityTracker.ts
+++ b/server/src/queue/workerActivityTracker.ts
@@ -1,0 +1,60 @@
+export type WorkerIdleStatus = {
+	activeWorkCount: number;
+	idleForMs: number;
+	shouldRecycle: boolean;
+	totalMessagesReceived: number;
+};
+
+export const createWorkerActivityTracker = ({
+	idleAfterMs,
+	now = Date.now,
+}: {
+	idleAfterMs: number;
+	now?: () => number;
+}) => {
+	let activeWorkCount = 0;
+	let lastMessageReceivedAt: number | null = null;
+	let totalMessagesReceived = 0;
+
+	const recordMessagesReceived = ({ count }: { count: number }) => {
+		if (count <= 0) return;
+		lastMessageReceivedAt = now();
+		totalMessagesReceived += count;
+	};
+
+	const startWork = () => {
+		activeWorkCount++;
+	};
+
+	const finishWork = () => {
+		activeWorkCount = Math.max(0, activeWorkCount - 1);
+	};
+
+	const getIdleStatus = (): WorkerIdleStatus => {
+		const idleForMs =
+			lastMessageReceivedAt === null
+				? 0
+				: Math.max(0, now() - lastMessageReceivedAt);
+
+		return {
+			activeWorkCount,
+			idleForMs,
+			shouldRecycle:
+				lastMessageReceivedAt !== null &&
+				activeWorkCount === 0 &&
+				idleForMs >= idleAfterMs,
+			totalMessagesReceived,
+		};
+	};
+
+	return {
+		finishWork,
+		getIdleStatus,
+		recordMessagesReceived,
+		startWork,
+	};
+};
+
+export type WorkerActivityTracker = ReturnType<
+	typeof createWorkerActivityTracker
+>;

--- a/server/tests/unit/queue/worker-activity-tracker.test.ts
+++ b/server/tests/unit/queue/worker-activity-tracker.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { createWorkerActivityTracker } from "@/queue/workerActivityTracker.js";
+
+const IDLE_AFTER_MS = 5 * 60 * 1000;
+
+describe("worker activity tracker", () => {
+	test("activity from any queue resets the process-wide idle timer", () => {
+		let now = 0;
+		const tracker = createWorkerActivityTracker({
+			idleAfterMs: IDLE_AFTER_MS,
+			now: () => now,
+		});
+
+		tracker.recordMessagesReceived({ count: 1 });
+		now += 4 * 60 * 1000;
+		tracker.recordMessagesReceived({ count: 2 });
+		now += 2 * 60 * 1000;
+
+		expect(tracker.getIdleStatus()).toMatchObject({
+			shouldRecycle: false,
+			totalMessagesReceived: 3,
+		});
+
+		now += 3 * 60 * 1000;
+		expect(tracker.getIdleStatus()).toMatchObject({
+			idleForMs: IDLE_AFTER_MS,
+			shouldRecycle: true,
+		});
+	});
+
+	test("does not recycle while work or acknowledgements are active", () => {
+		let now = 0;
+		const tracker = createWorkerActivityTracker({
+			idleAfterMs: IDLE_AFTER_MS,
+			now: () => now,
+		});
+
+		tracker.recordMessagesReceived({ count: 1 });
+		tracker.startWork();
+		now += IDLE_AFTER_MS;
+
+		expect(tracker.getIdleStatus().shouldRecycle).toBe(false);
+
+		tracker.finishWork();
+		expect(tracker.getIdleStatus().shouldRecycle).toBe(true);
+	});
+
+	test("does not recycle a process that has never received a message", () => {
+		let now = IDLE_AFTER_MS * 2;
+		const tracker = createWorkerActivityTracker({
+			idleAfterMs: IDLE_AFTER_MS,
+			now: () => now,
+		});
+
+		expect(tracker.getIdleStatus()).toEqual({
+			activeWorkCount: 0,
+			idleForMs: 0,
+			shouldRecycle: false,
+			totalMessagesReceived: 0,
+		});
+
+		now += IDLE_AFTER_MS;
+		expect(tracker.getIdleStatus().shouldRecycle).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- make the five-minute idle self-kill depend on activity across every queue in the worker process
- keep received batches and background jobs active through processing and acknowledgement
- remove the expensive reset backlog count while retaining queue depth, scan lag, and sweep progress telemetry

## Testing

- bun test --isolate tests/unit/queue/worker-activity-tracker.test.ts tests/unit/queue/init-workers-delete-batch.test.ts tests/integration/queue/start-polling-loop.test.ts
- bun run ts
- biome check on changed worker files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes idle worker recycling across queues. A worker now exits only after 5 minutes with no messages received process‑wide and no active work; background jobs and acknowledgements keep it alive.

- **Bug Fixes**
  - Added a process-wide worker activity tracker that resets the idle timer on any queue activity and tracks active work to block recycling during processing/acks.
  - Replaced interval-based checks with time-based logic; integrated tracker into the polling loop and migration jobs.

- **Performance**
  - Removed the expensive overdue backlog count from reset gauge logging; kept queue depth, in-flight, and scan lag/sweep progress metrics.
  - Updated the `explainResetCount` experiment to default to a 10k cap.

<sup>Written for commit 7ddb663a3592972b1fcce9a3db5f8a3cba5bc1ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes process-wide idle recycling and simplifies reset telemetry.

- **[Bug fixes]** Shares worker activity across all SQS polling loops so traffic on any queue resets the process-wide idle timer.
- **[Bug fixes]** Tracks received batches, background migrations, message processing, and acknowledgements to prevent recycling while work remains active.
- **[Improvements]** Removes the expensive overdue-entitlement count from reset backlog logging while retaining queue depth and scan-progress telemetry.
- **[Improvements]** Reduces the standalone reset-count diagnostic experiment's default cap from one million to ten thousand.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with worker activity correctly shared and balanced across all current production queue paths.

The sole production entry point passes one tracker to every polling loop, and received batches plus detached background jobs retain balanced activity references until processing and acknowledgement complete; no concrete blocking or non-blocking defect remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/queue/initWorkers.ts | Integrates one process-wide activity tracker across queue loops and balances batch and background-work lifetimes through processing and acknowledgement. |
| server/src/queue/workerActivityTracker.ts | Adds a small reference-counted tracker that combines last-receipt time, total receipts, and active work to determine recycle eligibility. |
| server/tests/unit/queue/worker-activity-tracker.test.ts | Covers cross-queue timer resets, active-work suppression, and the never-received state. |
| server/src/internal/balances/batchReset/logs/logResetBacklogGauge.ts | Removes the capped overdue-entitlement query while preserving queue-depth and sweep telemetry. |
| server/experiments/explainResetCount.ts | Reframes the count query as a diagnostic benchmark and lowers its default cap to ten thousand. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Q1[Primary queue] --> R[Record received messages]
  Q2[Tracking queue] --> R
  Q3[Other worker queues] --> R
  R --> T[Shared process-wide activity tracker]
  T --> B[Start batch work]
  B --> I[Inline processing and acknowledgement]
  B --> M[Background migration work]
  I --> F[Finish batch work]
  M --> G[Finish background work]
  F --> C{No active work and no messages for five minutes?}
  G --> C
  C -- No --> P[Continue polling]
  C -- Yes --> E[Exit for cluster respawn]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(workers): 🐛 share idle activity acr..."](https://github.com/useautumn/autumn/commit/7ddb663a3592972b1fcce9a3db5f8a3cba5bc1ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47684074)</sub>

**Context used:**

- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)
- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->