### PR TITLE
feat: make database capacity runtime configurable

### DIFF
--- a/server/src/cron.ts
+++ b/server/src/cron.ts
@@ -11,6 +11,7 @@ await import("./internal/misc/mainRedisCache/mainRedisCacheStore.js");
 await import("./internal/misc/cacheV2Ramp/cacheV2RampStore.js");
 await import("./internal/misc/resetJob/resetJobStore.js");
 await import("./internal/misc/resetJobV2/resetJobV2Store.js");
+await import("./internal/misc/dbCapacity/dbCapacityConfigStore.js");
 const { logger } = await import("./external/logtail/logtailUtils.js");
 const { startAllEdgeConfigPolling } = await import(
 	"./internal/misc/edgeConfig/edgeConfigRegistry.js"

--- a/server/src/db/dbPoolCapacity.ts
+++ b/server/src/db/dbPoolCapacity.ts
@@ -1,0 +1,189 @@
+import type { Pool } from "pg";
+import type { DbCapacityConfig } from "@/internal/misc/dbCapacity/dbCapacityConfigSchemas.js";
+import { getDefaultDbCapacityConfig } from "@/internal/misc/dbCapacity/dbCapacityConfigSchemas.js";
+
+export type ManagedDbPoolName = "critical" | "general" | "replica";
+
+type ManagedDbPool = {
+	pool: Pool;
+	normalMaxUses: number;
+	retirementTarget: number | null;
+	idleDrainRunning: boolean;
+	onRelease: () => void;
+	onRemove: () => void;
+};
+
+const managedPools = new Map<ManagedDbPoolName, ManagedDbPool>();
+let latestConfig = getDefaultDbCapacityConfig({
+	isProduction: process.env.NODE_ENV === "production",
+});
+
+const getConfiguredMaximum = ({
+	config,
+	name,
+}: {
+	config: DbCapacityConfig;
+	name: ManagedDbPoolName;
+}): number => {
+	switch (name) {
+		case "critical":
+			return config.critical_pool_max;
+		case "general":
+			return config.general_pool_max;
+		case "replica":
+			return config.replica_pool_max;
+	}
+};
+
+const stopRetiringSurplusConnections = ({
+	managedPool,
+}: {
+	managedPool: ManagedDbPool;
+}): void => {
+	if (managedPool.retirementTarget === null) return;
+	managedPool.pool.options.maxUses = managedPool.normalMaxUses;
+	managedPool.retirementTarget = null;
+};
+
+const stopRetiringWhenAtTarget = ({
+	managedPool,
+}: {
+	managedPool: ManagedDbPool;
+}): void => {
+	if (
+		managedPool.retirementTarget !== null &&
+		managedPool.pool.totalCount <= managedPool.retirementTarget
+	) {
+		stopRetiringSurplusConnections({ managedPool });
+	}
+};
+
+const drainIdleSurplusConnections = async ({
+	managedPool,
+}: {
+	managedPool: ManagedDbPool;
+}): Promise<void> => {
+	if (managedPool.idleDrainRunning) return;
+	managedPool.idleDrainRunning = true;
+
+	try {
+		while (
+			managedPool.retirementTarget !== null &&
+			managedPool.pool.totalCount > managedPool.retirementTarget &&
+			managedPool.pool.idleCount > 0
+		) {
+			const client = await managedPool.pool.connect();
+			if (
+				managedPool.retirementTarget === null ||
+				managedPool.pool.totalCount <= managedPool.retirementTarget
+			) {
+				client.release();
+				break;
+			}
+			client.release(true);
+		}
+	} catch {
+		// A concurrent checkout can consume the last idle client before ours.
+		// Busy clients are still retired safely by maxUses when they release.
+	} finally {
+		managedPool.idleDrainRunning = false;
+	}
+};
+
+const applyMaximumToPool = ({
+	name,
+	managedPool,
+	maximum,
+}: {
+	name: ManagedDbPoolName;
+	managedPool: ManagedDbPool;
+	maximum: number;
+}): void => {
+	managedPool.pool.options.max = maximum;
+
+	if (name === "critical") {
+		managedPool.pool.options.min = Math.min(10, maximum);
+	}
+
+	if (managedPool.pool.totalCount > maximum) {
+		if (managedPool.retirementTarget === null) {
+			managedPool.normalMaxUses = managedPool.pool.options.maxUses;
+		}
+		managedPool.retirementTarget = maximum;
+		// pg-pool removes a client when its use count reaches maxUses. Setting
+		// this to one only while above the new target drains surplus clients as
+		// active queries release them, without interrupting in-flight work.
+		managedPool.pool.options.maxUses = 1;
+		void drainIdleSurplusConnections({ managedPool });
+		return;
+	}
+
+	stopRetiringSurplusConnections({ managedPool });
+};
+
+export const applyDbCapacityConfig = ({
+	config,
+}: {
+	config: DbCapacityConfig;
+}): void => {
+	latestConfig = config;
+
+	for (const [name, managedPool] of managedPools) {
+		applyMaximumToPool({
+			name,
+			managedPool,
+			maximum: getConfiguredMaximum({ config, name }),
+		});
+	}
+};
+
+export const registerManagedDbPool = ({
+	name,
+	pool,
+}: {
+	name: ManagedDbPoolName;
+	pool: Pool;
+}): void => {
+	const existing = managedPools.get(name);
+	if (existing) {
+		existing.pool.off("release", existing.onRelease);
+		existing.pool.off("remove", existing.onRemove);
+	}
+
+	const managedPool: ManagedDbPool = {
+		pool,
+		normalMaxUses: pool.options.maxUses,
+		retirementTarget: null,
+		idleDrainRunning: false,
+		onRelease: () => undefined,
+		onRemove: () => undefined,
+	};
+	managedPool.onRelease = () => {
+		stopRetiringWhenAtTarget({ managedPool });
+	};
+	managedPool.onRemove = () => {
+		stopRetiringWhenAtTarget({ managedPool });
+	};
+
+	pool.on("release", managedPool.onRelease);
+	pool.on("remove", managedPool.onRemove);
+	managedPools.set(name, managedPool);
+
+	applyMaximumToPool({
+		name,
+		managedPool,
+		maximum: getConfiguredMaximum({ config: latestConfig, name }),
+	});
+};
+
+export const _resetManagedDbPoolsForTesting = (): void => {
+	for (const managedPool of managedPools.values()) {
+		managedPool.pool.off("release", managedPool.onRelease);
+		managedPool.pool.off("remove", managedPool.onRemove);
+		stopRetiringSurplusConnections({ managedPool });
+	}
+	managedPools.clear();
+	latestConfig = getDefaultDbCapacityConfig({
+		isProduction: process.env.NODE_ENV === "production",
+	});
+};

--- a/server/src/db/initDrizzle.ts
+++ b/server/src/db/initDrizzle.ts
@@ -8,8 +8,9 @@ import { instrumentDrizzleClient } from "@kubiks/otel-drizzle";
 import type { SQLWrapper } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import pg, { type PoolConfig } from "pg";
-import { logger } from "../external/logtail/logtailUtils.js";
+import { getRuntimeDbCapacityConfig } from "@/internal/misc/dbCapacity/dbCapacityConfigStore.js";
 import { otelConfig } from "../utils/otel/otelConfig.js";
+import { registerManagedDbPool } from "./dbPoolCapacity.js";
 import { attachPoolErrorHandlers, registerPool } from "./pgPoolMonitor.js";
 
 type AutumnDb = Omit<ReturnType<typeof drizzle<typeof schema>>, "execute"> & {
@@ -97,75 +98,31 @@ export const initDrizzle = ({
 
 // Strict latency limits in prod; relaxed locally so dev pool warm-up doesn't kill tests.
 const isProd = process.env.NODE_ENV === "production";
+const dbCapacityConfig = getRuntimeDbCapacityConfig();
 
-const poolMaxFromEnv = ({
-	envVar,
-	fallback,
-}: {
-	envVar: string;
-	fallback: number;
-}): number => {
-	const parsed = Number(process.env[envVar]);
-	return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
-};
-
-const PGBOUNCER_MAX_CLIENT_CONN = 7_600;
-const BUDGETED_FLEET_PROCESSES = 150;
-const BUDGETED_NON_SERVER_CONNECTIONS = 80;
-const POOL_BUDGET_HEADROOM = 0.85;
-
-const PROD_POOL_MAX = {
-	critical: 22,
-	general: 14,
-	replica: 6,
-};
-
-const criticalPoolMax = poolMaxFromEnv({
-	envVar: "CRITICAL_DB_POOL_MAX",
-	fallback: isProd ? PROD_POOL_MAX.critical : 10,
-});
-const generalPoolMax = poolMaxFromEnv({
-	envVar: "GENERAL_DB_POOL_MAX",
-	fallback: isProd ? PROD_POOL_MAX.general : 10,
-});
-const replicaPoolMax = poolMaxFromEnv({
-	envVar: "REPLICA_DB_POOL_MAX",
-	fallback: PROD_POOL_MAX.replica,
-});
-
-const budgetedFleetConnections =
-	BUDGETED_FLEET_PROCESSES *
-		(criticalPoolMax + generalPoolMax + replicaPoolMax) +
-	BUDGETED_NON_SERVER_CONNECTIONS;
-
-if (
-	budgetedFleetConnections >
-	PGBOUNCER_MAX_CLIENT_CONN * POOL_BUDGET_HEADROOM
-) {
-	logger.warn(
-		`[initDrizzle] pool budget (${budgetedFleetConnections}) exceeds ${POOL_BUDGET_HEADROOM} of max_client_conn (${PGBOUNCER_MAX_CLIENT_CONN}) — lower the pool maxes or raise the ceiling`,
-	);
-}
-
-export const { db: dbCritical, client: clientCritical } = initDrizzle({
+const criticalResult = initDrizzle({
 	name: "critical",
-	maxConnections: criticalPoolMax,
+	maxConnections: dbCapacityConfig.critical_pool_max,
 	connectTimeout: isProd ? 2 : 30,
 	databaseUrl: process.env.DATABASE_CRITICAL_URL,
 	poolConfig: {
 		application_name: "autumn-critical",
 		query_timeout: isProd ? 2_000 : 30_000,
 		// Keep warm conns to avoid TLS-handshake stampedes on bursty traffic.
-		min: Math.min(10, criticalPoolMax),
+		min: Math.min(10, dbCapacityConfig.critical_pool_max),
 	},
 });
+registerManagedDbPool({ name: "critical", pool: criticalResult.client });
+export const { db: dbCritical, client: clientCritical } = criticalResult;
 
 // -- General pool: used by all other endpoints --
-export const { db: dbGeneral, client: clientGeneral } = initDrizzle({
+const generalResult = initDrizzle({
 	name: "general",
-	maxConnections: generalPoolMax,
+	maxConnections: dbCapacityConfig.general_pool_max,
 	connectTimeout: isProd ? 5 : 30,
 });
+registerManagedDbPool({ name: "general", pool: generalResult.client });
+export const { db: dbGeneral, client: clientGeneral } = generalResult;
 
 // -- Replica pool: used as fallback when primary is degraded --
 // Only created if DATABASE_REPLICA_URL is configured.
@@ -173,10 +130,13 @@ const replicaResult = process.env.DATABASE_REPLICA_URL
 	? initDrizzle({
 			name: "replica",
 			replica: true,
-			maxConnections: replicaPoolMax,
+			maxConnections: dbCapacityConfig.replica_pool_max,
 			connectTimeout: null,
 		})
 	: null;
+if (replicaResult) {
+	registerManagedDbPool({ name: "replica", pool: replicaResult.client });
+}
 export const dbReplica = replicaResult?.db ?? null;
 export const clientReplica = replicaResult?.client ?? null;
 

--- a/server/src/external/aws/s3/adminS3Config.ts
+++ b/server/src/external/aws/s3/adminS3Config.ts
@@ -21,6 +21,7 @@ export const ADMIN_MISCELLANEOUS_EDGE_CONFIG_KEY =
 	"admin/miscellaneous-edge-config.json";
 export const ADMIN_FULL_SUBJECT_GATE_CONFIG_KEY =
 	"admin/full-subject-gate-config.json";
+export const ADMIN_DB_CAPACITY_CONFIG_KEY = "admin/db-capacity-config.json";
 export const ADMIN_ASYNC_BALANCE_UPDATE_CONFIG_KEY =
 	"admin/async-balance-update-config.json";
 export const ADMIN_ASYNC_TRACK_CONFIG_KEY = "admin/async-track-config.json";
@@ -113,6 +114,11 @@ export const getAdminEdgeConfigSources = () => ({
 			id: "full-subject-gate",
 			label: "FullSubject Concurrency Gate",
 			key: ADMIN_FULL_SUBJECT_GATE_CONFIG_KEY,
+		},
+		{
+			id: "db-capacity",
+			label: "Database Capacity",
+			key: ADMIN_DB_CAPACITY_CONFIG_KEY,
 		},
 		{
 			id: "async-balance-update",

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -32,6 +32,7 @@ import "./internal/misc/jobQueues/jobQueueStore.js";
 import "./internal/misc/batchReset/batchResetConfigStore.js";
 import "./internal/misc/resetJob/resetJobStore.js";
 import "./internal/misc/resetJobV2/resetJobV2Store.js";
+import "./internal/misc/dbCapacity/dbCapacityConfigStore.js";
 import "./internal/misc/asyncBalanceUpdate/asyncBalanceUpdateStore.js";
 import "./internal/misc/asyncTrack/asyncTrackStore.js";
 

--- a/server/src/internal/admin/adminRouter.ts
+++ b/server/src/internal/admin/adminRouter.ts
@@ -1,22 +1,23 @@
 import { Hono } from "hono";
 import type { HonoEnv } from "../../honoUtils/HonoEnv";
 import {
-    handleDeleteAdminCacheV2Ramp,
-    handleGetAdminCacheV2Ramp,
-    handleUpdateAdminCacheV2RampMigration,
-    handleUpsertAdminCacheV2Ramp,
+	handleDeleteAdminCacheV2Ramp,
+	handleGetAdminCacheV2Ramp,
+	handleUpdateAdminCacheV2RampMigration,
+	handleUpsertAdminCacheV2Ramp,
 } from "./handleAdminCacheV2Ramp";
 import {
-    handleDeleteAdminOrgRedisConfig,
-    handleGetAdminOrgRedisConfig,
-    handleUpdateAdminOrgRedisMigration,
-    handleUpdateAdminOrgRedisPublicUrl,
-    handleUpsertAdminOrgRedisConfig,
+	handleDeleteAdminOrgRedisConfig,
+	handleGetAdminOrgRedisConfig,
+	handleUpdateAdminOrgRedisMigration,
+	handleUpdateAdminOrgRedisPublicUrl,
+	handleUpsertAdminOrgRedisConfig,
 } from "./handleAdminOrgRedisConfig";
 import { handleGetAdminAsyncBalanceUpdateConfig } from "./handleGetAdminAsyncBalanceUpdateConfig";
 import { handleGetAdminAsyncTrackConfig } from "./handleGetAdminAsyncTrackConfig";
 import { handleGetAdminBatchResetConfig } from "./handleGetAdminBatchResetConfig";
 import { handleGetAdminCustomerBlockConfig } from "./handleGetAdminCustomerBlockConfig";
+import { handleGetAdminDbCapacityConfig } from "./handleGetAdminDbCapacityConfig";
 import { handleGetAdminEdgeConfigSources } from "./handleGetAdminEdgeConfigSources";
 import { handleGetAdminFeatureFlagsConfig } from "./handleGetAdminFeatureFlagsConfig";
 import { handleGetAdminFullSubjectGateConfig } from "./handleGetAdminFullSubjectGateConfig";
@@ -41,16 +42,17 @@ import { handleListAdminOrgs } from "./handleListAdminOrgs";
 import { handleListAdminUsers } from "./handleListAdminUsers";
 import { handleListOAuthClients } from "./handleListOAuthClients";
 import {
-    handleCreateSlackAdminInstall,
-    handleDeleteSlackAdminInstall,
-    handleGetSlackAdminInstall,
-    handleUpdateSlackAdminTarget,
+	handleCreateSlackAdminInstall,
+	handleDeleteSlackAdminInstall,
+	handleGetSlackAdminInstall,
+	handleUpdateSlackAdminTarget,
 } from "./handleSlackAdminChat";
 import { handleSyncCustomerEntitlementAnchors } from "./handleSyncCustomerEntitlementAnchors";
 import { handleUpsertAdminAsyncBalanceUpdateConfig } from "./handleUpsertAdminAsyncBalanceUpdateConfig";
 import { handleUpsertAdminAsyncTrackConfig } from "./handleUpsertAdminAsyncTrackConfig";
 import { handleUpsertAdminBatchResetConfig } from "./handleUpsertAdminBatchResetConfig";
 import { handleUpsertAdminCustomerBlockConfig } from "./handleUpsertAdminCustomerBlockConfig";
+import { handleUpsertAdminDbCapacityConfig } from "./handleUpsertAdminDbCapacityConfig";
 import { handleUpsertAdminFeatureFlagsConfig } from "./handleUpsertAdminFeatureFlagsConfig";
 import { handleUpsertAdminFullSubjectGateConfig } from "./handleUpsertAdminFullSubjectGateConfig";
 import { handleUpsertAdminJobQueueConfig } from "./handleUpsertAdminJobQueueConfig";
@@ -146,6 +148,11 @@ honoAdminRouter.get(
 honoAdminRouter.put(
 	"/full-subject-gate-config",
 	...handleUpsertAdminFullSubjectGateConfig,
+);
+honoAdminRouter.get("/db-capacity-config", ...handleGetAdminDbCapacityConfig);
+honoAdminRouter.put(
+	"/db-capacity-config",
+	...handleUpsertAdminDbCapacityConfig,
 );
 honoAdminRouter.get(
 	"/customer-block-config",

--- a/server/src/internal/admin/handleGetAdminDbCapacityConfig.ts
+++ b/server/src/internal/admin/handleGetAdminDbCapacityConfig.ts
@@ -1,0 +1,29 @@
+import { Scopes } from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import {
+	getDbCapacityConfigFromSource,
+	getRuntimeDbCapacityConfig,
+	getRuntimeDbCapacityConfigStatus,
+} from "@/internal/misc/dbCapacity/dbCapacityConfigStore.js";
+
+export const handleGetAdminDbCapacityConfig = createRoute({
+	scopes: [Scopes.Superuser],
+	handler: async (c) => {
+		const status = getRuntimeDbCapacityConfigStatus();
+		let config = getRuntimeDbCapacityConfig();
+		let sourceError: string | null = null;
+		try {
+			config = await getDbCapacityConfigFromSource();
+		} catch (error) {
+			sourceError = error instanceof Error ? error.message : String(error);
+		}
+
+		return c.json({
+			...config,
+			configHealthy: status.healthy && sourceError === null,
+			configConfigured: status.configured,
+			lastSuccessAt: status.lastSuccessAt ?? null,
+			error: sourceError ?? status.error ?? null,
+		});
+	},
+});

--- a/server/src/internal/admin/handleUpsertAdminDbCapacityConfig.ts
+++ b/server/src/internal/admin/handleUpsertAdminDbCapacityConfig.ts
@@ -1,0 +1,14 @@
+import { Scopes } from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { DbCapacityConfigSchema } from "@/internal/misc/dbCapacity/dbCapacityConfigSchemas.js";
+import { updateDbCapacityConfig } from "@/internal/misc/dbCapacity/dbCapacityConfigStore.js";
+
+export const handleUpsertAdminDbCapacityConfig = createRoute({
+	scopes: [Scopes.Superuser],
+	body: DbCapacityConfigSchema,
+	handler: async (c) => {
+		const body = c.req.valid("json");
+		await updateDbCapacityConfig({ config: body });
+		return c.json({ success: true });
+	},
+});

--- a/server/src/internal/misc/dbCapacity/dbCapacityConfigSchemas.ts
+++ b/server/src/internal/misc/dbCapacity/dbCapacityConfigSchemas.ts
@@ -1,0 +1,76 @@
+import { z } from "zod/v4";
+
+export const DB_POOL_BUDGET_HEADROOM = 0.85;
+
+const productionDefaults = {
+	critical_pool_max: 22,
+	general_pool_max: 14,
+	replica_pool_max: 6,
+	pgbouncer_max_client_conn: 7_600,
+	budgeted_fleet_processes: 150,
+	budgeted_non_server_connections: 80,
+} as const;
+
+const DbCapacityConfigFieldsSchema = z.object({
+	critical_pool_max: z.number().int().min(1).max(1_000).default(22),
+	general_pool_max: z.number().int().min(1).max(1_000).default(14),
+	replica_pool_max: z.number().int().min(1).max(1_000).default(6),
+	pgbouncer_max_client_conn: z
+		.number()
+		.int()
+		.min(1)
+		.max(1_000_000)
+		.default(7_600),
+	budgeted_fleet_processes: z.number().int().min(1).max(100_000).default(150),
+	budgeted_non_server_connections: z
+		.number()
+		.int()
+		.min(0)
+		.max(1_000_000)
+		.default(80),
+});
+
+export type DbCapacityConfig = z.infer<typeof DbCapacityConfigFieldsSchema>;
+
+export const calculateBudgetedFleetConnections = ({
+	config,
+}: {
+	config: DbCapacityConfig;
+}): number =>
+	config.budgeted_fleet_processes *
+		(config.critical_pool_max +
+			config.general_pool_max +
+			config.replica_pool_max) +
+	config.budgeted_non_server_connections;
+
+export const DbCapacityConfigSchema = DbCapacityConfigFieldsSchema.superRefine(
+	(config, context) => {
+		const budgetedFleetConnections = calculateBudgetedFleetConnections({
+			config,
+		});
+		const budgetCeiling =
+			config.pgbouncer_max_client_conn * DB_POOL_BUDGET_HEADROOM;
+
+		if (budgetedFleetConnections > budgetCeiling) {
+			context.addIssue({
+				code: "custom",
+				message: `DB fleet connection budget ${budgetedFleetConnections} exceeds ${DB_POOL_BUDGET_HEADROOM * 100}% of PgBouncer max_client_conn (${budgetCeiling})`,
+			});
+		}
+	},
+);
+
+export const getDefaultDbCapacityConfig = ({
+	isProduction,
+}: {
+	isProduction: boolean;
+}): DbCapacityConfig =>
+	DbCapacityConfigSchema.parse({
+		...productionDefaults,
+		...(isProduction
+			? {}
+			: {
+					critical_pool_max: 10,
+					general_pool_max: 10,
+				}),
+	});

--- a/server/src/internal/misc/dbCapacity/dbCapacityConfigStore.ts
+++ b/server/src/internal/misc/dbCapacity/dbCapacityConfigStore.ts
@@ -1,0 +1,47 @@
+import { applyDbCapacityConfig } from "@/db/dbPoolCapacity.js";
+import { ADMIN_DB_CAPACITY_CONFIG_KEY } from "@/external/aws/s3/adminS3Config.js";
+import { registerEdgeConfig } from "@/internal/misc/edgeConfig/edgeConfigRegistry.js";
+import { createEdgeConfigStore } from "@/internal/misc/edgeConfig/edgeConfigStore.js";
+import {
+	type DbCapacityConfig,
+	DbCapacityConfigSchema,
+	getDefaultDbCapacityConfig,
+} from "./dbCapacityConfigSchemas.js";
+
+const store = createEdgeConfigStore<DbCapacityConfig>({
+	s3Key: ADMIN_DB_CAPACITY_CONFIG_KEY,
+	schema: DbCapacityConfigSchema,
+	defaultValue: () =>
+		getDefaultDbCapacityConfig({
+			isProduction: process.env.NODE_ENV === "production",
+		}),
+	retainOnError: true,
+	onConfigChange: (config) => {
+		applyDbCapacityConfig({ config });
+	},
+});
+
+registerEdgeConfig({ store });
+
+export const getRuntimeDbCapacityConfigStatus = () => store.getStatus();
+
+export const getRuntimeDbCapacityConfig = (): DbCapacityConfig => store.get();
+
+export const getDbCapacityConfigFromSource =
+	async (): Promise<DbCapacityConfig> => store.readFromSource();
+
+export const updateDbCapacityConfig = async ({
+	config,
+}: {
+	config: DbCapacityConfig;
+}): Promise<void> => {
+	await store.writeToSource({ config });
+};
+
+export const _setDbCapacityConfigForTesting = ({
+	config,
+}: {
+	config: DbCapacityConfig;
+}): void => {
+	store._setRuntimeConfigForTesting(config);
+};

--- a/server/src/internal/misc/edgeConfig/edgeConfigStore.ts
+++ b/server/src/internal/misc/edgeConfig/edgeConfigStore.ts
@@ -60,6 +60,7 @@ export const createEdgeConfigStore = <T>({
 	schema,
 	defaultValue,
 	retainOnError = false,
+	onConfigChange,
 	pollIntervalMs = process.env.NODE_ENV === "development"
 		? ms.seconds(1)
 		: ms.seconds(10),
@@ -69,6 +70,7 @@ export const createEdgeConfigStore = <T>({
 	schema: z.ZodType<T>;
 	defaultValue: () => T;
 	retainOnError?: boolean;
+	onConfigChange?: (config: T) => void;
 	pollIntervalMs?: number;
 	s3Client?: S3Client;
 }) => {
@@ -79,6 +81,10 @@ export const createEdgeConfigStore = <T>({
 		error: "Edge config not yet initialized",
 	};
 	let pollTimer: ReturnType<typeof setInterval> | null = null;
+	const setRuntimeConfig = (config: T) => {
+		onConfigChange?.(config);
+		runtimeConfig = config;
+	};
 
 	// When the base64 test override is present, seed this store's config from it
 	// (or its default) once and operate fully in-memory — no S3, no polling.
@@ -86,9 +92,9 @@ export const createEdgeConfigStore = <T>({
 	if (override) {
 		const raw = override[s3Key];
 		try {
-			runtimeConfig = raw === undefined ? defaultValue() : schema.parse(raw);
+			setRuntimeConfig(raw === undefined ? defaultValue() : schema.parse(raw));
 		} catch {
-			runtimeConfig = defaultValue();
+			setRuntimeConfig(defaultValue());
 		}
 		runtimeStatus = {
 			configured: true,
@@ -146,7 +152,7 @@ export const createEdgeConfigStore = <T>({
 	const writeToSource = async ({ config }: { config: T }) => {
 		// Override mode: update the in-memory config only (no S3 creds available).
 		if (override) {
-			runtimeConfig = config;
+			setRuntimeConfig(config);
 			runtimeStatus = {
 				configured: true,
 				healthy: true,
@@ -176,7 +182,7 @@ export const createEdgeConfigStore = <T>({
 			}),
 		);
 
-		runtimeConfig = config;
+		setRuntimeConfig(config);
 		runtimeStatus = {
 			configured: true,
 			healthy: true,
@@ -199,7 +205,7 @@ export const createEdgeConfigStore = <T>({
 		};
 
 		if (!configured) {
-			runtimeConfig = defaultValue();
+			setRuntimeConfig(defaultValue());
 			runtimeStatus = {
 				configured: false,
 				healthy: false,
@@ -212,7 +218,7 @@ export const createEdgeConfigStore = <T>({
 
 		try {
 			const config = await readFromSource();
-			runtimeConfig = config;
+			setRuntimeConfig(config);
 			runtimeStatus = {
 				configured: true,
 				healthy: true,
@@ -225,7 +231,7 @@ export const createEdgeConfigStore = <T>({
 			const previouslyHealthy = runtimeStatus.healthy;
 			const sameError = runtimeStatus.error === errMsg;
 
-			if (!retainOnError) runtimeConfig = defaultValue();
+			if (!retainOnError) setRuntimeConfig(defaultValue());
 			runtimeStatus = {
 				configured: true,
 				healthy: false,
@@ -273,7 +279,7 @@ export const createEdgeConfigStore = <T>({
 		writeToSource,
 		/** Sets in-memory config without writing to S3. For testing only. */
 		_setRuntimeConfigForTesting: (config: T) => {
-			runtimeConfig = config;
+			setRuntimeConfig(config);
 		},
 	};
 };

--- a/server/src/workers.ts
+++ b/server/src/workers.ts
@@ -16,6 +16,7 @@ import "./internal/misc/mainRedisCache/mainRedisCacheStore.js";
 import "./internal/misc/cacheV2Ramp/cacheV2RampStore.js";
 import "./internal/misc/jobQueues/jobQueueStore.js";
 import "./internal/misc/batchReset/batchResetConfigStore.js";
+import "./internal/misc/dbCapacity/dbCapacityConfigStore.js";
 
 // Number of worker processes (defaults to CPU cores)
 const NUM_PROCESSES = process.env.NODE_ENV === "development" ? 3 : 4;

--- a/server/tests/unit/db/dbPoolCapacity.test.ts
+++ b/server/tests/unit/db/dbPoolCapacity.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import type { Pool } from "pg";
+import {
+	_resetManagedDbPoolsForTesting,
+	applyDbCapacityConfig,
+	registerManagedDbPool,
+} from "@/db/dbPoolCapacity.js";
+import { DbCapacityConfigSchema } from "@/internal/misc/dbCapacity/dbCapacityConfigSchemas.js";
+
+class TestPool extends EventEmitter {
+	idleCount: number;
+	totalCount: number;
+	options: { max: number; maxUses: number; min: number };
+
+	constructor({
+		max,
+		min = 0,
+		totalCount = 0,
+		idleCount = 0,
+	}: {
+		max: number;
+		min?: number;
+		totalCount?: number;
+		idleCount?: number;
+	}) {
+		super();
+		this.totalCount = totalCount;
+		this.idleCount = idleCount;
+		this.options = { max, maxUses: Number.POSITIVE_INFINITY, min };
+	}
+
+	connect = async () => {
+		if (this.idleCount < 1) {
+			throw new Error("No idle test client");
+		}
+		this.idleCount -= 1;
+
+		return {
+			release: (destroy?: boolean) => {
+				this.emit("release");
+				if (destroy) {
+					this.totalCount -= 1;
+					this.emit("remove");
+					return;
+				}
+				this.idleCount += 1;
+			},
+		};
+	};
+}
+
+const asPool = (pool: TestPool): Pool => pool as unknown as Pool;
+
+describe("DB pool capacity", () => {
+	afterEach(() => {
+		_resetManagedDbPoolsForTesting();
+	});
+
+	test("applies the latest config when a managed pool registers", () => {
+		applyDbCapacityConfig({
+			config: DbCapacityConfigSchema.parse({
+				critical_pool_max: 18,
+				general_pool_max: 12,
+				replica_pool_max: 5,
+			}),
+		});
+		const criticalPool = new TestPool({ max: 22, min: 10 });
+
+		registerManagedDbPool({
+			name: "critical",
+			pool: asPool(criticalPool),
+		});
+
+		expect(criticalPool.options.max).toBe(18);
+		expect(criticalPool.options.min).toBe(10);
+	});
+
+	test("updates every managed pool without touching in-flight connections", () => {
+		const criticalPool = new TestPool({ max: 22, min: 10, totalCount: 16 });
+		const generalPool = new TestPool({ max: 14, totalCount: 12 });
+		const replicaPool = new TestPool({ max: 6, totalCount: 5 });
+
+		registerManagedDbPool({
+			name: "critical",
+			pool: asPool(criticalPool),
+		});
+		registerManagedDbPool({
+			name: "general",
+			pool: asPool(generalPool),
+		});
+		registerManagedDbPool({
+			name: "replica",
+			pool: asPool(replicaPool),
+		});
+
+		applyDbCapacityConfig({
+			config: DbCapacityConfigSchema.parse({
+				critical_pool_max: 15,
+				general_pool_max: 10,
+				replica_pool_max: 4,
+				budgeted_fleet_processes: 100,
+			}),
+		});
+
+		expect(criticalPool.options.max).toBe(15);
+		expect(generalPool.options.max).toBe(10);
+		expect(replicaPool.options.max).toBe(4);
+		expect(criticalPool.totalCount).toBe(16);
+		expect(generalPool.totalCount).toBe(12);
+		expect(replicaPool.totalCount).toBe(5);
+	});
+
+	test("retires surplus clients on release and restores normal recycling at the target", () => {
+		const criticalPool = new TestPool({ max: 22, min: 10, totalCount: 16 });
+		registerManagedDbPool({
+			name: "critical",
+			pool: asPool(criticalPool),
+		});
+
+		applyDbCapacityConfig({
+			config: DbCapacityConfigSchema.parse({
+				critical_pool_max: 15,
+				budgeted_fleet_processes: 100,
+			}),
+		});
+
+		expect(criticalPool.options.maxUses).toBe(1);
+
+		criticalPool.totalCount = 15;
+		criticalPool.emit("release");
+
+		expect(criticalPool.options.maxUses).toBe(Number.POSITIVE_INFINITY);
+	});
+
+	test("keeps the critical warm minimum within its configured maximum", () => {
+		const criticalPool = new TestPool({ max: 22, min: 10 });
+		registerManagedDbPool({
+			name: "critical",
+			pool: asPool(criticalPool),
+		});
+
+		applyDbCapacityConfig({
+			config: DbCapacityConfigSchema.parse({
+				critical_pool_max: 6,
+				budgeted_fleet_processes: 100,
+			}),
+		});
+
+		expect(criticalPool.options.min).toBe(6);
+	});
+
+	test("immediately drains idle clients stranded above a lower warm minimum", async () => {
+		const criticalPool = new TestPool({
+			max: 22,
+			min: 10,
+			totalCount: 10,
+			idleCount: 10,
+		});
+		registerManagedDbPool({
+			name: "critical",
+			pool: asPool(criticalPool),
+		});
+
+		applyDbCapacityConfig({
+			config: DbCapacityConfigSchema.parse({
+				critical_pool_max: 6,
+				budgeted_fleet_processes: 100,
+			}),
+		});
+		await Bun.sleep(0);
+
+		expect(criticalPool.totalCount).toBe(6);
+		expect(criticalPool.idleCount).toBe(6);
+		expect(criticalPool.options.maxUses).toBe(Number.POSITIVE_INFINITY);
+	});
+});

--- a/server/tests/unit/edge-config/db-capacity-config.test.ts
+++ b/server/tests/unit/edge-config/db-capacity-config.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import {
+	calculateBudgetedFleetConnections,
+	DB_POOL_BUDGET_HEADROOM,
+	DbCapacityConfigSchema,
+	getDefaultDbCapacityConfig,
+} from "@/internal/misc/dbCapacity/dbCapacityConfigSchemas.js";
+
+describe("DB capacity edge config", () => {
+	test("preserves the existing production defaults", () => {
+		expect(getDefaultDbCapacityConfig({ isProduction: true })).toEqual({
+			critical_pool_max: 22,
+			general_pool_max: 14,
+			replica_pool_max: 6,
+			pgbouncer_max_client_conn: 7600,
+			budgeted_fleet_processes: 150,
+			budgeted_non_server_connections: 80,
+		});
+	});
+
+	test("preserves smaller local pool defaults", () => {
+		expect(getDefaultDbCapacityConfig({ isProduction: false })).toMatchObject({
+			critical_pool_max: 10,
+			general_pool_max: 10,
+			replica_pool_max: 6,
+		});
+	});
+
+	test("accepts coordinated pool and fleet budget changes", () => {
+		const config = DbCapacityConfigSchema.parse({
+			critical_pool_max: 30,
+			general_pool_max: 20,
+			replica_pool_max: 10,
+			budgeted_fleet_processes: 100,
+		});
+
+		expect(calculateBudgetedFleetConnections({ config })).toBe(6080);
+		expect(6080).toBeLessThanOrEqual(
+			config.pgbouncer_max_client_conn * DB_POOL_BUDGET_HEADROOM,
+		);
+	});
+
+	test("rejects a config whose fleet budget exceeds headroom", () => {
+		expect(() =>
+			DbCapacityConfigSchema.parse({
+				critical_pool_max: 30,
+				general_pool_max: 20,
+				replica_pool_max: 10,
+			}),
+		).toThrow("fleet connection budget");
+	});
+});

--- a/server/tests/unit/edge-config/edge-config-store.test.ts
+++ b/server/tests/unit/edge-config/edge-config-store.test.ts
@@ -57,6 +57,29 @@ describe("createEdgeConfigStore", () => {
 	});
 
 	describe("initial fetch via startPolling", () => {
+		test("notifies after a valid runtime config is loaded", async () => {
+			const onConfigChange = jest.fn();
+			const mockClient = createMockS3Client({
+				getResponse: () => makeBody({ enabled: true, message: "from-s3" }),
+			});
+
+			store = createEdgeConfigStore<TestConfig>({
+				s3Key: "admin/test-config.json",
+				schema: TestConfigSchema,
+				defaultValue: defaultConfig,
+				s3Client: mockClient,
+				onConfigChange,
+			});
+
+			await store.startPolling();
+
+			expect(onConfigChange).toHaveBeenCalledTimes(1);
+			expect(onConfigChange).toHaveBeenCalledWith({
+				enabled: true,
+				message: "from-s3",
+			});
+		});
+
 		test("populates get() with parsed config from S3", async () => {
 			const mockClient = createMockS3Client({
 				getResponse: () => makeBody({ enabled: true, message: "from-s3" }),

--- a/server/tests/unit/edge-config/worker-edge-config-registration.test.ts
+++ b/server/tests/unit/edge-config/worker-edge-config-registration.test.ts
@@ -14,3 +14,24 @@ test("workers register miscellaneous edge config before polling starts", async (
 	expect(storeImportIndex).toBeGreaterThanOrEqual(0);
 	expect(pollingStartIndex).toBeGreaterThan(storeImportIndex);
 });
+
+test("all long-running processes register DB capacity before polling starts", async () => {
+	const sourcePaths = [
+		path.resolve(import.meta.dir, "../../../src/init.ts"),
+		path.resolve(import.meta.dir, "../../../src/workers.ts"),
+		path.resolve(import.meta.dir, "../../../src/cron.ts"),
+	];
+
+	for (const sourcePath of sourcePaths) {
+		const source = await Bun.file(sourcePath).text();
+		const storeImportIndex = source.indexOf(
+			"internal/misc/dbCapacity/dbCapacityConfigStore.js",
+		);
+		const pollingStartIndex = source.indexOf(
+			"startAllEdgeConfigPolling({ logger })",
+		);
+
+		expect(storeImportIndex).toBeGreaterThanOrEqual(0);
+		expect(pollingStartIndex).toBeGreaterThan(storeImportIndex);
+	}
+});

--- a/vite/src/views/admin/components/DbCapacityConfigForm.tsx
+++ b/vite/src/views/admin/components/DbCapacityConfigForm.tsx
@@ -1,0 +1,205 @@
+import { Badge, Button, DialogFooter, Separator } from "@autumn/ui";
+import { useStore } from "@tanstack/react-form";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useAppForm } from "@/hooks/form/form";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
+import {
+	DB_CAPACITY_LIMITS,
+	DB_CAPACITY_QUERY_KEY,
+	type DbCapacityConfig,
+	type DbCapacityFormValues,
+} from "./dbCapacityConfigTypes";
+
+const HEADROOM = 0.85;
+
+export const DbCapacityConfigForm = ({
+	config,
+	onClose,
+}: {
+	config: DbCapacityConfig;
+	onClose: () => void;
+}) => {
+	const axiosInstance = useAxiosInstance();
+	const queryClient = useQueryClient();
+	const mutation = useMutation({
+		mutationFn: async (nextConfig: DbCapacityFormValues) => {
+			await axiosInstance.put("/admin/db-capacity-config", nextConfig);
+		},
+		onSuccess: async () => {
+			await queryClient.invalidateQueries({
+				queryKey: DB_CAPACITY_QUERY_KEY,
+			});
+			toast.success("Database capacity config saved");
+			onClose();
+		},
+		onError: (error) => {
+			toast.error(getBackendErr(error, "Failed to save capacity config"));
+		},
+	});
+	const form = useAppForm({
+		defaultValues: {
+			critical_pool_max: config.critical_pool_max as number | null,
+			general_pool_max: config.general_pool_max as number | null,
+			replica_pool_max: config.replica_pool_max as number | null,
+			pgbouncer_max_client_conn: config.pgbouncer_max_client_conn as
+				| number
+				| null,
+			budgeted_fleet_processes: config.budgeted_fleet_processes as
+				| number
+				| null,
+			budgeted_non_server_connections: config.budgeted_non_server_connections as
+				| number
+				| null,
+		},
+		onSubmit: async ({ value }) => {
+			const entries = Object.values(value);
+			if (entries.some((entry) => entry === null)) return;
+
+			await mutation.mutateAsync(value as DbCapacityFormValues);
+		},
+	});
+	const isDirty = useStore(form.store, (state) => state.isDirty);
+	const values = useStore(form.store, (state) => state.values);
+	const allValuesPresent = Object.values(values).every(
+		(value) => value !== null,
+	);
+	const budgetedConnections = allValuesPresent
+		? (values.budgeted_fleet_processes as number) *
+				((values.critical_pool_max as number) +
+					(values.general_pool_max as number) +
+					(values.replica_pool_max as number)) +
+			(values.budgeted_non_server_connections as number)
+		: null;
+	const budgetCeiling = allValuesPresent
+		? Math.floor((values.pgbouncer_max_client_conn as number) * HEADROOM)
+		: null;
+	const budgetIsValid =
+		budgetedConnections !== null &&
+		budgetCeiling !== null &&
+		budgetedConnections <= budgetCeiling;
+
+	return (
+		<>
+			<div className="flex flex-col gap-6">
+				<div className="grid gap-x-6 gap-y-5 md:grid-cols-2">
+					<form.AppField name="critical_pool_max">
+						{(field) => (
+							<field.NumberField
+								label="Critical pool max"
+								description="Reserved for latency-sensitive customer routes."
+								min={DB_CAPACITY_LIMITS.critical_pool_max.min}
+								max={DB_CAPACITY_LIMITS.critical_pool_max.max}
+								inputClassName="tabular-nums"
+							/>
+						)}
+					</form.AppField>
+					<form.AppField name="general_pool_max">
+						{(field) => (
+							<field.NumberField
+								label="General pool max"
+								description="All other HTTP database traffic."
+								min={DB_CAPACITY_LIMITS.general_pool_max.min}
+								max={DB_CAPACITY_LIMITS.general_pool_max.max}
+								inputClassName="tabular-nums"
+							/>
+						)}
+					</form.AppField>
+					<form.AppField name="replica_pool_max">
+						{(field) => (
+							<field.NumberField
+								label="Replica pool max"
+								description="Fallback reads when the primary is degraded."
+								min={DB_CAPACITY_LIMITS.replica_pool_max.min}
+								max={DB_CAPACITY_LIMITS.replica_pool_max.max}
+								inputClassName="tabular-nums"
+							/>
+						)}
+					</form.AppField>
+					<form.AppField name="pgbouncer_max_client_conn">
+						{(field) => (
+							<field.NumberField
+								label="PgBouncer client ceiling"
+								description="The configured max_client_conn value."
+								min={DB_CAPACITY_LIMITS.pgbouncer_max_client_conn.min}
+								max={DB_CAPACITY_LIMITS.pgbouncer_max_client_conn.max}
+								inputClassName="tabular-nums"
+							/>
+						)}
+					</form.AppField>
+					<form.AppField name="budgeted_fleet_processes">
+						{(field) => (
+							<field.NumberField
+								label="Budgeted fleet processes"
+								description="Worst-case number of HTTP processes."
+								min={DB_CAPACITY_LIMITS.budgeted_fleet_processes.min}
+								max={DB_CAPACITY_LIMITS.budgeted_fleet_processes.max}
+								inputClassName="tabular-nums"
+							/>
+						)}
+					</form.AppField>
+					<form.AppField name="budgeted_non_server_connections">
+						{(field) => (
+							<field.NumberField
+								label="Other reserved connections"
+								description="Workers, cron jobs, migrations, and direct clients."
+								min={DB_CAPACITY_LIMITS.budgeted_non_server_connections.min}
+								max={DB_CAPACITY_LIMITS.budgeted_non_server_connections.max}
+								inputClassName="tabular-nums"
+							/>
+						)}
+					</form.AppField>
+				</div>
+
+				<div className="flex flex-col gap-3 text-xs text-tertiary-foreground">
+					<Separator />
+					<div className="flex flex-wrap items-center gap-2">
+						<Badge
+							className={budgetIsValid ? undefined : "text-destructive"}
+							variant="muted"
+						>
+							{budgetedConnections === null || budgetCeiling === null
+								? "Complete all values"
+								: `${budgetedConnections.toLocaleString()} / ${budgetCeiling.toLocaleString()} budgeted`}
+						</Badge>
+						<Badge variant="muted">
+							{config.configHealthy ? "Config healthy" : "Config unavailable"}
+						</Badge>
+						<Badge variant="muted">
+							{config.configConfigured ? "S3 set" : "Using defaults"}
+						</Badge>
+						{config.lastSuccessAt && (
+							<span className="tabular-nums">
+								Last refresh: {new Date(config.lastSuccessAt).toLocaleString()}
+							</span>
+						)}
+					</div>
+					<p className="text-pretty">
+						{config.error ||
+							"Changes propagate within 10 seconds. Lower limits drain surplus connections as active queries finish; no in-flight query is cancelled."}
+					</p>
+				</div>
+			</div>
+
+			<DialogFooter className="flex-wrap pt-2">
+				{mutation.error && (
+					<span role="alert" className="mr-auto text-xs text-destructive">
+						{getBackendErr(mutation.error, "Failed to save capacity config")}
+					</span>
+				)}
+				<Button variant="secondary" onClick={onClose}>
+					Cancel
+				</Button>
+				<Button
+					variant="primary"
+					onClick={() => form.handleSubmit()}
+					isLoading={mutation.isPending}
+					disabled={!isDirty || !budgetIsValid || mutation.isPending}
+				>
+					Save
+				</Button>
+			</DialogFooter>
+		</>
+	);
+};

--- a/vite/src/views/admin/components/DbCapacityDialog.tsx
+++ b/vite/src/views/admin/components/DbCapacityDialog.tsx
@@ -1,0 +1,71 @@
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+	Skeleton,
+} from "@autumn/ui";
+import { useQuery } from "@tanstack/react-query";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { DbCapacityConfigForm } from "./DbCapacityConfigForm";
+import {
+	DB_CAPACITY_DEFAULTS,
+	DB_CAPACITY_QUERY_KEY,
+	type DbCapacityConfig,
+} from "./dbCapacityConfigTypes";
+import { EdgeConfigDialogBody } from "./EdgeConfigDialogBody";
+
+export function DbCapacityDialog({
+	open,
+	onOpenChange,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const axiosInstance = useAxiosInstance();
+	const configQuery = useQuery<DbCapacityConfig>({
+		queryKey: DB_CAPACITY_QUERY_KEY,
+		queryFn: async () => {
+			const { data } = await axiosInstance.get<DbCapacityConfig>(
+				"/admin/db-capacity-config",
+			);
+			return { ...DB_CAPACITY_DEFAULTS, ...data };
+		},
+		enabled: open,
+	});
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-2xl bg-card">
+				<DialogHeader>
+					<DialogTitle className="text-balance">Database Capacity</DialogTitle>
+					<DialogDescription className="text-pretty">
+						Resize the HTTP database pools and keep their fleet-wide connection
+						budget within the PgBouncer ceiling.
+					</DialogDescription>
+				</DialogHeader>
+
+				<EdgeConfigDialogBody
+					query={configQuery}
+					errorMessage="Failed to load database capacity config"
+					skeleton={
+						<div className="grid gap-4 md:grid-cols-2">
+							{Array.from({ length: 6 }, (_, index) => (
+								<Skeleton className="h-20" key={index} />
+							))}
+						</div>
+					}
+				>
+					{(config) => (
+						<DbCapacityConfigForm
+							key={`${config.critical_pool_max}:${config.general_pool_max}:${config.replica_pool_max}:${config.pgbouncer_max_client_conn}:${config.budgeted_fleet_processes}:${config.budgeted_non_server_connections}`}
+							config={config}
+							onClose={() => onOpenChange(false)}
+						/>
+					)}
+				</EdgeConfigDialogBody>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/vite/src/views/admin/components/EdgeConfigTab.tsx
+++ b/vite/src/views/admin/components/EdgeConfigTab.tsx
@@ -5,6 +5,7 @@ import { AsyncBalanceUpdateDialog } from "./AsyncBalanceUpdateDialog";
 import { AsyncTrackDialog } from "./AsyncTrackDialog";
 import { CacheV2RampDialog } from "./CacheV2RampDialog";
 import { CustomerBlockDialog } from "./CustomerBlockDialog";
+import { DbCapacityDialog } from "./DbCapacityDialog";
 import { EdgeConfigCard } from "./EdgeConfigCard";
 import { EdgeConfigDialog } from "./EdgeConfigDialog";
 import { EDGE_CONFIG_SECTIONS, type EdgeConfigCardId } from "./edgeConfigCards";
@@ -170,6 +171,11 @@ export function EdgeConfigTab() {
 
 			<FullSubjectGateDialog
 				open={openConfig === "full-subject-gate"}
+				onOpenChange={closeDialog}
+			/>
+
+			<DbCapacityDialog
+				open={openConfig === "db-capacity"}
 				onOpenChange={closeDialog}
 			/>
 

--- a/vite/src/views/admin/components/dbCapacityConfigTypes.ts
+++ b/vite/src/views/admin/components/dbCapacityConfigTypes.ts
@@ -1,0 +1,48 @@
+export type DbCapacityConfig = {
+	critical_pool_max: number;
+	general_pool_max: number;
+	replica_pool_max: number;
+	pgbouncer_max_client_conn: number;
+	budgeted_fleet_processes: number;
+	budgeted_non_server_connections: number;
+	configHealthy?: boolean;
+	configConfigured?: boolean;
+	lastSuccessAt?: string | null;
+	error?: string | null;
+};
+
+export type DbCapacityFormValues = Pick<
+	DbCapacityConfig,
+	| "critical_pool_max"
+	| "general_pool_max"
+	| "replica_pool_max"
+	| "pgbouncer_max_client_conn"
+	| "budgeted_fleet_processes"
+	| "budgeted_non_server_connections"
+>;
+
+export const DB_CAPACITY_DEFAULTS: DbCapacityFormValues = {
+	critical_pool_max: 22,
+	general_pool_max: 14,
+	replica_pool_max: 6,
+	pgbouncer_max_client_conn: 7_600,
+	budgeted_fleet_processes: 150,
+	budgeted_non_server_connections: 80,
+};
+
+export const DB_CAPACITY_LIMITS: Record<
+	keyof DbCapacityFormValues,
+	{ min: number; max: number }
+> = {
+	critical_pool_max: { min: 1, max: 1_000 },
+	general_pool_max: { min: 1, max: 1_000 },
+	replica_pool_max: { min: 1, max: 1_000 },
+	pgbouncer_max_client_conn: { min: 1, max: 1_000_000 },
+	budgeted_fleet_processes: { min: 1, max: 100_000 },
+	budgeted_non_server_connections: { min: 0, max: 1_000_000 },
+};
+
+export const DB_CAPACITY_QUERY_KEY = [
+	"admin-edge-config",
+	"db-capacity",
+] as const;

--- a/vite/src/views/admin/components/edgeConfigCards.ts
+++ b/vite/src/views/admin/components/edgeConfigCards.ts
@@ -39,6 +39,7 @@ export type EdgeConfigCardId =
 	| "main-redis-cache"
 	| "cache-v2-ramp"
 	| "full-subject-gate"
+	| "db-capacity"
 	| "miscellaneous";
 
 export type QueueCronCardId =
@@ -265,6 +266,32 @@ export const EDGE_CONFIG_SECTIONS: EdgeConfigSectionDef[] = [
 
 					return {
 						label: `${perCustomer} / ${perOrg} concurrent`,
+						tone: "neutral",
+					};
+				},
+			},
+			{
+				id: "db-capacity",
+				title: "Database Capacity",
+				description:
+					"Live pool limits and the fleet-wide PgBouncer connection budget.",
+				icon: Database,
+				endpoint: "/admin/db-capacity-config",
+				deriveStatus: (data) => {
+					const config = asRecord(data);
+					const critical = config.critical_pool_max;
+					const general = config.general_pool_max;
+					const replica = config.replica_pool_max;
+					if (
+						typeof critical !== "number" ||
+						typeof general !== "number" ||
+						typeof replica !== "number"
+					) {
+						return IDLE;
+					}
+
+					return {
+						label: `${critical} / ${general} / ${replica} pool max`,
 						tone: "neutral",
 					};
 				},


### PR DESCRIPTION
## Summary

- move the critical, general, and replica pool limits plus the PgBouncer fleet-budget inputs into a dedicated S3-backed Edge Config
- apply valid pool-limit changes to live `pg.Pool` instances across running processes without a restart
- add a Database Capacity editor to the admin Edge Config dashboard
- register the config before polling in HTTP, worker, and cron entrypoints

## Safety

- reject configurations whose modelled fleet usage exceeds 85% of `pgbouncer_max_client_conn`
- retain the last valid capacity when S3 reads or schema validation fail
- apply increases to subsequent checkouts immediately
- drain surplus idle clients when lowering a limit and retire busy clients only after their in-flight query finishes
- keep the critical pool warm minimum within its configured maximum

`pgbouncer_max_client_conn` is a validation reference and does not reconfigure PlanetScale itself. The live resizing applies to the managed critical, general, and replica pools; separately constructed worker and cron pools are unchanged.

## Validation

- 27 focused unit tests passed
- server typecheck passed
- dashboard typecheck passed
- scoped Biome check passed
- commit hooks passed, including Knip and both package typechecks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes database pool capacity runtime-configurable via an S3-backed Edge Config, with safe live resizing of `pg` pools and an admin editor. Keeps the fleet connection budget within PgBouncer headroom and applies changes across HTTP, worker, and cron processes without restarts.

- New Features
  - Added DB Capacity Edge Config with defaults and schema validation (rejects budgets > 85% of PgBouncer max_client_conn).
  - Live-apply changes to `pg.Pool` (critical/general/replica): immediate increases; drain idle; retire busy via maxUses; keep critical warm min ≤ max; retain last valid config on read/validation errors.
  - Admin dashboard editor with budget preview and health/status; new endpoints: GET/PUT /admin/db-capacity-config.
  - Registered the config before polling in HTTP, workers, and cron; only managed critical/general/replica pools are resized (ad hoc worker/cron pools unchanged).

- Refactors
  - `initDrizzle` now reads pool sizes from runtime config and registers pools for management.
  - `edgeConfigStore` supports an `onConfigChange` hook; added focused unit tests for config and pool behavior.

<sup>Written for commit 3ee18ff54e45bf73ccaa0b4dcf7a24317dc7c2e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds runtime-configurable database capacity management backed by S3 Edge Config.
- **[Improvements]** Introduces validated fleet-budget settings and live resizing for critical, general, and replica PostgreSQL pools.
- **[Improvements]** Registers capacity polling across HTTP, worker, and cron entrypoints while retaining the last valid configuration on source errors.
- **[API changes]** Adds superuser-protected GET and PUT endpoints for database-capacity configuration.
- **[Improvements]** Adds an admin dashboard editor with budget validation, source health, and refresh status.
- **[Improvements]** Extends the generic Edge Config store with a configuration-change callback and adds focused coverage for configuration loading and pool resizing.
</details>

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge, with no concrete blocking or independently actionable defects identified.

Runtime settings are schema-validated before persistence, polling retains valid capacity on source failures, startup ordering preserves defaults until configuration loads, and managed pools apply both increases and reductions without interrupting in-flight queries.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/db/dbPoolCapacity.ts | Adds managed PostgreSQL pool registration and live maximum resizing with surplus-client retirement. |
| server/src/db/initDrizzle.ts | Initializes managed pools from runtime capacity settings and registers them for subsequent live updates. |
| server/src/internal/misc/dbCapacity/dbCapacityConfigSchemas.ts | Defines capacity defaults, bounds, and fleet-wide PgBouncer headroom validation. |
| server/src/internal/misc/dbCapacity/dbCapacityConfigStore.ts | Adds the S3-backed runtime store and connects valid configuration changes to managed pools. |
| server/src/internal/misc/edgeConfig/edgeConfigStore.ts | Adds an optional synchronous callback whenever a validated runtime configuration is installed. |
| server/src/internal/admin/handleGetAdminDbCapacityConfig.ts | Exposes the persisted capacity configuration and runtime health metadata to superusers. |
| server/src/internal/admin/handleUpsertAdminDbCapacityConfig.ts | Adds a validated superuser endpoint for persisting capacity settings. |
| vite/src/views/admin/components/DbCapacityConfigForm.tsx | Adds the capacity editor, client-side budget preview, health indicators, and save workflow. |
| vite/src/views/admin/components/DbCapacityDialog.tsx | Adds query and dialog integration for the database-capacity editor. |
| server/tests/unit/db/dbPoolCapacity.test.ts | Covers live maximum updates, deferred retirement, idle draining, and critical-pool minimum adjustment. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Admin as Admin Dashboard
  participant API as Admin API
  participant S3 as S3 Edge Config
  participant Poller as Process Edge Config Poller
  participant Store as DB Capacity Store
  participant Pools as Managed pg.Pools

  Admin->>API: PUT /admin/db-capacity-config
  API->>API: Validate schema and fleet budget
  API->>S3: Persist valid configuration
  API-->>Admin: success

  loop Every polling interval
    Poller->>S3: Read capacity configuration
    S3-->>Poller: Configuration
    Poller->>Store: Update runtime configuration
    Store->>Pools: Apply critical/general/replica maxima
    Pools->>Pools: Drain surplus idle clients
    Pools->>Pools: Retire surplus busy clients after release
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: ⚡ make database capacity runtime c..."](https://github.com/useautumn/autumn/commit/3ee18ff54e45bf73ccaa0b4dcf7a24317dc7c2e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48297867)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Server API Routing: Request Lifecycle](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-api-routers.md)
- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)
- Knowledge Base — [External Integrations (non-Stripe)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-external-integrations.md)
</details>

<!-- /greptile_comment -->