### PR TITLE
perf(analytics): speed up customer event listing

### DIFF
--- a/server/tinybird/pipes/list_events_cursor.pipe
+++ b/server/tinybird/pipes/list_events_cursor.pipe
@@ -1,6 +1,7 @@
 DESCRIPTION >
     Lists raw events with cursor-based pagination for external API.
-    Supports filtering by customer_id, event_names (array), and optional date range.
+    Customer-scoped queries read the customer-sorted events source; org-wide queries use
+    events_by_timestamp_mv. Supports event_names and optional date-range filtering.
 
 TOKEN "list_events_cursor_read" READ
 
@@ -8,6 +9,8 @@ NODE endpoint
 TYPE endpoint
 SQL >
     %
+    {% set use_customer_source = defined(customer_id) and String(customer_id, '') != '' %}
+
     SELECT
         id,
         org_id,
@@ -16,11 +19,16 @@ SQL >
         event_name,
         timestamp,
         value,
-        properties,
+        toString(properties) as properties,
         idempotency_key,
-        entity_id,
-        deductions
-    FROM events_by_timestamp_mv
+        coalesce(entity_id, '') as entity_id,
+        toString(deductions) as deductions
+    FROM
+        {% if use_customer_source %}
+        events
+        {% else %}
+        events_by_timestamp_mv
+        {% end %}
     WHERE
         org_id = {{ String(org_id, '') }}
         AND env = {{ String(env, 'test') }}
@@ -40,19 +48,19 @@ SQL >
         AND entity_id = {{ String(entity_id) }}
         {% end %}
         {% if defined(filter_key_0) and String(filter_key_0, '') != '' %}
-        AND positionCaseInsensitive(assumeNotNull(properties), concat('"', {{ String(filter_key_0, '') }}, '":"', {{ String(filter_value_0, '') }}, '"')) > 0
+        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_0, '') }}, '":"', {{ String(filter_value_0, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_1) and String(filter_key_1, '') != '' %}
-        AND positionCaseInsensitive(assumeNotNull(properties), concat('"', {{ String(filter_key_1, '') }}, '":"', {{ String(filter_value_1, '') }}, '"')) > 0
+        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_1, '') }}, '":"', {{ String(filter_value_1, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_2) and String(filter_key_2, '') != '' %}
-        AND positionCaseInsensitive(assumeNotNull(properties), concat('"', {{ String(filter_key_2, '') }}, '":"', {{ String(filter_value_2, '') }}, '"')) > 0
+        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_2, '') }}, '":"', {{ String(filter_value_2, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_3) and String(filter_key_3, '') != '' %}
-        AND positionCaseInsensitive(assumeNotNull(properties), concat('"', {{ String(filter_key_3, '') }}, '":"', {{ String(filter_value_3, '') }}, '"')) > 0
+        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_3, '') }}, '":"', {{ String(filter_value_3, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_4) and String(filter_key_4, '') != '' %}
-        AND positionCaseInsensitive(assumeNotNull(properties), concat('"', {{ String(filter_key_4, '') }}, '":"', {{ String(filter_value_4, '') }}, '"')) > 0
+        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_4, '') }}, '":"', {{ String(filter_value_4, '') }}, '"')) > 0
         {% end %}
         {% if defined(cursor_timestamp) and String(cursor_timestamp, '') != '' and defined(cursor_id) and String(cursor_id, '') != '' %}
         AND (timestamp, id) < (toDateTime64({{ String(cursor_timestamp) }}, 6), {{ String(cursor_id) }})

--- a/server/tinybird/pipes/list_events_cursor.pipe
+++ b/server/tinybird/pipes/list_events_cursor.pipe
@@ -11,6 +11,7 @@ SQL >
     %
     {% set use_customer_source = defined(customer_id) and String(customer_id, '') != '' %}
 
+    WITH coalesce(toString(properties), '') AS serialized_properties
     SELECT
         id,
         org_id,
@@ -19,7 +20,7 @@ SQL >
         event_name,
         timestamp,
         value,
-        toString(properties) as properties,
+        serialized_properties as properties,
         idempotency_key,
         coalesce(entity_id, '') as entity_id,
         toString(deductions) as deductions
@@ -48,19 +49,19 @@ SQL >
         AND entity_id = {{ String(entity_id) }}
         {% end %}
         {% if defined(filter_key_0) and String(filter_key_0, '') != '' %}
-        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_0, '') }}, '":"', {{ String(filter_value_0, '') }}, '"')) > 0
+        AND positionCaseInsensitive(serialized_properties, concat('"', {{ String(filter_key_0, '') }}, '":"', {{ String(filter_value_0, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_1) and String(filter_key_1, '') != '' %}
-        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_1, '') }}, '":"', {{ String(filter_value_1, '') }}, '"')) > 0
+        AND positionCaseInsensitive(serialized_properties, concat('"', {{ String(filter_key_1, '') }}, '":"', {{ String(filter_value_1, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_2) and String(filter_key_2, '') != '' %}
-        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_2, '') }}, '":"', {{ String(filter_value_2, '') }}, '"')) > 0
+        AND positionCaseInsensitive(serialized_properties, concat('"', {{ String(filter_key_2, '') }}, '":"', {{ String(filter_value_2, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_3) and String(filter_key_3, '') != '' %}
-        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_3, '') }}, '":"', {{ String(filter_value_3, '') }}, '"')) > 0
+        AND positionCaseInsensitive(serialized_properties, concat('"', {{ String(filter_key_3, '') }}, '":"', {{ String(filter_value_3, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_4) and String(filter_key_4, '') != '' %}
-        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_4, '') }}, '":"', {{ String(filter_value_4, '') }}, '"')) > 0
+        AND positionCaseInsensitive(serialized_properties, concat('"', {{ String(filter_key_4, '') }}, '":"', {{ String(filter_value_4, '') }}, '"')) > 0
         {% end %}
         {% if defined(cursor_timestamp) and String(cursor_timestamp, '') != '' and defined(cursor_id) and String(cursor_id, '') != '' %}
         AND (timestamp, id) < (toDateTime64({{ String(cursor_timestamp) }}, 6), {{ String(cursor_id) }})

--- a/server/tinybird/pipes/list_events_paginated.pipe
+++ b/server/tinybird/pipes/list_events_paginated.pipe
@@ -1,6 +1,7 @@
 DESCRIPTION >
     Lists raw events with offset-based pagination for external API.
-    Supports filtering by customer_id, event_names (array), and optional date range.
+    Customer-scoped queries read the customer-sorted events source; org-wide queries use
+    events_by_timestamp_mv. Supports event_names and optional date-range filtering.
 
 TOKEN "list_events_paginated_read" READ
 
@@ -8,6 +9,8 @@ NODE endpoint
 TYPE endpoint
 SQL >
     %
+    {% set use_customer_source = defined(customer_id) and String(customer_id, '') != '' %}
+
     SELECT
         id,
         org_id,
@@ -16,11 +19,16 @@ SQL >
         event_name,
         timestamp,
         value,
-        properties,
+        toString(properties) as properties,
         idempotency_key,
-        entity_id,
-        deductions
-    FROM events_by_timestamp_mv
+        coalesce(entity_id, '') as entity_id,
+        toString(deductions) as deductions
+    FROM
+        {% if use_customer_source %}
+        events
+        {% else %}
+        events_by_timestamp_mv
+        {% end %}
     WHERE
         org_id = {{ String(org_id, '') }}
         AND env = {{ String(env, 'test') }}
@@ -40,19 +48,19 @@ SQL >
         AND entity_id = {{ String(entity_id) }}
         {% end %}
         {% if defined(filter_key_0) and String(filter_key_0, '') != '' %}
-        AND positionCaseInsensitive(assumeNotNull(properties), concat('"', {{ String(filter_key_0, '') }}, '":"', {{ String(filter_value_0, '') }}, '"')) > 0
+        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_0, '') }}, '":"', {{ String(filter_value_0, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_1) and String(filter_key_1, '') != '' %}
-        AND positionCaseInsensitive(assumeNotNull(properties), concat('"', {{ String(filter_key_1, '') }}, '":"', {{ String(filter_value_1, '') }}, '"')) > 0
+        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_1, '') }}, '":"', {{ String(filter_value_1, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_2) and String(filter_key_2, '') != '' %}
-        AND positionCaseInsensitive(assumeNotNull(properties), concat('"', {{ String(filter_key_2, '') }}, '":"', {{ String(filter_value_2, '') }}, '"')) > 0
+        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_2, '') }}, '":"', {{ String(filter_value_2, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_3) and String(filter_key_3, '') != '' %}
-        AND positionCaseInsensitive(assumeNotNull(properties), concat('"', {{ String(filter_key_3, '') }}, '":"', {{ String(filter_value_3, '') }}, '"')) > 0
+        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_3, '') }}, '":"', {{ String(filter_value_3, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_4) and String(filter_key_4, '') != '' %}
-        AND positionCaseInsensitive(assumeNotNull(properties), concat('"', {{ String(filter_key_4, '') }}, '":"', {{ String(filter_value_4, '') }}, '"')) > 0
+        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_4, '') }}, '":"', {{ String(filter_value_4, '') }}, '"')) > 0
         {% end %}
     ORDER BY timestamp DESC, id DESC
     LIMIT {{ Int32(limit, 101) }}

--- a/server/tinybird/pipes/list_events_paginated.pipe
+++ b/server/tinybird/pipes/list_events_paginated.pipe
@@ -11,6 +11,7 @@ SQL >
     %
     {% set use_customer_source = defined(customer_id) and String(customer_id, '') != '' %}
 
+    WITH coalesce(toString(properties), '') AS serialized_properties
     SELECT
         id,
         org_id,
@@ -19,7 +20,7 @@ SQL >
         event_name,
         timestamp,
         value,
-        toString(properties) as properties,
+        serialized_properties as properties,
         idempotency_key,
         coalesce(entity_id, '') as entity_id,
         toString(deductions) as deductions
@@ -48,19 +49,19 @@ SQL >
         AND entity_id = {{ String(entity_id) }}
         {% end %}
         {% if defined(filter_key_0) and String(filter_key_0, '') != '' %}
-        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_0, '') }}, '":"', {{ String(filter_value_0, '') }}, '"')) > 0
+        AND positionCaseInsensitive(serialized_properties, concat('"', {{ String(filter_key_0, '') }}, '":"', {{ String(filter_value_0, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_1) and String(filter_key_1, '') != '' %}
-        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_1, '') }}, '":"', {{ String(filter_value_1, '') }}, '"')) > 0
+        AND positionCaseInsensitive(serialized_properties, concat('"', {{ String(filter_key_1, '') }}, '":"', {{ String(filter_value_1, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_2) and String(filter_key_2, '') != '' %}
-        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_2, '') }}, '":"', {{ String(filter_value_2, '') }}, '"')) > 0
+        AND positionCaseInsensitive(serialized_properties, concat('"', {{ String(filter_key_2, '') }}, '":"', {{ String(filter_value_2, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_3) and String(filter_key_3, '') != '' %}
-        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_3, '') }}, '":"', {{ String(filter_value_3, '') }}, '"')) > 0
+        AND positionCaseInsensitive(serialized_properties, concat('"', {{ String(filter_key_3, '') }}, '":"', {{ String(filter_value_3, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_4) and String(filter_key_4, '') != '' %}
-        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_4, '') }}, '":"', {{ String(filter_value_4, '') }}, '"')) > 0
+        AND positionCaseInsensitive(serialized_properties, concat('"', {{ String(filter_key_4, '') }}, '":"', {{ String(filter_value_4, '') }}, '"')) > 0
         {% end %}
     ORDER BY timestamp DESC, id DESC
     LIMIT {{ Int32(limit, 101) }}


### PR DESCRIPTION
## Summary

- route customer-scoped offset and cursor event queries to the customer-leading `events` datasource
- retain `events_by_timestamp_mv` for org-wide listing and preserve timestamp/ID ordering plus response serialization

## Validation

- Tinybird branch build and endpoint parity checks passed for ordering, cursors, and filters
- `tb deploy --check` passed with only the two pipe changes and no data copy
- production-shaped query benchmark: 13–25s / 366.5M rows to 39ms / 73.7K rows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route customer-scoped event list queries to the customer-sorted `events` source while keeping org-wide queries on `events_by_timestamp_mv`. Cuts customer list latency from 13–25s (366.5M rows) to ~39ms (73.7K rows).

- **Refactors**
  - Customer-scoped offset and cursor queries now read from `events`; org-wide stays on `events_by_timestamp_mv`.
  - Preserve timestamp/id ordering and cursor behavior.
  - Normalize output and filters: reuse `serialized_properties` (coalesce(toString(properties), '')), cast `deductions` to string, default `entity_id` to ''.

<sup>Written for commit 03a1a64966adb925eff63fa37dc7c5a5de3c5e62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

