### PR TITLE
chore: support quantity updates on schedules

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts
@@ -126,12 +126,9 @@ export const autoSyncUpdatedSubscription = async ({
 		return;
 	}
 
-	const currentPhase = params.phases?.find(
-		(phase) => phase.starts_at === "now",
-	);
 	const incremental = buildIncrementalSyncParams({
 		match,
-		params: currentPhase ? { ...params, phases: [currentPhase] } : params,
+		params,
 		linkedCustomerProducts,
 	});
 	if (!incremental.shouldSync) {

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/autoSyncUpdatedSubscription.ts
@@ -126,9 +126,12 @@ export const autoSyncUpdatedSubscription = async ({
 		return;
 	}
 
+	const currentPhase = params.phases?.find(
+		(phase) => phase.starts_at === "now",
+	);
 	const incremental = buildIncrementalSyncParams({
 		match,
-		params,
+		params: currentPhase ? { ...params, phases: [currentPhase] } : params,
 		linkedCustomerProducts,
 	});
 	if (!incremental.shouldSync) {

--- a/server/src/internal/billing/v2/actions/sync/scope/buildIncrementalSyncParams.ts
+++ b/server/src/internal/billing/v2/actions/sync/scope/buildIncrementalSyncParams.ts
@@ -138,12 +138,8 @@ export const buildIncrementalSyncParams = ({
 		};
 	}
 
-	const phase = params.phases?.[0];
-	if (
-		!phase ||
-		params.phases?.length !== 1 ||
-		phase.plans.length !== phaseMatch.plans.length
-	) {
+	const phase = params.phases?.find((phase) => phase.starts_at === "now");
+	if (!phase || phase.plans.length !== phaseMatch.plans.length) {
 		return {
 			shouldSync: false,
 			reason: "unsupported_phase_shape",

--- a/server/src/internal/billing/v2/actions/sync/scope/buildIncrementalSyncParams.ts
+++ b/server/src/internal/billing/v2/actions/sync/scope/buildIncrementalSyncParams.ts
@@ -138,7 +138,10 @@ export const buildIncrementalSyncParams = ({
 		};
 	}
 
-	const phase = params.phases?.find((phase) => phase.starts_at === "now");
+	const phases = params.phases ?? [];
+	const phase =
+		phases.find((phase) => phase.starts_at === "now") ??
+		(phases.length === 1 ? phases[0] : undefined);
 	if (!phase || phase.plans.length !== phaseMatch.plans.length) {
 		return {
 			shouldSync: false,

--- a/server/tests/integration/billing/stripe-webhooks/subscription-updated/licenses/sub-updated-license-backsync.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/subscription-updated/licenses/sub-updated-license-backsync.test.ts
@@ -24,7 +24,7 @@
  * Post-impl green: subscription.updated sync maps the license price's
  * quantity delta onto the pool counters.
  */
-import { test } from "bun:test";
+import { expect, test } from "bun:test";
 import {
 	type ApiCustomerV5,
 	type ApiEntityV2,
@@ -244,6 +244,56 @@ test(`${chalk.yellowBright("sub.updated license back-sync: qty 3 -> 2 decrements
 		parentPlanId: parent.id,
 		paidQuantity: 2,
 	});
+});
+
+test(`${chalk.yellowBright("sub.updated license back-sync: current schedule quantity updates the pool")}`, async () => {
+	const customerId = "sub-updated-license-backsync-schedule";
+	const { autumnV2_3, parent, devSeat, subscription, seatItem } =
+		await setupLicenseSubscription({
+			customerId,
+			idPrefix: "lic-backsync-schedule",
+			quantity: 2,
+		});
+
+	const schedule = await ctx.stripeCli.subscriptionSchedules.create({
+		from_subscription: subscription.id,
+	});
+	const currentPhase = schedule.phases[0]!;
+	const currentEnd = currentPhase.end_date!;
+	const nextEnd = currentEnd + 31 * 24 * 60 * 60;
+	const phases = (quantity: number) => [
+		{
+			items: [{ price: seatItem.price.id, quantity }],
+			start_date: currentPhase.start_date,
+			end_date: currentEnd,
+		},
+		{
+			items: [{ price: seatItem.price.id, quantity: 1 }],
+			start_date: currentEnd,
+			end_date: nextEnd,
+		},
+	];
+
+	await ctx.stripeCli.subscriptionSchedules.update(schedule.id, {
+		phases: phases(2),
+	});
+	await ctx.stripeCli.subscriptionSchedules.update(schedule.id, {
+		phases: phases(3),
+	});
+
+	await waitForPoolCounters({
+		autumnV2_3,
+		customerId,
+		licensePlanId: devSeat.id,
+		parentPlanId: parent.id,
+		paidQuantity: 3,
+	});
+
+	const updatedSchedule =
+		await ctx.stripeCli.subscriptionSchedules.retrieve(schedule.id);
+	expect(updatedSchedule.phases.map((phase) => phase.items[0]?.quantity)).toEqual([
+		3, 1,
+	]);
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/server/tests/unit/billing/sync/build-incremental-sync-params.spec.ts
+++ b/server/tests/unit/billing/sync/build-incremental-sync-params.spec.ts
@@ -172,6 +172,46 @@ describe("buildIncrementalSyncParams", () => {
 		expect(result.params?.phases?.[0]?.plans[0]?.plan_id).toBe(current.id);
 	});
 
+	test("falls back to the only phase when no current sentinel exists", () => {
+		const pro = product({ id: "pro" });
+		const { match, params } = draft({
+			matchedPlans: [matchedPlan({ product: pro })],
+		});
+		params.phases![0]!.starts_at = 123;
+
+		const result = buildIncrementalSyncParams({
+			match,
+			params,
+			linkedCustomerProducts: [],
+		});
+
+		expect(result.shouldSync).toBe(true);
+		if (!result.shouldSync) throw new Error(result.reason);
+		expect(result.params?.phases?.[0]?.starts_at).toBe(123);
+	});
+
+	test("rejects multiple phases without a current sentinel", () => {
+		const pro = product({ id: "pro" });
+		const { match, params } = draft({
+			matchedPlans: [matchedPlan({ product: pro })],
+		});
+		params.phases = [
+			{ starts_at: 123, plans: params.phases![0]!.plans },
+			{ starts_at: 456, plans: params.phases![0]!.plans },
+		];
+
+		expect(
+			buildIncrementalSyncParams({
+				match,
+				params,
+				linkedCustomerProducts: [],
+			}),
+		).toMatchObject({
+			shouldSync: false,
+			reason: "unsupported_phase_shape",
+		});
+	});
+
 	test("keeps a plan when no linked customer product exists for its target", () => {
 		const pro = product({ id: "pro" });
 		const { match, params } = draft({

--- a/server/tests/unit/billing/sync/build-incremental-sync-params.spec.ts
+++ b/server/tests/unit/billing/sync/build-incremental-sync-params.spec.ts
@@ -148,6 +148,30 @@ const draft = ({
 });
 
 describe("buildIncrementalSyncParams", () => {
+	test("syncs the current phase when future schedule phases exist", () => {
+		const current = product({ id: "current" });
+		const future = product({ id: "future" });
+		const { match, params } = draft({
+			matchedPlans: [matchedPlan({ product: current })],
+		});
+		params.phases?.push({
+			starts_at: 456,
+			plans: [syncPlan({ productId: future.id })],
+		});
+
+		const result = buildIncrementalSyncParams({
+			match,
+			params,
+			linkedCustomerProducts: [],
+		});
+
+		expect(result.shouldSync).toBe(true);
+		if (!result.shouldSync) throw new Error(result.reason);
+		expect(result.params?.phases).toHaveLength(1);
+		expect(result.params?.phases?.[0]?.starts_at).toBe("now");
+		expect(result.params?.phases?.[0]?.plans[0]?.plan_id).toBe(current.id);
+	});
+
 	test("keeps a plan when no linked customer product exists for its target", () => {
 		const pro = product({ id: "pro" });
 		const { match, params } = draft({


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure quantity changes on Stripe subscription schedules update license pools. Incremental `subscription.updated` sync now uses the active schedule phase (`starts_at: "now"`) so counters match the current quantity while keeping future phases intact.

- **Bug Fixes**
  - In `buildIncrementalSyncParams`, select the current phase; fall back to the only phase when no `"now"` sentinel exists; reject multi-phase inputs without a current phase.
  - Added unit and integration tests for current-phase selection, single-phase fallback, and preserving future phase quantities.

<sup>Written for commit 727b8ab6e1ea99827f27c54ed412f0f6ae77a82f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR updates incremental Stripe schedule synchronization and expands coverage for scheduled license quantities.
- **Bug fixes:** Selects the active schedule phase when synchronizing quantity changes while future phases exist.
- **Improvements:** Preserves support for single-phase inputs without a `"now"` sentinel.
- **Improvements:** Adds unit and integration coverage for active-phase license-pool quantity updates and Stripe future-phase preservation.
</details>

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because active-phase incremental synchronization still drops future phases from the downstream parameters, leaving Autumn's scheduled transition stale.

The active phase is now selected correctly, but the incremental result reconstructs the phase list with only that phase; downstream schedule computation therefore cannot update the existing future-phase state.

**Files Needing Attention:** server/src/internal/billing/v2/actions/sync/scope/buildIncrementalSyncParams.ts; server/tests/unit/billing/sync/build-incremental-sync-params.spec.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/sync/scope/buildIncrementalSyncParams.ts | Selects the active phase for incremental synchronization, but the previously reported omission of future phases remains. |
| server/tests/integration/billing/stripe-webhooks/subscription-updated/licenses/sub-updated-license-backsync.test.ts | Adds end-to-end coverage showing that an active scheduled quantity update adjusts license-pool counters and leaves Stripe's future phase unchanged. |
| server/tests/unit/billing/sync/build-incremental-sync-params.spec.ts | Covers current-phase selection and single-phase fallback, while codifying the omission of future phases from incremental parameters. |

<sub>Reviews (3): Last reviewed commit: ["fix(billing): 🐛 preserve single-phase i..."](https://github.com/useautumn/autumn/commit/727b8ab6e1ea99827f27c54ed412f0f6ae77a82f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48260001)</sub>

<!-- /greptile_comment -->