### PR TITLE
Queue batching

### DIFF
--- a/server/src/cron/cronInit.ts
+++ b/server/src/cron/cronInit.ts
@@ -15,6 +15,7 @@ import {
 	stopBlueGreenHeartbeat,
 } from "../queue/blueGreen/blueGreenHeartbeat.js";
 import { stopBlueGreenSlotStorePolling } from "../queue/blueGreen/blueGreenSlotStore.js";
+import { shutdownPrimarySqsSendBatcher } from "../queue/queueUtils.js";
 import { runInvoiceCron } from "./invoiceCron/runInvoiceCron.js";
 import { runOneOffCleanup } from "./oneoffCron/runOneOffCleanup.js";
 import { runOneOffExpiry } from "./oneoffCron/runOneOffExpiry.js";
@@ -151,6 +152,7 @@ const shutdown = async (signal: string) => {
 	stopBlueGreenSlotStorePolling({ serviceName: "cron" });
 	stopAllEdgeConfigPolling();
 	await Promise.all([resetLoopPromise, resetLoopV2Promise]);
+	await shutdownPrimarySqsSendBatcher();
 	await client.end();
 	await probeClient.end();
 	process.exit(0);

--- a/server/src/external/tinybird/pipes/aggregateGroupablePipe.ts
+++ b/server/src/external/tinybird/pipes/aggregateGroupablePipe.ts
@@ -7,6 +7,9 @@ export const aggregateGroupablePipeResponseSchema = z.object({
 	event_name: z.string(),
 	group_value: z.string(),
 	total_value: z.number(),
+	// Optional: deployments predating the count column omit it, and the
+	// completeness check degrades to a sum-only comparison when absent.
+	event_count: z.number().optional(),
 	_truncated: z
 		.union([z.boolean(), z.number()])
 		.transform((v) => Boolean(v))

--- a/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
+++ b/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
@@ -16,6 +16,12 @@ const HIGH_VOLUME_SUCCESS_ROUTES = new Set<string>([
 	// "/v1/entities.get",
 ]);
 
+// Event pages run to megabytes each, dwarfing every other route's ingest.
+const RESPONSE_BODY_EXCLUDED_ROUTES = new Set<string>([
+	"/v1/events/list",
+	"/v1/events.list",
+]);
+
 const SUCCESS_REQUEST_LOG_SAMPLE_RATE = Number.parseFloat(
 	process.env.AXIOM_SUCCESS_REQUEST_LOG_SAMPLE_RATE ?? "0",
 );
@@ -64,7 +70,10 @@ export const logRequestResult = async ({
 			extras: ctx.extraLogs,
 		});
 
-		let finalResponseBody = responseBody;
+		const skipResponseBody =
+			isSuccess && RESPONSE_BODY_EXCLUDED_ROUTES.has(c.req.path);
+
+		let finalResponseBody = skipResponseBody ? null : responseBody;
 		if (finalResponseBody === undefined && c.req.path.includes("/v1")) {
 			const contentType = c.res.headers.get("content-type");
 			if (contentType?.includes("application/json")) {

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -52,6 +52,7 @@ import {
 import { preWarmOrgRedisConnections } from "./external/redis/orgRedisPool.js";
 import { createHonoApp } from "./initHono.js";
 import { otelSdk } from "./instrumentation.js";
+import { shutdownPrimarySqsSendBatcher } from "./queue/queueUtils.js";
 import { checkEnvVars } from "./utils/initUtils.js";
 import { startMemoryMonitor } from "./utils/memoryMonitor.js";
 
@@ -168,6 +169,8 @@ async function gracefulShutdown() {
 	shuttingDown = true;
 	console.log("Shutting down worker, flushing telemetry and closing DB...");
 	try {
+		await shutdownPrimarySqsSendBatcher();
+
 		// Flush any buffered OTel spans before shutting down
 		if (otelSdk) {
 			await otelSdk.shutdown();

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -13,6 +13,7 @@ import {
 import { startPgPoolMonitor, stopPgPoolMonitor } from "./db/pgPoolMonitor.js";
 import { getRedactedDatabaseUrls } from "./db/redactDatabaseUrl.js";
 import { logger } from "./external/logtail/logtailUtils.js";
+import { globalAsyncTrackSqsBatcher } from "./internal/balances/track/AsyncTrackSqsBatcher.js";
 import {
 	startAllEdgeConfigPolling,
 	stopAllEdgeConfigPolling,
@@ -169,7 +170,10 @@ async function gracefulShutdown() {
 	shuttingDown = true;
 	console.log("Shutting down worker, flushing telemetry and closing DB...");
 	try {
-		await shutdownPrimarySqsSendBatcher();
+		await Promise.all([
+			globalAsyncTrackSqsBatcher.shutdown(),
+			shutdownPrimarySqsSendBatcher(),
+		]);
 
 		// Flush any buffered OTel spans before shutting down
 		if (otelSdk) {

--- a/server/src/internal/analytics/actions/aggregate.ts
+++ b/server/src/internal/analytics/actions/aggregate.ts
@@ -26,6 +26,10 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { validatePropertyPathForJSON } from "@/internal/analytics/actions/eventValidationUtils.js";
 import { getBillingCycleStartDate } from "../analyticsUtils.js";
 import { getCountAndSum } from "./getCountAndSum.js";
+import {
+	groupedResultIsIncomplete,
+	sumAllRows,
+} from "./propertyRollupCompleteness.js";
 
 /** Flattens filter_by into indexed filter_key_N / filter_value_N params for Tinybird pipes */
 const buildFilterParams = ({
@@ -394,29 +398,6 @@ const formatGroupableResults = ({
 	return { meta, rows: data.length, data };
 };
 
-/**
- * Ducttape fallback for the property-rollup cardinality gate.
- *
- * Unfiltered property group-bys read events_property_mv, whose insert-time gate
- * drops high-entropy values (UUIDs, long hex, opaque strings) to keep the rollup
- * bounded. A group-by over such a key therefore returns an EMPTY grouped result
- * even though the events exist — the gate can't tell a genuinely explosive key
- * (per-request trace ids) from a low-cardinality-but-UUID-shaped one (a customer
- * with 21 project ids).
- *
- * When the grouped result is empty BUT the authoritative totals (getCountAndSum,
- * read from the ungated rollups) show real events, we know the gate ate the
- * values, so we retry the same query against the ungated events_hourly_mv. When
- * the totals are also empty, the customer simply has no events — no retry.
- *
- * This does NOT cover the partial case (a key with a mix of gate-surviving and
- * gate-dropped values), which needs cardinality-aware routing (topKWeighted).
- */
-const totalsHaveEvents = (
-	totals: Record<string, { count: number; sum: number }>,
-): boolean =>
-	Object.values(totals).some((t) => t.count > 0 && t.sum > 0);
-
 /** Aggregates events into time-bucketed timeseries data */
 export const aggregate = async ({
 	ctx,
@@ -489,22 +470,30 @@ export const aggregate = async ({
 
 		let result = await pipes.aggregateGroupable(pipeParams);
 
-		// The gated property rollup only serves unfiltered property group-bys. If it
-		// returns nothing, check whether real events exist (ungated totals); if so,
-		// the value-shape gate dropped the group values — retry against the ungated
-		// events_hourly_mv. See totalsHaveEvents for the full rationale.
-		const usedGatedRollup =
-			groupColumn === "property" &&
-			Object.keys(filterParams).length === 0 &&
-			result.data.length === 0;
+		// Only this query shape reads the gated property rollup.
+		const readsGatedRollup =
+			groupColumn === "property" && Object.keys(filterParams).length === 0;
 
-		if (usedGatedRollup) {
-			const totals = await getCountAndSum({ ctx, params });
-			if (totalsHaveEvents(totals)) {
-				result = await pipes.aggregateGroupable({
+		if (readsGatedRollup) {
+			const totals = await getCountAndSum({
+				ctx,
+				params,
+				dateRange: { startDate, endDate },
+			});
+
+			if (groupedResultIsIncomplete({ rows: result.data, totals })) {
+				const ungated = await pipes.aggregateGroupable({
 					...pipeParams,
 					skip_property_rollup: "1",
 				});
+
+				// A shortfall means gate loss OR events without the property; only the
+				// first is recoverable, and only the retry can tell them apart.
+				if (
+					sumAllRows({ rows: ungated.data }) > sumAllRows({ rows: result.data })
+				) {
+					result = ungated;
+				}
 			}
 		}
 

--- a/server/src/internal/analytics/actions/aggregate.ts
+++ b/server/src/internal/analytics/actions/aggregate.ts
@@ -28,7 +28,7 @@ import { getBillingCycleStartDate } from "../analyticsUtils.js";
 import { getCountAndSum } from "./getCountAndSum.js";
 import {
 	groupedResultIsIncomplete,
-	sumAllRows,
+	reportsMoreThan,
 } from "./propertyRollupCompleteness.js";
 
 /** Flattens filter_by into indexed filter_key_N / filter_value_N params for Tinybird pipes */
@@ -490,7 +490,7 @@ export const aggregate = async ({
 				// A shortfall means gate loss OR events without the property; only the
 				// first is recoverable, and only the retry can tell them apart.
 				if (
-					sumAllRows({ rows: ungated.data }) > sumAllRows({ rows: result.data })
+					reportsMoreThan({ candidate: ungated.data, current: result.data })
 				) {
 					result = ungated;
 				}

--- a/server/src/internal/analytics/actions/getCountAndSum.ts
+++ b/server/src/internal/analytics/actions/getCountAndSum.ts
@@ -86,14 +86,19 @@ const calculateDateRange = async ({
 export const getCountAndSum = async ({
 	ctx,
 	params,
+	dateRange,
 }: {
 	ctx: AutumnContext;
 	params: TotalEventsParams;
+	// Callers comparing these totals against another query's result must pass that
+	// query's window; resolving it here independently drifts by up to one bin.
+	dateRange?: DateRangeResult;
 }) => {
 	const ch = getClickhouseClient();
 	const { org, env } = ctx;
 
-	const { startDate, endDate } = await calculateDateRange({ ctx, params });
+	const { startDate, endDate } =
+		dateRange ?? (await calculateDateRange({ ctx, params }));
 
 	// Build dynamic filter_by clauses using native JSON sub-column access
 	let filterBySql = "";

--- a/server/src/internal/analytics/actions/propertyRollupCompleteness.ts
+++ b/server/src/internal/analytics/actions/propertyRollupCompleteness.ts
@@ -37,6 +37,53 @@ export const sumAllRows = ({
 	rows: AggregateGroupablePipeRow[];
 }): number => rows.reduce((sum, row) => sum + row.total_value, 0);
 
+// Event counts can't cancel the way signed values can, but older deployments of
+// the pipe don't return them, so every count check stays opt-in.
+const countRowsByEventName = ({
+	rows,
+}: {
+	rows: AggregateGroupablePipeRow[];
+}): Record<string, number> | null => {
+	const counts: Record<string, number> = {};
+	for (const row of rows) {
+		if (row.event_count === undefined) return null;
+		counts[row.event_name] = (counts[row.event_name] ?? 0) + row.event_count;
+	}
+	return counts;
+};
+
+const totalEventCount = ({
+	rows,
+}: {
+	rows: AggregateGroupablePipeRow[];
+}): number | null => {
+	let total = 0;
+	for (const row of rows) {
+		if (row.event_count === undefined) return null;
+		total += row.event_count;
+	}
+	return total;
+};
+
+/**
+ * Whether the retry recovered anything. Prefers event counts, since a recovered
+ * group whose values cancel to zero moves the count but not the sum.
+ */
+export const reportsMoreThan = ({
+	candidate,
+	current,
+}: {
+	candidate: AggregateGroupablePipeRow[];
+	current: AggregateGroupablePipeRow[];
+}): boolean => {
+	const candidateCount = totalEventCount({ rows: candidate });
+	const currentCount = totalEventCount({ rows: current });
+	if (candidateCount !== null && currentCount !== null) {
+		if (candidateCount !== currentCount) return candidateCount > currentCount;
+	}
+	return sumAllRows({ rows: candidate }) > sumAllRows({ rows: current });
+};
+
 /**
  * Whether the gated property rollup under-reports against the ungated totals.
  * A key with both gate-surviving and gate-dropped values comes back non-empty
@@ -50,13 +97,20 @@ export const groupedResultIsIncomplete = ({
 	totals: EventTotals;
 }): boolean => {
 	const groupedSums = sumGroupedRowsByEventName({ rows });
+	const groupedCounts = countRowsByEventName({ rows });
 
-	return Object.entries(totals).some(
-		([eventName, total]) =>
-			total.count > 0 &&
-			isMateriallyLessThan({
-				value: groupedSums[eventName] ?? 0,
-				reference: total.sum,
-			}),
-	);
+	return Object.entries(totals).some(([eventName, total]) => {
+		if (total.count <= 0) return false;
+
+		// Signed values can cancel, so a matching sum does not prove the groups are
+		// all present; the count catches what the sum hides.
+		if (groupedCounts && (groupedCounts[eventName] ?? 0) < total.count) {
+			return true;
+		}
+
+		return isMateriallyLessThan({
+			value: groupedSums[eventName] ?? 0,
+			reference: total.sum,
+		});
+	});
 };

--- a/server/src/internal/analytics/actions/propertyRollupCompleteness.ts
+++ b/server/src/internal/analytics/actions/propertyRollupCompleteness.ts
@@ -1,0 +1,62 @@
+// events_property_mv's insert-time gate drops high-entropy values (UUIDs, long
+// hex, 32+ char opaque ids) so per-event-unique keys can't explode the rollup.
+import type { AggregateGroupablePipeRow } from "@/external/tinybird/pipes/aggregateGroupablePipe.js";
+
+export type EventTotals = Record<string, { count: number; sum: number }>;
+
+// Sums are Float64 through two different aggregation paths, so exact equality
+// would report phantom shortfalls on large values.
+const RELATIVE_TOLERANCE = 1e-9;
+const ABSOLUTE_TOLERANCE = 1e-6;
+
+const isMateriallyLessThan = ({
+	value,
+	reference,
+}: {
+	value: number;
+	reference: number;
+}): boolean =>
+	reference - value >
+	Math.max(ABSOLUTE_TOLERANCE, Math.abs(reference) * RELATIVE_TOLERANCE);
+
+export const sumGroupedRowsByEventName = ({
+	rows,
+}: {
+	rows: AggregateGroupablePipeRow[];
+}): Record<string, number> => {
+	const sums: Record<string, number> = {};
+	for (const row of rows) {
+		sums[row.event_name] = (sums[row.event_name] ?? 0) + row.total_value;
+	}
+	return sums;
+};
+
+export const sumAllRows = ({
+	rows,
+}: {
+	rows: AggregateGroupablePipeRow[];
+}): number => rows.reduce((sum, row) => sum + row.total_value, 0);
+
+/**
+ * Whether the gated property rollup under-reports against the ungated totals.
+ * A key with both gate-surviving and gate-dropped values comes back non-empty
+ * yet short, so emptiness alone never detects it.
+ */
+export const groupedResultIsIncomplete = ({
+	rows,
+	totals,
+}: {
+	rows: AggregateGroupablePipeRow[];
+	totals: EventTotals;
+}): boolean => {
+	const groupedSums = sumGroupedRowsByEventName({ rows });
+
+	return Object.entries(totals).some(
+		([eventName, total]) =>
+			total.count > 0 &&
+			isMateriallyLessThan({
+				value: groupedSums[eventName] ?? 0,
+				reference: total.sum,
+			}),
+	);
+};

--- a/server/src/internal/balances/track/AsyncTrackSqsBatcher.ts
+++ b/server/src/internal/balances/track/AsyncTrackSqsBatcher.ts
@@ -1,0 +1,170 @@
+import { JobName } from "@/queue/JobName.js";
+import { addTasksToQueueBatch, type Payloads } from "@/queue/queueUtils.js";
+
+const DEFAULT_BATCH_WINDOW_MS = 10;
+const SQS_SEND_MESSAGE_BATCH_LIMIT = 10;
+
+type AsyncTrackQueueEntry = {
+	payload: Payloads[JobName.Track];
+	messageGroupId: string;
+	messageDeduplicationId: string;
+};
+
+export type SendAsyncTrackBatchArgs = {
+	jobName: JobName.Track;
+	queueUrl: string;
+	entries: AsyncTrackQueueEntry[];
+};
+
+type SendAsyncTrackBatch = (args: SendAsyncTrackBatchArgs) => Promise<{
+	successCount: number;
+	failures: Array<{ index: number; reason: string }>;
+}>;
+
+type PendingEntry = AsyncTrackQueueEntry & {
+	queueUrl: string;
+	resolve: () => void;
+	reject: (error: Error) => void;
+};
+
+export class AsyncTrackSqsBatcher {
+	private pendingEntries: PendingEntry[] = [];
+	private flushTimer: NodeJS.Timeout | null = null;
+	private readonly inFlightSends = new Set<Promise<void>>();
+	private readonly batchWindowMs: number;
+	private readonly sendBatch: SendAsyncTrackBatch;
+	private acceptingEntries = true;
+
+	constructor({
+		batchWindowMs = DEFAULT_BATCH_WINDOW_MS,
+		sendBatch = addTasksToQueueBatch as SendAsyncTrackBatch,
+	}: {
+		batchWindowMs?: number;
+		sendBatch?: SendAsyncTrackBatch;
+	} = {}) {
+		this.batchWindowMs = batchWindowMs;
+		this.sendBatch = sendBatch;
+	}
+
+	enqueue({
+		queueUrl,
+		payload,
+		messageGroupId,
+		messageDeduplicationId,
+	}: {
+		queueUrl: string;
+		payload: Payloads[JobName.Track];
+		messageGroupId: string;
+		messageDeduplicationId: string;
+	}): Promise<void> {
+		if (!this.acceptingEntries) {
+			return Promise.reject(
+				new Error("Async track SQS batcher is shutting down"),
+			);
+		}
+
+		if (
+			this.pendingEntries.length > 0 &&
+			this.pendingEntries[0].queueUrl !== queueUrl
+		) {
+			void this.startSend();
+		}
+
+		return new Promise<void>((resolve, reject) => {
+			this.pendingEntries.push({
+				queueUrl,
+				payload,
+				messageGroupId,
+				messageDeduplicationId,
+				resolve,
+				reject,
+			});
+
+			if (this.pendingEntries.length >= SQS_SEND_MESSAGE_BATCH_LIMIT) {
+				void this.startSend();
+			} else {
+				this.scheduleSend();
+			}
+		});
+	}
+
+	async flush(): Promise<void> {
+		await this.startSend();
+		while (this.inFlightSends.size > 0) {
+			await Promise.all(Array.from(this.inFlightSends));
+		}
+	}
+
+	async shutdown(): Promise<void> {
+		this.acceptingEntries = false;
+		await this.flush();
+	}
+
+	private scheduleSend(): void {
+		if (this.flushTimer) return;
+		this.flushTimer = setTimeout(() => {
+			this.flushTimer = null;
+			void this.startSend();
+		}, this.batchWindowMs);
+	}
+
+	private startSend(): Promise<void> {
+		if (this.pendingEntries.length === 0) return Promise.resolve();
+
+		const pendingEntries = this.pendingEntries;
+		this.pendingEntries = [];
+		if (this.flushTimer) {
+			clearTimeout(this.flushTimer);
+			this.flushTimer = null;
+		}
+
+		const sendPromise = this.sendEntries({ pendingEntries });
+		this.inFlightSends.add(sendPromise);
+		void sendPromise.then(() => {
+			this.inFlightSends.delete(sendPromise);
+		});
+		return sendPromise;
+	}
+
+	private async sendEntries({
+		pendingEntries,
+	}: {
+		pendingEntries: PendingEntry[];
+	}): Promise<void> {
+		let result: Awaited<ReturnType<SendAsyncTrackBatch>>;
+		try {
+			result = await this.sendBatch({
+				jobName: JobName.Track,
+				queueUrl: pendingEntries[0].queueUrl,
+				entries: pendingEntries.map(
+					({ payload, messageGroupId, messageDeduplicationId }) => ({
+						payload,
+						messageGroupId,
+						messageDeduplicationId,
+					}),
+				),
+			});
+		} catch (error) {
+			const sendError =
+				error instanceof Error
+					? error
+					: new Error("Unknown async track SQS batch error");
+			for (const pendingEntry of pendingEntries) {
+				pendingEntry.reject(sendError);
+			}
+			return;
+		}
+
+		const failureReasons = new Map(
+			result.failures.map(({ index, reason }) => [index, reason]),
+		);
+
+		for (const [index, pendingEntry] of pendingEntries.entries()) {
+			const failureReason = failureReasons.get(index);
+			if (failureReason === undefined) pendingEntry.resolve();
+			else pendingEntry.reject(new Error(failureReason));
+		}
+	}
+}
+
+export const globalAsyncTrackSqsBatcher = new AsyncTrackSqsBatcher();

--- a/server/src/internal/balances/track/AsyncTrackSqsBatcher.ts
+++ b/server/src/internal/balances/track/AsyncTrackSqsBatcher.ts
@@ -1,13 +1,16 @@
 import { JobName } from "@/queue/JobName.js";
 import { addTasksToQueueBatch, type Payloads } from "@/queue/queueUtils.js";
-
-const DEFAULT_BATCH_WINDOW_MS = 10;
-const SQS_SEND_MESSAGE_BATCH_LIMIT = 10;
+import { SqsBatchAccumulator } from "@/queue/SqsBatchAccumulator.js";
 
 type AsyncTrackQueueEntry = {
 	payload: Payloads[JobName.Track];
 	messageGroupId: string;
 	messageDeduplicationId: string;
+};
+
+type AsyncTrackAccumulatorEntry = AsyncTrackQueueEntry & {
+	queueUrl: string;
+	messageBody: string;
 };
 
 export type SendAsyncTrackBatchArgs = {
@@ -21,29 +24,31 @@ type SendAsyncTrackBatch = (args: SendAsyncTrackBatchArgs) => Promise<{
 	failures: Array<{ index: number; reason: string }>;
 }>;
 
-type PendingEntry = AsyncTrackQueueEntry & {
-	queueUrl: string;
-	resolve: () => void;
-	reject: (error: Error) => void;
-};
-
 export class AsyncTrackSqsBatcher {
-	private pendingEntries: PendingEntry[] = [];
-	private flushTimer: NodeJS.Timeout | null = null;
-	private readonly inFlightSends = new Set<Promise<void>>();
-	private readonly batchWindowMs: number;
-	private readonly sendBatch: SendAsyncTrackBatch;
-	private acceptingEntries = true;
+	private readonly accumulator: SqsBatchAccumulator<AsyncTrackAccumulatorEntry>;
 
 	constructor({
-		batchWindowMs = DEFAULT_BATCH_WINDOW_MS,
+		batchWindowMs,
 		sendBatch = addTasksToQueueBatch as SendAsyncTrackBatch,
 	}: {
 		batchWindowMs?: number;
 		sendBatch?: SendAsyncTrackBatch;
 	} = {}) {
-		this.batchWindowMs = batchWindowMs;
-		this.sendBatch = sendBatch;
+		this.accumulator = new SqsBatchAccumulator<AsyncTrackAccumulatorEntry>({
+			batchWindowMs,
+			sendBatch: ({ queueUrl, entries }) =>
+				sendBatch({
+					jobName: JobName.Track,
+					queueUrl,
+					entries: entries.map(
+						({ payload, messageGroupId, messageDeduplicationId }) => ({
+							payload,
+							messageGroupId,
+							messageDeduplicationId,
+						}),
+					),
+				}),
+		});
 	}
 
 	enqueue({
@@ -57,113 +62,24 @@ export class AsyncTrackSqsBatcher {
 		messageGroupId: string;
 		messageDeduplicationId: string;
 	}): Promise<void> {
-		if (!this.acceptingEntries) {
-			return Promise.reject(
-				new Error("Async track SQS batcher is shutting down"),
-			);
-		}
-
-		if (
-			this.pendingEntries.length > 0 &&
-			this.pendingEntries[0].queueUrl !== queueUrl
-		) {
-			void this.startSend();
-		}
-
-		return new Promise<void>((resolve, reject) => {
-			this.pendingEntries.push({
-				queueUrl,
-				payload,
-				messageGroupId,
-				messageDeduplicationId,
-				resolve,
-				reject,
-			});
-
-			if (this.pendingEntries.length >= SQS_SEND_MESSAGE_BATCH_LIMIT) {
-				void this.startSend();
-			} else {
-				this.scheduleSend();
-			}
+		return this.accumulator.enqueue({
+			queueUrl,
+			payload,
+			messageGroupId,
+			messageDeduplicationId,
+			messageBody: JSON.stringify({
+				name: JobName.Track,
+				data: payload,
+			}),
 		});
 	}
 
-	async flush(): Promise<void> {
-		await this.startSend();
-		while (this.inFlightSends.size > 0) {
-			await Promise.all(Array.from(this.inFlightSends));
-		}
+	flush(): Promise<void> {
+		return this.accumulator.flush();
 	}
 
-	async shutdown(): Promise<void> {
-		this.acceptingEntries = false;
-		await this.flush();
-	}
-
-	private scheduleSend(): void {
-		if (this.flushTimer) return;
-		this.flushTimer = setTimeout(() => {
-			this.flushTimer = null;
-			void this.startSend();
-		}, this.batchWindowMs);
-	}
-
-	private startSend(): Promise<void> {
-		if (this.pendingEntries.length === 0) return Promise.resolve();
-
-		const pendingEntries = this.pendingEntries;
-		this.pendingEntries = [];
-		if (this.flushTimer) {
-			clearTimeout(this.flushTimer);
-			this.flushTimer = null;
-		}
-
-		const sendPromise = this.sendEntries({ pendingEntries });
-		this.inFlightSends.add(sendPromise);
-		void sendPromise.then(() => {
-			this.inFlightSends.delete(sendPromise);
-		});
-		return sendPromise;
-	}
-
-	private async sendEntries({
-		pendingEntries,
-	}: {
-		pendingEntries: PendingEntry[];
-	}): Promise<void> {
-		let result: Awaited<ReturnType<SendAsyncTrackBatch>>;
-		try {
-			result = await this.sendBatch({
-				jobName: JobName.Track,
-				queueUrl: pendingEntries[0].queueUrl,
-				entries: pendingEntries.map(
-					({ payload, messageGroupId, messageDeduplicationId }) => ({
-						payload,
-						messageGroupId,
-						messageDeduplicationId,
-					}),
-				),
-			});
-		} catch (error) {
-			const sendError =
-				error instanceof Error
-					? error
-					: new Error("Unknown async track SQS batch error");
-			for (const pendingEntry of pendingEntries) {
-				pendingEntry.reject(sendError);
-			}
-			return;
-		}
-
-		const failureReasons = new Map(
-			result.failures.map(({ index, reason }) => [index, reason]),
-		);
-
-		for (const [index, pendingEntry] of pendingEntries.entries()) {
-			const failureReason = failureReasons.get(index);
-			if (failureReason === undefined) pendingEntry.resolve();
-			else pendingEntry.reject(new Error(failureReason));
-		}
+	shutdown(): Promise<void> {
+		return this.accumulator.shutdown();
 	}
 }
 

--- a/server/src/internal/balances/track/runAsyncTrack.ts
+++ b/server/src/internal/balances/track/runAsyncTrack.ts
@@ -1,7 +1,7 @@
 import { ErrCode, RecaseError, type TrackParams } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { globalAsyncTrackSqsBatcher } from "./AsyncTrackSqsBatcher.js";
 import { getAsyncTrackMessageGroupId } from "./utils/getAsyncTrackMessageGroupId.js";
-import { queueTrack } from "./utils/queueTrack.js";
 
 const ASYNC_TRACK_UNAVAILABLE_MESSAGE =
 	"Async track is not available right now";
@@ -26,22 +26,32 @@ export const runAsyncTrack = async ({
 	}
 	const messageDeduplicationId = ctx.id;
 
-	const queued = await queueTrack({
-		ctx,
-		body,
-		queueUrl,
-		messageGroupId: getAsyncTrackMessageGroupId({
-			orgId: ctx.org.id,
-			env: ctx.env,
-			customerId: body.customer_id,
-			entityId: body.entity_id,
+	try {
+		await globalAsyncTrackSqsBatcher.enqueue({
+			queueUrl,
+			payload: {
+				orgId: ctx.org.id,
+				env: ctx.env,
+				customerId: body.customer_id,
+				entityId: body.entity_id,
+				requestId: ctx.id,
+				apiVersion: ctx.apiVersion.value,
+				body,
+			},
+			messageGroupId: getAsyncTrackMessageGroupId({
+				orgId: ctx.org.id,
+				env: ctx.env,
+				customerId: body.customer_id,
+				entityId: body.entity_id,
+				messageDeduplicationId,
+			}),
 			messageDeduplicationId,
-		}),
-		messageDeduplicationId,
-		logFallback: false,
-		markQueuedForReplay: false,
-	});
-	if (!queued) {
+		});
+	} catch (error) {
+		ctx.logger.warn("[track] Queue fallback failed (SQS)", {
+			type: "track_queue_fallback_failed",
+			error,
+		});
 		throw new RecaseError({
 			message: ASYNC_TRACK_UNAVAILABLE_MESSAGE,
 			code: ErrCode.InternalError,

--- a/server/src/queue/PrimarySqsSendBatcher.ts
+++ b/server/src/queue/PrimarySqsSendBatcher.ts
@@ -1,0 +1,166 @@
+const DEFAULT_BATCH_WINDOW_MS = 10;
+const SQS_SEND_MESSAGE_BATCH_LIMIT = 10;
+const SQS_SEND_MESSAGE_BATCH_MAX_BODY_BYTES = 1024 * 1024;
+
+export type PrimarySqsQueueEntry = {
+	queueUrl: string;
+	jobName: string;
+	messageBody: string;
+	messageGroupId?: string;
+	messageDeduplicationId?: string;
+	delaySeconds?: number;
+};
+
+export type SendPrimarySqsBatchArgs = {
+	queueUrl: string;
+	entries: PrimarySqsQueueEntry[];
+};
+
+type SendPrimarySqsBatch = (args: SendPrimarySqsBatchArgs) => Promise<{
+	failures: Array<{ index: number; reason: string }>;
+}>;
+
+type PendingEntry = PrimarySqsQueueEntry & {
+	resolve: () => void;
+	reject: (error: Error) => void;
+};
+
+export class PrimarySqsSendBatcher {
+	private pendingEntries: PendingEntry[] = [];
+	private pendingMessageBodyBytes = 0;
+	private flushTimer: NodeJS.Timeout | null = null;
+	private readonly inFlightSends = new Set<Promise<void>>();
+	private readonly batchWindowMs: number;
+	private readonly sendBatch: SendPrimarySqsBatch;
+	private acceptingEntries = true;
+
+	constructor({
+		batchWindowMs = DEFAULT_BATCH_WINDOW_MS,
+		sendBatch,
+	}: {
+		batchWindowMs?: number;
+		sendBatch: SendPrimarySqsBatch;
+	}) {
+		this.batchWindowMs = batchWindowMs;
+		this.sendBatch = sendBatch;
+	}
+
+	enqueue(entry: PrimarySqsQueueEntry): Promise<void> {
+		if (!this.acceptingEntries) {
+			return Promise.reject(
+				new Error("Primary SQS send batcher is shutting down"),
+			);
+		}
+
+		const messageBodyBytes = Buffer.byteLength(entry.messageBody, "utf8");
+		const pendingQueueUrl = this.pendingEntries[0]?.queueUrl;
+		const mustStartNewBatch =
+			this.pendingEntries.length > 0 &&
+			(pendingQueueUrl !== entry.queueUrl ||
+				this.pendingMessageBodyBytes + messageBodyBytes >
+					SQS_SEND_MESSAGE_BATCH_MAX_BODY_BYTES);
+
+		if (mustStartNewBatch) {
+			void this.startSend();
+		}
+
+		return new Promise<void>((resolve, reject) => {
+			this.pendingEntries.push({ ...entry, resolve, reject });
+			this.pendingMessageBodyBytes += messageBodyBytes;
+
+			if (this.pendingEntries.length >= SQS_SEND_MESSAGE_BATCH_LIMIT) {
+				void this.startSend();
+			} else {
+				this.scheduleSend();
+			}
+		});
+	}
+
+	async flush(): Promise<void> {
+		await this.startSend();
+		while (this.inFlightSends.size > 0) {
+			await Promise.all(Array.from(this.inFlightSends));
+		}
+	}
+
+	async shutdown(): Promise<void> {
+		this.acceptingEntries = false;
+		await this.flush();
+	}
+
+	private scheduleSend(): void {
+		if (this.flushTimer) return;
+		this.flushTimer = setTimeout(() => {
+			this.flushTimer = null;
+			void this.startSend();
+		}, this.batchWindowMs);
+	}
+
+	private startSend(): Promise<void> {
+		if (this.pendingEntries.length === 0) return Promise.resolve();
+
+		const pendingEntries = this.pendingEntries;
+		this.pendingEntries = [];
+		this.pendingMessageBodyBytes = 0;
+		if (this.flushTimer) {
+			clearTimeout(this.flushTimer);
+			this.flushTimer = null;
+		}
+
+		const sendPromise = this.sendEntries({ pendingEntries });
+		this.inFlightSends.add(sendPromise);
+		void sendPromise.then(() => {
+			this.inFlightSends.delete(sendPromise);
+		});
+		return sendPromise;
+	}
+
+	private async sendEntries({
+		pendingEntries,
+	}: {
+		pendingEntries: PendingEntry[];
+	}): Promise<void> {
+		let failures: Array<{ index: number; reason: string }>;
+		try {
+			const result = await this.sendBatch({
+				queueUrl: pendingEntries[0].queueUrl,
+				entries: pendingEntries.map(
+					({
+						queueUrl,
+						jobName,
+						messageBody,
+						messageGroupId,
+						messageDeduplicationId,
+						delaySeconds,
+					}) => ({
+						queueUrl,
+						jobName,
+						messageBody,
+						messageGroupId,
+						messageDeduplicationId,
+						delaySeconds,
+					}),
+				),
+			});
+			failures = result.failures;
+		} catch (error) {
+			const sendError =
+				error instanceof Error
+					? error
+					: new Error("Unknown primary SQS batch error");
+			for (const pendingEntry of pendingEntries) {
+				pendingEntry.reject(sendError);
+			}
+			return;
+		}
+
+		const failureReasons = new Map(
+			failures.map(({ index, reason }) => [index, reason]),
+		);
+		for (const [index, pendingEntry] of pendingEntries.entries()) {
+			const failureReason = failureReasons.get(index);
+			if (failureReason === undefined) pendingEntry.resolve();
+			else pendingEntry.reject(new Error(failureReason));
+		}
+	}
+}

--- a/server/src/queue/SqsBatchAccumulator.ts
+++ b/server/src/queue/SqsBatchAccumulator.ts
@@ -1,74 +1,83 @@
 const DEFAULT_BATCH_WINDOW_MS = 10;
-const SQS_SEND_MESSAGE_BATCH_LIMIT = 10;
-const SQS_SEND_MESSAGE_BATCH_MAX_BODY_BYTES = 1024 * 1024;
+const DEFAULT_MAX_BATCH_ENTRIES = 10;
+const DEFAULT_MAX_BATCH_BODY_BYTES = 1024 * 1024;
 
-export type PrimarySqsQueueEntry = {
+export type SqsBatchAccumulatorEntry = {
 	queueUrl: string;
-	jobName: string;
 	messageBody: string;
-	messageGroupId?: string;
-	messageDeduplicationId?: string;
-	delaySeconds?: number;
 };
 
-export type SendPrimarySqsBatchArgs = {
+export type SendSqsAccumulatorBatchArgs<
+	TEntry extends SqsBatchAccumulatorEntry,
+> = {
 	queueUrl: string;
-	entries: PrimarySqsQueueEntry[];
+	entries: TEntry[];
 };
 
-type SendPrimarySqsBatch = (args: SendPrimarySqsBatchArgs) => Promise<{
+type SendSqsAccumulatorBatch<TEntry extends SqsBatchAccumulatorEntry> = (
+	args: SendSqsAccumulatorBatchArgs<TEntry>,
+) => Promise<{
 	failures: Array<{ index: number; reason: string }>;
 }>;
 
-type PendingEntry = PrimarySqsQueueEntry & {
+type PendingEntry<TEntry extends SqsBatchAccumulatorEntry> = {
+	entry: TEntry;
 	resolve: () => void;
 	reject: (error: Error) => void;
 };
 
-export class PrimarySqsSendBatcher {
-	private pendingEntries: PendingEntry[] = [];
+export class SqsBatchAccumulator<TEntry extends SqsBatchAccumulatorEntry> {
+	private pendingEntries: PendingEntry<TEntry>[] = [];
 	private pendingMessageBodyBytes = 0;
 	private flushTimer: NodeJS.Timeout | null = null;
 	private readonly inFlightSends = new Set<Promise<void>>();
 	private readonly batchWindowMs: number;
-	private readonly sendBatch: SendPrimarySqsBatch;
+	private readonly maxBatchEntries: number;
+	private readonly maxBatchBodyBytes: number;
+	private readonly sendBatch: SendSqsAccumulatorBatch<TEntry>;
 	private acceptingEntries = true;
 
 	constructor({
 		batchWindowMs = DEFAULT_BATCH_WINDOW_MS,
+		maxBatchEntries = DEFAULT_MAX_BATCH_ENTRIES,
+		maxBatchBodyBytes = DEFAULT_MAX_BATCH_BODY_BYTES,
 		sendBatch,
 	}: {
 		batchWindowMs?: number;
-		sendBatch: SendPrimarySqsBatch;
+		maxBatchEntries?: number;
+		maxBatchBodyBytes?: number;
+		sendBatch: SendSqsAccumulatorBatch<TEntry>;
 	}) {
 		this.batchWindowMs = batchWindowMs;
+		this.maxBatchEntries = maxBatchEntries;
+		this.maxBatchBodyBytes = maxBatchBodyBytes;
 		this.sendBatch = sendBatch;
 	}
 
-	enqueue(entry: PrimarySqsQueueEntry): Promise<void> {
+	enqueue(entry: TEntry): Promise<void> {
 		if (!this.acceptingEntries) {
 			return Promise.reject(
-				new Error("Primary SQS send batcher is shutting down"),
+				new Error("SQS batch accumulator is shutting down"),
 			);
 		}
 
 		const messageBodyBytes = Buffer.byteLength(entry.messageBody, "utf8");
-		const pendingQueueUrl = this.pendingEntries[0]?.queueUrl;
+		const pendingQueueUrl = this.pendingEntries[0]?.entry.queueUrl;
 		const mustStartNewBatch =
 			this.pendingEntries.length > 0 &&
 			(pendingQueueUrl !== entry.queueUrl ||
 				this.pendingMessageBodyBytes + messageBodyBytes >
-					SQS_SEND_MESSAGE_BATCH_MAX_BODY_BYTES);
+					this.maxBatchBodyBytes);
 
 		if (mustStartNewBatch) {
 			void this.startSend();
 		}
 
 		return new Promise<void>((resolve, reject) => {
-			this.pendingEntries.push({ ...entry, resolve, reject });
+			this.pendingEntries.push({ entry, resolve, reject });
 			this.pendingMessageBodyBytes += messageBodyBytes;
 
-			if (this.pendingEntries.length >= SQS_SEND_MESSAGE_BATCH_LIMIT) {
+			if (this.pendingEntries.length >= this.maxBatchEntries) {
 				void this.startSend();
 			} else {
 				this.scheduleSend();
@@ -118,36 +127,18 @@ export class PrimarySqsSendBatcher {
 	private async sendEntries({
 		pendingEntries,
 	}: {
-		pendingEntries: PendingEntry[];
+		pendingEntries: PendingEntry<TEntry>[];
 	}): Promise<void> {
 		let failures: Array<{ index: number; reason: string }>;
 		try {
 			const result = await this.sendBatch({
-				queueUrl: pendingEntries[0].queueUrl,
-				entries: pendingEntries.map(
-					({
-						queueUrl,
-						jobName,
-						messageBody,
-						messageGroupId,
-						messageDeduplicationId,
-						delaySeconds,
-					}) => ({
-						queueUrl,
-						jobName,
-						messageBody,
-						messageGroupId,
-						messageDeduplicationId,
-						delaySeconds,
-					}),
-				),
+				queueUrl: pendingEntries[0].entry.queueUrl,
+				entries: pendingEntries.map(({ entry }) => entry),
 			});
 			failures = result.failures;
 		} catch (error) {
 			const sendError =
-				error instanceof Error
-					? error
-					: new Error("Unknown primary SQS batch error");
+				error instanceof Error ? error : new Error("Unknown SQS batch error");
 			for (const pendingEntry of pendingEntries) {
 				pendingEntry.reject(sendError);
 			}

--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -33,6 +33,7 @@ import {
 import { getSqsClient, QUEUE_URL, recreateSqsClient } from "./initSqs.js";
 import { JobName } from "./JobName.js";
 import { processMessage, type SqsJob } from "./processMessage.js";
+import { shutdownPrimarySqsSendBatcher } from "./queueUtils.js";
 import {
 	createWorkerActivityTracker,
 	type WorkerActivityTracker,
@@ -614,6 +615,7 @@ export const initWorkers = async ({
 		for (const controller of abortControllers) {
 			controller.abort();
 		}
+		await shutdownPrimarySqsSendBatcher();
 
 		const isProd = process.env.NODE_ENV === "production";
 		if (isProd) {

--- a/server/src/queue/queueUtils.ts
+++ b/server/src/queue/queueUtils.ts
@@ -21,10 +21,7 @@ import type { ClearCreditSystemCachePayload } from "@/internal/features/featureA
 import type { GenerateFeatureDisplayPayload } from "@/internal/features/workflows/generateFeatureDisplay.js";
 import { getSqsClient } from "./initSqs.js";
 import { JobName } from "./JobName.js";
-import {
-	PrimarySqsSendBatcher,
-	type SendPrimarySqsBatchArgs,
-} from "./PrimarySqsSendBatcher.js";
+import { PrimarySqsSendBatcher } from "./PrimarySqsSendBatcher.js";
 import type {
 	BatchResetCusEntsPayload,
 	SendProductsUpdatedPayload,
@@ -132,95 +129,133 @@ const sendBatchFailuresCounter = meter.createCounter(
 const getQueueName = ({ queueUrl }: { queueUrl: string }) =>
 	queueUrl.split("/").pop() ?? "unknown";
 
-const sendPrimarySqsBatch = async ({
+type SqsBatchMessage = {
+	jobName: string;
+	messageBody: string;
+	messageGroupId?: string;
+	messageDeduplicationId?: string;
+	delaySeconds?: number;
+};
+
+const sendSqsMessagesBatch = async ({
 	queueUrl,
 	entries,
-}: SendPrimarySqsBatchArgs): Promise<{
+}: {
+	queueUrl: string;
+	entries: SqsBatchMessage[];
+}): Promise<{
+	successCount: number;
 	failures: Array<{ index: number; reason: string }>;
 }> => {
 	const sqsClient = getSqsClient({ queueUrl });
 	const queueName = getQueueName({ queueUrl });
-	sendBatchCallsCounter.add(1, {
-		queue_name: queueName,
-		batch_size: entries.length,
-	});
-
-	const entryCountByJobName = new Map<string, number>();
-	for (const entry of entries) {
-		entryCountByJobName.set(
-			entry.jobName,
-			(entryCountByJobName.get(entry.jobName) ?? 0) + 1,
-		);
-	}
-	for (const [jobName, entryCount] of entryCountByJobName) {
-		sendBatchEntriesCounter.add(entryCount, {
-			queue_name: queueName,
-			job_name: jobName,
-		});
-	}
-
-	let response: SendMessageBatchCommandOutput;
-	try {
-		response = (await sqsClient.send(
-			new SendMessageBatchCommand({
-				QueueUrl: queueUrl,
-				Entries: entries.map((entry, index) => ({
-					Id: index.toString(),
-					MessageBody: entry.messageBody,
-					...(entry.delaySeconds !== undefined && {
-						DelaySeconds: entry.delaySeconds,
-					}),
-					...(entry.messageGroupId !== undefined && {
-						MessageGroupId: entry.messageGroupId,
-					}),
-					...(entry.messageDeduplicationId !== undefined && {
-						MessageDeduplicationId: entry.messageDeduplicationId,
-					}),
-				})),
-			}),
-		)) as SendMessageBatchCommandOutput;
-	} catch (error) {
-		sendBatchFailuresCounter.add(entries.length, {
-			queue_name: queueName,
-			failure_type: "transport",
-		});
-		throw error;
-	}
-
-	const successfulIds = new Set(
-		(response.Successful ?? []).map(({ Id }) => Id),
-	);
-	const failureReasonById = new Map(
-		(response.Failed ?? []).map(({ Id, Message, Code }) => [
-			Id,
-			Message ?? Code ?? "Unknown SQS batch failure",
-		]),
-	);
 	const failures: Array<{ index: number; reason: string }> = [];
-	for (const [index] of entries.entries()) {
-		const id = index.toString();
-		const failureReason = failureReasonById.get(id);
-		if (failureReason !== undefined) {
-			failures.push({ index, reason: failureReason });
-		} else if (!successfulIds.has(id)) {
-			failures.push({
-				index,
-				reason: "SQS batch response omitted the entry result",
+	let successCount = 0;
+
+	for (
+		let chunkStartIndex = 0;
+		chunkStartIndex < entries.length;
+		chunkStartIndex += SQS_SEND_MESSAGE_BATCH_LIMIT
+	) {
+		const chunk = entries.slice(
+			chunkStartIndex,
+			chunkStartIndex + SQS_SEND_MESSAGE_BATCH_LIMIT,
+		);
+		sendBatchCallsCounter.add(1, {
+			queue_name: queueName,
+			batch_size: chunk.length,
+		});
+
+		const entryCountByJobName = new Map<string, number>();
+		for (const entry of chunk) {
+			entryCountByJobName.set(
+				entry.jobName,
+				(entryCountByJobName.get(entry.jobName) ?? 0) + 1,
+			);
+		}
+		for (const [jobName, entryCount] of entryCountByJobName) {
+			sendBatchEntriesCounter.add(entryCount, {
+				queue_name: queueName,
+				job_name: jobName,
+			});
+		}
+
+		let response: SendMessageBatchCommandOutput;
+		try {
+			response = (await sqsClient.send(
+				new SendMessageBatchCommand({
+					QueueUrl: queueUrl,
+					Entries: chunk.map((entry, index) => ({
+						Id: index.toString(),
+						MessageBody: entry.messageBody,
+						...(entry.delaySeconds !== undefined && {
+							DelaySeconds: entry.delaySeconds,
+						}),
+						...(entry.messageGroupId !== undefined && {
+							MessageGroupId: entry.messageGroupId,
+						}),
+						...(entry.messageDeduplicationId !== undefined && {
+							MessageDeduplicationId: entry.messageDeduplicationId,
+						}),
+					})),
+				}),
+			)) as SendMessageBatchCommandOutput;
+		} catch (error) {
+			const reason =
+				error instanceof Error ? error.message : "Unknown SQS send error";
+			for (const [index] of chunk.entries()) {
+				failures.push({ index: chunkStartIndex + index, reason });
+			}
+			sendBatchFailuresCounter.add(chunk.length, {
+				queue_name: queueName,
+				failure_type: "transport",
+			});
+			continue;
+		}
+
+		const successfulIds = new Set(
+			(response.Successful ?? []).map(({ Id }) => Id),
+		);
+		const failureReasonById = new Map(
+			(response.Failed ?? []).map(({ Id, Message, Code }) => [
+				Id,
+				Message ?? Code ?? "Unknown SQS batch failure",
+			]),
+		);
+		successCount += successfulIds.size;
+
+		let chunkFailureCount = 0;
+		for (const [index] of chunk.entries()) {
+			const id = index.toString();
+			const failureReason = failureReasonById.get(id);
+			if (failureReason !== undefined) {
+				failures.push({
+					index: chunkStartIndex + index,
+					reason: failureReason,
+				});
+				chunkFailureCount += 1;
+			} else if (!successfulIds.has(id)) {
+				failures.push({
+					index: chunkStartIndex + index,
+					reason: "SQS batch response omitted the entry result",
+				});
+				chunkFailureCount += 1;
+			}
+		}
+
+		if (chunkFailureCount > 0) {
+			sendBatchFailuresCounter.add(chunkFailureCount, {
+				queue_name: queueName,
+				failure_type: "entry",
 			});
 		}
 	}
 
-	if (failures.length > 0) {
-		sendBatchFailuresCounter.add(failures.length, {
-			queue_name: queueName,
-			failure_type: "entry",
-		});
-	}
-	return { failures };
+	return { successCount, failures };
 };
 
 const globalPrimarySqsSendBatcher = new PrimarySqsSendBatcher({
-	sendBatch: sendPrimarySqsBatch,
+	sendBatch: sendSqsMessagesBatch,
 });
 
 export const flushPrimarySqsSendBatcher = (): Promise<void> =>
@@ -319,77 +354,18 @@ export const addTasksToQueueBatch = async <T extends keyof Payloads>({
 }): Promise<{
 	successCount: number;
 	failures: Array<{ index: number; reason: string }>;
-}> => {
-	const sqsClient = getSqsClient({ queueUrl });
-	const failures: Array<{ index: number; reason: string }> = [];
-	let successCount = 0;
-
-	for (
-		let chunkStartIndex = 0;
-		chunkStartIndex < entries.length;
-		chunkStartIndex += SQS_SEND_MESSAGE_BATCH_LIMIT
-	) {
-		const chunk = entries
-			.slice(chunkStartIndex, chunkStartIndex + SQS_SEND_MESSAGE_BATCH_LIMIT)
-			.map((entry, index) => {
-				const originalIndex = chunkStartIndex + index;
-
-				return {
-					originalIndex,
-					sqsEntry: {
-						Id: index.toString(),
-						MessageBody: JSON.stringify({
-							name: jobName as string,
-							data: entry.payload,
-						}),
-						MessageGroupId: entry.messageGroupId,
-						MessageDeduplicationId: entry.messageDeduplicationId,
-					},
-				};
-			});
-		const originalIndexById = new Map(
-			chunk.map((entry) => [entry.sqsEntry.Id, entry.originalIndex]),
-		);
-
-		const resolveOriginalIndex = (id: string | undefined) => {
-			if (id !== undefined) {
-				const mapped = originalIndexById.get(id);
-				if (mapped !== undefined) return mapped;
-				const parsed = Number.parseInt(id, 10);
-				if (Number.isFinite(parsed)) return chunkStartIndex + parsed;
-			}
-			return chunkStartIndex;
-		};
-
-		let response: SendMessageBatchCommandOutput;
-		try {
-			response = (await sqsClient.send(
-				new SendMessageBatchCommand({
-					QueueUrl: queueUrl,
-					Entries: chunk.map((entry) => entry.sqsEntry),
+}> =>
+	sendSqsMessagesBatch({
+		queueUrl,
+		entries: entries.map(
+			({ payload, messageGroupId, messageDeduplicationId }) => ({
+				jobName: jobName as string,
+				messageBody: JSON.stringify({
+					name: jobName as string,
+					data: payload,
 				}),
-			)) as SendMessageBatchCommandOutput;
-		} catch (error) {
-			const reason =
-				error instanceof Error ? error.message : "Unknown SQS send error";
-			for (const entry of chunk) {
-				failures.push({ index: entry.originalIndex, reason });
-			}
-			continue;
-		}
-
-		successCount += response.Successful?.length ?? 0;
-
-		for (const failedEntry of response.Failed ?? []) {
-			failures.push({
-				index: resolveOriginalIndex(failedEntry.Id),
-				reason:
-					failedEntry.Message ??
-					failedEntry.Code ??
-					"Unknown SQS batch failure",
-			});
-		}
-	}
-
-	return { successCount, failures };
-};
+				messageGroupId,
+				messageDeduplicationId,
+			}),
+		),
+	});

--- a/server/src/queue/queueUtils.ts
+++ b/server/src/queue/queueUtils.ts
@@ -21,7 +21,7 @@ import type { ClearCreditSystemCachePayload } from "@/internal/features/featureA
 import type { GenerateFeatureDisplayPayload } from "@/internal/features/workflows/generateFeatureDisplay.js";
 import { getSqsClient } from "./initSqs.js";
 import { JobName } from "./JobName.js";
-import { PrimarySqsSendBatcher } from "./PrimarySqsSendBatcher.js";
+import { SqsBatchAccumulator } from "./SqsBatchAccumulator.js";
 import type {
 	BatchResetCusEntsPayload,
 	SendProductsUpdatedPayload,
@@ -135,6 +135,10 @@ type SqsBatchMessage = {
 	messageGroupId?: string;
 	messageDeduplicationId?: string;
 	delaySeconds?: number;
+};
+
+type PrimarySqsQueueEntry = SqsBatchMessage & {
+	queueUrl: string;
 };
 
 const sendSqsMessagesBatch = async ({
@@ -254,9 +258,10 @@ const sendSqsMessagesBatch = async ({
 	return { successCount, failures };
 };
 
-const globalPrimarySqsSendBatcher = new PrimarySqsSendBatcher({
-	sendBatch: sendSqsMessagesBatch,
-});
+const globalPrimarySqsSendBatcher =
+	new SqsBatchAccumulator<PrimarySqsQueueEntry>({
+		sendBatch: sendSqsMessagesBatch,
+	});
 
 export const flushPrimarySqsSendBatcher = (): Promise<void> =>
 	globalPrimarySqsSendBatcher.flush();

--- a/server/src/queue/queueUtils.ts
+++ b/server/src/queue/queueUtils.ts
@@ -12,6 +12,7 @@ import {
 	type SendMessageBatchCommandOutput,
 	SendMessageCommand,
 } from "@aws-sdk/client-sqs";
+import { metrics } from "@opentelemetry/api";
 import { generateId } from "@server/utils/genUtils";
 import type { StripeWebhookReplayPayload } from "@/external/stripe/webhookReplay/runStripeWebhookReplay.js";
 import type { BatchResetCustomerEntitlementsV2Payload } from "@/internal/balances/batchReset/types.js";
@@ -20,6 +21,10 @@ import type { ClearCreditSystemCachePayload } from "@/internal/features/featureA
 import type { GenerateFeatureDisplayPayload } from "@/internal/features/workflows/generateFeatureDisplay.js";
 import { getSqsClient } from "./initSqs.js";
 import { JobName } from "./JobName.js";
+import {
+	PrimarySqsSendBatcher,
+	type SendPrimarySqsBatchArgs,
+} from "./PrimarySqsSendBatcher.js";
 import type {
 	BatchResetCusEntsPayload,
 	SendProductsUpdatedPayload,
@@ -110,6 +115,119 @@ export interface Payloads {
 }
 
 const SQS_SEND_MESSAGE_BATCH_LIMIT = 10;
+const meter = metrics.getMeter("autumn-server");
+const sendBatchCallsCounter = meter.createCounter(
+	"autumn.sqs.send_batch.calls",
+	{ description: "SQS SendMessageBatch API calls" },
+);
+const sendBatchEntriesCounter = meter.createCounter(
+	"autumn.sqs.send_batch.entries",
+	{ description: "Entries submitted through SQS SendMessageBatch" },
+);
+const sendBatchFailuresCounter = meter.createCounter(
+	"autumn.sqs.send_batch.failures",
+	{ description: "Entries that failed during SQS SendMessageBatch" },
+);
+
+const getQueueName = ({ queueUrl }: { queueUrl: string }) =>
+	queueUrl.split("/").pop() ?? "unknown";
+
+const sendPrimarySqsBatch = async ({
+	queueUrl,
+	entries,
+}: SendPrimarySqsBatchArgs): Promise<{
+	failures: Array<{ index: number; reason: string }>;
+}> => {
+	const sqsClient = getSqsClient({ queueUrl });
+	const queueName = getQueueName({ queueUrl });
+	sendBatchCallsCounter.add(1, {
+		queue_name: queueName,
+		batch_size: entries.length,
+	});
+
+	const entryCountByJobName = new Map<string, number>();
+	for (const entry of entries) {
+		entryCountByJobName.set(
+			entry.jobName,
+			(entryCountByJobName.get(entry.jobName) ?? 0) + 1,
+		);
+	}
+	for (const [jobName, entryCount] of entryCountByJobName) {
+		sendBatchEntriesCounter.add(entryCount, {
+			queue_name: queueName,
+			job_name: jobName,
+		});
+	}
+
+	let response: SendMessageBatchCommandOutput;
+	try {
+		response = (await sqsClient.send(
+			new SendMessageBatchCommand({
+				QueueUrl: queueUrl,
+				Entries: entries.map((entry, index) => ({
+					Id: index.toString(),
+					MessageBody: entry.messageBody,
+					...(entry.delaySeconds !== undefined && {
+						DelaySeconds: entry.delaySeconds,
+					}),
+					...(entry.messageGroupId !== undefined && {
+						MessageGroupId: entry.messageGroupId,
+					}),
+					...(entry.messageDeduplicationId !== undefined && {
+						MessageDeduplicationId: entry.messageDeduplicationId,
+					}),
+				})),
+			}),
+		)) as SendMessageBatchCommandOutput;
+	} catch (error) {
+		sendBatchFailuresCounter.add(entries.length, {
+			queue_name: queueName,
+			failure_type: "transport",
+		});
+		throw error;
+	}
+
+	const successfulIds = new Set(
+		(response.Successful ?? []).map(({ Id }) => Id),
+	);
+	const failureReasonById = new Map(
+		(response.Failed ?? []).map(({ Id, Message, Code }) => [
+			Id,
+			Message ?? Code ?? "Unknown SQS batch failure",
+		]),
+	);
+	const failures: Array<{ index: number; reason: string }> = [];
+	for (const [index] of entries.entries()) {
+		const id = index.toString();
+		const failureReason = failureReasonById.get(id);
+		if (failureReason !== undefined) {
+			failures.push({ index, reason: failureReason });
+		} else if (!successfulIds.has(id)) {
+			failures.push({
+				index,
+				reason: "SQS batch response omitted the entry result",
+			});
+		}
+	}
+
+	if (failures.length > 0) {
+		sendBatchFailuresCounter.add(failures.length, {
+			queue_name: queueName,
+			failure_type: "entry",
+		});
+	}
+	return { failures };
+};
+
+const globalPrimarySqsSendBatcher = new PrimarySqsSendBatcher({
+	sendBatch: sendPrimarySqsBatch,
+});
+
+export const flushPrimarySqsSendBatcher = (): Promise<void> =>
+	globalPrimarySqsSendBatcher.flush();
+
+export const shutdownPrimarySqsSendBatcher = (): Promise<void> =>
+	globalPrimarySqsSendBatcher.shutdown();
 
 /**
  * Add a task to the queue (auto-detects SQS or BullMQ)
@@ -155,7 +273,7 @@ export const addTaskToQueue = async <T extends keyof Payloads>({
 			messageDeduplicationId ??
 			Bun.hash(messageId ?? generateId("dedup")).toString();
 
-		const command = new SendMessageCommand({
+		const messageInput = {
 			QueueUrl: resolvedQueueUrl,
 			MessageBody: JSON.stringify(message),
 			...(delaySeconds && { DelaySeconds: delaySeconds }),
@@ -164,8 +282,21 @@ export const addTaskToQueue = async <T extends keyof Payloads>({
 				MessageGroupId: messageGroupId || generateId("msg"),
 				MessageDeduplicationId: resolvedMessageDeduplicationId,
 			}),
-		});
+		};
 
+		if (resolvedQueueUrl === process.env.SQS_QUEUE_URL_V2) {
+			await globalPrimarySqsSendBatcher.enqueue({
+				queueUrl: resolvedQueueUrl,
+				jobName: jobName as string,
+				messageBody: messageInput.MessageBody,
+				messageGroupId: messageInput.MessageGroupId,
+				messageDeduplicationId: messageInput.MessageDeduplicationId,
+				delaySeconds: messageInput.DelaySeconds,
+			});
+			return;
+		}
+
+		const command = new SendMessageCommand(messageInput);
 		await sqsClient.send(command);
 		return;
 	}

--- a/server/tests/integration/analytics/aggregate/partial-gate-drop-fallback.test.ts
+++ b/server/tests/integration/analytics/aggregate/partial-gate-drop-fallback.test.ts
@@ -1,0 +1,138 @@
+/**
+ * TDD test for events.aggregate silently returning PARTIAL data when a grouped
+ * property has a MIX of gate-surviving and gate-dropped values (StackOne:
+ * group_by "properties.projectId", short slugs alongside 32-char opaque ids).
+ *
+ * Distinct from uuid-group-by-fallback.test.ts, where EVERY value is dropped and
+ * the rollup comes back empty. Here the short value materializes, so the result
+ * is non-empty and any emptiness-based fallback never fires.
+ *
+ * Red-failure mode (pre-fix):
+ *  - grouped_values contains only the short project id; the 32-char one is
+ *    absent and the grouped sums fall short of total.sum, with no error.
+ *
+ * Green-success criteria:
+ *  - The grouped sums reconcile against the ungated totals, so the server
+ *    detects the shortfall and retries with skip_property_rollup=1 against
+ *    events_hourly_mv, recovering both project ids.
+ */
+
+import { expect, test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+// Survives the value-shape gate: short and not opaque-shaped.
+const PROJECT_SHORT = "qa-71607";
+// Dropped by the gate's `^[A-Za-z0-9_-]{32,}$` rule: exactly 32 alphanumerics.
+const PROJECT_OPAQUE = "4uSlnf8w0kUb5WV6gEmBz07JVvgxfxTR";
+const PROJECT_SHORT_VALUE = 7;
+const PROJECT_OPAQUE_VALUE = 83;
+
+const EVENT_INGEST_TIMEOUT_MS = 30_000;
+const POLL_INTERVAL_MS = 3_000;
+
+type AggregateResponse = {
+	list: {
+		period: number;
+		values: Record<string, number>;
+		grouped_values?: Record<string, Record<string, number>>;
+	}[];
+	total: Record<string, { count: number; sum: number }>;
+};
+
+const sumGroupValue = (
+	response: AggregateResponse,
+	featureId: string,
+	groupValue: string,
+): number =>
+	response.list.reduce(
+		(sum, row) => sum + (row.grouped_values?.[featureId]?.[groupValue] ?? 0),
+		0,
+	);
+
+const sumAllGroupValues = (
+	response: AggregateResponse,
+	featureId: string,
+): number =>
+	response.list.reduce(
+		(sum, row) =>
+			sum +
+			Object.values(row.grouped_values?.[featureId] ?? {}).reduce(
+				(rowSum, value) => rowSum + value,
+				0,
+			),
+		0,
+	);
+
+test.concurrent(
+	`${chalk.yellowBright("aggregate partial-gate-drop: a property mixing gate-dropped and surviving values returns every group")}`,
+	async () => {
+		// Unique per run: tracked events persist in Tinybird across runs, and the
+		// project ids are fixed, so only the customer scope keeps runs isolated.
+		const customerId = `aggregate-partial-gate-drop-${Date.now()}`;
+		const messagesItem = items.monthlyMessages({ includedUsage: 1000 });
+		const freeProd = products.base({ id: "free", items: [messagesItem] });
+
+		const { autumnV1, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [freeProd], prefix: customerId }),
+			],
+			actions: [s.attach({ productId: freeProd.id })],
+		});
+
+		await autumnV1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: PROJECT_SHORT_VALUE,
+			properties: { projectId: PROJECT_SHORT },
+		});
+		await autumnV1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: PROJECT_OPAQUE_VALUE,
+			properties: { projectId: PROJECT_OPAQUE },
+		});
+
+		// Events reach Tinybird via async batching — poll on the ungated totals so
+		// the assertions aren't a false red from ingest lag.
+		const expectedTotal = PROJECT_SHORT_VALUE + PROJECT_OPAQUE_VALUE;
+		const deadline = Date.now() + EVENT_INGEST_TIMEOUT_MS;
+		let response: AggregateResponse;
+		do {
+			await timeout(POLL_INTERVAL_MS);
+			response = (await autumnV2_2.events.aggregate({
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				group_by: "properties.projectId",
+				range: "7d",
+			})) as AggregateResponse;
+		} while (
+			Date.now() < deadline &&
+			response.total[TestFeature.Messages]?.sum !== expectedTotal
+		);
+
+		expect(response.total[TestFeature.Messages]?.sum).toBe(expectedTotal);
+
+		// The gate-surviving value alone makes the result non-empty, which is what
+		// hides the shortfall from an emptiness check.
+		expect(sumGroupValue(response, TestFeature.Messages, PROJECT_SHORT)).toBe(
+			PROJECT_SHORT_VALUE,
+		);
+
+		// The bug: this group is dropped at insert and never comes back.
+		expect(sumGroupValue(response, TestFeature.Messages, PROJECT_OPAQUE)).toBe(
+			PROJECT_OPAQUE_VALUE,
+		);
+
+		// The invariant that makes the shortfall detectable at all.
+		expect(sumAllGroupValues(response, TestFeature.Messages)).toBe(
+			expectedTotal,
+		);
+	},
+);

--- a/server/tests/unit/analytics/property-rollup-completeness.test.ts
+++ b/server/tests/unit/analytics/property-rollup-completeness.test.ts
@@ -149,6 +149,25 @@ test(`${chalk.yellowBright(
 });
 
 test(`${chalk.yellowBright(
+	"property rollup: per-bin top-N truncation is not a shortfall",
+)}`, () => {
+	// The pipe relabels groups beyond max_groups to AUTUMN_RESERVED rather than
+	// dropping them, so a truncated result still carries the full mass. If a pipe
+	// change ever drops them instead, every truncated query would retry ungated.
+	const rows = [
+		row({ groupValue: "qa-71607", totalValue: 722 }),
+		row({ groupValue: "AUTUMN_RESERVED", totalValue: 29_880 }),
+	];
+
+	expect(
+		groupedResultIsIncomplete({
+			rows,
+			totals: totals({ count: 2533, sum: 30_602 }),
+		}),
+	).toBe(false);
+});
+
+test(`${chalk.yellowBright(
 	"property rollup: the ungated retry only wins when it reports more",
 )}`, () => {
 	// The retry probes whether the shortfall was gate loss or an absent property;

--- a/server/tests/unit/analytics/property-rollup-completeness.test.ts
+++ b/server/tests/unit/analytics/property-rollup-completeness.test.ts
@@ -4,6 +4,7 @@ import type { AggregateGroupablePipeRow } from "@/external/tinybird/pipes/aggreg
 import {
 	type EventTotals,
 	groupedResultIsIncomplete,
+	reportsMoreThan,
 	sumAllRows,
 	sumGroupedRowsByEventName,
 } from "@/internal/analytics/actions/propertyRollupCompleteness.js";
@@ -12,15 +13,18 @@ const row = ({
 	eventName = "action_calls",
 	groupValue,
 	totalValue,
+	eventCount,
 }: {
 	eventName?: string;
 	groupValue: string;
 	totalValue: number;
+	eventCount?: number;
 }): AggregateGroupablePipeRow => ({
 	period: "2026-07-29 00:00:00",
 	event_name: eventName,
 	group_value: groupValue,
 	total_value: totalValue,
+	...(eventCount === undefined ? {} : { event_count: eventCount }),
 });
 
 const totals = ({
@@ -187,6 +191,79 @@ test(`${chalk.yellowBright(
 	expect(sumAllRows({ rows: ungatedWithAbsentProperty })).toBe(
 		sumAllRows({ rows: gated }),
 	);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: gate-dropped groups whose values cancel are still detected",
+)}`, () => {
+	// Negative values are mainstream (117 orgs in a 7d prod sample), so dropped
+	// groups can net to zero and leave the sum comparison blind. The count can't
+	// cancel, so it catches them.
+	const rows = [
+		row({ groupValue: "qa-71607", totalValue: 500, eventCount: 5 }),
+	];
+
+	expect(
+		groupedResultIsIncomplete({
+			rows,
+			totals: { action_calls: { count: 9, sum: 500 } },
+		}),
+	).toBe(true);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: counts matching the totals are complete",
+)}`, () => {
+	const rows = [
+		row({ groupValue: "qa-71607", totalValue: 500, eventCount: 5 }),
+		row({ groupValue: "joe-test-94143", totalValue: -500, eventCount: 4 }),
+	];
+
+	expect(
+		groupedResultIsIncomplete({
+			rows,
+			totals: { action_calls: { count: 9, sum: 0 } },
+		}),
+	).toBe(false);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: falls back to sum-only when the pipe omits counts",
+)}`, () => {
+	// A deployment predating the count column must not report every result as
+	// incomplete just because the field is missing.
+	const rows = [row({ groupValue: "qa-71607", totalValue: 500 })];
+
+	expect(
+		groupedResultIsIncomplete({
+			rows,
+			totals: { action_calls: { count: 9, sum: 500 } },
+		}),
+	).toBe(false);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: the retry wins on recovered events even when sums tie",
+)}`, () => {
+	const gated = [
+		row({ groupValue: "qa-71607", totalValue: 500, eventCount: 5 }),
+	];
+	const ungated = [
+		row({ groupValue: "qa-71607", totalValue: 500, eventCount: 5 }),
+		row({
+			groupValue: "4uSlnf8w0kUb5WV6gEmBz07JVvgxfxTR",
+			totalValue: 60,
+			eventCount: 2,
+		}),
+		row({
+			groupValue: "stackone-integrations-testing---eu-66912",
+			totalValue: -60,
+			eventCount: 2,
+		}),
+	];
+
+	expect(reportsMoreThan({ candidate: ungated, current: gated })).toBe(true);
+	expect(reportsMoreThan({ candidate: gated, current: ungated })).toBe(false);
 });
 
 test(`${chalk.yellowBright(

--- a/server/tests/unit/analytics/property-rollup-completeness.test.ts
+++ b/server/tests/unit/analytics/property-rollup-completeness.test.ts
@@ -1,0 +1,186 @@
+import { expect, test } from "bun:test";
+import chalk from "chalk";
+import type { AggregateGroupablePipeRow } from "@/external/tinybird/pipes/aggregateGroupablePipe.js";
+import {
+	type EventTotals,
+	groupedResultIsIncomplete,
+	sumAllRows,
+	sumGroupedRowsByEventName,
+} from "@/internal/analytics/actions/propertyRollupCompleteness.js";
+
+const row = ({
+	eventName = "action_calls",
+	groupValue,
+	totalValue,
+}: {
+	eventName?: string;
+	groupValue: string;
+	totalValue: number;
+}): AggregateGroupablePipeRow => ({
+	period: "2026-07-29 00:00:00",
+	event_name: eventName,
+	group_value: groupValue,
+	total_value: totalValue,
+});
+
+const totals = ({
+	eventName = "action_calls",
+	count,
+	sum,
+}: {
+	eventName?: string;
+	count: number;
+	sum: number;
+}): EventTotals => ({ [eventName]: { count, sum } });
+
+test(`${chalk.yellowBright(
+	"property rollup: a result matching the ungated totals is complete",
+)}`, () => {
+	// StackOne's accountId control: every value is short enough to survive the
+	// gate, so the grouped sums reconcile exactly against the totals.
+	const rows = [
+		row({ groupValue: "2GwnUDjVN8TZtba2AqvCR", totalValue: 18_686 }),
+		row({ groupValue: "aRq2ZOEzeItvNlnn8OPFF", totalValue: 11_916 }),
+	];
+
+	expect(
+		groupedResultIsIncomplete({
+			rows,
+			totals: totals({ count: 2533, sum: 30_602 }),
+		}),
+	).toBe(false);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: a partially gate-dropped key is detected as incomplete",
+)}`, () => {
+	// StackOne's projectId: short slugs survive the gate, 32+ char opaque ids are
+	// dropped at insert, so a NON-EMPTY result still under-reports by ~93%.
+	const rows = [
+		row({ groupValue: "qa-71607", totalValue: 970 }),
+		row({ groupValue: "give-jeran-a-project-92237", totalValue: 284 }),
+		row({ groupValue: "pa-agent-31675", totalValue: 587 }),
+		row({ groupValue: "joe-test-94143", totalValue: 39 }),
+		row({ groupValue: "sales-prod-39557", totalValue: 108 }),
+		row({ groupValue: "production-09042", totalValue: 60 }),
+		row({ groupValue: "test-73448", totalValue: 25 }),
+		row({ groupValue: "alex-academy-00433", totalValue: 31 }),
+		row({ groupValue: "development-66099", totalValue: 18 }),
+		row({ groupValue: "integrations---external-31154", totalValue: 1 }),
+		row({ groupValue: "bryce-test-13857", totalValue: 1 }),
+	];
+
+	expect(
+		groupedResultIsIncomplete({
+			rows,
+			totals: totals({ count: 2533, sum: 30_602 }),
+		}),
+	).toBe(true);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: a fully gate-dropped key is still detected as incomplete",
+)}`, () => {
+	// mastra's all-UUID project_id: the rollup has zero rows for the key.
+	expect(
+		groupedResultIsIncomplete({
+			rows: [],
+			totals: totals({ count: 42, sum: 420 }),
+		}),
+	).toBe(true);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: an empty result with no events is complete",
+)}`, () => {
+	expect(
+		groupedResultIsIncomplete({
+			rows: [],
+			totals: totals({ count: 0, sum: 0 }),
+		}),
+	).toBe(false);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: float drift between aggregation paths is not a shortfall",
+)}`, () => {
+	const rows = [row({ groupValue: "qa-71607", totalValue: 30_601.999_999_99 })];
+
+	expect(
+		groupedResultIsIncomplete({
+			rows,
+			totals: totals({ count: 2533, sum: 30_602 }),
+		}),
+	).toBe(false);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: one lossy feature among several marks the result incomplete",
+)}`, () => {
+	const rows = [
+		row({ eventName: "action_calls", groupValue: "qa-71607", totalValue: 500 }),
+		row({ eventName: "api_calls", groupValue: "qa-71607", totalValue: 10 }),
+	];
+
+	expect(
+		groupedResultIsIncomplete({
+			rows,
+			totals: {
+				action_calls: { count: 10, sum: 500 },
+				api_calls: { count: 90, sum: 9000 },
+			},
+		}),
+	).toBe(true);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: grouped sums exceeding totals are not a shortfall",
+)}`, () => {
+	// Late-arriving events can land in the rollup before the totals rollup sees
+	// them; retrying would not recover anything.
+	const rows = [row({ groupValue: "qa-71607", totalValue: 31_000 })];
+
+	expect(
+		groupedResultIsIncomplete({
+			rows,
+			totals: totals({ count: 2533, sum: 30_602 }),
+		}),
+	).toBe(false);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: the ungated retry only wins when it reports more",
+)}`, () => {
+	// The retry probes whether the shortfall was gate loss or an absent property;
+	// an absent property returns the same mass, so the gated result is kept.
+	const gated = [row({ groupValue: "qa-71607", totalValue: 2124 })];
+	const ungatedWithGateLoss = [
+		row({ groupValue: "qa-71607", totalValue: 2124 }),
+		row({ groupValue: "4uSlnf8w0kUb5WV6gEmBz07JVvgxfxTR", totalValue: 28_478 }),
+	];
+	const ungatedWithAbsentProperty = [
+		row({ groupValue: "qa-71607", totalValue: 2124 }),
+	];
+
+	expect(sumAllRows({ rows: ungatedWithGateLoss })).toBeGreaterThan(
+		sumAllRows({ rows: gated }),
+	);
+	expect(sumAllRows({ rows: ungatedWithAbsentProperty })).toBe(
+		sumAllRows({ rows: gated }),
+	);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: sums grouped rows per event name",
+)}`, () => {
+	const rows = [
+		row({ eventName: "action_calls", groupValue: "a", totalValue: 3 }),
+		row({ eventName: "action_calls", groupValue: "b", totalValue: 4 }),
+		row({ eventName: "api_calls", groupValue: "a", totalValue: 5 }),
+	];
+
+	expect(sumGroupedRowsByEventName({ rows })).toEqual({
+		action_calls: 7,
+		api_calls: 5,
+	});
+});

--- a/server/tests/unit/balances/track/asyncTrackSqsBatcher.test.ts
+++ b/server/tests/unit/balances/track/asyncTrackSqsBatcher.test.ts
@@ -1,0 +1,171 @@
+/**
+ * TDD contract for batching async-track SQS sends without changing the worker
+ * payload or combining multiple track events into one SQS message.
+ *
+ * Contract under test:
+ *   New behavior:
+ *     - up to 10 independent track messages share one SendMessageBatch call
+ *     - the tenth entry flushes immediately
+ *     - a short window flushes partial batches
+ *     - each caller awaits and receives its own SQS entry result
+ *     - partial failures reject only the corresponding callers
+ *     - shutdown rejects new entries and drains pending plus in-flight sends
+ *   Preserved behavior:
+ *     - every SQS entry contains exactly one legacy track payload
+ *     - message group and deduplication IDs remain per event
+ *
+ * Pre-implementation red: AsyncTrackSqsBatcher does not exist.
+ * Post-implementation green: all producer batching and delivery assertions pass.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { ApiVersion, AppEnv } from "@autumn/shared";
+import {
+	AsyncTrackSqsBatcher,
+	type SendAsyncTrackBatchArgs,
+} from "@/internal/balances/track/AsyncTrackSqsBatcher.js";
+
+const QUEUE_URL =
+	"https://sqs.eu-west-1.amazonaws.com/123456789012/track-async.fifo";
+const BATCH_WINDOW_MS = 10;
+
+const createEntry = ({ index }: { index: number }) => ({
+	queueUrl: QUEUE_URL,
+	payload: {
+		orgId: "org_1",
+		env: AppEnv.Live,
+		customerId: `customer_${index}`,
+		requestId: `request_${index}`,
+		apiVersion: ApiVersion.V2_1,
+		body: {
+			customer_id: `customer_${index}`,
+			feature_id: "messages",
+			value: index + 1,
+		},
+	},
+	messageGroupId: `org_1:live:customer_${index}:none:shard-0`,
+	messageDeduplicationId: `request_${index}`,
+});
+
+const createBatcher = ({
+	sendBatch,
+}: {
+	sendBatch?: (args: SendAsyncTrackBatchArgs) => Promise<{
+		successCount: number;
+		failures: Array<{ index: number; reason: string }>;
+	}>;
+} = {}) => {
+	const calls: SendAsyncTrackBatchArgs[] = [];
+	const batcher = new AsyncTrackSqsBatcher({
+		batchWindowMs: BATCH_WINDOW_MS,
+		sendBatch:
+			sendBatch ??
+			(async (args) => {
+				calls.push(args);
+				return { successCount: args.entries.length, failures: [] };
+			}),
+	});
+
+	return { batcher, calls };
+};
+
+describe("AsyncTrackSqsBatcher", () => {
+	test("flushes 10 independent SQS messages in one batch call", async () => {
+		const { batcher, calls } = createBatcher();
+
+		await Promise.all(
+			Array.from({ length: 10 }, (_, index) =>
+				batcher.enqueue(createEntry({ index })),
+			),
+		);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0].entries).toHaveLength(10);
+		expect(calls[0].entries[0]).toMatchObject({
+			messageDeduplicationId: "request_0",
+			payload: {
+				customerId: "customer_0",
+				body: {
+					customer_id: "customer_0",
+					value: 1,
+				},
+			},
+		});
+		expect(calls[0].entries[9].messageDeduplicationId).toBe("request_9");
+	});
+
+	test("flushes a partial batch after the short batching window", async () => {
+		const { batcher, calls } = createBatcher();
+
+		await batcher.enqueue(createEntry({ index: 0 }));
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0].entries).toHaveLength(1);
+	});
+
+	test("rejects only callers whose SQS entries failed", async () => {
+		const calls: SendAsyncTrackBatchArgs[] = [];
+		const { batcher } = createBatcher({
+			sendBatch: async (args) => {
+				calls.push(args);
+				return {
+					successCount: 2,
+					failures: [{ index: 1, reason: "SQS throttled entry 1" }],
+				};
+			},
+		});
+		const resultsPromise = Promise.allSettled(
+			Array.from({ length: 3 }, (_, index) =>
+				batcher.enqueue(createEntry({ index })),
+			),
+		);
+
+		await batcher.flush();
+		const results = await resultsPromise;
+
+		expect(calls).toHaveLength(1);
+		expect(results.map((result) => result.status)).toEqual([
+			"fulfilled",
+			"rejected",
+			"fulfilled",
+		]);
+		expect(results[1]).toMatchObject({
+			status: "rejected",
+			reason: expect.objectContaining({
+				message: "SQS throttled entry 1",
+			}),
+		});
+	});
+
+	test("shutdown drains pending and in-flight sends before resolving", async () => {
+		let resolveSend:
+			| ((result: {
+					successCount: number;
+					failures: Array<{ index: number; reason: string }>;
+			  }) => void)
+			| undefined;
+		const { batcher } = createBatcher({
+			sendBatch: () =>
+				new Promise((resolve) => {
+					resolveSend = resolve;
+				}),
+		});
+		const queued = batcher.enqueue(createEntry({ index: 0 }));
+		let shutdownResolved = false;
+
+		const shutdown = batcher.shutdown().then(() => {
+			shutdownResolved = true;
+		});
+		await Promise.resolve();
+
+		expect(shutdownResolved).toBeFalse();
+		await expect(batcher.enqueue(createEntry({ index: 1 }))).rejects.toThrow(
+			"shutting down",
+		);
+
+		resolveSend?.({ successCount: 1, failures: [] });
+		await Promise.all([queued, shutdown]);
+
+		expect(shutdownResolved).toBeTrue();
+	});
+});

--- a/server/tests/unit/balances/track/handle-track-tokens.test.ts
+++ b/server/tests/unit/balances/track/handle-track-tokens.test.ts
@@ -165,7 +165,11 @@ describe("handleTrackTokens", () => {
 		mockState.originalSend = sqsClient.send.bind(sqsClient);
 		sqsClient.send = (async (command: { input: Record<string, unknown> }) => {
 			mockState.queueCommands.push(command.input);
-			return {};
+			const entries =
+				(command.input.Entries as Array<{ Id?: string }> | undefined) ?? [];
+			return {
+				Successful: entries.map((entry) => ({ Id: entry.Id })),
+			};
 		}) as typeof sqsClient.send;
 
 		const ctx = createCtx();
@@ -190,14 +194,16 @@ describe("handleTrackTokens", () => {
 		expect(mockState.queueCommands).toHaveLength(1);
 		expect(mockState.queueCommands[0]).toMatchObject({
 			QueueUrl: trackAsyncQueueUrl,
-			MessageDeduplicationId: "req_track_tokens_1",
 		});
-		expect(mockState.queueCommands[0]?.MessageGroupId).toMatch(
+		const entries = mockState.queueCommands[0]?.Entries as Array<
+			Record<string, unknown>
+		>;
+		expect(entries).toHaveLength(1);
+		expect(entries[0]?.MessageDeduplicationId).toBe("req_track_tokens_1");
+		expect(entries[0]?.MessageGroupId).toMatch(
 			/^org_123:sandbox:cus_123:ent_123:shard-[0-7]$/,
 		);
-		expect(
-			JSON.parse(mockState.queueCommands[0]?.MessageBody as string),
-		).toMatchObject({
+		expect(JSON.parse(entries[0]?.MessageBody as string)).toMatchObject({
 			name: "track",
 			data: {
 				customerId: "cus_123",

--- a/server/tests/unit/balances/track/handle-track.test.ts
+++ b/server/tests/unit/balances/track/handle-track.test.ts
@@ -58,7 +58,11 @@ describe("handleTrack", () => {
 		mockState.originalSend = sqsClient.send.bind(sqsClient);
 		sqsClient.send = (async (command: { input: Record<string, unknown> }) => {
 			mockState.queueCommands.push(command.input);
-			return {};
+			const entries =
+				(command.input.Entries as Array<{ Id?: string }> | undefined) ?? [];
+			return {
+				Successful: entries.map((entry) => ({ Id: entry.Id })),
+			};
 		}) as typeof sqsClient.send;
 	});
 
@@ -92,8 +96,12 @@ describe("handleTrack", () => {
 		expect(mockState.queueCommands).toHaveLength(1);
 		expect(mockState.queueCommands[0]).toMatchObject({
 			QueueUrl: trackAsyncQueueUrl,
-			MessageDeduplicationId: "req_track_1",
 		});
+		const entries = mockState.queueCommands[0]?.Entries as Array<
+			Record<string, unknown>
+		>;
+		expect(entries).toHaveLength(1);
+		expect(entries[0]?.MessageDeduplicationId).toBe("req_track_1");
 	});
 
 	test("returns 202 success for configured org slug", async () => {

--- a/server/tests/unit/balances/track/runAsyncTrack.test.ts
+++ b/server/tests/unit/balances/track/runAsyncTrack.test.ts
@@ -15,9 +15,9 @@ const trackAsyncQueueUrl =
 
 import { runAsyncTrack } from "@/internal/balances/track/runAsyncTrack.js";
 
-const buildCtx = () =>
+const buildCtx = ({ requestId = "req_async_1" }: { requestId?: string } = {}) =>
 	({
-		id: "req_async_1",
+		id: requestId,
 		org: { id: "org_123" },
 		env: AppEnv.Sandbox,
 		apiVersion: new ApiVersionClass(ApiVersion.V2_1),
@@ -53,7 +53,11 @@ describe("runAsyncTrack", () => {
 				throw new Error("SQS unavailable");
 			}
 
-			return {};
+			const entries =
+				(command.input.Entries as Array<{ Id?: string }> | undefined) ?? [];
+			return {
+				Successful: entries.map((entry) => ({ Id: entry.Id })),
+			};
 		}) as typeof sqsClient.send;
 	});
 
@@ -75,14 +79,16 @@ describe("runAsyncTrack", () => {
 		expect(ctx.extraLogs.trackQueuedForReplay).toBeUndefined();
 		expect(mockState.queueCommands[0]).toMatchObject({
 			QueueUrl: trackAsyncQueueUrl,
-			MessageDeduplicationId: "req_async_1",
 		});
-		expect(mockState.queueCommands[0]?.MessageGroupId).toMatch(
+		const entries = mockState.queueCommands[0]?.Entries as Array<
+			Record<string, unknown>
+		>;
+		expect(entries).toHaveLength(1);
+		expect(entries[0]?.MessageDeduplicationId).toBe("req_async_1");
+		expect(entries[0]?.MessageGroupId).toMatch(
 			/^org_123:sandbox:cus_123:none:shard-[0-7]$/,
 		);
-		expect(
-			JSON.parse(mockState.queueCommands[0]?.MessageBody as string),
-		).toMatchObject({
+		expect(JSON.parse(entries[0]?.MessageBody as string)).toMatchObject({
 			name: "track",
 			data: {
 				customerId: "cus_123",
@@ -99,8 +105,37 @@ describe("runAsyncTrack", () => {
 		await runAsyncTrack({ ctx: secondCtx, body });
 
 		expect(mockState.queueCommands).toHaveLength(2);
-		expect(mockState.queueCommands[0]?.MessageGroupId).toBe(
-			mockState.queueCommands[1]?.MessageGroupId,
+		const firstEntries = mockState.queueCommands[0]?.Entries as Array<
+			Record<string, unknown>
+		>;
+		const secondEntries = mockState.queueCommands[1]?.Entries as Array<
+			Record<string, unknown>
+		>;
+		expect(firstEntries[0]?.MessageGroupId).toBe(
+			secondEntries[0]?.MessageGroupId,
+		);
+	});
+
+	test("shares one SQS batch call across 10 concurrent async tracks", async () => {
+		await Promise.all(
+			Array.from({ length: 10 }, (_, index) =>
+				runAsyncTrack({
+					ctx: buildCtx({ requestId: `req_async_${index}` }),
+					body: {
+						...body,
+						customer_id: `cus_${index}`,
+					},
+				}),
+			),
+		);
+
+		expect(mockState.queueCommands).toHaveLength(1);
+		const entries = mockState.queueCommands[0]?.Entries as Array<
+			Record<string, unknown>
+		>;
+		expect(entries).toHaveLength(10);
+		expect(entries.map((entry) => entry.MessageDeduplicationId)).toEqual(
+			Array.from({ length: 10 }, (_, index) => `req_async_${index}`),
 		);
 	});
 
@@ -118,7 +153,7 @@ describe("runAsyncTrack", () => {
 		expect(ctx.logger.error).toHaveBeenCalled();
 	});
 
-	test("throws 503 RecaseError when queueTrack returns null", async () => {
+	test("throws 503 RecaseError when the batched SQS send fails", async () => {
 		mockState.queueFailureIndex = 0;
 		const ctx = buildCtx();
 

--- a/server/tests/unit/logging/logRequestResult.test.ts
+++ b/server/tests/unit/logging/logRequestResult.test.ts
@@ -187,6 +187,96 @@ describe("logRequestResult", () => {
 		});
 	});
 
+	test("drops the response body on the legacy events list route", async () => {
+		const captured: CapturedLog[] = [];
+		let cloneCount = 0;
+		const ctx = {
+			timestamp: 123,
+			logger: createCapturingLogger({ captured }),
+			extraLogs: {},
+			org: { slug: "test-org" },
+		} as unknown as AutumnContext;
+		const c = {
+			req: { path: "/v1/events/list" },
+			res: {
+				status: 200,
+				headers: new Headers({ "content-type": "application/json" }),
+				clone: () => {
+					cloneCount++;
+					return { json: async () => ({ events: [{ id: "evt_1" }] }) };
+				},
+			},
+		} as unknown as Context<HonoEnv>;
+
+		await logRequestResult({ ctx, c, durationMs: 40 });
+
+		expect(cloneCount).toBe(0);
+		expect(captured).toHaveLength(1);
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 40,
+			res: null,
+		});
+	});
+
+	test("drops an explicitly supplied response body on the rpc events list route", async () => {
+		const captured: CapturedLog[] = [];
+		const ctx = {
+			timestamp: 123,
+			logger: createCapturingLogger({ captured }),
+			extraLogs: {},
+			org: { slug: "test-org" },
+		} as unknown as AutumnContext;
+		const c = {
+			req: { path: "/v1/events.list" },
+			res: {
+				status: 200,
+				headers: new Headers({ "content-type": "application/json" }),
+			},
+		} as Context<HonoEnv>;
+
+		await logRequestResult({
+			ctx,
+			c,
+			durationMs: 40,
+			responseBody: { events: [{ id: "evt_1" }] },
+		});
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 40,
+			res: null,
+		});
+	});
+
+	test("keeps the response body on failed events list requests", async () => {
+		const captured: CapturedLog[] = [];
+		const responseBody = { code: "internal_error", message: "boom" };
+		const ctx = {
+			timestamp: 123,
+			logger: createCapturingLogger({ captured }),
+			extraLogs: {},
+			org: { slug: "test-org" },
+		} as unknown as AutumnContext;
+		const c = {
+			req: { path: "/v1/events/list" },
+			res: {
+				status: 500,
+				headers: new Headers({ "content-type": "application/json" }),
+			},
+		} as Context<HonoEnv>;
+
+		await logRequestResult({ ctx, c, durationMs: 40, responseBody });
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 500,
+			durationMs: 40,
+			res: responseBody,
+		});
+	});
+
 	test("does not mutate logger context or emit for explicitly skipped routes", async () => {
 		const captured: CapturedLog[] = [];
 		const logger = createCapturingLogger({ captured });

--- a/server/tests/unit/queue/PrimarySqsSendBatcher.test.ts
+++ b/server/tests/unit/queue/PrimarySqsSendBatcher.test.ts
@@ -1,0 +1,191 @@
+/**
+ * TDD contract for batching primary SQS queue sends.
+ *
+ * Contract under test:
+ *   - up to 10 independent queue entries share one send-batch call
+ *   - the tenth entry flushes immediately and a short window flushes partial batches
+ *   - each caller resolves or rejects from its own SQS entry result
+ *   - transport failures reject every caller in the affected batch
+ *   - shutdown rejects new entries and drains pending plus in-flight sends
+ *   - each entry preserves its job body, FIFO identifiers, and delay
+ *   - the combined message bodies in one batch never exceed SQS's 1 MiB limit
+ *
+ * Pre-implementation red: PrimarySqsSendBatcher does not exist.
+ * Post-implementation green: all batching and delivery assertions pass.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	PrimarySqsSendBatcher,
+	type SendPrimarySqsBatchArgs,
+} from "@/queue/PrimarySqsSendBatcher.js";
+
+const QUEUE_URL =
+	"https://sqs.us-east-2.amazonaws.com/123456789012/autumn-prod.fifo";
+const BATCH_WINDOW_MS = 10;
+
+const createEntry = ({ index }: { index: number }) => ({
+	queueUrl: QUEUE_URL,
+	jobName: index % 2 === 0 ? "sync-customer-dirty" : "insert-event-batch",
+	messageBody: JSON.stringify({
+		id: `job_${index}`,
+		name: index % 2 === 0 ? "sync-customer-dirty" : "insert-event-batch",
+		data: { index },
+	}),
+	messageGroupId: `customer_${index % 3}`,
+	messageDeduplicationId: `dedup_${index}`,
+	delaySeconds: index === 0 ? 2 : undefined,
+});
+
+const createBatcher = ({
+	sendBatch,
+}: {
+	sendBatch?: (args: SendPrimarySqsBatchArgs) => Promise<{
+		failures: Array<{ index: number; reason: string }>;
+	}>;
+} = {}) => {
+	const calls: SendPrimarySqsBatchArgs[] = [];
+	const batcher = new PrimarySqsSendBatcher({
+		batchWindowMs: BATCH_WINDOW_MS,
+		sendBatch:
+			sendBatch ??
+			(async (args) => {
+				calls.push(args);
+				return { failures: [] };
+			}),
+	});
+
+	return { batcher, calls };
+};
+
+describe("PrimarySqsSendBatcher", () => {
+	test("flushes 10 independent entries in one batch call", async () => {
+		const { batcher, calls } = createBatcher();
+
+		await Promise.all(
+			Array.from({ length: 10 }, (_, index) =>
+				batcher.enqueue(createEntry({ index })),
+			),
+		);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0].entries).toEqual(
+			Array.from({ length: 10 }, (_, index) => createEntry({ index })),
+		);
+	});
+
+	test("flushes a partial batch after the batching window", async () => {
+		const { batcher, calls } = createBatcher();
+
+		await Promise.all(
+			Array.from({ length: 3 }, (_, index) =>
+				batcher.enqueue(createEntry({ index })),
+			),
+		);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0].entries).toHaveLength(3);
+	});
+
+	test("splits entries before their combined message bodies exceed 1 MiB", async () => {
+		const { batcher, calls } = createBatcher();
+		const largeBody = "x".repeat(600 * 1024);
+
+		await Promise.all([
+			batcher.enqueue({
+				...createEntry({ index: 0 }),
+				messageBody: largeBody,
+			}),
+			batcher.enqueue({
+				...createEntry({ index: 1 }),
+				messageBody: largeBody,
+			}),
+		]);
+
+		expect(calls).toHaveLength(2);
+		expect(calls.map(({ entries }) => entries.length)).toEqual([1, 1]);
+	});
+
+	test("rejects only callers whose SQS entries failed", async () => {
+		const { batcher } = createBatcher({
+			sendBatch: async () => ({
+				failures: [{ index: 1, reason: "SQS throttled entry 1" }],
+			}),
+		});
+		const resultsPromise = Promise.allSettled(
+			Array.from({ length: 3 }, (_, index) =>
+				batcher.enqueue(createEntry({ index })),
+			),
+		);
+
+		await batcher.flush();
+		const results = await resultsPromise;
+
+		expect(results.map((result) => result.status)).toEqual([
+			"fulfilled",
+			"rejected",
+			"fulfilled",
+		]);
+		expect(results[1]).toMatchObject({
+			status: "rejected",
+			reason: expect.objectContaining({
+				message: "SQS throttled entry 1",
+			}),
+		});
+	});
+
+	test("rejects every caller when the batch transport fails", async () => {
+		const { batcher } = createBatcher({
+			sendBatch: async () => {
+				throw new Error("SQS unavailable");
+			},
+		});
+		const resultsPromise = Promise.allSettled(
+			Array.from({ length: 2 }, (_, index) =>
+				batcher.enqueue(createEntry({ index })),
+			),
+		);
+
+		await batcher.flush();
+		const results = await resultsPromise;
+
+		expect(results).toHaveLength(2);
+		for (const result of results) {
+			expect(result).toMatchObject({
+				status: "rejected",
+				reason: expect.objectContaining({ message: "SQS unavailable" }),
+			});
+		}
+	});
+
+	test("shutdown drains pending and in-flight sends before resolving", async () => {
+		let resolveSend:
+			| ((result: {
+					failures: Array<{ index: number; reason: string }>;
+			  }) => void)
+			| undefined;
+		const { batcher } = createBatcher({
+			sendBatch: () =>
+				new Promise((resolve) => {
+					resolveSend = resolve;
+				}),
+		});
+		const queued = batcher.enqueue(createEntry({ index: 0 }));
+		let shutdownResolved = false;
+
+		const shutdown = batcher.shutdown().then(() => {
+			shutdownResolved = true;
+		});
+		await Promise.resolve();
+
+		expect(shutdownResolved).toBeFalse();
+		await expect(batcher.enqueue(createEntry({ index: 1 }))).rejects.toThrow(
+			"shutting down",
+		);
+
+		resolveSend?.({ failures: [] });
+		await Promise.all([queued, shutdown]);
+
+		expect(shutdownResolved).toBeTrue();
+	});
+});

--- a/server/tests/unit/queue/SqsBatchAccumulator.test.ts
+++ b/server/tests/unit/queue/SqsBatchAccumulator.test.ts
@@ -1,5 +1,5 @@
 /**
- * TDD contract for batching primary SQS queue sends.
+ * Contract for accumulating independent SQS sends into bounded batches.
  *
  * Contract under test:
  *   - up to 10 independent queue entries share one send-batch call
@@ -10,15 +10,15 @@
  *   - each entry preserves its job body, FIFO identifiers, and delay
  *   - the combined message bodies in one batch never exceed SQS's 1 MiB limit
  *
- * Pre-implementation red: PrimarySqsSendBatcher does not exist.
- * Post-implementation green: all batching and delivery assertions pass.
+ * The generic accumulator owns timing, bounds, per-entry results, and shutdown;
+ * queue-specific code supplies the entry shape and batch sender.
  */
 
 import { describe, expect, test } from "bun:test";
 import {
-	PrimarySqsSendBatcher,
-	type SendPrimarySqsBatchArgs,
-} from "@/queue/PrimarySqsSendBatcher.js";
+	type SendSqsAccumulatorBatchArgs,
+	SqsBatchAccumulator,
+} from "@/queue/SqsBatchAccumulator.js";
 
 const QUEUE_URL =
 	"https://sqs.us-east-2.amazonaws.com/123456789012/autumn-prod.fifo";
@@ -37,15 +37,17 @@ const createEntry = ({ index }: { index: number }) => ({
 	delaySeconds: index === 0 ? 2 : undefined,
 });
 
+type TestEntry = ReturnType<typeof createEntry>;
+
 const createBatcher = ({
 	sendBatch,
 }: {
-	sendBatch?: (args: SendPrimarySqsBatchArgs) => Promise<{
+	sendBatch?: (args: SendSqsAccumulatorBatchArgs<TestEntry>) => Promise<{
 		failures: Array<{ index: number; reason: string }>;
 	}>;
 } = {}) => {
-	const calls: SendPrimarySqsBatchArgs[] = [];
-	const batcher = new PrimarySqsSendBatcher({
+	const calls: SendSqsAccumulatorBatchArgs<TestEntry>[] = [];
+	const batcher = new SqsBatchAccumulator<TestEntry>({
 		batchWindowMs: BATCH_WINDOW_MS,
 		sendBatch:
 			sendBatch ??
@@ -58,7 +60,7 @@ const createBatcher = ({
 	return { batcher, calls };
 };
 
-describe("PrimarySqsSendBatcher", () => {
+describe("SqsBatchAccumulator", () => {
 	test("flushes 10 independent entries in one batch call", async () => {
 		const { batcher, calls } = createBatcher();
 

--- a/server/tests/unit/queue/primary-queue-batching.test.ts
+++ b/server/tests/unit/queue/primary-queue-batching.test.ts
@@ -1,0 +1,220 @@
+/**
+ * TDD contract for routing primary queue sends through SendMessageBatch.
+ *
+ * Contract under test:
+ *   - SQS_QUEUE_URL_V2 sends use SendMessageBatch with up to 10 entries
+ *   - mixed job envelopes, FIFO identifiers, and delays are preserved
+ *   - partial AWS failures reject only the corresponding addTaskToQueue caller
+ *   - explicit dedicated queue overrides continue using SendMessage
+ *
+ * Pre-implementation red: queueUtils has no primary batcher routing or flush hook.
+ * Post-implementation green: primary sends batch while dedicated queues stay unchanged.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
+import type { SQSClient } from "@aws-sdk/client-sqs";
+import { getSqsClient } from "@/queue/initSqs.js";
+import { JobName } from "@/queue/JobName.js";
+import {
+	addTaskToQueue,
+	flushPrimarySqsSendBatcher,
+} from "@/queue/queueUtils.js";
+
+const PRIMARY_QUEUE_URL =
+	"https://sqs.us-east-2.amazonaws.com/123456789012/autumn-prod.fifo";
+const DEDICATED_QUEUE_URL =
+	"https://sqs.us-east-2.amazonaws.com/123456789012/track-prod.fifo";
+
+const createPayload = ({ index }: { index: number }) => ({
+	customerId: `customer_${index}`,
+	orgId: "org_1",
+	env: AppEnv.Live,
+	region: "us-east-2",
+	redisInstance: "redis-main",
+	timestamp: index,
+});
+
+describe("primary queue send batching", () => {
+	const originalPrimaryQueueUrl = process.env.SQS_QUEUE_URL_V2;
+	let originalPrimarySend: SQSClient["send"];
+	let originalDedicatedSend: SQSClient["send"];
+	let primaryCommands: Array<{ input: Record<string, unknown> }>;
+	let dedicatedCommands: Array<{ input: Record<string, unknown> }>;
+
+	beforeEach(() => {
+		process.env.SQS_QUEUE_URL_V2 = PRIMARY_QUEUE_URL;
+		primaryCommands = [];
+		dedicatedCommands = [];
+
+		const primaryClient = getSqsClient({ queueUrl: PRIMARY_QUEUE_URL });
+		const dedicatedClient = getSqsClient({ queueUrl: DEDICATED_QUEUE_URL });
+		originalPrimarySend = primaryClient.send.bind(primaryClient);
+		originalDedicatedSend = dedicatedClient.send.bind(dedicatedClient);
+
+		primaryClient.send = (async (command: {
+			input: {
+				Entries?: Array<{ Id: string }>;
+			};
+		}) => {
+			primaryCommands.push(command);
+			return {
+				Successful: command.input.Entries?.map(({ Id }) => ({ Id })) ?? [],
+			};
+		}) as typeof primaryClient.send;
+		dedicatedClient.send = (async (command: {
+			input: Record<string, unknown>;
+		}) => {
+			dedicatedCommands.push(command);
+			return {};
+		}) as typeof dedicatedClient.send;
+	});
+
+	afterEach(async () => {
+		await flushPrimarySqsSendBatcher();
+		getSqsClient({ queueUrl: PRIMARY_QUEUE_URL }).send = originalPrimarySend;
+		getSqsClient({ queueUrl: DEDICATED_QUEUE_URL }).send =
+			originalDedicatedSend;
+		process.env.SQS_QUEUE_URL_V2 = originalPrimaryQueueUrl;
+	});
+
+	test("sends 10 primary jobs in one SQS batch with their original envelopes", async () => {
+		await Promise.all(
+			Array.from({ length: 10 }, (_, index) =>
+				addTaskToQueue({
+					jobName: JobName.SyncCustomerDirty,
+					payload: createPayload({ index }),
+					messageGroupId: `customer_${index % 2}`,
+					messageDeduplicationId: `dedup_${index}`,
+				}),
+			),
+		);
+
+		expect(primaryCommands).toHaveLength(1);
+		const entries = primaryCommands[0].input.Entries as Array<{
+			Id: string;
+			MessageBody: string;
+			MessageGroupId: string;
+			MessageDeduplicationId: string;
+		}>;
+		expect(entries).toHaveLength(10);
+		expect(entries.map(({ Id }) => Id)).toEqual(
+			Array.from({ length: 10 }, (_, index) => index.toString()),
+		);
+		expect(entries[0]).toMatchObject({
+			MessageGroupId: "customer_0",
+			MessageDeduplicationId: "dedup_0",
+		});
+		expect(JSON.parse(entries[0].MessageBody)).toMatchObject({
+			id: expect.any(String),
+			name: JobName.SyncCustomerDirty,
+			data: createPayload({ index: 0 }),
+		});
+	});
+
+	test("allows different primary queue job types to share a batch", async () => {
+		const syncJob = addTaskToQueue({
+			jobName: JobName.SyncCustomerDirty,
+			payload: createPayload({ index: 0 }),
+			messageGroupId: "customer_0",
+			messageDeduplicationId: "sync_0",
+		});
+		const refreshJob = addTaskToQueue({
+			jobName: JobName.RefreshEntityAggregate,
+			payload: {
+				customerId: "customer_1",
+				orgId: "org_1",
+				env: AppEnv.Live,
+				region: "us-east-2",
+				internalFeatureIds: ["feature_1"],
+			},
+			messageGroupId: "customer_1",
+			messageDeduplicationId: "refresh_1",
+		});
+
+		await flushPrimarySqsSendBatcher();
+		await Promise.all([syncJob, refreshJob]);
+
+		const entries = primaryCommands[0].input.Entries as Array<{
+			MessageBody: string;
+		}>;
+		expect(
+			entries.map(({ MessageBody }) => JSON.parse(MessageBody).name),
+		).toEqual([JobName.SyncCustomerDirty, JobName.RefreshEntityAggregate]);
+	});
+
+	test("preserves per-entry delays in a partial primary batch", async () => {
+		const queued = addTaskToQueue({
+			jobName: JobName.SyncCustomerDirty,
+			payload: createPayload({ index: 0 }),
+			messageGroupId: "customer_0",
+			messageDeduplicationId: "dedup_0",
+			delayMs: 2_500,
+		});
+
+		await flushPrimarySqsSendBatcher();
+		await queued;
+
+		const entries = primaryCommands[0].input.Entries as Array<{
+			DelaySeconds?: number;
+		}>;
+		expect(entries).toHaveLength(1);
+		expect(entries[0].DelaySeconds).toBe(2);
+	});
+
+	test("rejects only the primary caller whose batch entry failed", async () => {
+		const primaryClient = getSqsClient({ queueUrl: PRIMARY_QUEUE_URL });
+		primaryClient.send = (async (command: {
+			input: {
+				Entries: Array<{ Id: string }>;
+			};
+		}) => {
+			primaryCommands.push(command);
+			return {
+				Successful: [{ Id: "0" }, { Id: "2" }],
+				Failed: [{ Id: "1", Code: "Throttled", Message: "entry failed" }],
+			};
+		}) as typeof primaryClient.send;
+
+		const resultsPromise = Promise.allSettled(
+			Array.from({ length: 3 }, (_, index) =>
+				addTaskToQueue({
+					jobName: JobName.SyncCustomerDirty,
+					payload: createPayload({ index }),
+					messageGroupId: `customer_${index}`,
+					messageDeduplicationId: `dedup_${index}`,
+				}),
+			),
+		);
+		await flushPrimarySqsSendBatcher();
+		const results = await resultsPromise;
+
+		expect(results.map(({ status }) => status)).toEqual([
+			"fulfilled",
+			"rejected",
+			"fulfilled",
+		]);
+		expect(results[1]).toMatchObject({
+			status: "rejected",
+			reason: expect.objectContaining({ message: "entry failed" }),
+		});
+	});
+
+	test("keeps an explicit dedicated queue override on SendMessage", async () => {
+		await addTaskToQueue({
+			jobName: JobName.SyncCustomerDirty,
+			payload: createPayload({ index: 0 }),
+			queueUrl: DEDICATED_QUEUE_URL,
+			messageGroupId: "customer_0",
+			messageDeduplicationId: "dedup_0",
+		});
+
+		expect(dedicatedCommands).toHaveLength(1);
+		expect(dedicatedCommands[0].input).toMatchObject({
+			QueueUrl: DEDICATED_QUEUE_URL,
+			MessageGroupId: "customer_0",
+			MessageDeduplicationId: "dedup_0",
+		});
+		expect(dedicatedCommands[0].input).not.toHaveProperty("Entries");
+	});
+});

--- a/server/tinybird/pipes/aggregate_groupable.pipe
+++ b/server/tinybird/pipes/aggregate_groupable.pipe
@@ -44,7 +44,8 @@ SQL >
         {% else %}
         {{ column('properties.' + String(property_key, '')) }}::String as group_value,
         {% end %}
-        sum(total_value) as total_value
+        sum(total_value) as total_value,
+        sum(event_count) as event_count
     FROM
         {% if use_no_props %}
         events_customer_hourly_mv
@@ -111,6 +112,7 @@ SQL >
         event_name,
         if(rn <= {{ Int32(max_groups, 9) }}, group_value, 'AUTUMN_RESERVED') as group_value,
         sum(total_value) as total_value,
+        sum(event_count) as event_count,
         max(rn) > {{ Int32(max_groups, 9) }} as _truncated
     FROM ranked
     GROUP BY period, event_name, group_value


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batches primary and async-track SQS sends to reduce API calls and adds graceful shutdown flushing. Improves property group-by completeness by reconciling grouped sums and counts against ungated totals and retrying only when the retry recovers data; also trims logs for events list routes.

- **New Features**
  - Primary queue (`SQS_QUEUE_URL_V2`) uses `SendMessageBatch` via `SqsBatchAccumulator`; preserves FIFO IDs and delays; explicit `queueUrl` overrides still use `SendMessage`.
  - Async track uses `AsyncTrackSqsBatcher` to batch without coalescing messages; wired into `runAsyncTrack`.
  - Added counters with `@opentelemetry/api` for batch calls, entries, and failures; expose `flushPrimarySqsSendBatcher`/`shutdownPrimarySqsSendBatcher` and hook shutdown in server, workers, and cron.

- **Bug Fixes**
  - Property group-bys: detect shortfalls using grouped sums and event counts vs ungated totals; pass the caller’s date range to `getCountAndSum`; retry with `skip_property_rollup=1` and keep the retry only if it reports more via `reportsMoreThan`. `aggregate_groupable.pipe` now emits `event_count` and the schema treats it as optional for older deployments.
  - Logging: drop response body for successful `/v1/events.list` and `/v1/events/list`; keep it on errors.

<sup>Written for commit 46df5e51ed03cceba583575bf7419b07202e093a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces queue batching and expands analytics fallback coverage.
- **Improvements:** Batches primary and async-track SQS messages, records batch metrics, and flushes accumulators during graceful shutdown.
- **Bug fixes:** Adds count-aware property-rollup completeness checks and an ungated retry for partially dropped property groups.
- **Improvements:** Excludes successful event-list response bodies from request logs.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the previously reported net-zero group omission remains reachable until every deployed Tinybird pipe returns `event_count`.

The server deliberately accepts responses without `event_count` and then reverts to net-sum comparisons, so an older deployed pipe can still cause signed gate-dropped groups that cancel to zero to be silently omitted.

**Files Needing Attention:** server/src/internal/analytics/actions/propertyRollupCompleteness.ts, server/src/external/tinybird/pipes/aggregateGroupablePipe.ts, server/tinybird/pipes/aggregate_groupable.pipe

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/queue/SqsBatchAccumulator.ts | Adds queue-aware accumulation, timer and size flushing, per-entry result settlement, and shutdown draining. |
| server/src/queue/queueUtils.ts | Routes primary-queue sends through `SendMessageBatch` while preserving direct sends for explicit queue overrides. |
| server/src/internal/balances/track/AsyncTrackSqsBatcher.ts | Adds batching for independent async-track messages without changing their worker payloads or FIFO identifiers. |
| server/src/internal/analytics/actions/propertyRollupCompleteness.ts | Adds count-aware completeness and retry-selection helpers, but the prior net-zero omission remains reachable during Tinybird deployment skew. |
| server/tinybird/pipes/aggregate_groupable.pipe | Exposes aggregate event counts needed to detect missing groups whose signed values cancel. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Caller
  participant Accumulator as SQS Batch Accumulator
  participant SQS
  participant Shutdown
  Caller->>Accumulator: enqueue(message)
  alt 10 entries, size boundary, or timer
    Accumulator->>SQS: SendMessageBatch
    SQS-->>Accumulator: per-entry results
    Accumulator-->>Caller: resolve or reject entry
  end
  Shutdown->>Accumulator: shutdown()
  Accumulator->>SQS: flush pending batch
  SQS-->>Accumulator: final results
  Accumulator-->>Shutdown: pending and in-flight sends drained
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge pull request #2491 from useautumn/..."](https://github.com/useautumn/autumn/commit/46df5e51ed03cceba583575bf7419b07202e093a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48657409)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [External Integrations (non-Stripe)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-external-integrations.md)
- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)
</details>

<!-- /greptile_comment -->