### PR TITLE
fix(vercel): install vite deps from the committed lockfile

### DIFF
--- a/vite/vercel.json
+++ b/vite/vercel.json
@@ -1,3 +1,4 @@
 {
+	"installCommand": "cd .. && bun install --frozen-lockfile",
 	"rewrites": [{ "source": "/(.*)", "destination": "/" }]
 }


### PR DESCRIPTION
## Problem

The usage chart plot renders empty in production — legend totals populate, but no bars, axes or grid — while the **same commit works locally**.

`main` pins recharts `3.9.2` in all three manifests and in `bun.lock`, and locally that version renders the chart correctly. Production is built from that commit and still fails.

## What was ruled out

- **Wrong commit deployed** — Vercel deployed `83aa07f`, which contains the 3.9.2 pin.
- **Browser cache** — reproduced in a fresh incognito window.
- **Build cache** — a redeploy with "Use existing Build Cache" and "Ignore Build Step" both disabled still failed.
- **Chart never mounting / zero-sized container** — DOM inspection on prod shows the `[data-slot="chart"]` wrapper present at a healthy `942 × 284.66`, but with no `.recharts-surface` inside it and `0` bar rectangles. Recharts mounted with a correctly-sized parent and rendered nothing, which is a component-level failure rather than a layout one.

## Cause

The dashboard build runs a bare `cd .. && bun install`, which is free to resolve dependencies differently from the committed `bun.lock`. The build succeeds either way, so a differently-resolved recharts ships behind a green build.

## Fix

Add `--frozen-lockfile` to the install command so the build installs exactly what is committed, and **fails loudly** if resolution would differ — instead of silently producing a bundle whose dependencies don't match the lockfile.

Verified `bun install --frozen-lockfile` passes cleanly against the committed lockfile locally.

## Follow-up

Bun is not pinned anywhere in the repo (no `packageManager`, `.bun-version`, or `engines`), so Vercel selects its own version — it used `1.3.12` on the last build. Worth pinning separately so local and CI resolve identically.

If this build **fails**, that is a useful result: it means Vercel's install genuinely diverges from the lockfile, and the error will name the package.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force Vercel to install dependencies from the committed lockfile by setting the install command to `bun install --frozen-lockfile`. This prevents dependency drift and fixes the blank usage chart in production by ensuring `recharts@3.9.2` from `bun.lock` is used.

<sup>Written for commit b782af37d7d1c5c2fec82db3c5a3ac3f85a54c3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds deterministic dependency installation for the Vercel dashboard build.
- **Bug fixes:** Configures Vercel to install the monorepo dependencies from the committed Bun lockfile with `--frozen-lockfile`, failing the deployment when manifests and lockfile diverge.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the Vercel install now explicitly constrained to the committed lockfile.

The command installs from the repository root containing the Bun workspace and lockfile, and lockfile divergence appropriately causes an explicit deployment failure rather than a differently resolved production bundle.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/vercel.json | Adds a frozen root-workspace Bun install command so Vercel builds use the committed dependency resolution. |

<sub>Reviews (1): Last reviewed commit: ["fix(vercel): 🐛 install vite deps from t..."](https://github.com/useautumn/autumn/commit/b782af37d7d1c5c2fec82db3c5a3ac3f85a54c3c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48345641)</sub>

<!-- /greptile_comment -->