### PR TITLE
fix(webhooks): save subscriptions row on stripe sub.created

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/handleStripeSubscriptionCreated.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/handleStripeSubscriptionCreated.ts
@@ -13,15 +13,15 @@ export const handleStripeSubscriptionCreated = async ({
 		await setupStripeSubscriptionCreatedContext({ ctx });
 	if (!subscriptionCreatedContext) return;
 
-	await upsertSubscriptionRow({
-		ctx,
-		subscription: subscriptionCreatedContext.subscription,
-	});
-
 	await linkScheduledCustomerProductsToSubscription({
 		ctx,
 		subscription: subscriptionCreatedContext.subscription,
 	});
 
 	await autoSyncFromSubscriptionWithLock({ ctx, subscriptionCreatedContext });
+
+	await upsertSubscriptionRow({
+		ctx,
+		subscription: subscriptionCreatedContext.subscription,
+	});
 };

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/handleStripeSubscriptionCreated.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/handleStripeSubscriptionCreated.ts
@@ -2,6 +2,7 @@ import type { StripeWebhookContext } from "../../webhookMiddlewares/stripeWebhoo
 import { setupStripeSubscriptionCreatedContext } from "./setupStripeSubscriptionCreatedContext.js";
 import { autoSyncFromSubscriptionWithLock } from "./tasks/autoSyncFromSubscription.js";
 import { linkScheduledCustomerProductsToSubscription } from "./tasks/linkScheduledCustomerProductsToSubscription.js";
+import { upsertSubscriptionRow } from "./tasks/upsertSubscriptionRow.js";
 
 export const handleStripeSubscriptionCreated = async ({
 	ctx,
@@ -11,6 +12,11 @@ export const handleStripeSubscriptionCreated = async ({
 	const subscriptionCreatedContext =
 		await setupStripeSubscriptionCreatedContext({ ctx });
 	if (!subscriptionCreatedContext) return;
+
+	await upsertSubscriptionRow({
+		ctx,
+		subscription: subscriptionCreatedContext.subscription,
+	});
 
 	await linkScheduledCustomerProductsToSubscription({
 		ctx,

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/tasks/upsertSubscriptionRow.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/tasks/upsertSubscriptionRow.ts
@@ -1,0 +1,25 @@
+import type Stripe from "stripe";
+import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext.js";
+import { upsertSubscriptionFromBilling } from "@/internal/billing/v2/utils/upsertFromStripe/upsertSubscriptionFromBilling.js";
+
+/** sub.updated only patches existing rows, so a subscription missed here never
+ *  gets period tracking — upsert for every known customer's new subscription. */
+export const upsertSubscriptionRow = async ({
+	ctx,
+	subscription,
+}: {
+	ctx: StripeWebhookContext;
+	subscription: Stripe.Subscription;
+}) => {
+	try {
+		await upsertSubscriptionFromBilling({
+			ctx,
+			stripeSubscription: subscription,
+		});
+	} catch (err) {
+		ctx.logger.error(
+			`[sub.created] failed to upsert subscription row for ${subscription.id}`,
+			err,
+		);
+	}
+};

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/tasks/upsertSubscriptionRow.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/tasks/upsertSubscriptionRow.ts
@@ -1,9 +1,10 @@
 import type Stripe from "stripe";
+import { isTransientDbError } from "@/db/dbUtils.js";
 import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext.js";
 import { upsertSubscriptionFromBilling } from "@/internal/billing/v2/utils/upsertFromStripe/upsertSubscriptionFromBilling.js";
 
-/** sub.updated only patches existing rows, so a subscription missed here never
- *  gets period tracking — upsert for every known customer's new subscription. */
+/** Runs last: sub.updated only patches existing rows, so a lost row must fail
+ *  the handler and ride webhook replay/redelivery — but only when retry helps. */
 export const upsertSubscriptionRow = async ({
 	ctx,
 	subscription,
@@ -16,10 +17,12 @@ export const upsertSubscriptionRow = async ({
 			ctx,
 			stripeSubscription: subscription,
 		});
-	} catch (err) {
+	} catch (error) {
+		// Deterministic failures would loop the replay without ever succeeding.
+		if (isTransientDbError({ error })) throw error;
 		ctx.logger.error(
 			`[sub.created] failed to upsert subscription row for ${subscription.id}`,
-			err,
+			{ error },
 		);
 	}
 };

--- a/server/tests/integration/billing/stripe-webhooks/subscription-created/sub-created-subscription-row.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/subscription-created/sub-created-subscription-row.test.ts
@@ -1,10 +1,29 @@
 /**
- * Regression: sub.created must persist a `subscriptions` row for a known
- * customer even when auto-sync skips (e.g. no product match). sub.updated only
- * patches existing rows, so a missed row means period tracking never lands.
+ * TDD test for persisting a `subscriptions` row on customer.subscription.created.
+ *
+ * Contract under test:
+ *   New behaviors:
+ *     - known customer + external sub, auto-sync skips (no product match)
+ *       -> subscriptions row exists with org/env/periods/anchor
+ *     - unknown Stripe customer -> NO row (no auto-provisioning)
+ *     - auto-sync runs (matched product) -> exactly one row (idempotent with
+ *       syncV2's own upsertSubscription)
+ *     - attach-created sub (row already written by the attach flow) -> still
+ *       exactly one row (upsertByStripeId updates, never duplicates)
+ *   Side effects:
+ *     - upsertSubscriptionRow runs LAST in the handler and rethrows TRANSIENT
+ *       DB errors, so a lost row fails the webhook and rides replay / Stripe
+ *       redelivery; deterministic errors log without looping the replay.
+ *       Not fault-injectable here; enforced by structure.
+ *
+ * Pre-impl red: handleStripeSubscriptionCreated never wrote to the
+ * subscriptions table itself; rows only appeared when syncV2 executed.
+ * Post-impl green: the upsertSubscriptionRow step saves the row for every
+ * known customer's subscription.
  */
 
 import { expect, test } from "bun:test";
+import { createStripeSubscriptionFromProduct } from "@tests/integration/billing/sync/utils/syncTestUtils";
 import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
 import { timeout } from "@tests/utils/genUtils";
@@ -14,7 +33,7 @@ import chalk from "chalk";
 import { CusService } from "@/internal/customers/CusService";
 import { SubService } from "@/internal/subscriptions/SubService";
 
-test(`${chalk.yellowBright("customer.subscription.created: saves subscriptions row even when auto-sync skips")}`, async () => {
+test(`${chalk.yellowBright("sub-created row 1: saves subscriptions row even when auto-sync skips")}`, async () => {
 	const customerId = "sub-created-subscription-row";
 
 	const pro = products.pro({
@@ -60,7 +79,7 @@ test(`${chalk.yellowBright("customer.subscription.created: saves subscriptions r
 
 	await timeout(10000);
 
-	// ── Contract: subscriptions row exists for the new stripe sub ──────────
+	// ── Contract: row exists with correct org/env/periods/anchor ───────────
 	const subscriptionRow = await SubService.getByStripeId({
 		db: ctx.db,
 		stripeId: stripeSubscription.id,
@@ -74,5 +93,117 @@ test(`${chalk.yellowBright("customer.subscription.created: saves subscriptions r
 	);
 	expect(subscriptionRow?.billing_cycle_anchor_seconds).toBe(
 		stripeSubscription.billing_cycle_anchor,
+	);
+});
+
+test(`${chalk.yellowBright("sub-created row 2: no row for unknown Stripe customer")}`, async () => {
+	const stripeCustomer = await ctx.stripeCli.customers.create({
+		email: "sub-created-subscription-row-unknown@example.com",
+	});
+	const stripeProduct = await ctx.stripeCli.products.create({
+		name: "Sub Created Subscription Row Unknown Customer",
+	});
+	const stripeSubscription = await ctx.stripeCli.subscriptions.create({
+		customer: stripeCustomer.id,
+		items: [
+			{
+				price_data: {
+					currency: "usd",
+					product: stripeProduct.id,
+					recurring: { interval: "month" },
+					unit_amount: 4242,
+				},
+			},
+		],
+		payment_behavior: "default_incomplete",
+	});
+
+	await timeout(10000);
+
+	// ── Contract: unknown customer -> no auto-provisioned row ──────────────
+	const subscriptionRow = await SubService.getByStripeId({
+		db: ctx.db,
+		stripeId: stripeSubscription.id,
+	});
+	expect(subscriptionRow).toBeUndefined();
+});
+
+test(`${chalk.yellowBright("sub-created row 3: exactly one row when auto-sync runs")}`, async () => {
+	const customerId = "sub-created-subscription-row-synced";
+
+	const pro = products.pro({
+		id: "pro",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+
+	await initScenario({
+		customerId,
+		ctx,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [],
+	});
+
+	const stripeSubscription = await createStripeSubscriptionFromProduct({
+		ctx,
+		customerId,
+		productId: pro.id,
+	});
+
+	await timeout(10000);
+
+	// ── Contract: idempotent with syncV2's upsert — exactly one row ────────
+	const subscriptionRows = await SubService.getInStripeIds({
+		db: ctx.db,
+		ids: [stripeSubscription.id],
+	});
+	expect(subscriptionRows.length).toBe(1);
+	expect(subscriptionRows[0].current_period_start).toBeGreaterThan(0);
+});
+
+test(`${chalk.yellowBright("sub-created row 4: attach-created sub keeps exactly one row")}`, async () => {
+	const customerId = "sub-created-subscription-row-attach";
+
+	const pro = products.pro({
+		id: "pro",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+
+	await initScenario({
+		customerId,
+		ctx,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	await timeout(10000);
+
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+		withSubs: true,
+	});
+	const customerProduct = fullCustomer.customer_products.find(
+		(product) => product.product_id === pro.id,
+	);
+	const stripeSubscriptionId = customerProduct?.subscription_ids?.[0];
+	if (!stripeSubscriptionId) {
+		throw new Error(`Customer ${customerId} has no attached subscription`);
+	}
+
+	// ── Contract: attach row updated, never duplicated ─────────────────────
+	const subscriptionRows = await SubService.getInStripeIds({
+		db: ctx.db,
+		ids: [stripeSubscriptionId],
+	});
+	expect(subscriptionRows.length).toBe(1);
+	expect(subscriptionRows[0].current_period_start).toBeGreaterThan(0);
+	expect(subscriptionRows[0].current_period_end).toBeGreaterThan(
+		subscriptionRows[0].current_period_start ?? 0,
 	);
 });

--- a/server/tests/integration/billing/stripe-webhooks/subscription-created/sub-created-subscription-row.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/subscription-created/sub-created-subscription-row.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression: sub.created must persist a `subscriptions` row for a known
+ * customer even when auto-sync skips (e.g. no product match). sub.updated only
+ * patches existing rows, so a missed row means period tracking never lands.
+ */
+
+import { expect, test } from "bun:test";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { timeout } from "@tests/utils/genUtils";
+import ctx from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { CusService } from "@/internal/customers/CusService";
+import { SubService } from "@/internal/subscriptions/SubService";
+
+test(`${chalk.yellowBright("customer.subscription.created: saves subscriptions row even when auto-sync skips")}`, async () => {
+	const customerId = "sub-created-subscription-row";
+
+	const pro = products.pro({
+		id: "pro",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+
+	await initScenario({
+		customerId,
+		ctx,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [],
+	});
+
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	const stripeCustomerId = fullCustomer.processor?.id;
+	if (!stripeCustomerId) {
+		throw new Error(`Customer ${customerId} has no Stripe customer ID`);
+	}
+
+	const stripeProduct = await ctx.stripeCli.products.create({
+		name: "Sub Created Subscription Row No Match",
+	});
+	const stripeSubscription = await ctx.stripeCli.subscriptions.create({
+		customer: stripeCustomerId,
+		items: [
+			{
+				price_data: {
+					currency: "usd",
+					product: stripeProduct.id,
+					recurring: { interval: "month" },
+					unit_amount: 5555,
+				},
+			},
+		],
+	});
+
+	await timeout(10000);
+
+	// ── Contract: subscriptions row exists for the new stripe sub ──────────
+	const subscriptionRow = await SubService.getByStripeId({
+		db: ctx.db,
+		stripeId: stripeSubscription.id,
+	});
+	expect(subscriptionRow).toBeDefined();
+	expect(subscriptionRow?.org_id).toBe(ctx.org.id);
+	expect(subscriptionRow?.env).toBe(ctx.env);
+	expect(subscriptionRow?.current_period_start).toBeGreaterThan(0);
+	expect(subscriptionRow?.current_period_end).toBeGreaterThan(
+		subscriptionRow?.current_period_start ?? 0,
+	);
+	expect(subscriptionRow?.billing_cycle_anchor_seconds).toBe(
+		stripeSubscription.billing_cycle_anchor,
+	);
+});


### PR DESCRIPTION
## Summary

**Hotfix over main.** `handleStripeSubscriptionCreated` never wrote to the `subscriptions` table itself — the row only appeared when auto-sync actually executed `syncV2` (whose billing plan carries `upsertSubscription`). Whenever auto-sync skipped (no product match, checkout-originated, multi-match/ineligible) or only `linkScheduledCustomerProductsToSubscription` engaged, **no row was ever saved**.

Downstream damage: `sub.updated` → `SubService.updateFromStripe` silently no-ops when the row is missing, so `current_period_start/end` and `billing_cycle_anchor_seconds` never land for those subscriptions.

## Fix

New `upsertSubscriptionRow` step in the handler (reusing `upsertSubscriptionFromBilling`), for every known customer's subscription — the context already returns early for unknown Stripe customers, so no auto-provisioning.

**Failure semantics** (review follow-up): the step runs **last**, so a failed upsert never blocks link/auto-sync, and it **rethrows only transient DB errors** — failing the webhook so the early-ack replay queue (Autumn-originated events) or Stripe redelivery (sync-mode external events) recreates the row. Deterministic errors log loudly instead of looping the replay. Both other steps are idempotent on re-run.

## Contract test coverage (`sub-created-subscription-row.test.ts`)

1. Known customer + external sub, auto-sync skips → row exists with correct org/env/periods/anchor (**see-red verified**: `undefined` without the fix)
2. Unknown Stripe customer → no row
3. Auto-sync runs → exactly one row (idempotent with syncV2's upsert)
4. Attach-created sub → exactly one row (update, not duplicate)

Existing `sub-created-auto-sync.test.ts` suite: 5/5 green. `bun ts` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Persists Stripe-created subscriptions for known Autumn customers.
- **[Bug fixes]** Adds a subscription-row upsert to the `customer.subscription.created` handler.
- **[Bug fixes]** Reuses the billing upsert helper to populate subscription period, environment, organization, and billing-anchor data.
- **[Improvements]** Adds integration coverage for unmatched products, unknown customers, auto-synced subscriptions, and attach-created subscriptions.
</details>

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because auto-sync failures can prevent persistence, while non-transient upsert failures can still leave the subscription row missing after the handler reports success.

The persistence step runs after an operation that propagates failures, so execution can stop before the row is written; when the upsert itself reports a non-transient error, that error is logged and suppressed, preventing retry or replay while later update-only handling leaves the row absent.

**Files Needing Attention:** server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/handleStripeSubscriptionCreated.ts; server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/tasks/upsertSubscriptionRow.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/handleStripeSubscriptionCreated.ts | Adds subscription-row persistence after automatic synchronization, so an auto-sync exception can prevent the required write. |
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/tasks/upsertSubscriptionRow.ts | Introduces the shared subscription upsert call, but its non-transient error path still suppresses failures and can leave the required row absent. |
| server/tests/integration/billing/stripe-webhooks/subscription-created/sub-created-subscription-row.test.ts | Covers successful persistence and idempotency across unmatched, unknown-customer, auto-sync, and attach-created scenarios. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/handleStripeSubscriptionCreated.ts:21-26
**Auto-sync failure skips persistence**

When `autoSyncFromSubscriptionWithLock` throws, execution stops before `upsertSubscriptionRow`, leaving the subscription absent; early-ack events then depend on best-effort replay, and later `subscription.updated` processing silently skips the missing row.

```suggestion
	await upsertSubscriptionRow({
		ctx,
		subscription: subscriptionCreatedContext.subscription,
	});

	await autoSyncFromSubscriptionWithLock({ ctx, subscriptionCreatedContext });
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(webhooks): 🐛 run subscription-row u..."](https://github.com/useautumn/autumn/commit/326a153319ce1d6378ce647bc7b6937ae0756e51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48293273)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->