### PR TITLE
fix(billing): release checkout reservation when a peer already materialized

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata.ts
@@ -25,6 +25,20 @@ export const withClaimedCheckoutSessionMetadata = async ({
 	metadata: NonNullable<CheckoutSessionCompletedContext["metadata"]>;
 	execute: () => Promise<void>;
 }): Promise<void> => {
+	const deferredData = metadata.data as DeferredAutumnBillingPlanData;
+	const lockCustomerId =
+		deferredData?.billingContext?.fullCustomer?.id ??
+		deferredData?.billingContext?.fullCustomer?.internal_id;
+
+	const clearCheckoutReservation = async () => {
+		if (!lockCustomerId) return;
+		await checkoutSessionLock.clearIfOwned({
+			ctx,
+			customerId: lockCustomerId,
+			checkoutSessionId: checkoutContext.stripeCheckoutSession.id,
+		});
+	};
+
 	const claimed = await MetadataService.claim({
 		db: ctx.db,
 		id: metadata.id,
@@ -33,16 +47,22 @@ export const withClaimedCheckoutSessionMetadata = async ({
 	});
 
 	if (!claimed) {
+		// A peer still mid-execute clears the reservation in its own finally; a
+		// deleted row means materialization already finished and nobody will.
+		const current = await MetadataService.get({ db: ctx.db, id: metadata.id });
+		if (current?.type === MetadataType.CheckoutSessionV2Processing) {
+			ctx.logger.info(
+				`[checkout.completed] Metadata ${metadata.id} claimed by an in-flight executor, skipping`,
+			);
+			return;
+		}
+
 		ctx.logger.info(
-			`[checkout.completed] Metadata ${metadata.id} already claimed by another executor, skipping`,
+			`[checkout.completed] Metadata ${metadata.id} already materialized, releasing checkout reservation`,
 		);
+		await clearCheckoutReservation();
 		return;
 	}
-
-	const deferredData = metadata.data as DeferredAutumnBillingPlanData;
-	const lockCustomerId =
-		deferredData?.billingContext?.fullCustomer?.id ??
-		deferredData?.billingContext?.fullCustomer?.internal_id;
 
 	try {
 		if (checkoutContext.stripeSubscription) {
@@ -57,13 +77,7 @@ export const withClaimedCheckoutSessionMetadata = async ({
 		await revertMetadataClaim({ ctx, metadataId: metadata.id });
 		throw error;
 	} finally {
-		if (lockCustomerId) {
-			await checkoutSessionLock.clearIfOwned({
-				ctx,
-				customerId: lockCustomerId,
-				checkoutSessionId: checkoutContext.stripeCheckoutSession.id,
-			});
-		}
+		await clearCheckoutReservation();
 	}
 };
 

--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata.ts
@@ -47,12 +47,13 @@ export const withClaimedCheckoutSessionMetadata = async ({
 	});
 
 	if (!claimed) {
-		// A peer still mid-execute clears the reservation in its own finally; a
-		// deleted row means materialization already finished and nobody will.
+		// Only a deleted row proves materialization finished with nobody left to
+		// clear. Any surviving row is still owned — by a peer mid-execute, or by
+		// a webhook retry once that peer reverts its claim.
 		const current = await MetadataService.get({ db: ctx.db, id: metadata.id });
-		if (current?.type === MetadataType.CheckoutSessionV2Processing) {
+		if (current) {
 			ctx.logger.info(
-				`[checkout.completed] Metadata ${metadata.id} claimed by an in-flight executor, skipping`,
+				`[checkout.completed] Metadata ${metadata.id} still owned by another executor, skipping`,
 			);
 			return;
 		}

--- a/server/src/internal/billing/v2/actions/locks/checkoutSessionLock/checkoutSessionLock.ts
+++ b/server/src/internal/billing/v2/actions/locks/checkoutSessionLock/checkoutSessionLock.ts
@@ -4,9 +4,6 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { CacheManager } from "@/utils/cacheUtils/CacheManager";
 
 const FALLBACK_CHECKOUT_LOCK_TTL_SECONDS = 2 * 60;
-// Stripe sessions expire ~24h out; capping bounds how long a reservation that
-// escaped its clear path can 423 every billing action for the customer.
-const MAX_CHECKOUT_LOCK_TTL_SECONDS = 30 * 60;
 
 interface CheckoutSessionLockData {
 	paramsHash: string;
@@ -51,10 +48,7 @@ const set = async ({
 }): Promise<void> => {
 	try {
 		const ttlSeconds = data.expiresAt
-			? Math.min(
-					MAX_CHECKOUT_LOCK_TTL_SECONDS,
-					Math.max(1, Math.ceil((data.expiresAt - Date.now()) / 1000)),
-				)
+			? Math.max(1, Math.ceil((data.expiresAt - Date.now()) / 1000))
 			: FALLBACK_CHECKOUT_LOCK_TTL_SECONDS;
 		await CacheManager.setJson(buildKey({ ctx, customerId }), data, ttlSeconds);
 	} catch (error) {

--- a/server/src/internal/billing/v2/actions/locks/checkoutSessionLock/checkoutSessionLock.ts
+++ b/server/src/internal/billing/v2/actions/locks/checkoutSessionLock/checkoutSessionLock.ts
@@ -4,6 +4,9 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { CacheManager } from "@/utils/cacheUtils/CacheManager";
 
 const FALLBACK_CHECKOUT_LOCK_TTL_SECONDS = 2 * 60;
+// Stripe sessions expire ~24h out; capping bounds how long a reservation that
+// escaped its clear path can 423 every billing action for the customer.
+const MAX_CHECKOUT_LOCK_TTL_SECONDS = 30 * 60;
 
 interface CheckoutSessionLockData {
 	paramsHash: string;
@@ -48,7 +51,10 @@ const set = async ({
 }): Promise<void> => {
 	try {
 		const ttlSeconds = data.expiresAt
-			? Math.max(1, Math.ceil((data.expiresAt - Date.now()) / 1000))
+			? Math.min(
+					MAX_CHECKOUT_LOCK_TTL_SECONDS,
+					Math.max(1, Math.ceil((data.expiresAt - Date.now()) / 1000)),
+				)
 			: FALLBACK_CHECKOUT_LOCK_TTL_SECONDS;
 		await CacheManager.setJson(buildKey({ ctx, customerId }), data, ttlSeconds);
 	} catch (error) {


### PR DESCRIPTION
## What's broken

`withClaimedCheckoutSessionMetadata` returns early whenever it loses the metadata claim, which skips the `finally` block that clears the checkout session reservation.

Stripe does not guarantee that `checkout.session.completed` arrives before `invoice.paid`. When `invoice.paid` lands first it runs `executeDeferredBillingPlan`, which materializes the plan and **deletes** the metadata row. The `checkout.session.completed` handler then finds nothing to claim, logs `already claimed by another executor, skipping`, and returns — leaving the reservation in Redis with nobody left to clear it.

The stranded key survives until its TTL, which `checkoutSessionLock.set` derives from the Stripe session's `expires_at` — up to 24 hours. Every subsequent `billing.attach` / `createSchedule` for that customer then goes: params differ → `expireAndClearIfOwned` → Stripe refuses to expire an already-completed session → `status !== "expired"` → `return false` → **423 `lock_already_exists`**.

Observed on org `eLdyEOKBHerTmwQRwSkN2qMYGChrTAHQ`, customer `test2` (sandbox), 2026-07-28:

```
07:13:04.576  Created checkout session for customer test2
07:13:15.577  invoice.paid          -> materializes, deletes metadata
07:13:16.429  checkout.session.completed -> "already claimed by another executor, skipping"
07:14:28.538  Checkout session cs_test_b13ybl... is complete; keeping reservation
07:14:28.596  [423] /v1/billing.attach          <- and 4 more over the next 90s
```

## The fix

Hoist `lockCustomerId` and the clear call above the claim, then distinguish the two reasons a claim can fail:

- Row still in `CheckoutSessionV2Processing` → a peer executor is genuinely mid-`execute()` and will clear the reservation in its own `finally`. Skip, exactly as before — the 423 guard keeps meaning what it says.
- Row missing → materialization already finished and nobody will ever clear it. Release the reservation.

Also cap the reservation TTL at 30 minutes. Stripe sessions expire ~24h out, so any *future* escape (Redis not ready during `clearIfOwned`, a hard crash mid-`execute`) degrades into a short stall instead of a day-long lockout. Side effect: same-params session reuse now dedupes for 30 minutes rather than a day, which seems right — a customer returning later should get a fresh session anyway.

## Blast radius

The lockout itself is still contained: 13 occurrences, all today, all in one sandbox org, zero production. The throw only shipped in 5ea3eb4e2 (2026-07-21), so it has had seven days of exposure.

The *trigger* is not rare, though — `already claimed by another executor` fired 69 times in 14 days across 24 distinct orgs. Each one stranded a reservation; they went unnoticed because a stranded lock only surfaces as a 423 if that customer attaches again with different params before the TTL expires. Latent rather than absent, and it scales with checkout volume.

(The ~82k other `lock_already_exists` 423s across 54 orgs are unrelated — route-level `buildBillingLockKey` locks with a 120s self-expiring TTL. Separate issue, but firecrawl alone accounts for 79,656 of them across 16,842 customers and is worth its own look.)

## Testing

`bun ts` clean. No regression test yet — the natural one drives `invoice.paid` before `checkout.session.completed` and asserts the next attach doesn't 423. Happy to add it here if you'd rather it not land bare.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release stranded checkout reservations when a peer already materialized the plan to stop 423 lock_already_exists after out‑of‑order Stripe webhooks. Keep the reservation for the full Stripe session to avoid duplicate payable sessions.

- **Bug Fixes**
  - On failed metadata claim: only release the reservation when the metadata row is gone; if any row exists, skip so the peer clears it (prevents the reverted‑claim race).
  - Hoisted customerId/clear logic so `checkoutSessionLock.clearIfOwned` runs on both claim‑failure and in `finally`.
  - Dropped the 30‑minute TTL cap; reservation now lasts until Stripe `expires_at`.

<sup>Written for commit 384c790521c9d5cbaece2525d1baec47f13b43db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes checkout reservation cleanup after out-of-order Stripe webhook processing.
- **[Bug fixes]** Distinguishes an existing metadata row, which indicates pending or actively processed work, from a deleted row that indicates completed materialization.
- **[Bug fixes]** Releases the checkout reservation when metadata has already been materialized and deleted by a peer executor.
- **[Improvements]** Reuses the same ownership-checked reservation cleanup helper across the peer-materialized and normal execution paths.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata.ts | Correctly preserves the reservation for any surviving metadata state and releases it only after peer materialization has deleted the row. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Invoice as invoice.paid
  participant Checkout as checkout.session.completed
  participant Metadata as Metadata store
  participant Redis as Checkout reservation

  Invoice->>Metadata: Claim and materialize plan
  Invoice->>Metadata: Delete completed metadata
  Checkout->>Metadata: Attempt metadata claim
  Metadata-->>Checkout: Claim failed
  Checkout->>Metadata: Read current metadata
  Metadata-->>Checkout: Row absent
  Checkout->>Redis: Clear reservation if session owns it
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(billing): 🐛 only release reservatio..."](https://github.com/useautumn/autumn/commit/384c790521c9d5cbaece2525d1baec47f13b43db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47870728)</sub>

**Context used:**

- Knowledge Base — [Stripe Integration](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-stripe-integration.md)

<!-- /greptile_comment -->