### PR TITLE
chore: redis unavailable

### DIFF
--- a/server/src/internal/balances/finalizeLock/queueFinalizeLock.ts
+++ b/server/src/internal/balances/finalizeLock/queueFinalizeLock.ts
@@ -1,0 +1,61 @@
+import type { FinalizeLockParamsV0 } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { JobName } from "@/queue/JobName.js";
+import { addTaskToQueue } from "@/queue/queueUtils.js";
+import { addToExtraLogs } from "@/utils/logging/addToExtraLogs.js";
+
+/** Queues a finalize-lock replay on the track queue when Redis is down.
+ *  Returns the accepted response, or null when queueing is unavailable. */
+export const queueFinalizeLock = async ({
+	ctx,
+	params,
+}: {
+	ctx: AutumnContext;
+	params: FinalizeLockParamsV0;
+}) => {
+	try {
+		const queueUrl = process.env.TRACK_SQS_QUEUE_URL;
+		if (!queueUrl) {
+			ctx.logger.warn(
+				"[finalizeLock] Redis unavailable and TRACK_SQS_QUEUE_URL is unset; cannot queue finalize replay",
+			);
+			return null;
+		}
+
+		await addTaskToQueue({
+			jobName: JobName.FinalizeLock,
+			queueUrl,
+			messageGroupId: `${ctx.org.id}:${ctx.env}:lock:${params.lock_id}`,
+			messageDeduplicationId: ctx.id,
+			payload: {
+				orgId: ctx.org.id,
+				env: ctx.env,
+				customerId: ctx.customerId,
+				requestId: ctx.id,
+				params,
+			},
+		});
+
+		ctx.logger.warn(
+			"[finalizeLock] Redis unavailable, queued finalize replay",
+			{
+				type: "finalize_lock_queue_fallback",
+				lock_id: params.lock_id,
+				action: params.action,
+			},
+		);
+		addToExtraLogs({
+			ctx,
+			extras: { finalizeLockQueuedForReplay: true },
+		});
+
+		return { success: true };
+	} catch (error) {
+		ctx.logger.warn("[finalizeLock] Queue fallback failed (SQS)", {
+			type: "finalize_lock_queue_fallback_failed",
+			error,
+		});
+
+		return null;
+	}
+};

--- a/server/src/internal/balances/finalizeLock/runFinalizeLock.ts
+++ b/server/src/internal/balances/finalizeLock/runFinalizeLock.ts
@@ -2,8 +2,8 @@ import type { FinalizeLockParamsV0 } from "@autumn/shared";
 import { withRedisFailOpen } from "@/external/redis/utils/withRedisFailOpen.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { fetchLockReceipt } from "@/internal/balances/utils/lock/fetchLockReceipt.js";
-import { isFullSubjectRolloutEnabled } from "@/internal/misc/rollouts/fullSubjectRolloutUtils.js";
-import { addToExtraLogs } from "@/utils/logging/addToExtraLogs.js";
+import { releaseLockClaimMarker } from "@/internal/balances/utils/lockV2/releaseLockClaimMarker.js";
+import { queueFinalizeLock } from "./queueFinalizeLock.js";
 import { runFinalizeLockV2 } from "./runFinalizeLockV2.js";
 
 type RunFinalizeLockArgs = {
@@ -12,23 +12,30 @@ type RunFinalizeLockArgs = {
 };
 
 export const runFinalizeLock = async (args: RunFinalizeLockArgs) => {
-	if (isFullSubjectRolloutEnabled({ ctx: args.ctx })) {
-	}
-
 	return withRedisFailOpen({
 		source: "runFinalizeLock",
 		run: () => runFinalizeLockInner(args),
-		fallback: () => {
-			addToExtraLogs({
+		fallback: async (error) => {
+			// The dying attempt may have claimed the receipt; release so the
+			// queued replay can reclaim.
+			await releaseLockClaimMarker({
 				ctx: args.ctx,
-				extras: { finalizeLockFailedOpen: true },
+				lockId: args.params.lock_id,
 			});
-			return { success: true };
+			const queuedResponse = await queueFinalizeLock({
+				ctx: args.ctx,
+				params: args.params,
+			});
+			if (queuedResponse) return queuedResponse;
+			throw error;
 		},
 	});
 };
 
-const runFinalizeLockInner = async ({ ctx, params }: RunFinalizeLockArgs) => {
+export const runFinalizeLockInner = async ({
+	ctx,
+	params,
+}: RunFinalizeLockArgs) => {
 	const fetchedReceipt = await fetchLockReceipt({
 		ctx,
 		lockId: params.lock_id,

--- a/server/src/internal/balances/finalizeLock/runQueuedFinalizeLock.ts
+++ b/server/src/internal/balances/finalizeLock/runQueuedFinalizeLock.ts
@@ -1,0 +1,29 @@
+import { type FinalizeLockParamsV0, RecaseError } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { runFinalizeLockInner } from "./runFinalizeLock.js";
+
+/** Queued finalize replay. Never re-queues — the same dedup id would drop
+ *  inside the FIFO window; transient errors rethrow so SQS redelivery retries. */
+export const runQueuedFinalizeLock = async ({
+	ctx,
+	params,
+}: {
+	ctx: AutumnContext;
+	params: FinalizeLockParamsV0;
+}) => {
+	try {
+		return await runFinalizeLockInner({ ctx, params });
+	} catch (error) {
+		if (
+			error instanceof RecaseError &&
+			error.message.includes("Lock not found")
+		) {
+			ctx.logger.info("[finalizeLock] queued replay already resolved", {
+				type: "finalize_lock_queue_replay_resolved",
+				lock_id: params.lock_id,
+			});
+			return { success: true };
+		}
+		throw error;
+	}
+};

--- a/server/src/internal/balances/handlers/handleFinalizeLock.ts
+++ b/server/src/internal/balances/handlers/handleFinalizeLock.ts
@@ -10,7 +10,7 @@ export const handleFinalizeLock = createRoute({
 		const params = c.req.valid("json");
 
 		const response = await runFinalizeLock({ ctx, params });
-		const status = ctx.extraLogs.finalizeLockFailedOpen ? 202 : 200;
+		const status = ctx.extraLogs.finalizeLockQueuedForReplay ? 202 : 200;
 
 		return c.json(response, status);
 	},

--- a/server/src/internal/balances/utils/lockV2/releaseLockClaimMarker.ts
+++ b/server/src/internal/balances/utils/lockV2/releaseLockClaimMarker.ts
@@ -1,0 +1,34 @@
+import { getRedisV2LockReceiptCandidates } from "@/external/redis/orgRedisUtils/orgRedisMigrationUtils.js";
+import { tryRedisOp } from "@/external/redis/utils/runRedisOp.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { buildLockReceiptKey } from "../lock/buildLockReceiptKey.js";
+import { buildClaimMarkerKey } from "./buildClaimMarkerKey.js";
+
+/** Best-effort claim-marker DEL after a failed finalize attempt, so an inline
+ *  retry or queued replay can reclaim instead of hitting a contested 409. */
+export const releaseLockClaimMarker = async ({
+	ctx,
+	lockId,
+}: {
+	ctx: AutumnContext;
+	lockId: string;
+}) => {
+	const hashedKey = Bun.hash(lockId).toString();
+	const claimMarkerKey = buildClaimMarkerKey(
+		buildLockReceiptKey({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			lockKey: hashedKey,
+		}),
+	);
+
+	await Promise.all(
+		getRedisV2LockReceiptCandidates({ ctx }).map((redisInstance) =>
+			tryRedisOp({
+				operation: () => redisInstance.del(claimMarkerKey),
+				source: "releaseLockClaimMarker",
+				redisInstance,
+			}),
+		),
+	);
+};

--- a/server/src/queue/JobName.ts
+++ b/server/src/queue/JobName.ts
@@ -40,6 +40,9 @@ export enum JobName {
 	/** Replays failed early-acked Stripe webhooks from the dedicated queue */
 	StripeWebhookReplay = "stripe-webhook-replay",
 
+	/** Queued finalize-lock replay when Redis was unavailable at finalize time */
+	FinalizeLock = "finalize-lock",
+
 	// EventBridge scheduled jobs
 	ExpireLockReceipt = "expire-lock-receipt",
 }

--- a/server/src/queue/processMessage.ts
+++ b/server/src/queue/processMessage.ts
@@ -17,6 +17,7 @@ import { autoTopup } from "@/internal/balances/autoTopUp/autoTopup.js";
 import { batchResetCustomerEntitlementsV2 } from "@/internal/balances/batchReset/batchResetCustomerEntitlementsV2.js";
 import { runInsertEventBatch } from "@/internal/balances/events/runInsertEventBatch.js";
 import { expireLock } from "@/internal/balances/finalizeLock/expireLock.js";
+import { runQueuedFinalizeLock } from "@/internal/balances/finalizeLock/runQueuedFinalizeLock.js";
 import { runQueuedTrack } from "@/internal/balances/track/runQueuedTrack.js";
 import { runUpdateBalanceV2 } from "@/internal/balances/updateBalance/v2/updateBalanceV2.js";
 import { refreshEntityAggregateCache } from "@/internal/balances/utils/refreshEntityAggregate/index.js";
@@ -53,6 +54,17 @@ export interface SqsJob {
 	data: any;
 }
 
+const isClaimContestedError = ({ error }: { error: unknown }): boolean => {
+	if (!(error instanceof RecaseError)) return false;
+	const { data } = error;
+	return (
+		typeof data === "object" &&
+		data !== null &&
+		"blockingStatus" in data &&
+		data.blockingStatus === "RESERVATION_ALREADY_PROCESSING"
+	);
+};
+
 export const shouldRetrySqsJobError = ({
 	jobName,
 	error,
@@ -72,6 +84,14 @@ export const shouldRetrySqsJobError = ({
 		case JobName.Track:
 		case JobName.UpdateBalance:
 			return isTransientDbError({ error }) || isTransientRedisError({ error });
+		// Finalize replays also redeliver while a dying attempt's claim marker
+		// clears — dropping one leaks the customer's reserved balance.
+		case JobName.FinalizeLock:
+			return (
+				isTransientDbError({ error }) ||
+				isTransientRedisError({ error }) ||
+				isClaimContestedError({ error })
+			);
 		// Top-up shares the customer billing lock — retry instead of dropping the job
 		// when it collides with an attach or checkout materialization.
 		case JobName.AutoTopUp:
@@ -158,7 +178,9 @@ export const processMessage = async ({
 
 		// Jobs below need worker context
 		const usesCustomerCache =
-			job.name === JobName.Track || job.name === JobName.UpdateBalance;
+			job.name === JobName.Track ||
+			job.name === JobName.UpdateBalance ||
+			job.name === JobName.FinalizeLock;
 		const ctx = await createWorkerContext({
 			db,
 			payload: job.data,
@@ -403,6 +425,18 @@ export const processMessage = async ({
 			await expireLock({
 				ctx,
 				payload: job.data,
+			});
+			return;
+		}
+
+		if (job.name === JobName.FinalizeLock) {
+			if (!ctx) {
+				workerLogger.error("No context found for finalize lock job");
+				return;
+			}
+			await runQueuedFinalizeLock({
+				ctx,
+				params: job.data.params,
 			});
 			return;
 		}

--- a/server/src/queue/queueUtils.ts
+++ b/server/src/queue/queueUtils.ts
@@ -2,6 +2,7 @@ import type {
 	ApiVersion,
 	AppEnv,
 	EventInsert,
+	FinalizeLockParamsV0,
 	Price,
 	TrackParams,
 	UpdateBalanceParamsV0,
@@ -97,6 +98,13 @@ export interface Payloads {
 		customerId: string;
 		lockId: string;
 		hashedKey: string;
+	};
+	[JobName.FinalizeLock]: {
+		orgId: string;
+		env: AppEnv;
+		customerId?: string;
+		requestId: string;
+		params: FinalizeLockParamsV0;
 	};
 	[key: string]: unknown;
 }

--- a/server/tests/integration/balances/lock/finalize-lock-queued-replay.test.ts
+++ b/server/tests/integration/balances/lock/finalize-lock-queued-replay.test.ts
@@ -1,0 +1,103 @@
+/**
+ * TDD test for end-to-end finalize-lock queued replay.
+ *
+ * Contract under test:
+ *   New behaviors:
+ *     - a JobName.FinalizeLock message on the track queue (the payload
+ *       runFinalizeLock's outage fallback enqueues) is processed by the
+ *       worker: the lock is released, the reserved balance refunded, and
+ *       the receipt + claim marker deleted
+ *
+ * Pre-impl red: JobName.FinalizeLock does not exist / the worker has no
+ * dispatch case, so the queued message is dropped and the balance stays
+ * reserved.
+ * Post-impl green: the replay releases the lock within the poll window.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV5 } from "@autumn/shared";
+import { deleteLock } from "@tests/integration/balances/utils/lockUtils/deleteLock.js";
+import { expectLockReceiptDeleted } from "@tests/integration/balances/utils/lockUtils/expectLockReceiptDeleted.js";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { JobName } from "@/queue/JobName.js";
+import { addTaskToQueue } from "@/queue/queueUtils.js";
+import { timeout } from "@/utils/genUtils";
+
+const POLL_INTERVAL_MS = 2000;
+const POLL_DEADLINE_MS = 60_000;
+
+test.concurrent(
+	`${chalk.yellowBright("finalize-lock-queued-replay 1: queued release job refunds the reserved balance")}`,
+	async () => {
+		const hourlyMessages = items.hourlyMessages({ includedUsage: 5 });
+		const monthlyMessages = items.monthlyMessages({ includedUsage: 10 });
+		const freeProd = products.base({
+			id: "free",
+			items: [hourlyMessages, monthlyMessages],
+		});
+
+		const customerId = `finalize-queued-replay-${Date.now()}`;
+		const { autumnV2_1, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [freeProd] }),
+			],
+			actions: [s.attach({ productId: freeProd.id })],
+		});
+
+		await deleteLock({ ctx, lockId: customerId });
+
+		await autumnV2_1.check({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			required_balance: 8,
+			lock: { enabled: true, lock_id: customerId },
+		});
+
+		const customerLocked =
+			await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer: customerLocked,
+			featureId: TestFeature.Messages,
+			remaining: 7,
+		});
+
+		// The exact message runFinalizeLock's outage fallback enqueues.
+		await addTaskToQueue({
+			jobName: JobName.FinalizeLock,
+			queueUrl: process.env.TRACK_SQS_QUEUE_URL,
+			messageGroupId: `${ctx.org.id}:${ctx.env}:lock:${customerId}`,
+			messageDeduplicationId: `${customerId}-release`,
+			payload: {
+				orgId: ctx.org.id,
+				env: ctx.env,
+				customerId,
+				requestId: `${customerId}-release`,
+				params: {
+					lock_id: customerId,
+					action: "release",
+					override_value: 0,
+				},
+			},
+		});
+
+		const deadline = Date.now() + POLL_DEADLINE_MS;
+		let remaining: number | undefined;
+		while (Date.now() < deadline) {
+			const customer =
+				await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+			remaining = customer.balances[TestFeature.Messages]?.remaining;
+			if (remaining === 15) break;
+			await timeout(POLL_INTERVAL_MS);
+		}
+
+		expect(remaining).toBe(15);
+		await expectLockReceiptDeleted({ ctx, lockId: customerId });
+	},
+);

--- a/server/tests/unit/balances/lock/runFinalizeLock-queue-fallback.test.ts
+++ b/server/tests/unit/balances/lock/runFinalizeLock-queue-fallback.test.ts
@@ -1,0 +1,296 @@
+/**
+ * TDD test for the finalizeLock queue fallback.
+ *
+ * Contract under test:
+ *   New types/fields:
+ *     - JobName.FinalizeLock = "finalize-lock" queued to TRACK_SQS_QUEUE_URL
+ *     - payload: { orgId, env, customerId?, requestId, params }
+ *     - ctx.extraLogs.finalizeLockQueuedForReplay: true when queued
+ *   New behaviors (runFinalizeLock):
+ *     - transient Redis/DB error or not_ready outage -> claim marker released
+ *       (best-effort), job queued (group org:env:lock:<lock_id>, dedup
+ *       ctx.id), returns { success: true } + queued extras flag
+ *     - queue unavailable -> original error rethrown (no fake success)
+ *     - non-transient errors propagate untouched, nothing queued
+ *   New behaviors (runQueuedFinalizeLock):
+ *     - "Lock not found" -> resolved as already-finalized success
+ *     - transient errors -> rethrown (no re-queue; SQS redelivery owns retry)
+ *
+ * Pre-impl red: queueFinalizeLock / runQueuedFinalizeLock /
+ * releaseLockClaimMarker do not exist and runFinalizeLock still returns a
+ * fake { success: true } fallback.
+ * Post-impl green: all assertions pass once the queue fallback ships.
+ */
+
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	test,
+} from "bun:test";
+import {
+	ApiVersion,
+	ApiVersionClass,
+	AppEnv,
+	ErrCode,
+	RecaseError,
+} from "@autumn/shared";
+import { RedisUnavailableError } from "@/external/redis/utils/errors.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { getSqsClient } from "@/queue/initSqs.js";
+
+const trackQueueUrl =
+	"https://sqs.eu-west-1.amazonaws.com/123456789012/track-dev.fifo";
+
+const mockState = {
+	queueCommands: [] as Record<string, unknown>[],
+	queueError: null as Error | null,
+	originalSend: null as ReturnType<typeof getSqsClient>["send"] | null,
+	fetchBehaviors: [] as (Error | "ok")[],
+	fetchCalls: 0,
+	v2Behaviors: [] as (Error | "ok")[],
+	v2Calls: 0,
+	releaseClaimCalls: [] as Record<string, unknown>[],
+	redisV2Ready: true,
+};
+
+const nextBehavior = (behaviors: (Error | "ok")[]) => {
+	const behavior = behaviors.length > 1 ? behaviors.shift() : behaviors[0];
+	if (behavior instanceof Error) throw behavior;
+};
+
+mock.module("@/external/redis/initUtils/redisV2Availability.js", () => ({
+	shouldUseRedisV2: () => mockState.redisV2Ready,
+	getRedisV2Availability: () => ({ configured: true, state: "ready" }),
+	primeRedisV2Monitor: () => {},
+	startRedisV2Monitor: () => {},
+	stopRedisV2Monitor: () => {},
+}));
+
+mock.module("@/internal/balances/utils/lock/fetchLockReceipt.js", () => ({
+	fetchLockReceipt: async () => {
+		mockState.fetchCalls += 1;
+		nextBehavior(mockState.fetchBehaviors);
+		return {
+			receipt: { customer_id: "cus_123", feature_id: "messages", items: [] },
+			lockReceiptKey: "{org_123}:sandbox:lock:hashed",
+			claimed: true,
+			redisInstance: {},
+		};
+	},
+}));
+
+mock.module("@/internal/balances/finalizeLock/runFinalizeLockV2.js", () => ({
+	runFinalizeLockV2: async () => {
+		mockState.v2Calls += 1;
+		nextBehavior(mockState.v2Behaviors);
+		return { success: true };
+	},
+}));
+
+mock.module(
+	"@/internal/balances/utils/lockV2/releaseLockClaimMarker.js",
+	() => ({
+		releaseLockClaimMarker: async (args: Record<string, unknown>) => {
+			mockState.releaseClaimCalls.push(args);
+		},
+	}),
+);
+
+import { runFinalizeLock } from "@/internal/balances/finalizeLock/runFinalizeLock.js";
+import { runQueuedFinalizeLock } from "@/internal/balances/finalizeLock/runQueuedFinalizeLock.js";
+
+const params = {
+	lock_id: "lock_abc",
+	action: "confirm" as const,
+	override_value: 5,
+};
+
+const makeCtx = () =>
+	({
+		id: "req_fin_123",
+		org: { id: "org_123" },
+		env: AppEnv.Sandbox,
+		customerId: "cus_123",
+		apiVersion: new ApiVersionClass(ApiVersion.V2_1),
+		logger: { warn: () => undefined, info: () => undefined },
+		extraLogs: {},
+	}) as unknown as AutumnContext;
+
+const originalTrackQueueUrl = process.env.TRACK_SQS_QUEUE_URL;
+
+describe("runFinalizeLock queue fallback", () => {
+	beforeEach(() => {
+		mockState.queueCommands = [];
+		mockState.queueError = null;
+		mockState.fetchBehaviors = ["ok"];
+		mockState.fetchCalls = 0;
+		mockState.v2Behaviors = ["ok"];
+		mockState.v2Calls = 0;
+		mockState.releaseClaimCalls = [];
+		mockState.redisV2Ready = true;
+		process.env.TRACK_SQS_QUEUE_URL = trackQueueUrl;
+
+		const sqsClient = getSqsClient({ queueUrl: trackQueueUrl });
+		mockState.originalSend = sqsClient.send.bind(sqsClient);
+		sqsClient.send = (async (command: { input: Record<string, unknown> }) => {
+			if (mockState.queueError) throw mockState.queueError;
+			mockState.queueCommands.push(command.input);
+			return {};
+		}) as typeof sqsClient.send;
+	});
+
+	afterEach(() => {
+		const sqsClient = getSqsClient({ queueUrl: trackQueueUrl });
+		if (mockState.originalSend) sqsClient.send = mockState.originalSend;
+	});
+
+	// ── Contract: transient Redis error queues the replay ───────────────────
+	test("queues the finalize replay on a transient Redis error", async () => {
+		const ctx = makeCtx();
+		mockState.v2Behaviors = [
+			new RedisUnavailableError({ source: "test", reason: "not_ready" }),
+		];
+
+		const response = await runFinalizeLock({ ctx, params });
+
+		expect(response).toEqual({ success: true });
+		expect(mockState.v2Calls).toBe(1);
+		expect(mockState.queueCommands).toHaveLength(1);
+		expect(mockState.queueCommands[0]).toMatchObject({
+			QueueUrl: trackQueueUrl,
+			MessageGroupId: "org_123:sandbox:lock:lock_abc",
+			MessageDeduplicationId: "req_fin_123",
+		});
+		const body = JSON.parse(
+			mockState.queueCommands[0]?.MessageBody as string,
+		) as Record<string, unknown>;
+		expect(body).toMatchObject({
+			name: "finalize-lock",
+			data: {
+				orgId: "org_123",
+				env: AppEnv.Sandbox,
+				customerId: "cus_123",
+				requestId: "req_fin_123",
+				params,
+			},
+		});
+		expect(ctx.extraLogs.finalizeLockQueuedForReplay).toBe(true);
+		expect(mockState.releaseClaimCalls.length).toBeGreaterThanOrEqual(1);
+	});
+
+	// ── Contract: redis not ready before the first attempt -> straight to queue
+	test("queues immediately when redis is not ready, without attempting", async () => {
+		const ctx = makeCtx();
+		mockState.redisV2Ready = false;
+
+		const response = await runFinalizeLock({ ctx, params });
+
+		expect(response).toEqual({ success: true });
+		expect(mockState.v2Calls).toBe(0);
+		expect(mockState.fetchCalls).toBe(0);
+		expect(mockState.queueCommands).toHaveLength(1);
+	});
+
+	// ── Contract: raw transient Redis errors also queue ─────────────────────
+	test("queues on a raw closed-connection Redis error", async () => {
+		const ctx = makeCtx();
+		mockState.v2Behaviors = [new Error("Connection is closed.")];
+
+		const response = await runFinalizeLock({ ctx, params });
+
+		expect(response).toEqual({ success: true });
+		expect(mockState.v2Calls).toBe(1);
+		expect(mockState.queueCommands).toHaveLength(1);
+	});
+
+	// ── Contract: transient DB error also queues ────────────────────────────
+	test("queues on a transient DB error", async () => {
+		const ctx = makeCtx();
+		mockState.v2Behaviors = [new Error("Connection terminated unexpectedly")];
+
+		const response = await runFinalizeLock({ ctx, params });
+
+		expect(response).toEqual({ success: true });
+		expect(mockState.v2Calls).toBe(1);
+		expect(mockState.queueCommands).toHaveLength(1);
+	});
+
+	// ── Contract: queue failure rethrows the original error ─────────────────
+	test("rethrows the original error when the queue fallback fails", async () => {
+		const ctx = makeCtx();
+		const outage = new RedisUnavailableError({
+			source: "test",
+			reason: "not_ready",
+		});
+		mockState.v2Behaviors = [outage];
+		mockState.queueError = new Error("sqs unavailable");
+
+		await expect(runFinalizeLock({ ctx, params })).rejects.toBe(outage);
+		expect(mockState.queueCommands).toHaveLength(0);
+	});
+
+	// ── Contract: non-transient errors propagate, nothing queued ────────────
+	test("propagates non-transient errors without retry or queueing", async () => {
+		const ctx = makeCtx();
+		mockState.v2Behaviors = [
+			new RecaseError({
+				message: "Lock receipt not claimable: RESERVATION_ALREADY_PROCESSING",
+				code: ErrCode.InvalidRequest,
+				statusCode: 409,
+				data: { blockingStatus: "RESERVATION_ALREADY_PROCESSING" },
+			}),
+		];
+
+		await expect(runFinalizeLock({ ctx, params })).rejects.toBeInstanceOf(
+			RecaseError,
+		);
+		expect(mockState.v2Calls).toBe(1);
+		expect(mockState.queueCommands).toHaveLength(0);
+	});
+});
+
+describe("runQueuedFinalizeLock", () => {
+	beforeEach(() => {
+		mockState.queueCommands = [];
+		mockState.queueError = null;
+		mockState.fetchBehaviors = ["ok"];
+		mockState.fetchCalls = 0;
+		mockState.v2Behaviors = ["ok"];
+		mockState.v2Calls = 0;
+		mockState.releaseClaimCalls = [];
+		mockState.redisV2Ready = true;
+	});
+
+	// ── Contract: replay treats Lock not found as already resolved ──────────
+	test("resolves without error when the lock receipt no longer exists", async () => {
+		const ctx = makeCtx();
+		mockState.fetchBehaviors = [
+			new RecaseError({
+				message: "Lock not found for ID: lock_abc",
+				code: ErrCode.InvalidRequest,
+			}),
+		];
+
+		await expect(runQueuedFinalizeLock({ ctx, params })).resolves.toBeDefined();
+	});
+
+	// ── Contract: replay rethrows transient errors instead of re-queueing ───
+	test("rethrows transient errors so SQS redelivery owns the retry", async () => {
+		const ctx = makeCtx();
+		mockState.v2Behaviors = [new Error("Command timed out")];
+
+		await expect(runQueuedFinalizeLock({ ctx, params })).rejects.toThrow(
+			"Command timed out",
+		);
+		expect(mockState.queueCommands).toHaveLength(0);
+	});
+});
+
+afterAll(() => {
+	process.env.TRACK_SQS_QUEUE_URL = originalTrackQueueUrl;
+	mock.restore();
+});

--- a/server/tests/unit/queue/processMessage-finalize-lock.test.ts
+++ b/server/tests/unit/queue/processMessage-finalize-lock.test.ts
@@ -1,0 +1,142 @@
+/**
+ * TDD test for the finalize-lock queued replay worker wiring.
+ *
+ * Contract under test:
+ *   New behaviors:
+ *     - processMessage builds a Redis-capable worker ctx (skipCache: false)
+ *       for JobName.FinalizeLock messages
+ *     - shouldRetrySqsJobError keeps FinalizeLock messages in SQS on
+ *       transient Redis/DB errors and claim-contested 409s; app errors
+ *       (Lock not found, generic) are not retried
+ *   (End-to-end dispatch to runQueuedFinalizeLock is covered by
+ *   tests/integration/balances/lock/finalize-lock-queued-replay.test.ts —
+ *   module mocks can't intercept alias imports under a cache-busted parent.)
+ *
+ * Pre-impl red: JobName.FinalizeLock and the processMessage case do not exist.
+ * Post-impl green: ctx construction + retry policy match the contract.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { AppEnv, ErrCode, RecaseError } from "@autumn/shared";
+import type { Message } from "@aws-sdk/client-sqs";
+import { RedisUnavailableError } from "@/external/redis/utils/errors.js";
+import { JobName } from "@/queue/JobName.js";
+
+const mockState = {
+	createWorkerContextCalls: [] as Record<string, unknown>[],
+};
+
+mock.module("@/queue/createWorkerContext.js", () => ({
+	createWorkerContext: async (args: Record<string, unknown>) => {
+		mockState.createWorkerContextCalls.push(args);
+		const logger = {
+			child: mock(() => logger),
+			error: mock(() => {}),
+			info: mock(() => {}),
+			debug: mock(() => {}),
+		};
+		return {
+			logger,
+			skipCache: args.skipCache ?? true,
+			extraLogs: {},
+		};
+	},
+}));
+
+const { processMessage, shouldRetrySqsJobError } = await import(
+	// @ts-expect-error - Bun test cache-busting import query isolates module mocks.
+	"@/queue/processMessage.js?finalizeLockDispatch"
+);
+
+const finalizeParams = {
+	lock_id: "lock_abc",
+	action: "release",
+	override_value: 0,
+};
+
+describe("processMessage finalize-lock jobs", () => {
+	beforeEach(() => {
+		mockState.createWorkerContextCalls = [];
+	});
+
+	// ── Contract: FinalizeLock jobs get a Redis-capable worker context ──────
+	test("builds a worker context with skipCache false for FinalizeLock", async () => {
+		const message = {
+			MessageId: "msg_fin_123",
+			Body: JSON.stringify({
+				name: JobName.FinalizeLock,
+				data: {
+					orgId: "org_123",
+					env: AppEnv.Sandbox,
+					customerId: "cus_123",
+					requestId: "req_fin_123",
+					params: finalizeParams,
+				},
+			}),
+		} satisfies Pick<Message, "MessageId" | "Body">;
+
+		await processMessage({ message: message as Message, db: {} as never });
+
+		expect(mockState.createWorkerContextCalls).toHaveLength(1);
+		expect(mockState.createWorkerContextCalls[0]).toMatchObject({
+			payload: expect.objectContaining({ requestId: "req_fin_123" }),
+			skipCache: false,
+		});
+	});
+});
+
+describe("shouldRetrySqsJobError finalize-lock policy", () => {
+	// ── Contract: transient infra errors stay in SQS for redelivery ─────────
+	test("retries transient Redis and DB errors", () => {
+		expect(
+			shouldRetrySqsJobError({
+				jobName: JobName.FinalizeLock,
+				error: new RedisUnavailableError({ source: "t", reason: "timeout" }),
+			}),
+		).toBe(true);
+		expect(
+			shouldRetrySqsJobError({
+				jobName: JobName.FinalizeLock,
+				error: new Error("Connection terminated unexpectedly"),
+			}),
+		).toBe(true);
+	});
+
+	// ── Contract: claim-contested replays redeliver until the claim clears ──
+	test("retries claim-contested finalize replays", () => {
+		expect(
+			shouldRetrySqsJobError({
+				jobName: JobName.FinalizeLock,
+				error: new RecaseError({
+					message: "Lock receipt not claimable: RESERVATION_ALREADY_PROCESSING",
+					code: ErrCode.InvalidRequest,
+					statusCode: 409,
+					data: { blockingStatus: "RESERVATION_ALREADY_PROCESSING" },
+				}),
+			}),
+		).toBe(true);
+	});
+
+	// ── Contract: application errors are not retried ────────────────────────
+	test("does not retry application errors", () => {
+		expect(
+			shouldRetrySqsJobError({
+				jobName: JobName.FinalizeLock,
+				error: new RecaseError({
+					message: "Lock not found for ID: lock_abc",
+					code: ErrCode.InvalidRequest,
+				}),
+			}),
+		).toBe(false);
+		expect(
+			shouldRetrySqsJobError({
+				jobName: JobName.FinalizeLock,
+				error: new Error("boom"),
+			}),
+		).toBe(false);
+	});
+});
+
+afterAll(() => {
+	mock.restore();
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Queues finalize-lock replays to SQS when Redis is unavailable and processes them in the worker to safely refund reserved balances during outages. This adds a dedicated `finalize-lock` job, claim-marker cleanup, and clear retry behavior.

- **New Features**
  - Introduced `JobName.FinalizeLock` and payload `{ orgId, env, customerId?, requestId, params }`; enqueued to `TRACK_SQS_QUEUE_URL` with group `org:env:lock:<lock_id>` and dedup `<requestId>`.
  - `runFinalizeLock` fallback: on Redis/DB outage, releases the claim marker, queues the replay, sets `extraLogs.finalizeLockQueuedForReplay`, and `handleFinalizeLock` returns 202.
  - Worker support: handles `finalize-lock` through `runQueuedFinalizeLock`; treats “Lock not found” as success; retries on transient Redis/DB errors and contested-claim 409s; builds a Redis-capable ctx (`skipCache: false`).
  - If the queue is unavailable or `TRACK_SQS_QUEUE_URL` is unset, the original error is rethrown (no fake success).
  - Added unit and integration tests for fallback queuing, worker dispatch, retry policy, and end-to-end refund behavior.

<sup>Written for commit 7575f6ec152fa78158849a44a8d1002e1851b9c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes finalize-lock requests durable when Redis is unavailable.
- **[Bug fixes]** Queues failed finalize-lock operations to the track SQS queue and returns an accepted response only after enqueue succeeds.
- **[Improvements]** Adds worker dispatch, retry classification, payload typing, logging, and replay handling for finalize-lock jobs.
- **[Improvements]** Adds unit and integration coverage for outage fallback and queued replay behavior.
</details>

<h3>Confidence Score: 3/5</h3>

The PR should not merge until replay is made safe when a transient failure occurs after the original finalization mutation has committed.

The fallback removes the only claim guard and schedules another attempt despite not knowing whether the first attempt already changed the balance, allowing the replay to process the same surviving receipt twice.

**Files Needing Attention:** server/src/internal/balances/finalizeLock/runFinalizeLock.ts and server/src/internal/balances/utils/lockV2/releaseLockClaimMarker.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/finalizeLock/runFinalizeLock.ts | Adds durable queue fallback, but releasing the claim after an ambiguous partial failure can permit duplicate finalization. |
| server/src/internal/balances/utils/lockV2/releaseLockClaimMarker.ts | Adds unconditional cross-instance claim-marker deletion without ownership or completion checks. |
| server/src/internal/balances/finalizeLock/queueFinalizeLock.ts | Enqueues typed FIFO replay jobs and records accepted fallback state. |
| server/src/internal/balances/finalizeLock/runQueuedFinalizeLock.ts | Replays finalization directly and treats an absent receipt as already resolved. |
| server/src/queue/processMessage.ts | Adds worker context, dispatch, and transient or contested-claim retry handling for finalize jobs. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant API
  participant Redis
  participant SQS
  participant Worker
  API->>Redis: Claim and finalize lock
  Redis-->>API: Transient failure
  API->>Redis: Delete claim marker
  API->>SQS: Enqueue FinalizeLock replay
  API-->>API: Return 202 Accepted
  SQS->>Worker: Deliver replay
  Worker->>Redis: Reclaim receipt
  Worker->>Redis: Finalize lock
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/balances/finalizeLock/runFinalizeLock.ts:21-24
**Claim release permits duplicate finalization**

When a transient error occurs after the balance mutation succeeds but before receipt cleanup, this fallback unconditionally deletes the ownership-free claim marker and queues another attempt. The replay can reclaim the surviving receipt and apply the same confirm or release operation again, causing an incorrect customer balance and duplicate finalize events.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: finalize lock fallback"](https://github.com/useautumn/autumn/commit/7575f6ec152fa78158849a44a8d1002e1851b9c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48269491)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)

<!-- /greptile_comment -->