### PR TITLE
Fix coalesced syncs for dedicated Redis customers

### DIFF
--- a/server/src/external/redis/customerRedisRouting.ts
+++ b/server/src/external/redis/customerRedisRouting.ts
@@ -7,7 +7,11 @@ import {
 import { getActiveRedisV2Instance } from "@/internal/misc/redisV2Cache/redisV2CacheStore.js";
 import { redisV2 as redisV2Primary } from "./initRedisV2.js";
 import { getOrgRedis, type OrgWithRedisConfig } from "./orgRedisPool.js";
-import { resolveRedisV2 } from "./resolveRedisV2.js";
+import {
+	getCurrentRedisV2InstanceName,
+	type ResolvedRedisV2InstanceName,
+	resolveRedisV2,
+} from "./resolveRedisV2.js";
 
 export {
 	type CustomerRedisRoutingInfo,
@@ -21,6 +25,12 @@ import {
 	getCustomerRedisRoutingInfoForOrg,
 } from "./customerRedisRoutingInfo.js";
 
+export const ORG_REDIS_SYNC_TARGET = "org" as const;
+
+export type CustomerRedisSyncTarget =
+	| ResolvedRedisV2InstanceName
+	| typeof ORG_REDIS_SYNC_TARGET;
+
 export const getCustomerRedisRoutingInfo = ({
 	org,
 	customerId,
@@ -32,6 +42,19 @@ export const getCustomerRedisRoutingInfo = ({
 		org,
 		customerId,
 	});
+};
+
+export const getCustomerRedisSyncTarget = ({
+	org,
+	customerId,
+}: {
+	org: OrgWithRedisConfig;
+	customerId: string;
+}): CustomerRedisSyncTarget => {
+	const routingInfo = getCustomerRedisRoutingInfo({ org, customerId });
+	if (routingInfo.usesDedicatedRedis) return ORG_REDIS_SYNC_TARGET;
+
+	return getCurrentRedisV2InstanceName({ customerId });
 };
 
 export const resolveCustomerRedisRouting = ({

--- a/server/src/internal/balances/finalizeLock/runRedisFinalizeLockV2.ts
+++ b/server/src/internal/balances/finalizeLock/runRedisFinalizeLockV2.ts
@@ -1,3 +1,4 @@
+import { getCustomerRedisSyncTarget } from "@/external/redis/customerRedisRouting.js";
 import { currentRegion } from "@/external/redis/initRedis.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { executeRedisDeductionV2 } from "@/internal/balances/utils/deductionV2/executeRedisDeductionV2.js";
@@ -69,6 +70,10 @@ export const runRedisFinalizeLockV2 = async ({
 			coalesce: ctx.testOptions?.syncCoalesce ?? isSyncCoalesceEnabled(),
 			// The drain resolves via worker ctx, so the mark must use the same routing.
 			coalesceRedis: ctx.redisV2,
+			redisInstance: getCustomerRedisSyncTarget({
+				org: ctx.org,
+				customerId: receipt.customer_id,
+			}),
 		});
 	}
 

--- a/server/src/internal/balances/track/v3/runRedisTrackV3.ts
+++ b/server/src/internal/balances/track/v3/runRedisTrackV3.ts
@@ -5,6 +5,7 @@ import type {
 	TrackResponseV3,
 } from "@autumn/shared";
 import { tryCatch } from "@autumn/shared";
+import { getCustomerRedisSyncTarget } from "@/external/redis/customerRedisRouting.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { globalEventBatchingManager } from "@/internal/balances/events/EventBatchingManager.js";
 import {
@@ -62,6 +63,10 @@ const queueSyncItem = ({
 		usageWindowUpdates,
 		coalesce: ctx.testOptions?.syncCoalesce ?? isSyncCoalesceEnabled(),
 		coalesceRedis: ctx.redisV2,
+		redisInstance: getCustomerRedisSyncTarget({
+			org: ctx.org,
+			customerId: body.customer_id,
+		}),
 	});
 };
 

--- a/server/src/internal/balances/utils/sync/SyncBatchingManagerV3.ts
+++ b/server/src/internal/balances/utils/sync/SyncBatchingManagerV3.ts
@@ -1,13 +1,13 @@
 import type { AppEnv } from "@autumn/shared";
 import type { Redis } from "ioredis";
 import { logger } from "@/external/logtail/logtailUtils.js";
+import type { CustomerRedisSyncTarget } from "@/external/redis/customerRedisRouting.js";
 import { currentRegion } from "@/external/redis/initRedis.js";
-import { getCurrentRedisV2InstanceName } from "@/external/redis/resolveRedisV2.js";
 import { JobName } from "@/queue/JobName.js";
 import { addTaskToQueue } from "@/queue/queueUtils.js";
+import type { UsageWindowUpdate } from "../types/usageWindowUpdate.js";
 import { markSyncDirty } from "./dirtyState/markSyncDirty.js";
 import { buildSyncDirtyKeys } from "./dirtyState/syncDirtyKeys.js";
-import type { UsageWindowUpdate } from "../types/usageWindowUpdate.js";
 
 /** Signal marker TTL: an enqueue that silently fails re-signals after this. */
 const SIGNAL_TTL_SECONDS = 60;
@@ -31,7 +31,7 @@ interface CustomerBatchContext {
 	/** Coalescing flushes into Redis dirty state instead of enqueueing a full payload. */
 	coalesce: boolean;
 	coalesceRedis?: Redis;
-	redisInstance?: string;
+	redisInstance?: CustomerRedisSyncTarget;
 }
 
 interface CustomerBatch {
@@ -100,6 +100,7 @@ export class SyncBatchingManagerV3 {
 		usageWindowUpdates,
 		coalesce,
 		coalesceRedis,
+		redisInstance,
 	}: {
 		customerId: string;
 		orgId: string;
@@ -114,6 +115,8 @@ export class SyncBatchingManagerV3 {
 		coalesce?: boolean;
 		/** The Redis instance the deduction ran on (dirty state must co-locate) */
 		coalesceRedis?: Redis;
+		/** Stable target name for the worker that drains the dirty state. */
+		redisInstance: CustomerRedisSyncTarget;
 	}): void {
 		const batchKey = this.buildBatchKey({ orgId, env, customerId });
 		let batch = this.customerBatches.get(batchKey);
@@ -132,9 +135,7 @@ export class SyncBatchingManagerV3 {
 		if (coalesce && coalesceRedis) {
 			batch.context.coalesce = true;
 			batch.context.coalesceRedis = coalesceRedis;
-			batch.context.redisInstance = getCurrentRedisV2InstanceName({
-				customerId,
-			});
+			batch.context.redisInstance = redisInstance;
 		}
 
 		for (const [featureId, ids] of Object.entries(

--- a/server/src/internal/balances/utils/sync/syncItemV5.ts
+++ b/server/src/internal/balances/utils/sync/syncItemV5.ts
@@ -1,4 +1,6 @@
 import type { AppEnv } from "@autumn/shared";
+import { ORG_REDIS_SYNC_TARGET } from "@/external/redis/customerRedisRouting.js";
+import { getOrgRedis } from "@/external/redis/orgRedisPool.js";
 import { getRedisV2ByInstanceName } from "@/external/redis/resolveRedisV2.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { claimSyncDirty, clearSyncClaim } from "./dirtyState/claimSyncDirty.js";
@@ -45,9 +47,12 @@ export const syncItemV5 = async ({
 		env: payload.env,
 		customerId: payload.customerId,
 	};
-	const redis = payload.redisInstance
-		? (getRedisV2ByInstanceName(payload.redisInstance) ?? ctx.redisV2)
-		: ctx.redisV2;
+	const redis =
+		payload.redisInstance === ORG_REDIS_SYNC_TARGET
+			? getOrgRedis({ org: ctx.org })
+			: payload.redisInstance
+				? (getRedisV2ByInstanceName(payload.redisInstance) ?? ctx.redisV2)
+				: ctx.redisV2;
 
 	// Coalescing window: FIFO queues don't support per-message DelaySeconds,
 	// so the window is enforced here — writes landing between the signal and

--- a/server/tests/unit/balances/sync/sync-batching-dedicated-redis-target.test.ts
+++ b/server/tests/unit/balances/sync/sync-batching-dedicated-redis-target.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Regression coverage for the producer side of dedicated Redis coalescing.
+ *
+ * Before the fix, the batching manager overwrote the actual deduction target
+ * with a global Redis target name. The queued signal must preserve the target
+ * of the Redis instance where its dirty state was written.
+ */
+
+import { expect, mock, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
+import type { Redis } from "ioredis";
+
+const queuedJobs: Array<{ payload: { redisInstance?: string } }> = [];
+const dirtyRedisInstances: Redis[] = [];
+
+mock.module("@/external/logtail/logtailUtils.js", () => ({
+	logger: { error: () => undefined },
+}));
+
+mock.module("@/external/redis/initRedis.js", () => ({
+	currentRegion: "us-west-2",
+}));
+
+mock.module("@/queue/queueUtils.js", () => ({
+	addTaskToQueue: async (job: { payload: { redisInstance?: string } }) => {
+		queuedJobs.push(job);
+	},
+}));
+
+mock.module(
+	"@/internal/balances/utils/sync/dirtyState/markSyncDirty.js",
+	() => ({
+		markSyncDirty: ({ redis }: { redis: Redis }) => {
+			dirtyRedisInstances.push(redis);
+			return { shouldSignal: true };
+		},
+	}),
+);
+
+import { SyncBatchingManagerV3 } from "@/internal/balances/utils/sync/SyncBatchingManagerV3.js";
+
+test("coalesced sync signal preserves its org Redis target", async () => {
+	queuedJobs.length = 0;
+	dirtyRedisInstances.length = 0;
+	const dedicatedRedis = { name: "dedicated" } as unknown as Redis;
+	const manager = new SyncBatchingManagerV3({ batchWindowMs: 60_000 });
+
+	manager.addSyncItem({
+		customerId: "customer_dedicated",
+		orgId: "org_dedicated",
+		env: AppEnv.Sandbox,
+		cusEntIds: ["entitlement_1"],
+		modifiedCusEntIdsByFeatureId: {
+			emails: ["entitlement_1"],
+		},
+		coalesce: true,
+		coalesceRedis: dedicatedRedis,
+		redisInstance: "org",
+	});
+
+	await manager.flush();
+
+	expect(dirtyRedisInstances).toEqual([dedicatedRedis]);
+	expect(queuedJobs).toHaveLength(1);
+	expect(queuedJobs[0]?.payload.redisInstance).toBe("org");
+});

--- a/server/tests/unit/balances/sync/sync-item-v5-dedicated-redis.test.ts
+++ b/server/tests/unit/balances/sync/sync-item-v5-dedicated-redis.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Regression test for coalesced balance syncs on org-dedicated Redis.
+ *
+ * Red-failure mode (current behavior):
+ *  - an `org` sync target falls back to the worker's shared Redis client, so
+ *    the dirty state written to dedicated Redis is never claimed.
+ *
+ * Green-success criteria (after fix):
+ *  - the worker resolves an `org` sync target to the org-dedicated Redis client.
+ */
+
+import { expect, mock, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
+import type { Redis } from "ioredis";
+
+const sharedRedis = { name: "shared" } as unknown as Redis;
+const dedicatedRedis = { name: "dedicated" } as unknown as Redis;
+const claimedRedisInstances: Redis[] = [];
+
+mock.module("@/external/redis/orgRedisPool.js", () => ({
+	getOrgRedis: () => dedicatedRedis,
+}));
+
+mock.module("@/external/redis/resolveRedisV2.js", () => ({
+	getRedisV2ByInstanceName: () => null,
+}));
+
+mock.module(
+	"@/internal/balances/utils/sync/dirtyState/claimSyncDirty.js",
+	() => ({
+		claimSyncDirty: ({ redis }: { redis: Redis }) => {
+			claimedRedisInstances.push(redis);
+			return null;
+		},
+		clearSyncClaim: () => undefined,
+	}),
+);
+
+mock.module("@/internal/balances/utils/sync/syncItemV4.js", () => ({
+	syncItemV4: () => undefined,
+}));
+
+import { syncItemV5 } from "@/internal/balances/utils/sync/syncItemV5.js";
+
+test("syncItemV5 claims org-targeted dirty state from dedicated Redis", async () => {
+	claimedRedisInstances.length = 0;
+
+	await syncItemV5({
+		ctx: {
+			org: {
+				id: "org_dedicated",
+				redis_config: {
+					connectionString: "encrypted",
+					url: "dragonfly.internal:6379",
+					migrationPercent: 100,
+					previousMigrationPercent: 0,
+					migrationChangedAt: 1,
+				},
+			},
+			redisV2: sharedRedis,
+			logger: { debug: () => undefined },
+		} as never,
+		payload: {
+			customerId: "customer_dedicated",
+			orgId: "org_dedicated",
+			env: AppEnv.Sandbox,
+			redisInstance: "org",
+			timestamp: 0,
+		},
+	});
+
+	expect(claimedRedisInstances).toEqual([dedicatedRedis]);
+});


### PR DESCRIPTION
## Summary

- preserve the actual customer Redis target in coalesced sync signals
- resolve org-targeted dirty state through the org Redis pool in workers
- retain compatibility with legacy global Redis target names and mixed-version rollout

## Root cause

SyncBatchingManagerV3 wrote dirty state through the customer-routed Redis client, but recomputed the queued target using only global Redis routing. Dedicated-org tracks therefore queued dragonfly and workers silently found no dirty state on shared Redis.

## Verification

- bun test tests/unit/redis/customer-redis-routing.test.ts tests/unit/balances/sync/sync-item-v5-dedicated-redis.test.ts tests/unit/balances/sync/sync-batching-dedicated-redis-target.test.ts (9 pass)
- cd server && bun ts
- scoped Biome check on all changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes coalesced balance syncs for orgs on dedicated Redis by preserving the correct sync target and resolving it in workers. Prevents missed dirty-state claims for dedicated-Redis customers.

- **Bug Fixes**
  - Preserve customer Redis sync target in coalesced signals via `getCustomerRedisSyncTarget` with an `"org"` sentinel.
  - Workers resolve `"org"` to the org Redis pool (`getOrgRedis`); legacy/global instance names still work.
  - `SyncBatchingManagerV3` no longer recomputes the target; `runRedisTrackV3` and `runRedisFinalizeLockV2` pass it through.
  - Added unit tests for producer and worker paths to guard against regressions.

<sup>Written for commit cee546c187b29a0c070b2f90d678d478d7f771af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

