### PR TITLE
fix(auth): handle narrowed MCP refresh scopes

### DIFF
--- a/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
+++ b/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
@@ -116,17 +116,16 @@ const jsonTokenResponse = ({
 		headers: tokenResponseHeaders(response),
 	});
 
-const getRefreshTokenConsentId = async (request: Request) => {
+const getRefreshTokenRecord = async (request: Request) => {
 	const refreshToken = await getRefreshTokenForConsentLookup(request);
 	if (!refreshToken) return null;
 
 	const hashedToken = await hashOAuthToken(refreshToken);
 	const tokenValues = [...new Set([hashedToken, refreshToken])];
-	const tokenRecord = await oauthRefreshTokenRepo.getByTokenValues({
+	return oauthRefreshTokenRepo.getByTokenValues({
 		db,
 		tokenValues,
 	});
-	return tokenRecord?.oauthConsentId ?? null;
 };
 
 const getUniqueOAuthConsentId = async ({
@@ -171,12 +170,27 @@ const allowsScopeLessOAuthToken = async ({
 	return isUnrestrictedChatOAuthConsentMetadata(metadata);
 };
 
-// better-auth issues a stateless JWT access token whenever a `resource`
-// (audience) is present, which never lands in oauth_access_token and so can't
-// be validated by handleOAuthMiddleware or linked to a consent. Drop `resource`
-// before better-auth sees it to force an opaque, persisted token; we keep the
-// original `resource` (read above) for our own MCP/audience handling.
-const stripResourceParam = async (request: Request): Promise<Request> => {
+// Resource tokens are JWTs this handler cannot link to consent.
+// MCP refreshes may only re-request scopes from the original grant.
+const constrainScope = ({
+	scope,
+	grantedScopes,
+}: {
+	scope: string;
+	grantedScopes: string[];
+}) => {
+	const granted = new Set(grantedScopes);
+	const constrained = scope.split(/\s+/).filter((value) => granted.has(value));
+	return constrained.length > 0 ? constrained.join(" ") : scope;
+};
+
+const normalizeTokenRequest = async ({
+	request,
+	grantedScopes,
+}: {
+	request: Request;
+	grantedScopes?: string[];
+}): Promise<Request> => {
 	const contentType = request.headers.get("content-type") ?? "";
 	const rawBody = await request.text();
 	if (!rawBody) return request;
@@ -185,6 +199,9 @@ const stripResourceParam = async (request: Request): Promise<Request> => {
 		try {
 			const body = JSON.parse(rawBody) as Record<string, unknown>;
 			delete body.resource;
+			if (grantedScopes && typeof body.scope === "string") {
+				body.scope = constrainScope({ scope: body.scope, grantedScopes });
+			}
 			return new Request(request, { body: JSON.stringify(body) });
 		} catch {
 			return new Request(request, { body: rawBody });
@@ -193,16 +210,30 @@ const stripResourceParam = async (request: Request): Promise<Request> => {
 
 	const params = new URLSearchParams(rawBody);
 	params.delete("resource");
+	const scope = params.get("scope");
+	if (grantedScopes && scope) {
+		params.set("scope", constrainScope({ scope, grantedScopes }));
+	}
 	return new Request(request, { body: params });
 };
 
 export const handleOAuthTokenWithApiKey = async (c: Context) => {
 	const resource = await getResourceFromOAuthTokenRequest(c.req.raw.clone());
-	const refreshTokenConsentId = await getRefreshTokenConsentId(
-		c.req.raw.clone(),
-	);
+	const refreshTokenRecord = await getRefreshTokenRecord(c.req.raw.clone());
+	const refreshScopes =
+		refreshTokenRecord &&
+		(await isMcpOAuthClient({
+			clientId: refreshTokenRecord.clientId,
+			db,
+			resource: resource ?? undefined,
+		}))
+			? refreshTokenRecord.scopes
+			: undefined;
 	const response = await auth.handler(
-		await stripResourceParam(c.req.raw.clone()),
+		await normalizeTokenRequest({
+			request: c.req.raw.clone(),
+			grantedScopes: refreshScopes,
+		}),
 	);
 	if (!response.ok) return response;
 
@@ -231,7 +262,7 @@ export const handleOAuthTokenWithApiKey = async (c: Context) => {
 		});
 		const oauthConsentId =
 			tokenRecord.oauthConsentId ??
-			refreshTokenConsentId ??
+			refreshTokenRecord?.oauthConsentId ??
 			(await getUniqueOAuthConsentId({
 				clientId: tokenRecord.clientId,
 				referenceId: tokenRecord.referenceId,

--- a/server/tests/integration/auth/mcp-oauth-refresh-scopes.test.ts
+++ b/server/tests/integration/auth/mcp-oauth-refresh-scopes.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "bun:test";
+import { getDefaultOAuthScopes, MCP_CLIENT_KIND } from "@autumn/auth/oauth";
+import {
+	AppEnv,
+	DEFAULT_OAUTH_RESOURCE_SCOPES,
+	oauthClient,
+	oauthConsent,
+	oauthRefreshToken,
+	Scopes,
+} from "@autumn/shared";
+import defaultCtx from "@tests/utils/testInitUtils/createTestContext.js";
+import { createDashboardSession } from "@tests/utils/testInitUtils/dashboardSession.js";
+import { OAuth2Client } from "arctic";
+import { eq } from "drizzle-orm";
+import { initDrizzle } from "@/db/initDrizzle.js";
+import { generateId } from "@/utils/genUtils.js";
+import { hashOAuthToken } from "@/utils/oauthUtils.js";
+
+const { db } = initDrizzle();
+const baseUrl =
+	process.env.AUTUMN_TEST_BASE_URL?.replace(/\/$/, "") ??
+	`http://localhost:${process.env.SERVER_PORT ?? "8080"}`;
+
+test("MCP OAuth refresh accepts Arctic's advertised scope set after consent narrowing", async () => {
+	const session = await createDashboardSession(defaultCtx);
+	const clientId = generateId("oauth_client");
+	const consentId = generateId("oauth_consent");
+	const refreshToken = "r".repeat(32);
+	const grantedScopes = getDefaultOAuthScopes([
+		Scopes.Organisation.Read,
+		"offline_access",
+	]);
+
+	try {
+		await db.insert(oauthClient).values({
+			id: generateId("oauth_client"),
+			clientId,
+			name: "Devin",
+			redirectUris: ["http://127.0.0.1/callback"],
+			scopes: [...DEFAULT_OAUTH_RESOURCE_SCOPES, "offline_access"],
+			tokenEndpointAuthMethod: "none",
+			grantTypes: ["authorization_code", "refresh_token"],
+			responseTypes: ["code"],
+			public: true,
+			type: "native",
+			metadata: { kind: MCP_CLIENT_KIND, mcpClientType: "dynamic" },
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		});
+		await db.insert(oauthConsent).values({
+			id: consentId,
+			clientId,
+			userId: session.userId,
+			referenceId: defaultCtx.org.id,
+			scopes: grantedScopes,
+			env: AppEnv.Sandbox,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		});
+		await db.insert(oauthRefreshToken).values({
+			id: generateId("oauth_refresh"),
+			token: await hashOAuthToken(refreshToken),
+			clientId,
+			userId: session.userId,
+			referenceId: defaultCtx.org.id,
+			oauthConsentId: consentId,
+			expiresAt: new Date(Date.now() + 60_000),
+			createdAt: new Date(),
+			scopes: grantedScopes,
+		});
+
+		const tokens = await new OAuth2Client(
+			clientId,
+			null,
+			null,
+		).refreshAccessToken(`${baseUrl}/api/auth/oauth2/token`, refreshToken, [
+			...DEFAULT_OAUTH_RESOURCE_SCOPES,
+			"offline_access",
+		]);
+
+		expect(tokens.accessToken()).toStartWith("am_oauth_");
+		expect(tokens.scopes()).toEqual(grantedScopes);
+
+		const organization = await fetch(`${baseUrl}/v1/organization`, {
+			headers: {
+				Authorization: `Bearer ${tokens.accessToken()}`,
+				"x-autumn-oauth-resource": "https://mcp.useautumn.com/mcp",
+			},
+		});
+		expect(organization.status).toBe(200);
+	} finally {
+		await db.delete(oauthClient).where(eq(oauthClient.clientId, clientId));
+		await session.cleanup();
+	}
+});


### PR DESCRIPTION
## Summary
- constrain MCP refresh requests to scopes granted on the refresh token
- route Better Auth token failures through the existing request logger
- add an Arctic regression test covering narrowed consent and authenticated API access

## Test plan
- `bunx tsgo --build --noEmit`
- `AUTUMN_TEST_BASE_URL=http://localhost:8081 ./run.sh server/tests/integration/auth/mcp-oauth-refresh-scopes.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Constrain MCP OAuth refreshes to the scopes on the refresh token and normalize token requests to keep access tokens opaque. Fixes refreshes when `arctic` advertises full scopes after consent narrowing and keeps authenticated API access working.

- **Bug Fixes**
  - Restrict MCP refresh scopes to those granted on the refresh token; clamp incoming `scope` even if `arctic` advertises full scopes.
  - Normalize token requests by removing `resource` and constraining `scope` so tokens stay opaque and consent-linked; fall back to the refresh token’s consent when needed.
  - Route `better-auth` token failures through the existing request logger; add an integration test for narrowed consent refresh and `/v1/organization` access.

<sup>Written for commit 407c402fc3d43a44b1c8384f3f2b076d296f75f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

