### PR TITLE
fix: skip response body logging on events list routes

### DIFF
--- a/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
+++ b/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
@@ -16,6 +16,12 @@ const HIGH_VOLUME_SUCCESS_ROUTES = new Set<string>([
 	// "/v1/entities.get",
 ]);
 
+// Event pages run to megabytes each, dwarfing every other route's ingest.
+const RESPONSE_BODY_EXCLUDED_ROUTES = new Set<string>([
+	"/v1/events/list",
+	"/v1/events.list",
+]);
+
 const SUCCESS_REQUEST_LOG_SAMPLE_RATE = Number.parseFloat(
 	process.env.AXIOM_SUCCESS_REQUEST_LOG_SAMPLE_RATE ?? "0",
 );
@@ -64,7 +70,10 @@ export const logRequestResult = async ({
 			extras: ctx.extraLogs,
 		});
 
-		let finalResponseBody = responseBody;
+		const skipResponseBody =
+			isSuccess && RESPONSE_BODY_EXCLUDED_ROUTES.has(c.req.path);
+
+		let finalResponseBody = skipResponseBody ? null : responseBody;
 		if (finalResponseBody === undefined && c.req.path.includes("/v1")) {
 			const contentType = c.res.headers.get("content-type");
 			if (contentType?.includes("application/json")) {

--- a/server/tests/unit/logging/logRequestResult.test.ts
+++ b/server/tests/unit/logging/logRequestResult.test.ts
@@ -187,6 +187,96 @@ describe("logRequestResult", () => {
 		});
 	});
 
+	test("drops the response body on the legacy events list route", async () => {
+		const captured: CapturedLog[] = [];
+		let cloneCount = 0;
+		const ctx = {
+			timestamp: 123,
+			logger: createCapturingLogger({ captured }),
+			extraLogs: {},
+			org: { slug: "test-org" },
+		} as unknown as AutumnContext;
+		const c = {
+			req: { path: "/v1/events/list" },
+			res: {
+				status: 200,
+				headers: new Headers({ "content-type": "application/json" }),
+				clone: () => {
+					cloneCount++;
+					return { json: async () => ({ events: [{ id: "evt_1" }] }) };
+				},
+			},
+		} as unknown as Context<HonoEnv>;
+
+		await logRequestResult({ ctx, c, durationMs: 40 });
+
+		expect(cloneCount).toBe(0);
+		expect(captured).toHaveLength(1);
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 40,
+			res: null,
+		});
+	});
+
+	test("drops an explicitly supplied response body on the rpc events list route", async () => {
+		const captured: CapturedLog[] = [];
+		const ctx = {
+			timestamp: 123,
+			logger: createCapturingLogger({ captured }),
+			extraLogs: {},
+			org: { slug: "test-org" },
+		} as unknown as AutumnContext;
+		const c = {
+			req: { path: "/v1/events.list" },
+			res: {
+				status: 200,
+				headers: new Headers({ "content-type": "application/json" }),
+			},
+		} as Context<HonoEnv>;
+
+		await logRequestResult({
+			ctx,
+			c,
+			durationMs: 40,
+			responseBody: { events: [{ id: "evt_1" }] },
+		});
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 40,
+			res: null,
+		});
+	});
+
+	test("keeps the response body on failed events list requests", async () => {
+		const captured: CapturedLog[] = [];
+		const responseBody = { code: "internal_error", message: "boom" };
+		const ctx = {
+			timestamp: 123,
+			logger: createCapturingLogger({ captured }),
+			extraLogs: {},
+			org: { slug: "test-org" },
+		} as unknown as AutumnContext;
+		const c = {
+			req: { path: "/v1/events/list" },
+			res: {
+				status: 500,
+				headers: new Headers({ "content-type": "application/json" }),
+			},
+		} as Context<HonoEnv>;
+
+		await logRequestResult({ ctx, c, durationMs: 40, responseBody });
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 500,
+			durationMs: 40,
+			res: responseBody,
+		});
+	});
+
 	test("does not mutate logger context or emit for explicitly skipped routes", async () => {
 		const captured: CapturedLog[] = [];
 		const logger = createCapturingLogger({ captured });


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip logging response bodies for event list endpoints to reduce log size and avoid heavy response cloning. Applies to successful `/v1/events/list` and `/v1/events.list` responses; failed requests still include the body.

- **Bug Fixes**
  - Added `RESPONSE_BODY_EXCLUDED_ROUTES` and set body to `null` for successful matches.
  - Bypassed response cloning/reading on these routes to cut overhead.
  - Added unit tests for legacy and RPC routes, explicit body drop, and failure path retaining the body.

<sup>Written for commit 38c016061e8a16df0e122c5a31abc8b9624f8ae1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Prevents oversized event-list responses from being included in successful request logs.
- **Bug fixes:** Excludes response bodies for both `/v1/events/list` and `/v1/events.list` while retaining error response bodies.
- **Improvements:** Avoids cloning and parsing successful event-list responses solely for logging.
- **Improvements:** Adds unit coverage for both route forms and the failure-response behavior.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The exclusion matches both registered event-list paths, bypasses expensive response cloning on successful requests, and preserves response details for non-success statuses.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/honoMiddlewares/requestLogging/logRequestResult.ts | Adds correctly scoped response-body suppression for the two registered event-list routes without suppressing diagnostic error bodies. |
| server/tests/unit/logging/logRequestResult.test.ts | Verifies suppression for both event-list route forms, avoidance of response cloning, and preservation of failed-response bodies. |

<sub>Reviews (1): Last reviewed commit: ["fix: skip response body logging on event..."](https://github.com/useautumn/autumn/commit/38c016061e8a16df0e122c5a31abc8b9624f8ae1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48660929)</sub>

<!-- /greptile_comment -->