### PR TITLE
fix(billing): prevent defaults with active paid plans

### DIFF
--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeDefaultCustomerProduct.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeDefaultCustomerProduct.ts
@@ -1,11 +1,45 @@
 import {
 	CusProductStatus,
+	cp,
 	enrichFullCustomerWithEntity,
 	type FullCusProduct,
+	hasCustomerProductEnded,
+	isFutureStartDate,
 	type UpdateSubscriptionBillingContext,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { initFullCustomerProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/initFullCustomerProduct";
+
+const hasOtherEffectivePaidMainProduct = ({
+	billingContext,
+	effectiveAt,
+}: {
+	billingContext: UpdateSubscriptionBillingContext;
+	effectiveAt: number;
+}) => {
+	const { customerProduct, fullCustomer } = billingContext;
+	const internalEntityId = customerProduct.internal_entity_id ?? undefined;
+
+	return fullCustomer.customer_products.some((candidate) => {
+		if (candidate.id === customerProduct.id) return false;
+
+		const inScope = cp(candidate)
+			.hasRelevantStatus()
+			.paidRecurring()
+			.main()
+			.hasProductGroup({ productGroup: customerProduct.product.group })
+			.onEntity({ internalEntityId }).valid;
+
+		return (
+			inScope &&
+			!isFutureStartDate(candidate.starts_at, effectiveAt, 0) &&
+			!hasCustomerProductEnded(candidate, {
+				nowMs: effectiveAt,
+				toleranceMs: 0,
+			})
+		);
+	});
+};
 
 /**
  * Creates the default customer product to insert when canceling.
@@ -44,6 +78,15 @@ export const computeDefaultCustomerProduct = ({
 		cancelAction === "cancel_immediately"
 			? CusProductStatus.Active
 			: CusProductStatus.Scheduled;
+
+	if (
+		hasOtherEffectivePaidMainProduct({
+			billingContext,
+			effectiveAt: startsAt,
+		})
+	) {
+		return undefined;
+	}
 
 	const newDefaultProduct = initFullCustomerProduct({
 		ctx,

--- a/server/tests/integration/billing/update-subscription/cancel/cancel-multiple-paid-products.test.ts
+++ b/server/tests/integration/billing/update-subscription/cancel/cancel-multiple-paid-products.test.ts
@@ -1,0 +1,228 @@
+/** Red: canceling one paid main product creates Basic despite another effective paid main product in scope.
+ * Green: preview and execution omit Basic while leaving the remaining paid product and Stripe subscription unchanged. */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV3, UpdateSubscriptionV1Params } from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import {
+	getEntitySubscriptionId,
+	getSubscriptionId,
+} from "@tests/integration/billing/utils/stripe/getSubscriptionId";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { billingActions } from "@/internal/billing/v2/actions";
+import { ProductService } from "@/internal/products/ProductService";
+
+const cases = [
+	{
+		cancelAction: "cancel_immediately",
+		suffix: "immediate",
+		remainingScope: "same",
+		expectDefault: false,
+	},
+	{
+		cancelAction: "cancel_end_of_cycle",
+		suffix: "end-of-cycle",
+		remainingScope: "same",
+		expectDefault: false,
+	},
+	{
+		cancelAction: "cancel_immediately",
+		suffix: "different-group",
+		remainingScope: "group",
+		expectDefault: true,
+	},
+	{
+		cancelAction: "cancel_end_of_cycle",
+		suffix: "different-group-end-of-cycle",
+		remainingScope: "group",
+		expectDefault: true,
+	},
+	{
+		cancelAction: "cancel_immediately",
+		suffix: "different-entity",
+		remainingScope: "entity",
+		expectDefault: true,
+	},
+] as const;
+
+for (const { cancelAction, suffix, remainingScope, expectDefault } of cases) {
+	test.concurrent(
+		`${chalk.yellowBright(`cancel ${suffix}: default respects paid product scope`)}`,
+		async () => {
+			const customerId = `cancel-multi-paid-${suffix}`;
+			const basic = products.base({
+				id: "basic",
+				isDefault: true,
+				items: [items.monthlyMessages({ includedUsage: 10 })],
+			});
+			const target = products.pro({
+				id: "target",
+				items: [items.monthlyMessages({ includedUsage: 100 })],
+			});
+			const remaining = products.base({
+				id: "remaining",
+				group:
+					remainingScope === "entity" ? undefined : `${customerId}-separate`,
+				items: [
+					items.monthlyUsers({ includedUsage: 10 }),
+					items.monthlyPrice({ price: 30 }),
+				],
+			});
+
+			const { autumnV1, autumnV2_2, ctx, entities } = await initScenario({
+				customerId,
+				setup: [
+					s.customer({ paymentMethod: "success", withDefault: true }),
+					s.products({ list: [basic, target, remaining] }),
+					...(remainingScope === "entity"
+						? [s.entities({ count: 1, featureId: TestFeature.Users })]
+						: []),
+				],
+				actions: [],
+			});
+
+			const customerWithDefault =
+				await autumnV1.customers.get<ApiCustomerV3>(customerId);
+			await expectCustomerProducts({
+				customer: customerWithDefault,
+				active: [basic.id],
+			});
+
+			await autumnV2_2.billing.attach({
+				customer_id: customerId,
+				plan_id: target.id,
+			});
+			await autumnV2_2.billing.attach({
+				customer_id: customerId,
+				plan_id: remaining.id,
+				new_billing_subscription: true,
+				entity_id: remainingScope === "entity" ? entities[0].id : undefined,
+			});
+
+			if (remainingScope === "same") {
+				const [targetProduct, remainingProduct] = await Promise.all([
+					ProductService.getFull({
+						db: ctx.db,
+						idOrInternalId: target.id,
+						orgId: ctx.org.id,
+						env: ctx.env,
+					}),
+					ProductService.getFull({
+						db: ctx.db,
+						idOrInternalId: remaining.id,
+						orgId: ctx.org.id,
+						env: ctx.env,
+					}),
+				]);
+
+				// Simulate the confirmed overlap without reproducing historical creation races.
+				await ProductService.updateByInternalId({
+					db: ctx.db,
+					internalId: remainingProduct.internal_id,
+					update: { group: targetProduct.group },
+				});
+			}
+
+			const targetSubscriptionId = await getSubscriptionId({
+				ctx,
+				customerId,
+				productId: target.id,
+			});
+			const remainingSubscriptionId =
+				remainingScope === "entity"
+					? await getEntitySubscriptionId({
+							ctx,
+							customerId,
+							entityId: entities[0].id,
+							productId: remaining.id,
+						})
+					: await getSubscriptionId({
+							ctx,
+							customerId,
+							productId: remaining.id,
+						});
+			expect(remainingSubscriptionId).not.toBe(targetSubscriptionId);
+			const remainingSubscriptionBefore =
+				await ctx.stripeCli.subscriptions.retrieve(remainingSubscriptionId);
+			const updateParams = {
+				customer_id: customerId,
+				plan_id: target.id,
+				cancel_action: cancelAction,
+			} satisfies UpdateSubscriptionV1Params;
+
+			const { billingPlan: previewPlan } =
+				await billingActions.updateSubscription({
+					ctx,
+					params: updateParams,
+					preview: true,
+				});
+			const previewDefault = previewPlan?.autumn.insertCustomerProducts.find(
+				(customerProduct) => customerProduct.product.id === basic.id,
+			);
+
+			await autumnV2_2.billing.update(updateParams);
+
+			const customerAfterCancel =
+				await autumnV1.customers.get<ApiCustomerV3>(customerId);
+			await expectCustomerProducts({
+				customer: customerAfterCancel,
+				active: [
+					...(remainingScope === "entity" ? [] : [remaining.id]),
+					...(expectDefault && cancelAction === "cancel_immediately"
+						? [basic.id]
+						: []),
+				],
+				canceling:
+					cancelAction === "cancel_end_of_cycle" ? [target.id] : undefined,
+				scheduled:
+					expectDefault && cancelAction === "cancel_end_of_cycle"
+						? [basic.id]
+						: undefined,
+				notPresent:
+					cancelAction === "cancel_immediately"
+						? [target.id, ...(!expectDefault ? [basic.id] : [])]
+						: !expectDefault
+							? [basic.id]
+							: undefined,
+			});
+
+			if (remainingScope === "entity") {
+				const entityAfterCancel = await autumnV1.entities.get(
+					customerId,
+					entities[0].id,
+				);
+				await expectCustomerProducts({
+					customer: entityAfterCancel,
+					active: [remaining.id],
+				});
+			}
+
+			const remainingSubscriptionAfter =
+				await ctx.stripeCli.subscriptions.retrieve(remainingSubscriptionId);
+			expect(remainingSubscriptionAfter.status).toBe(
+				remainingSubscriptionBefore.status,
+			);
+			expect(remainingSubscriptionAfter.cancel_at_period_end).toBe(
+				remainingSubscriptionBefore.cancel_at_period_end,
+			);
+			expect(
+				remainingSubscriptionAfter.items.data.map((item) => ({
+					id: item.id,
+					priceId: item.price.id,
+					quantity: item.quantity,
+				})),
+			).toEqual(
+				remainingSubscriptionBefore.items.data.map((item) => ({
+					id: item.id,
+					priceId: item.price.id,
+					quantity: item.quantity,
+				})),
+			);
+			expect(previewDefault === undefined).toBe(!expectDefault);
+		},
+	);
+}


### PR DESCRIPTION
## Summary

- prevent cancellation from creating a default plan while another applicable paid main plan remains effective
- evaluate remaining plans at the immediate or end-of-cycle transition time with product-group and entity scoping
- cover preview, execution, Stripe subscription preservation, and scope isolation

## Testing

- `bunx tsgo --build --noEmit`
- default-product cancellation regression matrix (5 passed)
- checkout subscription guard (2 passed)
- cross-migration customer idempotency (1 passed)
- migration customer lock (3 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops creating a default product when canceling a paid main plan if another effective paid main plan exists in the same product group and entity scope. Works for immediate and end-of-cycle cancellations, and keeps the remaining Stripe subscription unchanged.

- Bug Fixes
  - Added a scope-aware check in `computeDefaultCustomerProduct` to skip default insertion when another paid main product is effective at the transition time.
  - Added integration tests covering immediate/EOC, same vs different product-group/entity scopes, and preview vs execution behavior.

<sup>Written for commit 6d8f43ff01920cba61149f6fa25937bcb0fb534b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Prevents cancellation from creating a default plan when another applicable paid main plan remains effective.
- **Bug fixes:** Evaluates remaining paid plans at the cancellation transition time, scoped by product group and entity.
- **Improvements:** Adds integration coverage for preview and execution behavior, Stripe subscription preservation, and group/entity isolation.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The cancellation guard consistently evaluates other paid recurring main products at the intended transition time and limits suppression to matching product-group and entity scope, with integration coverage for both preview and execution.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeDefaultCustomerProduct.ts | Adds a transition-time, product-group, and entity-scoped guard that suppresses unnecessary default-plan creation. |
| server/tests/integration/billing/update-subscription/cancel/cancel-multiple-paid-products.test.ts | Covers immediate and end-of-cycle cancellation across same-group, different-group, and different-entity scenarios, including preview and Stripe preservation assertions. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Cancel paid main plan] --> B[Determine transition time]
    B --> C{Another effective paid recurring main plan?}
    C -->|Same product group and entity scope| D[Do not create default plan]
    C -->|No applicable remaining plan| E[Create default plan]
    D --> F[Preserve remaining Stripe subscription]
    E --> G[Activate now or schedule at cycle end]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): 🐛 prevent defaults with a..."](https://github.com/useautumn/autumn/commit/6d8f43ff01920cba61149f6fa25937bcb0fb534b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47956981)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->