### PR TITLE
Release dev to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   #   staging repo (autumn-staging) -> us-east-1
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix feat/firelens-log-transport-v2
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: main dev feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix feat/firelens-log-transport-v2
 
 jobs:
   checks:
@@ -75,7 +75,7 @@ jobs:
           # Sanitize branch name for Docker tag (replace / with -)
           SAFE_BRANCH=$(echo $BRANCH_NAME | sed 's/\//-/g')
 
-          if [ "$REQUESTED_STAGING_DEPLOY" = "true" ] && [ "$BRANCH_NAME" != "dev" ]; then
+          if [ "$REQUESTED_STAGING_DEPLOY" = "true" ]; then
             for ALLOWED_BRANCH in $STAGING_DEPLOY_BRANCH_ALLOWLIST; do
               if [ "$BRANCH_NAME" = "$ALLOWED_BRANCH" ]; then
                 DEPLOY_STAGING_OVERRIDE="true"
@@ -100,8 +100,8 @@ jobs:
           echo "sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
           echo "deploy_staging_override=$DEPLOY_STAGING_OVERRIDE" >> $GITHUB_OUTPUT
           
-          # Select ECR repository + region based on branch
-          if [ "$BRANCH_NAME" = "dev" ] || [ "$DEPLOY_STAGING_OVERRIDE" = "true" ]; then
+          # Only an explicitly requested and allowlisted staging deploy uses staging ECR.
+          if [ "$DEPLOY_STAGING_OVERRIDE" = "true" ]; then
             echo "ecr_repo=autumn-staging" >> $GITHUB_OUTPUT
             echo "region=us-east-1" >> $GITHUB_OUTPUT
           else
@@ -163,7 +163,7 @@ jobs:
           echo "Tag: ${COMBINED_TAG}"
 
       - name: Auto-deploy production
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && steps.meta.outputs.deploy_staging_override != 'true'
         env:
           DEPLOY_URL: ${{ secrets.DEPLOY_URL }}
           DEPLOY_SECRET: ${{ secrets.DEPLOY_SECRET }}
@@ -177,7 +177,7 @@ jobs:
           echo "Auto-deploy triggered!"
 
       - name: Auto-deploy staging
-        if: github.ref == 'refs/heads/dev' || steps.meta.outputs.deploy_staging_override == 'true'
+        if: steps.meta.outputs.deploy_staging_override == 'true'
         env:
           DEPLOY_URL: ${{ secrets.DEPLOY_URL }}
           DEPLOY_SECRET: ${{ secrets.DEPLOY_SECRET }}

--- a/server/src/external/redis/resolveRedisV2.ts
+++ b/server/src/external/redis/resolveRedisV2.ts
@@ -15,6 +15,7 @@ let lastLoggedInstance: RedisV2InstanceName | null = null;
 let publicRouteWarned = false;
 
 export type ResolvedRedisV2InstanceName = RedisV2InstanceName | "ramp";
+export type RedisV2RoutingTarget = ResolvedRedisV2InstanceName | "org";
 
 export const getRedisV2ByInstanceName = (name: string): Redis | null => {
 	if (name === "dragonfly") return redisV2Primary;
@@ -23,6 +24,16 @@ export const getRedisV2ByInstanceName = (name: string): Redis | null => {
 		return getAlternateRedisV2Instance(name);
 	}
 	return null;
+};
+
+export const getRedisV2RoutingTarget = (redis: Redis): RedisV2RoutingTarget => {
+	const globalTargets = ["dragonfly", "upstash", "redis", "ramp"] as const;
+	for (const target of globalTargets) {
+		if (getRedisV2ByInstanceName(target) === redis) {
+			return target;
+		}
+	}
+	return "org";
 };
 
 const resolveRedisV2InstanceName = ({
@@ -38,10 +49,7 @@ const resolveRedisV2InstanceName = ({
 			: "dragonfly";
 	}
 
-	if (
-		isCacheV2RampEnabled({ customerId }) &&
-		getRampDestinationRedis()
-	) {
+	if (isCacheV2RampEnabled({ customerId }) && getRampDestinationRedis()) {
 		return "ramp";
 	}
 	return "dragonfly";

--- a/server/src/internal/balances/utils/sync/SyncBatchingManagerV3.ts
+++ b/server/src/internal/balances/utils/sync/SyncBatchingManagerV3.ts
@@ -2,12 +2,12 @@ import type { AppEnv } from "@autumn/shared";
 import type { Redis } from "ioredis";
 import { logger } from "@/external/logtail/logtailUtils.js";
 import { currentRegion } from "@/external/redis/initRedis.js";
-import { getCurrentRedisV2InstanceName } from "@/external/redis/resolveRedisV2.js";
+import { getRedisV2RoutingTarget } from "@/external/redis/resolveRedisV2.js";
 import { JobName } from "@/queue/JobName.js";
 import { addTaskToQueue } from "@/queue/queueUtils.js";
+import type { UsageWindowUpdate } from "../types/usageWindowUpdate.js";
 import { markSyncDirty } from "./dirtyState/markSyncDirty.js";
 import { buildSyncDirtyKeys } from "./dirtyState/syncDirtyKeys.js";
-import type { UsageWindowUpdate } from "../types/usageWindowUpdate.js";
 
 /** Signal marker TTL: an enqueue that silently fails re-signals after this. */
 const SIGNAL_TTL_SECONDS = 60;
@@ -132,9 +132,7 @@ export class SyncBatchingManagerV3 {
 		if (coalesce && coalesceRedis) {
 			batch.context.coalesce = true;
 			batch.context.coalesceRedis = coalesceRedis;
-			batch.context.redisInstance = getCurrentRedisV2InstanceName({
-				customerId,
-			});
+			batch.context.redisInstance = getRedisV2RoutingTarget(coalesceRedis);
 		}
 
 		for (const [featureId, ids] of Object.entries(

--- a/server/src/internal/balances/utils/sync/syncItemV5.ts
+++ b/server/src/internal/balances/utils/sync/syncItemV5.ts
@@ -1,4 +1,5 @@
 import type { AppEnv } from "@autumn/shared";
+import { getOrgRedis } from "@/external/redis/orgRedisPool.js";
 import { getRedisV2ByInstanceName } from "@/external/redis/resolveRedisV2.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { claimSyncDirty, clearSyncClaim } from "./dirtyState/claimSyncDirty.js";
@@ -45,9 +46,12 @@ export const syncItemV5 = async ({
 		env: payload.env,
 		customerId: payload.customerId,
 	};
-	const redis = payload.redisInstance
-		? (getRedisV2ByInstanceName(payload.redisInstance) ?? ctx.redisV2)
-		: ctx.redisV2;
+	const redis =
+		payload.redisInstance === "org"
+			? getOrgRedis({ org: ctx.org })
+			: payload.redisInstance
+				? (getRedisV2ByInstanceName(payload.redisInstance) ?? ctx.redisV2)
+				: ctx.redisV2;
 
 	// Coalescing window: FIFO queues don't support per-message DelaySeconds,
 	// so the window is enforced here — writes landing between the signal and

--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeDefaultCustomerProduct.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeDefaultCustomerProduct.ts
@@ -1,11 +1,45 @@
 import {
 	CusProductStatus,
+	cp,
 	enrichFullCustomerWithEntity,
 	type FullCusProduct,
+	hasCustomerProductEnded,
+	isFutureStartDate,
 	type UpdateSubscriptionBillingContext,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { initFullCustomerProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/initFullCustomerProduct";
+
+const hasOtherEffectivePaidMainProduct = ({
+	billingContext,
+	effectiveAt,
+}: {
+	billingContext: UpdateSubscriptionBillingContext;
+	effectiveAt: number;
+}) => {
+	const { customerProduct, fullCustomer } = billingContext;
+	const internalEntityId = customerProduct.internal_entity_id ?? undefined;
+
+	return fullCustomer.customer_products.some((candidate) => {
+		if (candidate.id === customerProduct.id) return false;
+
+		const inScope = cp(candidate)
+			.hasRelevantStatus()
+			.paidRecurring()
+			.main()
+			.hasProductGroup({ productGroup: customerProduct.product.group })
+			.onEntity({ internalEntityId }).valid;
+
+		return (
+			inScope &&
+			!isFutureStartDate(candidate.starts_at, effectiveAt, 0) &&
+			!hasCustomerProductEnded(candidate, {
+				nowMs: effectiveAt,
+				toleranceMs: 0,
+			})
+		);
+	});
+};
 
 /**
  * Creates the default customer product to insert when canceling.
@@ -44,6 +78,15 @@ export const computeDefaultCustomerProduct = ({
 		cancelAction === "cancel_immediately"
 			? CusProductStatus.Active
 			: CusProductStatus.Scheduled;
+
+	if (
+		hasOtherEffectivePaidMainProduct({
+			billingContext,
+			effectiveAt: startsAt,
+		})
+	) {
+		return undefined;
+	}
 
 	const newDefaultProduct = initFullCustomerProduct({
 		ctx,

--- a/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/billingPlanToNextCyclePreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/billingPlanToNextCyclePreview.ts
@@ -198,7 +198,9 @@ export const billingPlanToNextCyclePreview = ({
 			startsAtMs: event.startsAtMs - MS_PER_SECOND,
 		});
 		const billingCycleAnchorMs =
-			productsForUsageLineItems.length === 0 ? event.startsAtMs : anchorMs;
+			event.resetsBillingCycle || productsForUsageLineItems.length === 0
+				? event.startsAtMs
+				: anchorMs;
 		const lineItemsResult = billingPlanToNextCycleLineItems({
 			ctx,
 			customerProducts: event.customerProducts,

--- a/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/billingPlanToNextCyclePreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/billingPlanToNextCyclePreview.ts
@@ -157,7 +157,9 @@ export const billingPlanToNextCyclePreview = ({
 				{
 					customerProducts: event.incomingCustomerProducts,
 					direction: "charge",
-					billingCycleAnchorMs: anchorMs,
+					billingCycleAnchorMs: event.resetsBillingCycle
+						? event.startsAtMs
+						: anchorMs,
 					filterBillingPeriodStart: false,
 					priceFilters: { excludeOneOffPrices: true },
 				},

--- a/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/classifyNextCycleEvent.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/classifyNextCycleEvent.ts
@@ -10,12 +10,12 @@ import {
 	uniqueCustomerProductsById,
 } from "./customerProductDiffs";
 import { SECOND_MS, timestampsEqual } from "./timeUtils";
-import type { NextCycleEvent, SmallestInterval } from "./types";
 import {
 	getExactTransitionTimestamp,
 	hasProductTransitionAt,
 	hasTrialEndAt,
 } from "./transitionCandidates";
+import type { NextCycleEvent, SmallestInterval } from "./types";
 
 /** Classifies one candidate timestamp into the invoice event it represents. */
 export const classifyNextCycleEvent = ({
@@ -57,10 +57,14 @@ export const classifyNextCycleEvent = ({
 		};
 	}
 
-	const isAnchorReset = timestampsEqual(
-		billingContext.requestedBillingCycleAnchor,
-		startsAtMs,
-	);
+	const isAnchorReset =
+		timestampsEqual(billingContext.requestedBillingCycleAnchor, startsAtMs) ||
+		normalizedCustomerProducts.some((customerProduct) =>
+			timestampsEqual(
+				customerProduct.billing_cycle_anchor_resets_at ?? undefined,
+				startsAtMs,
+			),
+		);
 	const isProductTransition = hasProductTransitionAt({
 		customerProducts: normalizedCustomerProducts,
 		startsAtMs,
@@ -102,6 +106,7 @@ export const classifyNextCycleEvent = ({
 			kind: "scheduled_change",
 			smallestInterval,
 			startsAtMs: exactStartsAtMs,
+			resetsBillingCycle: isAnchorReset,
 			incomingCustomerProducts,
 			outgoingCustomerProducts,
 		};
@@ -121,6 +126,7 @@ export const classifyNextCycleEvent = ({
 			kind: "scheduled_change",
 			smallestInterval,
 			startsAtMs: exactStartsAtMs,
+			resetsBillingCycle: isAnchorReset,
 			incomingCustomerProducts,
 			outgoingCustomerProducts,
 		};

--- a/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/classifyNextCycleEvent.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/classifyNextCycleEvent.ts
@@ -117,6 +117,7 @@ export const classifyNextCycleEvent = ({
 			kind: "scheduled_start",
 			smallestInterval,
 			startsAtMs: exactStartsAtMs,
+			resetsBillingCycle: isAnchorReset,
 			customerProducts: incomingCustomerProducts,
 		};
 	}

--- a/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/types.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/types.ts
@@ -1,7 +1,4 @@
-import type {
-	BillingInterval,
-	FullCusProduct,
-} from "@autumn/shared";
+import type { BillingInterval, FullCusProduct } from "@autumn/shared";
 
 export type SmallestInterval = {
 	interval: BillingInterval;
@@ -33,6 +30,7 @@ export type NextCycleEvent =
 	| ({
 			kind: "scheduled_change";
 			startsAtMs: number;
+			resetsBillingCycle: boolean;
 			incomingCustomerProducts: FullCusProduct[];
 			outgoingCustomerProducts: FullCusProduct[];
 	  } & NextCycleEventContext);

--- a/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/types.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/types.ts
@@ -20,6 +20,7 @@ export type NextCycleEvent =
 	| ({
 			kind: "scheduled_start";
 			startsAtMs: number;
+			resetsBillingCycle: boolean;
 			customerProducts: FullCusProduct[];
 	  } & NextCycleEventContext)
 	| ({

--- a/server/tests/integration/billing/create-schedule/preview/create-schedule-phase-anchor-reset-preview.test.ts
+++ b/server/tests/integration/billing/create-schedule/preview/create-schedule-phase-anchor-reset-preview.test.ts
@@ -1,0 +1,77 @@
+// Before: a future phase anchor reset previews a partial cycle from the saved schedule start.
+// After: it previews a full new cycle minus the unused current-plan credit.
+
+import { expect, test } from "bun:test";
+import {
+	type AttachPreviewResponse,
+	applyProration,
+	type CreateScheduleParamsV0Input,
+	ms,
+	truncateMsToSecondPrecision,
+} from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import { addMonths } from "date-fns";
+
+test.concurrent(
+	"create-schedule preview: future plan transition with phase anchor reset starts a full cycle",
+	async () => {
+		const currentPlan = products.pro({
+			id: "phase-anchor-preview-current",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const nextPlan = products.premium({
+			id: "phase-anchor-preview-next",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+		const { customerId, autumnV1, advancedTo } = await initScenario({
+			customerId: "create-schedule-phase-anchor-reset-preview",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [currentPlan, nextPlan] }),
+			],
+			actions: [],
+		});
+
+		const currentPlanEndsAt = truncateMsToSecondPrecision(
+			addMonths(advancedTo, 1).getTime(),
+		);
+		const transitionAt = currentPlanEndsAt - ms.days(2);
+		const phases: CreateScheduleParamsV0Input["phases"] = [
+			{ starts_at: advancedTo, plans: [{ plan_id: currentPlan.id }] },
+			{ starts_at: transitionAt, plans: [{ plan_id: nextPlan.id }] },
+		];
+
+		await autumnV1.billing.createSchedule({
+			customer_id: customerId,
+			billing_behavior: "none",
+			phases,
+		});
+
+		const preview: AttachPreviewResponse = await autumnV1.post(
+			"/billing.preview_create_schedule",
+			{
+				customer_id: customerId,
+				billing_behavior: "none",
+				phases: [
+					phases[0],
+					{ ...phases[1], billing_cycle_anchor: "phase_start" },
+				],
+			},
+		);
+		const unusedCurrentPlan = applyProration({
+			now: transitionAt,
+			billingPeriod: { start: advancedTo, end: currentPlanEndsAt },
+			amount: 20,
+		});
+		const positiveTotal = preview.next_cycle?.line_items
+			.filter((lineItem) => lineItem.total > 0)
+			.reduce((total, lineItem) => total + lineItem.total, 0);
+
+		expect(preview.total).toBe(0);
+		expect(positiveTotal).toBeCloseTo(50, 2);
+		expect(preview.next_cycle?.total).toBeCloseTo(50 - unusedCurrentPlan, 2);
+		expect(preview.next_cycle?.starts_at).toBe(transitionAt);
+	},
+);

--- a/server/tests/integration/billing/update-subscription/cancel/cancel-multiple-paid-products.test.ts
+++ b/server/tests/integration/billing/update-subscription/cancel/cancel-multiple-paid-products.test.ts
@@ -1,0 +1,228 @@
+/** Red: canceling one paid main product creates Basic despite another effective paid main product in scope.
+ * Green: preview and execution omit Basic while leaving the remaining paid product and Stripe subscription unchanged. */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV3, UpdateSubscriptionV1Params } from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import {
+	getEntitySubscriptionId,
+	getSubscriptionId,
+} from "@tests/integration/billing/utils/stripe/getSubscriptionId";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { billingActions } from "@/internal/billing/v2/actions";
+import { ProductService } from "@/internal/products/ProductService";
+
+const cases = [
+	{
+		cancelAction: "cancel_immediately",
+		suffix: "immediate",
+		remainingScope: "same",
+		expectDefault: false,
+	},
+	{
+		cancelAction: "cancel_end_of_cycle",
+		suffix: "end-of-cycle",
+		remainingScope: "same",
+		expectDefault: false,
+	},
+	{
+		cancelAction: "cancel_immediately",
+		suffix: "different-group",
+		remainingScope: "group",
+		expectDefault: true,
+	},
+	{
+		cancelAction: "cancel_end_of_cycle",
+		suffix: "different-group-end-of-cycle",
+		remainingScope: "group",
+		expectDefault: true,
+	},
+	{
+		cancelAction: "cancel_immediately",
+		suffix: "different-entity",
+		remainingScope: "entity",
+		expectDefault: true,
+	},
+] as const;
+
+for (const { cancelAction, suffix, remainingScope, expectDefault } of cases) {
+	test.concurrent(
+		`${chalk.yellowBright(`cancel ${suffix}: default respects paid product scope`)}`,
+		async () => {
+			const customerId = `cancel-multi-paid-${suffix}`;
+			const basic = products.base({
+				id: "basic",
+				isDefault: true,
+				items: [items.monthlyMessages({ includedUsage: 10 })],
+			});
+			const target = products.pro({
+				id: "target",
+				items: [items.monthlyMessages({ includedUsage: 100 })],
+			});
+			const remaining = products.base({
+				id: "remaining",
+				group:
+					remainingScope === "entity" ? undefined : `${customerId}-separate`,
+				items: [
+					items.monthlyUsers({ includedUsage: 10 }),
+					items.monthlyPrice({ price: 30 }),
+				],
+			});
+
+			const { autumnV1, autumnV2_2, ctx, entities } = await initScenario({
+				customerId,
+				setup: [
+					s.customer({ paymentMethod: "success", withDefault: true }),
+					s.products({ list: [basic, target, remaining] }),
+					...(remainingScope === "entity"
+						? [s.entities({ count: 1, featureId: TestFeature.Users })]
+						: []),
+				],
+				actions: [],
+			});
+
+			const customerWithDefault =
+				await autumnV1.customers.get<ApiCustomerV3>(customerId);
+			await expectCustomerProducts({
+				customer: customerWithDefault,
+				active: [basic.id],
+			});
+
+			await autumnV2_2.billing.attach({
+				customer_id: customerId,
+				plan_id: target.id,
+			});
+			await autumnV2_2.billing.attach({
+				customer_id: customerId,
+				plan_id: remaining.id,
+				new_billing_subscription: true,
+				entity_id: remainingScope === "entity" ? entities[0].id : undefined,
+			});
+
+			if (remainingScope === "same") {
+				const [targetProduct, remainingProduct] = await Promise.all([
+					ProductService.getFull({
+						db: ctx.db,
+						idOrInternalId: target.id,
+						orgId: ctx.org.id,
+						env: ctx.env,
+					}),
+					ProductService.getFull({
+						db: ctx.db,
+						idOrInternalId: remaining.id,
+						orgId: ctx.org.id,
+						env: ctx.env,
+					}),
+				]);
+
+				// Simulate the confirmed overlap without reproducing historical creation races.
+				await ProductService.updateByInternalId({
+					db: ctx.db,
+					internalId: remainingProduct.internal_id,
+					update: { group: targetProduct.group },
+				});
+			}
+
+			const targetSubscriptionId = await getSubscriptionId({
+				ctx,
+				customerId,
+				productId: target.id,
+			});
+			const remainingSubscriptionId =
+				remainingScope === "entity"
+					? await getEntitySubscriptionId({
+							ctx,
+							customerId,
+							entityId: entities[0].id,
+							productId: remaining.id,
+						})
+					: await getSubscriptionId({
+							ctx,
+							customerId,
+							productId: remaining.id,
+						});
+			expect(remainingSubscriptionId).not.toBe(targetSubscriptionId);
+			const remainingSubscriptionBefore =
+				await ctx.stripeCli.subscriptions.retrieve(remainingSubscriptionId);
+			const updateParams = {
+				customer_id: customerId,
+				plan_id: target.id,
+				cancel_action: cancelAction,
+			} satisfies UpdateSubscriptionV1Params;
+
+			const { billingPlan: previewPlan } =
+				await billingActions.updateSubscription({
+					ctx,
+					params: updateParams,
+					preview: true,
+				});
+			const previewDefault = previewPlan?.autumn.insertCustomerProducts.find(
+				(customerProduct) => customerProduct.product.id === basic.id,
+			);
+
+			await autumnV2_2.billing.update(updateParams);
+
+			const customerAfterCancel =
+				await autumnV1.customers.get<ApiCustomerV3>(customerId);
+			await expectCustomerProducts({
+				customer: customerAfterCancel,
+				active: [
+					...(remainingScope === "entity" ? [] : [remaining.id]),
+					...(expectDefault && cancelAction === "cancel_immediately"
+						? [basic.id]
+						: []),
+				],
+				canceling:
+					cancelAction === "cancel_end_of_cycle" ? [target.id] : undefined,
+				scheduled:
+					expectDefault && cancelAction === "cancel_end_of_cycle"
+						? [basic.id]
+						: undefined,
+				notPresent:
+					cancelAction === "cancel_immediately"
+						? [target.id, ...(!expectDefault ? [basic.id] : [])]
+						: !expectDefault
+							? [basic.id]
+							: undefined,
+			});
+
+			if (remainingScope === "entity") {
+				const entityAfterCancel = await autumnV1.entities.get(
+					customerId,
+					entities[0].id,
+				);
+				await expectCustomerProducts({
+					customer: entityAfterCancel,
+					active: [remaining.id],
+				});
+			}
+
+			const remainingSubscriptionAfter =
+				await ctx.stripeCli.subscriptions.retrieve(remainingSubscriptionId);
+			expect(remainingSubscriptionAfter.status).toBe(
+				remainingSubscriptionBefore.status,
+			);
+			expect(remainingSubscriptionAfter.cancel_at_period_end).toBe(
+				remainingSubscriptionBefore.cancel_at_period_end,
+			);
+			expect(
+				remainingSubscriptionAfter.items.data.map((item) => ({
+					id: item.id,
+					priceId: item.price.id,
+					quantity: item.quantity,
+				})),
+			).toEqual(
+				remainingSubscriptionBefore.items.data.map((item) => ({
+					id: item.id,
+					priceId: item.price.id,
+					quantity: item.quantity,
+				})),
+			);
+			expect(previewDefault === undefined).toBe(!expectDefault);
+		},
+	);
+}

--- a/server/tests/integration/crud/plans/create-plan-errors.test.ts
+++ b/server/tests/integration/crud/plans/create-plan-errors.test.ts
@@ -77,6 +77,21 @@ const expectRpcError = async ({
 	});
 };
 
+/**
+ * TDD test for unsafe large finite allowances.
+ *
+ * Red-failure mode: a plan with more than 10 trillion included units is accepted.
+ * Green-success criteria: plan creation rejects it and recommends unlimited usage.
+ */
+test.concurrent(`${chalk.yellowBright("included usage: REJECT more than 10 trillion")}`, async () => {
+	await expectRestError({
+		productId: `err_included_usage_${getSuffix()}`,
+		items: [{ feature_id: TestFeature.Messages, included: 10_000_000_000_001 }],
+		errMessage:
+			"Included usage cannot exceed 10 trillion; use unlimited usage instead",
+	});
+});
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // PRICE: amount OR tiers (not neither, not both)
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/server/tests/unit/balances/syncItemV5-dedicated-redis.test.ts
+++ b/server/tests/unit/balances/syncItemV5-dedicated-redis.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, mock, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
+
+const dedicatedRedis = {};
+const sharedRedis = {};
+let claimedRedis: unknown;
+
+mock.module("@/external/redis/orgRedisPool.js", () => ({
+	getOrgRedis: () => dedicatedRedis,
+}));
+
+mock.module(
+	"@/internal/balances/utils/sync/dirtyState/claimSyncDirty.js",
+	() => ({
+		claimSyncDirty: ({ redis }: { redis: unknown }) => {
+			claimedRedis = redis;
+			return null;
+		},
+		clearSyncClaim: () => {},
+	}),
+);
+
+mock.module("@/internal/balances/utils/sync/syncItemV4.js", () => ({
+	syncItemV4: () => {},
+}));
+
+const { syncItemV5 } = await import(
+	"@/internal/balances/utils/sync/syncItemV5.js"
+);
+
+describe("syncItemV5 Redis routing", () => {
+	test("claims dirty state from the org Redis for dedicated writes", async () => {
+		await syncItemV5({
+			ctx: {
+				org: { id: "org_1", redis_config: {} },
+				redisV2: sharedRedis,
+				logger: { debug: () => {} },
+			} as never,
+			payload: {
+				customerId: "customer_1",
+				orgId: "org_1",
+				env: AppEnv.Sandbox,
+				redisInstance: "org",
+				timestamp: 0,
+			},
+		});
+
+		expect(claimedRedis).toBe(dedicatedRedis);
+	});
+});

--- a/server/tests/unit/billing/next-cycle-event-anchor-reset.test.ts
+++ b/server/tests/unit/billing/next-cycle-event-anchor-reset.test.ts
@@ -1,0 +1,53 @@
+// A phase reset must survive classification when it only starts a product.
+// The preview uses this metadata to charge the incoming product from phase start.
+
+import { expect, test } from "bun:test";
+import {
+	type BillingContext,
+	BillingInterval,
+	type FullCusProduct,
+} from "@autumn/shared";
+import { classifyNextCycleEvent } from "@/internal/billing/v2/utils/billingPlan/toNextCyclePreview/getNextCycleEvent/classifyNextCycleEvent";
+
+const customerProduct = ({
+	id,
+	startsAt,
+	resetAt,
+}: {
+	id: string;
+	startsAt: number;
+	resetAt?: number;
+}) =>
+	({
+		id,
+		starts_at: startsAt,
+		ended_at: null,
+		billing_cycle_anchor_resets_at: resetAt ?? null,
+		product: { group: null, is_add_on: false },
+	}) as unknown as FullCusProduct;
+
+test("scheduled start carries its second-normalized phase anchor reset", () => {
+	const startsAtMs = Date.UTC(2026, 6, 20, 10);
+	const stableProduct = customerProduct({ id: "stable", startsAt: 0 });
+	const incomingProduct = customerProduct({
+		id: "incoming",
+		startsAt: startsAtMs,
+		resetAt: startsAtMs + 999,
+	});
+
+	const event = classifyNextCycleEvent({
+		billingContext: {} as BillingContext,
+		customerProducts: [stableProduct, incomingProduct],
+		normalizedCustomerProducts: [stableProduct, incomingProduct],
+		startsAtMs,
+		renewalBoundaryMs: startsAtMs + 86_400_000,
+		smallestInterval: { interval: BillingInterval.Month, intervalCount: 1 },
+	});
+
+	expect(event).toMatchObject({
+		kind: "scheduled_start",
+		startsAtMs,
+		resetsBillingCycle: true,
+		customerProducts: [incomingProduct],
+	});
+});

--- a/server/tinybird/pipes/list_events_cursor.pipe
+++ b/server/tinybird/pipes/list_events_cursor.pipe
@@ -1,6 +1,7 @@
 DESCRIPTION >
     Lists raw events with cursor-based pagination for external API.
-    Supports filtering by customer_id, event_names (array), and optional date range.
+    Customer-scoped queries read the customer-sorted events source; org-wide queries use
+    events_by_timestamp_mv. Supports event_names and optional date-range filtering.
 
 TOKEN "list_events_cursor_read" READ
 
@@ -8,6 +9,8 @@ NODE endpoint
 TYPE endpoint
 SQL >
     %
+    {% set use_customer_source = defined(customer_id) and String(customer_id, '') != '' %}
+
     SELECT
         id,
         org_id,
@@ -16,11 +19,16 @@ SQL >
         event_name,
         timestamp,
         value,
-        properties,
+        toString(properties) as properties,
         idempotency_key,
-        entity_id,
-        deductions
-    FROM events_by_timestamp_mv
+        coalesce(entity_id, '') as entity_id,
+        toString(deductions) as deductions
+    FROM
+        {% if use_customer_source %}
+        events
+        {% else %}
+        events_by_timestamp_mv
+        {% end %}
     WHERE
         org_id = {{ String(org_id, '') }}
         AND env = {{ String(env, 'test') }}
@@ -40,19 +48,19 @@ SQL >
         AND entity_id = {{ String(entity_id) }}
         {% end %}
         {% if defined(filter_key_0) and String(filter_key_0, '') != '' %}
-        AND positionCaseInsensitive(assumeNotNull(properties), concat('"', {{ String(filter_key_0, '') }}, '":"', {{ String(filter_value_0, '') }}, '"')) > 0
+        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_0, '') }}, '":"', {{ String(filter_value_0, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_1) and String(filter_key_1, '') != '' %}
-        AND positionCaseInsensitive(assumeNotNull(properties), concat('"', {{ String(filter_key_1, '') }}, '":"', {{ String(filter_value_1, '') }}, '"')) > 0
+        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_1, '') }}, '":"', {{ String(filter_value_1, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_2) and String(filter_key_2, '') != '' %}
-        AND positionCaseInsensitive(assumeNotNull(properties), concat('"', {{ String(filter_key_2, '') }}, '":"', {{ String(filter_value_2, '') }}, '"')) > 0
+        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_2, '') }}, '":"', {{ String(filter_value_2, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_3) and String(filter_key_3, '') != '' %}
-        AND positionCaseInsensitive(assumeNotNull(properties), concat('"', {{ String(filter_key_3, '') }}, '":"', {{ String(filter_value_3, '') }}, '"')) > 0
+        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_3, '') }}, '":"', {{ String(filter_value_3, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_4) and String(filter_key_4, '') != '' %}
-        AND positionCaseInsensitive(assumeNotNull(properties), concat('"', {{ String(filter_key_4, '') }}, '":"', {{ String(filter_value_4, '') }}, '"')) > 0
+        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_4, '') }}, '":"', {{ String(filter_value_4, '') }}, '"')) > 0
         {% end %}
         {% if defined(cursor_timestamp) and String(cursor_timestamp, '') != '' and defined(cursor_id) and String(cursor_id, '') != '' %}
         AND (timestamp, id) < (toDateTime64({{ String(cursor_timestamp) }}, 6), {{ String(cursor_id) }})

--- a/server/tinybird/pipes/list_events_cursor.pipe
+++ b/server/tinybird/pipes/list_events_cursor.pipe
@@ -11,6 +11,7 @@ SQL >
     %
     {% set use_customer_source = defined(customer_id) and String(customer_id, '') != '' %}
 
+    WITH coalesce(toString(properties), '') AS serialized_properties
     SELECT
         id,
         org_id,
@@ -19,7 +20,7 @@ SQL >
         event_name,
         timestamp,
         value,
-        toString(properties) as properties,
+        serialized_properties as properties,
         idempotency_key,
         coalesce(entity_id, '') as entity_id,
         toString(deductions) as deductions
@@ -48,19 +49,19 @@ SQL >
         AND entity_id = {{ String(entity_id) }}
         {% end %}
         {% if defined(filter_key_0) and String(filter_key_0, '') != '' %}
-        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_0, '') }}, '":"', {{ String(filter_value_0, '') }}, '"')) > 0
+        AND positionCaseInsensitive(serialized_properties, concat('"', {{ String(filter_key_0, '') }}, '":"', {{ String(filter_value_0, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_1) and String(filter_key_1, '') != '' %}
-        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_1, '') }}, '":"', {{ String(filter_value_1, '') }}, '"')) > 0
+        AND positionCaseInsensitive(serialized_properties, concat('"', {{ String(filter_key_1, '') }}, '":"', {{ String(filter_value_1, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_2) and String(filter_key_2, '') != '' %}
-        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_2, '') }}, '":"', {{ String(filter_value_2, '') }}, '"')) > 0
+        AND positionCaseInsensitive(serialized_properties, concat('"', {{ String(filter_key_2, '') }}, '":"', {{ String(filter_value_2, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_3) and String(filter_key_3, '') != '' %}
-        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_3, '') }}, '":"', {{ String(filter_value_3, '') }}, '"')) > 0
+        AND positionCaseInsensitive(serialized_properties, concat('"', {{ String(filter_key_3, '') }}, '":"', {{ String(filter_value_3, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_4) and String(filter_key_4, '') != '' %}
-        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_4, '') }}, '":"', {{ String(filter_value_4, '') }}, '"')) > 0
+        AND positionCaseInsensitive(serialized_properties, concat('"', {{ String(filter_key_4, '') }}, '":"', {{ String(filter_value_4, '') }}, '"')) > 0
         {% end %}
         {% if defined(cursor_timestamp) and String(cursor_timestamp, '') != '' and defined(cursor_id) and String(cursor_id, '') != '' %}
         AND (timestamp, id) < (toDateTime64({{ String(cursor_timestamp) }}, 6), {{ String(cursor_id) }})

--- a/server/tinybird/pipes/list_events_paginated.pipe
+++ b/server/tinybird/pipes/list_events_paginated.pipe
@@ -1,6 +1,7 @@
 DESCRIPTION >
     Lists raw events with offset-based pagination for external API.
-    Supports filtering by customer_id, event_names (array), and optional date range.
+    Customer-scoped queries read the customer-sorted events source; org-wide queries use
+    events_by_timestamp_mv. Supports event_names and optional date-range filtering.
 
 TOKEN "list_events_paginated_read" READ
 
@@ -8,6 +9,8 @@ NODE endpoint
 TYPE endpoint
 SQL >
     %
+    {% set use_customer_source = defined(customer_id) and String(customer_id, '') != '' %}
+
     SELECT
         id,
         org_id,
@@ -16,11 +19,16 @@ SQL >
         event_name,
         timestamp,
         value,
-        properties,
+        toString(properties) as properties,
         idempotency_key,
-        entity_id,
-        deductions
-    FROM events_by_timestamp_mv
+        coalesce(entity_id, '') as entity_id,
+        toString(deductions) as deductions
+    FROM
+        {% if use_customer_source %}
+        events
+        {% else %}
+        events_by_timestamp_mv
+        {% end %}
     WHERE
         org_id = {{ String(org_id, '') }}
         AND env = {{ String(env, 'test') }}
@@ -40,19 +48,19 @@ SQL >
         AND entity_id = {{ String(entity_id) }}
         {% end %}
         {% if defined(filter_key_0) and String(filter_key_0, '') != '' %}
-        AND positionCaseInsensitive(assumeNotNull(properties), concat('"', {{ String(filter_key_0, '') }}, '":"', {{ String(filter_value_0, '') }}, '"')) > 0
+        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_0, '') }}, '":"', {{ String(filter_value_0, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_1) and String(filter_key_1, '') != '' %}
-        AND positionCaseInsensitive(assumeNotNull(properties), concat('"', {{ String(filter_key_1, '') }}, '":"', {{ String(filter_value_1, '') }}, '"')) > 0
+        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_1, '') }}, '":"', {{ String(filter_value_1, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_2) and String(filter_key_2, '') != '' %}
-        AND positionCaseInsensitive(assumeNotNull(properties), concat('"', {{ String(filter_key_2, '') }}, '":"', {{ String(filter_value_2, '') }}, '"')) > 0
+        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_2, '') }}, '":"', {{ String(filter_value_2, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_3) and String(filter_key_3, '') != '' %}
-        AND positionCaseInsensitive(assumeNotNull(properties), concat('"', {{ String(filter_key_3, '') }}, '":"', {{ String(filter_value_3, '') }}, '"')) > 0
+        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_3, '') }}, '":"', {{ String(filter_value_3, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_4) and String(filter_key_4, '') != '' %}
-        AND positionCaseInsensitive(assumeNotNull(properties), concat('"', {{ String(filter_key_4, '') }}, '":"', {{ String(filter_value_4, '') }}, '"')) > 0
+        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_4, '') }}, '":"', {{ String(filter_value_4, '') }}, '"')) > 0
         {% end %}
     ORDER BY timestamp DESC, id DESC
     LIMIT {{ Int32(limit, 101) }}

--- a/server/tinybird/pipes/list_events_paginated.pipe
+++ b/server/tinybird/pipes/list_events_paginated.pipe
@@ -11,6 +11,7 @@ SQL >
     %
     {% set use_customer_source = defined(customer_id) and String(customer_id, '') != '' %}
 
+    WITH coalesce(toString(properties), '') AS serialized_properties
     SELECT
         id,
         org_id,
@@ -19,7 +20,7 @@ SQL >
         event_name,
         timestamp,
         value,
-        toString(properties) as properties,
+        serialized_properties as properties,
         idempotency_key,
         coalesce(entity_id, '') as entity_id,
         toString(deductions) as deductions
@@ -48,19 +49,19 @@ SQL >
         AND entity_id = {{ String(entity_id) }}
         {% end %}
         {% if defined(filter_key_0) and String(filter_key_0, '') != '' %}
-        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_0, '') }}, '":"', {{ String(filter_value_0, '') }}, '"')) > 0
+        AND positionCaseInsensitive(serialized_properties, concat('"', {{ String(filter_key_0, '') }}, '":"', {{ String(filter_value_0, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_1) and String(filter_key_1, '') != '' %}
-        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_1, '') }}, '":"', {{ String(filter_value_1, '') }}, '"')) > 0
+        AND positionCaseInsensitive(serialized_properties, concat('"', {{ String(filter_key_1, '') }}, '":"', {{ String(filter_value_1, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_2) and String(filter_key_2, '') != '' %}
-        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_2, '') }}, '":"', {{ String(filter_value_2, '') }}, '"')) > 0
+        AND positionCaseInsensitive(serialized_properties, concat('"', {{ String(filter_key_2, '') }}, '":"', {{ String(filter_value_2, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_3) and String(filter_key_3, '') != '' %}
-        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_3, '') }}, '":"', {{ String(filter_value_3, '') }}, '"')) > 0
+        AND positionCaseInsensitive(serialized_properties, concat('"', {{ String(filter_key_3, '') }}, '":"', {{ String(filter_value_3, '') }}, '"')) > 0
         {% end %}
         {% if defined(filter_key_4) and String(filter_key_4, '') != '' %}
-        AND positionCaseInsensitive(coalesce(toString(properties), ''), concat('"', {{ String(filter_key_4, '') }}, '":"', {{ String(filter_value_4, '') }}, '"')) > 0
+        AND positionCaseInsensitive(serialized_properties, concat('"', {{ String(filter_key_4, '') }}, '":"', {{ String(filter_value_4, '') }}, '"')) > 0
         {% end %}
     ORDER BY timestamp DESC, id DESC
     LIMIT {{ Int32(limit, 101) }}

--- a/shared/api/products/items/crud/createPlanItemParamsV1.ts
+++ b/shared/api/products/items/crud/createPlanItemParamsV1.ts
@@ -15,12 +15,17 @@ import {
 } from "@models/productV2Models/productItemModels/productItemEnums";
 import { z } from "zod/v4";
 
+export const IncludedUsageParamsSchema = z.number().max(10_000_000_000_000, {
+	error:
+		"Included usage cannot exceed 10 trillion; use unlimited usage instead",
+});
+
 export const CreatePlanItemParamsV1Schema = z
 	.object({
 		feature_id: z.string().meta({
 			description: "The ID of the feature to configure.",
 		}),
-		included: z.number().optional().meta({
+		included: IncludedUsageParamsSchema.optional().meta({
 			description:
 				"Number of free units included. Balance resets to this each interval for consumable features.",
 		}),

--- a/shared/api/products/productOpModels.ts
+++ b/shared/api/products/productOpModels.ts
@@ -1,15 +1,19 @@
 import { CustomerBillingControlsParamsSchema } from "@models/cusModels/billingControls/customerBillingControls.js";
 import { CreateFreeTrialSchema } from "@models/productModels/freeTrialModels/freeTrialModels.js";
 import { ProductConfigParamsSchema } from "@models/productModels/productConfig/productConfig.js";
+import { Infinite } from "@models/productModels/productEnums.js";
 import { ProductMetadataSchema } from "@models/productModels/productMetadata.js";
 import { ProductItemSchema } from "@models/productV2Models/productItemModels/productItemModels.js";
 import { idRegex } from "@utils/utils.js";
 import { z } from "zod/v4";
 import { AppEnv } from "../../models/genModels/genEnums.js";
 import { PlanLicenseParamsSchema } from "./crud/licenses/planLicenseParams.js";
+import { IncludedUsageParamsSchema } from "./items/crud/createPlanItemParamsV1.js";
 
 // Use the full ProductItemSchema but mark backend fields as internal
-export const CreateProductItemParamsSchema = ProductItemSchema;
+export const CreateProductItemParamsSchema = ProductItemSchema.extend({
+	included_usage: IncludedUsageParamsSchema.or(z.literal(Infinite)).nullish(),
+});
 
 // Base product params
 

--- a/vite/src/views/products/plan/components/edit-plan-details/PlanTypeSection.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-details/PlanTypeSection.tsx
@@ -8,6 +8,7 @@ import { CoinsIcon } from "@phosphor-icons/react";
 import { IncludedUsageIcon } from "@/components/v2/icons/AutumnIcons";
 import { useProduct } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 import { SheetSection } from "@/components/v2/sheets/InlineSheet";
+import { selectPaidPlanType } from "@/views/products/plan/utils/selectPaidPlanType";
 
 export const PlanTypeSection = () => {
 	const { product, setProduct } = useProduct();
@@ -48,17 +49,7 @@ export const PlanTypeSection = () => {
 					<div className="flex w-full items-center gap-4">
 						<PanelButton
 							isSelected={planType === "paid"}
-							onClick={async () => {
-								setProduct({
-									...product,
-									planType: "paid",
-									basePriceType: "usage",
-									is_default: false,
-									items: product.items.filter(
-										(item: ProductItem) => !isPriceItem(item),
-									),
-								});
-							}}
+							onClick={() => setProduct(selectPaidPlanType({ product }))}
 							icon={<CoinsIcon size={16} color="currentColor" />}
 						/>
 						<div className="flex-1">

--- a/vite/src/views/products/plan/utils/selectPaidPlanType.ts
+++ b/vite/src/views/products/plan/utils/selectPaidPlanType.ts
@@ -1,0 +1,20 @@
+import {
+	type FrontendProduct,
+	isPriceItem,
+	productV2ToPlanType,
+} from "@autumn/shared";
+
+export const selectPaidPlanType = ({
+	product,
+}: {
+	product: FrontendProduct;
+}): FrontendProduct =>
+	productV2ToPlanType({ product }) === "paid"
+		? product
+		: {
+				...product,
+				planType: "paid",
+				basePriceType: "usage",
+				is_default: false,
+				items: product.items.filter((item) => !isPriceItem(item)),
+			};

--- a/vite/tests/views/products/plan/plan-type-section.test.ts
+++ b/vite/tests/views/products/plan/plan-type-section.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import type { FrontendProduct, ProductItem } from "@autumn/shared";
+import { buildUpdateSubscriptionCustomizationParams } from "@/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody";
+import { selectPaidPlanType } from "@/views/products/plan/utils/selectPaidPlanType";
+
+describe("paid plan type selection", () => {
+	test("preserves the existing base price and feature items", () => {
+		const items = [
+			{ price: 3_000, interval: "year", interval_count: 1 },
+			{ feature_id: "AI_CREDITS", included_usage: 10_000 },
+		] as ProductItem[];
+		const product = {
+			id: "pro_yearly",
+			name: "Pro Yearly",
+			planType: "paid",
+			basePriceType: "recurring",
+			items,
+		} as FrontendProduct;
+
+		const selectedProduct = selectPaidPlanType({ product });
+		const request = buildUpdateSubscriptionCustomizationParams({
+			items: selectedProduct.items,
+			addLicenses: null,
+		});
+
+		expect(request.items).toEqual(items);
+	});
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes key billing edge cases (phase anchor resets, default product on cancel), routes balance sync dirty-state to dedicated org Redis, and speeds up customer event listings. Also caps included usage at 10T, preserves paid base price in the dashboard, and requires explicit opt-in for staging deploys.

- **Bug Fixes**
  - Billing: carry phase anchor resets through next-cycle classification and previews so scheduled starts begin a full cycle and unused-time credits apply; stop inserting the default plan when another effective paid main product is in scope. Added unit and integration tests.
  - Balances: route dirty-state claims to the org’s dedicated Redis via an `org` routing target.
  - Dashboard: reselecting a paid plan now keeps the existing base price and feature items.
  - API validation: cap finite included usage at 10 trillion units; advise unlimited usage beyond that.

- **Performance**
  - Analytics: for customer-scoped listings, query the customer-sorted `events` source; keep org-wide on `events_by_timestamp_mv`. Reuse serialized properties to reduce processing.

<sup>Written for commit a18bc6dd8fa04bb41619218179a316893a811d8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

