### PR TITLE
fix(billing): associate trial invoice lines with plans

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/invoiceLines/convertToDbLineItem/stripeLineItemGroupToDbLineItems.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoiceLines/convertToDbLineItem/stripeLineItemGroupToDbLineItems.ts
@@ -92,6 +92,7 @@ export const stripeLineItemGroupToDbLineItems = ({
 			invoiceId,
 			stripeInvoiceId,
 			stripeSubscriptionItemId,
+			subscriptionItemMetadata: subItemMetadata,
 		});
 	});
 
@@ -311,14 +312,19 @@ const createDbLineItemFromStripeOnly = ({
 	invoiceId,
 	stripeInvoiceId,
 	stripeSubscriptionItemId,
+	subscriptionItemMetadata,
 }: {
 	stripeLineItem: ExpandedStripeInvoiceLineItem;
 	stripeDiscounts: Stripe.Discount[];
 	invoiceId: string;
 	stripeInvoiceId: string;
 	stripeSubscriptionItemId: string | null;
+	subscriptionItemMetadata?: Stripe.Metadata;
 }): InsertDbInvoiceLineItem => {
-	const metadata = stripeLineItem.metadata;
+	const metadata = {
+		...stripeLineItem.metadata,
+		...subscriptionItemMetadata,
+	};
 	const priceDetails = stripeLineItem.pricing?.price_details;
 
 	const amount = stripeToAtmnAmount({

--- a/server/src/internal/billing/v2/providers/stripe/utils/stripeItemSpec/cusPriceToStripeItemSpec/cusPriceToStripeItemSpec.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/stripeItemSpec/cusPriceToStripeItemSpec/cusPriceToStripeItemSpec.ts
@@ -104,8 +104,9 @@ export const cusPriceToStripeItemSpec = ({
 		return null;
 	}
 
-	// Attach metadata for correlating Stripe items back to Autumn prices
+	// Correlate Stripe-generated invoice lines back to Autumn billing context.
 	spec.metadata = {
+		autumn_product_id: cusProduct.product.id,
 		autumn_price_id: price.id,
 		autumn_customer_price_id: cusPrice.id,
 		...(spec.metadata ?? {}),

--- a/server/tests/integration/billing/multi-attach/multi-attach-trial.test.ts
+++ b/server/tests/integration/billing/multi-attach/multi-attach-trial.test.ts
@@ -22,6 +22,7 @@ import {
 	expectProductNotTrialing,
 	expectProductTrialing,
 } from "@tests/integration/billing/utils/expectCustomerProductTrialing";
+import { waitForInvoiceLineItems } from "@tests/integration/billing/utils/expectInvoiceLineItemsCorrect";
 import { expectSubToBeCorrect } from "@tests/merged/mergeUtils/expectSubCorrect";
 import { TestFeature } from "@tests/setup/v2Features";
 import { items } from "@tests/utils/fixtures/items";
@@ -43,6 +44,8 @@ import chalk from "chalk";
 // - Preview total = $10 (only one-off addon charged, recurring deferred)
 // - Invoice total = $10 ($0 for trial sub + $10 for one-off addon)
 // ═══════════════════════════════════════════════════════════════════
+// Red: Stripe's $0 trial line has no product and displays as "Custom Item".
+// Green: The trial line retains the Pro product ID and groups under "Pro".
 test.concurrent(`${chalk.yellowBright("multi-attach trial 1: trial inherited from recurring product")}`, async () => {
 	const messagesItem = items.monthlyMessages({ includedUsage: 500 });
 	const dashboardItem = items.dashboard();
@@ -111,6 +114,18 @@ test.concurrent(`${chalk.yellowBright("multi-attach trial 1: trial inherited fro
 		org: ctx.org,
 		env: ctx.env,
 	});
+
+	const invoice = customer.invoices?.[0];
+	expect(invoice?.stripe_id).toBeDefined();
+	const lineItems = await waitForInvoiceLineItems({
+		stripeInvoiceId: invoice!.stripe_id,
+	});
+	const trialLineItems = lineItems.filter(
+		(lineItem) =>
+			lineItem.amount === 0 && lineItem.stripe_subscription_item_id !== null,
+	);
+	expect(trialLineItems).toHaveLength(1);
+	expect(trialLineItems[0].product_id).toBe(proTrial.id);
 });
 
 // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- attach Autumn product IDs to Stripe subscription-item metadata
- retain subscription-item metadata when ingesting Stripe-generated invoice lines
- cover the multi-product trial invoice regression

## Testing

- `bunx tsgo --build --noEmit`
- targeted multi-attach trial integration test (1 passed, 2 filtered)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes trial invoice lines showing as “Custom Item” by preserving subscription-item metadata and tagging items with the Autumn product ID. Trial lines now map to the correct plan in our DB and UI.

- **Bug Fixes**
  - Add `autumn_product_id` to Stripe item spec metadata for correlation.
  - Merge subscription-item metadata into Stripe-only invoice lines during DB conversion.
  - Add integration test to ensure multi-attach trial lines associate with the correct product (e.g., Pro).

<sup>Written for commit ffeb3d3b227d2090a4d6805e4d7dff771a23ef18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Associates Stripe-generated trial invoice lines with their Autumn plans by propagating product metadata through subscription items and invoice ingestion.
- **Bug fixes:** Adds Autumn product IDs to Stripe subscription-item metadata so zero-value trial lines retain their plan association.
- **Improvements:** Merges subscription-item metadata into Stripe-only invoice lines during persistence.
- **Improvements:** Adds integration coverage confirming a multi-attach trial line is grouped under the correct product.
</details>

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge, with the trial invoice correlation flow consistently covered from subscription-item creation through invoice-line persistence.

The added product metadata is scoped by Stripe subscription-item ID, merged only into the corresponding invoice-line group, and validated by the multi-attach trial integration test.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/invoiceLines/convertToDbLineItem/stripeLineItemGroupToDbLineItems.ts | Propagates subscription-item metadata into unmatched Stripe invoice lines so generated trial lines retain product and price correlation. |
| server/src/internal/billing/v2/providers/stripe/utils/stripeItemSpec/cusPriceToStripeItemSpec/cusPriceToStripeItemSpec.ts | Adds the Autumn product ID to metadata attached to generated Stripe subscription items. |
| server/tests/integration/billing/multi-attach/multi-attach-trial.test.ts | Verifies that the generated zero-value trial invoice line is associated with the expected Autumn product. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Autumn as Autumn billing
    participant Stripe as Stripe
    participant Ingest as Invoice ingestion
    participant DB as Invoice line storage
    Autumn->>Stripe: Create subscription item with Autumn product metadata
    Stripe-->>Ingest: Generate trial invoice line
    Ingest->>Stripe: Fetch subscription-item metadata
    Ingest->>Ingest: Merge metadata into Stripe-only line
    Ingest->>DB: Store line with product_id
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): 🐛 associate trial invoice..."](https://github.com/useautumn/autumn/commit/ffeb3d3b227d2090a4d6805e4d7dff771a23ef18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47945929)</sub>

<!-- /greptile_comment -->