### PR TITLE
perf: poll edge configs through shared timestamp

### DIFF
--- a/server/src/external/aws/s3/adminS3Config.ts
+++ b/server/src/external/aws/s3/adminS3Config.ts
@@ -24,6 +24,8 @@ export const ADMIN_FULL_SUBJECT_GATE_CONFIG_KEY =
 export const ADMIN_ASYNC_BALANCE_UPDATE_CONFIG_KEY =
 	"admin/async-balance-update-config.json";
 export const ADMIN_ASYNC_TRACK_CONFIG_KEY = "admin/async-track-config.json";
+export const ADMIN_EDGE_CONFIG_TIMESTAMP_KEY =
+	"admin/edge-config-timestamp.json";
 export const BLUE_GREEN_ACTIVE_SLOT_KEY = "admin/blue-green-active-slot.json";
 export const BLUE_GREEN_CRON_ACTIVE_SLOT_KEY =
 	"admin/blue-green-cron-active-slot.json";

--- a/server/src/internal/misc/edgeConfig/edgeConfigRegistry.ts
+++ b/server/src/internal/misc/edgeConfig/edgeConfigRegistry.ts
@@ -1,28 +1,99 @@
+import { ms } from "@autumn/shared";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
+import {
+	readEdgeConfigTimestamp,
+	writeEdgeConfigTimestamp,
+} from "./edgeConfigTimestamp.js";
 
 type EdgeConfigLifecycle = {
-	startPolling: (options?: { logger?: Logger }) => Promise<void>;
-	stopPolling: () => void;
+	refresh: (options?: { logger?: Logger }) => Promise<void>;
 };
 
-const stores: EdgeConfigLifecycle[] = [];
-
-export const registerEdgeConfig = ({
-	store,
+export const createEdgeConfigRegistry = ({
+	readTimestamp = readEdgeConfigTimestamp,
+	writeTimestamp = writeEdgeConfigTimestamp,
+	pollIntervalMs = process.env.NODE_ENV === "development"
+		? ms.seconds(1)
+		: ms.seconds(10),
 }: {
-	store: EdgeConfigLifecycle;
-}) => {
-	stores.push(store);
-};
-
-export const startAllEdgeConfigPolling = async ({
-	logger,
-}: {
-	logger?: Logger;
+	readTimestamp?: () => Promise<string | null>;
+	writeTimestamp?: () => Promise<string>;
+	pollIntervalMs?: number;
 } = {}) => {
-	await Promise.all(stores.map((store) => store.startPolling({ logger })));
+	const stores: EdgeConfigLifecycle[] = [];
+	let lastTimestamp: string | null | undefined;
+	let lastTimestampError: string | undefined;
+	let pollTimer: ReturnType<typeof setInterval> | null = null;
+	let pollPromise: Promise<void> | null = null;
+
+	const register = ({ store }: { store: EdgeConfigLifecycle }) => {
+		stores.push(store);
+	};
+
+	const refreshAll = async ({ logger }: { logger?: Logger } = {}) => {
+		await Promise.all(stores.map((store) => store.refresh({ logger })));
+	};
+
+	const warnTimestampError = ({
+		error,
+		logger,
+	}: {
+		error: unknown;
+		logger?: Logger;
+	}) => {
+		const message = error instanceof Error ? error.message : String(error);
+		if (message !== lastTimestampError) {
+			logger?.warn(`Failed to read edge config timestamp: ${message}`);
+		}
+		lastTimestampError = message;
+	};
+
+	const checkForChanges = async ({ logger }: { logger?: Logger } = {}) => {
+		try {
+			const timestamp = await readTimestamp();
+			lastTimestampError = undefined;
+			if (timestamp === lastTimestamp && timestamp !== null) return;
+
+			await refreshAll({ logger });
+			lastTimestamp = timestamp ?? (await writeTimestamp());
+		} catch (error) {
+			warnTimestampError({ error, logger });
+			await refreshAll({ logger });
+		}
+	};
+
+	const start = async ({ logger }: { logger?: Logger } = {}) => {
+		if (pollTimer || process.env.AUTUMN_EDGE_CONFIG_OVERRIDE_B64) {
+			await refreshAll({ logger });
+			return;
+		}
+
+		try {
+			lastTimestamp = (await readTimestamp()) ?? (await writeTimestamp());
+			lastTimestampError = undefined;
+		} catch (error) {
+			warnTimestampError({ error, logger });
+		}
+		await refreshAll({ logger });
+
+		pollTimer = setInterval(() => {
+			if (pollPromise) return;
+			pollPromise = checkForChanges({ logger }).finally(() => {
+				pollPromise = null;
+			});
+		}, pollIntervalMs);
+	};
+
+	const stop = () => {
+		if (pollTimer) clearInterval(pollTimer);
+		pollTimer = null;
+	};
+
+	return { register, start, stop, checkForChanges };
 };
 
-export const stopAllEdgeConfigPolling = () => {
-	for (const store of stores) store.stopPolling();
-};
+const registry = createEdgeConfigRegistry();
+
+export const registerEdgeConfig = registry.register;
+export const startAllEdgeConfigPolling = registry.start;
+export const stopAllEdgeConfigPolling = registry.stop;

--- a/server/src/internal/misc/edgeConfig/edgeConfigRegistry.ts
+++ b/server/src/internal/misc/edgeConfig/edgeConfigRegistry.ts
@@ -15,10 +15,12 @@ export const createEdgeConfigRegistry = ({
 	pollIntervalMs = process.env.NODE_ENV === "development"
 		? ms.seconds(1)
 		: ms.seconds(10),
+	backstopIntervalMs = ms.minutes(10),
 }: {
 	readTimestamp?: () => Promise<string | null>;
 	writeTimestamp?: () => Promise<string>;
 	pollIntervalMs?: number;
+	backstopIntervalMs?: number;
 } = {}) => {
 	const stores: EdgeConfigLifecycle[] = [];
 	let lastTimestamp: string | null | undefined;
@@ -26,6 +28,8 @@ export const createEdgeConfigRegistry = ({
 	let timestampWriteAttempted = false;
 	let pollTimer: ReturnType<typeof setInterval> | null = null;
 	let pollPromise: Promise<void> | null = null;
+	let backstopTimer: ReturnType<typeof setInterval> | null = null;
+	let backstopPromise: Promise<void> | null = null;
 
 	const register = ({ store }: { store: EdgeConfigLifecycle }) => {
 		stores.push(store);
@@ -94,11 +98,22 @@ export const createEdgeConfigRegistry = ({
 				pollPromise = null;
 			});
 		}, pollIntervalMs);
+
+		// Self-heals a config whose timestamp never advanced (write lost after the
+		// config landed), which the timestamp poll alone cannot detect.
+		backstopTimer = setInterval(() => {
+			if (backstopPromise) return;
+			backstopPromise = refreshAll({ logger }).finally(() => {
+				backstopPromise = null;
+			});
+		}, backstopIntervalMs);
 	};
 
 	const stop = () => {
 		if (pollTimer) clearInterval(pollTimer);
+		if (backstopTimer) clearInterval(backstopTimer);
 		pollTimer = null;
+		backstopTimer = null;
 	};
 
 	return { register, start, stop, checkForChanges };

--- a/server/src/internal/misc/edgeConfig/edgeConfigRegistry.ts
+++ b/server/src/internal/misc/edgeConfig/edgeConfigRegistry.ts
@@ -23,6 +23,7 @@ export const createEdgeConfigRegistry = ({
 	const stores: EdgeConfigLifecycle[] = [];
 	let lastTimestamp: string | null | undefined;
 	let lastTimestampError: string | undefined;
+	let timestampWriteAttempted = false;
 	let pollTimer: ReturnType<typeof setInterval> | null = null;
 	let pollPromise: Promise<void> | null = null;
 
@@ -48,14 +49,23 @@ export const createEdgeConfigRegistry = ({
 		lastTimestampError = message;
 	};
 
+	/** One create attempt per missing-key stretch: every process polls, so
+	 *  retrying each tick would hammer S3 fleet-wide while the key stays absent. */
+	const ensureTimestamp = async (): Promise<string | null> => {
+		if (timestampWriteAttempted) return null;
+		timestampWriteAttempted = true;
+		return await writeTimestamp();
+	};
+
 	const checkForChanges = async ({ logger }: { logger?: Logger } = {}) => {
 		try {
 			const timestamp = await readTimestamp();
 			lastTimestampError = undefined;
+			if (timestamp !== null) timestampWriteAttempted = false;
 			if (timestamp === lastTimestamp && timestamp !== null) return;
 
 			await refreshAll({ logger });
-			lastTimestamp = timestamp ?? (await writeTimestamp());
+			lastTimestamp = timestamp ?? (await ensureTimestamp());
 		} catch (error) {
 			warnTimestampError({ error, logger });
 			await refreshAll({ logger });
@@ -69,7 +79,9 @@ export const createEdgeConfigRegistry = ({
 		}
 
 		try {
-			lastTimestamp = (await readTimestamp()) ?? (await writeTimestamp());
+			const timestamp = await readTimestamp();
+			if (timestamp !== null) timestampWriteAttempted = false;
+			lastTimestamp = timestamp ?? (await ensureTimestamp());
 			lastTimestampError = undefined;
 		} catch (error) {
 			warnTimestampError({ error, logger });

--- a/server/src/internal/misc/edgeConfig/edgeConfigStore.ts
+++ b/server/src/internal/misc/edgeConfig/edgeConfigStore.ts
@@ -7,6 +7,7 @@ import { getS3Client } from "@/external/aws/s3/initS3.js";
 import { getS3BodyAsString } from "@/external/aws/s3/s3Utils.js";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
 import RecaseError from "@/utils/errorUtils.js";
+import { writeEdgeConfigTimestamp } from "./edgeConfigTimestamp.js";
 
 export type EdgeConfigStatus = {
 	configured: boolean;
@@ -175,6 +176,7 @@ export const createEdgeConfigStore = <T>({
 				ContentType: "application/json",
 			}),
 		);
+		await writeEdgeConfigTimestamp({ s3Client: client });
 
 		runtimeConfig = config;
 		runtimeStatus = {

--- a/server/src/internal/misc/edgeConfig/edgeConfigStore.ts
+++ b/server/src/internal/misc/edgeConfig/edgeConfigStore.ts
@@ -144,7 +144,13 @@ export const createEdgeConfigStore = <T>({
 		}
 	};
 
-	const writeToSource = async ({ config }: { config: T }) => {
+	const writeToSource = async ({
+		config,
+		logger,
+	}: {
+		config: T;
+		logger?: Logger;
+	}) => {
 		// Override mode: update the in-memory config only (no S3 creds available).
 		if (override) {
 			runtimeConfig = config;
@@ -176,7 +182,15 @@ export const createEdgeConfigStore = <T>({
 				ContentType: "application/json",
 			}),
 		);
-		await writeEdgeConfigTimestamp({ s3Client: client });
+		// The config object is durable by now, so a lost signal must not fail the
+		// write or strand this process on the old value; the backstop still catches it.
+		try {
+			await writeEdgeConfigTimestamp({ s3Client: client });
+		} catch (error) {
+			logger?.error(
+				`Edge config "${s3Key}" written but timestamp signal failed; propagation waits for the backstop refresh: ${error}`,
+			);
+		}
 
 		runtimeConfig = config;
 		runtimeStatus = {

--- a/server/src/internal/misc/edgeConfig/edgeConfigTimestamp.ts
+++ b/server/src/internal/misc/edgeConfig/edgeConfigTimestamp.ts
@@ -1,0 +1,69 @@
+import { randomUUID } from "node:crypto";
+import type { S3Client } from "@aws-sdk/client-s3";
+import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+	ADMIN_EDGE_CONFIG_TIMESTAMP_KEY,
+	getAdminS3Config,
+} from "@/external/aws/s3/adminS3Config.js";
+import { getS3Client } from "@/external/aws/s3/initS3.js";
+import { getS3BodyAsString } from "@/external/aws/s3/s3Utils.js";
+
+const getClient = (s3Client?: S3Client) => {
+	if (s3Client) return s3Client;
+	const { region } = getAdminS3Config();
+	return getS3Client({ region });
+};
+
+export const readEdgeConfigTimestamp = async ({
+	s3Client,
+}: {
+	s3Client?: S3Client;
+} = {}): Promise<string | null> => {
+	const { bucket } = getAdminS3Config();
+
+	try {
+		const response = await getClient(s3Client).send(
+			new GetObjectCommand({
+				Bucket: bucket,
+				Key: ADMIN_EDGE_CONFIG_TIMESTAMP_KEY,
+			}),
+		);
+		if (!response.Body) return null;
+
+		const raw = await getS3BodyAsString({ body: response.Body });
+		const { updatedAt, changeId } = JSON.parse(raw) as {
+			updatedAt?: unknown;
+			changeId?: unknown;
+		};
+		if (typeof updatedAt !== "string") {
+			throw new Error("Edge config timestamp is invalid");
+		}
+		return typeof changeId === "string"
+			? `${updatedAt}:${changeId}`
+			: updatedAt;
+	} catch (error) {
+		if (error instanceof Error && error.name === "NoSuchKey") return null;
+		throw error;
+	}
+};
+
+export const writeEdgeConfigTimestamp = async ({
+	s3Client,
+}: {
+	s3Client?: S3Client;
+} = {}): Promise<string> => {
+	const { bucket } = getAdminS3Config();
+	const updatedAt = new Date().toISOString();
+	const changeId = randomUUID();
+
+	await getClient(s3Client).send(
+		new PutObjectCommand({
+			Bucket: bucket,
+			Key: ADMIN_EDGE_CONFIG_TIMESTAMP_KEY,
+			Body: JSON.stringify({ updatedAt, changeId }),
+			ContentType: "application/json",
+		}),
+	);
+
+	return `${updatedAt}:${changeId}`;
+};

--- a/server/src/internal/misc/edgeConfig/edgeConfigTimestamp.ts
+++ b/server/src/internal/misc/edgeConfig/edgeConfigTimestamp.ts
@@ -58,12 +58,14 @@ export const writeEdgeConfigTimestamp = async ({
 	s3Client?: S3Client;
 } = {}): Promise<string> => {
 	const { bucket } = getAdminS3Config();
-	const updatedAt = new Date().toISOString();
-	const changeId = randomUUID();
 	const client = getClient(s3Client);
 
 	let lastError: unknown;
 	for (let attempt = 1; attempt <= WRITE_ATTEMPTS; attempt++) {
+		// Fresh marker per attempt: a retry reusing the first marker can overwrite a
+		// concurrent writer's signal with a value pollers already observed.
+		const updatedAt = new Date().toISOString();
+		const changeId = randomUUID();
 		try {
 			await client.send(
 				new PutObjectCommand({

--- a/server/src/internal/misc/edgeConfig/edgeConfigTimestamp.ts
+++ b/server/src/internal/misc/edgeConfig/edgeConfigTimestamp.ts
@@ -47,6 +47,11 @@ export const readEdgeConfigTimestamp = async ({
 	}
 };
 
+const WRITE_ATTEMPTS = 3;
+const WRITE_RETRY_DELAY_MS = 50;
+
+/** Retries because the config object is already written by the time this runs:
+ *  a lost timestamp leaves that config in S3 with nothing signalling it. */
 export const writeEdgeConfigTimestamp = async ({
 	s3Client,
 }: {
@@ -55,15 +60,29 @@ export const writeEdgeConfigTimestamp = async ({
 	const { bucket } = getAdminS3Config();
 	const updatedAt = new Date().toISOString();
 	const changeId = randomUUID();
+	const client = getClient(s3Client);
 
-	await getClient(s3Client).send(
-		new PutObjectCommand({
-			Bucket: bucket,
-			Key: ADMIN_EDGE_CONFIG_TIMESTAMP_KEY,
-			Body: JSON.stringify({ updatedAt, changeId }),
-			ContentType: "application/json",
-		}),
-	);
+	let lastError: unknown;
+	for (let attempt = 1; attempt <= WRITE_ATTEMPTS; attempt++) {
+		try {
+			await client.send(
+				new PutObjectCommand({
+					Bucket: bucket,
+					Key: ADMIN_EDGE_CONFIG_TIMESTAMP_KEY,
+					Body: JSON.stringify({ updatedAt, changeId }),
+					ContentType: "application/json",
+				}),
+			);
+			return `${updatedAt}:${changeId}`;
+		} catch (error) {
+			lastError = error;
+			if (attempt < WRITE_ATTEMPTS) {
+				await new Promise((resolve) =>
+					setTimeout(resolve, WRITE_RETRY_DELAY_MS * attempt),
+				);
+			}
+		}
+	}
 
-	return `${updatedAt}:${changeId}`;
+	throw lastError;
 };

--- a/server/tests/unit/edge-config/edge-config-registry.test.ts
+++ b/server/tests/unit/edge-config/edge-config-registry.test.ts
@@ -130,6 +130,25 @@ describe("edge config registry", () => {
 		expect(refresh).toHaveBeenCalledTimes(3);
 	});
 
+	// The timestamp is the only propagation signal, so a write that never lands
+	// would otherwise leave every process serving stale config indefinitely.
+	test("refreshes on the backstop interval even when the timestamp is unchanged", async () => {
+		const refresh = jest.fn(async () => {});
+		const registry = createEdgeConfigRegistry({
+			readTimestamp: async () => "v1",
+			writeTimestamp: async () => "v1",
+			pollIntervalMs: 60_000,
+			backstopIntervalMs: 20,
+		});
+		registry.register({ store: { refresh } });
+		registries.push(registry);
+		await registry.start();
+
+		await new Promise((resolve) => setTimeout(resolve, 70));
+
+		expect(refresh.mock.calls.length).toBeGreaterThan(1);
+	});
+
 	test("recreates the timestamp again after it reappears and is deleted", async () => {
 		const writeTimestamp = jest.fn(async () => "recreated");
 		const { registry } = createRegistry({

--- a/server/tests/unit/edge-config/edge-config-registry.test.ts
+++ b/server/tests/unit/edge-config/edge-config-registry.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, jest, test } from "bun:test";
+import { createEdgeConfigRegistry } from "@/internal/misc/edgeConfig/edgeConfigRegistry.js";
+
+const registries: ReturnType<typeof createEdgeConfigRegistry>[] = [];
+
+const createRegistry = ({
+	timestamps,
+	writeTimestamp = jest.fn(async () => "created"),
+}: {
+	timestamps: (string | null | Error)[];
+	writeTimestamp?: ReturnType<typeof jest.fn<() => Promise<string>>>;
+}) => {
+	let readIndex = 0;
+	const readTimestamp = jest.fn(async () => {
+		const value = timestamps[Math.min(readIndex++, timestamps.length - 1)];
+		if (value instanceof Error) throw value;
+		return value ?? null;
+	});
+	const registry = createEdgeConfigRegistry({
+		readTimestamp,
+		writeTimestamp,
+		pollIntervalMs: 60_000,
+	});
+	const refresh = jest.fn(async () => {});
+	registry.register({ store: { refresh } });
+	registries.push(registry);
+
+	return { readTimestamp, refresh, registry, writeTimestamp };
+};
+
+afterEach(() => {
+	for (const registry of registries) registry.stop();
+	registries.length = 0;
+});
+
+describe("edge config registry", () => {
+	test("loads every config on startup and creates a missing timestamp", async () => {
+		const { refresh, registry, writeTimestamp } = createRegistry({
+			timestamps: [null],
+		});
+
+		await registry.start();
+
+		expect(refresh).toHaveBeenCalledTimes(1);
+		expect(writeTimestamp).toHaveBeenCalledTimes(1);
+	});
+
+	test("only reads the timestamp while it is unchanged", async () => {
+		const { readTimestamp, refresh, registry } = createRegistry({
+			timestamps: ["v1", "v1"],
+		});
+		await registry.start();
+
+		await registry.checkForChanges();
+
+		expect(readTimestamp).toHaveBeenCalledTimes(2);
+		expect(refresh).toHaveBeenCalledTimes(1);
+	});
+
+	test("refreshes every config when the timestamp changes", async () => {
+		const { refresh, registry } = createRegistry({
+			timestamps: ["v1", "v2"],
+		});
+		const secondRefresh = jest.fn(async () => {});
+		registry.register({ store: { refresh: secondRefresh } });
+		await registry.start();
+
+		await registry.checkForChanges();
+
+		expect(refresh).toHaveBeenCalledTimes(2);
+		expect(secondRefresh).toHaveBeenCalledTimes(2);
+	});
+
+	test("falls back to refreshing configs when timestamp polling fails", async () => {
+		const { refresh, registry } = createRegistry({
+			timestamps: ["v1", new Error("S3 unavailable")],
+		});
+		await registry.start();
+
+		await registry.checkForChanges();
+
+		expect(refresh).toHaveBeenCalledTimes(2);
+	});
+
+	test("recreates a deleted timestamp after refreshing configs", async () => {
+		const writeTimestamp = jest.fn(async () => "v2");
+		const { refresh, registry } = createRegistry({
+			timestamps: ["v1", null],
+			writeTimestamp,
+		});
+		await registry.start();
+
+		await registry.checkForChanges();
+
+		expect(refresh).toHaveBeenCalledTimes(2);
+		expect(writeTimestamp).toHaveBeenCalledTimes(1);
+	});
+});

--- a/server/tests/unit/edge-config/edge-config-registry.test.ts
+++ b/server/tests/unit/edge-config/edge-config-registry.test.ts
@@ -95,4 +95,52 @@ describe("edge config registry", () => {
 		expect(refresh).toHaveBeenCalledTimes(2);
 		expect(writeTimestamp).toHaveBeenCalledTimes(1);
 	});
+
+	// Every process runs this loop, so an unbounded create-on-null retries the
+	// write on each poll across the whole fleet while the key stays missing.
+	test("creates the timestamp once while it stays missing", async () => {
+		const writeTimestamp = jest.fn(async () => "created");
+		const { refresh, registry } = createRegistry({
+			timestamps: [null],
+			writeTimestamp,
+		});
+		await registry.start();
+
+		await registry.checkForChanges();
+		await registry.checkForChanges();
+
+		expect(writeTimestamp).toHaveBeenCalledTimes(1);
+		expect(refresh).toHaveBeenCalledTimes(3);
+	});
+
+	test("stops retrying a failing timestamp write but keeps refreshing", async () => {
+		const writeTimestamp = jest.fn(async () => {
+			throw new Error("AccessDenied");
+		});
+		const { refresh, registry } = createRegistry({
+			timestamps: [null],
+			writeTimestamp,
+		});
+		await registry.start();
+
+		await registry.checkForChanges();
+		await registry.checkForChanges();
+
+		expect(writeTimestamp).toHaveBeenCalledTimes(1);
+		expect(refresh).toHaveBeenCalledTimes(3);
+	});
+
+	test("recreates the timestamp again after it reappears and is deleted", async () => {
+		const writeTimestamp = jest.fn(async () => "recreated");
+		const { registry } = createRegistry({
+			timestamps: [null, "v1", null],
+			writeTimestamp,
+		});
+		await registry.start();
+
+		await registry.checkForChanges();
+		await registry.checkForChanges();
+
+		expect(writeTimestamp).toHaveBeenCalledTimes(2);
+	});
 });

--- a/server/tests/unit/edge-config/edge-config-store.test.ts
+++ b/server/tests/unit/edge-config/edge-config-store.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, jest, test } from "bun:test";
 import type { S3Client } from "@aws-sdk/client-s3";
 import { z } from "zod/v4";
+import { ADMIN_EDGE_CONFIG_TIMESTAMP_KEY } from "@/external/aws/s3/adminS3Config.js";
 import { createEdgeConfigStore } from "@/internal/misc/edgeConfig/edgeConfigStore.js";
 
 const TestConfigSchema = z.object({
@@ -300,7 +301,7 @@ describe("createEdgeConfigStore", () => {
 			expect(store.getStatus().healthy).toBe(true);
 		});
 
-		test("calls S3 PutObject with correct payload", async () => {
+		test("writes the config followed by the shared timestamp", async () => {
 			const mockClient = createMockS3Client({
 				getResponse: () => makeBody(defaultConfig()),
 			});
@@ -319,9 +320,21 @@ describe("createEdgeConfigStore", () => {
 			const sendFn = (
 				mockClient as unknown as { send: ReturnType<typeof jest.fn> }
 			).send;
-			const calls = sendFn.mock.calls;
-			const lastCall = calls[calls.length - 1]?.[0];
-			expect(lastCall?.constructor?.name).toBe("PutObjectCommand");
+			const putCommands = sendFn.mock.calls
+				.map(([command]) => command)
+				.filter(
+					(command) => command?.constructor?.name === "PutObjectCommand",
+				) as { input: { Key: string; Body: string } }[];
+
+			expect(putCommands.map(({ input }) => input.Key)).toEqual([
+				"admin/test-config.json",
+				ADMIN_EDGE_CONFIG_TIMESTAMP_KEY,
+			]);
+			expect(JSON.parse(putCommands[0]!.input.Body)).toEqual({
+				enabled: true,
+				message: "test-write",
+			});
+			expect(JSON.parse(putCommands[1]!.input.Body).updatedAt).toBeString();
 		});
 	});
 

--- a/server/tests/unit/edge-config/edge-config-store.test.ts
+++ b/server/tests/unit/edge-config/edge-config-store.test.ts
@@ -278,6 +278,34 @@ describe("createEdgeConfigStore", () => {
 	});
 
 	describe("writeToSource", () => {
+		// The config object is already durable at this point; only the propagation
+		// signal failed, and the registry backstop still picks it up.
+		test("keeps the written config locally when the timestamp write fails", async () => {
+			const send = jest.fn(async (command: unknown) => {
+				const input = (command as { input?: { Key?: string; Body?: string } })
+					.input;
+				const name = command?.constructor?.name;
+				if (name === "GetObjectCommand") return makeBody(defaultConfig());
+				if (input?.Key === ADMIN_EDGE_CONFIG_TIMESTAMP_KEY) {
+					throw new Error("AccessDenied");
+				}
+				return {};
+			});
+
+			store = createEdgeConfigStore<TestConfig>({
+				s3Key: "admin/test-config.json",
+				schema: TestConfigSchema,
+				defaultValue: defaultConfig,
+				s3Client: { send } as unknown as S3Client,
+			});
+
+			await store.writeToSource({
+				config: { enabled: true, message: "written" },
+			});
+
+			expect(store.get()).toEqual({ enabled: true, message: "written" });
+		});
+
 		test("updates local cache immediately after write", async () => {
 			const mockClient = createMockS3Client({
 				getResponse: () => makeBody(defaultConfig()),

--- a/server/tests/unit/edge-config/edge-config-timestamp.test.ts
+++ b/server/tests/unit/edge-config/edge-config-timestamp.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, jest, test } from "bun:test";
+import type { S3Client } from "@aws-sdk/client-s3";
+import { ADMIN_EDGE_CONFIG_TIMESTAMP_KEY } from "@/external/aws/s3/adminS3Config.js";
+import {
+	readEdgeConfigTimestamp,
+	writeEdgeConfigTimestamp,
+} from "@/internal/misc/edgeConfig/edgeConfigTimestamp.js";
+
+const makeBody = (data: unknown) => ({
+	Body: {
+		transformToString: async () => JSON.stringify(data),
+	},
+});
+
+describe("edge config timestamp", () => {
+	test("reads the timestamp and unique change ID", async () => {
+		const s3Client = {
+			send: jest.fn(async () =>
+				makeBody({ updatedAt: "2026-01-01T00:00:00.000Z", changeId: "abc" }),
+			),
+		} as unknown as S3Client;
+
+		expect(await readEdgeConfigTimestamp({ s3Client })).toBe(
+			"2026-01-01T00:00:00.000Z:abc",
+		);
+	});
+
+	test("treats a missing timestamp as uninitialized", async () => {
+		const error = new Error("missing");
+		error.name = "NoSuchKey";
+		const s3Client = {
+			send: jest.fn(async () => {
+				throw error;
+			}),
+		} as unknown as S3Client;
+
+		expect(await readEdgeConfigTimestamp({ s3Client })).toBeNull();
+	});
+
+	test("writes the shared timestamp object", async () => {
+		const send = jest.fn(async (_command: unknown) => ({}));
+		const s3Client = { send } as unknown as S3Client;
+
+		const timestamp = await writeEdgeConfigTimestamp({ s3Client });
+		const command = send.mock.calls[0]![0] as {
+			input: { Key: string; Body: string };
+		};
+		const body = JSON.parse(command.input.Body);
+
+		expect(command.input.Key).toBe(ADMIN_EDGE_CONFIG_TIMESTAMP_KEY);
+		expect(timestamp).toBe(`${body.updatedAt}:${body.changeId}`);
+	});
+});

--- a/server/tests/unit/edge-config/edge-config-timestamp.test.ts
+++ b/server/tests/unit/edge-config/edge-config-timestamp.test.ts
@@ -50,4 +50,32 @@ describe("edge config timestamp", () => {
 		expect(command.input.Key).toBe(ADMIN_EDGE_CONFIG_TIMESTAMP_KEY);
 		expect(timestamp).toBe(`${body.updatedAt}:${body.changeId}`);
 	});
+
+	// A config PUT that lands while the timestamp PUT fails leaves the new config
+	// in S3 with nothing signalling it, so every process keeps serving the old one.
+	test("retries a transient timestamp write failure", async () => {
+		let attempts = 0;
+		const send = jest.fn(async (_command: unknown) => {
+			attempts++;
+			if (attempts < 3) throw new Error("InternalError");
+			return {};
+		});
+		const s3Client = { send } as unknown as S3Client;
+
+		const timestamp = await writeEdgeConfigTimestamp({ s3Client });
+
+		expect(attempts).toBe(3);
+		expect(timestamp).toContain(":");
+	});
+
+	test("surfaces the error once retries are exhausted", async () => {
+		const send = jest.fn(async (_command: unknown) => {
+			throw new Error("AccessDenied");
+		});
+		const s3Client = { send } as unknown as S3Client;
+
+		await expect(writeEdgeConfigTimestamp({ s3Client })).rejects.toThrow(
+			"AccessDenied",
+		);
+	});
 });

--- a/server/tests/unit/edge-config/edge-config-timestamp.test.ts
+++ b/server/tests/unit/edge-config/edge-config-timestamp.test.ts
@@ -68,6 +68,27 @@ describe("edge config timestamp", () => {
 		expect(timestamp).toContain(":");
 	});
 
+	// A retry that reuses the first attempt's marker can overwrite a concurrent
+	// writer's signal with a value pollers have already observed and skipped.
+	test("uses a distinct marker on each retry attempt", async () => {
+		const bodies: string[] = [];
+		let attempts = 0;
+		const send = jest.fn(async (command: unknown) => {
+			attempts++;
+			const input = (command as { input: { Body: string } }).input;
+			bodies.push(input.Body);
+			if (attempts < 2) throw new Error("InternalError");
+			return {};
+		});
+		const s3Client = { send } as unknown as S3Client;
+
+		const timestamp = await writeEdgeConfigTimestamp({ s3Client });
+		const changeIds = bodies.map((b) => JSON.parse(b).changeId);
+
+		expect(new Set(changeIds).size).toBe(2);
+		expect(timestamp).toContain(changeIds[1]);
+	});
+
 	test("surfaces the error once retries are exhausted", async () => {
 		const send = jest.fn(async (_command: unknown) => {
 			throw new Error("AccessDenied");


### PR DESCRIPTION
## Summary
- poll one shared S3 timestamp instead of every registered edge config
- refresh all registered configs only when the timestamp changes
- update the timestamp after every config write and self-initialize it on startup
- fall back to full refreshes when timestamp polling fails

## Verification
- bun test server/tests/unit (2,067 passing)
- bun -F @autumn/server ts
- Biome checks on all changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Poll a single shared S3 timestamp to refresh all edge configs together, reducing redundant reads and simplifying updates. Timestamp writes now retry with unique markers, we add a 10-minute backstop, bump the marker after each write, keep local state if the signal fails, and bound auto-creation to one attempt while the key is missing.

- **Refactors**
  - Added `admin/edge-config-timestamp.json` with `updatedAt`/unique `changeId`, plus `readEdgeConfigTimestamp` and `writeEdgeConfigTimestamp` (retries with fresh markers).
  - Centralized polling with `createEdgeConfigRegistry` (`register/start/stop`); poll 1s in dev/10s in prod; 10m backstop; skip when `AUTUMN_EDGE_CONFIG_OVERRIDE_B64`; on read errors, refresh all; create-once while missing; de-duplicated warning logs.
  - Edge config writes PUT the config, then update the shared timestamp with retry; if the timestamp write fails, keep the new config in-memory and log; tests cover registry behavior, timestamp helpers, write ordering, and the backstop.

<sup>Written for commit a82d065c3d1d6d8362f29cc6561d3e6105d715f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR centralizes edge-config propagation around a shared S3 marker.
- **Improvements:** Replaces per-config polling with shared timestamp polling and a periodic full-refresh backstop.
- **Improvements:** Adds timestamp initialization, unique change identifiers, retry handling, and registry lifecycle management.
- **Bug fixes:** Keeps the writer's runtime config updated when timestamp signaling fails, while relying on the backstop to refresh other processes.
- **Improvements:** Adds unit coverage for timestamp helpers, registry polling and recovery, and config-write ordering.
</details>

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because failed timestamp signaling can leave other processes serving stale edge configuration for ten minutes after the write reports success.

The writer now retains the newly persisted value and no longer rejects the operation, but suppression of an exhausted marker write still prevents immediate fleet-wide propagation; remote processes recover only through the periodic backstop.

**Files Needing Attention:** server/src/internal/misc/edgeConfig/edgeConfigStore.ts, server/src/internal/misc/edgeConfig/edgeConfigRegistry.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/misc/edgeConfig/edgeConfigRegistry.ts | Introduces shared timestamp polling and a ten-minute backstop, but that interval leaves unsignaled config writes stale on other processes. |
| server/src/internal/misc/edgeConfig/edgeConfigStore.ts | Writes the shared marker after persisting config and suppresses marker failures, preserving local state while delaying fleet-wide propagation. |
| server/src/internal/misc/edgeConfig/edgeConfigTimestamp.ts | Adds S3 marker serialization, missing-key handling, unique change identifiers, and bounded retries. |
| server/src/external/aws/s3/adminS3Config.ts | Defines the S3 key used by the shared edge-config marker. |
| server/tests/unit/edge-config/edge-config-registry.test.ts | Covers registry initialization, timestamp changes, fallback refreshes, bounded creation, and backstop behavior. |
| server/tests/unit/edge-config/edge-config-store.test.ts | Covers config-before-marker ordering and retention of the writer's local value after marker failure. |
| server/tests/unit/edge-config/edge-config-timestamp.test.ts | Covers marker reads, writes, missing keys, retries, unique retry markers, and exhausted failures. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Writer
    participant Config as Config object in S3
    participant Marker as Shared timestamp in S3
    participant Pollers as Other processes
    Writer->>Config: PUT updated config
    Writer->>Marker: PUT new timestamp (up to 3 attempts)
    alt Timestamp write succeeds
        Pollers->>Marker: Poll timestamp
        Pollers->>Config: Refresh all registered configs
    else Timestamp write fails
        Writer-->>Writer: Update local runtime config
        Pollers->>Config: Refresh on 10-minute backstop
    end
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: keep edge config local state and ma..."](https://github.com/useautumn/autumn/commit/a82d065c3d1d6d8362f29cc6561d3e6105d715f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48423650)</sub>

<!-- /greptile_comment -->