### PR TITLE
fix(check): preserve fail-open allowed in v1.2 response converter

### DIFF
--- a/shared/api/balances/check/changes/V1.2_CheckChange.ts
+++ b/shared/api/balances/check/changes/V1.2_CheckChange.ts
@@ -46,9 +46,10 @@ export const V1_2_CheckChange = defineVersionChange({
 
 		const { featureToUse } = legacyData;
 
+		// Preserve upstream `allowed` (e.g. fail-open returns allowed: true with a null balance)
 		if (!input.balance) {
 			return {
-				allowed: false,
+				allowed: input.allowed,
 				code: "feature_found",
 				customer_id: input.customer_id,
 				feature_id: featureToUse.id,


### PR DESCRIPTION
## Problem

When \`/check\` fails open (Redis down, FullSubject gate rejection, or org rate-cap degradation), \`buildCheckFallbackResponse\` returns \`allowed: true\` with \`balance: null\` and \`flag: null\`, then runs the response through \`applyResponseVersionChanges\`.

For orgs on API version ≤ V1.2, \`V1_2_CheckChange.transformResponse\` hard-coded \`allowed: false\` in its no-balance branch. Since the fallback's \`flag\` is null, \`V2_0_CheckChange\` leaves \`balance\` null, so every fail-open response hit that branch and got flipped to \`allowed: false\` — denying access to exactly the customers fail-open is meant to protect.

## Fix

The no-balance branch now passes through \`input.allowed\` instead of hard-coding \`false\`.

Safe for normal (non-fail-open) flows: by the time this converter runs, boolean/unlimited features already have a balance object (flag→balance conversion happens in \`V2_0_CheckChange\` first), so a null balance otherwise only occurs on paths that already carry \`allowed: false\` upstream. \`V0_2_CheckChange\` and \`V2_0_CheckChange\` both pass \`allowed\` through faithfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes fail-open handling in `/check` for API v1.2 conversions. Prevents allowed responses with a null balance from being flipped to denied.

- **Bug Fixes**
  - In `V1_2_CheckChange`, when `balance` is null, return `allowed: input.allowed` instead of `false` to preserve fail-open behavior without affecting normal flows.

<sup>Written for commit 2c66b6da09dd03392fd80e0060c253069ab38108. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Preserves the upstream access decision when converting a check response with no balance to API version V1.2.
- **Bug fixes, API changes:** Return `input.allowed` from the V1.2 no-balance branch so intentional fail-open responses remain allowed for legacy clients.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The converter now preserves the access decision established upstream, restoring intended fail-open behavior while ordinary denied responses continue carrying `allowed: false`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/api/balances/check/changes/V1.2_CheckChange.ts | Correctly preserves the upstream `allowed` value for balance-less responses instead of unconditionally denying access. |

<sub>Reviews (1): Last reviewed commit: ["fix(check): 🐛 preserve fail-open allowe..."](https://github.com/useautumn/autumn/commit/2c66b6da09dd03392fd80e0060c253069ab38108) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48327774)</sub>

<!-- /greptile_comment -->