### PR TITLE
feat: migrate dashboard UI to Chord

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -488,6 +488,7 @@
       "dependencies": {
         "@base-ui/react": "^1.4.1",
         "@phosphor-icons/react": "^2.1.10",
+        "@radix-ui/colors": "^3.0.0",
         "@squircle/tailwindcss": "^1.0.6",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.18",
@@ -500,7 +501,7 @@
         "embla-carousel-react": "^8.6.0",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.562.0",
-        "motion": "^12.26.1",
+        "motion": "^12.42.2",
         "nanoid": "^5.1.6",
         "react-day-picker": "^8.10.1",
         "react-hotkeys-hook": "^4.6.1",
@@ -2104,6 +2105,8 @@
     "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
 
     "@puzzmo/revenue-cat-webhook-types": ["@puzzmo/revenue-cat-webhook-types@1.1.0", "", {}, "sha512-ChEa8v4dHUlZyQ7mt5i8x2lBcZ7STRSe3D+YO+DhXicJI0Thjcy23Ehbn9l071bxgmbeH7OErOphJrCLpq/SEg=="],
+
+    "@radix-ui/colors": ["@radix-ui/colors@3.0.0", "", {}, "sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.2", "", {}, "sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig=="],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -36,6 +36,7 @@
 	"dependencies": {
 		"@base-ui/react": "^1.4.1",
 		"@phosphor-icons/react": "^2.1.10",
+		"@radix-ui/colors": "^3.0.0",
 		"@squircle/tailwindcss": "^1.0.6",
 		"@tanstack/react-table": "^8.21.3",
 		"@tanstack/react-virtual": "^3.13.18",
@@ -48,7 +49,7 @@
 		"embla-carousel-react": "^8.6.0",
 		"input-otp": "^1.4.2",
 		"lucide-react": "^0.562.0",
-		"motion": "^12.26.1",
+		"motion": "^12.42.2",
 		"nanoid": "^5.1.6",
 		"react-day-picker": "^8.10.1",
 		"react-hotkeys-hook": "^4.6.1",

--- a/packages/ui/src/components/ai-elements/code-block.tsx
+++ b/packages/ui/src/components/ai-elements/code-block.tsx
@@ -102,7 +102,7 @@ export const CodeBlock = ({
 		<CodeBlockContext.Provider value={{ code }}>
 			<div
 				className={cn(
-					"group relative w-full overflow-hidden rounded-md border bg-background text-foreground",
+					"group relative w-full overflow-hidden rounded-lg border bg-background text-foreground",
 					className,
 				)}
 				{...props}

--- a/packages/ui/src/components/ai-elements/compact-prompt-input.tsx
+++ b/packages/ui/src/components/ai-elements/compact-prompt-input.tsx
@@ -36,7 +36,7 @@ export function CompactPromptInput({
 
 	return (
 		<form onSubmit={handleSubmit} className={cn("w-full", className)}>
-			<div className="flex items-center gap-2 rounded-xl border bg-white dark:bg-card px-3 py-2 dark:border-white/15 shadow-lg">
+			<div className="flex items-center gap-2 rounded-lg border bg-white dark:bg-card px-3 py-2 dark:border-white/15 shadow-lg">
 				<input
 					type="text"
 					value={value}

--- a/packages/ui/src/components/ai-elements/controls.tsx
+++ b/packages/ui/src/components/ai-elements/controls.tsx
@@ -9,8 +9,8 @@ export type ControlsProps = ComponentProps<typeof ControlsPrimitive>;
 export const Controls = ({ className, ...props }: ControlsProps) => (
 	<ControlsPrimitive
 		className={cn(
-			"gap-px overflow-hidden rounded-md border bg-card p-1 shadow-none!",
-			"[&>button]:rounded-md [&>button]:border-none! [&>button]:bg-transparent! [&>button]:hover:bg-secondary!",
+			"gap-px overflow-hidden rounded-lg border bg-card p-1 shadow-none!",
+			"[&>button]:rounded-lg [&>button]:border-none! [&>button]:bg-transparent! [&>button]:hover:bg-secondary!",
 			className,
 		)}
 		{...props}

--- a/packages/ui/src/components/ai-elements/image.tsx
+++ b/packages/ui/src/components/ai-elements/image.tsx
@@ -16,7 +16,7 @@ export const Image = ({
 		{...props}
 		alt={props.alt}
 		className={cn(
-			"h-auto max-w-full overflow-hidden rounded-md",
+			"h-auto max-w-full overflow-hidden rounded-lg",
 			props.className,
 		)}
 		src={`data:${mediaType};base64,${base64}`}

--- a/packages/ui/src/components/ai-elements/node.tsx
+++ b/packages/ui/src/components/ai-elements/node.tsx
@@ -21,7 +21,7 @@ export type NodeProps = ComponentProps<typeof Card> & {
 export const Node = ({ handles, className, ...props }: NodeProps) => (
 	<Card
 		className={cn(
-			"node-container relative size-full h-auto w-sm gap-0 rounded-md p-0",
+			"node-container relative size-full h-auto w-sm gap-0 rounded-lg p-0",
 			className,
 		)}
 		{...props}

--- a/packages/ui/src/components/ai-elements/panel.tsx
+++ b/packages/ui/src/components/ai-elements/panel.tsx
@@ -7,7 +7,7 @@ type PanelProps = ComponentProps<typeof PanelPrimitive>;
 export const Panel = ({ className, ...props }: PanelProps) => (
 	<PanelPrimitive
 		className={cn(
-			"m-4 overflow-hidden rounded-md border bg-card p-1",
+			"m-4 overflow-hidden rounded-lg border bg-card p-1",
 			className,
 		)}
 		{...props}

--- a/packages/ui/src/components/ai-elements/prompt-input.tsx
+++ b/packages/ui/src/components/ai-elements/prompt-input.tsx
@@ -294,7 +294,7 @@ export function PromptInputAttachment({
 			<HoverCardTrigger asChild>
 				<div
 					className={cn(
-						"group relative flex h-8 cursor-pointer select-none items-center gap-1.5 rounded-md border border-border px-1.5 font-medium text-sm transition-all hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+						"group relative flex h-8 cursor-pointer select-none items-center gap-1.5 rounded-lg border border-border px-1.5 font-medium text-sm transition-all hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
 						className,
 					)}
 					key={data.id}
@@ -337,7 +337,7 @@ export function PromptInputAttachment({
 			<PromptInputHoverCardContent className="w-auto p-2">
 				<div className="w-auto space-y-3">
 					{isImage && (
-						<div className="flex max-h-96 w-96 items-center justify-center overflow-hidden rounded-md border">
+						<div className="flex max-h-96 w-96 items-center justify-center overflow-hidden rounded-lg border">
 							<img
 								alt={filename || "attachment preview"}
 								className="max-h-full max-w-full object-contain"

--- a/packages/ui/src/components/ai-elements/queue.tsx
+++ b/packages/ui/src/components/ai-elements/queue.tsx
@@ -36,7 +36,7 @@ export type QueueItemProps = ComponentProps<"li">;
 export const QueueItem = ({ className, ...props }: QueueItemProps) => (
 	<li
 		className={cn(
-			"group flex flex-col gap-1 rounded-md px-3 py-1 text-sm transition-colors hover:bg-muted",
+			"group flex flex-col gap-1 rounded-lg px-3 py-1 text-sm transition-colors hover:bg-muted",
 			className,
 		)}
 		{...props}
@@ -215,7 +215,7 @@ export const QueueSectionTrigger = ({
 	<CollapsibleTrigger asChild>
 		<button
 			className={cn(
-				"group flex w-full items-center justify-between rounded-md bg-muted/40 px-3 py-2 text-left font-medium text-muted-foreground text-sm transition-colors hover:bg-muted",
+				"group flex w-full items-center justify-between rounded-lg bg-muted/40 px-3 py-2 text-left font-medium text-muted-foreground text-sm transition-colors hover:bg-muted",
 				className,
 			)}
 			type="button"
@@ -266,7 +266,7 @@ export type QueueProps = ComponentProps<"div">;
 export const Queue = ({ className, ...props }: QueueProps) => (
 	<div
 		className={cn(
-			"flex flex-col gap-2 rounded-xl border border-border bg-background px-3 pt-2 pb-2 shadow-xs",
+			"flex flex-col gap-2 rounded-lg border border-border bg-background px-3 pt-2 pb-2 shadow-xs",
 			className,
 		)}
 		{...props}

--- a/packages/ui/src/components/ai-elements/task.tsx
+++ b/packages/ui/src/components/ai-elements/task.tsx
@@ -18,7 +18,7 @@ export const TaskItemFile = ({
 }: TaskItemFileProps) => (
 	<div
 		className={cn(
-			"inline-flex items-center gap-1 rounded-md border bg-secondary px-1.5 py-0.5 text-foreground text-xs",
+			"inline-flex items-center gap-1 rounded-lg border bg-secondary px-1.5 py-0.5 text-foreground text-xs",
 			className,
 		)}
 		{...props}

--- a/packages/ui/src/components/ai-elements/tool.tsx
+++ b/packages/ui/src/components/ai-elements/tool.tsx
@@ -24,7 +24,7 @@ export type ToolProps = ComponentProps<typeof Collapsible>;
 
 export const Tool = ({ className, ...props }: ToolProps) => (
 	<Collapsible
-		className={cn("not-prose mb-4 w-full rounded-md border", className)}
+		className={cn("not-prose mb-4 w-full rounded-lg border", className)}
 		{...props}
 	/>
 );
@@ -111,7 +111,7 @@ export const ToolInput = ({ className, input, ...props }: ToolInputProps) => (
 		<h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
 			Parameters
 		</h4>
-		<div className="rounded-md bg-muted/50">
+		<div className="rounded-lg bg-muted/50">
 			<CodeBlock code={JSON.stringify(input, null, 2)} language="json" />
 		</div>
 	</div>
@@ -149,7 +149,7 @@ export const ToolOutput = ({
 			</h4>
 			<div
 				className={cn(
-					"overflow-x-auto rounded-md text-xs [&_table]:w-full",
+					"overflow-x-auto rounded-lg text-xs [&_table]:w-full",
 					errorText
 						? "bg-destructive/10 text-destructive"
 						: "bg-muted/50 text-foreground",

--- a/packages/ui/src/components/ai-elements/toolbar.tsx
+++ b/packages/ui/src/components/ai-elements/toolbar.tsx
@@ -7,7 +7,7 @@ type ToolbarProps = ComponentProps<typeof NodeToolbar>;
 export const Toolbar = ({ className, ...props }: ToolbarProps) => (
 	<NodeToolbar
 		className={cn(
-			"flex items-center gap-1 rounded-sm border bg-background p-1.5",
+			"flex items-center gap-1 rounded-lg border bg-background p-1.5",
 			className,
 		)}
 		position={Position.Bottom}

--- a/packages/ui/src/components/general/copy-text-button.tsx
+++ b/packages/ui/src/components/general/copy-text-button.tsx
@@ -32,7 +32,7 @@ export function CopyTextButton({
 			variant={variant as ButtonProps["variant"]}
 			size="icon"
 			className={cn(
-				"h-6 px-2 text-muted-foreground w-fit font-mono rounded-md truncate justify-start",
+				"h-6 px-2 text-muted-foreground w-fit font-mono rounded-lg truncate justify-start",
 				className,
 			)}
 			onClick={(e) => {

--- a/packages/ui/src/components/general/copyable-pre.tsx
+++ b/packages/ui/src/components/general/copyable-pre.tsx
@@ -48,7 +48,7 @@ export function CopyableSpan({
 
 	return (
 		<span
-			className={`inline-flex items-center rounded-xl bg-muted/50 pl-3 py-1 text-md font-mono text-muted-foreground relative font-normal gap-1 cursor-pointer transition-opacity ${
+			className={`inline-flex items-center rounded-lg bg-muted/50 pl-3 py-1 text-md font-mono text-muted-foreground relative font-normal gap-1 cursor-pointer transition-opacity ${
 				copied ? "opacity-30" : ""
 			}${className ? ` ${className}` : ""}`}
 			onClick={handleClick}

--- a/packages/ui/src/components/general/date-input-unix.tsx
+++ b/packages/ui/src/components/general/date-input-unix.tsx
@@ -70,7 +70,7 @@ function TimePicker({
 						<button
 							type="button"
 							onClick={togglePeriod}
-							className="rounded-sm px-1.5 py-0.5 text-xs font-medium text-muted-foreground transition-none hover:bg-accent select-none"
+							className="rounded-lg px-1.5 py-0.5 text-xs font-medium text-muted-foreground transition-none hover:bg-accent select-none"
 						>
 							{period}
 						</button>

--- a/packages/ui/src/components/general/icon-badge.tsx
+++ b/packages/ui/src/components/general/icon-badge.tsx
@@ -51,7 +51,7 @@ const IconBadge = React.forwardRef<HTMLSpanElement, IconBadgeProps>(
 				case "muted":
 					return "text-subtle";
 				case "default":
-					return "text-zinc-50";
+					return "text-mauve-1";
 				default:
 					return "text-subtle"; // Default fallback
 			}

--- a/packages/ui/src/components/general/panel-button.tsx
+++ b/packages/ui/src/components/general/panel-button.tsx
@@ -71,7 +71,7 @@ export function PanelButton({
 			{/* Centered icon */}
 			<div
 				className={cn(
-					"size-9 rounded-xl flex items-center justify-center relative bg-interactive-secondary-hover border",
+					"size-9 rounded-lg flex items-center justify-center relative bg-interactive-secondary-hover border",
 					// isSelected ? "bg-interactive-secondary-hover" : " border-input",
 				)}
 			>

--- a/packages/ui/src/components/general/searchable-select.tsx
+++ b/packages/ui/src/components/general/searchable-select.tsx
@@ -126,7 +126,7 @@ export function SearchableSelect<T>({
 					<PopoverContent
 						align="start"
 						className={cn(
-							"w-(--anchor-width) p-0 z-200 rounded-md overflow-hidden",
+							"w-(--anchor-width) p-0 z-200 rounded-lg overflow-hidden",
 							contentClassName,
 						)}
 						asChild

--- a/packages/ui/src/components/general/sheet-backdrop.tsx
+++ b/packages/ui/src/components/general/sheet-backdrop.tsx
@@ -25,7 +25,7 @@ export function SheetBackdrop({
 					initial={{ opacity: 0 }}
 					animate={{ opacity: 1 }}
 					exit={{ opacity: 0 }}
-					className="fixed inset-0 bg-white/70 dark:bg-black/70"
+					className="fixed inset-0 bg-mauve-1/70 dark:bg-black/60"
 					style={{ zIndex }}
 					onMouseDown={onClose}
 				/>

--- a/packages/ui/src/components/general/sheet-close-button.tsx
+++ b/packages/ui/src/components/general/sheet-close-button.tsx
@@ -9,7 +9,7 @@ export const SheetCloseButton = ({ onClose }: SheetCloseButtonProps) => {
 		<button
 			type="button"
 			onClick={onClose}
-			className="ring-offset-background focus:ring-ring absolute top-3 right-3 md:top-4 md:right-4 flex items-center justify-center size-10 md:size-auto rounded-sm md:rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none z-10"
+			className="ring-offset-background focus:ring-ring absolute top-3 right-3 md:top-4 md:right-4 flex items-center justify-center size-10 md:size-auto rounded-lg md:rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none z-10"
 			aria-label="Close"
 		>
 			<XIcon className="size-5 md:size-4" />

--- a/packages/ui/src/components/general/shortcut-button.tsx
+++ b/packages/ui/src/components/general/shortcut-button.tsx
@@ -42,7 +42,7 @@ export const ShortcutButton = ({
 	const keystrokeContainer = (keyStroke: string, isEnter = false) => {
 		const isSingleChar = keyStroke.length === 1;
 		const sizeClasses = isSingleChar ? "w-4" : "px-1";
-		const baseClasses = `flex items-center justify-center ${sizeClasses} h-4 rounded-md text-tiny font-medium`;
+		const baseClasses = `flex items-center justify-center ${sizeClasses} h-4 rounded-lg text-tiny font-medium`;
 		const variantClasses =
 			variant === "secondary"
 				? "bg-muted text-body-secondary"

--- a/packages/ui/src/components/general/stack-badge.tsx
+++ b/packages/ui/src/components/general/stack-badge.tsx
@@ -36,7 +36,7 @@ export function StackBadge({
 			onClick={handleClick}
 			data-state={isSelected ? "selected" : "unselected"}
 			className={cn(
-				"pr-2 rounded-md shadow-[0px_4px_4px_0px_rgba(0,0,0,0.02)] shadow-[inset_0px_-3px_4px_0px_rgba(0,0,0,0.04)] outline outline-1 outline-offset-[-1px] inline-flex justify-start items-center gap-1.5 transition-none",
+				"pr-2 rounded-lg shadow-[0px_4px_4px_0px_rgba(0,0,0,0.02)] shadow-[inset_0px_-3px_4px_0px_rgba(0,0,0,0.04)] outline outline-1 outline-offset-[-1px] inline-flex justify-start items-center gap-1.5 transition-none",
 				isSelected
 					? "bg-interactive-secondary outline-primary"
 					: "bg-interactive-secondary outline-border",

--- a/packages/ui/src/components/general/step-badge.tsx
+++ b/packages/ui/src/components/general/step-badge.tsx
@@ -1,6 +1,6 @@
 export const StepBadge = ({ children }: { children: React.ReactNode }) => {
 	return (
-		<div className="w-6 h-6 p-2.5 bg-interactive-secondary rounded-md shadow-[inset_0px_-3px_4px_0px_rgba(0,0,0,0.04)] border inline-flex justify-center items-center gap-2.5">
+		<div className="w-6 h-6 p-2.5 bg-interactive-secondary rounded-lg shadow-[inset_0px_-3px_4px_0px_rgba(0,0,0,0.04)] border inline-flex justify-center items-center gap-2.5">
 			<div className="justify-start text-violet-600 text-sm font-semibold font-['Inter']">
 				{children}
 			</div>

--- a/packages/ui/src/components/general/tag-input.tsx
+++ b/packages/ui/src/components/general/tag-input.tsx
@@ -126,7 +126,7 @@ function TagInput({
 				return (
 					<div
 						key={index}
-						className="flex items-center gap-1 border border-zinc-300 dark:border-zinc-600 bg-zinc-50 dark:bg-zinc-800 rounded-lg pl-3 pr-2 py-1 text-xs"
+						className="flex items-center gap-1 border border-mauve-6 dark:border-mauve-7 bg-mauve-2 dark:bg-mauve-3 rounded-lg pl-3 pr-2 py-1 text-xs"
 					>
 						<span className="text-tiny">{displayValue}</span>
 						<button

--- a/packages/ui/src/components/general/time-picker-input.tsx
+++ b/packages/ui/src/components/general/time-picker-input.tsx
@@ -124,7 +124,7 @@ const TimePickerInput = React.forwardRef<
 				className={cn(
 					"w-8 text-center text-sm tabular-nums caret-transparent",
 					"bg-transparent outline-none transition-none",
-					"rounded-sm focus:bg-accent focus:text-accent-foreground",
+					"rounded-lg focus:bg-accent focus:text-accent-foreground",
 					className,
 				)}
 				value={value || calculatedValue}

--- a/packages/ui/src/components/table/table-column-visibility.tsx
+++ b/packages/ui/src/components/table/table-column-visibility.tsx
@@ -61,7 +61,7 @@ function ColumnGroupSubmenu<T>({
 			<DropdownMenuSubTrigger className="flex items-center gap-2 cursor-pointer text-sm">
 				{group.label}
 				{visibleCount > 0 && (
-					<span className="text-xs text-tertiary-foreground bg-muted px-1 py-0 rounded-md">
+					<span className="text-xs text-tertiary-foreground bg-muted px-1 py-0 rounded-lg">
 						{visibleCount}
 					</span>
 				)}

--- a/packages/ui/src/components/table/table-content-virtualized.tsx
+++ b/packages/ui/src/components/table/table-content-virtualized.tsx
@@ -106,7 +106,7 @@ export function TableContentVirtualized({
 				)}
 			>
 				{(isLoading || isTransitioning) && (
-					<div className="bg-white/40 dark:bg-black/40 absolute pointer-events-none rounded-lg -inset-[1px] z-70" />
+					<div className="bg-mauve-1/40 dark:bg-black/30 absolute pointer-events-none rounded-lg -inset-[1px] z-70" />
 				)}
 
 				<div

--- a/packages/ui/src/components/table/table-content.tsx
+++ b/packages/ui/src/components/table/table-content.tsx
@@ -37,7 +37,7 @@ export function TableContent({
 			)}
 		>
 			{(isLoading || isTransitioning) && (
-				<div className="bg-white/40 dark:bg-black/40 absolute pointer-events-none rounded-lg -inset-[1px] z-70" />
+				<div className="bg-mauve-1/40 dark:bg-black/30 absolute pointer-events-none rounded-lg -inset-[1px] z-70" />
 			)}
 			{enableColumnVisibility && (
 				<div className="absolute right-2 top-1 z-45 h-fit">

--- a/packages/ui/src/components/table/table-mobile-cards.tsx
+++ b/packages/ui/src/components/table/table-mobile-cards.tsx
@@ -34,12 +34,12 @@ export function TableMobileCards() {
 				{Array.from({ length: SKELETON_CARD_COUNT }).map((_, cardIndex) => (
 					<div
 						key={`skeleton-card-${cardIndex}`}
-						className="rounded-xl border bg-interactive-secondary p-4 flex flex-col gap-3"
+						className="rounded-lg border bg-interactive-secondary p-4 flex flex-col gap-3"
 					>
-						<Skeleton className="h-4 w-28 rounded-sm" />
+						<Skeleton className="h-4 w-28 rounded-lg" />
 						<div className="flex flex-col gap-2">
-							<Skeleton className="h-3 w-40 rounded-sm" />
-							<Skeleton className="h-3 w-32 rounded-sm" />
+							<Skeleton className="h-3 w-40 rounded-lg" />
+							<Skeleton className="h-3 w-32 rounded-lg" />
 						</div>
 					</div>
 				))}
@@ -49,7 +49,7 @@ export function TableMobileCards() {
 
 	if (!rows.length) {
 		return (
-			<div className="rounded-xl border border-dashed bg-interactive-secondary dark:bg-transparent p-6 text-center text-subtle text-xs">
+			<div className="rounded-lg border border-dashed bg-interactive-secondary dark:bg-transparent p-6 text-center text-subtle text-xs">
 				{emptyStateChildren || emptyStateText}
 			</div>
 		);
@@ -98,7 +98,7 @@ function MobileCard<T>({
 
 	const interactive = Boolean(rowHref || onRowClick);
 	const cardClassName = cn(
-		"rounded-xl border bg-interactive-secondary p-4 flex flex-col gap-3 transition-colors",
+		"rounded-lg border bg-interactive-secondary p-4 flex flex-col gap-3 transition-colors",
 		isSelected ? "border-primary" : "active:bg-interactive-secondary-hover",
 		interactive && "cursor-pointer",
 	);

--- a/packages/ui/src/components/table/table-row-cells.tsx
+++ b/packages/ui/src/components/table/table-row-cells.tsx
@@ -185,7 +185,7 @@ export function TableSkeletonRows({
 						style={cellStyle}
 					>
 						{skeletonContent ?? (
-							<Skeleton className={cn("h-3.5 rounded-sm", widthClass)} />
+							<Skeleton className={cn("h-3.5 rounded-lg", widthClass)} />
 						)}
 					</TableCell>
 				);

--- a/packages/ui/src/components/table/table-skeleton-presets.tsx
+++ b/packages/ui/src/components/table/table-skeleton-presets.tsx
@@ -13,9 +13,9 @@ const pickWidth = (widths: string[], rowIndex: number): string =>
 export const nameWithIconSkeleton: ColumnSkeletonMeta = {
 	skeleton: (rowIndex: number) => (
 		<div className="flex items-center gap-2">
-			<Skeleton className="size-4 rounded-sm shrink-0" />
+			<Skeleton className="size-4 rounded-lg shrink-0" />
 			<Skeleton
-				className={cn("h-3.5 rounded-sm", pickWidth(NAME_WIDTHS, rowIndex))}
+				className={cn("h-3.5 rounded-lg", pickWidth(NAME_WIDTHS, rowIndex))}
 			/>
 		</div>
 	),
@@ -25,7 +25,7 @@ export const statusSkeleton: ColumnSkeletonMeta = {
 	skeleton: (rowIndex: number) => (
 		<div className="flex items-center gap-1.5">
 			<Skeleton
-				className={cn("h-3.5 rounded-sm", pickWidth(LABEL_WIDTHS, rowIndex))}
+				className={cn("h-3.5 rounded-lg", pickWidth(LABEL_WIDTHS, rowIndex))}
 			/>
 			<Skeleton className="size-3.5 rounded-full shrink-0" />
 		</div>
@@ -35,7 +35,7 @@ export const statusSkeleton: ColumnSkeletonMeta = {
 export const dateSkeleton: ColumnSkeletonMeta = {
 	skeleton: (rowIndex: number) => (
 		<Skeleton
-			className={cn("h-3.5 rounded-sm", pickWidth(DATE_WIDTHS, rowIndex))}
+			className={cn("h-3.5 rounded-lg", pickWidth(DATE_WIDTHS, rowIndex))}
 		/>
 	),
 };
@@ -43,7 +43,7 @@ export const dateSkeleton: ColumnSkeletonMeta = {
 export const idSkeleton: ColumnSkeletonMeta = {
 	skeleton: (rowIndex: number) => (
 		<Skeleton
-			className={cn("h-3.5 rounded-sm", pickWidth(ID_WIDTHS, rowIndex))}
+			className={cn("h-3.5 rounded-lg", pickWidth(ID_WIDTHS, rowIndex))}
 		/>
 	),
 };

--- a/packages/ui/src/components/ui/accordion.tsx
+++ b/packages/ui/src/components/ui/accordion.tsx
@@ -37,7 +37,7 @@ function AccordionTrigger({
 			<AccordionPrimitive.Trigger
 				data-slot="accordion-trigger"
 				className={cn(
-					"focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[aria-expanded=true]>svg]:rotate-180",
+					"focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-lg py-4 text-left text-sm font-medium transition-all outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[aria-expanded=true]>svg]:rotate-180",
 					className,
 				)}
 				{...props}

--- a/packages/ui/src/components/ui/badge.tsx
+++ b/packages/ui/src/components/ui/badge.tsx
@@ -4,18 +4,18 @@ import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
 
 const badgeVariants = cva(
-	"inline-flex items-center rounded-lg border border-zinc-200 px-1.5 py-0.5 text-body-secondary",
+	"inline-flex items-center rounded-lg border border-mauve-6 px-1.5 py-0.5 text-body-secondary",
 	{
 		variants: {
 			variant: {
 				default:
-					"border-transparent bg-zinc-900 text-zinc-50 shadow hover:bg-zinc-900/80 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-50/80",
+					"border-transparent bg-mauve-12 text-mauve-1 shadow hover:bg-mauve-12/80 dark:bg-mauve-2 dark:text-mauve-12 dark:hover:bg-mauve-2/80",
 
 				muted: "bg-muted border border-border/50",
 				green: "bg-green-500/10 text-green-500 border-transparent",
 				secondary:
-					"border-transparent bg-zinc-100 text-zinc-900 hover:bg-zinc-100/80 dark:bg-zinc-800 dark:text-zinc-50 dark:hover:bg-zinc-800/80",
-				outline: "text-zinc-950 dark:text-zinc-50",
+					"border-transparent bg-mauve-3 text-mauve-12 hover:bg-mauve-3/80 dark:bg-mauve-3 dark:text-mauve-1 dark:hover:bg-mauve-3/80",
+				outline: "text-mauve-12 dark:text-mauve-1",
 			},
 			size: {
 				default: "px-1.5 py-0.5 text-xs",

--- a/packages/ui/src/components/ui/button-group.tsx
+++ b/packages/ui/src/components/ui/button-group.tsx
@@ -55,7 +55,7 @@ function ButtonGroupText({
 		props: mergeProps<"div">(
 			{
 				className: cn(
-					"bg-muted flex items-center gap-2 rounded-md border px-4 text-sm font-medium shadow-xs [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+					"bg-muted flex items-center gap-2 rounded-lg border px-4 text-sm font-medium shadow-sm [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
 					className,
 				),
 			},

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -7,8 +7,8 @@ import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 const buttonVariants = cva(
-	`relative inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none cursor-pointer
-  rounded-lg group/btn transition-colors  w-fit transform-gpu
+	`relative inline-flex h-8 w-max items-center justify-center gap-1.5 whitespace-nowrap rounded-lg border border-b-2 px-3 text-sm font-medium disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none cursor-pointer transition-[background-color,border-color,color,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] enabled:active:scale-[0.97] focus-visible:outline-2 focus-visible:outline-violet-8 focus-visible:outline-offset-2 motion-reduce:transform-none
+	  group/btn transform-gpu
   `,
 	{
 		variants: {

--- a/packages/ui/src/components/ui/calendar.tsx
+++ b/packages/ui/src/components/ui/calendar.tsx
@@ -49,7 +49,7 @@ function CalendarCaption({ displayMonth, id }: CaptionProps) {
 				type="button"
 				disabled={!previousMonth}
 				onClick={() => previousMonth && goToMonth(previousMonth)}
-				className="inline-flex items-center justify-center size-7 rounded-md text-tertiary-foreground hover:bg-accent hover:text-foreground transition-colors p-0 disabled:opacity-30 disabled:pointer-events-none"
+				className="inline-flex items-center justify-center size-7 rounded-lg text-tertiary-foreground hover:bg-accent hover:text-foreground transition-colors p-0 disabled:opacity-30 disabled:pointer-events-none"
 			>
 				<ChevronLeft className="size-4" />
 			</button>
@@ -93,7 +93,7 @@ function CalendarCaption({ displayMonth, id }: CaptionProps) {
 				type="button"
 				disabled={!nextMonth}
 				onClick={() => nextMonth && goToMonth(nextMonth)}
-				className="inline-flex items-center justify-center size-7 rounded-md text-tertiary-foreground hover:bg-accent hover:text-foreground transition-colors p-0 disabled:opacity-30 disabled:pointer-events-none"
+				className="inline-flex items-center justify-center size-7 rounded-lg text-tertiary-foreground hover:bg-accent hover:text-foreground transition-colors p-0 disabled:opacity-30 disabled:pointer-events-none"
 			>
 				<ChevronRight className="size-4" />
 			</button>
@@ -127,21 +127,21 @@ function Calendar({
 				vhidden: "hidden",
 				nav: "flex items-center gap-1",
 				nav_button:
-					"inline-flex items-center justify-center size-7 rounded-md text-tertiary-foreground hover:bg-accent hover:text-foreground transition-colors p-0",
+					"inline-flex items-center justify-center size-7 rounded-lg text-tertiary-foreground hover:bg-accent hover:text-foreground transition-colors p-0",
 				nav_button_previous: "absolute left-1",
 				nav_button_next: "absolute right-1",
 				table: "w-full border-collapse space-x-1",
 				head_row: "flex",
 				head_cell:
-					"text-tertiary-foreground rounded-md w-8 font-normal text-[0.8rem]",
+					"text-tertiary-foreground rounded-lg w-8 font-normal text-[0.8rem]",
 				row: "flex w-full mt-2",
 				cell: cn(
 					"relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-range-end)]:rounded-r-md",
 					props.mode === "range"
 						? "[&:has(>.day-range-end)]:rounded-r-md [&:has(>.day-range-start)]:rounded-l-md first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md"
-						: "[&:has([aria-selected])]:rounded-md",
+						: "[&:has([aria-selected])]:rounded-lg",
 				),
-				day: "inline-flex items-center justify-center size-8 p-0 font-normal text-muted-foreground rounded-md cursor-pointer hover:bg-accent hover:text-accent-foreground transition-colors aria-selected:opacity-100",
+				day: "inline-flex items-center justify-center size-8 p-0 font-normal text-muted-foreground rounded-lg cursor-pointer hover:bg-accent hover:text-accent-foreground transition-colors aria-selected:opacity-100",
 				day_range_start:
 					"day-range-start aria-selected:bg-primary aria-selected:text-primary-foreground",
 				day_range_end:

--- a/packages/ui/src/components/ui/card.tsx
+++ b/packages/ui/src/components/ui/card.tsx
@@ -6,7 +6,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
 		<div
 			data-slot="card"
 			className={cn(
-				"bg-card text-card-foreground flex flex-col gap-3 rounded-xl border py-4 shadow-sm",
+				"bg-card text-card-foreground flex flex-col gap-3 rounded-lg border py-4 shadow-sm",
 				className,
 			)}
 			{...props}

--- a/packages/ui/src/components/ui/checkbox.tsx
+++ b/packages/ui/src/components/ui/checkbox.tsx
@@ -39,7 +39,7 @@ function Checkbox({
 			disabled={disabled}
 			style={{ cursor: disabled ? undefined : "pointer", ...style }}
 			className={cn(
-				"peer border-input dark:bg-input/30 data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary data-checked:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive  shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+				"peer border-input dark:bg-input/30 data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary data-checked:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive  shrink-0 rounded-[4px] border shadow-sm transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
 
 				!disabled && "hover:bg-hover-primary hover:border-primary",
 				size === "sm" && "size-3.5",

--- a/packages/ui/src/components/ui/command.tsx
+++ b/packages/ui/src/components/ui/command.tsx
@@ -146,7 +146,7 @@ function CommandItem({
 		<CommandPrimitive.Item
 			data-slot="command-item"
 			className={cn(
-				"data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground relative flex cursor-default items-center gap-1.5 rounded-lg px-1.5 py-1 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
 			{...props}

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -63,7 +63,7 @@ function DialogOverlay({
 		<DialogPrimitive.Backdrop
 			data-slot="dialog-overlay"
 			className={cn(
-				"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 z-[170] bg-black/50 dark:bg-black/80",
+				"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 z-[170] bg-black/50 dark:bg-black/60",
 				className,
 			)}
 			{...props}
@@ -95,7 +95,7 @@ const DialogContent = React.forwardRef<
 			ref={ref}
 			data-slot="dialog-content"
 			className={cn(
-				"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 fixed top-[50%] left-[50%] z-[180] grid translate-x-[-50%] translate-y-[-50%] rounded-lg shadow-lg ring-1 ring-foreground/10 duration-200",
+				"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 fixed top-[50%] left-[50%] z-[180] grid translate-x-[-50%] translate-y-[-50%] rounded-lg shadow-chord-md ring-1 ring-foreground/10 duration-200",
 				"w-full max-w-md gap-3 bg-background",
 				"p-4",
 				className,

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -22,7 +22,7 @@ const DropdownMenuContext = React.createContext<{
 });
 
 const dropdownMenuItemVariants = cva(
-	"group/dropdown-menu-item relative flex cursor-default select-none items-center gap-1.5 rounded-md px-1.5 py-1 text-sm text-muted-foreground outline-hidden data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+	"group/dropdown-menu-item relative flex cursor-default select-none items-center gap-1.5 rounded-lg px-1.5 py-1 text-sm text-muted-foreground outline-hidden data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 	{
 		variants: {
 			variant: {
@@ -124,7 +124,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
 			ref={ref}
 			data-slot="dropdown-menu-sub-trigger"
 			className={cn(
-				"flex cursor-default gap-1.5 select-none items-center rounded-md px-1.5 py-1 text-sm text-muted-foreground outline-hidden focus:bg-accent focus:text-accent-foreground data-popup-open:bg-accent data-popup-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"flex cursor-default gap-1.5 select-none items-center rounded-lg px-1.5 py-1 text-sm text-muted-foreground outline-hidden focus:bg-accent focus:text-accent-foreground data-popup-open:bg-accent data-popup-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				inset && "pl-7",
 				className,
 			)}
@@ -158,7 +158,7 @@ const DropdownMenuSubContent = React.forwardRef<
 					ref={ref}
 					data-slot="dropdown-menu-sub-content"
 					className={cn(
-						"min-w-[8rem] overflow-x-hidden overflow-y-auto rounded-lg bg-interactive-secondary p-1 text-muted-foreground shadow-lg ring-1 ring-foreground/10 duration-100 origin-(--transform-origin)",
+						"min-w-[8rem] overflow-x-hidden overflow-y-auto rounded-lg bg-interactive-secondary p-1 text-muted-foreground shadow-chord-md ring-1 ring-foreground/10 duration-100 origin-(--transform-origin)",
 						"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
 						className,
 					)}
@@ -203,7 +203,7 @@ const DropdownMenuContent = React.forwardRef<
 					ref={ref}
 					data-slot="dropdown-menu-content"
 					className={cn(
-						"max-h-(--available-height) min-w-32 overflow-x-hidden overflow-y-auto rounded-lg bg-interactive-secondary p-1 text-muted-foreground shadow-md ring-1 ring-foreground/10 duration-100 origin-(--transform-origin)",
+						"max-h-(--available-height) min-w-32 overflow-x-hidden overflow-y-auto rounded-lg bg-interactive-secondary p-1 text-muted-foreground shadow-chord-md ring-1 ring-foreground/10 duration-100 origin-(--transform-origin)",
 						"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
 						className,
 					)}
@@ -313,7 +313,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
 			data-inset={inset}
 			closeOnClick={false}
 			className={cn(
-				"relative flex cursor-default select-none items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"relative flex cursor-default select-none items-center gap-1.5 rounded-lg py-1 pr-8 pl-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
 			{...rest}
@@ -339,7 +339,7 @@ const DropdownMenuRadioItem = React.forwardRef<
 			data-slot="dropdown-menu-radio-item"
 			data-inset={inset}
 			className={cn(
-				"relative flex cursor-default select-none items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"relative flex cursor-default select-none items-center gap-1.5 rounded-lg py-1 pr-8 pl-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
 			{...rest}

--- a/packages/ui/src/components/ui/hover-card.tsx
+++ b/packages/ui/src/components/ui/hover-card.tsx
@@ -57,7 +57,7 @@ function HoverCardContent({
 				<PreviewCardPrimitive.Popup
 					data-slot="hover-card-content"
 					className={cn(
-						"bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 w-64 origin-(--transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+						"bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 w-64 origin-(--transform-origin) rounded-lg border p-4 shadow-chord-md outline-hidden",
 						className,
 					)}
 					{...props}

--- a/packages/ui/src/components/ui/input-group.tsx
+++ b/packages/ui/src/components/ui/input-group.tsx
@@ -20,7 +20,7 @@ function InputGroup({
 			data-slot="input-group"
 			role="group"
 			className={cn(
-				"group/input-group border-input dark:bg-input/30 relative flex w-full items-center rounded-lg border shadow-xs outline-none cursor-text",
+				"group/input-group border-input dark:bg-input/30 relative flex w-full items-center rounded-lg border shadow-sm outline-none cursor-text",
 
 				// CUSTOM STYLES
 				`!pr-0 h-input input-base input-shadow-default input-state-focus-within`,
@@ -103,7 +103,7 @@ const inputGroupButtonVariants = cva(
 		variants: {
 			size: {
 				xs: "h-6 gap-1 px-2 rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-3.5 has-[>svg]:px-2",
-				sm: "h-8 px-2.5 gap-1.5 rounded-md has-[>svg]:px-2.5",
+				sm: "h-8 px-2.5 gap-1.5 rounded-lg has-[>svg]:px-2.5",
 				"icon-xs":
 					"size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0",
 				"icon-sm": "size-8 p-0 has-[>svg]:p-0",

--- a/packages/ui/src/components/ui/input-otp.tsx
+++ b/packages/ui/src/components/ui/input-otp.tsx
@@ -48,7 +48,7 @@ function InputOTPSlot({
 			data-slot="input-otp-slot"
 			data-active={isActive}
 			className={cn(
-				"data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 border-input relative flex h-9 w-9 items-center justify-center border-y border-r text-sm shadow-xs transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md data-[active=true]:z-10 data-[active=true]:ring-[3px]",
+				"data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 border-input relative flex h-9 w-9 items-center justify-center border-y border-r text-sm shadow-sm transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md data-[active=true]:z-10 data-[active=true]:ring-[3px]",
 				className,
 			)}
 			{...props}

--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -60,7 +60,7 @@ function PopoverContent({
 				<PopoverPrimitive.Popup
 					data-slot="popover-content"
 					className={cn(
-						"bg-interactive-secondary text-muted-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 w-72 rounded-lg ring-1 ring-foreground/10 p-4 shadow-md outline-hidden",
+						"bg-interactive-secondary text-muted-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 w-72 rounded-lg ring-1 ring-foreground/10 p-4 shadow-chord-md outline-hidden",
 						className,
 					)}
 					{...props}

--- a/packages/ui/src/components/ui/radio-group.tsx
+++ b/packages/ui/src/components/ui/radio-group.tsx
@@ -25,10 +25,10 @@ const RadioGroupItem = React.forwardRef<HTMLButtonElement, Radio.Root.Props>(
 				data-slot="radio-group-item"
 				style={{ cursor: "pointer", ...style }}
 				className={cn(
-					"w-[13px] h-[13px] px-0.5 py-[3px] rounded-xl inline-flex flex-col justify-center items-center gap-2.5 overflow-hidden transition-none focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+					"w-[13px] h-[13px] px-0.5 py-[3px] rounded-lg inline-flex flex-col justify-center items-center gap-2.5 overflow-hidden transition-none focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
 
 					"bg-interactive-secondary shadow-[0px_2px_4px_0px_rgba(0,0,0,0.02)] border-[0.70px] border",
-					"data-checked:bg-violet-600 data-checked:shadow-none data-checked:border-none",
+					"data-checked:bg-violet-9 data-checked:shadow-none data-checked:border-none",
 
 					"hover:bg-interactive-secondary-hover hover:border-primary hover:border-[1px]",
 					className,
@@ -39,7 +39,7 @@ const RadioGroupItem = React.forwardRef<HTMLButtonElement, Radio.Root.Props>(
 					data-slot="radio-group-indicator"
 					className="flex items-center justify-center"
 				>
-					<div className="w-1 h-1 bg-white rounded-full" />
+					<div className="w-1 h-1 bg-mauve-1 rounded-full" />
 				</Radio.Indicator>
 			</Radio.Root>
 		);

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -100,7 +100,7 @@ function SelectContent({
 				<SelectPrimitive.Popup
 					data-slot="select-content"
 					className={cn(
-						"bg-interactive-secondary text-muted-foreground relative max-h-[var(--available-height)] min-w-[var(--anchor-width)] overflow-x-hidden overflow-y-auto rounded-lg shadow-md ring-1 ring-foreground/10 p-1",
+						"bg-interactive-secondary text-muted-foreground relative max-h-[var(--available-height)] min-w-[var(--anchor-width)] overflow-x-hidden overflow-y-auto rounded-lg shadow-chord-md ring-1 ring-foreground/10 p-1",
 						className,
 					)}
 					{...props}
@@ -134,7 +134,7 @@ function SelectItem({
 		<SelectPrimitive.Item
 			data-slot="select-item"
 			className={cn(
-				"data-highlighted:bg-accent data-highlighted:text-accent-foreground data-highlighted:**:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+				"data-highlighted:bg-accent data-highlighted:text-accent-foreground data-highlighted:**:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default items-center gap-1.5 rounded-lg py-1 pr-8 pl-1.5 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
 				className,
 			)}
 			{...props}

--- a/packages/ui/src/components/ui/sheet.tsx
+++ b/packages/ui/src/components/ui/sheet.tsx
@@ -73,7 +73,7 @@ function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
 		<SheetPrimitive.Backdrop
 			data-slot="sheet-overlay"
 			className={cn(
-				"fixed inset-0 z-[150] bg-white/70 dark:bg-black/70 transition-opacity duration-300 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0",
+				"fixed inset-0 z-[150] bg-mauve-1/70 dark:bg-black/70 transition-opacity duration-300 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0",
 				className,
 			)}
 			{...props}

--- a/packages/ui/src/components/ui/skeleton.tsx
+++ b/packages/ui/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
 	return (
 		<div
 			data-slot="skeleton"
-			className={cn("bg-accent animate-pulse rounded-md", className)}
+			className={cn("bg-accent animate-pulse rounded-lg", className)}
 			{...props}
 		/>
 	);

--- a/packages/ui/src/components/ui/switch.tsx
+++ b/packages/ui/src/components/ui/switch.tsx
@@ -25,7 +25,7 @@ function Switch({
 			data-slot="switch"
 			onKeyDown={handleKeyDown}
 			className={cn(
-				"peer data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 inline-flex h-5 w-9 shrink-0 items-center rounded-full border-2 border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+				"peer data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 inline-flex h-5 w-9 shrink-0 items-center rounded-full border-2 border-transparent shadow-sm transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
 				className,
 			)}
 			{...props}
@@ -33,7 +33,7 @@ function Switch({
 			<SwitchPrimitive.Thumb
 				data-slot="switch-thumb"
 				className={cn(
-					"bg-background pointer-events-none block size-4 rounded-full ring-0 shadow-lg transition-transform data-checked:translate-x-4 data-unchecked:translate-x-0",
+					"bg-background pointer-events-none block size-4 rounded-full ring-0 shadow-chord-md transition-transform data-checked:translate-x-4 data-unchecked:translate-x-0",
 					thumbClassName,
 				)}
 			/>

--- a/packages/ui/src/components/ui/table.tsx
+++ b/packages/ui/src/components/ui/table.tsx
@@ -50,7 +50,7 @@ function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
 		<tfoot
 			data-slot="table-footer"
 			className={cn(
-				"border-t bg-zinc-100/50 font-medium [&>tr]:last:border-b-0 dark:bg-zinc-800/50",
+				"border-t bg-mauve-3/50 font-medium [&>tr]:last:border-b-0 dark:bg-mauve-3/50",
 				className,
 			)}
 			{...props}
@@ -63,7 +63,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
 		<tr
 			data-slot="table-row"
 			className={cn(
-				"data-[state=selected]:bg-zinc-100 dark:data-[state=selected]:bg-zinc-800",
+				"data-[state=selected]:bg-mauve-3 dark:data-[state=selected]:bg-mauve-3",
 				className,
 			)}
 			{...props}
@@ -76,7 +76,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
 		<th
 			data-slot="table-head"
 			className={cn(
-				"h-6 text-muted-foreground text-left align-middle font-normal text-xs [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px] dark:text-zinc-400",
+				"h-6 text-muted-foreground text-left align-middle font-normal text-xs [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px] dark:text-mauve-10",
 				className,
 			)}
 			{...props}
@@ -104,7 +104,7 @@ function TableCaption({
 	return (
 		<caption
 			data-slot="table-caption"
-			className={cn("mt-4 text-sm text-zinc-500 dark:text-zinc-400", className)}
+			className={cn("mt-4 text-sm text-mauve-11 dark:text-mauve-10", className)}
 			{...props}
 		/>
 	);

--- a/packages/ui/src/components/ui/tabs.tsx
+++ b/packages/ui/src/components/ui/tabs.tsx
@@ -13,7 +13,7 @@ const TabsList = React.forwardRef<HTMLDivElement, TabsPrimitive.List.Props>(
 		<TabsPrimitive.List
 			ref={ref}
 			className={cn(
-				"inline-flex h-9 items-center justify-center rounded-lg bg-transparent text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400 px-1",
+				"inline-flex h-9 items-center justify-center rounded-lg bg-transparent text-mauve-11 dark:bg-mauve-3 dark:text-mauve-10 px-1",
 				className,
 			)}
 			{...props}
@@ -31,7 +31,7 @@ const TabsTrigger = React.forwardRef<
 	<TabsPrimitive.Tab
 		ref={ref}
 		className={cn(
-			"inline-flex items-center justify-center whitespace-nowrap rounded-md px-2 py-1 text-sm font-medium ring-offset-background transition-all cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[active]:text-primary hover:bg-interactive-secondary-hover dark:focus-visible:ring-zinc-300 dark:data-[active]:bg-zinc-950 dark:data-[active]:text-zinc-50",
+			"inline-flex items-center justify-center whitespace-nowrap rounded-lg px-2 py-1 text-sm font-medium ring-offset-background transition-all cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-8 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[active]:text-primary hover:bg-interactive-secondary-hover dark:focus-visible:ring-violet-8 dark:data-[active]:bg-mauve-12 dark:data-[active]:text-mauve-1",
 			className,
 			variant === "onboarding" &&
 				"data-[active]:bg-stone-200 data-[active]:text-muted-foreground data-[active]:font-medium",

--- a/packages/ui/src/components/ui/textarea.tsx
+++ b/packages/ui/src/components/ui/textarea.tsx
@@ -6,7 +6,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
 		<textarea
 			data-slot="textarea"
 			className={cn(
-				"border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+				"border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-lg border bg-transparent px-3 py-2 text-base shadow-sm transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
 				className,
 			)}
 			{...props}

--- a/packages/ui/src/styles/chord.css
+++ b/packages/ui/src/styles/chord.css
@@ -1,0 +1,54 @@
+/* Chord surface tokens: Radix purple accent with mauve grayscale. */
+@theme inline {
+	--color-grayscale-0: #fff;
+	--color-grayscale-1: var(--mauve-1);
+	--color-grayscale-2: var(--mauve-2);
+	--color-grayscale-3: var(--mauve-3);
+	--color-grayscale-4: var(--mauve-4);
+	--color-grayscale-5: var(--mauve-5);
+	--color-grayscale-6: var(--mauve-6);
+	--color-grayscale-7: var(--mauve-7);
+	--color-grayscale-8: var(--mauve-8);
+	--color-grayscale-9: var(--mauve-9);
+	--color-grayscale-10: var(--mauve-10);
+	--color-grayscale-11: var(--mauve-11);
+	--color-grayscale-12: var(--mauve-12);
+	--color-accent-1: var(--violet-1);
+	--color-accent-2: var(--violet-2);
+	--color-accent-3: var(--violet-3);
+	--color-accent-4: var(--violet-4);
+	--color-accent-5: var(--violet-5);
+	--color-accent-6: var(--violet-6);
+	--color-accent-7: var(--violet-7);
+	--color-accent-8: var(--violet-8);
+	--color-accent-9: var(--violet-9);
+	--color-accent-10: var(--violet-10);
+	--color-accent-11: var(--violet-11);
+	--color-accent-12: var(--violet-12);
+	--shadow-chord-sm: 2px 2px 4px rgb(0 0 0 / 0.02), 0 1px 2px rgb(0 0 0 / 0.03);
+	--shadow-chord-md:
+		0 4px 16px rgb(0 0 0 / 0.06), 0 1.5px 6px rgb(0 0 0 / 0.04);
+}
+
+.small-shadow {
+	box-shadow: var(--shadow-chord-sm);
+}
+.medium-shadow {
+	box-shadow: var(--shadow-chord-md);
+}
+
+[data-slot="button"],
+[data-slot="input"],
+[data-slot="select-trigger"] {
+	transition-property:
+		background-color, border-color, color, box-shadow, transform;
+	transition-duration: 150ms;
+	transition-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+[data-slot="button"]:focus-visible,
+[data-slot="input"]:focus-visible,
+[data-slot="select-trigger"]:focus-visible {
+	outline: 2px solid var(--violet-8);
+	outline-offset: 2px;
+}

--- a/packages/ui/src/styles/colors.css
+++ b/packages/ui/src/styles/colors.css
@@ -1,0 +1,80 @@
+@import "@radix-ui/colors/gray.css";
+@import "@radix-ui/colors/gray-dark.css";
+
+@import "@radix-ui/colors/mauve.css";
+@import "@radix-ui/colors/mauve-dark.css";
+
+@import "@radix-ui/colors/slate.css";
+@import "@radix-ui/colors/slate-dark.css";
+
+@import "@radix-ui/colors/sage.css";
+@import "@radix-ui/colors/sage-dark.css";
+
+@import "@radix-ui/colors/olive.css";
+@import "@radix-ui/colors/olive-dark.css";
+
+@import "@radix-ui/colors/sand.css";
+@import "@radix-ui/colors/sand-dark.css";
+
+@import "@radix-ui/colors/bronze.css";
+@import "@radix-ui/colors/bronze-dark.css";
+
+@import "@radix-ui/colors/gold.css";
+@import "@radix-ui/colors/gold-dark.css";
+
+@import "@radix-ui/colors/brown.css";
+@import "@radix-ui/colors/brown-dark.css";
+
+@import "@radix-ui/colors/orange.css";
+@import "@radix-ui/colors/orange-dark.css";
+
+@import "@radix-ui/colors/tomato.css";
+@import "@radix-ui/colors/tomato-dark.css";
+
+@import "@radix-ui/colors/red.css";
+@import "@radix-ui/colors/red-dark.css";
+
+@import "@radix-ui/colors/ruby.css";
+@import "@radix-ui/colors/ruby-dark.css";
+
+@import "@radix-ui/colors/crimson.css";
+@import "@radix-ui/colors/crimson-dark.css";
+
+@import "@radix-ui/colors/pink.css";
+@import "@radix-ui/colors/pink-dark.css";
+
+@import "@radix-ui/colors/plum.css";
+@import "@radix-ui/colors/plum-dark.css";
+
+@import "@radix-ui/colors/purple.css";
+@import "@radix-ui/colors/purple-dark.css";
+
+@import "@radix-ui/colors/violet.css";
+@import "@radix-ui/colors/violet-dark.css";
+
+@import "@radix-ui/colors/iris.css";
+@import "@radix-ui/colors/iris-dark.css";
+
+@import "@radix-ui/colors/indigo.css";
+@import "@radix-ui/colors/indigo-dark.css";
+
+@import "@radix-ui/colors/blue.css";
+@import "@radix-ui/colors/blue-dark.css";
+
+@import "@radix-ui/colors/cyan.css";
+@import "@radix-ui/colors/cyan-dark.css";
+
+@import "@radix-ui/colors/teal.css";
+@import "@radix-ui/colors/teal-dark.css";
+
+@import "@radix-ui/colors/jade.css";
+@import "@radix-ui/colors/jade-dark.css";
+
+@import "@radix-ui/colors/green.css";
+@import "@radix-ui/colors/green-dark.css";
+
+@import "@radix-ui/colors/grass.css";
+@import "@radix-ui/colors/grass-dark.css";
+
+@import "@radix-ui/colors/sky.css";
+@import "@radix-ui/colors/sky-dark.css";

--- a/packages/ui/src/styles/index.css
+++ b/packages/ui/src/styles/index.css
@@ -6,6 +6,8 @@
 @import url("https://fonts.googleapis.com/css2?family=Rubik+Glitch&family=Nabla&family=Noto+Sans+Cuneiform&display=swap");
 
 @import "tailwindcss";
+@import "./colors.css";
+@import "./chord.css";
 @import "tailwind-scrollbar-hide/v4";
 @import "@squircle/tailwindcss";
 
@@ -56,46 +58,46 @@ html {
 	color: rgba(255, 255, 255, 0.87);
 
 	/* Editted */
-	background-color: #fafaf9;
-	--foreground: #121212;
-	--background: #fafaf9;
+	background-color: var(--mauve-1);
+	--foreground: var(--mauve-12);
+	--background: var(--mauve-1);
 
-	--outer-background: #f5f5f4;
+	--outer-background: var(--mauve-2);
 
-	--interactive-secondary: #fff;
-	--interactive-secondary-hover: #fcfaff;
+	--interactive-secondary: var(--mauve-1);
+	--interactive-secondary-hover: var(--mauve-3);
 
-	--muted-foreground: #444;
-	--tertiary-foreground: #666;
-	--subtle: #767676;
-	--placeholder: #aaa;
+	--muted-foreground: var(--mauve-11);
+	--tertiary-foreground: var(--mauve-11);
+	--subtle: var(--mauve-10);
+	--placeholder: var(--mauve-9);
 	--sandbox: #0f9bff;
-	--radius: 0.375rem; /* 6px */
+	--radius: 0.5rem;
 
-	--primary: #8838ff;
+	--primary: var(--violet-9);
 	--primary-foreground: white;
-	--hover-primary: #fcfaff;
-	--active-primary: #f6f0ff;
-	--radio-group-hover-primary: #fcfaff;
+	--hover-primary: var(--violet-3);
+	--active-primary: var(--violet-4);
+	--radio-group-hover-primary: var(--violet-3);
 
-	--border: #e5e5e5;
-	--border-sheet: #eaeae9;
-	--border-table: #e5e5e5;
-	--card-border: #d1d1d1;
+	--border: var(--mauve-6);
+	--border-sheet: var(--mauve-6);
+	--border-table: var(--mauve-6);
+	--card-border: var(--mauve-6);
 
-	--input: #dddddd;
+	--input: var(--mauve-7);
 
 	--icon1: #888;
-	--muted: #f2f2f2;
+	--muted: var(--mauve-3);
 
-	--destructive: #e40000;
-	--destructive-hover: #c30000;
-	--destructive-foreground: #fafaf9;
-	--destructive-border: #940000;
+	--destructive: var(--red-9);
+	--destructive-hover: var(--red-10);
+	--destructive-foreground: white;
+	--destructive-border: var(--red-8);
 
 	/* White */
-	--input-background: #ffffff;
-	--card: #f8f8f7;
+	--input-background: var(--mauve-1);
+	--card: var(--mauve-1);
 	/* --card: #f5f5f5; */
 	/* --card: #fafaf9; */
 
@@ -106,21 +108,21 @@ html {
 	-moz-osx-font-smoothing: grayscale;
 	/* --background: oklch(1 0 0); */
 
-	--card-foreground: oklch(0.141 0.005 285.823);
+	--card-foreground: var(--mauve-12);
 
-	--popover: oklch(1 0 0);
-	--popover-foreground: oklch(0.141 0.005 285.823);
+	--popover: var(--mauve-1);
+	--popover-foreground: var(--mauve-12);
 
-	--secondary: oklch(0.967 0.001 286.375);
-	--secondary-foreground: oklch(0.21 0.006 285.885);
+	--secondary: var(--mauve-3);
+	--secondary-foreground: var(--mauve-12);
 
-	--accent: oklch(0.967 0.001 286.375);
-	--accent-foreground: oklch(0.21 0.006 285.885);
+	--accent: var(--violet-3);
+	--accent-foreground: var(--violet-12);
 
 	/* --border: oklch(0.92 0.004 286.32); */
 
 	/* --input: oklch(0.92 0.004 286.32); */
-	--ring: oklch(0.705 0.015 286.067);
+	--ring: var(--violet-8);
 	--chart-1: var(--primary);
 	/* --chart-2: #9c5aff; */
 	--chart-2: #a97eff;
@@ -146,40 +148,40 @@ html {
 }
 
 .dark {
-	--background: #161616;
-	--foreground: #ddd;
-	--muted-foreground: #ccc;
-	--tertiary-foreground: #999;
+	--background: var(--mauve-1);
+	--foreground: var(--mauve-12);
+	--muted-foreground: var(--mauve-11);
+	--tertiary-foreground: var(--mauve-10);
 
-	--primary: #8838ff;
+	--primary: var(--violet-9);
 
-	--outer-background: #121212;
+	--outer-background: var(--mauve-2);
 
-	--interactive-secondary: #1d1d1d;
-	--interactive-secondary-hover: #292929;
+	--interactive-secondary: var(--mauve-2);
+	--interactive-secondary-hover: var(--mauve-3);
 
-	--active-primary: #292929;
-	--input-background: #1d1d1d;
-	--muted: #1c1c1d;
+	--active-primary: var(--violet-4);
+	--input-background: var(--mauve-2);
+	--muted: var(--mauve-3);
 	--sandbox: #0f9bff;
 
-	--card: #121212;
-	--border: #222222;
+	--card: var(--mauve-2);
+	--border: var(--mauve-6);
 
 	--chart-grid-stroke: #262626;
 
-	--card-foreground: oklch(0.985 0 0);
-	--popover: oklch(0.141 0.005 285.823);
+	--card-foreground: var(--mauve-12);
+	--popover: var(--mauve-2);
 	--popover-foreground: white;
 	--primary-foreground: white;
-	--secondary: oklch(0.274 0.006 286.033);
-	--secondary-foreground: oklch(0.985 0 0);
-	--accent: oklch(0.274 0.006 286.033);
-	--accent-foreground: oklch(0.985 0 0);
-	--destructive: oklch(0.396 0.141 25.723);
-	--destructive-foreground: oklch(0.637 0.237 25.331);
-	--input: oklch(0.274 0.006 286.033);
-	--ring: oklch(0.442 0.017 285.786);
+	--secondary: var(--mauve-3);
+	--secondary-foreground: var(--mauve-12);
+	--accent: var(--violet-3);
+	--accent-foreground: var(--violet-12);
+	--destructive: var(--red-9);
+	--destructive-foreground: var(--red-12);
+	--input: var(--mauve-7);
+	--ring: var(--violet-8);
 	--sidebar: oklch(0.21 0.006 285.885);
 	--sidebar-foreground: oklch(0.985 0 0);
 	--sidebar-primary: oklch(0.488 0.243 264.376);


### PR DESCRIPTION
<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/e2e26f15-26ef-46ab-880a-7fb07b8ab493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-047" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/e2e26f15-26ef-46ab-880a-7fb07b8ab493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-047&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-047"><img alt="SCO-047" src="https://capy.ai/api/badge/thread.svg?label=SCO-047"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the dashboard UI to the Chord design system using Radix color scales, unified radius, and consistent focus/shadow styles. Aligns the dashboard with Chord (SCO-047) for a cohesive, accessible look across components.

- **Refactors**
  - Added `src/styles/chord.css` (Chord tokens, shadows) and `src/styles/colors.css` (Radix palettes); imported both in `styles/index.css`.
  - Switched to Radix `mauve`/`violet` variables and standardized radius to rounded-lg; updated overlays, skeletons, and badges.
  - Refreshed focus rings, transitions, and shadows for buttons, inputs, popovers, dropdowns, dialogs, sheets, tables, and AI elements.
  - Visual-only changes; no behavior updates.

- **Dependencies**
  - Added `@radix-ui/colors` ^3.0.0.
  - Bumped `motion` to ^12.42.2.

<sup>Written for commit 2f340558087fae9fbd77d196a49d0b695582d4fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Migrates the shared dashboard UI to the Chord visual system.
- **Improvements:** Adds Radix color scales and Chord theme tokens for the dashboard’s light and dark palettes.
- **Improvements:** Standardizes component radii, shadows, borders, focus treatments, and interaction styling.
- **Improvements:** Updates the shared UI dependency and stylesheet pipeline to support the new design tokens.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete functional or security defects identified in the changed code.

The changes consistently update shared visual tokens and component styling, while the new color dependency is represented in both the package manifest and lockfile and the existing component APIs remain intact.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/styles/index.css | Reworks the shared light and dark semantic tokens around Radix mauve and violet scales. |
| packages/ui/src/styles/chord.css | Introduces Chord color aliases, shadow tokens, transitions, and focus-visible styling. |
| packages/ui/src/styles/colors.css | Imports the Radix color scales required by the new semantic theme. |
| packages/ui/src/components/ui/button.tsx | Restyles the shared button foundation with Chord sizing, borders, typography, focus, and pressed-state behavior. |
| packages/ui/package.json | Adds the Radix color dependency and updates Motion while retaining compatible package exports. |

<sub>Reviews (1): Last reviewed commit: ["feat: migrate dashboard UI to Chord"](https://github.com/useautumn/autumn/commit/2f340558087fae9fbd77d196a49d0b695582d4fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47693464)</sub>

<!-- /greptile_comment -->