### PR TITLE
fix(billing): anchor verify to current schedule phase

### DIFF
--- a/server/src/internal/billing/v2/actions/verify/evaluate/evaluateSchedulePhases.ts
+++ b/server/src/internal/billing/v2/actions/verify/evaluate/evaluateSchedulePhases.ts
@@ -48,22 +48,30 @@ export const evaluateSchedulePhases = async ({
 		});
 	}
 
+	const currentPhaseStart =
+		schedule.current_phase?.start_date ?? schedule.phases[0]?.start_date;
 	for (let i = 0; i < scheduledPhases.length; i++) {
 		const expectedPhase = scheduledPhases[i];
 		const expectedStartSeconds = expectedPhase.start_date as number;
 
 		const actualPhase = schedule.phases.find((phase) =>
-			similarUnix({
-				unix1: expectedStartSeconds * 1000,
-				unix2: phase.start_date * 1000,
-			}),
+			i === 0 && currentPhaseStart
+				? phase.start_date === currentPhaseStart
+				: similarUnix({
+						unix1: expectedStartSeconds * 1000,
+						unix2: phase.start_date * 1000,
+					}),
 		);
+		const phaseStartsAt =
+			i === 0
+				? (currentPhaseStart ?? expectedStartSeconds)
+				: expectedStartSeconds;
 
 		if (!actualPhase) {
 			mismatches.push({
 				type: "schedule_mismatch",
 				reason: "phase_start_mismatch",
-				phase_starts_at: expectedStartSeconds,
+				phase_starts_at: phaseStartsAt,
 			});
 			continue;
 		}
@@ -75,7 +83,7 @@ export const evaluateSchedulePhases = async ({
 			mismatches.push({
 				type: "schedule_mismatch",
 				reason: "billing_cycle_anchor_mismatch",
-				phase_starts_at: expectedStartSeconds,
+				phase_starts_at: phaseStartsAt,
 			});
 		}
 
@@ -88,7 +96,7 @@ export const evaluateSchedulePhases = async ({
 				actualPhaseItems: actualPhase.items,
 				storedPriceCatalog,
 				cusPriceCatalog,
-				phaseStartsAt: expectedStartSeconds,
+				phaseStartsAt,
 			}),
 		);
 	}

--- a/server/tests/integration/billing/verify/billing-verify-schedule-mismatches.test.ts
+++ b/server/tests/integration/billing/verify/billing-verify-schedule-mismatches.test.ts
@@ -10,7 +10,7 @@
  *       mismatch on that phase carrying `phase_starts_at`.
  */
 
-import { expect, test } from "bun:test";
+import { expect, spyOn, test as testSequentially } from "bun:test";
 import { type CreateScheduleParamsV0Input, ms } from "@autumn/shared";
 import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
@@ -61,7 +61,7 @@ const buildTwoPhaseSchedule = ({
 	return params;
 };
 
-test.concurrent(
+testSequentially(
 	`${chalk.yellowBright("billing-verify schedule-mismatches 1: schedule released externally -> missing_schedule")}`,
 	async () => {
 		const customerId = "verify-schedule-missing";
@@ -121,8 +121,10 @@ test.concurrent(
 	},
 );
 
-test.concurrent(
-	`${chalk.yellowBright("billing-verify schedule-mismatches 2: future phase item quantity drifted -> mismatch carries phase_starts_at")}`,
+// Delayed verification previously reported phase_start_mismatch for an unchanged current phase.
+// Phase zero must stay valid while genuine future-phase drift remains detectable.
+testSequentially(
+	`${chalk.yellowBright("billing-verify schedule-mismatches 2: delayed verification accepts current phase and detects future drift")}`,
 	async () => {
 		const customerId = "verify-schedule-phase-item";
 
@@ -171,32 +173,48 @@ test.concurrent(
 		expect(schedule.phases.length).toBe(2);
 
 		const secondPhase = schedule.phases[1];
-		const updatedPhases = schedule.phases.map((phase, index) => ({
-			start_date: phase.start_date,
-			end_date: phase.end_date,
-			proration_behavior: "none" as const,
-			items: phase.items.map((item, itemIndex) => ({
-				price: typeof item.price === "string" ? item.price : item.price.id,
-				quantity:
-					index === 1 && itemIndex === 0
-						? (item.quantity ?? 1) + 1
-						: item.quantity,
-			})),
-		}));
+		const verificationNow = Date.now() + ms.days(3);
+		const dateNow = spyOn(Date, "now").mockReturnValue(verificationNow);
 
-		await ctx.stripeCli.subscriptionSchedules.update(scheduleId, {
-			phases: updatedPhases,
-		});
+		try {
+			const unchanged = await verify({
+				ctx,
+				params: { customer_id: customerId },
+			});
+			expect(unchanged.subscriptions[0].mismatches).toEqual([]);
+			expect(unchanged.subscriptions[0].status).toBe("correct");
 
-		const result = await verify({ ctx, params: { customer_id: customerId } });
+			const updatedPhases = schedule.phases.map((phase, index) => ({
+				start_date: phase.start_date,
+				end_date: phase.end_date,
+				proration_behavior: "none" as const,
+				items: phase.items.map((item, itemIndex) => ({
+					price: typeof item.price === "string" ? item.price : item.price.id,
+					quantity:
+						index === 1 && itemIndex === 0
+							? (item.quantity ?? 1) + 1
+							: item.quantity,
+				})),
+			}));
 
-		expect(result.subscriptions.length).toBe(1);
-		expect(result.subscriptions[0].status).toBe("mismatched");
-		expect(result.subscriptions[0].mismatches.length).toBeGreaterThan(0);
-		for (const mismatch of result.subscriptions[0].mismatches) {
-			const phaseStartsAt = (mismatch as { phase_starts_at?: number })
-				.phase_starts_at;
-			expect(phaseStartsAt).toBe(secondPhase.start_date);
+			await ctx.stripeCli.subscriptionSchedules.update(scheduleId, {
+				phases: updatedPhases,
+			});
+
+			const drifted = await verify({
+				ctx,
+				params: { customer_id: customerId },
+			});
+
+			expect(drifted.subscriptions[0].status).toBe("mismatched");
+			expect(drifted.subscriptions[0].mismatches.length).toBeGreaterThan(0);
+			for (const mismatch of drifted.subscriptions[0].mismatches) {
+				const phaseStartsAt = (mismatch as { phase_starts_at?: number })
+					.phase_starts_at;
+				expect(phaseStartsAt).toBe(secondPhase.start_date);
+			}
+		} finally {
+			dateNow.mockRestore();
 		}
 	},
 );


### PR DESCRIPTION
## Summary

- resolve schedule phase zero from Stripe's current phase instead of the verification timestamp
- continue matching future phases by their expected transition timestamps
- preserve current-phase billing-cycle-anchor checks using the actual phase start
- add delayed verification coverage that still detects genuine future-phase drift

## TDD

Red reproduced the unchanged schedule as `schedule_mismatch / phase_start_mismatch` after advancing verification by three days.

Green confirms the unchanged schedule is correct, then detects a deliberately mutated future phase.

## Tests

- `bunx tsgo --build --noEmit`
- `./run.sh server/tests/integration/billing/verify/billing-verify-schedule-mismatches.test.ts` (2 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix false schedule mismatches in billing verification by anchoring phase 0 to Stripe’s current schedule phase. Delayed verifications now accept the current phase and still detect real future-phase drift.

- Bug Fixes
  - Resolve phase 0 using `schedule.current_phase.start_date` (fallback to the first phase).
  - Continue matching future phases by expected transition time with tolerant comparison.
  - Preserve billing_cycle_anchor checks; report `phase_starts_at` using the resolved start.
  - Add delayed-verification coverage that advances time; unchanged schedules stay "correct" and mutated future phases are flagged.

<sup>Written for commit 53dcf085ff71abe48c07733844af67c46c34d58f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects delayed billing-schedule verification while preserving future-phase drift detection.
- [Bug fixes] Matches the first expected phase to Stripe’s current schedule phase and reports its actual start timestamp.
- [Improvements] Continues matching future phases by their expected transition timestamps.
- [Improvements] Adds sequential integration coverage for delayed verification and genuine future-phase item drift.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The current phase is resolved from Stripe’s authoritative current-phase start, future phases retain their expected timestamp matching, and the regression test covers both unchanged and deliberately drifted schedules.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/verify/evaluate/evaluateSchedulePhases.ts | Anchors current-phase matching and mismatch metadata to Stripe’s actual current phase while retaining timestamp-based matching for future phases. |
| server/tests/integration/billing/verify/billing-verify-schedule-mismatches.test.ts | Adds delayed-verification regression coverage and restores the global Date.now spy safely after validating future-phase drift. |

<sub>Reviews (1): Last reviewed commit: ["fix(billing): 🐛 anchor verify to curren..."](https://github.com/useautumn/autumn/commit/53dcf085ff71abe48c07733844af67c46c34d58f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47934994)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->