### PR TITLE
feat: ship logs to Axiom via FireLens sidecar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   #   staging repo (autumn-staging) -> us-east-1
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix feat/firelens-log-transport
 
 jobs:
   checks:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   #   staging repo (autumn-staging) -> us-east-1
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix feat/firelens-log-transport
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix feat/firelens-log-transport-v2
 
 jobs:
   checks:

--- a/firelens.conf
+++ b/firelens.conf
@@ -33,6 +33,15 @@
     Match *
     Add region ${AWS_REGION}
 
+# The runtime splits stdout lines above ~16KB, so a large response would reach
+# the parser as JSON fragments and fall through to `ecs` as text. Must precede
+# the parser so it sees a whole line.
+[FILTER]
+    Name multiline
+    Match *-firelens-*
+    multiline.key_content log
+    mode partial_message
+
 [FILTER]
     Name parser
     Match *-firelens-*

--- a/server/.env.example
+++ b/server/.env.example
@@ -56,6 +56,8 @@ RESEND_DOMAIN=
 # AXIOM
 # This will send pino and Open Telemetry logs to https://axiom.co/
 AXIOM_TOKEN=
+# firelens activates only in ECS; other runtimes retain the direct transport.
+AXIOM_LOG_TRANSPORT=direct
 
 # SVIX
 # This will enable webhooks using Svix: https://www.svix.com

--- a/server/src/utils/logging/initLogger.ts
+++ b/server/src/utils/logging/initLogger.ts
@@ -163,15 +163,22 @@ const createConsoleJsonStream = () =>
  */
 export type InitLoggerOptions = {
 	mode?: "default" | "dual";
+	transport?: "direct" | "firelens";
 };
 
 export const initLogger = (options: InitLoggerOptions = {}) => {
-	const { mode = "default" } = options;
+	const { mode = "default", transport } = options;
 
 	const streams: pino.StreamEntry[] = [];
 	const isDev = process.env.NODE_ENV === "development";
 	const isTest = process.env.NODE_ENV === "test";
 	const isDevOrTest = isDev || isTest;
+	const configuredTransport =
+		transport ??
+		(process.env.AXIOM_LOG_TRANSPORT === "firelens" ? "firelens" : "direct");
+	const isRunningInEcs = Boolean(process.env.ECS_CONTAINER_METADATA_URI_V4);
+	const shouldUseFirelens =
+		configuredTransport === "firelens" && !isDevOrTest && isRunningInEcs;
 
 	if (mode === "dual") {
 		streams.push({
@@ -181,9 +188,11 @@ export const initLogger = (options: InitLoggerOptions = {}) => {
 						trailingNewline: false,
 						useConsoleLog: true,
 					})
-				: createConsoleJsonStream(),
+				: shouldUseFirelens
+					? process.stdout
+					: createConsoleJsonStream(),
 		});
-		if (process.env.AXIOM_TOKEN) {
+		if (!shouldUseFirelens && process.env.AXIOM_TOKEN) {
 			streams.push({
 				level: "info",
 				stream: pino.transport({
@@ -204,7 +213,12 @@ export const initLogger = (options: InitLoggerOptions = {}) => {
 			});
 		}
 
-		if (process.env.AXIOM_TOKEN) {
+		if (shouldUseFirelens) {
+			streams.push({
+				level: "info",
+				stream: process.stdout,
+			});
+		} else if (process.env.AXIOM_TOKEN) {
 			streams.push({
 				level: "info",
 				stream: pino.transport({

--- a/server/src/utils/logging/initLogger.ts
+++ b/server/src/utils/logging/initLogger.ts
@@ -173,9 +173,11 @@ export const initLogger = (options: InitLoggerOptions = {}) => {
 	const isDev = process.env.NODE_ENV === "development";
 	const isTest = process.env.NODE_ENV === "test";
 	const isDevOrTest = isDev || isTest;
+	// FireLens is the default: the sidecar already ships stdout, so no per-process
+	// Axiom transport thread. `AXIOM_LOG_TRANSPORT=direct` reverts without a rebuild.
 	const configuredTransport =
 		transport ??
-		(process.env.AXIOM_LOG_TRANSPORT === "firelens" ? "firelens" : "direct");
+		(process.env.AXIOM_LOG_TRANSPORT === "direct" ? "direct" : "firelens");
 	const isRunningInEcs = Boolean(process.env.ECS_CONTAINER_METADATA_URI_V4);
 	const shouldUseFirelens =
 		configuredTransport === "firelens" && !isDevOrTest && isRunningInEcs;

--- a/server/tests/unit/logging/firelens-config.test.ts
+++ b/server/tests/unit/logging/firelens-config.test.ts
@@ -27,6 +27,17 @@ test.concurrent(
 		expect(config).toMatch(
 			/\[FILTER\]\s+Name modify\s+Match axiom_express\s+Remove time\s+Remove region\s+Remove container_id\s+Remove container_name/,
 		);
+		// Ordering is the contract: a split line reaching the parser first would be
+		// unparseable JSON, lose its `level`, and fall through to `ecs` as text.
+		expect(config).toContain("mode partial_message");
+		expect(config).toContain("multiline.key_content log");
+		expect(config.indexOf("mode partial_message")).toBeLessThan(
+			config.indexOf("Parser json"),
+		);
+		expect(config).not.toMatch(
+			/mode partial_message[\s\S]*?multiline\.parser/,
+		);
+
 		expect(config).toContain("URI /v1/ingest/express");
 		expect(config).toContain("URI /v1/ingest/ecs");
 		expect(config.match(/retry_limit 5/g)).toHaveLength(2);

--- a/server/tests/unit/logging/init-logger-transport.test.ts
+++ b/server/tests/unit/logging/init-logger-transport.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Contract: FireLens mode writes complete Pino JSON to stdout without creating
+ * an Axiom transport, while direct mode retains the existing Axiom transport.
+ */
+
+import { expect, spyOn, test } from "bun:test";
+import { Writable } from "node:stream";
+import pino from "pino";
+import { initLogger } from "@/utils/logging/initLogger.js";
+
+test("logger selects FireLens without changing structured records", () => {
+	const previousNodeEnv = process.env.NODE_ENV;
+	const previousAxiomToken = process.env.AXIOM_TOKEN;
+	const previousLogTransport = process.env.AXIOM_LOG_TRANSPORT;
+	const previousEcsMetadataUri = process.env.ECS_CONTAINER_METADATA_URI_V4;
+	const stdoutChunks: string[] = [];
+	const directChunks: string[] = [];
+	const directStream = new Writable({
+		write(chunk, _encoding, callback) {
+			directChunks.push(chunk.toString());
+			callback();
+		},
+	});
+	const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(
+		(chunk: string | Uint8Array) => {
+			stdoutChunks.push(chunk.toString());
+			return true;
+		},
+	);
+	const transportSpy = spyOn(pino, "transport").mockReturnValue(
+		directStream as ReturnType<typeof pino.transport>,
+	);
+
+	try {
+		process.env.NODE_ENV = "production";
+		process.env.AXIOM_TOKEN = "test-token";
+		process.env.AXIOM_LOG_TRANSPORT = "firelens";
+		process.env.ECS_CONTAINER_METADATA_URI_V4 = "http://169.254.170.2/v4/test";
+
+		const firelensLogger = initLogger();
+		const responseBody = {
+			customer_id: "customer_123",
+			balances: {
+				messages: {
+					remaining: 42,
+				},
+			},
+		};
+
+		firelensLogger.info(
+			{
+				req: {
+					id: "request_123",
+					name: "balances.track",
+					url: "/v1/balances.track",
+				},
+				context: {
+					org_id: "org_123",
+					env: "production",
+				},
+				res: responseBody,
+				statusCode: 200,
+				durationMs: 12,
+			},
+			"Request completed",
+		);
+
+		expect(transportSpy).not.toHaveBeenCalled();
+		expect(stdoutChunks).toHaveLength(1);
+
+		const firelensRecord = JSON.parse(stdoutChunks[0] ?? "{}");
+		expect(firelensRecord).toMatchObject({
+			level: "INFO",
+			msg: "Request completed",
+			req: {
+				id: "request_123",
+				name: "balances.track",
+				url: "/v1/balances.track",
+			},
+			context: {
+				org_id: "org_123",
+				env: "production",
+			},
+			res: responseBody,
+			statusCode: 200,
+			durationMs: 12,
+		});
+
+		process.env.AXIOM_LOG_TRANSPORT = "direct";
+		const directLogger = initLogger();
+		directLogger.info({ req: { id: "request_456" } }, "Direct request");
+
+		expect(transportSpy).toHaveBeenCalledTimes(1);
+		expect(directChunks.join("")).toContain("request_456");
+
+		process.env.AXIOM_LOG_TRANSPORT = "firelens";
+		delete process.env.ECS_CONTAINER_METADATA_URI_V4;
+		initLogger();
+		expect(transportSpy).toHaveBeenCalledTimes(2);
+	} finally {
+		stdoutSpy.mockRestore();
+		transportSpy.mockRestore();
+		restoreEnvironmentVariable({
+			name: "NODE_ENV",
+			previousValue: previousNodeEnv,
+		});
+		restoreEnvironmentVariable({
+			name: "AXIOM_TOKEN",
+			previousValue: previousAxiomToken,
+		});
+		restoreEnvironmentVariable({
+			name: "AXIOM_LOG_TRANSPORT",
+			previousValue: previousLogTransport,
+		});
+		restoreEnvironmentVariable({
+			name: "ECS_CONTAINER_METADATA_URI_V4",
+			previousValue: previousEcsMetadataUri,
+		});
+	}
+});
+
+const restoreEnvironmentVariable = ({
+	name,
+	previousValue,
+}: {
+	name: string;
+	previousValue: string | undefined;
+}) => {
+	if (previousValue === undefined) {
+		delete process.env[name];
+		return;
+	}
+
+	process.env[name] = previousValue;
+};

--- a/server/tests/unit/logging/init-logger-transport.test.ts
+++ b/server/tests/unit/logging/init-logger-transport.test.ts
@@ -119,6 +119,60 @@ test("logger selects FireLens without changing structured records", () => {
 	}
 });
 
+// FireLens is the default, so an unset variable must not fall back to spawning
+// a transport thread — that would silently keep the old path in production.
+test("logger defaults to FireLens in ECS when the variable is unset", () => {
+	const previousNodeEnv = process.env.NODE_ENV;
+	const previousAxiomToken = process.env.AXIOM_TOKEN;
+	const previousLogTransport = process.env.AXIOM_LOG_TRANSPORT;
+	const previousEcsMetadataUri = process.env.ECS_CONTAINER_METADATA_URI_V4;
+	const stdoutChunks: string[] = [];
+	const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(
+		(chunk: string | Uint8Array) => {
+			stdoutChunks.push(chunk.toString());
+			return true;
+		},
+	);
+	const transportSpy = spyOn(pino, "transport").mockReturnValue(
+		new Writable({
+			write(_chunk, _encoding, callback) {
+				callback();
+			},
+		}) as ReturnType<typeof pino.transport>,
+	);
+
+	try {
+		process.env.NODE_ENV = "production";
+		process.env.AXIOM_TOKEN = "test-token";
+		process.env.ECS_CONTAINER_METADATA_URI_V4 = "http://169.254.170.2/v4/test";
+		delete process.env.AXIOM_LOG_TRANSPORT;
+
+		initLogger().info({ req: { id: "request_default" } }, "Default request");
+
+		expect(transportSpy).not.toHaveBeenCalled();
+		expect(stdoutChunks.join("")).toContain("request_default");
+	} finally {
+		stdoutSpy.mockRestore();
+		transportSpy.mockRestore();
+		restoreEnvironmentVariable({
+			name: "NODE_ENV",
+			previousValue: previousNodeEnv,
+		});
+		restoreEnvironmentVariable({
+			name: "AXIOM_TOKEN",
+			previousValue: previousAxiomToken,
+		});
+		restoreEnvironmentVariable({
+			name: "AXIOM_LOG_TRANSPORT",
+			previousValue: previousLogTransport,
+		});
+		restoreEnvironmentVariable({
+			name: "ECS_CONTAINER_METADATA_URI_V4",
+			previousValue: previousEcsMetadataUri,
+		});
+	}
+});
+
 const restoreEnvironmentVariable = ({
 	name,
 	previousValue,


### PR DESCRIPTION
- **route Axiom logs through FireLens**
- **ci: allow feat/firelens-log-transport-v2 to deploy to staging**
- **feat: default log shipping to FireLens sidecar**
- **fix: reassemble runtime-split log lines before JSON parsing**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default ECS log shipping now uses the FireLens sidecar, sending structured JSON to Axiom via stdout. Outside ECS or when AXIOM_LOG_TRANSPORT=direct, the app keeps the existing direct transport.

- **New Features**
  - Logger selects FireLens in production ECS; dev/test stay unchanged.
  - AXIOM_LOG_TRANSPORT env toggle supports `direct` or `firelens` without a rebuild.
  - Unit tests cover transport selection and verify FireLens writes complete JSON to stdout.

- **Bug Fixes**
  - Added a multiline filter before the JSON parser in firelens.conf to reassemble runtime-split stdout lines and prevent fallback to plain `ecs` logs.

<sup>Written for commit 851434ecee30c9c67e287c8beb70eeb6de8604c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

