### PR TITLE
feat: batch async track SQS sends

### DIFF
--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -13,6 +13,7 @@ import {
 import { startPgPoolMonitor, stopPgPoolMonitor } from "./db/pgPoolMonitor.js";
 import { getRedactedDatabaseUrls } from "./db/redactDatabaseUrl.js";
 import { logger } from "./external/logtail/logtailUtils.js";
+import { globalAsyncTrackSqsBatcher } from "./internal/balances/track/AsyncTrackSqsBatcher.js";
 import {
 	startAllEdgeConfigPolling,
 	stopAllEdgeConfigPolling,
@@ -169,7 +170,10 @@ async function gracefulShutdown() {
 	shuttingDown = true;
 	console.log("Shutting down worker, flushing telemetry and closing DB...");
 	try {
-		await shutdownPrimarySqsSendBatcher();
+		await Promise.all([
+			globalAsyncTrackSqsBatcher.shutdown(),
+			shutdownPrimarySqsSendBatcher(),
+		]);
 
 		// Flush any buffered OTel spans before shutting down
 		if (otelSdk) {

--- a/server/src/internal/balances/track/AsyncTrackSqsBatcher.ts
+++ b/server/src/internal/balances/track/AsyncTrackSqsBatcher.ts
@@ -1,0 +1,170 @@
+import { JobName } from "@/queue/JobName.js";
+import { addTasksToQueueBatch, type Payloads } from "@/queue/queueUtils.js";
+
+const DEFAULT_BATCH_WINDOW_MS = 10;
+const SQS_SEND_MESSAGE_BATCH_LIMIT = 10;
+
+type AsyncTrackQueueEntry = {
+	payload: Payloads[JobName.Track];
+	messageGroupId: string;
+	messageDeduplicationId: string;
+};
+
+export type SendAsyncTrackBatchArgs = {
+	jobName: JobName.Track;
+	queueUrl: string;
+	entries: AsyncTrackQueueEntry[];
+};
+
+type SendAsyncTrackBatch = (args: SendAsyncTrackBatchArgs) => Promise<{
+	successCount: number;
+	failures: Array<{ index: number; reason: string }>;
+}>;
+
+type PendingEntry = AsyncTrackQueueEntry & {
+	queueUrl: string;
+	resolve: () => void;
+	reject: (error: Error) => void;
+};
+
+export class AsyncTrackSqsBatcher {
+	private pendingEntries: PendingEntry[] = [];
+	private flushTimer: NodeJS.Timeout | null = null;
+	private readonly inFlightSends = new Set<Promise<void>>();
+	private readonly batchWindowMs: number;
+	private readonly sendBatch: SendAsyncTrackBatch;
+	private acceptingEntries = true;
+
+	constructor({
+		batchWindowMs = DEFAULT_BATCH_WINDOW_MS,
+		sendBatch = addTasksToQueueBatch as SendAsyncTrackBatch,
+	}: {
+		batchWindowMs?: number;
+		sendBatch?: SendAsyncTrackBatch;
+	} = {}) {
+		this.batchWindowMs = batchWindowMs;
+		this.sendBatch = sendBatch;
+	}
+
+	enqueue({
+		queueUrl,
+		payload,
+		messageGroupId,
+		messageDeduplicationId,
+	}: {
+		queueUrl: string;
+		payload: Payloads[JobName.Track];
+		messageGroupId: string;
+		messageDeduplicationId: string;
+	}): Promise<void> {
+		if (!this.acceptingEntries) {
+			return Promise.reject(
+				new Error("Async track SQS batcher is shutting down"),
+			);
+		}
+
+		if (
+			this.pendingEntries.length > 0 &&
+			this.pendingEntries[0].queueUrl !== queueUrl
+		) {
+			void this.startSend();
+		}
+
+		return new Promise<void>((resolve, reject) => {
+			this.pendingEntries.push({
+				queueUrl,
+				payload,
+				messageGroupId,
+				messageDeduplicationId,
+				resolve,
+				reject,
+			});
+
+			if (this.pendingEntries.length >= SQS_SEND_MESSAGE_BATCH_LIMIT) {
+				void this.startSend();
+			} else {
+				this.scheduleSend();
+			}
+		});
+	}
+
+	async flush(): Promise<void> {
+		await this.startSend();
+		while (this.inFlightSends.size > 0) {
+			await Promise.all(Array.from(this.inFlightSends));
+		}
+	}
+
+	async shutdown(): Promise<void> {
+		this.acceptingEntries = false;
+		await this.flush();
+	}
+
+	private scheduleSend(): void {
+		if (this.flushTimer) return;
+		this.flushTimer = setTimeout(() => {
+			this.flushTimer = null;
+			void this.startSend();
+		}, this.batchWindowMs);
+	}
+
+	private startSend(): Promise<void> {
+		if (this.pendingEntries.length === 0) return Promise.resolve();
+
+		const pendingEntries = this.pendingEntries;
+		this.pendingEntries = [];
+		if (this.flushTimer) {
+			clearTimeout(this.flushTimer);
+			this.flushTimer = null;
+		}
+
+		const sendPromise = this.sendEntries({ pendingEntries });
+		this.inFlightSends.add(sendPromise);
+		void sendPromise.then(() => {
+			this.inFlightSends.delete(sendPromise);
+		});
+		return sendPromise;
+	}
+
+	private async sendEntries({
+		pendingEntries,
+	}: {
+		pendingEntries: PendingEntry[];
+	}): Promise<void> {
+		let result: Awaited<ReturnType<SendAsyncTrackBatch>>;
+		try {
+			result = await this.sendBatch({
+				jobName: JobName.Track,
+				queueUrl: pendingEntries[0].queueUrl,
+				entries: pendingEntries.map(
+					({ payload, messageGroupId, messageDeduplicationId }) => ({
+						payload,
+						messageGroupId,
+						messageDeduplicationId,
+					}),
+				),
+			});
+		} catch (error) {
+			const sendError =
+				error instanceof Error
+					? error
+					: new Error("Unknown async track SQS batch error");
+			for (const pendingEntry of pendingEntries) {
+				pendingEntry.reject(sendError);
+			}
+			return;
+		}
+
+		const failureReasons = new Map(
+			result.failures.map(({ index, reason }) => [index, reason]),
+		);
+
+		for (const [index, pendingEntry] of pendingEntries.entries()) {
+			const failureReason = failureReasons.get(index);
+			if (failureReason === undefined) pendingEntry.resolve();
+			else pendingEntry.reject(new Error(failureReason));
+		}
+	}
+}
+
+export const globalAsyncTrackSqsBatcher = new AsyncTrackSqsBatcher();

--- a/server/src/internal/balances/track/AsyncTrackSqsBatcher.ts
+++ b/server/src/internal/balances/track/AsyncTrackSqsBatcher.ts
@@ -1,13 +1,16 @@
 import { JobName } from "@/queue/JobName.js";
 import { addTasksToQueueBatch, type Payloads } from "@/queue/queueUtils.js";
-
-const DEFAULT_BATCH_WINDOW_MS = 10;
-const SQS_SEND_MESSAGE_BATCH_LIMIT = 10;
+import { SqsBatchAccumulator } from "@/queue/SqsBatchAccumulator.js";
 
 type AsyncTrackQueueEntry = {
 	payload: Payloads[JobName.Track];
 	messageGroupId: string;
 	messageDeduplicationId: string;
+};
+
+type AsyncTrackAccumulatorEntry = AsyncTrackQueueEntry & {
+	queueUrl: string;
+	messageBody: string;
 };
 
 export type SendAsyncTrackBatchArgs = {
@@ -21,29 +24,31 @@ type SendAsyncTrackBatch = (args: SendAsyncTrackBatchArgs) => Promise<{
 	failures: Array<{ index: number; reason: string }>;
 }>;
 
-type PendingEntry = AsyncTrackQueueEntry & {
-	queueUrl: string;
-	resolve: () => void;
-	reject: (error: Error) => void;
-};
-
 export class AsyncTrackSqsBatcher {
-	private pendingEntries: PendingEntry[] = [];
-	private flushTimer: NodeJS.Timeout | null = null;
-	private readonly inFlightSends = new Set<Promise<void>>();
-	private readonly batchWindowMs: number;
-	private readonly sendBatch: SendAsyncTrackBatch;
-	private acceptingEntries = true;
+	private readonly accumulator: SqsBatchAccumulator<AsyncTrackAccumulatorEntry>;
 
 	constructor({
-		batchWindowMs = DEFAULT_BATCH_WINDOW_MS,
+		batchWindowMs,
 		sendBatch = addTasksToQueueBatch as SendAsyncTrackBatch,
 	}: {
 		batchWindowMs?: number;
 		sendBatch?: SendAsyncTrackBatch;
 	} = {}) {
-		this.batchWindowMs = batchWindowMs;
-		this.sendBatch = sendBatch;
+		this.accumulator = new SqsBatchAccumulator<AsyncTrackAccumulatorEntry>({
+			batchWindowMs,
+			sendBatch: ({ queueUrl, entries }) =>
+				sendBatch({
+					jobName: JobName.Track,
+					queueUrl,
+					entries: entries.map(
+						({ payload, messageGroupId, messageDeduplicationId }) => ({
+							payload,
+							messageGroupId,
+							messageDeduplicationId,
+						}),
+					),
+				}),
+		});
 	}
 
 	enqueue({
@@ -57,113 +62,24 @@ export class AsyncTrackSqsBatcher {
 		messageGroupId: string;
 		messageDeduplicationId: string;
 	}): Promise<void> {
-		if (!this.acceptingEntries) {
-			return Promise.reject(
-				new Error("Async track SQS batcher is shutting down"),
-			);
-		}
-
-		if (
-			this.pendingEntries.length > 0 &&
-			this.pendingEntries[0].queueUrl !== queueUrl
-		) {
-			void this.startSend();
-		}
-
-		return new Promise<void>((resolve, reject) => {
-			this.pendingEntries.push({
-				queueUrl,
-				payload,
-				messageGroupId,
-				messageDeduplicationId,
-				resolve,
-				reject,
-			});
-
-			if (this.pendingEntries.length >= SQS_SEND_MESSAGE_BATCH_LIMIT) {
-				void this.startSend();
-			} else {
-				this.scheduleSend();
-			}
+		return this.accumulator.enqueue({
+			queueUrl,
+			payload,
+			messageGroupId,
+			messageDeduplicationId,
+			messageBody: JSON.stringify({
+				name: JobName.Track,
+				data: payload,
+			}),
 		});
 	}
 
-	async flush(): Promise<void> {
-		await this.startSend();
-		while (this.inFlightSends.size > 0) {
-			await Promise.all(Array.from(this.inFlightSends));
-		}
+	flush(): Promise<void> {
+		return this.accumulator.flush();
 	}
 
-	async shutdown(): Promise<void> {
-		this.acceptingEntries = false;
-		await this.flush();
-	}
-
-	private scheduleSend(): void {
-		if (this.flushTimer) return;
-		this.flushTimer = setTimeout(() => {
-			this.flushTimer = null;
-			void this.startSend();
-		}, this.batchWindowMs);
-	}
-
-	private startSend(): Promise<void> {
-		if (this.pendingEntries.length === 0) return Promise.resolve();
-
-		const pendingEntries = this.pendingEntries;
-		this.pendingEntries = [];
-		if (this.flushTimer) {
-			clearTimeout(this.flushTimer);
-			this.flushTimer = null;
-		}
-
-		const sendPromise = this.sendEntries({ pendingEntries });
-		this.inFlightSends.add(sendPromise);
-		void sendPromise.then(() => {
-			this.inFlightSends.delete(sendPromise);
-		});
-		return sendPromise;
-	}
-
-	private async sendEntries({
-		pendingEntries,
-	}: {
-		pendingEntries: PendingEntry[];
-	}): Promise<void> {
-		let result: Awaited<ReturnType<SendAsyncTrackBatch>>;
-		try {
-			result = await this.sendBatch({
-				jobName: JobName.Track,
-				queueUrl: pendingEntries[0].queueUrl,
-				entries: pendingEntries.map(
-					({ payload, messageGroupId, messageDeduplicationId }) => ({
-						payload,
-						messageGroupId,
-						messageDeduplicationId,
-					}),
-				),
-			});
-		} catch (error) {
-			const sendError =
-				error instanceof Error
-					? error
-					: new Error("Unknown async track SQS batch error");
-			for (const pendingEntry of pendingEntries) {
-				pendingEntry.reject(sendError);
-			}
-			return;
-		}
-
-		const failureReasons = new Map(
-			result.failures.map(({ index, reason }) => [index, reason]),
-		);
-
-		for (const [index, pendingEntry] of pendingEntries.entries()) {
-			const failureReason = failureReasons.get(index);
-			if (failureReason === undefined) pendingEntry.resolve();
-			else pendingEntry.reject(new Error(failureReason));
-		}
+	shutdown(): Promise<void> {
+		return this.accumulator.shutdown();
 	}
 }
 

--- a/server/src/internal/balances/track/runAsyncTrack.ts
+++ b/server/src/internal/balances/track/runAsyncTrack.ts
@@ -1,7 +1,7 @@
 import { ErrCode, RecaseError, type TrackParams } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { globalAsyncTrackSqsBatcher } from "./AsyncTrackSqsBatcher.js";
 import { getAsyncTrackMessageGroupId } from "./utils/getAsyncTrackMessageGroupId.js";
-import { queueTrack } from "./utils/queueTrack.js";
 
 const ASYNC_TRACK_UNAVAILABLE_MESSAGE =
 	"Async track is not available right now";
@@ -26,22 +26,32 @@ export const runAsyncTrack = async ({
 	}
 	const messageDeduplicationId = ctx.id;
 
-	const queued = await queueTrack({
-		ctx,
-		body,
-		queueUrl,
-		messageGroupId: getAsyncTrackMessageGroupId({
-			orgId: ctx.org.id,
-			env: ctx.env,
-			customerId: body.customer_id,
-			entityId: body.entity_id,
+	try {
+		await globalAsyncTrackSqsBatcher.enqueue({
+			queueUrl,
+			payload: {
+				orgId: ctx.org.id,
+				env: ctx.env,
+				customerId: body.customer_id,
+				entityId: body.entity_id,
+				requestId: ctx.id,
+				apiVersion: ctx.apiVersion.value,
+				body,
+			},
+			messageGroupId: getAsyncTrackMessageGroupId({
+				orgId: ctx.org.id,
+				env: ctx.env,
+				customerId: body.customer_id,
+				entityId: body.entity_id,
+				messageDeduplicationId,
+			}),
 			messageDeduplicationId,
-		}),
-		messageDeduplicationId,
-		logFallback: false,
-		markQueuedForReplay: false,
-	});
-	if (!queued) {
+		});
+	} catch (error) {
+		ctx.logger.warn("[track] Queue fallback failed (SQS)", {
+			type: "track_queue_fallback_failed",
+			error,
+		});
 		throw new RecaseError({
 			message: ASYNC_TRACK_UNAVAILABLE_MESSAGE,
 			code: ErrCode.InternalError,

--- a/server/tests/unit/balances/track/asyncTrackSqsBatcher.test.ts
+++ b/server/tests/unit/balances/track/asyncTrackSqsBatcher.test.ts
@@ -1,0 +1,171 @@
+/**
+ * TDD contract for batching async-track SQS sends without changing the worker
+ * payload or combining multiple track events into one SQS message.
+ *
+ * Contract under test:
+ *   New behavior:
+ *     - up to 10 independent track messages share one SendMessageBatch call
+ *     - the tenth entry flushes immediately
+ *     - a short window flushes partial batches
+ *     - each caller awaits and receives its own SQS entry result
+ *     - partial failures reject only the corresponding callers
+ *     - shutdown rejects new entries and drains pending plus in-flight sends
+ *   Preserved behavior:
+ *     - every SQS entry contains exactly one legacy track payload
+ *     - message group and deduplication IDs remain per event
+ *
+ * Pre-implementation red: AsyncTrackSqsBatcher does not exist.
+ * Post-implementation green: all producer batching and delivery assertions pass.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { ApiVersion, AppEnv } from "@autumn/shared";
+import {
+	AsyncTrackSqsBatcher,
+	type SendAsyncTrackBatchArgs,
+} from "@/internal/balances/track/AsyncTrackSqsBatcher.js";
+
+const QUEUE_URL =
+	"https://sqs.eu-west-1.amazonaws.com/123456789012/track-async.fifo";
+const BATCH_WINDOW_MS = 10;
+
+const createEntry = ({ index }: { index: number }) => ({
+	queueUrl: QUEUE_URL,
+	payload: {
+		orgId: "org_1",
+		env: AppEnv.Live,
+		customerId: `customer_${index}`,
+		requestId: `request_${index}`,
+		apiVersion: ApiVersion.V2_1,
+		body: {
+			customer_id: `customer_${index}`,
+			feature_id: "messages",
+			value: index + 1,
+		},
+	},
+	messageGroupId: `org_1:live:customer_${index}:none:shard-0`,
+	messageDeduplicationId: `request_${index}`,
+});
+
+const createBatcher = ({
+	sendBatch,
+}: {
+	sendBatch?: (args: SendAsyncTrackBatchArgs) => Promise<{
+		successCount: number;
+		failures: Array<{ index: number; reason: string }>;
+	}>;
+} = {}) => {
+	const calls: SendAsyncTrackBatchArgs[] = [];
+	const batcher = new AsyncTrackSqsBatcher({
+		batchWindowMs: BATCH_WINDOW_MS,
+		sendBatch:
+			sendBatch ??
+			(async (args) => {
+				calls.push(args);
+				return { successCount: args.entries.length, failures: [] };
+			}),
+	});
+
+	return { batcher, calls };
+};
+
+describe("AsyncTrackSqsBatcher", () => {
+	test("flushes 10 independent SQS messages in one batch call", async () => {
+		const { batcher, calls } = createBatcher();
+
+		await Promise.all(
+			Array.from({ length: 10 }, (_, index) =>
+				batcher.enqueue(createEntry({ index })),
+			),
+		);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0].entries).toHaveLength(10);
+		expect(calls[0].entries[0]).toMatchObject({
+			messageDeduplicationId: "request_0",
+			payload: {
+				customerId: "customer_0",
+				body: {
+					customer_id: "customer_0",
+					value: 1,
+				},
+			},
+		});
+		expect(calls[0].entries[9].messageDeduplicationId).toBe("request_9");
+	});
+
+	test("flushes a partial batch after the short batching window", async () => {
+		const { batcher, calls } = createBatcher();
+
+		await batcher.enqueue(createEntry({ index: 0 }));
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0].entries).toHaveLength(1);
+	});
+
+	test("rejects only callers whose SQS entries failed", async () => {
+		const calls: SendAsyncTrackBatchArgs[] = [];
+		const { batcher } = createBatcher({
+			sendBatch: async (args) => {
+				calls.push(args);
+				return {
+					successCount: 2,
+					failures: [{ index: 1, reason: "SQS throttled entry 1" }],
+				};
+			},
+		});
+		const resultsPromise = Promise.allSettled(
+			Array.from({ length: 3 }, (_, index) =>
+				batcher.enqueue(createEntry({ index })),
+			),
+		);
+
+		await batcher.flush();
+		const results = await resultsPromise;
+
+		expect(calls).toHaveLength(1);
+		expect(results.map((result) => result.status)).toEqual([
+			"fulfilled",
+			"rejected",
+			"fulfilled",
+		]);
+		expect(results[1]).toMatchObject({
+			status: "rejected",
+			reason: expect.objectContaining({
+				message: "SQS throttled entry 1",
+			}),
+		});
+	});
+
+	test("shutdown drains pending and in-flight sends before resolving", async () => {
+		let resolveSend:
+			| ((result: {
+					successCount: number;
+					failures: Array<{ index: number; reason: string }>;
+			  }) => void)
+			| undefined;
+		const { batcher } = createBatcher({
+			sendBatch: () =>
+				new Promise((resolve) => {
+					resolveSend = resolve;
+				}),
+		});
+		const queued = batcher.enqueue(createEntry({ index: 0 }));
+		let shutdownResolved = false;
+
+		const shutdown = batcher.shutdown().then(() => {
+			shutdownResolved = true;
+		});
+		await Promise.resolve();
+
+		expect(shutdownResolved).toBeFalse();
+		await expect(batcher.enqueue(createEntry({ index: 1 }))).rejects.toThrow(
+			"shutting down",
+		);
+
+		resolveSend?.({ successCount: 1, failures: [] });
+		await Promise.all([queued, shutdown]);
+
+		expect(shutdownResolved).toBeTrue();
+	});
+});

--- a/server/tests/unit/balances/track/handle-track-tokens.test.ts
+++ b/server/tests/unit/balances/track/handle-track-tokens.test.ts
@@ -165,7 +165,11 @@ describe("handleTrackTokens", () => {
 		mockState.originalSend = sqsClient.send.bind(sqsClient);
 		sqsClient.send = (async (command: { input: Record<string, unknown> }) => {
 			mockState.queueCommands.push(command.input);
-			return {};
+			const entries =
+				(command.input.Entries as Array<{ Id?: string }> | undefined) ?? [];
+			return {
+				Successful: entries.map((entry) => ({ Id: entry.Id })),
+			};
 		}) as typeof sqsClient.send;
 
 		const ctx = createCtx();
@@ -190,14 +194,16 @@ describe("handleTrackTokens", () => {
 		expect(mockState.queueCommands).toHaveLength(1);
 		expect(mockState.queueCommands[0]).toMatchObject({
 			QueueUrl: trackAsyncQueueUrl,
-			MessageDeduplicationId: "req_track_tokens_1",
 		});
-		expect(mockState.queueCommands[0]?.MessageGroupId).toMatch(
+		const entries = mockState.queueCommands[0]?.Entries as Array<
+			Record<string, unknown>
+		>;
+		expect(entries).toHaveLength(1);
+		expect(entries[0]?.MessageDeduplicationId).toBe("req_track_tokens_1");
+		expect(entries[0]?.MessageGroupId).toMatch(
 			/^org_123:sandbox:cus_123:ent_123:shard-[0-7]$/,
 		);
-		expect(
-			JSON.parse(mockState.queueCommands[0]?.MessageBody as string),
-		).toMatchObject({
+		expect(JSON.parse(entries[0]?.MessageBody as string)).toMatchObject({
 			name: "track",
 			data: {
 				customerId: "cus_123",

--- a/server/tests/unit/balances/track/handle-track.test.ts
+++ b/server/tests/unit/balances/track/handle-track.test.ts
@@ -58,7 +58,11 @@ describe("handleTrack", () => {
 		mockState.originalSend = sqsClient.send.bind(sqsClient);
 		sqsClient.send = (async (command: { input: Record<string, unknown> }) => {
 			mockState.queueCommands.push(command.input);
-			return {};
+			const entries =
+				(command.input.Entries as Array<{ Id?: string }> | undefined) ?? [];
+			return {
+				Successful: entries.map((entry) => ({ Id: entry.Id })),
+			};
 		}) as typeof sqsClient.send;
 	});
 
@@ -92,8 +96,12 @@ describe("handleTrack", () => {
 		expect(mockState.queueCommands).toHaveLength(1);
 		expect(mockState.queueCommands[0]).toMatchObject({
 			QueueUrl: trackAsyncQueueUrl,
-			MessageDeduplicationId: "req_track_1",
 		});
+		const entries = mockState.queueCommands[0]?.Entries as Array<
+			Record<string, unknown>
+		>;
+		expect(entries).toHaveLength(1);
+		expect(entries[0]?.MessageDeduplicationId).toBe("req_track_1");
 	});
 
 	test("returns 202 success for configured org slug", async () => {

--- a/server/tests/unit/balances/track/runAsyncTrack.test.ts
+++ b/server/tests/unit/balances/track/runAsyncTrack.test.ts
@@ -15,9 +15,9 @@ const trackAsyncQueueUrl =
 
 import { runAsyncTrack } from "@/internal/balances/track/runAsyncTrack.js";
 
-const buildCtx = () =>
+const buildCtx = ({ requestId = "req_async_1" }: { requestId?: string } = {}) =>
 	({
-		id: "req_async_1",
+		id: requestId,
 		org: { id: "org_123" },
 		env: AppEnv.Sandbox,
 		apiVersion: new ApiVersionClass(ApiVersion.V2_1),
@@ -53,7 +53,11 @@ describe("runAsyncTrack", () => {
 				throw new Error("SQS unavailable");
 			}
 
-			return {};
+			const entries =
+				(command.input.Entries as Array<{ Id?: string }> | undefined) ?? [];
+			return {
+				Successful: entries.map((entry) => ({ Id: entry.Id })),
+			};
 		}) as typeof sqsClient.send;
 	});
 
@@ -75,14 +79,16 @@ describe("runAsyncTrack", () => {
 		expect(ctx.extraLogs.trackQueuedForReplay).toBeUndefined();
 		expect(mockState.queueCommands[0]).toMatchObject({
 			QueueUrl: trackAsyncQueueUrl,
-			MessageDeduplicationId: "req_async_1",
 		});
-		expect(mockState.queueCommands[0]?.MessageGroupId).toMatch(
+		const entries = mockState.queueCommands[0]?.Entries as Array<
+			Record<string, unknown>
+		>;
+		expect(entries).toHaveLength(1);
+		expect(entries[0]?.MessageDeduplicationId).toBe("req_async_1");
+		expect(entries[0]?.MessageGroupId).toMatch(
 			/^org_123:sandbox:cus_123:none:shard-[0-7]$/,
 		);
-		expect(
-			JSON.parse(mockState.queueCommands[0]?.MessageBody as string),
-		).toMatchObject({
+		expect(JSON.parse(entries[0]?.MessageBody as string)).toMatchObject({
 			name: "track",
 			data: {
 				customerId: "cus_123",
@@ -99,8 +105,37 @@ describe("runAsyncTrack", () => {
 		await runAsyncTrack({ ctx: secondCtx, body });
 
 		expect(mockState.queueCommands).toHaveLength(2);
-		expect(mockState.queueCommands[0]?.MessageGroupId).toBe(
-			mockState.queueCommands[1]?.MessageGroupId,
+		const firstEntries = mockState.queueCommands[0]?.Entries as Array<
+			Record<string, unknown>
+		>;
+		const secondEntries = mockState.queueCommands[1]?.Entries as Array<
+			Record<string, unknown>
+		>;
+		expect(firstEntries[0]?.MessageGroupId).toBe(
+			secondEntries[0]?.MessageGroupId,
+		);
+	});
+
+	test("shares one SQS batch call across 10 concurrent async tracks", async () => {
+		await Promise.all(
+			Array.from({ length: 10 }, (_, index) =>
+				runAsyncTrack({
+					ctx: buildCtx({ requestId: `req_async_${index}` }),
+					body: {
+						...body,
+						customer_id: `cus_${index}`,
+					},
+				}),
+			),
+		);
+
+		expect(mockState.queueCommands).toHaveLength(1);
+		const entries = mockState.queueCommands[0]?.Entries as Array<
+			Record<string, unknown>
+		>;
+		expect(entries).toHaveLength(10);
+		expect(entries.map((entry) => entry.MessageDeduplicationId)).toEqual(
+			Array.from({ length: 10 }, (_, index) => `req_async_${index}`),
 		);
 	});
 
@@ -118,7 +153,7 @@ describe("runAsyncTrack", () => {
 		expect(ctx.logger.error).toHaveBeenCalled();
 	});
 
-	test("throws 503 RecaseError when queueTrack returns null", async () => {
+	test("throws 503 RecaseError when the batched SQS send fails", async () => {
 		mockState.queueFailureIndex = 0;
 		const ctx = buildCtx();
 


### PR DESCRIPTION
## Summary

- Batch concurrent `async: true` track sends into SQS `SendMessageBatch` requests of up to 10 entries.
- Wait up to 10 ms to fill a partial batch, then send immediately.
- Reuse the generic `SqsBatchAccumulator` introduced by #2481 for batching, size limits, failure routing, flushing, and shutdown.
- Preserve one independent SQS message per track event, including its existing payload, FIFO message-group ID, and deduplication ID.
- Leave synchronous tracking, the normal track replay queue, and worker message parsing unchanged.

## Delivery semantics

Each async-track request waits for the result of its own SQS batch entry before returning success. Whole-request failures reject every affected request, while partial SQS failures reject only the corresponding request. Graceful shutdown drains both the async-track and primary-queue accumulators before exiting.

This does not coalesce multiple track events into one SQS message. It only groups up to 10 independent messages into one SQS send API call, so workers continue receiving the existing single-track-job payload.

## Why

High-volume async tracking previously issued one `SendMessage` request per event. `SendMessageBatch` reduces SQS API calls and request overhead without increasing the work represented by each queue message or requiring worker changes.

## Validation

- Relevant queue, track, update-balance, and recovery suites: 132 tests passed.
- Focused Biome checks passed.
- Server typecheck and commit hooks passed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Batch async-track requests now share SQS `SendMessageBatch` calls while preserving independent event delivery and per-request results.
- **[Improvements]** Adds a short-window accumulator that sends up to ten async-track events per SQS API call while retaining each event’s payload, FIFO group ID, and deduplication ID.
- **[Bug fixes]** Awaits each event’s SQS result, maps partial failures to the corresponding request, and drains pending and in-flight sends during graceful shutdown.
- **[API changes]** Async-track requests continue returning success only after their individual queue entry is accepted; queue failures return an unavailable response.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported failed-send, shutdown-drain, and process-local acceptance paths are addressed by per-entry promise settlement and tracked shutdown flushing.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/track/AsyncTrackSqsBatcher.ts | Introduces the track-specific batching adapter while preserving independent payload and FIFO metadata for every SQS entry. |
| server/src/internal/balances/track/runAsyncTrack.ts | Replaces single-message sends with awaited per-entry batcher promises and translates queue failures into 503 responses. |
| server/src/init.ts | Adds the async-track batcher to graceful shutdown so pending and active sends are drained before exit. |
| server/tests/unit/balances/track/asyncTrackSqsBatcher.test.ts | Covers size- and timer-triggered batching, partial failure isolation, and shutdown draining. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant API as Async Track API
  participant Batcher as SQS Batch Accumulator
  participant SQS
  Client->>API: Track request
  API->>Batcher: Enqueue independent event
  Batcher->>Batcher: Collect up to 10 entries / 10 ms
  Batcher->>SQS: SendMessageBatch
  SQS-->>Batcher: Per-entry success or failure
  Batcher-->>API: Resolve or reject this request
  API-->>Client: 202 or 503
```
</details>

<sub>Reviews (3): Last reviewed commit: ["refactor: reuse generic SQS batch accumu..."](https://github.com/useautumn/autumn/commit/2ff2f9613a44be89d0c2aa4c83fa0b62547e42e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48353577)</sub>

**Context used:**

- Knowledge Base — [Server API Routing: Request Lifecycle](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-api-routers.md)
- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)

<!-- /greptile_comment -->