### PR TITLE
perf(migrations): speed up customer selection and previews

### DIFF
--- a/.plans/fast-customer-select.md
+++ b/.plans/fast-customer-select.md
@@ -1,0 +1,247 @@
+# fast-customer-select — migration filter query optimization
+
+Branch: `feat/fast-customer-select` (off dev). Laser focus: make the
+`buildCustomerSelect` query family efficient at 4M+ customer scale so regular
+migrations (and the dashboard) never block. Transplants cleanly into the
+batch-migrations stack afterwards (files are byte-identical on both branches).
+
+## Measured problem (bench org: 4M customers, dev Neon DB)
+
+One query family (`buildCustomerSelect` / `buildCustomerCount` /
+`buildProcessedPreviewSelect|Count`) serves four callers: migration claim loop,
+dashboard filter preview page, dashboard count, execution view. All inherit the
+same candidate-query shape, measured on bench-paid (600k matched of 4M):
+
+| Scenario | Time |
+|---|---|
+| Fresh claim page (5k customers) | ~4.0s — flat per page, every page |
+| Mid-run claim, stale mir stats (300k processed) | **>5min, cancelled** — planner still assumes mir ≈ 1 row, materialized nested-loop anti-join |
+| Mid-run claim, fresh stats, no cursor | ~4.4s (Hash Anti Join, +0.4s only) |
+| Mid-run claim, fresh stats, with cursor | ~3.2s (cursor pushes into scan) |
+
+Root causes:
+
+1. **Full-set materialization**: access-path source is a closed
+   `SELECT DISTINCT` subquery (products CTE → cp join → customers join), so
+   ORDER/LIMIT/cursor can never reach the scan. Every call seq-scans 4M
+   customers, HashAggregates 600k rows (61MB disk spill), then top-N sorts for
+   5000. Cost ∝ matched set, not page size.
+2. **Plan filter evaluated twice**: the access path narrows the *source* but
+   the fallback IR WHERE re-proves plan membership as a hash semi-join —
+   second full cp scan + 600k-row hash per call.
+3. **mir stats trap**: a new `migration_internal_id` isn't in the stats
+   histogram (est ~1 row even on a freshly analyzed table), and a migration
+   inserts 500k+ mir rows faster than autoanalyze reacts on a big shared
+   table. The claim's anti-join keeps the materialize/nested-loop plan →
+   unbounded blowup. This is prod's "1M+ migration dies at ~500k" (observed:
+   `plan-update-all-2-ljq`, 586,891 run, 1 orphaned `running`, trigger task
+   long dead).
+4. **Execution view UNION**: with `migrationId` set, preview takes the UNION
+   path — full filter-set materialization UNION 587k mir-driven semi-join,
+   then dedupe. Pays cause 1 + a mir scan + a million-row UNION.
+5. Dashboard count (`buildCustomerCount`) is an unbounded COUNT over the same
+   materialization — no LIMIT possible, tens of seconds at prod scale.
+
+## Architecture insight
+
+The compiler split is sound: `filterToIr → irToSql` = semantic truth over
+`customers c`; `chooseCustomerAccessPath` swaps in a narrowed source as an
+optimization. Fixes are surgical — mostly `planPlanIdAccessPath` + the
+composition layer (`buildCustomerSelect`), not a compiler rewrite.
+
+Key files:
+- `server/src/internal/migrations/v2/filters/customers/buildCustomerSelect.ts`
+- `shared/api/migrations/filters/planner/buildCustomerCandidateQuery.ts`
+- `shared/api/migrations/filters/planner/accessPaths/planPlanIdAccessPath.ts`
+- `server/src/internal/migrations/v2/handlers/handlePreviewMigrationFilter.ts`
+- bench tooling: `server/tests/perf/batch-migrations/` (probes + 4M seeded org)
+
+## Units
+
+### U0 — Baseline matrix + facts (bench only)
+Shape-matrix probe runner: selective plan (600k), dominant plan (2.2M),
+multi-plan IN, plan+custom=false residual, mid-run ±cursor, restart path,
+full count, execution-view UNION. Record baseline ms per query. Also check
+`SELECT version()`: PG17 keeps index order through `= ANY(...)` scans; below
+17, U2's multi-plan ordered scan needs a MergeAppend workaround.
+
+#### U0 results (2026-07-29, dev Neon, 4M bench org)
+
+PG **18.4**, `work_mem=4MB`. PG ≥17 → index order survives `= ANY(...)` scans,
+so U2's multi-plan MergeAppend workaround is NOT needed. The 4MB work_mem is
+why every aggregate spills (61–258MB sets vs 4MB budget).
+
+Timed (plain-run) baselines; explain-analyze wall is 2–6× higher from
+instrumentation:
+
+| Scenario | Timed | Notes |
+|---|---|---|
+| S1 claim selective (600k) | 4.0s | flat per page |
+| S2 claim dominant (2.4M) | 10.2s | ∝ matched set; 480-page run ≈ 80min of claims |
+| S3 claim multi-plan (1.6M) | 8.0s | fallback semi-join SEQ-SCANS cp (4M rows) |
+| S4 claim +custom:false (2.2M) | 10.2s | residual adds ~nothing; set size rules |
+| S5 claim deep cursor | 2.7s | cursor shrinks the set, never page-proportional |
+| S6 claim mid-run +cursor (300k mir) | 3.1s | anti-join cheap w/ fresh stats |
+| S7 claim restart, no cursor | 4.3s | +0.3s over S1 for 300k rejects |
+| P1 dashboard page (51 rows!) | 10.0s | LIMIT never pushes down |
+| C1 count selective | 3.7s | same shape as S1 minus sort |
+| C2 count dominant | 9.5s | the "Search 0 customers" hang |
+| E1 execution page (51 rows) | 5.1s | UNION: S1-cost + mir branch + 600k spill sort |
+| E2 execution count | 5.7s | worst family member per useful byte |
+
+Every scenario's plan contains all three sins: 4M customers seq scan, cp
+scanned twice (S3: one of them a full 4M seq scan), spilled HashAggregate.
+mir anti-join confirmed cheap with fresh stats (S6/S7). Raw plans:
+`server/tests/perf/batch-migrations/results/*.json`.
+
+### U1 — Consume the predicate the access path proved
+Leaf-consumption contract in `buildCustomerCandidateQuery`: when the plan
+access path is used, drop the `plan.plan_id` leaf from the fallback WHERE.
+Kills the duplicate cp scan + semi-join.
+Acceptance: EXPLAIN shows one cp scan; row-set parity on matrix; filter tests
+green.
+
+#### U1 results (implemented, matrix re-run)
+
+All-or-nothing quantifier consumption shipped: provable set = plan_id eq/in,
+version eq/in, addon/custom eq. Duplicate cp scan + semi-join gone from every
+plan (S3's 4M cp seq scan eliminated; S4's custom pushed into source).
+Planner tests updated (95 pass). Timed before → after:
+
+S1 4.0→4.7s (first-run noise), S2 10.2→8.8s, S3 8.0→5.5s, S4 10.2→7.1s,
+S5 2.7→1.0s, S6 3.1→2.6s, S7 4.3→3.6s, P1 10.0→7.0s, C1 3.7→3.2s,
+C2 9.5→6.6s, E1 5.1→4.1s, E2 5.7→3.9s.
+
+~15–30% off most shapes. Remaining flat cost = the materialization itself
+(customers seq scan + DISTINCT spill) — U2's target.
+
+### U2 — Streaming candidate source (centerpiece)
+Ordered, keyset-aware source; thread `{order, limit, cursor}` hints from
+`buildCustomerSelect` into the access path:
+
+```sql
+SELECT c.* FROM (
+  SELECT DISTINCT ON (cp.internal_customer_id) cp.internal_customer_id
+  FROM customer_products cp
+  WHERE cp.internal_product_id IN (<plan product ids>)
+    AND cp.status IN (...) AND cp.internal_customer_id < $cursor
+  ORDER BY cp.internal_customer_id COLLATE "C" DESC
+) m JOIN customers c ON c.internal_id = m.internal_customer_id
+WHERE <residual IR where> AND <checkpoint anti-join>
+ORDER BY c.internal_id DESC LIMIT 5000
+```
+
+Pipelined end to end: ordered index scan → streaming dedupe → per-row probes →
+stops at LIMIT. New index (manual CONCURRENTLY apply):
+`(internal_product_id, internal_customer_id COLLATE "C")` on customer_products.
+Acceptance: page cost ∝ page size — target <500ms at any cursor depth on 4M;
+no HashAggregate / top-N sort in EXPLAIN; row-set parity vs old query.
+
+#### U2 results (implemented — cohesive composition)
+
+Design pivoted from a gated "streaming fast path" to a first-class compiler
+composition (John's call): `composeCustomerPage` in the shared planner builds
+a page-bounded query for EVERY filter shape:
+
+- driver = per-product ordered LATERAL index walks on
+  `idx_customer_products_product_customer_c` (plan access path) or an ordered
+  customers walk (fallback shapes);
+- EVERY predicate — residual filter (joins customers inside the walk),
+  checkpoint, cursor, dashboard search/list filters — evaluates INSIDE the
+  walk, so LIMIT counts matches: a short page provably means exhausted and
+  NO iteration contracts changed anywhere.
+- `buildCustomerSelect` with a limit always delegates to the composer;
+  without a limit the legacy query is byte-identical. Checkpoint predicate
+  has one raw source of truth (`buildCheckpointPredicateSql`).
+
+Membership parity proven at 4M scale (probeFilterParity, legacy vs paged,
+EXCEPT ALL both directions): 12 shapes ALL OK — incl. custom:false = exactly
+2.2M / custom:true = exactly 200k, checkpoint mid-run = exactly 300k, page
+iteration 120×5000 full pages, short page = exhaustion. Perf: claim/preview
+shapes at 8–100ms (was 4–10s); S7 restart ~715ms.
+
+Trade-off documented: sparse residuals make one page query walk far
+internally (bounded memory, ≤ legacy work; escape hatch = cost-based access
+choice in the compiler if ever needed).
+
+### U3 — Counts never touch customers
+When all residual leaves are cp-level (plan + custom filters are),
+`buildCustomerCount` → `COUNT(DISTINCT cp.internal_customer_id)` off the cp
+index. Join customers only when customer-level leaves exist. Optional product
+call (out of scope): cap dashboard counts via existing
+`buildLimitedCustomerCount`.
+Acceptance: dominant-plan count <1s on bench.
+
+#### U3 results (implemented — compiler-owned aggregation access paths)
+
+`composeCustomerCount` ALWAYS returns the query (no undefined/fallback gate):
+fully plan-level filters → cp-only GROUP BY count (no customers join, no row
+payloads); residual/search shapes → batch-hash count composed from the same
+candidate source/where pieces (optimal for unbounded aggregation). Server
+`buildCustomerCount` is a thin adapter; `buildLimitedCustomerCount` wraps the
+bounded page query. Count parity 7/7 shapes exact; timings: selective
+3.6s→0.5s, dominant 8.7s→2.8s, custom-false 14.6s→3.1s, checkpoint
+3.7s→0.8s; residual counts ≈ legacy by design.
+
+### U4 — Execution view drops the UNION
+Processed branch drives from `migration_item_runs` (small, indexed side)
+joined to customers; statuses read off mir directly.
+Acceptance: execution page at 300k processed <1s on bench.
+
+#### U4 results (implemented — preview union on shared composers)
+
+`composeCustomerPage` refactored into reusable pieces (`composeCandidateIdPage`
+bounded id-walk, `composeCustomerIdSet` unbounded id-set,
+`wrapIdsWithCustomerColumns` payload join). New `composeCustomerPreview.ts`
+reuses them verbatim and adds only the mir branch: preview page = bounded
+filter walk ∪ bounded mir walk (C-collation index, cursor + predicates
+inside) → dedupe → re-limit → payload join; preview count = distinct union
+of the two id sets (customers table untouched). Server preview builders route
+mode "all" (+limit) through the composers; explicit-status / not_run / mixed
+modes unchanged (mir-rooted or rarer — follow-up: migrate them onto branch
+selection + per-branch predicates).
+
+Parity: overlap case (processed ⊆ filter, union exactly 600k — dedupe) and
+disjoint case (processed outside filter, union exactly 1.3M) both exact,
+EXCEPT ALL clean. Execution page 51 rows: ~4–5s → 10–18ms; count 3.7s →
+1.2–1.8s. 110 unit tests green.
+
+#### Final scoreboard (U0 baseline → post-U4, 4M bench org)
+
+| Scenario | U0 | Final | × |
+|---|---|---|---|
+| S1 claim selective (600k) | 4.0s | 58ms | 70× |
+| S2 claim dominant (2.4M) | 10.2s | 54ms | 190× |
+| S3 claim multi-plan | 8.0s | 62ms | 130× |
+| S4 claim +custom:false | 10.2s | 48ms | 210× |
+| S5 deep cursor | 2.7s | 50ms | 55× |
+| S6 mid-run resume (300k mir) | 3.1s | 70ms | 45× |
+| S7 restart no cursor | 4.3s | 674ms | 6× (once/crash) |
+| P1 dashboard page | 10.0s | 8ms | 1250× |
+| C1 count selective | 3.7s | 571ms | 6.5× |
+| C2 count dominant | 9.5s | 2.8s | 3.5× (floor-bound) |
+| E1 execution page | 5.1s | 10ms | 500× |
+| E2 execution count | 5.7s | 748ms | 7.6× |
+
+### U5 — Stats guard for the claim
+`ANALYZE migration_item_runs` (~100ms) at chunk boundaries in the run loop.
+Acceptance: stale-stats probe scenario no longer reaches the catastrophic
+plan.
+
+### U6 — Regression sweep + ship
+Full matrix before/after table; existing migrations-v2 integration suite;
+commit per unit; PR to dev. Batch branch inherits via clean merge.
+
+Order: U0 → U1 → U2 → U3/U4 (independent) → U5 → U6.
+Riskiest decision: multi-plan ordered scan on PG <17 — settled by U0.
+
+## Bench context notes
+
+- Bench org `batch-bench` on dev Neon DB: 4M customers, shapes documented in
+  `seedBatchBench.ts`. Mid-migration state seeded: `probe_mig_mid` = 300k
+  succeeded mir rows over ids 3,500,001..3,800,000 (top half of bench-paid in
+  claim order). Cleanup: `probeClaimMidMigration.ts --cleanup`.
+- `benchRunMigration.ts` is parked in the session scratchpad (imports
+  batch-lane code absent on dev); restore when back on `feat/batch-bench`.
+- Stash `batch-bench: local test-file deletions` holds John's local deletions
+  for `feat/batch-bench`.

--- a/packages/ui/src/components/table/index.tsx
+++ b/packages/ui/src/components/table/index.tsx
@@ -43,4 +43,7 @@ export { TableDropdownMenuCell } from "@autumn/ui/components/table/table-dropdow
 export { TableProvider } from "@autumn/ui/components/table/table-provider";
 export type { ColumnSkeletonMeta } from "@autumn/ui/components/table/table-row-cells";
 export * from "@autumn/ui/components/table/table-skeleton-presets";
-export { useCursorPagination } from "@autumn/ui/components/table/use-cursor-pagination";
+export {
+	type CursorPaginationState,
+	useCursorPagination,
+} from "@autumn/ui/components/table/use-cursor-pagination";

--- a/packages/ui/src/components/table/use-cursor-pagination.ts
+++ b/packages/ui/src/components/table/use-cursor-pagination.ts
@@ -5,6 +5,8 @@ type CursorState = {
 	stack: string[];
 };
 
+export type CursorPaginationState = ReturnType<typeof useCursorPagination>;
+
 export function useCursorPagination({
 	pageSize,
 	resetKey = "",

--- a/server/src/internal/migrations/v2/filters/customers/buildCustomerSelect.ts
+++ b/server/src/internal/migrations/v2/filters/customers/buildCustomerSelect.ts
@@ -1,6 +1,14 @@
-import type { CustomerFilter, MigrationItemRunStatus } from "@autumn/shared";
-import type { ResolutionContext } from "@autumn/shared/api/migrations/compiler/filterToIr/resolutionContext.js";
-import { buildCustomerCandidateQuery } from "@autumn/shared/api/migrations/filters/planner/buildCustomerCandidateQuery.js";
+import {
+	buildCustomerCandidateQuery,
+	composeCustomerCount,
+	composeCustomerPage,
+	composeCustomerPreviewCount,
+	composeCustomerPreviewPage,
+	type CustomerFilter,
+	type CustomerPagePredicate,
+	type MigrationItemRunStatus,
+	type ResolutionContext,
+} from "@autumn/shared";
 import { type SQL, sql } from "drizzle-orm";
 import type { CustomerListFilters } from "@/internal/customers/customerListFilters.js";
 import {
@@ -9,7 +17,10 @@ import {
 	parseDashboardStatusFilter,
 	parseDashboardVersionFilter,
 } from "@/internal/customers/getFullCusQuery.js";
-import { rawWithParamsToDrizzle } from "../rawWithParamsToDrizzle.js";
+import {
+	drizzleToRawWithParams,
+	rawWithParamsToDrizzle,
+} from "../rawWithParamsToDrizzle.js";
 
 export type IncludeProcessed = {
 	migrationInternalId: string;
@@ -67,36 +78,74 @@ export type CustomerCheckpointExclusion = {
 	excludedStatuses: MigrationItemRunStatus[];
 };
 
+/** Single source of truth for the checkpoint exclusion predicate. The paged
+ * composer correlates it on the walk key; legacy queries on c.internal_id. */
+const buildCheckpointPredicateSql = (
+	checkpoint: CustomerCheckpointExclusion,
+	keyColumn: string,
+): { sql: string; params: unknown[] } => {
+	const params: unknown[] = [checkpoint.migrationInternalId];
+	let dryRunScope = "AND mir.dry_run = false";
+	if (checkpoint.dryRun) {
+		dryRunScope =
+			"AND (mir.dry_run = false OR (mir.dry_run = true AND mir.migration_run_id = ?))";
+		params.push(checkpoint.migrationRunId);
+	}
+	const statusPlaceholders = checkpoint.excludedStatuses
+		.map(() => "?")
+		.join(", ");
+	params.push(...checkpoint.excludedStatuses);
+
+	return {
+		sql: [
+			"NOT EXISTS (SELECT 1 FROM migration_item_runs mir",
+			"WHERE mir.migration_internal_id = ?",
+			dryRunScope,
+			"AND mir.item_kind = 'customer'",
+			`AND mir.item_id = ${keyColumn}`,
+			`AND mir.status IN (${statusPlaceholders}))`,
+		].join(" "),
+		params,
+	};
+};
+
 const buildCheckpointWhere = (
 	checkpoint: CustomerCheckpointExclusion | undefined,
 ): SQL => {
 	if (!checkpoint || checkpoint.excludedStatuses.length === 0) return sql``;
+	return sql`AND ${rawWithParamsToDrizzle(
+		buildCheckpointPredicateSql(checkpoint, "c.internal_id"),
+	)}`;
+};
 
-	const checkpointScope = checkpoint.dryRun
-		? sql`AND (
-				mir.dry_run = false
-				OR (
-					mir.dry_run = true
-					AND mir.migration_run_id = ${checkpoint.migrationRunId}
-				)
-			)`
-		: sql`AND mir.dry_run = false`;
-	const statuses = sql.join(
-		checkpoint.excludedStatuses.map((status) => sql`${status}`),
-		sql`, `,
+/** Caller predicates for the paged/count composers: checkpoint (sinks onto
+ * the walk key) + dashboard search/list filters (need the customer row). */
+const buildPagePredicates = ({
+	checkpoint,
+	orgId,
+	env,
+	search,
+	customerFilters,
+}: {
+	checkpoint?: CustomerCheckpointExclusion;
+	orgId: string;
+	env: string;
+	search?: string;
+	customerFilters?: CustomerListFilters;
+}): CustomerPagePredicate[] => {
+	const predicates: CustomerPagePredicate[] = [];
+	if (checkpoint && checkpoint.excludedStatuses.length > 0) {
+		predicates.push({
+			build: (keyColumn) => buildCheckpointPredicateSql(checkpoint, keyColumn),
+		});
+	}
+	const listWhere = drizzleToRawWithParams(
+		sql`TRUE ${buildCustomerListWhere({ orgId, env, search, customerFilters })}`,
 	);
-
-	return sql`
-		AND NOT EXISTS (
-			SELECT 1
-			FROM migration_item_runs mir
-			WHERE mir.migration_internal_id = ${checkpoint.migrationInternalId}
-				${checkpointScope}
-				AND mir.item_kind = 'customer'
-				AND mir.item_id = c.internal_id
-				AND mir.status IN (${statuses})
-		)
-	`;
+	if (listWhere.sql.trim() !== "TRUE") {
+		predicates.push({ needsCustomerAlias: true, build: () => listWhere });
+	}
+	return predicates;
 };
 
 const buildCustomerListWhere = ({
@@ -309,18 +358,35 @@ export const buildCustomerSelect = ({
 	limit?: number;
 	afterInternalId?: string;
 }): SQL => {
+	if (limit !== undefined) {
+		return rawWithParamsToDrizzle(
+			composeCustomerPage({
+				filter,
+				ctx,
+				ambient: { orgId, env },
+				limit,
+				cursor: afterInternalId || undefined,
+				predicates: buildPagePredicates({
+					checkpoint,
+					orgId,
+					env,
+					search,
+					customerFilters,
+				}),
+			}),
+		);
+	}
 	const candidate = compileCustomerCandidate({ orgId, env, filter, ctx });
-	const limitClause = limit !== undefined ? sql`LIMIT ${limit}` : sql``;
 	return sql`
 		SELECT c.internal_id, c.id, c.name, c.email
 		FROM ${candidate.source}
 		WHERE (${candidate.where}) ${buildCommonWhere({ checkpoint, orgId, env, search, customerFilters, afterInternalId })}
 		ORDER BY c.internal_id DESC
-		${limitClause}
 	`;
 };
 
-/** COUNT(*) applying the same filter. */
+/** COUNT(*) applying the same filter. The compiler picks the aggregation
+ * access path (cp-only vs batch-hash). */
 export const buildCustomerCount = ({
 	orgId,
 	env,
@@ -329,36 +395,29 @@ export const buildCustomerCount = ({
 	checkpoint,
 	search,
 	customerFilters,
-}: CustomerQueryArgs): SQL => {
-	const candidate = compileCustomerCandidate({ orgId, env, filter, ctx });
-	return sql`
-		SELECT COUNT(*)::bigint AS count
-		FROM ${candidate.source}
-		WHERE (${candidate.where}) ${buildCommonWhere({ checkpoint, orgId, env, search, customerFilters })}
-	`;
-};
+}: CustomerQueryArgs): SQL =>
+	rawWithParamsToDrizzle(
+		composeCustomerCount({
+			filter,
+			ctx,
+			ambient: { orgId, env },
+			predicates: buildPagePredicates({
+				checkpoint,
+				orgId,
+				env,
+				search,
+				customerFilters,
+			}),
+		}),
+	);
 
 export const buildLimitedCustomerCount = ({
 	limit,
 	...args
-}: CustomerQueryArgs & { limit: number }): SQL => {
-	const candidate = compileCustomerCandidate(args);
-	return sql`
-		SELECT COUNT(*)::bigint AS count
-		FROM (
-			SELECT 1
-			FROM ${candidate.source}
-			WHERE (${candidate.where}) ${buildCommonWhere({
-				checkpoint: args.checkpoint,
-				orgId: args.orgId,
-				env: args.env,
-				search: args.search,
-				customerFilters: args.customerFilters,
-			})}
-			LIMIT ${limit}
-		) limited
-	`;
-};
+}: CustomerQueryArgs & { limit: number }): SQL => sql`
+	SELECT COUNT(*)::bigint AS count
+	FROM (${buildCustomerSelect({ ...args, limit })}) limited
+`;
 
 // ─── Preview-only: filter set ∪ already-processed set ────────────────
 // The live view surfaces customers an in-flight migration already ran for,
@@ -387,10 +446,32 @@ export const buildProcessedPreviewSelect = ({
 	limit?: number;
 	afterInternalId?: string;
 }): SQL => {
+	const mode = getExecutionFilterMode(includeProcessed);
+	if (mode === "all" && limit !== undefined) {
+		return rawWithParamsToDrizzle(
+			composeCustomerPreviewPage({
+				filter,
+				ctx,
+				ambient: { orgId, env },
+				processed: {
+					migrationInternalId: includeProcessed.migrationInternalId,
+				},
+				limit,
+				cursor: afterInternalId || undefined,
+				predicates: buildPagePredicates({
+					checkpoint,
+					orgId,
+					env,
+					search,
+					customerFilters,
+				}),
+			}),
+		);
+	}
+
 	const candidate = compileCustomerCandidate({ orgId, env, filter, ctx });
 	const processed = buildProcessedIn(includeProcessed);
 	const limitClause = limit !== undefined ? sql`LIMIT ${limit}` : sql``;
-	const mode = getExecutionFilterMode(includeProcessed);
 
 	if (mode === "explicit_only") {
 		return sql`
@@ -438,9 +519,29 @@ export const buildProcessedPreviewCount = ({
 	customerFilters,
 	includeProcessed,
 }: ProcessedPreviewArgs): SQL => {
+	const mode = getExecutionFilterMode(includeProcessed);
+	if (mode === "all") {
+		return rawWithParamsToDrizzle(
+			composeCustomerPreviewCount({
+				filter,
+				ctx,
+				ambient: { orgId, env },
+				processed: {
+					migrationInternalId: includeProcessed.migrationInternalId,
+				},
+				predicates: buildPagePredicates({
+					checkpoint,
+					orgId,
+					env,
+					search,
+					customerFilters,
+				}),
+			}),
+		);
+	}
+
 	const candidate = compileCustomerCandidate({ orgId, env, filter, ctx });
 	const processed = buildProcessedIn(includeProcessed);
-	const mode = getExecutionFilterMode(includeProcessed);
 
 	if (mode === "explicit_only") {
 		return sql`

--- a/server/src/internal/migrations/v2/filters/rawWithParamsToDrizzle.ts
+++ b/server/src/internal/migrations/v2/filters/rawWithParamsToDrizzle.ts
@@ -1,4 +1,14 @@
 import { type SQL, sql } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+/** Convert a Drizzle SQL chunk to the compiler's `{ sql, params }` shape. */
+export const drizzleToRawWithParams = (query: SQL) => {
+	const compiled = new PgDialect().sqlToQuery(query);
+	return {
+		sql: compiled.sql.replace(/\$\d+/g, "?"),
+		params: [...compiled.params],
+	};
+};
 
 /** Convert the compiler's `{ sql, params }` output to a Drizzle SQL chunk. */
 export const rawWithParamsToDrizzle = ({

--- a/server/src/internal/migrations/v2/handlers/handlePreviewMigrationFilter.ts
+++ b/server/src/internal/migrations/v2/handlers/handlePreviewMigrationFilter.ts
@@ -169,11 +169,21 @@ export const handlePreviewMigrationFilter = createRoute({
 			itemRuns.map((run) => [run.item_id, run]),
 		);
 
-		const grouped = groupByCustomer(enriched).map((customer) => ({
-			...customer,
-			migration_item_run:
-				itemRunsByCustomer.get(customer.internal_id as string) ?? null,
-		}));
+		// enrichCustomers returns join order — restore the page's cursor order.
+		const pageOrder = new Map(
+			pageRows.map((row, index) => [row.internal_id, index]),
+		);
+		const grouped = groupByCustomer(enriched)
+			.sort(
+				(a, b) =>
+					(pageOrder.get(a.internal_id as string) ?? 0) -
+					(pageOrder.get(b.internal_id as string) ?? 0),
+			)
+			.map((customer) => ({
+				...customer,
+				migration_item_run:
+					itemRunsByCustomer.get(customer.internal_id as string) ?? null,
+			}));
 
 		return c.json({
 			count,

--- a/server/tests/integration/billing/migrations-v2/add-plan-operation/add-plan-op-preview.test.ts
+++ b/server/tests/integration/billing/migrations-v2/add-plan-operation/add-plan-op-preview.test.ts
@@ -1,11 +1,4 @@
-/**
- * Integration tests for add_plan — preview output.
- *
- * Contract under test:
- *   - add_plan preview emits a "created" plan_change with the plan_id.
- *   - add_plan with boolean features emits flag_changes.
- *   - add_plan with metered features emits balance_changes.
- */
+/** add_plan previews use the shared customer plan-change contract. */
 
 import { expect, test } from "bun:test";
 import { TestFeature } from "@tests/setup/v2Features";
@@ -17,11 +10,12 @@ import { runMigrationAndWait } from "../utils/runMigrationPreview";
 
 type PreviewPlanChange = {
 	action: string;
-	plan_id: string;
+	subscription?: { plan_id: string };
+	purchase?: { plan_id: string };
 	item_changes: Array<{ action: string; feature_id: string }>;
 };
 
-test(`${chalk.yellowBright("add_plan preview: emits created plan_change")}`, async () => {
+test(`${chalk.yellowBright("add_plan preview: emits activated plan_change")}`, async () => {
 	const suffix = Date.now();
 	const customerId = `add-plan-preview-created-${suffix}`;
 	const existing = products.base({
@@ -61,8 +55,10 @@ test(`${chalk.yellowBright("add_plan preview: emits created plan_change")}`, asy
 			? preview.plan_changes[0]
 			: JSON.stringify(preview.plan_changes[0]),
 	) as PreviewPlanChange;
-	expect(planChange.action).toBe("created");
-	expect(planChange.plan_id).toBe(newPlan.id);
+	expect(planChange.action).toBe("activated");
+	expect(planChange.subscription?.plan_id ?? planChange.purchase?.plan_id).toBe(
+		newPlan.id,
+	);
 
 	expect(preview.flag_changes.length).toBeGreaterThan(0);
 	expect(preview.balance_changes.length).toBeGreaterThan(0);

--- a/server/tests/integration/billing/migrations-v2/controls/idempotency/migration-idempotency.test.ts
+++ b/server/tests/integration/billing/migrations-v2/controls/idempotency/migration-idempotency.test.ts
@@ -8,6 +8,7 @@ import {
 	type Migration,
 	MigrationItemKind,
 	MigrationItemRunStatus,
+	MigrationRunStatus,
 } from "@autumn/shared";
 import { expectFlagCorrect } from "@tests/integration/utils/expectFlagCorrect.js";
 import { TestFeature } from "@tests/setup/v2Features.js";
@@ -16,11 +17,17 @@ import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { CusService } from "@/internal/customers/CusService.js";
-import { migrationItemRunRepo } from "@/internal/migrations/v2/repos/index.js";
+import {
+	migrationItemRunRepo,
+	migrationRunRepo,
+} from "@/internal/migrations/v2/repos/index.js";
 import { waitForMigrationResult } from "../../utils/runUpdatePlanMigration.js";
 
 const timeout = (ms: number) =>
 	new Promise((resolve) => setTimeout(resolve, ms));
+
+const migrationIdSuffix = Date.now().toString(36);
+const uniqueMigrationId = (id: string) => `${id}-${migrationIdSuffix}`;
 
 const buildDashboardMigration = ({
 	id,
@@ -137,7 +144,7 @@ test(`${chalk.yellowBright("migrations idempotency: run API does not replay a su
 	const internalCustomerId = await getInternalCustomerId({ customerId, ctx });
 	const migration = await autumnV2_2.migrationsV2.deleteAndCreate(
 		buildDashboardMigration({
-			id: `${customerId}-mig`,
+			id: uniqueMigrationId(`${customerId}-mig`),
 			planId: plan.id,
 		}),
 	);
@@ -172,7 +179,7 @@ test(`${chalk.yellowBright("migrations idempotency: run API does not replay a su
 
 	const otherMigration = await autumnV2_2.migrationsV2.deleteAndCreate(
 		buildDashboardMigration({
-			id: `${customerId}-other-mig`,
+			id: uniqueMigrationId(`${customerId}-other-mig`),
 			planId: plan.id,
 		}),
 	);
@@ -200,7 +207,7 @@ test(`${chalk.yellowBright("migrations idempotency: run API skips running and fa
 
 	const runningMigration = await autumnV2_2.migrationsV2.deleteAndCreate(
 		buildDashboardMigration({
-			id: `${customerId}-running-mig`,
+			id: uniqueMigrationId(`${customerId}-running-mig`),
 			planId: plan.id,
 		}),
 	);
@@ -223,7 +230,7 @@ test(`${chalk.yellowBright("migrations idempotency: run API skips running and fa
 
 	const failedMigration = await autumnV2_2.migrationsV2.deleteAndCreate(
 		buildDashboardMigration({
-			id: `${customerId}-failed-mig`,
+			id: uniqueMigrationId(`${customerId}-failed-mig`),
 			planId: plan.id,
 		}),
 	);
@@ -289,7 +296,7 @@ test(`${chalk.yellowBright("migrations idempotency: retry_item_statuses and dry_
 
 	const retryMigration = await autumnV2_2.migrationsV2.deleteAndCreate(
 		buildDashboardMigration({
-			id: `${retryCustomerId}-mig`,
+			id: uniqueMigrationId(`${retryCustomerId}-mig`),
 			planId: retryPlan.id,
 		}),
 	);
@@ -327,7 +334,7 @@ test(`${chalk.yellowBright("migrations idempotency: retry_item_statuses and dry_
 
 	const dryRunMigration = await autumnV2_2.migrationsV2.deleteAndCreate(
 		buildDashboardMigration({
-			id: `${dryRunCustomerId}-mig`,
+			id: uniqueMigrationId(`${dryRunCustomerId}-mig`),
 			planId: dryRunPlan.id,
 		}),
 	);
@@ -433,89 +440,55 @@ test(`${chalk.yellowBright("migrations idempotency: item run checkpoints are dry
 	).resolves.toMatchObject({ claimed: true });
 });
 
-test(`${chalk.yellowBright("migrations idempotency: run API rejects concurrent migration runs per org")}`, async () => {
-	const firstCustomerId = "migration-idem-serial-first";
-	const secondCustomerId = "migration-idem-serial-second";
-	const firstPlan = products.pro({ id: "serial-pro", items: [] });
-	const secondPlan = products.premium({ id: "serial-premium", items: [] });
+test(`${chalk.yellowBright("migrations idempotency: run API rejects a second active run for the same migration")}`, async () => {
+	const customerId = "migration-idem-active-run";
+	const plan = products.pro({ id: "active-run-pro", items: [] });
 	const { autumnV2_2, ctx } = await initScenario({
-		customerId: firstCustomerId,
+		customerId,
 		setup: [
 			s.customer({ paymentMethod: "success" }),
-			s.otherCustomers([{ id: secondCustomerId, paymentMethod: "success" }]),
-			s.products({ list: [firstPlan, secondPlan] }),
+			s.products({ list: [plan] }),
 		],
-		actions: [
-			s.billing.attach({ productId: firstPlan.id }),
-			s.billing.attach({
-				customerId: secondCustomerId,
-				productId: secondPlan.id,
-			}),
-		],
+		actions: [s.billing.attach({ productId: plan.id })],
 	});
-	const firstMigration = await autumnV2_2.migrationsV2.deleteAndCreate(
+	const migration = await autumnV2_2.migrationsV2.deleteAndCreate(
 		buildDashboardMigration({
-			id: `${firstCustomerId}-mig`,
-			planId: firstPlan.id,
+			id: uniqueMigrationId(`${customerId}-mig`),
+			planId: plan.id,
 		}),
 	);
-	const secondMigration = await autumnV2_2.migrationsV2.deleteAndCreate(
-		buildDashboardMigration({
-			id: `${secondCustomerId}-mig`,
-			planId: secondPlan.id,
-		}),
-	);
-
-	await autumnV2_2.migrationsV2.run({
-		id: firstMigration.id,
-		dry_run: false,
-	});
-	await expect(
-		autumnV2_2.migrationsV2.run({
-			id: secondMigration.id,
+	const activeRun = await migrationRunRepo.insert({
+		ctx,
+		insert: {
+			migration_internal_id: migration.internal_id,
 			dry_run: false,
-		}),
-	).rejects.toMatchObject({
-		code: ErrCode.MigrationAlreadyInProgress,
-		message: expect.stringContaining("already running"),
+			lazy_run: false,
+			only_ids: null,
+			target_limit: undefined,
+		},
 	});
+	expect(activeRun).not.toBeNull();
 
-	const firstInternalCustomerId = await getInternalCustomerId({
-		customerId: firstCustomerId,
-		ctx,
-	});
-	const secondInternalCustomerId = await getInternalCustomerId({
-		customerId: secondCustomerId,
-		ctx,
-	});
-	await waitForCustomerItemRunStatus({
-		ctx,
-		migration: firstMigration,
-		internalCustomerId: firstInternalCustomerId,
-		status: MigrationItemRunStatus.Succeeded,
-	});
-
-	await waitForMigrationRunAccepted({ autumnV2_2, id: secondMigration.id });
-	await waitForCustomerItemRunStatus({
-		ctx,
-		migration: secondMigration,
-		internalCustomerId: secondInternalCustomerId,
-		status: MigrationItemRunStatus.Succeeded,
-	});
-	const firstItemRun = await getCustomerItemRun({
-		ctx,
-		migration: firstMigration,
-		internalCustomerId: firstInternalCustomerId,
-	});
-	const secondItemRun = await getCustomerItemRun({
-		ctx,
-		migration: secondMigration,
-		internalCustomerId: secondInternalCustomerId,
-	});
-	expect(firstItemRun).toMatchObject({
-		status: MigrationItemRunStatus.Succeeded,
-	});
-	expect(secondItemRun).toMatchObject({
-		status: MigrationItemRunStatus.Succeeded,
-	});
+	try {
+		await expect(
+			autumnV2_2.migrationsV2.run({
+				id: migration.id,
+				dry_run: false,
+			}),
+		).rejects.toMatchObject({
+			code: ErrCode.MigrationAlreadyInProgress,
+			message: expect.stringContaining("already running"),
+		});
+	} finally {
+		if (activeRun) {
+			await migrationRunRepo.update({
+				ctx,
+				internalId: activeRun.internal_id,
+				updates: {
+					status: MigrationRunStatus.Succeeded,
+					finished_at: Date.now(),
+				},
+			});
+		}
+	}
 });

--- a/server/tests/integration/billing/migrations-v2/lazy/lazy-migration-basic.test.ts
+++ b/server/tests/integration/billing/migrations-v2/lazy/lazy-migration-basic.test.ts
@@ -41,6 +41,9 @@ import {
 const timeout = (ms: number) =>
 	new Promise((resolve) => setTimeout(resolve, ms));
 
+const migrationIdSuffix = Date.now().toString(36);
+const uniqueMigrationId = (id: string) => `${id}-${migrationIdSuffix}`;
+
 test.concurrent(`${chalk.yellowBright("lazy migration: multiple customers on pro fetch + auto-migrate")}`, async () => {
 	const firstCustomerId = "lazy-basic-first";
 	const secondCustomerId = "lazy-basic-second";
@@ -73,7 +76,7 @@ test.concurrent(`${chalk.yellowBright("lazy migration: multiple customers on pro
 	const { migration, run_id } = await startLazyMigration({
 		autumnV2_2,
 		ctx,
-		id: `${firstCustomerId}-mig`,
+		id: uniqueMigrationId(`${firstCustomerId}-mig`),
 		planId: plan.id,
 	});
 
@@ -142,7 +145,7 @@ test.concurrent(`${chalk.yellowBright("lazy migration: non-matching customer is 
 	const { migration, run_id } = await startLazyMigration({
 		autumnV2_2,
 		ctx,
-		id: `${matchingCustomerId}-mig`,
+		id: uniqueMigrationId(`${matchingCustomerId}-mig`),
 		planId: proPlan.id,
 	});
 
@@ -190,13 +193,12 @@ test.concurrent(`${chalk.yellowBright("lazy migration: marking the run as done c
 	const { migration, run_id } = await startLazyMigration({
 		autumnV2_2,
 		ctx,
-		id: `${customerId}-mig`,
+		id: uniqueMigrationId(`${customerId}-mig`),
 		planId: plan.id,
 	});
 
 	try {
-		// Trigger the migration once and wait for it to land.
-		await getCustomerAndAwaitMigration({ autumnV2_2, customerId });
+		await autumnV2_2.customers.get(customerId);
 		await waitForCustomerItemRunStatus({
 			ctx,
 			migration,

--- a/server/tests/integration/billing/migrations-v2/update-plan-operation/previews/versioning-preview.test.ts
+++ b/server/tests/integration/billing/migrations-v2/update-plan-operation/previews/versioning-preview.test.ts
@@ -1,12 +1,4 @@
-/**
- * TDD coverage for update_plan version preview scenarios.
- *
- * Contract under test:
- *   New behaviors:
- *     - Version previews use the webhook-shaped plan change contract.
- *     - Version previews emit balance_changes for metered grant changes and
- *       flag_changes for boolean removals.
- */
+/** Version previews expose structural, balance, and flag changes. */
 
 import { expect, test } from "bun:test";
 import { TestFeature } from "@tests/setup/v2Features";
@@ -59,12 +51,15 @@ test(`${chalk.yellowBright("migrations preview version: emits plan, balance, and
 	});
 
 	expectMigrationPreviewCorrect({ preview, customerId, log: false });
-	const planChange = expectPreviewPlanChange({
+	expectPreviewPlanChange({
 		preview,
 		action: "updated",
 		planId: base.id,
+		itemChanges: [
+			{ action: "created", feature_id: TestFeature.Credits },
+			{ action: "deleted", feature_id: TestFeature.AdminRights },
+		],
 	});
-	expect(planChange.item_changes).toEqual([]);
 	expectPreviewBalanceChange({
 		preview,
 		featureId: TestFeature.Messages,

--- a/server/tests/perf/batch-migrations/.gitignore
+++ b/server/tests/perf/batch-migrations/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/server/tests/perf/batch-migrations/probeShapeMatrix.ts
+++ b/server/tests/perf/batch-migrations/probeShapeMatrix.ts
@@ -1,0 +1,229 @@
+/**
+ * U0 baseline matrix: every migration read-query shape (claim page, dashboard
+ * preview page, count, execution view) probed read-only against the 4M bench
+ * org. Prints per-scenario timings + plan offenders (seq scans, >=100k-row
+ * nodes, disk spills); full EXPLAIN JSON saved under results/.
+ *
+ *   bun tests/perf/batch-migrations/probeShapeMatrix.ts
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { CustomerFilter } from "@autumn/shared";
+import { MigrationItemRunStatus } from "@autumn/shared";
+import { type SQL, sql } from "drizzle-orm";
+import {
+	buildCustomerCount,
+	buildCustomerSelect,
+	buildProcessedPreviewCount,
+	buildProcessedPreviewSelect,
+	type CustomerCheckpointExclusion,
+} from "@/internal/migrations/v2/filters/customers/buildCustomerSelect.js";
+import {
+	BENCH_FREE_BARE_PRODUCT_ID,
+	BENCH_FREE_PRODUCT_ID,
+	BENCH_PAID_PRODUCT_ID,
+	getBenchContext,
+} from "./utils/benchContext.js";
+
+const PAGE_SIZE = 5000;
+const DASHBOARD_PAGE_SIZE = 51;
+const MID_MIGRATION_ID = "probe_mig_mid";
+const MID_CURSOR = "cus_bench_3500001";
+const RESULTS_DIR = join(import.meta.dir, "results");
+
+type PlanNode = {
+	"Node Type": string;
+	"Relation Name"?: string;
+	"Actual Rows"?: number;
+	"Actual Loops"?: number;
+	"Actual Total Time"?: number;
+	"Sort Method"?: string;
+	"Disk Usage"?: number;
+	Plans?: PlanNode[];
+};
+
+const walkOffenders = (node: PlanNode, out: string[]) => {
+	const rows = (node["Actual Rows"] ?? 0) * (node["Actual Loops"] ?? 1);
+	const ms = Math.round(node["Actual Total Time"] ?? 0);
+	const label = `${node["Node Type"]}${node["Relation Name"] ? ` on ${node["Relation Name"]}` : ""}`;
+	if (node["Node Type"].includes("Seq Scan")) {
+		out.push(`SEQ   ${label}: ${rows.toLocaleString()} rows, ${ms}ms`);
+	} else if (node["Disk Usage"] || node["Sort Method"]?.includes("external")) {
+		out.push(
+			`DISK  ${label}: ${rows.toLocaleString()} rows, ${ms}ms, ${node["Disk Usage"] ?? "?"}kB spilled`,
+		);
+	} else if (rows >= 100_000) {
+		out.push(`BIG   ${label}: ${rows.toLocaleString()} rows, ${ms}ms`);
+	}
+	for (const child of node.Plans ?? []) walkOffenders(child, out);
+};
+
+const main = async () => {
+	const { ctx } = await getBenchContext();
+	const { db } = ctx;
+	mkdirSync(RESULTS_DIR, { recursive: true });
+
+	const [versionRow] = (await db.execute(
+		sql`SELECT version() AS v, current_setting('work_mem') AS work_mem`,
+	)) as { v: string; work_mem: string }[];
+	console.log(`pg: ${versionRow.v}`);
+	console.log(`pg: work_mem=${versionRow.work_mem}`);
+
+	const filterCtx = { features: ctx.features };
+	const base = { orgId: ctx.org.id, env: ctx.env, ctx: filterCtx };
+	const freshCheckpoint: CustomerCheckpointExclusion = {
+		migrationInternalId: "probe_mig_none",
+		migrationRunId: "probe_run_none",
+		dryRun: false,
+		excludedStatuses: [
+			MigrationItemRunStatus.Succeeded,
+			MigrationItemRunStatus.Skipped,
+			MigrationItemRunStatus.Failed,
+		],
+	};
+	const midCheckpoint: CustomerCheckpointExclusion = {
+		...freshCheckpoint,
+		migrationInternalId: MID_MIGRATION_ID,
+	};
+
+	const paid: CustomerFilter = { plan: { plan_id: BENCH_PAID_PRODUCT_ID } };
+	const free: CustomerFilter = { plan: { plan_id: BENCH_FREE_PRODUCT_ID } };
+	const multi: CustomerFilter = {
+		plan: {
+			plan_id: { $in: [BENCH_PAID_PRODUCT_ID, BENCH_FREE_BARE_PRODUCT_ID] },
+		},
+	};
+	const freeNonCustom: CustomerFilter = {
+		plan: { plan_id: BENCH_FREE_PRODUCT_ID, custom: false },
+	};
+
+	const scenarios: { key: string; note: string; build: () => SQL }[] = [
+		{
+			key: "S1-claim-selective",
+			note: "claim page, bench-paid (600k matched), fresh, no cursor",
+			build: () =>
+				buildCustomerSelect({ ...base, filter: paid, checkpoint: freshCheckpoint, limit: PAGE_SIZE }),
+		},
+		{
+			key: "S2-claim-dominant",
+			note: "claim page, bench-free (2.4M matched), fresh, no cursor",
+			build: () =>
+				buildCustomerSelect({ ...base, filter: free, checkpoint: freshCheckpoint, limit: PAGE_SIZE }),
+		},
+		{
+			key: "S3-claim-multiplan",
+			note: "claim page, plan_id $in [paid, free-bare] (1.6M matched)",
+			build: () =>
+				buildCustomerSelect({ ...base, filter: multi, checkpoint: freshCheckpoint, limit: PAGE_SIZE }),
+		},
+		{
+			key: "S4-claim-residual",
+			note: "claim page, bench-free + custom:false (prod screenshot shape)",
+			build: () =>
+				buildCustomerSelect({ ...base, filter: freeNonCustom, checkpoint: freshCheckpoint, limit: PAGE_SIZE }),
+		},
+		{
+			key: "S5-claim-deep-cursor",
+			note: "claim page, bench-free, cursor deep at cus_bench_1100000",
+			build: () =>
+				buildCustomerSelect({
+					...base,
+					filter: free,
+					checkpoint: freshCheckpoint,
+					limit: PAGE_SIZE,
+					afterInternalId: "cus_bench_1100000",
+				}),
+		},
+		{
+			key: "S6-claim-midrun-cursor",
+			note: "claim page, bench-paid, 300k processed, resume cursor",
+			build: () =>
+				buildCustomerSelect({
+					...base,
+					filter: paid,
+					checkpoint: midCheckpoint,
+					limit: PAGE_SIZE,
+					afterInternalId: MID_CURSOR,
+				}),
+		},
+		{
+			key: "S7-claim-midrun-restart",
+			note: "claim page, bench-paid, 300k processed, NO cursor (restart)",
+			build: () =>
+				buildCustomerSelect({ ...base, filter: paid, checkpoint: midCheckpoint, limit: PAGE_SIZE }),
+		},
+		{
+			key: "P1-dashboard-page",
+			note: "dashboard preview page, bench-free, limit 51",
+			build: () =>
+				buildCustomerSelect({ ...base, filter: free, limit: DASHBOARD_PAGE_SIZE }),
+		},
+		{
+			key: "C1-count-selective",
+			note: "dashboard count, bench-paid (600k)",
+			build: () => buildCustomerCount({ ...base, filter: paid }),
+		},
+		{
+			key: "C2-count-dominant",
+			note: "dashboard count, bench-free (2.4M)",
+			build: () => buildCustomerCount({ ...base, filter: free }),
+		},
+		{
+			key: "E1-execution-page",
+			note: "execution view page (UNION), bench-paid + 300k processed, limit 51",
+			build: () =>
+				buildProcessedPreviewSelect({
+					...base,
+					filter: paid,
+					includeProcessed: { migrationInternalId: MID_MIGRATION_ID },
+					limit: DASHBOARD_PAGE_SIZE,
+				}),
+		},
+		{
+			key: "E2-execution-count",
+			note: "execution view count (UNION), bench-paid + 300k processed",
+			build: () =>
+				buildProcessedPreviewCount({
+					...base,
+					filter: paid,
+					includeProcessed: { migrationInternalId: MID_MIGRATION_ID },
+				}),
+		},
+	];
+
+	const summary: string[] = [];
+	for (const scenario of scenarios) {
+		const explainStarted = Date.now();
+		const planRows = (await db.execute(
+			sql`EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) ${scenario.build()}`,
+		)) as Record<string, unknown>[];
+		const raw = Object.values(planRows[0])[0];
+		const parsed = (typeof raw === "string" ? JSON.parse(raw) : raw) as {
+			Plan: PlanNode;
+			"Execution Time": number;
+		}[];
+		writeFileSync(
+			join(RESULTS_DIR, `${scenario.key}.json`),
+			JSON.stringify(parsed, null, 2),
+		);
+
+		const timedStarted = Date.now();
+		const rows = (await db.execute(scenario.build())) as unknown[];
+		const timedMs = Date.now() - timedStarted;
+
+		const offenders: string[] = [];
+		walkOffenders(parsed[0].Plan, offenders);
+		const line = `${scenario.key}: ${timedMs}ms (explain ${Math.round(parsed[0]["Execution Time"])}ms, analyze wall ${Date.now() - explainStarted - timedMs}ms) — ${rows.length.toLocaleString()} rows`;
+		summary.push(line);
+		console.log(`\n■ ${line}`);
+		console.log(`  ${scenario.note}`);
+		for (const offender of offenders) console.log(`  ${offender}`);
+	}
+
+	console.log("\n── summary ──────────────────────────────────────");
+	for (const line of summary) console.log(line);
+	process.exit(0);
+};
+
+await main();

--- a/server/tests/perf/batch-migrations/probes/probeActivity.ts
+++ b/server/tests/perf/batch-migrations/probes/probeActivity.ts
@@ -1,0 +1,16 @@
+/** Read-only: show active queries + waits on the bench DB. */
+import { sql } from "drizzle-orm";
+import { initDrizzle } from "@/db/initDrizzle.js";
+import { assertBenchDatabaseSafe } from "../utils/benchContext.js";
+
+assertBenchDatabaseSafe();
+const { db } = initDrizzle();
+const rows = (await db.execute(sql`
+	SELECT pid, state, wait_event_type, wait_event,
+		NOW() - query_start AS running_for, LEFT(query, 140) AS query
+	FROM pg_stat_activity
+	WHERE state <> 'idle' AND pid <> pg_backend_pid()
+	ORDER BY query_start
+`)) as Record<string, unknown>[];
+console.log(JSON.stringify(rows, null, 2));
+process.exit(0);

--- a/server/tests/perf/batch-migrations/probes/probeCancelStuck.ts
+++ b/server/tests/perf/batch-migrations/probes/probeCancelStuck.ts
@@ -1,0 +1,19 @@
+/** Cancel leftover probe backends, then refresh migration_item_runs stats. */
+import { sql } from "drizzle-orm";
+import { initDrizzle } from "@/db/initDrizzle.js";
+import { assertBenchDatabaseSafe } from "../utils/benchContext.js";
+
+assertBenchDatabaseSafe();
+const { db } = initDrizzle();
+const cancelled = (await db.execute(sql`
+	SELECT pid, pg_cancel_backend(pid) AS cancelled
+	FROM pg_stat_activity
+	WHERE state = 'active' AND pid <> pg_backend_pid()
+		AND query LIKE '%EXPLAIN (ANALYZE, BUFFERS)%'
+`)) as Record<string, unknown>[];
+console.log("cancelled:", JSON.stringify(cancelled));
+
+const started = Date.now();
+await db.execute(sql`ANALYZE migration_item_runs`);
+console.log(`ANALYZE migration_item_runs done in ${Date.now() - started}ms`);
+process.exit(0);

--- a/server/tests/perf/batch-migrations/probes/probeClaimMidMigration.ts
+++ b/server/tests/perf/batch-migrations/probes/probeClaimMidMigration.ts
@@ -1,0 +1,114 @@
+/**
+ * Replicates the mid-migration claim state: half of bench-paid's 600k
+ * customers already have `succeeded` item runs, then times the claim SELECT
+ * both without a cursor (restart/crash-recovery path — anti-join must reject
+ * all processed rows) and with the resume cursor (normal mid-run page).
+ *
+ *   bun tests/perf/batch-migrations/probeClaimMidMigration.ts
+ *   bun tests/perf/batch-migrations/probeClaimMidMigration.ts --cleanup
+ */
+
+import { MigrationItemRunStatus } from "@autumn/shared";
+import { sql } from "drizzle-orm";
+import { buildCustomerSelect } from "@/internal/migrations/v2/filters/customers/buildCustomerSelect.js";
+import {
+	BENCH_INTERNAL_CUSTOMER_PREFIX,
+	BENCH_PAID_PRODUCT_ID,
+	getBenchContext,
+} from "../utils/benchContext.js";
+
+const PROBE_MIGRATION_ID = "probe_mig_mid";
+const PAGE_SIZE = 5000;
+// bench-paid seed range is 3,200,001..3,800,000; the top half in claim order
+// (internal_id DESC) is 3,500,001..3,800,000.
+const PROCESSED_START = 3_500_001;
+const PROCESSED_END = 3_800_000;
+const RESUME_CURSOR = `${BENCH_INTERNAL_CUSTOMER_PREFIX}${PROCESSED_START}`;
+
+const main = async () => {
+	const cleanup = process.argv.includes("--cleanup");
+	const { ctx } = await getBenchContext();
+	const { db } = ctx;
+
+	if (cleanup) {
+		await db.execute(
+			sql`DELETE FROM migration_item_runs WHERE migration_internal_id = ${PROBE_MIGRATION_ID}`,
+		);
+		console.log("probe: cleaned up seeded item runs");
+		process.exit(0);
+	}
+
+	const seedStarted = Date.now();
+	await db.execute(sql`
+		INSERT INTO migration_item_runs (
+			migration_item_run_id, migration_internal_id, migration_run_id,
+			dry_run, item_kind, item_id, status, created_at, updated_at
+		)
+		SELECT
+			'mir_probe_' || i,
+			${PROBE_MIGRATION_ID},
+			'probe_run_prior',
+			false,
+			'customer',
+			${BENCH_INTERNAL_CUSTOMER_PREFIX} || i,
+			${MigrationItemRunStatus.Succeeded},
+			${Date.now()}::bigint,
+			NULL
+		FROM GENERATE_SERIES(${PROCESSED_START}::int, ${PROCESSED_END}::int) AS g(i)
+		ON CONFLICT DO NOTHING
+	`);
+	const [{ count }] = (await db.execute(sql`
+		SELECT COUNT(*)::bigint AS count FROM migration_item_runs
+		WHERE migration_internal_id = ${PROBE_MIGRATION_ID}
+	`)) as { count: string }[];
+	console.log(
+		`probe: seeded state — ${Number(count).toLocaleString()} succeeded item runs in ${Date.now() - seedStarted}ms`,
+	);
+
+	const buildSelect = (afterInternalId?: string) =>
+		buildCustomerSelect({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			filter: { plan: { plan_id: BENCH_PAID_PRODUCT_ID } },
+			ctx: { features: ctx.features },
+			checkpoint: {
+				migrationInternalId: PROBE_MIGRATION_ID,
+				migrationRunId: "probe_run_resume",
+				dryRun: false,
+				excludedStatuses: [
+					MigrationItemRunStatus.Succeeded,
+					MigrationItemRunStatus.Skipped,
+					MigrationItemRunStatus.Failed,
+				],
+			},
+			limit: PAGE_SIZE,
+			afterInternalId,
+		});
+
+	const scenarios: { label: string; after?: string }[] = [
+		{ label: "mid-run, NO cursor (restart path)", after: undefined },
+		{ label: `mid-run, cursor=${RESUME_CURSOR}`, after: RESUME_CURSOR },
+	];
+
+	for (const scenario of scenarios) {
+		console.log(`── ${scenario.label} ───────────────────────────────`);
+		const planRows = (await db.execute(
+			sql`EXPLAIN (ANALYZE, BUFFERS) ${buildSelect(scenario.after)}`,
+		)) as Record<string, string>[];
+		for (const row of planRows) console.log(Object.values(row)[0]);
+
+		for (let run = 1; run <= 2; run++) {
+			const started = Date.now();
+			const rows = (await db.execute(buildSelect(scenario.after))) as {
+				internal_id: string;
+			}[];
+			const ms = Date.now() - started;
+			console.log(
+				`timed run ${run}: ${rows.length.toLocaleString()} rows in ${ms}ms (${rows[0]?.internal_id} .. ${rows[rows.length - 1]?.internal_id})`,
+			);
+		}
+	}
+	process.exit(0);
+};
+
+await main();

--- a/server/tests/perf/batch-migrations/probes/probeClaimSelect.ts
+++ b/server/tests/perf/batch-migrations/probes/probeClaimSelect.ts
@@ -1,0 +1,81 @@
+/**
+ * Read-only probe for the claim step's SELECT (buildCustomerSelect): prints
+ * the compiled SQL, EXPLAIN (ANALYZE, BUFFERS), and wall-clock timings.
+ *
+ *   bun tests/perf/batch-migrations/probeClaimSelect.ts --plan bench-paid
+ *   bun tests/perf/batch-migrations/probeClaimSelect.ts --plan bench-paid --after cus_bench_999999
+ */
+
+import { MigrationItemRunStatus } from "@autumn/shared";
+import { sql } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { buildCustomerSelect } from "@/internal/migrations/v2/filters/customers/buildCustomerSelect.js";
+import { BENCH_PAID_PRODUCT_ID, getBenchContext } from "../utils/benchContext.js";
+
+const PAGE_SIZE = 5000;
+
+const parseArgs = () => {
+	const args = process.argv.slice(2);
+	const get = (flag: string) => {
+		const index = args.indexOf(flag);
+		return index === -1 ? undefined : args[index + 1];
+	};
+	return {
+		plan: get("--plan") ?? BENCH_PAID_PRODUCT_ID,
+		after: get("--after"),
+		limit: Number(get("--limit") ?? PAGE_SIZE),
+	};
+};
+
+const main = async () => {
+	const { plan, after, limit } = parseArgs();
+	const { ctx } = await getBenchContext();
+	const { db } = ctx;
+
+	const buildSelect = () =>
+		buildCustomerSelect({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			filter: { plan: { plan_id: plan } },
+			ctx: { features: ctx.features },
+			checkpoint: {
+				migrationInternalId: "probe_mig_none",
+				migrationRunId: "probe_run_none",
+				dryRun: false,
+				excludedStatuses: [
+					MigrationItemRunStatus.Succeeded,
+					MigrationItemRunStatus.Skipped,
+					MigrationItemRunStatus.Failed,
+				],
+			},
+			limit,
+			afterInternalId: after,
+		});
+
+	const compiled = new PgDialect().sqlToQuery(buildSelect());
+	console.log("── compiled SQL ─────────────────────────────────────");
+	console.log(compiled.sql);
+	console.log("── params ───────────────────────────────────────────");
+	console.log(compiled.params);
+
+	console.log("── EXPLAIN (ANALYZE, BUFFERS) ───────────────────────");
+	const planRows = (await db.execute(
+		sql`EXPLAIN (ANALYZE, BUFFERS) ${buildSelect()}`,
+	)) as Record<string, string>[];
+	for (const row of planRows) console.log(Object.values(row)[0]);
+
+	console.log("── timed runs ───────────────────────────────────────");
+	for (let run = 1; run <= 3; run++) {
+		const started = Date.now();
+		const rows = (await db.execute(buildSelect())) as { internal_id: string }[];
+		const ms = Date.now() - started;
+		const first = rows[0]?.internal_id;
+		const last = rows[rows.length - 1]?.internal_id;
+		console.log(
+			`run ${run}: ${rows.length.toLocaleString()} rows in ${ms}ms (${first} .. ${last})`,
+		);
+	}
+	process.exit(0);
+};
+
+await main();

--- a/server/tests/perf/batch-migrations/probes/probeCountParity.ts
+++ b/server/tests/perf/batch-migrations/probes/probeCountParity.ts
@@ -1,0 +1,106 @@
+/**
+ * U3 count verification: buildCustomerCount (compiler-chosen access path)
+ * vs ground truth (COUNT over the legacy no-limit select) — value parity
+ * plus timings, per filter shape.
+ *
+ *   bun tests/perf/batch-migrations/probes/probeCountParity.ts
+ */
+
+import type { CustomerFilter } from "@autumn/shared";
+import { MigrationItemRunStatus } from "@autumn/shared";
+import { sql } from "drizzle-orm";
+import type { CustomerCheckpointExclusion } from "@/internal/migrations/v2/filters/customers/buildCustomerSelect.js";
+import {
+	buildCustomerCount,
+	buildCustomerSelect,
+} from "@/internal/migrations/v2/filters/customers/buildCustomerSelect.js";
+import {
+	BENCH_FREE_BARE_PRODUCT_ID,
+	BENCH_FREE_PRODUCT_ID,
+	BENCH_PAID_PRODUCT_ID,
+	getBenchContext,
+} from "../utils/benchContext.js";
+
+const midCheckpoint: CustomerCheckpointExclusion = {
+	migrationInternalId: "probe_mig_mid",
+	migrationRunId: "probe_run_count",
+	dryRun: false,
+	excludedStatuses: [
+		MigrationItemRunStatus.Succeeded,
+		MigrationItemRunStatus.Skipped,
+		MigrationItemRunStatus.Failed,
+	],
+};
+
+const main = async () => {
+	const { ctx } = await getBenchContext();
+	const { db } = ctx;
+
+	const shapes: {
+		key: string;
+		filter: CustomerFilter;
+		checkpoint?: CustomerCheckpointExclusion;
+	}[] = [
+		{ key: "selective", filter: { plan: { plan_id: BENCH_PAID_PRODUCT_ID } } },
+		{ key: "dominant", filter: { plan: { plan_id: BENCH_FREE_PRODUCT_ID } } },
+		{
+			key: "multi-plan",
+			filter: {
+				plan: {
+					plan_id: { $in: [BENCH_PAID_PRODUCT_ID, BENCH_FREE_BARE_PRODUCT_ID] },
+				},
+			},
+		},
+		{
+			key: "custom-false",
+			filter: { plan: { plan_id: BENCH_FREE_PRODUCT_ID, custom: false } },
+		},
+		{
+			key: "custom-true",
+			filter: { plan: { plan_id: BENCH_FREE_PRODUCT_ID, custom: true } },
+		},
+		{
+			key: "residual-paid-false",
+			filter: { plan: { plan_id: BENCH_FREE_PRODUCT_ID, paid: false } },
+		},
+		{
+			key: "checkpoint-midrun",
+			filter: { plan: { plan_id: BENCH_PAID_PRODUCT_ID } },
+			checkpoint: midCheckpoint,
+		},
+	];
+
+	let failures = 0;
+	for (const shape of shapes) {
+		const baseArgs = {
+			orgId: ctx.org.id,
+			env: ctx.env,
+			filter: shape.filter,
+			ctx: { features: ctx.features },
+			checkpoint: shape.checkpoint,
+		};
+
+		const started = Date.now();
+		const [countRow] = (await db.execute(buildCustomerCount(baseArgs))) as {
+			count: string;
+		}[];
+		const countMs = Date.now() - started;
+
+		const truthStarted = Date.now();
+		const [truthRow] = (await db.execute(
+			sql`SELECT COUNT(*)::bigint AS count FROM (${buildCustomerSelect(baseArgs)}) legacy`,
+		)) as { count: string }[];
+		const truthMs = Date.now() - truthStarted;
+
+		const ok = countRow.count === truthRow.count;
+		if (!ok) failures++;
+		console.log(
+			`${ok ? "OK  " : "FAIL"} ${shape.key}: count=${Number(countRow.count).toLocaleString()} in ${countMs}ms (truth=${Number(truthRow.count).toLocaleString()} in ${truthMs}ms)`,
+		);
+	}
+
+	console.log(failures === 0 ? "\nALL COUNT CHECKS PASSED" : `\n${failures} FAILURES`);
+	process.exit(failures === 0 ? 0 : 1);
+};
+
+await main();

--- a/server/tests/perf/batch-migrations/probes/probeDeepPages.ts
+++ b/server/tests/perf/batch-migrations/probes/probeDeepPages.ts
@@ -1,0 +1,47 @@
+/** Verifies page cost is flat across page depth: times pages 1, 2, 100,
+ * 6000, 11999 of the dashboard preview (pageSize 50) via real cursors. */
+
+import { sql } from "drizzle-orm";
+import { getCustomerPage } from "@/internal/migrations/v2/filters/customers/filterCustomers.js";
+import {
+	BENCH_PAID_PRODUCT_ID,
+	getBenchContext,
+} from "../utils/benchContext.js";
+
+const PAGE_SIZE = 50;
+const CHECKPOINTS = [1, 2, 100, 6000, 11_999];
+
+const main = async () => {
+	const { ctx } = await getBenchContext();
+
+	let cursor: string | undefined;
+	let page = 0;
+	const started = Date.now();
+	for (const target of CHECKPOINTS) {
+		// Advance to the target page by walking cursors (cheap: each hop is one
+		// paged query — this loop itself demonstrates flat per-page cost).
+		let ms = 0;
+		let rows: { internal_id: string }[] = [];
+		while (page < target) {
+			const pageStarted = Date.now();
+			const result = await getCustomerPage({
+				ctx,
+				filter: { plan: { plan_id: BENCH_PAID_PRODUCT_ID } },
+				pageSize: PAGE_SIZE,
+				cursor,
+			});
+			ms = Date.now() - pageStarted;
+			rows = result.rows;
+			cursor = result.nextCursor ?? undefined;
+			page++;
+			if (!result.nextCursor) break;
+		}
+		console.log(
+			`page ${page.toLocaleString()}: ${rows.length} rows in ${ms}ms (first=${rows[0]?.internal_id})`,
+		);
+	}
+	console.log(`walked ${page.toLocaleString()} pages total in ${Math.round((Date.now() - started) / 1000)}s`);
+	process.exit(0);
+};
+
+await main();

--- a/server/tests/perf/batch-migrations/probes/probeFilterParity.ts
+++ b/server/tests/perf/batch-migrations/probes/probeFilterParity.ts
@@ -1,0 +1,186 @@
+/**
+ * Membership-accuracy probe: for every filter shape, diffs the legacy
+ * materializing query (ground truth, buildCustomerSelect without limit)
+ * against the paged walk (buildCustomerSelect with a full-set limit) —
+ * DB-side, EXCEPT ALL both directions, so missing rows, extra rows, and
+ * duplicates all surface. Also validates page iteration integrity.
+ *
+ *   bun tests/perf/batch-migrations/probes/probeFilterParity.ts
+ */
+
+import type { CustomerFilter } from "@autumn/shared";
+import { MigrationItemRunStatus } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { sql } from "drizzle-orm";
+import type { CustomerCheckpointExclusion } from "@/internal/migrations/v2/filters/customers/buildCustomerSelect.js";
+import { buildCustomerSelect } from "@/internal/migrations/v2/filters/customers/buildCustomerSelect.js";
+import {
+	BENCH_FREE_BARE_PRODUCT_ID,
+	BENCH_FREE_PRODUCT_ID,
+	BENCH_PAID_PRODUCT_ID,
+	getBenchContext,
+} from "../utils/benchContext.js";
+
+const FULL_SET_LIMIT = 10_000_000;
+const PAGE_SIZE = 5000;
+const MID_MIGRATION_ID = "probe_mig_mid";
+
+const midCheckpoint: CustomerCheckpointExclusion = {
+	migrationInternalId: MID_MIGRATION_ID,
+	migrationRunId: "probe_run_parity",
+	dryRun: false,
+	excludedStatuses: [
+		MigrationItemRunStatus.Succeeded,
+		MigrationItemRunStatus.Skipped,
+		MigrationItemRunStatus.Failed,
+	],
+};
+
+const main = async () => {
+	const { ctx } = await getBenchContext();
+	const { db } = ctx;
+
+	const shapes: {
+		key: string;
+		filter: CustomerFilter;
+		checkpoint?: CustomerCheckpointExclusion;
+		cursor?: string;
+	}[] = [
+		{ key: "selective", filter: { plan: { plan_id: BENCH_PAID_PRODUCT_ID } } },
+		{ key: "dominant", filter: { plan: { plan_id: BENCH_FREE_PRODUCT_ID } } },
+		{
+			key: "multi-plan",
+			filter: {
+				plan: {
+					plan_id: { $in: [BENCH_PAID_PRODUCT_ID, BENCH_FREE_BARE_PRODUCT_ID] },
+				},
+			},
+		},
+		{
+			key: "custom-false",
+			filter: { plan: { plan_id: BENCH_FREE_PRODUCT_ID, custom: false } },
+		},
+		{
+			key: "custom-true",
+			filter: { plan: { plan_id: BENCH_FREE_PRODUCT_ID, custom: true } },
+		},
+		{
+			key: "residual-paid-false",
+			filter: { plan: { plan_id: BENCH_FREE_PRODUCT_ID, paid: false } },
+		},
+		{
+			key: "residual-paid-true",
+			filter: { plan: { plan_id: BENCH_FREE_PRODUCT_ID, paid: true } },
+		},
+		{
+			key: "residual-item",
+			filter: {
+				plan: {
+					plan_id: BENCH_FREE_BARE_PRODUCT_ID,
+					item: { feature_id: TestFeature.Messages },
+				},
+			},
+		},
+		{ key: "customer-id", filter: { customer_id: "bench-c-1234" } },
+		{
+			key: "none-quantifier",
+			filter: { plan: { $none: { plan_id: BENCH_PAID_PRODUCT_ID } } },
+		},
+		{
+			key: "checkpoint-midrun",
+			filter: { plan: { plan_id: BENCH_PAID_PRODUCT_ID } },
+			checkpoint: midCheckpoint,
+		},
+		{
+			key: "cursor-midrange",
+			filter: { plan: { plan_id: BENCH_PAID_PRODUCT_ID } },
+			cursor: "cus_bench_3500001",
+		},
+	];
+
+	let failures = 0;
+	for (const shape of shapes) {
+		const baseArgs = {
+			orgId: ctx.org.id,
+			env: ctx.env,
+			filter: shape.filter,
+			ctx: { features: ctx.features },
+			checkpoint: shape.checkpoint,
+			afterInternalId: shape.cursor,
+		};
+		const legacy = buildCustomerSelect(baseArgs);
+		const paged = buildCustomerSelect({ ...baseArgs, limit: FULL_SET_LIMIT });
+
+		const started = Date.now();
+		const [row] = (await db.execute(sql`
+			WITH legacy AS (${legacy}), paged AS (${paged})
+			SELECT
+				(SELECT COUNT(*) FROM legacy)::bigint AS legacy_count,
+				(SELECT COUNT(*) FROM paged)::bigint AS paged_count,
+				(SELECT COUNT(*) FROM (
+					SELECT internal_id FROM legacy EXCEPT ALL SELECT internal_id FROM paged
+				) d)::bigint AS missing_from_paged,
+				(SELECT COUNT(*) FROM (
+					SELECT internal_id FROM paged EXCEPT ALL SELECT internal_id FROM legacy
+				) d)::bigint AS extra_in_paged
+		`)) as Record<string, string>[];
+
+		const ok =
+			row.legacy_count === row.paged_count &&
+			Number(row.missing_from_paged) === 0 &&
+			Number(row.extra_in_paged) === 0;
+		if (!ok) failures++;
+		console.log(
+			`${ok ? "OK  " : "FAIL"} ${shape.key}: legacy=${Number(row.legacy_count).toLocaleString()} paged=${Number(row.paged_count).toLocaleString()} missing=${row.missing_from_paged} extra=${row.extra_in_paged} (${Date.now() - started}ms)`,
+		);
+	}
+
+	// Page-iteration integrity: full pages until the set is exhausted, ids
+	// strictly descending across page boundaries, total == full-set count.
+	console.log("── page iteration (selective, 5k pages) ─────────");
+	let cursor: string | undefined;
+	let total = 0;
+	let pages = 0;
+	let previousLast: string | undefined;
+	let integrityOk = true;
+	while (true) {
+		const rows = (await db.execute(
+			buildCustomerSelect({
+				orgId: ctx.org.id,
+				env: ctx.env,
+				filter: { plan: { plan_id: BENCH_PAID_PRODUCT_ID } },
+				ctx: { features: ctx.features },
+				limit: PAGE_SIZE,
+				afterInternalId: cursor,
+			}),
+		)) as { internal_id: string }[];
+		if (rows.length === 0) break;
+		pages++;
+		total += rows.length;
+		if (previousLast !== undefined && rows[0].internal_id >= previousLast) {
+			integrityOk = false;
+			console.log(`FAIL page ${pages}: first id not below previous page's last`);
+		}
+		if (rows.length < PAGE_SIZE) {
+			console.log(`final page ${pages}: ${rows.length} rows`);
+			cursor = rows[rows.length - 1].internal_id;
+			previousLast = cursor;
+			// A short page must mean exhaustion — verified by the loop's next
+			// iteration returning zero rows.
+			continue;
+		}
+		cursor = rows[rows.length - 1].internal_id;
+		previousLast = cursor;
+	}
+	const expectedTotal = 600_000;
+	const totalOk = total === expectedTotal;
+	if (!totalOk || !integrityOk) failures++;
+	console.log(
+		`${totalOk && integrityOk ? "OK  " : "FAIL"} iterated ${pages} pages, ${total.toLocaleString()} customers (expected ${expectedTotal.toLocaleString()})`,
+	);
+
+	console.log(failures === 0 ? "\nALL PARITY CHECKS PASSED" : `\n${failures} FAILURES`);
+	process.exit(failures === 0 ? 0 : 1);
+};
+
+await main();

--- a/server/tests/perf/batch-migrations/probes/probeMirIndexes.ts
+++ b/server/tests/perf/batch-migrations/probes/probeMirIndexes.ts
@@ -1,0 +1,13 @@
+/** Read-only: list indexes present on migration_item_runs. */
+import { sql } from "drizzle-orm";
+import { initDrizzle } from "@/db/initDrizzle.js";
+import { assertBenchDatabaseSafe } from "../utils/benchContext.js";
+
+assertBenchDatabaseSafe();
+const { db } = initDrizzle();
+const rows = (await db.execute(sql`
+	SELECT indexname, indexdef FROM pg_indexes
+	WHERE tablename = 'migration_item_runs'
+`)) as { indexname: string; indexdef: string }[];
+for (const row of rows) console.log(`${row.indexname}\n  ${row.indexdef}`);
+process.exit(0);

--- a/server/tests/perf/batch-migrations/probes/probePreviewParity.ts
+++ b/server/tests/perf/batch-migrations/probes/probePreviewParity.ts
@@ -1,0 +1,118 @@
+/**
+ * U4 verification: execution-view (mode "all") union — membership parity vs
+ * legacy semantics (filter-set ∪ processed⋈customers), plus page/count
+ * timings. Includes the disjoint case: processed ids OUTSIDE the filter set.
+ *
+ *   bun tests/perf/batch-migrations/probes/probePreviewParity.ts
+ */
+
+import type { CustomerFilter } from "@autumn/shared";
+import { sql } from "drizzle-orm";
+import {
+	buildCustomerSelect,
+	buildProcessedPreviewCount,
+	buildProcessedPreviewSelect,
+} from "@/internal/migrations/v2/filters/customers/buildCustomerSelect.js";
+import {
+	BENCH_FREE_BARE_PRODUCT_ID,
+	BENCH_PAID_PRODUCT_ID,
+	getBenchContext,
+} from "../utils/benchContext.js";
+
+const MID_MIGRATION_ID = "probe_mig_mid";
+const FULL_SET_LIMIT = 10_000_000;
+
+const main = async () => {
+	const { ctx } = await getBenchContext();
+	const { db } = ctx;
+
+	const shapes: { key: string; filter: CustomerFilter; expected: string }[] = [
+		{
+			key: "overlap (paid ∪ processed⊆paid)",
+			filter: { plan: { plan_id: BENCH_PAID_PRODUCT_ID } },
+			expected: "600,000",
+		},
+		{
+			key: "disjoint (free-bare ∪ processed outside filter)",
+			filter: { plan: { plan_id: BENCH_FREE_BARE_PRODUCT_ID } },
+			expected: "1,300,000",
+		},
+	];
+
+	let failures = 0;
+	for (const shape of shapes) {
+		const baseArgs = {
+			orgId: ctx.org.id,
+			env: ctx.env,
+			filter: shape.filter,
+			ctx: { features: ctx.features },
+			includeProcessed: { migrationInternalId: MID_MIGRATION_ID },
+		};
+
+		// Ground truth: legacy filter select (no limit) ∪ processed⋈customers.
+		const legacyFilterSelect = buildCustomerSelect({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			filter: shape.filter,
+			ctx: { features: ctx.features },
+		});
+		const truthUnion = sql`
+			SELECT l.internal_id FROM (${legacyFilterSelect}) l
+			UNION
+			SELECT c.internal_id FROM customers c
+			WHERE c.org_id = ${ctx.org.id} AND c.env = ${ctx.env}
+				AND c.internal_id IN (
+					SELECT mir.item_id FROM migration_item_runs mir
+					WHERE mir.migration_internal_id = ${MID_MIGRATION_ID}
+						AND mir.item_kind = 'customer' AND mir.dry_run = false
+				)
+		`;
+		const newFullSet = buildProcessedPreviewSelect({
+			...baseArgs,
+			limit: FULL_SET_LIMIT,
+		});
+
+		const [diff] = (await db.execute(sql`
+			WITH truth AS (${truthUnion}), paged AS (SELECT internal_id FROM (${newFullSet}) p)
+			SELECT
+				(SELECT COUNT(*) FROM truth)::bigint AS truth_count,
+				(SELECT COUNT(*) FROM paged)::bigint AS paged_count,
+				(SELECT COUNT(*) FROM (
+					SELECT internal_id FROM truth EXCEPT ALL SELECT internal_id FROM paged
+				) d)::bigint AS missing,
+				(SELECT COUNT(*) FROM (
+					SELECT internal_id FROM paged EXCEPT ALL SELECT internal_id FROM truth
+				) d)::bigint AS extra
+		`)) as Record<string, string>[];
+
+		const membershipOk =
+			diff.truth_count === diff.paged_count &&
+			Number(diff.missing) === 0 &&
+			Number(diff.extra) === 0;
+
+		const pageStarted = Date.now();
+		const pageRows = (await db.execute(
+			buildProcessedPreviewSelect({ ...baseArgs, limit: 51 }),
+		)) as unknown[];
+		const pageMs = Date.now() - pageStarted;
+
+		const countStarted = Date.now();
+		const [countRow] = (await db.execute(
+			buildProcessedPreviewCount(baseArgs),
+		)) as { count: string }[];
+		const countMs = Date.now() - countStarted;
+
+		const countOk =
+			Number(countRow.count).toLocaleString() === shape.expected &&
+			countRow.count === diff.truth_count;
+		if (!membershipOk || !countOk) failures++;
+		console.log(
+			`${membershipOk && countOk ? "OK  " : "FAIL"} ${shape.key}: union=${Number(diff.truth_count).toLocaleString()} missing=${diff.missing} extra=${diff.extra} | page(51)=${pageRows.length} rows in ${pageMs}ms | count in ${countMs}ms`,
+		);
+	}
+
+	console.log(failures === 0 ? "\nALL PREVIEW CHECKS PASSED" : `\n${failures} FAILURES`);
+	process.exit(failures === 0 ? 0 : 1);
+};
+
+await main();

--- a/server/tests/perf/batch-migrations/probes/probeStreamingSpike.ts
+++ b/server/tests/perf/batch-migrations/probes/probeStreamingSpike.ts
@@ -1,0 +1,246 @@
+/**
+ * U2 spike: validates the streaming candidate-source shape against the new
+ * idx_customer_products_product_customer_c index BEFORE changing the
+ * compiler. Read-only. For each scenario: EXPLAIN, timed runs, and row
+ * parity (same ids, same order) vs today's buildCustomerSelect.
+ *
+ *   bun tests/perf/batch-migrations/probes/probeStreamingSpike.ts
+ */
+
+import { MigrationItemRunStatus } from "@autumn/shared";
+import { type SQL, sql } from "drizzle-orm";
+import { buildCustomerSelect } from "@/internal/migrations/v2/filters/customers/buildCustomerSelect.js";
+import type { CustomerCheckpointExclusion } from "@/internal/migrations/v2/filters/customers/buildCustomerSelect.js";
+import {
+	BENCH_FREE_PRODUCT_ID,
+	BENCH_PAID_PRODUCT_ID,
+	getBenchContext,
+} from "../utils/benchContext.js";
+
+const PAGE_SIZE = 5000;
+const MID_MIGRATION_ID = "probe_mig_mid";
+const MID_CURSOR = "cus_bench_3500001";
+
+type PlanNode = {
+	"Node Type": string;
+	"Relation Name"?: string;
+	"Index Name"?: string;
+	"Actual Rows"?: number;
+	"Actual Loops"?: number;
+	"Actual Total Time"?: number;
+	"Sort Method"?: string;
+	"Disk Usage"?: number;
+	Plans?: PlanNode[];
+};
+
+const walkOffenders = (node: PlanNode, out: string[]) => {
+	const rows = (node["Actual Rows"] ?? 0) * (node["Actual Loops"] ?? 1);
+	const ms = Math.round(node["Actual Total Time"] ?? 0);
+	const label = `${node["Node Type"]}${node["Relation Name"] ? ` on ${node["Relation Name"]}` : ""}${node["Index Name"] ? ` [${node["Index Name"]}]` : ""}`;
+	if (node["Node Type"].includes("Seq Scan")) {
+		out.push(`SEQ   ${label}: ${rows.toLocaleString()} rows, ${ms}ms`);
+	} else if (node["Disk Usage"] || node["Sort Method"]?.includes("external")) {
+		out.push(`DISK  ${label}: ${rows.toLocaleString()} rows, ${ms}ms`);
+	} else if (rows >= 50_000) {
+		out.push(`BIG   ${label}: ${rows.toLocaleString()} rows, ${ms}ms`);
+	}
+	for (const child of node.Plans ?? []) walkOffenders(child, out);
+};
+
+const main = async () => {
+	const { ctx } = await getBenchContext();
+	const { db } = ctx;
+
+	const streamingSelect = ({
+		planIds,
+		cursor,
+		checkpointMigrationId,
+	}: {
+		planIds: string[];
+		cursor?: string;
+		checkpointMigrationId?: string;
+	}): SQL => {
+		const planIdList = sql.join(
+			planIds.map((id) => sql`${id}`),
+			sql`, `,
+		);
+		const cursorFilter = cursor
+			? sql`AND cp.internal_customer_id COLLATE "C" < ${cursor}`
+			: sql``;
+		// The checkpoint anti-join keys on the customer internal id, which cp
+		// already has — so it can live INSIDE the inner query, making the inner
+		// LIMIT legal and the ordered index walk reachable.
+		const checkpointFilter = checkpointMigrationId
+			? sql`AND NOT EXISTS (
+					SELECT 1 FROM migration_item_runs mir
+					WHERE mir.migration_internal_id = ${checkpointMigrationId}
+						AND mir.dry_run = false
+						AND mir.item_kind = 'customer'
+						AND mir.item_id = cp.internal_customer_id
+						AND mir.status IN (${MigrationItemRunStatus.Succeeded}, ${MigrationItemRunStatus.Skipped}, ${MigrationItemRunStatus.Failed})
+				)`
+			: sql``;
+
+		// One ordered index walk per plan product (equality pin → the walk is
+		// order-guaranteed), each limited; merging k×page rows is trivial.
+		return sql`
+			SELECT c.internal_id, c.id, c.name, c.email
+			FROM (
+				SELECT DISTINCT ON (walk.internal_customer_id COLLATE "C")
+					walk.internal_customer_id
+				FROM (
+					SELECT p.internal_id FROM products p
+					WHERE p.org_id = ${ctx.org.id} AND p.env = ${ctx.env}
+						AND p.id IN (${planIdList})
+				) plans
+				CROSS JOIN LATERAL (
+					SELECT cp.internal_customer_id
+					FROM customer_products cp
+					WHERE cp.internal_product_id = plans.internal_id
+						AND cp.status IN ('active', 'past_due', 'scheduled')
+						${cursorFilter}
+						${checkpointFilter}
+					ORDER BY cp.internal_customer_id COLLATE "C" DESC
+					LIMIT ${PAGE_SIZE}
+				) walk
+				ORDER BY walk.internal_customer_id COLLATE "C" DESC
+				LIMIT ${PAGE_SIZE}
+			) m
+			JOIN customers c ON c.internal_id = m.internal_customer_id
+			WHERE c.org_id = ${ctx.org.id} AND c.env = ${ctx.env}
+			ORDER BY m.internal_customer_id COLLATE "C" DESC
+		`;
+	};
+
+	const scenarios: {
+		key: string;
+		build: () => SQL;
+		parity?: () => SQL;
+	}[] = [
+		{
+			key: "stream-selective",
+			build: () => streamingSelect({ planIds: [BENCH_PAID_PRODUCT_ID] }),
+			parity: () =>
+				buildCustomerSelect({
+					orgId: ctx.org.id,
+					env: ctx.env,
+					filter: { plan: { plan_id: BENCH_PAID_PRODUCT_ID } },
+					ctx: { features: ctx.features },
+					limit: PAGE_SIZE,
+				}),
+		},
+		{
+			key: "stream-dominant",
+			build: () => streamingSelect({ planIds: [BENCH_FREE_PRODUCT_ID] }),
+			parity: () =>
+				buildCustomerSelect({
+					orgId: ctx.org.id,
+					env: ctx.env,
+					filter: { plan: { plan_id: BENCH_FREE_PRODUCT_ID } },
+					ctx: { features: ctx.features },
+					limit: PAGE_SIZE,
+				}),
+		},
+		{
+			key: "stream-multiplan",
+			build: () =>
+				streamingSelect({
+					planIds: [BENCH_PAID_PRODUCT_ID, BENCH_FREE_PRODUCT_ID],
+				}),
+		},
+		{
+			key: "stream-midrun-cursor",
+			build: () =>
+				streamingSelect({
+					planIds: [BENCH_PAID_PRODUCT_ID],
+					cursor: MID_CURSOR,
+					checkpointMigrationId: MID_MIGRATION_ID,
+				}),
+			parity: () =>
+				buildCustomerSelect({
+					orgId: ctx.org.id,
+					env: ctx.env,
+					filter: { plan: { plan_id: BENCH_PAID_PRODUCT_ID } },
+					ctx: { features: ctx.features },
+					checkpoint: midCheckpoint,
+					limit: PAGE_SIZE,
+					afterInternalId: MID_CURSOR,
+				}),
+		},
+		{
+			key: "stream-deep-cursor",
+			build: () =>
+				streamingSelect({
+					planIds: [BENCH_FREE_PRODUCT_ID],
+					cursor: "cus_bench_1100000",
+				}),
+			parity: () =>
+				buildCustomerSelect({
+					orgId: ctx.org.id,
+					env: ctx.env,
+					filter: { plan: { plan_id: BENCH_FREE_PRODUCT_ID } },
+					ctx: { features: ctx.features },
+					limit: PAGE_SIZE,
+					afterInternalId: "cus_bench_1100000",
+				}),
+		},
+	];
+
+	const midCheckpoint: CustomerCheckpointExclusion = {
+		migrationInternalId: MID_MIGRATION_ID,
+		migrationRunId: "probe_run_spike",
+		dryRun: false,
+		excludedStatuses: [
+			MigrationItemRunStatus.Succeeded,
+			MigrationItemRunStatus.Skipped,
+			MigrationItemRunStatus.Failed,
+		],
+	};
+
+	for (const scenario of scenarios) {
+		console.log(`\n■ ${scenario.key}`);
+		const planRows = (await db.execute(
+			sql`EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) ${scenario.build()}`,
+		)) as Record<string, unknown>[];
+		const raw = Object.values(planRows[0])[0];
+		const parsed = (typeof raw === "string" ? JSON.parse(raw) : raw) as {
+			Plan: PlanNode;
+			"Execution Time": number;
+		}[];
+		console.log(`  explain: ${Math.round(parsed[0]["Execution Time"])}ms`);
+		const offenders: string[] = [];
+		walkOffenders(parsed[0].Plan, offenders);
+		for (const offender of offenders) console.log(`  ${offender}`);
+		if (offenders.length === 0) console.log("  (no offenders — pipelined)");
+
+		for (let run = 1; run <= 2; run++) {
+			const started = Date.now();
+			const rows = (await db.execute(scenario.build())) as {
+				internal_id: string;
+			}[];
+			console.log(
+				`  timed ${run}: ${rows.length.toLocaleString()} rows in ${Date.now() - started}ms (${rows[0]?.internal_id} .. ${rows[rows.length - 1]?.internal_id})`,
+			);
+		}
+
+		if (scenario.parity) {
+			const [newRows, oldRows] = (await Promise.all([
+				db.execute(scenario.build()),
+				db.execute(scenario.parity()),
+			])) as { internal_id: string }[][];
+			const same =
+				newRows.length === oldRows.length &&
+				newRows.every(
+					(row, index) => row.internal_id === oldRows[index].internal_id,
+				);
+			console.log(
+				same
+					? `  parity: OK (${newRows.length.toLocaleString()} rows identical + same order)`
+					: `  parity: MISMATCH new=${newRows.length} old=${oldRows.length} firstNew=${newRows[0]?.internal_id} firstOld=${oldRows[0]?.internal_id}`,
+			);
+		}
+	}
+	process.exit(0);
+};
+
+await main();

--- a/server/tests/perf/batch-migrations/seedBatchBench.ts
+++ b/server/tests/perf/batch-migrations/seedBatchBench.ts
@@ -1,0 +1,319 @@
+/**
+ * Seeds the bench org with N customers spread across every anchor-ladder
+ * shape, so each migration query path can be benchmarked in isolation via
+ * its plan_filter:
+ *
+ *   shape     %   plan              rung exercised
+ *   sibling   55  bench-free        sibling cusEnt anchor (monthly Messages)
+ *   freeBare  15  bench-free-bare   starts_at fallback
+ *   cpAnchor  10  bench-free-bare   cp.billing_cycle_anchor
+ *   paidSub   10  bench-paid        subscriptions.billing_cycle_anchor_seconds
+ *                                   (mock sub row + $20/mo cusPrice, no Stripe)
+ *   paidNow    5  bench-paid        paid-recurring "now" fallback (cusPrice only)
+ *   custom     5  bench-free        is_custom → skipped partition path
+ *
+ * Pure server-side generate_series inserts — no API/Stripe calls. Reruns are
+ * resumable (ON CONFLICT DO NOTHING).
+ *
+ *   bun tests/perf/batch-migrations/seedBatchBench.ts --customers 4000000
+ *   bun tests/perf/batch-migrations/seedBatchBench.ts --reset
+ *
+ * For a full reset at 4M scale, prefer re-branching the Neon bench branch —
+ * --reset issues row DELETEs and is only sensible for small seeds.
+ */
+
+import { CusProductStatus } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { type SQL, sql } from "drizzle-orm";
+import {
+	BENCH_CUSTOMER_ENTITLEMENT_PREFIX,
+	BENCH_CUSTOMER_ID_PREFIX,
+	BENCH_CUSTOMER_PRICE_PREFIX,
+	BENCH_CUSTOMER_PRODUCT_PREFIX,
+	BENCH_ENV,
+	BENCH_FREE_BARE_PRODUCT_ID,
+	BENCH_FREE_PRODUCT_ID,
+	BENCH_INTERNAL_CUSTOMER_PREFIX,
+	BENCH_PAID_PRODUCT_ID,
+	BENCH_STRIPE_SUBSCRIPTION_PREFIX,
+	BENCH_SUBSCRIPTION_PREFIX,
+	type BenchContext,
+	getBenchContext,
+} from "./utils/benchContext.js";
+
+const DAY_MS = 86_400_000;
+const APPROX_MONTH_MS = 30 * DAY_MS;
+
+type BenchShape = {
+	key: string;
+	fraction: number;
+	productId: string;
+	productInternalId: (products: BenchContext["benchProducts"]) => string;
+	withSiblingEntitlement?: boolean;
+	withCpAnchor?: boolean;
+	withCustomerPrice?: boolean;
+	withSubscription?: boolean;
+	isCustom?: boolean;
+};
+
+const SHAPES: BenchShape[] = [
+	{
+		key: "sibling",
+		fraction: 0.55,
+		productId: BENCH_FREE_PRODUCT_ID,
+		productInternalId: (products) => products.free.internalId,
+		withSiblingEntitlement: true,
+	},
+	{
+		key: "freeBare",
+		fraction: 0.15,
+		productId: BENCH_FREE_BARE_PRODUCT_ID,
+		productInternalId: (products) => products.freeBare.internalId,
+	},
+	{
+		key: "cpAnchor",
+		fraction: 0.1,
+		productId: BENCH_FREE_BARE_PRODUCT_ID,
+		productInternalId: (products) => products.freeBare.internalId,
+		withCpAnchor: true,
+	},
+	{
+		key: "paidSub",
+		fraction: 0.1,
+		productId: BENCH_PAID_PRODUCT_ID,
+		productInternalId: (products) => products.paid.internalId,
+		withCustomerPrice: true,
+		withSubscription: true,
+	},
+	{
+		key: "paidNow",
+		fraction: 0.05,
+		productId: BENCH_PAID_PRODUCT_ID,
+		productInternalId: (products) => products.paid.internalId,
+		withCustomerPrice: true,
+	},
+	{
+		key: "custom",
+		fraction: 0.05,
+		productId: BENCH_FREE_PRODUCT_ID,
+		productInternalId: (products) => products.free.internalId,
+		withSiblingEntitlement: true,
+		isCustom: true,
+	},
+];
+
+const parseArgs = () => {
+	const args = process.argv.slice(2);
+	const get = (flag: string) => {
+		const index = args.indexOf(flag);
+		return index === -1 ? undefined : args[index + 1];
+	};
+	return {
+		customers: Number(get("--customers") ?? 4_000_000),
+		chunk: Number(get("--chunk") ?? 200_000),
+		reset: args.includes("--reset"),
+	};
+};
+
+const seedShapeChunk = async ({
+	bench,
+	shape,
+	start,
+	end,
+	now,
+}: {
+	bench: BenchContext;
+	shape: BenchShape;
+	start: number;
+	end: number;
+	now: number;
+}) => {
+	const { ctx, org, benchProducts } = bench;
+	const { db } = ctx;
+
+	// starts_at spreads deterministically across the past year so anchors vary
+	// per customer; the same expression repeats across tables without joins.
+	const startsAt = sql`${now}::bigint - (i % 365) * ${DAY_MS}::bigint`;
+	const series = sql`GENERATE_SERIES(${start}::int, ${end}::int) AS g(i)`;
+
+	await db.execute(sql`
+		INSERT INTO customers (internal_id, id, org_id, env, created_at, name)
+		SELECT
+			${BENCH_INTERNAL_CUSTOMER_PREFIX} || i,
+			${BENCH_CUSTOMER_ID_PREFIX} || i,
+			${org.id},
+			${BENCH_ENV},
+			${startsAt},
+			'Bench ' || i
+		FROM ${series}
+		ON CONFLICT DO NOTHING
+	`);
+
+	const cpAnchorColumn: SQL = shape.withCpAnchor
+		? sql`${startsAt} + ${3 * DAY_MS}::bigint`
+		: sql`NULL`;
+	const subscriptionIdsColumn: SQL = shape.withSubscription
+		? sql`ARRAY[${BENCH_STRIPE_SUBSCRIPTION_PREFIX} || i]`
+		: sql`NULL`;
+
+	await db.execute(sql`
+		INSERT INTO customer_products (
+			id, internal_customer_id, internal_product_id, created_at, status,
+			starts_at, is_custom, product_id, customer_id, billing_cycle_anchor,
+			subscription_ids
+		)
+		SELECT
+			${BENCH_CUSTOMER_PRODUCT_PREFIX} || i,
+			${BENCH_INTERNAL_CUSTOMER_PREFIX} || i,
+			${shape.productInternalId(benchProducts)},
+			${startsAt},
+			${CusProductStatus.Active},
+			${startsAt},
+			${shape.isCustom === true},
+			${shape.productId},
+			${BENCH_CUSTOMER_ID_PREFIX} || i,
+			${cpAnchorColumn},
+			${subscriptionIdsColumn}
+		FROM ${series}
+		ON CONFLICT DO NOTHING
+	`);
+
+	if (shape.withSiblingEntitlement) {
+		await db.execute(sql`
+			INSERT INTO customer_entitlements (
+				id, customer_product_id, entitlement_id, internal_customer_id,
+				internal_entity_id, internal_feature_id, unlimited, balance,
+				created_at, reset_cycle_anchor, next_reset_at, usage_allowed,
+				separate_interval, adjustment, additional_balance, entities,
+				expires_at, cache_version, customer_id, feature_id, external_id
+			)
+			SELECT
+				${BENCH_CUSTOMER_ENTITLEMENT_PREFIX} || i,
+				${BENCH_CUSTOMER_PRODUCT_PREFIX} || i,
+				${benchProducts.free.entitlementId},
+				${BENCH_INTERNAL_CUSTOMER_PREFIX} || i,
+				NULL,
+				${benchProducts.messagesInternalFeatureId},
+				false,
+				100,
+				${startsAt},
+				${startsAt},
+				${startsAt} + ${APPROX_MONTH_MS}::bigint,
+				false,
+				false,
+				0,
+				0,
+				NULL,
+				NULL,
+				0,
+				${BENCH_CUSTOMER_ID_PREFIX} || i,
+				${TestFeature.Messages},
+				NULL
+			FROM ${series}
+			ON CONFLICT DO NOTHING
+		`);
+	}
+
+	if (shape.withCustomerPrice) {
+		await db.execute(sql`
+			INSERT INTO customer_prices (
+				id, created_at, price_id, internal_customer_id, customer_product_id
+			)
+			SELECT
+				${BENCH_CUSTOMER_PRICE_PREFIX} || i,
+				${startsAt},
+				${benchProducts.paid.priceId},
+				${BENCH_INTERNAL_CUSTOMER_PREFIX} || i,
+				${BENCH_CUSTOMER_PRODUCT_PREFIX} || i
+			FROM ${series}
+			ON CONFLICT DO NOTHING
+		`);
+	}
+
+	if (shape.withSubscription) {
+		await db.execute(sql`
+			INSERT INTO subscriptions (
+				id, org_id, stripe_id, created_at, env,
+				current_period_start, current_period_end, billing_cycle_anchor_seconds
+			)
+			SELECT
+				${BENCH_SUBSCRIPTION_PREFIX} || i,
+				${org.id},
+				${BENCH_STRIPE_SUBSCRIPTION_PREFIX} || i,
+				${startsAt},
+				${BENCH_ENV},
+				${now}::bigint - (i % 30) * ${DAY_MS}::bigint,
+				${now}::bigint - (i % 30) * ${DAY_MS}::bigint + ${APPROX_MONTH_MS}::bigint,
+				((${startsAt}) / 1000)::bigint
+			FROM ${series}
+			ON CONFLICT DO NOTHING
+		`);
+	}
+};
+
+const main = async () => {
+	const { customers, chunk, reset } = parseArgs();
+	const bench = await getBenchContext();
+	const { ctx, org } = bench;
+	const { db } = ctx;
+
+	if (reset) {
+		console.log(
+			"bench: deleting seeded rows (slow at large N — prefer re-branching)",
+		);
+		const internalPrefix = `${BENCH_INTERNAL_CUSTOMER_PREFIX}%`;
+		await db.execute(
+			sql`DELETE FROM customer_entitlements WHERE internal_customer_id LIKE ${internalPrefix}`,
+		);
+		await db.execute(
+			sql`DELETE FROM customer_prices WHERE internal_customer_id LIKE ${internalPrefix}`,
+		);
+		await db.execute(
+			sql`DELETE FROM customer_products WHERE internal_customer_id LIKE ${internalPrefix}`,
+		);
+		await db.execute(
+			sql`DELETE FROM subscriptions WHERE org_id = ${org.id} AND stripe_id LIKE ${`${BENCH_STRIPE_SUBSCRIPTION_PREFIX}%`}`,
+		);
+		await db.execute(
+			sql`DELETE FROM customers WHERE org_id = ${org.id} AND internal_id LIKE ${internalPrefix}`,
+		);
+		console.log("bench: reset done");
+		process.exit(0);
+	}
+
+	const now = Date.now();
+	console.log(
+		`bench: seeding ${customers.toLocaleString()} customers into org ${org.slug} (chunk ${chunk.toLocaleString()})`,
+	);
+
+	const startedAt = Date.now();
+	let rangeStart = 1;
+	for (const shape of SHAPES) {
+		const count = Math.floor(customers * shape.fraction);
+		const rangeEnd = rangeStart + count - 1;
+		console.log(
+			`bench: shape ${shape.key} → customers ${rangeStart.toLocaleString()}..${rangeEnd.toLocaleString()}`,
+		);
+
+		for (let start = rangeStart; start <= rangeEnd; start += chunk) {
+			const end = Math.min(start + chunk - 1, rangeEnd);
+			const chunkStartedAt = Date.now();
+			await seedShapeChunk({ bench, shape, start, end, now });
+			console.log(
+				`bench:   ${shape.key} ${end.toLocaleString()}/${rangeEnd.toLocaleString()} (${Date.now() - chunkStartedAt}ms)`,
+			);
+		}
+		rangeStart = rangeEnd + 1;
+	}
+
+	console.log("bench: running ANALYZE");
+	await db.execute(
+		sql`ANALYZE customers, customer_products, customer_entitlements, customer_prices, subscriptions`,
+	);
+
+	const totalSeconds = Math.round((Date.now() - startedAt) / 1000);
+	console.log(`bench: done in ${totalSeconds}s`);
+	process.exit(0);
+};
+
+await main();

--- a/server/tests/perf/batch-migrations/utils/benchContext.ts
+++ b/server/tests/perf/batch-migrations/utils/benchContext.ts
@@ -1,0 +1,271 @@
+import {
+	AllowanceType,
+	ApiVersionClass,
+	AppEnv,
+	AuthType,
+	BillingInterval,
+	EntInterval,
+	entitlements,
+	type Feature,
+	FixedPriceConfigSchema,
+	LATEST_VERSION,
+	type Organization,
+	prices,
+	products,
+} from "@autumn/shared";
+import { getFeatures, TestFeature } from "@tests/setup/v2Features.js";
+import { and, eq, sql } from "drizzle-orm";
+import { initDrizzle } from "@/db/initDrizzle.js";
+import { logger } from "@/external/logtail/logtailUtils.js";
+import { resolveRedisV2 } from "@/external/redis/resolveRedisV2.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { FeatureService } from "@/internal/features/FeatureService.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import { generateId } from "@/utils/genUtils.js";
+
+export const BENCH_ORG_SLUG = "batch-bench";
+export const BENCH_ENV = AppEnv.Sandbox;
+
+export const BENCH_FREE_PRODUCT_ID = "bench-free";
+export const BENCH_FREE_BARE_PRODUCT_ID = "bench-free-bare";
+export const BENCH_PAID_PRODUCT_ID = "bench-paid";
+
+export const BENCH_CUSTOMER_ID_PREFIX = "bench-c-";
+export const BENCH_INTERNAL_CUSTOMER_PREFIX = "cus_bench_";
+export const BENCH_CUSTOMER_PRODUCT_PREFIX = "cp_bench_";
+export const BENCH_CUSTOMER_ENTITLEMENT_PREFIX = "ce_bench_";
+export const BENCH_CUSTOMER_PRICE_PREFIX = "cpr_bench_";
+export const BENCH_SUBSCRIPTION_PREFIX = "sub_bench_";
+export const BENCH_STRIPE_SUBSCRIPTION_PREFIX = "sub_mock_bench_";
+
+/** Refuse to run against anything that smells like prod. */
+export const assertBenchDatabaseSafe = () => {
+	const url = process.env.DATABASE_URL ?? "";
+	if (url.includes("us-east-2")) {
+		throw new Error("bench: refusing to run against a prod DATABASE_URL");
+	}
+};
+
+export type BenchProducts = {
+	/** Free plan WITH a monthly Messages entitlement (sibling-anchor rung). */
+	free: { internalId: string; entitlementId: string };
+	/** Free plan with no entitlements (starts_at / cp-anchor rungs). */
+	freeBare: { internalId: string };
+	/** $20/mo base-price plan, no entitlements (sub-anchor / paid-now rungs). */
+	paid: { internalId: string; priceId: string };
+	messagesInternalFeatureId: string;
+};
+
+export type BenchContext = {
+	ctx: AutumnContext;
+	org: Organization;
+	benchProducts: BenchProducts;
+};
+
+/** The dashboard's org list is membership-driven; make the bench org
+ * browsable by adding every dev-DB user as an owner. */
+const ensureAllUsersAreMembers = async ({
+	db,
+	org,
+}: {
+	db: ReturnType<typeof initDrizzle>["db"];
+	org: Organization;
+}) => {
+	await db.execute(sql`
+		INSERT INTO member (id, organization_id, user_id, role, created_at)
+		SELECT 'mem_bench_' || u.id, ${org.id}, u.id, 'owner', NOW()
+		FROM "user" AS u
+		WHERE NOT EXISTS (
+			SELECT 1 FROM member AS m
+			WHERE m.organization_id = ${org.id} AND m.user_id = u.id
+		)
+	`);
+};
+
+const ensureFeatures = async ({
+	db,
+	org,
+}: {
+	db: ReturnType<typeof initDrizzle>["db"];
+	org: Organization;
+}): Promise<Feature[]> => {
+	const existing = await FeatureService.list({
+		db,
+		orgId: org.id,
+		env: BENCH_ENV,
+	});
+	if (existing.length > 0) return existing;
+
+	await FeatureService.insert({
+		db,
+		data: Object.values(getFeatures({ orgId: org.id })),
+		logger,
+	});
+	return FeatureService.list({ db, orgId: org.id, env: BENCH_ENV });
+};
+
+const ensureProduct = async ({
+	db,
+	org,
+	productId,
+	name,
+}: {
+	db: ReturnType<typeof initDrizzle>["db"];
+	org: Organization;
+	productId: string;
+	name: string;
+}) => {
+	const [existing] = await db
+		.select()
+		.from(products)
+		.where(
+			and(
+				eq(products.org_id, org.id),
+				eq(products.env, BENCH_ENV),
+				eq(products.id, productId),
+			),
+		)
+		.limit(1);
+	if (existing) return existing.internal_id;
+
+	const internalId = generateId("prod");
+	await db.insert(products).values({
+		internal_id: internalId,
+		id: productId,
+		org_id: org.id,
+		env: BENCH_ENV,
+		name,
+		created_at: Date.now(),
+		version: 1,
+	});
+	return internalId;
+};
+
+const ensureBenchProducts = async ({
+	db,
+	org,
+	features,
+}: {
+	db: ReturnType<typeof initDrizzle>["db"];
+	org: Organization;
+	features: Feature[];
+}): Promise<BenchProducts> => {
+	const messagesFeature = features.find(
+		(feature) => feature.id === TestFeature.Messages,
+	);
+	if (!messagesFeature)
+		throw new Error("bench: messages feature missing after seed");
+
+	const freeInternalId = await ensureProduct({
+		db,
+		org,
+		productId: BENCH_FREE_PRODUCT_ID,
+		name: "Bench Free",
+	});
+	const freeBareInternalId = await ensureProduct({
+		db,
+		org,
+		productId: BENCH_FREE_BARE_PRODUCT_ID,
+		name: "Bench Free Bare",
+	});
+	const paidInternalId = await ensureProduct({
+		db,
+		org,
+		productId: BENCH_PAID_PRODUCT_ID,
+		name: "Bench Paid",
+	});
+
+	const [existingEntitlement] = await db
+		.select()
+		.from(entitlements)
+		.where(eq(entitlements.internal_product_id, freeInternalId))
+		.limit(1);
+	let entitlementId = existingEntitlement?.id;
+	if (!entitlementId) {
+		entitlementId = generateId("ent");
+		await db.insert(entitlements).values({
+			id: entitlementId,
+			created_at: Date.now(),
+			org_id: org.id,
+			internal_product_id: freeInternalId,
+			internal_feature_id: messagesFeature.internal_id,
+			feature_id: messagesFeature.id,
+			allowance_type: AllowanceType.Fixed,
+			allowance: 100,
+			interval: EntInterval.Month,
+			interval_count: 1,
+		});
+	}
+
+	const [existingPrice] = await db
+		.select()
+		.from(prices)
+		.where(eq(prices.internal_product_id, paidInternalId))
+		.limit(1);
+	let priceId = existingPrice?.id;
+	if (!priceId) {
+		priceId = generateId("pr");
+		await db.insert(prices).values({
+			id: priceId,
+			org_id: org.id,
+			internal_product_id: paidInternalId,
+			created_at: Date.now(),
+			config: FixedPriceConfigSchema.parse({
+				type: "fixed",
+				amount: 20,
+				interval: BillingInterval.Month,
+				interval_count: 1,
+			}),
+		});
+	}
+
+	return {
+		free: { internalId: freeInternalId, entitlementId },
+		freeBare: { internalId: freeBareInternalId },
+		paid: { internalId: paidInternalId, priceId },
+		messagesInternalFeatureId: messagesFeature.internal_id,
+	};
+};
+
+/** Resolve-or-create the dedicated bench org (never the shared test org),
+ * its features, and the three bench plans covering every anchor-ladder rung. */
+export const getBenchContext = async (): Promise<BenchContext> => {
+	assertBenchDatabaseSafe();
+	const { db } = initDrizzle();
+
+	let org = await OrgService.getBySlug({ db, slug: BENCH_ORG_SLUG });
+	if (!org) {
+		org = await OrgService.create({
+			db,
+			id: generateId("org"),
+			slug: BENCH_ORG_SLUG,
+			name: "Batch Migrations Bench",
+			createdBy: "batch-bench-seed",
+		});
+	}
+
+	await ensureAllUsersAreMembers({ db, org });
+	const features = await ensureFeatures({ db, org });
+	const benchProducts = await ensureBenchProducts({ db, org, features });
+
+	const ctx: AutumnContext = {
+		org,
+		env: BENCH_ENV,
+		features,
+		db,
+		dbGeneral: db,
+		logger,
+		redisV2: resolveRedisV2(),
+		id: generateId("bench"),
+		isPublic: false,
+		authType: AuthType.Unknown,
+		apiVersion: new ApiVersionClass(LATEST_VERSION),
+		timestamp: Date.now(),
+		scopes: [],
+		skipCache: false,
+		expand: [],
+		extraLogs: {},
+	};
+
+	return { ctx, org, benchProducts };
+};

--- a/server/tests/unit/compiler/customer/compose-page.test.ts
+++ b/server/tests/unit/compiler/customer/compose-page.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, test } from "bun:test";
+import type { Feature } from "@autumn/shared";
+import {
+	composeCustomerCount,
+	composeCustomerPage,
+	type CustomerPagePredicate,
+} from "@autumn/shared/api/migrations/filters/planner/composeCustomerPage.js";
+import {
+	composeCustomerPreviewCount,
+	composeCustomerPreviewPage,
+} from "@autumn/shared/api/migrations/filters/planner/composeCustomerPreview.js";
+import type { CustomerFilter } from "@autumn/shared/api/migrations/filters/customerFilter.js";
+import { contexts } from "@tests/utils/fixtures/db/contexts";
+
+const features: Feature[] = [
+	{ id: "credits", internal_id: "fea_credits_internal" } as Feature,
+];
+
+const ctx = contexts.create({ features });
+const ambient = { orgId: "org_test", env: "live" };
+const RELEVANT_STATUS_PARAMS = ["active", "past_due", "scheduled"];
+
+const normalize = (sql: string) => sql.replace(/\s+/g, " ").trim();
+
+const compose = ({
+	filter,
+	cursor,
+	predicates,
+}: {
+	filter: CustomerFilter;
+	cursor?: string;
+	predicates?: CustomerPagePredicate[];
+}) =>
+	composeCustomerPage({
+		filter,
+		ctx: { features: ctx.features },
+		ambient,
+		limit: 5000,
+		cursor,
+		predicates,
+	});
+
+/** The lateral walk section (between CROSS JOIN LATERAL and `) walk`). */
+const walkSection = (sql: string) => {
+	const normalized = normalize(sql);
+	const start = normalized.indexOf("CROSS JOIN LATERAL");
+	const end = normalized.indexOf(") walk ORDER BY");
+	expect(start).toBeGreaterThan(-1);
+	expect(end).toBeGreaterThan(start);
+	return normalized.slice(start, end);
+};
+
+const checkpointPredicate: CustomerPagePredicate = {
+	build: (keyColumn) => ({
+		sql: `NOT EXISTS (SELECT 1 FROM migration_item_runs mir WHERE mir.item_id = ${keyColumn})`,
+		params: [],
+	}),
+};
+
+describe("composeCustomerPage", () => {
+	test("consumed plan filter drives a pure cp walk — no customers join inside", () => {
+		const page = compose({
+			filter: { plan: { plan_id: "enterprise" } },
+			cursor: "cus_after",
+			predicates: [checkpointPredicate],
+		});
+		const walk = walkSection(page.sql);
+
+		// Everything filters INSIDE the walk, so LIMIT counts matches.
+		expect(walk).toContain('cp.internal_customer_id COLLATE "C" < ?');
+		expect(walk).toContain("mir.item_id = cp.internal_customer_id");
+		expect(walk).toContain("LIMIT ?");
+		expect(walk).not.toContain("JOIN customers");
+		expect(normalize(page.sql)).toContain(
+			"JOIN customers c ON c.internal_id = m.internal_customer_id",
+		);
+		expect(page.params).toEqual([
+			"org_test",
+			"live",
+			"enterprise",
+			...RELEVANT_STATUS_PARAMS,
+			"cus_after",
+			5000,
+			5000,
+			"org_test",
+			"live",
+		]);
+	});
+
+	test("consumed extras (custom/version) filter inside the walk", () => {
+		const page = compose({
+			filter: { plan: { plan_id: "enterprise", version: 2, custom: false } },
+		});
+		const normalized = normalize(page.sql);
+		const walk = walkSection(page.sql);
+
+		expect(normalized).toContain("AND p.id = ? AND p.version = ?");
+		expect(walk).toContain("cp.is_custom = ?");
+		expect(walk).not.toContain("JOIN customers");
+	});
+
+	test("non-consumable residual joins customers inside the walk and filters pre-limit", () => {
+		const page = compose({
+			filter: { plan: { plan_id: "enterprise", paid: true } },
+		});
+		const walk = walkSection(page.sql);
+
+		expect(walk).toContain(
+			"JOIN customers c ON c.internal_id = cp.internal_customer_id",
+		);
+		// The full quantifier re-proof (EXISTS over customer_prices) sits inside
+		// the walk, BEFORE its ORDER BY/LIMIT — pages stay exact.
+		expect(walk).toContain("customer_prices cpr");
+		const limitIndex = walk.indexOf("LIMIT ?");
+		const residualIndex = walk.indexOf("customer_prices cpr");
+		expect(residualIndex).toBeGreaterThan(-1);
+		expect(residualIndex).toBeLessThan(limitIndex);
+	});
+
+	test("customer-level residual filters inside the walk", () => {
+		const page = compose({
+			filter: { customer_id: "cus_123", plan: { plan_id: "enterprise" } },
+		});
+		const walk = walkSection(page.sql);
+
+		expect(walk).toContain("JOIN customers c");
+		expect(walk).toContain("c.id = ?");
+	});
+
+	test("needsCustomerAlias predicate forces the walk customers join", () => {
+		const page = compose({
+			filter: { plan: { plan_id: "enterprise" } },
+			predicates: [
+				{
+					needsCustomerAlias: true,
+					build: () => ({ sql: "c.name ILIKE ?", params: ["%acme%"] }),
+				},
+			],
+		});
+		const walk = walkSection(page.sql);
+
+		expect(walk).toContain("JOIN customers c");
+		expect(walk).toContain("c.name ILIKE ?");
+	});
+
+	test("filters without a plan access path walk customers directly", () => {
+		const page = compose({
+			filter: { customer_id: "cus_123" },
+			cursor: "cus_after",
+			predicates: [checkpointPredicate],
+		});
+		const normalized = normalize(page.sql);
+
+		expect(normalized).not.toContain("CROSS JOIN LATERAL");
+		expect(normalized).toContain("FROM customers c");
+		expect(normalized).toContain("AND c.internal_id < ?");
+		expect(normalized).toContain("mir.item_id = c.internal_id");
+		expect(normalized).toContain("ORDER BY c.internal_id DESC LIMIT ?");
+		expect(page.params).toEqual([
+			"org_test",
+			"live",
+			"cus_123",
+			"cus_after",
+			5000,
+			"org_test",
+			"live",
+		]);
+	});
+
+	test("count: plan-level-only filters count off customer_products alone", () => {
+		const count = composeCustomerCount({
+			filter: { plan: { plan_id: "enterprise", custom: false } },
+			ctx: { features: ctx.features },
+			ambient,
+			predicates: [checkpointPredicate],
+		});
+
+		const normalized = normalize(count.sql);
+		expect(normalized).toContain("FROM customer_products cp");
+		expect(normalized).toContain("cp.is_custom = ?");
+		expect(normalized).toContain("mir.item_id = cp.internal_customer_id");
+		expect(normalized).toContain("GROUP BY cp.internal_customer_id");
+		expect(normalized).not.toContain("JOIN customers");
+		expect(normalized).not.toContain("FROM customers");
+	});
+
+	test("count: residuals and customer-row predicates take the batch-hash path", () => {
+		const withResidual = composeCustomerCount({
+			filter: { plan: { plan_id: "enterprise", paid: true } },
+			ctx: { features: ctx.features },
+			ambient,
+		});
+		expect(normalize(withResidual.sql)).toContain(
+			"WITH plan_products AS MATERIALIZED",
+		);
+		expect(normalize(withResidual.sql)).toContain("customer_prices cpr");
+
+		const withCustomerPredicate = composeCustomerCount({
+			filter: { plan: { plan_id: "enterprise" } },
+			ctx: { features: ctx.features },
+			ambient,
+			predicates: [
+				{
+					needsCustomerAlias: true,
+					build: () => ({ sql: "c.name ILIKE ?", params: ["%x%"] }),
+				},
+			],
+		});
+		expect(normalize(withCustomerPredicate.sql)).toContain(
+			"WITH plan_products AS MATERIALIZED",
+		);
+		expect(normalize(withCustomerPredicate.sql)).toContain("c.name ILIKE ?");
+
+		const fallbackFilter = composeCustomerCount({
+			filter: { customer_id: "cus_123" },
+			ctx: { features: ctx.features },
+			ambient,
+		});
+		expect(normalize(fallbackFilter.sql)).toContain("FROM customers c");
+		expect(normalize(fallbackFilter.sql)).toContain("COUNT(*)");
+	});
+
+	test("preview page: filter walk UNION bounded mir walk, deduped and re-limited", () => {
+		const page = composeCustomerPreviewPage({
+			filter: { plan: { plan_id: "enterprise" } },
+			ctx: { features: ctx.features },
+			ambient,
+			processed: { migrationInternalId: "mig_1" },
+			limit: 51,
+			cursor: "cus_after",
+		});
+		const normalized = normalize(page.sql);
+
+		// Branch A: the same bounded filter walk the page query uses.
+		expect(normalized).toContain("CROSS JOIN LATERAL");
+		// Branch B: bounded mir walk in customer order, cursor inside.
+		expect(normalized).toContain(
+			'DISTINCT ON (mir.item_id COLLATE "C") mir.item_id',
+		);
+		expect(normalized).toContain('mir.item_id COLLATE "C" < ?');
+		expect(normalized).toContain("UNION");
+		// The union is re-limited, then joined for payload columns.
+		expect(normalized).toContain(
+			') u ORDER BY internal_customer_id COLLATE "C" DESC LIMIT ?',
+		);
+		expect(normalized).toContain(
+			"JOIN customers c ON c.internal_id = m.internal_customer_id",
+		);
+	});
+
+	test("preview count: distinct union of the two id sets, no customers table", () => {
+		const count = composeCustomerPreviewCount({
+			filter: { plan: { plan_id: "enterprise" } },
+			ctx: { features: ctx.features },
+			ambient,
+			processed: { migrationInternalId: "mig_1" },
+		});
+		const normalized = normalize(count.sql);
+
+		expect(normalized).toContain("GROUP BY cp.internal_customer_id");
+		expect(normalized).toContain("FROM migration_item_runs mir");
+		expect(normalized).toContain("UNION");
+		expect(normalized).toContain("COUNT(*)");
+		expect(normalized).not.toContain("customers");
+	});
+
+	test("negative plan quantifiers stay on the customers driver with the full filter", () => {
+		const page = compose({
+			filter: { plan: { $none: { plan_id: "enterprise" } } },
+		});
+		const normalized = normalize(page.sql);
+
+		expect(normalized).not.toContain("CROSS JOIN LATERAL");
+		expect(normalized).toContain("FROM customers c");
+		expect(normalized).toContain("NOT EXISTS");
+	});
+});

--- a/server/tests/unit/compiler/customer/planner.test.ts
+++ b/server/tests/unit/compiler/customer/planner.test.ts
@@ -13,6 +13,9 @@ const ctx = contexts.create({ features });
 const ambient = { orgId: "org_test", env: "live" };
 const RELEVANT_STATUS_PARAMS = ["active", "past_due", "scheduled"];
 
+/** Residual WHERE once the source consumed the whole plan quantifier. */
+const AMBIENT_ONLY_WHERE = "c.org_id = ? AND c.env = ? AND TRUE";
+
 const normalize = (sql: string) =>
 	sql.replace(/\s+/g, " ").replace(/\(\s+/g, "(").replace(/\s+\)/g, ")").trim();
 
@@ -23,6 +26,8 @@ const buildCandidate = (filter: CustomerFilter) =>
 		ambient,
 	});
 
+/** Unconsumed paths must keep the exact fallback WHERE (source is narrowing
+ * only, the WHERE re-proves everything). */
 const expectFallbackWhereParity = (filter: CustomerFilter) => {
 	const candidate = buildCandidate(filter);
 	const fallback = compileFilter({
@@ -37,14 +42,13 @@ const expectFallbackWhereParity = (filter: CustomerFilter) => {
 };
 
 describe("customer filter planner", () => {
-	test("plan.plan_id eq uses a products-driven candidate source", () => {
-		const candidate = expectFallbackWhereParity({
-			plan: { plan_id: "enterprise" },
-		});
+	test("plan.plan_id eq consumes the quantifier into the source", () => {
+		const candidate = buildCandidate({ plan: { plan_id: "enterprise" } });
 
 		expect(candidate.accessPath).toEqual({
 			kind: "planned",
 			id: "plan.plan_id",
+			consumed: true,
 		});
 		expect(normalize(candidate.source.sql)).toBe(
 			normalize(`
@@ -69,16 +73,19 @@ describe("customer filter planner", () => {
 			"org_test",
 			"live",
 		]);
+		expect(normalize(candidate.where.sql)).toBe(AMBIENT_ONLY_WHERE);
+		expect(candidate.where.params).toEqual(["org_test", "live"]);
 	});
 
-	test("plan.plan_id in uses the same candidate path", () => {
-		const candidate = expectFallbackWhereParity({
+	test("plan.plan_id in consumes via the same candidate path", () => {
+		const candidate = buildCandidate({
 			plan: { plan_id: { $in: ["enterprise", "pro"] } },
 		});
 
 		expect(candidate.accessPath).toEqual({
 			kind: "planned",
 			id: "plan.plan_id",
+			consumed: true,
 		});
 		expect(normalize(candidate.source.sql)).toContain("p.id IN (?, ?)");
 		expect(candidate.source.params).toEqual([
@@ -90,6 +97,118 @@ describe("customer filter planner", () => {
 			"org_test",
 			"live",
 		]);
+		expect(normalize(candidate.where.sql)).toBe(AMBIENT_ONLY_WHERE);
+	});
+
+	test("plan_id + version consumes version into the products CTE", () => {
+		const candidate = buildCandidate({
+			plan: { plan_id: "enterprise", version: 2 },
+		});
+
+		expect(candidate.accessPath).toEqual({
+			kind: "planned",
+			id: "plan.plan_id",
+			consumed: true,
+		});
+		expect(normalize(candidate.source.sql)).toContain(
+			"AND p.id = ? AND p.version = ?",
+		);
+		expect(candidate.source.params).toEqual([
+			"org_test",
+			"live",
+			"enterprise",
+			2,
+			...RELEVANT_STATUS_PARAMS,
+			"org_test",
+			"live",
+		]);
+		expect(normalize(candidate.where.sql)).toBe(AMBIENT_ONLY_WHERE);
+	});
+
+	test("plan_id + custom consumes is_custom onto the cp join", () => {
+		const candidate = buildCandidate({
+			plan: { plan_id: "enterprise", custom: false },
+		});
+
+		expect(candidate.accessPath).toEqual({
+			kind: "planned",
+			id: "plan.plan_id",
+			consumed: true,
+		});
+		expect(normalize(candidate.source.sql)).toContain(
+			"WHERE cp.status IN (?, ?, ?) AND cp.is_custom = ?",
+		);
+		expect(candidate.source.params).toEqual([
+			"org_test",
+			"live",
+			"enterprise",
+			...RELEVANT_STATUS_PARAMS,
+			false,
+			"org_test",
+			"live",
+		]);
+		expect(normalize(candidate.where.sql)).toBe(AMBIENT_ONLY_WHERE);
+	});
+
+	test("plan_id + version + addon + custom consumes all simple leaves", () => {
+		const candidate = buildCandidate({
+			plan: { plan_id: "enterprise", version: 2, addon: false, custom: false },
+		});
+
+		expect(candidate.accessPath).toEqual({
+			kind: "planned",
+			id: "plan.plan_id",
+			consumed: true,
+		});
+		expect(normalize(candidate.source.sql)).toContain(
+			"AND p.id = ? AND p.version = ? AND p.is_add_on = ?",
+		);
+		expect(normalize(candidate.source.sql)).toContain(
+			"WHERE cp.status IN (?, ?, ?) AND cp.is_custom = ?",
+		);
+		expect(candidate.source.params).toEqual([
+			"org_test",
+			"live",
+			"enterprise",
+			2,
+			false,
+			...RELEVANT_STATUS_PARAMS,
+			false,
+			"org_test",
+			"live",
+		]);
+		expect(normalize(candidate.where.sql)).toBe(AMBIENT_ONLY_WHERE);
+	});
+
+	test("consumed plan quantifier keeps sibling customer predicates residual", () => {
+		const candidate = buildCandidate({
+			customer_id: "cus_123",
+			plan: { plan_id: "enterprise" },
+		});
+
+		expect(candidate.accessPath).toEqual({
+			kind: "planned",
+			id: "plan.plan_id",
+			consumed: true,
+		});
+		expect(normalize(candidate.where.sql)).toBe(
+			"c.org_id = ? AND c.env = ? AND (c.id = ?)",
+		);
+		expect(candidate.where.params).toEqual(["org_test", "live", "cus_123"]);
+		expect(normalize(candidate.where.sql)).not.toContain("customer_products");
+	});
+
+	test("non-consumable version op keeps the full fallback WHERE", () => {
+		const candidate = expectFallbackWhereParity({
+			plan: { plan_id: "enterprise", version: { $gte: 2 } },
+		});
+
+		expect(candidate.accessPath).toEqual({
+			kind: "planned",
+			id: "plan.plan_id",
+			consumed: false,
+		});
+		expect(normalize(candidate.source.sql)).not.toContain("p.version");
 	});
 
 	test("compound filters use plan_id as a candidate and keep fallback semantics", () => {
@@ -103,60 +222,10 @@ describe("customer filter planner", () => {
 		expect(candidate.accessPath).toEqual({
 			kind: "planned",
 			id: "plan.plan_id",
+			consumed: false,
 		});
 		expect(normalize(candidate.source.sql)).toContain("p.id = ?");
 		expect(normalize(candidate.where.sql)).toContain("e.internal_feature_id = ?");
-	});
-
-	test("plan_id + version keeps version as a residual fallback predicate", () => {
-		const candidate = expectFallbackWhereParity({
-			plan: {
-				plan_id: "enterprise",
-				version: 2,
-			},
-		});
-
-		expect(candidate.accessPath).toEqual({
-			kind: "planned",
-			id: "plan.plan_id",
-		});
-		expect(normalize(candidate.source.sql)).toContain("p.id = ?");
-		expect(normalize(candidate.source.sql)).not.toContain("p.version = ?");
-		expect(normalize(candidate.where.sql)).toContain(
-			"(p.id = ? AND p.version = ?)",
-		);
-		expect(candidate.where.params).toEqual([
-			"org_test",
-			"live",
-			...RELEVANT_STATUS_PARAMS,
-			"enterprise",
-			2,
-		]);
-	});
-
-	test("plan_id + custom keeps customer-product custom state as a residual predicate", () => {
-		const candidate = expectFallbackWhereParity({
-			plan: {
-				plan_id: "enterprise",
-				custom: false,
-			},
-		});
-
-		expect(candidate.accessPath).toEqual({
-			kind: "planned",
-			id: "plan.plan_id",
-		});
-		expect(normalize(candidate.source.sql)).not.toContain("cp.is_custom = ?");
-		expect(normalize(candidate.where.sql)).toContain(
-			"(p.id = ? AND cp.is_custom = ?)",
-		);
-		expect(candidate.where.params).toEqual([
-			"org_test",
-			"live",
-			...RELEVANT_STATUS_PARAMS,
-			"enterprise",
-			false,
-		]);
 	});
 
 	test("plan_id + price keeps base-price existence as a residual predicate", () => {
@@ -170,6 +239,7 @@ describe("customer filter planner", () => {
 		expect(candidate.accessPath).toEqual({
 			kind: "planned",
 			id: "plan.plan_id",
+			consumed: false,
 		});
 		expect(normalize(candidate.source.sql)).not.toContain("base_cpr.id");
 		expect(normalize(candidate.where.sql)).toContain("base_cpr.id");
@@ -188,6 +258,7 @@ describe("customer filter planner", () => {
 		expect(candidate.accessPath).toEqual({
 			kind: "planned",
 			id: "plan.plan_id",
+			consumed: false,
 		});
 		expect(normalize(candidate.source.sql)).not.toContain("customer_prices");
 		expect(normalize(candidate.where.sql)).toContain("customer_prices cpr");
@@ -207,6 +278,7 @@ describe("customer filter planner", () => {
 		expect(candidate.accessPath).toEqual({
 			kind: "planned",
 			id: "plan.plan_id",
+			consumed: false,
 		});
 		expect(normalize(candidate.source.sql)).not.toContain("e.rollover");
 		expect(normalize(candidate.where.sql)).toContain("e.rollover IS NOT NULL");

--- a/server/tests/unit/migrations-v2/compiler/customer-select-planner.test.ts
+++ b/server/tests/unit/migrations-v2/compiler/customer-select-planner.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	buildCustomerCount,
 	buildCustomerSelect,
+	buildProcessedPreviewSelect,
 } from "@/internal/migrations/v2/filters/customers/buildCustomerSelect.js";
 import { PgDialect } from "drizzle-orm/pg-core";
 
@@ -11,7 +12,7 @@ const ctx = { features: [] };
 const normalize = (sql: string) => sql.replace(/\s+/g, " ").trim();
 
 describe("migration customer select planner wiring", () => {
-	test("plan_id filters use a planned customer source plus fallback predicate", () => {
+	test("plan-level counts aggregate off customer_products alone", () => {
 		const query = buildCustomerCount({
 			orgId: "org_test",
 			env: "live",
@@ -20,13 +21,9 @@ describe("migration customer select planner wiring", () => {
 		});
 		const { sql, params } = dialect.sqlToQuery(query);
 
-		expect(normalize(sql)).toContain(
-			"FROM (WITH plan_products AS MATERIALIZED",
-		);
-		expect(normalize(sql)).toContain("SELECT p.internal_id FROM products p");
-		expect(normalize(sql)).toContain(
-			"AND EXISTS (SELECT 1 FROM customer_products cp JOIN products p",
-		);
+		expect(normalize(sql)).toContain("FROM customer_products cp");
+		expect(normalize(sql)).toContain("GROUP BY cp.internal_customer_id");
+		expect(normalize(sql)).not.toContain("customers");
 		expect(params).toEqual([
 			"org_test",
 			"live",
@@ -34,15 +31,90 @@ describe("migration customer select planner wiring", () => {
 			"active",
 			"past_due",
 			"scheduled",
-			"org_test",
-			"live",
-			"org_test",
-			"live",
-			"active",
-			"past_due",
-			"scheduled",
-			"enterprise",
 		]);
+	});
+
+	test("counts with search keep the batch-hash shape", () => {
+		const query = buildCustomerCount({
+			orgId: "org_test",
+			env: "live",
+			filter: { plan: { plan_id: "enterprise" } },
+			ctx,
+			search: "acme",
+		});
+		const { sql } = dialect.sqlToQuery(query);
+
+		expect(normalize(sql)).toContain("WITH plan_products AS MATERIALIZED");
+		expect(normalize(sql)).toContain("ILIKE");
+	});
+
+	test("consumed plan filter with a limit emits the streaming lateral walk", () => {
+		const query = buildCustomerSelect({
+			orgId: "org_test",
+			env: "live",
+			filter: { plan: { plan_id: "enterprise" } },
+			ctx,
+			checkpoint: {
+				migrationInternalId: "mig_1",
+				migrationRunId: "run_1",
+				dryRun: false,
+				excludedStatuses: ["succeeded"],
+			},
+			limit: 5000,
+			afterInternalId: "cus_abc",
+		});
+		const { sql } = dialect.sqlToQuery(query);
+		const normalized = normalize(sql);
+
+		expect(normalized).toContain("CROSS JOIN LATERAL");
+		expect(normalized).toContain(
+			'DISTINCT ON (cp.internal_customer_id COLLATE "C")',
+		);
+		// Cursor + checkpoint live INSIDE the walk so the inner LIMIT is exact.
+		expect(normalized).toContain('cp.internal_customer_id COLLATE "C" < $');
+		expect(normalized).toContain("mir.item_id = cp.internal_customer_id");
+		expect(normalized).not.toContain("WITH plan_products AS MATERIALIZED");
+	});
+
+	test("search and residual predicates move INSIDE the walk (pages stay exact)", () => {
+		const withSearch = buildCustomerSelect({
+			orgId: "org_test",
+			env: "live",
+			filter: { plan: { plan_id: "enterprise" } },
+			ctx,
+			search: "acme",
+			limit: 5000,
+		});
+		const searchSql = normalize(dialect.sqlToQuery(withSearch).sql);
+		expect(searchSql).toContain("CROSS JOIN LATERAL");
+		// The search predicate must filter BEFORE the walk's LIMIT.
+		const walkEnd = searchSql.indexOf(") walk ORDER BY");
+		expect(searchSql.indexOf("JOIN customers c ON c.internal_id = cp.internal_customer_id")).toBeLessThan(walkEnd);
+		expect(searchSql.indexOf("ILIKE")).toBeGreaterThan(-1);
+		expect(searchSql.indexOf("ILIKE")).toBeLessThan(walkEnd);
+
+		const withResidual = buildCustomerSelect({
+			orgId: "org_test",
+			env: "live",
+			filter: { customer_id: "cus_123", plan: { plan_id: "enterprise" } },
+			ctx,
+			limit: 5000,
+		});
+		const residualSql = normalize(dialect.sqlToQuery(withResidual).sql);
+		expect(residualSql).toContain("CROSS JOIN LATERAL");
+		expect(residualSql.indexOf("c.id = $")).toBeLessThan(
+			residualSql.indexOf(") walk ORDER BY"),
+		);
+
+		const withoutLimit = buildCustomerSelect({
+			orgId: "org_test",
+			env: "live",
+			filter: { plan: { plan_id: "enterprise" } },
+			ctx,
+		});
+		expect(normalize(dialect.sqlToQuery(withoutLimit).sql)).not.toContain(
+			"CROSS JOIN LATERAL",
+		);
 	});
 
 	test("non-planned filters keep the customer root source", () => {
@@ -57,7 +129,44 @@ describe("migration customer select planner wiring", () => {
 
 		expect(normalize(sql)).toContain("FROM customers c");
 		expect(normalize(sql)).not.toContain("FROM (SELECT DISTINCT");
-		expect(params).toEqual(["org_test", "live", "cus_123", 10]);
+		expect(params).toEqual([
+			"org_test",
+			"live",
+			"cus_123",
+			10,
+			"org_test",
+			"live",
+		]);
+	});
+
+	test("preview mode 'all' takes the bounded union; status modes keep legacy", () => {
+		const previewAll = buildProcessedPreviewSelect({
+			orgId: "org_test",
+			env: "live",
+			filter: { plan: { plan_id: "enterprise" } },
+			ctx,
+			includeProcessed: { migrationInternalId: "mig_1" },
+			limit: 51,
+		});
+		const allSql = normalize(dialect.sqlToQuery(previewAll).sql);
+		expect(allSql).toContain("CROSS JOIN LATERAL");
+		expect(allSql).toContain('DISTINCT ON (mir.item_id COLLATE "C")');
+		expect(allSql).toContain("UNION");
+
+		const previewStatuses = buildProcessedPreviewSelect({
+			orgId: "org_test",
+			env: "live",
+			filter: { plan: { plan_id: "enterprise" } },
+			ctx,
+			includeProcessed: {
+				migrationInternalId: "mig_1",
+				executionFilter: { statuses: ["succeeded"] },
+			},
+			limit: 51,
+		});
+		const statusSql = normalize(dialect.sqlToQuery(previewStatuses).sql);
+		expect(statusSql).not.toContain("CROSS JOIN LATERAL");
+		expect(statusSql).toContain("c.internal_id IN ( SELECT mir.item_id");
 	});
 
 	test("customer list filters are applied in the select SQL", () => {

--- a/shared/api/migrations/filters/index.ts
+++ b/shared/api/migrations/filters/index.ts
@@ -4,8 +4,10 @@ export * from "./match/index.js";
 export * from "./matcher.js";
 export * from "./migrationFilter.js";
 export * from "./planFilter.js";
+export * from "./planner/index.js";
 export {
 	DEFAULT_PLAN_ITEM_FILTER as DEFAULT_MIGRATION_PLAN_ITEM_FILTER,
 	type PlanItemFilter as MigrationPlanItemFilter,
 	PlanItemFilterSchema as MigrationPlanItemFilterSchema,
 } from "./planItemFilter.js";
+export type { ResolutionContext } from "../compiler/filterToIr/resolutionContext.js";

--- a/shared/api/migrations/filters/planner/accessPaths/planPlanIdAccessPath.ts
+++ b/shared/api/migrations/filters/planner/accessPaths/planPlanIdAccessPath.ts
@@ -1,44 +1,113 @@
 import { RELEVANT_STATUSES } from "../../../../../utils/cusProductUtils/cusProductConstants.js";
 import type { IRLeaf } from "../../../compiler/ir/irTypes.js";
+import type { CompiledSql } from "../../../compiler/irToSql/irToSql.js";
 import type { CustomerAccessPath } from "../types.js";
+
+/** Sibling plan-quantifier predicate the source can prove itself. */
+export type PlanSourceExtra =
+	| { field: "version"; op: "eq" | "in"; value: number | readonly number[] }
+	| { field: "addon" | "custom"; op: "eq"; value: boolean };
 
 export type PlanIdConstraint = Pick<IRLeaf, "op" | "value"> & {
 	field: "plan_id";
 	op: "eq" | "in";
+	/** Present only when the source proves the ENTIRE plan quantifier. */
+	extras?: PlanSourceExtra[];
+};
+
+const EXTRA_COLUMNS: Record<PlanSourceExtra["field"], string> = {
+	version: "p.version",
+	addon: "p.is_add_on",
+	custom: "cp.is_custom",
+};
+
+const renderExtra = (extra: PlanSourceExtra, params: unknown[]): string => {
+	const column = EXTRA_COLUMNS[extra.field];
+	if (extra.op === "eq") {
+		params.push(extra.value);
+		return `AND ${column} = ?`;
+	}
+	const values = extra.value as readonly number[];
+	params.push(...values);
+	return `AND ${column} IN (${values.map(() => "?").join(", ")})`;
+};
+
+/** SELECT of matching plan product internal ids (org/env + plan predicate +
+ * consumed product-level extras). */
+export const buildPlanProductsSql = ({
+	constraint,
+	ambient,
+}: {
+	constraint: PlanIdConstraint;
+	ambient: Record<string, unknown>;
+}): CompiledSql => {
+	const orgId = ambient.orgId;
+	const env = ambient.env;
+	if (orgId === undefined) throw new Error("Missing ambient orgId");
+	if (env === undefined) throw new Error("Missing ambient env");
+
+	const params: unknown[] = [orgId, env];
+	const planPredicate =
+		constraint.op === "eq"
+			? buildEqPredicate(constraint.value, params)
+			: buildInPredicate(constraint.value, params);
+	const productExtras = (constraint.extras ?? []).filter(
+		(extra) => extra.field !== "custom",
+	);
+	const extraSql = productExtras.map((extra) => renderExtra(extra, params));
+
+	return {
+		sql: [
+			"SELECT p.internal_id FROM products p",
+			"WHERE p.org_id = ? AND p.env = ?",
+			`AND ${planPredicate}`,
+			...extraSql,
+		].join(" "),
+		params,
+	};
+};
+
+/** cp-level predicates: relevant-status ambient + consumed cp extras. */
+export const buildCustomerProductWhereSql = (
+	constraint: PlanIdConstraint,
+): CompiledSql => {
+	const params: unknown[] = [...RELEVANT_STATUSES];
+	const statusPlaceholders = RELEVANT_STATUSES.map(() => "?").join(", ");
+	const customerProductExtras = (constraint.extras ?? []).filter(
+		(extra) => extra.field === "custom",
+	);
+	const extraSql = customerProductExtras.map((extra) =>
+		renderExtra(extra, params),
+	);
+	return {
+		sql: [`cp.status IN (${statusPlaceholders})`, ...extraSql].join(" "),
+		params,
+	};
 };
 
 export const planPlanIdAccessPath: CustomerAccessPath<PlanIdConstraint> = {
 	id: "plan.plan_id",
 	buildSource: ({ constraint, ambient }) => {
-		const params: unknown[] = [];
-		const orgId = ambient.orgId;
-		const env = ambient.env;
-		if (orgId === undefined) throw new Error("Missing ambient orgId");
-		if (env === undefined) throw new Error("Missing ambient env");
-
-		params.push(orgId, env);
-		const planPredicate =
-			constraint.op === "eq"
-				? buildEqPredicate(constraint.value, params)
-				: buildInPredicate(constraint.value, params);
-		params.push(...RELEVANT_STATUSES, orgId, env);
-		const statusPlaceholders = RELEVANT_STATUSES.map(() => "?").join(", ");
-
+		const planProducts = buildPlanProductsSql({ constraint, ambient });
+		const customerProductWhere = buildCustomerProductWhereSql(constraint);
 		return {
 			sql: [
 				"(WITH plan_products AS MATERIALIZED (",
-				"SELECT p.internal_id FROM products p",
-				"WHERE p.org_id = ? AND p.env = ?",
-				`AND ${planPredicate}`,
+				planProducts.sql,
 				") SELECT DISTINCT c.internal_id, c.id, c.name, c.email, c.org_id, c.env",
 				"FROM plan_products pp",
 				"JOIN customer_products cp ON cp.internal_product_id = pp.internal_id",
 				"JOIN customers c ON c.internal_id = cp.internal_customer_id",
-				`WHERE cp.status IN (${statusPlaceholders})`,
+				`WHERE ${customerProductWhere.sql}`,
 				"AND c.org_id = ?",
 				"AND c.env = ?) c",
 			].join(" "),
-			params,
+			params: [
+				...planProducts.params,
+				...customerProductWhere.params,
+				ambient.orgId,
+				ambient.env,
+			],
 		};
 	},
 };

--- a/shared/api/migrations/filters/planner/buildCustomerCandidateQuery.ts
+++ b/shared/api/migrations/filters/planner/buildCustomerCandidateQuery.ts
@@ -1,5 +1,6 @@
 import type { CustomerFilter } from "../customerFilter.js";
 import { filterToIr } from "../../compiler/filterToIr/filterToIr.js";
+import type { IRNav, IRNode } from "../../compiler/ir/irTypes.js";
 import type { ResolutionContext } from "../../compiler/filterToIr/resolutionContext.js";
 import {
 	type AmbientContext,
@@ -9,6 +10,13 @@ import { customerRegistry } from "../../compiler/registry/customerRegistry.js";
 import { planPlanIdAccessPath } from "./accessPaths/planPlanIdAccessPath.js";
 import { chooseCustomerAccessPath } from "./chooseCustomerAccessPath.js";
 import type { CustomerCandidateQuery } from "./types.js";
+
+export const withoutConsumedNav = (ir: IRNode, nav: IRNav): IRNode => {
+	if (ir === nav) return { kind: "and", children: [] };
+	if (ir.kind === "and")
+		return { ...ir, children: ir.children.filter((child) => child !== nav) };
+	return ir;
+};
 
 export const buildCustomerCandidateQuery = ({
 	filter,
@@ -20,31 +28,29 @@ export const buildCustomerCandidateQuery = ({
 	ambient: AmbientContext;
 }): CustomerCandidateQuery => {
 	const ir = filterToIr({ filter, ctx });
-	const fallbackWhere = irToSql({ ir, root: customerRegistry, ambient });
 	const accessPath = chooseCustomerAccessPath(ir);
 
-	if (!accessPath) {
-		return {
-			source: { sql: "customers c", params: [] },
-			where: fallbackWhere,
-			accessPath: { kind: "fallback" },
-		};
-	}
-
-	if (accessPath.id === "plan.plan_id") {
+	if (accessPath?.id === "plan.plan_id") {
+		const residualIr = accessPath.consumedNav
+			? withoutConsumedNav(ir, accessPath.consumedNav)
+			: ir;
 		return {
 			source: planPlanIdAccessPath.buildSource({
 				constraint: accessPath.constraint,
 				ambient,
 			}),
-			where: fallbackWhere,
-			accessPath: { kind: "planned", id: accessPath.id },
+			where: irToSql({ ir: residualIr, root: customerRegistry, ambient }),
+			accessPath: {
+				kind: "planned",
+				id: accessPath.id,
+				consumed: accessPath.consumedNav !== undefined,
+			},
 		};
 	}
 
 	return {
 		source: { sql: "customers c", params: [] },
-		where: fallbackWhere,
+		where: irToSql({ ir, root: customerRegistry, ambient }),
 		accessPath: { kind: "fallback" },
 	};
 };

--- a/shared/api/migrations/filters/planner/chooseCustomerAccessPath.ts
+++ b/shared/api/migrations/filters/planner/chooseCustomerAccessPath.ts
@@ -1,50 +1,64 @@
 import type { IRLeaf, IRNav, IRNode } from "../../compiler/ir/irTypes.js";
-import type { PlanIdConstraint } from "./accessPaths/planPlanIdAccessPath.js";
+import type {
+	PlanIdConstraint,
+	PlanSourceExtra,
+} from "./accessPaths/planPlanIdAccessPath.js";
 
 export type ChosenCustomerAccessPath = {
 	id: "plan.plan_id";
 	constraint: PlanIdConstraint;
+	/** Set when the source proves the ENTIRE plan quantifier, so the caller
+	 * may drop this nav from the fallback WHERE. */
+	consumedNav?: IRNav;
 };
 
+/**
+ * Consumption is all-or-nothing per quantifier: every predicate shares one
+ * `$some` (one cp row must satisfy all of them), so dropping only some from
+ * the WHERE would let different cp rows satisfy different predicates.
+ */
 export const chooseCustomerAccessPath = (
 	ir: IRNode,
 ): ChosenCustomerAccessPath | undefined => {
 	const planNav = findNecessaryPlanNav(ir);
 	if (!planNav) return undefined;
 
-	const planIdLeaf = findNecessaryPlanIdLeaf(planNav.child);
-	if (!planIdLeaf) return undefined;
+	const nodes = childrenOf(planNav.child);
+	const planIdNode = nodes.find(isPlanIdLeaf);
+	const constraint = planIdNode && toPlanIdConstraint(planIdNode);
+	if (!constraint) return undefined;
 
+	const extras: PlanSourceExtra[] = [];
+	for (const node of nodes) {
+		if (node === planIdNode) continue;
+		const extra = node.kind === "leaf" ? toSourceExtra(node) : undefined;
+		if (!extra) return { id: "plan.plan_id", constraint };
+		extras.push(extra);
+	}
 	return {
 		id: "plan.plan_id",
-		constraint: {
-			field: "plan_id",
-			op: planIdLeaf.op,
-			value: planIdLeaf.value,
-		},
+		constraint: { ...constraint, extras },
+		consumedNav: planNav,
 	};
 };
 
-const findNecessaryPlanNav = (node: IRNode): IRNav | undefined => {
-	const children = node.kind === "and" ? node.children : [node];
-	return children.find(
+const childrenOf = (node: IRNode): readonly IRNode[] =>
+	node.kind === "and" ? node.children : [node];
+
+const findNecessaryPlanNav = (node: IRNode): IRNav | undefined =>
+	childrenOf(node).find(
 		(child): child is IRNav =>
 			child.kind === "nav" &&
 			child.name === "plan" &&
 			child.quantifier === "some",
 	);
-};
 
-const findNecessaryPlanIdLeaf = (node: IRNode): PlanIdConstraint | undefined => {
-	const children = node.kind === "and" ? node.children : [node];
-	const leaf = children.find(
-		(child): child is IRLeaf =>
-			child.kind === "leaf" &&
-			child.field === "plan_id" &&
-			(child.op === "eq" || child.op === "in"),
-	);
+const isPlanIdLeaf = (node: IRNode): node is IRLeaf =>
+	node.kind === "leaf" &&
+	node.field === "plan_id" &&
+	(node.op === "eq" || node.op === "in");
 
-	if (!leaf) return undefined;
+const toPlanIdConstraint = (leaf: IRLeaf): PlanIdConstraint | undefined => {
 	if (leaf.op === "eq" && typeof leaf.value === "string") {
 		return { field: "plan_id", op: "eq", value: leaf.value };
 	}
@@ -55,6 +69,31 @@ const findNecessaryPlanIdLeaf = (node: IRNode): PlanIdConstraint | undefined => 
 		leaf.value.every((value) => typeof value === "string")
 	) {
 		return { field: "plan_id", op: "in", value: leaf.value };
+	}
+	return undefined;
+};
+
+const toSourceExtra = (leaf: IRLeaf): PlanSourceExtra | undefined => {
+	if (leaf.field === "version") {
+		if (leaf.op === "eq" && typeof leaf.value === "number") {
+			return { field: "version", op: "eq", value: leaf.value };
+		}
+		if (
+			leaf.op === "in" &&
+			Array.isArray(leaf.value) &&
+			leaf.value.length > 0 &&
+			leaf.value.every((value) => typeof value === "number")
+		) {
+			return { field: "version", op: "in", value: leaf.value };
+		}
+		return undefined;
+	}
+	if (
+		(leaf.field === "addon" || leaf.field === "custom") &&
+		leaf.op === "eq" &&
+		typeof leaf.value === "boolean"
+	) {
+		return { field: leaf.field, op: "eq", value: leaf.value };
 	}
 	return undefined;
 };

--- a/shared/api/migrations/filters/planner/composeCustomerPage.ts
+++ b/shared/api/migrations/filters/planner/composeCustomerPage.ts
@@ -1,0 +1,280 @@
+import { filterToIr } from "../../compiler/filterToIr/filterToIr.js";
+import type { ResolutionContext } from "../../compiler/filterToIr/resolutionContext.js";
+import type { IRNode } from "../../compiler/ir/irTypes.js";
+import {
+	type AmbientContext,
+	type CompiledSql,
+	irToSql,
+} from "../../compiler/irToSql/irToSql.js";
+import { customerRegistry } from "../../compiler/registry/customerRegistry.js";
+import type { CustomerFilter } from "../customerFilter.js";
+import {
+	buildCustomerProductWhereSql,
+	buildPlanProductsSql,
+	type PlanIdConstraint,
+} from "./accessPaths/planPlanIdAccessPath.js";
+import {
+	buildCustomerCandidateQuery,
+	withoutConsumedNav,
+} from "./buildCustomerCandidateQuery.js";
+import { chooseCustomerAccessPath } from "./chooseCustomerAccessPath.js";
+
+/** Caller-supplied per-candidate predicate (e.g. the migration checkpoint). */
+export type CustomerPagePredicate = {
+	/** Bare predicate SQL correlated via `keyColumn` (the candidate-id column). */
+	build: (keyColumn: string) => CompiledSql;
+	/** Set when the predicate references the `c` customers alias beyond the
+	 * key column — forces the customers join inside the walk. */
+	needsCustomerAlias?: boolean;
+};
+
+const CUSTOMER_COLUMNS = "c.internal_id, c.id, c.name, c.email";
+
+const isEmptyResidual = (ir: IRNode): boolean =>
+	ir.kind === "and" && ir.children.length === 0;
+
+type SqlAssembler = {
+	push: (sql: string, sqlParams?: readonly unknown[]) => void;
+	compile: () => CompiledSql;
+};
+
+const sqlAssembler = (): SqlAssembler => {
+	const parts: string[] = [];
+	const params: unknown[] = [];
+	return {
+		push: (sql, sqlParams = []) => {
+			parts.push(sql);
+			params.push(...sqlParams);
+		},
+		compile: () => ({ sql: parts.join(" "), params }),
+	};
+};
+
+type CustomerScopeArgs = {
+	filter: CustomerFilter;
+	ctx: ResolutionContext;
+	ambient: AmbientContext;
+	predicates?: CustomerPagePredicate[];
+};
+
+/** Wraps a candidate-id subquery with the payload join over customers. */
+export const wrapIdsWithCustomerColumns = ({
+	ids,
+	ambient,
+}: {
+	ids: CompiledSql;
+	ambient: AmbientContext;
+}): CompiledSql => {
+	const query = sqlAssembler();
+	query.push(`SELECT ${CUSTOMER_COLUMNS} FROM (`);
+	query.push(ids.sql, ids.params);
+	query.push(") m JOIN customers c ON c.internal_id = m.internal_customer_id");
+	query.push("WHERE c.org_id = ? AND c.env = ?", [ambient.orgId, ambient.env]);
+	query.push('ORDER BY m.internal_customer_id COLLATE "C" DESC');
+	return query.compile();
+};
+
+/**
+ * Bounded candidate-id page for ANY filter: a driver enumerates candidate ids
+ * newest-first and EVERY predicate (residual filter, checkpoint, cursor) is
+ * evaluated inside the driver, so LIMIT counts matches — a short page always
+ * means the set is exhausted, never that rows were filtered away.
+ */
+export const composeCandidateIdPage = ({
+	filter,
+	ctx,
+	ambient,
+	limit,
+	cursor,
+	predicates = [],
+}: CustomerScopeArgs & {
+	limit: number;
+	cursor?: string;
+}): CompiledSql => {
+	const ir = filterToIr({ filter, ctx });
+	const accessPath = chooseCustomerAccessPath(ir);
+
+	if (!accessPath) {
+		return composeCustomersDriverIdPage({ ir, ambient, limit, cursor, predicates });
+	}
+
+	const residualIr = accessPath.consumedNav
+		? withoutConsumedNav(ir, accessPath.consumedNav)
+		: ir;
+	return composePlanWalkIdPage({
+		constraint: accessPath.constraint,
+		residualIr,
+		ambient,
+		limit,
+		cursor,
+		predicates,
+	});
+};
+
+/** Page-bounded customer query: bounded id page + payload join. */
+export const composeCustomerPage = ({
+	limit,
+	cursor,
+	...scope
+}: CustomerScopeArgs & {
+	limit: number;
+	cursor?: string;
+}): CompiledSql =>
+	wrapIdsWithCustomerColumns({
+		ids: composeCandidateIdPage({ ...scope, limit, cursor }),
+		ambient: scope.ambient,
+	});
+
+/**
+ * Unbounded candidate-id set. Two access paths, chosen by the compiler:
+ * fully plan-level filters read customer_products alone (no customers join,
+ * no row payloads); anything needing the customer row keeps the batch-hash
+ * shape — optimal when no LIMIT can stop the scan.
+ */
+export const composeCustomerIdSet = ({
+	filter,
+	ctx,
+	ambient,
+	predicates = [],
+}: CustomerScopeArgs): CompiledSql => {
+	const ir = filterToIr({ filter, ctx });
+	const accessPath = chooseCustomerAccessPath(ir);
+	const decidableFromCustomerProducts =
+		accessPath?.consumedNav !== undefined &&
+		isEmptyResidual(withoutConsumedNav(ir, accessPath.consumedNav)) &&
+		predicates.every((predicate) => !predicate.needsCustomerAlias);
+	const query = sqlAssembler();
+
+	if (decidableFromCustomerProducts && accessPath) {
+		const planProducts = buildPlanProductsSql({
+			constraint: accessPath.constraint,
+			ambient,
+		});
+		const customerProductWhere = buildCustomerProductWhereSql(
+			accessPath.constraint,
+		);
+
+		query.push("SELECT cp.internal_customer_id FROM customer_products cp");
+		query.push("WHERE cp.internal_product_id IN (");
+		query.push(planProducts.sql, planProducts.params);
+		query.push(")");
+		query.push(`AND ${customerProductWhere.sql}`, customerProductWhere.params);
+		for (const predicate of predicates) {
+			const compiled = predicate.build("cp.internal_customer_id");
+			query.push(`AND ${compiled.sql}`, compiled.params);
+		}
+		query.push("GROUP BY cp.internal_customer_id");
+		return query.compile();
+	}
+
+	const candidate = buildCustomerCandidateQuery({ filter, ctx, ambient });
+	query.push("SELECT c.internal_id AS internal_customer_id FROM");
+	query.push(candidate.source.sql, candidate.source.params);
+	query.push(`WHERE (${candidate.where.sql})`, candidate.where.params);
+	for (const predicate of predicates) {
+		const compiled = predicate.build("c.internal_id");
+		query.push(`AND ${compiled.sql}`, compiled.params);
+	}
+	return query.compile();
+};
+
+/** Full-set count over the candidate-id set. */
+export const composeCustomerCount = (args: CustomerScopeArgs): CompiledSql => {
+	const idSet = composeCustomerIdSet(args);
+	return {
+		sql: `SELECT COUNT(*)::bigint AS count FROM ( ${idSet.sql} ) matched`,
+		params: idSet.params,
+	};
+};
+
+/** Driver: ordered index walks of customer_products, one per plan product. */
+const composePlanWalkIdPage = ({
+	constraint,
+	residualIr,
+	ambient,
+	limit,
+	cursor,
+	predicates,
+}: {
+	constraint: PlanIdConstraint;
+	residualIr: IRNode;
+	ambient: AmbientContext;
+	limit: number;
+	cursor?: string;
+	predicates: CustomerPagePredicate[];
+}): CompiledSql => {
+	const planProducts = buildPlanProductsSql({ constraint, ambient });
+	const customerProductWhere = buildCustomerProductWhereSql(constraint);
+	const residual = isEmptyResidual(residualIr)
+		? undefined
+		: irToSql({ ir: residualIr, root: customerRegistry, ambient });
+	const joinCustomersInWalk =
+		residual !== undefined ||
+		predicates.some((predicate) => predicate.needsCustomerAlias);
+	const query = sqlAssembler();
+
+	query.push(
+		'SELECT DISTINCT ON (walk.internal_customer_id COLLATE "C") walk.internal_customer_id',
+	);
+	query.push("FROM (");
+	query.push(planProducts.sql, planProducts.params);
+	query.push(") plans CROSS JOIN LATERAL (");
+	query.push(
+		'SELECT DISTINCT ON (cp.internal_customer_id COLLATE "C") cp.internal_customer_id',
+	);
+	query.push("FROM customer_products cp");
+	if (joinCustomersInWalk) {
+		query.push("JOIN customers c ON c.internal_id = cp.internal_customer_id");
+	}
+	query.push("WHERE cp.internal_product_id = plans.internal_id");
+	query.push(`AND ${customerProductWhere.sql}`, customerProductWhere.params);
+	if (cursor !== undefined) {
+		query.push('AND cp.internal_customer_id COLLATE "C" < ?', [cursor]);
+	}
+	if (residual) {
+		query.push(`AND (${residual.sql})`, residual.params);
+	}
+	for (const predicate of predicates) {
+		const compiled = predicate.build("cp.internal_customer_id");
+		query.push(`AND ${compiled.sql}`, compiled.params);
+	}
+	query.push('ORDER BY cp.internal_customer_id COLLATE "C" DESC LIMIT ?', [
+		limit,
+	]);
+	query.push(") walk");
+	query.push('ORDER BY walk.internal_customer_id COLLATE "C" DESC LIMIT ?', [
+		limit,
+	]);
+	return query.compile();
+};
+
+/** Driver: ordered walk of customers itself (filters with no plan access
+ * path). Same shape as the legacy fallback query — LIMIT is post-filter. */
+const composeCustomersDriverIdPage = ({
+	ir,
+	ambient,
+	limit,
+	cursor,
+	predicates,
+}: {
+	ir: IRNode;
+	ambient: AmbientContext;
+	limit: number;
+	cursor?: string;
+	predicates: CustomerPagePredicate[];
+}): CompiledSql => {
+	const where = irToSql({ ir, root: customerRegistry, ambient });
+	const query = sqlAssembler();
+
+	query.push("SELECT c.internal_id AS internal_customer_id FROM customers c");
+	query.push(`WHERE (${where.sql})`, where.params);
+	if (cursor !== undefined) {
+		query.push("AND c.internal_id < ?", [cursor]);
+	}
+	for (const predicate of predicates) {
+		const compiled = predicate.build("c.internal_id");
+		query.push(`AND ${compiled.sql}`, compiled.params);
+	}
+	query.push("ORDER BY c.internal_id DESC LIMIT ?", [limit]);
+	return query.compile();
+};

--- a/shared/api/migrations/filters/planner/composeCustomerPreview.ts
+++ b/shared/api/migrations/filters/planner/composeCustomerPreview.ts
@@ -1,0 +1,161 @@
+import type { ResolutionContext } from "../../compiler/filterToIr/resolutionContext.js";
+import type {
+	AmbientContext,
+	CompiledSql,
+} from "../../compiler/irToSql/irToSql.js";
+import type { CustomerFilter } from "../customerFilter.js";
+import {
+	composeCandidateIdPage,
+	composeCustomerIdSet,
+	type CustomerPagePredicate,
+	wrapIdsWithCustomerColumns,
+} from "./composeCustomerPage.js";
+
+/** The already-processed side of a migration preview. */
+export type ProcessedScope = { migrationInternalId: string };
+
+type PreviewArgs = {
+	filter: CustomerFilter;
+	ctx: ResolutionContext;
+	ambient: AmbientContext;
+	processed: ProcessedScope;
+	predicates?: CustomerPagePredicate[];
+};
+
+/** Bounded walk of the migration's processed ids in customer order (the
+ * live C-collation mir index). Same exactness rule as the filter walk:
+ * every predicate applies inside, short page ⟹ exhausted. */
+const composeProcessedIdPage = ({
+	processed,
+	limit,
+	cursor,
+	predicates = [],
+}: {
+	processed: ProcessedScope;
+	limit: number;
+	cursor?: string;
+	predicates?: CustomerPagePredicate[];
+}): CompiledSql => {
+	const parts: string[] = [];
+	const params: unknown[] = [];
+	const push = (sql: string, sqlParams: readonly unknown[] = []) => {
+		parts.push(sql);
+		params.push(...sqlParams);
+	};
+
+	push(
+		'SELECT DISTINCT ON (mir.item_id COLLATE "C") mir.item_id AS internal_customer_id',
+	);
+	push("FROM migration_item_runs mir");
+	if (predicates.some((predicate) => predicate.needsCustomerAlias)) {
+		push("JOIN customers c ON c.internal_id = mir.item_id");
+	}
+	push("WHERE mir.migration_internal_id = ?", [processed.migrationInternalId]);
+	push("AND mir.item_kind = 'customer' AND mir.dry_run = false");
+	if (cursor !== undefined) {
+		push('AND mir.item_id COLLATE "C" < ?', [cursor]);
+	}
+	for (const predicate of predicates) {
+		const compiled = predicate.build("mir.item_id");
+		push(`AND ${compiled.sql}`, compiled.params);
+	}
+	push('ORDER BY mir.item_id COLLATE "C" DESC LIMIT ?', [limit]);
+	return { sql: parts.join(" "), params };
+};
+
+/** Unbounded processed-id set (skinny, mir index only). */
+const composeProcessedIdSet = ({
+	processed,
+	predicates = [],
+}: {
+	processed: ProcessedScope;
+	predicates?: CustomerPagePredicate[];
+}): CompiledSql => {
+	const parts: string[] = [];
+	const params: unknown[] = [];
+	const push = (sql: string, sqlParams: readonly unknown[] = []) => {
+		parts.push(sql);
+		params.push(...sqlParams);
+	};
+
+	push("SELECT mir.item_id AS internal_customer_id FROM migration_item_runs mir");
+	if (predicates.some((predicate) => predicate.needsCustomerAlias)) {
+		push("JOIN customers c ON c.internal_id = mir.item_id");
+	}
+	push("WHERE mir.migration_internal_id = ?", [processed.migrationInternalId]);
+	push("AND mir.item_kind = 'customer' AND mir.dry_run = false");
+	for (const predicate of predicates) {
+		const compiled = predicate.build("mir.item_id");
+		push(`AND ${compiled.sql}`, compiled.params);
+	}
+	return { sql: parts.join(" "), params };
+};
+
+/**
+ * Preview page: filter-set ∪ processed-set (customers an in-flight migration
+ * already ran for, even when the live filter no longer matches them). Both
+ * branches are bounded walks, so the union page is exact and O(page).
+ */
+export const composeCustomerPreviewPage = ({
+	filter,
+	ctx,
+	ambient,
+	processed,
+	limit,
+	cursor,
+	predicates = [],
+}: PreviewArgs & {
+	limit: number;
+	cursor?: string;
+}): CompiledSql => {
+	const filterIds = composeCandidateIdPage({
+		filter,
+		ctx,
+		ambient,
+		limit,
+		cursor,
+		predicates,
+	});
+	const processedIds = composeProcessedIdPage({
+		processed,
+		limit,
+		cursor,
+		predicates,
+	});
+
+	const union: CompiledSql = {
+		sql: [
+			"SELECT internal_customer_id FROM (",
+			`( ${filterIds.sql} )`,
+			"UNION",
+			`( ${processedIds.sql} )`,
+			") u",
+			'ORDER BY internal_customer_id COLLATE "C" DESC LIMIT ?',
+		].join(" "),
+		params: [...filterIds.params, ...processedIds.params, limit],
+	};
+	return wrapIdsWithCustomerColumns({ ids: union, ambient });
+};
+
+/** Preview count: distinct union of the two id sets — customers table is
+ * never touched unless a predicate needs it. */
+export const composeCustomerPreviewCount = ({
+	filter,
+	ctx,
+	ambient,
+	processed,
+	predicates = [],
+}: PreviewArgs): CompiledSql => {
+	const filterIds = composeCustomerIdSet({ filter, ctx, ambient, predicates });
+	const processedIds = composeProcessedIdSet({ processed, predicates });
+	return {
+		sql: [
+			"SELECT COUNT(*)::bigint AS count FROM (",
+			`( ${filterIds.sql} )`,
+			"UNION",
+			`( ${processedIds.sql} )`,
+			") matched",
+		].join(" "),
+		params: [...filterIds.params, ...processedIds.params],
+	};
+};

--- a/shared/api/migrations/filters/planner/index.ts
+++ b/shared/api/migrations/filters/planner/index.ts
@@ -1,0 +1,16 @@
+export { buildCustomerCandidateQuery } from "./buildCustomerCandidateQuery.js";
+export {
+	composeCustomerCount,
+	composeCustomerPage,
+	type CustomerPagePredicate,
+} from "./composeCustomerPage.js";
+export {
+	composeCustomerPreviewCount,
+	composeCustomerPreviewPage,
+	type ProcessedScope,
+} from "./composeCustomerPreview.js";
+export type {
+	CustomerAccessPath,
+	CustomerAccessPathId,
+	CustomerCandidateQuery,
+} from "./types.js";

--- a/shared/api/migrations/filters/planner/types.ts
+++ b/shared/api/migrations/filters/planner/types.ts
@@ -5,11 +5,12 @@ export type CustomerAccessPathId = "plan.plan_id";
 export type CustomerCandidateQuery = {
 	/** SQL source for FROM. It must expose a `c` alias with customer columns. */
 	source: CompiledSql;
-	/** Final customer predicate. Planned paths keep the fallback predicate here. */
+	/** Final customer predicate. When the source consumed the plan quantifier,
+	 * this holds only the residual filter (ambient + non-plan predicates). */
 	where: CompiledSql;
 	accessPath:
 		| { kind: "fallback" }
-		| { kind: "planned"; id: CustomerAccessPathId };
+		| { kind: "planned"; id: CustomerAccessPathId; consumed: boolean };
 };
 
 export type CustomerAccessPath<TConstraint> = {

--- a/shared/drizzle/0057_demonic_lionheart.sql
+++ b/shared/drizzle/0057_demonic_lionheart.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY "idx_customer_products_product_customer_c" ON "customer_products" USING btree ("internal_product_id","internal_customer_id" COLLATE "C");

--- a/shared/drizzle/meta/0057_snapshot.json
+++ b/shared/drizzle/meta/0057_snapshot.json
@@ -1,0 +1,10783 @@
+{
+  "id": "10e2ad74-d05e-4984-91a8-99528cc599ee",
+  "prevId": "acf98457-a5de-4524-8419-8403c99f4f6a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.actions": {
+      "name": "actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_actions_on_internal_entity_id": {
+          "name": "idx_actions_on_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "actions_org_id_fkey": {
+          "name": "actions_org_id_fkey",
+          "tableFrom": "actions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "actions_customer_id_fkey": {
+          "name": "actions_customer_id_fkey",
+          "tableFrom": "actions",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "actions_entity_id_fkey": {
+          "name": "actions_entity_id_fkey",
+          "tableFrom": "actions",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.agent_rules": {
+      "name": "agent_rules",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_rules": {
+          "name": "entity_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_rules": {
+          "name": "credit_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_rules_org_id_fkey": {
+          "name": "agent_rules_org_id_fkey",
+          "tableFrom": "agent_rules",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_org_id_fkey": {
+          "name": "api_keys_org_id_fkey",
+          "tableFrom": "api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_key": {
+          "name": "api_keys_hashed_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auto_topup_limit_states": {
+      "name": "auto_topup_limit_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_window_ends_at": {
+          "name": "purchase_window_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_count": {
+          "name": "purchase_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attempt_window_ends_at": {
+          "name": "attempt_window_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_attempt_window_ends_at": {
+          "name": "failed_attempt_window_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_attempt_count": {
+          "name": "failed_attempt_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failed_attempt_at": {
+          "name": "last_failed_attempt_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failure_count": {
+          "name": "consecutive_failure_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_reason": {
+          "name": "suspended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_payment_method_fingerprint": {
+          "name": "suspended_payment_method_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "auto_topup_limits_org_env_internal_customer_feature_unique": {
+          "name": "auto_topup_limits_org_env_internal_customer_feature_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auto_topup_limits_org_id_fkey": {
+          "name": "auto_topup_limits_org_id_fkey",
+          "tableFrom": "auto_topup_limit_states",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auto_topup_limits_internal_customer_id_fkey": {
+          "name": "auto_topup_limits_internal_customer_id_fkey",
+          "tableFrom": "auto_topup_limit_states",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_approvals": {
+      "name": "chat_approvals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_ts": {
+          "name": "message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_args": {
+          "name": "tool_args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview": {
+          "name": "preview",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_provider_user_id": {
+          "name": "decided_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_approvals_org_id_fkey": {
+          "name": "chat_approvals_org_id_fkey",
+          "tableFrom": "chat_approvals",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_installations": {
+      "name": "chat_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_env": {
+          "name": "default_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_api_key_id": {
+          "name": "sandbox_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_api_key": {
+          "name": "sandbox_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_api_key_id": {
+          "name": "live_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_api_key": {
+          "name": "live_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_provider_user_id": {
+          "name": "installed_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_installations_org_id_fkey": {
+          "name": "chat_installations_org_id_fkey",
+          "tableFrom": "chat_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_installations_org_provider_key": {
+          "name": "chat_installations_org_provider_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "provider"
+          ]
+        },
+        "chat_installations_provider_workspace_key": {
+          "name": "chat_installations_provider_workspace_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_oauth_credentials": {
+      "name": "chat_oauth_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_installation_id": {
+          "name": "chat_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_consent_id": {
+          "name": "oauth_consent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_oauth_credentials_installation_id_fkey": {
+          "name": "chat_oauth_credentials_installation_id_fkey",
+          "tableFrom": "chat_oauth_credentials",
+          "tableTo": "chat_installations",
+          "columnsFrom": [
+            "chat_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_oauth_credentials_org_id_fkey": {
+          "name": "chat_oauth_credentials_org_id_fkey",
+          "tableFrom": "chat_oauth_credentials",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_oauth_credentials_installation_org_env_user_key": {
+          "name": "chat_oauth_credentials_installation_org_env_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chat_installation_id",
+            "org_id",
+            "env",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_results": {
+      "name": "chat_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "leaf.chat_thread_contexts": {
+      "name": "chat_thread_contexts",
+      "schema": "leaf",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_installation_id": {
+          "name": "chat_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_identifier": {
+          "name": "target_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_provider_user_id": {
+          "name": "created_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_thread_contexts_thread_key": {
+          "name": "chat_thread_contexts_thread_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "channel_id",
+            "thread_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkouts": {
+      "name": "checkouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_version": {
+          "name": "params_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_checkouts_stripe_invoice_id": {
+          "name": "idx_checkouts_stripe_invoice_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leaf.cma_memory": {
+      "name": "cma_memory",
+      "schema": "leaf",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_store_id": {
+          "name": "memory_store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "cma_memory_org_id_env_pk": {
+          "name": "cma_memory_org_id_env_pk",
+          "columns": [
+            "org_id",
+            "env"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leaf.cma_sessions": {
+      "name": "cma_sessions",
+      "schema": "leaf",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "braintrust_parent": {
+          "name": "braintrust_parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "cma_sessions_org_id_env_thread_key_pk": {
+          "name": "cma_sessions_org_id_env_thread_key_pk",
+          "columns": [
+            "org_id",
+            "env",
+            "thread_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leaf.cma_vaults": {
+      "name": "cma_vaults",
+      "schema": "leaf",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_installation_id": {
+          "name": "chat_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vault_id": {
+          "name": "vault_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cma_vaults_installation_org_env_user_key": {
+          "name": "cma_vaults_installation_org_env_user_key",
+          "nullsNotDistinct": true,
+          "columns": [
+            "chat_installation_id",
+            "org_id",
+            "env",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_entitlements": {
+      "name": "customer_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_product_id": {
+          "name": "customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unlimited": {
+          "name": "unlimited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_cycle_anchor": {
+          "name": "reset_cycle_anchor",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reset_at": {
+          "name": "next_reset_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_allowed": {
+          "name": "usage_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "separate_interval": {
+          "name": "separate_interval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_pooled_balance": {
+          "name": "is_pooled_balance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pooled_balance_id": {
+          "name": "pooled_balance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pooled_contribution_id": {
+          "name": "pooled_contribution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adjustment": {
+          "name": "adjustment",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_balance": {
+          "name": "additional_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "entities": {
+          "name": "entities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_version": {
+          "name": "cache_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired": {
+          "name": "expired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_by_invoice": {
+          "name": "reset_by_invoice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_entitlements_product_id": {
+          "name": "idx_customer_entitlements_product_id",
+          "columns": [
+            {
+              "expression": "customer_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_customer_id": {
+          "name": "idx_customer_entitlements_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_customer_id_btree": {
+          "name": "idx_customer_entitlements_internal_customer_id_btree",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_entitlement_id": {
+          "name": "idx_customer_entitlements_entitlement_id",
+          "columns": [
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_feature_id_c": {
+          "name": "idx_customer_entitlements_internal_feature_id_c",
+          "columns": [
+            {
+              "expression": "\"internal_feature_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ce_internal_feature_id": {
+          "name": "idx_ce_internal_feature_id",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ce_customer_product_id_c": {
+          "name": "idx_ce_customer_product_id_c",
+          "columns": [
+            {
+              "expression": "\"customer_product_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ce_loose_next_reset": {
+          "name": "idx_ce_loose_next_reset",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"customer_product_id\" IS NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_nonnull_entity_by_id": {
+          "name": "idx_customer_entitlements_nonnull_entity_by_id",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"internal_entity_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_entity_id": {
+          "name": "idx_customer_entitlements_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        },
+        "idx_customer_entitlements_on_next_reset_at": {
+          "name": "idx_customer_entitlements_on_next_reset_at",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_separate_interval_reset": {
+          "name": "idx_customer_entitlements_separate_interval_reset",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"separate_interval\" = true AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_loose_customer_expires": {
+          "name": "idx_customer_entitlements_loose_customer_expires",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"customer_product_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_next_reset_not_expired": {
+          "name": "idx_customer_entitlements_next_reset_not_expired",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"expired\" IS NOT TRUE AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_pooled_contribution": {
+          "name": "idx_customer_entitlements_pooled_contribution",
+          "columns": [
+            {
+              "expression": "pooled_contribution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"pooled_contribution_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_reset_scan": {
+          "name": "idx_customer_entitlements_reset_scan",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"expired\" IS NOT TRUE AND \"customer_entitlements\".\"reset_by_invoice\" IS NOT TRUE AND \"customer_entitlements\".\"pooled_contribution_id\" IS NULL AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entitlements_internal_feature_id_fkey": {
+          "name": "entitlements_internal_feature_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_entitlements_internal_entity_id_fkey": {
+          "name": "customer_entitlements_internal_entity_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_entitlements_customer_product_id_fkey": {
+          "name": "customer_entitlements_customer_product_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "customer_entitlements_entitlement_id_fkey": {
+          "name": "customer_entitlements_entitlement_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "entitlements",
+          "columnsFrom": [
+            "entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_jwt_families": {
+      "name": "customer_jwt_families",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "refresh_kid": {
+          "name": "refresh_kid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "indefinite": {
+          "name": "indefinite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "customer_jwt_families_internal_customer_id_fkey": {
+          "name": "customer_jwt_families_internal_customer_id_fkey",
+          "tableFrom": "customer_jwt_families",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "customer_jwt_families_internal_customer_id_key": {
+          "name": "customer_jwt_families_internal_customer_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "internal_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_licenses": {
+      "name": "customer_licenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_customer_product_id": {
+          "name": "parent_customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_internal_product_id": {
+          "name": "license_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_license_id": {
+          "name": "plan_license_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted": {
+          "name": "granted",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "paid_quantity": {
+          "name": "paid_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "idx_customer_licenses_plan_license": {
+          "name": "idx_customer_licenses_plan_license",
+          "columns": [
+            {
+              "expression": "plan_license_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_customer_license": {
+          "name": "unique_customer_license",
+          "columns": [
+            {
+              "expression": "parent_customer_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "license_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_licenses_customer": {
+          "name": "idx_customer_licenses_customer",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_licenses_link": {
+          "name": "idx_customer_licenses_link",
+          "columns": [
+            {
+              "expression": "link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_licenses_customer_fkey": {
+          "name": "customer_licenses_customer_fkey",
+          "tableFrom": "customer_licenses",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_licenses_parent_customer_product_fkey": {
+          "name": "customer_licenses_parent_customer_product_fkey",
+          "tableFrom": "customer_licenses",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "parent_customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_licenses_license_product_fkey": {
+          "name": "customer_licenses_license_product_fkey",
+          "tableFrom": "customer_licenses",
+          "tableTo": "products",
+          "columnsFrom": [
+            "license_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_licenses_plan_license_fkey": {
+          "name": "customer_licenses_plan_license_fkey",
+          "tableFrom": "customer_licenses",
+          "tableTo": "plan_license",
+          "columnsFrom": [
+            "plan_license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_prices": {
+      "name": "customer_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_product_id": {
+          "name": "customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_prices_product_id": {
+          "name": "idx_customer_prices_product_id",
+          "columns": [
+            {
+              "expression": "customer_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_prices_price_id": {
+          "name": "idx_customer_prices_price_id",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_prices_internal_customer_id": {
+          "name": "idx_customer_prices_internal_customer_id",
+          "columns": [
+            {
+              "expression": "\"internal_customer_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_prices\".\"internal_customer_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cpr_customer_product_id_c": {
+          "name": "idx_cpr_customer_product_id_c",
+          "columns": [
+            {
+              "expression": "\"customer_product_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_prices_customer_product_id_fkey": {
+          "name": "customer_prices_customer_product_id_fkey",
+          "tableFrom": "customer_prices",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_prices_internal_customer_id_fkey": {
+          "name": "customer_prices_internal_customer_id_fkey",
+          "tableFrom": "customer_prices",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_prices_price_id_fkey": {
+          "name": "customer_prices_price_id_fkey",
+          "tableFrom": "customer_prices",
+          "tableTo": "prices",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_products": {
+      "name": "customer_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processor": {
+          "name": "processor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled": {
+          "name": "canceled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_starts_at": {
+          "name": "access_starts_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "free_trial_id": {
+          "name": "free_trial_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle_anchor": {
+          "name": "billing_cycle_anchor",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle_anchor_resets_at": {
+          "name": "billing_cycle_anchor_resets_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_method": {
+          "name": "collection_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'charge_automatically'"
+        },
+        "subscription_ids": {
+          "name": "subscription_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_ids": {
+          "name": "scheduled_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "customer_license_link_id": {
+          "name": "customer_license_link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_version": {
+          "name": "billing_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_version": {
+          "name": "api_version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_semver": {
+          "name": "api_semver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_customer_product_id": {
+          "name": "previous_customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_trial_end": {
+          "name": "on_trial_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_products_customer_status": {
+          "name": "idx_customer_products_customer_status",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_customer_status_created_at": {
+          "name": "idx_customer_products_customer_status_created_at",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_product_status": {
+          "name": "idx_customer_products_product_status",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_on_internal_entity_id": {
+          "name": "idx_customer_products_on_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_product_customer_c": {
+          "name": "idx_customer_products_product_customer_c",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"internal_customer_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_on_internal_product_id": {
+          "name": "idx_customer_products_on_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_subscription_ids": {
+          "name": "idx_customer_products_subscription_ids",
+          "columns": [
+            {
+              "expression": "subscription_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customer_products_scheduled_ids": {
+          "name": "idx_customer_products_scheduled_ids",
+          "columns": [
+            {
+              "expression": "scheduled_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customer_products_stripe_checkout_session_id": {
+          "name": "idx_customer_products_stripe_checkout_session_id",
+          "columns": [
+            {
+              "expression": "stripe_checkout_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_customer_license": {
+          "name": "idx_customer_products_customer_license",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_license_seat_order": {
+          "name": "idx_customer_products_license_seat_order",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_seat_sync": {
+          "name": "idx_customer_products_seat_sync",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_unused_seats": {
+          "name": "idx_customer_products_unused_seats",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "released_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL AND \"customer_products\".\"internal_entity_id\" IS NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_active_pool_assignment": {
+          "name": "unique_active_pool_assignment",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL AND \"customer_products\".\"internal_entity_id\" IS NOT NULL AND \"customer_products\".\"status\" IN ('active', 'past_due')",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_free_trial_id": {
+          "name": "idx_customer_products_free_trial_id",
+          "columns": [
+            {
+              "expression": "free_trial_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"free_trial_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_revenuecat_processor": {
+          "name": "idx_customer_products_revenuecat_processor",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"customer_products\".\"processor\" ->> 'type') = 'revenuecat'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_ended_at": {
+          "name": "idx_customer_products_ended_at",
+          "columns": [
+            {
+              "expression": "ended_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"status\" IN ('active', 'past_due') AND \"customer_products\".\"ended_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_trial_ends_at": {
+          "name": "idx_customer_products_trial_ends_at",
+          "columns": [
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"status\" IN ('active', 'past_due') AND \"customer_products\".\"trial_ends_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_product_id": {
+          "name": "idx_customer_products_product_id",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_products_free_trial_id_fkey": {
+          "name": "customer_products_free_trial_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "free_trials",
+          "columnsFrom": [
+            "free_trial_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "customer_products_internal_customer_id_fkey": {
+          "name": "customer_products_internal_customer_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "customer_products_internal_product_id_fkey": {
+          "name": "customer_products_internal_product_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "customer_products_internal_entity_id_fkey": {
+          "name": "customer_products_internal_entity_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processor": {
+          "name": "processor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processors": {
+          "name": "processors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "send_email_receipts": {
+          "name": "send_email_receipts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_topups": {
+          "name": "auto_topups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spend_limits": {
+          "name": "spend_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limits": {
+          "name": "usage_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_alerts": {
+          "name": "usage_alerts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overage_allowed": {
+          "name": "overage_allowed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "customers_email_null_id_unique": {
+          "name": "customers_email_null_id_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"customers\".\"id\" IS NULL AND \"customers\".\"email\" IS NOT NULL AND \"customers\".\"email\" != ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_org_env_fingerprint": {
+          "name": "idx_customers_org_env_fingerprint",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"fingerprint\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processor_id": {
+          "name": "idx_customers_processor_id",
+          "columns": [
+            {
+              "expression": "(\"processor\" ->> 'id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_composite": {
+          "name": "idx_customers_composite",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_org_env_internal_id": {
+          "name": "idx_customers_org_env_internal_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"internal_id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_email_trgm": {
+          "name": "idx_customers_email_trgm",
+          "columns": [
+            {
+              "expression": "\"email\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"email\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_name_trgm": {
+          "name": "idx_customers_name_trgm",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_id_trgm": {
+          "name": "idx_customers_id_trgm",
+          "columns": [
+            {
+              "expression": "\"id\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_org_id_env_created_at": {
+          "name": "idx_customers_org_id_env_created_at",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_cursor": {
+          "name": "idx_customers_cursor",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processors_revenuecat": {
+          "name": "idx_customers_processors_revenuecat",
+          "columns": [
+            {
+              "expression": "(\"processors\" ->> 'revenuecat')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processors_revenuecat_id": {
+          "name": "idx_customers_processors_revenuecat_id",
+          "columns": [
+            {
+              "expression": "(\"processors\" -> 'revenuecat' ->> 'id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processors_revenuecat_aliases": {
+          "name": "idx_customers_processors_revenuecat_aliases",
+          "columns": [
+            {
+              "expression": "(\"processors\" -> 'revenuecat' -> 'aliases')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_processors_vercel": {
+          "name": "idx_customers_processors_vercel",
+          "columns": [
+            {
+              "expression": "(\"processors\" ->> 'vercel')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customers_org_id_fkey": {
+          "name": "customers_org_id_fkey",
+          "tableFrom": "customers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cus_id_constraint": {
+          "name": "cus_id_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "id",
+            "env"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spend_limits": {
+          "name": "spend_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limits": {
+          "name": "usage_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_alerts": {
+          "name": "usage_alerts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overage_allowed": {
+          "name": "overage_allowed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_entities_internal_customer_id": {
+          "name": "idx_entities_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_internal_feature_id_c": {
+          "name": "idx_entities_internal_feature_id_c",
+          "columns": [
+            {
+              "expression": "\"internal_feature_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"entities\".\"internal_feature_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_internal_feature_id": {
+          "name": "idx_entities_internal_feature_id",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"entities\".\"internal_feature_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_customer_internal_desc": {
+          "name": "idx_entities_customer_internal_desc",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"internal_id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_org_env_id": {
+          "name": "idx_entities_org_env_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_cursor": {
+          "name": "idx_entities_cursor",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_customer_created_at": {
+          "name": "idx_entities_customer_created_at",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entities_internal_customer_id_fkey": {
+          "name": "entities_internal_customer_id_fkey",
+          "tableFrom": "entities",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entities_internal_feature_id_fkey": {
+          "name": "entities_internal_feature_id_fkey",
+          "tableFrom": "entities",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entities_org_id_fkey": {
+          "name": "entities_org_id_fkey",
+          "tableFrom": "entities",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entity_id_constraint": {
+          "name": "entity_id_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "env",
+            "internal_customer_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entitlements": {
+      "name": "entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_id": {
+          "name": "internal_reward_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "allowance_type": {
+          "name": "allowance_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowance": {
+          "name": "allowance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_count": {
+          "name": "interval_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "carry_from_previous": {
+          "name": "carry_from_previous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "entity_feature_id": {
+          "name": "entity_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "pooled": {
+          "name": "pooled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limit": {
+          "name": "usage_limit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_duration": {
+          "name": "expiry_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_length": {
+          "name": "expiry_length",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollover": {
+          "name": "rollover",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_entitlements_internal_product_id": {
+          "name": "idx_entitlements_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_reward_id": {
+          "name": "idx_entitlements_internal_reward_id",
+          "columns": [
+            {
+              "expression": "internal_reward_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_reward_feature": {
+          "name": "idx_entitlements_reward_feature",
+          "columns": [
+            {
+              "expression": "internal_reward_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_feature_id_c": {
+          "name": "idx_entitlements_internal_feature_id_c",
+          "columns": [
+            {
+              "expression": "\"internal_feature_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_feature_id": {
+          "name": "idx_entitlements_internal_feature_id",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_reward_id_c_partial": {
+          "name": "idx_entitlements_internal_reward_id_c_partial",
+          "columns": [
+            {
+              "expression": "\"internal_reward_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"entitlements\".\"internal_reward_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entitlements_internal_feature_id_fkey": {
+          "name": "entitlements_internal_feature_id_fkey",
+          "tableFrom": "entitlements",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entitlements_internal_product_id_fkey": {
+          "name": "entitlements_internal_product_id_fkey",
+          "tableFrom": "entitlements",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "entitlements_internal_reward_id_fkey": {
+          "name": "entitlements_internal_reward_id_fkey",
+          "tableFrom": "entitlements",
+          "tableTo": "rewards",
+          "columnsFrom": [
+            "internal_reward_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entitlements_id_key": {
+          "name": "entitlements_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_usage": {
+          "name": "set_usage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductions": {
+          "name": "deductions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_events_internal_customer_id": {
+          "name": "idx_events_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_internal_entity_id": {
+          "name": "idx_events_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_customer_non_usage_ts": {
+          "name": "idx_events_customer_non_usage_ts",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"timestamp\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"set_usage\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_timestamp": {
+          "name": "idx_events_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_internal_customer_id_fkey": {
+          "name": "events_internal_customer_id_fkey",
+          "tableFrom": "events",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_constraint": {
+          "name": "unique_event_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "env",
+            "customer_id",
+            "event_name",
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.features": {
+      "name": "features",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display": {
+          "name": "display",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_names": {
+          "name": "event_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "model_markups": {
+          "name": "model_markups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "stripe_meter": {
+          "name": "stripe_meter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        }
+      },
+      "indexes": {
+        "idx_features_composite": {
+          "name": "idx_features_composite",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "features_org_id_fkey": {
+          "name": "features_org_id_fkey",
+          "tableFrom": "features",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_id_constraint": {
+          "name": "feature_id_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "id",
+            "env"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.free_trials": {
+      "name": "free_trials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'day'"
+        },
+        "length": {
+          "name": "length",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unique_fingerprint": {
+          "name": "unique_fingerprint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "card_required": {
+          "name": "card_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "on_end": {
+          "name": "on_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_free_trials_internal_product_id": {
+          "name": "idx_free_trials_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "free_trials_internal_product_id_fkey": {
+          "name": "free_trials_internal_product_id_fkey",
+          "tableFrom": "free_trials",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leaf.harness_sessions": {
+      "name": "harness_sessions",
+      "schema": "leaf",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resume_state": {
+          "name": "resume_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "braintrust_parent": {
+          "name": "braintrust_parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "idx_harness_sessions_session_id": {
+          "name": "idx_harness_sessions_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "harness_sessions_org_id_env_thread_key_pk": {
+          "name": "harness_sessions_org_id_env_thread_key_pk",
+          "columns": [
+            "org_id",
+            "env",
+            "thread_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organizations_id_fk": {
+          "name": "invitation_organization_id_organizations_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.invoice_line_items": {
+      "name": "invoice_line_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_item_id": {
+          "name": "stripe_invoice_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_item_id": {
+          "name": "stripe_subscription_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_discountable": {
+          "name": "stripe_discountable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_after_discounts": {
+          "name": "amount_after_discounts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_quantity": {
+          "name": "stripe_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_quantity": {
+          "name": "total_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_quantity": {
+          "name": "paid_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_source": {
+          "name": "description_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_timing": {
+          "name": "billing_timing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prorated": {
+          "name": "prorated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_product_ids": {
+          "name": "customer_product_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customer_price_ids": {
+          "name": "customer_price_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customer_entitlement_ids": {
+          "name": "customer_entitlement_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_period_start": {
+          "name": "effective_period_start",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_period_end": {
+          "name": "effective_period_end",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discounts": {
+          "name": "discounts",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "idx_invoice_line_items_customer_product_ids": {
+          "name": "idx_invoice_line_items_customer_product_ids",
+          "columns": [
+            {
+              "expression": "customer_product_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_invoice_line_items_stripe_invoice_id": {
+          "name": "idx_invoice_line_items_stripe_invoice_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoice_line_items\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoice_line_items_invoice_id": {
+          "name": "idx_invoice_line_items_invoice_id",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoice_line_items\".\"invoice_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoice_line_items_stripe_invoice_item_id": {
+          "name": "idx_invoice_line_items_stripe_invoice_item_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoice_line_items\".\"stripe_invoice_item_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_line_items_invoice_id_fkey": {
+          "name": "invoice_line_items_invoice_id_fkey",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_line_items_stripe_id_unique": {
+          "name": "invoice_line_items_stripe_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_templates": {
+      "name": "invoice_templates",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footer": {
+          "name": "footer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "net_terms_days": {
+          "name": "net_terms_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_invoice_templates_org_id": {
+          "name": "idx_invoice_templates_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_templates_org_id_fkey": {
+          "name": "invoice_templates_org_id_fkey",
+          "tableFrom": "invoice_templates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_templates_id_unique": {
+          "name": "invoice_templates_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "product_ids": {
+          "name": "product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "internal_product_ids": {
+          "name": "internal_product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processor_type": {
+          "name": "processor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "hosted_invoice_url": {
+          "name": "hosted_invoice_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_amount": {
+          "name": "refunded_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "discounts": {
+          "name": "discounts",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "items": {
+          "name": "items",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "idx_invoices_customer_created": {
+          "name": "idx_invoices_customer_created",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_internal_entity_id": {
+          "name": "idx_invoices_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoices\".\"internal_entity_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_internal_customer_id_fkey": {
+          "name": "invoices_internal_customer_id_fkey",
+          "tableFrom": "invoices",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoices_internal_entity_id_fkey": {
+          "name": "invoices_internal_entity_id_fkey",
+          "tableFrom": "invoices",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_stripe_id_key": {
+          "name": "invoices_stripe_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.license_entitlements": {
+      "name": "license_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_license_id": {
+          "name": "plan_license_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "unique_license_entitlement": {
+          "name": "unique_license_entitlement",
+          "columns": [
+            {
+              "expression": "plan_license_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_license_entitlements_entitlement": {
+          "name": "idx_license_entitlements_entitlement",
+          "columns": [
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "license_entitlements_plan_license_fkey": {
+          "name": "license_entitlements_plan_license_fkey",
+          "tableFrom": "license_entitlements",
+          "tableTo": "plan_license",
+          "columnsFrom": [
+            "plan_license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "license_entitlements_entitlement_fkey": {
+          "name": "license_entitlements_entitlement_fkey",
+          "tableFrom": "license_entitlements",
+          "tableTo": "entitlements",
+          "columnsFrom": [
+            "entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.license_prices": {
+      "name": "license_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_license_id": {
+          "name": "plan_license_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "unique_license_price": {
+          "name": "unique_license_price",
+          "columns": [
+            {
+              "expression": "plan_license_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_license_prices_price": {
+          "name": "idx_license_prices_price",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "license_prices_plan_license_fkey": {
+          "name": "license_prices_plan_license_fkey",
+          "tableFrom": "license_prices",
+          "tableTo": "plan_license",
+          "columnsFrom": [
+            "plan_license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "license_prices_price_fkey": {
+          "name": "license_prices_price_fkey",
+          "tableFrom": "license_prices",
+          "tableTo": "prices",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organizations_id_fk": {
+          "name": "member_organization_id_organizations_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.metadata": {
+      "name": "metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_metadata_on_type_expires_at": {
+          "name": "idx_metadata_on_type_expires_at",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "metadata_expires_at_idx": {
+          "name": "metadata_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"metadata\".\"expires_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_errors": {
+      "name": "migration_errors",
+      "schema": "",
+      "columns": {
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "migration_job_id": {
+          "name": "migration_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "migration_customers_internal_customer_id_fkey": {
+          "name": "migration_customers_internal_customer_id_fkey",
+          "tableFrom": "migration_errors",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_customers_migration_job_id_fkey": {
+          "name": "migration_customers_migration_job_id_fkey",
+          "tableFrom": "migration_errors",
+          "tableTo": "migration_jobs",
+          "columnsFrom": [
+            "migration_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "migration_errors_pkey": {
+          "name": "migration_errors_pkey",
+          "columns": [
+            "internal_customer_id",
+            "migration_job_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_item_runs": {
+      "name": "migration_item_runs",
+      "schema": "",
+      "columns": {
+        "migration_item_run_id": {
+          "name": "migration_item_run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "migration_internal_id": {
+          "name": "migration_internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "migration_run_id": {
+          "name": "migration_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "item_kind": {
+          "name": "item_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_item_runs_live_unique": {
+          "name": "migration_item_runs_live_unique",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_item_runs\".\"dry_run\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_item_runs_live_c_idx": {
+          "name": "migration_item_runs_live_c_idx",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"item_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_item_runs\".\"dry_run\" = false",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_item_runs_dry_run_unique": {
+          "name": "migration_item_runs_dry_run_unique",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "migration_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_item_runs\".\"dry_run\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_item_runs_customer_recent_idx": {
+          "name": "migration_item_runs_customer_recent_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_item_runs\".\"item_kind\" = 'customer'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_jobs": {
+      "name": "migration_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_internal_product_id": {
+          "name": "from_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_internal_product_id": {
+          "name": "to_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_details": {
+          "name": "step_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "migration_jobs_from_internal_product_id_fkey": {
+          "name": "migration_jobs_from_internal_product_id_fkey",
+          "tableFrom": "migration_jobs",
+          "tableTo": "products",
+          "columnsFrom": [
+            "from_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_jobs_org_id_fkey": {
+          "name": "migration_jobs_org_id_fkey",
+          "tableFrom": "migration_jobs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_jobs_to_internal_product_id_fkey": {
+          "name": "migration_jobs_to_internal_product_id_fkey",
+          "tableFrom": "migration_jobs",
+          "tableTo": "products",
+          "columnsFrom": [
+            "to_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "migration_internal_id": {
+          "name": "migration_internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lazy_run": {
+          "name": "lazy_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trigger_run_id": {
+          "name": "trigger_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "only_ids": {
+          "name": "only_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_limit": {
+          "name": "target_limit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_per_migration_unique": {
+          "name": "migration_runs_active_per_migration_unique",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" IN ('queued', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_migration_internal_id_fkey": {
+          "name": "migration_runs_migration_internal_id_fkey",
+          "tableFrom": "migration_runs",
+          "tableTo": "migrations",
+          "columnsFrom": [
+            "migration_internal_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_runs_org_id_fkey": {
+          "name": "migration_runs_org_id_fkey",
+          "tableFrom": "migration_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migrations": {
+      "name": "migrations",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operations": {
+          "name": "operations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prepared_state": {
+          "name": "prepared_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_billing_changes": {
+          "name": "no_billing_changes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_failed": {
+          "name": "retry_failed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migrations_org_env_id_unique": {
+          "name": "migrations_org_env_id_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migrations_org_id_fkey": {
+          "name": "migrations_org_id_fkey",
+          "tableFrom": "migrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_consent_id": {
+          "name": "oauth_consent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_oauth_consent_id_oauth_consent_id_fk": {
+          "name": "oauth_access_token_oauth_consent_id_oauth_consent_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_consent",
+          "columnsFrom": [
+            "oauth_consent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_api_key_id": {
+          "name": "oauth_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_consent_id": {
+          "name": "oauth_consent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_oauth_consent_id_oauth_consent_id_fk": {
+          "name": "oauth_refresh_token_oauth_consent_id_oauth_consent_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_consent",
+          "columnsFrom": [
+            "oauth_consent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_currency": {
+          "name": "default_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'usd'"
+        },
+        "stripe_connected": {
+          "name": "stripe_connected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "stripe_config": {
+          "name": "stripe_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_stripe_connect": {
+          "name": "test_stripe_connect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "live_stripe_connect": {
+          "name": "live_stripe_connect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "processor_configs": {
+          "name": "processor_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_pkey": {
+          "name": "test_pkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_pkey": {
+          "name": "live_pkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "svix_config": {
+          "name": "svix_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "custom_buttons": {
+          "name": "custom_buttons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded": {
+          "name": "onboarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "deployed": {
+          "name": "deployed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_sandbox": {
+          "name": "is_sandbox",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sandbox_color": {
+          "name": "sandbox_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_icon": {
+          "name": "sandbox_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redis_config": {
+          "name": "redis_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_organizations_name_trgm": {
+          "name": "idx_organizations_name_trgm",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"organizations\".\"name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_organizations_slug_trgm": {
+          "name": "idx_organizations_slug_trgm",
+          "columns": [
+            {
+              "expression": "\"slug\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"organizations\".\"slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_organizations_created_at_id": {
+          "name": "idx_organizations_created_at_id",
+          "columns": [
+            {
+              "expression": "\"createdAt\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orgs_test_connect_default_account": {
+          "name": "idx_orgs_test_connect_default_account",
+          "columns": [
+            {
+              "expression": "(\"test_stripe_connect\"->>'default_account_id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orgs_test_connect_account": {
+          "name": "idx_orgs_test_connect_account",
+          "columns": [
+            {
+              "expression": "(\"test_stripe_connect\"->>'account_id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orgs_live_connect_account": {
+          "name": "idx_orgs_live_connect_account",
+          "columns": [
+            {
+              "expression": "(\"live_stripe_connect\"->>'account_id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organizations_test_pkey_key": {
+          "name": "organizations_test_pkey_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_pkey"
+          ]
+        },
+        "organizations_live_pkey_key": {
+          "name": "organizations_live_pkey_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "live_pkey"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialId_idx": {
+          "name": "passkey_credentialId_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passkey_credential_id_unique": {
+          "name": "passkey_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.plan_license": {
+      "name": "plan_license",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_internal_product_id": {
+          "name": "parent_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_internal_product_id": {
+          "name": "license_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "included": {
+          "name": "included",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prepaid_only": {
+          "name": "prepaid_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "customized": {
+          "name": "customized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "unique_plan_license": {
+          "name": "unique_plan_license",
+          "columns": [
+            {
+              "expression": "parent_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "license_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"plan_license\".\"is_custom\" = false",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_plan_license_parent_product": {
+          "name": "idx_plan_license_parent_product",
+          "columns": [
+            {
+              "expression": "parent_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_plan_license_license": {
+          "name": "idx_plan_license_license",
+          "columns": [
+            {
+              "expression": "license_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plan_license_parent_product_fkey": {
+          "name": "plan_license_parent_product_fkey",
+          "tableFrom": "plan_license",
+          "tableTo": "products",
+          "columnsFrom": [
+            "parent_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_license_license_product_fkey": {
+          "name": "plan_license_license_product_fkey",
+          "tableFrom": "plan_license",
+          "tableTo": "products",
+          "columnsFrom": [
+            "license_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pooled_balance_contributions": {
+      "name": "pooled_balance_contributions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pooled_balance_id": {
+          "name": "pooled_balance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_customer_product_id": {
+          "name": "source_customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_customer_entitlement_id": {
+          "name": "source_customer_entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_contribution": {
+          "name": "current_contribution",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_cycle_contribution": {
+          "name": "next_cycle_contribution",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "idx_pooled_balance_contributions_pool": {
+          "name": "idx_pooled_balance_contributions_pool",
+          "columns": [
+            {
+              "expression": "pooled_balance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balance_contributions_source_customer_entitlement": {
+          "name": "idx_pooled_balance_contributions_source_customer_entitlement",
+          "columns": [
+            {
+              "expression": "source_customer_entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pooled_balance_contributions_pool_fkey": {
+          "name": "pooled_balance_contributions_pool_fkey",
+          "tableFrom": "pooled_balance_contributions",
+          "tableTo": "pooled_balances",
+          "columnsFrom": [
+            "pooled_balance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pooled_balance_contributions_customer_product_fkey": {
+          "name": "pooled_balance_contributions_customer_product_fkey",
+          "tableFrom": "pooled_balance_contributions",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "source_customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pooled_balance_contributions_customer_entitlement_fkey": {
+          "name": "pooled_balance_contributions_customer_entitlement_fkey",
+          "tableFrom": "pooled_balance_contributions",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "source_customer_entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_pooled_balance_contribution": {
+          "name": "unique_pooled_balance_contribution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_customer_entitlement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pooled_balance_contributions_current_non_negative": {
+          "name": "pooled_balance_contributions_current_non_negative",
+          "value": "\"pooled_balance_contributions\".\"current_contribution\" >= 0"
+        },
+        "pooled_balance_contributions_next_non_negative": {
+          "name": "pooled_balance_contributions_next_non_negative",
+          "value": "\"pooled_balance_contributions\".\"next_cycle_contribution\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pooled_balances": {
+      "name": "pooled_balances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unlimited": {
+          "name": "unlimited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "granted": {
+          "name": "granted",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval_count": {
+          "name": "interval_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reset_cycle_anchor": {
+          "name": "reset_cycle_anchor",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_mode": {
+          "name": "reset_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_license_link_id": {
+          "name": "customer_license_link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollover_signature": {
+          "name": "rollover_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "customer_entitlement_id": {
+          "name": "customer_entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_applied_reset_at": {
+          "name": "last_applied_reset_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "idx_pooled_balances_org": {
+          "name": "idx_pooled_balances_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balances_reset_mode": {
+          "name": "idx_pooled_balances_reset_mode",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reset_mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balances_feature": {
+          "name": "idx_pooled_balances_feature",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balances_stripe_subscription": {
+          "name": "idx_pooled_balances_stripe_subscription",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pooled_balances\".\"stripe_subscription_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balances_customer_license": {
+          "name": "idx_pooled_balances_customer_license",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pooled_balances\".\"customer_license_link_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pooled_balances_customer_fkey": {
+          "name": "pooled_balances_customer_fkey",
+          "tableFrom": "pooled_balances",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pooled_balances_feature_fkey": {
+          "name": "pooled_balances_feature_fkey",
+          "tableFrom": "pooled_balances",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "pooled_balances_customer_entitlement_fkey": {
+          "name": "pooled_balances_customer_entitlement_fkey",
+          "tableFrom": "pooled_balances",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "customer_entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_pooled_balance": {
+          "name": "unique_pooled_balance",
+          "nullsNotDistinct": true,
+          "columns": [
+            "internal_customer_id",
+            "internal_feature_id",
+            "unlimited",
+            "interval",
+            "interval_count",
+            "reset_cycle_anchor",
+            "reset_mode",
+            "stripe_subscription_id",
+            "customer_license_link_id",
+            "rollover_signature",
+            "expires_at"
+          ]
+        },
+        "unique_pooled_balance_customer_entitlement": {
+          "name": "unique_pooled_balance_customer_entitlement",
+          "nullsNotDistinct": false,
+          "columns": [
+            "customer_entitlement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pooled_balances_interval_count_positive": {
+          "name": "pooled_balances_interval_count_positive",
+          "value": "\"pooled_balances\".\"interval_count\" > 0"
+        },
+        "pooled_balances_granted_non_negative": {
+          "name": "pooled_balances_granted_non_negative",
+          "value": "\"pooled_balances\".\"granted\" >= 0"
+        },
+        "pooled_balances_reset_mode_valid": {
+          "name": "pooled_balances_reset_mode_valid",
+          "value": "\"pooled_balances\".\"reset_mode\" IN ('lazy', 'subscription', 'lifetime')"
+        },
+        "pooled_balances_lifecycle_ids_valid": {
+          "name": "pooled_balances_lifecycle_ids_valid",
+          "value": "(\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'subscription'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NOT NULL\n\t\t\t\tAND \"pooled_balances\".\"customer_license_link_id\" IS NULL\n\t\t\t) OR (\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'lazy'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NULL\n\t\t\t) OR (\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'lifetime'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NULL\n\t\t\t\tAND \"pooled_balances\".\"customer_license_link_id\" IS NULL\n\t\t\t)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.prices": {
+      "name": "prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_type": {
+          "name": "billing_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier_behavior": {
+          "name": "tier_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "proration_config": {
+          "name": "proration_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        }
+      },
+      "indexes": {
+        "idx_prices_internal_product_id": {
+          "name": "idx_prices_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_entitlement_id": {
+          "name": "idx_prices_entitlement_id",
+          "columns": [
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prices_entitlement_id_fkey": {
+          "name": "prices_entitlement_id_fkey",
+          "tableFrom": "prices",
+          "tableTo": "entitlements",
+          "columnsFrom": [
+            "entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prices_internal_product_id_fkey": {
+          "name": "prices_internal_product_id_fkey",
+          "tableFrom": "prices",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "prices_id_key": {
+          "name": "prices_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_add_on": {
+          "name": "is_add_on",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "version": {
+          "name": "version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "processor": {
+          "name": "processor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "base_variant_id": {
+          "name": "base_variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_internal_product_id": {
+          "name": "base_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "auto_topups": {
+          "name": "auto_topups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spend_limits": {
+          "name": "spend_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limits": {
+          "name": "usage_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_alerts": {
+          "name": "usage_alerts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overage_allowed": {
+          "name": "overage_allowed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_products_org_env_id_version": {
+          "name": "idx_products_org_env_id_version",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_org_env_base_internal_product_id": {
+          "name": "idx_products_org_env_base_internal_product_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "base_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"products\".\"base_internal_product_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_org_id_fkey": {
+          "name": "products_org_id_fkey",
+          "tableFrom": "products",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_product": {
+          "name": "unique_product",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "id",
+            "env",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.referral_codes": {
+      "name": "referral_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_program_id": {
+          "name": "internal_reward_program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_referral_codes_internal_customer_id": {
+          "name": "idx_referral_codes_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "referral_codes_internal_customer_id_fkey": {
+          "name": "referral_codes_internal_customer_id_fkey",
+          "tableFrom": "referral_codes",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "referral_codes_internal_reward_program_id_fkey": {
+          "name": "referral_codes_internal_reward_program_id_fkey",
+          "tableFrom": "referral_codes",
+          "tableTo": "reward_programs",
+          "columnsFrom": [
+            "internal_reward_program_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "referral_codes_org_id_fkey": {
+          "name": "referral_codes_org_id_fkey",
+          "tableFrom": "referral_codes",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "referral_codes_pkey": {
+          "name": "referral_codes_pkey",
+          "columns": [
+            "code",
+            "org_id",
+            "env"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "referral_codes_id_key": {
+          "name": "referral_codes_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.replaceables": {
+      "name": "replaceables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cus_ent_id": {
+          "name": "cus_ent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_next_cycle": {
+          "name": "delete_next_cycle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_replaceables_cus_ent_id": {
+          "name": "idx_replaceables_cus_ent_id",
+          "columns": [
+            {
+              "expression": "cus_ent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "replaceables_cus_ent_id_fkey": {
+          "name": "replaceables_cus_ent_id_fkey",
+          "tableFrom": "replaceables",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "cus_ent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.revenuecat_mappings": {
+      "name": "revenuecat_mappings",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "autumn_product_id": {
+          "name": "autumn_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revenuecat_product_ids": {
+          "name": "revenuecat_product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "feature_quantities": {
+          "name": "feature_quantities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "revenuecat_mappings_org_id_fkey": {
+          "name": "revenuecat_mappings_org_id_fkey",
+          "tableFrom": "revenuecat_mappings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "revenuecat_mappings_pkey": {
+          "name": "revenuecat_mappings_pkey",
+          "columns": [
+            "org_id",
+            "env",
+            "autumn_product_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reward_programs": {
+      "name": "reward_programs",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_id": {
+          "name": "internal_reward_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_redemptions": {
+          "name": "max_redemptions",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unlimited_redemptions": {
+          "name": "unlimited_redemptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when": {
+          "name": "when",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'immediately'"
+        },
+        "product_ids": {
+          "name": "product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"\"}'"
+        },
+        "exclude_trial": {
+          "name": "exclude_trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reward_triggers_internal_reward_id_fkey": {
+          "name": "reward_triggers_internal_reward_id_fkey",
+          "tableFrom": "reward_programs",
+          "tableTo": "rewards",
+          "columnsFrom": [
+            "internal_reward_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reward_triggers_org_id_fkey": {
+          "name": "reward_triggers_org_id_fkey",
+          "tableFrom": "reward_programs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reward_redemptions": {
+      "name": "reward_redemptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered": {
+          "name": "triggered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_program_id": {
+          "name": "internal_reward_program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "redeemer_applied": {
+          "name": "redeemer_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "referral_code_id": {
+          "name": "referral_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_internal_id": {
+          "name": "reward_internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_code": {
+          "name": "promo_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_reward_redemptions_referral_code_id": {
+          "name": "idx_reward_redemptions_referral_code_id",
+          "columns": [
+            {
+              "expression": "referral_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reward_redemptions_reward_internal_id": {
+          "name": "idx_reward_redemptions_reward_internal_id",
+          "columns": [
+            {
+              "expression": "reward_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reward_redemptions_customer_reward": {
+          "name": "idx_reward_redemptions_customer_reward",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reward_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reward_redemptions_internal_customer_id_fkey": {
+          "name": "reward_redemptions_internal_customer_id_fkey",
+          "tableFrom": "reward_redemptions",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reward_redemptions_internal_reward_program_id_fkey": {
+          "name": "reward_redemptions_internal_reward_program_id_fkey",
+          "tableFrom": "reward_redemptions",
+          "tableTo": "reward_programs",
+          "columnsFrom": [
+            "internal_reward_program_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reward_redemptions_referral_code_id_fkey": {
+          "name": "reward_redemptions_referral_code_id_fkey",
+          "tableFrom": "reward_redemptions",
+          "tableTo": "referral_codes",
+          "columnsFrom": [
+            "referral_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards": {
+      "name": "rewards",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount_config": {
+          "name": "discount_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "free_product_config": {
+          "name": "free_product_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "free_product_id": {
+          "name": "free_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_codes": {
+          "name": "promo_codes",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_rewards_org_id_env": {
+          "name": "idx_rewards_org_id_env",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "coupons_org_id_fkey": {
+          "name": "coupons_org_id_fkey",
+          "tableFrom": "rewards",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rollovers": {
+      "name": "rollovers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cus_ent_id": {
+          "name": "cus_ent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "entities": {
+          "name": "entities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "idx_rollovers_cus_ent_id": {
+          "name": "idx_rollovers_cus_ent_id",
+          "columns": [
+            {
+              "expression": "cus_ent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rollovers_cus_ent_expires": {
+          "name": "idx_rollovers_cus_ent_expires",
+          "columns": [
+            {
+              "expression": "cus_ent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rollover_cus_ent_id_fkey": {
+          "name": "rollover_cus_ent_id_fkey",
+          "tableFrom": "rollovers",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "cus_ent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.phases": {
+      "name": "phases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_product_ids": {
+          "name": "customer_product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "phases_schedule_id_fkey": {
+          "name": "phases_schedule_id_fkey",
+          "tableFrom": "phases",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "phases_schedule_id_starts_at_key": {
+          "name": "phases_schedule_id_starts_at_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "schedule_id",
+            "starts_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "schedules_customer_scope_unique": {
+          "name": "schedules_customer_scope_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"internal_entity_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_entity_scope_unique": {
+          "name": "schedules_entity_scope_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"internal_entity_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_schedules_internal_customer_id": {
+          "name": "idx_schedules_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_schedules_internal_entity_id": {
+          "name": "idx_schedules_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_org_id_fkey": {
+          "name": "schedules_org_id_fkey",
+          "tableFrom": "schedules",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedules_internal_customer_id_fkey": {
+          "name": "schedules_internal_customer_id_fkey",
+          "tableFrom": "schedules",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedules_internal_entity_id_fkey": {
+          "name": "schedules_internal_entity_id_fkey",
+          "tableFrom": "schedules",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "leaf.slack_admin_threads": {
+      "name": "slack_admin_threads",
+      "schema": "leaf",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_installation_id": {
+          "name": "chat_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_identifier": {
+          "name": "target_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_provider_user_id": {
+          "name": "created_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_admin_threads_thread_key": {
+          "name": "slack_admin_threads_thread_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "channel_id",
+            "thread_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_connection": {
+      "name": "sso_connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_domain_verification'"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sso_connection_organization_id_idx": {
+          "name": "sso_connection_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_connection_provider_id_sso_provider_provider_id_fk": {
+          "name": "sso_connection_provider_id_sso_provider_provider_id_fk",
+          "tableFrom": "sso_connection",
+          "tableTo": "sso_provider",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "provider_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_connection_organization_id_organizations_id_fk": {
+          "name": "sso_connection_organization_id_organizations_id_fk",
+          "tableFrom": "sso_connection",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_connection_provider_id_unique": {
+          "name": "sso_connection_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        },
+        "sso_connection_organization_id_unique": {
+          "name": "sso_connection_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "sso_provider_user_id_idx": {
+          "name": "sso_provider_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_organization_id_idx": {
+          "name": "sso_provider_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_domain_idx": {
+          "name": "sso_provider_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organizations_id_fk": {
+          "name": "sso_provider_organization_id_organizations_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_domain_unique": {
+          "name": "sso_provider_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        },
+        "sso_provider_provider_id_unique": {
+          "name": "sso_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_schedule_id": {
+          "name": "stripe_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "usage_features": {
+          "name": "usage_features",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle_anchor_seconds": {
+          "name": "billing_cycle_anchor_seconds",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_org_id_fkey": {
+          "name": "subscriptions_org_id_fkey",
+          "tableFrom": "subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_id_key": {
+          "name": "subscriptions_stripe_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transition_rules": {
+      "name": "transition_rules",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "carry_over_usages": {
+          "name": "carry_over_usages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transition_rules_org_id_fkey": {
+          "name": "transition_rules_org_id_fkey",
+          "tableFrom": "transition_rules",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transition_rules_pkey": {
+          "name": "transition_rules_pkey",
+          "columns": [
+            "org_id",
+            "env"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_windows": {
+      "name": "usage_windows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter_key": {
+          "name": "filter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anchor_customer_entitlement_id": {
+          "name": "anchor_customer_entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage": {
+          "name": "usage",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_usage_windows_internal_customer_id": {
+          "name": "idx_usage_windows_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_windows_internal_customer_id_c": {
+          "name": "idx_usage_windows_internal_customer_id_c",
+          "columns": [
+            {
+              "expression": "\"internal_customer_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_uw_internal_feature_id": {
+          "name": "idx_uw_internal_feature_id",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_windows_customer_feature_scope": {
+          "name": "idx_usage_windows_customer_feature_scope",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "COALESCE(\"internal_entity_id\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "COALESCE(\"filter_key\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_windows_internal_customer_id_fkey": {
+          "name": "usage_windows_internal_customer_id_fkey",
+          "tableFrom": "usage_windows",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_windows_internal_entity_id_fkey": {
+          "name": "usage_windows_internal_entity_id_fkey",
+          "tableFrom": "usage_windows",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_windows_internal_feature_id_fkey": {
+          "name": "usage_windows_internal_feature_id_fkey",
+          "tableFrom": "usage_windows",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_windows_anchor_customer_entitlement_id_fkey": {
+          "name": "usage_windows_anchor_customer_entitlement_id_fkey",
+          "tableFrom": "usage_windows",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "anchor_customer_entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_name_trgm": {
+          "name": "idx_user_name_trgm",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user\".\"name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_user_email_trgm": {
+          "name": "idx_user_email_trgm",
+          "columns": [
+            {
+              "expression": "\"email\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user\".\"email\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_user_created_at_id": {
+          "name": "idx_user_created_at_id",
+          "columns": [
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_created_by_fkey": {
+          "name": "user_created_by_fkey",
+          "tableFrom": "user",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vercel_resources": {
+      "name": "vercel_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "vercel_resources_installation_name_unique_idx": {
+          "name": "vercel_resources_installation_name_unique_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status <> 'uninstalled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vercel_resources_org_id_fkey": {
+          "name": "vercel_resources_org_id_fkey",
+          "tableFrom": "vercel_resources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "leaf": "leaf"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/drizzle/meta/_journal.json
+++ b/shared/drizzle/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1785268449447,
       "tag": "0056_lean_maginty",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1785337088338,
+      "tag": "0057_demonic_lionheart",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/models/cusProductModels/cusProductTable.ts
+++ b/shared/models/cusProductModels/cusProductTable.ts
@@ -118,6 +118,14 @@ export const customerProducts = pgTable(
 		index("idx_customer_products_on_internal_entity_id").on(
 			table.internal_entity_id,
 		),
+		// COLLATE "C" matches customers.internal_id so migration-filter pages can
+		// walk this index in customer order and stop at the page limit.
+		index("idx_customer_products_product_customer_c")
+			.on(
+				table.internal_product_id,
+				sql`${table.internal_customer_id} COLLATE "C"`,
+			)
+			.concurrently(),
 		index("idx_customer_products_on_internal_product_id").on(
 			table.internal_product_id,
 		),

--- a/vite/src/views/migrations/migration/filters/CustomerPreview.tsx
+++ b/vite/src/views/migrations/migration/filters/CustomerPreview.tsx
@@ -1,34 +1,22 @@
-import type { CustomerFilter, CustomerWithProducts } from "@autumn/shared";
 import {
-	IconButton,
-	Input,
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-	Separator,
-} from "@autumn/ui";
-import {
-	ArrowSquareOutIcon,
-	CaretLeftIcon,
-	CaretRightIcon,
-	ListMagnifyingGlassIcon,
-} from "@phosphor-icons/react";
+	AppEnv,
+	type CustomerFilter,
+	type CustomerWithProducts,
+} from "@autumn/shared";
+import { Separator } from "@autumn/ui";
+import { ArrowSquareOutIcon } from "@phosphor-icons/react";
 import type { ColumnDef, Row } from "@tanstack/react-table";
 import { useDeferredValue, useState } from "react";
 import { Link } from "react-router";
-import { Table } from "@/components/general/table";
-import { useCursorPagination } from "@/components/general/table";
+import { Table, useCursorPagination } from "@/components/general/table";
 import { useMigrationFilterPreview } from "@/hooks/queries/useMigrationFilterPreview";
 import { cn } from "@/lib/utils";
-import {
-	CUSTOMER_LIST_PAGE_SIZE_OPTIONS,
-	DEFAULT_CUSTOMER_LIST_PAGE_SIZE,
-} from "@/utils/constants/customerListPagination";
+import { DEFAULT_CUSTOMER_LIST_PAGE_SIZE } from "@/utils/constants/customerListPagination";
+import { useEnv } from "@/utils/envUtils";
 import { pushPage } from "@/utils/genUtils";
 import { createCustomerListColumns } from "@/views/customers2/components/table/customer-list/CustomerListColumns";
 import { useProductTable } from "@/views/products/hooks/useProductTable";
+import { CustomerSearchToolbar } from "../shared/CustomerSearchToolbar";
 
 const previewColumns = createCustomerListColumns()
 	.filter((col) => col.id !== "actions")
@@ -66,23 +54,17 @@ export function CustomerPreview({ filter }: { filter: CustomerFilter }) {
 	const [search, setSearch] = useState("");
 	const deferredSearch = useDeferredValue(search.trim());
 	const [pageSize, setPageSize] = useState(DEFAULT_CUSTOMER_LIST_PAGE_SIZE);
-	const {
-		currentCursor,
-		currentPage,
-		pagination,
-		canPrev,
-		pushCursor,
-		popCursor,
-	} = useCursorPagination({
+	const cursorPagination = useCursorPagination({
 		pageSize,
 		resetKey: JSON.stringify({ filter, pageSize, search: search.trim() }),
 	});
+	const env = useEnv();
 
 	const { count, customers, nextCursor, isLoading } = useMigrationFilterPreview(
 		{
 			filter,
 			search: deferredSearch,
-			cursor: currentCursor,
+			cursor: cursorPagination.currentCursor,
 			pageSize,
 		},
 	);
@@ -96,77 +78,23 @@ export function CustomerPreview({ filter }: { filter: CustomerFilter }) {
 		options: {
 			manualPagination: true,
 			pageCount,
-			state: { pagination },
+			state: { pagination: cursorPagination.pagination },
 		},
 	});
-	const canGoNext = Boolean(nextCursor);
-	const isDisabled = isLoading;
 
 	return (
 		<div className="flex flex-col gap-3">
 			<Separator />
-			<div className="flex items-center gap-2">
-				<div className="relative flex items-center flex-1 min-w-0">
-					<ListMagnifyingGlassIcon
-						size={16}
-						className="text-tertiary-foreground absolute left-2.5 pointer-events-none"
-					/>
-					<Input
-						value={search}
-						onChange={(e) => setSearch(e.target.value)}
-						className="pl-8! text-sm"
-						placeholder={`Search ${count ?? 0} customers`}
-					/>
-				</div>
-				<div className="flex items-center gap-2 shrink-0">
-					<IconButton
-						variant="secondary"
-						size="default"
-						icon={<CaretLeftIcon size={12} weight="bold" />}
-						onClick={popCursor}
-						disabled={isDisabled || !canPrev}
-						className={cn(
-							(isDisabled || !canPrev) && "pointer-events-none opacity-50",
-						)}
-					/>
-					<span className="text-xs text-muted-foreground font-medium">
-						{currentPage} / {pageCount}
-					</span>
-					<IconButton
-						variant="secondary"
-						size="default"
-						icon={<CaretRightIcon size={12} weight="bold" />}
-						onClick={() => nextCursor && pushCursor(nextCursor)}
-						disabled={isDisabled || !canGoNext}
-						className={cn(
-							(isDisabled || !canGoNext) && "pointer-events-none opacity-50",
-						)}
-					/>
-					<Select
-						value={pageSize.toString()}
-						onValueChange={(v) => {
-							setPageSize(Number(v));
-						}}
-						items={Object.fromEntries(
-							CUSTOMER_LIST_PAGE_SIZE_OPTIONS.map((s) => [
-								s.toString(),
-								s.toString(),
-							]),
-						)}
-					>
-						<SelectTrigger className="h-7 w-fit px-2 text-xs">
-							<SelectValue />
-						</SelectTrigger>
-						<SelectContent>
-							{CUSTOMER_LIST_PAGE_SIZE_OPTIONS.map((s) => (
-								<SelectItem key={s} value={s.toString()}>
-									{s}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
-				</div>
-			</div>
+			<CustomerSearchToolbar
+				search={search}
+				onSearchChange={setSearch}
+				count={count}
+				pageSize={pageSize}
+				onPageSizeChange={setPageSize}
+				pagination={cursorPagination}
+				nextCursor={nextCursor}
+				isLoading={isLoading}
+			/>
 			<Table.Provider
 				config={{
 					table,
@@ -179,7 +107,14 @@ export function CustomerPreview({ filter }: { filter: CustomerFilter }) {
 				}}
 			>
 				<Table.Container>
-					<Table.Content>
+					<Table.Content
+						className={cn(
+							"overflow-y-auto [&_thead]:sticky [&_thead]:top-0 [&_thead]:z-20 [&_thead]:bg-card",
+							env === AppEnv.Sandbox
+								? "max-h-[calc(100vh-425px)]"
+								: "max-h-[calc(100vh-385px)]",
+						)}
+					>
 						<Table.Header />
 						<Table.Body />
 					</Table.Content>

--- a/vite/src/views/migrations/migration/live/MigrationLiveView.tsx
+++ b/vite/src/views/migrations/migration/live/MigrationLiveView.tsx
@@ -12,13 +12,7 @@ import {
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuTrigger,
-	IconButton,
 	Input,
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
 	Separator,
 	ShortcutButton,
 	Switch,
@@ -26,11 +20,8 @@ import {
 import {
 	ArrowSquareOutIcon,
 	CaretDownIcon,
-	CaretLeftIcon,
-	CaretRightIcon,
 	CheckIcon,
 	EyeIcon,
-	ListMagnifyingGlassIcon,
 	PlayIcon,
 	StopIcon,
 	UsersIcon,
@@ -83,6 +74,7 @@ import { useProductTable } from "@/views/products/hooks/useProductTable";
 import { useRealtimeSubscriptions } from "../hooks/useRealtimeSubscriptions";
 import { ItemEventStatusBadge } from "../runs/RunStatusBadge";
 import { type StepId, StepIndicator } from "../StepIndicator";
+import { CustomerSearchToolbar } from "../shared/CustomerSearchToolbar";
 import { OperationsPreview } from "../shared/OperationsPreview";
 import { RunSummaryRows } from "../shared/RunSummaryRows";
 import { ActiveDot } from "./ActiveDot";
@@ -249,14 +241,7 @@ export function MigrationLiveView({
 			customerFilters.processor,
 		],
 	);
-	const {
-		currentCursor,
-		currentPage,
-		pagination,
-		canPrev,
-		pushCursor,
-		popCursor,
-	} = useCursorPagination({
+	const cursorPagination = useCursorPagination({
 		pageSize,
 		resetKey: JSON.stringify({
 			executionStatuses,
@@ -287,13 +272,6 @@ export function MigrationLiveView({
 	const resolvedRunControls = {
 		retryItemStatuses: buildRetryItemStatuses(runControls),
 	};
-
-	const handleSearchChange = useCallback(
-		(e: React.ChangeEvent<HTMLInputElement>) => {
-			setExecutionQuery({ q: e.target.value });
-		},
-		[setExecutionQuery],
-	);
 
 	const handleExecutionStatusesChange = useCallback(
 		(statuses: ExecutionStatus[]) => {
@@ -330,7 +308,7 @@ export function MigrationLiveView({
 		filter: filter.customer ?? {},
 		search: deferredSearch,
 		customerFilters: previewCustomerFilters,
-		cursor: currentCursor,
+		cursor: cursorPagination.currentCursor,
 		pageSize,
 		migrationId,
 		executionStatuses,
@@ -416,7 +394,7 @@ export function MigrationLiveView({
 	);
 
 	const pageCount =
-		count !== null ? Math.max(Math.ceil(count / pagination.pageSize), 1) : 1;
+		count !== null ? Math.max(Math.ceil(count / pageSize), 1) : 1;
 
 	const table = useProductTable<CustomerRow>({
 		data: enrichedCustomers,
@@ -424,11 +402,9 @@ export function MigrationLiveView({
 		options: {
 			manualPagination: true,
 			pageCount,
-			state: { pagination },
+			state: { pagination: cursorPagination.pagination },
 		},
 	});
-	const canGoNext = Boolean(nextCursor);
-	const isDisabled = isLoadingCustomers;
 
 	const latestFailedRun =
 		latestRun?.status === "failed" && latestRun.error_message
@@ -778,85 +754,37 @@ export function MigrationLiveView({
 				</Dialog>
 			</StepIndicator>
 
-			<div className="flex items-center gap-2">
-				<CustomerListFilterButton
-					extraMenuItems={
-						<ExecutionStatusSubMenu
-							selected={executionStatuses}
-							onChange={handleExecutionStatusesChange}
-						/>
-					}
-					hasActiveExtraFilters={hasActiveExecutionFilters(executionStatuses)}
-					onClearExtra={() => handleExecutionStatusesChange([])}
-					hideSavedViews
-				/>
-				<div className="relative flex items-center flex-1 min-w-0">
-					<ListMagnifyingGlassIcon
-						size={16}
-						className="text-tertiary-foreground absolute left-2.5 pointer-events-none"
+			<CustomerSearchToolbar
+				search={search}
+				onSearchChange={(value) => setExecutionQuery({ q: value })}
+				count={count}
+				pageSize={pageSize}
+				onPageSizeChange={(size) => setExecutionQuery({ pageSize: size })}
+				pagination={cursorPagination}
+				nextCursor={nextCursor}
+				isLoading={isLoadingCustomers}
+				leading={
+					<CustomerListFilterButton
+						extraMenuItems={
+							<ExecutionStatusSubMenu
+								selected={executionStatuses}
+								onChange={handleExecutionStatusesChange}
+							/>
+						}
+						hasActiveExtraFilters={hasActiveExecutionFilters(executionStatuses)}
+						onClearExtra={() => handleExecutionStatusesChange([])}
+						hideSavedViews
 					/>
-					<Input
-						value={search}
-						onChange={handleSearchChange}
-						className="pl-8! text-sm"
-						placeholder={`Search ${(count ?? 0).toLocaleString()} customers`}
-					/>
-				</div>
-				<div className="flex items-center gap-2 shrink-0">
-					<IconButton
-						variant="secondary"
-						size="default"
-						icon={<CaretLeftIcon size={12} weight="bold" />}
-						onClick={popCursor}
-						disabled={isDisabled || !canPrev}
-						className={cn(
-							(isDisabled || !canPrev) && "pointer-events-none opacity-50",
-						)}
-					/>
-					<span className="text-xs text-muted-foreground font-medium">
-						{currentPage} / {pageCount}
-					</span>
-					<IconButton
-						variant="secondary"
-						size="default"
-						icon={<CaretRightIcon size={12} weight="bold" />}
-						onClick={() => nextCursor && pushCursor(nextCursor)}
-						disabled={isDisabled || !canGoNext}
-						className={cn(
-							(isDisabled || !canGoNext) && "pointer-events-none opacity-50",
-						)}
-					/>
-					<Select
-						value={pageSize.toString()}
-						onValueChange={(v) => {
-							setExecutionQuery({ pageSize: Number(v) });
-						}}
-						items={Object.fromEntries(
-							CUSTOMER_LIST_PAGE_SIZE_OPTIONS.map((s) => [
-								s.toString(),
-								s.toString(),
-							]),
-						)}
-					>
-						<SelectTrigger className="h-7 w-fit px-2 text-xs">
-							<SelectValue />
-						</SelectTrigger>
-						<SelectContent>
-							{CUSTOMER_LIST_PAGE_SIZE_OPTIONS.map((s) => (
-								<SelectItem key={s} value={s.toString()}>
-									{s}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
-					{progressCounts && (
+				}
+				trailing={
+					progressCounts && (
 						<ExecutionProgressBadge
 							completed={progressCounts.completed}
 							running={progressCounts.running}
 						/>
-					)}
-				</div>
-			</div>
+					)
+				}
+			/>
 
 			<Table.Provider
 				config={{

--- a/vite/src/views/migrations/migration/shared/CustomerSearchToolbar.tsx
+++ b/vite/src/views/migrations/migration/shared/CustomerSearchToolbar.tsx
@@ -1,0 +1,76 @@
+import { Input } from "@autumn/ui";
+import { ListMagnifyingGlassIcon } from "@phosphor-icons/react";
+import type { ReactNode } from "react";
+import {
+	CursorPagination,
+	type CursorPaginationState,
+	PageSizeSelector,
+} from "@/components/general/table";
+import { CUSTOMER_LIST_PAGE_SIZE_OPTIONS } from "@/utils/constants/customerListPagination";
+
+export function CustomerSearchToolbar({
+	search,
+	onSearchChange,
+	count,
+	pageSize,
+	onPageSizeChange,
+	pagination,
+	nextCursor,
+	isLoading = false,
+	leading,
+	trailing,
+}: {
+	search: string;
+	onSearchChange: (value: string) => void;
+	/** Lazily loaded — null renders neutral placeholders instead of blocking. */
+	count: number | null;
+	pageSize: number;
+	onPageSizeChange: (size: number) => void;
+	pagination: CursorPaginationState;
+	nextCursor: string | null;
+	isLoading?: boolean;
+	leading?: ReactNode;
+	trailing?: ReactNode;
+}) {
+	const totalPages =
+		count !== null ? Math.max(Math.ceil(count / pageSize), 1) : null;
+
+	return (
+		<div className="flex items-center gap-2">
+			{leading}
+			<div className="relative flex items-center flex-1 min-w-0">
+				<ListMagnifyingGlassIcon
+					size={16}
+					className="text-tertiary-foreground absolute left-2.5 pointer-events-none"
+				/>
+				<Input
+					value={search}
+					onChange={(e) => onSearchChange(e.target.value)}
+					className="pl-8! text-sm"
+					placeholder={
+						count
+							? `Search ${count.toLocaleString()} customers`
+							: "Search customers"
+					}
+				/>
+			</div>
+			<div className="flex items-center gap-2 shrink-0">
+				<CursorPagination
+					currentPage={pagination.currentPage}
+					totalPages={totalPages}
+					canGoPrev={pagination.canPrev}
+					canGoNext={Boolean(nextCursor)}
+					onPrev={pagination.popCursor}
+					onNext={() => nextCursor && pagination.pushCursor(nextCursor)}
+					disabled={isLoading}
+				/>
+				<PageSizeSelector
+					pageSize={pageSize}
+					options={CUSTOMER_LIST_PAGE_SIZE_OPTIONS}
+					onChange={onPageSizeChange}
+				/>
+				{trailing}
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

- consume plan predicates proven by the selected access path
- stream ordered customer pages through the customer-products index with cursor and predicates inside the walk
- add compiler-owned count and execution-preview access paths
- add the supporting concurrent index migration, dashboard pagination wiring, and parity/performance probes
- align stale preview assertions and make migration integration fixtures deterministic

## Benchmarks (4M customers)

- selective claim page: 4.0s → 58ms
- dominant-plan claim page: 10.2s → 54ms
- dashboard page: 10.0s → 8ms
- execution page: 5.1s → 10ms
- execution count: 5.7s → 748ms

Row-set parity was exact across the filter, count, cursor, checkpoint, and preview matrices.

## Verification

- commit hooks: knip, server typecheck, Vite typecheck
- focused customer planner/composition unit tests
- migration preview version and add-plan preview integration tests
- migration idempotency and lazy completion integration cases
- 4M-row parity and performance probe matrix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up customer selection and migration previews by streaming pages from an ordered index and consuming plan predicates in the compiler. Claim, dashboard, and execution views now load in tens of milliseconds at 4M customers.

- **New Features**
  - Consume plan-level predicates in the compiler, leaving only residual WHEREs; added `composeCustomerPage`, `composeCustomerPreview`, and `CustomerPagePredicate` in `@autumn/shared`.
  - Stream customer pages through `customer_products` using `internal_product_id` + `internal_customer_id COLLATE "C"` with cursor predicates applied inside the walk; preview pages preserve cursor order.
  - Fast counts and execution previews via planned access paths and exact set unions of filter and processed ids.
  - Server utilities: `drizzleToRawWithParams`, page-order restoration in preview handler, and deterministic fixtures; extensive parity/perf probes cover filter, count, cursor, and preview.
  - UI: new `CustomerSearchToolbar`, stable cursor pagination (`CursorPaginationState` export), and simplified controls.

- **Migration**
  - Adds concurrent index `idx_customer_products_product_customer_c` (`0057_demonic_lionheart`) on `customer_products` for ordered, paged walks.
  - Run the migration; it’s online and non-breaking.
  - Optional: use the included bench seeding and probes to validate parity and measure performance.

<sup>Written for commit 4af6ee5a46b1cd259e550a97e6edf34d208758e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR substantially optimizes migration customer selection and preview pagination.
- **Improvements:** Adds compiler-owned streaming page, count, and processed-preview access paths that push cursor, checkpoint, and dashboard predicates into ordered index walks.
- **Improvements:** Adds the concurrent customer-products index and wires cursor pagination through migration dashboard views.
- **API changes, Improvements:** Exports shared customer planner composition APIs and the cursor-pagination state type.
- **Bug fixes, Improvements:** Restores cursor order after customer enrichment and updates migration integration fixtures and preview expectations.
- **Improvements:** Adds large-data parity and performance probes for migration filters, counts, previews, and checkpoints.
</details>

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking need to strengthen the benchmark environment guard before it changes organization memberships.

The migration planner, preview, count, index, and dashboard changes have no identified blocking correctness defect; the remaining concern is confined to manually invoked benchmark tooling whose permissive URL check precedes broad owner-membership insertion.

**Files Needing Attention:** server/tests/perf/batch-migrations/utils/benchContext.ts

<details open><summary><h3>Security Review</h3></summary>

The benchmark database guard is non-blocking but should be hardened: a URL outside the single blocked region can pass the check before the script grants every database user owner access to the benchmark organization.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/api/migrations/filters/planner/composeCustomerPage.ts | Adds compiler-owned ordered page and count composition with predicates evaluated inside the selected access-path walk. |
| shared/api/migrations/filters/planner/composeCustomerPreview.ts | Adds bounded processed-ID walks and deduplicated filter/processed unions for preview pages and counts. |
| server/src/internal/migrations/v2/filters/customers/buildCustomerSelect.ts | Routes limited selection, counts, and unfiltered execution previews through the new shared composers while retaining legacy status-filter branches. |
| shared/api/migrations/filters/planner/chooseCustomerAccessPath.ts | Extends plan access-path selection to consume fully provable plan quantifiers and push supported sibling predicates into the source. |
| shared/drizzle/0057_demonic_lionheart.sql | Adds the concurrent product/customer C-collation index required by ordered customer-product walks. |
| vite/src/views/migrations/migration/filters/CustomerPreview.tsx | Consolidates search and cursor controls into the shared toolbar and adds a bounded sticky-header customer table. |
| server/tests/perf/batch-migrations/utils/benchContext.ts | Adds benchmark setup utilities, but its database safety check does not positively identify an approved benchmark environment before granting broad owner memberships. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  F[Customer migration filter] --> IR[Filter IR and access-path planner]
  IR -->|Plan path| PW[Ordered customer-products index walk]
  IR -->|Fallback| CW[Ordered customers walk]
  P[Checkpoint and dashboard predicates] --> PW
  P --> CW
  PW --> IDs[Bounded customer ID page]
  CW --> IDs
  MIR[Processed migration-item IDs] --> U[Deduplicated preview union]
  IDs --> U
  IDs --> J[Customer payload join]
  U --> J
  J --> API[Cursor-ordered preview response]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/tests/perf/batch-migrations/utils/benchContext.ts:43-46
**Benchmark database guard is brittle**

The guard treats every database URL without `us-east-2` as safe, after which `getBenchContext` grants every database user owner access to the benchmark organization. Use a positive benchmark-environment check before changing memberships or seeding data, so running this command with another shared or production database URL does not expose the organization or populate the wrong database.

**How this was verified:** The accepted URL flows directly to an `INSERT` that selects every row from `user` and assigns the `owner` role.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(migrations): ⚡️ speed up customer s..."](https://github.com/useautumn/autumn/commit/4af6ee5a46b1cd259e550a97e6edf34d208758e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48389799)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [Shared Database Schema](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/shared-db-schema.md)

<!-- /greptile_comment -->