### PR TITLE
Add a SECURITY.md security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Autumn, please report it privately
+rather than opening a public issue.
+
+- Email: **security@useautumn.com**
+- Or use GitHub's private vulnerability reporting on this repository
+  (the **Security** tab, then **Report a vulnerability**).
+
+Please include a description of the issue, steps to reproduce, and the affected
+version or component. We appreciate responsible disclosure and will get back to
+you as soon as we can.


### PR DESCRIPTION
Hi, thanks for maintaining this project.

I noticed the repository does not have a `SECURITY.md` yet, so GitHub shows no
security policy on the Security tab and there's no clear channel for reporting a
vulnerability. This PR adds a minimal one that points reporters at a private
channel instead of a public issue.

It is intentionally minimal: just the reporting channel. Response timelines,
scope, and any safe-harbour language are left for you to define as you see fit.
Feel free to adjust the contact address (I used the conventional
`security@<domain>`) or point it at GitHub's private vulnerability reporting.

Happy to tweak anything if this doesn't fit how you'd like to handle it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add SECURITY.md with a minimal security policy to provide a private disclosure channel and show a security policy in the Security tab. Includes contact at security@useautumn.com and enables GitHub’s private vulnerability reporting.

<sup>Written for commit 1ab1785e263082d0e53663e5b07b70376a51c1bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

