### PR TITLE
Deprecate autumn-js React hooks

### DIFF
--- a/packages/autumn-js/src/react/AutumnContext.tsx
+++ b/packages/autumn-js/src/react/AutumnContext.tsx
@@ -7,6 +7,9 @@ export type AutumnContextValue = {
 
 export const AutumnContext = createContext<AutumnContextValue | null>(null);
 
+/**
+ * @deprecated Autumn's React hooks are deprecated, as they don't scale well over time. Please use our backend SDK instead.
+ */
 export const useAutumnClient = ({
 	caller,
 }: {

--- a/packages/autumn-js/src/react/hooks/internal/useCustomerActions.ts
+++ b/packages/autumn-js/src/react/hooks/internal/useCustomerActions.ts
@@ -42,6 +42,9 @@ const redirectToUrl = ({
 	}
 };
 
+/**
+ * @deprecated Autumn's React hooks are deprecated, as they don't scale well over time. Please use our backend SDK instead.
+ */
 export const useCustomerActions = ({
 	client,
 	customer,

--- a/packages/autumn-js/src/react/hooks/useAggregateEvents.ts
+++ b/packages/autumn-js/src/react/hooks/useAggregateEvents.ts
@@ -13,6 +13,9 @@ export type UseAggregateEventsParams = HookParams<
 	AggregateEventsResponse
 >;
 
+/**
+ * @deprecated Autumn's React hooks are deprecated, as they don't scale well over time. Please use our backend SDK instead.
+ */
 export const useAggregateEvents = (params: UseAggregateEventsParams) => {
 	const client = useAutumnClient({ caller: "useAggregateEvents" });
 	const { queryOptions, customRange, ...restParams } = params;

--- a/packages/autumn-js/src/react/hooks/useCustomer.ts
+++ b/packages/autumn-js/src/react/hooks/useCustomer.ts
@@ -130,6 +130,7 @@ export type UseCustomerResult = HookResultWithMethods<
  * Fetches or creates an Autumn customer and provides billing actions.
  *
  * @returns Customer data along with billing methods: `attach`, `previewAttach`, `updateSubscription`, `previewUpdateSubscription`, `multiAttach`, `previewMultiAttach`, `check`, `setupPayment`, and `openCustomerPortal`.
+ * @deprecated Autumn's React hooks are deprecated, as they don't scale well over time. Please use our backend SDK instead.
  */
 export const useCustomer = (
 	params: UseCustomerParams = {},

--- a/packages/autumn-js/src/react/hooks/useEntity.ts
+++ b/packages/autumn-js/src/react/hooks/useEntity.ts
@@ -18,6 +18,7 @@ export type UseEntityResult = HookResult<GetEntityResponse | null>;
  * Fetches an Autumn entity (sub-resource of a customer, eg. a seat or project).
  *
  * @returns Entity data including subscriptions, purchases, and balances.
+ * @deprecated Autumn's React hooks are deprecated, as they don't scale well over time. Please use our backend SDK instead.
  */
 export const useEntity = (params: UseEntityParams): UseEntityResult => {
 	const client = useAutumnClient({ caller: "useEntity" });

--- a/packages/autumn-js/src/react/hooks/useListEvents.ts
+++ b/packages/autumn-js/src/react/hooks/useListEvents.ts
@@ -13,6 +13,9 @@ export type UseListEventsParams = HookParams<
 	ListEventsResponse
 >;
 
+/**
+ * @deprecated Autumn's React hooks are deprecated, as they don't scale well over time. Please use our backend SDK instead.
+ */
 export const useListEvents = (params: UseListEventsParams = {}) => {
 	const client = useAutumnClient({ caller: "useListEvents" });
 	const {

--- a/packages/autumn-js/src/react/hooks/useListPlans.ts
+++ b/packages/autumn-js/src/react/hooks/useListPlans.ts
@@ -9,6 +9,9 @@ import type { HookParams } from "./types";
 
 export type UseListPlansParams = HookParams<ListPlansParams, ListPlansList[]>;
 
+/**
+ * @deprecated Autumn's React hooks are deprecated, as they don't scale well over time. Please use our backend SDK instead.
+ */
 export const useListPlans = (params: UseListPlansParams = {}) => {
 	const client = useAutumnClient({ caller: "useListPlans" });
 	const { queryOptions, ...listPlansParams } = params;

--- a/packages/autumn-js/src/react/hooks/useReferrals.ts
+++ b/packages/autumn-js/src/react/hooks/useReferrals.ts
@@ -35,6 +35,7 @@ export type UseReferralsResult = HookResultWithMethods<
  * - `data` is the latest create-code response.
  * - Access the code as `data?.code`.
  * - Call `refetch()` to create/fetch the code for `programId`.
+ * @deprecated Autumn's React hooks are deprecated, as they don't scale well over time. Please use our backend SDK instead.
  */
 export const useReferrals = (
 	params: UseReferralsParams,


### PR DESCRIPTION
Marks every React hook in `packages/autumn-js` as deprecated through JSDoc, directing consumers to the backend SDK while preserving existing runtime behavior.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/509fba05-5810-4eab-8ddf-6fb0464a0d1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-054" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/509fba05-5810-4eab-8ddf-6fb0464a0d1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-054&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-054"><img alt="SCO-054" src="https://capy.ai/api/badge/thread.svg?label=SCO-054"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprecates all React hooks in `packages/autumn-js` via JSDoc and points consumers to the backend SDK. Runtime behavior is unchanged; this only adds deprecation warnings.

<sup>Written for commit c6837fada97d05bfc1c9f6b349a136a8eb9b37cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR deprecates the autumn-js React hooks without changing runtime behavior.
- **[API changes]** Adds JSDoc deprecation notices to every publicly exported React hook, directing consumers to the backend SDK.
- **[Improvements]** Applies the same notice to the internal customer-actions hook for consistent editor guidance.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it changes only JSDoc metadata and covers the complete public React hook surface.

The annotations preserve all function signatures and implementations while consistently marking every publicly exported autumn-js React hook as deprecated.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/autumn-js/src/react/AutumnContext.tsx | Marks the publicly exported useAutumnClient hook as deprecated without changing its implementation. |
| packages/autumn-js/src/react/hooks/internal/useCustomerActions.ts | Marks the internal customer-actions hook as deprecated without changing runtime behavior. |
| packages/autumn-js/src/react/hooks/useAggregateEvents.ts | Adds the intended deprecation annotation to useAggregateEvents. |
| packages/autumn-js/src/react/hooks/useCustomer.ts | Extends the existing useCustomer documentation with the intended deprecation annotation. |
| packages/autumn-js/src/react/hooks/useEntity.ts | Extends the existing useEntity documentation with the intended deprecation annotation. |
| packages/autumn-js/src/react/hooks/useListEvents.ts | Adds the intended deprecation annotation to useListEvents. |
| packages/autumn-js/src/react/hooks/useListPlans.ts | Adds the intended deprecation annotation to useListPlans. |
| packages/autumn-js/src/react/hooks/useReferrals.ts | Extends the existing useReferrals documentation with the intended deprecation annotation. |

<sub>Reviews (1): Last reviewed commit: ["deprecate autumn-js React hooks"](https://github.com/useautumn/autumn/commit/c6837fada97d05bfc1c9f6b349a136a8eb9b37cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47911121)</sub>

**Context used:**

- Knowledge Base — [Client SDK Packages](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/client-sdk-packages.md)

<!-- /greptile_comment -->