### PR TITLE
fix(billing): provision add-ons purchased via Stripe Checkout optional_items

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts
@@ -5,6 +5,7 @@ import {
 } from "@autumn/shared";
 import type { CheckoutSessionCompletedContext } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/setupCheckoutSessionCompletedContext";
 import { createStripeScheduleFromCheckout } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionEnabledImmediately/createStripeScheduleFromCheckout";
+import { matchOptionalInvoiceItemsToProducts } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/matchOptionalInvoiceItemsToProducts";
 import { modifyStripeSubscriptionFromCheckout } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/modifyStripeSubscriptionFromCheckout";
 import { syncSubscriptionItemMetadataFromCheckout } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/syncSubscriptionItemMetadataFromCheckout";
 import { updateBillingPlanFromCheckout } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/updateBillingPlanFromCheckout";
@@ -85,6 +86,18 @@ const executeCheckoutSessionMetadataV2 = async ({
 		checkoutContext,
 		deferredData,
 	});
+
+	// 2b. Fold in Stripe Checkout "optional items" the caller didn't request via
+	// plan_id but the customer selected and paid for.
+	const optionalItemProducts = await matchOptionalInvoiceItemsToProducts({
+		ctx,
+		checkoutContext,
+		autumnBillingPlan: updatedDeferredData.billingPlan.autumn,
+		fullCustomer: updatedDeferredData.billingContext.fullCustomer,
+	});
+	updatedDeferredData.billingPlan.autumn.insertCustomerProducts.push(
+		...optionalItemProducts,
+	);
 
 	// 3. Modify Stripe subscription to include other interval prices / 0 quantity prices
 	await modifyStripeSubscriptionFromCheckout({

--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts
@@ -11,7 +11,10 @@ import { syncSubscriptionItemMetadataFromCheckout } from "@/external/stripe/webh
 import { updateBillingPlanFromCheckout } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/updateBillingPlanFromCheckout";
 import { withClaimedCheckoutSessionMetadata } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata";
 import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
-import { persistDeferredCreateSchedule } from "@/internal/billing/v2/actions/createSchedule/utils/persistDeferredCreateSchedule";
+import {
+	isCreateScheduleBillingContext,
+	persistDeferredCreateSchedule,
+} from "@/internal/billing/v2/actions/createSchedule/utils/persistDeferredCreateSchedule";
 import { addStripeSubscriptionScheduleIdToBillingPlan } from "@/internal/billing/v2/execute/addStripeSubscriptionScheduleIdToBillingPlan";
 import { executeAutumnBillingPlan } from "@/internal/billing/v2/execute/executeAutumnBillingPlan";
 import { buildBillingLockKey } from "@/internal/billing/v2/utils/billingLock/buildBillingLockKey";
@@ -80,24 +83,52 @@ const executeCheckoutSessionMetadataV2 = async ({
 		checkoutContext,
 	});
 
+	// 1b. Fold in Stripe Checkout "optional items" the caller didn't request via
+	// plan_id but the customer selected and paid for. Skipped for create-schedule
+	// checkouts: the deferred phase bookkeeping only knows about the products it
+	// was told about ahead of time, and can't place an unplanned product into a
+	// phase after the fact.
+	let dataWithOptionalItems = deferredData;
+	if (!isCreateScheduleBillingContext(deferredData.billingContext)) {
+		const optionalItemMatch = await matchOptionalInvoiceItemsToProducts({
+			ctx,
+			checkoutContext,
+			autumnBillingPlan: deferredData.billingPlan.autumn,
+			fullCustomer: deferredData.billingContext.fullCustomer,
+		});
+
+		if (optionalItemMatch.customerProducts.length > 0) {
+			dataWithOptionalItems = {
+				...deferredData,
+				billingContext: {
+					...deferredData.billingContext,
+					fullProducts: [
+						...deferredData.billingContext.fullProducts,
+						...optionalItemMatch.fullProducts,
+					],
+				},
+				billingPlan: {
+					...deferredData.billingPlan,
+					autumn: {
+						...deferredData.billingPlan.autumn,
+						insertCustomerProducts: [
+							...deferredData.billingPlan.autumn.insertCustomerProducts,
+							...optionalItemMatch.customerProducts,
+						],
+					},
+				},
+			};
+		}
+	}
+
 	// 2. Update billing plan with checkout data (upsertSubscription, upsertInvoice)
+	// Runs after 1b so the invoice's product_ids/items include any matched
+	// optional-item add-on, not just what plan_id originally requested.
 	const updatedDeferredData = await updateBillingPlanFromCheckout({
 		ctx,
 		checkoutContext,
-		deferredData,
+		deferredData: dataWithOptionalItems,
 	});
-
-	// 2b. Fold in Stripe Checkout "optional items" the caller didn't request via
-	// plan_id but the customer selected and paid for.
-	const optionalItemProducts = await matchOptionalInvoiceItemsToProducts({
-		ctx,
-		checkoutContext,
-		autumnBillingPlan: updatedDeferredData.billingPlan.autumn,
-		fullCustomer: updatedDeferredData.billingContext.fullCustomer,
-	});
-	updatedDeferredData.billingPlan.autumn.insertCustomerProducts.push(
-		...optionalItemProducts,
-	);
 
 	// 3. Modify Stripe subscription to include other interval prices / 0 quantity prices
 	await modifyStripeSubscriptionFromCheckout({

--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/matchOptionalInvoiceItemsToProducts.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/matchOptionalInvoiceItemsToProducts.ts
@@ -1,0 +1,79 @@
+import type { AutumnBillingPlan, FullCusProduct, FullCustomer } from "@autumn/shared";
+import { getStripePriceIdsForAutumnPrice } from "@/internal/billing/v2/providers/stripe/utils/sync/matchUtils/getStripePriceIdsForAutumnPrice";
+import { initFullCustomerProductFromProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/initFullCustomerProductFromProduct";
+import type { CheckoutSessionCompletedContext } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/setupCheckoutSessionCompletedContext";
+import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
+import { ProductService } from "@/internal/products/ProductService";
+
+/**
+ * Stripe Checkout's `optional_items` upsell lands on the invoice as a plain
+ * one-time line item — Autumn never requested it via `plan_id`, so it's
+ * absent from `insertCustomerProducts`. Match any such leftover line item's
+ * price against the org's product catalog and provision it alongside
+ * whatever the caller originally requested.
+ */
+export const matchOptionalInvoiceItemsToProducts = async ({
+	ctx,
+	checkoutContext,
+	autumnBillingPlan,
+	fullCustomer,
+}: {
+	ctx: StripeWebhookContext;
+	checkoutContext: CheckoutSessionCompletedContext;
+	autumnBillingPlan: AutumnBillingPlan;
+	fullCustomer: FullCustomer;
+}): Promise<FullCusProduct[]> => {
+	const invoiceLines = checkoutContext.stripeInvoice?.lines.data ?? [];
+	if (invoiceLines.length === 0) return [];
+
+	const alreadyCoveredStripePriceIds = new Set(
+		autumnBillingPlan.insertCustomerProducts.flatMap((cusProduct) =>
+			cusProduct.customer_prices.flatMap((cusPrice) =>
+				getStripePriceIdsForAutumnPrice({ price: cusPrice.price }),
+			),
+		),
+	);
+
+	const leftoverStripePriceIds = invoiceLines
+		.filter((line) => line.parent?.type === "invoice_item_details")
+		.map((line) => line.pricing?.price_details?.price)
+		.filter((stripePriceId): stripePriceId is string => Boolean(stripePriceId))
+		.filter((stripePriceId) => !alreadyCoveredStripePriceIds.has(stripePriceId));
+
+	if (leftoverStripePriceIds.length === 0) return [];
+
+	const fullProducts = await ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+
+	const matchedProducts = leftoverStripePriceIds
+		.map((stripePriceId) =>
+			fullProducts.find((product) =>
+				product.prices.some((price) =>
+					getStripePriceIdsForAutumnPrice({ price }).includes(stripePriceId),
+				),
+			),
+		)
+		.filter((product): product is NonNullable<typeof product> =>
+			Boolean(product),
+		);
+
+	if (matchedProducts.length === 0) return [];
+
+	ctx.logger.info(
+		`[checkout.completed] Matched optional_items to add-on(s) for customer ${fullCustomer.id}: ${matchedProducts.map((p) => p.id).join(", ")}`,
+	);
+
+	return matchedProducts.map((product) =>
+		initFullCustomerProductFromProduct({
+			ctx,
+			initContext: {
+				fullCustomer,
+				fullProduct: product,
+				currentEpochMs: Date.now(),
+			},
+		}),
+	);
+};

--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/matchOptionalInvoiceItemsToProducts.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/matchOptionalInvoiceItemsToProducts.ts
@@ -1,16 +1,32 @@
-import type { AutumnBillingPlan, FullCusProduct, FullCustomer } from "@autumn/shared";
+import type {
+	AutumnBillingPlan,
+	FullCusProduct,
+	FullCustomer,
+	FullProduct,
+} from "@autumn/shared";
 import { getStripePriceIdsForAutumnPrice } from "@/internal/billing/v2/providers/stripe/utils/sync/matchUtils/getStripePriceIdsForAutumnPrice";
 import { initFullCustomerProductFromProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/initFullCustomerProductFromProduct";
 import type { CheckoutSessionCompletedContext } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/setupCheckoutSessionCompletedContext";
 import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
 import { ProductService } from "@/internal/products/ProductService";
 
+export type OptionalInvoiceItemMatch = {
+	fullProducts: FullProduct[];
+	customerProducts: FullCusProduct[];
+};
+
+const EMPTY_MATCH: OptionalInvoiceItemMatch = {
+	fullProducts: [],
+	customerProducts: [],
+};
+
 /**
  * Stripe Checkout's `optional_items` upsell lands on the invoice as a plain
  * one-time line item — Autumn never requested it via `plan_id`, so it's
  * absent from `insertCustomerProducts`. Match any such leftover line item's
- * price against the org's product catalog and provision it alongside
- * whatever the caller originally requested.
+ * price against the org's product catalog and return both the matched
+ * catalog product (so the caller can fold it into invoice construction) and
+ * the provisioned customer product, scaled to the quantity purchased.
  */
 export const matchOptionalInvoiceItemsToProducts = async ({
 	ctx,
@@ -22,9 +38,9 @@ export const matchOptionalInvoiceItemsToProducts = async ({
 	checkoutContext: CheckoutSessionCompletedContext;
 	autumnBillingPlan: AutumnBillingPlan;
 	fullCustomer: FullCustomer;
-}): Promise<FullCusProduct[]> => {
+}): Promise<OptionalInvoiceItemMatch> => {
 	const invoiceLines = checkoutContext.stripeInvoice?.lines.data ?? [];
-	if (invoiceLines.length === 0) return [];
+	if (invoiceLines.length === 0) return EMPTY_MATCH;
 
 	const alreadyCoveredStripePriceIds = new Set(
 		autumnBillingPlan.insertCustomerProducts.flatMap((cusProduct) =>
@@ -34,13 +50,19 @@ export const matchOptionalInvoiceItemsToProducts = async ({
 		),
 	);
 
-	const leftoverStripePriceIds = invoiceLines
+	const leftoverLines = invoiceLines
 		.filter((line) => line.parent?.type === "invoice_item_details")
-		.map((line) => line.pricing?.price_details?.price)
-		.filter((stripePriceId): stripePriceId is string => Boolean(stripePriceId))
-		.filter((stripePriceId) => !alreadyCoveredStripePriceIds.has(stripePriceId));
+		.map((line) => ({
+			stripePriceId: line.pricing?.price_details?.price,
+			quantity: line.quantity ?? 1,
+		}))
+		.filter(
+			(entry): entry is { stripePriceId: string; quantity: number } =>
+				Boolean(entry.stripePriceId) &&
+				!alreadyCoveredStripePriceIds.has(entry.stripePriceId as string),
+		);
 
-	if (leftoverStripePriceIds.length === 0) return [];
+	if (leftoverLines.length === 0) return EMPTY_MATCH;
 
 	const fullProducts = await ProductService.listFull({
 		db: ctx.db,
@@ -48,32 +70,52 @@ export const matchOptionalInvoiceItemsToProducts = async ({
 		env: ctx.env,
 	});
 
-	const matchedProducts = leftoverStripePriceIds
-		.map((stripePriceId) =>
-			fullProducts.find((product) =>
-				product.prices.some((price) =>
-					getStripePriceIdsForAutumnPrice({ price }).includes(stripePriceId),
+	const matches = leftoverLines
+		.map((entry) => {
+			const product = fullProducts.find((candidate) =>
+				candidate.prices.some((price) =>
+					getStripePriceIdsForAutumnPrice({ price }).includes(
+						entry.stripePriceId,
+					),
 				),
-			),
-		)
-		.filter((product): product is NonNullable<typeof product> =>
-			Boolean(product),
+			);
+			return product ? { product, quantity: entry.quantity } : null;
+		})
+		.filter((match): match is { product: FullProduct; quantity: number } =>
+			Boolean(match),
 		);
 
-	if (matchedProducts.length === 0) return [];
+	if (matches.length === 0) return EMPTY_MATCH;
 
 	ctx.logger.info(
-		`[checkout.completed] Matched optional_items to add-on(s) for customer ${fullCustomer.id}: ${matchedProducts.map((p) => p.id).join(", ")}`,
+		`[checkout.completed] Matched optional_items to add-on(s) for customer ${fullCustomer.id}: ${matches
+			.map(({ product, quantity }) => `${product.id} x${quantity}`)
+			.join(", ")}`,
 	);
 
-	return matchedProducts.map((product) =>
-		initFullCustomerProductFromProduct({
+	const customerProducts = matches.map(({ product, quantity }) => {
+		const customerProduct = initFullCustomerProductFromProduct({
 			ctx,
 			initContext: {
 				fullCustomer,
 				fullProduct: product,
 				currentEpochMs: Date.now(),
 			},
-		}),
-	);
+		});
+
+		// initFullCustomerProductFromProduct always grants quantity 1 — scale to
+		// what Checkout actually charged. Boolean/unlimited entitlements start
+		// at balance 0 regardless, so this is a no-op for them.
+		customerProduct.quantity = quantity;
+		for (const cusEnt of customerProduct.customer_entitlements) {
+			cusEnt.balance = (cusEnt.balance ?? 0) * quantity;
+		}
+
+		return customerProduct;
+	});
+
+	return {
+		fullProducts: matches.map(({ product }) => product),
+		customerProducts,
+	};
 };

--- a/server/src/internal/billing/v2/actions/createSchedule/utils/persistDeferredCreateSchedule.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/utils/persistDeferredCreateSchedule.ts
@@ -6,7 +6,7 @@ import type {
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { persistCreateSchedule } from "./persistCreateSchedule";
 
-const isCreateScheduleBillingContext = (
+export const isCreateScheduleBillingContext = (
 	billingContext: BillingContext,
 ): billingContext is CreateScheduleBillingContext =>
 	"immediatePhase" in billingContext &&

--- a/server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-optional-items-addon.test.ts
+++ b/server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-optional-items-addon.test.ts
@@ -14,13 +14,17 @@
  *     - Originally requested plan is still provisioned (no regression).
  *     - New customer_product exists for the matched add-on (status active).
  *     - Customer entitlement for the add-on's feature exists.
+ *     - The persisted invoice reflects both products, not just plan_id's —
+ *       invoice construction must see the matched add-on too, not only the
+ *       customer_product insert.
  *
  * Pre-impl red: the add-on assertions fail because `checkout.session.completed`
  * only provisions what `plan_id` requested — it never inspects the invoice's
  * one-time line items for unrequested-but-matching optional items.
  * Post-impl green: all assertions pass once the checkout handler matches
- * leftover one-time invoice line items against the org's add-on prices and
- * folds any match into the billing plan before executing it.
+ * leftover one-time invoice line items against the org's add-on prices,
+ * folds the match in before invoice construction runs, and folds the
+ * resulting customer product into the billing plan before executing it.
  */
 
 import { expect, test } from "bun:test";
@@ -106,5 +110,9 @@ test.concurrent(
 		// ── Contract: the add-on's entitlement exists on the customer ──
 		const dashboardFeature = customer.features?.[TestFeature.Dashboard];
 		expect(dashboardFeature).toBeDefined();
+
+		// ── Contract: the invoice reflects both products, not just plan_id's ──
+		const latestInvoice = customer.invoices?.[0];
+		expect(latestInvoice?.product_ids?.length).toBe(2);
 	},
 );

--- a/server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-optional-items-addon.test.ts
+++ b/server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-optional-items-addon.test.ts
@@ -1,0 +1,110 @@
+/**
+ * TDD test for provisioning an Autumn add-on purchased via Stripe Checkout's
+ * "optional items" upsell.
+ *
+ * Contract under test:
+ *   New behavior:
+ *     - `billing.attach` with `checkout_session_params.optional_items`
+ *       referencing a Stripe price that matches a configured Autumn add-on
+ *       product's price -> when the customer selects that optional item at
+ *       checkout, `checkout.session.completed` provisions the matching
+ *       add-on as an active customer_product, IN ADDITION to the originally
+ *       requested plan.
+ *   Side effects:
+ *     - Originally requested plan is still provisioned (no regression).
+ *     - New customer_product exists for the matched add-on (status active).
+ *     - Customer entitlement for the add-on's feature exists.
+ *
+ * Pre-impl red: the add-on assertions fail because `checkout.session.completed`
+ * only provisions what `plan_id` requested — it never inspects the invoice's
+ * one-time line items for unrequested-but-matching optional items.
+ * Post-impl green: all assertions pass once the checkout handler matches
+ * leftover one-time invoice line items against the org's add-on prices and
+ * folds any match into the billing plan before executing it.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV3, AttachParamsV1Input } from "@autumn/shared";
+import { expectProductActive } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { completeStripeCheckoutFormV2 as completeStripeCheckoutForm } from "@tests/utils/browserPool/completeStripeCheckoutFormV2";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { timeout } from "@tests/utils/genUtils";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { ProductService } from "@/internal/products/ProductService";
+
+test.concurrent(
+	`${chalk.yellowBright("checkout optional_items: purchased add-on is provisioned")}`,
+	async () => {
+		// Unique per run: Stripe's idempotency cache returns the SAME (already
+		// completed) checkout session for a reused customerId, which makes
+		// every re-run collide with a prior iteration's completed session.
+		const customerId = `checkout-optional-item-addon-${Date.now()}`;
+
+		const pro = products.pro({
+			id: "pro-optional-item",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const unfairAdvantage = products.oneOffAddOn({
+			id: "unfair-advantage",
+			items: [items.dashboard()],
+		});
+
+		const { autumnV1, autumnV2_1, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.deleteCustomer({ customerId }), // clean slate across TDD re-runs
+				s.customer({ testClock: true }), // No payment method -> Stripe checkout
+				s.products({ list: [pro, unfairAdvantage] }),
+			],
+			actions: [],
+		});
+
+		// The add-on's Stripe price already exists on the org's catalog once
+		// `s.products` syncs it — this is what Magica's checkout passes as an
+		// `optional_items` entry, independent of what `plan_id` was attached.
+		const fullAddOn = await ProductService.getFull({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			env: ctx.env,
+			idOrInternalId: unfairAdvantage.id,
+		});
+		const addOnStripePriceId = fullAddOn?.prices[0]?.config?.stripe_price_id as
+			| string
+			| undefined;
+		expect(addOnStripePriceId).toBeDefined();
+
+		// 1. Attach the base plan; offer the add-on as a Checkout optional item.
+		const result = await autumnV2_1.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			checkout_session_params: {
+				optional_items: [{ price: addOnStripePriceId, quantity: 1 }],
+			},
+		});
+
+		expect(result.payment_url).toBeDefined();
+		expect(result.payment_url).toContain("checkout.stripe.com");
+
+		// 2. Complete checkout, selecting the optional item.
+		await completeStripeCheckoutForm({
+			url: result.payment_url,
+			addOptionalItem: true,
+		});
+		await timeout(15000);
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+		// ── Contract: originally requested plan still provisions (no regression) ──
+		await expectProductActive({ customer, productId: pro.id });
+
+		// ── Contract: the optional item's matching add-on is also provisioned ──
+		await expectProductActive({ customer, productId: unfairAdvantage.id });
+
+		// ── Contract: the add-on's entitlement exists on the customer ──
+		const dashboardFeature = customer.features?.[TestFeature.Dashboard];
+		expect(dashboardFeature).toBeDefined();
+	},
+);

--- a/server/tests/utils/browserPool/completeStripeCheckoutFormV2.ts
+++ b/server/tests/utils/browserPool/completeStripeCheckoutFormV2.ts
@@ -20,11 +20,14 @@ export const completeStripeCheckoutFormV2 = async ({
 	overrideQuantity,
 	promoCode,
 	billingAddress,
+	addOptionalItem,
 }: {
 	url: string;
 	overrideQuantity?: number;
 	promoCode?: string;
 	billingAddress?: StripeCheckoutBillingAddress;
+	/** Click "Add" on the first Stripe Checkout optional item. */
+	addOptionalItem?: boolean;
 }): Promise<void> => {
 	const concurrency = Number(process.env.TEST_FILE_CONCURRENCY || "0");
 	const timeout = concurrency > 1 ? 10000 : 0;
@@ -36,7 +39,7 @@ export const completeStripeCheckoutFormV2 = async ({
 		await kernelExecute({
 			sessionId,
 			fn: stripeCheckout,
-			args: { url, overrideQuantity, promoCode, billingAddress },
+			args: { url, overrideQuantity, promoCode, billingAddress, addOptionalItem },
 		});
 		console.log("[completeStripeCheckoutFormV2] Done");
 
@@ -49,7 +52,7 @@ export const completeStripeCheckoutFormV2 = async ({
 	console.log("[completeStripeCheckoutFormV2] Using local Playwright...");
 	await playwrightPool.runInPage({
 		fn: stripeCheckout,
-		args: { url, overrideQuantity, promoCode, billingAddress },
+		args: { url, overrideQuantity, promoCode, billingAddress, addOptionalItem },
 	});
 
 	if (timeout > 0) {

--- a/server/tests/utils/browserPool/playwright/stripeCheckout.ts
+++ b/server/tests/utils/browserPool/playwright/stripeCheckout.ts
@@ -28,17 +28,28 @@ export const stripeCheckout = async ({
 	overrideQuantity,
 	promoCode,
 	billingAddress,
+	addOptionalItem,
 }: {
 	page: Page;
 	url: string;
 	overrideQuantity?: number;
 	promoCode?: string;
 	billingAddress?: StripeCheckoutBillingAddress;
+	/** Click "Add" on the first Stripe Checkout optional item (session's `optional_items`). */
+	addOptionalItem?: boolean;
 }) => {
 	await page.goto(url, { waitUntil: "domcontentloaded", timeout: 60000 });
 	console.log("[stripeCheckout] Page loaded");
 
 	await page.waitForTimeout(3000);
+
+	if (addOptionalItem) {
+		const addBtn = page.getByRole("button", { name: /^add$/i }).first();
+		await addBtn.waitFor({ timeout: 15000 });
+		await addBtn.evaluate((el) => (el as HTMLElement).click());
+		console.log("[stripeCheckout] Optional item added");
+		await page.waitForTimeout(1000);
+	}
 
 	// Select Card. The radio is hidden by an AccordionButton overlay; click
 	// the data-testid button via JS, fall back to the radio.


### PR DESCRIPTION
## Summary
- Stripe Checkout's `optional_items` upsell lands on the invoice as a one-time line item that Autumn never requested via `plan_id` — customers could pay for an add-on at checkout and never get it provisioned.
- On `checkout.session.completed`, match any leftover one-time invoice line item's Stripe price against the org's product catalog and fold a match into the billing plan alongside whatever was originally attached.
- Adds a single log line (`[checkout.completed] Matched optional_items to add-on(s)...`) for Axiom visibility when this path fires.

## Root cause
Found via a real customer case: a purchased add-on (offered as a Stripe Checkout optional item) was charged and paid for, but never provisioned in Autumn, because `checkout.session.completed` only provisions what the `billing.attach` call explicitly requested via `plan_id` — it never inspected the invoice's own line items for anything else the customer selected and paid for.

## Test plan
- [x] `bunx tsgo --build --noEmit` passes
- [x] New integration test drives a real Stripe Checkout session (via Playwright) with an `optional_items` entry, selects it at checkout, and asserts the matching add-on is provisioned with its entitlement — confirmed red before the fix, green after
- [x] Regression-checked: originally requested plan still provisions normally alongside the add-on

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes provisioning for add-ons selected via Stripe Checkout `optional_items`. We now match paid one-time invoice lines to catalog products before invoice construction and fold them into the billing plan so entitlements and invoices reflect the add-on.

- **Bug Fixes**
  - Match leftover one-time invoice `price` IDs to products and append to `insertCustomerProducts` before invoice construction; preserve line-item quantity when initializing customer products.
  - Skip matching for create-schedule checkouts to avoid deferred phase mismatches.
  - Log `[checkout.completed] Matched optional_items to add-on(s)...`; add an end-to-end `optional_items` test and update Playwright helpers to select the upsell.

<sup>Written for commit d8b1ce33dccb274d336987eb9b153bf9d871cf55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This follow-up revises optional-item provisioning after checkout completion.
- **Bug fixes:** Matches paid one-time Stripe invoice lines to catalog add-ons and folds them into the customer billing plan and invoice.
- **Bug fixes:** Avoids deferred create-schedule phase inconsistency by bypassing optional-item matching for those contexts.
- **Improvements:** Adds visibility when optional invoice items are matched and extends checkout test helpers and integration coverage.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because create-schedule checkouts can still charge for optional add-ons without provisioning them, and archived products remain provisionable through matching.

The create-schedule guard prevents the previously reported phase-count exception by skipping the new behavior entirely, leaving paid optional items absent from customer products, entitlements, deferred phases, and Autumn invoices; separately, the catalog lookup still includes archived products and can activate their retired entitlements.

**Files Needing Attention:** server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts; server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/matchOptionalInvoiceItemsToProducts.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts | Adds optional-item matching before invoice construction, but its create-schedule bypass silently drops paid add-ons. |
| server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/matchOptionalInvoiceItemsToProducts.ts | Matches invoice prices to catalog products and provisions quantities, while the previously reported archived-product eligibility remains. |
| server/src/internal/billing/v2/actions/createSchedule/utils/persistDeferredCreateSchedule.ts | Exports the create-schedule context predicate used to avoid inconsistent deferred phase bookkeeping. |
| server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-optional-items-addon.test.ts | Covers optional add-on provisioning for a normal attach checkout, but not the create-schedule path implicated by the bypass. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Stripe checkout completed] --> B{Create-schedule context?}
  B -->|No| C[Match leftover invoice prices]
  C --> D[Append catalog add-ons to billing plan]
  D --> E[Persist products, entitlements, and invoice]
  B -->|Yes| F[Skip optional-item matching]
  F --> G[Persist only originally scheduled products]
  G --> H[Paid optional add-on remains unprovisioned]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts:92
**Scheduled add-ons remain unprovisioned**

When a customer selects an optional item during a create-schedule Checkout session, this condition skips matching the paid invoice item entirely, causing the add-on to be omitted from the customer products, entitlements, deferred phases, and Autumn invoice.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(billing): address review findings on..."](https://github.com/useautumn/autumn/commit/d8b1ce33dccb274d336987eb9b153bf9d871cf55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49005434)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [Stripe Integration](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-stripe-integration.md)

<!-- /greptile_comment -->