### PR TITLE
docs(licenses): document idempotent assignment

### DIFF
--- a/apps/docs/api-reference-generator/licenses/attachLicense.mdx
+++ b/apps/docs/api-reference-generator/licenses/attachLicense.mdx
@@ -1,0 +1,13 @@
+---
+title: "Attach License"
+openapi: "openapi POST /v1/licenses.attach"
+---
+
+<Note>
+  License assignment is idempotent for an entity that already has an active
+  assignment for the same license plan. Autumn skips those entities without
+  consuming another license; mixed batches assign only unassigned entities. A
+  duplicate-only request still returns `200` with `{ "success": true }`.
+  Duplicate IDs within one batch and insufficient capacity for new assignments
+  still return an error.
+</Note>

--- a/apps/docs/mintlify/api-reference/licenses/attachLicense.mdx
+++ b/apps/docs/mintlify/api-reference/licenses/attachLicense.mdx
@@ -7,6 +7,15 @@ import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
 import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
 import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
+<Note>
+  License assignment is idempotent for an entity that already has an active
+  assignment for the same license plan. Autumn skips those entities without
+  consuming another license; mixed batches assign only unassigned entities. A
+  duplicate-only request still returns `200` with `{ "success": true }`.
+  Duplicate IDs within one batch and insufficient capacity for new assignments
+  still return an error.
+</Note>
+
 ### Body Parameters
 
 <DynamicParamField body="customer_id" type="string" required />


### PR DESCRIPTION
## Summary
- clarify that already-assigned entities are skipped without consuming another license
- document mixed-batch behavior and the `{ "success": true }` 200 response
- distinguish repeated assignments from other validation errors

## Validation
- API-reference generator output matches the committed page
- `mint validate` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document idempotent assignment for `POST /v1/licenses.attach` in the API reference. Clarifies that already-assigned entities are skipped without consuming a license, mixed batches assign only unassigned entities, duplicate-only requests return 200 with `{ "success": true }`, and duplicate IDs in one batch or insufficient capacity still error.

<sup>Written for commit 765bcacd22269b0f35a385970f16ce4df89c2433. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR documents the idempotent behavior of the license-assignment endpoint.
- **[Improvements]** Clarifies that entities with an active assignment for the same license plan are skipped without consuming additional capacity.
- **[API changes]** Documents mixed-batch behavior, duplicate-only `200` responses with `{ "success": true }`, and validation errors for repeated IDs or insufficient capacity.
- **[Improvements]** Adds the source API-reference fragment and keeps the generated Mintlify page synchronized.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the documentation matches the implemented and tested license-assignment behavior.

The source fragment and generated page remain synchronized, and the documented duplicate-only, mixed-batch, capacity, and repeated-ID outcomes agree with the current endpoint behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/docs/api-reference-generator/licenses/attachLicense.mdx | Adds the canonical manual API-reference note accurately describing idempotent license assignment and related validation behavior. |
| apps/docs/mintlify/api-reference/licenses/attachLicense.mdx | Carries the same note into the generated Mintlify API-reference page, consistent with the documented generation pipeline. |

<sub>Reviews (1): Last reviewed commit: ["docs(licenses): ✏️ document idempotent l..."](https://github.com/useautumn/autumn/commit/765bcacd22269b0f35a385970f16ce4df89c2433) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47880973)</sub>

**Context used:**

- Knowledge Base — [Marketing and Docs Sites](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/marketing-and-docs-sites.md)

<!-- /greptile_comment -->