### PR TITLE
feat: reduce Axiom ingest duplication

### DIFF
--- a/server/src/external/redis/otel/instrumentRedis.ts
+++ b/server/src/external/redis/otel/instrumentRedis.ts
@@ -17,6 +17,7 @@ import {
 	type ResolvedThresholds,
 	resolveThresholds,
 } from "./redisSlowlogConfig.js";
+import { buildRedisSpanOutcomeAttributes } from "./redisSpanOutcomeAttributes.js";
 
 const TRACER_NAME = "autumn.redis";
 const INSTRUMENTED = new WeakSet<object>();
@@ -67,15 +68,12 @@ const finalizeSpan = ({
 		spanCtx;
 	try {
 		const durationMs = performance.now() - startedAt;
-		span.setAttribute("db.redis.duration_ms", durationMs);
-
-		if (durationMs > thresholds.slowMs) {
-			span.setAttribute("db.redis.slow", true);
-			span.setAttribute(
-				"db.redis.breach_ratio",
-				thresholds.slowMs > 0 ? durationMs / thresholds.slowMs : 0,
-			);
-		}
+		span.setAttributes(
+			buildRedisSpanOutcomeAttributes({
+				durationMs,
+				slowMs: thresholds.slowMs,
+			}),
+		);
 
 		if (durationMs > thresholds.severeMs) {
 			emitRedisSlowLog({

--- a/server/src/external/redis/otel/redisSpanOutcomeAttributes.ts
+++ b/server/src/external/redis/otel/redisSpanOutcomeAttributes.ts
@@ -1,0 +1,14 @@
+import type { Attributes } from "@opentelemetry/api";
+
+export const buildRedisSpanOutcomeAttributes = ({
+	durationMs,
+	slowMs,
+}: {
+	durationMs: number;
+	slowMs: number;
+}): Attributes =>
+	durationMs > slowMs
+		? {
+				"db.redis.slow": true,
+			}
+		: {};

--- a/server/src/external/redis/otel/redisSpanOutcomeAttributes.ts
+++ b/server/src/external/redis/otel/redisSpanOutcomeAttributes.ts
@@ -9,6 +9,10 @@ export const buildRedisSpanOutcomeAttributes = ({
 }): Attributes =>
 	durationMs > slowMs
 		? {
+				"db.redis.duration_ms": durationMs,
 				"db.redis.slow": true,
+				"db.redis.breach_ratio": slowMs > 0 ? durationMs / slowMs : 0,
 			}
-		: {};
+		: {
+				"db.redis.duration_ms": durationMs,
+			};

--- a/server/src/honoMiddlewares/baseMiddleware.ts
+++ b/server/src/honoMiddlewares/baseMiddleware.ts
@@ -12,7 +12,8 @@ import { logger } from "@/external/logtail/logtailUtils.js";
 import { resolveRedisV2 } from "@/external/redis/resolveRedisV2.js";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { generateId } from "@/utils/genUtils.js";
-import { addRequestToLogs } from "@/utils/logging/addContextToLogs";
+import { addRequestToLogs } from "@/utils/logging/addContextToLogs.js";
+import { buildRequestLogContexts } from "@/utils/logging/requestLogContext.js";
 import { resolveCustomerId } from "./utils/resolveCustomerId.js";
 import { resolveEntityId } from "./utils/resolveEntityId.js";
 
@@ -84,23 +85,26 @@ export const baseMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 		query: c.req.query(),
 	});
 
+	const requestLogContext = {
+		id,
+		method: c.req.method,
+		url: c.req.url,
+		timestamp,
+		customer_id: customerId,
+		entity_id: entityId,
+		user_agent: c.req.header("user-agent"),
+		ip_address: c.req.header("x-forwarded-for"),
+		region: process.env.AWS_REGION,
+		query: c.req.query(),
+		body: redactSensitiveRequestBody({ body }),
+		name: `${c.req.method} ${c.req.path}`,
+	};
+	const requestLogContexts = buildRequestLogContexts({
+		requestContext: requestLogContext,
+	});
 	const childLogger = addRequestToLogs({
 		logger,
-		requestContext: {
-			id,
-			method: c.req.method,
-			url: c.req.url,
-			timestamp,
-			customer_id: customerId,
-			entity_id: entityId,
-			user_agent: c.req.header("user-agent"),
-			ip_address: c.req.header("x-forwarded-for"),
-			region: process.env.AWS_REGION,
-			query: c.req.query(),
-			body: redactSensitiveRequestBody({ body }),
-
-			name: `${c.req.method} ${c.req.path}`,
-		},
+		requestContext: requestLogContexts.internal,
 	});
 
 	// Set up the request context
@@ -125,6 +129,7 @@ export const baseMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 		customerId,
 		entityId,
 		requestBody: body,
+		requestLogContext: requestLogContexts.terminal,
 		authType: AuthType.Unknown,
 		env: AppEnv.Sandbox, // maybe use app_env headers
 		scopes: [],

--- a/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
+++ b/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
@@ -1,7 +1,10 @@
 import chalk from "chalk";
 import type { Context } from "hono";
 import type { AutumnContext, HonoEnv } from "@/honoUtils/HonoEnv.js";
-import { addExtrasToLogs } from "@/utils/logging/addContextToLogs";
+import {
+	addExtrasToLogs,
+	addRequestToLogs,
+} from "@/utils/logging/addContextToLogs.js";
 import { maskExtraLogs } from "@/utils/logging/maskExtraLogs.js";
 
 const HIGH_VOLUME_SUCCESS_ROUTES = new Set<string>([
@@ -47,6 +50,13 @@ export const logRequestResult = async ({
 
 		if (isHighVolumeSuccess && !shouldSampleSuccessLog()) {
 			return;
+		}
+
+		if (ctx.requestLogContext) {
+			ctx.logger = addRequestToLogs({
+				logger: ctx.logger,
+				requestContext: ctx.requestLogContext,
+			});
 		}
 
 		ctx.logger = addExtrasToLogs({

--- a/server/src/honoUtils/HonoEnv.ts
+++ b/server/src/honoUtils/HonoEnv.ts
@@ -11,6 +11,7 @@ import type { Redis } from "ioredis";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
 import type { OidcClaims } from "@/external/vercel/misc/vercelAuth.js";
+import type { LogRequestContext } from "@/utils/logging/loggerTypes.js";
 
 export type RolloutSnapshot = {
 	rolloutId: string | null;
@@ -32,6 +33,7 @@ export type RequestContext = {
 	customerId?: string;
 	entityId?: string;
 	requestBody?: unknown;
+	requestLogContext?: LogRequestContext;
 
 	// Objects
 	db: DrizzleCli;

--- a/server/src/instrumentation.ts
+++ b/server/src/instrumentation.ts
@@ -1,11 +1,23 @@
 import "dotenv/config";
-import { DiagConsoleLogger, DiagLogLevel, diag } from "@opentelemetry/api";
+import {
+	DiagConsoleLogger,
+	DiagLogLevel,
+	diag,
+	SpanStatusCode,
+	trace,
+} from "@opentelemetry/api";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
-import { NodeSDK } from "@opentelemetry/sdk-node";
+import { NodeSDK, resources } from "@opentelemetry/sdk-node";
 import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { resolveAwsTaskIdentity } from "./external/aws/ecs/awsTaskIdentity.js";
 import { FilteringSpanProcessor } from "./utils/otel/FilteringSpanProcessor.js";
+import {
+	buildCompactOtelResourceAttributes,
+	buildOtelResourceDefinitionAttributes,
+	createOtelServiceInstanceId,
+} from "./utils/otel/otelResourceDefinition.js";
 import { TenantAttrSpanProcessor } from "./utils/otel/TenantAttrSpanProcessor.js";
 
 // Surface OTel internal warnings/errors (export failures, auth issues, etc.)
@@ -15,8 +27,10 @@ diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.WARN);
 let sdk: NodeSDK | null = null;
 
 if (process.env.AXIOM_TOKEN) {
-	// NodeSDK reads OTEL_SERVICE_NAME to set the service resource attribute
-	process.env.OTEL_SERVICE_NAME = "autumn-server";
+	const serviceInstanceId = createOtelServiceInstanceId();
+	const resource = resources.resourceFromAttributes(
+		buildCompactOtelResourceAttributes({ serviceInstanceId }),
+	);
 
 	const traceExporter = new OTLPTraceExporter({
 		url: "https://api.axiom.co/v1/traces",
@@ -51,11 +65,33 @@ if (process.env.AXIOM_TOKEN) {
 	// No auto-instrumentations — Bun doesn't support require-in-the-middle.
 	// Stripe, Drizzle, and Redis are instrumented via manual patchers in utils/otel/.
 	sdk = new NodeSDK({
+		autoDetectResources: false,
+		resource,
 		spanProcessors: [new TenantAttrSpanProcessor(), filteredExportProcessor],
 		metricReader,
 	});
 
 	sdk.start();
+
+	void resolveAwsTaskIdentity().then((awsIdentity) => {
+		const defaultResourceAttributes = resources.defaultResource().attributes;
+		const resourceDefinitionSpan = trace
+			.getTracer("autumn.resource")
+			.startSpan("otel.resource_definition");
+		resourceDefinitionSpan.setAttributes(
+			buildOtelResourceDefinitionAttributes({
+				serviceInstanceId,
+				awsIdentity,
+				telemetrySdk: {
+					language: String(defaultResourceAttributes["telemetry.sdk.language"]),
+					name: String(defaultResourceAttributes["telemetry.sdk.name"]),
+					version: String(defaultResourceAttributes["telemetry.sdk.version"]),
+				},
+			}),
+		);
+		resourceDefinitionSpan.setStatus({ code: SpanStatusCode.OK });
+		resourceDefinitionSpan.end();
+	});
 
 	// Flush spans on SIGTERM/SIGINT so dev restarts (nodemon) and prod rollouts
 	// don't swallow in-flight batches.

--- a/server/src/utils/logging/addContextToLogs.ts
+++ b/server/src/utils/logging/addContextToLogs.ts
@@ -1,5 +1,6 @@
 import type { Logger } from "@/external/logtail/logtailUtils.js";
 import type {
+	InternalLogRequestContext,
 	LogAppContext,
 	LogRedisData,
 	LogRequestContext,
@@ -14,7 +15,7 @@ export const addRequestToLogs = ({
 	requestContext,
 }: {
 	logger: Logger;
-	requestContext: LogRequestContext;
+	requestContext: LogRequestContext | InternalLogRequestContext;
 }): Logger => {
 	return logger.child({ context: { req: requestContext } });
 };

--- a/server/src/utils/logging/loggerTypes.ts
+++ b/server/src/utils/logging/loggerTypes.ts
@@ -21,6 +21,8 @@ export type LogRequestContext = {
 	name: string;
 };
 
+export type InternalLogRequestContext = Omit<LogRequestContext, "body">;
+
 /** App context - emits as context.* fields. */
 export type LogAppContext = {
 	org_id: string;

--- a/server/src/utils/logging/requestLogContext.ts
+++ b/server/src/utils/logging/requestLogContext.ts
@@ -1,0 +1,20 @@
+import type {
+	InternalLogRequestContext,
+	LogRequestContext,
+} from "./loggerTypes.js";
+
+export const buildRequestLogContexts = ({
+	requestContext,
+}: {
+	requestContext: LogRequestContext;
+}): {
+	internal: InternalLogRequestContext;
+	terminal: LogRequestContext;
+} => {
+	const { body: _body, ...internal } = requestContext;
+
+	return {
+		internal,
+		terminal: requestContext,
+	};
+};

--- a/server/src/utils/otel/FilteringSpanProcessor.ts
+++ b/server/src/utils/otel/FilteringSpanProcessor.ts
@@ -4,6 +4,7 @@ import type {
 	Span,
 	SpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
+import { SpanIngestCompactor } from "./SpanIngestCompactor.js";
 import { recordSpanDurationMetric } from "./spanMetrics.js";
 
 const REDIS_SUCCESS_SAMPLE_RATE = Number.parseFloat(
@@ -44,6 +45,8 @@ const shouldDropSuccessfulRedisSpan = (span: ReadableSpan): boolean => {
 };
 
 export class FilteringSpanProcessor implements SpanProcessor {
+	private readonly spanIngestCompactor = new SpanIngestCompactor();
+
 	constructor(private readonly delegate: SpanProcessor) {}
 
 	onStart(span: Span, parentContext: Context): void {
@@ -54,7 +57,7 @@ export class FilteringSpanProcessor implements SpanProcessor {
 		recordSpanDurationMetric(span);
 
 		if (shouldDropSuccessfulRedisSpan(span)) return;
-		this.delegate.onEnd(span);
+		this.delegate.onEnd(this.spanIngestCompactor.compact({ span }));
 	}
 
 	forceFlush(): Promise<void> {

--- a/server/src/utils/otel/SpanIngestCompactor.ts
+++ b/server/src/utils/otel/SpanIngestCompactor.ts
@@ -1,0 +1,58 @@
+import { createHash } from "node:crypto";
+import type { Attributes } from "@opentelemetry/api";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+
+const MAX_TRACKED_QUERY_IDS = 4096;
+
+const getQueryId = ({ statement }: { statement: string }) =>
+	createHash("sha256").update(statement).digest("hex").slice(0, 16);
+
+const withAttributes = ({
+	span,
+	attributes,
+}: {
+	span: ReadableSpan;
+	attributes: Attributes;
+}): ReadableSpan =>
+	new Proxy(span, {
+		get(target, property) {
+			if (property === "attributes") return attributes;
+
+			const value = Reflect.get(target, property, target);
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+	});
+
+export class SpanIngestCompactor {
+	private readonly seenQueryIds = new Set<string>();
+
+	compact({ span }: { span: ReadableSpan }): ReadableSpan {
+		const statement = span.attributes["db.statement"];
+		if (
+			!span.name.startsWith("drizzle.") ||
+			typeof statement !== "string" ||
+			statement.length === 0
+		) {
+			return span;
+		}
+
+		const queryId = getQueryId({ statement });
+		const attributes: Attributes = {
+			...span.attributes,
+			"db.query_id": queryId,
+		};
+
+		if (!this.seenQueryIds.has(queryId)) {
+			if (this.seenQueryIds.size >= MAX_TRACKED_QUERY_IDS) {
+				const oldestQueryId = this.seenQueryIds.values().next().value;
+				if (oldestQueryId) this.seenQueryIds.delete(oldestQueryId);
+			}
+			this.seenQueryIds.add(queryId);
+			attributes["db.query_definition"] = true;
+			return withAttributes({ span, attributes });
+		}
+
+		delete attributes["db.statement"];
+		return withAttributes({ span, attributes });
+	}
+}

--- a/server/src/utils/otel/SpanIngestCompactor.ts
+++ b/server/src/utils/otel/SpanIngestCompactor.ts
@@ -3,9 +3,13 @@ import type { Attributes } from "@opentelemetry/api";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 
 const MAX_TRACKED_QUERY_IDS = 4096;
+const SLOW_QUERY_STATEMENT_THRESHOLD_MS = 100;
 
 const getQueryId = ({ statement }: { statement: string }) =>
 	createHash("sha256").update(statement).digest("hex").slice(0, 16);
+
+const getDurationMs = ({ span }: { span: ReadableSpan }) =>
+	span.duration[0] * 1000 + span.duration[1] / 1_000_000;
 
 const withAttributes = ({
 	span,
@@ -52,7 +56,9 @@ export class SpanIngestCompactor {
 			return withAttributes({ span, attributes });
 		}
 
-		delete attributes["db.statement"];
+		if (getDurationMs({ span }) < SLOW_QUERY_STATEMENT_THRESHOLD_MS) {
+			delete attributes["db.statement"];
+		}
 		return withAttributes({ span, attributes });
 	}
 }

--- a/server/src/utils/otel/otelResourceDefinition.ts
+++ b/server/src/utils/otel/otelResourceDefinition.ts
@@ -1,0 +1,96 @@
+import { randomBytes } from "node:crypto";
+import { hostname, userInfo } from "node:os";
+import { basename } from "node:path";
+import type { Attributes } from "@opentelemetry/api";
+import type { AwsTaskIdentity } from "@/external/aws/ecs/awsTaskIdentity.js";
+
+type RuntimeMetadata = {
+	hostArch: string;
+	hostName: string;
+	processCommand: string;
+	processCommandArgs: string[];
+	processExecutableName: string;
+	processExecutablePath: string;
+	processOwner: string;
+	processPid: number;
+	runtimeDescription: string;
+	runtimeName: string;
+	runtimeVersion: string;
+};
+
+type TelemetrySdkMetadata = {
+	language: string;
+	name: string;
+	version: string;
+};
+
+const getProcessOwner = () => {
+	try {
+		return userInfo().username;
+	} catch {
+		return "unknown";
+	}
+};
+
+const getRuntimeMetadata = (): RuntimeMetadata => ({
+	hostArch: process.arch,
+	hostName: hostname(),
+	processCommand: process.argv[1] ?? process.argv[0] ?? "",
+	processCommandArgs: [...process.argv],
+	processExecutableName: basename(process.execPath),
+	processExecutablePath: process.execPath,
+	processOwner: getProcessOwner(),
+	processPid: process.pid,
+	runtimeDescription: "Node.js",
+	runtimeName: "nodejs",
+	runtimeVersion: process.versions.node,
+});
+
+export const createOtelServiceInstanceId = () => randomBytes(8).toString("hex");
+
+export const buildCompactOtelResourceAttributes = ({
+	serviceInstanceId,
+}: {
+	serviceInstanceId: string;
+}): Attributes => ({
+	"service.name": "autumn-server",
+	"service.instance.id": serviceInstanceId,
+});
+
+export const buildOtelResourceDefinitionAttributes = ({
+	serviceInstanceId,
+	awsIdentity,
+	runtime = getRuntimeMetadata(),
+	telemetrySdk,
+}: {
+	serviceInstanceId: string;
+	awsIdentity?: AwsTaskIdentity;
+	runtime?: RuntimeMetadata;
+	telemetrySdk?: TelemetrySdkMetadata;
+}): Attributes => ({
+	"otel.definition.type": "resource",
+	"service.name": "autumn-server",
+	"service.instance.id": serviceInstanceId,
+	"host.arch": runtime.hostArch,
+	"host.name": runtime.hostName,
+	"process.command": runtime.processCommand,
+	"process.command_args": runtime.processCommandArgs,
+	"process.executable.name": runtime.processExecutableName,
+	"process.executable.path": runtime.processExecutablePath,
+	"process.owner": runtime.processOwner,
+	"process.pid": runtime.processPid,
+	"process.runtime.description": runtime.runtimeDescription,
+	"process.runtime.name": runtime.runtimeName,
+	"process.runtime.version": runtime.runtimeVersion,
+	...(telemetrySdk
+		? {
+				"telemetry.sdk.language": telemetrySdk.language,
+				"telemetry.sdk.name": telemetrySdk.name,
+				"telemetry.sdk.version": telemetrySdk.version,
+			}
+		: {}),
+	...(awsIdentity?.serviceArn
+		? { "aws.service_arn": awsIdentity.serviceArn }
+		: {}),
+	...(awsIdentity?.imageSha ? { "aws.image_sha": awsIdentity.imageSha } : {}),
+});

--- a/server/tests/unit/logging/logRequestResult.test.ts
+++ b/server/tests/unit/logging/logRequestResult.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, test } from "bun:test";
+import type { Context } from "hono";
+import type { Logger } from "@/external/logtail/logtailUtils.js";
+import { logRequestResult } from "@/honoMiddlewares/requestLogging/logRequestResult.js";
+import type { AutumnContext, HonoEnv } from "@/honoUtils/HonoEnv.js";
+import type { LogRequestContext } from "@/utils/logging/loggerTypes.js";
+
+type CapturedLog = {
+	level: "debug" | "info" | "warn" | "error";
+	bindings: Record<string, unknown>;
+	args: unknown[];
+};
+
+const createCapturingLogger = ({
+	bindings = {},
+	captured,
+}: {
+	bindings?: Record<string, unknown>;
+	captured: CapturedLog[];
+}): Logger => ({
+	debug: (...args) => captured.push({ level: "debug", bindings, args }),
+	info: (...args) => captured.push({ level: "info", bindings, args }),
+	warn: (...args) => captured.push({ level: "warn", bindings, args }),
+	error: (...args) => captured.push({ level: "error", bindings, args }),
+	child: ({ context }) =>
+		createCapturingLogger({
+			bindings: { ...bindings, ...context },
+			captured,
+		}),
+});
+
+describe("logRequestResult", () => {
+	test("restores the full request body on the terminal request record", async () => {
+		const captured: CapturedLog[] = [];
+		const requestLogContext: LogRequestContext = {
+			id: "req_123",
+			method: "POST",
+			url: "https://api.useautumn.com/v1/check",
+			timestamp: 123,
+			customer_id: "cus_123",
+			query: {},
+			body: { feature_id: "messages" },
+			name: "POST /v1/check",
+		};
+		const internalRequestContext = {
+			id: requestLogContext.id,
+			method: requestLogContext.method,
+			url: requestLogContext.url,
+			timestamp: requestLogContext.timestamp,
+			customer_id: requestLogContext.customer_id,
+			query: requestLogContext.query,
+			name: requestLogContext.name,
+		};
+		const ctx = {
+			timestamp: 123,
+			logger: createCapturingLogger({
+				bindings: { req: internalRequestContext },
+				captured,
+			}),
+			requestLogContext,
+			extraLogs: {},
+			org: { slug: "test-org" },
+		} as unknown as AutumnContext;
+		const c = {
+			req: { path: "/v1/check" },
+			res: {
+				status: 200,
+				headers: new Headers({ "content-type": "application/json" }),
+			},
+		} as Context<HonoEnv>;
+
+		await logRequestResult({
+			ctx,
+			c,
+			durationMs: 20,
+			responseBody: { allowed: true },
+		});
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0]?.level).toBe("info");
+		expect(captured[0]?.bindings.req).toEqual(requestLogContext);
+		expect(captured[0]?.bindings.extras).toEqual({});
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 20,
+			res: { allowed: true },
+		});
+	});
+
+	test("keeps request and response bodies unchanged on failed terminal records", async () => {
+		const captured: CapturedLog[] = [];
+		const requestLogContext: LogRequestContext = {
+			id: "req_failed",
+			method: "POST",
+			url: "https://api.useautumn.com/v1/track",
+			timestamp: 123,
+			customer_id: "cus_123",
+			query: {},
+			body: {
+				feature_id: "messages",
+				value: 10,
+			},
+			name: "POST /v1/track",
+		};
+		const ctx = {
+			timestamp: 123,
+			logger: createCapturingLogger({
+				bindings: {
+					req: {
+						id: requestLogContext.id,
+						method: requestLogContext.method,
+						url: requestLogContext.url,
+						timestamp: requestLogContext.timestamp,
+						query: requestLogContext.query,
+						name: requestLogContext.name,
+					},
+				},
+				captured,
+			}),
+			requestLogContext,
+			extraLogs: { operation: "track" },
+			org: { slug: "test-org" },
+		} as unknown as AutumnContext;
+		const c = {
+			req: { path: "/v1/track" },
+			res: {
+				status: 500,
+				headers: new Headers({ "content-type": "application/json" }),
+			},
+		} as Context<HonoEnv>;
+		const responseBody = {
+			code: "internal_error",
+			message: "Something went wrong",
+		};
+
+		await logRequestResult({
+			ctx,
+			c,
+			durationMs: 30,
+			responseBody,
+		});
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0]?.level).toBe("warn");
+		expect(captured[0]?.bindings.req).toEqual(requestLogContext);
+		expect(captured[0]?.bindings.extras).toEqual({ operation: "track" });
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 500,
+			durationMs: 30,
+			res: responseBody,
+		});
+	});
+
+	test("still reads and logs successful JSON response bodies when not supplied", async () => {
+		const captured: CapturedLog[] = [];
+		const responseBody = { allowed: true, balance: 90 };
+		let cloneCount = 0;
+		const ctx = {
+			timestamp: 123,
+			logger: createCapturingLogger({ captured }),
+			extraLogs: {},
+			org: { slug: "test-org" },
+		} as unknown as AutumnContext;
+		const c = {
+			req: { path: "/v1/check" },
+			res: {
+				status: 200,
+				headers: new Headers({ "content-type": "application/json" }),
+				clone: () => {
+					cloneCount++;
+					return {
+						json: async () => responseBody,
+					};
+				},
+			},
+		} as unknown as Context<HonoEnv>;
+
+		await logRequestResult({ ctx, c, durationMs: 10 });
+
+		expect(cloneCount).toBe(1);
+		expect(captured).toHaveLength(1);
+		expect(captured[0]?.level).toBe("info");
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 10,
+			res: responseBody,
+		});
+	});
+
+	test("does not mutate logger context or emit for explicitly skipped routes", async () => {
+		const captured: CapturedLog[] = [];
+		const logger = createCapturingLogger({ captured });
+		const ctx = {
+			timestamp: 123,
+			logger,
+			requestLogContext: {
+				id: "req_health",
+				method: "GET",
+				url: "https://api.useautumn.com/health",
+				timestamp: 123,
+				query: {},
+				body: undefined,
+				name: "GET /health",
+			},
+			extraLogs: {},
+		} as unknown as AutumnContext;
+		const c = {
+			req: { path: "/health" },
+			res: {
+				status: 200,
+				headers: new Headers(),
+			},
+		} as Context<HonoEnv>;
+
+		await logRequestResult({
+			ctx,
+			c,
+			skipUrls: ["/health"],
+		});
+
+		expect(captured).toHaveLength(0);
+		expect(ctx.logger).toBe(logger);
+	});
+});

--- a/server/tests/unit/logging/requestLogContext.test.ts
+++ b/server/tests/unit/logging/requestLogContext.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import type { LogRequestContext } from "@/utils/logging/loggerTypes.js";
+import { buildRequestLogContexts } from "@/utils/logging/requestLogContext.js";
+
+describe("request log context", () => {
+	test("keeps the complete body once on the terminal record", () => {
+		const requestContext: LogRequestContext = {
+			id: "req_123",
+			method: "POST",
+			url: "https://api.useautumn.com/v1/balances.check",
+			timestamp: 123,
+			customer_id: "cus_123",
+			entity_id: "ent_123",
+			user_agent: "test-agent",
+			ip_address: "127.0.0.1",
+			region: "us-east-2",
+			query: { expand: "balances" },
+			body: {
+				customer_id: "cus_123",
+				feature_id: "messages",
+			},
+			name: "POST /v1/balances.check",
+		};
+
+		const contexts = buildRequestLogContexts({ requestContext });
+
+		expect(contexts.terminal).toEqual(requestContext);
+		expect(contexts.internal).toEqual({
+			id: "req_123",
+			method: "POST",
+			url: "https://api.useautumn.com/v1/balances.check",
+			timestamp: 123,
+			customer_id: "cus_123",
+			entity_id: "ent_123",
+			user_agent: "test-agent",
+			ip_address: "127.0.0.1",
+			region: "us-east-2",
+			query: { expand: "balances" },
+			name: "POST /v1/balances.check",
+		});
+		expect("body" in contexts.internal).toBe(false);
+	});
+
+	test("keeps the terminal context and body by reference without copying payloads", () => {
+		const body = {
+			items: Array.from({ length: 100 }, (_, index) => ({ index })),
+		};
+		const requestContext: LogRequestContext = {
+			id: "req_large",
+			method: "POST",
+			url: "https://api.useautumn.com/v1/track",
+			timestamp: 123,
+			query: {},
+			body,
+			name: "POST /v1/track",
+		};
+
+		const contexts = buildRequestLogContexts({ requestContext });
+
+		expect(contexts.terminal).toBe(requestContext);
+		expect(contexts.terminal.body).toBe(body);
+		expect("body" in contexts.internal).toBe(false);
+	});
+});

--- a/server/tests/unit/otel/filteringSpanProcessor.test.ts
+++ b/server/tests/unit/otel/filteringSpanProcessor.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "bun:test";
+import { type Context, SpanKind, SpanStatusCode } from "@opentelemetry/api";
+import type {
+	ReadableSpan,
+	SpanProcessor,
+	Span as WritableSpan,
+} from "@opentelemetry/sdk-trace-base";
+import { FilteringSpanProcessor } from "@/utils/otel/FilteringSpanProcessor.js";
+
+const createSpan = ({
+	name,
+	attributes,
+	statusCode = SpanStatusCode.OK,
+}: {
+	name: string;
+	attributes: ReadableSpan["attributes"];
+	statusCode?: SpanStatusCode;
+}): ReadableSpan =>
+	({
+		name,
+		kind: SpanKind.CLIENT,
+		attributes,
+		resource: {} as ReadableSpan["resource"],
+		instrumentationScope: { name: "test" },
+		status: { code: statusCode },
+		events: [],
+		links: [],
+		startTime: [0, 0],
+		endTime: [0, 1],
+		duration: [0, 1],
+		ended: true,
+		droppedAttributesCount: 0,
+		droppedEventsCount: 0,
+		droppedLinksCount: 0,
+		spanContext: () => ({
+			traceId: "00000000000000000000000000000001",
+			spanId: "0000000000000001",
+			traceFlags: 1,
+		}),
+	}) as ReadableSpan;
+
+class CapturingSpanProcessor implements SpanProcessor {
+	readonly started: Array<{ span: WritableSpan; parentContext: Context }> = [];
+	readonly ended: ReadableSpan[] = [];
+	forceFlushCount = 0;
+	shutdownCount = 0;
+
+	onStart(span: WritableSpan, parentContext: Context): void {
+		this.started.push({ span, parentContext });
+	}
+
+	onEnd(span: ReadableSpan): void {
+		this.ended.push(span);
+	}
+
+	forceFlush(): Promise<void> {
+		this.forceFlushCount++;
+		return Promise.resolve();
+	}
+
+	shutdown(): Promise<void> {
+		this.shutdownCount++;
+		return Promise.resolve();
+	}
+}
+
+describe("FilteringSpanProcessor", () => {
+	test("compacts repeated Drizzle statements before delegating export", () => {
+		const delegate = new CapturingSpanProcessor();
+		const processor = new FilteringSpanProcessor(delegate);
+		const statement = "select * from organizations where id = $1";
+
+		processor.onEnd(
+			createSpan({
+				name: "drizzle.select",
+				attributes: {
+					"db.statement": statement,
+					org_id: "org_123",
+				},
+			}),
+		);
+		processor.onEnd(
+			createSpan({
+				name: "drizzle.select",
+				attributes: {
+					"db.statement": statement,
+					org_id: "org_123",
+				},
+			}),
+		);
+
+		expect(delegate.ended).toHaveLength(2);
+		expect(delegate.ended[0]?.attributes["db.statement"]).toBe(statement);
+		expect(delegate.ended[0]?.attributes["db.query_definition"]).toBe(true);
+		expect(delegate.ended[1]?.attributes["db.statement"]).toBeUndefined();
+		expect(delegate.ended[1]?.attributes["db.query_id"]).toBe(
+			delegate.ended[0]?.attributes["db.query_id"],
+		);
+		expect(delegate.ended[1]?.attributes.org_id).toBe("org_123");
+	});
+
+	test("forwards non-Drizzle spans without replacing them", () => {
+		const delegate = new CapturingSpanProcessor();
+		const processor = new FilteringSpanProcessor(delegate);
+		const source = createSpan({
+			name: "stripe.invoices.retrieve",
+			attributes: { "stripe.invoice_id": "in_123" },
+		});
+
+		processor.onEnd(source);
+
+		expect(delegate.ended).toEqual([source]);
+	});
+
+	test("always exports successful slow Redis spans", () => {
+		const delegate = new CapturingSpanProcessor();
+		const processor = new FilteringSpanProcessor(delegate);
+		const source = createSpan({
+			name: "redis.get",
+			attributes: {
+				"db.redis.slow": true,
+				"db.redis.org_id": "org_123",
+			},
+		});
+
+		processor.onEnd(source);
+
+		expect(delegate.ended).toEqual([source]);
+	});
+
+	test("always exports failed Redis spans even when they are not marked slow", () => {
+		const delegate = new CapturingSpanProcessor();
+		const processor = new FilteringSpanProcessor(delegate);
+		const source = createSpan({
+			name: "redis.set",
+			attributes: {
+				"db.redis.org_id": "org_123",
+			},
+			statusCode: SpanStatusCode.ERROR,
+		});
+
+		processor.onEnd(source);
+
+		expect(delegate.ended).toEqual([source]);
+	});
+
+	test("forwards lifecycle calls to the wrapped processor", async () => {
+		const delegate = new CapturingSpanProcessor();
+		const processor = new FilteringSpanProcessor(delegate);
+		const span = {} as WritableSpan;
+		const parentContext = {} as Context;
+
+		processor.onStart(span, parentContext);
+		await processor.forceFlush();
+		await processor.shutdown();
+
+		expect(delegate.started).toEqual([{ span, parentContext }]);
+		expect(delegate.forceFlushCount).toBe(1);
+		expect(delegate.shutdownCount).toBe(1);
+	});
+});

--- a/server/tests/unit/otel/filteringSpanProcessor.test.ts
+++ b/server/tests/unit/otel/filteringSpanProcessor.test.ts
@@ -11,10 +11,12 @@ const createSpan = ({
 	name,
 	attributes,
 	statusCode = SpanStatusCode.OK,
+	durationMs = 0.000001,
 }: {
 	name: string;
 	attributes: ReadableSpan["attributes"];
 	statusCode?: SpanStatusCode;
+	durationMs?: number;
 }): ReadableSpan =>
 	({
 		name,
@@ -27,7 +29,7 @@ const createSpan = ({
 		links: [],
 		startTime: [0, 0],
 		endTime: [0, 1],
-		duration: [0, 1],
+		duration: [Math.floor(durationMs / 1000), (durationMs % 1000) * 1_000_000],
 		ended: true,
 		droppedAttributesCount: 0,
 		droppedEventsCount: 0,
@@ -110,6 +112,31 @@ describe("FilteringSpanProcessor", () => {
 		processor.onEnd(source);
 
 		expect(delegate.ended).toEqual([source]);
+	});
+
+	test("keeps SQL on repeated slow Drizzle spans at export", () => {
+		const delegate = new CapturingSpanProcessor();
+		const processor = new FilteringSpanProcessor(delegate);
+		const statement = "update customers set updated_at = now() where id = $1";
+
+		processor.onEnd(
+			createSpan({
+				name: "drizzle.update",
+				attributes: { "db.statement": statement },
+			}),
+		);
+		processor.onEnd(
+			createSpan({
+				name: "drizzle.update",
+				attributes: { "db.statement": statement },
+				durationMs: 100,
+			}),
+		);
+
+		expect(delegate.ended[1]?.attributes["db.statement"]).toBe(statement);
+		expect(
+			delegate.ended[1]?.attributes["db.query_definition"],
+		).toBeUndefined();
 	});
 
 	test("always exports successful slow Redis spans", () => {

--- a/server/tests/unit/otel/otelResourceDefinition.test.ts
+++ b/server/tests/unit/otel/otelResourceDefinition.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildCompactOtelResourceAttributes,
+	buildOtelResourceDefinitionAttributes,
+	createOtelServiceInstanceId,
+} from "@/utils/otel/otelResourceDefinition.js";
+
+describe("OTel resource definition", () => {
+	test("generates a compact random process instance id", () => {
+		const first = createOtelServiceInstanceId();
+		const second = createOtelServiceInstanceId();
+
+		expect(first).toMatch(/^[a-f0-9]{16}$/);
+		expect(second).toMatch(/^[a-f0-9]{16}$/);
+		expect(first).not.toBe(second);
+	});
+
+	test("keeps per-span resource attributes compact and searchable", () => {
+		expect(
+			buildCompactOtelResourceAttributes({
+				serviceInstanceId: "instance_123",
+			}),
+		).toEqual({
+			"service.name": "autumn-server",
+			"service.instance.id": "instance_123",
+		});
+	});
+
+	test("retains full process, host, runtime, and AWS metadata in one definition", () => {
+		expect(
+			buildOtelResourceDefinitionAttributes({
+				serviceInstanceId: "instance_123",
+				awsIdentity: {
+					serviceArn: "arn:aws:ecs:us-east-2:123:service/cluster/autumn-server",
+					imageSha: "abc123",
+				},
+				runtime: {
+					hostArch: "arm64",
+					hostName: "task-host",
+					processCommand: "/app/server/src/workers.ts",
+					processCommandArgs: [
+						"/usr/local/bin/bun",
+						"/app/server/src/workers.ts",
+					],
+					processExecutableName: "bun",
+					processExecutablePath: "/usr/local/bin/bun",
+					processOwner: "unknown",
+					processPid: 42,
+					runtimeDescription: "Node.js",
+					runtimeName: "nodejs",
+					runtimeVersion: "24.3.0",
+				},
+				telemetrySdk: {
+					language: "nodejs",
+					name: "opentelemetry",
+					version: "2.0.1",
+				},
+			}),
+		).toEqual({
+			"otel.definition.type": "resource",
+			"service.name": "autumn-server",
+			"service.instance.id": "instance_123",
+			"host.arch": "arm64",
+			"host.name": "task-host",
+			"process.command": "/app/server/src/workers.ts",
+			"process.command_args": [
+				"/usr/local/bin/bun",
+				"/app/server/src/workers.ts",
+			],
+			"process.executable.name": "bun",
+			"process.executable.path": "/usr/local/bin/bun",
+			"process.owner": "unknown",
+			"process.pid": 42,
+			"process.runtime.description": "Node.js",
+			"process.runtime.name": "nodejs",
+			"process.runtime.version": "24.3.0",
+			"telemetry.sdk.language": "nodejs",
+			"telemetry.sdk.name": "opentelemetry",
+			"telemetry.sdk.version": "2.0.1",
+			"aws.service_arn":
+				"arn:aws:ecs:us-east-2:123:service/cluster/autumn-server",
+			"aws.image_sha": "abc123",
+		});
+	});
+
+	test("omits unavailable AWS and optional SDK attributes instead of indexing nulls", () => {
+		const attributes = buildOtelResourceDefinitionAttributes({
+			serviceInstanceId: "instance_123",
+			awsIdentity: {
+				serviceArn: null,
+				imageSha: null,
+			},
+			runtime: {
+				hostArch: "arm64",
+				hostName: "task-host",
+				processCommand: "/app/server/src/index.ts",
+				processCommandArgs: [],
+				processExecutableName: "bun",
+				processExecutablePath: "/usr/local/bin/bun",
+				processOwner: "unknown",
+				processPid: 42,
+				runtimeDescription: "Node.js",
+				runtimeName: "nodejs",
+				runtimeVersion: "24.3.0",
+			},
+		});
+
+		expect(attributes["aws.service_arn"]).toBeUndefined();
+		expect(attributes["aws.image_sha"]).toBeUndefined();
+		expect(attributes["telemetry.sdk.language"]).toBeUndefined();
+		expect(Object.values(attributes)).not.toContain(null);
+		expect(Object.values(attributes)).not.toContain(undefined);
+	});
+});

--- a/server/tests/unit/otel/spanIngestCompactor.test.ts
+++ b/server/tests/unit/otel/spanIngestCompactor.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { SpanIngestCompactor } from "@/utils/otel/SpanIngestCompactor.js";
+
+const createSpan = ({
+	name,
+	attributes,
+}: {
+	name: string;
+	attributes: ReadableSpan["attributes"];
+}): ReadableSpan =>
+	({
+		name,
+		kind: SpanKind.CLIENT,
+		attributes,
+		resource: {} as ReadableSpan["resource"],
+		instrumentationScope: { name: "test" },
+		status: { code: SpanStatusCode.OK },
+		events: [],
+		links: [],
+		startTime: [0, 0],
+		endTime: [0, 1],
+		duration: [0, 1],
+		ended: true,
+		droppedAttributesCount: 0,
+		droppedEventsCount: 0,
+		droppedLinksCount: 0,
+		spanContext: () => ({
+			traceId: "00000000000000000000000000000001",
+			spanId: "0000000000000001",
+			traceFlags: 1,
+		}),
+	}) as ReadableSpan;
+
+describe("SpanIngestCompactor", () => {
+	test("retains one full Drizzle query definition and references it thereafter", () => {
+		const compactor = new SpanIngestCompactor();
+		const statement = 'insert into "events" ("id", "org_id") values ($1, $2)';
+		const searchableAttributes = {
+			req_id: "req_123",
+			org_id: "org_123",
+			customer_id: "cus_123",
+			entity_id: "ent_123",
+		};
+		const firstSource = createSpan({
+			name: "drizzle.insert",
+			attributes: {
+				...searchableAttributes,
+				"db.operation": "INSERT",
+				"db.statement": statement,
+			},
+		});
+		const repeatedSource = createSpan({
+			name: "drizzle.insert",
+			attributes: {
+				...searchableAttributes,
+				"db.operation": "INSERT",
+				"db.statement": statement,
+			},
+		});
+
+		const first = compactor.compact({ span: firstSource });
+		const repeated = compactor.compact({ span: repeatedSource });
+
+		expect(first.attributes["db.statement"]).toBe(statement);
+		expect(first.attributes["db.query_definition"]).toBe(true);
+		expect(first.attributes["db.query_id"]).toMatch(/^[a-f0-9]{16}$/);
+
+		expect(repeated.attributes["db.statement"]).toBeUndefined();
+		expect(repeated.attributes["db.query_definition"]).toBeUndefined();
+		expect(repeated.attributes["db.query_id"]).toBe(
+			first.attributes["db.query_id"],
+		);
+
+		for (const [key, value] of Object.entries(searchableAttributes)) {
+			expect(first.attributes[key]).toBe(value);
+			expect(repeated.attributes[key]).toBe(value);
+		}
+
+		expect(firstSource.attributes["db.statement"]).toBe(statement);
+		expect(repeatedSource.attributes["db.statement"]).toBe(statement);
+	});
+
+	test("retains definitions independently for different SQL statements", () => {
+		const compactor = new SpanIngestCompactor();
+		const first = compactor.compact({
+			span: createSpan({
+				name: "drizzle.select",
+				attributes: { "db.statement": "select 1" },
+			}),
+		});
+		const second = compactor.compact({
+			span: createSpan({
+				name: "drizzle.select",
+				attributes: { "db.statement": "select 2" },
+			}),
+		});
+
+		expect(first.attributes["db.query_definition"]).toBe(true);
+		expect(second.attributes["db.query_definition"]).toBe(true);
+		expect(first.attributes["db.query_id"]).not.toBe(
+			second.attributes["db.query_id"],
+		);
+	});
+
+	test("generates the same query id across processes for the same statement", () => {
+		const statement = "select * from customers where id = $1";
+		const first = new SpanIngestCompactor().compact({
+			span: createSpan({
+				name: "drizzle.select",
+				attributes: { "db.statement": statement },
+			}),
+		});
+		const second = new SpanIngestCompactor().compact({
+			span: createSpan({
+				name: "drizzle.select",
+				attributes: { "db.statement": statement },
+			}),
+		});
+
+		expect(first.attributes["db.query_id"]).toBe(
+			second.attributes["db.query_id"],
+		);
+	});
+
+	test("preserves the full span interface when replacing attributes", () => {
+		const source = createSpan({
+			name: "drizzle.select",
+			attributes: { "db.statement": "select 1" },
+		});
+
+		const compacted = new SpanIngestCompactor().compact({ span: source });
+
+		expect(compacted.name).toBe(source.name);
+		expect(compacted.status).toBe(source.status);
+		expect(compacted.duration).toBe(source.duration);
+		expect(compacted.resource).toBe(source.resource);
+		expect(compacted.spanContext()).toEqual(source.spanContext());
+	});
+
+	test("leaves spans without a usable SQL statement unchanged", () => {
+		const compactor = new SpanIngestCompactor();
+		const missingStatement = createSpan({
+			name: "drizzle.select",
+			attributes: { "db.operation": "SELECT" },
+		});
+		const emptyStatement = createSpan({
+			name: "drizzle.select",
+			attributes: { "db.statement": "" },
+		});
+		const nonStringStatement = createSpan({
+			name: "drizzle.select",
+			attributes: { "db.statement": 123 },
+		});
+
+		expect(compactor.compact({ span: missingStatement })).toBe(
+			missingStatement,
+		);
+		expect(compactor.compact({ span: emptyStatement })).toBe(emptyStatement);
+		expect(compactor.compact({ span: nonStringStatement })).toBe(
+			nonStringStatement,
+		);
+	});
+
+	test("bounds tracked query ids and safely emits an evicted definition again", () => {
+		const compactor = new SpanIngestCompactor();
+		const firstStatement = "select 0";
+
+		compactor.compact({
+			span: createSpan({
+				name: "drizzle.select",
+				attributes: { "db.statement": firstStatement },
+			}),
+		});
+		for (let index = 1; index <= 4096; index++) {
+			compactor.compact({
+				span: createSpan({
+					name: "drizzle.select",
+					attributes: { "db.statement": `select ${index}` },
+				}),
+			});
+		}
+
+		const redefined = compactor.compact({
+			span: createSpan({
+				name: "drizzle.select",
+				attributes: { "db.statement": firstStatement },
+			}),
+		});
+
+		expect(redefined.attributes["db.statement"]).toBe(firstStatement);
+		expect(redefined.attributes["db.query_definition"]).toBe(true);
+	});
+
+	test("does not compact Redis keys or non-Drizzle statements", () => {
+		const compactor = new SpanIngestCompactor();
+		const redisKey = "{org_123}:live:customer:v2:cus_123";
+		const source = createSpan({
+			name: "redis.get",
+			attributes: { "db.statement": redisKey },
+		});
+
+		const compacted = compactor.compact({ span: source });
+
+		expect(compacted).toBe(source);
+		expect(compacted.attributes["db.statement"]).toBe(redisKey);
+		expect(compacted.attributes["db.query_id"]).toBeUndefined();
+	});
+});

--- a/server/tests/unit/otel/spanIngestCompactor.test.ts
+++ b/server/tests/unit/otel/spanIngestCompactor.test.ts
@@ -6,9 +6,11 @@ import { SpanIngestCompactor } from "@/utils/otel/SpanIngestCompactor.js";
 const createSpan = ({
 	name,
 	attributes,
+	durationMs = 0.000001,
 }: {
 	name: string;
 	attributes: ReadableSpan["attributes"];
+	durationMs?: number;
 }): ReadableSpan =>
 	({
 		name,
@@ -21,7 +23,7 @@ const createSpan = ({
 		links: [],
 		startTime: [0, 0],
 		endTime: [0, 1],
-		duration: [0, 1],
+		duration: [Math.floor(durationMs / 1000), (durationMs % 1000) * 1_000_000],
 		ended: true,
 		droppedAttributesCount: 0,
 		droppedEventsCount: 0,
@@ -137,6 +139,39 @@ describe("SpanIngestCompactor", () => {
 		expect(compacted.duration).toBe(source.duration);
 		expect(compacted.resource).toBe(source.resource);
 		expect(compacted.spanContext()).toEqual(source.spanContext());
+	});
+
+	test("retains SQL on repeated slow spans for Axiom slow-query investigations", () => {
+		const compactor = new SpanIngestCompactor();
+		const statement = "select * from customers where id = $1";
+		const first = compactor.compact({
+			span: createSpan({
+				name: "drizzle.select",
+				attributes: { "db.statement": statement },
+			}),
+		});
+		const repeatedSlow = compactor.compact({
+			span: createSpan({
+				name: "drizzle.select",
+				attributes: { "db.statement": statement },
+				durationMs: 100,
+			}),
+		});
+		const repeatedFast = compactor.compact({
+			span: createSpan({
+				name: "drizzle.select",
+				attributes: { "db.statement": statement },
+				durationMs: 99,
+			}),
+		});
+
+		expect(first.attributes["db.query_definition"]).toBe(true);
+		expect(repeatedSlow.attributes["db.statement"]).toBe(statement);
+		expect(repeatedSlow.attributes["db.query_definition"]).toBeUndefined();
+		expect(repeatedSlow.attributes["db.query_id"]).toBe(
+			first.attributes["db.query_id"],
+		);
+		expect(repeatedFast.attributes["db.statement"]).toBeUndefined();
 	});
 
 	test("leaves spans without a usable SQL statement unchanged", () => {

--- a/server/tests/unit/redis-otel/redisSpanOutcomeAttributes.test.ts
+++ b/server/tests/unit/redis-otel/redisSpanOutcomeAttributes.test.ts
@@ -2,26 +2,28 @@ import { describe, expect, test } from "bun:test";
 import { buildRedisSpanOutcomeAttributes } from "@/external/redis/otel/redisSpanOutcomeAttributes.js";
 
 describe("Redis span outcome attributes", () => {
-	test("marks slow spans without duplicating duration or derived breach ratio", () => {
+	test("preserves duration and breach ratio for existing Axiom queries", () => {
 		const attributes = buildRedisSpanOutcomeAttributes({
 			durationMs: 30,
 			slowMs: 15,
 		});
 
 		expect(attributes).toEqual({
+			"db.redis.duration_ms": 30,
 			"db.redis.slow": true,
+			"db.redis.breach_ratio": 2,
 		});
-		expect(attributes["db.redis.duration_ms"]).toBeUndefined();
-		expect(attributes["db.redis.breach_ratio"]).toBeUndefined();
 	});
 
-	test("does not add outcome attributes to successful non-slow spans", () => {
+	test("preserves duration without marking successful non-slow spans as slow", () => {
 		expect(
 			buildRedisSpanOutcomeAttributes({
 				durationMs: 10,
 				slowMs: 15,
 			}),
-		).toEqual({});
+		).toEqual({
+			"db.redis.duration_ms": 10,
+		});
 	});
 
 	test("does not classify a span exactly at the slow threshold as slow", () => {
@@ -30,15 +32,21 @@ describe("Redis span outcome attributes", () => {
 				durationMs: 15,
 				slowMs: 15,
 			}),
-		).toEqual({});
+		).toEqual({
+			"db.redis.duration_ms": 15,
+		});
 	});
 
-	test("classifies any positive duration as slow when the threshold is zero", () => {
+	test("retains the original zero-threshold breach-ratio fallback", () => {
 		expect(
 			buildRedisSpanOutcomeAttributes({
 				durationMs: 0.01,
 				slowMs: 0,
 			}),
-		).toEqual({ "db.redis.slow": true });
+		).toEqual({
+			"db.redis.duration_ms": 0.01,
+			"db.redis.slow": true,
+			"db.redis.breach_ratio": 0,
+		});
 	});
 });

--- a/server/tests/unit/redis-otel/redisSpanOutcomeAttributes.test.ts
+++ b/server/tests/unit/redis-otel/redisSpanOutcomeAttributes.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { buildRedisSpanOutcomeAttributes } from "@/external/redis/otel/redisSpanOutcomeAttributes.js";
+
+describe("Redis span outcome attributes", () => {
+	test("marks slow spans without duplicating duration or derived breach ratio", () => {
+		const attributes = buildRedisSpanOutcomeAttributes({
+			durationMs: 30,
+			slowMs: 15,
+		});
+
+		expect(attributes).toEqual({
+			"db.redis.slow": true,
+		});
+		expect(attributes["db.redis.duration_ms"]).toBeUndefined();
+		expect(attributes["db.redis.breach_ratio"]).toBeUndefined();
+	});
+
+	test("does not add outcome attributes to successful non-slow spans", () => {
+		expect(
+			buildRedisSpanOutcomeAttributes({
+				durationMs: 10,
+				slowMs: 15,
+			}),
+		).toEqual({});
+	});
+
+	test("does not classify a span exactly at the slow threshold as slow", () => {
+		expect(
+			buildRedisSpanOutcomeAttributes({
+				durationMs: 15,
+				slowMs: 15,
+			}),
+		).toEqual({});
+	});
+
+	test("classifies any positive duration as slow when the threshold is zero", () => {
+		expect(
+			buildRedisSpanOutcomeAttributes({
+				durationMs: 0.01,
+				slowMs: 0,
+			}),
+		).toEqual({ "db.redis.slow": true });
+	});
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces Axiom ingest by compacting repeated Drizzle SQL spans (keeps SQL on slow repeats), emitting one resource-definition span, and splitting request log context; preserves Redis fields used by existing Axiom queries. Lowers trace/log volume while keeping key fields easy to query.

- New Features
  - SQL span compaction: keep the first Drizzle span with `db.statement`, mark it `db.query_definition=true` with a stable `db.query_id`; strip `db.statement` from repeats under 100 ms; retain SQL on repeated slow spans.
  - Compact OTel resources: per-span attributes are minimal (`service.name`, `service.instance.id`); emit one `otel.resource_definition` span with host/process/runtime/AWS/SDK metadata.
  - Unit tests cover compaction (including slow-span behavior), resource attributes, request logging, `FilteringSpanProcessor`, and Redis outcome attributes.

- Refactors
  - Request logging: only the terminal request log includes the redacted `body`; internal logger context omits `body`.
  - Redis spans: preserve `db.redis.duration_ms`; set `db.redis.slow` and `db.redis.breach_ratio` when slow; keep existing export rules (always export slow or error spans).
  - `FilteringSpanProcessor` integrates the compactor and retains Redis export behavior.

<sup>Written for commit 4880d895bba55bf57325fc6818d0c0189e09d5ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR reduces observability ingest volume while retaining fields needed for request, SQL, and Redis analysis.
- **[Improvements]** Compacts repeated Drizzle SQL spans using stable query IDs while retaining definitions and slow-query statements.
- **[Improvements]** Replaces repeated OpenTelemetry resource metadata with compact per-span identity and a dedicated resource-definition span.
- **[Improvements]** Removes request bodies from internal logger context and restores the redacted body on terminal request records.
- **[Improvements]** Refactors Redis outcome attributes while preserving duration, slow-span, breach-ratio, and export behavior.
- **[Bug fixes]** Adds focused tests for span compaction, resource metadata, request logging, filtering, and Redis telemetry.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/utils/otel/SpanIngestCompactor.ts | Introduces bounded, deterministic SQL-span compaction while retaining first definitions and repeated slow statements. |
| server/src/instrumentation.ts | Configures compact OTel resources and asynchronously emits one detailed resource-definition span per process. |
| server/src/honoMiddlewares/baseMiddleware.ts | Splits request context into body-free internal logging data and a complete redacted terminal context. |
| server/src/honoMiddlewares/requestLogging/logRequestResult.ts | Restores the complete redacted request context immediately before emitting terminal request logs. |
| server/src/utils/otel/FilteringSpanProcessor.ts | Integrates SQL compaction after Redis filtering and before delegated span export. |
| server/src/external/redis/otel/redisSpanOutcomeAttributes.ts | Centralizes Redis duration, slow classification, and breach-ratio span attributes. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Request[Request processing] --> InternalLogs[Internal logs without body]
  Request --> TerminalLog[Terminal request log with redacted body]
  Drizzle[Drizzle spans] --> Filter[FilteringSpanProcessor]
  Redis[Redis spans] --> Filter
  Resource[Resource-definition span] --> Filter
  Filter --> Compactor[SQL ingest compactor]
  Compactor --> Batch[BatchSpanProcessor]
  Batch --> Axiom[Axiom]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: retain SQL on slow Drizzle spans"](https://github.com/useautumn/autumn/commit/4880d895bba55bf57325fc6818d0c0189e09d5ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48057540)</sub>

<!-- /greptile_comment -->