### PR TITLE
fix: respect per-call timeout overrides

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "packages/autumn-js/**"
       - "packages/openapi/**"
+      - "packages/sdk/**"
 
   workflow_dispatch:
     inputs:
@@ -44,11 +45,12 @@ jobs:
       contents: write
     with:
       package-dir: packages/autumn-js
-      commit-paths: packages/autumn-js packages/openapi
+      commit-paths: packages/autumn-js packages/openapi packages/sdk
       install-speakeasy: true
       pre-build-command: bun api
       build-command: bun js:build
       typecheck-command: bun js:ts
+      test-command: cd packages/sdk && bun test
       version-bump: ${{ github.event_name == 'workflow_dispatch' && inputs.version-bump || '' }}
       dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || 'false' }}
       publish-name-override: ${{ github.event_name == 'workflow_dispatch' && inputs.test-package == 'true' && '@useautumn/js-test' || '' }}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -21,6 +21,7 @@
   },
   "sideEffects": false,
   "scripts": {
+    "test": "bun test",
     "lint": "eslint --cache --max-warnings=0 src",
     "build": "tshy",
     "prepublishOnly": "npm run build"

--- a/packages/sdk/src/hooks/registration.ts
+++ b/packages/sdk/src/hooks/registration.ts
@@ -12,6 +12,6 @@ export function initHooks(hooks: Hooks) {
 	const failOpenHook = new FailOpenHook();
 	const timeoutFixHook = new TimeoutFixHook();
 	hooks.registerSDKInitHook(failOpenHook);
-	hooks.registerBeforeRequestHook(timeoutFixHook);
+	hooks.registerBeforeCreateRequestHook(timeoutFixHook);
 	hooks.registerAfterErrorHook(failOpenHook);
 }

--- a/packages/sdk/src/hooks/timeoutFixHook.ts
+++ b/packages/sdk/src/hooks/timeoutFixHook.ts
@@ -1,24 +1,30 @@
-import type { BeforeRequestContext, BeforeRequestHook } from "./types.js";
+import type { RequestInput } from "../lib/http.js";
+import type {
+  BeforeCreateRequestContext,
+  BeforeCreateRequestHook,
+} from "./types.js";
 
 const DEFAULT_TIMEOUT_MS = 5000;
 const AUTO_TIMEOUT_OPERATION_IDS = new Set(["check", "track"]);
 
-export class TimeoutFixHook implements BeforeRequestHook {
-  beforeRequest(hookCtx: BeforeRequestContext, request: Request): Request {
-    let timeoutMs = hookCtx.options.timeoutMs;
+export class TimeoutFixHook implements BeforeCreateRequestHook {
+  beforeCreateRequest(
+    hookCtx: BeforeCreateRequestContext,
+    input: RequestInput,
+  ): RequestInput {
+    if (
+      input.options?.signal
+      || !AUTO_TIMEOUT_OPERATION_IDS.has(hookCtx.operationID)
+    ) {
+      return input;
+    }
 
-    if ((!timeoutMs || timeoutMs <= 0) && AUTO_TIMEOUT_OPERATION_IDS.has(hookCtx.operationID))
-      timeoutMs = DEFAULT_TIMEOUT_MS;
-
-    if (!timeoutMs || timeoutMs <= 0) return request;
-
-    const signal =
-      typeof AbortSignal.any === "function"
-        ? AbortSignal.any([request.signal, AbortSignal.timeout(timeoutMs)])
-        : AbortSignal.timeout(timeoutMs);
-
-    return new Request(request, {
-      signal,
-    });
+    return {
+      ...input,
+      options: {
+        ...input.options,
+        signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+      },
+    };
   }
 }

--- a/packages/sdk/test/timeout-precedence.test.ts
+++ b/packages/sdk/test/timeout-precedence.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test";
+import { Autumn } from "../src/sdk/sdk.js";
+
+const startDelayedServer = () =>
+  Bun.serve({
+    port: 0,
+    async fetch() {
+      await Bun.sleep(250);
+      return Response.json({ list: [], total: {} });
+    },
+  });
+
+test("a per-call timeout can extend the client timeout", async () => {
+  const server = startDelayedServer();
+
+  try {
+    const autumn = new Autumn({
+      secretKey: "test",
+      serverURL: `http://127.0.0.1:${server.port}`,
+      timeoutMs: 100,
+    });
+    const response = await autumn.events.aggregate(
+      { featureId: "credits", range: "90d" },
+      { timeoutMs: 1_000 },
+    );
+
+    expect(response).toEqual({ list: [], total: {} });
+  } finally {
+    await server.stop(true);
+  }
+});
+
+test("the client timeout applies without a per-call override", async () => {
+  const server = startDelayedServer();
+
+  try {
+    const autumn = new Autumn({
+      failOpen: false,
+      secretKey: "test",
+      serverURL: `http://127.0.0.1:${server.port}`,
+      timeoutMs: 100,
+    });
+
+    await expect(
+      autumn.events.aggregate({ featureId: "credits", range: "90d" }),
+    ).rejects.toMatchObject({ name: "RequestTimeoutError" });
+  } finally {
+    await server.stop(true);
+  }
+});


### PR DESCRIPTION
## Summary

- stop reapplying the client timeout after Speakeasy resolves a per-call override
- preserve the default 5-second timeout for `check` and `track` when no signal is configured
- cover Firecrawl's timeout combination over real HTTP
- trigger an autumn-js patch publish for `packages/sdk/**` changes

## Verification

- `bun test test/timeout-precedence.test.ts` — real delayed HTTP server; longer per-call override succeeds and client default still aborts without an override
- `bun run lint` and `bun run build` in `packages/sdk`
- `bun -F autumn-js build`
- built `autumn-js/dist/sdk/index.mjs` exercised against the delayed HTTP server: 263 ms response with a 100 ms client default and 1,000 ms per-call override
- [SDK Publish dry-run](https://github.com/useautumn/autumn/actions/runs/30646627401) on final commit `062ca2378` — patch selection, Speakeasy regeneration, build, typecheck, real-HTTP regression, manifest preparation, and npm publish dry-run all passed
