### PR TITLE
add subjectLookupDbOnly toggle

### DIFF
--- a/server/src/internal/customers/handlers/handleGetOrCreateCustomer/handleGetOrCreateCustomer.ts
+++ b/server/src/internal/customers/handlers/handleGetOrCreateCustomer/handleGetOrCreateCustomer.ts
@@ -12,6 +12,7 @@ import {
 } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { getOrCreateApiCustomerByRollout } from "@/internal/customers/actions/getOrCreateApiCustomerByRollout.js";
+import { applySubjectLookupDbOnly } from "@/internal/misc/miscellaneousEdgeConfig/applySubjectLookupDbOnly.js";
 
 export const handlePostCustomer = createRoute({
 	scopes: [Scopes.Customers.Write],
@@ -49,6 +50,8 @@ export const handlePostCustomer = createRoute({
 				],
 			});
 		}
+
+		applySubjectLookupDbOnly({ ctx });
 
 		const start = Date.now();
 

--- a/server/src/internal/customers/handlers/handleGetOrCreateCustomer/handleGetOrCreateCustomerV2.ts
+++ b/server/src/internal/customers/handlers/handleGetOrCreateCustomer/handleGetOrCreateCustomerV2.ts
@@ -6,6 +6,7 @@ import {
 } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { getOrCreateApiCustomerByRollout } from "@/internal/customers/actions/getOrCreateApiCustomerByRollout.js";
+import { applySubjectLookupDbOnly } from "@/internal/misc/miscellaneousEdgeConfig/applySubjectLookupDbOnly.js";
 import { isFullSubjectRolloutEnabled } from "@/internal/misc/rollouts/fullSubjectRolloutUtils.js";
 
 export const handleGetOrCreateCustomerV2 = createRoute({
@@ -15,6 +16,8 @@ export const handleGetOrCreateCustomerV2 = createRoute({
 	handler: async (c) => {
 		const ctx = c.get("ctx");
 		const createCusParams = c.req.valid("json");
+
+		applySubjectLookupDbOnly({ ctx });
 
 		const start = Date.now();
 

--- a/server/src/internal/entities/handlers/handleGetEntity/handleGetEntity.ts
+++ b/server/src/internal/entities/handlers/handleGetEntity/handleGetEntity.ts
@@ -5,6 +5,7 @@ import {
 	Scopes,
 } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { applySubjectLookupDbOnly } from "@/internal/misc/miscellaneousEdgeConfig/applySubjectLookupDbOnly.js";
 import { getApiEntityByRollout } from "../../actions/getApiEntityByRollout.js";
 
 export const handleGetEntity = createRoute({
@@ -18,6 +19,8 @@ export const handleGetEntity = createRoute({
 		const { customer_id, entity_id } = c.req.param();
 		const ctx = c.get("ctx");
 		const { with_autumn_id } = c.req.valid("query");
+
+		applySubjectLookupDbOnly({ ctx });
 
 		const apiEntity = await getApiEntityByRollout({
 			ctx,

--- a/server/src/internal/entities/handlers/handleGetEntity/handleGetEntityV2.ts
+++ b/server/src/internal/entities/handlers/handleGetEntity/handleGetEntityV2.ts
@@ -6,6 +6,7 @@ import {
 } from "@autumn/shared";
 import { shed503OnTransientError } from "@/db/shed503OnTransientError.js";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { applySubjectLookupDbOnly } from "@/internal/misc/miscellaneousEdgeConfig/applySubjectLookupDbOnly.js";
 import { findCustomerForEntity } from "../../actions/findCustomer.js";
 import { getApiEntityByRollout } from "../../actions/getApiEntityByRollout.js";
 
@@ -17,6 +18,8 @@ export const handleGetEntityV2 = createRoute({
 		const ctx = c.get("ctx");
 		const body = c.req.valid("json");
 		let { customer_id: customerId, entity_id: entityId } = body;
+
+		applySubjectLookupDbOnly({ ctx });
 
 		// 1. Entity -> Customer ID
 		if (!customerId) {

--- a/server/src/internal/misc/miscellaneousEdgeConfig/applySubjectLookupDbOnly.ts
+++ b/server/src/internal/misc/miscellaneousEdgeConfig/applySubjectLookupDbOnly.ts
@@ -1,0 +1,6 @@
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { isSubjectLookupDbOnlyEnabled } from "./miscellaneousEdgeConfigStore.js";
+
+export const applySubjectLookupDbOnly = ({ ctx }: { ctx: AutumnContext }) => {
+	if (isSubjectLookupDbOnlyEnabled()) ctx.skipCache = true;
+};

--- a/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.ts
+++ b/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.ts
@@ -5,6 +5,9 @@ export const MiscellaneousEdgeConfigSchema = z.object({
 	/** Global switch: coalesce balance syncs via per-customer Redis dirty state
 	 *  (signal-only SQS messages). Dark by default. */
 	syncCoalesce: z.boolean().default(false),
+	/** Global switch: customer get_or_create and entity get read the subject
+	 *  straight from Postgres, bypassing the FullSubject cache entirely. */
+	subjectLookupDbOnly: z.boolean().default(false),
 });
 
 export type MiscellaneousEdgeConfig = z.infer<

--- a/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.ts
+++ b/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.ts
@@ -55,3 +55,7 @@ export const _setMiscellaneousEdgeConfigForTesting = ({
 
 /** Global sync-coalescing gate (balance syncs via Redis dirty state). */
 export const isSyncCoalesceEnabled = (): boolean => store.get().syncCoalesce;
+
+/** Global gate: serve subject lookups from Postgres instead of the cache. */
+export const isSubjectLookupDbOnlyEnabled = (): boolean =>
+	store.get().subjectLookupDbOnly;

--- a/server/tests/unit/edge-config/subject-lookup-db-only.test.ts
+++ b/server/tests/unit/edge-config/subject-lookup-db-only.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { applySubjectLookupDbOnly } from "@/internal/misc/miscellaneousEdgeConfig/applySubjectLookupDbOnly.js";
+import { MiscellaneousEdgeConfigSchema } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.js";
+import {
+	_setMiscellaneousEdgeConfigForTesting,
+	isSubjectLookupDbOnlyEnabled,
+} from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
+
+const defaultConfig = MiscellaneousEdgeConfigSchema.parse({});
+
+const setSubjectLookupDbOnly = (subjectLookupDbOnly: boolean) => {
+	_setMiscellaneousEdgeConfigForTesting({
+		config: { ...defaultConfig, subjectLookupDbOnly },
+	});
+};
+
+describe("subject lookup db-only edge config", () => {
+	afterEach(() => {
+		_setMiscellaneousEdgeConfigForTesting({ config: defaultConfig });
+	});
+
+	test("defaults to off", () => {
+		expect(defaultConfig.subjectLookupDbOnly).toBe(false);
+		expect(isSubjectLookupDbOnlyEnabled()).toBe(false);
+	});
+
+	test("reads the runtime flag", () => {
+		setSubjectLookupDbOnly(true);
+
+		expect(isSubjectLookupDbOnlyEnabled()).toBe(true);
+	});
+
+	test("forces skipCache on the context when enabled", () => {
+		setSubjectLookupDbOnly(true);
+		const ctx = { skipCache: false } as AutumnContext;
+
+		applySubjectLookupDbOnly({ ctx });
+
+		expect(ctx.skipCache).toBe(true);
+	});
+
+	test("leaves the context untouched when disabled", () => {
+		setSubjectLookupDbOnly(false);
+		const ctx = { skipCache: false } as AutumnContext;
+
+		applySubjectLookupDbOnly({ ctx });
+
+		expect(ctx.skipCache).toBe(false);
+	});
+
+	test("never re-enables the cache for a request that already opted out", () => {
+		setSubjectLookupDbOnly(false);
+		const ctx = { skipCache: true } as AutumnContext;
+
+		applySubjectLookupDbOnly({ ctx });
+
+		expect(ctx.skipCache).toBe(true);
+	});
+});

--- a/vite/src/views/admin/components/MiscellaneousEdgeConfigDialog.tsx
+++ b/vite/src/views/admin/components/MiscellaneousEdgeConfigDialog.tsx
@@ -35,6 +35,7 @@ export function MiscellaneousEdgeConfigDialog({
 				...data,
 				newFlatCusModel: data.newFlatCusModel ?? [],
 				syncCoalesce: data.syncCoalesce ?? false,
+				subjectLookupDbOnly: data.subjectLookupDbOnly ?? false,
 			};
 		},
 		enabled: open,

--- a/vite/src/views/admin/components/MiscellaneousEdgeConfigForm.tsx
+++ b/vite/src/views/admin/components/MiscellaneousEdgeConfigForm.tsx
@@ -1,17 +1,11 @@
-import {
-	Badge,
-	Button,
-	DialogFooter,
-	Input,
-	Separator,
-	Switch,
-} from "@autumn/ui";
+import { Badge, Button, DialogFooter, Input, Separator } from "@autumn/ui";
 import Editor from "@monaco-editor/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
+import { MiscellaneousEdgeConfigSwitch } from "./MiscellaneousEdgeConfigSwitch";
 import {
 	buildMiscellaneousJsonText,
 	getStatusMessage,
@@ -71,6 +65,8 @@ export const MiscellaneousEdgeConfigForm = ({
 				...prev,
 				newFlatCusModel: parsed.newFlatCusModel ?? prev.newFlatCusModel,
 				syncCoalesce: parsed.syncCoalesce ?? prev.syncCoalesce,
+				subjectLookupDbOnly:
+					parsed.subjectLookupDbOnly ?? prev.subjectLookupDbOnly,
 			}));
 			setJsonError(null);
 		} catch {
@@ -182,25 +178,27 @@ export const MiscellaneousEdgeConfigForm = ({
 						</div>
 					</div>
 
-					<div className="rounded-lg border border-border p-3 flex items-center justify-between gap-6">
-						<div className="flex min-w-0 flex-col gap-1">
-							<div className="text-sm font-medium text-foreground">
-								Sync coalescing
-							</div>
-							<div className="text-pretty text-xs text-tertiary-foreground">
-								Batches balance syncs per customer instead of one per change.
-								Affects every org at once.
-							</div>
-						</div>
-						<Switch
-							aria-label="Enable sync coalescing"
-							checked={config.syncCoalesce}
-							onCheckedChange={(syncCoalesce) => {
-								setSyncSource("form");
-								setConfig((prev) => ({ ...prev, syncCoalesce }));
-							}}
-						/>
-					</div>
+					<MiscellaneousEdgeConfigSwitch
+						title="Sync coalescing"
+						description="Batches balance syncs per customer instead of one per change. Affects every org at once."
+						ariaLabel="Enable sync coalescing"
+						checked={config.syncCoalesce}
+						onCheckedChange={(syncCoalesce) => {
+							setSyncSource("form");
+							setConfig((prev) => ({ ...prev, syncCoalesce }));
+						}}
+					/>
+
+					<MiscellaneousEdgeConfigSwitch
+						title="Subject lookups bypass Redis"
+						description="customers.get_or_create and entities.get read the subject straight from Postgres and skip the cache write-back. Affects every org at once."
+						ariaLabel="Enable db-only subject lookups"
+						checked={config.subjectLookupDbOnly}
+						onCheckedChange={(subjectLookupDbOnly) => {
+							setSyncSource("form");
+							setConfig((prev) => ({ ...prev, subjectLookupDbOnly }));
+						}}
+					/>
 
 					<div className="flex flex-col gap-3 text-xs text-tertiary-foreground">
 						<Separator />

--- a/vite/src/views/admin/components/MiscellaneousEdgeConfigSwitch.tsx
+++ b/vite/src/views/admin/components/MiscellaneousEdgeConfigSwitch.tsx
@@ -1,0 +1,29 @@
+import { Switch } from "@autumn/ui";
+
+export const MiscellaneousEdgeConfigSwitch = ({
+	title,
+	description,
+	ariaLabel,
+	checked,
+	onCheckedChange,
+}: {
+	title: string;
+	description: string;
+	ariaLabel: string;
+	checked: boolean;
+	onCheckedChange: (checked: boolean) => void;
+}) => (
+	<div className="rounded-lg border border-border p-3 flex items-center justify-between gap-6">
+		<div className="flex min-w-0 flex-col gap-1">
+			<div className="text-sm font-medium text-foreground">{title}</div>
+			<div className="text-pretty text-xs text-tertiary-foreground">
+				{description}
+			</div>
+		</div>
+		<Switch
+			aria-label={ariaLabel}
+			checked={checked}
+			onCheckedChange={onCheckedChange}
+		/>
+	</div>
+);

--- a/vite/src/views/admin/components/miscellaneousEdgeConfigTypes.ts
+++ b/vite/src/views/admin/components/miscellaneousEdgeConfigTypes.ts
@@ -1,6 +1,7 @@
 export type MiscellaneousEdgeConfig = {
 	newFlatCusModel: string[];
 	syncCoalesce: boolean;
+	subjectLookupDbOnly: boolean;
 	configHealthy: boolean;
 	configConfigured: boolean;
 	lastSuccessAt: string | null;
@@ -10,6 +11,7 @@ export type MiscellaneousEdgeConfig = {
 export const MISCELLANEOUS_DEFAULT_CONFIG: MiscellaneousEdgeConfig = {
 	newFlatCusModel: [],
 	syncCoalesce: false,
+	subjectLookupDbOnly: false,
 	configHealthy: false,
 	configConfigured: false,
 	lastSuccessAt: null,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new `subjectLookupDbOnly` edge-config toggle to bypass Redis and read subjects directly from Postgres. This lets us force `customers.get_or_create` and `entities.get` to skip the subject cache when needed.

- **New Features**
  - Server: `subjectLookupDbOnly` flag (default false) and `applySubjectLookupDbOnly` set `ctx.skipCache = true` in `handleGetOrCreateCustomer` (v1/v2) and `handleGetEntity` (v1/v2).
  - Admin UI: new “Subject lookups bypass Redis” switch in the Misc Edge Config dialog; added `MiscellaneousEdgeConfigSwitch` component.
  - Config: schema and types updated; request behavior covered by unit tests.

<sup>Written for commit 98e0f373531fe9ae1e08bbae4a8b7cc35c4860c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a global edge-config toggle for serving selected subject lookups directly from Postgres.
- **[API changes]** Adds `subjectLookupDbOnly` to the miscellaneous edge-config schema and runtime store, defaulting to disabled.
- **[Improvements]** Applies the toggle to customer get-or-create and entity-get handlers across legacy and V2 lookup paths.
- **[Improvements]** Adds an admin UI switch and JSON-editor support for controlling the toggle.
- **[Improvements]** Adds unit coverage for default, enabled, disabled, and pre-existing cache-bypass behavior.
</details>

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge with no actionable correctness or security issues identified.

The new flag is propagated through the selected handlers into the existing skipCache contract, and both legacy and current subject lookup implementations consistently bypass Redis reads and write-back when it is enabled.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/misc/miscellaneousEdgeConfig/applySubjectLookupDbOnly.ts | Introduces the helper that turns the global edge-config value into the existing request-level cache-bypass signal. |
| server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.ts | Adds the backward-compatible boolean configuration field with a disabled default. |
| server/src/internal/customers/handlers/handleGetOrCreateCustomer/handleGetOrCreateCustomer.ts | Applies DB-only lookup behavior before the legacy customer get-or-create flow. |
| server/src/internal/customers/handlers/handleGetOrCreateCustomer/handleGetOrCreateCustomerV2.ts | Applies DB-only lookup behavior before the V2 customer get-or-create flow. |
| server/src/internal/entities/handlers/handleGetEntity/handleGetEntity.ts | Applies DB-only lookup behavior before the legacy entity lookup flow. |
| server/src/internal/entities/handlers/handleGetEntity/handleGetEntityV2.ts | Applies DB-only lookup behavior before V2 entity resolution and subject hydration. |
| vite/src/views/admin/components/MiscellaneousEdgeConfigForm.tsx | Exposes the new setting through the form and JSON-editor synchronization paths while extracting a reusable switch component. |
| server/tests/unit/edge-config/subject-lookup-db-only.test.ts | Covers the flag default and its request-context mutation semantics. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Admin as Admin UI
    participant Config as Edge Config Store
    participant Handler as Customer/Entity Handler
    participant Lookup as Subject Lookup
    participant Redis
    participant Postgres

    Admin->>Config: Set subjectLookupDbOnly
    Handler->>Config: Read toggle
    alt Toggle enabled
        Handler->>Handler: "Set ctx.skipCache = true"
        Handler->>Lookup: Request subject
        Lookup->>Postgres: Read subject directly
        Postgres-->>Lookup: Subject data
    else Toggle disabled
        Handler->>Lookup: Request subject
        Lookup->>Redis: Read cached subject
        Redis-->>Lookup: Cached data or miss
        opt Cache miss
            Lookup->>Postgres: Read subject
        end
    end
    Lookup-->>Handler: API subject response
```
</details>

<sub>Reviews (1): Last reviewed commit: ["add subjectLookupDbOnly toggle to edge c..."](https://github.com/useautumn/autumn/commit/98e0f373531fe9ae1e08bbae4a8b7cc35c4860c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47959827)</sub>

<!-- /greptile_comment -->