### PR TITLE
fix(queue): bound auto top-up lock-contention retries

### DIFF
--- a/server/src/internal/balances/autoTopUp/autoTopup.ts
+++ b/server/src/internal/balances/autoTopUp/autoTopup.ts
@@ -1,4 +1,4 @@
-import { AppEnv } from "@autumn/shared";
+import { AppEnv, ErrCode, RecaseError } from "@autumn/shared";
 import { withLock } from "@/external/redis/redisUtils.js";
 import { voidStripeInvoiceIfOpen } from "@/external/stripe/invoices/operations/voidStripeInvoiceIfOpen.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
@@ -21,6 +21,9 @@ import {
 } from "./webhooks/sendAutoTopupFailedWebhook.js";
 import { sendAutoTopupSucceededWebhook } from "./webhooks/sendAutoTopupSucceededWebhook.js";
 
+const isAutoTopupLockConflict = ({ error }: { error: unknown }) =>
+	error instanceof RecaseError && error.code === ErrCode.LockAlreadyExists;
+
 /** Workflow handler for auto top-ups. */
 export const autoTopup = async ({
 	ctx,
@@ -32,6 +35,7 @@ export const autoTopup = async ({
 	const { org, env, logger } = ctx;
 	const { customerId, featureId } = payload;
 	let failureWebhookSent = false;
+	let lockConflict = false;
 	let lastAutoTopupContext: AutoTopupContext | undefined;
 
 	const sendFailureWebhook = async ({
@@ -190,6 +194,11 @@ export const autoTopup = async ({
 			fn: executeAutoTopup,
 		});
 	} catch (error) {
+		// The pending key is this customer+feature's enqueue throttle. Clearing it
+		// after losing the lock lets the next deduction enqueue immediately, so a
+		// busy customer turns lock contention into a queue-wide flood.
+		if (isAutoTopupLockConflict({ error })) lockConflict = true;
+
 		if (!failureWebhookSent) {
 			const failure = classifyAutoTopupError({ error });
 			await sendFailureWebhook({
@@ -200,6 +209,8 @@ export const autoTopup = async ({
 		}
 		throw error;
 	} finally {
-		await clearAutoTopupPendingKey({ ctx, customerId, featureId });
+		if (!lockConflict) {
+			await clearAutoTopupPendingKey({ ctx, customerId, featureId });
+		}
 	}
 };

--- a/server/src/queue/processMessage.ts
+++ b/server/src/queue/processMessage.ts
@@ -65,12 +65,19 @@ const isClaimContestedError = ({ error }: { error: unknown }): boolean => {
 	);
 };
 
+// A contended customer lock resolves in seconds; anything past that is a
+// redelivery loop on one hot customer, and the next deduction below the
+// threshold re-enqueues the top-up anyway.
+const AUTO_TOP_UP_LOCK_MAX_RECEIVES = 3;
+
 export const shouldRetrySqsJobError = ({
 	jobName,
 	error,
+	receiveCount,
 }: {
 	jobName: string;
 	error: unknown;
+	receiveCount?: number;
 }) => {
 	switch (jobName) {
 		case JobName.CustomerCreationRecovery:
@@ -93,10 +100,16 @@ export const shouldRetrySqsJobError = ({
 				isClaimContestedError({ error })
 			);
 		// Top-up shares the customer billing lock — retry instead of dropping the job
-		// when it collides with an attach or checkout materialization.
+		// when it collides with an attach or checkout materialization, but only for a
+		// bounded number of deliveries so one locked customer cannot flood the queue.
 		case JobName.AutoTopUp:
 			return (
-				error instanceof RecaseError && error.code === ErrCode.LockAlreadyExists
+				error instanceof RecaseError &&
+				error.code === ErrCode.LockAlreadyExists &&
+				!(
+					Number.isFinite(receiveCount) &&
+					(receiveCount as number) >= AUTO_TOP_UP_LOCK_MAX_RECEIVES
+				)
 			);
 		case JobName.StripeWebhookReplay:
 			return (
@@ -471,7 +484,7 @@ export const processMessage = async ({
 		// Sync jobs: re-throw infrastructure errors so the message stays in SQS.
 		// Application errors (RecaseError, InternalError) are swallowed — they
 		// won't fix on retry. DB errors (connection, timeout) will.
-		if (shouldRetrySqsJobError({ jobName: job.name, error })) {
+		if (shouldRetrySqsJobError({ jobName: job.name, error, receiveCount })) {
 			Sentry.captureException(error);
 			errorLogger.error(`[${job.name}] Retryable error, keeping in SQS`, {
 				jobName: job.name,

--- a/server/tests/unit/queue/processMessage.test.ts
+++ b/server/tests/unit/queue/processMessage.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { ErrCode, RecaseError } from "@autumn/shared";
 import { RedisUnavailableError } from "@/external/redis/utils/errors.js";
 import { JobName } from "@/queue/JobName.js";
 import { shouldRetrySqsJobError } from "@/queue/processMessage.js";
@@ -53,6 +54,45 @@ describe("shouldRetrySqsJobError", () => {
 			shouldRetrySqsJobError({
 				jobName: JobName.Track,
 				error: new Error("insufficient balance"),
+			}),
+		).toBe(false);
+	});
+});
+
+describe("shouldRetrySqsJobError - auto top-up lock contention", () => {
+	const lockError = new RecaseError({
+		message:
+			"Another billing operation is already in progress for customer cus_1",
+		code: ErrCode.LockAlreadyExists,
+		statusCode: 423,
+	});
+
+	test("retries the first deliveries so a brief attach collision resolves", () => {
+		expect(
+			shouldRetrySqsJobError({
+				jobName: JobName.AutoTopUp,
+				error: lockError,
+				receiveCount: 1,
+			}),
+		).toBe(true);
+	});
+
+	test("stops retrying once the delivery cap is reached", () => {
+		expect(
+			shouldRetrySqsJobError({
+				jobName: JobName.AutoTopUp,
+				error: lockError,
+				receiveCount: 3,
+			}),
+		).toBe(false);
+	});
+
+	test("does not retry non-lock auto top-up failures", () => {
+		expect(
+			shouldRetrySqsJobError({
+				jobName: JobName.AutoTopUp,
+				error: new Error("card declined"),
+				receiveCount: 1,
 			}),
 		).toBe(false);
 	});


### PR DESCRIPTION
<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/69219c1b-daf9-41f1-8d26-46a356263cdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-070" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/69219c1b-daf9-41f1-8d26-46a356263cdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-070&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-070"><img alt="SCO-070" src="https://capy.ai/api/badge/thread.svg?label=SCO-070"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds auto top-up lock contention retries and avoids clearing the pending key on lock conflicts to prevent queue floods from hot customers. This stabilizes auto top-up processing and reduces SQS retry loops.

- **Bug Fixes**
  - Auto top-up keeps the pending key when a customer billing lock conflict occurs; only clears it when there’s no conflict.
  - Caps AutoTopUp lock-retry deliveries at 3 using the message receive count, so brief contention retries but hot customers don’t flood the queue.
  - Adds unit tests for the bounded retry behavior and non-lock failures.

<sup>Written for commit fb4f4a18ad8e5b89fe1d27dbab630f27c98f8ef4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR bounds auto-top-up lock-contention redeliveries and preserves the short-lived enqueue throttle during contention to prevent a hot customer from amplifying queue traffic.

- **[Bug fixes]** Stops retrying an auto-top-up lock conflict after the third SQS delivery.
- **[Bug fixes, Improvements]** Retains the customer-and-feature pending key after lock contention so deductions cannot immediately enqueue duplicate work.
- **[Improvements]** Adds unit coverage for retryable lock conflicts, the receive cap, and non-lock failures.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

The retry cap receives the numeric SQS delivery count from the sole production polling path, lock conflicts are classified using the exact propagated shared error type, and the retained throttle key self-expires after 30 seconds.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/autoTopUp/autoTopup.ts | Detects billing-lock conflicts and preserves the 30-second enqueue-throttle key only for that contention path. |
| server/src/queue/processMessage.ts | Passes SQS receive count into retry classification and stops auto-top-up lock retries on the third delivery. |
| server/tests/unit/queue/processMessage.test.ts | Covers early lock-conflict retries, the delivery cap, and non-lock auto-top-up failures. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant D as Deduction
  participant R as Redis pending key
  participant Q as SQS
  participant W as Auto-top-up worker
  participant L as Billing lock
  D->>R: SET pending key NX (30s TTL)
  R-->>D: Acquired
  D->>Q: Enqueue auto-top-up
  Q->>W: Deliver message with receive count
  W->>L: Acquire customer billing lock
  alt Lock acquired
    W->>W: Execute auto-top-up
    W->>R: Clear pending key
    W-->>Q: Acknowledge
  else "Lock contended and receive count < 3"
    W-->>Q: Preserve message for retry
    Note over W,R: Pending key remains until expiry
  else "Lock contended and receive count >= 3"
    W-->>Q: Stop retrying and acknowledge
    Note over R: Pending key expires automatically
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(queue): bound auto top-up lock-conte..."](https://github.com/useautumn/autumn/commit/fb4f4a18ad8e5b89fe1d27dbab630f27c98f8ef4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49311913)</sub>

**Context used:**

- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)

<!-- /greptile_comment -->