### PR TITLE
fix(logging): preserve application log type in FireLens

### DIFF
--- a/firelens.conf
+++ b/firelens.conf
@@ -8,25 +8,25 @@
     Name modify
     Match *
     Condition Key_value_matches container_name .*-server-.*
-    Add type server
+    Add source_type server
 
 [FILTER]
     Name modify
     Match *
     Condition Key_value_matches container_name .*-workers-.*
-    Add type workers
+    Add source_type workers
 
 [FILTER]
     Name modify
     Match *
     Condition Key_value_matches container_name .*-cron-.*
-    Add type cron
+    Add source_type cron
 
 [FILTER]
     Name modify
     Match *
     Condition Key_value_matches container_name .*-leaf-.*
-    Add type leaf
+    Add source_type leaf
 
 [FILTER]
     Name modify

--- a/server/tests/unit/logging/firelens-config.test.ts
+++ b/server/tests/unit/logging/firelens-config.test.ts
@@ -34,13 +34,27 @@ test.concurrent(
 		expect(config.indexOf("mode partial_message")).toBeLessThan(
 			config.indexOf("Parser json"),
 		);
-		expect(config).not.toMatch(
-			/mode partial_message[\s\S]*?multiline\.parser/,
-		);
+		expect(config).not.toMatch(/mode partial_message[\s\S]*?multiline\.parser/);
 
 		expect(config).toContain("URI /v1/ingest/express");
 		expect(config).toContain("URI /v1/ingest/ecs");
 		expect(config.match(/retry_limit 5/g)).toHaveLength(2);
 		expect(config).not.toMatch(/\[OUTPUT\]\s+Name http\s+Match \*(?:\s|$)/);
+	},
+);
+
+test.concurrent(
+	"FireLens preserves Pino type while adding source metadata",
+	async () => {
+		const configPath = path.resolve(
+			import.meta.dir,
+			"../../../../firelens.conf",
+		);
+		const config = await Bun.file(configPath).text();
+
+		for (const sourceType of ["server", "workers", "cron", "leaf"]) {
+			expect(config).toContain(`Add source_type ${sourceType}`);
+		}
+		expect(config).not.toMatch(/^\s*Add type (?:server|workers|cron|leaf)$/m);
 	},
 );


### PR DESCRIPTION
## Summary

- rename FireLens container metadata from `type` to `source_type`
- preserve application-defined Pino `type` values such as `redis_slow_command` and `memory_log`
- add a configuration contract test covering all server, workers, cron, and leaf filters

## Root cause

The service metadata filters run before the JSON parser and injected `type=server|workers|cron|leaf`. That field won the collision with the application's parsed `type`, breaking type-based Axiom queries.

## Impact

Structured logs retain their application event type in `type`, while container identity remains available under `source_type`.

## Validation

- `bun test tests/unit/logging/firelens-config.test.ts` — 2 passed
- `bun ts` — passed
- `bunx biome check server/tests/unit/logging/firelens-config.test.ts` — passed
- `git diff --check` — passed
- commit hook: Knip and `@autumn/server` typecheck passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches FireLens container metadata from `type` to `source_type` so it no longer overwrites the application’s `pino` log `type`. Preserves app event types (e.g., `redis_slow_command`, `memory_log`) and adds a config test to verify `source_type` for server, workers, cron, and leaf.

<sup>Written for commit abc116e26fedd6d2f2da6b4d6dfb7a6cb6dc7329. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

