### PR TITLE
fix: detect gate-dropped groups via event counts, not net sums

### DIFF
--- a/server/src/external/tinybird/pipes/aggregateGroupablePipe.ts
+++ b/server/src/external/tinybird/pipes/aggregateGroupablePipe.ts
@@ -7,6 +7,9 @@ export const aggregateGroupablePipeResponseSchema = z.object({
 	event_name: z.string(),
 	group_value: z.string(),
 	total_value: z.number(),
+	// Optional: deployments predating the count column omit it, and the
+	// completeness check degrades to a sum-only comparison when absent.
+	event_count: z.number().optional(),
 	_truncated: z
 		.union([z.boolean(), z.number()])
 		.transform((v) => Boolean(v))

--- a/server/src/internal/analytics/actions/aggregate.ts
+++ b/server/src/internal/analytics/actions/aggregate.ts
@@ -28,7 +28,7 @@ import { getBillingCycleStartDate } from "../analyticsUtils.js";
 import { getCountAndSum } from "./getCountAndSum.js";
 import {
 	groupedResultIsIncomplete,
-	sumAllRows,
+	reportsMoreThan,
 } from "./propertyRollupCompleteness.js";
 
 /** Flattens filter_by into indexed filter_key_N / filter_value_N params for Tinybird pipes */
@@ -490,7 +490,7 @@ export const aggregate = async ({
 				// A shortfall means gate loss OR events without the property; only the
 				// first is recoverable, and only the retry can tell them apart.
 				if (
-					sumAllRows({ rows: ungated.data }) > sumAllRows({ rows: result.data })
+					reportsMoreThan({ candidate: ungated.data, current: result.data })
 				) {
 					result = ungated;
 				}

--- a/server/src/internal/analytics/actions/propertyRollupCompleteness.ts
+++ b/server/src/internal/analytics/actions/propertyRollupCompleteness.ts
@@ -37,6 +37,53 @@ export const sumAllRows = ({
 	rows: AggregateGroupablePipeRow[];
 }): number => rows.reduce((sum, row) => sum + row.total_value, 0);
 
+// Event counts can't cancel the way signed values can, but older deployments of
+// the pipe don't return them, so every count check stays opt-in.
+const countRowsByEventName = ({
+	rows,
+}: {
+	rows: AggregateGroupablePipeRow[];
+}): Record<string, number> | null => {
+	const counts: Record<string, number> = {};
+	for (const row of rows) {
+		if (row.event_count === undefined) return null;
+		counts[row.event_name] = (counts[row.event_name] ?? 0) + row.event_count;
+	}
+	return counts;
+};
+
+const totalEventCount = ({
+	rows,
+}: {
+	rows: AggregateGroupablePipeRow[];
+}): number | null => {
+	let total = 0;
+	for (const row of rows) {
+		if (row.event_count === undefined) return null;
+		total += row.event_count;
+	}
+	return total;
+};
+
+/**
+ * Whether the retry recovered anything. Prefers event counts, since a recovered
+ * group whose values cancel to zero moves the count but not the sum.
+ */
+export const reportsMoreThan = ({
+	candidate,
+	current,
+}: {
+	candidate: AggregateGroupablePipeRow[];
+	current: AggregateGroupablePipeRow[];
+}): boolean => {
+	const candidateCount = totalEventCount({ rows: candidate });
+	const currentCount = totalEventCount({ rows: current });
+	if (candidateCount !== null && currentCount !== null) {
+		if (candidateCount !== currentCount) return candidateCount > currentCount;
+	}
+	return sumAllRows({ rows: candidate }) > sumAllRows({ rows: current });
+};
+
 /**
  * Whether the gated property rollup under-reports against the ungated totals.
  * A key with both gate-surviving and gate-dropped values comes back non-empty
@@ -50,13 +97,20 @@ export const groupedResultIsIncomplete = ({
 	totals: EventTotals;
 }): boolean => {
 	const groupedSums = sumGroupedRowsByEventName({ rows });
+	const groupedCounts = countRowsByEventName({ rows });
 
-	return Object.entries(totals).some(
-		([eventName, total]) =>
-			total.count > 0 &&
-			isMateriallyLessThan({
-				value: groupedSums[eventName] ?? 0,
-				reference: total.sum,
-			}),
-	);
+	return Object.entries(totals).some(([eventName, total]) => {
+		if (total.count <= 0) return false;
+
+		// Signed values can cancel, so a matching sum does not prove the groups are
+		// all present; the count catches what the sum hides.
+		if (groupedCounts && (groupedCounts[eventName] ?? 0) < total.count) {
+			return true;
+		}
+
+		return isMateriallyLessThan({
+			value: groupedSums[eventName] ?? 0,
+			reference: total.sum,
+		});
+	});
 };

--- a/server/tests/unit/analytics/property-rollup-completeness.test.ts
+++ b/server/tests/unit/analytics/property-rollup-completeness.test.ts
@@ -4,6 +4,7 @@ import type { AggregateGroupablePipeRow } from "@/external/tinybird/pipes/aggreg
 import {
 	type EventTotals,
 	groupedResultIsIncomplete,
+	reportsMoreThan,
 	sumAllRows,
 	sumGroupedRowsByEventName,
 } from "@/internal/analytics/actions/propertyRollupCompleteness.js";
@@ -12,15 +13,18 @@ const row = ({
 	eventName = "action_calls",
 	groupValue,
 	totalValue,
+	eventCount,
 }: {
 	eventName?: string;
 	groupValue: string;
 	totalValue: number;
+	eventCount?: number;
 }): AggregateGroupablePipeRow => ({
 	period: "2026-07-29 00:00:00",
 	event_name: eventName,
 	group_value: groupValue,
 	total_value: totalValue,
+	...(eventCount === undefined ? {} : { event_count: eventCount }),
 });
 
 const totals = ({
@@ -187,6 +191,79 @@ test(`${chalk.yellowBright(
 	expect(sumAllRows({ rows: ungatedWithAbsentProperty })).toBe(
 		sumAllRows({ rows: gated }),
 	);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: gate-dropped groups whose values cancel are still detected",
+)}`, () => {
+	// Negative values are mainstream (117 orgs in a 7d prod sample), so dropped
+	// groups can net to zero and leave the sum comparison blind. The count can't
+	// cancel, so it catches them.
+	const rows = [
+		row({ groupValue: "qa-71607", totalValue: 500, eventCount: 5 }),
+	];
+
+	expect(
+		groupedResultIsIncomplete({
+			rows,
+			totals: { action_calls: { count: 9, sum: 500 } },
+		}),
+	).toBe(true);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: counts matching the totals are complete",
+)}`, () => {
+	const rows = [
+		row({ groupValue: "qa-71607", totalValue: 500, eventCount: 5 }),
+		row({ groupValue: "joe-test-94143", totalValue: -500, eventCount: 4 }),
+	];
+
+	expect(
+		groupedResultIsIncomplete({
+			rows,
+			totals: { action_calls: { count: 9, sum: 0 } },
+		}),
+	).toBe(false);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: falls back to sum-only when the pipe omits counts",
+)}`, () => {
+	// A deployment predating the count column must not report every result as
+	// incomplete just because the field is missing.
+	const rows = [row({ groupValue: "qa-71607", totalValue: 500 })];
+
+	expect(
+		groupedResultIsIncomplete({
+			rows,
+			totals: { action_calls: { count: 9, sum: 500 } },
+		}),
+	).toBe(false);
+});
+
+test(`${chalk.yellowBright(
+	"property rollup: the retry wins on recovered events even when sums tie",
+)}`, () => {
+	const gated = [
+		row({ groupValue: "qa-71607", totalValue: 500, eventCount: 5 }),
+	];
+	const ungated = [
+		row({ groupValue: "qa-71607", totalValue: 500, eventCount: 5 }),
+		row({
+			groupValue: "4uSlnf8w0kUb5WV6gEmBz07JVvgxfxTR",
+			totalValue: 60,
+			eventCount: 2,
+		}),
+		row({
+			groupValue: "stackone-integrations-testing---eu-66912",
+			totalValue: -60,
+			eventCount: 2,
+		}),
+	];
+
+	expect(reportsMoreThan({ candidate: ungated, current: gated })).toBe(true);
+	expect(reportsMoreThan({ candidate: gated, current: ungated })).toBe(false);
 });
 
 test(`${chalk.yellowBright(

--- a/server/tinybird/pipes/aggregate_groupable.pipe
+++ b/server/tinybird/pipes/aggregate_groupable.pipe
@@ -44,7 +44,8 @@ SQL >
         {% else %}
         {{ column('properties.' + String(property_key, '')) }}::String as group_value,
         {% end %}
-        sum(total_value) as total_value
+        sum(total_value) as total_value,
+        sum(event_count) as event_count
     FROM
         {% if use_no_props %}
         events_customer_hourly_mv
@@ -111,6 +112,7 @@ SQL >
         event_name,
         if(rn <= {{ Int32(max_groups, 9) }}, group_value, 'AUTUMN_RESERVED') as group_value,
         sum(total_value) as total_value,
+        sum(event_count) as event_count,
         max(rn) > {{ Int32(max_groups, 9) }} as _truncated
     FROM ranked
     GROUP BY period, event_name, group_value


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use event counts to detect gate-dropped groups in property rollups, fixing cases where net sums hid missing groups. Prefers counts when present and falls back to sums for older Tinybird deployments.

- **Bug Fixes**
  - Tinybird `aggregate_groupable` now aggregates and returns `event_count`; API schema accepts optional `event_count`.
  - Completeness check and retry logic use event counts per event before sums (`reportsMoreThan`), so recovered events are detected even when values cancel.
  - Added unit tests for count-based detection and fallback behavior.

<sup>Written for commit 1953ac5dd75e09216c4e3f32964d13869548241d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes property-rollup completeness detection for signed event values.
- **Bug fixes:** Adds event counts to grouped Tinybird results so gate-dropped groups remain detectable when their signed values cancel out.
- **Bug fixes:** Uses event counts to decide whether an ungated retry recovered data, with sum-based fallback for older pipe deployments.
- **Improvements:** Adds compatibility and regression coverage for count-aware completeness checks and retry selection.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with count-aware detection correctly preserving compatibility with deployments that do not yet return event counts.

The Tinybird pipe propagates event counts at the same requested-property granularity used by completeness checks, and both detection and retry selection fall back to the prior sum comparison when count data is unavailable.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/tinybird/pipes/aggregate_groupable.pipe | Propagates event counts through both grouped aggregation stages without changing existing grouping behavior. |
| server/src/external/tinybird/pipes/aggregateGroupablePipe.ts | Adds an optional event-count response field to preserve compatibility with older Tinybird deployments. |
| server/src/internal/analytics/actions/propertyRollupCompleteness.ts | Adds count-aware completeness and retry comparisons while retaining sum-based fallback behavior. |
| server/src/internal/analytics/actions/aggregate.ts | Selects an ungated retry when it recovers additional events, including when signed sums cancel. |
| server/tests/unit/analytics/property-rollup-completeness.test.ts | Covers cancellation, matching counts, legacy responses, and count-aware retry selection. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Query gated property rollup] --> B[Compare grouped sums and event counts with totals]
  B -->|Complete| C[Return gated result]
  B -->|Incomplete| D[Retry using ungated hourly events]
  D --> E{Retry reports more events?}
  E -->|Yes| F[Return ungated result]
  E -->|No| G{Counts unavailable or equal and sum is larger?}
  G -->|Yes| F
  G -->|No| C
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: detect gate-dropped groups via even..."](https://github.com/useautumn/autumn/commit/1953ac5dd75e09216c4e3f32964d13869548241d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48664791)</sub>

**Context used:**

- Knowledge Base — [External Integrations (non-Stripe)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-external-integrations.md)

<!-- /greptile_comment -->