### PR TITLE
Fix Stripe sync product webhook

### DIFF
--- a/server/src/internal/billing/v2/actions/sync/syncV2.ts
+++ b/server/src/internal/billing/v2/actions/sync/syncV2.ts
@@ -3,6 +3,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { persistCreateSchedule } from "@/internal/billing/v2/actions/createSchedule/utils/persistCreateSchedule";
 import { executeAutumnBillingPlan } from "@/internal/billing/v2/execute/executeAutumnBillingPlan";
 import { sendBillingUpdatedWebhook } from "@/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook";
+import { billingPlanToSendProductsUpdated } from "@/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated";
 import { reconcileLicenseStateForCustomer } from "@/internal/licenses/actions/reconcile/reconcileLicenseState";
 import { computeSyncPlan } from "./compute/computeSyncPlan";
 import { handleSyncErrors } from "./errors/handleSyncErrors";
@@ -73,6 +74,12 @@ export const syncV2 = async ({
 		scheduleId = persisted.scheduleId;
 		scheduledPhases = persisted.insertedPhases;
 	}
+
+	await billingPlanToSendProductsUpdated({
+		ctx,
+		autumnBillingPlan,
+		billingContext: syncContext,
+	});
 
 	void sendBillingUpdatedWebhook({
 		ctx,

--- a/server/src/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated.ts
+++ b/server/src/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated.ts
@@ -7,7 +7,7 @@
  * - Filters out scheduled products from insert webhooks
  */
 
-import type { AutumnBillingPlan, BillingContext } from "@autumn/shared";
+import type { AutumnBillingPlan, FullCustomer } from "@autumn/shared";
 import {
 	AttachScenario,
 	CusProductStatus,
@@ -18,7 +18,6 @@ import {
 	isProductUpgrade,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import type { CreateCustomerContext } from "@/internal/customers/actions/createWithDefaults/createCustomerContext";
 import {
 	getExpiredUpdatedCustomerProducts,
 	getUpdateCustomerProducts,
@@ -128,15 +127,19 @@ export const billingPlanToSendProductsUpdated = async ({
 }: {
 	ctx: AutumnContext;
 	autumnBillingPlan: AutumnBillingPlan;
-	billingContext: BillingContext | CreateCustomerContext;
+	billingContext: { fullCustomer: FullCustomer };
 }) => {
 	if (ctx.testOptions?.skipWebhooks) return;
 
 	const { fullCustomer } = billingContext;
 	const customerId = fullCustomer.id ?? fullCustomer.internal_id;
 	const { insertCustomerProducts } = autumnBillingPlan;
-	const updateCustomerProducts = getUpdateCustomerProducts({ autumnBillingPlan });
-	const expiredProducts = getExpiredUpdatedCustomerProducts({ autumnBillingPlan });
+	const updateCustomerProducts = getUpdateCustomerProducts({
+		autumnBillingPlan,
+	});
+	const expiredProducts = getExpiredUpdatedCustomerProducts({
+		autumnBillingPlan,
+	});
 
 	// A. Handle cancel/uncancel webhook for updateCustomerProduct
 	for (const updateCustomerProduct of updateCustomerProducts) {

--- a/server/tests/integration/billing/autumn-webhooks/customer-products-updated-sync.test.ts
+++ b/server/tests/integration/billing/autumn-webhooks/customer-products-updated-sync.test.ts
@@ -3,7 +3,7 @@
 
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import type { ApiCustomerV3, ApiProduct, SyncParamsV1 } from "@autumn/shared";
-import { getSubscriptionId } from "@tests/integration/billing/utils/stripe/getSubscriptionId.js";
+import { createStripeSubscriptionFromProduct } from "@tests/integration/billing/sync/utils/syncTestUtils.js";
 import {
 	getTestSvixAppId,
 	setupWebhookTest,
@@ -50,21 +50,22 @@ test(`${chalk.yellowBright("customer.products.updated: sync emits webhook for at
 			s.customer({ paymentMethod: "success", skipWebhooks: true }),
 			s.products({ list: [pro] }),
 		],
-		actions: [s.attach({ productId: pro.id })],
+		actions: [],
 	});
-	const subscriptionId = await getSubscriptionId({
+	const subscription = await createStripeSubscriptionFromProduct({
 		ctx,
 		customerId,
 		productId: pro.id,
+		metadata: { autumn_managed_at: String(Date.now()) },
 	});
 
 	await autumnV1.post("/billing.sync_v2", {
 		customer_id: customerId,
-		stripe_subscription_id: subscriptionId,
+		stripe_subscription_id: subscription.id,
 		phases: [
 			{
 				starts_at: "now",
-				plans: [{ plan_id: pro.id, expire_previous: true }],
+				plans: [{ plan_id: pro.id }],
 			},
 		],
 	} satisfies SyncParamsV1);
@@ -74,7 +75,7 @@ test(`${chalk.yellowBright("customer.products.updated: sync emits webhook for at
 		predicate: (payload) =>
 			payload.type === "customer.products.updated" &&
 			payload.data?.customer?.id === customerId &&
-			payload.data?.scenario === "cancel",
+			payload.data?.scenario === "new",
 		timeoutMs: 15000,
 	});
 
@@ -85,4 +86,6 @@ test(`${chalk.yellowBright("customer.products.updated: sync emits webhook for at
 			(product) => product.id === pro.id,
 		)?.status,
 	).toBe("active");
+
+	await ctx.stripeCli.subscriptions.cancel(subscription.id);
 });

--- a/server/tests/integration/billing/autumn-webhooks/customer-products-updated-sync.test.ts
+++ b/server/tests/integration/billing/autumn-webhooks/customer-products-updated-sync.test.ts
@@ -1,0 +1,88 @@
+/** Red: billing.sync_v2 attaches the plan but omits customer.products.updated.
+ * Green: sync emits the webhook with the attached active plan. */
+
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import type { ApiCustomerV3, ApiProduct, SyncParamsV1 } from "@autumn/shared";
+import { getSubscriptionId } from "@tests/integration/billing/utils/stripe/getSubscriptionId.js";
+import {
+	getTestSvixAppId,
+	setupWebhookTest,
+	type WebhookTestSetup,
+	waitForWebhook,
+} from "@tests/integration/utils/svixWebhookTestUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+type CustomerProductsUpdatedPayload = {
+	type: string;
+	data: {
+		scenario: string;
+		customer: ApiCustomerV3;
+		updated_product: ApiProduct;
+	};
+};
+
+let webhook: WebhookTestSetup;
+
+beforeAll(async () => {
+	webhook = await setupWebhookTest({
+		appId: getTestSvixAppId({ svixConfig: ctx.org.svix_config }),
+		filterTypes: ["customer.products.updated"],
+	});
+});
+
+afterAll(async () => {
+	await webhook?.cleanup();
+});
+
+test(`${chalk.yellowBright("customer.products.updated: sync emits webhook for attached plan")}`, async () => {
+	const customerId = "customer-products-updated-sync";
+	const pro = products.pro({
+		id: "pro",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success", skipWebhooks: true }),
+			s.products({ list: [pro] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+	const subscriptionId = await getSubscriptionId({
+		ctx,
+		customerId,
+		productId: pro.id,
+	});
+
+	await autumnV1.post("/billing.sync_v2", {
+		customer_id: customerId,
+		stripe_subscription_id: subscriptionId,
+		phases: [
+			{
+				starts_at: "now",
+				plans: [{ plan_id: pro.id, expire_previous: true }],
+			},
+		],
+	} satisfies SyncParamsV1);
+
+	const result = await waitForWebhook<CustomerProductsUpdatedPayload>({
+		token: webhook.playToken,
+		predicate: (payload) =>
+			payload.type === "customer.products.updated" &&
+			payload.data?.customer?.id === customerId &&
+			payload.data?.scenario === "cancel",
+		timeoutMs: 15000,
+	});
+
+	expect(result).not.toBeNull();
+	expect(result?.payload.data.updated_product.id).toBe(pro.id);
+	expect(
+		result?.payload.data.customer.products.find(
+			(product) => product.id === pro.id,
+		)?.status,
+	).toBe("active");
+});

--- a/server/tests/integration/billing/sync/utils/syncTestUtils.ts
+++ b/server/tests/integration/billing/sync/utils/syncTestUtils.ts
@@ -15,15 +15,18 @@ export const createStripeSubscriptionFromProduct = async ({
 	ctx,
 	customerId,
 	productId,
+	metadata,
 }: {
 	ctx: TestContext;
 	customerId: string;
 	productId: string;
+	metadata?: Stripe.MetadataParam;
 }): Promise<Stripe.Subscription> => {
 	return createStripeSubscriptionFromProducts({
 		ctx,
 		customerId,
 		productIds: [productId],
+		metadata,
 	});
 };
 
@@ -36,10 +39,12 @@ export const createStripeSubscriptionFromProducts = async ({
 	ctx,
 	customerId,
 	productIds,
+	metadata,
 }: {
 	ctx: TestContext;
 	customerId: string;
 	productIds: string[];
+	metadata?: Stripe.MetadataParam;
 }): Promise<Stripe.Subscription> => {
 	const fullCustomer = await CusService.getFull({
 		ctx,
@@ -74,6 +79,7 @@ export const createStripeSubscriptionFromProducts = async ({
 	return ctx.stripeCli.subscriptions.create({
 		customer: stripeCustomerId,
 		items: stripePriceIds.map((priceId) => ({ price: priceId })),
+		metadata,
 	});
 };
 


### PR DESCRIPTION
## Summary

- queue `customer.products.updated` after `billing.sync_v2` persists synced plans
- reuse the standard attach/update webhook workflow with the minimal customer context it needs
- add end-to-end Svix regression coverage for the synced active plan and entitlements

## Investigation

Axiom confirmed the reported sync emitted `billing.updated` but omitted `customer.products.updated`; the later manual plan update emitted both.

## Test plan

- [x] regression test fails before the fix with no sync-specific webhook
- [x] regression test passes after the fix and contains the active synced plan
- [x] existing `billing.updated` sync regression passes
- [x] Biome and diff checks pass
- [ ] repository-wide typecheck is blocked by existing Better Auth dependency/type errors; no changed-file errors were reported

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing `customer.products.updated` after `billing.sync_v2` by emitting the webhook once the synced plan is persisted, ensuring the active plan and entitlements are included.

- **Bug Fixes**
  - Call `billingPlanToSendProductsUpdated` from `syncV2` after plan persistence to trigger `customer.products.updated`.
  - Reuse the standard attach/update webhook workflow with minimal context `{ fullCustomer: FullCustomer }` from `@autumn/shared`.
  - Add targeted Svix E2E test for the sync scenario and update test utils to pass Stripe subscription `metadata`.

<sup>Written for commit ef92b1d2e3082194a94aaf99cef367f146e9a319. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

