### PR TITLE
fix(vite): preserve coupon major units

### DIFF
--- a/vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx
@@ -1,4 +1,3 @@
-import type { ApiDiscount } from "@autumn/shared";
 import {
 	billingControlsFromColumns,
 	CusProductStatus,
@@ -46,17 +45,9 @@ import {
 	SubscriptionDetailLicenses,
 } from "./SubscriptionDetailLicenses";
 import { SubscriptionLicenseRow } from "./SubscriptionLicenseRow";
+import { formatDiscountLabel } from "./subscriptionDetailUtils";
 
 const ID_CHIP_INNER_CLASS = "max-w-40 text-tiny-id truncate !font-normal";
-
-function formatDiscountLabel({ discount }: { discount: ApiDiscount }): string {
-	const value =
-		discount.type === "percentage_discount"
-			? `${discount.discount_value}% off`
-			: `${discount.discount_value / 100} ${discount.currency?.toUpperCase() ?? ""} off`;
-
-	return discount.name ? `${discount.name} (${value})` : value;
-}
 
 export function SubscriptionDetailSheet() {
 	const { customer, features = [], testClockFrozenTimeMs } = useCusQuery();

--- a/vite/src/views/customers2/components/sheets/subscriptionDetailUtils.ts
+++ b/vite/src/views/customers2/components/sheets/subscriptionDetailUtils.ts
@@ -1,0 +1,14 @@
+import type { ApiDiscount } from "@autumn/shared";
+
+export function formatDiscountLabel({
+	discount,
+}: {
+	discount: ApiDiscount;
+}): string {
+	const value =
+		discount.type === "percentage_discount"
+			? `${discount.discount_value}% off`
+			: `${discount.discount_value} ${discount.currency?.toUpperCase() ?? ""} off`;
+
+	return discount.name ? `${discount.name} (${value})` : value;
+}

--- a/vite/tests/views/customers2/components/sheets/subscription-detail-sheet.test.ts
+++ b/vite/tests/views/customers2/components/sheets/subscription-detail-sheet.test.ts
@@ -1,0 +1,21 @@
+// Before: $1,050 rendered as 10.5. After: API major units display unchanged.
+import { expect, test } from "bun:test";
+import {
+	type ApiDiscount,
+	CouponDurationType,
+	RewardType,
+} from "@autumn/shared";
+import { formatDiscountLabel } from "@/views/customers2/components/sheets/subscriptionDetailUtils";
+
+test("formats fixed subscription discounts in major currency units", () => {
+	const discount = {
+		id: "alludium",
+		name: "alludium",
+		type: RewardType.FixedDiscount,
+		discount_value: 1050,
+		currency: "usd",
+		duration_type: CouponDurationType.Forever,
+	} as ApiDiscount;
+
+	expect(formatDiscountLabel({ discount })).toBe("alludium (1050 USD off)");
+});


### PR DESCRIPTION
## Summary
- display fixed subscription discounts in Autumn major currency units
- remove the stale second cents-to-dollars conversion in the subscription sheet
- add regression coverage for the $1,050 → 10.5 display bug

## Validation
- Vite unit tests: 401 passed
- Vite TypeScript check
- server getCusRewards major-unit contract test
- Biome changed-file check
- React Doctor changed-file scan: no issues

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix discount labels to preserve major currency units from the API and display correct amounts for fixed coupon discounts. Removed the extra cents-to-dollars conversion in `SubscriptionDetailSheet`, moved label formatting to `subscriptionDetailUtils.ts`, and added a regression test so $1,050 no longer renders as 10.5.

<sup>Written for commit 3ab6dc09706ac834a6abbbf1fcd7a5827c465470. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes fixed subscription discount labels to preserve the API’s major currency units.
- **Bug fixes:** Removes the stale second cents-to-dollars conversion from subscription discount labels.
- **Improvements:** Extracts discount-label formatting into a reusable utility.
- **Improvements:** Adds regression coverage for displaying a 1,050-unit fixed discount without converting it to 10.5.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The customer rewards producer already converts fixed coupon amounts from Stripe minor units into Autumn major units, and the updated formatter now displays that established API value without applying a duplicate conversion.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx | Replaces the inline discount formatter with the extracted utility while preserving the existing call path. |
| vite/src/views/customers2/components/sheets/subscriptionDetailUtils.ts | Formats fixed discounts directly in the major units supplied by the customer rewards API. |
| vite/tests/views/customers2/components/sheets/subscription-detail-sheet.test.ts | Adds focused regression coverage ensuring a fixed discount of 1,050 is not divided by 100 again. |

<sub>Reviews (1): Last reviewed commit: ["fix(vite): 🐛 preserve coupon major unit..."](https://github.com/useautumn/autumn/commit/3ab6dc09706ac834a6abbbf1fcd7a5827c465470) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49144263)</sub>

<!-- /greptile_comment -->