### PR TITLE
feat: probe postgres replication slot health

### DIFF
--- a/server/src/db/probes/registry.ts
+++ b/server/src/db/probes/registry.ts
@@ -1,4 +1,8 @@
 import { longTxnProbe } from "./longTxnProbe.js";
+import { replicationSlotProbe } from "./replicationSlotProbe.js";
 import type { DbProbe } from "./types.js";
 
-export const dbProbes: readonly DbProbe[] = [longTxnProbe];
+export const dbProbes: readonly DbProbe[] = [
+	longTxnProbe,
+	replicationSlotProbe,
+];

--- a/server/src/db/probes/replicationSlotProbe.ts
+++ b/server/src/db/probes/replicationSlotProbe.ts
@@ -1,0 +1,89 @@
+import { sql } from "drizzle-orm";
+import { logger } from "../../external/logtail/logtailUtils.js";
+import type { DbProbe } from "./types.js";
+
+type SlotRow = {
+	in_recovery: boolean | null;
+	slot_name: string | null;
+	slot_type: string | null;
+	active: boolean | null;
+	failover: boolean | null;
+	wal_status: string | null;
+	confirmed_flush_lsn: string | null;
+	retained_wal_bytes: string | number | null;
+};
+
+const toBytes = (value: string | number | null): number | null => {
+	if (value === null) return null;
+	const parsed = Number(value);
+	return Number.isFinite(parsed) ? parsed : null;
+};
+
+export const replicationSlotProbe: DbProbe = {
+	name: "db_replication_slots",
+	run: async ({ db }) => {
+		// LEFT JOIN so a primary with zero slots still returns a row: "the slots
+		// vanished" and "we never reached the server" must not look identical.
+		const rows = await db.execute<SlotRow>(sql`
+			SELECT
+				recovery.in_recovery,
+				slots.slot_name,
+				slots.slot_type,
+				slots.active,
+				slots.failover,
+				slots.wal_status,
+				slots.confirmed_flush_lsn::text AS confirmed_flush_lsn,
+				CASE
+					WHEN recovery.in_recovery OR slots.restart_lsn IS NULL THEN NULL
+					ELSE (pg_current_wal_lsn() - slots.restart_lsn)::bigint
+				END AS retained_wal_bytes
+			FROM (SELECT pg_is_in_recovery() AS in_recovery) AS recovery
+			LEFT JOIN pg_replication_slots AS slots ON true
+			ORDER BY slots.slot_name ASC
+		`);
+
+		const inRecovery = rows[0]?.in_recovery ?? null;
+		const blind = rows.length === 0 || inRecovery !== false;
+		const slots = rows.filter((row) => row.slot_name !== null);
+
+		if (blind) {
+			logger.warn(
+				{ type: "db_replication_slots_blind", in_recovery: inRecovery },
+				"Replication slot probe is not reading a primary",
+			);
+		} else if (slots.length === 0) {
+			logger.warn(
+				{ type: "db_replication_slots_empty" },
+				"Primary reports zero replication slots",
+			);
+		}
+
+		logger.info(
+			{
+				type: "db_replication_slots",
+				blind,
+				in_recovery: inRecovery,
+				slot_count: slots.length,
+				slot_names: slots.map((slot) => slot.slot_name).join(","),
+			},
+			"DB replication slot probe",
+		);
+
+		for (const slot of slots) {
+			logger.info(
+				{
+					type: "db_replication_slot",
+					blind,
+					slot_name: slot.slot_name,
+					slot_type: slot.slot_type,
+					active: slot.active,
+					failover: slot.failover,
+					wal_status: slot.wal_status,
+					confirmed_flush_lsn: slot.confirmed_flush_lsn,
+					retained_wal_bytes: toBytes(slot.retained_wal_bytes),
+				},
+				"DB replication slot",
+			);
+		}
+	},
+};

--- a/server/tests/unit/db/probes.test.ts
+++ b/server/tests/unit/db/probes.test.ts
@@ -15,6 +15,9 @@ mock.module("@/external/logtail/logtailUtils.js", () => ({
 
 const { runDbProbes } = await import("@/db/probes/runDbProbes.js");
 const { longTxnProbe } = await import("@/db/probes/longTxnProbe.js");
+const { replicationSlotProbe } = await import(
+	"@/db/probes/replicationSlotProbe.js"
+);
 
 // biome-ignore lint/suspicious/noExplicitAny: probes ignore the db in these tests
 const fakeDb = {} as any;
@@ -170,6 +173,132 @@ describe("longTxnProbe", () => {
 			blind: true,
 			longest_txn_seconds: null,
 			xmin_lag: null,
+		});
+	});
+});
+
+describe("replicationSlotProbe", () => {
+	const slotRow = (overrides: Record<string, unknown> = {}) => ({
+		in_recovery: false,
+		slot_name: "rw_slot",
+		slot_type: "logical",
+		active: true,
+		failover: true,
+		wal_status: "reserved",
+		confirmed_flush_lsn: "D9C/512A62A0",
+		retained_wal_bytes: "1048576",
+		...overrides,
+	});
+
+	const findCall = (type: string) =>
+		info.mock.calls.find(
+			(call) => (call[0] as { type?: string }).type === type,
+		)?.[0] as Record<string, unknown> | undefined;
+
+	it("emits a line per slot plus a summary naming every slot", async () => {
+		const db = {
+			execute: async () => [
+				slotRow(),
+				slotRow({ slot_name: "tinybird_slot", failover: false }),
+			],
+			// biome-ignore lint/suspicious/noExplicitAny: minimal db stub
+		} as any;
+
+		await replicationSlotProbe.run({ db });
+
+		expect(findCall("db_replication_slots")).toMatchObject({
+			blind: false,
+			in_recovery: false,
+			slot_count: 2,
+			slot_names: "rw_slot,tinybird_slot",
+		});
+
+		const slotLines = info.mock.calls
+			.map((call) => call[0] as Record<string, unknown>)
+			.filter((fields) => fields.type === "db_replication_slot");
+		expect(slotLines).toHaveLength(2);
+		expect(slotLines[0]).toMatchObject({
+			blind: false,
+			slot_name: "rw_slot",
+			slot_type: "logical",
+			active: true,
+			failover: true,
+			wal_status: "reserved",
+			confirmed_flush_lsn: "D9C/512A62A0",
+			retained_wal_bytes: 1_048_576,
+		});
+		expect(slotLines[1]).toMatchObject({
+			slot_name: "tinybird_slot",
+			failover: false,
+		});
+	});
+
+	it("warns when a primary reports no slots at all", async () => {
+		const db = {
+			execute: async () => [
+				slotRow({
+					slot_name: null,
+					slot_type: null,
+					active: null,
+					failover: null,
+					wal_status: null,
+					confirmed_flush_lsn: null,
+					retained_wal_bytes: null,
+				}),
+			],
+			// biome-ignore lint/suspicious/noExplicitAny: minimal db stub
+		} as any;
+
+		await replicationSlotProbe.run({ db });
+
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0][0]).toMatchObject({
+			type: "db_replication_slots_empty",
+		});
+		expect(findCall("db_replication_slots")).toMatchObject({
+			blind: false,
+			slot_count: 0,
+			slot_names: "",
+		});
+		expect(findCall("db_replication_slot")).toBeUndefined();
+	});
+
+	it("marks a standby reading blind so its slots can't look authoritative", async () => {
+		const db = {
+			execute: async () => [
+				slotRow({ in_recovery: true, retained_wal_bytes: null }),
+			],
+			// biome-ignore lint/suspicious/noExplicitAny: minimal db stub
+		} as any;
+
+		await replicationSlotProbe.run({ db });
+
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0][0]).toMatchObject({
+			type: "db_replication_slots_blind",
+			in_recovery: true,
+		});
+		expect(findCall("db_replication_slots")).toMatchObject({ blind: true });
+		expect(findCall("db_replication_slot")).toMatchObject({
+			blind: true,
+			retained_wal_bytes: null,
+		});
+	});
+
+	it("treats an empty result as blind rather than zero healthy slots", async () => {
+		// biome-ignore lint/suspicious/noExplicitAny: minimal db stub
+		const db = { execute: async () => [] } as any;
+
+		await replicationSlotProbe.run({ db });
+
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0][0]).toMatchObject({
+			type: "db_replication_slots_blind",
+		});
+		expect(findCall("db_replication_slots")).toMatchObject({
+			blind: true,
+			in_recovery: null,
+			slot_count: 0,
 		});
 	});
 });


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Postgres replication slot health probe to track slot status and WAL retention on primaries, and warn when running on a standby or when no slots exist.

- **New Features**
  - Added `db_replication_slots` probe that queries `pg_is_in_recovery()` and `pg_replication_slots`.
  - Flags “blind” mode when on a standby or no rows are returned; warns with `db_replication_slots_blind`.
  - Warns when a primary reports zero slots via `db_replication_slots_empty`.
  - Emits a summary line (slot count and names) and per-slot lines with `retained_wal_bytes` (computed on primaries).
  - Registered the probe in the `dbProbes` registry.

<sup>Written for commit 770f6c9ba95534d06888c577787ddd09fc4789e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds PostgreSQL replication-slot observability to the scheduled database probes.
- [Improvements] Registers a replication-slot probe that reports primary visibility, slot count, names, activity, WAL state, and retained WAL bytes.
- [Improvements] Emits warnings when the probe reads a standby or a primary reports no replication slots.
- [Improvements] Adds unit coverage for populated, empty, standby, and empty-result probe states.
</details>

<h3>Confidence Score: 3/5</h3>

This PR should not merge until the replication-slot query works on PostgreSQL versions before 17 or the required database version is explicitly enforced.

The unconditionally scheduled query references a PostgreSQL 17-only catalog column, causing the entire probe to fail and emit no slot-health telemetry on PostgreSQL 13–16; its per-slot logging also scales linearly on every scheduled tick.

**Files Needing Attention:** server/src/db/probes/replicationSlotProbe.ts, server/src/db/probes/registry.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/db/probes/registry.ts | Registers the new probe unconditionally, exposing incompatible PostgreSQL versions to its query. |
| server/src/db/probes/replicationSlotProbe.ts | Adds replication-slot telemetry, but uses a PostgreSQL 17-only column and emits an unbounded number of per-slot events each minute. |
| server/tests/unit/db/probes.test.ts | Covers result classification and logging, but mocked execution does not exercise database-version compatibility. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Cron as Scheduled probe tick
    participant Runner as runDbProbes
    participant Probe as replicationSlotProbe
    participant PG as PostgreSQL
    participant Logs as Structured logs
    Cron->>Runner: Run registered probes
    Runner->>Probe: "run({ db })"
    Probe->>PG: Query recovery and replication slots
    alt Query succeeds
        PG-->>Probe: Slot rows
        Probe->>Logs: Summary and per-slot events
    else Unsupported metadata column
        PG-->>Probe: SQL error
        Probe-->>Runner: Reject
        Runner->>Logs: db_probe_error
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/db/probes/replicationSlotProbe.ts:33
**PostgreSQL version breaks probe**

When this scheduled probe runs on PostgreSQL 13–16, selecting `pg_replication_slots.failover`, which was introduced in PostgreSQL 17, causes the query to fail with a missing-column error. The runner then emits `db_probe_error` instead of any replication-slot health data on every probe tick.

### Issue 2
server/src/db/probes/replicationSlotProbe.ts:72-87
**Per-slot logs scale unboundedly**

The probe emits one info event per replication slot on every one-minute tick without sampling or a cardinality limit. Databases with many slots therefore generate sustained high-volume telemetry in addition to the summary event; consider relying on the summary or limiting per-slot emissions.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["probe postgres replication slot health"](https://github.com/useautumn/autumn/commit/770f6c9ba95534d06888c577787ddd09fc4789e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47898664)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->