### PR TITLE
Carry negative balances across plan attach

### DIFF
--- a/server/src/internal/billing/v2/utils/handleCarryOvers/cusProductToExistingBalanceCarryOvers.ts
+++ b/server/src/internal/billing/v2/utils/handleCarryOvers/cusProductToExistingBalanceCarryOvers.ts
@@ -67,7 +67,7 @@ export const cusProductToExistingBalanceCarryOvers = ({
 
 		if (isEntityScopedCusEnt(cusEnt)) {
 			const entityPairs = Object.entries(cusEnt.entities)
-				.filter(([, entityBalance]) => entityBalance.balance > 0)
+				.filter(([, entityBalance]) => entityBalance.balance !== 0)
 				.flatMap(([entityId, entityBalance]) => {
 					const entity = fullCustomer.entities?.find((e) => e.id === entityId);
 					if (!entity) return [];
@@ -94,7 +94,7 @@ export const cusProductToExistingBalanceCarryOvers = ({
 		}
 
 		const balance = cusEnt.balance ?? 0;
-		if (balance <= 0) continue;
+		if (balance === 0) continue;
 
 		const ent = initCarryOverEntitlement({
 			cusEnt,

--- a/server/tests/integration/billing/attach/params/carry-over-balances/carry-over-balance-basic.test.ts
+++ b/server/tests/integration/billing/attach/params/carry-over-balances/carry-over-balance-basic.test.ts
@@ -1,17 +1,11 @@
-/**
- * Carry Over Balances - Basic Tests
- *
- * Tests for carry_over_balances: { enabled: true } on immediate plan upgrades.
- *
- * Key behaviors:
- * - Remaining balance is carried as a loose entitlement on upgrade
- * - Zero balance is a silent no-op (no loose entitlement created)
- * - Negative balance (overage) is not carried — new plan starts at full allowance
- */
+/** Regression: carry_over_balances previously dropped negative balances during immediate plan attachments.
+ * It must preserve overage so the incoming allowance is reduced by the carried debt. */
 
-import { test } from "bun:test";
+import { expect, test } from "bun:test";
 import type { ApiCustomerV3 } from "@autumn/shared";
+import { findCustomerEntitlement } from "@tests/balances/utils/findCustomerEntitlement";
 import { expectCustomerFeatureCorrect } from "@tests/integration/billing/utils/expectCustomerFeatureCorrect";
+import { waitForPostgresBalance } from "@tests/integration/cron/batch-reset-v2/batchResetV2TestUtils";
 import { TestFeature } from "@tests/setup/v2Features";
 import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
@@ -126,15 +120,9 @@ test.concurrent(`${chalk.yellowBright("carry-over-balance 2: zero balance is a n
 	});
 });
 
-// ═══════════════════════════════════════════════════════════════════════════════
-// TEST 3: Negative balance (overage) — don't carry negative
-//
-// Pro: 100 messages + consumable overage, 120 used (balance=-20)
-// Upgrade to Premium (500) with carry_over_balances: { enabled: true }
-// Expected: balance = 500 (negative balance is not carried)
-// ═══════════════════════════════════════════════════════════════════════════════
+// Pro has -20 messages; carrying that over to Premium's 500 leaves 480.
 
-test.concurrent(`${chalk.yellowBright("carry-over-balance 3: negative balance (overage) is not carried — new plan starts at full allowance")}`, async () => {
+test.concurrent(`${chalk.yellowBright("carry-over-balance 3: negative balance carries over to the new plan")}`, async () => {
 	// Use a consumable item to allow overage past the included usage
 	const proMessages = items.consumableMessages({ includedUsage: 100 });
 	const premiumMessages = items.monthlyMessages({ includedUsage: 500 });
@@ -142,14 +130,15 @@ test.concurrent(`${chalk.yellowBright("carry-over-balance 3: negative balance (o
 	const pro = products.pro({ id: "pro", items: [proMessages] });
 	const premium = products.premium({ id: "premium", items: [premiumMessages] });
 
-	const { customerId, autumnV2_1, autumnV1 } = await initScenario({
-		customerId: "carry-over-balance-negative",
-		setup: [
-			s.customer({ paymentMethod: "success" }),
-			s.products({ list: [pro, premium] }),
-		],
-		actions: [s.attach({ productId: pro.id, timeout: 4000 })],
-	});
+	const { customerId, autumnV2_1, autumnV2_2, autumnV1, ctx } =
+		await initScenario({
+			customerId: "carry-over-balance-negative",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [s.attach({ productId: pro.id, timeout: 4000 })],
+		});
 
 	// Track 120 — 20 over the 100 allowance (balance: 100 → -20)
 	await autumnV2_1.track({
@@ -158,11 +147,19 @@ test.concurrent(`${chalk.yellowBright("carry-over-balance 3: negative balance (o
 		value: 120,
 	});
 
-	// Wait for Redis → Postgres sync
-	await new Promise((resolve) => setTimeout(resolve, 2000));
+	const cusEnt = await findCustomerEntitlement({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+	expect(cusEnt).toBeDefined();
+	await waitForPostgresBalance({
+		db: ctx.db,
+		customerEntitlementId: cusEnt!.id,
+		expectedBalance: -20,
+	});
 
-	// Upgrade with carry_over_balances — negative balance must not be carried
-	await autumnV2_1.billing.attach({
+	await autumnV2_2.billing.attach({
 		customer_id: customerId,
 		plan_id: premium.id,
 		carry_over_balances: { enabled: true },
@@ -172,11 +169,10 @@ test.concurrent(`${chalk.yellowBright("carry-over-balance 3: negative balance (o
 
 	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
 
-	// Balance = 500 only (negative not carried — no loose entitlement)
 	expectCustomerFeatureCorrect({
 		customer,
 		featureId: TestFeature.Messages,
-		balance: 500,
+		balance: 480,
 		usage: 0,
 	});
 });

--- a/server/tests/integration/billing/attach/params/carry-over-balances/carry-over-balance-per-entity-features.test.ts
+++ b/server/tests/integration/billing/attach/params/carry-over-balances/carry-over-balance-per-entity-features.test.ts
@@ -1,37 +1,18 @@
-/**
- * Carry Over Balances — Per-Entity Feature Tests
- *
- * Products with entityFeatureId — balances distributed per entity from a single
- * customer-level product. carry_over_balances creates one loose entitlement per
- * entity that has a positive remaining balance.
- *
- * Key behaviors:
- * - Each entity's remaining balance is carried independently as a loose entitlement
- * - Entities with zero/negative balance produce no loose entitlement
- */
+/** Regression: carry_over_balances must preserve each entity's non-zero balance independently.
+ * Negative balances remain debts on their originating entity. */
 
-import { test } from "bun:test";
+import { expect, test } from "bun:test";
 import type { ApiCustomerV3, ApiEntityV0 } from "@autumn/shared";
+import { findCustomerEntitlement } from "@tests/balances/utils/findCustomerEntitlement";
 import { expectCustomerFeatureCorrect } from "@tests/integration/billing/utils/expectCustomerFeatureCorrect";
 import { TestFeature } from "@tests/setup/v2Features";
 import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
+import { updateCusEntDbAndCache } from "@/internal/customers/cusProducts/cusEnts/actions/updateCusEntDbAndCache";
 
-// ═══════════════════════════════════════════════════════════════════════════════
-// TEST 1: Per-entity feature — balance carry over per entity
-//
-// Pro with per-entity messages (200 each):
-//   e1: 150 used → balance=50 remaining
-//   e2: 100 used → balance=100 remaining
-// Upgrade to Premium (300 per entity) with carry_over_balances: { enabled: true }
-// Expected:
-//   e1: 300 + 50 = 350
-//   e2: 300 + 100 = 400
-// ═══════════════════════════════════════════════════════════════════════════════
-
-test.concurrent(`${chalk.yellowBright("carry-over-balance-per-entity 1: per-entity remaining balances carried independently as loose entitlements")}`, async () => {
+test.concurrent(`${chalk.yellowBright("carry-over-balance-per-entity 1: positive and negative balances carry independently")}`, async () => {
 	const proMessages = items.monthlyMessages({
 		includedUsage: 200,
 		entityFeatureId: TestFeature.Users,
@@ -44,27 +25,34 @@ test.concurrent(`${chalk.yellowBright("carry-over-balance-per-entity 1: per-enti
 	const pro = products.pro({ id: "pro", items: [proMessages] });
 	const premium = products.premium({ id: "premium", items: [premiumMessages] });
 
-	const { customerId, autumnV2_1, autumnV1, entities } = await initScenario({
+	const { customerId, autumnV2_1, autumnV1, entities, ctx } = await initScenario({
 		customerId: "carry-over-balance-per-entity1",
 		setup: [
 			s.customer({ paymentMethod: "success" }),
 			s.products({ list: [pro, premium] }),
 			s.entities({ count: 2, featureId: TestFeature.Users }),
 		],
-		actions: [
-			// Attach per-entity product to customer (not to each entity)
-			s.billing.attach({ productId: pro.id, timeout: 4000 }),
-			s.track({ featureId: TestFeature.Messages, value: 150, entityIndex: 0 }),
-			s.track({
-				featureId: TestFeature.Messages,
-				value: 100,
-				entityIndex: 1,
-				timeout: 2000,
-			}),
-		],
+		actions: [s.billing.attach({ productId: pro.id, timeout: 4000 })],
 	});
 
-	// Verify pre-upgrade balances per entity
+	const cusEnt = await findCustomerEntitlement({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+	expect(cusEnt).toBeDefined();
+
+	const entityBalances = structuredClone(cusEnt!.entities!);
+	entityBalances[entities[0].id].balance = -50;
+	await updateCusEntDbAndCache({
+		ctx,
+		customerId,
+		cusEntId: cusEnt!.id,
+		featureId: TestFeature.Messages,
+		updates: { entities: entityBalances },
+		incrementCacheVersion: false,
+	});
+
 	const e1Before = await autumnV1.entities.get<ApiEntityV0>(
 		customerId,
 		entities[0].id,
@@ -72,8 +60,8 @@ test.concurrent(`${chalk.yellowBright("carry-over-balance-per-entity 1: per-enti
 	expectCustomerFeatureCorrect({
 		customer: e1Before,
 		featureId: TestFeature.Messages,
-		balance: 50,
-		usage: 150,
+		balance: -50,
+		usage: 250,
 	});
 
 	const e2Before = await autumnV1.entities.get<ApiEntityV0>(
@@ -83,11 +71,10 @@ test.concurrent(`${chalk.yellowBright("carry-over-balance-per-entity 1: per-enti
 	expectCustomerFeatureCorrect({
 		customer: e2Before,
 		featureId: TestFeature.Messages,
-		balance: 100,
-		usage: 100,
+		balance: 200,
+		usage: 0,
 	});
 
-	// Upgrade the whole customer product, carrying over per-entity balances
 	await autumnV2_1.billing.attach({
 		customer_id: customerId,
 		plan_id: premium.id,
@@ -96,7 +83,6 @@ test.concurrent(`${chalk.yellowBright("carry-over-balance-per-entity 1: per-enti
 
 	await new Promise((resolve) => setTimeout(resolve, 2000));
 
-	// e1: 300 (Premium grant per entity) + 50 (loose carried) = 350
 	const e1After = await autumnV1.entities.get<ApiEntityV0>(
 		customerId,
 		entities[0].id,
@@ -104,11 +90,10 @@ test.concurrent(`${chalk.yellowBright("carry-over-balance-per-entity 1: per-enti
 	expectCustomerFeatureCorrect({
 		customer: e1After,
 		featureId: TestFeature.Messages,
-		balance: 350,
+		balance: 250,
 		usage: 0,
 	});
 
-	// e2: 300 + 100 = 400
 	const e2After = await autumnV1.entities.get<ApiEntityV0>(
 		customerId,
 		entities[1].id,
@@ -116,11 +101,10 @@ test.concurrent(`${chalk.yellowBright("carry-over-balance-per-entity 1: per-enti
 	expectCustomerFeatureCorrect({
 		customer: e2After,
 		featureId: TestFeature.Messages,
-		balance: 400,
+		balance: 500,
 		usage: 0,
 	});
 
-	// Customer-level totals: (350 + 400) = 750
 	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
 	expectCustomerFeatureCorrect({
 		customer,

--- a/server/tests/scenarios/attach/carry-over-negative-balance-scenario.test.ts
+++ b/server/tests/scenarios/attach/carry-over-negative-balance-scenario.test.ts
@@ -1,0 +1,58 @@
+/** Leaves a Pro customer at -20 with Premium available for a manual carry-over attach.
+ * Attach Premium with carry_over_balances enabled; the resulting balance should be 480. */
+
+import { test } from "bun:test";
+import { findCustomerEntitlement } from "@tests/balances/utils/findCustomerEntitlement";
+import { waitForPostgresBalance } from "@tests/integration/cron/batch-reset-v2/batchResetV2TestUtils";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+
+test(`${chalk.yellowBright("scenario: negative balance ready for carry-over attach")}`, async () => {
+	const customerId = "carry-over-negative-balance-repro";
+	const pro = products.pro({
+		id: "pro",
+		items: [items.consumableMessages({ includedUsage: 100 })],
+	});
+	const premium = products.premium({
+		id: "premium",
+		items: [items.monthlyMessages({ includedUsage: 500 })],
+	});
+
+	const { autumnV2_1, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro, premium] }),
+		],
+		actions: [s.billing.attach({ productId: pro.id, timeout: 4000 })],
+	});
+
+	await autumnV2_1.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 120,
+	});
+
+	const cusEnt = await findCustomerEntitlement({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+	if (!cusEnt) throw new Error("Messages balance not found");
+	await waitForPostgresBalance({
+		db: ctx.db,
+		customerEntitlementId: cusEnt.id,
+		expectedBalance: -20,
+	});
+
+	console.log(
+		chalk.cyanBright(
+			`\nCustomer ${customerId} is ready.\n` +
+				`Current plan: ${pro.id}; messages balance: -20.\n` +
+				`Attach ${premium.id} with carry over balances enabled; expect 480.\n`,
+		),
+	);
+});

--- a/vite/src/components/forms/attach-v2/components/AttachAdvancedSection.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachAdvancedSection.tsx
@@ -82,7 +82,7 @@ function FeatureSelectDropdown({
 					<CaretDownIcon className="size-3.5 text-tertiary-foreground" />
 				</Button>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent align="end" className="min-w-48">
+			<DropdownMenuContent align="end" className="w-(--anchor-width)">
 				<DropdownMenuCheckboxItem
 					checked={isAllSelected}
 					onCheckedChange={() => onChange({ featureIds: [] })}


### PR DESCRIPTION
## Summary

- preserve negative customer and entity balances when carry_over_balances is enabled
- keep zero balances as a no-op
- update the permanent attach regression to assert -20 carries into a 500-unit plan as 480

## Testing

- PASS: focused carry-over-balance integration regression (red at 500 vs 480 before the fix, green after)
- PASS: targeted Biome lint and git diff --check
- BASELINE FAILURE: bunx tsgo --build --noEmit still reports the existing LanguageModelV4 vs LanguageModelV3 mismatch in pricingAgentRouter.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Carry over negative balances on plan attach when `carry_over_balances` is enabled for customer and per-entity scopes. Overage now reduces the new plan’s allowance instead of being dropped; negative entity balances stay with their entity. Also aligns the carry-over dropdown width in the dashboard.

- **Bug Fixes**
  - Carry over any non-zero balance (customer or per-entity); negatives reduce the new allowance, zero is a no-op.
  - Dashboard: match carry-over dropdown width to its trigger in `AttachAdvancedSection`.

<sup>Written for commit 2977d841c40367d704945bfffce8b47d8e0a421a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Carry-over attachments now preserve negative balances instead of discarding overage.
- **[Bug fixes]** Carry any non-zero customer- or entity-scoped balance into the incoming plan.
- **[Improvements]** Add customer-level and per-entity regressions verifying that negative debt reduces the new allowance while remaining attributed to its originating entity.
- **[Improvements]** Replace timing-based database synchronization in the customer regression with an explicit persisted-balance wait.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/utils/handleCarryOvers/cusProductToExistingBalanceCarryOvers.ts | Expands carry-over selection from positive balances to all non-zero customer and entity balances. |
| server/tests/integration/billing/attach/params/carry-over-balances/carry-over-balance-basic.test.ts | Verifies that a customer-level balance of -20 reduces a new 500-unit allowance to 480. |
| server/tests/integration/billing/attach/params/carry-over-balances/carry-over-balance-per-entity-features.test.ts | Covers positive and negative per-entity carry-over, including correct attribution of debt to the originating entity. |
| server/tests/scenarios/attach/carry-over-negative-balance-scenario.test.ts | Adds a manual scenario that prepares a persisted negative balance for carry-over validation. |

<sub>Reviews (3): Last reviewed commit: ["test(billing): 💍 add negative carryover..."](https://github.com/useautumn/autumn/commit/41282397c3aa30e4e278ccedc77ebe4822c71d61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47712913)</sub>

<!-- /greptile_comment -->