### PR TITLE
Support pooled boolean entitlements

### DIFF
--- a/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/computePooledBalanceLifecycle.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/computePooledBalanceLifecycle.ts
@@ -4,6 +4,7 @@ import {
 	type FullCustomerEntitlement,
 	getCycleEnd,
 	InternalError,
+	isBooleanEntitlement,
 	isCustomerProductFree,
 	isCustomerProductPaidRecurring,
 	isUnlimitedEntitlement,
@@ -175,6 +176,9 @@ export const computePooledBalanceLifecycle = ({
 	const unlimited = isUnlimitedEntitlement({
 		entitlement: customerEntitlement.entitlement,
 	});
+	const isBoolean = isBooleanEntitlement({
+		entitlement: customerEntitlement.entitlement,
+	});
 
 	const resetMode = getResetMode({ customerProduct, interval });
 	const { stripeSubscriptionId, customerLicenseLinkId } =
@@ -184,7 +188,7 @@ export const computePooledBalanceLifecycle = ({
 			stripeSubscriptionId: existingStripeSubscriptionId,
 		});
 
-	if (unlimited) {
+	if (unlimited || isBoolean) {
 		return {
 			resetMode,
 			resetCycleAnchor: null,

--- a/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/initCustomerEntitlementPooledIdentity.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/initCustomerEntitlementPooledIdentity.ts
@@ -31,6 +31,9 @@ export const initCustomerEntitlementPooledIdentity = ({
 		!isBooleanEntitlement({
 			entitlement: customerEntitlement.entitlement,
 		});
+	const rollover = tracksBalance
+		? customerEntitlement.entitlement.rollover
+		: null;
 
 	return {
 		internalFeatureId: customerEntitlement.internal_feature_id,
@@ -41,10 +44,6 @@ export const initCustomerEntitlementPooledIdentity = ({
 		resetMode: lifecycle.resetMode,
 		stripeSubscriptionId: lifecycle.stripeSubscriptionId,
 		customerLicenseLinkId: lifecycle.customerLicenseLinkId,
-		rolloverSignature: tracksBalance
-			? rolloverConfigToSignature({
-					rollover: customerEntitlement.entitlement.rollover,
-				})
-			: "none",
+		rolloverSignature: rolloverConfigToSignature({ rollover }),
 	};
 };

--- a/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/initCustomerEntitlementPooledIdentity.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/initCustomerEntitlementPooledIdentity.ts
@@ -1,6 +1,7 @@
 import {
 	EntInterval,
 	type FullCustomerEntitlement,
+	isBooleanEntitlement,
 	isUnlimitedEntitlement,
 	type PooledBalanceIdentity,
 	rolloverConfigToSignature,
@@ -25,6 +26,11 @@ export const initCustomerEntitlementPooledIdentity = ({
 	const unlimited = isUnlimitedEntitlement({
 		entitlement: customerEntitlement.entitlement,
 	});
+	const tracksBalance =
+		!unlimited &&
+		!isBooleanEntitlement({
+			entitlement: customerEntitlement.entitlement,
+		});
 
 	return {
 		internalFeatureId: customerEntitlement.internal_feature_id,
@@ -35,10 +41,10 @@ export const initCustomerEntitlementPooledIdentity = ({
 		resetMode: lifecycle.resetMode,
 		stripeSubscriptionId: lifecycle.stripeSubscriptionId,
 		customerLicenseLinkId: lifecycle.customerLicenseLinkId,
-		rolloverSignature: unlimited
-			? "none"
-			: rolloverConfigToSignature({
+		rolloverSignature: tracksBalance
+			? rolloverConfigToSignature({
 					rollover: customerEntitlement.entitlement.rollover,
-				}),
+				})
+			: "none",
 	};
 };

--- a/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/initPooledBalanceGraph.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/initPooledBalanceGraph.ts
@@ -2,12 +2,35 @@ import {
 	AllowanceType,
 	type FullCusProduct,
 	type FullCustomerEntitlement,
+	isBooleanEntitlement,
 	type PooledBalanceIdentity,
 	PooledBalanceResetMode,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { generateId } from "@/utils/genUtils";
 import type { MutablePooledCustomerEntitlement } from "../types/pooledBalanceComputeTypes";
+
+const getPooledEntitlementConfig = ({
+	isBoolean,
+	unlimited,
+	rollover,
+}: {
+	isBoolean: boolean;
+	unlimited: boolean;
+	rollover: FullCustomerEntitlement["entitlement"]["rollover"];
+}) => {
+	if (isBoolean) {
+		return { allowance: null, allowance_type: null, rollover: null };
+	}
+	if (unlimited) {
+		return {
+			allowance: null,
+			allowance_type: AllowanceType.Unlimited,
+			rollover: null,
+		};
+	}
+	return { allowance: 0, allowance_type: AllowanceType.Fixed, rollover };
+};
 
 export const initPooledBalanceGraph = ({
 	ctx,
@@ -31,18 +54,16 @@ export const initPooledBalanceGraph = ({
 	const entitlementId = generateId("ent");
 	const customerEntitlementId = generateId("cus_ent");
 	const pooledBalanceId = generateId("pool");
-	const pooledEntitlementConfig = identity.unlimited
-		? {
-				allowance: null,
-				allowance_type: AllowanceType.Unlimited,
-				rollover: null,
-			}
-		: {
-				allowance: 0,
-				allowance_type: AllowanceType.Fixed,
-				rollover: contributionCustomerEntitlement.entitlement.rollover,
-			};
+	const isBoolean = isBooleanEntitlement({
+		entitlement: contributionCustomerEntitlement.entitlement,
+	});
+	const pooledEntitlementConfig = getPooledEntitlementConfig({
+		isBoolean,
+		unlimited: identity.unlimited,
+		rollover: contributionCustomerEntitlement.entitlement.rollover,
+	});
 	const resetsViaInvoice =
+		!isBoolean &&
 		!identity.unlimited &&
 		identity.resetMode === PooledBalanceResetMode.Subscription;
 

--- a/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/upsertPooledBalance.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/upsertPooledBalance.ts
@@ -2,6 +2,7 @@ import {
 	addSafe,
 	type FullCusProduct,
 	type FullCustomerEntitlement,
+	isBooleanEntitlement,
 	type PooledBalanceIdentity,
 	pooledBalanceIdentityToKey,
 } from "@autumn/shared";
@@ -41,11 +42,17 @@ export const upsertPooledBalance = ({
 		computeContext.pooledCustomerEntitlementByIdentity.get(
 			pooledBalanceIdentityToKey({ identity }),
 		);
+	const tracksBalance =
+		!identity.unlimited &&
+		!isBooleanEntitlement({
+			entitlement: contributionCustomerEntitlement.entitlement,
+		});
 
-	let balanceDelta = contributionCustomerEntitlement.balance ?? 0;
-	if (identity.unlimited) {
-		balanceDelta = 0;
-	} else if (
+	let balanceDelta = tracksBalance
+		? (contributionCustomerEntitlement.balance ?? 0)
+		: 0;
+	if (
+		tracksBalance &&
 		existingPooledCustomerEntitlement &&
 		computeContext.pooledBalanceIdsWithRemovedContributions.has(
 			existingPooledCustomerEntitlement.pooled_balance.id,
@@ -70,7 +77,7 @@ export const upsertPooledBalance = ({
 			computeContext,
 			pooledCustomerEntitlement: insertedPooledCustomerEntitlement,
 		});
-		if (!identity.unlimited) {
+		if (tracksBalance) {
 			carrySourceRolloversToPool({
 				pooledBalancePlan: computeContext.plan,
 				contributionCustomerEntitlement,
@@ -97,7 +104,7 @@ export const upsertPooledBalance = ({
 			}),
 		});
 	}
-	if (!identity.unlimited) {
+	if (tracksBalance) {
 		carrySourceRolloversToPool({
 			pooledBalancePlan: computeContext.plan,
 			contributionCustomerEntitlement,

--- a/server/src/internal/customers/repos/getFullSubject/subjectQueryRowToNormalized.ts
+++ b/server/src/internal/customers/repos/getFullSubject/subjectQueryRowToNormalized.ts
@@ -187,6 +187,9 @@ export const subjectQueryRowToNormalized = ({
 				internalEntityId: customerEntitlement.internal_entity_id,
 				expiresAt: customerEntitlement.expires_at,
 				externalId: customerEntitlement.external_id,
+				isPooledBalance: customerEntitlement.is_pooled_balance,
+				pooledBalanceId: customerEntitlement.pooled_balance_id,
+				pooledBalance: customerEntitlement.pooled_balance ?? undefined,
 			};
 		} else {
 			const customerProduct = customerEntitlement.customer_product_id

--- a/server/src/internal/customers/repos/getFullSubject/subjectQueryRowToNormalized.ts
+++ b/server/src/internal/customers/repos/getFullSubject/subjectQueryRowToNormalized.ts
@@ -187,9 +187,6 @@ export const subjectQueryRowToNormalized = ({
 				internalEntityId: customerEntitlement.internal_entity_id,
 				expiresAt: customerEntitlement.expires_at,
 				externalId: customerEntitlement.external_id,
-				isPooledBalance: customerEntitlement.is_pooled_balance,
-				pooledBalanceId: customerEntitlement.pooled_balance_id,
-				pooledBalance: customerEntitlement.pooled_balance ?? undefined,
 			};
 		} else {
 			const customerProduct = customerEntitlement.customer_product_id

--- a/server/src/internal/products/product-items/validateProductItems.ts
+++ b/server/src/internal/products/product-items/validateProductItems.ts
@@ -49,9 +49,29 @@ const validateProductItem = ({
 		});
 	}
 
-	if (item.pooled && feature?.type === FeatureType.Boolean) {
+	if (
+		item.pooled &&
+		feature?.type === FeatureType.Boolean &&
+		(isFeaturePriceItem(item) ||
+			item.included_usage === Infinite ||
+			(typeof item.included_usage === "number" && item.included_usage !== 0) ||
+			notNullish(item.interval) ||
+			notNullish(item.config?.rollover))
+	) {
 		throw new RecaseError({
-			message: "Pooled items are only supported for metered features",
+			message: "Pooled boolean items cannot include balance or pricing fields",
+			code: ErrCode.InvalidProductItem,
+			statusCode: StatusCodes.BAD_REQUEST,
+		});
+	}
+
+	if (
+		item.pooled &&
+		isFeaturePriceItem(item) &&
+		item.included_usage === Infinite
+	) {
+		throw new RecaseError({
+			message: "Pooled unlimited items cannot include pricing",
 			code: ErrCode.InvalidProductItem,
 			statusCode: StatusCodes.BAD_REQUEST,
 		});

--- a/server/src/internal/products/product-items/validateProductItems.ts
+++ b/server/src/internal/products/product-items/validateProductItems.ts
@@ -49,15 +49,15 @@ const validateProductItem = ({
 		});
 	}
 
-	if (
-		item.pooled &&
-		feature?.type === FeatureType.Boolean &&
-		(isFeaturePriceItem(item) ||
-			item.included_usage === Infinite ||
-			(typeof item.included_usage === "number" && item.included_usage !== 0) ||
-			notNullish(item.interval) ||
-			notNullish(item.config?.rollover))
-	) {
+	const isPooledBooleanItem =
+		item.pooled && feature?.type === FeatureType.Boolean;
+	const hasUnsupportedPooledBooleanFields =
+		isFeaturePriceItem(item) ||
+		(notNullish(item.included_usage) && item.included_usage !== 0) ||
+		notNullish(item.interval) ||
+		notNullish(item.config?.rollover);
+
+	if (isPooledBooleanItem && hasUnsupportedPooledBooleanFields) {
 		throw new RecaseError({
 			message: "Pooled boolean items cannot include balance or pricing fields",
 			code: ErrCode.InvalidProductItem,

--- a/server/tests/integration/billing/pooled-balances/boolean/pooled-balance-boolean.test.ts
+++ b/server/tests/integration/billing/pooled-balances/boolean/pooled-balance-boolean.test.ts
@@ -1,0 +1,333 @@
+// Pooled Boolean grants form one customer flag backed by zero-valued source contributions.
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	type ApiEntityV2,
+	type CheckResponseV3,
+	EntInterval,
+	entitlements,
+	PooledBalanceResetMode,
+	type UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { expectNoStripeSubscription } from "@tests/integration/billing/utils/expectNoStripeSubscription.js";
+import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect/index.js";
+import { expectFlagCorrect } from "@tests/integration/utils/expectFlagCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import { eq } from "drizzle-orm";
+import { expectPooledBalanceCorrect } from "../utils/expectPooledBalanceCorrect.js";
+import {
+	getPooledBalanceDbState,
+	getPooledSourceCustomerProduct,
+} from "../utils/getPooledBalanceDbState.js";
+
+const pooledDashboardItem = () => ({
+	...items.dashboard(),
+	pooled: true,
+});
+
+const booleanPoolLifecycle = {
+	interval: EntInterval.Lifetime,
+	nextResetAt: null,
+	resetCycleAnchor: null,
+	resetMode: PooledBalanceResetMode.Lifetime,
+	stripeSubscriptionId: null,
+} as const;
+
+test.concurrent(
+	"pooled boolean sources coalesce into one flag for every entity",
+	async () => {
+		const customerId = "pooled-boolean-coalesce";
+		const plan = products.base({
+			id: "pooled-boolean-coalesce-plan",
+			items: [pooledDashboardItem()],
+		});
+		const { autumnV2_2, ctx, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 3, featureId: TestFeature.Users }),
+				s.products({ list: [plan] }),
+			],
+			actions: [
+				s.billing.attach({ productId: plan.id, entityIndex: 0 }),
+				s.billing.attach({ productId: plan.id, entityIndex: 1 }),
+			],
+		});
+
+		const state = await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			pool: {
+				balance: 0,
+				adjustment: 0,
+				granted: 0,
+				unlimited: false,
+				customerEntitlementUnlimited: null,
+				...booleanPoolLifecycle,
+			},
+			contributions: {
+				count: 2,
+				currentContribution: 0,
+				nextCycleContribution: 0,
+			},
+			sources: { count: 2, balance: 0, adjustment: 0 },
+		});
+		const pooledCustomerEntitlement = state.poolCustomerEntitlements[0];
+		const pooledEntitlement = await ctx.db.query.entitlements.findFirst({
+			where: eq(entitlements.id, pooledCustomerEntitlement.entitlement_id),
+		});
+		expect(pooledEntitlement).toMatchObject({
+			allowance: null,
+			allowance_type: null,
+			interval: null,
+			rollover: null,
+			pooled: true,
+		});
+
+		const uncachedCustomer = await autumnV2_2.customers.get<ApiCustomerV5>(
+			customerId,
+			{
+				skip_cache: "true",
+			},
+		);
+		expectFlagCorrect({
+			customer: uncachedCustomer,
+			featureId: TestFeature.Dashboard,
+			planId: null,
+		});
+		expect(uncachedCustomer.balances[TestFeature.Dashboard]).toBeUndefined();
+
+		const cachedCustomer =
+			await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		expectFlagCorrect({
+			customer: cachedCustomer,
+			featureId: TestFeature.Dashboard,
+			planId: null,
+		});
+
+		for (const entity of entities) {
+			const entityResponse = await autumnV2_2.entities.get<ApiEntityV2>(
+				customerId,
+				entity.id,
+			);
+			expectFlagCorrect({
+				customer: entityResponse,
+				featureId: TestFeature.Dashboard,
+				planId: null,
+			});
+		}
+
+		const check = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			entity_id: entities[2].id,
+			feature_id: TestFeature.Dashboard,
+		});
+		expect(check).toMatchObject({
+			allowed: true,
+			balance: null,
+			flag: {
+				feature_id: TestFeature.Dashboard,
+				plan_id: null,
+			},
+		});
+
+		await expectNoStripeSubscription({
+			db: ctx.db,
+			customerId,
+			org: ctx.org,
+			env: ctx.env,
+		});
+	},
+);
+
+test.concurrent(
+	"pooled boolean flag expires only after its final source is removed",
+	async () => {
+		const customerId = "pooled-boolean-expiry";
+		const plan = products.base({
+			id: "pooled-boolean-expiry-plan",
+			items: [pooledDashboardItem()],
+		});
+		const { autumnV2_2, ctx, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [plan] }),
+			],
+			actions: [
+				s.billing.attach({ productId: plan.id, entityIndex: 0 }),
+				s.billing.attach({ productId: plan.id, entityIndex: 1 }),
+			],
+		});
+		const initial = await getPooledBalanceDbState({ db: ctx.db, customerId });
+		const firstSource = getPooledSourceCustomerProduct({
+			state: initial,
+			productId: plan.id,
+			entityId: entities[0].id,
+		});
+		const secondSource = getPooledSourceCustomerProduct({
+			state: initial,
+			productId: plan.id,
+			entityId: entities[1].id,
+		});
+
+		await autumnV2_2.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			customer_product_id: firstSource.id,
+			entity_id: entities[0].id,
+			cancel_action: "cancel_immediately",
+		});
+
+		await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			pool: {
+				balance: 0,
+				adjustment: 0,
+				granted: 0,
+				unlimited: false,
+				customerEntitlementUnlimited: null,
+				...booleanPoolLifecycle,
+			},
+			contributions: { count: 1 },
+			sources: { count: 2, balance: 0, adjustment: 0 },
+		});
+		const afterFirstRemoval = await autumnV2_2.customers.get<ApiCustomerV5>(
+			customerId,
+			{
+				skip_cache: "true",
+			},
+		);
+		expectFlagCorrect({
+			customer: afterFirstRemoval,
+			featureId: TestFeature.Dashboard,
+			planId: null,
+		});
+
+		await autumnV2_2.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			customer_product_id: secondSource.id,
+			entity_id: entities[1].id,
+			cancel_action: "cancel_immediately",
+		});
+
+		const finalState = await getPooledBalanceDbState({
+			db: ctx.db,
+			customerId,
+		});
+		expect(finalState.contributions).toHaveLength(0);
+		expect(finalState.poolCustomerEntitlements[0].expires_at).not.toBeNull();
+		expect(finalState.pools[0].expires_at).not.toBeNull();
+
+		const afterFinalRemoval = await autumnV2_2.customers.get<ApiCustomerV5>(
+			customerId,
+			{
+				skip_cache: "true",
+			},
+		);
+		expectFlagCorrect({
+			customer: afterFinalRemoval,
+			featureId: TestFeature.Dashboard,
+			present: false,
+		});
+		const check = await autumnV2_2.check<CheckResponseV3>({
+			customer_id: customerId,
+			feature_id: TestFeature.Dashboard,
+		});
+		expect(check.allowed).toBe(false);
+	},
+);
+
+test.concurrent(
+	"paid plans can grant an unpriced pooled boolean feature",
+	async () => {
+		const customerId = "pooled-boolean-paid";
+		const plan = products.pro({
+			id: "pooled-boolean-paid-plan",
+			items: [pooledDashboardItem()],
+		});
+		const { autumnV2_2, ctx, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [plan] }),
+			],
+			actions: [s.billing.attach({ productId: plan.id, entityIndex: 0 })],
+		});
+
+		await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			pool: {
+				balance: 0,
+				adjustment: 0,
+				granted: 0,
+				unlimited: false,
+				customerEntitlementUnlimited: null,
+				...booleanPoolLifecycle,
+			},
+			contributions: {
+				count: 1,
+				currentContribution: 0,
+				nextCycleContribution: 0,
+			},
+			sources: { count: 1, balance: 0, adjustment: 0 },
+		});
+		const entity = await autumnV2_2.entities.get<ApiEntityV2>(
+			customerId,
+			entities[0].id,
+			{ skip_cache: "true" },
+		);
+		expectFlagCorrect({
+			customer: entity,
+			featureId: TestFeature.Dashboard,
+			planId: null,
+		});
+		await expectStripeSubscriptionCorrect({ ctx, customerId });
+	},
+);
+
+test.concurrent(
+	"disable_pooled_balance hides a pooled boolean flag from entity scope",
+	async () => {
+		const customerId = "pooled-boolean-disabled";
+		const plan = products.base({
+			id: "pooled-boolean-disabled-plan",
+			items: [pooledDashboardItem()],
+		});
+		const { autumnV2_2, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({
+					testClock: false,
+					data: { config: { disable_pooled_balance: true } },
+				}),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [plan] }),
+			],
+			actions: [s.billing.attach({ productId: plan.id, entityIndex: 0 })],
+		});
+
+		const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		expectFlagCorrect({
+			customer,
+			featureId: TestFeature.Dashboard,
+			planId: null,
+		});
+		const entity = await autumnV2_2.entities.get<ApiEntityV2>(
+			customerId,
+			entities[0].id,
+		);
+		expectFlagCorrect({
+			customer: entity,
+			featureId: TestFeature.Dashboard,
+			present: false,
+		});
+	},
+);

--- a/server/tests/integration/billing/pooled-balances/boolean/pooled-balance-boolean.test.ts
+++ b/server/tests/integration/billing/pooled-balances/boolean/pooled-balance-boolean.test.ts
@@ -45,7 +45,7 @@ test.concurrent(
 			id: "pooled-boolean-coalesce-plan",
 			items: [pooledDashboardItem()],
 		});
-		const { autumnV2_2, ctx, entities } = await initScenario({
+		const { autumnV2_2, autumnV2_3, ctx, entities } = await initScenario({
 			customerId,
 			setup: [
 				s.customer({ testClock: false }),
@@ -77,6 +77,7 @@ test.concurrent(
 			sources: { count: 2, balance: 0, adjustment: 0 },
 		});
 		const pooledCustomerEntitlement = state.poolCustomerEntitlements[0];
+		expect(state.pools[0]?.rollover_signature).toBe("none");
 		const pooledEntitlement = await ctx.db.query.entitlements.findFirst({
 			where: eq(entitlements.id, pooledCustomerEntitlement.entitlement_id),
 		});
@@ -102,7 +103,7 @@ test.concurrent(
 		expect(uncachedCustomer.balances[TestFeature.Dashboard]).toBeUndefined();
 
 		const cachedCustomer =
-			await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+			await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
 		expectFlagCorrect({
 			customer: cachedCustomer,
 			featureId: TestFeature.Dashboard,

--- a/server/tests/integration/billing/pooled-balances/utils/expectPooledBalanceCorrect.ts
+++ b/server/tests/integration/billing/pooled-balances/utils/expectPooledBalanceCorrect.ts
@@ -10,6 +10,7 @@ type PoolExpectation = {
 	cacheVersion?: number;
 	granted: number;
 	unlimited?: boolean;
+	customerEntitlementUnlimited?: boolean | null;
 	interval: EntInterval;
 	nextResetAt: "present" | null;
 	resetCycleAnchor: "present" | null;
@@ -66,9 +67,13 @@ export const expectPooledBalanceCorrect = async ({
 	expect(state.pools).toHaveLength(poolCount);
 	expect(state.poolCustomerEntitlements).toHaveLength(poolCount);
 	for (const pooledCustomerEntitlement of state.poolCustomerEntitlements) {
+		const customerEntitlementUnlimited =
+			pool.customerEntitlementUnlimited === undefined
+				? (pool.unlimited ?? false)
+				: pool.customerEntitlementUnlimited;
 		expect(pooledCustomerEntitlement).toMatchObject({
 			is_pooled_balance: true,
-			unlimited: pool.unlimited ?? false,
+			unlimited: customerEntitlementUnlimited,
 			customer_product_id: null,
 			balance: pool.balance,
 			adjustment: pool.adjustment,

--- a/server/tests/integration/crud/plans/create/pooled-item-validation.test.ts
+++ b/server/tests/integration/crud/plans/create/pooled-item-validation.test.ts
@@ -1,6 +1,8 @@
 import { test } from "bun:test";
 import {
 	ApiVersion,
+	BillingInterval,
+	BillingMethod,
 	type CreatePlanParamsV2Input,
 	ErrCode,
 } from "@autumn/shared";
@@ -35,11 +37,51 @@ const expectPooledItemRejected = async ({
 };
 
 test.concurrent(
-	"pooled item validation: rejects boolean features",
+	"pooled item validation: accepts unpriced boolean features",
+	async () => {
+		const planId = `pooled-boolean-${crypto.randomUUID()}`;
+		await autumnRpc.plans.create<unknown, CreatePlanParamsV2Input>({
+			plan_id: planId,
+			name: planId,
+			group: `group-${planId}`,
+			auto_enable: false,
+			items: [{ ...itemsV2.dashboard(), pooled: true }],
+		});
+	},
+);
+
+test.concurrent(
+	"pooled item validation: rejects priced boolean features",
 	async () => {
 		await expectPooledItemRejected({
-			planId: `pooled-boolean-${crypto.randomUUID()}`,
-			item: { ...itemsV2.dashboard(), pooled: true },
+			planId: `pooled-priced-boolean-${crypto.randomUUID()}`,
+			item: {
+				...itemsV2.dashboard(),
+				pooled: true,
+				price: {
+					amount: 10,
+					interval: BillingInterval.Month,
+					billing_method: BillingMethod.Prepaid,
+				},
+			},
+			errMessage:
+				"Pooled boolean items cannot include balance or pricing fields",
+		});
+	},
+);
+
+test.concurrent(
+	"pooled item validation: rejects boolean balance configuration",
+	async () => {
+		await expectPooledItemRejected({
+			planId: `pooled-configured-boolean-${crypto.randomUUID()}`,
+			item: {
+				...itemsV2.dashboard(),
+				pooled: true,
+				included: 1,
+			},
+			errMessage:
+				"Pooled boolean items cannot include balance or pricing fields",
 		});
 	},
 );
@@ -60,6 +102,26 @@ test.concurrent(
 					pooled: true,
 				},
 			],
+		});
+	},
+);
+
+test.concurrent(
+	"pooled item validation: rejects priced unlimited features",
+	async () => {
+		await expectPooledItemRejected({
+			planId: `pooled-priced-unlimited-${crypto.randomUUID()}`,
+			item: {
+				feature_id: TestFeature.Messages,
+				unlimited: true,
+				pooled: true,
+				price: {
+					amount: 10,
+					interval: BillingInterval.Month,
+					billing_method: BillingMethod.Prepaid,
+				},
+			},
+			errMessage: "Pooled unlimited items cannot include pricing",
 		});
 	},
 );

--- a/server/tests/unit/full-subject-cache/full-subject-cache-model.test.ts
+++ b/server/tests/unit/full-subject-cache/full-subject-cache-model.test.ts
@@ -2,12 +2,10 @@ import { describe, expect, test } from "bun:test";
 import {
 	AppEnv,
 	BillingInterval,
-	EntInterval,
 	FeatureType,
 	isCustomerProductOneOff,
 	type NormalizedFullSubject,
 	normalizedToFullSubject,
-	PooledBalanceResetMode,
 	PriceType,
 	SubjectType,
 } from "@autumn/shared";
@@ -287,12 +285,13 @@ describe("fullSubject cache model", () => {
 		).toEqual(["cus_ent_pooled"]);
 	});
 
-	test("preserves pooled boolean metadata across cache roundtrip", () => {
+	test("reconstructs pooled boolean without caching pool metadata", () => {
 		const normalized = buildNormalized();
 		const entitlement = {
 			...normalized.customer_entitlements[0].entitlement,
 			id: "ent_boolean",
 			internal_product_id: null,
+			is_custom: true,
 			allowance: null,
 			allowance_type: null,
 			interval: null,
@@ -317,29 +316,6 @@ describe("fullSubject cache model", () => {
 				internalEntityId: null,
 				expiresAt: null,
 				externalId: null,
-				isPooledBalance: true,
-				pooledBalanceId: "pool_boolean",
-				pooledBalance: {
-					id: "pool_boolean",
-					org_id: "org_1",
-					env: AppEnv.Live,
-					internal_customer_id: "cus_int_1",
-					internal_feature_id: "feat_boolean",
-					unlimited: false,
-					granted: 0,
-					interval: EntInterval.Lifetime,
-					interval_count: 1,
-					reset_cycle_anchor: null,
-					reset_mode: PooledBalanceResetMode.Lifetime,
-					stripe_subscription_id: null,
-					customer_license_link_id: null,
-					rollover_signature: "none",
-					customer_entitlement_id: "cus_ent_boolean",
-					last_applied_reset_at: null,
-					expires_at: null,
-					created_at: 1,
-					updated_at: 1,
-				},
 			},
 		};
 
@@ -347,6 +323,7 @@ describe("fullSubject cache model", () => {
 			normalized,
 			subjectViewEpoch: 0,
 		});
+		expect(cached.flags.dashboard).toEqual(normalized.flags.dashboard);
 		const reconstructed = cachedFullSubjectToNormalized({
 			cached,
 			customerEntitlements: [],
@@ -358,9 +335,10 @@ describe("fullSubject cache model", () => {
 		expect(fullSubject.pooled_customer_entitlements?.[0]).toMatchObject({
 			id: "cus_ent_boolean",
 			is_pooled_balance: true,
-			pooled_balance_id: "pool_boolean",
-			pooled_balance: { id: "pool_boolean" },
 		});
+		expect(
+			fullSubject.pooled_customer_entitlements?.[0]?.pooled_balance,
+		).toBeUndefined();
 	});
 
 	test("preserves fixed prices without entitlements across cache roundtrip", () => {

--- a/server/tests/unit/full-subject-cache/full-subject-cache-model.test.ts
+++ b/server/tests/unit/full-subject-cache/full-subject-cache-model.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, test } from "bun:test";
 import {
 	AppEnv,
 	BillingInterval,
+	EntInterval,
+	FeatureType,
 	isCustomerProductOneOff,
 	type NormalizedFullSubject,
 	normalizedToFullSubject,
+	PooledBalanceResetMode,
 	PriceType,
 	SubjectType,
 } from "@autumn/shared";
@@ -282,6 +285,82 @@ describe("fullSubject cache model", () => {
 				(customerEntitlement) => customerEntitlement.id,
 			),
 		).toEqual(["cus_ent_pooled"]);
+	});
+
+	test("preserves pooled boolean metadata across cache roundtrip", () => {
+		const normalized = buildNormalized();
+		const entitlement = {
+			...normalized.customer_entitlements[0].entitlement,
+			id: "ent_boolean",
+			internal_product_id: null,
+			allowance: null,
+			allowance_type: null,
+			interval: null,
+			pooled: true,
+			feature: {
+				...normalized.customer_entitlements[0].entitlement.feature,
+				id: "dashboard",
+				internal_id: "feat_boolean",
+				type: FeatureType.Boolean,
+			},
+		};
+		normalized.customer_entitlements = [];
+		normalized.entitlements = [entitlement];
+		normalized.flags = {
+			dashboard: {
+				featureId: "dashboard",
+				internalFeatureId: "feat_boolean",
+				entitlementId: entitlement.id,
+				customerEntitlementId: "cus_ent_boolean",
+				customerProductId: null,
+				internalCustomerId: "cus_int_1",
+				internalEntityId: null,
+				expiresAt: null,
+				externalId: null,
+				isPooledBalance: true,
+				pooledBalanceId: "pool_boolean",
+				pooledBalance: {
+					id: "pool_boolean",
+					org_id: "org_1",
+					env: AppEnv.Live,
+					internal_customer_id: "cus_int_1",
+					internal_feature_id: "feat_boolean",
+					unlimited: false,
+					granted: 0,
+					interval: EntInterval.Lifetime,
+					interval_count: 1,
+					reset_cycle_anchor: null,
+					reset_mode: PooledBalanceResetMode.Lifetime,
+					stripe_subscription_id: null,
+					customer_license_link_id: null,
+					rollover_signature: "none",
+					customer_entitlement_id: "cus_ent_boolean",
+					last_applied_reset_at: null,
+					expires_at: null,
+					created_at: 1,
+					updated_at: 1,
+				},
+			},
+		};
+
+		const cached = normalizedToCachedFullSubject({
+			normalized,
+			subjectViewEpoch: 0,
+		});
+		const reconstructed = cachedFullSubjectToNormalized({
+			cached,
+			customerEntitlements: [],
+		});
+		const fullSubject = normalizedToFullSubject({ normalized: reconstructed });
+
+		expect(fullSubject.extra_customer_entitlements).toEqual([]);
+		expect(fullSubject.pooled_customer_entitlements).toHaveLength(1);
+		expect(fullSubject.pooled_customer_entitlements?.[0]).toMatchObject({
+			id: "cus_ent_boolean",
+			is_pooled_balance: true,
+			pooled_balance_id: "pool_boolean",
+			pooled_balance: { id: "pool_boolean" },
+		});
 	});
 
 	test("preserves fixed prices without entitlements across cache roundtrip", () => {

--- a/shared/models/cusModels/fullSubject/normalizedFullSubjectModel.ts
+++ b/shared/models/cusModels/fullSubject/normalizedFullSubjectModel.ts
@@ -47,25 +47,9 @@ export const SubjectFlagSchema = z.object({
 	internalEntityId: z.string().nullable(),
 	expiresAt: z.number().nullable(),
 	externalId: z.string().nullable(),
-	isPooledBalance: z.boolean().optional(),
-	pooledBalanceId: z.string().nullable().optional(),
-	pooledBalance: z.custom<DbPooledBalance>().optional(),
 });
 
-export type SubjectFlag = {
-	featureId: string;
-	internalFeatureId: string;
-	entitlementId: string;
-	customerEntitlementId: string;
-	customerProductId: string | null;
-	internalCustomerId: string;
-	internalEntityId: string | null;
-	expiresAt: number | null;
-	externalId: string | null;
-	isPooledBalance?: boolean;
-	pooledBalanceId?: string | null;
-	pooledBalance?: DbPooledBalance;
-};
+export type SubjectFlag = z.infer<typeof SubjectFlagSchema>;
 
 /**
  * Schema mirror of `SubjectBalance`. Extends `FullCustomerEntitlementSchema`

--- a/shared/models/cusModels/fullSubject/normalizedFullSubjectModel.ts
+++ b/shared/models/cusModels/fullSubject/normalizedFullSubjectModel.ts
@@ -47,6 +47,9 @@ export const SubjectFlagSchema = z.object({
 	internalEntityId: z.string().nullable(),
 	expiresAt: z.number().nullable(),
 	externalId: z.string().nullable(),
+	isPooledBalance: z.boolean().optional(),
+	pooledBalanceId: z.string().nullable().optional(),
+	pooledBalance: z.custom<DbPooledBalance>().optional(),
 });
 
 export type SubjectFlag = {
@@ -59,6 +62,9 @@ export type SubjectFlag = {
 	internalEntityId: string | null;
 	expiresAt: number | null;
 	externalId: string | null;
+	isPooledBalance?: boolean;
+	pooledBalanceId?: string | null;
+	pooledBalance?: DbPooledBalance;
 };
 
 /**

--- a/shared/utils/fullSubjectUtils/normalizedToFullSubject.ts
+++ b/shared/utils/fullSubjectUtils/normalizedToFullSubject.ts
@@ -98,6 +98,11 @@ const subjectFlagToFullCustomerEntitlement = ({
 	internalCustomerId: string;
 	internalEntityId: string | null;
 }): FullCustomerEntitlement => {
+	const isPooledBalance =
+		fullEntitlement.pooled === true &&
+		fullEntitlement.internal_product_id === null &&
+		subjectFlag.customerProductId === null;
+
 	return {
 		id: subjectFlag.customerEntitlementId,
 		internal_customer_id: internalCustomerId,
@@ -112,9 +117,7 @@ const subjectFlagToFullCustomerEntitlement = ({
 		additional_balance: 0,
 		usage_allowed: null,
 		separate_interval: false,
-		is_pooled_balance: subjectFlag.isPooledBalance,
-		pooled_balance_id: subjectFlag.pooledBalanceId,
-		pooled_balance: subjectFlag.pooledBalance,
+		is_pooled_balance: isPooledBalance,
 		reset_cycle_anchor: null,
 		next_reset_at: null,
 		adjustment: 0,

--- a/shared/utils/fullSubjectUtils/normalizedToFullSubject.ts
+++ b/shared/utils/fullSubjectUtils/normalizedToFullSubject.ts
@@ -112,6 +112,9 @@ const subjectFlagToFullCustomerEntitlement = ({
 		additional_balance: 0,
 		usage_allowed: null,
 		separate_interval: false,
+		is_pooled_balance: subjectFlag.isPooledBalance,
+		pooled_balance_id: subjectFlag.pooledBalanceId,
+		pooled_balance: subjectFlag.pooledBalance,
 		reset_cycle_anchor: null,
 		next_reset_at: null,
 		adjustment: 0,
@@ -291,6 +294,7 @@ export const normalizedToFullSubject = ({
 		FullCustomerEntitlement[]
 	>();
 	const extraBooleanCes: FullCustomerEntitlement[] = [];
+	const pooledBooleanCes: FullCustomerEntitlement[] = [];
 
 	for (const flag of Object.values(flags)) {
 		const entitlement = entitlementsById.get(flag.entitlementId);
@@ -308,7 +312,11 @@ export const normalizedToFullSubject = ({
 		});
 
 		if (!flag.customerProductId) {
-			extraBooleanCes.push(fullCustomerEntitlement);
+			if (fullCustomerEntitlement.is_pooled_balance) {
+				pooledBooleanCes.push(fullCustomerEntitlement);
+			} else {
+				extraBooleanCes.push(fullCustomerEntitlement);
+			}
 		} else {
 			const existing =
 				booleanCesByCustomerProductId.get(flag.customerProductId) ?? [];
@@ -422,7 +430,7 @@ export const normalizedToFullSubject = ({
 		customer: normalized.customer,
 		customer_products: customerProducts,
 		extra_customer_entitlements: extraCustomerEntitlements,
-		pooled_customer_entitlements: pooledMeteredCes,
+		pooled_customer_entitlements: [...pooledMeteredCes, ...pooledBooleanCes],
 		// Normalized carries ALL scopes (the balance-hash field must stay
 		// complete); the subject view narrows to the rows that can gate it --
 		// an entity sees its own rows plus the inheritable customer-scope ones.


### PR DESCRIPTION
## Summary

- model pooled Boolean entitlements as customer-level flags with zero contributions
- infer pooled Boolean identity from catalog entitlement metadata already present in the subject cache
- add no pooled fields or balance rows to cached Boolean flags
- handle attach, removal, disable, and paid-plan lifecycle behavior
- reject unsupported pricing and balance configuration for pooled Boolean items, including priced unlimited pooled items

## Tests

- `bun test server/tests/integration/billing/pooled-balances/boolean/pooled-balance-boolean.test.ts --timeout 120000`
- `bun test server/tests/integration/crud/plans/create/pooled-item-validation.test.ts --timeout 120000`
- `bun test server/tests/unit/full-subject-cache/full-subject-cache-model.test.ts --timeout 120000`
- `bun test server/tests/integration/billing/attach/scheduled-switch/scheduled-switch-entity-boolean-flags.test.ts --timeout 120000`
- pooled unlimited, finite attach, and cancel regression suites
- `bun ts`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Support for pooled Boolean entitlements is added across pooled-balance computation, validation, and cached full-subject reconstruction.
- **[API changes] [Improvements]** Permit unpriced pooled Boolean plan items while rejecting unsupported pricing and balance configuration.
- **[Improvements]** Represent pooled Boolean grants as customer-level flags with zero-valued contributions and no balance, rollover, or invoice-reset metadata.
- **[Bug fixes]** Reconstruct cached pooled Boolean flags in `pooled_customer_entitlements` without adding pooled-balance fields to the cached flag shape.
- **[Improvements]** Add coverage for attach, removal, disabled pooling, paid-plan behavior, validation, and cache reconstruction.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/computePooledBalanceLifecycle.ts | Adds no-reset lifecycle handling for pooled Boolean entitlements. |
| server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/initCustomerEntitlementPooledIdentity.ts | Normalizes Boolean pool identity to omit rollover semantics. |
| server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/initPooledBalanceGraph.ts | Creates Boolean pooled entitlements without allowance or rollover fields. |
| server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/upsertPooledBalance.ts | Keeps Boolean pool contributions balance-neutral and skips rollover transfer. |
| server/src/internal/products/product-items/validateProductItems.ts | Allows unpriced pooled Boolean items and rejects unsupported pooled pricing or balance configurations. |
| shared/utils/fullSubjectUtils/normalizedToFullSubject.ts | Reconstructs cached pooled Boolean flags into the pooled-entitlement collection. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Pooled Boolean source entitlement] --> B[Derive lifetime identity]
  B --> C[Create or reuse customer-level pool]
  C --> D[Record zero-valued contribution]
  D --> E[Expose Boolean flag]
  E --> F[Cache flag without balance metadata]
  F --> G[Reconstruct pooled customer entitlement]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["refactor(pooled-balances): 💡 centralize..."](https://github.com/useautumn/autumn/commit/8ecd0467ccd14dc4f84e79341c927940ab31983c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48055533)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [Pooled Balances](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/pooled-balances.md)

<!-- /greptile_comment -->