### PR TITLE
Cap finite included usage at 10 trillion

### DIFF
--- a/server/tests/integration/crud/plans/create-plan-errors.test.ts
+++ b/server/tests/integration/crud/plans/create-plan-errors.test.ts
@@ -77,6 +77,21 @@ const expectRpcError = async ({
 	});
 };
 
+/**
+ * TDD test for unsafe large finite allowances.
+ *
+ * Red-failure mode: a plan with more than 10 trillion included units is accepted.
+ * Green-success criteria: plan creation rejects it and recommends unlimited usage.
+ */
+test.concurrent(`${chalk.yellowBright("included usage: REJECT more than 10 trillion")}`, async () => {
+	await expectRestError({
+		productId: `err_included_usage_${getSuffix()}`,
+		items: [{ feature_id: TestFeature.Messages, included: 10_000_000_000_001 }],
+		errMessage:
+			"Included usage cannot exceed 10 trillion; use unlimited usage instead",
+	});
+});
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // PRICE: amount OR tiers (not neither, not both)
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/shared/api/products/items/crud/createPlanItemParamsV1.ts
+++ b/shared/api/products/items/crud/createPlanItemParamsV1.ts
@@ -15,12 +15,17 @@ import {
 } from "@models/productV2Models/productItemModels/productItemEnums";
 import { z } from "zod/v4";
 
+export const IncludedUsageParamsSchema = z.number().max(10_000_000_000_000, {
+	error:
+		"Included usage cannot exceed 10 trillion; use unlimited usage instead",
+});
+
 export const CreatePlanItemParamsV1Schema = z
 	.object({
 		feature_id: z.string().meta({
 			description: "The ID of the feature to configure.",
 		}),
-		included: z.number().optional().meta({
+		included: IncludedUsageParamsSchema.optional().meta({
 			description:
 				"Number of free units included. Balance resets to this each interval for consumable features.",
 		}),

--- a/shared/api/products/productOpModels.ts
+++ b/shared/api/products/productOpModels.ts
@@ -1,15 +1,19 @@
 import { CustomerBillingControlsParamsSchema } from "@models/cusModels/billingControls/customerBillingControls.js";
 import { CreateFreeTrialSchema } from "@models/productModels/freeTrialModels/freeTrialModels.js";
 import { ProductConfigParamsSchema } from "@models/productModels/productConfig/productConfig.js";
+import { Infinite } from "@models/productModels/productEnums.js";
 import { ProductMetadataSchema } from "@models/productModels/productMetadata.js";
 import { ProductItemSchema } from "@models/productV2Models/productItemModels/productItemModels.js";
 import { idRegex } from "@utils/utils.js";
 import { z } from "zod/v4";
 import { AppEnv } from "../../models/genModels/genEnums.js";
 import { PlanLicenseParamsSchema } from "./crud/licenses/planLicenseParams.js";
+import { IncludedUsageParamsSchema } from "./items/crud/createPlanItemParamsV1.js";
 
 // Use the full ProductItemSchema but mark backend fields as internal
-export const CreateProductItemParamsSchema = ProductItemSchema;
+export const CreateProductItemParamsSchema = ProductItemSchema.extend({
+	included_usage: IncludedUsageParamsSchema.or(z.literal(Infinite)).nullish(),
+});
 
 // Base product params
 


### PR DESCRIPTION
## Summary
- cap finite included usage at 10 trillion in current and legacy request schemas
- preserve unlimited usage and compatibility with existing stored oversized plans
- add a regression test for oversized plan creation

## Why
Very large finite allowances can lose small deductions when Redis Lua serializes balances. Rejecting unsafe new allowances prevents silent balance drift while the underlying serialization path is addressed separately.

## Test plan
- 17/17 create-plan error integration tests pass
- `bunx tsgo --build --noEmit`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps finite included usage at 10 trillion to prevent balance drift with very large numbers. Unlimited usage stays allowed; existing oversized plans keep working.

- **Bug Fixes**
  - Enforce a 10T max in both current and legacy plan item request schemas using IncludedUsageParamsSchema.
  - Keep `Infinite`/unlimited usage and compatibility with stored oversized plans.
  - Add an integration test that rejects values >10T with the message: "Included usage cannot exceed 10 trillion; use unlimited usage instead".

<sup>Written for commit 80fcb785b84ec290761a5673c970e35901cbfdbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

