### PR TITLE
fix: fail open when compacting spans

### DIFF
--- a/server/src/utils/otel/FilteringSpanProcessor.ts
+++ b/server/src/utils/otel/FilteringSpanProcessor.ts
@@ -1,4 +1,4 @@
-import { type Context, SpanStatusCode } from "@opentelemetry/api";
+import { type Context, diag, SpanStatusCode } from "@opentelemetry/api";
 import type {
 	ReadableSpan,
 	Span,
@@ -54,10 +54,24 @@ export class FilteringSpanProcessor implements SpanProcessor {
 	}
 
 	onEnd(span: ReadableSpan): void {
-		recordSpanDurationMetric(span);
+		let spanToExport = span;
 
-		if (shouldDropSuccessfulRedisSpan(span)) return;
-		this.delegate.onEnd(this.spanIngestCompactor.compact({ span }));
+		try {
+			recordSpanDurationMetric(span);
+			if (shouldDropSuccessfulRedisSpan(span)) return;
+			spanToExport = this.spanIngestCompactor.compact({ span });
+		} catch (error) {
+			try {
+				diag.error(
+					"Failed to process span before export; exporting the original span",
+					error,
+				);
+			} catch {
+				// Diagnostic reporting must not block fail-open span export.
+			}
+		}
+
+		this.delegate.onEnd(spanToExport);
 	}
 
 	forceFlush(): Promise<void> {

--- a/server/src/utils/otel/SpanIngestCompactor.ts
+++ b/server/src/utils/otel/SpanIngestCompactor.ts
@@ -17,15 +17,25 @@ const withAttributes = ({
 }: {
 	span: ReadableSpan;
 	attributes: Attributes;
-}): ReadableSpan =>
-	new Proxy(span, {
-		get(target, property) {
-			if (property === "attributes") return attributes;
-
-			const value = Reflect.get(target, property, target);
-			return typeof value === "function" ? value.bind(target) : value;
-		},
-	});
+}): ReadableSpan => ({
+	name: span.name,
+	kind: span.kind,
+	spanContext: () => span.spanContext(),
+	parentSpanContext: span.parentSpanContext,
+	startTime: span.startTime,
+	endTime: span.endTime,
+	status: span.status,
+	attributes,
+	links: span.links,
+	events: span.events,
+	duration: span.duration,
+	ended: span.ended,
+	resource: span.resource,
+	instrumentationScope: span.instrumentationScope,
+	droppedAttributesCount: span.droppedAttributesCount,
+	droppedEventsCount: span.droppedEventsCount,
+	droppedLinksCount: span.droppedLinksCount,
+});
 
 export class SpanIngestCompactor {
 	private readonly seenQueryIds = new Set<string>();

--- a/server/tests/unit/otel/filteringSpanProcessor.test.ts
+++ b/server/tests/unit/otel/filteringSpanProcessor.test.ts
@@ -114,6 +114,31 @@ describe("FilteringSpanProcessor", () => {
 		expect(delegate.ended).toEqual([source]);
 	});
 
+	test("exports the original span when custom processing fails", () => {
+		const delegate = new CapturingSpanProcessor();
+		const processor = new FilteringSpanProcessor(delegate);
+		const source = createSpan({
+			name: "drizzle.select",
+			attributes: { "db.statement": "select 1" },
+		});
+
+		Object.assign(
+			processor as unknown as {
+				spanIngestCompactor: { compact: () => ReadableSpan };
+			},
+			{
+				spanIngestCompactor: {
+					compact: () => {
+						throw new Error("compaction failed");
+					},
+				},
+			},
+		);
+
+		expect(() => processor.onEnd(source)).not.toThrow();
+		expect(delegate.ended).toEqual([source]);
+	});
+
 	test("keeps SQL on repeated slow Drizzle spans at export", () => {
 		const delegate = new CapturingSpanProcessor();
 		const processor = new FilteringSpanProcessor(delegate);

--- a/server/tests/unit/otel/spanIngestCompactor.test.ts
+++ b/server/tests/unit/otel/spanIngestCompactor.test.ts
@@ -139,6 +139,7 @@ describe("SpanIngestCompactor", () => {
 		expect(compacted.duration).toBe(source.duration);
 		expect(compacted.resource).toBe(source.resource);
 		expect(compacted.spanContext()).toEqual(source.spanContext());
+		expect(compacted.spanContext).toBe(compacted.spanContext);
 	});
 
 	test("retains SQL on repeated slow spans for Axiom slow-query investigations", () => {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fail open span export when compaction or metrics processing throws, so telemetry isn’t dropped. Replaced the Proxy-based compactor with a plain `ReadableSpan` wrapper and added guarded `diag.error` logging.

- **Bug Fixes**
  - Wrap `FilteringSpanProcessor.onEnd` in try/catch; on error, export the original span.
  - Guard metrics recording and `diag.error` from `@opentelemetry/api` so failures never block export.
  - Added a unit test to confirm original span export on compaction failure.

- **Refactors**
  - Replace Proxy-based `withAttributes` with a plain object that copies core fields and overrides `attributes`.
  - Preserve method behavior like `spanContext()`; added an assertion to ensure stability.

<sup>Written for commit f5c139d5751aad015877ed06ffcfc484276d73c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes span preprocessing fail open while replacing proxy-based compacted spans with explicit `ReadableSpan` wrappers.
- **[Bug fixes]** Exports the original span when duration recording, filtering, or compaction throws, and protects that fallback from diagnostic logging failures.
- **[Improvements]** Replaces the proxy-based attribute override with an explicit `ReadableSpan` wrapper that preserves the standard span fields and behavior.
- **[Improvements]** Adds unit coverage for fail-open export and stable `spanContext` access.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the fail-open path preserving telemetry export and the replacement wrapper retaining the standard span contract.

The changed processor catches preprocessing failures without swallowing delegate export, and the explicit compacted-span wrapper supplies the fields consumed through the standard `ReadableSpan` interface.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/utils/otel/FilteringSpanProcessor.ts | Adds guarded fail-open preprocessing so processing and diagnostic failures do not prevent export of the original span. |
| server/src/utils/otel/SpanIngestCompactor.ts | Replaces dynamic proxy forwarding with an explicit wrapper preserving the complete standard `ReadableSpan` surface while overriding attributes. |
| server/tests/unit/otel/filteringSpanProcessor.test.ts | Verifies that a compaction exception does not escape and that the original span reaches the delegate. |
| server/tests/unit/otel/spanIngestCompactor.test.ts | Adds an assertion that the compacted wrapper exposes a stable `spanContext` function reference. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Span ends] --> B[Record duration metric]
  B --> C{Drop successful Redis span?}
  C -->|Yes| D[Do not export]
  C -->|No| E[Compact span attributes]
  E --> F[Delegate export]
  B -. exception .-> G[Log diagnostic error]
  C -. exception .-> G
  E -. exception .-> G
  G --> H[Export original span]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into dev"](https://github.com/useautumn/autumn/commit/f5c139d5751aad015877ed06ffcfc484276d73c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48636865)</sub>

<!-- /greptile_comment -->