### PR TITLE
feat: extract shed503 Redis fallback from load-test branch

### DIFF
--- a/server/src/db/shed503OnTransientError.ts
+++ b/server/src/db/shed503OnTransientError.ts
@@ -8,20 +8,45 @@ export const shed503OnTransientError = async <T>({
 	source,
 	run,
 	onTransientError,
+	fallbackOnRedisUnavailable,
 }: {
 	ctx: AutumnContext;
 	source: string;
 	run: () => T | Promise<T>;
 	onTransientError?: (error: unknown) => Promise<void>;
+	/** Opt-in Postgres path for cache-only failures. Callers that omit it keep
+	 *  the shed-everything behaviour. */
+	fallbackOnRedisUnavailable?: (error: unknown) => T | Promise<T>;
 }): Promise<T> => {
 	try {
 		return await run();
 	} catch (error) {
-		if (!(isTransientDbError({ error }) || isTransientRedisError({ error }))) {
+		const isDbTransient = isTransientDbError({ error });
+		const isRedisTransient = isTransientRedisError({ error });
+
+		if (!(isDbTransient || isRedisTransient)) {
 			throw error;
 		}
-		ctx.logger.warn(`[${source}] transient DB error, shedding with 503`, {
-			type: `${source}_fail_open`,
+
+		// Only when Postgres is uninvolved — it is what the fallback reads from,
+		// so a struggling DB must shed rather than take more load.
+		if (isRedisTransient && !isDbTransient && fallbackOnRedisUnavailable) {
+			try {
+				ctx.logger.warn(`[${source}] redis unavailable, reading postgres`, {
+					type: `${source}_redis_fallback`,
+					error,
+				});
+				return await fallbackOnRedisUnavailable(error);
+			} catch (fallbackError) {
+				ctx.logger.error(`[${source}] postgres fallback failed, shedding`, {
+					type: `${source}_redis_fallback_failed`,
+					error: fallbackError,
+				});
+			}
+		}
+
+		ctx.logger.warn(`[${source}] transient error, shedding with 503`, {
+			type: `${source}_shed`,
 			error,
 		});
 		try {
@@ -36,7 +61,9 @@ export const shed503OnTransientError = async <T>({
 			message: "Service is temporarily unavailable, please retry shortly.",
 			code: "service_unavailable",
 			statusCode: 503,
-			data: { reason: "critical_db_saturated" },
+			data: {
+				reason: isDbTransient ? "critical_db_saturated" : "cache_unavailable",
+			},
 		});
 	}
 };

--- a/server/src/internal/customers/actions/getApiCustomerByRollout.ts
+++ b/server/src/internal/customers/actions/getApiCustomerByRollout.ts
@@ -1,6 +1,7 @@
 import { shed503OnTransientError } from "@/db/shed503OnTransientError.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubject/index.js";
+import { isRedisFallbackToDbEnabled } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 import { isFullSubjectRolloutEnabled } from "@/internal/misc/rollouts/fullSubjectRolloutUtils.js";
 import { getApiCustomerV2 } from "../cusUtils/getApiCustomerV2/index.js";
 
@@ -20,10 +21,21 @@ export const getApiCustomerByRollout = async ({
 	if (isFullSubjectRolloutEnabled({ ctx })) {
 	}
 
+	const lookup = ({ skipCache }: { skipCache: boolean }) =>
+		getOrSetCachedFullSubject({
+			ctx: skipCache ? { ...ctx, skipCache: true } : ctx,
+			customerId,
+			entityId,
+			source,
+		});
+
 	const fullSubject = await shed503OnTransientError({
 		ctx,
 		source: "get_customer",
-		run: () => getOrSetCachedFullSubject({ ctx, customerId, entityId, source }),
+		run: () => lookup({ skipCache: false }),
+		fallbackOnRedisUnavailable: isRedisFallbackToDbEnabled()
+			? () => lookup({ skipCache: true })
+			: undefined,
 	});
 
 	return getApiCustomerV2({

--- a/server/src/internal/customers/actions/getOrCreateApiCustomerByRollout.ts
+++ b/server/src/internal/customers/actions/getOrCreateApiCustomerByRollout.ts
@@ -7,6 +7,7 @@ import {
 	setCustomerCreationRecoveryStage,
 } from "@/internal/customers/recovery/customerCreationRecoveryStage.js";
 import { queueFailedCustomerCreation } from "@/internal/customers/recovery/queueFailedCustomerCreation.js";
+import { isRedisFallbackToDbEnabled } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 import { isFullSubjectRolloutEnabled } from "@/internal/misc/rollouts/fullSubjectRolloutUtils.js";
 import { getApiCustomerV2 } from "../cusUtils/getApiCustomerV2/index.js";
 import { ensureStripeCustomerFromCustomerData } from "./ensureStripeCustomerFromCustomerData.js";
@@ -31,10 +32,20 @@ export const getOrCreateApiCustomerByRollout = async ({
 	if (isFullSubjectRolloutEnabled({ ctx })) {
 	}
 
+	const lookup = ({ skipCache }: { skipCache: boolean }) =>
+		getOrCreateCachedFullSubject({
+			ctx: skipCache ? { ...ctx, skipCache: true } : ctx,
+			params,
+			source,
+		});
+
 	const fullSubject = await shed503OnTransientError({
 		ctx,
 		source: "get_or_create",
-		run: () => getOrCreateCachedFullSubject({ ctx, params, source }),
+		run: () => lookup({ skipCache: false }),
+		fallbackOnRedisUnavailable: isRedisFallbackToDbEnabled()
+			? () => lookup({ skipCache: true })
+			: undefined,
 		onTransientError: enqueueRecoveryOnTransientFailure
 			? async () => {
 					await queueFailedCustomerCreation({

--- a/server/src/internal/entities/actions/getApiEntityByRollout.ts
+++ b/server/src/internal/entities/actions/getApiEntityByRollout.ts
@@ -2,6 +2,7 @@ import type { ApiEntityV2 } from "@autumn/shared";
 import { shed503OnTransientError } from "@/db/shed503OnTransientError.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubject/index.js";
+import { isRedisFallbackToDbEnabled } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 import { isFullSubjectRolloutEnabled } from "@/internal/misc/rollouts/fullSubjectRolloutUtils.js";
 import { getApiEntityV2 } from "../entityUtils/getApiEntityV2/getApiEntityV2.js";
 
@@ -21,10 +22,21 @@ export const getApiEntityByRollout = async ({
 	if (isFullSubjectRolloutEnabled({ ctx })) {
 	}
 
+	const lookup = ({ skipCache }: { skipCache: boolean }) =>
+		getOrSetCachedFullSubject({
+			ctx: skipCache ? { ...ctx, skipCache: true } : ctx,
+			customerId,
+			entityId,
+			source,
+		});
+
 	const fullSubject = await shed503OnTransientError({
 		ctx,
 		source: "entities.get",
-		run: () => getOrSetCachedFullSubject({ ctx, customerId, entityId, source }),
+		run: () => lookup({ skipCache: false }),
+		fallbackOnRedisUnavailable: isRedisFallbackToDbEnabled()
+			? () => lookup({ skipCache: true })
+			: undefined,
 	});
 
 	return getApiEntityV2({

--- a/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.ts
+++ b/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.ts
@@ -8,6 +8,10 @@ export const MiscellaneousEdgeConfigSchema = z.object({
 	/** Global switch: customer get_or_create and entity get read the subject
 	 *  straight from Postgres, bypassing the FullSubject cache entirely. */
 	subjectLookupDbOnly: z.boolean().default(false),
+	/** Global switch: when Redis is unavailable, subject reads fall back to
+	 *  Postgres instead of shedding a 503. Dark by default — turning this on
+	 *  converts a cache outage into full primary read load. */
+	redisFallbackToDb: z.boolean().default(false),
 });
 
 export type MiscellaneousEdgeConfig = z.infer<

--- a/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.ts
+++ b/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.ts
@@ -59,3 +59,7 @@ export const isSyncCoalesceEnabled = (): boolean => store.get().syncCoalesce;
 /** Global gate: serve subject lookups from Postgres instead of the cache. */
 export const isSubjectLookupDbOnlyEnabled = (): boolean =>
 	store.get().subjectLookupDbOnly;
+
+/** Global gate: fall back to Postgres on Redis outage instead of shedding. */
+export const isRedisFallbackToDbEnabled = (): boolean =>
+	store.get().redisFallbackToDb;

--- a/server/tests/unit/db/shed503OnTransientError.test.ts
+++ b/server/tests/unit/db/shed503OnTransientError.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import { shed503OnTransientError } from "@/db/shed503OnTransientError.js";
+import { RedisUnavailableError } from "@/external/redis/utils/errors.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 
 const buildContext = () =>
@@ -12,6 +13,11 @@ const buildContext = () =>
 
 const transientError = Object.assign(new Error("connect timeout"), {
 	code: "CONNECT_TIMEOUT",
+});
+
+const redisError = new RedisUnavailableError({
+	source: "test",
+	reason: "not_ready",
 });
 
 describe("shed503OnTransientError", () => {
@@ -75,5 +81,85 @@ describe("shed503OnTransientError", () => {
 		).rejects.toBe(applicationError);
 
 		expect(onTransientError).not.toHaveBeenCalled();
+	});
+
+	test("sheds redis failures when no fallback is supplied", async () => {
+		const ctx = buildContext();
+
+		await expect(
+			shed503OnTransientError({
+				ctx,
+				source: "find_customer",
+				run: () => {
+					throw redisError;
+				},
+			}),
+		).rejects.toMatchObject({
+			statusCode: 503,
+			data: { reason: "cache_unavailable" },
+		});
+	});
+
+	test("serves the postgres fallback when only redis failed", async () => {
+		const ctx = buildContext();
+		const onTransientError = mock(async () => {});
+
+		const result = await shed503OnTransientError({
+			ctx,
+			source: "get_customer",
+			run: () => {
+				throw redisError;
+			},
+			fallbackOnRedisUnavailable: () => "from-postgres",
+			onTransientError,
+		});
+
+		expect(result).toBe("from-postgres");
+		expect(onTransientError).not.toHaveBeenCalled();
+	});
+
+	test("never falls back when postgres is implicated", async () => {
+		const ctx = buildContext();
+		const fallback = mock(() => "from-postgres");
+
+		await expect(
+			shed503OnTransientError({
+				ctx,
+				source: "get_customer",
+				run: () => {
+					throw transientError;
+				},
+				fallbackOnRedisUnavailable: fallback,
+			}),
+		).rejects.toMatchObject({
+			statusCode: 503,
+			data: { reason: "critical_db_saturated" },
+		});
+
+		expect(fallback).not.toHaveBeenCalled();
+	});
+
+	test("sheds and still captures recovery when the fallback itself fails", async () => {
+		const ctx = buildContext();
+		const onTransientError = mock(async () => {});
+
+		await expect(
+			shed503OnTransientError({
+				ctx,
+				source: "get_or_create",
+				run: () => {
+					throw redisError;
+				},
+				fallbackOnRedisUnavailable: () => {
+					throw new Error("postgres also down");
+				},
+				onTransientError,
+			}),
+		).rejects.toMatchObject({
+			statusCode: 503,
+			data: { reason: "cache_unavailable" },
+		});
+
+		expect(onTransientError).toHaveBeenCalledWith(redisError);
 	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Surgical extract of the `shed503OnTransientError` Redis→Postgres fallback from `feat/saving-autumn-with-my-load`, without the other load-test / pool / redis-timeout / otel changes on that branch.

### What's included
- **`shed503OnTransientError`**: optional `fallbackOnRedisUnavailable`; on Redis-only transient errors, call the fallback instead of shedding. Postgres-implicated failures still shed. Distinct 503 reason: `cache_unavailable` vs `critical_db_saturated`.
- **Edge config**: `redisFallbackToDb` (dark by default) + `isRedisFallbackToDbEnabled()`.
- **Call sites**: `getApiCustomerByRollout`, `getOrCreateApiCustomerByRollout`, `getApiEntityByRollout` — when the flag is on, fallback re-runs the subject lookup with `skipCache: true`.
- **Unit tests** for shed / fallback / no-fallback-on-DB-transient / fallback-failure paths.

### Explicitly left out
Everything else from that branch (pg pool prewarm/monitor, redis op timeouts, Axiom/otel compaction, async track SQS batcher, staging deploy allowlist, `executeResetMutations`, `applySubjectLookupDbOnly` wiring on get-customer handlers, etc.).

## Test plan
- [ ] Run `server/tests/unit/db/shed503OnTransientError.test.ts`
- [ ] Confirm `redisFallbackToDb` defaults off and subject lookups still shed 503 on Redis outage
- [ ] Flip `redisFallbackToDb` on in misc edge config and confirm get/get-or-create/entity get serve from Postgres when Redis is down
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1785439143088889?thread_ts=1785439143.088889&cid=C0BCAQQK0KS)

<div><a href="https://cursor.com/agents/bc-c9ef8d0c-f612-5240-bd98-96e4c4fceb2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9ef8d0c-f612-5240-bd98-96e4c4fceb2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an opt-in Postgres fallback for Redis-only outages so subject lookups keep serving instead of returning 503s. DB-transient errors still shed, with clearer 503 reasons.

- **New Features**
  - `shed503OnTransientError`: new `fallbackOnRedisUnavailable` path for Redis-only transient errors; distinct 503 reasons `cache_unavailable` vs `critical_db_saturated`.
  - Edge config: `redisFallbackToDb` (off by default) with `isRedisFallbackToDbEnabled()`.
  - Call sites: `getApiCustomerByRollout`, `getOrCreateApiCustomerByRollout`, `getApiEntityByRollout` re-run lookups with `skipCache: true` when enabled.
  - Added unit tests for fallback, shed, DB-transient, and fallback-failure paths.

- **Migration**
  - No change by default. To enable, set `redisFallbackToDb: true` in edge config.

<sup>Written for commit e76f1575a696e9cdc7218c0436a87431b0e24e0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

