### PR TITLE
fix(analytics): dedupe recharts so the usage chart renders

### DIFF
--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -50,7 +50,9 @@ export default defineConfig({
 	],
 
 	resolve: {
-		dedupe: ["react", "react-dom"],
+		// recharts builds on React context; two copies mean the chart's provider
+		// and its children read different stores and nothing renders.
+		dedupe: ["react", "react-dom", "recharts"],
 		alias: {
 			"@": path.resolve(__dirname, "./src"),
 


### PR DESCRIPTION
## Root cause

`vite` and `packages/ui` resolve **two physically distinct recharts installs** — same `3.9.2` version, different bun store hashes:

```
vite        -> .bun/recharts@3.9.2+ee6c651cc619fb7f/...
packages/ui -> .bun/recharts@3.9.2+da88fb24a67b2c15/...
```

Bun created two copies because each resolves against a different React peer — `vite` gets react `19.2.7`, `packages/ui` gets `19.2.8` (the lockfile currently carries five React 19.2.x versions).

recharts 3.x is built on React context and a Redux store. `ChartContainer` lives in `packages/ui` and renders `ResponsiveContainer` from copy A, while `BarChart` / `Bar` / `XAxis` / `YAxis` are created in `AnalyticsGraph.tsx` in `vite` from copy B. The children register with a store the parent never reads, so recharts mounts and renders **nothing** inside a correctly-sized container.

This matches the observed DOM on production exactly: the `[data-slot="chart"]` wrapper is present at a healthy `942 x 284.66`, with no `.recharts-surface` inside it and `0` bar rectangles.

## Why it only broke in production

`vite.config.ts` already deduped `["react", "react-dom"]` but not `recharts`. The dev server's dependency pre-bundler collapses the duplicate anyway, so the chart works under `bun run dev`. The production build honours the config literally and ships both copies.

This is also why the version pins appeared to fix it locally and never in production — each reinstall reshuffles bun's store hashes and sometimes collapses the copies by chance.

## Fix

Add `recharts` to `resolve.dedupe`.

## Verification

Production is confirmed to already serve recharts **3.9.2** (the theme-colour marker `#d6d3d1`, present in 4 files of 3.10.1 and absent from 3.9.2, does not appear in the deployed bundle) — so the version pins were not the fix and the duplication is what remained.

Please confirm on the preview deployment before merging:

```js
console.log(document.querySelectorAll('.recharts-bar-rectangle').length,
            !!document.querySelector('.recharts-surface'));
```

Non-zero bars and `true` means it is fixed.

## Follow-up

The five React 19.2.x copies in the lockfile are the underlying cause and will keep producing duplicate peers for other libraries. Worth aligning React to a single version across the workspace separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dedupes `recharts` in Vite so the Analytics usage chart renders in production. Ensures all chart components share a single `recharts` instance.

- **Bug Fixes**
  - Added `recharts` to `resolve.dedupe` in `vite/vite.config.ts` (alongside `react` and `react-dom`).
  - Prevents a context/store split across duplicate installs that left the chart empty.

<sup>Written for commit 9e67d64e35af837de706ee30f6920fbf382dd243. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes production analytics charts by ensuring all chart components share one Recharts module instance.
- **[Bug fixes]** Adds `recharts` to Vite’s `resolve.dedupe` configuration so direct imports and components from `@autumn/ui` use the same React context and internal store.
- **[Improvements]** Documents why Recharts must remain deduplicated.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the focused Vite configuration change consistently resolving Recharts for both application and workspace UI imports.

The Vite application declares the same Recharts version used by the UI workspace, and deduplication aligns direct and indirect imports to one module instance without changing application APIs or runtime data.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/vite.config.ts | Correctly extends the existing React dependency deduplication configuration to Recharts, addressing split chart context without introducing a concrete regression. |

<sub>Reviews (1): Last reviewed commit: ["fix(analytics): 🐛 dedupe recharts so th..."](https://github.com/useautumn/autumn/commit/9e67d64e35af837de706ee30f6920fbf382dd243) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48347644)</sub>

<!-- /greptile_comment -->