### PR TITLE
read slot failover through jsonb

### DIFF
--- a/server/src/db/probes/replicationSlotProbe.ts
+++ b/server/src/db/probes/replicationSlotProbe.ts
@@ -30,7 +30,9 @@ export const replicationSlotProbe: DbProbe = {
 				slots.slot_name,
 				slots.slot_type,
 				slots.active,
-				slots.failover,
+				-- Read through jsonb: failover only exists on PG 17+, and naming it
+				-- directly would fail parsing and cost us every other slot field.
+				(to_jsonb(slots) ->> 'failover')::boolean AS failover,
 				slots.wal_status,
 				slots.confirmed_flush_lsn::text AS confirmed_flush_lsn,
 				CASE


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Read replication slot `failover` via JSONB in `replicationSlotProbe` instead of selecting the column directly. Keeps the probe working on Postgres <17 (column absent) while still returning `failover` on 17+.

<sup>Written for commit a7430ffcd76f4e2ec12a9bf0b4a02d97a66787b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes replication-slot probing compatible with PostgreSQL versions before 17.
- **[Bug fixes]** Reads the version-dependent `failover` field through JSONB so its absence does not prevent collecting other replication-slot fields.
- **[Improvements]** Preserves `NULL` for `failover` on PostgreSQL versions where the field is unavailable.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The JSONB lookup returns NULL when the version-dependent field is absent and a boolean when present, matching the probe’s existing nullable boolean result contract.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/db/probes/replicationSlotProbe.ts | Safely extracts the PostgreSQL 17+ `failover` field while retaining the probe’s existing nullable boolean contract on older versions. |

<sub>Reviews (1): Last reviewed commit: ["read slot failover through jsonb"](https://github.com/useautumn/autumn/commit/a7430ffcd76f4e2ec12a9bf0b4a02d97a66787b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47900652)</sub>

<!-- /greptile_comment -->