### PR TITLE
fix(check): resolve exhausted credit balances against customer's owned pools

### DIFF
--- a/server/tests/integration/balances/check/check-overlapping-credit-systems.test.ts
+++ b/server/tests/integration/balances/check/check-overlapping-credit-systems.test.ts
@@ -1,0 +1,66 @@
+/**
+ * TDD test for /check with two credit systems sharing the same metered feature
+ * (credits and credits3 both cover action1), where the customer only carries
+ * the later-created one (credits3) and has exhausted it.
+ *
+ * Red-failure mode (pre-fix):
+ *  - getFeatureToUseForCheck fell back to creditSystems[0] (catalog order), so
+ *    check resolved to the unowned credits: feature_id = credits,
+ *    required_balance converted at its cost (0.2), and NO balance/usage fields.
+ *
+ * Green-success criteria (after fix):
+ *  - Resolves to the customer's owned pool: feature_id = credits3,
+ *    allowed false, balance 0, required_balance converted at credits3's cost (2).
+ */
+
+import { expect, test } from "bun:test";
+
+import type { CheckResponseV1 } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("check-overlapping-credit-systems: resolves to the customer's owned pool")}`,
+	async () => {
+		const creditsItem = items.free({
+			featureId: TestFeature.Credits3,
+			includedUsage: 12,
+		});
+		const freeProd = products.base({
+			id: "free",
+			items: [creditsItem],
+		});
+
+		const { customerId, autumnV1 } = await initScenario({
+			customerId: "check-olap-credit-systems",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [freeProd] }),
+			],
+			actions: [s.attach({ productId: freeProd.id })],
+		});
+
+		// 6 units × credit_cost 2 = 12 credits → drains credits3 to 0
+		await autumnV1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+			value: 6,
+		});
+		await timeout(2000);
+
+		const checkResponse = (await autumnV1.check({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+		})) as unknown as CheckResponseV1;
+
+		expect(checkResponse.feature_id).toBe(TestFeature.Credits3);
+		expect(checkResponse.allowed).toBe(false);
+		expect(checkResponse.balance).toBe(0);
+		// 1 unit converted at credits3's cost — not credits' (0.2)
+		expect(checkResponse.required_balance).toBe(2);
+	},
+);

--- a/server/tests/integration/balances/check/check-send-event-credit-system.test.ts
+++ b/server/tests/integration/balances/check/check-send-event-credit-system.test.ts
@@ -11,71 +11,85 @@ import chalk from "chalk";
 //  - keep `balance` populated with the tracked feature (backwards compat)
 //  - populate `balances` with both the feature and the credit system
 
-test.concurrent(`${chalk.yellowBright("check-send-event-credit-system: returns balance + balances for linked credit system")}`, async () => {
-	const action1Item = items.free({
-		featureId: TestFeature.Action1,
-		includedUsage: 100,
-	});
-	const creditsItem = items.free({
-		featureId: TestFeature.Credits,
-		includedUsage: 200,
-	});
-	const freeProd = products.base({
-		id: "free",
-		items: [action1Item, creditsItem],
-	});
+test.concurrent(
+	`${chalk.yellowBright("check-send-event-credit-system: returns balance + balances for linked credit system")}`,
+	async () => {
+		const action1Item = items.free({
+			featureId: TestFeature.Action1,
+			includedUsage: 100,
+		});
+		const creditsItem = items.free({
+			featureId: TestFeature.Credits,
+			includedUsage: 200,
+		});
+		const freeProd = products.base({
+			id: "free",
+			items: [action1Item, creditsItem],
+		});
 
-	const { customerId, autumnV2_2 } = await initScenario({
-		customerId: "check-send-event-credit-system",
-		setup: [s.customer({ testClock: false }), s.products({ list: [freeProd] })],
-		actions: [s.attach({ productId: freeProd.id })],
-	});
+		const { customerId, autumnV2_2 } = await initScenario({
+			customerId: "check-send-event-credit-system",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [freeProd] }),
+			],
+			actions: [s.attach({ productId: freeProd.id })],
+		});
 
-	const checkRes = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		feature_id: TestFeature.Action1,
-		required_balance: 5,
-		send_event: true,
-	});
+		const checkRes = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+			required_balance: 5,
+			send_event: true,
+		});
 
-	expect(checkRes.allowed).toBe(true);
-	// Backwards-compat single balance
-	expect(checkRes.balance).not.toBeNull();
-	expect(checkRes.balance?.feature_id).toBe(TestFeature.Action1);
-	// New balances field exposes both the feature and its credit system
-	expect(checkRes.balances).toBeDefined();
-	expect(Object.keys(checkRes.balances ?? {}).sort()).toEqual(
-		[TestFeature.Action1, TestFeature.Credits].sort(),
-	);
-	expect(checkRes.balances?.[TestFeature.Action1]).not.toBeNull();
-	expect(checkRes.balances?.[TestFeature.Credits]).not.toBeNull();
-});
+		expect(checkRes.allowed).toBe(true);
+		// Backwards-compat single balance
+		expect(checkRes.balance).not.toBeNull();
+		expect(checkRes.balance?.feature_id).toBe(TestFeature.Action1);
+		// New balances field exposes the feature and every linked credit system;
+		// pools the customer doesn't carry (credits3) are present but null
+		expect(checkRes.balances).toBeDefined();
+		expect(Object.keys(checkRes.balances ?? {}).sort()).toEqual(
+			[TestFeature.Action1, TestFeature.Credits, TestFeature.Credits3].sort(),
+		);
+		expect(checkRes.balances?.[TestFeature.Action1]).not.toBeNull();
+		expect(checkRes.balances?.[TestFeature.Credits]).not.toBeNull();
+		expect(checkRes.balances?.[TestFeature.Credits3]).toBeNull();
+	},
+);
 
-test.concurrent(`${chalk.yellowBright("check-send-event-no-credit-system: returns single balance and no balances field")}`, async () => {
-	const messagesItem = items.free({
-		featureId: TestFeature.Messages,
-		includedUsage: 100,
-	});
-	const freeProd = products.base({
-		id: "free",
-		items: [messagesItem],
-	});
+test.concurrent(
+	`${chalk.yellowBright("check-send-event-no-credit-system: returns single balance and no balances field")}`,
+	async () => {
+		const messagesItem = items.free({
+			featureId: TestFeature.Messages,
+			includedUsage: 100,
+		});
+		const freeProd = products.base({
+			id: "free",
+			items: [messagesItem],
+		});
 
-	const { customerId, autumnV2_2 } = await initScenario({
-		customerId: "check-send-event-no-credit-system",
-		setup: [s.customer({ testClock: false }), s.products({ list: [freeProd] })],
-		actions: [s.attach({ productId: freeProd.id })],
-	});
+		const { customerId, autumnV2_2 } = await initScenario({
+			customerId: "check-send-event-no-credit-system",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [freeProd] }),
+			],
+			actions: [s.attach({ productId: freeProd.id })],
+		});
 
-	const checkRes = await autumnV2_2.check<CheckResponseV3>({
-		customer_id: customerId,
-		feature_id: TestFeature.Messages,
-		required_balance: 1,
-		send_event: true,
-	});
+		const checkRes = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			required_balance: 1,
+			send_event: true,
+		});
 
-	expect(checkRes.allowed).toBe(true);
-	expect(checkRes.balance).not.toBeNull();
-	expect(checkRes.balance?.feature_id).toBe(TestFeature.Messages);
-	expect(checkRes.balances).toBeUndefined();
-});
+		expect(checkRes.allowed).toBe(true);
+		expect(checkRes.balance).not.toBeNull();
+		expect(checkRes.balance?.feature_id).toBe(TestFeature.Messages);
+		expect(checkRes.balances).toBeUndefined();
+	},
+);

--- a/server/tests/integration/balances/track/basic/track-credit-system-all-balances.test.ts
+++ b/server/tests/integration/balances/track/basic/track-credit-system-all-balances.test.ts
@@ -9,178 +9,201 @@ import chalk from "chalk";
 
 // ═══════════════════════════════════════════════════════════════════
 // Scenario A: track feature_id linked to 2 credit systems
-// Action1 → Credits, and we add an extra credit system entry that
-// references Action1 too. v2Features only ships Credits referencing
-// Action1; we use Action1 + Credits (1 main + 1 credit system) = 2
-// balances. To get 3 balances we'd need an extra credit system —
-// instead we cover the multi-credit-system case via Scenario B.
+// Action1 → Credits (entitled) + Credits3 (not entitled → null entry).
 // ═══════════════════════════════════════════════════════════════════
 
-test.concurrent(`${chalk.yellowBright("track-all-balances-A: track feature_id linked to credit system returns both balances")}`, async () => {
-	const action1Item = items.free({
-		featureId: TestFeature.Action1,
-		includedUsage: 100,
-	});
-	const creditsItem = items.free({
-		featureId: TestFeature.Credits,
-		includedUsage: 200,
-	});
-	const freeProd = products.base({
-		id: "free",
-		items: [action1Item, creditsItem],
-	});
+test.concurrent(
+	`${chalk.yellowBright("track-all-balances-A: track feature_id linked to credit system returns both balances")}`,
+	async () => {
+		const action1Item = items.free({
+			featureId: TestFeature.Action1,
+			includedUsage: 100,
+		});
+		const creditsItem = items.free({
+			featureId: TestFeature.Credits,
+			includedUsage: 200,
+		});
+		const freeProd = products.base({
+			id: "free",
+			items: [action1Item, creditsItem],
+		});
 
-	const { customerId, autumnV2_2 } = await initScenario({
-		customerId: "track-all-balances-a",
-		setup: [s.customer({ testClock: false }), s.products({ list: [freeProd] })],
-		actions: [s.attach({ productId: freeProd.id })],
-	});
+		const { customerId, autumnV2_2 } = await initScenario({
+			customerId: "track-all-balances-a",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [freeProd] }),
+			],
+			actions: [s.attach({ productId: freeProd.id })],
+		});
 
-	const trackRes: TrackResponseV3 = await autumnV2_2.track({
-		customer_id: customerId,
-		feature_id: TestFeature.Action1,
-		value: 10,
-	});
+		const trackRes: TrackResponseV3 = await autumnV2_2.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+			value: 10,
+		});
 
-	// `balance` keeps backwards-compat single-feature heuristic
-	expect(trackRes.balance).not.toBeNull();
-	expect(trackRes.balance?.feature_id).toBe(TestFeature.Action1);
-	// `balances` exposes the feature plus its linked credit system
-	expect(trackRes.balances).toBeDefined();
-	expect(Object.keys(trackRes.balances ?? {}).sort()).toEqual(
-		[TestFeature.Action1, TestFeature.Credits].sort(),
-	);
-	expect(trackRes.balances?.[TestFeature.Action1]).not.toBeNull();
-	expect(trackRes.balances?.[TestFeature.Credits]).not.toBeNull();
-});
+		// `balance` keeps backwards-compat single-feature heuristic
+		expect(trackRes.balance).not.toBeNull();
+		expect(trackRes.balance?.feature_id).toBe(TestFeature.Action1);
+		// `balances` exposes the feature plus every linked credit system
+		expect(trackRes.balances).toBeDefined();
+		expect(Object.keys(trackRes.balances ?? {}).sort()).toEqual(
+			[TestFeature.Action1, TestFeature.Credits, TestFeature.Credits3].sort(),
+		);
+		expect(trackRes.balances?.[TestFeature.Action1]).not.toBeNull();
+		expect(trackRes.balances?.[TestFeature.Credits]).not.toBeNull();
+		expect(trackRes.balances?.[TestFeature.Credits3]).toBeNull();
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════
-// Scenario B: event_name → 2 features, each with 1 credit system
-// "action-event" matches Action1 (→ Credits) and Action3 (→ Credits2).
-// Expect 4 balances: Action1, Action3, Credits, Credits2.
+// Scenario B: event_name → 2 features with their credit systems
+// "action-event" matches Action1 (→ Credits, Credits3) and Action3
+// (→ Credits2). Credits3 is unentitled → null entry.
 // ═══════════════════════════════════════════════════════════════════
 
-test.concurrent(`${chalk.yellowBright("track-all-balances-B: event_name across two features returns four balances")}`, async () => {
-	const action1Item = items.free({
-		featureId: TestFeature.Action1,
-		includedUsage: 80,
-	});
-	const creditsItem = items.free({
-		featureId: TestFeature.Credits,
-		includedUsage: 150,
-	});
-	const action3Item = items.free({
-		featureId: TestFeature.Action3,
-		includedUsage: 60,
-	});
-	const credits2Item = items.free({
-		featureId: TestFeature.Credits2,
-		includedUsage: 100,
-	});
-	const freeProd = products.base({
-		id: "free",
-		items: [action1Item, creditsItem, action3Item, credits2Item],
-	});
+test.concurrent(
+	`${chalk.yellowBright("track-all-balances-B: event_name across two features returns four balances")}`,
+	async () => {
+		const action1Item = items.free({
+			featureId: TestFeature.Action1,
+			includedUsage: 80,
+		});
+		const creditsItem = items.free({
+			featureId: TestFeature.Credits,
+			includedUsage: 150,
+		});
+		const action3Item = items.free({
+			featureId: TestFeature.Action3,
+			includedUsage: 60,
+		});
+		const credits2Item = items.free({
+			featureId: TestFeature.Credits2,
+			includedUsage: 100,
+		});
+		const freeProd = products.base({
+			id: "free",
+			items: [action1Item, creditsItem, action3Item, credits2Item],
+		});
 
-	const { customerId, autumnV2_2 } = await initScenario({
-		customerId: "track-all-balances-b",
-		setup: [s.customer({ testClock: false }), s.products({ list: [freeProd] })],
-		actions: [s.attach({ productId: freeProd.id })],
-	});
+		const { customerId, autumnV2_2 } = await initScenario({
+			customerId: "track-all-balances-b",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [freeProd] }),
+			],
+			actions: [s.attach({ productId: freeProd.id })],
+		});
 
-	const trackRes: TrackResponseV3 = await autumnV2_2.track({
-		customer_id: customerId,
-		event_name: "action-event",
-		value: 5,
-	});
+		const trackRes: TrackResponseV3 = await autumnV2_2.track({
+			customer_id: customerId,
+			event_name: "action-event",
+			value: 5,
+		});
 
-	expect(trackRes.balance).toBeNull();
-	expect(trackRes.balances).toBeDefined();
-	expect(Object.keys(trackRes.balances ?? {}).sort()).toEqual(
-		[
+		expect(trackRes.balance).toBeNull();
+		expect(trackRes.balances).toBeDefined();
+		expect(Object.keys(trackRes.balances ?? {}).sort()).toEqual(
+			[
+				TestFeature.Action1,
+				TestFeature.Action3,
+				TestFeature.Credits,
+				TestFeature.Credits2,
+				TestFeature.Credits3,
+			].sort(),
+		);
+		for (const fid of [
 			TestFeature.Action1,
 			TestFeature.Action3,
 			TestFeature.Credits,
 			TestFeature.Credits2,
-		].sort(),
-	);
-	for (const fid of [
-		TestFeature.Action1,
-		TestFeature.Action3,
-		TestFeature.Credits,
-		TestFeature.Credits2,
-	]) {
-		expect(trackRes.balances?.[fid]).not.toBeNull();
-	}
-});
+		]) {
+			expect(trackRes.balances?.[fid]).not.toBeNull();
+		}
+		expect(trackRes.balances?.[TestFeature.Credits3]).toBeNull();
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════
 // Scenario C: feature_id with no linked credit systems
 // Messages has no credit system referencing it. Expect single balance.
 // ═══════════════════════════════════════════════════════════════════
 
-test.concurrent(`${chalk.yellowBright("track-all-balances-C: feature_id with no credit systems returns single balance")}`, async () => {
-	const messagesItem = items.free({
-		featureId: TestFeature.Messages,
-		includedUsage: 100,
-	});
-	const freeProd = products.base({
-		id: "free",
-		items: [messagesItem],
-	});
+test.concurrent(
+	`${chalk.yellowBright("track-all-balances-C: feature_id with no credit systems returns single balance")}`,
+	async () => {
+		const messagesItem = items.free({
+			featureId: TestFeature.Messages,
+			includedUsage: 100,
+		});
+		const freeProd = products.base({
+			id: "free",
+			items: [messagesItem],
+		});
 
-	const { customerId, autumnV2_2 } = await initScenario({
-		customerId: "track-all-balances-c",
-		setup: [s.customer({ testClock: false }), s.products({ list: [freeProd] })],
-		actions: [s.attach({ productId: freeProd.id })],
-	});
+		const { customerId, autumnV2_2 } = await initScenario({
+			customerId: "track-all-balances-c",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [freeProd] }),
+			],
+			actions: [s.attach({ productId: freeProd.id })],
+		});
 
-	const trackRes: TrackResponseV3 = await autumnV2_2.track({
-		customer_id: customerId,
-		feature_id: TestFeature.Messages,
-		value: 7,
-	});
+		const trackRes: TrackResponseV3 = await autumnV2_2.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 7,
+		});
 
-	expect(trackRes.balance).not.toBeNull();
-	expect(trackRes.balance?.feature_id).toBe(TestFeature.Messages);
-	expect(trackRes.balances).toBeUndefined();
-});
+		expect(trackRes.balance).not.toBeNull();
+		expect(trackRes.balance?.feature_id).toBe(TestFeature.Messages);
+		expect(trackRes.balances).toBeUndefined();
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════
 // Scenario D: tracking a credit system directly does NOT return its
 // metered features (no walking backwards).
 // ═══════════════════════════════════════════════════════════════════
 
-test.concurrent(`${chalk.yellowBright("track-all-balances-D: tracking credit system directly returns only that balance")}`, async () => {
-	const action1Item = items.free({
-		featureId: TestFeature.Action1,
-		includedUsage: 100,
-	});
-	const creditsItem = items.free({
-		featureId: TestFeature.Credits,
-		includedUsage: 200,
-	});
-	const freeProd = products.base({
-		id: "free",
-		items: [action1Item, creditsItem],
-	});
+test.concurrent(
+	`${chalk.yellowBright("track-all-balances-D: tracking credit system directly returns only that balance")}`,
+	async () => {
+		const action1Item = items.free({
+			featureId: TestFeature.Action1,
+			includedUsage: 100,
+		});
+		const creditsItem = items.free({
+			featureId: TestFeature.Credits,
+			includedUsage: 200,
+		});
+		const freeProd = products.base({
+			id: "free",
+			items: [action1Item, creditsItem],
+		});
 
-	const { customerId, autumnV2_2 } = await initScenario({
-		customerId: "track-all-balances-d",
-		setup: [s.customer({ testClock: false }), s.products({ list: [freeProd] })],
-		actions: [s.attach({ productId: freeProd.id })],
-	});
+		const { customerId, autumnV2_2 } = await initScenario({
+			customerId: "track-all-balances-d",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [freeProd] }),
+			],
+			actions: [s.attach({ productId: freeProd.id })],
+		});
 
-	const trackRes: TrackResponseV3 = await autumnV2_2.track({
-		customer_id: customerId,
-		feature_id: TestFeature.Credits,
-		value: 5,
-	});
+		const trackRes: TrackResponseV3 = await autumnV2_2.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Credits,
+			value: 5,
+		});
 
-	expect(trackRes.balance).not.toBeNull();
-	expect(trackRes.balance?.feature_id).toBe(TestFeature.Credits);
-	expect(trackRes.balances).toBeUndefined();
-});
+		expect(trackRes.balance).not.toBeNull();
+		expect(trackRes.balance?.feature_id).toBe(TestFeature.Credits);
+		expect(trackRes.balances).toBeUndefined();
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════
 // Scenario E: relevant credit system feature exists in the org but
@@ -188,36 +211,43 @@ test.concurrent(`${chalk.yellowBright("track-all-balances-D: tracking credit sys
 // with value null.
 // ═══════════════════════════════════════════════════════════════════
 
-test.concurrent(`${chalk.yellowBright("track-all-balances-E: missing entitlement on related feature returns null entry")}`, async () => {
-	const action1Item = items.free({
-		featureId: TestFeature.Action1,
-		includedUsage: 100,
-	});
-	const freeProd = products.base({
-		id: "free",
-		items: [action1Item],
-	});
+test.concurrent(
+	`${chalk.yellowBright("track-all-balances-E: missing entitlement on related feature returns null entry")}`,
+	async () => {
+		const action1Item = items.free({
+			featureId: TestFeature.Action1,
+			includedUsage: 100,
+		});
+		const freeProd = products.base({
+			id: "free",
+			items: [action1Item],
+		});
 
-	const { customerId, autumnV2_2 } = await initScenario({
-		customerId: "track-all-balances-e",
-		setup: [s.customer({ testClock: false }), s.products({ list: [freeProd] })],
-		actions: [s.attach({ productId: freeProd.id })],
-	});
+		const { customerId, autumnV2_2 } = await initScenario({
+			customerId: "track-all-balances-e",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [freeProd] }),
+			],
+			actions: [s.attach({ productId: freeProd.id })],
+		});
 
-	const trackRes: TrackResponseV3 = await autumnV2_2.track({
-		customer_id: customerId,
-		feature_id: TestFeature.Action1,
-		value: 5,
-	});
+		const trackRes: TrackResponseV3 = await autumnV2_2.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+			value: 5,
+		});
 
-	// `balance` falls back to Action1 (Credits is not entitled)
-	expect(trackRes.balance).not.toBeNull();
-	expect(trackRes.balance?.feature_id).toBe(TestFeature.Action1);
-	// `balances` includes the null entry for the missing entitlement
-	expect(trackRes.balances).toBeDefined();
-	expect(Object.keys(trackRes.balances ?? {}).sort()).toEqual(
-		[TestFeature.Action1, TestFeature.Credits].sort(),
-	);
-	expect(trackRes.balances?.[TestFeature.Action1]).not.toBeNull();
-	expect(trackRes.balances?.[TestFeature.Credits]).toBeNull();
-});
+		// `balance` falls back to Action1 (Credits is not entitled)
+		expect(trackRes.balance).not.toBeNull();
+		expect(trackRes.balance?.feature_id).toBe(TestFeature.Action1);
+		// `balances` includes null entries for the missing entitlements
+		expect(trackRes.balances).toBeDefined();
+		expect(Object.keys(trackRes.balances ?? {}).sort()).toEqual(
+			[TestFeature.Action1, TestFeature.Credits, TestFeature.Credits3].sort(),
+		);
+		expect(trackRes.balances?.[TestFeature.Action1]).not.toBeNull();
+		expect(trackRes.balances?.[TestFeature.Credits]).toBeNull();
+		expect(trackRes.balances?.[TestFeature.Credits3]).toBeNull();
+	},
+);

--- a/server/tests/setup/v2Features.ts
+++ b/server/tests/setup/v2Features.ts
@@ -27,6 +27,8 @@ export enum TestFeature {
 	Action3 = "action3", // single use (pay per use)
 	Credits2 = "credits2", // credit system
 
+	Credits3 = "credits3", // credit system (overlaps with credits on action1)
+
 	AiCredits = "ai_credits", // AI credit system (models.dev pricing)
 	AiCredits2 = "ai_credits_2", // second AI credit system (for disambiguation tests)
 	AiCreditsTiered = "ai_credits_tiered", // AI credit system with global + provider markup tiers
@@ -125,6 +127,18 @@ export const getFeatures = ({ orgId }: { orgId: string }) => ({
 			{
 				metered_feature_id: TestFeature.Action3,
 				credit_cost: 1.4,
+			},
+		],
+	}),
+	// Overlaps with Credits on action1, and is seeded after it in the catalog
+	[TestFeature.Credits3]: constructCreditSystem({
+		featureId: TestFeature.Credits3,
+		orgId,
+		env: AppEnv.Sandbox,
+		schema: [
+			{
+				metered_feature_id: TestFeature.Action1,
+				credit_cost: 2,
 			},
 		],
 	}),

--- a/shared/api/customers/cusFeatures/utils/check/getFeatureToUseForCheck.ts
+++ b/shared/api/customers/cusFeatures/utils/check/getFeatureToUseForCheck.ts
@@ -35,9 +35,13 @@ export const getFeatureToUseForCheck = ({
 		return feature;
 	}
 
+	// Nothing allowed — prefer pools the subject actually has over catalog order
+	let ownedCreditSystem: Feature | undefined;
 	for (const creditSystem of creditSystems) {
 		const apiBalance = apiSubject.balances?.[creditSystem.id];
 		if (!apiBalance) continue;
+
+		ownedCreditSystem ??= creditSystem;
 
 		if (
 			apiBalanceToAllowed({
@@ -50,6 +54,9 @@ export const getFeatureToUseForCheck = ({
 			return creditSystem;
 		}
 	}
+
+	if (ownedCreditSystem) return ownedCreditSystem;
+	if (mainBalance) return feature;
 
 	return creditSystems[0];
 };


### PR DESCRIPTION
## Problem

Customer report: with two credit systems whose \`credit_schema\` covers the same metered feature, \`/v1/check\` on that feature resolved to the **wrong pool** when the customer's credits ran out. A customer carrying only the later-created system (exhausted) got:

\`\`\`json
{"allowed": false, "code": "feature_found", "feature_id": "credits_1", "required_balance": 6}
\`\`\`

— \`credits_1\` being a pool they don't even have, with \`required_balance\` converted at that pool's cost and **no balance/usage fields**. That shape is identical to "feature not in this customer's plan", which integrators commonly fail open on, so exhausted customers kept getting served.

## Root cause

\`getFeatureToUseForCheck\` respects ownership on every allowed path, but when nothing is allowed it fell back to \`creditSystems[0]\` — org-catalog order (earliest created wins), blind to the customer's attached pools. Shared by both the V1 (\`getCheckData\`) and V2 (\`getCheckDataV2\`) check paths.

## Fix

While scanning credit systems for an allowed pool, remember the first **owned** one; when nothing is allowed, resolve owned credit system → owned main feature → catalog fallback. An exhausted owned pool now returns \`allowed: false, balance: 0\` explicitly, so missing balance fields once again reliably mean "not in this customer's plan".

## Tests

- New \`check-overlapping-credit-systems.test.ts\`: red pre-fix (resolved to unowned \`credits\`), green post-fix (\`credits3\`, balance 0, required_balance at the owned pool's cost).
- New shared fixture \`Credits3\` (credit system overlapping \`Credits\` on \`action1\`).
- Updated \`balances\`-map assertions in \`check-send-event-credit-system\` and \`track-credit-system-all-balances\` — the map now includes the unowned pool as an explicit \`null\` entry (documented behavior of \`deductionToBalancesResponse\`).
- Regression sweep green one-file-at-a-time: credit-systems1–5, check-fallback, track-credit-system, concurrent-track6–8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `/v1/check` and `/v2/check` choosing the wrong credit pool when overlapping credit systems cover the same feature and the customer’s credits are exhausted. We now resolve to the customer’s owned pool and return `allowed: false` with `balance: 0` and the correct `required_balance`.

- **Bug Fixes**
  - Updated `getFeatureToUseForCheck` fallback: owned credit system → owned main feature → catalog (`creditSystems[0]`).
  - `balances` now includes all linked credit systems; unowned pools (e.g., `credits3`) are present as `null` in `check` and `track` responses.
  - Added `Credits3` fixture and `check-overlapping-credit-systems.test.ts`; updated assertions in `check-send-event-credit-system` and `track-credit-system-all-balances`.

<sup>Written for commit 98b4b4479ebd055842c2f9df516d9e7ca8ec067d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes exhausted-credit checks when multiple pools cover one metered feature.
- **Bug fixes, API changes:** Prefers a customer’s owned credit pool when no eligible balance allows the request, preserving the correct pool identifier, balance, and cost conversion.
- **Improvements:** Adds an overlapping credit-system fixture and regression coverage for exhausted owned pools.
- **API changes:** Updates balance-map expectations to include related but unowned pools as explicit null entries.
</details>

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge, with the ownership-aware fallback matching the established balance representation and covered by a focused regression test.

Owned exhausted pools remain represented by balance objects, so the new fallback retains the correct pool while preserving existing allowed-pool selection and catalog fallback behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/api/customers/cusFeatures/utils/check/getFeatureToUseForCheck.ts | Records the first owned linked pool and uses it before main-feature or catalog fallback when every balance denies access. |
| server/tests/integration/balances/check/check-overlapping-credit-systems.test.ts | Verifies that an exhausted later-created owned pool supplies the denied response’s feature, zero balance, and converted required balance. |
| server/tests/setup/v2Features.ts | Adds a second credit system covering Action1 at a different conversion cost to exercise overlapping-pool behavior. |
| server/tests/integration/balances/check/check-send-event-credit-system.test.ts | Updates response-map assertions for the newly related but unowned credit pool’s explicit null entry. |
| server/tests/integration/balances/track/basic/track-credit-system-all-balances.test.ts | Updates linked-balance scenarios to account for the additional overlapping pool and its null entitlement state. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Check metered feature] --> B{Main balance allows?}
  B -- Yes --> C[Use main feature]
  B -- No --> D[Scan linked credit systems]
  D --> E{Owned pool allows?}
  E -- Yes --> F[Use allowing pool]
  E -- No --> G{Owned pool found?}
  G -- Yes --> H[Use first owned pool]
  G -- No --> I{Main balance exists?}
  I -- Yes --> C
  I -- No --> J[Use catalog fallback]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/check-overl..."](https://github.com/useautumn/autumn/commit/98b4b4479ebd055842c2f9df516d9e7ca8ec067d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47931620)</sub>

<!-- /greptile_comment -->