### PR TITLE
docs(licenses): document idempotent assignment

### DIFF
--- a/apps/docs/api-reference-generator/licenses/attachLicense.mdx
+++ b/apps/docs/api-reference-generator/licenses/attachLicense.mdx
@@ -1,0 +1,13 @@
+---
+title: "Attach License"
+openapi: "openapi POST /v1/licenses.attach"
+---
+
+<Note>
+  License assignment is idempotent for an entity that already has an active
+  assignment for the same license plan. Autumn skips those entities without
+  consuming another license; mixed batches assign only unassigned entities. A
+  duplicate-only request still returns `200` with `{ "success": true }`.
+  Duplicate IDs within one batch and insufficient capacity for new assignments
+  still return an error.
+</Note>

--- a/apps/docs/mintlify/api-reference/licenses/attachLicense.mdx
+++ b/apps/docs/mintlify/api-reference/licenses/attachLicense.mdx
@@ -7,6 +7,15 @@ import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
 import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
 import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
+<Note>
+  License assignment is idempotent for an entity that already has an active
+  assignment for the same license plan. Autumn skips those entities without
+  consuming another license; mixed batches assign only unassigned entities. A
+  duplicate-only request still returns `200` with `{ "success": true }`.
+  Duplicate IDs within one batch and insufficient capacity for new assignments
+  still return an error.
+</Note>
+
 ### Body Parameters
 
 <DynamicParamField body="customer_id" type="string" required />


### PR DESCRIPTION
## Summary
- clarify that already-assigned entities are skipped without consuming another license
- document mixed-batch behavior and the `{ "success": true }` 200 response
- distinguish repeated assignments from other validation errors

## Validation
- API-reference generator output matches the committed page
- `mint validate` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented idempotent behavior for `POST /v1/licenses.attach`: entities already assigned to the same plan are skipped without using another license, and mixed batches only assign unassigned entities. Clarified responses: duplicate-only requests return `200` with `{ "success": true }`, while duplicate IDs in a single batch and insufficient capacity still return errors.

<sup>Written for commit c318a1662a9f2297bac15b1c4d648d0e10386648. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR clarifies the idempotent behavior of license assignment.
- [Improvements] Documents that entities with an active assignment for the same license plan are skipped without consuming capacity.
- [API changes] Documents mixed-batch behavior, duplicate-only success responses, and validation errors for duplicate IDs or insufficient capacity.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The documented idempotency, mixed-batch, capacity, validation, status-code, and response-body behavior agrees with the current implementation, and the generator source is correctly synchronized with the committed Mintlify page.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/docs/api-reference-generator/licenses/attachLicense.mdx | Adds the canonical manual API-reference note, accurately reflecting current license-assignment behavior and following generator conventions. |
| apps/docs/mintlify/api-reference/licenses/attachLicense.mdx | Includes the matching generated documentation note without introducing content, navigation, or rendering issues. |

<sub>Reviews (1): Last reviewed commit: ["docs(licenses): ✏️ document idempotent l..."](https://github.com/useautumn/autumn/commit/c318a1662a9f2297bac15b1c4d648d0e10386648) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47881164)</sub>

<!-- /greptile_comment -->