### PR TITLE
fix(website): smooth the mobile story carousel wrap

### DIFF
--- a/apps/website/app/constant.tsx
+++ b/apps/website/app/constant.tsx
@@ -1349,6 +1349,7 @@ export type CustomerStory = {
 	slug: string;
 	name: string;
 	href?: string;
+	linkLabel?: string;
 	logo: string;
 	iconLogo: string;
 	logoClassName?: string;
@@ -1369,6 +1370,7 @@ export const customerStoriesData: CustomerStory[] = [
 		slug: "mintlify",
 		name: "Mintlify",
 		href: "/blog/how-mintlify-is-scaling-sales-led-gtm",
+		linkLabel: "How Mintlify is scaling sales-led GTM",
 		logo: "/images/logos/mintlify_logo.svg.svg",
 		iconLogo: "/images/logos/icons/mintlify.svg",
 		logoClassName: "scale-90",
@@ -1411,7 +1413,7 @@ export const customerStoriesData: CustomerStory[] = [
 		quote:
 			"I warned them ahead of time how complicated our billing was, but the team has been incredible to work with. There's no way we'd be able to iterate as fast as we are without Autumn.",
 		author: {
-			name: "Micha Stairs",
+			name: "Micah Stairs",
 			title: "Head of Support Engineering at Firecrawl",
 		},
 	},
@@ -1443,6 +1445,7 @@ export const customerStoriesData: CustomerStory[] = [
 		slug: "t3-chat",
 		name: "T3.chat",
 		href: "/blog/working-with-t3-chat-on-a-new-way-of-pricing",
+		linkLabel: "Consumer psychology is important in AI pricing",
 		logo: "/images/logos/T3_svg.svg",
 		iconLogo: "/images/logos/icons/t3-chat.svg",
 		logoClassName: "scale-65",
@@ -1461,7 +1464,7 @@ export const customerStoriesData: CustomerStory[] = [
 		],
 		quote:
 			"We were spending nearly as much on the Redis instance to handle this ourselves (less well) than the cost with Autumn. It makes the switch even more of a no brainer.",
-		author: { name: "Mark", title: "Co-Founder at T3 Chat" },
+		author: { name: "Mark Florkowski", title: "Co-Founder at T3 Chat" },
 	},
 ];
 

--- a/apps/website/components/customer-stories/mobile-carousel.tsx
+++ b/apps/website/components/customer-stories/mobile-carousel.tsx
@@ -16,20 +16,24 @@ export function MobileCarousel() {
 				className="flex gap-3 px-4 cursor-grab active:cursor-grabbing"
 				style={{ x }}
 				drag="x"
-				dragElastic={0.18}
+				dragElastic={0.12}
+				dragMomentum={false}
 				onDragEnd={onDragEnd}
 			>
-				{featuredCustomerStories.map((story) => (
-					<div
-						key={story.slug}
-						className="relative shrink-0 w-[86vw] h-[440px] overflow-hidden"
-					>
-						<div className="absolute inset-0 p-6 flex flex-col">
-							<StoryPanel story={story} />
+				{["before", "main", "after"].map((copy) =>
+					featuredCustomerStories.map((story) => (
+						<div
+							aria-hidden={copy === "main" ? undefined : true}
+							key={`${copy}-${story.slug}`}
+							className="relative shrink-0 w-[86vw] h-[440px] overflow-hidden"
+						>
+							<div className="absolute inset-0 p-6 flex flex-col">
+								<StoryPanel story={story} />
+							</div>
+							<BracketCorners />
 						</div>
-						<BracketCorners />
-					</div>
-				))}
+					)),
+				)}
 			</motion.div>
 
 			<div className="flex justify-center gap-2 mt-5">

--- a/apps/website/components/customer-stories/story-panel.tsx
+++ b/apps/website/components/customer-stories/story-panel.tsx
@@ -85,9 +85,9 @@ export function StoryPanel({ story }: { story: CustomerStory }) {
 			{href && (
 				<Link
 					href={href}
-					className="group mt-7 inline-flex w-fit items-center gap-2 bg-[color:var(--fg)] px-3.5 py-2 font-mono text-[12px] font-medium tracking-[-2%] uppercase text-[#0A0A0A] hover:opacity-90 transition-opacity duration-300"
+					className="group mt-7 inline-flex w-fit max-w-full items-center gap-2 bg-[color:var(--fg)] px-3.5 py-2 font-mono text-[12px] font-medium tracking-[-2%] uppercase text-[#0A0A0A] hover:opacity-90 transition-opacity duration-300"
 				>
-					View full story
+					{story.linkLabel ?? "View full story"}
 					<IconArrowRightSmall className="text-current" />
 				</Link>
 			)}

--- a/apps/website/components/customer-stories/use-mobile-carousel.ts
+++ b/apps/website/components/customer-stories/use-mobile-carousel.ts
@@ -7,7 +7,7 @@ import {
 import { useCallback, useLayoutEffect, useRef, useState } from "react";
 
 const GAP = 12;
-const SNAP_SPRING = { type: "spring", stiffness: 320, damping: 38 } as const;
+const SNAP_SPRING = { type: "spring", duration: 0.42, bounce: 0.16 } as const;
 const FLICK_VELOCITY = 320;
 
 type MobileCarousel = {
@@ -24,6 +24,9 @@ const wrap = (index: number, count: number) =>
 
 export function useMobileCarousel(count: number): MobileCarousel {
 	const containerRef = useRef<HTMLDivElement | null>(null);
+	// Track renders three copies of the cards; `slot` indexes the middle copy so
+	// there is always a real card to slide onto in either direction.
+	const slotRef = useRef(count);
 	const x = useMotionValue(0);
 	const [activeIndex, setActiveIndex] = useState(0);
 	const [stepWidth, setStepWidth] = useState(0);
@@ -33,32 +36,49 @@ export function useMobileCarousel(count: number): MobileCarousel {
 		const measure = () => {
 			const card = containerRef.current
 				?.firstElementChild as HTMLElement | null;
-			setStepWidth(card ? card.offsetWidth + GAP : 0);
+			const step = card ? card.offsetWidth + GAP : 0;
+			setStepWidth(step);
+			slotRef.current = count + wrap(slotRef.current, count);
+			x.set(-slotRef.current * step);
 		};
 		measure();
 		window.addEventListener("resize", measure);
 		return () => window.removeEventListener("resize", measure);
-	}, []);
+	}, [count, x]);
 
-	// Animate toward a (possibly out-of-range) slot, then jump to the wrapped
-	// equivalent so the track stays in range and the loop feels seamless.
+	// Animate to the target slot, then silently recentre onto the equivalent
+	// card in the middle copy so the track never runs out of cards.
 	const settle = useCallback(
 		(slot: number) => {
 			const wrapped = wrap(slot, count);
+			slotRef.current = slot;
 			setActiveIndex(wrapped);
+
+			const recentre = () => {
+				const centred = count + wrapped;
+				slotRef.current = centred;
+				x.set(-centred * stepWidth);
+			};
+
 			if (reduceMotion) {
-				x.set(-wrapped * stepWidth);
+				recentre();
 				return;
 			}
-			animate(x, -slot * stepWidth, SNAP_SPRING).then(() => {
-				if (slot !== wrapped) x.set(-wrapped * stepWidth);
-			});
+			animate(x, -slot * stepWidth, SNAP_SPRING).then(recentre);
 		},
 		[count, reduceMotion, stepWidth, x],
 	);
 
 	const goTo = useCallback(
-		(index: number) => settle(wrap(index, count)),
+		(index: number) => {
+			const target = wrap(index, count);
+			const current = wrap(slotRef.current, count);
+			let delta = target - current;
+			// Take the shorter way round rather than scrolling back through the middle.
+			if (delta > count / 2) delta -= count;
+			if (delta < -count / 2) delta += count;
+			settle(slotRef.current + delta);
+		},
 		[count, settle],
 	);
 
@@ -69,10 +89,11 @@ export function useMobileCarousel(count: number): MobileCarousel {
 			let slot = Math.round(projected);
 			if (info.velocity.x < -FLICK_VELOCITY) slot = Math.ceil(projected);
 			else if (info.velocity.x > FLICK_VELOCITY) slot = Math.floor(projected);
-			slot = Math.max(activeIndex - 1, Math.min(activeIndex + 1, slot));
+			const from = slotRef.current;
+			slot = Math.max(from - 1, Math.min(from + 1, slot));
 			settle(slot);
 		},
-		[activeIndex, settle, stepWidth, x],
+		[settle, stepWidth, x],
 	);
 
 	return { containerRef, x, activeIndex, stepWidth, goTo, onDragEnd };


### PR DESCRIPTION
Follow-up to #2482.

## The bug

`settle()` animated to `-slot * stepWidth`, where `slot` could be `count` (past the last card) or `-1` (before the first). The track only rendered `count` cards, so wrapping in either direction animated onto **empty space** and then hard-snapped back to the wrapped card.

```
DOM cards at x =  0, -100, -200

drag past last  -> slot 3 -> animates to x = -300  (nothing there)
                           -> hard jump to x = 0

drag past first -> slot -1 -> animates to x = +100 (nothing there)
                           -> hard jump to x = -200
```

## The fix

Render the cards three times and keep the viewport in the middle copy, so there is always a real card to settle onto. Once the snap finishes, recentre silently onto the equivalent card in the middle copy — invisible, since it swaps to an identical card at the same position. Clones are `aria-hidden` so assistive tech still sees one set.

Two motion problems were also making it feel slow:

- **The snap spring was overdamped.** `stiffness: 320, damping: 38` gives a damping ratio of 1.06. Past 1.0 a spring stops overshooting and crawls the last few pixels. Replaced with Motion's `{ duration: 0.42, bounce: 0.16 }` form, per the animations skill.
- **Two animations fought for the same value.** `dragMomentum` defaults to `true`, so Motion ran its own inertia animation while `settle()` fired simultaneously. Which one won depended on flick velocity, which is why it was slow only *sometimes*. Disabled it so `settle()` owns the value.

`goTo` now also takes the shorter way round rather than scrolling back through the middle when you tap a dot.

## Also included

- Correct two names: `Micha Stairs` → **Micah Stairs**, `Mark` → **Mark Florkowski**
- Story buttons show the linked post's title instead of "View full story", via an optional `linkLabel`. Cards without a post keep the old fallback.

## Verification

`tsc --noEmit` clean, production build passes, lint clean. Wrap geometry checked at both boundaries.

Not tested on a physical device — the spring maths is sound but drag feel is worth a check on a real phone. If it needs tuning, `duration` is the dial: 0.35 snappier, 0.5 more relaxed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mobile story carousel wrapping so it never slides onto empty space. Dragging and dot navigation are now snappier and consistent on phones.

- **Bug Fixes**
  - Render three copies of each card and keep the viewport on the middle; snap to real cards and recentre silently. Clones are `aria-hidden`.
  - Disable drag inertia and use `{ duration: 0.42, bounce: 0.16 }` for snap; reduce `dragElastic` to 0.12.
  - Dot navigation takes the shorter path around the loop.
  - Correct author names: Micah Stairs and Mark Florkowski.

- **New Features**
  - Story buttons can show the linked post title via `linkLabel` (fallback to "View full story").

<sup>Written for commit f79051e2a706a9289795009ad6508cb8a05851c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves the mobile customer-story carousel and updates customer-story content.
- [Bug fixes] Renders adjacent carousel copies and recentres after wrapping so boundary transitions no longer animate through empty space.
- [Improvements] Disables competing drag momentum, tunes the snap animation, and chooses the shortest route when navigating with dots.
- [Improvements, API changes] Adds an optional linkLabel field and displays linked article titles in story CTAs.
- [Bug fixes] Corrects the displayed names of Micah Stairs and Mark Florkowski.
</details>

<h3>Confidence Score: 4/5</h3>

The carousel’s visual wrapping fix is sound, but the duplicated off-screen links need to be removed from keyboard navigation before merging.

The before and after copies contain real links, and aria-hidden on their wrappers does not prevent those links from receiving focus, producing invisible duplicate tab stops on the mobile carousel.

**Files Needing Attention:** apps/website/components/customer-stories/mobile-carousel.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/website/components/customer-stories/mobile-carousel.tsx | Renders three carousel copies and disables drag momentum, but cloned StoryPanel links remain keyboard-focusable despite aria-hidden wrappers. |
| apps/website/components/customer-stories/use-mobile-carousel.ts | Tracks physical slots in the middle copy, recentres after settling, and selects shorter dot-navigation paths. |
| apps/website/components/customer-stories/story-panel.tsx | Displays optional story-specific CTA labels and constrains CTA width. |
| apps/website/app/constant.tsx | Adds article labels and corrects two customer names. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Middle carousel copy] --> B{Drag or dot navigation}
  B --> C[Settle onto adjacent rendered slot]
  C --> D[Wrap logical active index]
  D --> E[Silently recenter equivalent card in middle copy]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/website/components/customer-stories/mobile-carousel.tsx:26
**Hidden clones remain focusable**

When a keyboard or screen-reader user tabs through the mobile carousel, the `aria-hidden` clones still expose their descendant links to sequential focus, causing duplicate off-screen tab stops that screen readers cannot reliably announce.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(website): smooth the mobile story ca..."](https://github.com/useautumn/autumn/commit/f79051e2a706a9289795009ad6508cb8a05851c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48433500)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->