### PR TITLE
Require explicit manual opt-in for staging deploys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   #   staging repo (autumn-staging) -> us-east-1
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix feat/firelens-log-transport-v2
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: main dev feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix feat/firelens-log-transport-v2
 
 jobs:
   checks:
@@ -75,7 +75,7 @@ jobs:
           # Sanitize branch name for Docker tag (replace / with -)
           SAFE_BRANCH=$(echo $BRANCH_NAME | sed 's/\//-/g')
 
-          if [ "$REQUESTED_STAGING_DEPLOY" = "true" ] && [ "$BRANCH_NAME" != "dev" ]; then
+          if [ "$REQUESTED_STAGING_DEPLOY" = "true" ]; then
             for ALLOWED_BRANCH in $STAGING_DEPLOY_BRANCH_ALLOWLIST; do
               if [ "$BRANCH_NAME" = "$ALLOWED_BRANCH" ]; then
                 DEPLOY_STAGING_OVERRIDE="true"
@@ -100,8 +100,8 @@ jobs:
           echo "sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
           echo "deploy_staging_override=$DEPLOY_STAGING_OVERRIDE" >> $GITHUB_OUTPUT
           
-          # Select ECR repository + region based on branch
-          if [ "$BRANCH_NAME" = "dev" ] || [ "$DEPLOY_STAGING_OVERRIDE" = "true" ]; then
+          # Only an explicitly requested and allowlisted staging deploy uses staging ECR.
+          if [ "$DEPLOY_STAGING_OVERRIDE" = "true" ]; then
             echo "ecr_repo=autumn-staging" >> $GITHUB_OUTPUT
             echo "region=us-east-1" >> $GITHUB_OUTPUT
           else
@@ -163,7 +163,7 @@ jobs:
           echo "Tag: ${COMBINED_TAG}"
 
       - name: Auto-deploy production
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && steps.meta.outputs.deploy_staging_override != 'true'
         env:
           DEPLOY_URL: ${{ secrets.DEPLOY_URL }}
           DEPLOY_SECRET: ${{ secrets.DEPLOY_SECRET }}
@@ -177,7 +177,7 @@ jobs:
           echo "Auto-deploy triggered!"
 
       - name: Auto-deploy staging
-        if: github.ref == 'refs/heads/dev' || steps.meta.outputs.deploy_staging_override == 'true'
+        if: steps.meta.outputs.deploy_staging_override == 'true'
         env:
           DEPLOY_URL: ${{ secrets.DEPLOY_URL }}
           DEPLOY_SECRET: ${{ secrets.DEPLOY_SECRET }}


### PR DESCRIPTION
Staging deployments now require both a `workflow_dispatch` run with the `deploy-staging` tag and an explicitly allowlisted branch. Pushes to `main` and `dev` can no longer target staging, while manually tagged runs from those allowlisted branches still can; a staging-tagged `main` run also skips the production deployment.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/6513f884-4373-4e2d-b52e-35b498e267af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-064" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/6513f884-4373-4e2d-b52e-35b498e267af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-064&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-064"><img alt="SCO-064" src="https://capy.ai/api/badge/thread.svg?label=SCO-064"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Staging deploys now require a manual run: trigger `workflow_dispatch` with the `deploy-staging` tag from an allowlisted branch (including `main` and `dev`). Automatic staging deploys from `dev` are removed, and a staging-tagged `main` run now skips the production auto-deploy.

<sup>Written for commit bc5c4331095ae4bf3e1a439e60e0e2fd8dc08d4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

