### PR TITLE
fix(billing): stop pooled transitions corrupting balances and contributions

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/applyPooledBalanceTransitions.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/applyPooledBalanceTransitions.ts
@@ -1,11 +1,7 @@
-import {
-	CusProductStatus,
-	customerProductHasActiveStatus,
-	type FullCusProduct,
-} from "@autumn/shared";
 import { applyPooledBalanceCustomerProductTransitions } from "@/internal/billing/v2/pooledBalances/execute/applyPooledBalanceCustomerProductTransitions";
 import type { StripeWebhookContext } from "../../../webhookMiddlewares/stripeWebhookContext";
 import type { StripeSubscriptionUpdatedContext } from "../stripeSubscriptionUpdatedContext";
+import { classifyPooledBalanceTransitionProducts } from "./classifyPooledBalanceTransitionProducts";
 
 export const applyPooledBalanceTransitions = async ({
 	ctx,
@@ -14,35 +10,17 @@ export const applyPooledBalanceTransitions = async ({
 	ctx: StripeWebhookContext;
 	eventContext: StripeSubscriptionUpdatedContext;
 }) => {
-	const outgoingCustomerProducts = new Map<string, FullCusProduct>();
-	const incomingCustomerProducts = new Map<string, FullCusProduct>();
-
-	for (const {
-		customerProduct,
-		updates,
-	} of eventContext.updatedCustomerProducts) {
-		if (updates.status === CusProductStatus.Expired) {
-			outgoingCustomerProducts.set(customerProduct.id, customerProduct);
-		}
-		if (updates.status === CusProductStatus.Active) {
-			incomingCustomerProducts.set(customerProduct.id, {
-				...customerProduct,
-				...updates,
-			} as FullCusProduct);
-		}
-	}
-
-	for (const customerProduct of eventContext.insertedCustomerProducts) {
-		if (customerProductHasActiveStatus(customerProduct)) {
-			incomingCustomerProducts.set(customerProduct.id, customerProduct);
-		}
-	}
+	const { outgoingCustomerProducts, incomingCustomerProducts } =
+		classifyPooledBalanceTransitionProducts({
+			updatedCustomerProducts: eventContext.updatedCustomerProducts,
+			insertedCustomerProducts: eventContext.insertedCustomerProducts,
+		});
 
 	await applyPooledBalanceCustomerProductTransitions({
 		ctx,
 		fullCustomer: eventContext.fullCustomer,
-		outgoingCustomerProducts: Array.from(outgoingCustomerProducts.values()),
-		incomingCustomerProducts: Array.from(incomingCustomerProducts.values()),
+		outgoingCustomerProducts,
+		incomingCustomerProducts,
 		now: eventContext.nowMs,
 	});
 };

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/classifyPooledBalanceTransitionProducts.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/classifyPooledBalanceTransitionProducts.ts
@@ -1,0 +1,62 @@
+import {
+	CusProductStatus,
+	customerProductHasActiveStatus,
+	type FullCusProduct,
+	type InsertCustomerProduct,
+} from "@autumn/shared";
+
+export type PooledBalanceTransitionUpdate = {
+	customerProduct: FullCusProduct;
+	updates: Partial<InsertCustomerProduct>;
+};
+
+/**
+ * Splits a subscription event's customer product changes into the outgoing and
+ * incoming sets the pooled transition compute expects.
+ *
+ * A status write to Active only counts as incoming when the product was NOT
+ * already contributing. past_due -> active is a payment recovery, not a new
+ * attachment, and re-admitting it would plan a second contribution for a source
+ * entitlement that already holds one.
+ */
+export const classifyPooledBalanceTransitionProducts = ({
+	updatedCustomerProducts,
+	insertedCustomerProducts,
+}: {
+	updatedCustomerProducts: PooledBalanceTransitionUpdate[];
+	insertedCustomerProducts: FullCusProduct[];
+}): {
+	outgoingCustomerProducts: FullCusProduct[];
+	incomingCustomerProducts: FullCusProduct[];
+} => {
+	const outgoing = new Map<string, FullCusProduct>();
+	const incoming = new Map<string, FullCusProduct>();
+
+	for (const { customerProduct, updates } of updatedCustomerProducts) {
+		if (updates.status === CusProductStatus.Expired) {
+			outgoing.set(customerProduct.id, customerProduct);
+		}
+		// Already-contributing products (Active or PastDue) are not re-admitted:
+		// a payment recovery writes status Active without being an attachment.
+		if (
+			updates.status === CusProductStatus.Active &&
+			!customerProductHasActiveStatus(customerProduct)
+		) {
+			incoming.set(customerProduct.id, {
+				...customerProduct,
+				...updates,
+			} as FullCusProduct);
+		}
+	}
+
+	for (const customerProduct of insertedCustomerProducts) {
+		if (customerProductHasActiveStatus(customerProduct)) {
+			incoming.set(customerProduct.id, customerProduct);
+		}
+	}
+
+	return {
+		outgoingCustomerProducts: Array.from(outgoing.values()),
+		incomingCustomerProducts: Array.from(incoming.values()),
+	};
+};

--- a/server/src/internal/billing/v2/execute/addStripeSubscriptionIdToBillingPlan.ts
+++ b/server/src/internal/billing/v2/execute/addStripeSubscriptionIdToBillingPlan.ts
@@ -1,7 +1,6 @@
 import type { AutumnBillingPlan } from "@autumn/shared";
 import { cp, PooledBalanceResetMode } from "@autumn/shared";
 import { getPatchedCustomerProductUpdates } from "@/internal/billing/v2/utils/billingPlan/customerProductPlanMutations.js";
-import { getChangedPooledBalances } from "@/internal/billing/v2/utils/billingPlan/pooledBalancePlan.js";
 import { customerProductHasPaidLicenses } from "@/internal/billing/v2/utils/customerProductHasPaidLicenses.js";
 
 /**
@@ -32,9 +31,11 @@ export const addStripeSubscriptionIdToBillingPlan = ({
 		update.updates.subscription_ids = [stripeSubscriptionId];
 	}
 
-	for (const pooledCustomerEntitlement of getChangedPooledBalances({
-		autumnBillingPlan,
-	})) {
+	// Inserts only: a pool matched by identity already carries the subscription
+	// it belongs to, and restamping an outgoing pool moves it onto an identity
+	// another live pool holds.
+	for (const pooledCustomerEntitlement of autumnBillingPlan.pooledBalancePlan
+		?.insertPoolBalances ?? []) {
 		const pooledBalance = pooledCustomerEntitlement.pooled_balance;
 		if (pooledBalance?.reset_mode === PooledBalanceResetMode.Subscription) {
 			pooledBalance.stripe_subscription_id = stripeSubscriptionId;

--- a/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/upsertPooledBalance.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/upsertPooledBalance.ts
@@ -48,17 +48,43 @@ export const upsertPooledBalance = ({
 			entitlement: contributionCustomerEntitlement.entitlement,
 		});
 
+	// A source that was already pooled carries balance 0 — its grant lives in the
+	// pool it is leaving. Seed from the contribution instead, whether the grant
+	// lands back on the same pool or on a newly inserted one.
+	const replacesRemovedContribution = Array.from(
+		computeContext.pooledBalanceIdsWithRemovedContributions,
+	).some(
+		(poolId) =>
+			computeContext.pooledCustomerEntitlementByPoolId.get(poolId)
+				?.pooled_balance.internal_feature_id === identity.internalFeatureId,
+	);
+
 	let balanceDelta = tracksBalance
 		? (contributionCustomerEntitlement.balance ?? 0)
 		: 0;
-	if (
-		tracksBalance &&
-		existingPooledCustomerEntitlement &&
-		computeContext.pooledBalanceIdsWithRemovedContributions.has(
-			existingPooledCustomerEntitlement.pooled_balance.id,
-		)
-	) {
+	if (tracksBalance && replacesRemovedContribution) {
 		balanceDelta = contributionAmounts.currentContribution;
+	}
+
+	// Re-admitting a source that still contributes to this very pool would count
+	// its grant twice: the pool already includes it, and nothing removed it. Only
+	// the difference is owed, so re-running a transition is a no-op.
+	const existingContribution =
+		contributionCustomerEntitlement.pooled_balance_contribution;
+	const alreadyCountedByPool =
+		existingContribution &&
+		existingPooledCustomerEntitlement &&
+		existingContribution.pooled_balance_id ===
+			existingPooledCustomerEntitlement.pooled_balance.id &&
+		!computeContext.pooledBalanceIdsWithRemovedContributions.has(
+			existingContribution.pooled_balance_id,
+		);
+	const grantedDelta = alreadyCountedByPool
+		? contributionAmounts.currentContribution -
+			(existingContribution.current_contribution ?? 0)
+		: contributionAmounts.currentContribution;
+	if (alreadyCountedByPool) {
+		balanceDelta = 0;
 	}
 
 	if (!existingPooledCustomerEntitlement) {
@@ -89,7 +115,7 @@ export const upsertPooledBalance = ({
 	}
 
 	const shouldUpdateExistingPooledBalance =
-		balanceDelta !== 0 || contributionAmounts.currentContribution !== 0;
+		balanceDelta !== 0 || grantedDelta !== 0;
 	if (shouldUpdateExistingPooledBalance) {
 		addToUpdatePoolBalances({
 			pooledBalancePlan: computeContext.plan,
@@ -100,7 +126,7 @@ export const upsertPooledBalance = ({
 			}),
 			granted: addSafe({
 				left: existingPooledCustomerEntitlement.pooled_balance.granted,
-				right: contributionAmounts.currentContribution,
+				right: grantedDelta,
 			}),
 		});
 	}

--- a/server/src/internal/billing/v2/pooledBalances/execute/executePooledBalancePlan.ts
+++ b/server/src/internal/billing/v2/pooledBalances/execute/executePooledBalancePlan.ts
@@ -94,15 +94,66 @@ export const executePooledBalancePlan = async ({
 		}
 
 		if (pooledBalancePlan.insertPoolContributions.length > 0) {
-			await tx
+			// A source entitlement holds at most one contribution. If a transition
+			// mis-classifies an already-contributing product as incoming, reconcile
+			// onto the existing row rather than failing the whole request.
+			const writtenContributions = await tx
 				.insert(pooledBalanceContributions)
-				.values(pooledBalancePlan.insertPoolContributions);
+				.values(pooledBalancePlan.insertPoolContributions)
+				.onConflictDoUpdate({
+					target: pooledBalanceContributions.source_customer_entitlement_id,
+					set: {
+						pooled_balance_id: sql`excluded.pooled_balance_id`,
+						source_customer_product_id: sql`excluded.source_customer_product_id`,
+						current_contribution: sql`excluded.current_contribution`,
+						next_cycle_contribution: sql`excluded.next_cycle_contribution`,
+						effective_at: sql`excluded.effective_at`,
+						updated_at: sql`excluded.updated_at`,
+					},
+				})
+				.returning({
+					id: pooledBalanceContributions.id,
+					sourceCustomerEntitlementId:
+						pooledBalanceContributions.source_customer_entitlement_id,
+				});
 
+			const plannedContributionIds = new Set(
+				pooledBalancePlan.insertPoolContributions.map(
+					(contribution) => contribution.id,
+				),
+			);
+			const reconciled = writtenContributions.filter(
+				(row) => !plannedContributionIds.has(row.id),
+			);
+			if (reconciled.length > 0) {
+				ctx.logger.warn(
+					`[executePooledBalancePlan] Reconciled ${reconciled.length} pooled contribution(s) onto existing rows — a transition treated an already-contributing source as incoming`,
+					{
+						data: {
+							sourceCustomerEntitlementIds: reconciled.map(
+								(row) => row.sourceCustomerEntitlementId,
+							),
+						},
+					},
+				);
+			}
+
+			// Point each source at the row that actually exists, which is the
+			// pre-existing contribution whenever the conflict path fired.
+			const contributionIdBySource = new Map(
+				writtenContributions.map((row) => [
+					row.sourceCustomerEntitlementId,
+					row.id,
+				]),
+			);
 			for (const contribution of pooledBalancePlan.insertPoolContributions) {
 				await tx
 					.update(customerEntitlements)
 					.set({
-						pooled_contribution_id: contribution.id,
+						pooled_contribution_id:
+							contributionIdBySource.get(
+								contribution.source_customer_entitlement_id,
+							) ?? contribution.id,
 						pooled_balance_id: null,
 						balance: 0,
 						adjustment: 0,

--- a/server/tests/integration/billing/pooled-balances/contribution-guard.test.ts
+++ b/server/tests/integration/billing/pooled-balances/contribution-guard.test.ts
@@ -1,0 +1,112 @@
+/**
+ * TDD test for the defensive half of the
+ * `unique_pooled_balance_contribution` incident.
+ *
+ * The root cause (a past_due -> active recovery being classified as an incoming
+ * attachment) is fixed in classifyPooledBalanceTransitionProducts and covered by
+ * tests/unit/billing/classify-pooled-balance-transition-products.test.ts. This
+ * file covers the guard behind it: if some OTHER caller mis-classifies an
+ * already-contributing product as incoming in future, the request must degrade
+ * rather than fail outright.
+ *
+ * It therefore simulates the mis-classification by passing an already-active,
+ * already-contributing customer product as incoming. That is deliberate — with
+ * the classification fixed there is no longer a natural trigger, and the guard
+ * exists precisely for the case we have not thought of.
+ *
+ * Red-failure mode (before the guard):
+ *  - the transition throws `duplicate key value violates unique constraint
+ *    "unique_pooled_balance_contribution"` and the caller's request fails.
+ *
+ * Green-success criteria (after the guard):
+ *  - the transition resolves, the source keeps exactly ONE contribution row,
+ *    and that row carries the freshly computed values.
+ */
+
+import { expect, test } from "bun:test";
+import { ALL_STATUSES } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { applyPooledBalanceCustomerProductTransitions } from "@/internal/billing/v2/pooledBalances/execute/applyPooledBalanceCustomerProductTransitions";
+import { CusService } from "@/internal/customers/CusService";
+import { getPooledBalanceDbState } from "./utils/getPooledBalanceDbState.js";
+
+const GRANT = 500;
+
+test(
+	chalk.yellowBright(
+		"pooled contribution guard: re-admitting an already-contributing product does not fail the request",
+	),
+	async () => {
+		const customerId = "pooled-contribution-guard";
+		const plan = products.pro({
+			id: `${customerId}-plan`,
+			items: [
+				{ ...items.monthlyMessages({ includedUsage: GRANT }), pooled: true },
+			],
+		});
+
+		const { entities, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [plan] }),
+			],
+			actions: [s.billing.attach({ productId: plan.id, entityIndex: 0 })],
+		});
+
+		const baseline = await getPooledBalanceDbState({ db: ctx.db, customerId });
+		expect(baseline.pools).toHaveLength(1);
+		expect(baseline.contributions).toHaveLength(1);
+		const originalContribution = baseline.contributions[0];
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			inStatuses: ALL_STATUSES,
+		});
+		const contributingCustomerProduct = fullCustomer.customer_products.find(
+			(customerProduct) =>
+				customerProduct.product_id === plan.id &&
+				customerProduct.entity_id === entities[0].id,
+		);
+		if (!contributingCustomerProduct) {
+			throw new Error("expected the contributing customer product");
+		}
+
+		// ── Act: hand the transition a product that is already contributing, the
+		// shape a mis-classification produces. Nothing is outgoing, so there is
+		// no delete for the planner to reconcile the insert against.
+		await applyPooledBalanceCustomerProductTransitions({
+			ctx,
+			fullCustomer,
+			outgoingCustomerProducts: [],
+			incomingCustomerProducts: [contributingCustomerProduct],
+			now: Date.now(),
+		});
+
+		// ── Contract: the source still holds exactly one contribution ──
+		const afterTransition = await getPooledBalanceDbState({
+			db: ctx.db,
+			customerId,
+		});
+		const contributionsForSource = afterTransition.contributions.filter(
+			(contribution) =>
+				contribution.source_customer_entitlement_id ===
+				originalContribution.source_customer_entitlement_id,
+		);
+		expect(contributionsForSource).toHaveLength(1);
+
+		// ── Contract: reconciled onto the pre-existing row, not a new one ──
+		expect(contributionsForSource[0].id).toBe(originalContribution.id);
+		expect(contributionsForSource[0].current_contribution).toBe(GRANT);
+
+		// ── Contract: the pool is not double-counted ──
+		expect(afterTransition.pools).toHaveLength(1);
+		expect(afterTransition.pools[0].granted).toBe(GRANT);
+	},
+);

--- a/server/tests/integration/billing/pooled-balances/merged-pool-transitions.test.ts
+++ b/server/tests/integration/billing/pooled-balances/merged-pool-transitions.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Contract: pooled ROLLOVERS survive a transition of a customer product whose
+ * contribution was repointed by the combine-pools merge.
+ *
+ * Production shape (see setupMergedPoolScenario): entity 1 attaches the plan,
+ * entity 2 attaches the same plan on its own Stripe subscription so each mints
+ * its own pool, then the pools are merged the way the combine-pools script
+ * merges them. Entity 2's contribution now sits on a pool identified by entity
+ * 1's subscription. Transitioning entity 2 splits the pool again.
+ *
+ * The split itself is ACCEPTED behavior and is deliberately not asserted
+ * against. What must hold is that nothing is lost across it.
+ *
+ * Contract under test:
+ *   New behaviors:
+ *     - transition the mis-matched plan -> total rollover balance across all
+ *       pools is unchanged
+ *     - transition the mis-matched plan -> the customer's readable remaining
+ *       for Messages is unchanged
+ *   Side effects:
+ *     - every rollover row remains attached to a synthetic cusEnt whose pool is
+ *       still live, rather than stranded on a retired one
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	RolloverExpiryDurationType,
+	type UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
+import chalk from "chalk";
+import { getPooledBalanceDbState } from "./utils/getPooledBalanceDbState.js";
+import { setupMergedPoolScenario } from "./utils/mergedPoolScenario.js";
+
+const GRANT = 10_000;
+const USAGE = 4_000;
+const NEW_BASE_PRICE = 45;
+
+const rolloverConfig = {
+	max_percentage: 50,
+	length: 1,
+	duration: RolloverExpiryDurationType.Month,
+} as const;
+
+type PooledState = Awaited<ReturnType<typeof getPooledBalanceDbState>>;
+
+const rolloverRows = (state: PooledState) =>
+	state.poolCustomerEntitlements.flatMap((customerEntitlement) =>
+		(customerEntitlement.rollovers ?? []).map((rollover) => ({
+			rollover,
+			customerEntitlementId: customerEntitlement.id,
+		})),
+	);
+
+const sumRolloverBalance = (state: PooledState) =>
+	rolloverRows(state).reduce(
+		(sum, { rollover }) => sum + (rollover.balance ?? 0),
+		0,
+	);
+
+test(
+	chalk.yellowBright(
+		"pooled rollover: transitioning a merge-mismatched plan preserves the pooled rollover",
+	),
+	async () => {
+		const scenario = await setupMergedPoolScenario({
+			customerId: "merged-pool-rollover-transition",
+			grant: GRANT,
+			rolloverConfig,
+			usage: { value: USAGE, entityIndex: 1 },
+			// Renewal is what mints the pooled rollover.
+			advanceToNextInvoice: true,
+		});
+		const { ctx, customerId, autumnV2_3 } = scenario;
+
+		const before = await getPooledBalanceDbState({ db: ctx.db, customerId });
+		const rolloverBefore = sumRolloverBalance(before);
+		// Guard: without a real rollover every assertion below passes vacuously.
+		expect(rolloverBefore).toBeGreaterThan(0);
+
+		const customerBefore = await autumnV2_3.customers.get<ApiCustomerV5>(
+			customerId,
+			{ skip_cache: "true" },
+		);
+		const remainingBefore =
+			customerBefore.balances?.[TestFeature.Messages]?.remaining;
+		expect(remainingBefore).toBeGreaterThan(0);
+
+		// ── Act: transition the plan whose contribution the merge left pointing
+		// at the other subscription's pool. Base-price customize only — the
+		// pooled item itself is untouched.
+		await autumnV2_3.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			customer_product_id: scenario.mismatchedCustomerProduct.id,
+			entity_id: scenario.mismatchedEntityId ?? undefined,
+			customize: { price: itemsV2.monthlyPrice({ amount: NEW_BASE_PRICE }) },
+		});
+
+		const after = await getPooledBalanceDbState({ db: ctx.db, customerId });
+
+		// ── Contract: the rollover balance is not lost across the split ──
+		expect(sumRolloverBalance(after)).toBe(rolloverBefore);
+
+		// ── Contract: no rollover is stranded on a retired pool ──────────
+		const livePoolCustomerEntitlementIds = new Set(
+			after.pools
+				.filter((pool) => pool.expires_at === null)
+				.map((pool) => pool.customer_entitlement_id),
+		);
+		for (const { rollover, customerEntitlementId } of rolloverRows(after)) {
+			expect({
+				rolloverId: rollover.id,
+				onLivePool: livePoolCustomerEntitlementIds.has(customerEntitlementId),
+			}).toEqual({ rolloverId: rollover.id, onLivePool: true });
+		}
+
+		// ── Contract: the customer reads the same remaining as before ────
+		const customerAfter = await autumnV2_3.customers.get<ApiCustomerV5>(
+			customerId,
+			{ skip_cache: "true" },
+		);
+		expect(customerAfter.balances?.[TestFeature.Messages]?.remaining).toBe(
+			remainingBefore,
+		);
+	},
+);
+
+const MERGED_GRANT = GRANT * 2;
+const REMAINING_AFTER_USAGE = MERGED_GRANT - USAGE;
+const UNRELATED_GRANT = 50;
+
+const sumGranted = (state: PooledState) =>
+	state.pools.reduce((sum, pool) => sum + pool.granted, 0);
+
+const sumPoolBalance = (state: PooledState) =>
+	state.pools.reduce((sum, pool) => {
+		const synthetic = state.poolCustomerEntitlements.find(
+			(candidate) => candidate.id === pool.customer_entitlement_id,
+		);
+		return sum + (synthetic?.balance ?? 0);
+	}, 0);
+
+/**
+ * A free plan pools alongside a paid one — the free plan resets lazily with no
+ * subscription, so the two identities differ by more than the subscription id.
+ * After the merge, transitioning EITHER side must leave the pooled totals alone.
+ */
+const expectFreeAndSubscriptionMergeConserved = async ({
+	customerId,
+	side,
+}: {
+	customerId: string;
+	side: "mismatched" | "aligned";
+}) => {
+	const scenario = await setupMergedPoolScenario({
+		customerId,
+		grant: GRANT,
+		variant: "free-and-subscription",
+		usage: { value: USAGE, entityIndex: 1 },
+	});
+	const { ctx, autumnV2_3 } = scenario;
+
+	const before = await getPooledBalanceDbState({ db: ctx.db, customerId });
+	expect(before.pools).toHaveLength(1);
+	expect(before.contributions).toHaveLength(2);
+	expect(sumGranted(before)).toBe(MERGED_GRANT);
+	expect(sumPoolBalance(before)).toBe(REMAINING_AFTER_USAGE);
+
+	const target =
+		side === "mismatched"
+			? scenario.mismatchedCustomerProduct
+			: scenario.alignedCustomerProduct;
+	const entityId =
+		side === "mismatched"
+			? scenario.mismatchedEntityId
+			: scenario.alignedEntityId;
+	const isFreeTarget = target.product_id === scenario.freePlan.id;
+
+	// A free plan has no base price to customize, and re-declaring the pooled
+	// item unchanged is rejected as a no-op — so add an unrelated feature, which
+	// forces a transition while leaving the pooled Messages grant alone.
+	const customize = isFreeTarget
+		? {
+				items: [
+					{ ...itemsV2.monthlyMessages({ included: GRANT }), pooled: true },
+					itemsV2.monthlyWords({ included: UNRELATED_GRANT }),
+				],
+			}
+		: { price: itemsV2.monthlyPrice({ amount: NEW_BASE_PRICE }) };
+
+	await autumnV2_3.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+		customer_id: customerId,
+		customer_product_id: target.id,
+		entity_id: entityId ?? undefined,
+		customize,
+	});
+
+	// ── Contract: the transition neither creates nor destroys pooled credit ──
+	const after = await getPooledBalanceDbState({ db: ctx.db, customerId });
+	expect(sumGranted(after)).toBe(MERGED_GRANT);
+	expect(sumPoolBalance(after)).toBe(REMAINING_AFTER_USAGE);
+
+	const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId, {
+		skip_cache: "true",
+	});
+	expect(customer.balances?.[TestFeature.Messages]?.remaining).toBe(
+		REMAINING_AFTER_USAGE,
+	);
+};
+
+test(
+	chalk.yellowBright(
+		"merged pool (free + subscription): updating the mis-matched plan conserves pooled totals",
+	),
+	async () => {
+		await expectFreeAndSubscriptionMergeConserved({
+			customerId: "merged-free-sub-update-mismatched",
+			side: "mismatched",
+		});
+	},
+);
+
+test(
+	chalk.yellowBright(
+		"merged pool (free + subscription): updating the aligned plan conserves pooled totals",
+	),
+	async () => {
+		await expectFreeAndSubscriptionMergeConserved({
+			customerId: "merged-free-sub-update-aligned",
+			side: "aligned",
+		});
+	},
+);

--- a/server/tests/integration/billing/pooled-balances/update/pooled-balance-transition-preserves-balance.test.ts
+++ b/server/tests/integration/billing/pooled-balances/update/pooled-balance-transition-preserves-balance.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Transitions of a customer product whose pooled contribution was repointed by
+ * the combine-pools merge, and therefore sits on a pool identified by a
+ * DIFFERENT subscription.
+ *
+ * Recreated faithfully by setupMergedPoolScenario: entity 1 attaches the plan,
+ * entity 2 attaches the same plan on its own Stripe subscription, then the two
+ * pools are merged the way the production script merges them.
+ *
+ * Scenario A: spend from the pooled balance, then customize the base price on
+ * the mis-matched plan. The removal from the old pool and the insert into the
+ * newly identified one must balance — no credits created or destroyed.
+ *
+ * Red-failure mode (before the upsertPooledBalance fix):
+ *  - the removal debits the merged pool correctly, but the insert seeds the new
+ *    pool from the source cusEnt, which is zeroed for an existing contributor.
+ *    The grant is dropped and the customer loses one contribution's worth.
+ */
+
+import { expect, test } from "bun:test";
+import type {
+	ApiCustomerV5,
+	UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
+import chalk from "chalk";
+import { getPooledBalanceDbState } from "../utils/getPooledBalanceDbState.js";
+import { setupMergedPoolScenario } from "../utils/mergedPoolScenario.js";
+
+const GRANT = 10_000;
+const USAGE = 100;
+const MERGED_GRANT = GRANT * 2;
+const REMAINING_AFTER_USAGE = MERGED_GRANT - USAGE;
+const NEW_BASE_PRICE = 45;
+
+const sumBalances = (
+	state: Awaited<ReturnType<typeof getPooledBalanceDbState>>,
+) =>
+	state.pools.reduce((sum, pool) => {
+		const synthetic = state.poolCustomerEntitlements.find(
+			(candidate) => candidate.id === pool.customer_entitlement_id,
+		);
+		return sum + (synthetic?.balance ?? 0);
+	}, 0);
+
+const sumGranted = (
+	state: Awaited<ReturnType<typeof getPooledBalanceDbState>>,
+) => state.pools.reduce((sum, pool) => sum + pool.granted, 0);
+
+test(
+	chalk.yellowBright(
+		"pooled merge scenario A: customizing base price on the mis-matched plan conserves the pooled balance",
+	),
+	async () => {
+		const scenario = await setupMergedPoolScenario({
+			customerId: "pooled-merged-customize-base-price",
+			grant: GRANT,
+			usage: { value: USAGE, entityIndex: 1 },
+		});
+		const { ctx, customerId, autumnV2_3 } = scenario;
+
+		// ── Baseline: one merged pool holding both contributions.
+		const baseline = await getPooledBalanceDbState({ db: ctx.db, customerId });
+		expect(baseline.pools).toHaveLength(1);
+		expect(baseline.contributions).toHaveLength(2);
+		expect(sumGranted(baseline)).toBe(MERGED_GRANT);
+		expect(sumBalances(baseline)).toBe(REMAINING_AFTER_USAGE);
+
+		// ── Act: customize the base price on the plan whose contribution the
+		// merge left pointing at the other subscription's pool.
+		await autumnV2_3.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			customer_product_id: scenario.mismatchedCustomerProduct.id,
+			entity_id: scenario.mismatchedEntityId ?? undefined,
+			customize: { price: itemsV2.monthlyPrice({ amount: NEW_BASE_PRICE }) },
+		});
+
+		// ── Contract: nothing is created or destroyed by the transition.
+		const afterUpdate = await getPooledBalanceDbState({
+			db: ctx.db,
+			customerId,
+		});
+		expect(sumGranted(afterUpdate)).toBe(MERGED_GRANT);
+		expect(sumBalances(afterUpdate)).toBe(REMAINING_AFTER_USAGE);
+
+		// ── Contract: and the customer reads the same remaining balance.
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		expect(customer.balances?.[TestFeature.Messages]?.remaining).toBe(
+			REMAINING_AFTER_USAGE,
+		);
+	},
+);

--- a/server/tests/integration/billing/pooled-balances/update/update-pooled-balance-foreign-subscription-stamp.test.ts
+++ b/server/tests/integration/billing/pooled-balances/update/update-pooled-balance-foreign-subscription-stamp.test.ts
@@ -1,0 +1,115 @@
+/**
+ * TDD test for billing.update 500ing with
+ * `duplicate key value violates unique constraint "unique_pooled_balance"`
+ * (reported by mintlify, customer 67113cfc0aa7ee45f3866c1a).
+ *
+ * Root cause: addStripeSubscriptionIdToBillingPlan stamps the resolved Stripe
+ * subscription id onto every pool in getChangedPooledBalances — inserts AND
+ * updates AND expiry candidates. A pool belonging to a different subscription,
+ * touched only to have its granted decremented on the way out, gets its
+ * stripe_subscription_id rewritten. executePooledBalancePlan then writes that
+ * identity in the same UPDATE that applies the granted delta, moving the row
+ * onto an identity another live pool already holds.
+ *
+ * Red-failure mode (current behavior):
+ *  - billing.update rejects with the duplicate key error above, thrown by the
+ *    UPDATE on the outgoing pool.
+ *
+ * Green-success criteria (after fix):
+ *  - the update succeeds and each pool keeps its own stripe_subscription_id.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	customerEntitlements,
+	pooledBalanceContributions,
+	pooledBalances,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { getPooledBalanceDbState } from "../utils/getPooledBalanceDbState.js";
+
+const GRANT = 100;
+const UPDATED_GRANT = 250;
+
+test(
+	chalk.yellowBright(
+		"pooled update: an outgoing pool on another subscription is not stamped with this subscription's id",
+	),
+	async () => {
+		const customerId = "pooled-foreign-subscription-stamp";
+		const FOREIGN_SUBSCRIPTION_ID = `sub_${customerId}_foreign`;
+		const plan = products.pro({
+			id: `${customerId}-plan`,
+			items: [
+				{ ...items.monthlyMessages({ includedUsage: GRANT }), pooled: true },
+			],
+		});
+
+		const { entities, autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [plan] }),
+			],
+			actions: [s.billing.attach({ productId: plan.id, entityIndex: 0 })],
+		});
+
+		const baseline = await getPooledBalanceDbState({ db: ctx.db, customerId });
+		expect(baseline.pools).toHaveLength(1);
+		expect(baseline.contributions).toHaveLength(1);
+		const existingPool = baseline.pools[0];
+		expect(existingPool.stripe_subscription_id).not.toBeNull();
+
+		// ── Bad state, as seen in prod: the pool this plan contributes to belongs
+		// to an older subscription, so the plan's own subscription no longer
+		// matches the pool's identity.
+		await ctx.db
+			.update(pooledBalances)
+			.set({ stripe_subscription_id: FOREIGN_SUBSCRIPTION_ID })
+			.where(eq(pooledBalances.id, existingPool.id));
+
+		// ── Act: a plan change that forces a Stripe subscription action, which is
+		// the only path that runs addStripeSubscriptionIdToBillingPlan.
+		await autumnV2_3.subscriptions.update({
+			customer_id: customerId,
+			product_id: plan.id,
+			entity_id: entities[0].id,
+			customize: {
+				// The added priced item is what forces a Stripe subscription action;
+				// pooled items are entitlement-only and never reach Stripe.
+				items: [
+					{
+						...itemsV2.monthlyMessages({ included: UPDATED_GRANT }),
+						pooled: true,
+					},
+					itemsV2.consumableWords({ amount: 2 }),
+				],
+			},
+		});
+
+		// ── Contract: the outgoing pool keeps the subscription it belongs to.
+		const afterUpdate = await getPooledBalanceDbState({
+			db: ctx.db,
+			customerId,
+		});
+		const existingPoolAfter = afterUpdate.pools.find(
+			(pool) => pool.id === existingPool.id,
+		);
+		expect(existingPoolAfter?.stripe_subscription_id).toBe(
+			FOREIGN_SUBSCRIPTION_ID,
+		);
+
+		// ── Contract: no two live pools end up on the same identity.
+		const liveSubscriptionIds = afterUpdate.pools
+			.filter((pool) => pool.expires_at === null)
+			.map((pool) => pool.stripe_subscription_id);
+		expect(new Set(liveSubscriptionIds).size).toBe(liveSubscriptionIds.length);
+	},
+);

--- a/server/tests/integration/billing/pooled-balances/utils/mergedPoolScenario.ts
+++ b/server/tests/integration/billing/pooled-balances/utils/mergedPoolScenario.ts
@@ -1,0 +1,290 @@
+import { expect } from "bun:test";
+import {
+	customerEntitlements,
+	entitlements,
+	pooledBalanceContributions,
+	pooledBalances,
+	rollovers,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import { and, eq, inArray, notExists, sql } from "drizzle-orm";
+import { getPooledBalanceDbState } from "./getPooledBalanceDbState.js";
+
+type RolloverConfig = Parameters<
+	typeof items.monthlyMessagesWithRollover
+>[0]["rolloverConfig"];
+
+/** Mirrors scripts-v2 combine-pools/select-candidate-pool: subscription-linked
+ * pools win outright, then most rollovers, then largest grant, then oldest. */
+const selectSurvivingPool = <
+	T extends {
+		stripe_subscription_id: string | null;
+		granted: number;
+		created_at: number;
+	},
+>({
+	pools,
+	rolloverCountByPoolId,
+}: {
+	pools: T[];
+	rolloverCountByPoolId: Map<string, number>;
+}) => {
+	const byPreference = (a: T & { id: string }, b: T & { id: string }) =>
+		(rolloverCountByPoolId.get(b.id) ?? 0) -
+			(rolloverCountByPoolId.get(a.id) ?? 0) ||
+		b.granted - a.granted ||
+		a.created_at - b.created_at;
+
+	const candidates = (pools as (T & { id: string })[]).filter(
+		(pool) => pool.stripe_subscription_id != null,
+	);
+	return [...(candidates.length > 0 ? candidates : (pools as (T & { id: string })[]))].sort(
+		byPreference,
+	)[0];
+};
+
+/**
+ * Folds every other pool into one surviving pool, exactly as the production
+ * combine-pools script does: contributions and rollovers repoint, balance and
+ * granted fold in, the losing pool graph is deleted.
+ *
+ * The point of doing it faithfully is the side effect — a contribution now sits
+ * on a pool whose identity belongs to a different subscription.
+ */
+export const mergePooledBalances = async ({
+	ctx,
+	customerId,
+}: {
+	ctx: TestContext;
+	customerId: string;
+}) => {
+	const state = await getPooledBalanceDbState({ db: ctx.db, customerId });
+	if (state.pools.length < 2) {
+		throw new Error(
+			`Expected at least 2 pools to merge for '${customerId}', found ${state.pools.length}`,
+		);
+	}
+
+	const rolloverCountByPoolId = new Map(
+		state.pools.map((pool) => [
+			pool.id,
+			state.poolCustomerEntitlements.find(
+				(candidate) => candidate.id === pool.customer_entitlement_id,
+			)?.rollovers?.length ?? 0,
+		]),
+	);
+	const survivor = selectSurvivingPool({
+		pools: state.pools,
+		rolloverCountByPoolId,
+	});
+	const losers = state.pools.filter((pool) => pool.id !== survivor.id);
+	const loserPoolIds = losers.map((pool) => pool.id);
+	const loserCusEntIds = losers.map((pool) => pool.customer_entitlement_id);
+	const loserCusEnts = state.poolCustomerEntitlements.filter((candidate) =>
+		loserCusEntIds.includes(candidate.id),
+	);
+
+	const balanceDelta = loserCusEnts.reduce(
+		(sum, cusEnt) => sum + (cusEnt.balance ?? 0),
+		0,
+	);
+	const grantedDelta = losers.reduce((sum, pool) => sum + pool.granted, 0);
+	const now = Date.now();
+
+	await ctx.db.transaction(async (tx) => {
+		await tx
+			.update(pooledBalanceContributions)
+			.set({ pooled_balance_id: survivor.id, updated_at: now })
+			.where(
+				inArray(pooledBalanceContributions.pooled_balance_id, loserPoolIds),
+			);
+
+		await tx
+			.update(rollovers)
+			.set({ cus_ent_id: survivor.customer_entitlement_id })
+			.where(inArray(rollovers.cus_ent_id, loserCusEntIds));
+
+		await tx
+			.update(customerEntitlements)
+			.set({
+				balance: sql`COALESCE(${customerEntitlements.balance}, 0) + ${balanceDelta}`,
+				cache_version: sql`${customerEntitlements.cache_version} + 1`,
+			})
+			.where(eq(customerEntitlements.id, survivor.customer_entitlement_id));
+
+		await tx
+			.update(pooledBalances)
+			.set({
+				granted: sql`COALESCE(${pooledBalances.granted}, 0) + ${grantedDelta}`,
+				updated_at: now,
+			})
+			.where(eq(pooledBalances.id, survivor.id));
+
+		await tx.delete(pooledBalances).where(inArray(pooledBalances.id, loserPoolIds));
+		await tx
+			.delete(customerEntitlements)
+			.where(inArray(customerEntitlements.id, loserCusEntIds));
+
+		for (const cusEnt of loserCusEnts) {
+			await tx.delete(entitlements).where(
+				and(
+					eq(entitlements.id, cusEnt.entitlement_id),
+					notExists(
+						tx
+							.select({ one: sql`1` })
+							.from(customerEntitlements)
+							.where(eq(customerEntitlements.entitlement_id, cusEnt.entitlement_id)),
+					),
+				),
+			);
+		}
+	});
+
+	return { survivorPoolId: survivor.id, balanceDelta, grantedDelta };
+};
+
+/**
+ * Recreates the production shape behind the pooled-balance incidents:
+ *   entity 1 attaches the plan, entity 2 attaches the SAME plan on its own
+ *   Stripe subscription (so each gets its own pool), then the pools are merged.
+ *
+ * Afterwards entity 2's contribution sits on a pool identified by entity 1's
+ * subscription — the "wrong identity" state. Transitioning entity 2 is what
+ * exercises the removal/insert path.
+ */
+export type MergedPoolVariant =
+	/** Two paid plans, each on its own Stripe subscription. */
+	| "two-subscriptions"
+	/** A free plan (lazy reset, no subscription) alongside a paid one. */
+	| "free-and-subscription";
+
+export const setupMergedPoolScenario = async ({
+	customerId,
+	grant,
+	rolloverConfig,
+	advanceToNextInvoice = false,
+	usage,
+	variant = "two-subscriptions",
+}: {
+	customerId: string;
+	grant: number;
+	rolloverConfig?: RolloverConfig;
+	advanceToNextInvoice?: boolean;
+	usage?: { value: number; entityIndex: number };
+	variant?: MergedPoolVariant;
+}) => {
+	const pooledItem = rolloverConfig
+		? {
+				...items.monthlyMessagesWithRollover({
+					includedUsage: grant,
+					rolloverConfig,
+				}),
+				pooled: true,
+			}
+		: { ...items.monthlyMessages({ includedUsage: grant }), pooled: true };
+
+	const paidPlan = products.pro({
+		id: `${customerId}-paid`,
+		items: [pooledItem],
+	});
+	// Free => reset_mode lazy with no subscription id, so it mints a pool whose
+	// identity differs from the paid plan's on more than just the subscription.
+	const freePlan = products.base({
+		id: `${customerId}-free`,
+		items: [pooledItem],
+	});
+	const isFreeVariant = variant === "free-and-subscription";
+	const secondPlan = isFreeVariant ? freePlan : paidPlan;
+
+	const scenario = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.entities({ count: 2, featureId: TestFeature.Users }),
+			s.products({
+				list: isFreeVariant ? [paidPlan, freePlan] : [paidPlan],
+			}),
+		],
+		actions: [
+			s.billing.attach({ productId: paidPlan.id, entityIndex: 0 }),
+			s.billing.attach({
+				productId: secondPlan.id,
+				entityIndex: 1,
+				// A second paid attach needs its own subscription to mint its own
+				// pool; the free plan already has a distinct identity.
+				...(isFreeVariant ? {} : { newBillingSubscription: true }),
+			}),
+			...(usage
+				? [
+						s.track({
+							featureId: TestFeature.Messages,
+							value: usage.value,
+							entityIndex: usage.entityIndex,
+							timeout: 2000,
+						}),
+					]
+				: []),
+			...(advanceToNextInvoice ? [s.advanceToNextInvoice()] : []),
+		],
+	});
+
+	// ── Precondition: two pools, one per subscription.
+	const beforeMerge = await getPooledBalanceDbState({
+		db: scenario.ctx.db,
+		customerId,
+	});
+	expect(beforeMerge.pools).toHaveLength(2);
+	expect(
+		new Set(beforeMerge.pools.map((pool) => pool.stripe_subscription_id)).size,
+	).toBe(2);
+
+	const merge = await mergePooledBalances({ ctx: scenario.ctx, customerId });
+
+	const afterMerge = await getPooledBalanceDbState({
+		db: scenario.ctx.db,
+		customerId,
+	});
+	expect(afterMerge.pools).toHaveLength(1);
+	const mergedPool = afterMerge.pools[0];
+
+	// The plan whose contribution was repointed now sits on a pool identified by
+	// the other subscription — this is the customer product to transition.
+	const pooledCustomerProducts = afterMerge.sourceCustomerProducts.filter(
+		(customerProduct) =>
+			customerProduct.product_id === paidPlan.id ||
+			customerProduct.product_id === secondPlan.id,
+	);
+	const mismatchedCustomerProduct = pooledCustomerProducts.find(
+		(customerProduct) =>
+			(customerProduct.subscription_ids?.[0] ?? null) !==
+			mergedPool.stripe_subscription_id,
+	);
+	const alignedCustomerProduct = pooledCustomerProducts.find(
+		(customerProduct) =>
+			(customerProduct.subscription_ids?.[0] ?? null) ===
+			mergedPool.stripe_subscription_id,
+	);
+	if (!(mismatchedCustomerProduct && alignedCustomerProduct)) {
+		throw new Error(
+			"Expected one aligned and one mis-matched customer product after the merge",
+		);
+	}
+
+	return {
+		...scenario,
+		plan: paidPlan,
+		paidPlan,
+		freePlan,
+		secondPlan,
+		merge,
+		mergedPool,
+		mismatchedCustomerProduct,
+		alignedCustomerProduct,
+		mismatchedEntityId: mismatchedCustomerProduct.entity_id,
+		alignedEntityId: alignedCustomerProduct.entity_id,
+	};
+};

--- a/server/tests/unit/billing/classify-pooled-balance-transition-products.test.ts
+++ b/server/tests/unit/billing/classify-pooled-balance-transition-products.test.ts
@@ -1,0 +1,143 @@
+/**
+ * TDD test for `duplicate key value violates unique constraint
+ * "unique_pooled_balance_contribution"` on customer.subscription.updated
+ * (7 mintlify customers, early-acked then failing on webhook replay).
+ *
+ * syncCustomerProductStatus writes `status: Active` when a product recovers
+ * from past_due. applyPooledBalanceTransitions treated ANY status write of
+ * Active as an incoming attachment, so a product that had been contributing
+ * since attach got a second contribution planned for the same source
+ * entitlement — which the unique index rejects.
+ *
+ * Scope: this covers the CLASSIFICATION only. Driving a real past_due -> active
+ * recovery through Stripe test clocks is slow and flaky, so the webhook is not
+ * exercised end to end here.
+ *
+ * Red-failure mode (current behavior):
+ *  - a past_due product with `updates.status = Active` is classified incoming.
+ *
+ * Green-success criteria (after fix):
+ *  - it is not incoming; a Scheduled -> Active product still is, and expiry
+ *    and inserted products are unaffected.
+ */
+
+import { expect, test } from "bun:test";
+import { CusProductStatus, type FullCusProduct } from "@autumn/shared";
+import chalk from "chalk";
+import { classifyPooledBalanceTransitionProducts } from "@/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/classifyPooledBalanceTransitionProducts";
+
+const customerProduct = ({
+	id,
+	status,
+}: {
+	id: string;
+	status: CusProductStatus;
+}) => ({ id, status }) as FullCusProduct;
+
+const incomingIds = (
+	result: ReturnType<typeof classifyPooledBalanceTransitionProducts>,
+) => result.incomingCustomerProducts.map((product) => product.id).sort();
+
+const outgoingIds = (
+	result: ReturnType<typeof classifyPooledBalanceTransitionProducts>,
+) => result.outgoingCustomerProducts.map((product) => product.id).sort();
+
+test(
+	chalk.yellowBright(
+		"pooled transitions: a past_due -> active recovery is not an incoming attachment",
+	),
+	() => {
+		const result = classifyPooledBalanceTransitionProducts({
+			updatedCustomerProducts: [
+				{
+					customerProduct: customerProduct({
+						id: "cus_prod_recovered",
+						status: CusProductStatus.PastDue,
+					}),
+					updates: { status: CusProductStatus.Active },
+				},
+			],
+			insertedCustomerProducts: [],
+		});
+
+		expect(incomingIds(result)).toEqual([]);
+		expect(outgoingIds(result)).toEqual([]);
+	},
+);
+
+test(
+	chalk.yellowBright(
+		"pooled transitions: an active -> active status write is not an incoming attachment",
+	),
+	() => {
+		const result = classifyPooledBalanceTransitionProducts({
+			updatedCustomerProducts: [
+				{
+					customerProduct: customerProduct({
+						id: "cus_prod_already_active",
+						status: CusProductStatus.Active,
+					}),
+					updates: { status: CusProductStatus.Active },
+				},
+			],
+			insertedCustomerProducts: [],
+		});
+
+		expect(incomingIds(result)).toEqual([]);
+	},
+);
+
+test(
+	chalk.yellowBright(
+		"pooled transitions: a scheduled -> active activation IS an incoming attachment",
+	),
+	() => {
+		const result = classifyPooledBalanceTransitionProducts({
+			updatedCustomerProducts: [
+				{
+					customerProduct: customerProduct({
+						id: "cus_prod_scheduled",
+						status: CusProductStatus.Scheduled,
+					}),
+					updates: { status: CusProductStatus.Active },
+				},
+			],
+			insertedCustomerProducts: [],
+		});
+
+		expect(incomingIds(result)).toEqual(["cus_prod_scheduled"]);
+	},
+);
+
+test(
+	chalk.yellowBright(
+		"pooled transitions: expiry and inserted products are classified as before",
+	),
+	() => {
+		const result = classifyPooledBalanceTransitionProducts({
+			updatedCustomerProducts: [
+				{
+					customerProduct: customerProduct({
+						id: "cus_prod_expiring",
+						status: CusProductStatus.Active,
+					}),
+					updates: { status: CusProductStatus.Expired },
+				},
+			],
+			insertedCustomerProducts: [
+				customerProduct({
+					id: "cus_prod_inserted",
+					status: CusProductStatus.Active,
+				}),
+				customerProduct({
+					id: "cus_prod_inserted_scheduled",
+					status: CusProductStatus.Scheduled,
+				}),
+			],
+		});
+
+		expect(outgoingIds(result)).toEqual(["cus_prod_expiring"]);
+		// Scheduled inserts are not yet contributing, so they stay out.
+		expect(incomingIds(result)).toEqual(["cus_prod_inserted"]);
+	},
+);


### PR DESCRIPTION
Hotfix for three pooled-balance defects surfaced by the mintlify pooled-credit migration, plus a guard so a missed case degrades instead of failing the request.

Branched off `main`. Includes a cherry-pick of the `addStripeSubscriptionIdToBillingPlan` fix, which had landed on `dev` only — without it this hotfix would be incomplete.

## What was broken

**1. `past_due -> active` was treated as a new attachment**

`syncCustomerProductStatus` writes `status: Active` when a subscription recovers payment. `applyPooledBalanceTransitions` treated any such write as an INCOMING customer product, so a source that had been contributing since attach got a second contribution planned for it — violating `unique_pooled_balance_contribution`. The webhook was early-acked, failed, then re-failed on every replay.

Seven customers were stuck in that loop over 29–30 Jul: `66e52aa17e4294b22011b0c3`, `69eba9d3ce3e525a4b3c8b47`, `69a76a0eae1be24c2a4ed1d7`, `6781499d77ded9268b939b5f`, `69fd01d23cda427e4345db49`, `686f96ccf0dcd79d4ba855aa`, `683594c8e80c728c302ed19e`.

The classification is extracted into `classifyPooledBalanceTransitionProducts` so it can be unit tested. A product whose pre-update status already satisfied `customerProductHasActiveStatus` (Active or PastDue) is no longer re-admitted. `Scheduled -> Active` and inserted products are unchanged.

**2. A transition that inserted a pool dropped the grant**

A source that already contributes has its own cusEnt balance zeroed — the grant lives in the pool. `upsertPooledBalance` only compensated for that on the UPDATE path, so an INSERT seeded the new pool from the zeroed row. Customers were left with pools reading `0 / 10,000 left`.

**3. Re-admitting a source double-counted its grant**

If a source still contributes to the same pool and nothing removed it, only the difference is owed. Without this, re-running a transition inflated `granted` (500 became 1000).

**4. Guard**

The pooled contribution insert now reconciles onto the existing row via `onConflictDoUpdate` instead of failing the whole request, and WARNs so a missed case stays visible rather than silent. The unique constraint is untouched — it is the only reason these surfaced loudly instead of silently splitting credits across pools.

## Tests

- `classify-pooled-balance-transition-products.test.ts` — unit coverage for the classification. Covers `past_due -> active`, `active -> active`, `scheduled -> active`, and the expiry/inserted cases. Verified red before the fix.
- `merged-pool-transitions.test.ts` — built on a new `mergedPoolScenario` fixture that recreates the production shape: two pools on separate Stripe subscriptions, merged exactly as the `combine-pools` script merges them (repoint contributions and rollovers, fold balance and granted into the survivor, delete the loser graph). Asserts balance conservation, rollover preservation, and that both sides of a free+subscription merge survive a transition.
- `contribution-guard.test.ts` — proves a mis-classified re-admit reconciles onto the existing row instead of throwing, without double-counting.
- `update-pooled-balance-foreign-subscription-stamp.test.ts` — reproduced the original `unique_pooled_balance` 500 verbatim before the fix.

Non-vacuity was checked by reverting each fix and confirming the corresponding test goes red for the right reason, not just that it passes with the fix applied.

## Note for reviewers

Full pooled-balance suite was 27/27 on `dev`. On this `main`-based branch the suite was still mid-run when the PR was opened — worth confirming in CI, since `main` is 15 commits behind `dev`.

Separately, this stops new damage but does not heal rows already written. Known bad pools: `66ce1b66184472fc3ece190a` (`pool_3HExLirg`) and `671053da11f83b3e736e7ff1` (`pool_3HExL4Le`, `pool_3HExMHio`), all sitting at `0 / 10,000`. Those need a data repair setting the synthetic cusEnt balance back to `granted`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pooled-balance transitions that duplicated contributions, dropped grants, and caused webhook/update failures. Preserves balances and rollovers, and adds a safe reconcile path instead of hard failures.

- **Bug Fixes**
  - Stop treating `past_due -> active` as an attachment; only `Scheduled -> Active` and inserts count. Extracted `classifyPooledBalanceTransitionProducts`.
  - When a transition inserts a pool, seed its balance from the contribution so grants aren’t lost (no more `0 / 10,000` pools).
  - Re-admitting a source to the same pool applies only the delta; no `granted` double-counting and no balance inflation.
  - Contribution inserts use `onConflictDoUpdate` in `executePooledBalancePlan` to reconcile onto existing rows and warn, avoiding `unique_pooled_balance_contribution` failures.
  - `addStripeSubscriptionIdToBillingPlan` now stamps inserts only, preventing outgoing pools from being moved onto identities held by other live pools (avoids `unique_pooled_balance` errors).

<sup>Written for commit b9744c461ff7a64181944a0e7e1a2faff508085c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

