### PR TITLE
Fix entity usage double-counting across add-ons

### DIFF
--- a/server/src/internal/billing/v2/utils/initFullCustomerProduct/applyExisting/applyExistingStatesToCustomerProduct.ts
+++ b/server/src/internal/billing/v2/utils/initFullCustomerProduct/applyExisting/applyExistingStatesToCustomerProduct.ts
@@ -6,11 +6,38 @@ import type {
 	FullCusProduct,
 	FullCustomer,
 } from "@autumn/shared";
+import {
+	cusProductsToCusEnts,
+	filterCustomerProductsByActiveStatuses,
+	isCustomerProductAddOn,
+} from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { applyExistingRollovers } from "@/internal/billing/v2/utils/handleExistingRollovers/applyExistingRollovers";
 import { cusProductToExistingRollovers } from "@/internal/billing/v2/utils/handleExistingRollovers/cusProductToExistingRollovers";
 import { applyExistingUsages } from "@/internal/billing/v2/utils/handleExistingUsages/applyExistingUsages";
 import { cusProductToExistingUsages } from "@/internal/billing/v2/utils/handleExistingUsages/cusProductToExistingUsages";
+
+const getEntitiesForExistingUsage = ({
+	fullCustomer,
+	customerProduct,
+}: {
+	fullCustomer: FullCustomer;
+	customerProduct: FullCusProduct;
+}) => {
+	if (!isCustomerProductAddOn(customerProduct)) return fullCustomer.entities;
+
+	const activeCustomerProducts = filterCustomerProductsByActiveStatuses({
+		customerProducts: fullCustomer.customer_products,
+	});
+	const coveredInternalFeatureIds = new Set(
+		cusProductsToCusEnts({ cusProducts: activeCustomerProducts }).map(
+			(customerEntitlement) => customerEntitlement.internal_feature_id,
+		),
+	);
+	return fullCustomer.entities.filter(
+		(entity) => !coveredInternalFeatureIds.has(entity.internal_feature_id),
+	);
+};
 
 export const applyExistingStatesToCustomerProduct = ({
 	ctx,
@@ -41,7 +68,10 @@ export const applyExistingStatesToCustomerProduct = ({
 		ctx,
 		customerProduct,
 		existingUsages,
-		entities: fullCustomer.entities,
+		entities: getEntitiesForExistingUsage({
+			fullCustomer,
+			customerProduct,
+		}),
 	});
 
 	let existingRollovers: ExistingRollover[] = [];

--- a/server/tests/integration/billing/attach/new-plan/attach-addon-entity-usage.test.ts
+++ b/server/tests/integration/billing/attach/new-plan/attach-addon-entity-usage.test.ts
@@ -1,0 +1,60 @@
+/** Red: one entity counts against both plans. Green: pooled base + add-on capacity counts it once. */
+
+import { test } from "bun:test";
+import type { ApiCustomerV5, AttachParamsV1Input } from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("addon entity usage: existing entity is counted once across base and add-on")}`,
+	async () => {
+		const customerId = "addon-existing-entity-usage";
+		const base = products.base({
+			id: "base",
+			items: [items.freeUsers({ includedUsage: 4 })],
+		});
+		const addon = products.base({
+			id: "extra-users",
+			isAddOn: true,
+			items: [items.prepaidUsers()],
+		});
+
+		const { autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.products({ list: [base, addon] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: base.id,
+			redirect_mode: "if_required",
+		});
+		await autumnV2_3.entities.create(customerId, [
+			{ id: "user-1", name: "User 1", feature_id: TestFeature.Users },
+		]);
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: addon.id,
+			feature_quantities: [{ feature_id: TestFeature.Users, quantity: 2 }],
+			redirect_mode: "if_required",
+		});
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Users,
+			granted: 6,
+			usage: 1,
+			remaining: 5,
+			breakdownCount: 2,
+		});
+	},
+);


### PR DESCRIPTION
## Summary

- Count an existing linked entity once across pooled base and add-on capacity.
- Avoid initializing a new add-on entitlement with entity usage already represented by an active plan.
- Add a regression test covering a grant of 4 plus a quantity-2 add-on with one entity: grant 6, usage 1, remaining 5.

## Testing

- bunx tsgo --build --noEmit (server)
- attach-addon-entity-usage.test.ts (1 pass, 0 failures)
- biome check on changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double-counting of entity usage when attaching add-ons. Existing entities now count once across pooled base and add-on capacity so balances stay accurate.

- **Bug Fixes**
  - On add-on init, filter out entities whose features are already covered by any active product to prevent duplicate usage.
  - Added integration test: base grant 4 + add-on quantity 2 with one entity → grant 6, usage 1, remaining 5.

<sup>Written for commit d0c37b5d0c5fa586a342b69f5e634a1163e42143. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes entity-usage initialization when attaching add-ons:
- **[Bug fixes]** Excludes entity usage already represented by active customer-product entitlements when initializing an add-on.
- **[Improvements]** Adds regression coverage confirming pooled base and add-on capacity counts an existing entity once.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/utils/initFullCustomerProduct/applyExisting/applyExistingStatesToCustomerProduct.ts | Filters entities already covered by active products before applying usage to a newly initialized add-on. |
| server/tests/integration/billing/attach/new-plan/attach-addon-entity-usage.test.ts | Adds integration coverage for one entity shared across base and quantity-based add-on capacity. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Attach as Add-on attach
  participant Init as Entitlement initializer
  participant Existing as Active customer products
  participant Usage as Usage application
  Attach->>Init: Initialize add-on customer product
  Init->>Existing: Collect covered feature IDs
  Existing-->>Init: Features already representing entities
  Init->>Usage: Apply usages with covered entities excluded
  Usage-->>Attach: Pooled balance counts each entity once
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: avoid double-counting entity usage ..."](https://github.com/useautumn/autumn/commit/fc57c8eb7782e33ab354fa374a2de38a41887336) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48696134)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->