### PR TITLE
fix: bound concurrent SQS batch sends

### DIFF
--- a/server/src/queue/SqsBatchAccumulator.ts
+++ b/server/src/queue/SqsBatchAccumulator.ts
@@ -1,6 +1,7 @@
 const DEFAULT_BATCH_WINDOW_MS = 10;
 const DEFAULT_MAX_BATCH_ENTRIES = 10;
 const DEFAULT_MAX_BATCH_BODY_BYTES = 1024 * 1024;
+const DEFAULT_MAX_IN_FLIGHT_SENDS = 10;
 
 export type SqsBatchAccumulatorEntry = {
 	queueUrl: string;
@@ -34,6 +35,7 @@ export class SqsBatchAccumulator<TEntry extends SqsBatchAccumulatorEntry> {
 	private readonly batchWindowMs: number;
 	private readonly maxBatchEntries: number;
 	private readonly maxBatchBodyBytes: number;
+	private readonly maxInFlightSends: number;
 	private readonly sendBatch: SendSqsAccumulatorBatch<TEntry>;
 	private acceptingEntries = true;
 
@@ -41,16 +43,19 @@ export class SqsBatchAccumulator<TEntry extends SqsBatchAccumulatorEntry> {
 		batchWindowMs = DEFAULT_BATCH_WINDOW_MS,
 		maxBatchEntries = DEFAULT_MAX_BATCH_ENTRIES,
 		maxBatchBodyBytes = DEFAULT_MAX_BATCH_BODY_BYTES,
+		maxInFlightSends = DEFAULT_MAX_IN_FLIGHT_SENDS,
 		sendBatch,
 	}: {
 		batchWindowMs?: number;
 		maxBatchEntries?: number;
 		maxBatchBodyBytes?: number;
+		maxInFlightSends?: number;
 		sendBatch: SendSqsAccumulatorBatch<TEntry>;
 	}) {
 		this.batchWindowMs = batchWindowMs;
 		this.maxBatchEntries = maxBatchEntries;
 		this.maxBatchBodyBytes = maxBatchBodyBytes;
+		this.maxInFlightSends = maxInFlightSends;
 		this.sendBatch = sendBatch;
 	}
 
@@ -116,18 +121,32 @@ export class SqsBatchAccumulator<TEntry extends SqsBatchAccumulatorEntry> {
 			this.flushTimer = null;
 		}
 
-		const sendPromise = this.sendEntries({ pendingEntries });
+		if (this.inFlightSends.size >= this.maxInFlightSends) {
+			const saturationError = new Error("SQS batch accumulator is saturated");
+			for (const pendingEntry of pendingEntries) {
+				pendingEntry.reject(saturationError);
+			}
+			return Promise.resolve();
+		}
+
+		let sendPromise: Promise<void> | undefined;
+		let sendSettled = false;
+		const releaseSendSlot = () => {
+			sendSettled = true;
+			if (sendPromise) this.inFlightSends.delete(sendPromise);
+		};
+		sendPromise = this.sendEntries({ pendingEntries, releaseSendSlot });
 		this.inFlightSends.add(sendPromise);
-		void sendPromise.then(() => {
-			this.inFlightSends.delete(sendPromise);
-		});
+		if (sendSettled) this.inFlightSends.delete(sendPromise);
 		return sendPromise;
 	}
 
 	private async sendEntries({
 		pendingEntries,
+		releaseSendSlot,
 	}: {
 		pendingEntries: PendingEntry<TEntry>[];
+		releaseSendSlot: () => void;
 	}): Promise<void> {
 		let failures: Array<{ index: number; reason: string }>;
 		try {
@@ -139,12 +158,14 @@ export class SqsBatchAccumulator<TEntry extends SqsBatchAccumulatorEntry> {
 		} catch (error) {
 			const sendError =
 				error instanceof Error ? error : new Error("Unknown SQS batch error");
+			releaseSendSlot();
 			for (const pendingEntry of pendingEntries) {
 				pendingEntry.reject(sendError);
 			}
 			return;
 		}
 
+		releaseSendSlot();
 		const failureReasons = new Map(
 			failures.map(({ index, reason }) => [index, reason]),
 		);

--- a/server/tests/unit/queue/SqsBatchAccumulator.test.ts
+++ b/server/tests/unit/queue/SqsBatchAccumulator.test.ts
@@ -6,6 +6,8 @@
  *   - the tenth entry flushes immediately and a short window flushes partial batches
  *   - each caller resolves or rejects from its own SQS entry result
  *   - transport failures reject every caller in the affected batch
+ *   - at most 10 batch requests are in flight at once
+ *   - saturated batches reject immediately and capacity returns after sends settle
  *   - shutdown rejects new entries and drains pending plus in-flight sends
  *   - each entry preserves its job body, FIFO identifiers, and delay
  *   - the combined message bodies in one batch never exceed SQS's 1 MiB limit
@@ -40,8 +42,10 @@ const createEntry = ({ index }: { index: number }) => ({
 type TestEntry = ReturnType<typeof createEntry>;
 
 const createBatcher = ({
+	maxBatchEntries,
 	sendBatch,
 }: {
+	maxBatchEntries?: number;
 	sendBatch?: (args: SendSqsAccumulatorBatchArgs<TestEntry>) => Promise<{
 		failures: Array<{ index: number; reason: string }>;
 	}>;
@@ -49,12 +53,11 @@ const createBatcher = ({
 	const calls: SendSqsAccumulatorBatchArgs<TestEntry>[] = [];
 	const batcher = new SqsBatchAccumulator<TestEntry>({
 		batchWindowMs: BATCH_WINDOW_MS,
-		sendBatch:
-			sendBatch ??
-			(async (args) => {
-				calls.push(args);
-				return { failures: [] };
-			}),
+		maxBatchEntries,
+		sendBatch: async (args) => {
+			calls.push(args);
+			return sendBatch ? sendBatch(args) : { failures: [] };
+		},
 	});
 
 	return { batcher, calls };
@@ -158,6 +161,65 @@ describe("SqsBatchAccumulator", () => {
 				reason: expect.objectContaining({ message: "SQS unavailable" }),
 			});
 		}
+	});
+
+	test("rejects batches above the in-flight send limit", async () => {
+		const sendResolvers: Array<
+			(result: { failures: Array<{ index: number; reason: string }> }) => void
+		> = [];
+		const { batcher, calls } = createBatcher({
+			maxBatchEntries: 1,
+			sendBatch: () =>
+				new Promise((resolve) => {
+					sendResolvers.push(resolve);
+				}),
+		});
+
+		const accepted = Array.from({ length: 10 }, (_, index) =>
+			batcher.enqueue(createEntry({ index })),
+		);
+		const saturated = batcher.enqueue(createEntry({ index: 10 }));
+
+		expect(calls).toHaveLength(10);
+		await expect(saturated).rejects.toThrow(
+			"SQS batch accumulator is saturated",
+		);
+
+		for (const resolveSend of sendResolvers) {
+			resolveSend({ failures: [] });
+		}
+		await Promise.all(accepted);
+	});
+
+	test("accepts another batch after an in-flight send settles", async () => {
+		const sendResolvers: Array<
+			(result: { failures: Array<{ index: number; reason: string }> }) => void
+		> = [];
+		const { batcher, calls } = createBatcher({
+			maxBatchEntries: 1,
+			sendBatch: () =>
+				new Promise((resolve) => {
+					sendResolvers.push(resolve);
+				}),
+		});
+
+		const accepted = Array.from({ length: 10 }, (_, index) =>
+			batcher.enqueue(createEntry({ index })),
+		);
+		await expect(batcher.enqueue(createEntry({ index: 10 }))).rejects.toThrow(
+			"SQS batch accumulator is saturated",
+		);
+
+		sendResolvers[0]?.({ failures: [] });
+		await accepted[0];
+
+		const afterRecovery = batcher.enqueue(createEntry({ index: 11 }));
+		expect(calls).toHaveLength(11);
+
+		for (const resolveSend of sendResolvers.slice(1)) {
+			resolveSend({ failures: [] });
+		}
+		await Promise.all([...accepted.slice(1), afterRecovery]);
 	});
 
 	test("shutdown drains pending and in-flight sends before resolving", async () => {


### PR DESCRIPTION
## Summary

- cap each `SqsBatchAccumulator` at 10 concurrent SQS batch requests
- reject saturated batches immediately instead of retaining an unbounded backlog
- release send capacity before resolving callers so recovery is immediately observable
- add regression coverage for saturation and capacity recovery

## Why

The accumulator tracked active sends in an unbounded set. If SQS latency increased while enqueue traffic continued, unresolved batches retained their payloads and caller promises indefinitely, amplifying memory pressure during broader infrastructure degradation.

Failing fast after 10 active sends keeps memory bounded and preserves delivery semantics: the caller is not acknowledged before SQS acceptance and can return an error for retry.

## Validation

- `bun ts`
- `CI=1 bun test tests/unit/queue` — 33 passed
- `CI=1 bun test tests/unit/balances/track` — 84 passed
- `CI=1 bun test tests/unit/balances/updateBalance` — 6 passed
- `CI=1 bun test tests/unit/customers/recovery` — 11 passed
- `bunx biome check server/src/queue/SqsBatchAccumulator.ts server/tests/unit/queue/SqsBatchAccumulator.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap concurrent SQS batch sends at 10 per accumulator, fail fast when saturated, and free send slots before resolving callers to improve recovery during latency spikes. This bounds memory and keeps retry semantics intact.

- **Bug Fixes**
  - Added `maxInFlightSends` (default 10) to limit concurrent batch sends; new batches reject with “SQS batch accumulator is saturated” when full.
  - Release send capacity before resolving callers so new batches can proceed as soon as a send settles.
  - Added tests for saturation, capacity recovery, and shutdown behavior.

<sup>Written for commit 95cb7a82ec97755d80e936bff517437337cd077b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Bounds concurrent SQS sends and adds saturation recovery coverage.
- **[Bug fixes]** Caps each `SqsBatchAccumulator` at ten concurrent SQS batch requests and rejects newly flushed batches while saturated.
- **[Improvements]** Releases capacity as soon as a send settles so subsequent batches can proceed immediately.
- **[Improvements]** Adds regression tests for saturation, capacity recovery, and shutdown draining.
</details>

<h3>Confidence Score: 4/5</h3>

The saturation behavior needs recovery handling before merge because existing production callers can permanently lose queued work when the new limit is reached.

The accumulator now rejects an eleventh concurrent batch, while callers such as EventBatchingManager clear their local work before enqueueing and do not restore it after rejection; other workflow and synchronization paths similarly swallow the failure without durable retry.

**Files Needing Attention:** server/src/queue/SqsBatchAccumulator.ts and saturation-sensitive queue callers such as EventBatchingManager.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/queue/SqsBatchAccumulator.ts | Adds the send-concurrency cap and early slot release, but saturation rejection can discard work in existing non-retrying callers. |
| server/tests/unit/queue/SqsBatchAccumulator.test.ts | Adds focused coverage for the concurrency limit and capacity recovery, though it does not cover production callers that must recover rejected work. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  E[Enqueue entries] --> B[Build or flush batch]
  B --> C{Fewer than 10 sends active?}
  C -->|Yes| S[Send batch to SQS]
  S --> R[Release send slot]
  R --> P[Resolve or reject entry callers]
  C -->|No| X[Reject batch as saturated]
  X --> L[Caller must retain or retry work]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/queue/SqsBatchAccumulator.ts:124-129
**Saturation permanently drops queued work**

When ten batch sends remain unresolved, this branch rejects the next batch after callers have already removed work from local state; production paths such as `EventBatchingManager` do not restore or durably retry that work, causing events, workflows, or balance synchronization jobs to be permanently dropped.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: bound concurrent SQS batch sends"](https://github.com/useautumn/autumn/commit/95cb7a82ec97755d80e936bff517437337cd077b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48734827)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->