### PR TITLE
fix(otel): restore drizzle spans on the prepared-statement path

### DIFF
--- a/server/src/db/executePrepared.ts
+++ b/server/src/db/executePrepared.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { SpanKind, SpanStatusCode, trace } from "@opentelemetry/api";
 import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 import type { Pool } from "pg";
@@ -6,6 +7,38 @@ import { logger } from "@/external/logtail/logtailUtils.js";
 import type { DrizzleCli } from "./initDrizzle.js";
 
 const dialect = new PgDialect();
+
+/**
+ * DB spans in this service come only from `instrumentDrizzleClient` in
+ * initDrizzle — there is no @opentelemetry/instrumentation-pg. Because this
+ * helper goes straight to the pg Pool (see poolOf), Drizzle never sees the call
+ * and would emit nothing, so the span is raised by hand here.
+ *
+ * It deliberately impersonates @kubiks/otel-drizzle rather than taking its own
+ * identity. Three panels in the infra-health dashboard filter on
+ * `scope.name == '@kubiks/otel-drizzle'`, and spanMetrics.ts derives the
+ * `autumn.db.query.duration_ms` histogram's `operation` label from
+ * `span.name.slice("drizzle.".length)` — so a different tracer name makes these
+ * spans invisible, and a fixed span name silently forks the metric series.
+ */
+const tracer = trace.getTracer("@kubiks/otel-drizzle");
+
+/** Leading keyword, for db.operation. */
+const operationOf = (text: string) =>
+	text.trimStart().split(/\s+/, 1)[0]?.toUpperCase() ?? "UNKNOWN";
+
+/** Matches the library: `drizzle.${leading keyword, lowercased}`. getFullSubject
+ *  compiles to text starting with WITH, so these land as `drizzle.with`. */
+const spanNameFor = (operation: string) => `drizzle.${operation.toLowerCase()}`;
+
+/** The library capped db.statement at 1000 chars plus a literal "...". Same
+ *  shape here. Do NOT trim or normalise the text — the leading whitespace is
+ *  what distinguishes the three getFullSubjectQuery variants in the dashboards. */
+const MAX_STATEMENT_CHARS = 1000;
+const truncateStatement = (text: string) =>
+	text.length > MAX_STATEMENT_CHARS
+		? `${text.slice(0, MAX_STATEMENT_CHARS)}...`
+		: text;
 
 /** Kept under PgBouncer's `max_prepared_statements` (200) so the pooler tracks
  *  every statement we mint rather than silently dropping the overflow. */
@@ -82,10 +115,43 @@ export const executePrepared = async <TRow = Record<string, unknown>>({
 		throw new Error(`[executePrepared] name collision for "${name}"`);
 	}
 
-	// Untyped on purpose: pg constrains its generic to QueryResultRow, which is
-	// narrower than the row shapes callers of db.execute() use.
-	const result = await pool.query({ name, text, values: params });
-	return result.rows as TRow[];
+	const operation = operationOf(text);
+
+	return tracer.startActiveSpan(
+		spanNameFor(operation),
+		{ kind: SpanKind.CLIENT },
+		async (span) => {
+			span.setAttributes({
+				// These three reproduce the library's attribute set exactly.
+				"db.system": "postgresql",
+				"db.operation": operation,
+				"db.statement": truncateStatement(text),
+				// Additive — the library emitted no equivalent.
+				"db.prepared_statement_name": name,
+				"autumn.db.label": label,
+			});
+
+			try {
+				// Untyped on purpose: pg constrains its generic to QueryResultRow,
+				// which is narrower than the row shapes callers of db.execute() use.
+				const result = await pool.query({ name, text, values: params });
+				span.setAttribute("db.response.returned_rows", result.rowCount ?? 0);
+				// The library set OK explicitly; leaving it UNSET flips status.code
+				// from "OK" to null in the dataset.
+				span.setStatus({ code: SpanStatusCode.OK });
+				return result.rows as TRow[];
+			} catch (error) {
+				span.recordException(error as Error);
+				span.setStatus({
+					code: SpanStatusCode.ERROR,
+					message: error instanceof Error ? error.message : String(error),
+				});
+				throw error;
+			} finally {
+				span.end();
+			}
+		},
+	);
 };
 
 /** Statement names minted by this process — for diagnostics and tests. */


### PR DESCRIPTION
## What broke

`executePrepared` bypasses Drizzle and goes straight to the `pg` Pool, so `instrumentDrizzleClient` never sees the call. Every query we moved onto prepared statements stopped emitting a span, and the `otel-drizzle-latency`, `otel-slow-drizzle` and `otel-drizzle-op-stats` panels went blank. The queries themselves got faster; the telemetry just disappeared.

## The fix

Raise the span by hand. It deliberately impersonates the library rather than taking its own identity, for two reasons that are easy to get wrong:

- **Tracer name must be `@kubiks/otel-drizzle`.** All three dashboard panels filter on `scope.name == '@kubiks/otel-drizzle'`. A tracer named `autumn.db` is invisible to every one of them.
- **Span name must be derived, not fixed.** `spanMetrics.ts:138` builds the `autumn.db.query.duration_ms` histogram's `operation` label from `span.name.slice("drizzle.".length)`. `getFullSubject` compiles to text starting with `WITH`, so it was emitting `drizzle.with` — hardcoding `drizzle.execute` wouldn't drop the metric, it would *fork* it into a new series and orphan the historical one, which is much harder to notice than a gap.

Also matches the library's 1000-char `db.statement` cap plus literal `"..."`, and sets `SpanStatusCode.OK` explicitly — without it `status.code` reads as null rather than `"OK"`.

Two attributes are additive, `db.prepared_statement_name` and `autumn.db.label`, so a span can be traced back to its call site.

## Verification

- `bun ts` clean against merged `dev`
- `experiments/verifyPreparedStatements.ts` still confirms the statement is live server-side and has reached a generic plan (`calls=24 generic=19 custom=5`)
- **After deploy, expect roughly 49k spans/hour**, p50 ~32ms, p99 ~200ms, named `drizzle.with`, split across three `db.statement` prefixes. If the panels stay empty, the tracer name didn't take.

## Note on `db.statement`

Do not trim or normalise the SQL text. The three `getFullSubjectQuery` variants are distinguished in the dashboards *only* by their leading whitespace depth, so trimming would collapse them into one indistinguishable group.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores OpenTelemetry spans for prepared-statement queries by instrumenting `executePrepared` to match `@kubiks/otel-drizzle`. This brings back the `otel-drizzle` dashboards without forking existing metrics.

- **Bug Fixes**
  - Starts client spans with tracer `@kubiks/otel-drizzle`; span name derived from the SQL operation (e.g., `drizzle.with`).
  - Sets `db.system`, `db.operation`, and `db.statement` (capped at 1000 chars + "…", keeps leading whitespace).
  - Adds `db.prepared_statement_name` and `autumn.db.label`; records returned row count.
  - Sets span status to OK/ERROR and records exceptions; always ends spans.

<sup>Written for commit a3bcb1c8c7411f60d011340371478739fd112f09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Restores observability for prepared-statement queries that bypass Drizzle instrumentation.
- **Bug fixes:** Creates `@kubiks/otel-drizzle` client spans around prepared queries with operation-derived names, compatible SQL statement truncation, explicit success/error status, exception recording, and returned-row counts.
- **Improvements:** Adds prepared-statement and call-site attributes to make manually generated database spans traceable.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable defects identified in the prepared-query tracing path.

The new span wraps the existing pool query without changing its result or exception semantics, derives the expected `drizzle.with` operation for current CTE queries, and always closes the span on success or failure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/db/executePrepared.ts | Adds a correctly scoped manual OpenTelemetry span around direct `pg` prepared-query execution, preserving query results and error propagation. |

<sub>Reviews (1): Last reviewed commit: ["fix(otel): 🐛 restore drizzle spans on t..."](https://github.com/useautumn/autumn/commit/a3bcb1c8c7411f60d011340371478739fd112f09) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47977989)</sub>

<!-- /greptile_comment -->