### PR TITLE
fix(auth): replay retried MCP refresh responses

### DIFF
--- a/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
+++ b/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
@@ -9,7 +9,10 @@ import {
 import { ErrCode, RecaseError } from "@autumn/shared";
 import type { Context } from "hono";
 import { db } from "@/db/initDrizzle.js";
+import { getPrimaryRedis } from "@/external/redis/initRedis.js";
 import { auth } from "@/utils/auth.js";
+import { decryptData, encryptData } from "@/utils/encryptUtils.js";
+import { timeout } from "@/utils/genUtils.js";
 import { hashOAuthToken } from "@/utils/oauthUtils.js";
 import {
 	oauthAccessTokenRepo,
@@ -116,6 +119,59 @@ const jsonTokenResponse = ({
 		headers: tokenResponseHeaders(response),
 	});
 
+const REFRESH_REPLAY_TTL_SECONDS = 30;
+const REFRESH_REPLAY_PENDING = "pending";
+
+const claimRefreshReplay = async (key: string) => {
+	try {
+		const redis = getPrimaryRedis();
+		if (redis.status !== "ready") return null;
+		for (let attempt = 0; attempt < 200; attempt++) {
+			const value = await redis.get(key);
+			if (value && value !== REFRESH_REPLAY_PENDING) {
+				return {
+					body: JSON.parse(decryptData(value)) as Record<string, unknown>,
+				};
+			}
+			if (
+				!value &&
+				(await redis.set(
+					key,
+					REFRESH_REPLAY_PENDING,
+					"EX",
+					REFRESH_REPLAY_TTL_SECONDS,
+					"NX",
+				))
+			) {
+				return { body: null };
+			}
+			await timeout(25);
+		}
+		return null;
+	} catch {
+		return null;
+	}
+};
+
+const storeRefreshReplay = async ({
+	body,
+	key,
+}: {
+	body: Record<string, unknown>;
+	key: string;
+}) => {
+	try {
+		await getPrimaryRedis().set(
+			key,
+			encryptData(JSON.stringify(body)),
+			"EX",
+			REFRESH_REPLAY_TTL_SECONDS,
+		);
+	} catch {
+		return;
+	}
+};
+
 const getRefreshTokenRecord = async (request: Request) => {
 	const refreshToken = await getRefreshTokenForConsentLookup(request);
 	if (!refreshToken) return null;
@@ -202,7 +258,9 @@ const normalizeTokenRequest = async ({
 			if (grantedScopes && typeof body.scope === "string") {
 				body.scope = constrainScope({ scope: body.scope, grantedScopes });
 			}
-			return new Request(request, { body: JSON.stringify(body) });
+			return new Request(request, {
+				body: JSON.stringify(body, Object.keys(body).sort()),
+			});
 		} catch {
 			return new Request(request, { body: rawBody });
 		}
@@ -214,6 +272,7 @@ const normalizeTokenRequest = async ({
 	if (grantedScopes && scope) {
 		params.set("scope", constrainScope({ scope, grantedScopes }));
 	}
+	params.sort();
 	return new Request(request, { body: params });
 };
 
@@ -229,12 +288,35 @@ export const handleOAuthTokenWithApiKey = async (c: Context) => {
 		}))
 			? refreshTokenRecord.scopes
 			: undefined;
-	const response = await auth.handler(
-		await normalizeTokenRequest({
-			request: c.req.raw.clone(),
-			grantedScopes: refreshScopes,
-		}),
-	);
+	const normalizedRequest = await normalizeTokenRequest({
+		request: c.req.raw.clone(),
+		grantedScopes: refreshScopes,
+	});
+	const refreshReplayKey = refreshScopes
+		? `oauth:refresh-replay:${await hashOAuthToken(
+				`${resource ?? ""}\n${normalizedRequest.headers.get("authorization") ?? ""}\n${await normalizedRequest.clone().text()}`,
+			)}`
+		: null;
+	if (refreshReplayKey) {
+		const replay = await claimRefreshReplay(refreshReplayKey);
+		if (!replay) {
+			return jsonTokenResponse({
+				body: {
+					error: "temporarily_unavailable",
+					error_description: "Refresh request coordination unavailable",
+				},
+				status: 503,
+			});
+		}
+		if (replay.body) {
+			return jsonTokenResponse({
+				body: replay.body,
+				status: 200,
+			});
+		}
+	}
+
+	const response = await auth.handler(normalizedRequest);
 	if (!response.ok) return response;
 
 	let body: Record<string, unknown>;
@@ -335,12 +417,19 @@ export const handleOAuthTokenWithApiKey = async (c: Context) => {
 			isMcpClient ||
 			returnsOAuthAccessTokenForClientId({ clientId: tokenRecord.clientId })
 		) {
+			const responseBody = rewriteOAuthAccessTokenBody({
+				accessToken: prefixOAuthToken({ token: accessToken }),
+				body,
+				scopes: tokenRecord.scopes,
+			});
+			if (refreshReplayKey) {
+				await storeRefreshReplay({
+					body: responseBody,
+					key: refreshReplayKey,
+				});
+			}
 			return jsonTokenResponse({
-				body: rewriteOAuthAccessTokenBody({
-					accessToken: prefixOAuthToken({ token: accessToken }),
-					body,
-					scopes: tokenRecord.scopes,
-				}),
+				body: responseBody,
 				response,
 				status: response.status,
 			});

--- a/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
+++ b/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
@@ -12,7 +12,7 @@ import { db } from "@/db/initDrizzle.js";
 import { getPrimaryRedis } from "@/external/redis/initRedis.js";
 import { auth } from "@/utils/auth.js";
 import { decryptData, encryptData } from "@/utils/encryptUtils.js";
-import { timeout } from "@/utils/genUtils.js";
+import { generateId, timeout } from "@/utils/genUtils.js";
 import { hashOAuthToken } from "@/utils/oauthUtils.js";
 import {
 	oauthAccessTokenRepo,
@@ -120,55 +120,97 @@ const jsonTokenResponse = ({
 	});
 
 const REFRESH_REPLAY_TTL_SECONDS = 30;
-const REFRESH_REPLAY_PENDING = "pending";
+const REFRESH_REPLAY_PENDING = "pending:";
+const REFRESH_REPLAY_RENEW_MS = 10_000;
+
+const UPDATE_REFRESH_REPLAY_SCRIPT = `
+if redis.call("GET", KEYS[1]) ~= ARGV[1] then return 0 end
+if ARGV[2] == "" then return redis.call("DEL", KEYS[1]) end
+redis.call("SET", KEYS[1], ARGV[2], "EX", ARGV[3])
+return 1
+`;
+
+const pendingRefreshReplay = (owner: string) =>
+	`${REFRESH_REPLAY_PENDING}${owner}`;
+
+const updateRefreshReplay = async ({
+	key,
+	owner,
+	value,
+}: {
+	key: string;
+	owner: string;
+	value?: string;
+}) => {
+	try {
+		await getPrimaryRedis().eval(
+			UPDATE_REFRESH_REPLAY_SCRIPT,
+			1,
+			key,
+			pendingRefreshReplay(owner),
+			value ?? "",
+			REFRESH_REPLAY_TTL_SECONDS,
+		);
+	} catch {
+		return;
+	}
+};
+
+const maintainRefreshReplay = ({
+	key,
+	owner,
+}: {
+	key: string;
+	owner: string;
+}) => {
+	let finished = false;
+	const interval = setInterval(
+		() =>
+			void updateRefreshReplay({
+				key,
+				owner,
+				value: pendingRefreshReplay(owner),
+			}),
+		REFRESH_REPLAY_RENEW_MS,
+	);
+	interval.unref();
+	return async (body?: Record<string, unknown>) => {
+		if (finished) return;
+		finished = true;
+		clearInterval(interval);
+		await updateRefreshReplay({
+			key,
+			owner,
+			value: body ? encryptData(JSON.stringify(body)) : undefined,
+		});
+	};
+};
 
 const claimRefreshReplay = async (key: string) => {
 	try {
 		const redis = getPrimaryRedis();
 		if (redis.status !== "ready") return null;
+		const owner = generateId("oauth_refresh_replay");
+		const pending = pendingRefreshReplay(owner);
 		for (let attempt = 0; attempt < 200; attempt++) {
 			const value = await redis.get(key);
-			if (value && value !== REFRESH_REPLAY_PENDING) {
+			if (value && !value.startsWith(REFRESH_REPLAY_PENDING)) {
 				return {
 					body: JSON.parse(decryptData(value)) as Record<string, unknown>,
+					owner: null,
 				};
 			}
 			if (
 				!value &&
-				(await redis.set(
-					key,
-					REFRESH_REPLAY_PENDING,
-					"EX",
-					REFRESH_REPLAY_TTL_SECONDS,
-					"NX",
-				))
+				(await redis.set(key, pending, "EX", REFRESH_REPLAY_TTL_SECONDS, "NX"))
 			) {
-				return { body: null };
+				return { body: null, owner };
 			}
 			await timeout(25);
 		}
 		return null;
 	} catch {
 		return null;
-	}
-};
-
-const storeRefreshReplay = async ({
-	body,
-	key,
-}: {
-	body: Record<string, unknown>;
-	key: string;
-}) => {
-	try {
-		await getPrimaryRedis().set(
-			key,
-			encryptData(JSON.stringify(body)),
-			"EX",
-			REFRESH_REPLAY_TTL_SECONDS,
-		);
-	} catch {
-		return;
 	}
 };
 
@@ -297,6 +339,7 @@ export const handleOAuthTokenWithApiKey = async (c: Context) => {
 				`${resource ?? ""}\n${normalizedRequest.headers.get("authorization") ?? ""}\n${await normalizedRequest.clone().text()}`,
 			)}`
 		: null;
+	let finishRefreshReplay = async (_body?: Record<string, unknown>) => {};
 	if (refreshReplayKey) {
 		const replay = await claimRefreshReplay(refreshReplayKey);
 		if (!replay) {
@@ -314,21 +357,38 @@ export const handleOAuthTokenWithApiKey = async (c: Context) => {
 				status: 200,
 			});
 		}
+		finishRefreshReplay = maintainRefreshReplay({
+			key: refreshReplayKey,
+			owner: replay.owner,
+		});
 	}
 
-	const response = await auth.handler(normalizedRequest);
-	if (!response.ok) return response;
+	let response: Response;
+	try {
+		response = await auth.handler(normalizedRequest);
+	} catch (error) {
+		await finishRefreshReplay();
+		throw error;
+	}
+	if (!response.ok) {
+		await finishRefreshReplay();
+		return response;
+	}
 
 	let body: Record<string, unknown>;
 	try {
 		body = (await response.clone().json()) as Record<string, unknown>;
 	} catch {
+		await finishRefreshReplay();
 		return response;
 	}
 
 	const tokenPayload = getTokenPayload(body);
 	const accessToken = getString(tokenPayload.access_token);
-	if (!accessToken) return response;
+	if (!accessToken) {
+		await finishRefreshReplay();
+		return response;
+	}
 
 	const parsedRequestedScopes = scopesFromOAuthScopeString(tokenPayload.scope);
 	const requestedScopes = parsedRequestedScopes
@@ -422,12 +482,7 @@ export const handleOAuthTokenWithApiKey = async (c: Context) => {
 				body,
 				scopes: tokenRecord.scopes,
 			});
-			if (refreshReplayKey) {
-				await storeRefreshReplay({
-					body: responseBody,
-					key: refreshReplayKey,
-				});
-			}
+			await finishRefreshReplay(responseBody);
 			return jsonTokenResponse({
 				body: responseBody,
 				response,
@@ -440,6 +495,7 @@ export const handleOAuthTokenWithApiKey = async (c: Context) => {
 			requestedScopes,
 		});
 	} catch (error) {
+		await finishRefreshReplay();
 		if (error instanceof RecaseError) {
 			return jsonTokenResponse({
 				body: {
@@ -451,8 +507,12 @@ export const handleOAuthTokenWithApiKey = async (c: Context) => {
 		}
 		throw error;
 	}
-	if (!apiKeyResult) return response;
+	if (!apiKeyResult) {
+		await finishRefreshReplay();
+		return response;
+	}
 
+	await finishRefreshReplay();
 	return jsonTokenResponse({
 		body: rewriteTokenBody({
 			apiKey: apiKeyResult.apiKey,

--- a/server/tests/integration/auth/mcp-oauth-refresh-scopes.test.ts
+++ b/server/tests/integration/auth/mcp-oauth-refresh-scopes.test.ts
@@ -21,7 +21,7 @@ const baseUrl =
 	process.env.AUTUMN_TEST_BASE_URL?.replace(/\/$/, "") ??
 	`http://localhost:${process.env.SERVER_PORT ?? "8080"}`;
 
-test("MCP OAuth refresh accepts Arctic's advertised scope set after consent narrowing", async () => {
+test("MCP OAuth refresh narrows scopes and replays consumed-token retries", async () => {
 	const session = await createDashboardSession(defaultCtx);
 	const clientId = generateId("oauth_client");
 	const consentId = generateId("oauth_consent");
@@ -69,17 +69,61 @@ test("MCP OAuth refresh accepts Arctic's advertised scope set after consent narr
 			scopes: grantedScopes,
 		});
 
-		const tokens = await new OAuth2Client(
-			clientId,
-			null,
-			null,
-		).refreshAccessToken(`${baseUrl}/api/auth/oauth2/token`, refreshToken, [
+		const arctic = new OAuth2Client(clientId, null, null);
+		const advertisedScopes = [
 			...DEFAULT_OAUTH_RESOURCE_SCOPES,
 			"offline_access",
+		];
+		const [tokens, concurrentRetry] = await Promise.all([
+			arctic.refreshAccessToken(
+				`${baseUrl}/api/auth/oauth2/token`,
+				refreshToken,
+				advertisedScopes,
+			),
+			arctic.refreshAccessToken(
+				`${baseUrl}/api/auth/oauth2/token`,
+				refreshToken,
+				advertisedScopes,
+			),
 		]);
 
 		expect(tokens.accessToken()).toStartWith("am_oauth_");
 		expect(tokens.scopes()).toEqual(grantedScopes);
+		expect(concurrentRetry.accessToken()).toBe(tokens.accessToken());
+		expect(concurrentRetry.refreshToken()).toBe(tokens.refreshToken());
+
+		const retryResponse = await fetch(`${baseUrl}/api/auth/oauth2/token`, {
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				scope: advertisedScopes.join(" "),
+				client_id: clientId,
+				refresh_token: refreshToken,
+				grant_type: "refresh_token",
+			}),
+		});
+		const retry = (await retryResponse.json()) as Record<string, unknown>;
+		expect(retry.access_token).toBe(tokens.accessToken());
+		expect(retry.refresh_token).toBe(tokens.refreshToken());
+
+		const replacement = tokens.refreshToken();
+		if (!replacement) throw new Error("Missing replacement refresh token");
+		await arctic.refreshAccessToken(
+			`${baseUrl}/api/auth/oauth2/token`,
+			replacement,
+			advertisedScopes,
+		);
+
+		const mismatchedRetry = await fetch(`${baseUrl}/api/auth/oauth2/token`, {
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				grant_type: "refresh_token",
+				refresh_token: refreshToken,
+				client_id: generateId("oauth_client"),
+			}),
+		});
+		expect(mismatchedRetry.status).toBe(400);
 
 		const organization = await fetch(`${baseUrl}/v1/organization`, {
 			headers: {

--- a/server/tests/integration/auth/mcp-oauth-refresh-scopes.test.ts
+++ b/server/tests/integration/auth/mcp-oauth-refresh-scopes.test.ts
@@ -114,16 +114,24 @@ test("MCP OAuth refresh narrows scopes and replays consumed-token retries", asyn
 			advertisedScopes,
 		);
 
-		const mismatchedRetry = await fetch(`${baseUrl}/api/auth/oauth2/token`, {
-			method: "POST",
-			headers: { "Content-Type": "application/x-www-form-urlencoded" },
-			body: new URLSearchParams({
-				grant_type: "refresh_token",
-				refresh_token: refreshToken,
-				client_id: generateId("oauth_client"),
-			}),
-		});
+		const mismatchedClientId = generateId("oauth_client");
+		const mismatchedRefresh = () =>
+			fetch(`${baseUrl}/api/auth/oauth2/token`, {
+				method: "POST",
+				headers: { "Content-Type": "application/x-www-form-urlencoded" },
+				body: new URLSearchParams({
+					grant_type: "refresh_token",
+					refresh_token: refreshToken,
+					client_id: mismatchedClientId,
+				}),
+			});
+		const mismatchedResponse = await mismatchedRefresh();
+		const mismatchedRetry = await mismatchedRefresh();
+		expect(mismatchedResponse.status).toBe(400);
 		expect(mismatchedRetry.status).toBe(400);
+		expect(await mismatchedRetry.json()).toEqual(
+			await mismatchedResponse.json(),
+		);
 
 		const organization = await fetch(`${baseUrl}/v1/organization`, {
 			headers: {


### PR DESCRIPTION
## Summary

- atomically coordinate identical in-flight MCP refresh requests across instances, then replay the encrypted response for 30 seconds
- canonicalize form/JSON field ordering and bind replay keys to resource, client authentication, and request fields
- fail closed with `temporarily_unavailable` if coordination is unavailable, avoiding destructive refresh-family invalidation
- keep Better Auth pinned at 1.6.25 with no dependency, schema, migration, discovery, consent, or transport changes

## Verification

- confirmed red first: two concurrent refreshes caused `invalid_grant` and invalidated the replacement family
- integration: concurrent and sequential retries return the same token pair, reordered form fields replay, mismatched client identity is rejected, and the replacement token remains usable
- `bunx tsgo --build --noEmit`
- `bunx biome check server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts server/tests/integration/auth/mcp-oauth-refresh-scopes.test.ts`
- auth unit suite: 73 passed
- adjacent RevenueCat MCP and Stripe OAuth tests: 5 passed
- previously merged to `dev` in #2505 with all GitHub checks green

## Scope

One commit and two existing files, branched directly from current `main`.

## Baseline note

`oauth-discovery-fallthrough.test.ts` has one unrelated failure for `/.well-known/oauth-protected-resource/api/auth`; the same failure reproduces on untouched `dev` and is not changed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coordinates identical MCP OAuth refresh requests and replays the successful response for 30 seconds. Adds owner-safe replay leases that renew during slow refreshes and release on failure to prevent token family invalidation.

- **Bug Fixes**
  - Deduplicates in-flight refreshes across instances via Redis with owner-held leases; renews pending replay TTL and cleans up on errors; if coordination is unavailable, returns 503 `temporarily_unavailable`.
  - Canonicalizes request bodies (sorted JSON fields and URL params) and binds replay keys to resource, client auth, and request fields.
  - Encrypts and caches the refresh response for 30s; retries get the same token pair, and the replacement refresh token stays usable.
  - No changes to dependencies, schema, migrations, discovery, consent, or transport; Better Auth remains pinned at 1.6.25.

<sup>Written for commit cb421cae0f97b28efba74744e61ab1ae7a7898f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

