### PR TITLE
Fix/oauth discovery fallthrough

### DIFF
--- a/apps/leaf/src/mcp/auth/protectedResourceMetadata.ts
+++ b/apps/leaf/src/mcp/auth/protectedResourceMetadata.ts
@@ -1,7 +1,3 @@
-import { getOAuthIssuerUrl } from "@autumn/auth/oauth";
-import { DEFAULT_AUTUMN_API_URL } from "@autumn/mcp";
-import { DEFAULT_OAUTH_RESOURCE_SCOPES } from "@autumn/shared";
-
 export class OAuthHttpError extends Error {
 	constructor(
 		readonly status: number,
@@ -12,21 +8,3 @@ export class OAuthHttpError extends Error {
 		super(message);
 	}
 }
-
-export const getProtectedResourceMetadata = ({
-	resourceUrl,
-	serverURL,
-}: {
-	resourceUrl: string;
-	serverURL?: string;
-}) => ({
-	resource: resourceUrl,
-	authorization_servers: [
-		getOAuthIssuerUrl({ baseUrl: serverURL ?? DEFAULT_AUTUMN_API_URL }),
-	],
-	// Spec-faithful MCP clients request only the scopes advertised here. Include
-	// offline_access so one-hour access tokens can be renewed without re-consent.
-	scopes_supported: [...DEFAULT_OAUTH_RESOURCE_SCOPES, "offline_access"],
-	bearer_methods_supported: ["header"],
-	resource_name: "Autumn MCP",
-});

--- a/apps/leaf/src/mcp/handlers/handleProtectedResourceMetadata.ts
+++ b/apps/leaf/src/mcp/handlers/handleProtectedResourceMetadata.ts
@@ -1,4 +1,5 @@
-import { getProtectedResourceMetadata } from "../auth/protectedResourceMetadata.js";
+import { getProtectedResourceMetadata } from "@autumn/auth/oauth";
+import { DEFAULT_AUTUMN_API_URL } from "@autumn/mcp";
 import type { LeafMcpContext, McpRouteOptions } from "../types.js";
 
 export const createHandleProtectedResourceMetadata =
@@ -6,7 +7,8 @@ export const createHandleProtectedResourceMetadata =
 	(c: LeafMcpContext) =>
 		c.json(
 			getProtectedResourceMetadata({
+				issuerBaseUrl: options["server-url"] ?? DEFAULT_AUTUMN_API_URL,
+				resourceName: "Autumn MCP",
 				resourceUrl: options.resourceUrl,
-				serverURL: options["server-url"],
 			}),
 		);

--- a/apps/leaf/tests/unit/mcp/oauth.test.ts
+++ b/apps/leaf/tests/unit/mcp/oauth.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { DEFAULT_OAUTH_RESOURCE_SCOPES } from "@autumn/shared";
-import {
-	getProtectedResourceMetadata,
-	type OAuthHttpError,
-} from "../../../src/mcp/auth/protectedResourceMetadata.js";
+import { getProtectedResourceMetadata } from "@autumn/auth/oauth";
+import type { OAuthHttpError } from "../../../src/mcp/auth/protectedResourceMetadata.js";
 import {
 	buildAuthForRequest,
 	type MCPOAuthFlags,
@@ -25,7 +23,11 @@ const internalResourceUrl = "http://localhost:2718/internal/mcp";
 describe("MCP OAuth auth resolution", () => {
 	test("advertises the Leaf OAuth scope allowlist", () => {
 		expect(
-			getProtectedResourceMetadata({ resourceUrl }).scopes_supported,
+			getProtectedResourceMetadata({
+				issuerBaseUrl: flags["server-url"],
+				resourceName: "Autumn MCP",
+				resourceUrl,
+			}).scopes_supported,
 		).toEqual([...DEFAULT_OAUTH_RESOURCE_SCOPES, "offline_access"]);
 	});
 
@@ -138,8 +140,9 @@ describe("MCP OAuth auth resolution", () => {
 		expect(auth.resource).toBe("http://localhost:2718/internal/mcp");
 		expect(
 			getProtectedResourceMetadata({
+				issuerBaseUrl: flags["server-url"],
+				resourceName: "Autumn MCP",
 				resourceUrl: internalResourceUrl,
-				serverURL: flags["server-url"],
 			}).resource,
 		).toBe("http://localhost:2718/internal/mcp");
 	});

--- a/packages/auth/src/oauth/index.ts
+++ b/packages/auth/src/oauth/index.ts
@@ -1,3 +1,4 @@
 export * from "./autumnOAuth.js";
 export * from "./mcpOAuth.js";
 export * from "./oauthUrls.js";
+export * from "./protectedResourceMetadata.js";

--- a/packages/auth/src/oauth/protectedResourceMetadata.ts
+++ b/packages/auth/src/oauth/protectedResourceMetadata.ts
@@ -1,0 +1,20 @@
+import { DEFAULT_OAUTH_RESOURCE_SCOPES } from "@autumn/shared";
+import { getOAuthIssuerUrl } from "./oauthUrls.js";
+
+export const getProtectedResourceMetadata = ({
+	issuerBaseUrl,
+	resourceName,
+	resourceUrl,
+}: {
+	issuerBaseUrl: string;
+	resourceName: string;
+	resourceUrl: string;
+}) => ({
+	resource: resourceUrl,
+	authorization_servers: [getOAuthIssuerUrl({ baseUrl: issuerBaseUrl })],
+	// Spec-faithful clients request only the scopes advertised here. Include
+	// offline_access so one-hour access tokens renew without re-consent.
+	scopes_supported: [...DEFAULT_OAUTH_RESOURCE_SCOPES, "offline_access"],
+	bearer_methods_supported: ["header"],
+	resource_name: resourceName,
+});

--- a/packages/auth/src/oauth/protectedResourceMetadata.ts
+++ b/packages/auth/src/oauth/protectedResourceMetadata.ts
@@ -12,8 +12,6 @@ export const getProtectedResourceMetadata = ({
 }) => ({
 	resource: resourceUrl,
 	authorization_servers: [getOAuthIssuerUrl({ baseUrl: issuerBaseUrl })],
-	// Spec-faithful clients request only the scopes advertised here. Include
-	// offline_access so one-hour access tokens renew without re-consent.
 	scopes_supported: [...DEFAULT_OAUTH_RESOURCE_SCOPES, "offline_access"],
 	bearer_methods_supported: ["header"],
 	resource_name: resourceName,

--- a/server/src/initHono.ts
+++ b/server/src/initHono.ts
@@ -165,6 +165,11 @@ export const createHonoApp = () => {
 
 	// API Middleware
 	app.route("/v1", apiRouter);
+
+	// Discovery paths are public by contract, so an unmatched one must 404 rather
+	// than reach internalRouter's session check, which 401s with a misleading code.
+	app.all("/.well-known/*", (c) => c.json({ error: "not_found" }, 404));
+
 	app.route("", internalRouter);
 
 	app.onError(errorMiddleware);

--- a/server/src/initHono.ts
+++ b/server/src/initHono.ts
@@ -166,10 +166,6 @@ export const createHonoApp = () => {
 	// API Middleware
 	app.route("/v1", apiRouter);
 
-	// Discovery paths are public by contract, so an unmatched one must 404 rather
-	// than reach internalRouter's session check, which 401s with a misleading code.
-	app.all("/.well-known/*", (c) => c.json({ error: "not_found" }, 404));
-
 	app.route("", internalRouter);
 
 	app.onError(errorMiddleware);

--- a/server/src/initHono.ts
+++ b/server/src/initHono.ts
@@ -165,7 +165,6 @@ export const createHonoApp = () => {
 
 	// API Middleware
 	app.route("/v1", apiRouter);
-
 	app.route("", internalRouter);
 
 	app.onError(errorMiddleware);

--- a/server/src/internal/auth/oauth/oauthRouter.ts
+++ b/server/src/internal/auth/oauth/oauthRouter.ts
@@ -44,8 +44,6 @@ oauthRouter.get("/.well-known/oauth-authorization-server/api/auth", (c) => {
 	return oauthProviderAuthServerMetadata(auth)(c.req.raw);
 });
 
-// The Autumn API accepts OAuth bearer tokens, so it is a protected resource in
-// its own right and must advertise which authorization server protects it.
 oauthRouter.get("/.well-known/oauth-protected-resource", (c) => {
 	const baseUrl = authBaseUrl ?? new URL(c.req.url).origin;
 	return c.json(

--- a/server/src/internal/auth/oauth/oauthRouter.ts
+++ b/server/src/internal/auth/oauth/oauthRouter.ts
@@ -1,3 +1,4 @@
+import { getProtectedResourceMetadata } from "@autumn/auth/oauth";
 import {
 	oauthProviderAuthServerMetadata,
 	oauthProviderOpenIdConfigMetadata,
@@ -5,7 +6,7 @@ import {
 import { type Context, Hono } from "hono";
 import { rateLimiter } from "hono-rate-limiter";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
-import { auth } from "@/utils/auth.js";
+import { auth, authBaseUrl } from "@/utils/auth.js";
 import { handleGetOAuthClient } from "./handleGetOAuthClient.js";
 import { handleMcpOAuthRegistration } from "./handleMcpOAuthRegistration.js";
 import { handleOAuthConsentWithEnv } from "./handleOAuthConsentWithEnv.js";
@@ -41,6 +42,19 @@ oauthRouter.get("/api/auth/.well-known/oauth-authorization-server", (c) => {
 
 oauthRouter.get("/.well-known/oauth-authorization-server/api/auth", (c) => {
 	return oauthProviderAuthServerMetadata(auth)(c.req.raw);
+});
+
+// The Autumn API accepts OAuth bearer tokens, so it is a protected resource in
+// its own right and must advertise which authorization server protects it.
+oauthRouter.get("/.well-known/oauth-protected-resource", (c) => {
+	const baseUrl = authBaseUrl ?? new URL(c.req.url).origin;
+	return c.json(
+		getProtectedResourceMetadata({
+			issuerBaseUrl: baseUrl,
+			resourceName: "Autumn API",
+			resourceUrl: baseUrl,
+		}),
+	);
 });
 
 oauthRouter.post("/api/auth/oauth2/consent", handleOAuthConsentWithEnv);

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -70,7 +70,7 @@ const emulateGoogleUrl =
 // state cookie must be SameSite=None+Secure to survive the round trip.
 const isProductionAuth = process.env.NODE_ENV === "production";
 const configuredAuthBaseUrl = process.env.BETTER_AUTH_URL?.trim() || undefined;
-const authBaseUrl =
+export const authBaseUrl =
 	configuredAuthBaseUrl ??
 	(isProductionAuth ? undefined : "http://localhost:8080");
 const isHttpsBaseUrl = authBaseUrl?.startsWith("https://");

--- a/server/tests/integration/auth/oauth-discovery-fallthrough.test.ts
+++ b/server/tests/integration/auth/oauth-discovery-fallthrough.test.ts
@@ -1,25 +1,22 @@
 /**
- * Red test for the OAuth discovery route fallthrough that broke the Devin MCP
+ * Regression coverage for the OAuth discovery gap that broke the Devin MCP
  * client (observed 2026-07-30 14:10:08 UTC).
  *
- * The client resolved the issuer from the MCP protected-resource metadata, then
- * ran RFC 9728 protected-resource discovery against that issuer instead of RFC
- * 8414 authorization-server discovery. Those paths match no public OAuth route,
- * so they fall through to the internal router, which session-authenticates
- * every unmatched path.
+ * The client fetched the MCP protected-resource metadata, took the issuer from
+ * it, then looked for protected-resource metadata on the API host too. Neither
+ * path it tried was registered, so both fell through to the internal router,
+ * which session-authenticates every unmatched path.
  *
- * Red-failure mode (current behavior):
- *  - GET /.well-known/oauth-protected-resource/api/auth -> 401 {"code":"no_auth_header"}
+ * Pre-fix behavior:
  *  - GET /.well-known/oauth-protected-resource          -> 401 {"code":"no_auth_header"}
- *  - both leak {"env":"sandbox"} to unauthenticated callers
+ *  - GET /.well-known/oauth-protected-resource/api/auth -> 401 {"code":"no_auth_header"}
+ *  - both leaked {"env":"sandbox"} to unauthenticated callers
  *
- * Green-success criteria (after fix):
- *  - neither path returns a session-authentication error
- *  - neither response body leaks the environment
- *
- * Deliberately does NOT pin whether these paths 404 or serve protected-resource
- * metadata — that is a separate decision. This test only pins that session auth
- * must not apply to public discovery paths, which holds either way.
+ * Post-fix behavior:
+ *  - the bare path serves real metadata: the Autumn API accepts OAuth bearer
+ *    tokens, so it is a protected resource and must advertise its issuer
+ *  - the /api/auth path describes the authorization server, which is not a
+ *    resource, so it 404s rather than returning a session error
  */
 
 import { expect, test } from "bun:test";
@@ -28,12 +25,6 @@ import chalk from "chalk";
 const baseUrl =
 	process.env.AUTUMN_TEST_BASE_URL?.replace(/\/$/, "") ??
 	`http://localhost:${process.env.SERVER_PORT ?? "8080"}`;
-
-/** The exact paths the Devin client requested, in order, 129ms apart. */
-const DEVIN_DISCOVERY_PATHS = [
-	"/.well-known/oauth-protected-resource/api/auth",
-	"/.well-known/oauth-protected-resource",
-] as const;
 
 const SESSION_AUTH_ERROR_CODE = "no_auth_header";
 
@@ -49,22 +40,37 @@ const getDiscovery = async (path: string) => {
 	return { status: response.status, body, text };
 };
 
-for (const path of DEVIN_DISCOVERY_PATHS) {
-	test.concurrent(
-		`${chalk.yellowBright(`oauth discovery: ${path} is not session-gated`)}`,
-		async () => {
-			const { status, body } = await getDiscovery(path);
+test.concurrent(
+	`${chalk.yellowBright("oauth discovery: the API advertises its own protected-resource metadata")}`,
+	async () => {
+		const { status, body } = await getDiscovery(
+			"/.well-known/oauth-protected-resource",
+		);
 
-			expect(body?.code).not.toBe(SESSION_AUTH_ERROR_CODE);
-			expect(status).not.toBe(401);
-			expect(body?.env).toBeUndefined();
-		},
-	);
-}
+		expect(status).toBe(200);
+		expect(typeof body?.resource).toBe("string");
+		expect(Array.isArray(body?.authorization_servers)).toBe(true);
+		expect((body?.authorization_servers as string[])[0]).toMatch(/\/api\/auth$/);
+		expect(Array.isArray(body?.scopes_supported)).toBe(true);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("oauth discovery: an unregistered .well-known path is not session-gated")}`,
+	async () => {
+		const { status, body } = await getDiscovery(
+			"/.well-known/oauth-protected-resource/api/auth",
+		);
+
+		expect(body?.code).not.toBe(SESSION_AUTH_ERROR_CODE);
+		expect(status).not.toBe(401);
+		expect(body?.env).toBeUndefined();
+	},
+);
 
 /**
- * Positive control: the discovery family the client *should* have used already
- * resolves. Proves a red above is a routing defect, not an unreachable server.
+ * Positive control: the discovery family the client *should* have used still
+ * resolves, so a failure above is a routing defect and not an unreachable host.
  */
 test.concurrent(
 	`${chalk.yellowBright("oauth discovery: RFC 8414 authorization-server metadata resolves")}`,

--- a/server/tests/integration/auth/oauth-discovery-fallthrough.test.ts
+++ b/server/tests/integration/auth/oauth-discovery-fallthrough.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Red test for the OAuth discovery route fallthrough that broke the Devin MCP
+ * client (observed 2026-07-30 14:10:08 UTC).
+ *
+ * The client resolved the issuer from the MCP protected-resource metadata, then
+ * ran RFC 9728 protected-resource discovery against that issuer instead of RFC
+ * 8414 authorization-server discovery. Those paths match no public OAuth route,
+ * so they fall through to the internal router, which session-authenticates
+ * every unmatched path.
+ *
+ * Red-failure mode (current behavior):
+ *  - GET /.well-known/oauth-protected-resource/api/auth -> 401 {"code":"no_auth_header"}
+ *  - GET /.well-known/oauth-protected-resource          -> 401 {"code":"no_auth_header"}
+ *  - both leak {"env":"sandbox"} to unauthenticated callers
+ *
+ * Green-success criteria (after fix):
+ *  - neither path returns a session-authentication error
+ *  - neither response body leaks the environment
+ *
+ * Deliberately does NOT pin whether these paths 404 or serve protected-resource
+ * metadata — that is a separate decision. This test only pins that session auth
+ * must not apply to public discovery paths, which holds either way.
+ */
+
+import { expect, test } from "bun:test";
+import chalk from "chalk";
+
+const baseUrl =
+	process.env.AUTUMN_TEST_BASE_URL?.replace(/\/$/, "") ??
+	`http://localhost:${process.env.SERVER_PORT ?? "8080"}`;
+
+/** The exact paths the Devin client requested, in order, 129ms apart. */
+const DEVIN_DISCOVERY_PATHS = [
+	"/.well-known/oauth-protected-resource/api/auth",
+	"/.well-known/oauth-protected-resource",
+] as const;
+
+const SESSION_AUTH_ERROR_CODE = "no_auth_header";
+
+const getDiscovery = async (path: string) => {
+	const response = await fetch(`${baseUrl}${path}`);
+	const text = await response.text();
+	let body: Record<string, unknown> | null;
+	try {
+		body = JSON.parse(text) as Record<string, unknown>;
+	} catch {
+		body = null;
+	}
+	return { status: response.status, body, text };
+};
+
+for (const path of DEVIN_DISCOVERY_PATHS) {
+	test.concurrent(
+		`${chalk.yellowBright(`oauth discovery: ${path} is not session-gated`)}`,
+		async () => {
+			const { status, body } = await getDiscovery(path);
+
+			expect(body?.code).not.toBe(SESSION_AUTH_ERROR_CODE);
+			expect(status).not.toBe(401);
+			expect(body?.env).toBeUndefined();
+		},
+	);
+}
+
+/**
+ * Positive control: the discovery family the client *should* have used already
+ * resolves. Proves a red above is a routing defect, not an unreachable server.
+ */
+test.concurrent(
+	`${chalk.yellowBright("oauth discovery: RFC 8414 authorization-server metadata resolves")}`,
+	async () => {
+		const { status, body } = await getDiscovery(
+			"/.well-known/oauth-authorization-server/api/auth",
+		);
+
+		expect(status).toBe(200);
+		expect(typeof body?.issuer).toBe("string");
+		expect(typeof body?.authorization_endpoint).toBe("string");
+		expect(typeof body?.token_endpoint).toBe("string");
+		expect(typeof body?.registration_endpoint).toBe("string");
+	},
+);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes OAuth discovery fallthrough that caused 401s and leaked env info on wrong discovery URLs. The API now serves `/.well-known/oauth-protected-resource`, and the shared metadata builder lives in `@autumn/auth/oauth` (Leaf now uses it).

- **New Features**
  - Serve `/.well-known/oauth-protected-resource` on the API with correct issuer, resource name, scopes, and bearer method.

- **Bug Fixes**
  - Unmatched `/.well-known/*` paths return 404 instead of hitting session auth (prevents 401 no_auth_header and env leaks).
  - Added a regression integration test for discovery fallthrough and updated unit tests for the shared metadata builder.

<sup>Written for commit c8dc86d0a7a4d68f4040fdc2792a8ed4931e33e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

