### PR TITLE
feat(diag): log in-flight requests on memory
  spike

### DIFF
--- a/server/src/honoMiddlewares/inFlightTrackingMiddleware.ts
+++ b/server/src/honoMiddlewares/inFlightTrackingMiddleware.ts
@@ -1,0 +1,31 @@
+import type { Context, Next } from "hono";
+import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { registerInFlightRequest } from "@/utils/memory/inFlightRequests.js";
+
+/**
+ * Records which requests a process is serving so the memory spike probe can
+ * name them. Identity is resolved lazily because auth runs after this.
+ */
+export const inFlightTrackingMiddleware = async (
+	c: Context<HonoEnv>,
+	next: Next,
+) => {
+	const release = registerInFlightRequest({
+		startedAt: Date.now(),
+		method: c.req.method,
+		path: c.req.path,
+		resolveIdentity: () => {
+			const ctx = c.get("ctx");
+			return {
+				orgSlug: ctx?.org?.slug,
+				customerId: ctx?.customerId,
+			};
+		},
+	});
+
+	try {
+		await next();
+	} finally {
+		release();
+	}
+};

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -55,7 +55,10 @@ import { createHonoApp } from "./initHono.js";
 import { otelSdk } from "./instrumentation.js";
 import { shutdownPrimarySqsSendBatcher } from "./queue/queueUtils.js";
 import { checkEnvVars } from "./utils/initUtils.js";
-import { startMemorySpikeProbe } from "./utils/memory/memorySpikeProbe.js";
+import {
+	startMemorySpikeProbe,
+	stopMemorySpikeProbe,
+} from "./utils/memory/memorySpikeProbe.js";
 import { startMemoryMonitor } from "./utils/memoryMonitor.js";
 
 checkEnvVars();
@@ -185,6 +188,7 @@ async function gracefulShutdown() {
 		stopPgPoolMonitor();
 		stopRedisMonitor();
 		stopRedisV2Monitor();
+		stopMemorySpikeProbe();
 		stopAllEdgeConfigPolling();
 		await Promise.all([
 			client.end(),

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -55,6 +55,7 @@ import { createHonoApp } from "./initHono.js";
 import { otelSdk } from "./instrumentation.js";
 import { shutdownPrimarySqsSendBatcher } from "./queue/queueUtils.js";
 import { checkEnvVars } from "./utils/initUtils.js";
+import { startMemorySpikeProbe } from "./utils/memory/memorySpikeProbe.js";
 import { startMemoryMonitor } from "./utils/memoryMonitor.js";
 
 checkEnvVars();
@@ -98,6 +99,7 @@ const init = async ({ startupStartedAt }: { startupStartedAt: number }) => {
 				`Server running on port ${PORT} (${startupDurationMs}ms startup)`,
 			);
 			startMemoryMonitor("server", 60_000);
+			startMemorySpikeProbe({ label: "server" });
 			resolve();
 		});
 	});

--- a/server/src/initHono.ts
+++ b/server/src/initHono.ts
@@ -11,6 +11,7 @@ import { vercelTestApiRouter } from "./external/vercel/vercelTestApiRouter.js";
 import { vercelWebhookRouter } from "./external/vercel/vercelWebhookRouter.js";
 import { baseMiddleware } from "./honoMiddlewares/baseMiddleware.js";
 import { errorMiddleware } from "./honoMiddlewares/errorMiddleware.js";
+import { inFlightTrackingMiddleware } from "./honoMiddlewares/inFlightTrackingMiddleware.js";
 import { replicaDbMiddleware } from "./honoMiddlewares/replicaDbMiddleware.js";
 import type { HonoEnv } from "./honoUtils/HonoEnv.js";
 import { handleHealthCheck } from "./honoUtils/handleHealthCheck.js";
@@ -132,6 +133,7 @@ export const createHonoApp = () => {
 			serviceVersion: "1.0.0",
 		}),
 	);
+	app.use("*", inFlightTrackingMiddleware);
 	app.use("*", baseMiddleware);
 	app.use("*", replicaDbMiddleware);
 

--- a/server/src/utils/memory/inFlightRequests.ts
+++ b/server/src/utils/memory/inFlightRequests.ts
@@ -1,0 +1,67 @@
+export type InFlightRequestSummary = {
+	method: string;
+	path: string;
+	elapsedMs: number;
+	orgSlug?: string;
+	customerId?: string;
+};
+
+type InFlightRequest = {
+	startedAt: number;
+	method: string;
+	path: string;
+	resolveIdentity: () => { orgSlug?: string; customerId?: string };
+};
+
+const inFlightRequests = new Set<InFlightRequest>();
+
+/** Returns a release function; callers must invoke it in a `finally`. */
+export const registerInFlightRequest = ({
+	startedAt,
+	method,
+	path,
+	resolveIdentity,
+}: InFlightRequest): (() => void) => {
+	const request: InFlightRequest = {
+		startedAt,
+		method,
+		path,
+		resolveIdentity,
+	};
+	inFlightRequests.add(request);
+
+	return () => {
+		inFlightRequests.delete(request);
+	};
+};
+
+export const listInFlightRequests = ({
+	now,
+}: {
+	now: number;
+}): InFlightRequestSummary[] => {
+	const summaries: InFlightRequestSummary[] = [];
+
+	for (const request of inFlightRequests) {
+		let identity: { orgSlug?: string; customerId?: string } = {};
+		try {
+			identity = request.resolveIdentity();
+		} catch {
+			// A half-built request context must not break the probe.
+		}
+
+		summaries.push({
+			method: request.method,
+			path: request.path,
+			elapsedMs: now - request.startedAt,
+			orgSlug: identity.orgSlug,
+			customerId: identity.customerId,
+		});
+	}
+
+	return summaries;
+};
+
+export const clearInFlightRequests = () => {
+	inFlightRequests.clear();
+};

--- a/server/src/utils/memory/memorySpikeProbe.ts
+++ b/server/src/utils/memory/memorySpikeProbe.ts
@@ -4,8 +4,16 @@ import {
 	listInFlightRequests,
 } from "./inFlightRequests.js";
 
-export type MemorySpikeReport = {
+/** arrayBuffers separates transport/buffer growth from ordinary object churn. */
+export type MemorySnapshotMB = {
 	rssMB: number;
+	heapUsedMB: number;
+	heapTotalMB: number;
+	externalMB: number;
+	arrayBuffersMB: number;
+};
+
+export type MemorySpikeReport = MemorySnapshotMB & {
 	inFlightCount: number;
 	requests: InFlightRequestSummary[];
 };
@@ -16,8 +24,11 @@ const DEFAULT_INTERVAL_MS = 2000;
 const DEFAULT_MAX_REPORTS = 3;
 const MAX_REQUESTS_LOGGED = 20;
 
+const toMB = (bytes: number): number =>
+	Math.round((bytes / 1024 / 1024) * 10) / 10;
+
 export const createMemorySpikeProbe = ({
-	readRssMB,
+	readMemoryMB,
 	listInFlightRequests: readInFlight,
 	report,
 	thresholdMB,
@@ -25,7 +36,7 @@ export const createMemorySpikeProbe = ({
 	maxReports,
 	maxRequestsLogged,
 }: {
-	readRssMB: () => number;
+	readMemoryMB: () => MemorySnapshotMB;
 	listInFlightRequests: () => InFlightRequestSummary[];
 	report: (payload: MemorySpikeReport) => void;
 	thresholdMB: number;
@@ -37,13 +48,14 @@ export const createMemorySpikeProbe = ({
 	let reportsSent = 0;
 
 	const sample = () => {
-		const rssMB = readRssMB();
+		const memory = readMemoryMB();
 
-		if (rssMB < rearmMB) {
+		if (memory.rssMB < rearmMB) {
 			armed = true;
 		}
 
-		if (!armed || rssMB < thresholdMB || reportsSent >= maxReports) return;
+		if (!armed || memory.rssMB < thresholdMB || reportsSent >= maxReports)
+			return;
 
 		armed = false;
 		reportsSent += 1;
@@ -54,7 +66,7 @@ export const createMemorySpikeProbe = ({
 			.slice(0, maxRequestsLogged);
 
 		report({
-			rssMB,
+			...memory,
 			inFlightCount: requests.length,
 			requests: longestRunning,
 		});
@@ -96,17 +108,26 @@ export const startMemorySpikeProbe = ({ label }: { label: string }) => {
 	if (thresholdMB <= 0) return;
 
 	const probe = createMemorySpikeProbe({
-		readRssMB: () => process.memoryUsage().rss / 1024 / 1024,
+		readMemoryMB: () => {
+			const memory = process.memoryUsage();
+			return {
+				rssMB: toMB(memory.rss),
+				heapUsedMB: toMB(memory.heapUsed),
+				heapTotalMB: toMB(memory.heapTotal),
+				externalMB: toMB(memory.external),
+				arrayBuffersMB: toMB(memory.arrayBuffers),
+			};
+		},
 		listInFlightRequests: () => listInFlightRequests({ now: Date.now() }),
-		report: ({ rssMB, inFlightCount, requests }) => {
+		report: ({ inFlightCount, requests, ...memory }) => {
 			logger.warn(
-				`memory_spike_inflight, rss: ${Math.round(rssMB)}MB, inFlight: ${inFlightCount}`,
+				`memory_spike_inflight, rss: ${memory.rssMB}MB, heapUsed: ${memory.heapUsedMB}MB, inFlight: ${inFlightCount}`,
 				{
 					type: "memory_spike_inflight",
 					data: {
 						label,
 						pid: process.pid,
-						rssMB: Math.round(rssMB),
+						...memory,
 						inFlightCount,
 						requests,
 					},

--- a/server/src/utils/memory/memorySpikeProbe.ts
+++ b/server/src/utils/memory/memorySpikeProbe.ts
@@ -18,8 +18,9 @@ export type MemorySpikeReport = MemorySnapshotMB & {
 	requests: InFlightRequestSummary[];
 };
 
-const DEFAULT_THRESHOLD_MB = 4500;
-const DEFAULT_REARM_MB = 3500;
+const DEFAULT_CEILING_MB = 4500;
+const DEFAULT_RISE_MB = 1500;
+const DEFAULT_BASELINE_SAMPLES = 30;
 const DEFAULT_INTERVAL_MS = 2000;
 const DEFAULT_MAX_REPORTS = 3;
 const MAX_REQUESTS_LOGGED = 20;
@@ -27,35 +28,46 @@ const MAX_REQUESTS_LOGGED = 20;
 const toMB = (bytes: number): number =>
 	Math.round((bytes / 1024 / 1024) * 10) / 10;
 
+/**
+ * Fires on a rapid RISE above the recent baseline, not just an absolute size —
+ * a process going 2GB to 4.4GB is the event; a steadily fat one is not.
+ */
 export const createMemorySpikeProbe = ({
 	readMemoryMB,
 	listInFlightRequests: readInFlight,
 	report,
-	thresholdMB,
-	rearmMB,
+	ceilingMB,
+	riseMB,
+	baselineSamples,
 	maxReports,
 	maxRequestsLogged,
 }: {
 	readMemoryMB: () => MemorySnapshotMB;
 	listInFlightRequests: () => InFlightRequestSummary[];
 	report: (payload: MemorySpikeReport) => void;
-	thresholdMB: number;
-	rearmMB: number;
+	ceilingMB: number;
+	riseMB: number;
+	baselineSamples: number;
 	maxReports: number;
 	maxRequestsLogged: number;
 }) => {
 	let armed = true;
 	let reportsSent = 0;
+	const history: number[] = [];
 
 	const sample = () => {
 		const memory = readMemoryMB();
+		const baselineMB = history.length ? Math.min(...history) : memory.rssMB;
 
-		if (memory.rssMB < rearmMB) {
-			armed = true;
-		}
+		history.push(memory.rssMB);
+		if (history.length > baselineSamples) history.shift();
 
-		if (!armed || memory.rssMB < thresholdMB || reportsSent >= maxReports)
-			return;
+		const spiking =
+			memory.rssMB - baselineMB >= riseMB || memory.rssMB >= ceilingMB;
+
+		// Re-arm as soon as the condition clears, so one event yields one report.
+		if (!spiking) armed = true;
+		if (!(spiking && armed) || reportsSent >= maxReports) return;
 
 		armed = false;
 		reportsSent += 1;
@@ -101,11 +113,11 @@ let intervalHandle: ReturnType<typeof setInterval> | null = null;
 
 /** Set MEMORY_SPIKE_PROBE_MB to 0 to disable. */
 export const startMemorySpikeProbe = ({ label }: { label: string }) => {
-	const thresholdMB = readEnvNumber({
+	const ceilingMB = readEnvNumber({
 		name: "MEMORY_SPIKE_PROBE_MB",
-		fallback: DEFAULT_THRESHOLD_MB,
+		fallback: DEFAULT_CEILING_MB,
 	});
-	if (thresholdMB <= 0) return;
+	if (ceilingMB <= 0) return;
 
 	const probe = createMemorySpikeProbe({
 		readMemoryMB: () => {
@@ -134,10 +146,14 @@ export const startMemorySpikeProbe = ({ label }: { label: string }) => {
 				},
 			);
 		},
-		thresholdMB,
-		rearmMB: readEnvNumber({
-			name: "MEMORY_SPIKE_PROBE_REARM_MB",
-			fallback: DEFAULT_REARM_MB,
+		ceilingMB,
+		riseMB: readEnvNumber({
+			name: "MEMORY_SPIKE_PROBE_RISE_MB",
+			fallback: DEFAULT_RISE_MB,
+		}),
+		baselineSamples: readEnvNumber({
+			name: "MEMORY_SPIKE_PROBE_BASELINE_SAMPLES",
+			fallback: DEFAULT_BASELINE_SAMPLES,
 		}),
 		maxReports: readEnvNumber({
 			name: "MEMORY_SPIKE_PROBE_MAX_REPORTS",

--- a/server/src/utils/memory/memorySpikeProbe.ts
+++ b/server/src/utils/memory/memorySpikeProbe.ts
@@ -76,6 +76,15 @@ const readEnvNumber = ({
 	return Number.isFinite(parsed) ? parsed : fallback;
 };
 
+/** A non-positive interval would clamp to a ~1ms sampling loop. */
+const readIntervalMs = (): number => {
+	const parsed = readEnvNumber({
+		name: "MEMORY_SPIKE_PROBE_INTERVAL_MS",
+		fallback: DEFAULT_INTERVAL_MS,
+	});
+	return parsed > 0 ? parsed : DEFAULT_INTERVAL_MS;
+};
+
 let intervalHandle: ReturnType<typeof setInterval> | null = null;
 
 /** Set MEMORY_SPIKE_PROBE_MB to 0 to disable. */
@@ -116,15 +125,9 @@ export const startMemorySpikeProbe = ({ label }: { label: string }) => {
 		maxRequestsLogged: MAX_REQUESTS_LOGGED,
 	});
 
-	intervalHandle = setInterval(
-		() => {
-			probe.sample();
-		},
-		readEnvNumber({
-			name: "MEMORY_SPIKE_PROBE_INTERVAL_MS",
-			fallback: DEFAULT_INTERVAL_MS,
-		}),
-	);
+	intervalHandle = setInterval(() => {
+		probe.sample();
+	}, readIntervalMs());
 
 	if (intervalHandle.unref) {
 		intervalHandle.unref();

--- a/server/src/utils/memory/memorySpikeProbe.ts
+++ b/server/src/utils/memory/memorySpikeProbe.ts
@@ -1,0 +1,139 @@
+import { logger } from "@/external/logtail/logtailUtils.js";
+import {
+	type InFlightRequestSummary,
+	listInFlightRequests,
+} from "./inFlightRequests.js";
+
+export type MemorySpikeReport = {
+	rssMB: number;
+	inFlightCount: number;
+	requests: InFlightRequestSummary[];
+};
+
+const DEFAULT_THRESHOLD_MB = 4500;
+const DEFAULT_REARM_MB = 3500;
+const DEFAULT_INTERVAL_MS = 2000;
+const DEFAULT_MAX_REPORTS = 3;
+const MAX_REQUESTS_LOGGED = 20;
+
+export const createMemorySpikeProbe = ({
+	readRssMB,
+	listInFlightRequests: readInFlight,
+	report,
+	thresholdMB,
+	rearmMB,
+	maxReports,
+	maxRequestsLogged,
+}: {
+	readRssMB: () => number;
+	listInFlightRequests: () => InFlightRequestSummary[];
+	report: (payload: MemorySpikeReport) => void;
+	thresholdMB: number;
+	rearmMB: number;
+	maxReports: number;
+	maxRequestsLogged: number;
+}) => {
+	let armed = true;
+	let reportsSent = 0;
+
+	const sample = () => {
+		const rssMB = readRssMB();
+
+		if (rssMB < rearmMB) {
+			armed = true;
+		}
+
+		if (!armed || rssMB < thresholdMB || reportsSent >= maxReports) return;
+
+		armed = false;
+		reportsSent += 1;
+
+		const requests = readInFlight();
+		const longestRunning = [...requests]
+			.sort((a, b) => b.elapsedMs - a.elapsedMs)
+			.slice(0, maxRequestsLogged);
+
+		report({
+			rssMB,
+			inFlightCount: requests.length,
+			requests: longestRunning,
+		});
+	};
+
+	return { sample };
+};
+
+const readEnvNumber = ({
+	name,
+	fallback,
+}: {
+	name: string;
+	fallback: number;
+}): number => {
+	const raw = process.env[name];
+	if (!raw) return fallback;
+	const parsed = Number(raw);
+	return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+let intervalHandle: ReturnType<typeof setInterval> | null = null;
+
+/** Set MEMORY_SPIKE_PROBE_MB to 0 to disable. */
+export const startMemorySpikeProbe = ({ label }: { label: string }) => {
+	const thresholdMB = readEnvNumber({
+		name: "MEMORY_SPIKE_PROBE_MB",
+		fallback: DEFAULT_THRESHOLD_MB,
+	});
+	if (thresholdMB <= 0) return;
+
+	const probe = createMemorySpikeProbe({
+		readRssMB: () => process.memoryUsage().rss / 1024 / 1024,
+		listInFlightRequests: () => listInFlightRequests({ now: Date.now() }),
+		report: ({ rssMB, inFlightCount, requests }) => {
+			logger.warn(
+				`memory_spike_inflight, rss: ${Math.round(rssMB)}MB, inFlight: ${inFlightCount}`,
+				{
+					type: "memory_spike_inflight",
+					data: {
+						label,
+						pid: process.pid,
+						rssMB: Math.round(rssMB),
+						inFlightCount,
+						requests,
+					},
+				},
+			);
+		},
+		thresholdMB,
+		rearmMB: readEnvNumber({
+			name: "MEMORY_SPIKE_PROBE_REARM_MB",
+			fallback: DEFAULT_REARM_MB,
+		}),
+		maxReports: readEnvNumber({
+			name: "MEMORY_SPIKE_PROBE_MAX_REPORTS",
+			fallback: DEFAULT_MAX_REPORTS,
+		}),
+		maxRequestsLogged: MAX_REQUESTS_LOGGED,
+	});
+
+	intervalHandle = setInterval(
+		() => {
+			probe.sample();
+		},
+		readEnvNumber({
+			name: "MEMORY_SPIKE_PROBE_INTERVAL_MS",
+			fallback: DEFAULT_INTERVAL_MS,
+		}),
+	);
+
+	if (intervalHandle.unref) {
+		intervalHandle.unref();
+	}
+};
+
+export const stopMemorySpikeProbe = () => {
+	if (intervalHandle) {
+		clearInterval(intervalHandle);
+		intervalHandle = null;
+	}
+};

--- a/server/tests/unit/memory/memory-spike-probe.test.ts
+++ b/server/tests/unit/memory/memory-spike-probe.test.ts
@@ -8,16 +8,14 @@ import {
 const buildRequest = ({
 	path,
 	elapsedMs,
-	orgSlug,
 }: {
 	path: string;
 	elapsedMs: number;
-	orgSlug?: string;
 }): InFlightRequestSummary => ({
 	method: "POST",
 	path,
 	elapsedMs,
-	orgSlug,
+	orgSlug: undefined,
 	customerId: undefined,
 });
 
@@ -26,21 +24,33 @@ const buildProbe = ({
 	requests = [],
 	maxReports = 3,
 	maxRequestsLogged = 20,
+	baselineSamples = 30,
 }: {
 	rssSamples: number[];
 	requests?: InFlightRequestSummary[];
 	maxReports?: number;
 	maxRequestsLogged?: number;
+	baselineSamples?: number;
 }) => {
 	const reports: MemorySpikeReport[] = [];
 	let index = 0;
 
 	const probe = createMemorySpikeProbe({
-		readRssMB: () => rssSamples[Math.min(index, rssSamples.length - 1)],
+		readMemoryMB: () => {
+			const rssMB = rssSamples[Math.min(index, rssSamples.length - 1)];
+			return {
+				rssMB,
+				heapUsedMB: rssMB / 3,
+				heapTotalMB: rssMB / 2,
+				externalMB: rssMB / 10,
+				arrayBuffersMB: 20,
+			};
+		},
 		listInFlightRequests: () => requests,
 		report: (payload) => reports.push(payload),
-		thresholdMB: 4500,
-		rearmMB: 3500,
+		ceilingMB: 4500,
+		riseMB: 1500,
+		baselineSamples,
 		maxReports,
 		maxRequestsLogged,
 	});
@@ -55,9 +65,9 @@ const buildProbe = ({
 };
 
 describe("memorySpikeProbe", () => {
-	test("stays silent while rss is below the threshold", () => {
+	test("stays silent while memory drifts gently below the ceiling", () => {
 		const { reports, sampleAll } = buildProbe({
-			rssSamples: [3000, 3200, 4499],
+			rssSamples: [2000, 2200, 2400, 2600, 2900, 3200],
 		});
 
 		sampleAll();
@@ -65,35 +75,66 @@ describe("memorySpikeProbe", () => {
 		expect(reports).toHaveLength(0);
 	});
 
-	test("reports once when rss crosses the threshold", () => {
+	test("stays silent for a process that is steadily fat", () => {
 		const { reports, sampleAll } = buildProbe({
-			rssSamples: [3000, 4600, 5200, 6000],
-			requests: [
-				buildRequest({ path: "/v1/entities.list", elapsedMs: 12_000 }),
-			],
+			rssSamples: [4000, 4050, 3990, 4100, 4020],
+		});
+
+		sampleAll();
+
+		expect(reports).toHaveLength(0);
+	});
+
+	test("fires on a rapid rise even below the ceiling", () => {
+		const { reports, sampleAll } = buildProbe({
+			rssSamples: [2000, 2100, 4000],
+			requests: [buildRequest({ path: "/v1/customers.list", elapsedMs: 9000 })],
 		});
 
 		sampleAll();
 
 		expect(reports).toHaveLength(1);
-		expect(reports[0].rssMB).toBe(4600);
-		expect(reports[0].inFlightCount).toBe(1);
-		expect(reports[0].requests[0].path).toBe("/v1/entities.list");
+		expect(reports[0].rssMB).toBe(4000);
+		expect(reports[0].arrayBuffersMB).toBe(20);
+		expect(reports[0].heapUsedMB).toBeCloseTo(4000 / 3);
+		expect(reports[0].requests[0].path).toBe("/v1/customers.list");
 	});
 
-	test("re-arms only after rss falls back below the rearm level", () => {
+	test("fires on the absolute ceiling with no preceding rise", () => {
 		const { reports, sampleAll } = buildProbe({
-			rssSamples: [4600, 4000, 4700, 3000, 4800],
+			rssSamples: [4600, 4650],
 		});
 
 		sampleAll();
 
-		expect(reports.map((r) => r.rssMB)).toEqual([4600, 4800]);
+		expect(reports.map((r) => r.rssMB)).toEqual([4600]);
+	});
+
+	test("reports once per event, not once per sample", () => {
+		const { reports, sampleAll } = buildProbe({
+			rssSamples: [2000, 2000, 4200, 4400, 4300, 4250],
+		});
+
+		sampleAll();
+
+		expect(reports).toHaveLength(1);
+	});
+
+	test("re-arms for a second event once memory settles", () => {
+		const { reports, sampleAll } = buildProbe({
+			rssSamples: [2000, 4000, 2000, 2000, 3800],
+			baselineSamples: 2,
+		});
+
+		sampleAll();
+
+		expect(reports.map((r) => r.rssMB)).toEqual([4000, 3800]);
 	});
 
 	test("stops reporting once the per-process cap is reached", () => {
 		const { reports, sampleAll } = buildProbe({
-			rssSamples: [4600, 3000, 4600, 3000, 4600, 3000, 4600],
+			rssSamples: [2000, 4000, 2000, 4000, 2000, 4000, 2000, 4000],
+			baselineSamples: 2,
 			maxReports: 2,
 		});
 

--- a/server/tests/unit/memory/memory-spike-probe.test.ts
+++ b/server/tests/unit/memory/memory-spike-probe.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+import type { InFlightRequestSummary } from "@/utils/memory/inFlightRequests.js";
+import {
+	createMemorySpikeProbe,
+	type MemorySpikeReport,
+} from "@/utils/memory/memorySpikeProbe.js";
+
+const buildRequest = ({
+	path,
+	elapsedMs,
+	orgSlug,
+}: {
+	path: string;
+	elapsedMs: number;
+	orgSlug?: string;
+}): InFlightRequestSummary => ({
+	method: "POST",
+	path,
+	elapsedMs,
+	orgSlug,
+	customerId: undefined,
+});
+
+const buildProbe = ({
+	rssSamples,
+	requests = [],
+	maxReports = 3,
+	maxRequestsLogged = 20,
+}: {
+	rssSamples: number[];
+	requests?: InFlightRequestSummary[];
+	maxReports?: number;
+	maxRequestsLogged?: number;
+}) => {
+	const reports: MemorySpikeReport[] = [];
+	let index = 0;
+
+	const probe = createMemorySpikeProbe({
+		readRssMB: () => rssSamples[Math.min(index, rssSamples.length - 1)],
+		listInFlightRequests: () => requests,
+		report: (payload) => reports.push(payload),
+		thresholdMB: 4500,
+		rearmMB: 3500,
+		maxReports,
+		maxRequestsLogged,
+	});
+
+	const sampleAll = () => {
+		for (index = 0; index < rssSamples.length; index++) {
+			probe.sample();
+		}
+	};
+
+	return { reports, sampleAll };
+};
+
+describe("memorySpikeProbe", () => {
+	test("stays silent while rss is below the threshold", () => {
+		const { reports, sampleAll } = buildProbe({
+			rssSamples: [3000, 3200, 4499],
+		});
+
+		sampleAll();
+
+		expect(reports).toHaveLength(0);
+	});
+
+	test("reports once when rss crosses the threshold", () => {
+		const { reports, sampleAll } = buildProbe({
+			rssSamples: [3000, 4600, 5200, 6000],
+			requests: [
+				buildRequest({ path: "/v1/entities.list", elapsedMs: 12_000 }),
+			],
+		});
+
+		sampleAll();
+
+		expect(reports).toHaveLength(1);
+		expect(reports[0].rssMB).toBe(4600);
+		expect(reports[0].inFlightCount).toBe(1);
+		expect(reports[0].requests[0].path).toBe("/v1/entities.list");
+	});
+
+	test("re-arms only after rss falls back below the rearm level", () => {
+		const { reports, sampleAll } = buildProbe({
+			rssSamples: [4600, 4000, 4700, 3000, 4800],
+		});
+
+		sampleAll();
+
+		expect(reports.map((r) => r.rssMB)).toEqual([4600, 4800]);
+	});
+
+	test("stops reporting once the per-process cap is reached", () => {
+		const { reports, sampleAll } = buildProbe({
+			rssSamples: [4600, 3000, 4600, 3000, 4600, 3000, 4600],
+			maxReports: 2,
+		});
+
+		sampleAll();
+
+		expect(reports).toHaveLength(2);
+	});
+
+	test("keeps the longest-running requests when trimming the list", () => {
+		const { reports, sampleAll } = buildProbe({
+			rssSamples: [4600],
+			requests: [
+				buildRequest({ path: "/v1/check", elapsedMs: 5 }),
+				buildRequest({ path: "/v1/entities.list", elapsedMs: 21_000 }),
+				buildRequest({ path: "/v1/track", elapsedMs: 12 }),
+			],
+			maxRequestsLogged: 2,
+		});
+
+		sampleAll();
+
+		expect(reports[0].inFlightCount).toBe(3);
+		expect(reports[0].requests).toHaveLength(2);
+		expect(reports[0].requests[0].path).toBe("/v1/entities.list");
+	});
+});


### PR DESCRIPTION
...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a memory spike probe that logs in-flight HTTP requests and a full memory breakdown when RSS rises quickly or crosses a ceiling. Hooks into the Hono app to track requests and stops cleanly on shutdown.

- **New Features**
  - `inFlightTrackingMiddleware` records method, path, start time, and lazy identity (orgSlug, customerId).
  - `startMemorySpikeProbe` triggers on sharp rise or ceiling; logs full memory metrics and up to 20 longest-running requests; re-arms per event, limits per-process reports, guards bad intervals, unrefs the timer.
  - Integrated into server init and Hono app; stops on shutdown; unit tests cover triggers and request trimming.

- **Migration**
  - Enabled by default at 4500MB RSS. Set `MEMORY_SPIKE_PROBE_MB=0` to disable.
  - Tunables: `MEMORY_SPIKE_PROBE_MB`, `MEMORY_SPIKE_PROBE_RISE_MB`, `MEMORY_SPIKE_PROBE_BASELINE_SAMPLES`, `MEMORY_SPIKE_PROBE_INTERVAL_MS`, `MEMORY_SPIKE_PROBE_MAX_REPORTS`.

<sup>Written for commit 0f94b8fd3c8e6952fb8f20dfdb55f912eba10854. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

