### PR TITLE
fix(billing): prevent auto top-up retry storms

### DIFF
--- a/server/src/internal/balances/autoTopUp/autoTopup.ts
+++ b/server/src/internal/balances/autoTopUp/autoTopup.ts
@@ -24,6 +24,8 @@ import {
 } from "./webhooks/sendAutoTopupFailedWebhook.js";
 import { sendAutoTopupSucceededWebhook } from "./webhooks/sendAutoTopupSucceededWebhook.js";
 
+// Must outlive the queue's full retry chain (maxReceiveCount 10 × 30s visibility = 5m),
+// else the gate reopens while copies still cycle and track traffic reseeds the storm.
 const AUTO_TOPUP_RETRY_SUPPRESSION_MS = ms.minutes(10);
 
 /** Workflow handler for auto top-ups. */

--- a/server/src/internal/balances/autoTopUp/autoTopup.ts
+++ b/server/src/internal/balances/autoTopUp/autoTopup.ts
@@ -1,4 +1,4 @@
-import { AppEnv } from "@autumn/shared";
+import { AppEnv, ms } from "@autumn/shared";
 import { withLock } from "@/external/redis/redisUtils.js";
 import { voidStripeInvoiceIfOpen } from "@/external/stripe/invoices/operations/voidStripeInvoiceIfOpen.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
@@ -11,7 +11,10 @@ import type { AutoTopUpPayload } from "@/queue/workflows.js";
 import type { AutoTopupContext } from "./autoTopupContext.js";
 import { computeAutoTopupPlan } from "./compute/computeAutoTopupPlan.js";
 import { buildAutoTopUpLockKey } from "./helpers/autoTopUpUtils.js";
-import { clearAutoTopupPendingKey } from "./helpers/enqueueAutoTopupWithBurstSuppression.js";
+import {
+	clearAutoTopupPendingKey,
+	keepAutoTopupPendingKey,
+} from "./helpers/enqueueAutoTopupWithBurstSuppression.js";
 import { recordAutoTopupAttempt } from "./helpers/limits/index.js";
 import { logAutoTopupContext } from "./logs/logAutoTopupContext.js";
 import { setupAutoTopupContext } from "./setup/setupAutoTopupContext.js";
@@ -20,6 +23,8 @@ import {
 	sendAutoTopupFailedWebhook,
 } from "./webhooks/sendAutoTopupFailedWebhook.js";
 import { sendAutoTopupSucceededWebhook } from "./webhooks/sendAutoTopupSucceededWebhook.js";
+
+const AUTO_TOPUP_RETRY_SUPPRESSION_MS = ms.minutes(10);
 
 /** Workflow handler for auto top-ups. */
 export const autoTopup = async ({
@@ -33,6 +38,7 @@ export const autoTopup = async ({
 	const { customerId, featureId } = payload;
 	let failureWebhookSent = false;
 	let lastAutoTopupContext: AutoTopupContext | undefined;
+	let pendingTtlMs: number | undefined;
 
 	const sendFailureWebhook = async ({
 		autoTopupContext,
@@ -69,6 +75,12 @@ export const autoTopup = async ({
 
 		if (!setupResult.ok) {
 			if (setupResult.failure) {
+				if (setupResult.failure.suppressionTtlMs) {
+					pendingTtlMs = Math.min(
+						setupResult.failure.suppressionTtlMs,
+						AUTO_TOPUP_RETRY_SUPPRESSION_MS,
+					);
+				}
 				await sendFailureWebhook(setupResult.failure);
 			}
 			return;
@@ -190,8 +202,10 @@ export const autoTopup = async ({
 			fn: executeAutoTopup,
 		});
 	} catch (error) {
-		if (!failureWebhookSent) {
-			const failure = classifyAutoTopupError({ error });
+		const failure = classifyAutoTopupError({ error });
+		if (failure.reason === "lock_contention") {
+			pendingTtlMs = AUTO_TOPUP_RETRY_SUPPRESSION_MS;
+		} else if (!failureWebhookSent) {
 			await sendFailureWebhook({
 				...failure,
 				error,
@@ -200,6 +214,15 @@ export const autoTopup = async ({
 		}
 		throw error;
 	} finally {
-		await clearAutoTopupPendingKey({ ctx, customerId, featureId });
+		if (pendingTtlMs) {
+			await keepAutoTopupPendingKey({
+				ctx,
+				customerId,
+				featureId,
+				ttlMs: pendingTtlMs,
+			});
+		} else {
+			await clearAutoTopupPendingKey({ ctx, customerId, featureId });
+		}
 	}
 };

--- a/server/src/internal/balances/autoTopUp/helpers/enqueueAutoTopupWithBurstSuppression.ts
+++ b/server/src/internal/balances/autoTopUp/helpers/enqueueAutoTopupWithBurstSuppression.ts
@@ -31,6 +31,21 @@ export const clearAutoTopupPendingKey = async ({
 	await tryRedisWrite(() => redis.del(pendingKey));
 };
 
+export const keepAutoTopupPendingKey = async ({
+	ctx,
+	customerId,
+	featureId,
+	ttlMs,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	featureId: string;
+	ttlMs: number;
+}) => {
+	const pendingKey = buildAutoTopupPendingKey({ ctx, customerId, featureId });
+	await tryRedisWrite(() => redis.set(pendingKey, "1", "PX", ttlMs));
+};
+
 export const enqueueAutoTopupWithBurstSuppression = async ({
 	ctx,
 	customerId,

--- a/server/src/queue/processMessage.ts
+++ b/server/src/queue/processMessage.ts
@@ -92,8 +92,8 @@ export const shouldRetrySqsJobError = ({
 				isTransientRedisError({ error }) ||
 				isClaimContestedError({ error })
 			);
-		// Top-up shares the customer billing lock — retry instead of dropping the job
-		// when it collides with an attach or checkout materialization.
+		// Top-up shares the customer billing lock — retry on collision with attach or
+		// checkout, safe only while AUTO_TOPUP_RETRY_SUPPRESSION_MS outlasts the chain.
 		case JobName.AutoTopUp:
 			return (
 				error instanceof RecaseError && error.code === ErrCode.LockAlreadyExists

--- a/server/tests/integration/balances/auto-topup/auto-topup-lock-retry-suppression.test.ts
+++ b/server/tests/integration/balances/auto-topup/auto-topup-lock-retry-suppression.test.ts
@@ -1,0 +1,110 @@
+/** Red: lock contention clears suppression and emits failure. Green: it keeps suppression and retries silently. */
+
+import { beforeEach, expect, mock, test } from "bun:test";
+import { AppEnv, ErrCode } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+const calls = {
+	clearPending: 0,
+	keepPending: [] as number[],
+	failureWebhook: 0,
+};
+const state = { lockContention: true, preflightBlocked: false };
+
+mock.module("@/external/redis/redisUtils.js", () => ({
+	withLock: async ({ fn }: { fn: () => Promise<void> }) => {
+		if (state.lockContention) throw { code: ErrCode.LockAlreadyExists };
+		return fn();
+	},
+}));
+
+mock.module(
+	"@/internal/balances/autoTopUp/setup/setupAutoTopupContext.js",
+	() => ({
+		setupAutoTopupContext: async () => {
+			if (state.preflightBlocked) {
+				return {
+					ok: false,
+					failure: {
+						reason: "purchase_limit_reached",
+						suppressionTtlMs: 60 * 60 * 1000,
+					},
+				};
+			}
+			throw new Error("Unexpected auto-topup setup");
+		},
+	}),
+);
+
+mock.module(
+	"@/internal/balances/autoTopUp/helpers/enqueueAutoTopupWithBurstSuppression.js",
+	() => ({
+		buildAutoTopupPendingKey: () => "auto_topup:pending:test",
+		clearAutoTopupPendingKey: async () => {
+			calls.clearPending++;
+		},
+		enqueueAutoTopupWithBurstSuppression: async () => ({
+			enqueued: false,
+			reason: "pending_key_exists" as const,
+		}),
+		keepAutoTopupPendingKey: async ({ ttlMs }: { ttlMs: number }) => {
+			calls.keepPending.push(ttlMs);
+		},
+	}),
+);
+
+mock.module(
+	"@/internal/balances/autoTopUp/webhooks/sendAutoTopupFailedWebhook.js",
+	() => ({
+		classifyAutoTopupError: () => ({ reason: "lock_contention" }),
+		sendAutoTopupFailedWebhook: async () => {
+			calls.failureWebhook++;
+		},
+	}),
+);
+
+const { autoTopup } = await import(
+	"@/internal/balances/autoTopUp/autoTopup.js"
+);
+
+beforeEach(() => {
+	calls.clearPending = 0;
+	calls.keepPending = [];
+	calls.failureWebhook = 0;
+	state.lockContention = true;
+	state.preflightBlocked = false;
+});
+
+const ctx = {
+	org: { id: "org_test", config: {} },
+	env: AppEnv.Live,
+	logger: { info: () => undefined },
+} as unknown as AutumnContext;
+
+const payload = {
+	orgId: ctx.org.id,
+	env: ctx.env,
+	customerId: "cus_test",
+	featureId: "messages",
+};
+
+test("auto-topup lock retry preserves burst suppression", async () => {
+	await expect(autoTopup({ ctx, payload })).rejects.toMatchObject({
+		code: ErrCode.LockAlreadyExists,
+	});
+
+	expect(calls.clearPending).toBe(0);
+	expect(calls.keepPending).toEqual([10 * 60 * 1000]);
+	expect(calls.failureWebhook).toBe(0);
+});
+
+test("auto-topup purchase limit preserves burst suppression", async () => {
+	state.lockContention = false;
+	state.preflightBlocked = true;
+
+	await autoTopup({ ctx, payload });
+
+	expect(calls.clearPending).toBe(0);
+	expect(calls.keepPending).toEqual([10 * 60 * 1000]);
+	expect(calls.failureWebhook).toBe(1);
+});


### PR DESCRIPTION
## Summary

- keep the auto-top-up pending marker for 10 minutes during retryable lock contention
- retain bounded suppression after purchase-limit and other suppressed preflight exits
- avoid emitting failure webhooks for retryable lock contention
- add focused regression coverage for both incident paths

## Incident

This stops concurrent AutoTopUp retries from deleting the burst-suppression key and allowing track traffic to continuously enqueue more copies onto the primary FIFO queue.

## Test plan

- [x] `./run.sh /Users/charlielamb/code/atmn/autumn/server/tests/integration/balances/auto-topup/auto-topup-lock-retry-suppression.test.ts` (2 passed)
- [x] `bunx biome check --write` on all changed files
- [x] `git diff --check`
- [ ] `bunx tsgo --build --noEmit` — blocked on the pre-existing Better Auth duplicate-core/plugin type errors on clean `main`; no errors reference changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents auto-topup retry storms by keeping the pending marker for up to 10 minutes during retryable lock contention and preflight suppression; 10 minutes is chosen to outlast the queue’s full retry chain. Also suppresses failure webhooks for lock contention so only terminal failures notify.

- **Bug Fixes**
  - Keep pending key with a TTL (up to 10 minutes) during lock contention and preflight-suppressed exits.
  - Do not emit failure webhooks for lock contention; terminal failures still send.
  - Added integration tests for lock-retry and preflight-suppression paths.

<sup>Written for commit 1c5b06549e01c8795c71ef3c9cd2e733b2aa8213. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This follow-up adjusts auto-top-up retry handling so transient lock contention and selected preflight exits retain bounded Redis burst suppression.

- **[Bug fixes]** Preserve the auto-top-up pending marker for ten minutes when billing-lock contention causes an SQS retry.
- **[Bug fixes]** Avoid failure webhooks for retryable lock contention while retaining terminal-failure notifications.
- **[Improvements]** Add focused integration coverage for lock-contention retries and preflight suppression.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains within the eligible follow-up-review scope.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/autoTopUp/autoTopup.ts | Retains bounded pending-key suppression for retryable lock contention and selected preflight exits while suppressing lock-contention failure webhooks. |
| server/src/internal/balances/autoTopUp/helpers/enqueueAutoTopupWithBurstSuppression.ts | Adds a helper that refreshes the scoped Redis pending marker with an explicit millisecond TTL. |
| server/src/queue/processMessage.ts | Documents the coupling between AutoTopUp retry duration and the pending-key suppression period without changing retry classification. |
| server/tests/integration/balances/auto-topup/auto-topup-lock-retry-suppression.test.ts | Covers pending-marker retention and webhook behavior for lock contention and purchase-limit preflight suppression. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Track as Track/Check flow
  participant Redis as Redis suppression key
  participant Queue as Primary SQS queue
  participant Worker as AutoTopUp worker
  participant Lock as Customer billing lock

  Track->>Redis: SET pending key NX
  Redis-->>Track: acquired
  Track->>Queue: enqueue AutoTopUp
  Queue->>Worker: deliver job
  Worker->>Lock: acquire
  Lock-->>Worker: lock contention
  Worker->>Redis: refresh pending key (10m)
  Worker-->>Queue: throw retryable error
  Queue->>Worker: redeliver
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(billing): 📝 explain auto top-up su..."](https://github.com/useautumn/autumn/commit/1c5b06549e01c8795c71ef3c9cd2e733b2aa8213) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49312032)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)

<!-- /greptile_comment -->