### PR TITLE
fix(analytics): pin recharts to 3.9.2

### DIFF
--- a/apps/testbench/package.json
+++ b/apps/testbench/package.json
@@ -25,7 +25,7 @@
 		"react-dom": "^18.2.0",
 		"react-resizable-panels": "^4.11.0",
 		"react-router-dom": "^7.13.0",
-		"recharts": "^3.3.0",
+		"recharts": "3.9.2",
 		"tailwind-merge": "^3.0.2",
 		"tailwind-scrollbar-hide": "^4.0.0",
 		"tailwindcss": "^4.0.13",

--- a/bun.lock
+++ b/bun.lock
@@ -184,7 +184,7 @@
         "react-dom": "^18.2.0",
         "react-resizable-panels": "^4.11.0",
         "react-router-dom": "^7.13.0",
-        "recharts": "^3.3.0",
+        "recharts": "3.9.2",
         "tailwind-merge": "^3.0.2",
         "tailwind-scrollbar-hide": "^4.0.0",
         "tailwindcss": "^4.0.13",
@@ -517,7 +517,7 @@
         "react-day-picker": "^8.10.1",
         "react-hotkeys-hook": "^4.6.1",
         "react-resizable-panels": "^4.11.0",
-        "recharts": "^3.3.0",
+        "recharts": "3.9.2",
         "shiki": "^3.20.0",
         "streamdown": "^1.6.10",
         "tailwind-merge": "^3.0.2",
@@ -787,7 +787,7 @@
         "react-resizable-panels": "^4.11.0",
         "react-router": "^7.3.0",
         "react-router-dom": "^7.6.2",
-        "recharts": "^3.3.0",
+        "recharts": "3.9.2",
         "shiki": "^3.20.0",
         "sonner": "^2.0.1",
         "streamdown": "^1.6.10",
@@ -5668,7 +5668,7 @@
 
     "recast": ["recast@0.23.12", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-dEWRjcINDu/F4l2dYx57ugBtD7HV9KXESyxhzw/MqWLeglJrsjJKqACPyUPg+6AF8mIgm+Zi0dZ3ACoIg+QtpA=="],
 
-    "recharts": ["recharts@3.10.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^11.1.8", "react-redux": "8.x.x || 9.x.x", "reselect": "5.2.0", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA=="],
+    "recharts": ["recharts@3.9.2", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^11.1.8", "react-redux": "8.x.x || 9.x.x", "reselect": "5.2.0", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-G4fy+Pk46RaXgwWMh+Nzhyo/lbFAVqXo9gtetlyehe6Ehge9CsgDuOTwQDD+i1+llaLktNBiNq4bhnGlDRXFtw=="],
 
     "recma-build-jsx": ["recma-build-jsx@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-build-jsx": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew=="],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -53,7 +53,7 @@
 		"react-day-picker": "^8.10.1",
 		"react-hotkeys-hook": "^4.6.1",
 		"react-resizable-panels": "^4.11.0",
-		"recharts": "^3.3.0",
+		"recharts": "3.9.2",
 		"shiki": "^3.20.0",
 		"streamdown": "^1.6.10",
 		"tailwind-merge": "^3.0.2",

--- a/vite/package.json
+++ b/vite/package.json
@@ -68,7 +68,7 @@
 		"react-resizable-panels": "^4.11.0",
 		"react-router": "^7.3.0",
 		"react-router-dom": "^7.6.2",
-		"recharts": "^3.3.0",
+		"recharts": "3.9.2",
 		"shiki": "^3.20.0",
 		"sonner": "^2.0.1",
 		"streamdown": "^1.6.10",


### PR DESCRIPTION
## Problem

The usage chart renders its legend totals correctly but the plot area stays empty — no bars, no axes, no grid.

## Cause

`b2c7d026a` ("fix: bun.lock", today 11:40) bumped recharts **3.9.2 → 3.10.1** on `dev` and `main`. The chart broke immediately after.

## Fix

Pin recharts to **3.9.2** — the exact version in the lockfile before that bump, and the last one the chart is known to have rendered on — across `vite`, `packages/ui` and `apps/testbench`.

Diff is recharts only; transitive deps (`immer`, `reselect`) are unchanged.

## Related

#2473 applies the same pin to `main`, correcting #2472 which pinned to 3.3.0 (a version this codebase never ran).

## Testing

`tsc --noEmit` and `knip` pass; `bun install --frozen-lockfile` is consistent. Browser verification pending.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Pins the workspace’s Recharts installation to a single resolved version.
- **[Bug fixes]** Pins Recharts to `3.9.2` in the Vite app, UI package, and testbench.
- **[Improvements]** Updates `bun.lock` so all three workspaces resolve Recharts `3.9.2`.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/package.json | Pins the Vite application’s Recharts dependency to version 3.9.2. |
| packages/ui/package.json | Pins the shared UI package’s Recharts dependency to version 3.9.2. |
| apps/testbench/package.json | Aligns the testbench with the exact Recharts version used by the application and UI package. |
| bun.lock | Re-resolves the workspace’s Recharts dependency from 3.10.1 to 3.9.2. |

<sub>Reviews (4): Last reviewed commit: ["fix(analytics): 🐛 pin recharts to 3.9.2"](https://github.com/useautumn/autumn/commit/31b56d6b3e8ca385bfc6ad000a8b289ee6898abf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48331252)</sub>

<!-- /greptile_comment -->