### PR TITLE
fix(entities): read primary for customer-scoped entities.list

### DIFF
--- a/server/src/honoMiddlewares/replicaDbMiddleware.ts
+++ b/server/src/honoMiddlewares/replicaDbMiddleware.ts
@@ -9,7 +9,13 @@ export const replicaDbMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 		return;
 	}
 
-	if (shouldUseReplicaDb(c)) {
+	const useReplica = await shouldUseReplicaDb({
+		method: c.req.method,
+		path: c.req.path,
+		readBody: () => c.req.json(),
+	});
+
+	if (useReplica) {
 		const ctx = c.get("ctx");
 		ctx.db = dbReplica;
 		ctx.useReplicaDb = true;

--- a/server/src/internal/misc/replicaDb/replicaDbConfigs.ts
+++ b/server/src/internal/misc/replicaDb/replicaDbConfigs.ts
@@ -1,28 +1,57 @@
-import type { Context } from "hono";
 import { matchRoute } from "@/honoMiddlewares/middlewareUtils.js";
-import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 
 type RoutePattern = {
 	method: string;
 	url: string;
+	/** Omit to always use the replica; set to decide from the request body. */
+	useReplicaForBody?: (body: unknown) => boolean;
 };
 
-const route = ({ method, url }: RoutePattern): RoutePattern => ({
-	method,
-	url,
-});
+const route = (pattern: RoutePattern): RoutePattern => pattern;
+
+const isCustomerScoped = (body: unknown) => {
+	if (typeof body !== "object" || body === null) return false;
+
+	const customerId = (body as { customer_id?: unknown }).customer_id;
+	return typeof customerId === "string" && customerId.trim().length > 0;
+};
 
 const REPLICA_ROUTE_PATTERNS: RoutePattern[] = [
 	route({ method: "POST", url: "/v1/customers/list" }),
 	route({ method: "POST", url: "/v1/customers.list" }),
-	route({ method: "POST", url: "/v1/entities.list" }),
+
+	// Callers list a customer's entities right after creating one, so a lagging
+	// replica returns a stale page. Only unscoped org-wide listing is shed.
+	route({
+		method: "POST",
+		url: "/v1/entities.list",
+		useReplicaForBody: (body) => !isCustomerScoped(body),
+	}),
 ];
 
-export const shouldUseReplicaDb = (c: Context<HonoEnv>) => {
-	const method = c.req.method;
-	const path = c.req.path;
-
-	return REPLICA_ROUTE_PATTERNS.some((pattern) =>
+export const shouldUseReplicaDb = async ({
+	method,
+	path,
+	readBody,
+}: {
+	method: string;
+	path: string;
+	readBody: () => Promise<unknown>;
+}): Promise<boolean> => {
+	const matched = REPLICA_ROUTE_PATTERNS.find((pattern) =>
 		matchRoute({ url: path, method, pattern }),
 	);
+
+	if (!matched) return false;
+	if (!matched.useReplicaForBody) return true;
+
+	let body: unknown;
+	try {
+		body = await readBody();
+	} catch {
+		// An unreadable body can't be proven unscoped, so keep the primary.
+		return false;
+	}
+
+	return matched.useReplicaForBody(body);
 };

--- a/server/tests/unit/replica-db/replica-db-body-read.test.ts
+++ b/server/tests/unit/replica-db/replica-db-body-read.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Guards the one integration risk in body-aware replica routing: the routing
+ * decision reads the request body in middleware, and the route's zod validator
+ * reads it again downstream. Hono caches the parsed body, so both see it — this
+ * pins that behaviour against the real validator and the real route schema
+ * rather than trusting the framework note.
+ *
+ * Contract under test:
+ *   - A customer-scoped entities.list body routes to the primary AND still
+ *     arrives intact at c.req.valid("json").
+ *   - An unscoped body routes to the replica AND still arrives intact.
+ *   - A malformed body routes to the primary and leaves the validator's own
+ *     empty-body fallback untouched.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { ListEntitiesV2_3ParamsSchema } from "@autumn/shared";
+import { Hono } from "hono";
+import { validator } from "@/honoMiddlewares/validatorMiddleware.js";
+import { shouldUseReplicaDb } from "@/internal/misc/replicaDb/replicaDbConfigs.js";
+
+const buildApp = () => {
+	const decisions: boolean[] = [];
+
+	const app = new Hono();
+
+	app.use("*", async (c, next) => {
+		decisions.push(
+			await shouldUseReplicaDb({
+				method: c.req.method,
+				path: c.req.path,
+				readBody: () => c.req.json(),
+			}),
+		);
+		await next();
+	});
+
+	// validatorMiddleware's json branch is untyped, so Hono can't widen
+	// c.req.valid to accept "json" the way a zValidator route would.
+	type ValidatedJsonRequest = {
+		valid: (target: "json") => Record<string, unknown>;
+	};
+
+	app.post(
+		"/v1/entities.list",
+		validator("json", ListEntitiesV2_3ParamsSchema),
+		(c) =>
+			c.json({
+				received: (c.req as unknown as ValidatedJsonRequest).valid("json"),
+			}),
+	);
+
+	return { app, decisions };
+};
+
+const post = (app: Hono, body: string) =>
+	app.request("/v1/entities.list", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body,
+	});
+
+describe("replica routing body read", () => {
+	test("customer-scoped body picks the primary and still reaches the validator", async () => {
+		const { app, decisions } = buildApp();
+
+		const res = await post(
+			app,
+			JSON.stringify({ customer_id: "cus_123", limit: 5 }),
+		);
+		const json = (await res.json()) as { received: Record<string, unknown> };
+
+		expect(res.status).toBe(200);
+		expect(decisions).toEqual([false]);
+		expect(json.received).toMatchObject({ customer_id: "cus_123", limit: 5 });
+	});
+
+	test("unscoped body picks the replica and still reaches the validator", async () => {
+		const { app, decisions } = buildApp();
+
+		const res = await post(app, JSON.stringify({ limit: 5, search: "acme" }));
+		const json = (await res.json()) as { received: Record<string, unknown> };
+
+		expect(res.status).toBe(200);
+		expect(decisions).toEqual([true]);
+		expect(json.received).toMatchObject({ limit: 5, search: "acme" });
+	});
+
+	test("malformed body picks the primary and leaves the validator fallback intact", async () => {
+		const { app, decisions } = buildApp();
+
+		const res = await post(app, "{not json");
+
+		expect(decisions).toEqual([false]);
+		// validatorMiddleware treats an unparseable body as {}, which this schema
+		// accepts because every field is optional.
+		expect(res.status).toBe(200);
+	});
+});

--- a/server/tests/unit/replica-db/replica-db-configs.test.ts
+++ b/server/tests/unit/replica-db/replica-db-configs.test.ts
@@ -1,49 +1,159 @@
+/**
+ * Contract for replica-vs-primary routing of list endpoints.
+ *
+ * Customers reported a read-after-write race: they create an entity, receive the
+ * customer.products.updated webhook, call entities.list, and the entity is missing
+ * because the request was served by a lagging read replica. Customer-scoped list
+ * requests must therefore read the primary; unscoped org-wide enumeration (the
+ * expensive query the replica routing exists to shed) stays on the replica.
+ *
+ * Contract under test:
+ *   Behaviors:
+ *     - POST /v1/customers/list          -> replica, body never read
+ *     - POST /v1/customers.list          -> replica, body never read
+ *     - POST /v1/entities.list, no customer_id -> replica
+ *     - POST /v1/entities.list, customer_id    -> primary
+ *     - POST /v1/entities.list, unreadable body -> primary (fail safe)
+ *     - any non-listed route/method      -> primary
+ *   Invariants:
+ *     - The body is only read for routes whose decision depends on it.
+ *     - A body that cannot be parsed never routes to the replica.
+ */
+
 import { describe, expect, test } from "bun:test";
-import type { Context } from "hono";
-import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { shouldUseReplicaDb } from "@/internal/misc/replicaDb/replicaDbConfigs.js";
 
-const createContext = ({
-	method,
-	path,
-}: {
-	method: string;
-	path: string;
-}): Context<HonoEnv> =>
-	({
-		req: {
-			method,
-			path,
-		},
-	}) as Context<HonoEnv>;
+const neverRead = () =>
+	Promise.reject(new Error("readBody should not have been called"));
+
+const bodyOf = (body: unknown) => () => Promise.resolve(body);
 
 describe("shouldUseReplicaDb", () => {
-	test("matches the v2 customer list endpoints", () => {
+	test("routes the customer list endpoints to the replica without reading the body", async () => {
 		expect(
-			shouldUseReplicaDb(
-				createContext({ method: "POST", path: "/v1/customers/list" }),
-			),
+			await shouldUseReplicaDb({
+				method: "POST",
+				path: "/v1/customers/list",
+				readBody: neverRead,
+			}),
 		).toBe(true);
+
 		expect(
-			shouldUseReplicaDb(
-				createContext({ method: "POST", path: "/v1/customers.list" }),
-			),
+			await shouldUseReplicaDb({
+				method: "POST",
+				path: "/v1/customers.list",
+				readBody: neverRead,
+			}),
 		).toBe(true);
 	});
 
-	test("does not match non-replica customer routes", () => {
+	test("routes unscoped entities.list to the replica", async () => {
 		expect(
-			shouldUseReplicaDb(createContext({ method: "GET", path: "/v1/customers" })),
+			await shouldUseReplicaDb({
+				method: "POST",
+				path: "/v1/entities.list",
+				readBody: bodyOf({}),
+			}),
+		).toBe(true);
+
+		expect(
+			await shouldUseReplicaDb({
+				method: "POST",
+				path: "/v1/entities.list",
+				readBody: bodyOf({ limit: 50, search: "acme" }),
+			}),
+		).toBe(true);
+	});
+
+	test("routes customer-scoped entities.list to the primary", async () => {
+		expect(
+			await shouldUseReplicaDb({
+				method: "POST",
+				path: "/v1/entities.list",
+				readBody: bodyOf({ customer_id: "cus_123" }),
+			}),
 		).toBe(false);
+
 		expect(
-			shouldUseReplicaDb(
-				createContext({ method: "GET", path: "/v1/customers/cus_123" }),
-			),
+			await shouldUseReplicaDb({
+				method: "POST",
+				path: "/v1/entities.list",
+				readBody: bodyOf({ customer_id: "cus_123", limit: 50 }),
+			}),
 		).toBe(false);
+	});
+
+	test("falls back to the primary when the body cannot be read", async () => {
 		expect(
-			shouldUseReplicaDb(
-				createContext({ method: "POST", path: "/customers/all/search" }),
-			),
+			await shouldUseReplicaDb({
+				method: "POST",
+				path: "/v1/entities.list",
+				readBody: () =>
+					Promise.reject(new SyntaxError("Unexpected end of JSON")),
+			}),
+		).toBe(false);
+	});
+
+	test("treats a blank or non-string customer_id as unscoped", async () => {
+		// The route schema is `z.string().trim().min(1).optional()`, so these are
+		// rejected with a 400 before any query runs. Pinning the routing keeps the
+		// decision aligned with what the schema considers a real scope.
+		for (const customerId of ["", "   ", 123, null]) {
+			expect(
+				await shouldUseReplicaDb({
+					method: "POST",
+					path: "/v1/entities.list",
+					readBody: bodyOf({ customer_id: customerId }),
+				}),
+			).toBe(true);
+		}
+	});
+
+	test("routes a non-object body to the replica", async () => {
+		for (const body of [null, "customer", 42]) {
+			expect(
+				await shouldUseReplicaDb({
+					method: "POST",
+					path: "/v1/entities.list",
+					readBody: bodyOf(body),
+				}),
+			).toBe(true);
+		}
+	});
+
+	test("does not match non-replica routes", async () => {
+		expect(
+			await shouldUseReplicaDb({
+				method: "GET",
+				path: "/v1/customers",
+				readBody: neverRead,
+			}),
+		).toBe(false);
+
+		expect(
+			await shouldUseReplicaDb({
+				method: "GET",
+				path: "/v1/customers/cus_123",
+				readBody: neverRead,
+			}),
+		).toBe(false);
+
+		expect(
+			await shouldUseReplicaDb({
+				method: "POST",
+				path: "/customers/all/search",
+				readBody: neverRead,
+			}),
+		).toBe(false);
+	});
+
+	test("does not match entities.list on a different method", async () => {
+		expect(
+			await shouldUseReplicaDb({
+				method: "GET",
+				path: "/v1/entities.list",
+				readBody: neverRead,
+			}),
 		).toBe(false);
 	});
 });


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Customer-scoped POST `/v1/entities.list` now reads from the primary to prevent stale results after writes; only unscoped listings continue to use the replica. Routing is body-aware with a safe fallback to the primary if the request body can’t be parsed.

- **Bug Fixes**
  - Made `shouldUseReplicaDb` body-aware: checks `customer_id` to decide primary vs replica; unreadable body routes to primary; only reads the body for routes that require it.
  - Updated `replicaDbMiddleware` to use the new async `shouldUseReplicaDb` with a body reader (`c.req.json()`).
  - Added tests to pin body caching and routing invariants for `/v1/entities.list` and customer list endpoints.

<sup>Written for commit 1054a1c2bf5f88e77c9229b8d0835a6f4f581c70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates replica-database routing for entity-list requests.

- **[Bug fixes]** Routes customer-scoped `POST /v1/entities.list` requests to the primary database to preserve read-after-write consistency.
- **[Improvements]** Keeps unscoped entity listings on the replica and safely defaults to the primary when the request body cannot be parsed.
- **[Improvements]** Adds unit and middleware integration coverage for routing decisions and repeated request-body reads.
</details>

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge, with customer-scoped entity listings consistently redirected to the primary database.

The accepted request schema uses the same nonblank string `customer_id` criterion as the new routing check, while Hono’s cached body handling preserves valid payloads for downstream validation and unreadable bodies safely remain on the primary.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/honoMiddlewares/replicaDbMiddleware.ts | Passes request metadata and a deferred JSON-body reader into the now-asynchronous replica-routing decision. |
| server/src/internal/misc/replicaDb/replicaDbConfigs.ts | Introduces body-aware routing so valid customer-scoped entity lists use the primary while unscoped lists continue using the replica. |
| server/tests/unit/replica-db/replica-db-body-read.test.ts | Verifies that middleware body inspection preserves the payload for downstream validation and handles malformed JSON safely. |
| server/tests/unit/replica-db/replica-db-configs.test.ts | Expands coverage across scoped, unscoped, malformed, invalid, and unmatched replica-routing cases. |

<sub>Reviews (1): Last reviewed commit: ["fix(entities): read primary for customer..."](https://github.com/useautumn/autumn/commit/1054a1c2bf5f88e77c9229b8d0835a6f4f581c70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47685892)</sub>

<!-- /greptile_comment -->