### PR TITLE
fix: worker idle

### DIFF
--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -33,10 +33,6 @@ import {
 import { getSqsClient, QUEUE_URL, recreateSqsClient } from "./initSqs.js";
 import { JobName } from "./JobName.js";
 import { processMessage, type SqsJob } from "./processMessage.js";
-import {
-	createWorkerActivityTracker,
-	type WorkerActivityTracker,
-} from "./workerActivityTracker.js";
 
 // ============ Shared State ============
 let isRunning = true;
@@ -46,7 +42,8 @@ export const getAbortControllerCountForTesting = () => abortControllers.size;
 // Process recycling — exit after processing this many messages to prevent memory leaks
 const MAX_MESSAGES_BEFORE_RECYCLE = 50_000;
 
-const IDLE_SELF_KILL_MS = ms.minutes(5);
+// Idle self-kill — exit if worker processes 0 messages for this many consecutive intervals
+const IDLE_SELF_KILL_THRESHOLD = 5; // ~5 min of 0 messages (5 * 60s)
 const shouldIdleSelfKill = process.env.NODE_ENV !== "development";
 
 // Per-message processing timeout — must be under VisibilityTimeout (30s)
@@ -120,9 +117,6 @@ export const startPollingLoop = async ({
 	recreateSqsClientFn,
 	shouldPoll = () => true,
 	visibilityTimeoutSeconds = 30,
-	workerActivity = createWorkerActivityTracker({
-		idleAfterMs: IDLE_SELF_KILL_MS,
-	}),
 }: {
 	db: DrizzleCli;
 	queueId: string;
@@ -135,7 +129,6 @@ export const startPollingLoop = async ({
 	 * a message redelivered mid-processing means two workers mutating the same
 	 * rows concurrently. */
 	visibilityTimeoutSeconds?: number;
-	workerActivity?: WorkerActivityTracker;
 }) => {
 	// Per-loop state
 	let messagesProcessed = 0;
@@ -205,10 +198,15 @@ export const startPollingLoop = async ({
 		if (messagesProcessed === 0) {
 			consecutiveZeroMessageIntervals++;
 
-			const idleStatus = workerActivity.getIdleStatus();
-			if (shouldIdleSelfKill && idleStatus.shouldRecycle) {
+			if (
+				shouldIdleSelfKill &&
+				consecutiveZeroMessageIntervals >= IDLE_SELF_KILL_THRESHOLD &&
+				totalMessagesProcessed > 0 &&
+				activeMigrationJobs === 0 &&
+				process.env.NODE_ENV !== "development"
+			) {
 				console.log(
-					`[SQS Worker ${process.pid}] Idle self-kill: no messages received across any queue for ${Math.floor(idleStatus.idleForMs / 60_000)} minutes after receiving ${idleStatus.totalMessagesReceived} total. Exiting for cluster respawn.`,
+					`${prefix} Idle self-kill: 0 messages for ${consecutiveZeroMessageIntervals} intervals after processing ${totalMessagesProcessed} total. Exiting for cluster respawn.`,
 				);
 				process.exit(0);
 			}
@@ -415,7 +413,6 @@ export const startPollingLoop = async ({
 
 	while (isRunning) {
 		let capacityLease: QueueCapacityLease | null = null;
-		let batchWorkStarted = false;
 		try {
 			if (!shouldPoll()) {
 				consecutiveEmptyPolls = 0;
@@ -445,11 +442,6 @@ export const startPollingLoop = async ({
 			);
 
 			const messages = response.Messages ?? [];
-			if (messages.length > 0) {
-				workerActivity.recordMessagesReceived({ count: messages.length });
-				workerActivity.startWork();
-				batchWorkStarted = true;
-			}
 			const leasedMessages = await capacityLease.assign(messages);
 
 			if (messages.length > 0) {
@@ -466,7 +458,6 @@ export const startPollingLoop = async ({
 					const override = getJobOverride(job.name);
 					if (override?.dispatch === "background" && !capacityLease.isLimited) {
 						activeMigrationJobs++;
-						workerActivity.startWork();
 						handleSingleMessage({ sqs, message, db })
 							.catch((error) => {
 								console.error(
@@ -475,10 +466,7 @@ export const startPollingLoop = async ({
 								);
 								Sentry.captureException(error);
 							})
-							.finally(() => {
-								activeMigrationJobs--;
-								workerActivity.finishWork();
-							});
+							.finally(() => activeMigrationJobs--);
 					} else {
 						regularMessages.push({
 							message,
@@ -522,7 +510,6 @@ export const startPollingLoop = async ({
 			if (newClient) sqs = newClient;
 			else if ((error as { name?: string }).name === "AbortError") break;
 		} finally {
-			if (batchWorkStarted) workerActivity.finishWork();
 			await capacityLease?.release();
 		}
 	}
@@ -578,9 +565,6 @@ export const initWorkers = async ({
 		`[Worker ${process.pid}] ${queueImplementation} worker ready in ${startupDurationMs}ms`,
 	);
 	const pollingLoops = [];
-	const workerActivity = createWorkerActivityTracker({
-		idleAfterMs: IDLE_SELF_KILL_MS,
-	});
 
 	for (const {
 		queueId,
@@ -638,7 +622,6 @@ export const initWorkers = async ({
 					isJobQueueEnabled({ queue: queueId, defaultEnabled }) &&
 					isActiveSlot({ serviceName: "workers" }),
 				visibilityTimeoutSeconds,
-				workerActivity,
 			}),
 		);
 	}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes SQS worker idle behavior by replacing the time-based activity tracker with a simple inactivity counter. Workers now exit only after 5 consecutive zero-message intervals and when no migration jobs are active.

- **Bug Fixes**
  - Removed `workerActivityTracker` and related start/finish calls.
  - Self-kill only triggers if the worker has processed at least one message, sees 0 messages for 5 intervals, and `NODE_ENV` is not `development`.
  - Skip self-kill while background migration jobs are running.

<sup>Written for commit dd6cb9d05b3e122998a3900d480d27d43b724736. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR revises SQS worker idle recycling.
- **Bug fixes:** Replaces the shared elapsed-time activity tracker with per-queue, five-interval idle detection.
- **Improvements:** Simplifies message and background-job activity bookkeeping in polling loops.
</details>

<h3>Confidence Score: 2/5</h3>

This PR is not safe to merge until idle recycling is coordinated across all polling loops in the worker process.

Each queue now evaluates process termination from local counters, so an idle queue can call process.exit(0) while another queue in the same process is handling work.

**Files Needing Attention:** server/src/queue/initWorkers.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/queue/initWorkers.ts | Replaces process-wide activity tracking with per-loop idle counters, allowing one idle queue to terminate a process whose sibling queues are active, and duplicates the development guard. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/queue/initWorkers.ts:202-206
**Per-queue state triggers process exit**

When one queue has processed a message and then records five empty intervals, its local counters call `process.exit(0)` even while sibling polling loops in the same process are handling work, interrupting those jobs and causing retries or partial processing.

### Issue 2 of 2
server/src/queue/initWorkers.ts:205-206
**Development guard is duplicated**

`shouldIdleSelfKill` already encodes the `NODE_ENV !== "development"` condition, so checking the environment again inside the same predicate adds redundant state to the recycling condition and makes future changes easier to apply inconsistently.

```suggestion
				activeMigrationJobs === 0
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: worker idle"](https://github.com/useautumn/autumn/commit/dd6cb9d05b3e122998a3900d480d27d43b724736) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47708648)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->