### PR TITLE
fix(atmn): preserve separate reset and billing intervals

### DIFF
--- a/packages/atmn/src/commands/push/validate.ts
+++ b/packages/atmn/src/commands/push/validate.ts
@@ -100,12 +100,20 @@ function validatePlanFeature(
 	const hasPriceInterval = priceInterval !== undefined;
 	const hasAnyReset = hasTopLevelReset || hasPriceInterval;
 
-	// ========== MUTUAL EXCLUSIVITY ==========
-	// Cannot have both top-level reset AND price.interval
-	if (hasTopLevelReset && hasPriceInterval) {
+	const hasDifferentResetAndPriceInterval =
+		hasTopLevelReset &&
+		hasPriceInterval &&
+		(topLevelReset.interval !== priceInterval.interval ||
+			(topLevelReset.intervalCount ?? 1) !==
+				(priceInterval.intervalCount ?? 1));
+	if (
+		hasDifferentResetAndPriceInterval &&
+		planFeature.price?.billingMethod !== "prepaid"
+	) {
 		errors.push({
 			path: basePath,
-			message: `Cannot have both "reset" and "price.interval". Use "reset" for free allocations, or "price.interval" for usage-based pricing.`,
+			message:
+				"reset.interval and price.interval can only differ for prepaid prices.",
 		});
 	}
 

--- a/packages/atmn/src/compose/models/planModels.ts
+++ b/packages/atmn/src/compose/models/planModels.ts
@@ -459,24 +459,20 @@ type Price = PriceAmountOrTiers & {
 	intervalCount?: number;
 };
 
-/**
- * Plan item with a reset cycle (e.g. 100 messages per month).
- * Cannot have price — reset and price are mutually exclusive.
- */
+/** Plan item with a free reset cycle (e.g. 100 messages per month). */
 export type PlanItemWithReset = PlanItemBaseFields & {
 	/** Reset configuration for the included allowance */
 	reset: ResetConfig;
-	/** Cannot have price when using reset — use price.interval instead */
 	price?: never;
 };
 
 /**
- * Plan item with usage-based pricing (e.g. $0.10/message, billed monthly).
- * price.interval encodes the billing cycle, so reset is not allowed.
+ * Plan item with prepaid or usage-based pricing.
+ * Prepaid items may reset on a different cycle from billing.
  */
 export type PlanItemWithPrice = PlanItemBaseFields & {
-	/** Cannot have reset when using price — price.interval encodes the billing cycle */
-	reset?: never;
+	/** Reset configuration when it differs from the billing cycle */
+	reset?: ResetConfig;
 	/** Pricing configuration */
 	price: Price;
 };
@@ -493,9 +489,9 @@ export type PlanItemNoReset = PlanItemBaseFields & {
 };
 
 /**
- * Plan item configuration. reset and price are mutually exclusive:
+ * Plan item configuration:
  * - PlanItemWithReset: included allowance that resets on an interval (e.g. 100/month free)
- * - PlanItemWithPrice: usage-based pricing with its own billing cycle
+ * - PlanItemWithPrice: prepaid or usage-based pricing with a billing cycle
  * - PlanItemNoReset: no reset, no price (continuous-use or boolean features)
  */
 export type PlanItem = PlanItemWithReset | PlanItemWithPrice | PlanItemNoReset;

--- a/packages/atmn/src/lib/transforms/apiToSdk/planItem.ts
+++ b/packages/atmn/src/lib/transforms/apiToSdk/planItem.ts
@@ -2,15 +2,7 @@ import type { PlanItem } from "../../../compose/models/planModels.js";
 import type { ApiPlanItem } from "../../api/types/index.js";
 import { createTransformer } from "./Transformer.js";
 
-/**
- * Declarative plan item transformer
- *
- * Maps snake_case API fields to camelCase SDK fields.
- *
- * Handles mutually exclusive reset patterns:
- * - API reset.interval -> SDK top-level reset (when no price, or price without interval)
- * - API price.interval -> SDK price.interval (when price exists)
- */
+/** Maps API plan items to SDK config while omitting redundant reset cycles. */
 export const planItemTransformer = createTransformer<
 	ApiPlanItem,
 	PlanItem
@@ -30,23 +22,19 @@ export const planItemTransformer = createTransformer<
 		// Only include included if not unlimited
 		included: (api) => (api.unlimited ? undefined : api.included),
 
-		// Top-level reset: only from api.reset when there's no price with interval
-		// If price exists with interval, the interval belongs in price.interval, not top-level
 		reset: (api) => {
-			// If price exists with interval, the reset belongs in price.interval, not top-level
-			if (api.price?.interval) {
-				return undefined;
-			}
-			// Only use top-level reset from api.reset
-			if (api.reset) {
-				return {
-					interval: api.reset.interval,
-					...(api.reset.interval_count !== undefined && {
-						intervalCount: api.reset.interval_count,
-					}),
-				};
-			}
-			return undefined;
+			if (!api.reset) return undefined;
+			const matchesPrice =
+				String(api.reset.interval) === String(api.price?.interval) &&
+				(api.reset.interval_count ?? 1) ===
+					(api.price?.interval_count ?? 1);
+			if (matchesPrice) return undefined;
+			return {
+				interval: api.reset.interval,
+				...(api.reset.interval_count !== undefined && {
+					intervalCount: api.reset.interval_count,
+				}),
+			};
 		},
 
 		// Transform price object with camelCase fields

--- a/packages/atmn/src/lib/transforms/sdkToApi/plan.ts
+++ b/packages/atmn/src/lib/transforms/sdkToApi/plan.ts
@@ -78,13 +78,7 @@ export interface ApiPlanItemParams {
 	};
 }
 
-/**
- * Transform SDK PlanItem to API format
- *
- * Handles mutually exclusive reset patterns:
- * - SDK top-level reset -> API reset.interval
- * - SDK price.interval -> API price.interval
- */
+/** Transforms SDK plan items while preserving reset and billing cycles independently. */
 export function transformPlanItem(planItem: PlanItem): ApiPlanItemParams {
 	const result: ApiPlanItemParams = {
 		feature_id: planItem.featureId,
@@ -98,7 +92,6 @@ export function transformPlanItem(planItem: PlanItem): ApiPlanItemParams {
 		result.unlimited = planItem.unlimited;
 	}
 
-	// Top-level reset (for features without price.interval)
 	if (planItem.reset) {
 		result.reset = {
 			interval: planItem.reset.interval,
@@ -109,7 +102,6 @@ export function transformPlanItem(planItem: PlanItem): ApiPlanItemParams {
 	}
 
 	if (planItem.price) {
-		// Get interval from price.interval (reset and price are mutually exclusive)
 		const priceWithInterval = planItem.price as {
 			interval?: string;
 			intervalCount?: number;

--- a/packages/atmn/test/codegen/separate-reset-price-intervals.test.ts
+++ b/packages/atmn/test/codegen/separate-reset-price-intervals.test.ts
@@ -1,0 +1,47 @@
+/** Red: pull drops a priced item's reset; green: pull and push preserve both intervals. */
+import { describe, expect, test } from "bun:test";
+import type { Plan } from "../../src/compose/models/index.js";
+import { transformApiPlan } from "../../src/lib/transforms/apiToSdk/plan.js";
+import { transformPlanToApi } from "../../src/lib/transforms/sdkToApi/plan.js";
+import { buildPlanCode } from "../../src/lib/transforms/sdkToCode/plan.js";
+
+const apiPlan = {
+	id: "scale-annual",
+	name: "Scale Annual",
+	version: 1,
+	items: [
+		{
+			feature_id: "credits",
+			included: 1_000,
+			unlimited: false,
+			reset: { interval: "month" as const },
+			price: {
+				amount: 100,
+				billing_method: "prepaid" as const,
+				billing_units: 1_000,
+				interval: "year" as const,
+			},
+		},
+	],
+};
+
+describe("separate reset and billing intervals", () => {
+	test("pull generates config with both intervals", () => {
+		const pulled = transformApiPlan(apiPlan as never);
+		const code = buildPlanCode(pulled, []);
+
+		expect(code).toContain("reset: {");
+		expect(code).toContain("interval: 'month'");
+		expect(code).toContain("interval: 'year'");
+	});
+
+	test("pull and push preserve both intervals", () => {
+		const pulled = transformApiPlan(apiPlan as never);
+		const pushed = transformPlanToApi(pulled as Plan);
+
+		expect(pushed.items?.[0]).toMatchObject({
+			reset: { interval: "month" },
+			price: { interval: "year", billing_method: "prepaid" },
+		});
+	});
+});

--- a/packages/atmn/test/integration/catalog/separate-reset-price-intervals.test.ts
+++ b/packages/atmn/test/integration/catalog/separate-reset-price-intervals.test.ts
@@ -1,0 +1,105 @@
+/** Verifies the built package preserves separate prepaid reset and billing intervals. */
+import { expect, test } from "bun:test";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { ApiVersion, type ApiPlanV1 } from "@autumn/shared";
+import chalk from "chalk";
+import { AutumnRpcCli } from "../../../../../server/src/external/autumn/autumnRpcCli.js";
+import {
+	createCleanAtmnIntegrationContext,
+	prepareAtmnIntegrationWorkspace,
+	runAtmnWorkspaceCli,
+} from "../utils/atmnTestWorkspace.js";
+
+const atmnPackageDir = fileURLToPath(new URL("../../../", import.meta.url));
+const builtCliPath = join(atmnPackageDir, "dist/cli.js");
+
+test(`${chalk.yellowBright("atmn built CLI: push → pull → push preserves separate intervals")}`, async () => {
+	const planId = "atmn_split_cycle_scale_annual";
+	const ctx = await createCleanAtmnIntegrationContext();
+	const build = Bun.spawn(["bun", "run", "build"], {
+		cwd: atmnPackageDir,
+		stderr: "inherit",
+		stdout: "inherit",
+	});
+	expect(await build.exited).toBe(0);
+	const workspace = await prepareAtmnIntegrationWorkspace({
+		atmnPackageDir,
+		secretKey: ctx.orgSecretKey,
+	});
+
+	await writeFile(
+		workspace.configPath,
+		`import { feature, item, plan } from 'atmn';
+
+export const splitCycleCredits = feature({
+\tid: 'atmn_split_cycle_credits',
+\tname: 'Split Cycle Credits',
+\ttype: 'metered',
+\tconsumable: true,
+});
+
+export const splitCycleScaleAnnual = plan({
+\tid: '${planId}',
+\tname: 'Split Cycle Scale Annual',
+\titems: [
+\t\titem({
+\t\t\tfeatureId: splitCycleCredits.id,
+\t\t\tincluded: 1000,
+\t\t\treset: { interval: 'month' },
+\t\t\tprice: {
+\t\t\t\tamount: 100,
+\t\t\t\tbillingUnits: 1000,
+\t\t\t\tbillingMethod: 'prepaid',
+\t\t\t\tinterval: 'year',
+\t\t\t},
+\t\t}),
+\t],
+});
+`,
+	);
+
+	await runAtmnWorkspaceCli({
+		args: ["--yes"],
+		cliPath: builtCliPath,
+		command: "push",
+		headless: true,
+		workspace,
+	});
+
+	const rpc = new AutumnRpcCli({
+		secretKey: ctx.orgSecretKey,
+		version: ApiVersion.V2_1,
+	});
+	const pushed = await rpc.plans.get<ApiPlanV1>(planId);
+	expect(pushed.items[0]).toMatchObject({
+		reset: { interval: "month" },
+		price: { billing_method: "prepaid", interval: "year" },
+	});
+
+	await runAtmnWorkspaceCli({
+		args: ["--force", "--no-declaration-file"],
+		cliPath: builtCliPath,
+		command: "pull",
+		headless: true,
+		workspace,
+	});
+	const pulledConfig = await readFile(workspace.configPath, "utf8");
+	expect(pulledConfig).toContain("reset: {");
+	expect(pulledConfig).toContain("interval: 'month'");
+	expect(pulledConfig).toContain("interval: 'year'");
+
+	await runAtmnWorkspaceCli({
+		args: ["--yes"],
+		cliPath: builtCliPath,
+		command: "push",
+		headless: true,
+		workspace,
+	});
+	const roundTripped = await rpc.plans.get<ApiPlanV1>(planId);
+	expect(roundTripped.items[0]).toMatchObject({
+		reset: { interval: "month" },
+		price: { billing_method: "prepaid", interval: "year" },
+	});
+});

--- a/packages/atmn/test/integration/utils/atmnTestWorkspace.ts
+++ b/packages/atmn/test/integration/utils/atmnTestWorkspace.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { AppEnv, migrationItemRuns, migrations } from "@autumn/shared";
@@ -300,9 +300,11 @@ export const prepareAtmnScenario = async ({
 };
 
 export const prepareAtmnIntegrationWorkspace = async ({
+	atmnPackageDir,
 	reset = true,
 	secretKey,
 }: {
+	atmnPackageDir?: string;
 	reset?: boolean;
 	secretKey: string;
 }): Promise<PreparedAtmnWorkspace> => {
@@ -314,6 +316,11 @@ export const prepareAtmnIntegrationWorkspace = async ({
 	}
 	await mkdir(workspaceDir, { recursive: true });
 	await ensureAtmnPackageShim(workspaceDir);
+	if (atmnPackageDir) {
+		const workspacePackageDir = join(workspaceDir, "node_modules/atmn");
+		await rm(workspacePackageDir, { force: true, recursive: true });
+		await symlink(atmnPackageDir, workspacePackageDir, "dir");
+	}
 
 	const configPath = join(workspaceDir, "autumn.config.ts");
 	await writeFile(
@@ -449,16 +456,20 @@ export const runAtmnCli = async ({
 
 export const runAtmnWorkspaceCli = async ({
 	args,
+	cliPath = atmnCliPath,
 	command,
 	headless = false,
 	workspace,
 }: {
 	args?: string[];
+	cliPath?: string;
 	command: AtmnCommand;
 	headless?: boolean;
 	workspace: PreparedAtmnWorkspace;
 }) => {
-	await ensureAtmnPackageShim(workspace.workspaceDir);
+	if (cliPath === atmnCliPath) {
+		await ensureAtmnPackageShim(workspace.workspaceDir);
+	}
 
 	if (command === "push" && !existsSync(workspace.configPath)) {
 		throw new Error("No autumn.config.ts found for atmn integration workspace");
@@ -468,7 +479,7 @@ export const runAtmnWorkspaceCli = async ({
 		"bun",
 		[
 			"--no-env-file",
-			atmnCliPath,
+			cliPath,
 			"--local",
 			...(headless ? ["--headless"] : []),
 			"--config",

--- a/packages/atmn/test/push/validate.test.ts
+++ b/packages/atmn/test/push/validate.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "bun:test";
+import { item } from "../../src/compose/builders/builderFunctions.js";
+import type { Plan } from "../../src/compose/models/variantModels.js";
 import { validateConfig } from "../../src/commands/push/validate.js";
 
 test("validateConfig rejects plan items that reference unexported features", () => {
@@ -61,5 +63,59 @@ test("validateConfig rejects invalid license configuration and cycles", () => {
 			'Duplicate license link "b".',
 			'License plan "missing" is not exported from your config.',
 		]),
+	);
+});
+
+test("validateConfig accepts separate reset and billing intervals for prepaid items", () => {
+	const plan = {
+		id: "scale-annual",
+		name: "Scale Annual",
+		items: [
+			item({
+				featureId: "credits",
+				included: 1_000,
+				reset: { interval: "month" },
+				price: {
+					amount: 100,
+					interval: "year",
+					billingMethod: "prepaid",
+				},
+			}),
+		],
+	} as const satisfies Plan;
+
+	const result = validateConfig(
+		[{ id: "credits", name: "Credits", type: "metered", consumable: true }],
+		[plan],
+	);
+
+	expect(result).toEqual({ valid: true, errors: [] });
+});
+
+test("validateConfig rejects separate reset and billing intervals for usage-based items", () => {
+	const plan = {
+		id: "scale-annual",
+		name: "Scale Annual",
+		items: [
+			item({
+				featureId: "credits",
+				included: 1_000,
+				reset: { interval: "month" },
+				price: {
+					amount: 0.01,
+					interval: "year",
+					billingMethod: "usage_based",
+				},
+			}),
+		],
+	} as const satisfies Plan;
+
+	const result = validateConfig(
+		[{ id: "credits", name: "Credits", type: "metered", consumable: true }],
+		[plan],
+	);
+
+	expect(result.errors.map((error) => error.message)).toContain(
+		"reset.interval and price.interval can only differ for prepaid prices.",
 	);
 });


### PR DESCRIPTION
## Summary
- allow prepaid plan items to define reset and billing intervals independently
- preserve distinct reset intervals through pull and subsequent push
- keep differing intervals invalid for usage-based prices

## Tests
- `bun -F atmn test:unit`
- `bun test packages/atmn/test/push/validate.test.ts packages/atmn/src/lib/transforms`
- `bun -F atmn ts`
- `bun -F atmn build`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow prepaid plan items in `atmn` to use different reset and billing intervals, and keep both intact across pull and push. Usage-based prices still require reset and billing to match.

- **Bug Fixes**
  - Validation: allow differing `reset.interval` and `price.interval` only for `prepaid`; reject for `usage_based` with a clear error.
  - API→SDK: emit top-level `reset` only when it differs from `price.interval`; omit when matching.
  - SDK→API: serialize `reset` and `price.interval` independently.
  - Types: `PlanItemWithPrice` supports an optional `reset` for prepaid items.
  - Tests: added unit validation, codegen, and built-CLI integration that builds `atmn` and verifies push→pull→push preserves distinct prepaid intervals; usage-based still errors.

<sup>Written for commit 45b47af4f36146402c6922c099d8529a59f6099b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR preserves independent prepaid allowance-reset and billing cycles across validation, pull, and push.
- **[Bug fixes, API changes]** Allows prepaid plan items to specify distinct reset and billing intervals while continuing to reject differing intervals for usage-based prices.
- **[Bug fixes]** Retains nonredundant reset configuration through API-to-SDK and SDK-to-API transformations.
- **[Improvements]** Adds unit, code-generation, and built-CLI integration coverage for split-cycle round trips.
- **[Improvements]** Extends the integration workspace helper to execute the built CLI against a linked package.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/atmn/src/commands/push/validate.ts | Aligns CLI validation with the server contract by permitting distinct cycles only for prepaid prices. |
| packages/atmn/src/compose/models/planModels.ts | Updates priced plan-item types to support an optional independent reset configuration. |
| packages/atmn/src/lib/transforms/apiToSdk/planItem.ts | Emits a top-level reset only when it is not redundant with the billing cycle. |
| packages/atmn/src/lib/transforms/sdkToApi/plan.ts | Serializes reset and billing cycles independently for API requests. |
| packages/atmn/test/integration/utils/atmnTestWorkspace.ts | Adds built-package linking and custom CLI execution support for integration coverage. |
| packages/atmn/test/integration/catalog/separate-reset-price-intervals.test.ts | Verifies the built CLI preserves distinct prepaid cycles through push, pull, and repush. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Config[SDK plan item] --> Validate[Validate billing method and intervals]
  Validate -->|Prepaid cycles may differ| Push[SDK-to-API transform]
  Validate -->|Usage-based cycles differ| Reject[Validation error]
  Push --> API[API plan item with reset and price intervals]
  API --> Pull[API-to-SDK transform]
  Pull -->|Cycles differ| Preserve[Emit reset and price intervals]
  Pull -->|Cycles match| Deduplicate[Emit price interval only]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["patch: 🩹 release separate reset and bil..."](https://github.com/useautumn/autumn/commit/45b47af4f36146402c6922c099d8529a59f6099b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48283046)</sub>

<!-- /greptile_comment -->