### PR TITLE
Subtle details on customer stories animation

### DIFF
--- a/apps/website/components/customer-stories/desktop-accordion.tsx
+++ b/apps/website/components/customer-stories/desktop-accordion.tsx
@@ -3,39 +3,41 @@ import { featuredCustomerStories } from "@/app/constant";
 import { BracketCorners } from "./bracket-corners";
 import { PixelDissolve } from "./pixel-dissolve";
 import { StoryPanel } from "./story-panel";
-import { StorySpine } from "./story-spine";
-import { SPINE_WIDTH, TRACK_GAP, useAccordion } from "./use-accordion";
+import { StorySpine, StorySpineIcon } from "./story-spine";
+import {
+	EXPAND_MS,
+	SPINE_WIDTH,
+	TRACK_GAP,
+	useAccordion,
+} from "./use-accordion";
 
 const CARD_HEIGHT = 420;
-const DARK_SURFACE = "#0A0A0A";
+const SECTION_SURFACE = "#0F0F0F";
 
-// Colour the pixels dissolve away from. DARK_SURFACE reads as the slide fading
-// up from black; the prev slide's surface gives a colour-to-colour crossfade.
-const DISSOLVE_FROM = "dark" as "dark" | "crossfade";
+function blendWithBlack(hex: string, blackOpacity: number) {
+	const match = /^#([0-9a-f]{6})$/i.exec(hex);
+	if (!match) return hex;
+
+	const keep = 1 - blackOpacity;
+	const value = Number.parseInt(match[1], 16);
+	const channel = (shift: number) =>
+		Math.round(((value >> shift) & 0xff) * keep)
+			.toString(16)
+			.padStart(2, "0");
+
+	return `#${channel(16)}${channel(8)}${channel(0)}`;
+}
 
 export function DesktopAccordion() {
 	const {
 		trackRef,
-		prevActiveIndex,
 		setActiveIndex,
 		revealKey,
 		dissolveDir,
+		isTransitioning,
 		contentWidth,
 		cardLayout,
 	} = useAccordion(featuredCustomerStories.length);
-
-	const fromColor =
-		DISSOLVE_FROM === "dark"
-			? DARK_SURFACE
-			: featuredCustomerStories[prevActiveIndex].surface;
-
-	// Track laid out left→right by flex order: left spine, content, right spine.
-	// trackX gives each surface its slot offset so the directional gradient is
-	// one continuous sweep across all three rather than restarting per card.
-	const trackWidth = contentWidth + 2 * (SPINE_WIDTH + TRACK_GAP);
-	const contentTrackX = SPINE_WIDTH + TRACK_GAP;
-	const rightSpineTrackX = contentTrackX + contentWidth + TRACK_GAP;
-	const spineTrackX = (order: number) => (order < 0 ? 0 : rightSpineTrackX);
 
 	return (
 		<div className="mt-8 mb-12 xl:mb-16 px-4 xl:px-22.75 hidden lg:block">
@@ -50,50 +52,44 @@ export function DesktopAccordion() {
 				}
 			>
 				{featuredCustomerStories.map((story, index) => {
-					const { state, order } = cardLayout(index);
+					const { state } = cardLayout(index);
 					const isActive = state === "active";
+					const isDeparting = state === "departing";
+					const compactSurface = blendWithBlack(story.surface, 0.3);
 					return (
 						<div
 							key={story.slug}
 							data-state={state}
-							style={{ order }}
 							className="cs-card relative h-full overflow-hidden"
 						>
 							<div
-								className="cs-content absolute inset-y-0 left-0 p-6 md:p-10 xl:p-12 flex flex-col bg-[#0A0A0A]"
+								className="cs-content absolute inset-y-0 left-0 z-10 p-6 md:p-10 xl:p-12 flex flex-col bg-[#0A0A0A]"
 								style={{ pointerEvents: isActive ? "auto" : "none" }}
 							>
 								<StoryPanel story={story} />
-								{isActive && (
+								{isDeparting && isTransitioning && (
 									<PixelDissolve
 										width={contentWidth}
 										height={CARD_HEIGHT}
 										revealKey={revealKey}
-										fromColor={fromColor}
+										fromColor={SECTION_SURFACE}
+										retainedColor={compactSurface}
+										retainedWidth={SPINE_WIDTH}
+										mode="cover"
 										direction={dissolveDir}
 										seed={revealKey}
-										trackX={contentTrackX}
-										trackWidth={trackWidth}
 									/>
 								)}
 							</div>
-							<div className="cs-spine absolute inset-0">
+							<div className="cs-spine absolute inset-0 z-0">
 								<StorySpine
 									story={story}
 									onClick={() => setActiveIndex(index)}
+									disabled={isActive || isTransitioning}
 								/>
-								{state === "neighbor" && (
-									<PixelDissolve
-										width={SPINE_WIDTH}
-										height={CARD_HEIGHT}
-										revealKey={revealKey}
-										fromColor={fromColor}
-										direction={dissolveDir}
-										seed={revealKey * 31 + index}
-										trackX={spineTrackX(order)}
-										trackWidth={trackWidth}
-									/>
-								)}
+							</div>
+							<div className="cs-compact-icon pointer-events-none absolute inset-0 z-40">
+								<StorySpineIcon story={story} />
 							</div>
 							{isActive && <BracketCorners />}
 						</div>
@@ -106,36 +102,64 @@ export function DesktopAccordion() {
 					gap: ${TRACK_GAP}px;
 				}
 				.cs-card {
-					flex: 0 0 0px;
+					flex: 0 0 ${SPINE_WIDTH}px;
 					min-width: 0;
-					opacity: 0;
+					opacity: 1;
+					transition:
+						flex-grow ${EXPAND_MS}ms cubic-bezier(0.77, 0, 0.175, 1),
+						flex-basis ${EXPAND_MS}ms cubic-bezier(0.77, 0, 0.175, 1);
+					will-change: flex-grow, flex-basis;
 				}
 				.cs-card[data-state="active"] {
-					flex: 1 1 0px;
-					opacity: 1;
+					flex-grow: 1;
+					flex-basis: 0px;
 				}
 				.cs-card[data-state="neighbor"] {
-					flex: 0 0 ${SPINE_WIDTH}px;
-					opacity: 1;
+					flex-grow: 0;
+					flex-basis: ${SPINE_WIDTH}px;
 				}
-				.cs-card[data-state="hidden"] {
-					flex: 0 0 0px;
-					margin-left: -${TRACK_GAP}px;
-					opacity: 0;
+				.cs-card[data-state="departing"] {
+					flex-grow: 0;
+					flex-basis: ${SPINE_WIDTH}px;
 				}
 				.cs-content {
 					width: var(--cs-content-w);
 					visibility: hidden;
+					opacity: 0;
+					transition: opacity 140ms cubic-bezier(0.23, 1, 0.32, 1);
 				}
 				.cs-card[data-state="active"] .cs-content {
 					visibility: visible;
+					opacity: 1;
+					transition-delay: 80ms;
+				}
+				.cs-card[data-state="departing"] .cs-content {
+					visibility: visible;
+					opacity: 1;
+					transition: none;
 				}
 				.cs-spine {
-					opacity: 1;
+					visibility: visible;
 				}
 				.cs-card[data-state="active"] .cs-spine {
-					opacity: 0;
 					pointer-events: none;
+				}
+				.cs-card[data-state="departing"] .cs-spine {
+					pointer-events: none;
+				}
+				.cs-compact-icon {
+					opacity: 0;
+					transition: opacity 220ms cubic-bezier(0.23, 1, 0.32, 1);
+				}
+				.cs-card[data-state="departing"] .cs-compact-icon {
+					opacity: 1;
+				}
+				@media (prefers-reduced-motion: reduce) {
+					.cs-card,
+					.cs-content,
+					.cs-compact-icon {
+						transition: none;
+					}
 				}
 			`}</style>
 		</div>

--- a/apps/website/components/customer-stories/story-spine.tsx
+++ b/apps/website/components/customer-stories/story-spine.tsx
@@ -3,35 +3,48 @@ import type { CustomerStory } from "@/app/constant";
 type StorySpineProps = {
 	story: CustomerStory;
 	onClick: () => void;
+	disabled?: boolean;
 };
 
-export function StorySpine({ story, onClick }: StorySpineProps) {
+export function StorySpineIcon({ story }: { story: CustomerStory }) {
+	return (
+		<span
+			className="absolute left-10 top-1/2 h-7 w-7 -translate-x-1/2 -translate-y-1/2 opacity-90"
+			style={{
+				WebkitMaskImage: `url(${story.iconLogo})`,
+				maskImage: `url(${story.iconLogo})`,
+				WebkitMaskRepeat: "no-repeat",
+				maskRepeat: "no-repeat",
+				WebkitMaskPosition: "center",
+				maskPosition: "center",
+				WebkitMaskSize: "contain",
+				maskSize: "contain",
+				backgroundColor: "#FFFFFF",
+			}}
+		/>
+	);
+}
+
+export function StorySpine({
+	story,
+	onClick,
+	disabled = false,
+}: StorySpineProps) {
 	return (
 		<button
 			type="button"
 			onClick={onClick}
+			disabled={disabled}
+			aria-hidden={disabled || undefined}
 			aria-label={`View ${story.name} story`}
-			className="group relative h-full w-full overflow-hidden cursor-pointer"
+			className="group relative h-full w-full overflow-hidden cursor-pointer disabled:cursor-default"
 		>
 			<div
 				className="absolute inset-0"
 				style={{ backgroundColor: story.surface }}
 			/>
 			<div className="absolute inset-0 bg-black/30 group-hover:bg-black/20 transition-colors duration-300" />
-			<span
-				className="absolute left-10 top-1/2 h-7 w-7 -translate-x-1/2 -translate-y-1/2 opacity-90"
-				style={{
-					WebkitMaskImage: `url(${story.iconLogo})`,
-					maskImage: `url(${story.iconLogo})`,
-					WebkitMaskRepeat: "no-repeat",
-					maskRepeat: "no-repeat",
-					WebkitMaskPosition: "center",
-					maskPosition: "center",
-					WebkitMaskSize: "contain",
-					maskSize: "contain",
-					backgroundColor: "#FFFFFF",
-				}}
-			/>
+			<StorySpineIcon story={story} />
 		</button>
 	);
 }

--- a/apps/website/components/customer-stories/use-accordion.ts
+++ b/apps/website/components/customer-stories/use-accordion.ts
@@ -1,48 +1,68 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export const SPINE_WIDTH = 80;
 export const TRACK_GAP = 12;
+export const EXPAND_MS = 500;
 
-type CardState = "active" | "neighbor" | "hidden";
+type CardState = "active" | "departing" | "neighbor";
 type CardLayout = { state: CardState; order: number };
+type TransitionPhase = "idle" | "transitioning";
 
 type Accordion = {
 	trackRef: React.RefObject<HTMLDivElement | null>;
-	prevActiveIndex: number;
 	setActiveIndex: (index: number) => void;
 	revealKey: number;
 	dissolveDir: number;
+	isTransitioning: boolean;
 	contentWidth: number;
 	cardLayout: (index: number) => CardLayout;
 };
-
-// Signed nearest-direction offset on a ring, e.g. for count 4 the card before
-// the active one is -1 even when it wraps from the end of the list.
-function ringOffset(index: number, active: number, count: number) {
-	const forward = (index - active + count) % count;
-	return forward > count / 2 ? forward - count : forward;
-}
 
 export function useAccordion(count: number): Accordion {
 	const trackRef = useRef<HTMLDivElement | null>(null);
 	const [trackWidth, setTrackWidth] = useState(0);
 	const [activeIndex, setActiveIndexState] = useState(0);
-	const [prevActiveIndex, setPrevActiveIndex] = useState(0);
+	const [departingIndex, setDepartingIndex] = useState<number | null>(null);
 	const [revealKey, setRevealKey] = useState(0);
 	const [dissolveDir, setDissolveDir] = useState(1);
+	const [transitionPhase, setTransitionPhase] =
+		useState<TransitionPhase>("idle");
 
-	const setActiveIndex = (index: number) => {
-		setActiveIndexState((current) => {
-			if (current !== index) {
-				setPrevActiveIndex(current);
-				setRevealKey((k) => k + 1);
-				// Sweep from the side the new slide was clicked on: +1 reveals
-				// right→left (clicked the right spine), -1 reveals left→right.
-				setDissolveDir(Math.sign(ringOffset(index, current, count)) || 1);
+	const setActiveIndex = useCallback(
+		(index: number) => {
+			if (
+				index < 0 ||
+				index >= count ||
+				index === activeIndex ||
+				transitionPhase !== "idle"
+			) {
+				return;
 			}
-			return index;
-		});
-	};
+
+			setDepartingIndex(activeIndex);
+			setActiveIndexState(index);
+			setDissolveDir(Math.sign(index - activeIndex) || 1);
+			setRevealKey((key) => key + 1);
+			setTransitionPhase("transitioning");
+		},
+		[activeIndex, count, transitionPhase],
+	);
+
+	useEffect(() => {
+		if (transitionPhase !== "transitioning") return;
+
+		const reduceMotion = window.matchMedia(
+			"(prefers-reduced-motion: reduce)",
+		).matches;
+		const timer = window.setTimeout(
+			() => {
+				setDepartingIndex(null);
+				setTransitionPhase("idle");
+			},
+			reduceMotion ? 0 : EXPAND_MS,
+		);
+		return () => window.clearTimeout(timer);
+	}, [transitionPhase]);
 
 	useEffect(() => {
 		const el = trackRef.current;
@@ -55,25 +75,28 @@ export function useAccordion(count: number): Accordion {
 	}, []);
 
 	const cardLayout = (index: number): CardLayout => {
-		const offset = ringOffset(index, activeIndex, count);
-		const distance = Math.abs(offset);
-		const state: CardState =
-			distance === 0 ? "active" : distance === 1 ? "neighbor" : "hidden";
-		return { state, order: offset };
+		return {
+			state:
+				index === activeIndex
+					? "active"
+					: index === departingIndex
+						? "departing"
+						: "neighbor",
+			order: index,
+		};
 	};
 
-	// With wrap, the active card always has two circular neighbors.
-	const neighborCount = count >= 3 ? 2 : count - 1;
+	const neighborCount = Math.max(0, count - 1);
 	const contentWidth = trackWidth
-		? trackWidth - neighborCount * (SPINE_WIDTH + TRACK_GAP)
+		? Math.max(0, trackWidth - neighborCount * (SPINE_WIDTH + TRACK_GAP))
 		: 0;
 
 	return {
 		trackRef,
-		prevActiveIndex,
 		setActiveIndex,
 		revealKey,
 		dissolveDir,
+		isTransitioning: transitionPhase !== "idle",
 		contentWidth,
 		cardLayout,
 	};

--- a/apps/website/components/customer-stories/use-pixel-dissolve.ts
+++ b/apps/website/components/customer-stories/use-pixel-dissolve.ts
@@ -1,7 +1,7 @@
 import { type RefObject, useEffect, useRef } from "react";
 
 export const PIXEL_CELL = 4;
-const SWEEP_MS = 520;
+const SWEEP_MS = 500;
 const DEFAULT_FROM = "#0A0A0A";
 const DIRECTION_BIAS = 0.5;
 
@@ -59,8 +59,13 @@ export type PixelDissolveOptions = {
 	width: number;
 	height: number;
 	revealKey: number;
-	// Colour the outgoing cells dissolve away from (defaults to the dark surface).
+	// Colour used by the pixel cells (defaults to the dark surface).
 	fromColor?: string;
+	// Optional colour for the left-hand strip that survives as the compact spine.
+	retainedColor?: string;
+	retainedWidth?: number;
+	// "reveal" removes a solid pixel layer; "cover" builds one over the content.
+	mode?: "reveal" | "cover";
 	// +1 sweeps right→left, -1 left→right.
 	direction?: number;
 	// Decorrelates the noise pattern between surfaces sharing a revealKey.
@@ -69,22 +74,31 @@ export type PixelDissolveOptions = {
 	// continuous sweep across neighbouring canvases instead of restarting locally.
 	trackX?: number;
 	trackWidth?: number;
+	onComplete?: () => void;
 };
 
-// Paints a canvas full of fromColor square cells (the outgoing surface) that
-// dissolve away cell by cell on each revealKey change, uncovering the new slide
-// beneath — so each pixel flips old-colour → new-slide, never through black.
+// Paints or removes square cells one by one. Reveal mode uncovers content below;
+// cover mode lets an outgoing surface disappear into the supplied colour.
 export function usePixelDissolve({
 	width,
 	height,
 	revealKey,
 	fromColor = DEFAULT_FROM,
+	retainedColor,
+	retainedWidth = 0,
+	mode = "reveal",
 	direction = 1,
 	seed,
 	trackX = 0,
 	trackWidth,
+	onComplete,
 }: PixelDissolveOptions): RefObject<HTMLCanvasElement | null> {
 	const canvasRef = useRef<HTMLCanvasElement | null>(null);
+	const onCompleteRef = useRef(onComplete);
+
+	useEffect(() => {
+		onCompleteRef.current = onComplete;
+	}, [onComplete]);
 
 	useEffect(() => {
 		const canvas = canvasRef.current;
@@ -111,23 +125,38 @@ export function usePixelDissolve({
 
 		const paint = (progress: number) => {
 			ctx.clearRect(0, 0, width, height);
-			ctx.fillStyle = fromColor;
-			for (let row = 0; row < rows; row++) {
-				for (let col = 0; col < cols; col++) {
-					if (thresholds[row * cols + col] > progress) {
-						ctx.fillRect(
-							col * PIXEL_CELL,
-							row * PIXEL_CELL,
-							PIXEL_CELL,
-							PIXEL_CELL,
-						);
+			const retainedCols = retainedColor
+				? Math.ceil(Math.min(retainedWidth, width) / PIXEL_CELL)
+				: 0;
+
+			const paintRange = (startCol: number, endCol: number, color: string) => {
+				ctx.fillStyle = color;
+				for (let row = 0; row < rows; row++) {
+					for (let col = startCol; col < endCol; col++) {
+						const threshold = thresholds[row * cols + col];
+						const shouldPaint =
+							mode === "cover" ? threshold <= progress : threshold > progress;
+						if (shouldPaint) {
+							ctx.fillRect(
+								col * PIXEL_CELL,
+								row * PIXEL_CELL,
+								PIXEL_CELL,
+								PIXEL_CELL,
+							);
+						}
 					}
 				}
+			};
+
+			if (retainedCols > 0 && retainedColor) {
+				paintRange(0, retainedCols, retainedColor);
 			}
+			paintRange(retainedCols, cols, fromColor);
 		};
 
 		if (prefersReducedMotion()) {
 			paint(1);
+			onCompleteRef.current?.();
 			return;
 		}
 
@@ -138,7 +167,11 @@ export function usePixelDissolve({
 			if (!start) start = now;
 			const progress = easeOut(Math.min((now - start) / SWEEP_MS, 1));
 			paint(progress);
-			if (progress < 1) raf = requestAnimationFrame(frame);
+			if (progress < 1) {
+				raf = requestAnimationFrame(frame);
+			} else {
+				onCompleteRef.current?.();
+			}
 		};
 		raf = requestAnimationFrame(frame);
 		return () => cancelAnimationFrame(raf);
@@ -147,6 +180,9 @@ export function usePixelDissolve({
 		height,
 		revealKey,
 		fromColor,
+		retainedColor,
+		retainedWidth,
+		mode,
 		direction,
 		seed,
 		trackX,


### PR DESCRIPTION
## Summary

- Scope the pixel dissolve to the outgoing customer story instead of replaying the whole accordion.
- Animate the outgoing collapse and selected-story expansion together with stable card ordering.
- Keep each compact spine mounted as the card's persistent base layer so the panel morphs back into the same object.
- Preserve the final 80px spine in its story colour while the discarded area dissolves into the section background.
- Synchronize the pixel dissolve and card resize at 500ms, lock overlapping clicks, and retain reduced-motion behavior.

## Why

The previous interaction changed the active layout immediately, then ran a coordinated pixel reveal across the active panel and both neighbouring spines. That made the whole customer-stories region appear to replay and created a visible handoff between expanded and compact states.

This change keeps the animation local to the cards involved and preserves spatial continuity throughout the transition.

## Impact

This affects the desktop customer-stories accordion only. The mobile carousel is unchanged.

## Validation

- `bunx biome check` on the four changed customer-story files
- `tsc --noEmit -p apps/website/tsconfig.json`
- `git diff --check`
- `bun run build` in `apps/website`
- Repository commit hook (`knip`)

## Visuals

A screenshot or recording should be attached before this draft is marked ready for review, per the contribution guide.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refines the desktop customer-stories accordion so only the departing story dissolves, while the compact spine persists and the panel resize syncs with the dissolve. Transitions run at 500ms with clicks locked and reduced-motion respected.

- **Refactors**
  - Localized dissolve: outgoing panel dissolves to the section surface; the left 80px spine is retained in the story color via a cover mode.
  - Stable layout and interactions: card order remains stable, spine/icon stay mounted, and clicks are disabled during transitions; desktop only (mobile unchanged).
  - Timing: pixel dissolve and flex expansion are synchronized to 500ms.
  - Implementation details: `use-accordion` tracks a departing index and transition phase; `use-pixel-dissolve` adds `mode`, `retainedColor/Width`, and `onComplete`; introduced `EXPAND_MS`; minor style adjustments for smoother opacity and flex transitions.

<sup>Written for commit df5a28e8d3cc2b1b93259f744f689f36bee85ea0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

