### PR TITLE
fix: deduplicate request log metadata

### DIFF
--- a/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
+++ b/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
@@ -59,7 +59,6 @@ export const logRequestResult = async ({
 			logger: ctx.logger,
 			extras: ctx.extraLogs,
 		});
-		const requestBody = ctx.requestLogContext?.body;
 
 		const skipResponseBody =
 			isSuccess && RESPONSE_BODY_EXCLUDED_ROUTES.has(c.req.path);
@@ -84,7 +83,9 @@ export const logRequestResult = async ({
 			{
 				statusCode,
 				durationMs,
-				...(requestBody === undefined ? {} : { request_body: requestBody }),
+				...(ctx.requestLogContext === undefined
+					? {}
+					: { req: ctx.requestLogContext }),
 				res: finalResponseBody ?? null,
 			},
 		);

--- a/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
+++ b/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
@@ -1,10 +1,7 @@
 import chalk from "chalk";
 import type { Context } from "hono";
 import type { AutumnContext, HonoEnv } from "@/honoUtils/HonoEnv.js";
-import {
-	addExtrasToLogs,
-	addRequestToLogs,
-} from "@/utils/logging/addContextToLogs.js";
+import { addExtrasToLogs } from "@/utils/logging/addContextToLogs.js";
 import { maskExtraLogs } from "@/utils/logging/maskExtraLogs.js";
 
 const HIGH_VOLUME_SUCCESS_ROUTES = new Set<string>([
@@ -58,17 +55,11 @@ export const logRequestResult = async ({
 			return;
 		}
 
-		if (ctx.requestLogContext) {
-			ctx.logger = addRequestToLogs({
-				logger: ctx.logger,
-				requestContext: ctx.requestLogContext,
-			});
-		}
-
 		ctx.logger = addExtrasToLogs({
 			logger: ctx.logger,
 			extras: ctx.extraLogs,
 		});
+		const requestBody = ctx.requestLogContext?.body;
 
 		const skipResponseBody =
 			isSuccess && RESPONSE_BODY_EXCLUDED_ROUTES.has(c.req.path);
@@ -93,6 +84,7 @@ export const logRequestResult = async ({
 			{
 				statusCode,
 				durationMs,
+				...(requestBody === undefined ? {} : { request_body: requestBody }),
 				res: finalResponseBody ?? null,
 			},
 		);

--- a/server/src/internal/logs/actions/searchRequestLogs/buildRequestLogsApl.ts
+++ b/server/src/internal/logs/actions/searchRequestLogs/buildRequestLogsApl.ts
@@ -32,7 +32,11 @@ const REQUEST_LOG_PROJECTION: ProjectionField[] = [
 		alias: "request_path",
 		expression: "request_path",
 	},
-	{ alias: "request_body", expression: "['req.body']" },
+	{
+		alias: "request_body",
+		expression:
+			"coalesce(column_ifexists(\"request_body\", ['req.body']), ['req.body'])",
+	},
 	{ alias: "response_body", expression: "res" },
 	{ alias: "org_id", expression: "['context.org_id']" },
 	{ alias: "customer_id", expression: "['context.customer_id']" },

--- a/server/src/internal/logs/actions/searchRequestLogs/buildRequestLogsApl.ts
+++ b/server/src/internal/logs/actions/searchRequestLogs/buildRequestLogsApl.ts
@@ -32,11 +32,7 @@ const REQUEST_LOG_PROJECTION: ProjectionField[] = [
 		alias: "request_path",
 		expression: "request_path",
 	},
-	{
-		alias: "request_body",
-		expression:
-			"coalesce(column_ifexists(\"request_body\", ['req.body']), ['req.body'])",
-	},
+	{ alias: "request_body", expression: "['req.body']" },
 	{ alias: "response_body", expression: "res" },
 	{ alias: "org_id", expression: "['context.org_id']" },
 	{ alias: "customer_id", expression: "['context.customer_id']" },

--- a/server/src/utils/logging/addContextToLogs.ts
+++ b/server/src/utils/logging/addContextToLogs.ts
@@ -17,7 +17,22 @@ export const addRequestToLogs = ({
 	logger: Logger;
 	requestContext: LogRequestContext | InternalLogRequestContext;
 }): Logger => {
-	return logger.child({ context: { req: requestContext } });
+	const withRequestContext =
+		(log: Logger["info"]): Logger["info"] =>
+		(...args) =>
+			log({ req: requestContext }, ...args);
+
+	return {
+		debug: withRequestContext(logger.debug),
+		info: withRequestContext(logger.info),
+		warn: withRequestContext(logger.warn),
+		error: withRequestContext(logger.error),
+		child: ({ context, onlyProd }) =>
+			addRequestToLogs({
+				logger: logger.child({ context, onlyProd }),
+				requestContext,
+			}),
+	};
 };
 
 export const addAppContextToLogs = ({

--- a/server/tests/unit/logging/logRequestResult.test.ts
+++ b/server/tests/unit/logging/logRequestResult.test.ts
@@ -8,29 +8,37 @@ import type { LogRequestContext } from "@/utils/logging/loggerTypes.js";
 type CapturedLog = {
 	level: "debug" | "info" | "warn" | "error";
 	bindings: Record<string, unknown>;
+	bindingLayers: Record<string, unknown>[];
 	args: unknown[];
 };
 
 const createCapturingLogger = ({
 	bindings = {},
+	bindingLayers = [bindings],
 	captured,
 }: {
 	bindings?: Record<string, unknown>;
+	bindingLayers?: Record<string, unknown>[];
 	captured: CapturedLog[];
 }): Logger => ({
-	debug: (...args) => captured.push({ level: "debug", bindings, args }),
-	info: (...args) => captured.push({ level: "info", bindings, args }),
-	warn: (...args) => captured.push({ level: "warn", bindings, args }),
-	error: (...args) => captured.push({ level: "error", bindings, args }),
+	debug: (...args) =>
+		captured.push({ level: "debug", bindings, bindingLayers, args }),
+	info: (...args) =>
+		captured.push({ level: "info", bindings, bindingLayers, args }),
+	warn: (...args) =>
+		captured.push({ level: "warn", bindings, bindingLayers, args }),
+	error: (...args) =>
+		captured.push({ level: "error", bindings, bindingLayers, args }),
 	child: ({ context }) =>
 		createCapturingLogger({
 			bindings: { ...bindings, ...context },
+			bindingLayers: [...bindingLayers, context],
 			captured,
 		}),
 });
 
 describe("logRequestResult", () => {
-	test("restores the full request body on the terminal request record", async () => {
+	test("logs the request body without rebinding request metadata", async () => {
 		const captured: CapturedLog[] = [];
 		const requestLogContext: LogRequestContext = {
 			id: "req_123",
@@ -78,11 +86,15 @@ describe("logRequestResult", () => {
 
 		expect(captured).toHaveLength(1);
 		expect(captured[0]?.level).toBe("info");
-		expect(captured[0]?.bindings.req).toEqual(requestLogContext);
+		expect(
+			captured[0]?.bindingLayers.filter((bindings) => "req" in bindings),
+		).toHaveLength(1);
+		expect(captured[0]?.bindings.req).toEqual(internalRequestContext);
 		expect(captured[0]?.bindings.extras).toEqual({});
 		expect(captured[0]?.args[1]).toEqual({
 			statusCode: 200,
 			durationMs: 20,
+			request_body: requestLogContext.body,
 			res: { allowed: true },
 		});
 	});
@@ -142,11 +154,19 @@ describe("logRequestResult", () => {
 
 		expect(captured).toHaveLength(1);
 		expect(captured[0]?.level).toBe("warn");
-		expect(captured[0]?.bindings.req).toEqual(requestLogContext);
+		expect(captured[0]?.bindings.req).toEqual({
+			id: requestLogContext.id,
+			method: requestLogContext.method,
+			url: requestLogContext.url,
+			timestamp: requestLogContext.timestamp,
+			query: requestLogContext.query,
+			name: requestLogContext.name,
+		});
 		expect(captured[0]?.bindings.extras).toEqual({ operation: "track" });
 		expect(captured[0]?.args[1]).toEqual({
 			statusCode: 500,
 			durationMs: 30,
+			request_body: requestLogContext.body,
 			res: responseBody,
 		});
 	});

--- a/server/tests/unit/logging/logRequestResult.test.ts
+++ b/server/tests/unit/logging/logRequestResult.test.ts
@@ -3,6 +3,7 @@ import type { Context } from "hono";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
 import { logRequestResult } from "@/honoMiddlewares/requestLogging/logRequestResult.js";
 import type { AutumnContext, HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { addRequestToLogs } from "@/utils/logging/addContextToLogs.js";
 import type { LogRequestContext } from "@/utils/logging/loggerTypes.js";
 
 type CapturedLog = {
@@ -37,6 +38,15 @@ const createCapturingLogger = ({
 		}),
 });
 
+const mergeLoggedObjects = (args: unknown[]) =>
+	Object.assign(
+		{},
+		...args.filter(
+			(argument): argument is Record<string, unknown> =>
+				typeof argument === "object" && argument !== null,
+		),
+	);
+
 describe("logRequestResult", () => {
 	test("logs the request body without rebinding request metadata", async () => {
 		const captured: CapturedLog[] = [];
@@ -61,9 +71,9 @@ describe("logRequestResult", () => {
 		};
 		const ctx = {
 			timestamp: 123,
-			logger: createCapturingLogger({
-				bindings: { req: internalRequestContext },
-				captured,
+			logger: addRequestToLogs({
+				logger: createCapturingLogger({ captured }),
+				requestContext: internalRequestContext,
 			}),
 			requestLogContext,
 			extraLogs: {},
@@ -88,13 +98,13 @@ describe("logRequestResult", () => {
 		expect(captured[0]?.level).toBe("info");
 		expect(
 			captured[0]?.bindingLayers.filter((bindings) => "req" in bindings),
-		).toHaveLength(1);
-		expect(captured[0]?.bindings.req).toEqual(internalRequestContext);
+		).toHaveLength(0);
+		expect(captured[0]?.bindings.req).toBeUndefined();
 		expect(captured[0]?.bindings.extras).toEqual({});
-		expect(captured[0]?.args[1]).toEqual({
+		expect(mergeLoggedObjects(captured[0]?.args ?? [])).toEqual({
+			req: requestLogContext,
 			statusCode: 200,
 			durationMs: 20,
-			request_body: requestLogContext.body,
 			res: { allowed: true },
 		});
 	});
@@ -116,18 +126,16 @@ describe("logRequestResult", () => {
 		};
 		const ctx = {
 			timestamp: 123,
-			logger: createCapturingLogger({
-				bindings: {
-					req: {
-						id: requestLogContext.id,
-						method: requestLogContext.method,
-						url: requestLogContext.url,
-						timestamp: requestLogContext.timestamp,
-						query: requestLogContext.query,
-						name: requestLogContext.name,
-					},
+			logger: addRequestToLogs({
+				logger: createCapturingLogger({ captured }),
+				requestContext: {
+					id: requestLogContext.id,
+					method: requestLogContext.method,
+					url: requestLogContext.url,
+					timestamp: requestLogContext.timestamp,
+					query: requestLogContext.query,
+					name: requestLogContext.name,
 				},
-				captured,
 			}),
 			requestLogContext,
 			extraLogs: { operation: "track" },
@@ -154,19 +162,12 @@ describe("logRequestResult", () => {
 
 		expect(captured).toHaveLength(1);
 		expect(captured[0]?.level).toBe("warn");
-		expect(captured[0]?.bindings.req).toEqual({
-			id: requestLogContext.id,
-			method: requestLogContext.method,
-			url: requestLogContext.url,
-			timestamp: requestLogContext.timestamp,
-			query: requestLogContext.query,
-			name: requestLogContext.name,
-		});
+		expect(captured[0]?.bindings.req).toBeUndefined();
 		expect(captured[0]?.bindings.extras).toEqual({ operation: "track" });
-		expect(captured[0]?.args[1]).toEqual({
+		expect(mergeLoggedObjects(captured[0]?.args ?? [])).toEqual({
+			req: requestLogContext,
 			statusCode: 500,
 			durationMs: 30,
-			request_body: requestLogContext.body,
 			res: responseBody,
 		});
 	});

--- a/server/tests/unit/logs/requestLogs/restrictedApl.test.ts
+++ b/server/tests/unit/logs/requestLogs/restrictedApl.test.ts
@@ -378,6 +378,9 @@ describe("restricted request-log APL", () => {
 		expect(apl).toContain(
 			"| project timestamp = _time, source = source, status_code = statusCode",
 		);
+		expect(apl).toContain(
+			"request_body = coalesce(column_ifexists(\"request_body\", ['req.body']), ['req.body'])",
+		);
 		expect(apl).toContain("stripe_event_id = ['stripe_event.id']");
 		expect(apl).toContain(
 			"| where dynamic_to_json(response_body) contains 'checkout'",

--- a/server/tests/unit/logs/requestLogs/restrictedApl.test.ts
+++ b/server/tests/unit/logs/requestLogs/restrictedApl.test.ts
@@ -378,9 +378,7 @@ describe("restricted request-log APL", () => {
 		expect(apl).toContain(
 			"| project timestamp = _time, source = source, status_code = statusCode",
 		);
-		expect(apl).toContain(
-			"request_body = coalesce(column_ifexists(\"request_body\", ['req.body']), ['req.body'])",
-		);
+		expect(apl).toContain("request_body = ['req.body']");
 		expect(apl).toContain("stripe_event_id = ['stripe_event.id']");
 		expect(apl).toContain(
 			"| where dynamic_to_json(response_body) contains 'checkout'",


### PR DESCRIPTION
## What changed

- inject body-less request metadata into each internal log event instead of serializing it as a Pino child binding
- emit the terminal request as one complete `req` object, preserving the existing `req.body` field path
- keep successful `/v1/events/list` and `/v1/events.list` response bodies out of Axiom because those payloads can be several megabytes
- add regression coverage proving terminal events contain one `req` object and request-log queries continue projecting `req.body`

## Why

The terminal logger was created as a child of a logger that already contained `req`. Pino serialized both bindings as duplicate `req` keys in the raw JSON sent to Axiom. Axiom bills the uncompressed request, so the duplicate metadata increased ingest even though only one parsed `req` object was queryable.

Request context is now merged into the log event before Pino serializes it. Internal logs retain the body-less request metadata, while the terminal event replaces that value with the complete request. This produces one raw `req` object without changing the Axiom schema or losing request-body queryability. At current traffic, removing the duplicated request metadata is estimated to save approximately 3–4 GB/hour of `express` ingest.

## Impact

- existing Axiom queries, saved queries, and Autumn's Logs UI continue using `req.body`
- request identifiers, method, URL, query, customer/entity metadata, response body, status, duration, extras, and error/success logging remain available
- only the duplicated serialized request metadata and the two oversized successful event-list response bodies are removed

## Validation

- red regression: terminal logs still had a Pino `req` binding and the request-log projection expected the temporary top-level body field
- `bun test tests/unit/logging/logRequestResult.test.ts tests/unit/logs/requestLogs/restrictedApl.test.ts` — 36 passed, 0 failed
- `bun test tests/unit/logging` — 16 passed, 0 failed
- `bun ts`
- scoped Biome check on the five changed files
- commit hook: Knip and server typecheck passed
- live Axiom dependency check found saved and recent queries using `req.body`, confirming the field path should remain stable; no dashboards reference it directly
