### PR TITLE
fix(revenuecat): resolve canonical customer on cancellation

### DIFF
--- a/server/src/external/revenueCat/misc/resolveRevenuecatResources.ts
+++ b/server/src/external/revenueCat/misc/resolveRevenuecatResources.ts
@@ -298,24 +298,24 @@ const resolveRevenueCatCustomer = async ({
 		if (processorMatch) matchedBy = "processors_key_original_app_user_id";
 	}
 
-	// Customer_id fallback, read-both. Always run so ambiguity can be detected.
-	let customerIdMatch = await CusService.getFull({
-		ctx,
-		idOrInternalId: appUserId,
-		withEntities: true,
-		withSubs: true,
-		allowNotFound: true,
-	});
-	let customerIdMatchedBy = customerIdMatch ? "customer_id_app_user_id" : null;
+	// Don't let an invalid legacy id conflict with a canonical processor match.
+	const getCustomerIdMatch = (id: string) => {
+		if (processorMatch && !CreateCustomerSchema.shape.id.safeParse(id).success)
+			return null;
 
-	if (!customerIdMatch && hasOriginal) {
-		customerIdMatch = await CusService.getFull({
+		return CusService.getFull({
 			ctx,
-			idOrInternalId: originalAppUserId as string,
+			idOrInternalId: id,
 			withEntities: true,
 			withSubs: true,
 			allowNotFound: true,
 		});
+	};
+	let customerIdMatch = await getCustomerIdMatch(appUserId);
+	let customerIdMatchedBy = customerIdMatch ? "customer_id_app_user_id" : null;
+
+	if (!customerIdMatch && hasOriginal) {
+		customerIdMatch = await getCustomerIdMatch(originalAppUserId as string);
 		if (customerIdMatch)
 			customerIdMatchedBy = "customer_id_original_app_user_id";
 	}

--- a/server/tests/integration/external-psps/revenuecat/revenuecat-override-attribute.test.ts
+++ b/server/tests/integration/external-psps/revenuecat/revenuecat-override-attribute.test.ts
@@ -265,29 +265,35 @@ test.concurrent(
 // ═══════════════════════════════════════════════════════════════════
 
 test.concurrent(
-	`${chalk.yellowBright("rc override: override wins even when a different customer matches by app_user_id")}`,
+	`${chalk.yellowBright("rc override: attribute-less cancellation uses the canonical customer")}`,
 	async () => {
 		const overrideId = "org_rc_override_wins";
-		const appUserId = "rc-override-appuser-match";
-		const RC_PRODUCT_ID = "com.app.rc_override_wins_pro";
+		const legacyId = `rc-override-legacy-email-${Date.now()}`;
+		const appUserId = "rc-override-appuser@example.com";
+		const RC_PRODUCT_ID = "com.app.rc_override_attrless_cancel_pro";
 		const proMonthly = rcProMonthly({ id: "rc-override-wins-pro" });
 
 		await setupRevenueCatOrg();
 
 		await initScenario({
-			customerId: appUserId,
+			customerId: legacyId,
 			setup: [
 				s.deleteCustomer({ customerId: overrideId }),
 				s.deleteCustomer({ customerId: appUserId }),
-				// Customer that WOULD match by customer_id == app_user_id.
+				s.deleteCustomer({ customerId: legacyId }),
 				s.customer({ testClock: false, skipWebhooks: true }),
-				s.products({ list: [proMonthly] }),
+				s.products({ list: [proMonthly], prefix: "rc-override-cancellation" }),
 			],
 			actions: [],
 		});
 
+		await ctx.db
+			.update(customers)
+			.set({ id: appUserId, email: appUserId })
+			.where(eq(customers.id, legacyId));
+
 		// Pre-create the override target so we can assert the plan lands here.
-		await initScenario({
+		const { autumnV1 } = await initScenario({
 			customerId: overrideId,
 			setup: [s.customer({ testClock: false, skipWebhooks: true })],
 			actions: [],
@@ -314,12 +320,24 @@ test.concurrent(
 		);
 		expect(overrideProductIds).toContain(proMonthly.id);
 
-		// The app_user_id-matched customer must NOT receive the plan.
 		const appUserCustomer = await getCustomerByCustomerId(appUserId);
 		const appUserProductIds = await activeRcProductIds(
 			appUserCustomer!.internal_id,
 		);
 		expect(appUserProductIds).not.toContain(proMonthly.id);
+
+		/** Pre-fix, an attribute-less cancellation returned 500 after an override.
+		 * Post-fix, the processor-mapped canonical customer is cancelled. */
+		expectWebhookSuccess(
+			await newRcClient().cancellation({
+				productId: RC_PRODUCT_ID,
+				appUserId,
+				originalTransactionId: "rc_override_wins_tx_001",
+			}),
+		);
+
+		const cancelledCustomer = await autumnV1.customers.get(overrideId);
+		expect(cancelledCustomer.products[0]?.canceled_at).toBeDefined();
 	},
 );
 


### PR DESCRIPTION
## Summary
- prefer the established RevenueCat processor mapping over an invalid legacy customer ID
- preserve ambiguity detection for valid Autumn customer IDs
- add regression coverage for attribute-less cancellation after an override

## Testing
- RevenueCat override integration suite: 4 passed
- RevenueCat dual-key integration suite: 7 passed
- bunx tsgo --build --noEmit
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RevenueCat cancellations to resolve the canonical customer via processor mapping and ignore invalid legacy `app_user_id`s. Prevents 500s on attribute-less cancellations after an override and ensures the correct customer is cancelled.

- **Bug Fixes**
  - Prefer the processor mapping when present; block legacy `app_user_id` fallback if it isn’t a valid Autumn customer ID, while keeping ambiguity checks for valid IDs.
  - Add regression test proving attribute-less cancellation after an override cancels the processor-mapped customer without error.

<sup>Written for commit 53ad052d6abf5a294822fd89bb5dd8a5c86b4b5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates RevenueCat customer resolution for cancellation webhooks:
- **Bug fixes:** Prefer an established RevenueCat processor mapping when the competing legacy customer ID is invalid.
- **Improvements:** Preserve ambiguity detection when the RevenueCat identifier is a valid Autumn customer ID.
- **Improvements:** Add regression coverage for attribute-less cancellation after a customer override.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/revenueCat/misc/resolveRevenuecatResources.ts | Avoids treating an invalid legacy customer ID as conflicting with an established RevenueCat processor mapping while retaining validation for legitimate ambiguity. |
| server/tests/integration/external-psps/revenuecat/revenuecat-override-attribute.test.ts | Adds regression coverage proving that an attribute-less cancellation after an override cancels the processor-mapped canonical customer. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[RevenueCat cancellation webhook] --> B[Resolve processor mapping]
  B --> C{Processor match exists?}
  C -- No --> D[Use customer ID fallback]
  C -- Yes --> E{Legacy ID is valid?}
  E -- Yes --> F[Check for ambiguous customer match]
  E -- No --> G[Use canonical processor-mapped customer]
  F --> G
  G --> H[Cancel canonical customer's product]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(revenuecat): 🐛 resolve canonical cu..."](https://github.com/useautumn/autumn/commit/53ad052d6abf5a294822fd89bb5dd8a5c86b4b5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48264903)</sub>

**Context used:**

- Knowledge Base — [External Integrations (non-Stripe)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-external-integrations.md)

<!-- /greptile_comment -->