### PR TITLE
fix(analytics): pin recharts to 3.3.0

### DIFF
--- a/apps/testbench/package.json
+++ b/apps/testbench/package.json
@@ -25,7 +25,7 @@
 		"react-dom": "^18.2.0",
 		"react-resizable-panels": "^4.11.0",
 		"react-router-dom": "^7.13.0",
-		"recharts": "^3.3.0",
+		"recharts": "3.3.0",
 		"tailwind-merge": "^3.0.2",
 		"tailwind-scrollbar-hide": "^4.0.0",
 		"tailwindcss": "^4.0.13",

--- a/bun.lock
+++ b/bun.lock
@@ -184,7 +184,7 @@
         "react-dom": "^18.2.0",
         "react-resizable-panels": "^4.11.0",
         "react-router-dom": "^7.13.0",
-        "recharts": "^3.3.0",
+        "recharts": "3.3.0",
         "tailwind-merge": "^3.0.2",
         "tailwind-scrollbar-hide": "^4.0.0",
         "tailwindcss": "^4.0.13",
@@ -517,7 +517,7 @@
         "react-day-picker": "^8.10.1",
         "react-hotkeys-hook": "^4.6.1",
         "react-resizable-panels": "^4.11.0",
-        "recharts": "^3.3.0",
+        "recharts": "3.3.0",
         "shiki": "^3.20.0",
         "streamdown": "^1.6.10",
         "tailwind-merge": "^3.0.2",
@@ -787,7 +787,7 @@
         "react-resizable-panels": "^4.11.0",
         "react-router": "^7.3.0",
         "react-router-dom": "^7.6.2",
-        "recharts": "^3.3.0",
+        "recharts": "3.3.0",
         "shiki": "^3.20.0",
         "sonner": "^2.0.1",
         "streamdown": "^1.6.10",
@@ -4488,7 +4488,7 @@
 
     "ignore-by-default": ["ignore-by-default@1.0.1", "", {}, "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA=="],
 
-    "immer": ["immer@11.1.15", "", {}, "sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ=="],
+    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
@@ -5668,7 +5668,7 @@
 
     "recast": ["recast@0.23.12", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-dEWRjcINDu/F4l2dYx57ugBtD7HV9KXESyxhzw/MqWLeglJrsjJKqACPyUPg+6AF8mIgm+Zi0dZ3ACoIg+QtpA=="],
 
-    "recharts": ["recharts@3.10.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^11.1.8", "react-redux": "8.x.x || 9.x.x", "reselect": "5.2.0", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA=="],
+    "recharts": ["recharts@3.3.0", "", { "dependencies": { "@reduxjs/toolkit": "1.x.x || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Vi0qmTB0iz1+/Cz9o5B7irVyUjX2ynvEgImbgMt/3sKRREcUM07QiYjS1QpAVrkmVlXqy5gykq4nGWMz9AS4Rg=="],
 
     "recma-build-jsx": ["recma-build-jsx@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-build-jsx": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew=="],
 
@@ -5762,7 +5762,7 @@
 
     "require-in-the-middle": ["require-in-the-middle@7.5.2", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3", "resolve": "^1.22.8" } }, "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ=="],
 
-    "reselect": ["reselect@5.2.0", "", {}, "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="],
+    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resend": ["resend@4.8.0", "", { "dependencies": { "@react-email/render": "1.1.2" } }, "sha512-R8eBOFQDO6dzRTDmaMEdpqrkmgSjPpVXt4nGfWsZdYOet0kqra0xgbvTES6HmCriZEXbmGk3e0DiGIaLFTFSHA=="],
 
@@ -6810,6 +6810,8 @@
 
     "@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@base-ui/utils/reselect": ["reselect@5.2.0", "", {}, "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="],
+
     "@better-auth/cli/@better-auth/core": ["@better-auth/core@1.4.21", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "zod": "^4.3.5" }, "peerDependencies": { "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21", "better-call": "1.1.8", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" } }, "sha512-R4s7pwShkqB21fZ599QASbXxqFcoxanLyz7DHSX6SJPNYV748wBLsm3xM9VrjfvWMpS+cQUErOCt9yWT1hMn6w=="],
 
     "@better-auth/cli/better-auth": ["better-auth@1.4.21", "", { "dependencies": { "@better-auth/core": "1.4.21", "@better-auth/telemetry": "1.4.21", "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.0.0", "@noble/hashes": "^2.0.0", "better-call": "1.1.8", "defu": "^6.1.4", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1", "zod": "^4.3.5" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": ">=0.41.0", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-qdrIZS7xnGF2HPBV5wYNPWTkPojhauOOjz1+MhLvwFy+zXpgLofQmWsI5I9DY+ef845NKt93XcgpyAc4RPPT9A=="],
@@ -7277,6 +7279,10 @@
     "@react-grab/cli/ora": ["ora@9.4.1", "", { "dependencies": { "chalk": "^5.6.2", "cli-cursor": "^5.0.0", "cli-spinners": "^3.2.0", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.1.0", "log-symbols": "^7.0.1", "stdin-discarder": "^0.3.2", "string-width": "^8.1.0" } }, "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw=="],
 
     "@react-grab/cli/tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
+    "@reduxjs/toolkit/immer": ["immer@11.1.15", "", {}, "sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ=="],
+
+    "@reduxjs/toolkit/reselect": ["reselect@5.2.0", "", {}, "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="],
 
     "@sentry/browser/@sentry/core": ["@sentry/core@10.68.0", "", { "dependencies": { "@sentry/conventions": "^0.16.0" } }, "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g=="],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -53,7 +53,7 @@
 		"react-day-picker": "^8.10.1",
 		"react-hotkeys-hook": "^4.6.1",
 		"react-resizable-panels": "^4.11.0",
-		"recharts": "^3.3.0",
+		"recharts": "3.3.0",
 		"shiki": "^3.20.0",
 		"streamdown": "^1.6.10",
 		"tailwind-merge": "^3.0.2",

--- a/vite/package.json
+++ b/vite/package.json
@@ -68,7 +68,7 @@
 		"react-resizable-panels": "^4.11.0",
 		"react-router": "^7.3.0",
 		"react-router-dom": "^7.6.2",
-		"recharts": "^3.3.0",
+		"recharts": "3.3.0",
 		"shiki": "^3.20.0",
 		"sonner": "^2.0.1",
 		"streamdown": "^1.6.10",


### PR DESCRIPTION
Production hotfix. Same commit as #2471 (which targets `dev`), cherry-picked onto `main`.

## Problem

The usage chart renders its legend totals correctly but the plot area stays empty — no bars, no axes, no grid.

## Cause

The `^3.3.0` caret range had drifted the lockfile to **recharts 3.10.1**. That version's `ResponsiveContainer` measurement timing leaves the chart measuring its parent as zero-sized, producing an empty SVG. The legend is plain DOM, which is why it populates while the plot does not.

## Fix

Pin `recharts` to `3.3.0` in `vite`, `packages/ui` and `apps/testbench` so the resolved version cannot drift again.

Lockfile diff is scoped to recharts and its own transitive pins (`immer`, `reselect`). No source changes.

## Scope

This pins the trigger only. There is a separate latent issue in `AnalyticsView` — the chart mounts inside a `motion.div` starting at `opacity: 0`, so recharts can measure an unlaid-out parent — which is what made the version bump break things rather than merely change them. That fix is deliberately **not** in this PR and is worth a follow-up, since the chart stays sensitive to anything that shifts mount timing.

## Testing

`bun install --frozen-lockfile` is consistent against `main`'s tree. **Not verified in a running browser** — please confirm the bars render before merging to production.

## Merge order

Frontend is identical on `main` and `dev`, so the two PRs don't conflict. Land both so `main` doesn't regress on the next `dev` promotion.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Pins Recharts to the known-good 3.3.0 release across all consuming workspaces.
- **[Bug fixes]** Replaces the `^3.3.0` ranges with exact `3.3.0` pins in Vite, the shared UI package, and testbench.
- **[Improvements]** Updates the Bun lockfile to resolve Recharts 3.3.0 and its compatible Immer and Reselect transitive dependencies.
</details>

<h3>Confidence Score: 5/5</h3>

The dependency-only change appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/testbench/package.json | Pins the testbench Recharts dependency to 3.3.0. |
| packages/ui/package.json | Pins the shared UI package's Recharts dependency to 3.3.0. |
| vite/package.json | Pins the production frontend's Recharts dependency to 3.3.0. |
| bun.lock | Resolves Recharts 3.3.0 and its compatible transitive dependency versions consistently. |

<sub>Reviews (2): Last reviewed commit: ["fix(analytics): 🐛 pin recharts to 3.3.0"](https://github.com/useautumn/autumn/commit/0626e0466a152c5ee0338a1c9d283c9d943feb19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48331504)</sub>

<!-- /greptile_comment -->