### PR TITLE
fix(events): make batch event insert idempotent

### DIFF
--- a/server/src/internal/api/events/EventService.ts
+++ b/server/src/internal/api/events/EventService.ts
@@ -15,17 +15,19 @@ export class EventService {
 		logger?: Logger;
 	}) {
 		try {
+			// Delivery is at-least-once, so a replayed id must skip its own row
+			// rather than abort the statement and drop the batch's other events.
 			const results = await db
 				.insert(events)
 				.values(event as any)
+				.onConflictDoNothing()
 				.returning();
 
 			return results?.[0];
 		} catch (error: any) {
 			if (error.code === "23505") {
 				throw new RecaseError({
-					message:
-						"Event (event_name, customer_id, idempotency_key) already exists.",
+					message: "Event already exists.",
 					code: ErrCode.DuplicateEvent,
 					statusCode: StatusCodes.CONFLICT,
 				});

--- a/server/tests/integration/balances/events/event-batch-duplicate-id.test.ts
+++ b/server/tests/integration/balances/events/event-batch-duplicate-id.test.ts
@@ -1,0 +1,147 @@
+/**
+ * TDD test for duplicate event inserts destroying an entire per-customer batch.
+ *
+ * Prod symptom (150,034 occurrences / 7 days, all orgs):
+ *   "❌ Failed to insert 2 events for customer cus_...: Event (event_name,
+ *    customer_id, idempotency_key) already exists."
+ *
+ * Event ids are random (initEvent: generateId("evt")), so two independent
+ * calls cannot collide — the whole SQS message is being delivered twice.
+ * runInsertEventBatch commits before the message is acked (deletion is
+ * deferred to batchDeleteMessages), so a worker recycle or failed delete
+ * replays the batch against rows that are already committed. Observed shape:
+ * every customer in a batch failing within ~1.8ms, 1,775 batches on 2026-08-01.
+ *
+ * All observed events carry idempotency_key: null and unique_event_constraint
+ * is NULLS DISTINCT, so the 23505 is the PRIMARY KEY on id — not the unique
+ * constraint the error message names.
+ *
+ * A pure replay loses nothing (the rows were written by the first delivery);
+ * the damage is a batch that MIXES replayed and fresh events, which is what
+ * this test pins.
+ *
+ * Red-failure mode (current behavior):
+ *  - One statement per customer with no conflict handling, so a single
+ *    duplicate id aborts the whole statement and the fresh events die with it.
+ *
+ * Green-success criteria (after fix):
+ *  - Every event ends up inserted exactly once: the duplicate is skipped, the
+ *    fresh event still lands, and the original row is not mutated.
+ */
+
+import { expect, test } from "bun:test";
+import { customers, events } from "@autumn/shared";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { and, eq } from "drizzle-orm";
+import { EventService } from "@/internal/api/events/EventService.js";
+import { generateId } from "@/utils/genUtils.js";
+
+test.concurrent(
+	`${chalk.yellowBright("events batch: duplicate event id must not discard the rest of the customer's batch")}`,
+	async () => {
+		const customerId = "event-batch-duplicate-id";
+
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		const [customerRow] = await ctx.db
+			.select()
+			.from(customers)
+			.where(
+				and(
+					eq(customers.id, customerId),
+					eq(customers.org_id, ctx.org.id),
+					eq(customers.env, ctx.env),
+				),
+			);
+
+		const internalCustomerId = customerRow?.internal_id;
+		expect(internalCustomerId).toBeTruthy();
+
+		const baseEvent = {
+			org_id: ctx.org.id,
+			org_slug: ctx.org.slug,
+			env: ctx.env,
+			internal_customer_id: internalCustomerId,
+			customer_id: customerId,
+			idempotency_key: null,
+			properties: {},
+			set_usage: false,
+		};
+
+		const replayedId = generateId("evt");
+		const freshId = generateId("evt");
+
+		// First delivery lands normally.
+		await EventService.insert({
+			db: ctx.db,
+			event: [
+				{
+					...baseEvent,
+					id: replayedId,
+					event_name: "duplicate_probe",
+					value: 1,
+					created_at: Date.now(),
+					timestamp: new Date(),
+				},
+			],
+		});
+
+		// Second delivery replays the same id alongside a brand-new event —
+		// exactly the shape runInsertEventBatch groups per customer.
+		const insertReplayBatch = () =>
+			EventService.insert({
+				db: ctx.db,
+				event: [
+					{
+						...baseEvent,
+						id: replayedId,
+						event_name: "duplicate_probe",
+						value: 1,
+						created_at: Date.now(),
+						timestamp: new Date(),
+					},
+					{
+						...baseEvent,
+						id: freshId,
+						event_name: "fresh_probe",
+						value: 7,
+						created_at: Date.now(),
+						timestamp: new Date(),
+					},
+				],
+			});
+
+		// ── Assertion 1: the replay must not throw ────────────────────────
+		// Pre-fix: throws RecaseError "Event (...) already exists."
+		await expect(insertReplayBatch()).resolves.toBeDefined();
+
+		// ── Assertion 2: the non-duplicate event must survive ─────────────
+		// Pre-fix: rolled back with the duplicate, silently lost.
+		const freshRows = await ctx.db
+			.select()
+			.from(events)
+			.where(
+				and(
+					eq(events.id, freshId),
+					eq(events.internal_customer_id, internalCustomerId!),
+				),
+			);
+
+		expect(freshRows).toHaveLength(1);
+		expect(freshRows[0]?.value).toBe(7);
+
+		// ── Assertion 3: the original row is untouched ────────────────────
+		const replayedRows = await ctx.db
+			.select()
+			.from(events)
+			.where(eq(events.id, replayedId));
+
+		expect(replayedRows).toHaveLength(1);
+		expect(replayedRows[0]?.event_name).toBe("duplicate_probe");
+	},
+);


### PR DESCRIPTION
## Summary

`EventService.insert` now uses `onConflictDoNothing()`, so a replayed SQS batch no longer aborts the whole per-customer statement.

## How the duplicate gets in

Not two events colliding — event ids are random (`initEvent.ts:59`, `generateId("evt")`), so independent calls can never produce the same id. It's the **same SQS message delivered twice**:

- `runInsertEventBatch` commits before the message is acked — deletion is deferred to `batchDeleteMessages` (`initWorkers.ts:359-377`).
- Anything in that window (worker recycle, failed delete, visibility-timeout expiry) replays the batch against rows that are already committed.
- Ruled out along the way: `EventBatchingManager.executeBatch` snapshots-and-clears synchronously, and `SqsBatchAccumulator` rejects failed entries rather than re-sending successful ones.

Prod shape confirms whole-message replay: every customer in a batch fails within ~1.8ms. **1,775 affected batches on 2026-08-01** (avg 6.58 customers each), **150,034 errors over 7 days**.

## Impact

A *pure* replay loses nothing — those rows were written by the first delivery, so it's noise and duplicated work. The real damage is a batch that **mixes** replayed and fresh events: one duplicate aborted the statement and took the fresh events with it. That's the case this test pins.

After the fix, a mixed batch ends with every event inserted exactly once — existing rows untouched, new rows written.

## Error message correction

The message claimed `"Event (event_name, customer_id, idempotency_key) already exists"`. Every affected event has `idempotency_key: null` and `unique_event_constraint` is `NULLS DISTINCT`, so the 23505 was the **primary key on `id`** — never the constraint it named. That wording is what made this read as an idempotency problem.

## Note

No conflict target is specified, so this covers the PK and `unique_event_constraint`. A genuine `idempotency_key` duplicate now skips silently instead of raising `DuplicateEvent`. `runInsertEventBatch` is the only caller, so no API surface changes — but that 409 path is now unreachable.

## Not fixed here

Why the ack window is being missed. Worker recycle is the prime suspect (same `process.exit` orphan pattern as the batch-reset queue). The insert is safe either way now, but that's the remaining defect.

## Test plan

- [x] `./run.sh server/tests/integration/balances/events/event-batch-duplicate-id.test.ts` — red for the right reason (replay batch rejects), then green, 6 assertions
- [x] `bunx tsgo --build --noEmit`
- [x] `bunx biome check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make batch event inserts idempotent so replayed SQS batches don’t abort per-customer statements. Duplicates are skipped; fresh events still insert exactly once.

- **Bug Fixes**
  - Use `.onConflictDoNothing()` in `EventService.insert` to skip conflicting rows on replay.
  - Covers both primary key and `unique_event_constraint`; no API changes.
  - Correct duplicate error message to "Event already exists."
  - Add integration test to verify mixed replay + fresh events inserts exactly once.

<sup>Written for commit e0aaf67259bbf4f06f1a36e43799ccd84e6f0301. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes batched event persistence resilient to at-least-once SQS delivery by skipping conflicting rows rather than aborting the entire statement.
- **[Bug fixes]** Adds conflict-tolerant insertion so replayed event IDs do not prevent fresh events in the same customer batch from being persisted.
- **[API changes]** Duplicate conflicts are now treated as successful no-ops, making the prior `DuplicateEvent` error path unreachable for insert conflicts.
- **[Improvements]** Adds an integration test covering a mixed batch containing one replayed event and one fresh event.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the intended replay behavior covered by a focused integration test and no actionable regressions identified.

Current callers discard the insert return value, mixed replay batches retain fresh rows, and the broader duplicate-conflict behavior is an explicitly documented API change.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/api/events/EventService.ts | Adds untargeted conflict suppression to preserve fresh rows during replayed batch inserts and simplifies the now-unreachable duplicate error wording. |
| server/tests/integration/balances/events/event-batch-duplicate-id.test.ts | Adds integration coverage proving that a replayed primary key is skipped, a fresh sibling event is inserted, and the original row remains unchanged. |

<sub>Reviews (1): Last reviewed commit: ["fix(events): 🐛 make batch event insert ..."](https://github.com/useautumn/autumn/commit/e0aaf67259bbf4f06f1a36e43799ccd84e6f0301) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49446017)</sub>

<!-- /greptile_comment -->