### PR TITLE
fix: reconcile property-rollup sums instead of checking for empty

### DIFF
--- a/server/src/internal/analytics/actions/aggregate.ts
+++ b/server/src/internal/analytics/actions/aggregate.ts
@@ -26,6 +26,10 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { validatePropertyPathForJSON } from "@/internal/analytics/actions/eventValidationUtils.js";
 import { getBillingCycleStartDate } from "../analyticsUtils.js";
 import { getCountAndSum } from "./getCountAndSum.js";
+import {
+	groupedResultIsIncomplete,
+	sumAllRows,
+} from "./propertyRollupCompleteness.js";
 
 /** Flattens filter_by into indexed filter_key_N / filter_value_N params for Tinybird pipes */
 const buildFilterParams = ({
@@ -394,29 +398,6 @@ const formatGroupableResults = ({
 	return { meta, rows: data.length, data };
 };
 
-/**
- * Ducttape fallback for the property-rollup cardinality gate.
- *
- * Unfiltered property group-bys read events_property_mv, whose insert-time gate
- * drops high-entropy values (UUIDs, long hex, opaque strings) to keep the rollup
- * bounded. A group-by over such a key therefore returns an EMPTY grouped result
- * even though the events exist — the gate can't tell a genuinely explosive key
- * (per-request trace ids) from a low-cardinality-but-UUID-shaped one (a customer
- * with 21 project ids).
- *
- * When the grouped result is empty BUT the authoritative totals (getCountAndSum,
- * read from the ungated rollups) show real events, we know the gate ate the
- * values, so we retry the same query against the ungated events_hourly_mv. When
- * the totals are also empty, the customer simply has no events — no retry.
- *
- * This does NOT cover the partial case (a key with a mix of gate-surviving and
- * gate-dropped values), which needs cardinality-aware routing (topKWeighted).
- */
-const totalsHaveEvents = (
-	totals: Record<string, { count: number; sum: number }>,
-): boolean =>
-	Object.values(totals).some((t) => t.count > 0 && t.sum > 0);
-
 /** Aggregates events into time-bucketed timeseries data */
 export const aggregate = async ({
 	ctx,
@@ -489,22 +470,30 @@ export const aggregate = async ({
 
 		let result = await pipes.aggregateGroupable(pipeParams);
 
-		// The gated property rollup only serves unfiltered property group-bys. If it
-		// returns nothing, check whether real events exist (ungated totals); if so,
-		// the value-shape gate dropped the group values — retry against the ungated
-		// events_hourly_mv. See totalsHaveEvents for the full rationale.
-		const usedGatedRollup =
-			groupColumn === "property" &&
-			Object.keys(filterParams).length === 0 &&
-			result.data.length === 0;
+		// Only this query shape reads the gated property rollup.
+		const readsGatedRollup =
+			groupColumn === "property" && Object.keys(filterParams).length === 0;
 
-		if (usedGatedRollup) {
-			const totals = await getCountAndSum({ ctx, params });
-			if (totalsHaveEvents(totals)) {
-				result = await pipes.aggregateGroupable({
+		if (readsGatedRollup) {
+			const totals = await getCountAndSum({
+				ctx,
+				params,
+				dateRange: { startDate, endDate },
+			});
+
+			if (groupedResultIsIncomplete({ rows: result.data, totals })) {
+				const ungated = await pipes.aggregateGroupable({
 					...pipeParams,
 					skip_property_rollup: "1",
 				});
+
+				// A shortfall means gate loss OR events without the property; only the
+				// first is recoverable, and only the retry can tell them apart.
+				if (
+					sumAllRows({ rows: ungated.data }) > sumAllRows({ rows: result.data })
+				) {
+					result = ungated;
+				}
 			}
 		}
 

--- a/server/src/internal/analytics/actions/getCountAndSum.ts
+++ b/server/src/internal/analytics/actions/getCountAndSum.ts
@@ -86,14 +86,19 @@ const calculateDateRange = async ({
 export const getCountAndSum = async ({
 	ctx,
 	params,
+	dateRange,
 }: {
 	ctx: AutumnContext;
 	params: TotalEventsParams;
+	// Callers comparing these totals against another query's result must pass that
+	// query's window; resolving it here independently drifts by up to one bin.
+	dateRange?: DateRangeResult;
 }) => {
 	const ch = getClickhouseClient();
 	const { org, env } = ctx;
 
-	const { startDate, endDate } = await calculateDateRange({ ctx, params });
+	const { startDate, endDate } =
+		dateRange ?? (await calculateDateRange({ ctx, params }));
 
 	// Build dynamic filter_by clauses using native JSON sub-column access
 	let filterBySql = "";

--- a/server/src/internal/analytics/actions/propertyRollupCompleteness.ts
+++ b/server/src/internal/analytics/actions/propertyRollupCompleteness.ts
@@ -1,0 +1,62 @@
+// events_property_mv's insert-time gate drops high-entropy values (UUIDs, long
+// hex, 32+ char opaque ids) so per-event-unique keys can't explode the rollup.
+import type { AggregateGroupablePipeRow } from "@/external/tinybird/pipes/aggregateGroupablePipe.js";
+
+export type EventTotals = Record<string, { count: number; sum: number }>;
+
+// Sums are Float64 through two different aggregation paths, so exact equality
+// would report phantom shortfalls on large values.
+const RELATIVE_TOLERANCE = 1e-9;
+const ABSOLUTE_TOLERANCE = 1e-6;
+
+const isMateriallyLessThan = ({
+	value,
+	reference,
+}: {
+	value: number;
+	reference: number;
+}): boolean =>
+	reference - value >
+	Math.max(ABSOLUTE_TOLERANCE, Math.abs(reference) * RELATIVE_TOLERANCE);
+
+export const sumGroupedRowsByEventName = ({
+	rows,
+}: {
+	rows: AggregateGroupablePipeRow[];
+}): Record<string, number> => {
+	const sums: Record<string, number> = {};
+	for (const row of rows) {
+		sums[row.event_name] = (sums[row.event_name] ?? 0) + row.total_value;
+	}
+	return sums;
+};
+
+export const sumAllRows = ({
+	rows,
+}: {
+	rows: AggregateGroupablePipeRow[];
+}): number => rows.reduce((sum, row) => sum + row.total_value, 0);
+
+/**
+ * Whether the gated property rollup under-reports against the ungated totals.
+ * A key with both gate-surviving and gate-dropped values comes back non-empty
+ * yet short, so emptiness alone never detects it.
+ */
+export const groupedResultIsIncomplete = ({
+	rows,
+	totals,
+}: {
+	rows: AggregateGroupablePipeRow[];
+	totals: EventTotals;
+}): boolean => {
+	const groupedSums = sumGroupedRowsByEventName({ rows });
+
+	return Object.entries(totals).some(
+		([eventName, total]) =>
+			total.count > 0 &&
+			isMateriallyLessThan({
+				value: groupedSums[eventName] ?? 0,
+				reference: total.sum,
+			}),
+	);
+};

--- a/server/tests/integration/analytics/aggregate/partial-gate-drop-fallback.test.ts
+++ b/server/tests/integration/analytics/aggregate/partial-gate-drop-fallback.test.ts
@@ -1,0 +1,138 @@
+/**
+ * TDD test for events.aggregate silently returning PARTIAL data when a grouped
+ * property has a MIX of gate-surviving and gate-dropped values (StackOne:
+ * group_by "properties.projectId", short slugs alongside 32-char opaque ids).
+ *
+ * Distinct from uuid-group-by-fallback.test.ts, where EVERY value is dropped and
+ * the rollup comes back empty. Here the short value materializes, so the result
+ * is non-empty and any emptiness-based fallback never fires.
+ *
+ * Red-failure mode (pre-fix):
+ *  - grouped_values contains only the short project id; the 32-char one is
+ *    absent and the grouped sums fall short of total.sum, with no error.
+ *
+ * Green-success criteria:
+ *  - The grouped sums reconcile against the ungated totals, so the server
+ *    detects the shortfall and retries with skip_property_rollup=1 against
+ *    events_hourly_mv, recovering both project ids.
+ */
+
+import { expect, test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+// Survives the value-shape gate: short and not opaque-shaped.
+const PROJECT_SHORT = "qa-71607";
+// Dropped by the gate's `^[A-Za-z0-9_-]{32,}$` rule: exactly 32 alphanumerics.
+const PROJECT_OPAQUE = "4uSlnf8w0kUb5WV6gEmBz07JVvgxfxTR";
+const PROJECT_SHORT_VALUE = 7;
+const PROJECT_OPAQUE_VALUE = 83;
+
+const EVENT_INGEST_TIMEOUT_MS = 30_000;
+const POLL_INTERVAL_MS = 3_000;
+
+type AggregateResponse = {
+	list: {
+		period: number;
+		values: Record<string, number>;
+		grouped_values?: Record<string, Record<string, number>>;
+	}[];
+	total: Record<string, { count: number; sum: number }>;
+};
+
+const sumGroupValue = (
+	response: AggregateResponse,
+	featureId: string,
+	groupValue: string,
+): number =>
+	response.list.reduce(
+		(sum, row) => sum + (row.grouped_values?.[featureId]?.[groupValue] ?? 0),
+		0,
+	);
+
+const sumAllGroupValues = (
+	response: AggregateResponse,
+	featureId: string,
+): number =>
+	response.list.reduce(
+		(sum, row) =>
+			sum +
+			Object.values(row.grouped_values?.[featureId] ?? {}).reduce(
+				(rowSum, value) => rowSum + value,
+				0,
+			),
+		0,
+	);
+
+test.concurrent(
+	`${chalk.yellowBright("aggregate partial-gate-drop: a property mixing gate-dropped and surviving values returns every group")}`,
+	async () => {
+		// Unique per run: tracked events persist in Tinybird across runs, and the
+		// project ids are fixed, so only the customer scope keeps runs isolated.
+		const customerId = `aggregate-partial-gate-drop-${Date.now()}`;
+		const messagesItem = items.monthlyMessages({ includedUsage: 1000 });
+		const freeProd = products.base({ id: "free", items: [messagesItem] });
+
+		const { autumnV1, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [freeProd], prefix: customerId }),
+			],
+			actions: [s.attach({ productId: freeProd.id })],
+		});
+
+		await autumnV1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: PROJECT_SHORT_VALUE,
+			properties: { projectId: PROJECT_SHORT },
+		});
+		await autumnV1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: PROJECT_OPAQUE_VALUE,
+			properties: { projectId: PROJECT_OPAQUE },
+		});
+
+		// Events reach Tinybird via async batching — poll on the ungated totals so
+		// the assertions aren't a false red from ingest lag.
+		const expectedTotal = PROJECT_SHORT_VALUE + PROJECT_OPAQUE_VALUE;
+		const deadline = Date.now() + EVENT_INGEST_TIMEOUT_MS;
+		let response: AggregateResponse;
+		do {
+			await timeout(POLL_INTERVAL_MS);
+			response = (await autumnV2_2.events.aggregate({
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				group_by: "properties.projectId",
+				range: "7d",
+			})) as AggregateResponse;
+		} while (
+			Date.now() < deadline &&
+			response.total[TestFeature.Messages]?.sum !== expectedTotal
+		);
+
+		expect(response.total[TestFeature.Messages]?.sum).toBe(expectedTotal);
+
+		// The gate-surviving value alone makes the result non-empty, which is what
+		// hides the shortfall from an emptiness check.
+		expect(sumGroupValue(response, TestFeature.Messages, PROJECT_SHORT)).toBe(
+			PROJECT_SHORT_VALUE,
+		);
+
+		// The bug: this group is dropped at insert and never comes back.
+		expect(sumGroupValue(response, TestFeature.Messages, PROJECT_OPAQUE)).toBe(
+			PROJECT_OPAQUE_VALUE,
+		);
+
+		// The invariant that makes the shortfall detectable at all.
+		expect(sumAllGroupValues(response, TestFeature.Messages)).toBe(
+			expectedTotal,
+		);
+	},
+);

--- a/server/tests/unit/analytics/property-rollup-completeness.test.ts
+++ b/server/tests/unit/analytics/property-rollup-completeness.test.ts
@@ -149,6 +149,25 @@ test(`${chalk.yellowBright(
 });
 
 test(`${chalk.yellowBright(
+	"property rollup: per-bin top-N truncation is not a shortfall",
+)}`, () => {
+	// The pipe relabels groups beyond max_groups to AUTUMN_RESERVED rather than
+	// dropping them, so a truncated result still carries the full mass. If a pipe
+	// change ever drops them instead, every truncated query would retry ungated.
+	const rows = [
+		row({ groupValue: "qa-71607", totalValue: 722 }),
+		row({ groupValue: "AUTUMN_RESERVED", totalValue: 29_880 }),
+	];
+
+	expect(
+		groupedResultIsIncomplete({
+			rows,
+			totals: totals({ count: 2533, sum: 30_602 }),
+		}),
+	).toBe(false);
+});
+
+test(`${chalk.yellowBright(
 	"property rollup: the ungated retry only wins when it reports more",
 )}`, () => {
 	// The retry probes whether the shortfall was gate loss or an absent property;

--- a/server/tests/unit/analytics/property-rollup-completeness.test.ts
+++ b/server/tests/unit/analytics/property-rollup-completeness.test.ts
@@ -1,0 +1,186 @@
+import { expect, test } from "bun:test";
+import chalk from "chalk";
+import type { AggregateGroupablePipeRow } from "@/external/tinybird/pipes/aggregateGroupablePipe.js";
+import {
+	type EventTotals,
+	groupedResultIsIncomplete,
+	sumAllRows,
+	sumGroupedRowsByEventName,
+} from "@/internal/analytics/actions/propertyRollupCompleteness.js";
+
+const row = ({
+	eventName = "action_calls",
+	groupValue,
+	totalValue,
+}: {
+	eventName?: string;
+	groupValue: string;
+	totalValue: number;
+}): AggregateGroupablePipeRow => ({
+	period: "2026-07-29 00:00:00",
+	event_name: eventName,
+	group_value: groupValue,
+	total_value: totalValue,
+});
+
+const totals = ({
+	eventName = "action_calls",
+	count,
+	sum,
+}: {
+	eventName?: string;
+	count: number;
+	sum: number;
+}): EventTotals => ({ [eventName]: { count, sum } });
+
+test(`${chalk.yellowBright(
+	"property rollup: a result matching the ungated totals is complete",
+)}`, () => {
+	// StackOne's accountId control: every value is short enough to survive the
+	// gate, so the grouped sums reconcile exactly against the totals.
+	const rows = [
+		row({ groupValue: "2GwnUDjVN8TZtba2AqvCR", totalValue: 18_686 }),
+		row({ groupValue: "aRq2ZOEzeItvNlnn8OPFF", totalValue: 11_916 }),
+	];
+
+	expect(
+		groupedResultIsIncomplete({
+			rows,
+			totals: totals({ count: 2533, sum: 30_602 }),
+		}),
+	).toBe(false);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: a partially gate-dropped key is detected as incomplete",
+)}`, () => {
+	// StackOne's projectId: short slugs survive the gate, 32+ char opaque ids are
+	// dropped at insert, so a NON-EMPTY result still under-reports by ~93%.
+	const rows = [
+		row({ groupValue: "qa-71607", totalValue: 970 }),
+		row({ groupValue: "give-jeran-a-project-92237", totalValue: 284 }),
+		row({ groupValue: "pa-agent-31675", totalValue: 587 }),
+		row({ groupValue: "joe-test-94143", totalValue: 39 }),
+		row({ groupValue: "sales-prod-39557", totalValue: 108 }),
+		row({ groupValue: "production-09042", totalValue: 60 }),
+		row({ groupValue: "test-73448", totalValue: 25 }),
+		row({ groupValue: "alex-academy-00433", totalValue: 31 }),
+		row({ groupValue: "development-66099", totalValue: 18 }),
+		row({ groupValue: "integrations---external-31154", totalValue: 1 }),
+		row({ groupValue: "bryce-test-13857", totalValue: 1 }),
+	];
+
+	expect(
+		groupedResultIsIncomplete({
+			rows,
+			totals: totals({ count: 2533, sum: 30_602 }),
+		}),
+	).toBe(true);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: a fully gate-dropped key is still detected as incomplete",
+)}`, () => {
+	// mastra's all-UUID project_id: the rollup has zero rows for the key.
+	expect(
+		groupedResultIsIncomplete({
+			rows: [],
+			totals: totals({ count: 42, sum: 420 }),
+		}),
+	).toBe(true);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: an empty result with no events is complete",
+)}`, () => {
+	expect(
+		groupedResultIsIncomplete({
+			rows: [],
+			totals: totals({ count: 0, sum: 0 }),
+		}),
+	).toBe(false);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: float drift between aggregation paths is not a shortfall",
+)}`, () => {
+	const rows = [row({ groupValue: "qa-71607", totalValue: 30_601.999_999_99 })];
+
+	expect(
+		groupedResultIsIncomplete({
+			rows,
+			totals: totals({ count: 2533, sum: 30_602 }),
+		}),
+	).toBe(false);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: one lossy feature among several marks the result incomplete",
+)}`, () => {
+	const rows = [
+		row({ eventName: "action_calls", groupValue: "qa-71607", totalValue: 500 }),
+		row({ eventName: "api_calls", groupValue: "qa-71607", totalValue: 10 }),
+	];
+
+	expect(
+		groupedResultIsIncomplete({
+			rows,
+			totals: {
+				action_calls: { count: 10, sum: 500 },
+				api_calls: { count: 90, sum: 9000 },
+			},
+		}),
+	).toBe(true);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: grouped sums exceeding totals are not a shortfall",
+)}`, () => {
+	// Late-arriving events can land in the rollup before the totals rollup sees
+	// them; retrying would not recover anything.
+	const rows = [row({ groupValue: "qa-71607", totalValue: 31_000 })];
+
+	expect(
+		groupedResultIsIncomplete({
+			rows,
+			totals: totals({ count: 2533, sum: 30_602 }),
+		}),
+	).toBe(false);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: the ungated retry only wins when it reports more",
+)}`, () => {
+	// The retry probes whether the shortfall was gate loss or an absent property;
+	// an absent property returns the same mass, so the gated result is kept.
+	const gated = [row({ groupValue: "qa-71607", totalValue: 2124 })];
+	const ungatedWithGateLoss = [
+		row({ groupValue: "qa-71607", totalValue: 2124 }),
+		row({ groupValue: "4uSlnf8w0kUb5WV6gEmBz07JVvgxfxTR", totalValue: 28_478 }),
+	];
+	const ungatedWithAbsentProperty = [
+		row({ groupValue: "qa-71607", totalValue: 2124 }),
+	];
+
+	expect(sumAllRows({ rows: ungatedWithGateLoss })).toBeGreaterThan(
+		sumAllRows({ rows: gated }),
+	);
+	expect(sumAllRows({ rows: ungatedWithAbsentProperty })).toBe(
+		sumAllRows({ rows: gated }),
+	);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: sums grouped rows per event name",
+)}`, () => {
+	const rows = [
+		row({ eventName: "action_calls", groupValue: "a", totalValue: 3 }),
+		row({ eventName: "action_calls", groupValue: "b", totalValue: 4 }),
+		row({ eventName: "api_calls", groupValue: "a", totalValue: 5 }),
+	];
+
+	expect(sumGroupedRowsByEventName({ rows })).toEqual({
+		action_calls: 7,
+		api_calls: 5,
+	});
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix property group-by to detect partial gate drops and return complete results. We reconcile grouped sums against ungated totals and only retry against the ungated rollup when the gated result is short.

- **Bug Fixes**
  - In `aggregate.ts`, detect incomplete results with `groupedResultIsIncomplete` and retry with `skip_property_rollup=1` only when the ungated sum exceeds the gated sum.
  - Added `propertyRollupCompleteness.ts` with tolerant float comparison, per-event grouped sum helpers, and `sumAllRows`.
  - `getCountAndSum` now accepts an explicit `dateRange` to align totals with the queried window.
  - Tests: integration for mixed gate-surviving/dropped property values, unit coverage for completeness logic, and a check that top-N truncation does not trigger an ungated retry.

<sup>Written for commit 399260e8e483b0e5f3fa6f0f76e847fcf33dc146. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR reconciles property-grouped analytics against ungated totals to recover partially gate-dropped groups.

- **Bug fixes:** Compares grouped sums per event with totals from the same date window and retries through the ungated rollup when results are short.
- **Improvements:** Adds reusable tolerant-sum helpers and coverage for partial gate drops, floating-point drift, truncation, and multi-event results.
- **API changes:** Extends `getCountAndSum` with an optional explicit date range for callers that need aligned query windows.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because valid negative-valued property groups can remain silently absent from aggregate results.

The reconciliation treats only a lower grouped sum as incomplete, although dropping a negative-valued gated row raises the grouped sum relative to the ungated total and therefore suppresses the required retry.

**Files Needing Attention:** server/src/internal/analytics/actions/propertyRollupCompleteness.ts, server/src/internal/analytics/actions/aggregate.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/analytics/actions/aggregate.ts | Adds aligned-total reconciliation and an ungated retry, but its greater-than-only replacement contributes to missing negative-valued groups. |
| server/src/internal/analytics/actions/getCountAndSum.ts | Adds an optional caller-provided date range so totals can use the exact aggregate query window. |
| server/src/internal/analytics/actions/propertyRollupCompleteness.ts | Adds tolerant per-event completeness checks, but the one-directional comparison cannot detect gate-dropped negative mass. |
| server/tests/integration/analytics/aggregate/partial-gate-drop-fallback.test.ts | Covers mixed surviving and opaque property values with positive event values. |
| server/tests/unit/analytics/property-rollup-completeness.test.ts | Covers positive shortfalls, tolerance, truncation, and multiple events, but not negative-valued dropped groups. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant A as aggregate
    participant G as Gated property rollup
    participant T as Ungated totals
    participant U as Ungated grouped rollup
    A->>G: Query property groups
    A->>T: Query aligned totals
    A->>A: Compare per-event sums
    alt Grouped sum is lower
        A->>U: Retry grouped query
        A->>A: Keep retry if aggregate sum increases
    else No detected shortfall
        A->>A: Keep gated result
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/analytics/actions/propertyRollupCompleteness.ts:54-59
**Negative gate loss goes undetected**

When a negative-valued event has a property value rejected by the property-rollup gate, dropping that row makes the grouped sum greater than the ungated total. This one-directional comparison therefore treats the result as complete and silently omits the valid property group instead of triggering the ungated retry.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: assert top-N truncation is not rea..."](https://github.com/useautumn/autumn/commit/399260e8e483b0e5f3fa6f0f76e847fcf33dc146) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48654027)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->