### PR TITLE
fix(dashboard): size billing units button to content

### DIFF
--- a/vite/src/views/products/plan/components/edit-plan-feature/BillingUnits.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/BillingUnits.tsx
@@ -39,7 +39,7 @@ export function BillingUnits() {
 	});
 
 	return (
-		<div className="flex shrink w-fit max-w-32">
+		<div className="flex w-fit shrink-0">
 			<Popover open={open} onOpenChange={setOpen}>
 				<PopoverTrigger asChild>
 					<Button
@@ -47,7 +47,7 @@ export function BillingUnits() {
 						className={cn(
 							item.tiers?.length && item.tiers.length > 1
 								? "max-w-20 text-tertiary-foreground"
-								: "w-full text-tertiary-foreground",
+								: "text-tertiary-foreground",
 						)}
 					>
 						<span className={cn("truncate text-xs")}>

--- a/vite/src/views/products/plan/components/edit-plan-feature/PriceTiers.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/PriceTiers.tsx
@@ -91,6 +91,7 @@ export function PriceTiers({
 			<div className="space-y-2">
 				<div className="flex gap-2 w-full items-center">
 					<CurrencyAmountInput
+						className="min-w-0 flex-1"
 						currencyCode={currency}
 						displayValue={amountDisplayValue(firstTier.amount)}
 						onRawChange={(raw) =>


### PR DESCRIPTION
## Summary

- let the single-tier billing-units trigger use its intrinsic text width
- prevent the trigger from shrinking or being capped
- let the amount input flex into the remaining row space so the controls stay within the sheet

## Root cause

The amount input claimed the full row width while the billing-units wrapper was both shrinkable and capped at `max-w-32`, causing longer feature labels to truncate and crowd the tier button.

## Verification

- `bun run --cwd vite ts`
- `bunx biome check vite/src/views/products/plan/components/edit-plan-feature/BillingUnits.tsx vite/src/views/products/plan/components/edit-plan-feature/PriceTiers.tsx`
- `NODE_OPTIONS=--max-old-space-size=8192 bun run --cwd vite build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sized the billing units button to its content and prevented shrinking, fixing truncated labels. The amount input now flexes to fill remaining space so the row stays within the sheet and the tier button isn’t crowded.

<sup>Written for commit 7f1511995930de20b242b4b121db4e302227f8ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

