### PR TITLE
Route dirty-state syncs to dedicated org Redis

### DIFF
--- a/server/src/external/redis/resolveRedisV2.ts
+++ b/server/src/external/redis/resolveRedisV2.ts
@@ -15,6 +15,7 @@ let lastLoggedInstance: RedisV2InstanceName | null = null;
 let publicRouteWarned = false;
 
 export type ResolvedRedisV2InstanceName = RedisV2InstanceName | "ramp";
+export type RedisV2RoutingTarget = ResolvedRedisV2InstanceName | "org";
 
 export const getRedisV2ByInstanceName = (name: string): Redis | null => {
 	if (name === "dragonfly") return redisV2Primary;
@@ -23,6 +24,16 @@ export const getRedisV2ByInstanceName = (name: string): Redis | null => {
 		return getAlternateRedisV2Instance(name);
 	}
 	return null;
+};
+
+export const getRedisV2RoutingTarget = (redis: Redis): RedisV2RoutingTarget => {
+	const globalTargets = ["dragonfly", "upstash", "redis", "ramp"] as const;
+	for (const target of globalTargets) {
+		if (getRedisV2ByInstanceName(target) === redis) {
+			return target;
+		}
+	}
+	return "org";
 };
 
 const resolveRedisV2InstanceName = ({
@@ -38,10 +49,7 @@ const resolveRedisV2InstanceName = ({
 			: "dragonfly";
 	}
 
-	if (
-		isCacheV2RampEnabled({ customerId }) &&
-		getRampDestinationRedis()
-	) {
+	if (isCacheV2RampEnabled({ customerId }) && getRampDestinationRedis()) {
 		return "ramp";
 	}
 	return "dragonfly";

--- a/server/src/internal/balances/utils/sync/SyncBatchingManagerV3.ts
+++ b/server/src/internal/balances/utils/sync/SyncBatchingManagerV3.ts
@@ -2,12 +2,12 @@ import type { AppEnv } from "@autumn/shared";
 import type { Redis } from "ioredis";
 import { logger } from "@/external/logtail/logtailUtils.js";
 import { currentRegion } from "@/external/redis/initRedis.js";
-import { getCurrentRedisV2InstanceName } from "@/external/redis/resolveRedisV2.js";
+import { getRedisV2RoutingTarget } from "@/external/redis/resolveRedisV2.js";
 import { JobName } from "@/queue/JobName.js";
 import { addTaskToQueue } from "@/queue/queueUtils.js";
+import type { UsageWindowUpdate } from "../types/usageWindowUpdate.js";
 import { markSyncDirty } from "./dirtyState/markSyncDirty.js";
 import { buildSyncDirtyKeys } from "./dirtyState/syncDirtyKeys.js";
-import type { UsageWindowUpdate } from "../types/usageWindowUpdate.js";
 
 /** Signal marker TTL: an enqueue that silently fails re-signals after this. */
 const SIGNAL_TTL_SECONDS = 60;
@@ -132,9 +132,7 @@ export class SyncBatchingManagerV3 {
 		if (coalesce && coalesceRedis) {
 			batch.context.coalesce = true;
 			batch.context.coalesceRedis = coalesceRedis;
-			batch.context.redisInstance = getCurrentRedisV2InstanceName({
-				customerId,
-			});
+			batch.context.redisInstance = getRedisV2RoutingTarget(coalesceRedis);
 		}
 
 		for (const [featureId, ids] of Object.entries(

--- a/server/src/internal/balances/utils/sync/syncItemV5.ts
+++ b/server/src/internal/balances/utils/sync/syncItemV5.ts
@@ -1,4 +1,5 @@
 import type { AppEnv } from "@autumn/shared";
+import { getOrgRedis } from "@/external/redis/orgRedisPool.js";
 import { getRedisV2ByInstanceName } from "@/external/redis/resolveRedisV2.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { claimSyncDirty, clearSyncClaim } from "./dirtyState/claimSyncDirty.js";
@@ -45,9 +46,12 @@ export const syncItemV5 = async ({
 		env: payload.env,
 		customerId: payload.customerId,
 	};
-	const redis = payload.redisInstance
-		? (getRedisV2ByInstanceName(payload.redisInstance) ?? ctx.redisV2)
-		: ctx.redisV2;
+	const redis =
+		payload.redisInstance === "org"
+			? getOrgRedis({ org: ctx.org })
+			: payload.redisInstance
+				? (getRedisV2ByInstanceName(payload.redisInstance) ?? ctx.redisV2)
+				: ctx.redisV2;
 
 	// Coalescing window: FIFO queues don't support per-message DelaySeconds,
 	// so the window is enforced here — writes landing between the signal and

--- a/server/tests/unit/balances/syncItemV5-dedicated-redis.test.ts
+++ b/server/tests/unit/balances/syncItemV5-dedicated-redis.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, mock, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
+
+const dedicatedRedis = {};
+const sharedRedis = {};
+let claimedRedis: unknown;
+
+mock.module("@/external/redis/orgRedisPool.js", () => ({
+	getOrgRedis: () => dedicatedRedis,
+}));
+
+mock.module(
+	"@/internal/balances/utils/sync/dirtyState/claimSyncDirty.js",
+	() => ({
+		claimSyncDirty: ({ redis }: { redis: unknown }) => {
+			claimedRedis = redis;
+			return null;
+		},
+		clearSyncClaim: () => {},
+	}),
+);
+
+mock.module("@/internal/balances/utils/sync/syncItemV4.js", () => ({
+	syncItemV4: () => {},
+}));
+
+const { syncItemV5 } = await import(
+	"@/internal/balances/utils/sync/syncItemV5.js"
+);
+
+describe("syncItemV5 Redis routing", () => {
+	test("claims dirty state from the org Redis for dedicated writes", async () => {
+		await syncItemV5({
+			ctx: {
+				org: { id: "org_1", redis_config: {} },
+				redisV2: sharedRedis,
+				logger: { debug: () => {} },
+			} as never,
+			payload: {
+				customerId: "customer_1",
+				orgId: "org_1",
+				env: AppEnv.Sandbox,
+				redisInstance: "org",
+				timestamp: 0,
+			},
+		});
+
+		expect(claimedRedis).toBe(dedicatedRedis);
+	});
+});


### PR DESCRIPTION
Dirty-state sync jobs now record the Redis client that received the write instead of recomputing a global target from the customer ID. Dedicated-org writes are tagged as `org`, and `syncItemV5` reconnects through `getOrgRedis` before claiming the dirty state; shared Dragonfly, Redis, Upstash, and ramp routes retain their existing behavior.

Adds a focused regression test proving dedicated sync jobs claim from the org Redis rather than the worker's shared Redis client.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/9eeee3ba-9181-49c4-a3d0-7197ee0f0997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-065" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/9eeee3ba-9181-49c4-a3d0-7197ee0f0997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-065&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-065"><img alt="SCO-065" src="https://capy.ai/api/badge/thread.svg?label=SCO-065"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes dirty-state sync claims to each org’s dedicated Redis when writes come from a dedicated client. Fixes misrouted claims and preserves isolation for dedicated orgs (SCO-065).

- Bug Fixes
  - On enqueue, store the routing target via `getRedisV2RoutingTarget`; dedicated writes are tagged `org`. Shared paths (`dragonfly`, `redis`, `upstash`, `ramp`) are unchanged.
  - In `syncItemV5`, use `getOrgRedis` when the target is `org`; otherwise resolve via `getRedisV2ByInstanceName` or fall back to `ctx.redisV2`.
  - Added `syncItemV5-dedicated-redis.test.ts` to verify `claimSyncDirty` reads from the org Redis.

<sup>Written for commit 31bccc3df43eefd95e694683a1c0115484019923. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

