### PR TITLE
fix(sdk): retry selected customer fetches

### DIFF
--- a/packages/sdk/src/hooks/failOpenHook.ts
+++ b/packages/sdk/src/hooks/failOpenHook.ts
@@ -14,6 +14,12 @@ const FAIL_OPEN_OPERATION_IDS = new Set([
 	"getEntity",
 ]);
 
+const NETWORK_RETRY_PATHS = new Set([
+	"/v1/customers.get",
+	"/v1/customers.get_or_create",
+	"/v1/entities.get",
+]);
+
 const FAIL_OPEN_LOG_MESSAGE =
 	"[Autumn] Request failed — failing open. Learn more: https://docs.useautumn.com/documentation/fail-open";
 
@@ -72,12 +78,34 @@ export class FailOpenHook implements SDKInitHook, AfterErrorHook {
 
 		opts.httpClient = new HTTPClient({
 			fetcher: async (input, init) => {
+				const request = new Request(input, init);
+				const retryRequest = request.clone();
+				const startedAt = Date.now();
+
 				try {
-					return init == null ? await fetch(input) : await fetch(input, init);
+					return await fetch(request);
 				} catch (error) {
-					console.log(error);
+					let finalError = error;
+
+					if (
+						NETWORK_RETRY_PATHS.has(new URL(request.url).pathname) &&
+						!this.isExplicitAbort(error)
+					) {
+						try {
+							const elapsedMs = Date.now() - startedAt;
+							const signal = retryRequest.signal.aborted
+								? AbortSignal.timeout(Math.max(elapsedMs, 100))
+								: retryRequest.signal;
+
+							return await fetch(new Request(retryRequest, { signal }));
+						} catch (retryError) {
+							finalError = retryError;
+						}
+					}
+
+					console.log(finalError);
 					console.log(
-						`Network failed to reach Autumn: ${error}. Returning 555 Network Error.`,
+						`Network failed to reach Autumn: ${finalError}. Returning 555 Network Error.`,
 					);
 					return new Response(null, {
 						status: 555,
@@ -124,5 +152,14 @@ export class FailOpenHook implements SDKInitHook, AfterErrorHook {
 			}),
 			error: null,
 		};
+	}
+
+	private isExplicitAbort(error: unknown): boolean {
+		return (
+			typeof error === "object" &&
+			error !== null &&
+			"name" in error &&
+			error.name === "AbortError"
+		);
 	}
 }

--- a/packages/sdk/test/failOpenHook.test.ts
+++ b/packages/sdk/test/failOpenHook.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { FailOpenHook } from "../src/hooks/failOpenHook.js";
+import type { AfterErrorContext } from "../src/hooks/types.js";
+import type { SDKOptions } from "../src/lib/config.js";
+
+const originalFetch = globalThis.fetch;
+const originalConsoleLog = console.log;
+const originalConsoleError = console.error;
+
+beforeEach(() => {
+	console.log = () => {};
+	console.error = () => {};
+});
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	console.log = originalConsoleLog;
+	console.error = originalConsoleError;
+});
+
+const getHookContext = (operationID: string): AfterErrorContext => ({
+	baseURL: "https://api.useautumn.com",
+	operationID,
+	oAuth2Scopes: null,
+	retryConfig: { strategy: "none" },
+	resolvedSecurity: null,
+	options: {},
+});
+
+const runRequest = async ({
+	hook,
+	operationID,
+	path = "/v1/test",
+	signal,
+}: {
+	hook: FailOpenHook;
+	operationID: string;
+	path?: string;
+	signal?: AbortSignal;
+}) => {
+	const options = hook.sdkInit({} satisfies SDKOptions);
+	const httpClient = options.httpClient;
+	if (!httpClient) throw new Error("Expected fail-open HTTP client");
+
+	const response = await httpClient.request(
+		new Request(`https://api.useautumn.com${path}`, {
+			method: "POST",
+			body: JSON.stringify({ id: "test" }),
+			signal,
+		}),
+	);
+
+	return hook.afterError(getHookContext(operationID), response, null);
+};
+
+describe("FailOpenHook network retries", () => {
+	test.each([
+		["getEntity", "/v1/entities.get"],
+		["getCustomer", "/v1/customers.get"],
+		["getOrCreateCustomer", "/v1/customers.get_or_create"],
+	])("retries %s once after a network failure", async (operationID, path) => {
+		let calls = 0;
+		globalThis.fetch = (async () => {
+			calls += 1;
+			if (calls === 1) {
+				throw new DOMException("Timed out", "TimeoutError");
+			}
+			return Response.json({ success: true });
+		}) as typeof fetch;
+
+		const result = await runRequest({
+			hook: new FailOpenHook(),
+			operationID,
+			path,
+		});
+
+		expect(calls).toBe(2);
+		expect(result.response?.status).toBe(200);
+		expect(result.error).toBeNull();
+	});
+
+	test("uses a fresh timeout signal for the retry", async () => {
+		const controller = new AbortController();
+		let calls = 0;
+		globalThis.fetch = (async (input) => {
+			calls += 1;
+			if (calls === 1) {
+				controller.abort(new DOMException("Timed out", "TimeoutError"));
+				throw controller.signal.reason;
+			}
+
+			expect(new Request(input).signal.aborted).toBeFalse();
+			return Response.json({ success: true });
+		}) as typeof fetch;
+
+		const result = await runRequest({
+			hook: new FailOpenHook(),
+			operationID: "getCustomer",
+			path: "/v1/customers.get",
+			signal: controller.signal,
+		});
+
+		expect(calls).toBe(2);
+		expect(result.response?.status).toBe(200);
+	});
+
+	test("does not retry an explicit caller abort", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		let calls = 0;
+		globalThis.fetch = (async (input) => {
+			calls += 1;
+			throw new Request(input).signal.reason;
+		}) as typeof fetch;
+
+		const result = await runRequest({
+			hook: new FailOpenHook(),
+			operationID: "getCustomer",
+			path: "/v1/customers.get",
+			signal: controller.signal,
+		});
+
+		expect(calls).toBe(1);
+		expect(result.response?.status).toBe(555);
+	});
+
+	test("does not retry other operations", async () => {
+		let calls = 0;
+		globalThis.fetch = (async () => {
+			calls += 1;
+			throw new TypeError("fetch failed");
+		}) as typeof fetch;
+
+		const result = await runRequest({
+			hook: new FailOpenHook(),
+			operationID: "track",
+		});
+
+		expect(calls).toBe(1);
+		expect(result.response?.status).toBe(200);
+		expect(result.error).toBeNull();
+	});
+
+	test("returns 555 after the selected operation retry also fails", async () => {
+		let calls = 0;
+		globalThis.fetch = (async () => {
+			calls += 1;
+			throw new TypeError("fetch failed");
+		}) as typeof fetch;
+
+		const result = await runRequest({
+			hook: new FailOpenHook(),
+			operationID: "getCustomer",
+			path: "/v1/customers.get",
+		});
+
+		expect(calls).toBe(2);
+		expect(result.response?.status).toBe(555);
+		expect(result.error).toBeNull();
+	});
+});


### PR DESCRIPTION
Retry one failed network fetch for `entities.get`, `customers.get`, and `customers.get_or_create` before returning the SDK's synthetic 555 response. Retries reuse the request body, refresh an elapsed timeout signal, and continue treating explicit caller aborts as final; all other operations retain their current behavior.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/ff597791-178e-49f7-b4d0-06302dcc80c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-043" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/ff597791-178e-49f7-b4d0-06302dcc80c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-043&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-043"><img alt="SCO-043" src="https://capy.ai/api/badge/thread.svg?label=SCO-043"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-time network retry in the SDK for `customers.get`, `customers.get_or_create`, and `entities.get` to reduce synthetic 555 errors on transient failures. Explicit aborts are respected; other operations are unchanged.

- **Bug Fixes**
  - Retry once on network failure before returning 555.
  - Refresh timeout signal for the retry; reuse original request body.
  - Do not retry explicit caller aborts (`AbortError`).
  - Added tests for retry behavior, abort handling, non-targeted ops, and failure-after-retry.

<sup>Written for commit 98773a7a0a01e56a7a3d42cd47e467c768d9452d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds one network retry for selected SDK customer and entity fetches.
- **[Bug fixes]** Retries the first failed fetch for `customers.get`, `customers.get_or_create`, and `entities.get` before producing the synthetic 555 response.
- **[Improvements]** Clones request bodies for reuse, refreshes elapsed timeout signals, and adds focused retry, timeout, cancellation, exclusion, and terminal-failure tests.
</details>

<h3>Confidence Score: 2/5</h3>

This PR should not merge until retries preserve caller cancellation and timeout budgets and work with supported path-prefixed server URLs.

The retry can issue a selected POST after cancellation, extend a configured request deadline by creating a fresh timeout, and silently skip retry selection when the configured server URL contains a path prefix.

**Files Needing Attention:** packages/sdk/src/hooks/failOpenHook.ts, packages/sdk/test/failOpenHook.test.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/sdk/src/hooks/failOpenHook.ts | Adds selected-path retries, but cancellation can be discarded, timeout budgets can be reset, and path-prefixed server URLs bypass retry selection. |
| packages/sdk/test/failOpenHook.test.ts | Adds useful retry coverage but does not cover custom abort reasons, transition-time cancellation, total timeout budgets, or path-prefixed server URLs. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Caller
  participant SDK
  participant API
  Caller->>SDK: Selected get request
  SDK->>API: First fetch
  API--xSDK: Network failure
  alt Explicit AbortError
    SDK-->>Caller: Synthetic 555/fail-open result
  else Other failure
    SDK->>API: Retry cloned request
    API-->>SDK: Response or second failure
    SDK-->>Caller: Response or synthetic 555/fail-open result
  end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/sdk/src/hooks/failOpenHook.ts:91-97
**Caller cancellation is discarded**

When a selected request is aborted with a custom reason not named `AbortError`, or cancellation occurs between the first failure and retry setup, this branch replaces the aborted caller signal with an unrelated timeout signal, causing another authenticated POST to run after cancellation and preventing the caller from cancelling that retry.

### Issue 2
packages/sdk/src/hooks/failOpenHook.ts:91
**Path prefixes disable retries**

When `serverURL` contains a supported path prefix, the request pathname includes that prefix and cannot equal any root-relative entry in `NETWORK_RETRY_PATHS`, causing transient failures for the selected operations to skip the new retry and immediately produce the synthetic 555/fail-open response.

### Issue 3
packages/sdk/src/hooks/failOpenHook.ts:96-98
**Retry resets the timeout budget**

When the first selected request exhausts its configured timeout, this creates a new timeout equal to the elapsed first attempt rather than preserving the original total deadline, so a request configured for five seconds can continue for nearly another five seconds and no longer observes the original signal.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sdk): retry selected customer reads"](https://github.com/useautumn/autumn/commit/98773a7a0a01e56a7a3d42cd47e467c768d9452d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47908826)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Client SDK Packages](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/client-sdk-packages.md)

<!-- /greptile_comment -->