### PR TITLE
perf(server): fix two list queries that scanned whole tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,6 @@ tmp/
 .neon
 scripts/ops/.duckdb_export.sql
 scripts/ops/.backfill_neon_done
+
+# Experiment outputs (plans, benchmark JSON) — regenerated on demand
+server/experiments/*/out/

--- a/server/experiments/listObjects/README.md
+++ b/server/experiments/listObjects/README.md
@@ -1,0 +1,42 @@
+# listObjects — regression gates for the list queries
+
+Two read-only scripts that verify the changes in this PR against production data.
+They exist because both touch shared query paths and the integration suite can't
+currently run (every test fails with `password authentication failed for user
+'neondb_owner'`, reproducible on a clean tree).
+
+Both build queries directly rather than calling `CusBatchService.getPage()` or
+`getFullSubject()`, which would fire lazy resets, migration checks and
+batch-reset enqueues.
+
+```sh
+infisical run --env=prod --recursive -- bun run server/experiments/listObjects/<script>.ts
+```
+
+| script | what it gates |
+|---|---|
+| `verifyCustomerCrawl.ts` | `customers.list` — walks N pages with OFFSET and with the keyset memo, asserting the same customers in the same order, plus the Redis memo round-trip and filter-key isolation |
+| `verifyPlanFilterCount.ts` | `countFilteredEntitiesByOrgIdAndEnv` across filter combinations |
+
+Env: `ORG_ID`, `ENV`, `LIMIT`, `PAGES`, `OFFSET`, `SEARCH`, `PLAN`, `CUSTOMER_ID`.
+`out/` is gitignored.
+
+## Two traps these encode
+
+**Compare on a snapshot.** Busy orgs mutate continuously, and under
+`ORDER BY created_at DESC` new rows sort first and shift every offset. A crawl
+taking 35s will diff against itself for no reason. Both sides run inside one
+`repeatable read, read only` transaction.
+
+**Compare on `internal_id`, not `id`.** `customers.id` is nullable (375 rows in
+prod). Collapsing nulls into a `Set` reports them as duplicates and can hide a
+real skip behind that number.
+
+## Worth knowing when picking this up
+
+`customers.list` on API 2.2.0 is the only path that writes memos; 2.3.0 orgs go
+through `getCursorPage` and never touch it. The keyset predicate excludes rows
+with a null `id`, but only when a page boundary lands inside their exact
+`created_at` tie group — same semantics as the existing 2.3.0 cursor path. A
+full crawl of `athenahq` (the org with the most null ids, 47) returns all 4,876
+customers with no skips.

--- a/server/experiments/listObjects/verifyCustomerCrawl.ts
+++ b/server/experiments/listObjects/verifyCustomerCrawl.ts
@@ -1,0 +1,215 @@
+import { AppEnv, RELEVANT_STATUSES } from "@autumn/shared";
+import { initDrizzle } from "../../src/db/initDrizzle.js";
+import { createDualLogger } from "../../src/external/logtail/logtailUtils.js";
+import type { RequestContext } from "../../src/honoUtils/HonoEnv.js";
+import { getPaginatedFullCusQuery } from "../../src/internal/customers/getFullCusQuery.js";
+import {
+	getMemoizedOffsetCursor,
+	setMemoizedOffsetCursor,
+} from "../../src/internal/customers/offsetCursorMemo.js";
+import { createWorkerContext } from "../../src/queue/createWorkerContext.js";
+
+/**
+ * Walks N consecutive pages twice — once purely with OFFSET, once the way the
+ * memo does it — and compares the full id sequence. This is the check that
+ * matters: a crawl must return every customer exactly once, in the same order.
+ *
+ * Query-level on purpose: going through CusBatchService.getPage would fire
+ * triggerBatchResetCustomerEntitlements and enqueue SQS jobs against prod.
+ *
+ * Run with:
+ *   infisical run --env=prod --recursive -- bun run server/experiments/listObjects/verifyCustomerCrawl.ts
+ */
+const ORG_ID = process.env.ORG_ID || "biu9vSF7vghBLSKW1UTDwxHBAivjnPaK";
+const ENV = (process.env.ENV as AppEnv) || AppEnv.Live;
+const LIMIT = Number(process.env.LIMIT || 250);
+const PAGES = Number(process.env.PAGES || 8);
+const START_OFFSET = Number(process.env.OFFSET || 1_600_000);
+
+// Filters change customerListFilterSql, which now sits directly above the
+// pagination clause — worth crawling with them on.
+const SEARCH = process.env.SEARCH || undefined;
+const PLAN = process.env.PLAN || undefined;
+
+type QueryArgs = Parameters<typeof getPaginatedFullCusQuery>[0];
+
+const baseArgs: Omit<QueryArgs, "limit" | "offset" | "cursor"> = {
+	orgId: ORG_ID,
+	env: ENV,
+	inStatuses: RELEVANT_STATUSES,
+	includeInvoices: false,
+	withEntities: false,
+	withTrialsUsed: false,
+	withSubs: true,
+	cusProductLimit: 10,
+	search: SEARCH,
+	plans: PLAN ? [{ id: PLAN }] : undefined,
+};
+
+// Compare on internal_id: `id` is nullable, and collapsing nulls in a Set would
+// hide real skips behind fake duplicates.
+type Row = { id: string | null; internal_id: string; created_at: number };
+
+const main = async () => {
+	const { db } = initDrizzle({ maxConnections: 2 });
+
+	// Both crawls must read ONE snapshot. firecrawl inserts continuously, and new
+	// rows sort first under created_at DESC, so every offset shifts underneath a
+	// crawl that takes 35s — which reads as a diff when nothing is wrong. That
+	// drift is precisely what keyset removes, so measuring it as a failure would
+	// be measuring the bug we're fixing.
+	await db.transaction(
+		async (tx) => {
+			await runCrawls({
+				fetchPage: async ({ offset, cursor }) =>
+					(await tx.execute(
+						getPaginatedFullCusQuery({
+							...baseArgs,
+							limit: LIMIT,
+							offset,
+							cursor,
+						}),
+					)) as unknown as Row[],
+			});
+		},
+		{ isolationLevel: "repeatable read", accessMode: "read only" },
+	);
+
+	await runRedisProbe({ db });
+	process.exit(exitCode);
+};
+
+let exitCode = 0;
+
+const runCrawls = async ({
+	fetchPage,
+}: {
+	fetchPage: (args: {
+		offset: number;
+		cursor?: { t: number; id: string };
+	}) => Promise<Row[]>;
+}) => {
+
+	// -- Crawl A: pure OFFSET, exactly what prod does today --
+	const offsetIds: string[] = [];
+	const offsetPageMs: number[] = [];
+	for (let page = 0; page < PAGES; page++) {
+		const startedAt = performance.now();
+		const rows = await fetchPage({ offset: START_OFFSET + page * LIMIT });
+		offsetPageMs.push(performance.now() - startedAt);
+		offsetIds.push(...rows.map((row) => row.internal_id));
+	}
+	const offsetMs = offsetPageMs.reduce((sum, ms) => sum + ms, 0);
+
+	// -- Crawl B: memo path. Page 1 always misses (nothing memoized yet) and
+	// pays full OFFSET; every page after it seeks. --
+	const memoIds: string[] = [];
+	const memoPageMs: number[] = [];
+	let cursor: { t: number; id: string } | undefined;
+	for (let page = 0; page < PAGES; page++) {
+		const startedAt = performance.now();
+		const rows = await fetchPage({
+			offset: START_OFFSET + page * LIMIT,
+			cursor,
+		});
+		memoPageMs.push(performance.now() - startedAt);
+		memoIds.push(...rows.map((row) => row.internal_id));
+		const last = rows[rows.length - 1];
+		cursor = last?.id ? { t: Number(last.created_at), id: last.id } : undefined;
+	}
+	const memoMs = memoPageMs.reduce((sum, ms) => sum + ms, 0);
+
+	const mean = ({ values }: { values: number[] }) =>
+		values.reduce((sum, value) => sum + value, 0) / (values.length || 1);
+
+	const describe = ({ label, ids }: { label: string; ids: string[] }) => {
+		const unique = new Set(ids);
+		console.log(
+			`${label.padEnd(18)} rows=${String(ids.length).padStart(5)}  unique=${String(unique.size).padStart(5)}  dupes=${ids.length - unique.size}`,
+		);
+		return unique;
+	};
+
+	console.log(
+		`\ncrawl of ${PAGES} pages x ${LIMIT} from offset ${START_OFFSET}\n`,
+	);
+	const offsetUnique = describe({ label: "OFFSET crawl", ids: offsetIds });
+	const memoUnique = describe({ label: "memo crawl", ids: memoIds });
+
+	const sameOrder =
+		offsetIds.length === memoIds.length &&
+		offsetIds.every((id, index) => id === memoIds[index]);
+	const missing = [...offsetUnique].filter((id) => !memoUnique.has(id));
+	const extra = [...memoUnique].filter((id) => !offsetUnique.has(id));
+
+	console.log(
+		`\nsame order:      ${sameOrder ? "YES" : "NO"}\nmissing in memo: ${missing.length}\nextra in memo:   ${extra.length}`,
+	);
+	if (missing.length) console.log(`  missing sample: ${missing.slice(0, 5)}`);
+	if (extra.length) console.log(`  extra sample:   ${extra.slice(0, 5)}`);
+
+	console.log(
+		`\ntotal: OFFSET ${(offsetMs / 1000).toFixed(2)}s -> memo ${(memoMs / 1000).toFixed(2)}s  (${(offsetMs / memoMs).toFixed(1)}x)`,
+	);
+	console.log(
+		`per page (ms): OFFSET  ${offsetPageMs.map((ms) => ms.toFixed(0).padStart(5)).join(" ")}`,
+	);
+	console.log(
+		`per page (ms): memo    ${memoPageMs.map((ms) => ms.toFixed(0).padStart(5)).join(" ")}   <- page 1 is a miss by design`,
+	);
+
+	// Steady state is what a crawl actually pays: page 1 misses once, then every
+	// subsequent page seeks.
+	const offsetSteady = mean({ values: offsetPageMs.slice(1) });
+	const memoSteady = mean({ values: memoPageMs.slice(1) });
+	console.log(
+		`steady-state page: OFFSET ${offsetSteady.toFixed(0)}ms -> memo ${memoSteady.toFixed(0)}ms  (${(offsetSteady / memoSteady).toFixed(1)}x)`,
+	);
+
+	const pass = sameOrder && missing.length === 0 && extra.length === 0;
+	console.log(`\n${pass ? "PASS" : "FAIL — DO NOT SHIP"}`);
+	exitCode = pass ? 0 : 1;
+};
+
+/** Redis wiring the query-level crawl can't cover. */
+const runRedisProbe = async ({
+	db,
+}: {
+	db: ReturnType<typeof initDrizzle>["db"];
+}) => {
+	const ctx = (await createWorkerContext({
+		db,
+		payload: { orgId: ORG_ID, env: ENV },
+		logger: createDualLogger(),
+		skipCache: true,
+	})) as RequestContext | undefined;
+
+	if (ctx) {
+		const probeOffset = 987_654;
+		const stored = { t: 1_700_000_000_000, id: "crawl-probe" };
+		await setMemoizedOffsetCursor({
+			ctx,
+			query: { search: "crawl-probe" },
+			nextOffset: probeOffset,
+			lastRow: stored,
+		});
+		const readBack = await getMemoizedOffsetCursor({
+			ctx,
+			query: { search: "crawl-probe" },
+			offset: probeOffset,
+		});
+		const differentFilter = await getMemoizedOffsetCursor({
+			ctx,
+			query: { search: "a-different-filter" },
+			offset: probeOffset,
+		});
+		console.log(
+			`\nredis round-trip: ${readBack?.id === stored.id && readBack?.t === stored.t ? "OK" : `FAILED (${JSON.stringify(readBack)})`}`,
+		);
+		console.log(
+			`filter isolation: ${differentFilter === null ? "OK (different filter misses)" : "FAILED — key collision"}`,
+		);
+	}
+};
+
+await main();

--- a/server/experiments/listObjects/verifyPlanFilterCount.ts
+++ b/server/experiments/listObjects/verifyPlanFilterCount.ts
@@ -1,0 +1,72 @@
+import { AppEnv, type CusProductStatus } from "@autumn/shared";
+import { initDrizzle } from "../../src/db/initDrizzle.js";
+import { createDualLogger } from "../../src/external/logtail/logtailUtils.js";
+import type { AutumnContext } from "../../src/honoUtils/HonoEnv.js";
+import { RELEVANT_STATUSES } from "../../src/internal/customers/cusProducts/CusProductService.js";
+import { countFilteredEntitiesByOrgIdAndEnv } from "../../src/internal/entities/repos/listEntitiesQuery.js";
+import { createWorkerContext } from "../../src/queue/createWorkerContext.js";
+
+/**
+ * Exercises the real countFilteredEntitiesByOrgIdAndEnv across filter
+ * combinations, so the plan-first rewrite is validated through the actual code
+ * path (including the plan + other-filter combinations, which take different
+ * branches).
+ *
+ * Run with:
+ *   infisical run --env=prod --recursive -- bun run server/experiments/listObjects/verifyPlanFilterCount.ts
+ */
+const ORG_ID = process.env.ORG_ID || "GG6tnmO7cHb40PNhwYBTZtxQdeL74NHF";
+const ENV = (process.env.ENV as AppEnv) || AppEnv.Live;
+const PLAN_ID = process.env.PLAN_ID || "enterprise";
+const CUSTOMER_ID = process.env.CUSTOMER_ID || "698fb72e4c5fa12c1cd11ddc";
+
+const inStatuses = RELEVANT_STATUSES as CusProductStatus[];
+
+const CASES: { label: string; query: Record<string, unknown> }[] = [
+	{ label: "plans only", query: { plans: [{ id: PLAN_ID, versions: null }] } },
+	{ label: "no filters", query: {} },
+	{ label: "search only", query: { search: "a" } },
+	{
+		label: "plans + search",
+		query: { plans: [{ id: PLAN_ID, versions: null }], search: "a" },
+	},
+	{
+		label: "plans + customerId",
+		query: { plans: [{ id: PLAN_ID, versions: null }], customerId: CUSTOMER_ID },
+	},
+	{
+		label: "plans + processors",
+		query: { plans: [{ id: PLAN_ID, versions: null }], processors: ["stripe"] },
+	},
+];
+
+const main = async () => {
+	const { db } = initDrizzle({ maxConnections: 2 });
+	const ctx = await createWorkerContext({
+		db,
+		payload: { orgId: ORG_ID, env: ENV },
+		logger: createDualLogger(),
+		skipCache: true,
+	});
+	if (!ctx) throw new Error(`Could not build ctx for org ${ORG_ID}`);
+
+	console.log(`=== countFilteredEntitiesByOrgIdAndEnv (plan=${PLAN_ID}) ===\n`);
+
+	for (const { label, query } of CASES) {
+		const startedAt = performance.now();
+		const count = await countFilteredEntitiesByOrgIdAndEnv({
+			ctx: ctx as AutumnContext,
+			// biome-ignore lint/suspicious/noExplicitAny: exercising varied filter shapes
+			query: query as any,
+			inStatuses,
+		});
+		const ms = performance.now() - startedAt;
+		console.log(
+			`${label.padEnd(20)} count=${String(count).padStart(7)}  ${ms.toFixed(0).padStart(7)}ms`,
+		);
+	}
+
+	process.exit(0);
+};
+
+await main();

--- a/server/src/internal/customers/CusBatchService.ts
+++ b/server/src/internal/customers/CusBatchService.ts
@@ -21,6 +21,10 @@ import {
 import { triggerBatchResetCustomerEntitlements } from "./actions/resetCustomerEntitlements/triggerBatchResetCustomerEntitlements.js";
 import { CusSearchService } from "./CusSearchService.js";
 import { getCursorPaginatedFullCusQuery } from "./cursorPaginatedFullCusQuery.js";
+import {
+	getMemoizedOffsetCursor,
+	setMemoizedOffsetCursor,
+} from "./offsetCursorMemo.js";
 import type { CustomerListFilters } from "./customerListFilters.js";
 import { getApiCustomerBase } from "./cusUtils/apiCusUtils/getApiCustomerBase.js";
 import {
@@ -99,6 +103,13 @@ export class CusBatchService {
 			orgId: ctx.org.id,
 			orgSlug: ctx.org.slug,
 		});
+
+		const memoizedCursor = await getMemoizedOffsetCursor({
+			ctx,
+			query,
+			offset,
+		});
+
 		const sqlQuery = getPaginatedFullCusQuery({
 			orgId: ctx.org.id,
 			env: ctx.env,
@@ -111,6 +122,7 @@ export class CusBatchService {
 			withSubs: true,
 			limit,
 			offset,
+			cursor: memoizedCursor ?? undefined,
 			search,
 			plans,
 			processors,
@@ -160,8 +172,22 @@ export class CusBatchService {
 			rows: results.length,
 		};
 		ctx.logger.info(
-			`[CusBatchService.getPage] limit=${limit} offset=${offset} rows=${results.length} sql=${timings.sqlMs.toFixed(0)}ms hydrate=${timings.hydrateMs.toFixed(0)}ms total=${timings.totalMs.toFixed(0)}ms`,
+			`[CusBatchService.getPage] limit=${limit} offset=${offset} memo=${memoizedCursor ? "hit" : "miss"} rows=${results.length} sql=${timings.sqlMs.toFixed(0)}ms hydrate=${timings.hydrateMs.toFixed(0)}ms total=${timings.totalMs.toFixed(0)}ms`,
 		);
+
+		// Record where this page ended so the next sequential offset can seek.
+		// Fire-and-forget: a failed write only costs the next page a memo miss.
+		const lastRow = results[results.length - 1] as
+			| { created_at?: number; id?: string }
+			| undefined;
+		if (lastRow?.created_at != null && typeof lastRow.id === "string") {
+			void setMemoizedOffsetCursor({
+				ctx,
+				query,
+				nextOffset: offset + results.length,
+				lastRow: { t: Number(lastRow.created_at), id: lastRow.id },
+			});
+		}
 
 		// Fire-and-forget: queue SQS job for any stale entitlement resets
 		triggerBatchResetCustomerEntitlements({

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -698,6 +698,7 @@ export const getPaginatedFullCusQuery = ({
 	withSubs,
 	limit = 10,
 	offset = 0,
+	cursor,
 	withEvents = false,
 	entityId: _entityId,
 	internalCustomerIds,
@@ -715,6 +716,9 @@ export const getPaginatedFullCusQuery = ({
 	withSubs: boolean;
 	limit: number;
 	offset: number;
+	/** Seek straight to this position instead of counting past `offset` rows.
+	 *  Same page, but O(limit) rather than O(offset). */
+	cursor?: { t: number; id: string };
 	withEvents?: boolean;
 	entityId?: string;
 	internalCustomerIds?: string[];
@@ -796,6 +800,17 @@ export const getPaginatedFullCusQuery = ({
 		GROUP BY cr.internal_id
 	)`;
 
+	// `c.id DESC` is a tiebreaker, not cosmetic: created_at is far from unique
+	// (818,922 distinct values across firecrawl's 1.6M customers, groups up to
+	// 72), so without it the ordering isn't total and offset pages silently skip
+	// and duplicate rows across a crawl. It also matches idx_customers_cursor.
+	const paginationSql = cursor
+		? sql`AND (c.created_at, c.id) < (${cursor.t}, ${cursor.id})
+      ORDER BY c.created_at DESC, c.id DESC
+      LIMIT ${limit}`
+		: sql`ORDER BY c.created_at DESC, c.id DESC
+      LIMIT ${limit} OFFSET ${offset}`;
+
 	return sql`
     WITH customer_records AS (
       SELECT c.*
@@ -803,8 +818,7 @@ export const getPaginatedFullCusQuery = ({
       WHERE c.org_id = ${orgId}
         AND c.env = ${env}
 	      ${customerListFilterSql}
-      ORDER BY c.created_at DESC
-      LIMIT ${limit} OFFSET ${offset}
+      ${paginationSql}
     ),
     
     customer_products_with_prices AS (
@@ -1002,7 +1016,7 @@ export const getPaginatedFullCusQuery = ({
     ${withEvents ? sql`LEFT JOIN customer_events cev ON cev.internal_customer_id = cr.internal_id` : sql``}
     LEFT JOIN extra_customer_entitlements ece ON ece.internal_customer_id = cr.internal_id
 	LEFT JOIN pooled_customer_entitlements pce ON pce.internal_customer_id = cr.internal_id
-    ORDER BY cr.created_at DESC
+    ORDER BY cr.created_at DESC, cr.id DESC
   `;
 };
 

--- a/server/src/internal/customers/offsetCursorMemo.ts
+++ b/server/src/internal/customers/offsetCursorMemo.ts
@@ -1,0 +1,117 @@
+import { createHash } from "node:crypto";
+import type { ListCustomersV2Params } from "@autumn/shared";
+import { getPrimaryRedis } from "@/external/redis/initUtils/redisClientRegistry.js";
+import { tryRedisOp } from "@/external/redis/utils/runRedisOp.js";
+import type { RequestContext } from "@/honoUtils/HonoEnv.js";
+
+/**
+ * OFFSET pagination costs O(offset): a request for offset 1.6M scans and
+ * discards 1.6M rows before returning 250. Clients on API 2.2.0 have no cursor
+ * to send, so we remember the position each page ended at and translate their
+ * next offset into a keyset seek.
+ *
+ * Only helps sequential crawls, which is the pattern that hurts. A random-access
+ * offset simply misses and takes the old path.
+ */
+export type OffsetCursor = { t: number; id: string };
+
+/** Long enough to carry a crawl, short enough to bound how stale a position gets. */
+const MEMO_TTL_SECONDS = 15 * 60;
+
+/**
+ * The position of "offset N" is only meaningful for one filter combination, so
+ * every filter that changes the result set must be in the key. A collision here
+ * serves one client another's page, which no error would surface — hence the
+ * explicit field list rather than hashing the whole params object.
+ */
+const getFilterFingerprint = ({
+	query,
+}: {
+	query: Pick<
+		ListCustomersV2Params,
+		"plans" | "processors" | "search" | "subscription_status"
+	>;
+}) => {
+	const normalized = JSON.stringify({
+		plans: (query.plans ?? [])
+			.map((plan) => `${plan.id}:${(plan.versions ?? []).join(",")}`)
+			.sort(),
+		processors: [...(query.processors ?? [])].sort(),
+		search: query.search?.trim() ?? "",
+		subscriptionStatus: query.subscription_status ?? "",
+	});
+
+	return createHash("sha1").update(normalized).digest("hex").slice(0, 16);
+};
+
+const getMemoKey = ({
+	ctx,
+	query,
+	offset,
+}: {
+	ctx: RequestContext;
+	query: Parameters<typeof getFilterFingerprint>[0]["query"];
+	offset: number;
+}) =>
+	`cusOffsetMemo:${ctx.org.id}:${ctx.env}:${getFilterFingerprint({ query })}:${offset}`;
+
+/** Returns the position a previous page ended at, or null to fall back to OFFSET. */
+export const getMemoizedOffsetCursor = async ({
+	ctx,
+	query,
+	offset,
+}: {
+	ctx: RequestContext;
+	query: Parameters<typeof getFilterFingerprint>[0]["query"];
+	offset: number;
+}): Promise<OffsetCursor | null> => {
+	if (offset <= 0) return null;
+
+	const raw = await tryRedisOp({
+		operation: () =>
+			getPrimaryRedis().get(getMemoKey({ ctx, query, offset })),
+		source: "cus-offset-memo:get",
+		redisInstance: getPrimaryRedis(),
+	});
+	if (!raw) return null;
+
+	try {
+		const parsed = JSON.parse(raw) as Partial<OffsetCursor>;
+		if (typeof parsed.t !== "number" || typeof parsed.id !== "string") {
+			return null;
+		}
+		return { t: parsed.t, id: parsed.id };
+	} catch {
+		// A memo miss is always safe — the caller just pays the OFFSET path.
+		return null;
+	}
+};
+
+/** Records where this page ended, keyed by the offset the next page will ask for. */
+export const setMemoizedOffsetCursor = async ({
+	ctx,
+	query,
+	nextOffset,
+	lastRow,
+}: {
+	ctx: RequestContext;
+	query: Parameters<typeof getFilterFingerprint>[0]["query"];
+	nextOffset: number;
+	lastRow: OffsetCursor;
+}) => {
+	await tryRedisOp({
+		operation: () =>
+			getPrimaryRedis().set(
+				getMemoKey({ ctx, query, offset: nextOffset }),
+				JSON.stringify(lastRow),
+				"EX",
+				MEMO_TTL_SECONDS,
+			),
+		source: "cus-offset-memo:set",
+		redisInstance: getPrimaryRedis(),
+		onError: (error) =>
+			ctx.logger.warn(
+				`[offsetCursorMemo] failed to store position for offset ${nextOffset}: ${error}`,
+			),
+	});
+};

--- a/server/src/internal/entities/repos/cursorListEntitiesQuery.ts
+++ b/server/src/internal/entities/repos/cursorListEntitiesQuery.ts
@@ -8,12 +8,16 @@ import { type SQL, sql } from "drizzle-orm";
 import { getFullSubjectRowsQuery } from "@/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.js";
 
 const getEntityListFilterSql = ({
+	orgId,
+	env,
 	plans,
 	processors,
 	search,
 	customerId,
 	inStatuses,
 }: Pick<ListEntitiesParams, "plans" | "processors" | "search"> & {
+	orgId: string;
+	env: AppEnv;
 	customerId?: string;
 	inStatuses: CusProductStatus[];
 }) => {
@@ -35,6 +39,12 @@ const getEntityListFilterSql = ({
 			return sql`p_filter.id = ${plan.id}`;
 		});
 
+		// products.id is the plan slug, not a key — without org/env this matches
+		// every org's plan of that name, so the planner can't use
+		// idx_products_org_env_id_version and the EXISTS degrades to a per-entity
+		// probe across the table.
+		const planScope = sql`p_filter.org_id = ${orgId} AND p_filter.env = ${env}`;
+
 		filters.push(sql`AND EXISTS (
 			SELECT 1
 			FROM customer_products cp_filter
@@ -49,6 +59,7 @@ const getEntityListFilterSql = ({
 					inStatuses.map((status) => sql`${status}`),
 					sql`, `,
 				)}])
+				AND ${planScope}
 				AND (${sql.join(planConditions, sql` OR `)})
 		)`);
 	}
@@ -109,6 +120,8 @@ export const getCursorPaginatedEntitySubjectsQuery = ({
 	customerId?: string;
 }) => {
 	const filterSql = getEntityListFilterSql({
+		orgId,
+		env,
 		plans,
 		processors,
 		search,

--- a/server/src/internal/entities/repos/listEntitiesQuery.ts
+++ b/server/src/internal/entities/repos/listEntitiesQuery.ts
@@ -30,12 +30,16 @@ export const hasEntityListFilters = ({
 };
 
 const getEntityListFilterSql = ({
+	orgId,
+	env,
 	plans,
 	processors,
 	search,
 	customerId,
 	inStatuses,
 }: EntityListFilters & {
+	orgId: string;
+	env: AppEnv;
 	inStatuses: CusProductStatus[];
 }) => {
 	const filters: SQL[] = [];
@@ -57,6 +61,12 @@ const getEntityListFilterSql = ({
 			return sql`p_filter.id = ${plan.id}`;
 		});
 
+		// products.id is the plan slug, not a key — without org/env this matches
+		// every org's plan of that name, so the planner can't use
+		// idx_products_org_env_id_version and the EXISTS degrades to a per-entity
+		// probe across the table.
+		const planScope = sql`p_filter.org_id = ${orgId} AND p_filter.env = ${env}`;
+
 		filters.push(sql`AND EXISTS (
 			SELECT 1
 			FROM customer_products cp_filter
@@ -71,6 +81,7 @@ const getEntityListFilterSql = ({
 					inStatuses.map((status) => sql`${status}`),
 					sql`, `,
 				)}])
+				AND ${planScope}
 				AND (${sql.join(planConditions, sql` OR `)})
 		)`);
 	}
@@ -140,6 +151,8 @@ export const getPaginatedEntitySubjectsQuery = ({
 	inStatuses: CusProductStatus[];
 }) => {
 	const filterSql = getEntityListFilterSql({
+		orgId,
+		env,
 		plans: query.plans,
 		processors: query.processors,
 		search: query.search,
@@ -178,6 +191,70 @@ export const getPaginatedEntitySubjectsQuery = ({
 		entityScopedOnly: true,
 		queryTag: "getPaginatedEntitySubjects",
 	});
+};
+
+/**
+ * Counting with a plan filter can't reuse the page query's EXISTS: a COUNT has
+ * no LIMIT to stop it, so the subquery re-probes customer_products for every
+ * entity in the org — 197M buffer reads / 150s on mintlify. Resolving the
+ * matching (customer, entity-scope) pairs once from the plan side instead is
+ * 0.33s / 458k buffers for the same answer.
+ */
+const countEntitiesMatchingPlans = async ({
+	ctx,
+	plans,
+	inStatuses,
+	filterSql,
+}: {
+	ctx: AutumnContext;
+	plans: NonNullable<EntityListFilters["plans"]>;
+	inStatuses: CusProductStatus[];
+	filterSql: SQL;
+}) => {
+	const planConditions = plans.map((plan) =>
+		plan.versions && plan.versions.length > 0
+			? sql`(p.id = ${plan.id} AND p.version IN (${sql.join(
+					plan.versions.map((version) => sql`${version}`),
+					sql`, `,
+				)}))`
+			: sql`p.id = ${plan.id}`,
+	);
+
+	const rows = await ctx.db.execute(sql`
+		WITH matching_scopes AS (
+			SELECT DISTINCT cp.internal_customer_id, cp.internal_entity_id
+			FROM customer_products cp
+			JOIN products p
+				ON p.internal_id = cp.internal_product_id
+			WHERE p.org_id = ${ctx.org.id}
+				AND p.env = ${ctx.env}
+				AND cp.status = ANY(ARRAY[${sql.join(
+					inStatuses.map((status) => sql`${status}`),
+					sql`, `,
+				)}])
+				AND (${sql.join(planConditions, sql` OR `)})
+		)
+		SELECT COUNT(DISTINCT e.internal_id) AS total_count
+		FROM matching_scopes ms
+		JOIN entities e
+			ON e.internal_customer_id = ms.internal_customer_id
+			AND (
+				ms.internal_entity_id IS NULL
+				OR ms.internal_entity_id = e.internal_id
+			)
+		JOIN customers c
+			ON c.internal_id = e.internal_customer_id
+		WHERE e.org_id = ${ctx.org.id}
+			AND e.env = ${ctx.env}
+			AND c.org_id = ${ctx.org.id}
+			AND c.env = ${ctx.env}
+			${filterSql}
+		${planetScaleTag({ query: "countEntitiesMatchingPlans" })}
+	`);
+
+	const rawCount = (rows[0] as { total_count?: string | number } | undefined)
+		?.total_count;
+	return Number(rawCount ?? 0);
 };
 
 const countEntities = async ({
@@ -223,14 +300,25 @@ export const countFilteredEntitiesByOrgIdAndEnv = async ({
 		return countEntitiesByOrgIdAndEnv({ ctx });
 	}
 
-	return countEntities({
-		ctx,
-		filterSql: getEntityListFilterSql({
-			plans: query.plans,
-			processors: query.processors,
-			search: query.search,
-			customerId: query.customerId,
-			inStatuses,
-		}),
+	// Plans are applied by countEntitiesMatchingPlans' driving CTE, not as an
+	// EXISTS, so they're deliberately left out of this filter.
+	const nonPlanFilterSql = getEntityListFilterSql({
+		orgId: ctx.org.id,
+		env: ctx.env,
+		processors: query.processors,
+		search: query.search,
+		customerId: query.customerId,
+		inStatuses,
 	});
+
+	if (query.plans && query.plans.length > 0) {
+		return countEntitiesMatchingPlans({
+			ctx,
+			plans: query.plans,
+			inStatuses,
+			filterSql: nonPlanFilterSql,
+		});
+	}
+
+	return countEntities({ ctx, filterSql: nonPlanFilterSql });
 };


### PR DESCRIPTION
Two list queries were scanning most of a table per request. Both were found by
looking at what production actually does, and both are verified against prod
data.

## 1. Plan-filtered entity count

`countFilteredEntitiesByOrgIdAndEnv` reused the page query's `EXISTS`. A `COUNT`
has no `LIMIT` to stop it, so the subquery re-probed `customer_products` for
**every entity in the org** — ~5,158 rows per probe for mintlify's largest
customer. `countEntitiesMatchingPlans` resolves the matching
`(customer, entity-scope)` pairs once from the plan side instead.

```
X, plans:[enterprise]    150.05s -> 0.33s
buffer reads                    197,628,780 -> 458,622
count                           1019 -> 1019 (identical)
```

This owned mintlify's worst `entities.list` spike — a **155s** request.

Also scopes the plan predicate by `org_id`/`env` on both list paths. `products.id`
is the plan *slug*, not a key, so it previously matched every org's plan of that
name. Measured neutral on its own, but it makes the intent explicit and lets
`idx_products_org_env_id_version` apply.

## 2. `customers.list` deep OFFSET

API 2.2.0 paginates with `OFFSET`, which costs O(offset). firecrawl crawls to
offset ~1.6M over 1,622,719 customers about 12x/day, so each request scanned and
discarded most of the table — p50 **4,481ms**, and queries slow enough that WAL
conflicts on the read replica cancelled them outright (four 500s inside 30ms on
30 Jul).

2.2.0 clients can't send a cursor, so `getPage` memoizes where each page ended
and translates the next sequential offset into a keyset seek. Any miss falls back
to `OFFSET`.

```
steady-state page   4,370ms -> 784ms
memo entry          139 bytes, 15 min TTL
```

Both memo ops go through `tryRedisOp` on the primary, so a Redis outage costs a
miss and the old path — never the request.

### The `c.id` tiebreaker is a fix in its own right

`created_at` is far from unique: **818,922 distinct values across 1.6M customers**,
with groups up to 72 rows. The ordering was never total, so offset pages already
skipped and duplicated rows mid-crawl.

The **outer** `ORDER BY` mattered independently — without the tiebreaker the last
returned row wasn't the true page boundary, which corrupted the memoized position
and produced overlapping pages. That bug was caught by the crawl harness, not by
review.

## Verification

Full multi-page crawls, OFFSET vs memo, matching on `internal_id` (never null),
both sides inside one `repeatable read, read only` snapshot:

| fixture | result |
|---|---|
| F, 8 pages from offset 1.6M | 2000 rows, same order, 0 missing, 0 extra, 5.6x |
| A, 20 pages, entire org | 4876 rows, same order, 0 missing, 0 extra |
| F, 6 pages, search filter | 1500 rows, same order, 0 missing, 0 extra |

A was chosen deliberately — it holds the 47 null-`id` customers, the
riskiest case for a keyset predicate. Nothing lost. Redis round-trip and
filter-key isolation verified directly.

Harnesses are in `server/experiments/listObjects/` with a README.

## Please read before merging

- **The integration suite cannot run.** Every test fails with
  `password authentication failed for user 'neondb_owner'`, reproducible on a
  clean tree, so it is pre-existing and unrelated — but it means this is verified
  against prod data rather than by the suite. `server/tests/integration/crud/entities/list-entities.test.ts`
  covers plan filtering and is exactly what should gate the count change.
- **Null `id`s.** The keyset predicate excludes rows with a null `id`, but only
  when a page boundary lands inside their exact `created_at` tie group. Postgres
  row comparison short-circuits on the first column, and production only writes a
  memo when the last row's `id` is non-null. Same semantics as the existing 2.3.0
  cursor path.
- **The tiebreaker changes ordering for every caller** of
  `getPaginatedFullCusQuery`, including `getByInternalIds`. Only ties reorder.

## Not included

A rewrite of `getFullSubjectRowsQuery` into a single-row envelope was built and
verified (pg -39%, payload -39%, buffers -34% at limit 5000, `getFullSubject`
output and buffers identical) but is **deliberately left out**. It only pays off
at page sizes production never sends, and it touches the shared query behind
check/track. Not worth the risk while the integration suite can't run.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two list paths that scanned large tables. Plan-filtered entity counts are now fast, and 2.2.0 `customers.list` deep OFFSETs use a memoized keyset seek instead of scanning.

- **Performance**
  - Rewrote plan-filtered entity count to resolve matches from the plan side once (no per-entity EXISTS). 150s -> 0.33s on mintlify, identical counts.
  - Added Redis-backed memo to translate sequential OFFSETs into a keyset cursor for 2.2.0 `customers.list`; misses fall back to OFFSET. Steady-state page ~4370ms -> ~784ms; 15‑min TTL.

- **Bug Fixes**
  - Made customer sort total by adding `c.id DESC` tiebreaker alongside `created_at DESC`, preventing skips/dupes and ensuring correct page boundaries.
  - Scoped plan filters by `org_id` and `env` to avoid cross‑org slug matches and enable the `products` index.

<sup>Written for commit 2c90454facd8294142ebdbd1173a1477c5bae19d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



