### PR TITLE
fix(balances): deduct sooner-expiring credits first

### DIFF
--- a/apps/docs/mintlify/documentation/concepts/balances.mdx
+++ b/apps/docs/mintlify/documentation/concepts/balances.mdx
@@ -155,6 +155,8 @@ When usage is tracked, Autumn deducts from balances in a specific order based on
 
 The order is: `hour` (shortest) > `day` > `week` > `month` > `quarter` > `semi_annual` > `year` > `one_off` (lifetime - never resets).
 
+Balances with the same interval are deducted by `expires_at`, soonest first. Balances without an expiry are deducted last.
+
 This ensures that expiring balances are used before permanent ones.
 
 <Note>

--- a/server/tests/integration/balances/track/basic/track-expiry-order.test.ts
+++ b/server/tests/integration/balances/track/basic/track-expiry-order.test.ts
@@ -1,0 +1,57 @@
+/** Red: equal-interval balances followed creation order, consuming the later-expiring batch first.
+ * Green: the soonest-expiring balance is consumed first. */
+
+import { expect, test } from "bun:test";
+import { type CheckResponseV2, ms } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("track-expiry-order: equal intervals deduct the soonest-expiring balance first")}`,
+	async () => {
+		const customerId = "track-expiry-order";
+		const { autumnV2, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Credits,
+			included_grant: 100,
+			balance_id: "later-expiry",
+			expires_at: Date.now() + ms.days(365),
+		});
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Credits,
+			included_grant: 100,
+			balance_id: "sooner-expiry",
+			expires_at: Date.now() + ms.days(30),
+		});
+
+		await autumnV2_2.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Credits,
+			value: 60,
+		});
+
+		const check = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Credits,
+		});
+		const balances = Object.fromEntries(
+			check.balance?.breakdown?.map((balance) => [
+				balance.id,
+				balance.current_balance,
+			]) ?? [],
+		);
+
+		expect(balances).toMatchObject({
+			"sooner-expiry": 40,
+			"later-expiry": 100,
+		});
+	},
+);

--- a/shared/utils/cusEntUtils/sortCusEntsForDeduction.ts
+++ b/shared/utils/cusEntUtils/sortCusEntsForDeduction.ts
@@ -115,6 +115,10 @@ export const sortCusEntsForDeduction = ({
 			}
 		}
 
+		if (a.expires_at !== b.expires_at) {
+			return (a.expires_at ?? Infinity) - (b.expires_at ?? Infinity);
+		}
+
 		// 0a. If both are entity products (attached to entities), sort by entity_id for consistent ordering
 		const aIsProductEntity = !!a.customer_product?.internal_entity_id;
 		const bIsProductEntity = !!b.customer_product?.internal_entity_id;


### PR DESCRIPTION
## Summary

- use `expires_at` as the tie-breaker when balance reset intervals match
- keep non-expiring balances behind expiring balances
- document the ordering and add an integration regression test

## Verification

- confirmed the regression test failed before the fix: the later-expiring balance fell to 40 while the sooner-expiring balance remained at 100
- confirmed the focused integration test passes against this worktree
- `bunx tsgo --build --noEmit`
- `bunx biome check shared/utils/cusEntUtils/sortCusEntsForDeduction.ts server/tests/integration/balances/track/basic/track-expiry-order.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes balance deduction ordering so equal-interval credits consume the soonest-expiring balance first. Keeps non-expiring balances behind expiring ones, with docs updated and an integration test added.

- **Bug Fixes**
  - Use `expires_at` as the tiebreaker when intervals match (earliest first; missing expiry last).
  - Added a regression test to lock the ordering and updated balances documentation.

<sup>Written for commit c8d95e3aaf27393def0bb12ae2ec4a175a8425c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

