### PR TITLE
fix(migrations): normalize prepared artifact hashes

### DIFF
--- a/server/src/internal/migrations/v2/operations/updatePlan/applyPrepareResults/applyPrepareResults.ts
+++ b/server/src/internal/migrations/v2/operations/updatePlan/applyPrepareResults/applyPrepareResults.ts
@@ -2,8 +2,9 @@ import type { AutumnBillingPlan } from "@autumn/shared";
 import type { UpdatePlanOp } from "@autumn/shared/api/migrations/operations/customer/updatePlan/index.js";
 import type { ReusePricesAndEntitlements } from "@/internal/billing/v2/setup/patch/index.js";
 import {
-	EnsurePricesAndEntitlementsResultSchema,
 	type EnsurePricesAndEntitlementsResult,
+	EnsurePricesAndEntitlementsResultSchema,
+	hashPlanItemArtifact,
 	type PreparedArtifactRef,
 } from "@/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/index.js";
 import { buildPrepareModuleKey } from "@/internal/migrations/v2/prepare/utils/index.js";
@@ -213,7 +214,7 @@ export const applyPrepareResultsToUpdatePlan = ({
 				kind: "add_item",
 				itemIndex,
 				internalProductId,
-				hash: hashJson({ value: item }),
+				hash: hashPlanItemArtifact({ item }),
 			});
 			addPreparedId({
 				ids: preparedIds,

--- a/server/src/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/ensurePricesAndEntitlements.ts
+++ b/server/src/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/ensurePricesAndEntitlements.ts
@@ -1,14 +1,14 @@
 import {
 	copyStripeResourcesToMatchingPrice,
 	type Entitlement,
-	findFeatureById,
 	type FullProduct,
+	findFeatureById,
 	type Price,
 } from "@autumn/shared";
 import type { UpdatePlanOp } from "@autumn/shared/api/migrations/operations/customer/updatePlan/index.js";
-import { planFilterMatchesProduct } from "@autumn/shared/api/products/utils/match/index.js";
 import { basePriceToProductItem } from "@autumn/shared/api/products/components/basePrice/basePriceToProductItem.js";
 import { planItemV1ToPriceAndEnt } from "@autumn/shared/api/products/items/mappers/planItemV1ToPriceAndEnt.js";
+import { planFilterMatchesProduct } from "@autumn/shared/api/products/utils/match/index.js";
 import { enrichEntitlementsWithFeatures } from "@autumn/shared/utils/productUtils/entUtils/enrichEntitlement.js";
 import { itemToPriceAndEnt } from "@autumn/shared/utils/productV2Utils/productItemUtils/mappers/itemToPriceAndEnt.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
@@ -19,6 +19,7 @@ import { PriceService } from "@/internal/products/prices/PriceService.js";
 import { applyStripeResourceReuseForProduct } from "@/internal/products/stripeResourceUtils/applyStripeResourceReuseForProduct.js";
 import { hashJson } from "@/utils/hash/hashJson.js";
 import type { PrepareModule } from "../../types/prepareModule.js";
+import { hashPlanItemArtifact } from "./hashPlanItemArtifact.js";
 import type {
 	EnsurePricesAndEntitlementsResult,
 	PreparedArtifactRef,
@@ -312,7 +313,7 @@ export const ensurePricesAndEntitlements: PrepareModule<
 						featureId: item.feature_id,
 						errorOnNotFound: true,
 					});
-					const hash = artifactHash({ value: item });
+					const hash = hashPlanItemArtifact({ item });
 					const entitlementId = entitlementIdFor({
 						scopeId,
 						opIndex,
@@ -357,7 +358,11 @@ export const ensurePricesAndEntitlements: PrepareModule<
 							ctx,
 							price: preparedPrice,
 							entitlement: newEnt
-								? { ...newEnt, id: entitlementId, internal_product_id: product.internal_id }
+								? {
+										...newEnt,
+										id: entitlementId,
+										internal_product_id: product.internal_id,
+									}
 								: undefined,
 							product,
 							basePlanVersionsCache,

--- a/server/src/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/hashPlanItemArtifact.ts
+++ b/server/src/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/hashPlanItemArtifact.ts
@@ -1,0 +1,14 @@
+import {
+	type CreatePlanItemParamsV1Input,
+	CreatePlanItemParamsV1Schema,
+} from "@autumn/shared/api/products/items/crud/createPlanItemParamsV1.js";
+import { hashJson } from "@/utils/hash/hashJson.js";
+
+export const hashPlanItemArtifact = ({
+	item,
+}: {
+	item: CreatePlanItemParamsV1Input;
+}) =>
+	hashJson({
+		value: CreatePlanItemParamsV1Schema.parse(item),
+	});

--- a/server/src/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/index.ts
+++ b/server/src/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/index.ts
@@ -1,2 +1,3 @@
 export * from "./ensurePricesAndEntitlements.js";
+export * from "./hashPlanItemArtifact.js";
 export * from "./types.js";

--- a/server/tests/integration/billing/migrations-v2/prepare/ensure-prices-and-ents/prepared-artifact-schema-defaults.test.ts
+++ b/server/tests/integration/billing/migrations-v2/prepare/ensure-prices-and-ents/prepared-artifact-schema-defaults.test.ts
@@ -1,0 +1,84 @@
+/** Regression: preparation and Trigger serialization must hash omitted plan-item defaults identically.
+ * Red missed the artifact after `pooled: false` appeared; green applies the boolean entitlement. */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV5 } from "@autumn/shared";
+import type { Operations } from "@autumn/shared/api/migrations/operations/operations.js";
+import { expectFlagCorrect } from "@tests/integration/utils/expectFlagCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { migrateCustomer } from "@/internal/migrations/v2/run/migrateCustomer/index.js";
+import { prepareMigration } from "@/internal/migrations/v2/run/runMigration.js";
+import { PreparedMigrationSnapshotSchema } from "@/trigger/migrations/migrationTaskPayload.js";
+
+test.concurrent(
+	`${chalk.yellowBright("migrations prepare runtime: schema defaults preserve prepared artifact identity")}`,
+	async () => {
+		const customerId = "prep-artifact-schema-defaults";
+		const plan = products.pro({
+			id: "prep-artifact-schema-defaults-plan",
+			items: [],
+		});
+		const { autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [plan] }),
+			],
+			actions: [s.billing.attach({ productId: plan.id })],
+		});
+		const rawOperations = {
+			customer: [
+				{
+					type: "update_plan",
+					plan_filter: { plan_id: plan.id },
+					customize: {
+						add_items: [
+							{
+								feature_id: TestFeature.Dashboard,
+								included: 0,
+								unlimited: false,
+							},
+						],
+					},
+				},
+			],
+		} satisfies Operations;
+
+		const storedMigration = await autumnV2_2.migrationsV2.deleteAndCreate({
+			id: `${customerId}-mig`,
+			filter: { customer: { plan: { plan_id: plan.id } } },
+			operations: rawOperations,
+			no_billing_changes: true,
+		});
+		const preparedMigration = await prepareMigration({
+			ctx,
+			migration: { ...storedMigration, operations: rawOperations },
+			dryRun: false,
+		});
+		const migrationSnapshot =
+			PreparedMigrationSnapshotSchema.parse(preparedMigration);
+		const operation = migrationSnapshot.operations?.customer?.[0];
+		if (operation?.type !== "update_plan") {
+			throw new Error("Expected an update_plan operation");
+		}
+
+		expect(operation.customize?.add_items?.[0]?.pooled).toBe(false);
+
+		const result = await migrateCustomer({
+			ctx,
+			customerId,
+			migration: migrationSnapshot,
+		});
+		expect(result.status).toBe("succeeded");
+
+		const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		expectFlagCorrect({
+			customer,
+			featureId: TestFeature.Dashboard,
+			planId: plan.id,
+		});
+	},
+);


### PR DESCRIPTION
## Summary

- normalize `update_plan` add-item inputs before deriving prepared artifact hashes
- share the canonical hash helper between preparation and execution lookup
- add an integration regression covering the prepare to Trigger snapshot serialization boundary

## Context

Trigger snapshot parsing injects schema defaults such as `pooled: false`. Preparation previously hashed the raw operation while execution hashed the normalized operation, so equivalent inputs produced different hashes and every matching customer failed with a missing prepared artifact.

## Test plan

- `bunx tsgo --build --noEmit`
- Biome check on all changed files
- focused schema-default regression: 1 passed
- preparation artifact suite: 4 passed
- multi-target update-plan suite: 3 passed
- migration run-scoping suite: 5 passed
- idempotency suite: 4 passed; the timing-sensitive concurrent-run rejection case accepted the second run locally, and its targeted rerun was blocked by the fixed test migration ID left from the first attempt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize hashing for prepared plan-item artifacts so preparation and execution agree, even when snapshot defaults like `pooled: false` are injected. Fixes missing prepared artifacts in `update_plan` add_item paths.

- **Bug Fixes**
  - Hash plan items after schema normalization using `CreatePlanItemParamsV1Schema` via a shared `hashPlanItemArtifact`.
  - Replace raw `hashJson({ value: item })` with `hashPlanItemArtifact` in both prepare and apply phases; re-export helper from the module index for consistent imports.
  - Add an integration test covering the prepare-to-snapshot boundary to ensure the `pooled` default does not break artifact lookup and the migration succeeds.

<sup>Written for commit d099bcfb166c34a700c84b0317e6c77ff797234c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR aligns prepared-artifact identity across migration preparation and execution.

- **[Bug fixes]** Normalizes `update_plan` add-item inputs through `CreatePlanItemParamsV1Schema` before hashing.
- **[Improvements]** Shares one canonical artifact-hash helper between preparation and execution lookup.
- **[Improvements]** Adds an integration regression covering schema defaults introduced across Trigger snapshot serialization.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/hashPlanItemArtifact.ts | Adds the canonical schema-normalized hash helper used to identify prepared plan-item artifacts. |
| server/src/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/ensurePricesAndEntitlements.ts | Uses the canonical helper when creating prepared add-item artifacts. |
| server/src/internal/migrations/v2/operations/updatePlan/applyPrepareResults/applyPrepareResults.ts | Uses the same canonical helper when resolving prepared artifacts during execution. |
| server/tests/integration/billing/migrations-v2/prepare/ensure-prices-and-ents/prepared-artifact-schema-defaults.test.ts | Verifies that snapshot-injected defaults preserve artifact lookup and allow migration completion. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant P as Migration preparation
    participant H as Canonical hash helper
    participant S as Trigger snapshot
    participant E as Migration execution
    P->>H: Parse add_item with schema defaults
    H-->>P: Canonical artifact hash
    P->>S: Store operation and prepared artifact
    S->>E: Deserialize normalized operation
    E->>H: Parse and hash add_item
    H-->>E: Matching canonical hash
    E->>E: Resolve and apply prepared artifact
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/migration-a..."](https://github.com/useautumn/autumn/commit/d099bcfb166c34a700c84b0317e6c77ff797234c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47725301)</sub>

<!-- /greptile_comment -->