### PR TITLE
feat(billing): support full multi-plan attach flows

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/errors/handleAttachV2Errors.ts
+++ b/server/src/internal/billing/v2/actions/attach/errors/handleAttachV2Errors.ts
@@ -97,7 +97,6 @@ export const handleAttachV2Errors = async ({
 	handleProrationBehaviorErrors({
 		billingContext,
 		billingPlan,
-		params,
 	});
 
 	// 11. Subscription ID uniqueness

--- a/server/src/internal/billing/v2/actions/attach/errors/handleRevertTrialErrors.ts
+++ b/server/src/internal/billing/v2/actions/attach/errors/handleRevertTrialErrors.ts
@@ -1,21 +1,16 @@
 import {
-	type AttachBillingContext,
+	type BillingContext,
 	ErrCode,
 	hasActivePaidSubscription,
 	RecaseError,
 } from "@autumn/shared";
 import { StatusCodes } from "http-status-codes";
 
-/**
- * Validates attach request when on_end is "revert".
- *
- * Throws if the customer has no active paid subscription anywhere
- * (across all entities).
- */
+/** Reject revert trials without an active paid subscription. */
 export const handleRevertTrialErrors = ({
 	billingContext,
 }: {
-	billingContext: AttachBillingContext;
+	billingContext: Pick<BillingContext, "trialContext" | "fullCustomer">;
 }) => {
 	const { trialContext, fullCustomer } = billingContext;
 	if (trialContext?.onEnd !== "revert") return;

--- a/server/src/internal/billing/v2/actions/common/immediateMultiProduct/computeImmediateMultiProductPlan.ts
+++ b/server/src/internal/billing/v2/actions/common/immediateMultiProduct/computeImmediateMultiProductPlan.ts
@@ -20,49 +20,32 @@ export const computeImmediateMultiProductPlan = ({
 	ctx: AutumnContext;
 	billingContext: MultiAttachBillingContext;
 }): AutumnBillingPlan => {
-	const productChanges = billingContext.productContexts.map(
-		(productContext) => {
-			const attachBillingContext = productContextToAttachBillingContext({
-				billingContext,
-				productContext,
-			});
-
-			return {
-				attachBillingContext,
-				incomingCustomerProduct: computeAttachNewCustomerProduct({
-					ctx,
-					attachBillingContext,
-				}),
-				outgoingCustomerProduct: productContext.currentCustomerProduct,
-				scheduledCustomerProduct: productContext.scheduledCustomerProduct,
-			};
-		},
-	);
-	const insertCustomerProducts = productChanges.map(
-		({ incomingCustomerProduct }) => incomingCustomerProduct,
-	);
+	const insertCustomerProducts: FullCusProduct[] = [];
 	const outgoingCustomerProducts: FullCusProduct[] = [];
 	const updateCustomerProducts: NonNullable<
 		AutumnBillingPlan["updateCustomerProducts"]
 	> = [];
-	const scheduledCustomerProducts = new Map<string, FullCusProduct>();
+	const deleteCustomerProducts: FullCusProduct[] = [];
 
-	for (const productChange of productChanges) {
-		if (productChange.outgoingCustomerProduct) {
-			outgoingCustomerProducts.push(productChange.outgoingCustomerProduct);
-			const updateCustomerProduct = computeAttachTransitionUpdates({
-				attachBillingContext: productChange.attachBillingContext,
-			});
-			if (updateCustomerProduct) {
-				updateCustomerProducts.push(updateCustomerProduct);
-			}
+	for (const productContext of billingContext.productContexts) {
+		const attachBillingContext = productContextToAttachBillingContext({
+			billingContext,
+			productContext,
+		});
+		insertCustomerProducts.push(
+			computeAttachNewCustomerProduct({ ctx, attachBillingContext }),
+		);
+
+		const updateCustomerProduct = computeAttachTransitionUpdates({
+			attachBillingContext,
+		});
+		if (updateCustomerProduct) {
+			updateCustomerProducts.push(updateCustomerProduct);
+			outgoingCustomerProducts.push(updateCustomerProduct.customerProduct);
 		}
 
-		if (productChange.scheduledCustomerProduct) {
-			scheduledCustomerProducts.set(
-				productChange.scheduledCustomerProduct.id,
-				productChange.scheduledCustomerProduct,
-			);
+		if (productContext.scheduledCustomerProduct) {
+			deleteCustomerProducts.push(productContext.scheduledCustomerProduct);
 		}
 	}
 
@@ -92,7 +75,7 @@ export const computeImmediateMultiProductPlan = ({
 			billingContext.fullCustomer.id ?? billingContext.fullCustomer.internal_id,
 		insertCustomerProducts,
 		updateCustomerProducts,
-		deleteCustomerProducts: [...scheduledCustomerProducts.values()],
+		deleteCustomerProducts,
 		customPrices: billingContext.customPrices,
 		customEntitlements: [
 			...(billingContext.customEnts ?? []),

--- a/server/src/internal/billing/v2/actions/common/immediateMultiProduct/computeImmediateMultiProductPlan.ts
+++ b/server/src/internal/billing/v2/actions/common/immediateMultiProduct/computeImmediateMultiProductPlan.ts
@@ -1,6 +1,6 @@
 import type {
-	AttachBillingContext,
 	AutumnBillingPlan,
+	FullCusProduct,
 	MultiAttachBillingContext,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
@@ -8,8 +8,9 @@ import { computeAttachNewCustomerProduct } from "@/internal/billing/v2/actions/a
 import { computeAttachTransitionUpdates } from "@/internal/billing/v2/actions/attach/compute/computeAttachTransitionUpdates";
 import { buildAutumnLineItems } from "@/internal/billing/v2/compute/computeAutumnUtils/buildAutumnLineItems";
 import { finalizeLineItems } from "@/internal/billing/v2/compute/finalize/finalizeLineItems";
+import { computePooledBalanceTransitionPlan } from "@/internal/billing/v2/pooledBalances/compute/computePooledBalanceTransitionPlan";
 import { productContextToAttachBillingContext } from "@/internal/billing/v2/utils/billingContext/productContextToAttachBillingContext";
-import { cusProductToOneOffPrepaidCarryOvers } from "@/internal/billing/v2/utils/handleOneOffPrepaidCarryOvers/cusProductToOneOffPrepaidCarryOvers";
+import { cusProductsToOneOffPrepaidCarryOvers } from "@/internal/billing/v2/utils/handleOneOffPrepaidCarryOvers/cusProductToOneOffPrepaidCarryOvers";
 
 /** Compute the billing plan for immediate multi-product billing. */
 export const computeImmediateMultiProductPlan = ({
@@ -19,60 +20,79 @@ export const computeImmediateMultiProductPlan = ({
 	ctx: AutumnContext;
 	billingContext: MultiAttachBillingContext;
 }): AutumnBillingPlan => {
-	const transitioningProductContext = billingContext.productContexts.find(
-		(productContext) => productContext.currentCustomerProduct !== undefined,
-	);
-	const deletedCustomerProduct =
-		transitioningProductContext?.currentCustomerProduct;
-	const scheduledCustomerProduct =
-		transitioningProductContext?.scheduledCustomerProduct;
-
-	let transitionContext: AttachBillingContext | undefined;
-	const insertCustomerProducts = billingContext.productContexts.map(
+	const productChanges = billingContext.productContexts.map(
 		(productContext) => {
 			const attachBillingContext = productContextToAttachBillingContext({
 				billingContext,
 				productContext,
 			});
 
-			if (productContext.currentCustomerProduct) {
-				transitionContext = attachBillingContext;
-			}
-
-			return computeAttachNewCustomerProduct({
-				ctx,
+			return {
 				attachBillingContext,
-			});
+				incomingCustomerProduct: computeAttachNewCustomerProduct({
+					ctx,
+					attachBillingContext,
+				}),
+				outgoingCustomerProduct: productContext.currentCustomerProduct,
+				scheduledCustomerProduct: productContext.scheduledCustomerProduct,
+			};
 		},
 	);
+	const insertCustomerProducts = productChanges.map(
+		({ incomingCustomerProduct }) => incomingCustomerProduct,
+	);
+	const outgoingCustomerProducts: FullCusProduct[] = [];
+	const updateCustomerProducts: NonNullable<
+		AutumnBillingPlan["updateCustomerProducts"]
+	> = [];
+	const scheduledCustomerProducts = new Map<string, FullCusProduct>();
 
-	const updateCustomerProduct = transitionContext
-		? computeAttachTransitionUpdates({
-				attachBillingContext: transitionContext,
-			})
-		: undefined;
+	for (const productChange of productChanges) {
+		if (productChange.outgoingCustomerProduct) {
+			outgoingCustomerProducts.push(productChange.outgoingCustomerProduct);
+			const updateCustomerProduct = computeAttachTransitionUpdates({
+				attachBillingContext: productChange.attachBillingContext,
+			});
+			if (updateCustomerProduct) {
+				updateCustomerProducts.push(updateCustomerProduct);
+			}
+		}
+
+		if (productChange.scheduledCustomerProduct) {
+			scheduledCustomerProducts.set(
+				productChange.scheduledCustomerProduct.id,
+				productChange.scheduledCustomerProduct,
+			);
+		}
+	}
+
+	const { pooledBalancePlan } = computePooledBalanceTransitionPlan({
+		ctx,
+		fullCustomer: billingContext.fullCustomer,
+		outgoingCustomerProducts,
+		incomingCustomerProducts: insertCustomerProducts,
+		stripeSubscriptionId: billingContext.stripeSubscription?.id,
+		now: billingContext.currentEpochMs,
+	});
 
 	const { allLineItems, updateCustomerEntitlements } = buildAutumnLineItems({
 		ctx,
 		newCustomerProducts: insertCustomerProducts,
-		deletedCustomerProduct,
+		deletedCustomerProducts: outgoingCustomerProducts,
 		billingContext,
-		includeArrearLineItems: deletedCustomerProduct !== undefined,
+		includeArrearLineItems: outgoingCustomerProducts.length > 0,
 	});
 
-	const oneOffPrepaidCarryOvers = deletedCustomerProduct
-		? cusProductToOneOffPrepaidCarryOvers({
-				currentCustomerProduct: deletedCustomerProduct,
-				fullCustomer: billingContext.fullCustomer,
-			})
-		: { entitlements: [], customerEntitlements: [] };
-
+	const oneOffPrepaidCarryOvers = cusProductsToOneOffPrepaidCarryOvers({
+		currentCustomerProducts: outgoingCustomerProducts,
+		fullCustomer: billingContext.fullCustomer,
+	});
 	const billingPlan: AutumnBillingPlan = {
 		customerId:
 			billingContext.fullCustomer.id ?? billingContext.fullCustomer.internal_id,
 		insertCustomerProducts,
-		updateCustomerProduct,
-		deleteCustomerProduct: scheduledCustomerProduct,
+		updateCustomerProducts,
+		deleteCustomerProducts: [...scheduledCustomerProducts.values()],
 		customPrices: billingContext.customPrices,
 		customEntitlements: [
 			...(billingContext.customEnts ?? []),
@@ -82,6 +102,7 @@ export const computeImmediateMultiProductPlan = ({
 		lineItems: allLineItems,
 		updateCustomerEntitlements,
 		insertCustomerEntitlements: oneOffPrepaidCarryOvers.customerEntitlements,
+		pooledBalancePlan,
 	};
 
 	billingPlan.lineItems = finalizeLineItems({

--- a/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
@@ -1,6 +1,10 @@
 import {
 	BillingVersion,
+	customerProductHasSubscription,
+	customerProductsToStripeSubscriptionIds,
 	type FullProduct,
+	filterCustomerProductsByStripeSubscriptionId,
+	getTargetSubscriptionCusProduct,
 	type InvoiceMode,
 	isFreeProduct,
 	isOneOffProduct,
@@ -8,7 +12,9 @@ import {
 	type MultiAttachBillingContext,
 	type MultiAttachParamsV0,
 	type MultiAttachProductContext,
+	notNullish,
 	orgToReturnUrl,
+	RecaseError,
 	resolveCustomerCurrency,
 } from "@autumn/shared";
 import type { FreeTrialParamsV1 } from "@shared/api/common/freeTrial/freeTrialParamsV1";
@@ -28,12 +34,30 @@ import {
 	handleFreeTrialParam,
 } from "@/internal/billing/v2/setup/trialContext";
 
-export type ImmediateMultiProductParams = Omit<MultiAttachParamsV0, "plans"> & {
-	plans: Array<
-		MultiAttachParamsV0["plans"][number] & {
-			entity_id?: string | null;
-		}
-	>;
+export type ImmediateMultiProductParams = MultiAttachParamsV0;
+
+const getSubscriptionTarget = ({
+	productContext,
+}: {
+	productContext: MultiAttachProductContext;
+}) => {
+	const { currentCustomerProduct, scheduledCustomerProduct, fullProduct } =
+		productContext;
+
+	if (customerProductHasSubscription(currentCustomerProduct)) {
+		return currentCustomerProduct;
+	}
+	if (customerProductHasSubscription(scheduledCustomerProduct)) {
+		return scheduledCustomerProduct;
+	}
+	if (!isProductPaidAndRecurring(fullProduct)) return undefined;
+
+	return getTargetSubscriptionCusProduct({
+		fullCus: productContext.fullCustomer,
+		productId: fullProduct.id,
+		productGroup: fullProduct.group ?? "",
+		cusProductId: currentCustomerProduct?.id ?? scheduledCustomerProduct?.id,
+	});
 };
 
 /** Resolve checkout mode for immediate multi-product billing. */
@@ -214,6 +238,35 @@ export const setupImmediateMultiProductBillingContext = async ({
 		throw new Error("setupImmediateMultiProductBillingContext requires plans");
 	}
 
+	const hasSubscriptionTransition = productContexts.some(
+		({ currentCustomerProduct, scheduledCustomerProduct }) =>
+			customerProductHasSubscription(currentCustomerProduct) ||
+			customerProductHasSubscription(scheduledCustomerProduct),
+	);
+	const forceNewSubscription =
+		params.new_billing_subscription === true && !hasSubscriptionTransition;
+	const targetCustomerProducts = forceNewSubscription
+		? []
+		: productContexts
+				.map((productContext) => getSubscriptionTarget({ productContext }))
+				.filter(notNullish);
+	const subscriptionIds = customerProductsToStripeSubscriptionIds({
+		customerProducts: targetCustomerProducts,
+	});
+
+	if (subscriptionIds.length > 1) {
+		throw new RecaseError({
+			message: "Cannot update products across multiple existing subscriptions.",
+			statusCode: 400,
+		});
+	}
+
+	const [subscriptionId] = subscriptionIds;
+	const [targetCustomerProduct] = filterCustomerProductsByStripeSubscriptionId({
+		customerProducts: targetCustomerProducts,
+		stripeSubscriptionId: subscriptionId,
+	});
+
 	const {
 		stripeSubscription,
 		stripeSubscriptionSchedule,
@@ -225,12 +278,12 @@ export const setupImmediateMultiProductBillingContext = async ({
 	} = await setupStripeBillingContext({
 		ctx,
 		fullCustomer,
-		targetCustomerProduct: undefined,
+		targetCustomerProduct,
 		params,
 		skipSubscriptionFetching: fullProducts.every((product) =>
 			isOneOffProduct({ product }),
 		),
-		newBillingSubscription: params.new_billing_subscription || undefined,
+		newBillingSubscription: forceNewSubscription || undefined,
 		includeScheduledProductsForScheduleLookup,
 		createStripeCustomerIfMissing: !preview,
 	});
@@ -310,6 +363,7 @@ export const setupImmediateMultiProductBillingContext = async ({
 		currentEpochMs,
 		billingCycleAnchorMs,
 		resetCycleAnchorMs,
+		requestedProrationBehavior: params.billing_behavior,
 		stripeCustomer,
 		stripeSubscription,
 		stripeSubscriptionSchedule,
@@ -319,6 +373,7 @@ export const setupImmediateMultiProductBillingContext = async ({
 		customPrices,
 		customEnts,
 		trialContext,
+		skipBillingChanges: trialContext?.onEnd === "revert",
 		isCustom: customPrices.length > 0 || customEnts.length > 0,
 		checkoutMode: setupImmediateMultiProductCheckoutMode({
 			paymentMethod,

--- a/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
@@ -34,8 +34,6 @@ import {
 	handleFreeTrialParam,
 } from "@/internal/billing/v2/setup/trialContext";
 
-export type ImmediateMultiProductParams = MultiAttachParamsV0;
-
 const getSubscriptionTarget = ({
 	productContext,
 }: {
@@ -154,7 +152,7 @@ export const setupImmediateMultiProductBillingContext = async ({
 	includeScheduledProductsForScheduleLookup,
 }: {
 	ctx: AutumnContext;
-	params: ImmediateMultiProductParams;
+	params: MultiAttachParamsV0;
 	preview?: boolean;
 	billingStartsAt?: number;
 	billingStartsAtToleranceMs?: number;

--- a/server/src/internal/billing/v2/actions/common/immediateMultiProduct/validateImmediateMultiProductTransitions.ts
+++ b/server/src/internal/billing/v2/actions/common/immediateMultiProduct/validateImmediateMultiProductTransitions.ts
@@ -1,4 +1,5 @@
 import { type MultiAttachProductContext, RecaseError } from "@autumn/shared";
+import { validateProductGroupsByScope } from "../validateProductGroupsByScope";
 
 /** Reject unsupported immediate multi-product transition combinations. */
 export const validateImmediateMultiProductTransitions = ({
@@ -6,6 +7,14 @@ export const validateImmediateMultiProductTransitions = ({
 }: {
 	productContexts: MultiAttachProductContext[];
 }) => {
+	validateProductGroupsByScope({
+		plans: productContexts.map((productContext) => ({
+			fullProduct: productContext.fullProduct,
+			scopeId: productContext.fullCustomer.entity?.internal_id,
+		})),
+		operation: "Multi-attach",
+	});
+
 	for (const productContext of productContexts) {
 		const { fullProduct, currentCustomerProduct } = productContext;
 
@@ -17,20 +26,5 @@ export const validateImmediateMultiProductTransitions = ({
 				statusCode: 400,
 			});
 		}
-	}
-
-	const transitioningProducts = productContexts.filter(
-		(productContext) => productContext.currentCustomerProduct !== undefined,
-	);
-
-	if (transitioningProducts.length > 1) {
-		const planIds = transitioningProducts
-			.map((productContext) => `"${productContext.fullProduct.id}"`)
-			.join(", ");
-
-		throw new RecaseError({
-			message: `Multi-attach supports at most one plan transition, but plans ${planIds} each replace an existing product in their group.`,
-			statusCode: 400,
-		});
 	}
 };

--- a/server/src/internal/billing/v2/actions/common/validateProductGroupsByScope.ts
+++ b/server/src/internal/billing/v2/actions/common/validateProductGroupsByScope.ts
@@ -1,0 +1,36 @@
+import { type FullProduct, isOneOffProduct, RecaseError } from "@autumn/shared";
+
+/** Reject conflicting main recurring plans within one group and scope. */
+export const validateProductGroupsByScope = ({
+	plans,
+	operation,
+}: {
+	plans: { fullProduct: FullProduct; scopeId?: string }[];
+	operation: string;
+}) => {
+	const groupedProducts = new Map<string, FullProduct[]>();
+
+	for (const { fullProduct, scopeId } of plans) {
+		if (fullProduct.is_add_on || isOneOffProduct({ product: fullProduct })) {
+			continue;
+		}
+
+		const key = JSON.stringify([scopeId ?? null, fullProduct.group ?? ""]);
+		const products = groupedProducts.get(key) ?? [];
+		products.push(fullProduct);
+		groupedProducts.set(key, products);
+	}
+
+	const conflictingProducts = [...groupedProducts.values()].flatMap(
+		(products) => (products.length > 1 ? products : []),
+	);
+	if (conflictingProducts.length === 0) return;
+
+	const planIds = conflictingProducts
+		.map((product) => `"${product.id}"`)
+		.join(", ");
+	throw new RecaseError({
+		message: `${operation} supports at most one plan per group and scope, but plans ${planIds} conflict.`,
+		statusCode: 400,
+	});
+};

--- a/server/src/internal/billing/v2/actions/createSchedule/errors/validateCreateSchedulePhasePlans.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/errors/validateCreateSchedulePhasePlans.ts
@@ -1,4 +1,5 @@
-import { type FullProduct, isOneOffProduct, RecaseError } from "@autumn/shared";
+import type { FullProduct } from "@autumn/shared";
+import { validateProductGroupsByScope } from "../../common/validateProductGroupsByScope";
 
 /** Reject conflicting main recurring plans within the same phase scope. */
 export const validateCreateSchedulePhasePlans = ({
@@ -6,32 +7,8 @@ export const validateCreateSchedulePhasePlans = ({
 }: {
 	plans: { fullProduct: FullProduct; scopeId?: string }[];
 }) => {
-	const groupedProducts = new Map<string, FullProduct[]>();
-
-	for (const { fullProduct, scopeId } of plans) {
-		if (fullProduct.is_add_on || isOneOffProduct({ product: fullProduct })) {
-			continue;
-		}
-
-		const group = fullProduct.group ?? "";
-		const key = JSON.stringify([scopeId ?? null, group]);
-		const productsInGroup = groupedProducts.get(key) ?? [];
-		productsInGroup.push(fullProduct);
-		groupedProducts.set(key, productsInGroup);
-	}
-
-	const conflictingProducts = [...groupedProducts.values()].flatMap(
-		(products) => (products.length > 1 ? products : []),
-	);
-
-	if (conflictingProducts.length === 0) return;
-
-	const planIds = conflictingProducts
-		.map((product) => `"${product.id}"`)
-		.join(", ");
-
-	throw new RecaseError({
-		message: `Create schedule supports at most one plan per group and scope in each phase, but plans ${planIds} conflict.`,
-		statusCode: 400,
+	validateProductGroupsByScope({
+		plans,
+		operation: "Create schedule",
 	});
 };

--- a/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
@@ -6,16 +6,14 @@ import {
 	isPastStartDate,
 	isProductPaidAndRecurring,
 	type MultiAttachBillingContext,
+	type MultiAttachParamsV0,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { setupAttachEndOfCycleMs } from "@/internal/billing/v2/actions/attach/setup/setupAttachEndOfCycleMs";
 import { setupAnchorResetRefund } from "@/internal/billing/v2/setup/setupAnchorResetRefund";
 import { setupBillingCycleAnchor } from "@/internal/billing/v2/setup/setupBillingCycleAnchor";
 import { setupResetCycleAnchor } from "@/internal/billing/v2/setup/setupResetCycleAnchor";
-import {
-	type ImmediateMultiProductParams,
-	setupImmediateMultiProductBillingContext,
-} from "../../common/immediateMultiProduct/setupImmediateMultiProductBillingContext";
+import { setupImmediateMultiProductBillingContext } from "../../common/immediateMultiProduct/setupImmediateMultiProductBillingContext";
 import { FIRST_PHASE_TOLERANCE_MS } from "../errors/handleFirstPhaseStartDateErrors";
 import {
 	getInitialCreateSchedulePhase,
@@ -81,7 +79,7 @@ const phaseToImmediateParams = ({
 }: {
 	params: CreateScheduleParamsV0;
 	phase: CreateScheduleParamsV0["phases"][number];
-}): ImmediateMultiProductParams => ({
+}): MultiAttachParamsV0 => ({
 	customer_id: params.customer_id,
 	entity_id: params.entity_id,
 	plans: phase.plans.map((plan) => ({

--- a/server/src/internal/billing/v2/actions/multiAttach/compute/computeMultiAttachPlan.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/compute/computeMultiAttachPlan.ts
@@ -6,13 +6,7 @@ import {
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { computeImmediateMultiProductPlan } from "../../common/immediateMultiProduct/computeImmediateMultiProductPlan";
 
-/**
- * Computes the billing plan for attaching multiple products.
- *
- * For each product, creates a temporary AttachBillingContext and reuses
- * computeAttachNewCustomerProduct to build the new customer product.
- * At most one product may trigger a transition (validated by error handler).
- */
+/** Computes the atomic Autumn plan for every requested product. */
 export const computeMultiAttachPlan = ({
 	ctx,
 	multiAttachBillingContext,

--- a/server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachErrors.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachErrors.ts
@@ -1,6 +1,8 @@
 import type { BillingPlan, MultiAttachBillingContext } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { handleRevertTrialErrors } from "@/internal/billing/v2/actions/attach/errors/handleRevertTrialErrors";
+import { handleProrationBehaviorErrors } from "@/internal/billing/v2/common/errors/handleBillingBehaviorErrors";
 import { handleSubscriptionIdErrors } from "@/internal/billing/v2/common/errors/handleSubscriptionIdErrors";
 import { handleStripeBillingPlanErrors } from "@/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors";
 import { handleMultiAttachCurrentProductErrors } from "./handleMultiAttachCurrentProductErrors";
@@ -25,6 +27,8 @@ export const handleMultiAttachErrors = async ({
 		stripeSubscription: billingContext.stripeSubscription,
 	});
 
+	handleRevertTrialErrors({ billingContext });
+
 	// Subscription ID uniqueness
 	await handleSubscriptionIdErrors({
 		db,
@@ -42,5 +46,6 @@ export const handleMultiAttachBillingPlanErrors = ({
 	billingContext: MultiAttachBillingContext;
 	billingPlan: BillingPlan;
 }) => {
+	handleProrationBehaviorErrors({ billingContext, billingPlan });
 	handleStripeBillingPlanErrors({ ctx, billingContext, billingPlan });
 };

--- a/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
@@ -5,11 +5,15 @@ import type {
 	MultiAttachParamsV0,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { checkCheckoutSessionLock } from "@/internal/billing/v2/actions/locks/checkoutSessionLock/checkCheckoutSessionLock";
+import { checkoutSessionLock } from "@/internal/billing/v2/actions/locks/checkoutSessionLock/checkoutSessionLock";
 import { executeBillingPlan } from "@/internal/billing/v2/execute/executeBillingPlan";
 import { evaluateStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan";
 import { logStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingPlan";
 import { logStripeBillingResult } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingResult";
+import { computeAttachPreviewBillingPlan } from "@/internal/billing/v2/utils/billingPlan/preview/computeAttachPreviewBillingPlan";
 import { logAutumnBillingPlan } from "@/internal/billing/v2/utils/logs/logAutumnBillingPlan";
+import { hashJson } from "@/utils/hash/hashJson";
 import { computeMultiAttachPlan } from "./compute/computeMultiAttachPlan";
 import { handleMultiAttachCurrencyErrors } from "./errors/handleMultiAttachCurrencyErrors";
 import {
@@ -34,6 +38,10 @@ export async function multiAttach({
 	params: MultiAttachParamsV0;
 	preview?: boolean;
 }): Promise<MultiAttachResult> {
+	const checkoutReservation = !preview
+		? await checkoutSessionLock.get({ ctx, customerId: params.customer_id })
+		: undefined;
+
 	// 1. Setup
 	const billingContext = await setupMultiAttachBillingContext({
 		ctx,
@@ -79,17 +87,32 @@ export async function multiAttach({
 	handleMultiAttachBillingPlanErrors({ ctx, billingContext, billingPlan });
 
 	if (preview) {
+		const previewBillingPlan = await computeAttachPreviewBillingPlan({
+			ctx,
+			billingContext,
+			autumnBillingPlan,
+		});
 		return {
 			billingContext,
-			billingPlan,
+			billingPlan: { ...billingPlan, preview: previewBillingPlan },
 		};
 	}
+
+	const cachedResult = await checkCheckoutSessionLock({
+		ctx,
+		params,
+		billingContext,
+		billingPlan,
+		existingLock: checkoutReservation,
+	});
+	if (cachedResult) return cachedResult;
 
 	// 5. Execute billing plan
 	const billingResult = await executeBillingPlan({
 		ctx,
 		billingContext,
 		billingPlan,
+		checkoutLockParamsHash: hashJson({ value: params }),
 	});
 
 	logStripeBillingResult({ ctx, result: billingResult.stripe });

--- a/server/src/internal/billing/v2/actions/multiAttach/setup/setupMultiAttachBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/setup/setupMultiAttachBillingContext.ts
@@ -5,9 +5,7 @@ import type {
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { setupImmediateMultiProductBillingContext } from "../../common/immediateMultiProduct/setupImmediateMultiProductBillingContext";
 
-/**
- * Assembles the full billing context for attaching multiple products.
- */
+/** Assemble the multi-attach billing context. */
 export const setupMultiAttachBillingContext = async ({
 	ctx,
 	params,

--- a/server/src/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
@@ -82,7 +82,6 @@ export const handleUpdateSubscriptionErrors = async ({
 	handleProrationBehaviorErrors({
 		billingContext,
 		billingPlan,
-		params,
 	});
 
 	// 10. Billing cycle anchor errors

--- a/server/src/internal/billing/v2/common/errors/handleBillingBehaviorErrors.ts
+++ b/server/src/internal/billing/v2/common/errors/handleBillingBehaviorErrors.ts
@@ -1,13 +1,5 @@
-import type {
-	AttachParamsV1,
-	BillingContext,
-	BillingPlan,
-} from "@autumn/shared";
-import {
-	ErrCode,
-	RecaseError,
-	type UpdateSubscriptionV1Params,
-} from "@autumn/shared";
+import type { BillingContext, BillingPlan } from "@autumn/shared";
+import { ErrCode, RecaseError } from "@autumn/shared";
 import { getTrialStateTransition } from "@/internal/billing/v2/utils/billingContext/getTrialStateTransition";
 import {
 	billingPlanWillCharge,
@@ -23,11 +15,9 @@ import {
 export const handleProrationBehaviorErrors = ({
 	billingContext,
 	billingPlan,
-	params,
 }: {
 	billingContext: BillingContext;
 	billingPlan: BillingPlan;
-	params: UpdateSubscriptionV1Params | AttachParamsV1;
 }) => {
 	if (billingContext.requestedProrationBehavior !== "none") return;
 

--- a/server/src/internal/billing/v2/utils/billingPlan/toPreviewChanges/billingPlanToChanges.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/toPreviewChanges/billingPlanToChanges.ts
@@ -14,7 +14,10 @@ import {
 } from "@autumn/shared";
 import { Decimal } from "decimal.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { billingPlanToUpdatedCustomerProduct } from "@/internal/billing/v2/utils/billingPlan/billingPlanToUpdatedCustomerProduct";
+import {
+	applyCustomerProductUpdate,
+	getUpdateCustomerProducts,
+} from "@/internal/billing/v2/utils/billingPlan/customerProductPlanMutations";
 import { cusProductToBalances } from "@/internal/customers/cusUtils/apiCusUtils/getApiBalance/cusProductToBalances.js";
 import { getApiSubscription } from "@/internal/customers/cusUtils/apiCusUtils/getApiSubscription/getApiSubscription.js";
 import { billingPlanToOutgoingEffectiveAt } from "./billingPlanToEffectiveAt";
@@ -182,11 +185,14 @@ export const billingPlanToChanges = async ({
 		prefix: "outgoing",
 	});
 
-	if (autumn.updateCustomerProduct) {
-		const updatedCustomerProduct = billingPlanToUpdatedCustomerProduct({
-			autumnBillingPlan: billingPlan.autumn,
+	for (const update of getUpdateCustomerProducts({
+		autumnBillingPlan: autumn,
+	})) {
+		const updatedCustomerProduct = applyCustomerProductUpdate({
+			customerProduct: update.customerProduct,
+			updates: update.updates,
 		});
-		const { updates } = autumn.updateCustomerProduct;
+		const { updates } = update;
 
 		const isOutgoing = getIsOutgoing({
 			billingContext,
@@ -198,7 +204,7 @@ export const billingPlanToChanges = async ({
 			incoming,
 		});
 
-		if (shouldIncludeIncoming && updatedCustomerProduct) {
+		if (shouldIncludeIncoming) {
 			const { data: subscription } = await getApiSubscription({
 				ctx: incomingCtx,
 				cusProduct: updatedCustomerProduct,
@@ -220,10 +226,9 @@ export const billingPlanToChanges = async ({
 			});
 		}
 
-		const outgoingCustomerProduct =
-			autumn.updateCustomerProduct.customerProduct;
+		const outgoingCustomerProduct = update.customerProduct;
 
-		if (isOutgoing && outgoingCustomerProduct) {
+		if (isOutgoing) {
 			const { data: subscription } = await getApiSubscription({
 				ctx: outgoingCtx,
 				cusProduct: outgoingCustomerProduct,

--- a/server/tests/integration/billing/create-schedule/params/create-schedule-immediate-multi-plan-entities.test.ts
+++ b/server/tests/integration/billing/create-schedule/params/create-schedule-immediate-multi-plan-entities.test.ts
@@ -10,6 +10,7 @@ import { expectNoStripeSubscription } from "@tests/integration/billing/utils/exp
 import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect";
 import { expectSubCount } from "@tests/merged/mergeUtils/expectSubCorrect";
 import { TestFeature } from "@tests/setup/v2Features";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils";
 import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
@@ -287,5 +288,62 @@ test.concurrent(
 			});
 		}
 		await expectStripeSubscriptionCorrect({ ctx, customerId });
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("create-schedule immediate multi-plan: rejects scopes on separate subscriptions")}`,
+	async () => {
+		const base = products.base({
+			id: "separate-sub-base",
+			items: [items.monthlyPrice({ price: 10 })],
+		});
+		const addOn = products.recurringAddOn({
+			id: "separate-sub-addon",
+			items: [items.monthlyWords()],
+		});
+		const { customerId, autumnV1, entities, ctx } = await initScenario({
+			customerId: "cs-immediate-separate-sub-scopes",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [base, addOn] }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+			],
+			actions: [
+				s.billing.attach({ productId: base.id, entityIndex: 0 }),
+				s.billing.attach({
+					productId: base.id,
+					entityIndex: 1,
+					newBillingSubscription: true,
+				}),
+			],
+		});
+
+		await expectAutumnError({
+			errMessage: "multiple existing subscriptions",
+			func: () =>
+				autumnV1.billing.createSchedule(
+					immediateSchedule({
+						customerId,
+						plans: entities.map((entity) => ({
+							plan_id: addOn.id,
+							entity_id: entity.id,
+						})),
+					}),
+				),
+		});
+
+		for (const entity of entities) {
+			const scopedCustomer = await autumnV1.entities.get<ApiEntityV0>(
+				customerId,
+				entity.id,
+			);
+			await expectCustomerProducts({
+				customer: scopedCustomer,
+				active: [base.id],
+				notPresent: [addOn.id],
+			});
+		}
+		await expectSubCount({ ctx, customerId, count: 2 });
 	},
 );

--- a/server/tests/integration/billing/multi-attach/basic/multi-attach-multiple-transitions.test.ts
+++ b/server/tests/integration/billing/multi-attach/basic/multi-attach-multiple-transitions.test.ts
@@ -1,0 +1,82 @@
+/** Multi-attach replaces multiple product groups atomically; this was previously rejected. */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV3 } from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect.js";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(
+	chalk.yellowBright("multi-attach: replaces multiple product groups"),
+	async () => {
+		const existingA = products.base({
+			id: "existing-a",
+			items: [items.monthlyPrice({ price: 5 })],
+		});
+		const existingB = products.base({
+			id: "existing-b",
+			items: [items.monthlyPrice({ price: 10 })],
+			group: "group-b",
+		});
+		const replacementA = products.base({
+			id: "replacement-a",
+			items: [items.monthlyPrice({ price: 15 })],
+		});
+		const replacementB = products.base({
+			id: "replacement-b",
+			items: [items.monthlyPrice({ price: 20 })],
+			group: "group-b",
+		});
+
+		const { autumnV1, autumnV2_2, customerId } = await initScenario({
+			customerId: "ma-multiple-transitions",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({
+					list: [existingA, existingB, replacementA, replacementB],
+				}),
+			],
+			actions: [
+				s.billing.attach({ productId: existingA.id }),
+				s.billing.attach({ productId: existingB.id }),
+			],
+		});
+
+		const params = {
+			customer_id: customerId,
+			plans: [{ plan_id: replacementA.id }, { plan_id: replacementB.id }],
+		};
+		const preview = await autumnV2_2.billing.previewMultiAttach(params);
+		expect(preview.total).toBeCloseTo(20);
+		expect(
+			preview.outgoing
+				.map((change: { plan_id: string }) => change.plan_id)
+				.sort(),
+		).toEqual([existingA.id, existingB.id].sort());
+		const noProrationPreview = await autumnV2_2.billing.previewMultiAttach({
+			...params,
+			billing_behavior: "none",
+		});
+		expect(noProrationPreview.total).toBe(0);
+
+		await autumnV2_2.billing.multiAttach({
+			...params,
+			billing_behavior: "none",
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerProducts({
+			customer,
+			active: [replacementA.id, replacementB.id],
+			notPresent: [existingA.id, existingB.id],
+		});
+		await expectCustomerInvoiceCorrect({
+			customer,
+			count: 2,
+			latestTotal: 10,
+		});
+	},
+);

--- a/server/tests/integration/billing/multi-attach/basic/multi-attach-plan-scopes.test.ts
+++ b/server/tests/integration/billing/multi-attach/basic/multi-attach-plan-scopes.test.ts
@@ -1,0 +1,126 @@
+/** Each multi-attach plan resolves its own scope: inherit, customer, or explicit entity. */
+
+import { test } from "bun:test";
+import type { ApiCustomerV3, ApiEntityV0 } from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect.js";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(
+	chalk.yellowBright("multi-attach: resolves scope per plan"),
+	async () => {
+		const inheritedPlan = products.base({
+			id: "inherited",
+			items: [
+				items.monthlyPrice({ price: 5 }),
+				items.monthlyMessages({ includedUsage: 10 }),
+			],
+		});
+		const customerPlan = products.base({
+			id: "customer",
+			items: [
+				items.monthlyPrice({ price: 10 }),
+				items.monthlyWords({ includedUsage: 20 }),
+			],
+		});
+		const explicitPlan = products.base({
+			id: "explicit",
+			items: [items.monthlyPrice({ price: 15 }), items.dashboard()],
+		});
+
+		const { autumnV1, autumnV2_2, customerId, entities } = await initScenario({
+			customerId: "ma-plan-scopes",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [inheritedPlan, customerPlan, explicitPlan] }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_2.billing.multiAttach({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			plans: [
+				{ plan_id: inheritedPlan.id },
+				{ plan_id: customerPlan.id, entity_id: null },
+				{ plan_id: explicitPlan.id, entity_id: entities[1].id },
+			],
+		});
+
+		const [customer, inheritedEntity, explicitEntity] = await Promise.all([
+			autumnV1.customers.get<ApiCustomerV3>(customerId),
+			autumnV1.entities.get<ApiEntityV0>(customerId, entities[0].id),
+			autumnV1.entities.get<ApiEntityV0>(customerId, entities[1].id),
+		]);
+
+		await expectCustomerProducts({ customer, active: [customerPlan.id] });
+		await expectCustomerInvoiceCorrect({
+			customer,
+			count: 1,
+			latestTotal: 30,
+		});
+		await expectCustomerProducts({
+			customer: inheritedEntity,
+			active: [inheritedPlan.id],
+			notPresent: [explicitPlan.id],
+		});
+		await expectCustomerProducts({
+			customer: explicitEntity,
+			active: [explicitPlan.id],
+			notPresent: [inheritedPlan.id],
+		});
+	},
+);
+
+test.concurrent(
+	chalk.yellowBright(
+		"multi-attach: preserves entity plans when adding scoped add-ons",
+	),
+	async () => {
+		const base = products.base({
+			id: "base",
+			items: [items.monthlyMessages({ includedUsage: 10 })],
+		});
+		const addOn = products.recurringAddOn({
+			id: "add-on",
+			items: [items.monthlyWords({ includedUsage: 20 })],
+		});
+		const { autumnV1, autumnV2_2, customerId, entities } = await initScenario({
+			customerId: "ma-scoped-add-ons",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [base, addOn] }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+			],
+			actions: [
+				s.billing.attach({ productId: base.id, entityIndex: 0 }),
+				s.billing.attach({ productId: base.id, entityIndex: 1 }),
+			],
+		});
+
+		await autumnV2_2.billing.multiAttach({
+			customer_id: customerId,
+			plans: entities.map((entity) => ({
+				plan_id: addOn.id,
+				entity_id: entity.id,
+			})),
+		});
+
+		const scopedEntities = await Promise.all(
+			entities.map((entity) =>
+				autumnV1.entities.get<ApiEntityV0>(customerId, entity.id),
+			),
+		);
+		for (const entity of scopedEntities) {
+			await expectCustomerProducts({
+				customer: entity,
+				active: [base.id, addOn.id],
+			});
+		}
+	},
+);

--- a/server/tests/integration/billing/multi-attach/basic/multi-attach-plan-scopes.test.ts
+++ b/server/tests/integration/billing/multi-attach/basic/multi-attach-plan-scopes.test.ts
@@ -58,7 +58,10 @@ test.concurrent(
 			autumnV1.entities.get<ApiEntityV0>(customerId, entities[1].id),
 		]);
 
-		await expectCustomerProducts({ customer, active: [customerPlan.id] });
+		await expectCustomerProducts({
+			customer,
+			active: [customerPlan.id, inheritedPlan.id, explicitPlan.id],
+		});
 		await expectCustomerInvoiceCorrect({
 			customer,
 			count: 1,
@@ -66,12 +69,12 @@ test.concurrent(
 		});
 		await expectCustomerProducts({
 			customer: inheritedEntity,
-			active: [inheritedPlan.id],
+			active: [customerPlan.id, inheritedPlan.id],
 			notPresent: [explicitPlan.id],
 		});
 		await expectCustomerProducts({
 			customer: explicitEntity,
-			active: [explicitPlan.id],
+			active: [customerPlan.id, explicitPlan.id],
 			notPresent: [inheritedPlan.id],
 		});
 	},

--- a/server/tests/integration/billing/multi-attach/checkout/multi-attach-checkout-lock.test.ts
+++ b/server/tests/integration/billing/multi-attach/checkout/multi-attach-checkout-lock.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Identical multi-attach checkout requests reuse the reserved Stripe session.
+ */
+
+import { expect, test } from "bun:test";
+import type { MultiAttachParamsV0Input } from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("multi-attach checkout lock: identical requests return the cached URL")}`,
+	async () => {
+		const customerId = "multi-attach-checkout-lock";
+		const core = products.base({
+			id: "core",
+			group: "core",
+			items: [items.monthlyPrice({ price: 20 })],
+		});
+		const data = products.base({
+			id: "data",
+			group: "data",
+			items: [items.monthlyPrice({ price: 30 })],
+		});
+		const { autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [core, data] }),
+			],
+			actions: [],
+		});
+		const params: MultiAttachParamsV0Input = {
+			customer_id: customerId,
+			plans: [{ plan_id: core.id }, { plan_id: data.id }],
+		};
+
+		const first = await autumnV2_2.billing.multiAttach(params, { timeout: 0 });
+		const second = await autumnV2_2.billing.multiAttach(params, { timeout: 0 });
+
+		expect(first.payment_url).toContain("checkout.stripe.com");
+		expect(second.payment_url).toBe(first.payment_url);
+	},
+);

--- a/server/tests/integration/billing/multi-attach/discounts/multi-attach-discounts.test.ts
+++ b/server/tests/integration/billing/multi-attach/discounts/multi-attach-discounts.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "bun:test";
+import type { ApiCustomerV3 } from "@autumn/shared";
+import {
+	createAmountCoupon,
+	createPercentCoupon,
+	getStripeSubscription,
+} from "@tests/integration/billing/utils/discounts/discountTestUtils";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { ProductService } from "@/internal/products/ProductService";
+
+test.concurrent(
+	chalk.yellowBright(
+		"multi-attach discounts: applies global and scoped coupons",
+	),
+	async () => {
+		const planA = products.pro({
+			id: "discount-plan-a",
+			items: [items.monthlyMessages()],
+		});
+		const planB = products.base({
+			id: "discount-plan-b",
+			group: "discount-group-b",
+			items: [items.monthlyWords(), items.monthlyPrice({ price: 30 })],
+		});
+		const { customerId, autumnV2_2, ctx } = await initScenario({
+			customerId: "ma-discounts",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [planA, planB] }),
+			],
+			actions: [],
+		});
+		const fullPlanB = await ProductService.getFull({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			env: ctx.env,
+			idOrInternalId: planB.id,
+		});
+		const [globalCoupon, scopedCoupon] = await Promise.all([
+			createPercentCoupon({ stripeCli: ctx.stripeCli, percentOff: 20 }),
+			createAmountCoupon({
+				stripeCli: ctx.stripeCli,
+				amountOffCents: 1000,
+				appliesToProducts: [fullPlanB.processor!.id],
+			}),
+		]);
+		const params = {
+			customer_id: customerId,
+			plans: [{ plan_id: planA.id }, { plan_id: planB.id }],
+			discounts: [
+				{ reward_id: globalCoupon.id },
+				{ reward_id: scopedCoupon.id },
+			],
+		};
+
+		const preview = await autumnV2_2.billing.previewMultiAttach(params);
+		expect(preview.total).toBe(30);
+
+		await autumnV2_2.billing.multiAttach(params);
+		const customer = await autumnV2_2.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerProducts({ customer, active: [planA.id, planB.id] });
+		await expectCustomerInvoiceCorrect({ customer, count: 1, latestTotal: 30 });
+		const { subscription } = await getStripeSubscription({
+			customerId,
+			expand: ["data.discounts.source.coupon"],
+		});
+		const couponIds = subscription.discounts?.map((discount) => {
+			if (typeof discount === "string") return discount;
+			const coupon = discount.source?.coupon;
+			return typeof coupon === "string" ? coupon : coupon?.id;
+		});
+		expect(couponIds).toEqual(
+			expect.arrayContaining([globalCoupon.id, scopedCoupon.id]),
+		);
+	},
+);

--- a/server/tests/integration/billing/multi-attach/multi-attach-errors.test.ts
+++ b/server/tests/integration/billing/multi-attach/multi-attach-errors.test.ts
@@ -1,4 +1,6 @@
 import { test } from "bun:test";
+import type { ApiCustomerV3, ApiEntityV0 } from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
 import { expectSubCount } from "@tests/merged/mergeUtils/expectSubCorrect";
 import { TestFeature } from "@tests/setup/v2Features";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils";
@@ -47,54 +49,30 @@ test.concurrent(`${chalk.yellowBright("multi-attach error: cannot re-attach same
 });
 
 // ═══════════════════════════════════════════════════════════════════
-// Test 2: Cannot multi-attach with more than one plan transition
+// Test 2: Cannot multi-attach two main plans in one group and scope
 // ═══════════════════════════════════════════════════════════════════
-test.concurrent(`${chalk.yellowBright("multi-attach error: multiple transitions in one batch")}`, async () => {
-	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
-	const usersItem = items.monthlyUsers({ includedUsage: 5 });
-
-	// Customer has products in two groups
-	const existingA = products.base({
-		id: "existing-a",
-		items: [messagesItem, items.monthlyPrice({ price: 5 })],
+test.concurrent(`${chalk.yellowBright("multi-attach error: conflicting plans in one scope")}`, async () => {
+	const planA = products.base({
+		id: "plan-a",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
 	});
-	const existingB = products.base({
-		id: "existing-b",
-		items: [usersItem, items.monthlyPrice({ price: 5 })],
-		group: "group-b",
+	const planB = products.base({
+		id: "plan-b",
+		items: [items.monthlyUsers({ includedUsage: 5 })],
 	});
 
-	// Multi-attach tries to replace both groups
-	const replacementA = products.pro({
-		id: "replacement-a",
-		items: [messagesItem],
-	});
-	const replacementB = products.base({
-		id: "replacement-b",
-		items: [usersItem, items.monthlyPrice({ price: 20 })],
-		group: "group-b",
-	});
-
-	const { customerId, autumnV1 } = await initScenario({
-		customerId: "ma-err-multi-transition",
-		setup: [
-			s.customer({ paymentMethod: "success" }),
-			s.products({
-				list: [existingA, existingB, replacementA, replacementB],
-			}),
-		],
-		actions: [
-			s.billing.attach({ productId: existingA.id }),
-			s.billing.attach({ productId: existingB.id }),
-		],
+	const { customerId, autumnV2_2 } = await initScenario({
+		customerId: "ma-err-same-group-scope",
+		setup: [s.customer({ testClock: false }), s.products({ list: [planA, planB] })],
+		actions: [],
 	});
 
 	await expectAutumnError({
-		errMessage: "at most one plan transition",
+		errMessage: "at most one plan per group and scope",
 		func: async () => {
-			await autumnV1.billing.multiAttach({
+			await autumnV2_2.billing.multiAttach({
 				customer_id: customerId,
-				plans: [{ plan_id: replacementA.id }, { plan_id: replacementB.id }],
+				plans: [{ plan_id: planA.id }, { plan_id: planB.id }],
 			});
 		},
 	});
@@ -141,6 +119,155 @@ test.concurrent(`${chalk.yellowBright("multi-attach error: redirect always with 
 		},
 	});
 });
+
+test.concurrent(
+	chalk.yellowBright("multi-attach error: cannot replace products across subscriptions"),
+	async () => {
+		const existingA = products.base({
+			id: "existing-a",
+			items: [items.monthlyPrice({ price: 5 })],
+		});
+		const existingB = products.base({
+			id: "existing-b",
+			items: [items.monthlyPrice({ price: 10 })],
+			group: "group-b",
+		});
+		const replacementA = products.base({
+			id: "replacement-a",
+			items: [items.monthlyPrice({ price: 15 })],
+		});
+		const replacementB = products.base({
+			id: "replacement-b",
+			items: [items.monthlyPrice({ price: 20 })],
+			group: "group-b",
+		});
+
+		const { customerId, autumnV2_2 } = await initScenario({
+			customerId: "ma-err-multiple-subscriptions",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({
+					list: [existingA, existingB, replacementA, replacementB],
+				}),
+			],
+			actions: [
+				s.billing.attach({ productId: existingA.id }),
+				s.billing.attach({
+					productId: existingB.id,
+					newBillingSubscription: true,
+				}),
+			],
+		});
+
+		await expectAutumnError({
+			errMessage: "multiple existing subscriptions",
+			func: () =>
+				autumnV2_2.billing.multiAttach({
+					customer_id: customerId,
+					plans: [
+						{ plan_id: replacementA.id },
+						{ plan_id: replacementB.id },
+					],
+				}),
+		});
+
+		const customer = await autumnV2_2.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerProducts({
+			customer,
+			active: [existingA.id, existingB.id],
+			notPresent: [replacementA.id, replacementB.id],
+		});
+		await expectSubCount({ ctx, customerId, count: 2 });
+	},
+);
+
+test.concurrent(
+	chalk.yellowBright(
+		"multi-attach error: scoped add-ons cannot span existing subscriptions",
+	),
+	async () => {
+		const base = products.base({
+			id: "scoped-base",
+			items: [items.monthlyPrice({ price: 10 })],
+		});
+		const addOn = products.recurringAddOn({
+			id: "scoped-add-on",
+			items: [items.monthlyWords({ includedUsage: 100 })],
+		});
+		const { autumnV1, autumnV2_2, customerId, entities } =
+			await initScenario({
+				customerId: "ma-err-scoped-add-ons-multiple-subscriptions",
+				setup: [
+					s.customer({ paymentMethod: "success" }),
+					s.products({ list: [base, addOn] }),
+					s.entities({ count: 2, featureId: TestFeature.Users }),
+				],
+				actions: [
+					s.billing.attach({ productId: base.id, entityIndex: 0 }),
+					s.billing.attach({
+						productId: base.id,
+						entityIndex: 1,
+						newBillingSubscription: true,
+					}),
+				],
+			});
+
+		await expectAutumnError({
+			errMessage: "multiple existing subscriptions",
+			func: () =>
+				autumnV2_2.billing.multiAttach({
+					customer_id: customerId,
+					plans: entities.map((entity) => ({
+						plan_id: addOn.id,
+						entity_id: entity.id,
+					})),
+				}),
+		});
+
+		const scopedEntities = await Promise.all(
+			entities.map((entity) =>
+				autumnV1.entities.get<ApiEntityV0>(customerId, entity.id),
+			),
+		);
+		for (const entity of scopedEntities) {
+			await expectCustomerProducts({
+				customer: entity,
+				active: [base.id],
+				notPresent: [addOn.id],
+			});
+		}
+		await expectSubCount({ ctx, customerId, count: 2 });
+	},
+);
+
+test.concurrent(
+	chalk.yellowBright("multi-attach error: revert trial requires an existing subscription"),
+	async () => {
+		const plan = products.base({
+			id: "revert-plan",
+			items: [items.monthlyPrice({ price: 10 })],
+		});
+		const { customerId, autumnV2_2 } = await initScenario({
+			customerId: "ma-err-revert-without-subscription",
+			setup: [s.customer(), s.products({ list: [plan] })],
+			actions: [],
+		});
+
+		await expectAutumnError({
+			errMessage: "without an existing paid subscription",
+			func: () =>
+				autumnV2_2.billing.multiAttach({
+					customer_id: customerId,
+					plans: [{ plan_id: plan.id }],
+					free_trial: {
+						duration_length: 14,
+						duration_type: "day",
+						on_end: "revert",
+					},
+				}),
+		});
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════
 // Test 4: redirect_mode "always" on entity without new_billing_sub → error

--- a/server/tests/integration/billing/multi-attach/multi-attach-new-billing-subscription.test.ts
+++ b/server/tests/integration/billing/multi-attach/multi-attach-new-billing-subscription.test.ts
@@ -1,5 +1,9 @@
-import { test } from "bun:test";
-import type { ApiCustomerV3, ApiEntityV0 } from "@autumn/shared";
+import { expect, test } from "bun:test";
+import {
+	ALL_STATUSES,
+	type ApiCustomerV3,
+	type ApiEntityV0,
+} from "@autumn/shared";
 import { expectCustomerFeatureCorrect } from "@tests/integration/billing/utils/expectCustomerFeatureCorrect";
 import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
 import {
@@ -14,6 +18,7 @@ import ctx from "@tests/utils/testInitUtils/createTestContext";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 import { addMonths } from "date-fns";
+import { CusService } from "@/internal/customers/CusService";
 
 // ═══════════════════════════════════════════════════════════════════
 // Test 1: Multi-attach on entity with new_billing_subscription
@@ -105,3 +110,62 @@ test.concurrent(`${chalk.yellowBright("multi-attach new-billing-sub: entity mult
 		latestTotal: 15,
 	});
 });
+
+test.concurrent(
+	`${chalk.yellowBright("multi-attach new-billing-sub: free to paid creates a new cycle beside an unrelated paid subscription")}`,
+	async () => {
+		const free = products.base({
+			id: "free-main",
+			items: [items.monthlyMessages({ includedUsage: 50 })],
+		});
+		const addOn = products.recurringAddOn({
+			id: "paid-add-on",
+			items: [items.monthlyWords({ includedUsage: 200 })],
+		});
+		const paid = products.pro({
+			id: "paid-main",
+			items: [items.monthlyMessages({ includedUsage: 300 })],
+		});
+		const { autumnV1, autumnV2_2, customerId } = await initScenario({
+			customerId: "ma-new-billing-sub-free-to-paid",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [free, addOn, paid] }),
+			],
+			actions: [
+				s.billing.attach({ productId: free.id }),
+				s.billing.attach({ productId: addOn.id }),
+			],
+		});
+
+		await expectSubCount({ ctx, customerId, count: 1 });
+		await autumnV2_2.billing.multiAttach({
+			customer_id: customerId,
+			plans: [{ plan_id: paid.id }],
+			new_billing_subscription: true,
+		});
+
+		await expectSubCount({ ctx, customerId, count: 2 });
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			inStatuses: ALL_STATUSES,
+		});
+		const subscriptionIdByProduct = new Map(
+			fullCustomer.customer_products.map((customerProduct) => [
+				customerProduct.product_id,
+				customerProduct.subscription_ids?.[0],
+			]),
+		);
+		expect(subscriptionIdByProduct.get(paid.id)).toBeDefined();
+		expect(subscriptionIdByProduct.get(paid.id)).not.toBe(
+			subscriptionIdByProduct.get(addOn.id),
+		);
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerProducts({
+			customer,
+			active: [paid.id, addOn.id],
+			notPresent: [free.id],
+		});
+	},
+);

--- a/server/tests/integration/billing/multi-attach/multi-attach-preview-tax-and-credits.test.ts
+++ b/server/tests/integration/billing/multi-attach/multi-attach-preview-tax-and-credits.test.ts
@@ -1,0 +1,74 @@
+/** Multi-attach previews include automatic tax and available invoice credits. */
+
+import { expect, test } from "bun:test";
+import type {
+	AttachPreviewResponse,
+	MultiAttachParamsV0Input,
+} from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const auAddress = {
+	country: "AU" as const,
+	line1: "1 Test St",
+	city: "Sydney",
+	postal_code: "2000",
+	state: "NSW",
+};
+
+test.concurrent(
+	`${chalk.yellowBright("multi-attach preview: includes tax and invoice credits")}`,
+	async () => {
+		const customerId = "multi-attach-preview-tax-credits";
+		const core = products.base({
+			id: "core",
+			group: "core",
+			items: [items.monthlyPrice({ price: 20 })],
+		});
+		const data = products.base({
+			id: "data",
+			group: "data",
+			items: [items.monthlyPrice({ price: 30 })],
+		});
+
+		const { autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					configOverrides: { automatic_tax: true },
+					taxRegistrations: ["AU"],
+				}),
+				s.customer({
+					testClock: false,
+					paymentMethod: "success",
+					stripeCustomerOverrides: { address: auAddress, balance: -1_000 },
+				}),
+				s.products({ list: [core, data] }),
+			],
+			actions: [],
+		});
+
+		const params: MultiAttachParamsV0Input = {
+			customer_id: customerId,
+			plans: [{ plan_id: core.id }, { plan_id: data.id }],
+		};
+		const preview = (await autumnV2_2.billing.previewMultiAttach(
+			params,
+		)) as AttachPreviewResponse;
+
+		expect(preview.subtotal).toBe(50);
+		expect(preview.tax?.status).toBe("complete");
+		expect(preview.tax?.total).toBeGreaterThan(0);
+		expect(preview.invoice_credits).toMatchObject({
+			balance: 10,
+			currency: preview.currency,
+		});
+		expect(preview.total).toBeCloseTo(
+			preview.subtotal + (preview.tax?.total ?? 0) - 10,
+			2,
+		);
+	},
+	300_000,
+);

--- a/server/tests/integration/billing/multi-attach/multi-attach-trial.test.ts
+++ b/server/tests/integration/billing/multi-attach/multi-attach-trial.test.ts
@@ -11,7 +11,13 @@ import type { MultiAttachParamsV0Input } from "@shared/api/billing/attachV2/mult
  */
 
 import { expect, test } from "bun:test";
-import { type ApiCustomerV3, FreeTrialDuration, ms } from "@autumn/shared";
+import {
+	ALL_STATUSES,
+	type ApiCustomerV3,
+	CusProductStatus,
+	FreeTrialDuration,
+	ms,
+} from "@autumn/shared";
 import {
 	expectCustomerFeatureCorrect,
 	expectCustomerFeatureExists,
@@ -29,6 +35,7 @@ import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
+import { CusService } from "@/internal/customers/CusService";
 
 // ═══════════════════════════════════════════════════════════════════
 // Test 1: Recurring product with free trial + add-on → trial inherited
@@ -44,7 +51,7 @@ import chalk from "chalk";
 // - Preview total = $10 (only one-off addon charged, recurring deferred)
 // - Invoice total = $10 ($0 for trial sub + $10 for one-off addon)
 // ═══════════════════════════════════════════════════════════════════
-// Red: Stripe's $0 trial line has no product and displays as "Custom Item".
+// Stripe's $0 trial line has no product and displays as "Custom Item".
 // Green: The trial line retains the Pro product ID and groups under "Pro".
 test.concurrent(`${chalk.yellowBright("multi-attach trial 1: trial inherited from recurring product")}`, async () => {
 	const messagesItem = items.monthlyMessages({ includedUsage: 500 });
@@ -127,6 +134,92 @@ test.concurrent(`${chalk.yellowBright("multi-attach trial 1: trial inherited fro
 	expect(trialLineItems).toHaveLength(1);
 	expect(trialLineItems[0].product_id).toBe(proTrial.id);
 });
+
+test.concurrent(
+	`${chalk.yellowBright("multi-attach trial 4: revert trial pauses and links multiple replaced plans")}`,
+	async () => {
+		const existingA = products.base({
+			id: "revert-existing-a",
+			items: [items.monthlyPrice({ price: 10 })],
+		});
+		const existingB = products.base({
+			id: "revert-existing-b",
+			items: [items.monthlyPrice({ price: 20 })],
+			group: "revert-group-b",
+		});
+		const replacementA = products.base({
+			id: "revert-replacement-a",
+			items: [items.monthlyPrice({ price: 30 })],
+		});
+		const replacementB = products.base({
+			id: "revert-replacement-b",
+			items: [items.monthlyPrice({ price: 40 })],
+			group: "revert-group-b",
+		});
+		const { autumnV1, autumnV2_2, customerId, ctx, advancedTo } =
+			await initScenario({
+				customerId: "ma-trial-revert-multiple",
+				setup: [
+					s.customer({ paymentMethod: "success" }),
+					s.products({
+						list: [existingA, existingB, replacementA, replacementB],
+					}),
+				],
+				actions: [
+					s.billing.attach({ productId: existingA.id }),
+					s.billing.attach({ productId: existingB.id }),
+				],
+			});
+
+		await autumnV2_2.billing.multiAttach({
+			customer_id: customerId,
+			plans: [{ plan_id: replacementA.id }, { plan_id: replacementB.id }],
+			free_trial: {
+				duration_length: 14,
+				duration_type: FreeTrialDuration.Day,
+				card_required: false,
+				on_end: "revert",
+			},
+		});
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			inStatuses: ALL_STATUSES,
+		});
+		const byProductId = new Map(
+			fullCustomer.customer_products.map((customerProduct) => [
+				customerProduct.product_id,
+				customerProduct,
+			]),
+		);
+
+		for (const [existing, replacement] of [
+			[existingA, replacementA],
+			[existingB, replacementB],
+		] as const) {
+			const paused = byProductId.get(existing.id);
+			const trial = byProductId.get(replacement.id);
+
+			expect(paused?.status).toBe(CusProductStatus.Paused);
+			expect(paused?.canceled).toBe(false);
+			expect(paused?.ended_at).toBeNull();
+			expect(trial?.previous_customer_product_id).toBe(paused?.id);
+			expect(trial?.on_trial_end).toBe("revert");
+			expect(trial?.trial_ends_at).toBeWithin(
+				advancedTo + ms.days(14) - ms.hours(1),
+				advancedTo + ms.days(14) + ms.hours(1),
+			);
+		}
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({
+			customer,
+			count: 2,
+			latestTotal: 20,
+		});
+	},
+);
 
 // ═══════════════════════════════════════════════════════════════════
 // Test 2: Recurring with trial + add-on, free_trial: null → no trial

--- a/server/tests/integration/billing/multi-attach/one-off-prepaid-preserve/preserve-on-multi-attach.test.ts
+++ b/server/tests/integration/billing/multi-attach/one-off-prepaid-preserve/preserve-on-multi-attach.test.ts
@@ -1,17 +1,4 @@
-/**
- * TDD test for auto-preservation of one-off prepaid balances on multiAttach
- * transitions.
- *
- * Contract under test:
- *   When billing.multiAttach replaces an existing main customer product that
- *   holds a one-off prepaid customer_entitlement with balance > 0, the
- *   remaining units are auto-preserved as a lifetime cusEnt on the new product.
- *
- * Pre-impl red: balance after multiAttach reflects only the new plan's
- *   contributions (preserved units dropped when the outgoing cusProduct expires).
- * Post-impl green: cusProductToOneOffPrepaidCarryOvers is invoked from the
- *   common immediateMultiProduct compute path, mirroring the attach pipeline.
- */
+/** Multi-attach preserves prepaid balances from every replaced plan. */
 
 import { test } from "bun:test";
 import type { ApiCustomerV3 } from "@autumn/shared";
@@ -79,6 +66,80 @@ test.concurrent(
 			customer,
 			featureId: TestFeature.Messages,
 			balance: 650,
+			usage: 0,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("one-off-preserve multiAttach 2: plural replacements preserve every outgoing prepaid balance")}`,
+	async () => {
+		const customerId = "one-off-preserve-multi-attach-plural";
+		const existingMessages = products.pro({
+			id: "existing-messages-ma",
+			items: [items.oneOffMessages()],
+		});
+		const existingWords = products.base({
+			id: "existing-words-ma",
+			group: "words-group-ma",
+			items: [items.monthlyPrice({ price: 15 }), items.oneOffWords()],
+		});
+		const replacementMessages = products.premium({
+			id: "replacement-messages-ma",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+		const replacementWords = products.base({
+			id: "replacement-words-ma",
+			group: "words-group-ma",
+			items: [
+				items.monthlyPrice({ price: 30 }),
+				items.monthlyWords({ includedUsage: 600 }),
+			],
+		});
+		const { autumnV1, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({
+					list: [
+						existingMessages,
+						existingWords,
+						replacementMessages,
+						replacementWords,
+					],
+				}),
+			],
+			actions: [
+				s.attach({
+					productId: existingMessages.id,
+					options: [{ feature_id: TestFeature.Messages, quantity: 200 }],
+				}),
+				s.attach({
+					productId: existingWords.id,
+					options: [{ feature_id: TestFeature.Words, quantity: 300 }],
+				}),
+			],
+		});
+
+		await autumnV2_2.billing.multiAttach({
+			customer_id: customerId,
+			plans: [
+				{ plan_id: replacementMessages.id },
+				{ plan_id: replacementWords.id },
+			],
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		expectCustomerFeatureCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			balance: 700,
+			usage: 0,
+		});
+		expectCustomerFeatureCorrect({
+			customer,
+			featureId: TestFeature.Words,
+			balance: 900,
 			usage: 0,
 		});
 	},

--- a/server/tests/integration/billing/multi-attach/one-off-prepaid-preserve/preserve-on-multi-attach.test.ts
+++ b/server/tests/integration/billing/multi-attach/one-off-prepaid-preserve/preserve-on-multi-attach.test.ts
@@ -2,7 +2,9 @@
 
 import { test } from "bun:test";
 import type { ApiCustomerV3 } from "@autumn/shared";
+import { findCustomerEntitlement } from "@tests/balances/utils/findCustomerEntitlement";
 import { expectCustomerFeatureCorrect } from "@tests/integration/billing/utils/expectCustomerFeatureCorrect";
+import { waitForPostgresBalance } from "@tests/integration/cron/batch-reset-v2/batchResetV2TestUtils";
 import { TestFeature } from "@tests/setup/v2Features";
 import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
@@ -31,7 +33,7 @@ test.concurrent(
 			items: [premiumMessages],
 		});
 
-		const { autumnV1, autumnV2_1 } = await initScenario({
+		const { autumnV1, autumnV2_1, ctx } = await initScenario({
 			customerId,
 			setup: [
 				s.customer({ paymentMethod: "success" }),
@@ -51,7 +53,16 @@ test.concurrent(
 			feature_id: TestFeature.Messages,
 			value: 50,
 		});
-		await new Promise((resolve) => setTimeout(resolve, 2000));
+		const customerEntitlement = await findCustomerEntitlement({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+		await waitForPostgresBalance({
+			db: ctx.db,
+			customerEntitlementId: customerEntitlement!.id,
+			expectedBalance: 150,
+		});
 
 		// multiAttach swap to premium.
 		await autumnV1.billing.multiAttach({

--- a/server/tests/integration/billing/pooled-balances/multi-attach-pooled-balances.test.ts
+++ b/server/tests/integration/billing/pooled-balances/multi-attach-pooled-balances.test.ts
@@ -1,0 +1,190 @@
+/** Multi-attach replaces every in-scope pooled source without disturbing other scopes. */
+
+import { expect, test } from "bun:test";
+import { EntInterval, PooledBalanceResetMode } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { expectPooledBalanceCorrect } from "./utils/expectPooledBalanceCorrect.js";
+import {
+	getPooledSourceCustomerProduct,
+	type PooledBalanceDbState,
+} from "./utils/getPooledBalanceDbState.js";
+
+const pooledPlan = ({
+	id,
+	group,
+	grant,
+}: {
+	id: string;
+	group: string;
+	grant: number;
+}) =>
+	products.base({
+		id,
+		group,
+		items: [
+			{
+				...items.monthlyMessages({ includedUsage: grant }),
+				pooled: true,
+			},
+		],
+	});
+
+const getContribution = ({
+	state,
+	sourceCustomerProductId,
+}: {
+	state: PooledBalanceDbState;
+	sourceCustomerProductId: string;
+}) => {
+	const contribution = state.contributions.find(
+		(candidate) =>
+			candidate.source_customer_product_id === sourceCustomerProductId,
+	);
+	if (!contribution) throw new Error("Expected pooled contribution");
+	return contribution;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("pooled multi-attach: wholesale entity replacement preserves unrelated sources")}`,
+	async () => {
+		const customerId = "pooled-multi-attach-entity-replacement";
+		const outgoingPrimary = pooledPlan({
+			id: "outgoing-primary",
+			group: "primary",
+			grant: 100,
+		});
+		const outgoingSecondary = pooledPlan({
+			id: "outgoing-secondary",
+			group: "secondary",
+			grant: 200,
+		});
+		const incomingPrimary = pooledPlan({
+			id: "incoming-primary",
+			group: "primary",
+			grant: 150,
+		});
+		const incomingSecondary = pooledPlan({
+			id: "incoming-secondary",
+			group: "secondary",
+			grant: 250,
+		});
+
+		const { entities, autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer(),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({
+					list: [
+						outgoingPrimary,
+						outgoingSecondary,
+						incomingPrimary,
+						incomingSecondary,
+					],
+				}),
+			],
+			actions: [
+				s.billing.attach({ productId: outgoingPrimary.id, entityIndex: 0 }),
+				s.billing.attach({ productId: outgoingSecondary.id, entityIndex: 0 }),
+				s.billing.attach({ productId: outgoingPrimary.id, entityIndex: 1 }),
+			],
+		});
+
+		const before = await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			pool: {
+				balance: 400,
+				adjustment: 0,
+				granted: 400,
+				interval: EntInterval.Month,
+				nextResetAt: "present",
+				resetCycleAnchor: "present",
+				resetMode: PooledBalanceResetMode.Lazy,
+				stripeSubscriptionId: null,
+			},
+			contributions: { count: 3 },
+			sources: { count: 3 },
+		});
+		const unrelatedSource = getPooledSourceCustomerProduct({
+			state: before,
+			productId: outgoingPrimary.id,
+			entityId: entities[1]!.id,
+		});
+		const unrelatedContribution = getContribution({
+			state: before,
+			sourceCustomerProductId: unrelatedSource.id,
+		});
+		const outgoingSourceIds = [outgoingPrimary, outgoingSecondary].map(
+			(product) =>
+				getPooledSourceCustomerProduct({
+					state: before,
+					productId: product.id,
+					entityId: entities[0]!.id,
+				}).id,
+		);
+
+		await autumnV2_2.billing.multiAttach({
+			customer_id: customerId,
+			entity_id: entities[0]!.id,
+			plans: [
+				{ plan_id: incomingPrimary.id },
+				{ plan_id: incomingSecondary.id },
+			],
+		});
+
+		const after = await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			pool: {
+				balance: 500,
+				adjustment: 0,
+				granted: 500,
+				interval: EntInterval.Month,
+				nextResetAt: "present",
+				resetCycleAnchor: "present",
+				resetMode: PooledBalanceResetMode.Lazy,
+				stripeSubscriptionId: null,
+			},
+			contributions: {
+				count: 3,
+				excludedSourceCustomerProductIds: outgoingSourceIds,
+			},
+			sources: { count: 5 },
+		});
+		expect(
+			getContribution({
+				state: after,
+				sourceCustomerProductId: unrelatedSource.id,
+			}),
+		).toMatchObject({
+			id: unrelatedContribution.id,
+			current_contribution: 100,
+			next_cycle_contribution: 100,
+		});
+
+		for (const [product, currentContribution] of [
+			[incomingPrimary, 150],
+			[incomingSecondary, 250],
+		] as const) {
+			const source = getPooledSourceCustomerProduct({
+				state: after,
+				productId: product.id,
+				entityId: entities[0]!.id,
+			});
+			expect(
+				getContribution({
+					state: after,
+					sourceCustomerProductId: source.id,
+				}),
+			).toMatchObject({
+				current_contribution: currentContribution,
+				next_cycle_contribution: currentContribution,
+			});
+		}
+	},
+);

--- a/shared/api/billing/attachV2/multiAttachParamsV0.ts
+++ b/shared/api/billing/attachV2/multiAttachParamsV0.ts
@@ -6,6 +6,7 @@ import { CreatePlanItemParamsV1Schema } from "@api/products/items/crud/createPla
 import { z } from "zod/v4";
 import { CustomerDataSchema } from "../../common/customerData";
 import { EntityDataSchema } from "../../common/entityData";
+import { BillingBehaviorSchema } from "../common/billingBehavior";
 import { InvoiceModeParamsSchema } from "../common/invoiceModeParams";
 import { RedirectModeSchema } from "../common/redirectMode";
 import { AttachDiscountSchema } from "./attachDiscount";
@@ -30,7 +31,7 @@ export const MultiAttachPlanSchema = z.object({
 	}),
 	customize: MultiAttachCustomizePlanSchema.meta({
 		description:
-			"Customize the plan to attach. Can override the price, items, or licenses.",
+			"Customize the plan to attach. Can override its price or items.",
 	}),
 	feature_quantities: z.array(FeatureQuantityParamsV0Schema).optional().meta({
 		description:
@@ -42,6 +43,10 @@ export const MultiAttachPlanSchema = z.object({
 	subscription_id: z.string().optional().meta({
 		description:
 			"A unique ID to identify this subscription. Useful when attaching the same plan multiple times.",
+	}),
+	entity_id: z.string().nullable().optional().meta({
+		description:
+			"The entity scope for this plan. Omit to inherit the request scope, or pass null for customer-level.",
 	}),
 });
 
@@ -79,6 +84,7 @@ export const MultiAttachParamsV0Schema = z.object({
 		description:
 			"List of discounts to apply. Each discount can be an Autumn reward ID, Stripe coupon ID, or Stripe promotion code.",
 	}),
+	billing_behavior: BillingBehaviorSchema.optional(),
 
 	success_url: z.string().optional().meta({
 		description: "URL to redirect to after successful checkout.",

--- a/vite/src/components/forms/attach-v2/components/AttachAdditionalPlanRow.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachAdditionalPlanRow.tsx
@@ -158,7 +158,7 @@ export function AttachAdditionalPlanRow({
 				/>
 			</ScopedPlanRow>
 			<AttachPlanPrepaidQuantityFields
-				items={displayedItems}
+				items={displayedItems ?? selectedProduct?.items}
 				quantities={plan.prepaidOptions}
 				additionalPlanIndex={planIndex}
 			/>

--- a/vite/src/components/forms/attach-v2/components/AttachAdditionalPlanRow.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachAdditionalPlanRow.tsx
@@ -11,6 +11,7 @@ import { useScopeEntitySearch } from "@/views/customers2/customer/hooks/useScope
 import type { AttachAdditionalPlan } from "../attachFormSchema";
 import { useAttachFormContext } from "../context/AttachFormProvider";
 import { getAttachDisplayItems } from "../utils/grantFreeUtils";
+import { AttachPlanPrepaidQuantityFields } from "./AttachPlanPrepaidQuantityFields";
 
 export function AttachAdditionalPlanRow({
 	plan,
@@ -113,24 +114,25 @@ export function AttachAdditionalPlanRow({
 	const planIndex = formValues.additionalPlans.findIndex(
 		(candidate) => candidate._id === plan._id,
 	);
-	const scopeSelector =
-		hasEntities && planIndex !== -1 ? (
-			<PlanEntityScopeSelector
-				entities={entities}
-				value={plan.entityId}
-				onChange={(nextEntityId) =>
-					form.setFieldValue(`additionalPlans[${planIndex}]`, {
-						...plan,
-						entityId: nextEntityId,
-					})
-				}
-				inheritLabel={entityId ? "Default entity scope" : undefined}
-				showLabel={false}
-				wrapInSection={false}
-				onSearchChange={setEntitySearch}
-				isLoading={isEntitiesLoading}
-			/>
-		) : null;
+	if (planIndex === -1) return null;
+
+	const scopeSelector = hasEntities ? (
+		<PlanEntityScopeSelector
+			entities={entities}
+			value={plan.entityId}
+			onChange={(nextEntityId) =>
+				form.setFieldValue(`additionalPlans[${planIndex}]`, {
+					...plan,
+					entityId: nextEntityId,
+				})
+			}
+			inheritLabel={entityId ? "Default entity scope" : undefined}
+			showLabel={false}
+			wrapInSection={false}
+			onSearchChange={setEntitySearch}
+			isLoading={isEntitiesLoading}
+		/>
+	) : null;
 	const rowScope = scopeSelector
 		? {
 				open: scopeOpen,
@@ -140,19 +142,26 @@ export function AttachAdditionalPlanRow({
 		: undefined;
 
 	return (
-		<ScopedPlanRow scope={rowScope}>
-			<SelectedPlanRow
-				productId={plan.productId}
-				product={selectedProduct}
-				customItems={displayedItems}
-				isCustom={plan.isCustom || formValues.grantFree}
-				onEdit={
-					formValues.grantFree
-						? undefined
-						: () => handleEditPlan({ additionalPlanId: plan._id })
-				}
-				onRemove={() => handleRemovePlan({ id: plan._id })}
+		<div className="space-y-1.5">
+			<ScopedPlanRow scope={rowScope}>
+				<SelectedPlanRow
+					productId={plan.productId}
+					product={selectedProduct}
+					customItems={displayedItems}
+					isCustom={plan.isCustom || formValues.grantFree}
+					onEdit={
+						formValues.grantFree
+							? undefined
+							: () => handleEditPlan({ additionalPlanId: plan._id })
+					}
+					onRemove={() => handleRemovePlan({ id: plan._id })}
+				/>
+			</ScopedPlanRow>
+			<AttachPlanPrepaidQuantityFields
+				items={displayedItems}
+				quantities={plan.prepaidOptions}
+				additionalPlanIndex={planIndex}
 			/>
-		</ScopedPlanRow>
+		</div>
 	);
 }

--- a/vite/src/components/forms/attach-v2/components/AttachMultiPlanSection.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachMultiPlanSection.tsx
@@ -6,6 +6,7 @@ import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
 import { useScopeEntitySearch } from "@/views/customers2/customer/hooks/useScopeEntitySearch";
 import { useAttachFormContext } from "../context/AttachFormProvider";
 import { getAttachDisplayItems } from "../utils/grantFreeUtils";
+import { AttachPlanPrepaidQuantityFields } from "./AttachPlanPrepaidQuantityFields";
 
 export function AttachMultiPlanSection() {
 	const { formValues, product, products, hasCustomizations, entityId } =
@@ -13,8 +14,8 @@ export function AttachMultiPlanSection() {
 	const { entities, selectedEntity } = useScopeEntitySearch({
 		selectedEntityId: entityId ?? undefined,
 	});
-	const selectedPlans = formValues.additionalPlans.filter(
-		(plan) => plan.productId,
+	const selectedPlans = formValues.additionalPlans.flatMap((plan, planIndex) =>
+		plan.productId ? [{ plan, planIndex }] : [],
 	);
 	const primaryItems = getAttachDisplayItems({
 		items: formValues.items,
@@ -27,17 +28,28 @@ export function AttachMultiPlanSection() {
 	return (
 		<SheetSection title="Plans" withSeparator>
 			<div className="space-y-1.5">
-				<SelectedPlanRow
-					productId={formValues.productId}
-					product={product}
-					customItems={primaryItems}
-					isCustom={hasCustomizations || formValues.grantFree}
-					scope={selectedEntity?.name || entityId || "Customer-level"}
-				/>
-				{selectedPlans.map((plan) => {
+				<div className="space-y-1.5">
+					<SelectedPlanRow
+						productId={formValues.productId}
+						product={product}
+						customItems={primaryItems}
+						isCustom={hasCustomizations || formValues.grantFree}
+						scope={selectedEntity?.name || entityId || "Customer-level"}
+					/>
+					<AttachPlanPrepaidQuantityFields
+						items={primaryItems}
+						quantities={formValues.prepaidOptions}
+					/>
+				</div>
+				{selectedPlans.map(({ plan, planIndex }) => {
 					const selectedProduct = products.find(
 						(candidate) => candidate.id === plan.productId,
 					);
+					const planItems = getAttachDisplayItems({
+						items: plan.items,
+						productItems: selectedProduct?.items,
+						grantFree: formValues.grantFree,
+					});
 					const planEntityId = resolvePlanEntityId({
 						planEntityId: plan.entityId,
 						defaultEntityId: entityId,
@@ -48,18 +60,20 @@ export function AttachMultiPlanSection() {
 					);
 
 					return (
-						<SelectedPlanRow
-							key={plan._id}
-							productId={plan.productId}
-							product={selectedProduct}
-							customItems={getAttachDisplayItems({
-								items: plan.items,
-								productItems: selectedProduct?.items,
-								grantFree: formValues.grantFree,
-							})}
-							isCustom={plan.isCustom || formValues.grantFree}
-							scope={planEntity?.name || planEntityId || "Customer-level"}
-						/>
+						<div key={plan._id} className="space-y-1.5">
+							<SelectedPlanRow
+								productId={plan.productId}
+								product={selectedProduct}
+								customItems={planItems}
+								isCustom={plan.isCustom || formValues.grantFree}
+								scope={planEntity?.name || planEntityId || "Customer-level"}
+							/>
+							<AttachPlanPrepaidQuantityFields
+								items={planItems}
+								quantities={plan.prepaidOptions}
+								additionalPlanIndex={planIndex}
+							/>
+						</div>
 					);
 				})}
 			</div>

--- a/vite/src/components/forms/attach-v2/components/AttachMultiPlanSection.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachMultiPlanSection.tsx
@@ -37,7 +37,7 @@ export function AttachMultiPlanSection() {
 						scope={selectedEntity?.name || entityId || "Customer-level"}
 					/>
 					<AttachPlanPrepaidQuantityFields
-						items={primaryItems}
+						items={primaryItems ?? product?.items}
 						quantities={formValues.prepaidOptions}
 					/>
 				</div>
@@ -69,7 +69,7 @@ export function AttachMultiPlanSection() {
 								scope={planEntity?.name || planEntityId || "Customer-level"}
 							/>
 							<AttachPlanPrepaidQuantityFields
-								items={planItems}
+								items={planItems ?? selectedProduct?.items}
 								quantities={plan.prepaidOptions}
 								additionalPlanIndex={planIndex}
 							/>

--- a/vite/src/components/forms/attach-v2/components/AttachPlanPrepaidQuantityFields.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachPlanPrepaidQuantityFields.tsx
@@ -1,0 +1,42 @@
+import type { ProductItem } from "@autumn/shared";
+import { PlanPrepaidQuantityFields } from "@/components/forms/shared";
+import { useAttachFormContext } from "../context/AttachFormProvider";
+
+export function AttachPlanPrepaidQuantityFields({
+	items,
+	quantities,
+	additionalPlanIndex,
+}: {
+	items?: ProductItem[] | null;
+	quantities: Record<string, number | undefined>;
+	additionalPlanIndex?: number;
+}) {
+	const { form, attachCurrency } = useAttachFormContext();
+	const getFieldName = ({ featureId }: { featureId: string }) => {
+		if (additionalPlanIndex === undefined) {
+			return `prepaidOptions.${featureId}` as const;
+		}
+		return `additionalPlans[${additionalPlanIndex}].prepaidOptions.${featureId}` as const;
+	};
+
+	return (
+		<PlanPrepaidQuantityFields
+			items={items}
+			quantities={quantities}
+			currency={attachCurrency.displayCurrency}
+			renderField={({ featureId, step }) => (
+				<form.AppField name={getFieldName({ featureId })}>
+					{(field) => (
+						<field.QuantityField
+							label=""
+							min={0}
+							step={step}
+							compact
+							hideFieldInfo
+						/>
+					)}
+				</form.AppField>
+			)}
+		/>
+	);
+}

--- a/vite/src/components/forms/attach-v2/components/AttachProductSelection.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachProductSelection.tsx
@@ -49,7 +49,7 @@ export function AttachProductSelection({
 						/>
 					</ScopedPlanRow>
 					<AttachPlanPrepaidQuantityFields
-						items={displayedPrimaryItems}
+						items={displayedPrimaryItems ?? product?.items}
 						quantities={formValues.prepaidOptions}
 					/>
 				</div>

--- a/vite/src/components/forms/attach-v2/components/AttachProductSelection.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachProductSelection.tsx
@@ -8,6 +8,7 @@ import {
 import { useAttachFormContext } from "../context/AttachFormProvider";
 import { getAttachDisplayItems } from "../utils/grantFreeUtils";
 import { AttachAdditionalPlanRow } from "./AttachAdditionalPlanRow";
+import { AttachPlanPrepaidQuantityFields } from "./AttachPlanPrepaidQuantityFields";
 
 export function AttachProductSelection({
 	scope,
@@ -37,15 +38,21 @@ export function AttachProductSelection({
 	return (
 		<div className="space-y-2">
 			{isMultiPlan && productId ? (
-				<ScopedPlanRow scope={scope}>
-					<SelectedPlanRow
-						productId={productId}
-						product={product}
-						customItems={displayedPrimaryItems}
-						isCustom={hasCustomizations || formValues.grantFree}
-						onEdit={formValues.grantFree ? undefined : () => handleEditPlan()}
+				<div className="space-y-1.5">
+					<ScopedPlanRow scope={scope}>
+						<SelectedPlanRow
+							productId={productId}
+							product={product}
+							customItems={displayedPrimaryItems}
+							isCustom={hasCustomizations || formValues.grantFree}
+							onEdit={formValues.grantFree ? undefined : () => handleEditPlan()}
+						/>
+					</ScopedPlanRow>
+					<AttachPlanPrepaidQuantityFields
+						items={displayedPrimaryItems}
+						quantities={formValues.prepaidOptions}
 					/>
-				</ScopedPlanRow>
+				</div>
 			) : (
 				<form.AppField name="productId">
 					{(field) => (

--- a/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
+++ b/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
@@ -23,7 +23,6 @@ import { useStore } from "@tanstack/react-form";
 import {
 	createContext,
 	type ReactNode,
-	useCallback,
 	useContext,
 	useEffect,
 	useMemo,
@@ -43,14 +42,15 @@ import {
 	useAttachAdditionalPlans,
 } from "../hooks/useAttachAdditionalPlans";
 import {
-	type UseAttachCurrencyReturn,
-	useAttachCurrency,
-} from "../hooks/useAttachCurrency";
-import {
 	type UseAttachBillingOptionsStateReturn,
 	useAttachBillingOptionsState,
 } from "../hooks/useAttachBillingOptionsState";
+import {
+	type UseAttachCurrencyReturn,
+	useAttachCurrency,
+} from "../hooks/useAttachCurrency";
 import { type UseAttachForm, useAttachForm } from "../hooks/useAttachForm";
+import { useAttachMultiRequestBody } from "../hooks/useAttachMultiRequestBody";
 import { useAttachMutation } from "../hooks/useAttachMutation";
 import { useAttachPlanEditor } from "../hooks/useAttachPlanEditor";
 import {
@@ -58,7 +58,6 @@ import {
 	useAttachPreview,
 } from "../hooks/useAttachPreview";
 import { useAttachRequestBody } from "../hooks/useAttachRequestBody";
-import { useAttachScheduleRequestBody } from "../hooks/useAttachScheduleRequestBody";
 import {
 	type UsePreviewDiffReturn,
 	usePreviewDiff,
@@ -470,9 +469,9 @@ export function AttachFormProvider({
 		currency: attachCurrency.requestCurrency,
 	});
 	const {
-		requestBody: scheduleRequestBody,
-		buildRequestBody: buildScheduleRequestBody,
-	} = useAttachScheduleRequestBody({
+		requestBody: multiRequestBody,
+		buildRequestBody: buildMultiRequestBody,
+	} = useAttachMultiRequestBody({
 		customerId,
 		entityId,
 		product: effectiveProduct,
@@ -487,17 +486,19 @@ export function AttachFormProvider({
 		trialDuration,
 		trialEnabled,
 		trialCardRequired,
+		trialOnEnd,
+		prorationBehavior,
 		redirectMode,
 		discounts,
 		currency: attachCurrency.requestCurrency,
 		hasInvalidPlanScopes: additionalPlans.hasInvalidPlanScopes,
 	});
 	const billingOperation = isMultiPlan
-		? BILLING_OPERATIONS.createSchedule
+		? BILLING_OPERATIONS.multiAttach
 		: BILLING_OPERATIONS.attach;
-	const operationRequestBody = isMultiPlan ? scheduleRequestBody : requestBody;
+	const operationRequestBody = isMultiPlan ? multiRequestBody : requestBody;
 	const buildOperationRequestBody = isMultiPlan
-		? buildScheduleRequestBody
+		? buildMultiRequestBody
 		: buildRequestBody;
 
 	const previewQuery = useAttachPreview({

--- a/vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts
@@ -8,13 +8,14 @@ import {
 } from "@autumn/shared";
 import { useCallback, useEffect } from "react";
 import type { AttachForm } from "../attachFormSchema";
-import type { UseAttachForm } from "./useAttachForm";
-import type { UseAttachPreviewReturn } from "./useAttachPreview";
 import {
+	getAttachProrationVisibility,
 	getNoChargesDisabledReason,
 	isNoChargesAllowedForAttach,
 	normalizeAttachProrationBehavior,
 } from "../utils/attachProrationBehaviorRules";
+import type { UseAttachForm } from "./useAttachForm";
+import type { UseAttachPreviewReturn } from "./useAttachPreview";
 
 /** Encapsulates planSchedule + prorationBehavior derived state and mutations. */
 export function useAttachBillingOptionsState({
@@ -37,6 +38,8 @@ export function useAttachBillingOptionsState({
 	const { planSchedule, prorationBehavior, newBillingSubscription, startDate } =
 		formValues;
 	const previewData = previewQuery.data;
+	const effectiveNewBillingSubscription =
+		!isMultiPlan && newBillingSubscription;
 
 	const hasActiveProductWithTrial = customerProducts.some(
 		(customerProduct) =>
@@ -66,7 +69,7 @@ export function useAttachBillingOptionsState({
 		outgoingPlan?.price?.interval !== BillingInterval.OneOff;
 
 	const createsNewStripeSubscription =
-		!hasActiveSubscription || newBillingSubscription;
+		!hasActiveSubscription || effectiveNewBillingSubscription;
 
 	// Usage-only plans have a null base price (billing lives on items), so a
 	// recurring sub can be created even when the base price and immediate total are $0.
@@ -101,27 +104,30 @@ export function useAttachBillingOptionsState({
 
 	const hasSubscriptionToProrate =
 		hasActiveSubscription && !hasActiveProductWithTrial;
-	const showProrationRow = !isMultiPlan && hasSubscriptionToProrate;
 
 	const freeToPaidWithNoExistingSubscription =
 		isFreeToPaidTransition && !hasActiveSubscription;
 
-	const showProrationBehavior =
-		showProrationRow && effectivePlanSchedule === "immediate";
+	const { showProrationRow, showProrationBehavior } =
+		getAttachProrationVisibility({
+			hasSubscriptionToProrate,
+			isMultiPlan,
+			planSchedule: effectivePlanSchedule,
+		});
 	const isNoChargesAllowed = isNoChargesAllowedForAttach({
-		newBillingSubscription,
+		newBillingSubscription: effectiveNewBillingSubscription,
 		disableProration: freeToPaidWithNoExistingSubscription,
 	});
 	const normalizedProrationBehavior = normalizeAttachProrationBehavior({
 		prorationBehavior,
-		newBillingSubscription,
+		newBillingSubscription: effectiveNewBillingSubscription,
 		disableProration: freeToPaidWithNoExistingSubscription,
 	});
 	const effectiveProrationBehavior =
 		normalizedProrationBehavior ??
 		(isNoChargesAllowed ? "none" : "prorate_immediately");
 	const noChargesDisabledReason = getNoChargesDisabledReason({
-		newBillingSubscription,
+		newBillingSubscription: effectiveNewBillingSubscription,
 		disableProration: freeToPaidWithNoExistingSubscription,
 	});
 
@@ -145,7 +151,12 @@ export function useAttachBillingOptionsState({
 	}, [form, startDate]);
 
 	useEffect(() => {
-		if (isMultiPlan) return;
+		if (isMultiPlan) {
+			if (!newBillingSubscription) return;
+			form.setFieldValue("newBillingSubscription", false);
+			movePastStartDateToNow();
+			return;
+		}
 		if (canChooseBillingCycle) return;
 		if (!newBillingSubscription) return;
 		form.setFieldValue("newBillingSubscription", false);
@@ -159,32 +170,23 @@ export function useAttachBillingOptionsState({
 	]);
 
 	useEffect(() => {
-		if (isMultiPlan) return;
 		if (showProrationBehavior) return;
 		if (prorationBehavior === null) return;
 		form.setFieldValue("prorationBehavior", null);
-	}, [showProrationBehavior, prorationBehavior, form, isMultiPlan]);
+	}, [showProrationBehavior, prorationBehavior, form]);
 
 	useEffect(() => {
-		if (isMultiPlan) return;
 		if (!showProrationBehavior) return;
 		if (prorationBehavior !== null) return;
 		if (!isNoChargesAllowed) return;
 		form.setFieldValue("prorationBehavior", "none");
-	}, [
-		showProrationBehavior,
-		prorationBehavior,
-		isNoChargesAllowed,
-		form,
-		isMultiPlan,
-	]);
+	}, [showProrationBehavior, prorationBehavior, isNoChargesAllowed, form]);
 
 	useEffect(() => {
-		if (isMultiPlan) return;
 		if (prorationBehavior !== "none") return;
 		if (isNoChargesAllowed) return;
 		form.setFieldValue("prorationBehavior", null);
-	}, [prorationBehavior, form, isNoChargesAllowed, isMultiPlan]);
+	}, [prorationBehavior, form, isNoChargesAllowed]);
 
 	const handleScheduleChange = (value: PlanTiming) => {
 		form.setFieldValue("planSchedule", value);

--- a/vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts
@@ -91,6 +91,7 @@ export function useAttachBillingOptionsState({
 		hasOutgoing && isPaidRecurringAttach && isOutgoingPaidRecurring;
 
 	const canChooseBillingCycle =
+		!isMultiPlan &&
 		isPaidRecurringAttach &&
 		hasPaidRecurringSubscription &&
 		!isDirectPaidTransition;
@@ -151,12 +152,6 @@ export function useAttachBillingOptionsState({
 	}, [form, startDate]);
 
 	useEffect(() => {
-		if (isMultiPlan) {
-			if (!newBillingSubscription) return;
-			form.setFieldValue("newBillingSubscription", false);
-			movePastStartDateToNow();
-			return;
-		}
 		if (canChooseBillingCycle) return;
 		if (!newBillingSubscription) return;
 		form.setFieldValue("newBillingSubscription", false);
@@ -166,7 +161,6 @@ export function useAttachBillingOptionsState({
 		form,
 		movePastStartDateToNow,
 		newBillingSubscription,
-		isMultiPlan,
 	]);
 
 	useEffect(() => {

--- a/vite/src/components/forms/attach-v2/hooks/useAttachMultiRequestBody.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachMultiRequestBody.ts
@@ -1,12 +1,8 @@
-import type {
-	CreateScheduleParamsV0,
-	Feature,
-	ProductV2,
-} from "@autumn/shared";
+import type { Feature, MultiAttachParamsV0, ProductV2 } from "@autumn/shared";
 import { useCallback, useMemo } from "react";
-import { applyCreateScheduleStageParams } from "@/components/forms/shared/utils/applyCreateScheduleStageParams";
+import { applyMultiPlanStageParams } from "@/components/forms/shared/utils/applyMultiPlanStageParams";
 import type { BillingStageParams } from "@/components/forms/shared/utils/billingStageParams";
-import { buildCreateSchedulePlan } from "@/components/forms/shared/utils/buildPlanCustomize";
+import { buildBillingPlan } from "@/components/forms/shared/utils/buildPlanCustomize";
 import { normalizeBillingRequestItems } from "@/components/forms/shared/utils/normalizeBillingRequestItems";
 import { getFreeTrial } from "@/components/forms/update-subscription-v2/utils/getFreeTrial";
 import type { AttachAdditionalPlan } from "../attachFormSchema";
@@ -14,7 +10,7 @@ import { filterValidDiscounts } from "../utils/discountUtils";
 import { stripPricesFromItems } from "../utils/grantFreeUtils";
 import type { BuildAttachRequestBodyParams } from "./useAttachRequestBody";
 
-export type BuildAttachScheduleRequestBodyParams = Pick<
+export type BuildAttachMultiRequestBodyParams = Pick<
 	BuildAttachRequestBodyParams,
 	| "customerId"
 	| "entityId"
@@ -27,6 +23,8 @@ export type BuildAttachScheduleRequestBodyParams = Pick<
 	| "trialDuration"
 	| "trialEnabled"
 	| "trialCardRequired"
+	| "trialOnEnd"
+	| "prorationBehavior"
 	| "redirectMode"
 	| "discounts"
 	| "currency"
@@ -63,7 +61,7 @@ function buildPlanParams({
 		? stripPricesFromItems({ items: normalizedItems ?? product?.items ?? [] })
 		: normalizedItems;
 
-	return buildCreateSchedulePlan({
+	return buildBillingPlan({
 		productId: planId,
 		prepaidOptions,
 		items: customizedItems,
@@ -76,7 +74,7 @@ function buildPlanParams({
 	});
 }
 
-export function buildAttachScheduleRequestBody({
+export function buildAttachMultiRequestBody({
 	customerId,
 	entityId,
 	product,
@@ -91,11 +89,13 @@ export function buildAttachScheduleRequestBody({
 	trialDuration,
 	trialEnabled,
 	trialCardRequired,
+	trialOnEnd,
+	prorationBehavior,
 	redirectMode,
 	discounts,
 	currency,
 	hasInvalidPlanScopes = false,
-}: BuildAttachScheduleRequestBodyParams): CreateScheduleParamsV0 | null {
+}: BuildAttachMultiRequestBodyParams): MultiAttachParamsV0 | null {
 	if (hasInvalidPlanScopes || !customerId || !product) return null;
 
 	const selectedAdditionalPlans = additionalPlans.filter(
@@ -136,29 +136,31 @@ export function buildAttachScheduleRequestBody({
 		trialDuration,
 		trialEnabled,
 		trialCardRequired,
+		trialOnEnd,
 	});
 	const validDiscounts = filterValidDiscounts(discounts);
 
 	return {
 		customer_id: customerId,
-		phases: [{ starts_at: "now", plans }],
-		preserve_add_ons: true,
+		plans,
 		redirect_mode: redirectMode,
 		free_trial: freeTrial
 			? {
 					duration_length: freeTrial.length,
 					duration_type: freeTrial.duration,
 					card_required: freeTrial.card_required,
+					...(freeTrial.on_end ? { on_end: freeTrial.on_end } : {}),
 				}
 			: null,
+		...(prorationBehavior ? { billing_behavior: prorationBehavior } : {}),
 		...(entityId ? { entity_id: entityId } : {}),
 		...(currency ? { currency: currency.toLowerCase() } : {}),
 		...(validDiscounts.length > 0 ? { discounts: validDiscounts } : {}),
 	};
 }
 
-export function useAttachScheduleRequestBody(
-	params: BuildAttachScheduleRequestBodyParams,
+export function useAttachMultiRequestBody(
+	params: BuildAttachMultiRequestBodyParams,
 ) {
 	const {
 		customerId,
@@ -175,6 +177,8 @@ export function useAttachScheduleRequestBody(
 		trialDuration,
 		trialEnabled,
 		trialCardRequired,
+		trialOnEnd,
+		prorationBehavior,
 		redirectMode,
 		discounts,
 		currency,
@@ -182,7 +186,7 @@ export function useAttachScheduleRequestBody(
 	} = params;
 	const requestBody = useMemo(
 		() =>
-			buildAttachScheduleRequestBody({
+			buildAttachMultiRequestBody({
 				customerId,
 				entityId,
 				product,
@@ -197,6 +201,8 @@ export function useAttachScheduleRequestBody(
 				trialDuration,
 				trialEnabled,
 				trialCardRequired,
+				trialOnEnd,
+				prorationBehavior,
 				redirectMode,
 				discounts,
 				currency,
@@ -217,6 +223,8 @@ export function useAttachScheduleRequestBody(
 			trialDuration,
 			trialEnabled,
 			trialCardRequired,
+			trialOnEnd,
+			prorationBehavior,
 			redirectMode,
 			discounts,
 			currency,
@@ -225,7 +233,7 @@ export function useAttachScheduleRequestBody(
 	);
 	const buildRequestBody = useCallback(
 		(stageParams: BillingStageParams = {}) =>
-			applyCreateScheduleStageParams({ ...stageParams, requestBody }),
+			applyMultiPlanStageParams({ ...stageParams, requestBody }),
 		[requestBody],
 	);
 

--- a/vite/src/components/forms/attach-v2/hooks/useAttachMutation.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachMutation.ts
@@ -1,8 +1,7 @@
 import type {
 	AttachParamsV0,
 	BillingResponse,
-	CreateScheduleParamsV0,
-	CreateScheduleResponse,
+	MultiAttachParamsV0,
 } from "@autumn/shared";
 import { useBillingMutation } from "@/components/forms/shared/hooks/useBillingMutation";
 import type { BillingStageParams } from "@/components/forms/shared/utils/billingStageParams";
@@ -18,15 +17,15 @@ export function useAttachMutation({
 	customerId: string | undefined;
 	buildRequestBody: (
 		params?: BillingStageParams,
-	) => AttachParamsV0 | CreateScheduleParamsV0 | null;
+	) => AttachParamsV0 | MultiAttachParamsV0 | null;
 	path: string;
 	invalidatesSchedule: boolean;
 	onCheckoutRedirect?: (checkoutUrl: string) => void;
 	onSuccess?: () => void;
 }) {
 	const mutation = useBillingMutation<
-		AttachParamsV0 | CreateScheduleParamsV0,
-		BillingResponse | CreateScheduleResponse
+		AttachParamsV0 | MultiAttachParamsV0,
+		BillingResponse
 	>({
 		customerId,
 		path,

--- a/vite/src/components/forms/attach-v2/hooks/useAttachPreview.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachPreview.ts
@@ -1,9 +1,9 @@
-import type { AttachParamsV0, CreateScheduleParamsV0 } from "@autumn/shared";
+import type { AttachParamsV0, MultiAttachParamsV0 } from "@autumn/shared";
 import { useBillingPreview } from "@/components/forms/shared/hooks/useBillingPreview";
 
 interface UseAttachPreviewParams {
 	path: string;
-	requestBody: AttachParamsV0 | CreateScheduleParamsV0 | null;
+	requestBody: AttachParamsV0 | MultiAttachParamsV0 | null;
 	enabled?: boolean;
 }
 

--- a/vite/src/components/forms/attach-v2/utils/attachProrationBehaviorRules.ts
+++ b/vite/src/components/forms/attach-v2/utils/attachProrationBehaviorRules.ts
@@ -1,4 +1,4 @@
-import type { BillingBehavior } from "@autumn/shared";
+import type { BillingBehavior, PlanTiming } from "@autumn/shared";
 
 const NO_CHARGES_NEW_CYCLE_DISABLED_REASON =
 	"No Charges is unavailable when Create New Cycle is selected.";
@@ -13,6 +13,23 @@ export function isNoChargesAllowedForAttach({
 	disableProration?: boolean;
 }) {
 	return !newBillingSubscription && !disableProration;
+}
+
+export function getAttachProrationVisibility({
+	hasSubscriptionToProrate,
+	isMultiPlan,
+	planSchedule,
+}: {
+	hasSubscriptionToProrate: boolean;
+	isMultiPlan: boolean;
+	planSchedule: PlanTiming;
+}) {
+	const showProrationRow = hasSubscriptionToProrate;
+	return {
+		showProrationRow,
+		showProrationBehavior:
+			showProrationRow && (isMultiPlan || planSchedule === "immediate"),
+	};
 }
 
 export function normalizeAttachProrationBehavior({

--- a/vite/src/components/forms/create-schedule/components/SchedulePlanRow.tsx
+++ b/vite/src/components/forms/create-schedule/components/SchedulePlanRow.tsx
@@ -117,6 +117,7 @@ export function SchedulePlanRow({
 				items={plan.items ?? selectedProduct?.items}
 				quantities={plan.prepaidOptions}
 				currency={displayCurrency}
+				readOnly={isLocked}
 				renderField={({ featureId, step }) => (
 					<form.AppField
 						name={`phases[${phaseIndex}].plans[${planIndex}].prepaidOptions.${featureId}`}

--- a/vite/src/components/forms/create-schedule/components/SchedulePlanRow.tsx
+++ b/vite/src/components/forms/create-schedule/components/SchedulePlanRow.tsx
@@ -1,6 +1,10 @@
 import { SearchableSelect } from "@autumn/ui";
-import { SelectedPlanRow } from "@/components/forms/shared";
+import {
+	PlanPrepaidQuantityFields,
+	SelectedPlanRow,
+} from "@/components/forms/shared";
 import { getProductGroupKey } from "@/components/forms/shared/utils/planGroupUtils";
+import { useCustomerDisplayCurrency } from "@/hooks/common/useCustomerDisplayCurrency";
 import { cn } from "@/lib/utils";
 import { useCreateScheduleFormContext } from "../context/CreateScheduleFormProvider";
 import { CopyFromPreviousPhaseButton } from "./CopyFromPreviousPhaseButton";
@@ -22,6 +26,7 @@ export function SchedulePlanRow({
 		isPhaseLocked,
 		setEditingPlan,
 	} = useCreateScheduleFormContext();
+	const { displayCurrency } = useCustomerDisplayCurrency();
 
 	const plan = formValues.phases[phaseIndex]?.plans[planIndex];
 	if (!plan) return null;
@@ -98,14 +103,36 @@ export function SchedulePlanRow({
 	}
 
 	return (
-		<SelectedPlanRow
-			productId={plan.productId}
-			product={selectedProduct}
-			customItems={plan.items}
-			isCustom={plan.isCustom}
-			disabled={isLocked}
-			onEdit={() => setEditingPlan({ phaseIndex, planIndex })}
-			onRemove={() => handleRemovePlan({ phaseIndex, planIndex })}
-		/>
+		<div className="space-y-1.5">
+			<SelectedPlanRow
+				productId={plan.productId}
+				product={selectedProduct}
+				customItems={plan.items}
+				isCustom={plan.isCustom}
+				disabled={isLocked}
+				onEdit={() => setEditingPlan({ phaseIndex, planIndex })}
+				onRemove={() => handleRemovePlan({ phaseIndex, planIndex })}
+			/>
+			<PlanPrepaidQuantityFields
+				items={plan.items ?? selectedProduct?.items}
+				quantities={plan.prepaidOptions}
+				currency={displayCurrency}
+				renderField={({ featureId, step }) => (
+					<form.AppField
+						name={`phases[${phaseIndex}].plans[${planIndex}].prepaidOptions.${featureId}`}
+					>
+						{(field) => (
+							<field.QuantityField
+								label=""
+								min={0}
+								step={step}
+								compact
+								hideFieldInfo
+							/>
+						)}
+					</form.AppField>
+				)}
+			/>
+		</div>
 	);
 }

--- a/vite/src/components/forms/create-schedule/hooks/useCreateScheduleRequestBody.ts
+++ b/vite/src/components/forms/create-schedule/hooks/useCreateScheduleRequestBody.ts
@@ -5,9 +5,9 @@ import type {
 	ProductV2,
 } from "@autumn/shared";
 import { useMemo } from "react";
-import { applyCreateScheduleStageParams } from "@/components/forms/shared/utils/applyCreateScheduleStageParams";
+import { applyMultiPlanStageParams } from "@/components/forms/shared/utils/applyMultiPlanStageParams";
 import type { BillingStageParams } from "@/components/forms/shared/utils/billingStageParams";
-import { buildCreateSchedulePlan } from "@/components/forms/shared/utils/buildPlanCustomize";
+import { buildBillingPlan } from "@/components/forms/shared/utils/buildPlanCustomize";
 import {
 	getCreateSchedulePhaseTimingError,
 	hasPersistedCreateSchedule,
@@ -52,7 +52,7 @@ export function buildCreateScheduleRequestBody({
 		const plans = phase.plans.flatMap((plan) =>
 			plan.productId
 				? [
-						buildCreateSchedulePlan({
+						buildBillingPlan({
 							productId: plan.productId,
 							prepaidOptions: plan.prepaidOptions,
 							items: plan.items,
@@ -195,7 +195,7 @@ export function useBuildCreateScheduleRequestBody({
 
 				if (!requestBody) return null;
 
-				return applyCreateScheduleStageParams({
+				return applyMultiPlanStageParams({
 					...stageParams,
 					requestBody,
 					enableProductImmediately:

--- a/vite/src/components/forms/shared/PlanPrepaidQuantityFields.tsx
+++ b/vite/src/components/forms/shared/PlanPrepaidQuantityFields.tsx
@@ -1,0 +1,44 @@
+import { type ProductItem, UsageModel } from "@autumn/shared";
+import type { ReactNode } from "react";
+import { PlanItemLabel } from "@/components/v2/PlanItemLabel";
+import { PrepaidQuantityControl } from "./plan-items/PrepaidQuantityControl";
+
+export function PlanPrepaidQuantityFields({
+	items,
+	quantities,
+	currency,
+	renderField,
+}: {
+	items?: ProductItem[] | null;
+	quantities: Record<string, number | undefined>;
+	currency?: string;
+	renderField: (params: { featureId: string; step: number }) => ReactNode;
+}) {
+	const prepaidItems = (items ?? []).flatMap((item) =>
+		item.usage_model === UsageModel.Prepaid && item.feature_id
+			? [{ featureId: item.feature_id, item }]
+			: [],
+	);
+	if (prepaidItems.length === 0) return null;
+
+	return (
+		<div className="ml-4 space-y-1 border-l border-border/40 pl-3">
+			{prepaidItems.map(({ featureId, item }) => {
+				const step = item.billing_units ?? 1;
+				return (
+					<div key={featureId} className="flex items-center gap-2">
+						<div className="min-w-0 flex-1 overflow-hidden">
+							<PlanItemLabel currency={currency} item={item} />
+						</div>
+						<PrepaidQuantityControl
+							quantity={quantities[featureId]}
+							billingUnits={step}
+						>
+							{renderField({ featureId, step })}
+						</PrepaidQuantityControl>
+					</div>
+				);
+			})}
+		</div>
+	);
+}

--- a/vite/src/components/forms/shared/PlanPrepaidQuantityFields.tsx
+++ b/vite/src/components/forms/shared/PlanPrepaidQuantityFields.tsx
@@ -38,7 +38,7 @@ export function PlanPrepaidQuantityFields({
 				const step = item.billing_units ?? 1;
 				return (
 					<div key={featureId} className="flex items-center gap-2">
-						<div className="min-w-0 flex-1 overflow-hidden">
+						<div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
 							<PlanItemLabel currency={currency} item={item} />
 						</div>
 						<PrepaidQuantityControl

--- a/vite/src/components/forms/shared/PlanPrepaidQuantityFields.tsx
+++ b/vite/src/components/forms/shared/PlanPrepaidQuantityFields.tsx
@@ -7,18 +7,29 @@ export function PlanPrepaidQuantityFields({
 	items,
 	quantities,
 	currency,
+	readOnly = false,
 	renderField,
 }: {
 	items?: ProductItem[] | null;
 	quantities: Record<string, number | undefined>;
 	currency?: string;
+	readOnly?: boolean;
 	renderField: (params: { featureId: string; step: number }) => ReactNode;
 }) {
-	const prepaidItems = (items ?? []).flatMap((item) =>
-		item.usage_model === UsageModel.Prepaid && item.feature_id
-			? [{ featureId: item.feature_id, item }]
-			: [],
-	);
+	const featureIds = new Set<string>();
+	const prepaidItems = (items ?? []).flatMap((item) => {
+		const featureId = item.feature_id;
+		if (
+			item.usage_model !== UsageModel.Prepaid ||
+			!featureId ||
+			featureIds.has(featureId)
+		) {
+			return [];
+		}
+
+		featureIds.add(featureId);
+		return [{ featureId, item }];
+	});
 	if (prepaidItems.length === 0) return null;
 
 	return (
@@ -33,6 +44,7 @@ export function PlanPrepaidQuantityFields({
 						<PrepaidQuantityControl
 							quantity={quantities[featureId]}
 							billingUnits={step}
+							readOnly={readOnly}
 						>
 							{renderField({ featureId, step })}
 						</PrepaidQuantityControl>

--- a/vite/src/components/forms/shared/index.ts
+++ b/vite/src/components/forms/shared/index.ts
@@ -2,6 +2,7 @@ export * from "./advanced-section";
 export * from "./DisabledTooltipButton";
 export * from "./PlanEntityScopeSelector";
 export * from "./PlanItemsSection";
+export * from "./PlanPrepaidQuantityFields";
 export * from "./PlanScopeToggleButton";
 export * from "./PlanSectionTitle";
 export * from "./ScopedPlanRow";

--- a/vite/src/components/forms/shared/plan-items/PrepaidQuantityControl.tsx
+++ b/vite/src/components/forms/shared/plan-items/PrepaidQuantityControl.tsx
@@ -1,0 +1,39 @@
+import { roundUsageToNearestBillingUnit } from "@autumn/shared";
+import { type ReactNode, useState } from "react";
+import { useDebounce } from "@/hooks/useDebounce";
+import { QuantityEditControl } from "./QuantityEditControl";
+
+export function PrepaidQuantityControl({
+	quantity,
+	billingUnits = 1,
+	readOnly = false,
+	children,
+}: {
+	quantity: number | undefined;
+	billingUnits?: number | null;
+	readOnly?: boolean;
+	children: ReactNode;
+}) {
+	const [isEditing, setIsEditing] = useState(false);
+	const step = billingUnits > 0 ? billingUnits : 1;
+	const roundedQuantity = roundUsageToNearestBillingUnit({
+		usage: quantity ?? 0,
+		billingUnits: step,
+	});
+	const showRing = useDebounce({
+		value: quantity !== undefined && step > 1 && roundedQuantity !== quantity,
+		delayMs: 200,
+	});
+
+	return (
+		<QuantityEditControl
+			readOnly={readOnly}
+			displayText={quantity !== undefined ? `x${quantity}` : undefined}
+			showRing={showRing}
+			isEditing={isEditing}
+			onEditingChange={setIsEditing}
+		>
+			{children}
+		</QuantityEditControl>
+	);
+}

--- a/vite/src/components/forms/shared/utils/applyMultiPlanStageParams.ts
+++ b/vite/src/components/forms/shared/utils/applyMultiPlanStageParams.ts
@@ -1,7 +1,12 @@
-import type { CreateScheduleParamsV0 } from "@autumn/shared";
+import type {
+	CreateScheduleParamsV0,
+	MultiAttachParamsV0,
+} from "@autumn/shared";
 import type { BillingStageParams } from "./billingStageParams";
 
-export function applyCreateScheduleStageParams({
+type MultiPlanParams = CreateScheduleParamsV0 | MultiAttachParamsV0;
+
+export function applyMultiPlanStageParams<T extends MultiPlanParams>({
 	requestBody,
 	useInvoice,
 	enableProductImmediately,
@@ -9,8 +14,8 @@ export function applyCreateScheduleStageParams({
 	invoiceTemplateId,
 	netTermsDays,
 }: BillingStageParams & {
-	requestBody: CreateScheduleParamsV0 | null;
-}): CreateScheduleParamsV0 | null {
+	requestBody: T | null;
+}): T | null {
 	if (!requestBody) return null;
 
 	if (useInvoice) {

--- a/vite/src/components/forms/shared/utils/billingOperations.ts
+++ b/vite/src/components/forms/shared/utils/billingOperations.ts
@@ -4,6 +4,11 @@ export const BILLING_OPERATIONS = {
 		previewPath: "/v1/billing.preview_attach",
 		invalidatesSchedule: false,
 	},
+	multiAttach: {
+		path: "/v1/billing.multi_attach",
+		previewPath: "/v1/billing.preview_multi_attach",
+		invalidatesSchedule: true,
+	},
 	createSchedule: {
 		path: "/v1/billing.create_schedule",
 		previewPath: "/v1/billing.preview_create_schedule",

--- a/vite/src/components/forms/shared/utils/buildPlanCustomize.ts
+++ b/vite/src/components/forms/shared/utils/buildPlanCustomize.ts
@@ -1,8 +1,8 @@
 import type {
 	ApiPlanItemV1,
 	CreatePlanItemParamsV1,
-	CreateScheduleParamsV0,
 	Feature,
+	MultiAttachParamsV0,
 	ProductItem,
 	ProductV2,
 } from "@autumn/shared";
@@ -110,7 +110,7 @@ export function buildCustomize({
 	};
 }
 
-export function buildCreateSchedulePlan({
+export function buildBillingPlan({
 	productId,
 	prepaidOptions,
 	items,
@@ -130,7 +130,7 @@ export function buildCreateSchedulePlan({
 	product?: ProductV2;
 	features: Feature[];
 	includeEmptyItems?: boolean;
-}): CreateScheduleParamsV0["phases"][number]["plans"][number] {
+}): MultiAttachParamsV0["plans"][number] {
 	const featureQuantities = convertPrepaidOptionsToFeatureOptions({
 		prepaidOptions,
 		product,

--- a/vite/src/components/forms/update-subscription-v2/components/SubscriptionItemRow.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/SubscriptionItemRow.tsx
@@ -1,14 +1,8 @@
-import {
-	type ProductItem,
-	roundUsageToNearestBillingUnit,
-	UsageModel,
-} from "@autumn/shared";
-import { useState } from "react";
+import { type ProductItem, UsageModel } from "@autumn/shared";
 import type { UseAttachForm } from "@/components/forms/attach-v2/hooks/useAttachForm";
-import { QuantityEditControl } from "@/components/forms/shared/plan-items/QuantityEditControl";
+import { PrepaidQuantityControl } from "@/components/forms/shared/plan-items/PrepaidQuantityControl";
 import { ItemStatusDot } from "@/components/v2/ItemStatusDot";
 import { PlanItemLabel } from "@/components/v2/PlanItemLabel";
-import { useDebounce } from "@/hooks/useDebounce";
 import { cn } from "@/lib/utils";
 import type { UseUpdateSubscriptionForm } from "../hooks/useUpdateSubscriptionForm";
 
@@ -23,86 +17,6 @@ interface SubscriptionItemRowProps {
 	currency?: string;
 }
 
-function usePrepaidDisplayState({
-	item,
-	prepaidQuantity,
-	isPrepaid,
-	form,
-	featureId,
-}: {
-	item: ProductItem;
-	prepaidQuantity: number | null | undefined;
-	isPrepaid: boolean;
-	form: SubscriptionItemRowProps["form"];
-	featureId: string | undefined;
-}) {
-	const inputQuantity = prepaidQuantity ?? undefined;
-	const billingUnitStep = item.billing_units ?? 1;
-
-	const normalizedBillingUnits = billingUnitStep > 0 ? billingUnitStep : 1;
-	const roundedQuantity = roundUsageToNearestBillingUnit({
-		usage: inputQuantity ?? 0,
-		billingUnits: normalizedBillingUnits,
-	});
-	const shouldShowRoundingHint =
-		inputQuantity !== undefined &&
-		normalizedBillingUnits > 1 &&
-		roundedQuantity !== inputQuantity;
-
-	const showDebouncedOffUnitRing = useDebounce({
-		value: shouldShowRoundingHint,
-		delayMs: 200,
-	});
-
-	const showPrepaidControl = isPrepaid && !!form && !!featureId;
-	const showRightControlRing = showPrepaidControl && showDebouncedOffUnitRing;
-
-	return {
-		inputQuantity,
-		billingUnitStep,
-		showPrepaidControl,
-		showRightControlRing,
-	};
-}
-
-function PrepaidQuantityControl({
-	readOnly,
-	form,
-	featureId,
-	inputQuantity,
-	step,
-	showRing,
-	isEditing,
-	onEditingChange,
-}: {
-	readOnly: boolean;
-	form: UseUpdateSubscriptionForm | UseAttachForm;
-	featureId: string;
-	inputQuantity: number | undefined;
-	step: number;
-	showRing: boolean;
-	isEditing: boolean;
-	onEditingChange: (editing: boolean) => void;
-}) {
-	return (
-		<QuantityEditControl
-			readOnly={readOnly}
-			displayText={
-				inputQuantity !== undefined ? `x${inputQuantity}` : undefined
-			}
-			showRing={showRing}
-			isEditing={isEditing}
-			onEditingChange={onEditingChange}
-		>
-			<form.AppField name={`prepaidOptions.${featureId}`}>
-				{(field) => (
-					<field.QuantityField label="" min={0} step={step} hideFieldInfo />
-				)}
-			</form.AppField>
-		</QuantityEditControl>
-	);
-}
-
 export function SubscriptionItemRow({
 	item,
 	form,
@@ -113,17 +27,8 @@ export function SubscriptionItemRow({
 	readOnly = false,
 	currency,
 }: SubscriptionItemRowProps) {
-	const [isEditingQuantity, setIsEditingQuantity] = useState(false);
-
 	const isPrepaid = item.usage_model === UsageModel.Prepaid;
-
-	const prepaid = usePrepaidDisplayState({
-		item,
-		prepaidQuantity,
-		isPrepaid,
-		form,
-		featureId,
-	});
+	const showPrepaidControl = isPrepaid && !!form && !!featureId;
 
 	const renderRowIndicator = () => {
 		if (isDeleted) return <ItemStatusDot state="removed" />;
@@ -157,17 +62,23 @@ export function SubscriptionItemRow({
 				</div>
 			</div>
 
-			{!isDeleted && prepaid.showPrepaidControl && form && featureId && (
+			{!isDeleted && showPrepaidControl && form && featureId && (
 				<PrepaidQuantityControl
 					readOnly={readOnly}
-					form={form}
-					featureId={featureId}
-					inputQuantity={prepaid.inputQuantity}
-					step={prepaid.billingUnitStep}
-					showRing={prepaid.showRightControlRing}
-					isEditing={isEditingQuantity}
-					onEditingChange={setIsEditingQuantity}
-				/>
+					quantity={prepaidQuantity ?? undefined}
+					billingUnits={item.billing_units}
+				>
+					<form.AppField name={`prepaidOptions.${featureId}`}>
+						{(field) => (
+							<field.QuantityField
+								label=""
+								min={0}
+								step={item.billing_units ?? 1}
+								hideFieldInfo
+							/>
+						)}
+					</form.AppField>
+				</PrepaidQuantityControl>
 			)}
 		</div>
 	);

--- a/vite/src/components/v2/LineItemsPreview.tsx
+++ b/vite/src/components/v2/LineItemsPreview.tsx
@@ -124,12 +124,12 @@ export function LineItemsPreview<T extends BillingLineItem>({
 												{filteredItems.map((item) => (
 													<div
 														key={item.description}
-														className="flex items-center justify-between"
+														className="flex items-center gap-3"
 													>
-														<span className="text-sm truncate max-w-75 text-tertiary-foreground">
+														<span className="min-w-0 flex-1 truncate text-sm text-tertiary-foreground">
 															{item.description}
 														</span>
-														<div className="flex w-24 justify-end gap-1.5">
+														<div className="flex shrink-0 items-center justify-end gap-1.5">
 															{item.subtotal !== item.total && (
 																<span className="text-sm text-tertiary-foreground line-through">
 																	{formatAmount({

--- a/vite/tests/components/forms/attach-v2/hooks/build-attach-multi-request-body.test.ts
+++ b/vite/tests/components/forms/attach-v2/hooks/build-attach-multi-request-body.test.ts
@@ -10,10 +10,10 @@ import {
 	EMPTY_ADDITIONAL_PLAN,
 } from "@/components/forms/attach-v2/attachFormSchema";
 import {
-	type BuildAttachScheduleRequestBodyParams,
-	buildAttachScheduleRequestBody,
-} from "@/components/forms/attach-v2/hooks/useAttachScheduleRequestBody";
-import { applyCreateScheduleStageParams } from "@/components/forms/shared/utils/applyCreateScheduleStageParams";
+	type BuildAttachMultiRequestBodyParams,
+	buildAttachMultiRequestBody,
+} from "@/components/forms/attach-v2/hooks/useAttachMultiRequestBody";
+import { applyMultiPlanStageParams } from "@/components/forms/shared/utils/applyMultiPlanStageParams";
 
 const planA = {
 	id: "plan-a",
@@ -38,8 +38,8 @@ const additionalPlan = (
 });
 
 const baseParams = (
-	overrides: Partial<BuildAttachScheduleRequestBodyParams> = {},
-): BuildAttachScheduleRequestBodyParams => ({
+	overrides: Partial<BuildAttachMultiRequestBodyParams> = {},
+): BuildAttachMultiRequestBodyParams => ({
 	customerId: "cus_1",
 	entityId: undefined,
 	product: planA,
@@ -54,30 +54,29 @@ const baseParams = (
 	trialDuration: FreeTrialDuration.Day,
 	trialEnabled: false,
 	trialCardRequired: true,
+	trialOnEnd: "bill",
+	prorationBehavior: null,
 	redirectMode: "if_required",
 	discounts: [],
 	currency: null,
 	...overrides,
 });
 
-test("builds one immediate schedule phase containing every selected plan", () => {
-	const body = buildAttachScheduleRequestBody(baseParams());
+test("builds one multi-attach request containing every selected plan", () => {
+	const body = buildAttachMultiRequestBody(baseParams());
 
-	expect(body?.phases).toMatchObject([
-		{
-			starts_at: "now",
-			plans: [{ plan_id: "plan-a" }, { plan_id: "plan-b" }],
-		},
+	expect(body?.plans).toMatchObject([
+		{ plan_id: "plan-a" },
+		{ plan_id: "plan-b" },
 	]);
-	expect(body?.preserve_add_ons).toBe(true);
 });
 
 test("returns null when no additional plan is selected", () => {
 	expect(
-		buildAttachScheduleRequestBody(baseParams({ additionalPlans: [] })),
+		buildAttachMultiRequestBody(baseParams({ additionalPlans: [] })),
 	).toBeNull();
 	expect(
-		buildAttachScheduleRequestBody(
+		buildAttachMultiRequestBody(
 			baseParams({ additionalPlans: [additionalPlan({ productId: "" })] }),
 		),
 	).toBeNull();
@@ -85,21 +84,21 @@ test("returns null when no additional plan is selected", () => {
 
 test("returns null while selected plan scopes conflict", () => {
 	expect(
-		buildAttachScheduleRequestBody(baseParams({ hasInvalidPlanScopes: true })),
+		buildAttachMultiRequestBody(baseParams({ hasInvalidPlanScopes: true })),
 	).toBeNull();
 });
 
 test("returns null without a customer or primary product", () => {
 	expect(
-		buildAttachScheduleRequestBody(baseParams({ customerId: undefined })),
+		buildAttachMultiRequestBody(baseParams({ customerId: undefined })),
 	).toBeNull();
 	expect(
-		buildAttachScheduleRequestBody(baseParams({ product: undefined })),
+		buildAttachMultiRequestBody(baseParams({ product: undefined })),
 	).toBeNull();
 });
 
 test("maps the form trial onto FreeTrialParamsV1 field names", () => {
-	const body = buildAttachScheduleRequestBody(
+	const body = buildAttachMultiRequestBody(
 		baseParams({
 			trialEnabled: true,
 			trialLength: 14,
@@ -116,22 +115,31 @@ test("maps the form trial onto FreeTrialParamsV1 field names", () => {
 });
 
 test("sends free_trial null when the trial is off", () => {
-	expect(buildAttachScheduleRequestBody(baseParams())?.free_trial).toBeNull();
+	expect(buildAttachMultiRequestBody(baseParams())?.free_trial).toBeNull();
 });
 
-test("omits unsupported trial end behavior", () => {
-	const body = buildAttachScheduleRequestBody(
+test("forwards request-wide trial end behavior", () => {
+	const body = buildAttachMultiRequestBody(
 		baseParams({
 			trialEnabled: true,
 			trialLength: 14,
+			trialOnEnd: "revert",
 		}),
 	);
 
-	expect(body?.free_trial?.on_end).toBeUndefined();
+	expect(body?.free_trial?.on_end).toBe("revert");
+});
+
+test("forwards request-wide proration behavior", () => {
+	const body = buildAttachMultiRequestBody(
+		baseParams({ prorationBehavior: "none" }),
+	);
+
+	expect(body?.billing_behavior).toBe("none");
 });
 
 test("passes entity and currency through", () => {
-	const body = buildAttachScheduleRequestBody(
+	const body = buildAttachMultiRequestBody(
 		baseParams({
 			entityId: "ent_1",
 			currency: "EUR",
@@ -143,39 +151,39 @@ test("passes entity and currency through", () => {
 });
 
 test("keeps additional plans customer-level when the primary scope changes", () => {
-	const body = buildAttachScheduleRequestBody(
+	const body = buildAttachMultiRequestBody(
 		baseParams({ entityId: "ent_default" }),
 	);
 
-	expect(body?.phases[0].plans[1]?.entity_id).toBeNull();
+	expect(body?.plans[1]?.entity_id).toBeNull();
 });
 
 test("preserves explicit per-plan entity inheritance and overrides", () => {
-	const inherited = buildAttachScheduleRequestBody(
+	const inherited = buildAttachMultiRequestBody(
 		baseParams({
 			entityId: "ent_default",
 			additionalPlans: [additionalPlan({ entityId: undefined })],
 		}),
 	);
-	const customerLevel = buildAttachScheduleRequestBody(
+	const customerLevel = buildAttachMultiRequestBody(
 		baseParams({
 			entityId: "ent_default",
 			additionalPlans: [additionalPlan({ entityId: null })],
 		}),
 	);
-	const entityLevel = buildAttachScheduleRequestBody(
+	const entityLevel = buildAttachMultiRequestBody(
 		baseParams({
 			additionalPlans: [additionalPlan({ entityId: "ent_other" })],
 		}),
 	);
 
-	expect(inherited?.phases[0].plans[1]?.entity_id).toBeUndefined();
-	expect(customerLevel?.phases[0].plans[1]?.entity_id).toBeNull();
-	expect(entityLevel?.phases[0].plans[1]?.entity_id).toBe("ent_other");
+	expect(inherited?.plans[1]?.entity_id).toBeUndefined();
+	expect(customerLevel?.plans[1]?.entity_id).toBeNull();
+	expect(entityLevel?.plans[1]?.entity_id).toBe("ent_other");
 });
 
 test("forwards per-plan version and prepaid quantities", () => {
-	const body = buildAttachScheduleRequestBody(
+	const body = buildAttachMultiRequestBody(
 		baseParams({
 			version: 3,
 			prepaidOptions: { seats: 5 },
@@ -188,7 +196,7 @@ test("forwards per-plan version and prepaid quantities", () => {
 		}),
 	);
 
-	const [primary, extra] = body?.phases[0].plans ?? [];
+	const [primary, extra] = body?.plans ?? [];
 	expect(primary?.version).toBe(3);
 	expect(primary?.feature_quantities).toEqual([
 		{ feature_id: "seats", quantity: 5 },
@@ -207,7 +215,7 @@ test("grant-free removes prices from every plan", () => {
 	} as ProductItem;
 	const paidPlanA = { ...planA, items: [paidItem] };
 	const paidPlanB = { ...planB, items: [paidItem] };
-	const body = buildAttachScheduleRequestBody(
+	const body = buildAttachMultiRequestBody(
 		baseParams({
 			product: paidPlanA,
 			products: [paidPlanA, paidPlanB],
@@ -215,20 +223,20 @@ test("grant-free removes prices from every plan", () => {
 		}),
 	);
 
-	expect(body?.phases[0].plans.map((plan) => plan.customize)).toEqual([
+	expect(body?.plans.map((plan) => plan.customize)).toEqual([
 		{ price: null, items: [] },
 		{ price: null, items: [] },
 	]);
 });
 
 test("empty item drafts do not create a customization", () => {
-	const body = buildAttachScheduleRequestBody(baseParams({ items: [] }));
+	const body = buildAttachMultiRequestBody(baseParams({ items: [] }));
 
-	expect(body?.phases[0].plans[0]?.customize).toBeUndefined();
+	expect(body?.plans[0]?.customize).toBeUndefined();
 });
 
 test("omits discounts that are not fully filled in", () => {
-	const body = buildAttachScheduleRequestBody(
+	const body = buildAttachMultiRequestBody(
 		baseParams({
 			discounts: [{ _id: "d1", reward_id: "" }],
 		}),
@@ -238,8 +246,8 @@ test("omits discounts that are not fully filled in", () => {
 });
 
 test("invoice mode nests the flags under invoice_mode", () => {
-	const requestBody = buildAttachScheduleRequestBody(baseParams());
-	const withInvoice = applyCreateScheduleStageParams({
+	const requestBody = buildAttachMultiRequestBody(baseParams());
+	const withInvoice = applyMultiPlanStageParams({
 		requestBody,
 		useInvoice: true,
 		enableProductImmediately: true,
@@ -256,8 +264,8 @@ test("invoice mode nests the flags under invoice_mode", () => {
 });
 
 test("checkout mode sets enable_plan_immediately without invoice_mode", () => {
-	const requestBody = buildAttachScheduleRequestBody(baseParams());
-	const withCheckout = applyCreateScheduleStageParams({
+	const requestBody = buildAttachMultiRequestBody(baseParams());
+	const withCheckout = applyMultiPlanStageParams({
 		requestBody,
 		enableProductImmediately: true,
 	});
@@ -268,6 +276,6 @@ test("checkout mode sets enable_plan_immediately without invoice_mode", () => {
 
 test("stage params on a null body stay null", () => {
 	expect(
-		applyCreateScheduleStageParams({ requestBody: null, useInvoice: true }),
+		applyMultiPlanStageParams({ requestBody: null, useInvoice: true }),
 	).toBeNull();
 });

--- a/vite/tests/components/forms/attach-v2/utils/attach-proration-behavior-rules.test.ts
+++ b/vite/tests/components/forms/attach-v2/utils/attach-proration-behavior-rules.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test";
+import { getAttachProrationVisibility } from "@/components/forms/attach-v2/utils/attachProrationBehaviorRules";
+
+test("multi-plan proration stays visible despite a stale single-plan schedule", () => {
+	expect(
+		getAttachProrationVisibility({
+			hasSubscriptionToProrate: true,
+			isMultiPlan: true,
+			planSchedule: "end_of_cycle",
+		}),
+	).toEqual({
+		showProrationRow: true,
+		showProrationBehavior: true,
+	});
+});
+
+test("single-plan proration follows its selected schedule", () => {
+	expect(
+		getAttachProrationVisibility({
+			hasSubscriptionToProrate: true,
+			isMultiPlan: false,
+			planSchedule: "end_of_cycle",
+		}),
+	).toEqual({
+		showProrationRow: true,
+		showProrationBehavior: false,
+	});
+});

--- a/vite/tests/components/forms/shared/utils/billing-operations.test.ts
+++ b/vite/tests/components/forms/shared/utils/billing-operations.test.ts
@@ -9,6 +9,11 @@ describe("BILLING_OPERATIONS", () => {
 				previewPath: "/v1/billing.preview_attach",
 				invalidatesSchedule: false,
 			},
+			multiAttach: {
+				path: "/v1/billing.multi_attach",
+				previewPath: "/v1/billing.preview_multi_attach",
+				invalidatesSchedule: true,
+			},
 			createSchedule: {
 				path: "/v1/billing.create_schedule",
 				previewPath: "/v1/billing.preview_create_schedule",


### PR DESCRIPTION
## Summary
- route dashboard multi-plan attaches and previews through billing.multi_attach
- support atomic plural transitions, per-plan scopes, request-wide trials, proration, discounts, checkout idempotency, pooled balances, and one-off carryover
- preserve unrelated add-ons and reject ambiguous cross-subscription batches before mutation
- share plan-building, stage-param, and group/scope validation logic with Create Schedule

## Validation
- server and Vite typechecks
- focused Multi Attach and Create Schedule integration suites covering transitions, mixed scopes, separate subscriptions, discounts, trials, proration, tax/credits, pooled balances, checkout locks, and prepaid carryover
- 60 focused frontend unit tests
- React Doctor 98/100 with no changed-file issues

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full multi-plan attach via `billing.multi_attach` with atomic replacements, per-plan scopes, trials/proration, discounts, pooled/one‑off balance handling, and cached checkout. Dashboard attach/preview now use this endpoint with per-plan prepaid quantity editing; previews include tax and invoice credits.

- **New Features**
  - Atomic replacements across multiple product groups; preserves unrelated add-ons.
  - Per-plan scope resolution with group/scope conflict rejection and subscription-target checks.
  - Request-wide trials (incl. on_end="revert" validation) and proration via `billing_behavior`.
  - Previews include automatic tax, invoice credits, and reuse checkout session URLs.
  - Pooled balance transitions and one-off prepaid carryover across all replaced plans; waits for posted usage before carryover.
  - Edit prepaid quantities per selected plan in attach and schedule flows.

- **Refactors**
  - Linearized immediate multi-product compute; added pooled-balance planning and explicit subscription targeting.
  - Extracted shared `validateProductGroupsByScope` for multi-attach and Create Schedule.
  - Frontend routed to multi-attach with `useAttachMultiRequestBody`, `applyMultiPlanStageParams`, and `buildBillingPlan`; proration visibility aligned with multi-plan behavior.
  - Canonical `MultiAttachParamsV0` used across server/UI; simplified proration error checks; fixed discounted line-item overlap and inline prepaid rows.

<sup>Written for commit 05b6157f287efd1a044ddd4582cc7a167635159c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds comprehensive multi-plan billing support across server and dashboard flows.
- **[API changes] [Improvements]** Extends multi-attach requests with per-plan scopes, customization, trials, proration, discounts, previews, and checkout-session reuse.
- **[Improvements] [Bug fixes]** Supports atomic transitions across multiple product groups while preserving unrelated add-ons, pooled balances, and one-off prepaid carryover.
- **[Improvements]** Shares plan construction, stage parameters, prepaid quantity controls, and group/scope validation between attach and schedule flows.
- **[Improvements]** Adds focused server integration and frontend unit coverage for the expanded billing behavior.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge based on the reviewed multi-plan setup, computation, execution, and dashboard request flows.

Plural customer-product mutations are consumed by existing plural-aware execution helpers, subscription targets are validated before mutation, and the expanded behavior is covered by focused billing and frontend tests.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/common/immediateMultiProduct/computeImmediateMultiProductPlan.ts | Expands immediate multi-product planning from one transition to plural atomic updates, carryovers, and pooled-balance transitions. |
| server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts | Resolves per-plan contexts and enforces a single existing Stripe subscription target before mutation. |
| server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts | Adds enriched previews and checkout-session idempotency to multi-attach execution. |
| shared/api/billing/attachV2/multiAttachParamsV0.ts | Extends the canonical multi-attach API contract for full multi-plan billing options. |
| vite/src/components/forms/attach-v2/hooks/useAttachMultiRequestBody.ts | Builds dashboard multi-plan requests with plan-level customization and shared billing-stage parameters. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Dashboard
  participant API as billing.multi_attach
  participant Plan as Billing Plan
  participant Stripe
  participant DB as Autumn State
  UI->>API: plans, scopes, quantities, billing options
  API->>API: resolve products and target subscription
  API->>Plan: compute atomic transitions
  Plan->>Plan: calculate proration, discounts, carryover, pooled balances
  alt Preview
    Plan-->>UI: invoice and plan changes
  else Execute
    Plan->>Stripe: create/update subscription or checkout
    Plan->>DB: apply customer products and entitlements
    API-->>UI: billing result or cached checkout URL
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(billing): 💍 wait for prepaid usage..."](https://github.com/useautumn/autumn/commit/05b6157f287efd1a044ddd4582cc7a167635159c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49053640)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [Pooled Balances](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/pooled-balances.md)

<!-- /greptile_comment -->