### PR TITLE
fix: advertise offline access to MCP OAuth clients

### DIFF
--- a/apps/leaf/src/mcp/auth/protectedResourceMetadata.ts
+++ b/apps/leaf/src/mcp/auth/protectedResourceMetadata.ts
@@ -24,7 +24,9 @@ export const getProtectedResourceMetadata = ({
 	authorization_servers: [
 		getOAuthIssuerUrl({ baseUrl: serverURL ?? DEFAULT_AUTUMN_API_URL }),
 	],
-	scopes_supported: [...DEFAULT_OAUTH_RESOURCE_SCOPES],
+	// Spec-faithful MCP clients request only the scopes advertised here. Include
+	// offline_access so one-hour access tokens can be renewed without re-consent.
+	scopes_supported: [...DEFAULT_OAUTH_RESOURCE_SCOPES, "offline_access"],
 	bearer_methods_supported: ["header"],
 	resource_name: "Autumn MCP",
 });

--- a/apps/leaf/tests/unit/mcp/oauth.test.ts
+++ b/apps/leaf/tests/unit/mcp/oauth.test.ts
@@ -26,7 +26,7 @@ describe("MCP OAuth auth resolution", () => {
 	test("advertises the Leaf OAuth scope allowlist", () => {
 		expect(
 			getProtectedResourceMetadata({ resourceUrl }).scopes_supported,
-		).toEqual([...DEFAULT_OAUTH_RESOURCE_SCOPES]);
+		).toEqual([...DEFAULT_OAUTH_RESOURCE_SCOPES, "offline_access"]);
 	});
 
 	test("returns a WWW-Authenticate challenge without a bearer token", async () => {


### PR DESCRIPTION
Spec-faithful MCP clients such as Devin derive their OAuth request scopes from Autumn’s protected-resource metadata. That metadata omitted `offline_access`, so those clients received one-hour access tokens without a refresh token.

Advertise `offline_access` alongside Autumn’s resource scopes and lock the metadata contract in the Leaf OAuth unit test.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/db5416bd-51ac-44cf-907c-8e7347f7a96b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-057" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/db5416bd-51ac-44cf-907c-8e7347f7a96b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-057&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-057"><img alt="SCO-057" src="https://capy.ai/api/badge/thread.svg?label=SCO-057"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `offline_access` in Autumn MCP OAuth protected-resource metadata so spec-compliant clients get refresh tokens instead of expiring after one hour. Also lock this contract in the Leaf OAuth unit test.

- **Bug Fixes**
  - Add `offline_access` to `scopes_supported` in the MCP protected resource metadata.
  - Update the OAuth unit test to assert `offline_access` is included.

<sup>Written for commit d4f70ef64324fbcebef3f9420a624fd13381c360. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Advertises refresh-token access in Leaf’s MCP OAuth metadata and locks the updated contract in a unit test.
- **[Bug fixes] [API changes]** Adds `offline_access` to the protected resource’s advertised OAuth scopes so compliant MCP clients can request refresh tokens.
- **[Improvements]** Updates the Leaf OAuth unit test to assert the expanded metadata scope list.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The newly advertised scope is already recognized and preserved by the OAuth server, while MCP clients are registered for refresh-token grants and the metadata contract is covered by the updated test.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/leaf/src/mcp/auth/protectedResourceMetadata.ts | Adds the supported `offline_access` protocol scope to MCP protected-resource metadata, consistent with the existing OAuth server configuration. |
| apps/leaf/tests/unit/mcp/oauth.test.ts | Updates the metadata contract assertion to cover the newly advertised scope. |

<sub>Reviews (1): Last reviewed commit: ["fix: advertise offline access to MCP cli..."](https://github.com/useautumn/autumn/commit/d4f70ef64324fbcebef3f9420a624fd13381c360) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48026949)</sub>

<!-- /greptile_comment -->