### PR TITLE
fix(api): return fixed discounts in major units

### DIFF
--- a/server/src/internal/customers/cusUtils/cusResponseUtils/getCusRewards.ts
+++ b/server/src/internal/customers/cusUtils/cusResponseUtils/getCusRewards.ts
@@ -6,6 +6,7 @@ import {
 	notNullish,
 	type Organization,
 	RewardType,
+	stripeToAtmnAmount,
 } from "@autumn/shared";
 import type Stripe from "stripe";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
@@ -88,7 +89,12 @@ export const getCusRewards = async ({
 					type: coupon.amount_off
 						? RewardType.FixedDiscount
 						: RewardType.PercentageDiscount,
-					discount_value: coupon.amount_off || coupon.percent_off || 0,
+					discount_value: coupon.amount_off
+						? stripeToAtmnAmount({
+								amount: coupon.amount_off,
+								currency: coupon.currency ?? undefined,
+							})
+						: (coupon.percent_off ?? 0),
 					currency: coupon.currency ?? null,
 					start: d.start ?? null,
 					end: d.end ?? null,

--- a/server/tests/integration/customers/rewards/customer-fixed-discount-major-units.test.ts
+++ b/server/tests/integration/customers/rewards/customer-fixed-discount-major-units.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Before: customer rewards returned fixed discounts in Stripe minor units.
+ * After: customer rewards return fixed discounts in Autumn major units.
+ */
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV3,
+	CouponDurationType,
+	CustomerExpand,
+	RewardType,
+} from "@autumn/shared";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+
+test(`${chalk.yellowBright("customer rewards: returns fixed discounts in major units")}`, async () => {
+	const customerId = "customer-fixed-discount-major-units";
+	const rewardId = "fixed-250";
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [s.platform.create(), s.customer({ testClock: false })],
+		actions: [],
+	});
+
+	await autumnV1.rewards.create({
+		id: rewardId,
+		name: "$250 off",
+		type: RewardType.FixedDiscount,
+		promo_codes: [],
+		discount_config: {
+			discount_value: 250,
+			duration_type: CouponDurationType.OneOff,
+			duration_value: 0,
+			apply_to_all: true,
+			price_ids: [],
+		},
+	});
+	await autumnV1.post(`/customers/${customerId}/coupons/${rewardId}`, {});
+
+	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId, {
+		expand: [CustomerExpand.Rewards],
+	});
+
+	expect(customer.rewards?.discounts).toHaveLength(1);
+	expect(customer.rewards?.discounts[0]?.discount_value).toBe(250);
+});


### PR DESCRIPTION
## Summary
- convert Stripe `amount_off` values to Autumn major currency units in expanded customer rewards
- keep percentage discount values unchanged
- add an integration regression test covering a $250 customer-level coupon

## Testing
- `bunx tsgo --build --noEmit`
- red: customer API returned `25000` instead of `250`
- green: `./run.sh .../customer-fixed-discount-major-units.test.ts` — 1 pass, 0 fail

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the customer rewards API to return fixed-discount coupon amounts in Autumn major currency units (e.g., $250 => 250, not 25000). Percentage discounts are unchanged.

<sup>Written for commit b25ee9345b44a338df94aec26779a4d0c6d83af1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Converts fixed Stripe coupon amounts from minor units into Autumn’s major currency units while leaving percentage discounts unchanged.
- **[Bug fixes, API changes]** Normalizes expanded customer fixed-discount values using the coupon currency.
- **[Improvements]** Adds an integration regression test for a $250 customer-level coupon.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The response conversion mirrors the existing major-to-minor Stripe coupon creation path, preserves percentage discounts, and is covered by a focused customer API regression test.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cusUtils/cusResponseUtils/getCusRewards.ts | Correctly applies the shared currency-aware minor-to-major unit conversion to fixed discounts without changing percentage values. |
| server/tests/integration/customers/rewards/customer-fixed-discount-major-units.test.ts | Adds focused regression coverage confirming that a $250 fixed coupon is returned as 250 rather than 25000. |

<sub>Reviews (1): Last reviewed commit: ["fix(api): 🐛 return fixed discounts in m..."](https://github.com/useautumn/autumn/commit/b25ee9345b44a338df94aec26779a4d0c6d83af1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48072437)</sub>

<!-- /greptile_comment -->