### PR TITLE
chore: add multi attach starts at

### DIFF
--- a/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
@@ -8,6 +8,7 @@ import {
 	type InvoiceMode,
 	isFreeProduct,
 	isOneOffProduct,
+	isPastStartDate,
 	isProductPaidAndRecurring,
 	type MultiAttachBillingContext,
 	type MultiAttachParamsV0,
@@ -311,6 +312,12 @@ export const setupImmediateMultiProductBillingContext = async ({
 		billingCycleAnchorMs = trialContext.trialEndsAt;
 	}
 
+	const subscriptionBackdateStartMs =
+		billingStartsAt !== undefined &&
+		isPastStartDate(billingStartsAt, currentEpochMs, billingStartsAtToleranceMs)
+			? billingStartsAt
+			: undefined;
+
 	// Reset anchor derives from billingCycleAnchorMs, which setupBillingCycleAnchor
 	// already aligns to a backdated start.
 	const resetCycleAnchorMs = setupResetCycleAnchor({
@@ -361,6 +368,8 @@ export const setupImmediateMultiProductBillingContext = async ({
 		currentEpochMs,
 		billingCycleAnchorMs,
 		resetCycleAnchorMs,
+		billingStartsAt,
+		subscriptionBackdateStartMs,
 		requestedProrationBehavior: params.billing_behavior,
 		stripeCustomer,
 		stripeSubscription,

--- a/server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachErrors.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachErrors.ts
@@ -1,4 +1,8 @@
-import type { BillingPlan, MultiAttachBillingContext } from "@autumn/shared";
+import type {
+	BillingPlan,
+	MultiAttachBillingContext,
+	MultiAttachParamsV0,
+} from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { handleRevertTrialErrors } from "@/internal/billing/v2/actions/attach/errors/handleRevertTrialErrors";
@@ -7,17 +11,22 @@ import { handleSubscriptionIdErrors } from "@/internal/billing/v2/common/errors/
 import { handleStripeBillingPlanErrors } from "@/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors";
 import { handleMultiAttachCurrentProductErrors } from "./handleMultiAttachCurrentProductErrors";
 import { handleMultiAttachRedirectErrors } from "./handleMultiAttachRedirectErrors";
+import { handleMultiAttachStartDateErrors } from "./handleMultiAttachStartDateErrors";
 
 /** Runs all multi-attach validation checks. */
 export const handleMultiAttachErrors = async ({
 	db,
 	billingContext,
 	redirectMode,
+	params,
 }: {
 	db: DrizzleCli;
 	billingContext: MultiAttachBillingContext;
 	redirectMode: string;
+	params: MultiAttachParamsV0;
 }) => {
+	handleMultiAttachStartDateErrors({ billingContext, params });
+
 	handleMultiAttachCurrentProductErrors({
 		productContexts: billingContext.productContexts,
 	});

--- a/server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachStartDateErrors.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachStartDateErrors.ts
@@ -1,0 +1,66 @@
+import {
+	ErrCode,
+	isFutureStartDate,
+	isOneOffProduct,
+	isProductPaidAndRecurring,
+	type MultiAttachBillingContext,
+	type MultiAttachParamsV0,
+	RecaseError,
+} from "@autumn/shared";
+import { assertNoBackdateWithExistingSubscription } from "@/internal/billing/v2/utils/backdate/assertNoBackdateWithExistingSubscription";
+import { assertStripeBackdateInvoiceLineItemLimit } from "@/internal/billing/v2/utils/backdate/stripeBackdateInvoiceLimit";
+
+export const handleMultiAttachStartDateErrors = ({
+	billingContext,
+	params,
+}: {
+	billingContext: MultiAttachBillingContext;
+	params: MultiAttachParamsV0;
+}) => {
+	if (params.starts_at === undefined) return;
+
+	if (isFutureStartDate(params.starts_at, billingContext.currentEpochMs)) {
+		throw new RecaseError({
+			message: "Multi-attach starts_at only supports past timestamps.",
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+
+	if (
+		!billingContext.fullProducts.some(isProductPaidAndRecurring) ||
+		billingContext.fullProducts.some((product) => isOneOffProduct({ product }))
+	) {
+		throw new RecaseError({
+			message:
+				"Past starts_at requires a paid recurring plan and does not support one-off plans.",
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+
+	assertNoBackdateWithExistingSubscription({ billingContext });
+
+	if (billingContext.checkoutMode === "stripe_checkout") {
+		throw new RecaseError({
+			message:
+				"Past starts_at cannot be used when Stripe Checkout is required.",
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+
+	if (billingContext.trialContext?.trialEndsAt) {
+		throw new RecaseError({
+			message: "Past starts_at cannot be used together with a free trial.",
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+
+	assertStripeBackdateInvoiceLineItemLimit({
+		products: billingContext.fullProducts,
+		startsAt: params.starts_at,
+		currentEpochMs: billingContext.currentEpochMs,
+	});
+};

--- a/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
@@ -54,6 +54,7 @@ export async function multiAttach({
 		db: ctx.db,
 		billingContext,
 		redirectMode: params.redirect_mode,
+		params,
 	});
 
 	handleMultiAttachCurrencyErrors({ ctx, billingContext, params });

--- a/server/src/internal/billing/v2/actions/multiAttach/setup/setupMultiAttachBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/setup/setupMultiAttachBillingContext.ts
@@ -19,4 +19,5 @@ export const setupMultiAttachBillingContext = async ({
 		ctx,
 		params,
 		preview,
+		billingStartsAt: params.starts_at,
 	});

--- a/server/tests/integration/billing/multi-attach/multi-attach-backdate.test.ts
+++ b/server/tests/integration/billing/multi-attach/multi-attach-backdate.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Multi-attach accepts one shared past starts_at for new paid subscriptions.
+ * It backdates every customer product, the Stripe subscription, and its invoice.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV3,
+	type MultiAttachParamsV0Input,
+	ms,
+} from "@autumn/shared";
+import { expectBackdatedStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectBackdatedStripeSubscriptionCorrect";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { getCustomerProduct } from "../attach/params/start-date/utils";
+
+test.concurrent(
+	`${chalk.yellowBright("multi-attach backdate: shared starts_at backdates every plan")}`,
+	async () => {
+		const customerId = "multi-attach-backdate";
+		const plan = products.pro({
+			id: "plan",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const addOn = products.recurringAddOn({
+			id: "add-on",
+			items: [items.monthlyUsers({ includedUsage: 5 })],
+		});
+		const { autumnV1, autumnV2_2, ctx, advancedTo } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [plan, addOn] }),
+			],
+			actions: [],
+		});
+		const startsAt = advancedTo - ms.days(35);
+		const params: MultiAttachParamsV0Input = {
+			customer_id: customerId,
+			plans: [{ plan_id: plan.id }, { plan_id: addOn.id }],
+			starts_at: startsAt,
+		};
+
+		const preview = await autumnV2_2.billing.previewMultiAttach(params);
+		expect(preview.total).toBeGreaterThan(40);
+		const result = await autumnV2_2.billing.multiAttach(params);
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		const customerProducts = await Promise.all(
+			[plan.id, addOn.id].map((productId) =>
+				getCustomerProduct({ ctx, customerId, productId }),
+			),
+		);
+		expect(
+			customerProducts.every(({ starts_at }) => starts_at === startsAt),
+		).toBe(true);
+		expect(
+			new Set(
+				customerProducts.flatMap(({ subscription_ids }) => subscription_ids),
+			).size,
+		).toBe(1);
+		await expectCustomerInvoiceCorrect({
+			customer,
+			count: 1,
+			latestTotal: result.invoice!.total,
+		});
+		await expectBackdatedStripeSubscriptionCorrect({
+			ctx,
+			stripeSubscriptionId: customerProducts[0]!.subscription_ids![0]!,
+			startsAt,
+			stripeInvoiceId: result.invoice!.stripe_id,
+			minInvoiceTotal: 4000,
+			minInvoiceLineCount: 4,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("multi-attach backdate: preview and execution reject Stripe Checkout")}`,
+	async () => {
+		const customerId = "multi-attach-backdate-checkout";
+		const plan = products.pro({
+			id: "plan",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const addOn = products.recurringAddOn({
+			id: "add-on",
+			items: [items.monthlyUsers({ includedUsage: 5 })],
+		});
+		const { autumnV2_2, advancedTo } = await initScenario({
+			customerId,
+			setup: [s.customer({}), s.products({ list: [plan, addOn] })],
+			actions: [],
+		});
+		const params: MultiAttachParamsV0Input = {
+			customer_id: customerId,
+			plans: [{ plan_id: plan.id }, { plan_id: addOn.id }],
+			starts_at: advancedTo - ms.days(10),
+		};
+		const expectedError = {
+			errCode: "invalid_request",
+			errMessage:
+				"Past starts_at cannot be used when Stripe Checkout is required",
+		};
+
+		await expectAutumnError({
+			...expectedError,
+			func: () => autumnV2_2.billing.previewMultiAttach(params),
+		});
+		await expectAutumnError({
+			...expectedError,
+			func: () => autumnV2_2.billing.multiAttach(params),
+		});
+	},
+);

--- a/shared/api/billing/attachV2/multiAttachParamsV0.ts
+++ b/shared/api/billing/attachV2/multiAttachParamsV0.ts
@@ -9,6 +9,7 @@ import { EntityDataSchema } from "../../common/entityData";
 import { BillingBehaviorSchema } from "../common/billingBehavior";
 import { InvoiceModeParamsSchema } from "../common/invoiceModeParams";
 import { RedirectModeSchema } from "../common/redirectMode";
+import { UnixMsTimestampSchema } from "../common/unixMsTimestamp";
 import { AttachDiscountSchema } from "./attachDiscount";
 
 /** Per-plan customize without free_trial */
@@ -68,6 +69,11 @@ export const MultiAttachParamsV0Schema = z.object({
 	free_trial: FreeTrialParamsV1Schema.nullable().optional().meta({
 		description:
 			"Free trial configuration applied to all plans. Pass an object to set a custom trial, or null to remove any trial.",
+	}),
+
+	starts_at: UnixMsTimestampSchema.optional().meta({
+		description:
+			"Unix timestamp in milliseconds for backdating every plan in this multi-attach.",
 	}),
 
 	currency: CurrencyCodeSchema.optional().meta({

--- a/vite/src/components/forms/attach-v2/components/AttachAdvancedSection.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachAdvancedSection.tsx
@@ -166,8 +166,17 @@ export function AttachAdvancedSection() {
 	const showStartDate =
 		isPaidRecurringProduct &&
 		!trialEnabled &&
-		effectivePlanSchedule !== "end_of_cycle";
+		effectivePlanSchedule !== "end_of_cycle" &&
+		(!isMultiPlan || createsNewStripeSubscription);
 	const allowBackdatedStartDate = createsNewStripeSubscription;
+	let startDateDescription = "Schedule the plan to start on a future date";
+	if (allowBackdatedStartDate) {
+		startDateDescription =
+			"Start the new subscription on a past or future date";
+	}
+	if (isMultiPlan) {
+		startDateDescription = "Backdate every plan to the same start date";
+	}
 	const showEndDate = !!product && !isFreeProductV2({ items: product.items });
 	const attachStartsAt =
 		effectivePlanSchedule === "end_of_cycle"
@@ -214,16 +223,12 @@ export function AttachAdvancedSection() {
 		form.setFieldValue("customLineItems", updated);
 	};
 
-	const moreOptions = isMultiPlan ? null : (
+	const moreOptions = (
 		<>
 			{showStartDate && (
 				<ConfigRow
 					title="Start Date"
-					description={
-						allowBackdatedStartDate
-							? "Start the new subscription on a past or future date"
-							: "Schedule the plan to start on a future date"
-					}
+					description={startDateDescription}
 					expanded={startDate !== null}
 					action={
 						<Switch
@@ -231,7 +236,9 @@ export function AttachAdvancedSection() {
 							onCheckedChange={(checked) =>
 								form.setFieldValue(
 									"startDate",
-									checked ? addDays(Date.now(), 1).getTime() : null,
+									checked
+										? addDays(Date.now(), isMultiPlan ? -1 : 1).getTime()
+										: null,
 								)
 							}
 						/>
@@ -241,7 +248,9 @@ export function AttachAdvancedSection() {
 						unixDate={startDate}
 						setUnixDate={(value) => form.setFieldValue("startDate", value)}
 						disablePastDates={!allowBackdatedStartDate}
+						disableFutureDates={isMultiPlan}
 						minUnixDate={allowBackdatedStartDate ? undefined : Date.now()}
+						maxUnixDate={isMultiPlan ? Date.now() : undefined}
 						fromYear={
 							allowBackdatedStartDate
 								? new Date().getFullYear() - BACKDATE_START_YEAR_LOOKBACK
@@ -252,7 +261,7 @@ export function AttachAdvancedSection() {
 				</ConfigRow>
 			)}
 
-			{showEndDate && (
+			{!isMultiPlan && showEndDate && (
 				<ConfigRow
 					title="End Date"
 					description="End the plan on a future date"
@@ -427,7 +436,7 @@ export function AttachAdvancedSection() {
 				/>
 			)}
 
-			{hasActiveSubscription && (
+			{!isMultiPlan && hasActiveSubscription && (
 				<ConfigRow
 					title="Reset Billing Cycle"
 					description="Restart the billing cycle from today"
@@ -445,23 +454,27 @@ export function AttachAdvancedSection() {
 				/>
 			)}
 
-			<ConfigRow
-				title="Skip Billing"
-				description="Attach the plan without making changes in Stripe"
-				action={
-					<Switch
-						checked={noBillingChanges}
-						onCheckedChange={(checked) =>
-							form.setFieldValue("noBillingChanges", !!checked)
-						}
-					/>
-				}
-			/>
+			{!isMultiPlan && (
+				<ConfigRow
+					title="Skip Billing"
+					description="Attach the plan without making changes in Stripe"
+					action={
+						<Switch
+							checked={noBillingChanges}
+							onCheckedChange={(checked) =>
+								form.setFieldValue("noBillingChanges", !!checked)
+							}
+						/>
+					}
+				/>
+			)}
 		</>
 	);
 
 	return (
-		<AdvancedSection moreOptions={moreOptions}>
+		<AdvancedSection
+			moreOptions={isMultiPlan && !showStartDate ? undefined : moreOptions}
+		>
 			<ConfigRow
 				title="Discounts"
 				description="Apply percentage or fixed-amount discounts to this plan"

--- a/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
+++ b/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
@@ -491,6 +491,7 @@ export function AttachFormProvider({
 		redirectMode,
 		discounts,
 		currency: attachCurrency.requestCurrency,
+		startDate,
 		hasInvalidPlanScopes: additionalPlans.hasInvalidPlanScopes,
 	});
 	const billingOperation = isMultiPlan

--- a/vite/src/components/forms/attach-v2/hooks/useAttachMultiRequestBody.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachMultiRequestBody.ts
@@ -28,6 +28,7 @@ export type BuildAttachMultiRequestBodyParams = Pick<
 	| "redirectMode"
 	| "discounts"
 	| "currency"
+	| "startDate"
 > & {
 	products: ProductV2[];
 	features: Feature[];
@@ -94,6 +95,7 @@ export function buildAttachMultiRequestBody({
 	redirectMode,
 	discounts,
 	currency,
+	startDate,
 	hasInvalidPlanScopes = false,
 }: BuildAttachMultiRequestBodyParams): MultiAttachParamsV0 | null {
 	if (hasInvalidPlanScopes || !customerId || !product) return null;
@@ -156,6 +158,7 @@ export function buildAttachMultiRequestBody({
 		...(entityId ? { entity_id: entityId } : {}),
 		...(currency ? { currency: currency.toLowerCase() } : {}),
 		...(validDiscounts.length > 0 ? { discounts: validDiscounts } : {}),
+		...(startDate ? { starts_at: startDate } : {}),
 	};
 }
 
@@ -182,6 +185,7 @@ export function useAttachMultiRequestBody(
 		redirectMode,
 		discounts,
 		currency,
+		startDate,
 		hasInvalidPlanScopes,
 	} = params;
 	const requestBody = useMemo(
@@ -206,6 +210,7 @@ export function useAttachMultiRequestBody(
 				redirectMode,
 				discounts,
 				currency,
+				startDate,
 				hasInvalidPlanScopes,
 			}),
 		[
@@ -228,6 +233,7 @@ export function useAttachMultiRequestBody(
 			redirectMode,
 			discounts,
 			currency,
+			startDate,
 			hasInvalidPlanScopes,
 		],
 	);

--- a/vite/tests/components/forms/attach-v2/hooks/build-attach-multi-request-body.test.ts
+++ b/vite/tests/components/forms/attach-v2/hooks/build-attach-multi-request-body.test.ts
@@ -59,6 +59,7 @@ const baseParams = (
 	redirectMode: "if_required",
 	discounts: [],
 	currency: null,
+	startDate: null,
 	...overrides,
 });
 
@@ -148,6 +149,14 @@ test("passes entity and currency through", () => {
 
 	expect(body?.entity_id).toBe("ent_1");
 	expect(body?.currency).toBe("eur");
+});
+
+test("forwards one shared start date", () => {
+	const startDate = Date.now() - 86_400_000;
+
+	expect(
+		buildAttachMultiRequestBody(baseParams({ startDate }))?.starts_at,
+	).toBe(startDate);
 });
 
 test("keeps additional plans customer-level when the primary scope changes", () => {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for a shared backdated start date for multi-attach. A single past `starts_at` now backdates all paid recurring plans and the new Stripe subscription and invoice.

- **New Features**
  - API: `MultiAttachParamsV0` accepts optional `starts_at` (unix ms) to backdate every plan.
  - Server: validates past-only; requires paid recurring plans; rejects one-off plans, existing subscriptions, Stripe Checkout, and free trials; enforces Stripe invoice line-item limits.
  - Billing: propagates `billingStartsAt` and computes `subscriptionBackdateStartMs` for anchors and invoicing.
  - UI: Attach form shows one “Start Date” control for multi-plan backdating (past-only); hides End Date, Reset Cycle, and Skip Billing for multi-plan; forwards `startDate` as `starts_at`.
  - Tests: adds integration coverage for backdated multi-attach and hook tests verifying `starts_at` forwarding.

<sup>Written for commit f4aa452b0cb39d7d9ddfb656fec61514ac67db10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a shared `starts_at` parameter for backdating multi-plan attachments across API validation, billing context setup, Stripe execution, tests, and the dashboard form.
- **[API changes]** Adds optional `starts_at` to the multi-attach request schema.
- **[Improvements]** Propagates one backdate through customer products, billing anchors, invoice calculation, and Stripe subscription creation.
- **[Improvements]** Exposes a multi-plan backdate control and adds server and frontend coverage.
- **[Bug fixes]** Rejects unsupported combinations such as future dates, existing subscriptions, trials, one-off plans, and Stripe Checkout.
</details>

<h3>Confidence Score: 4/5</h3>

The retained hidden start date must be prevented from reaching multi-attach requests before this PR is merged.

Multi-plan form transitions can hide the start-date option while preserving its value, and the changed request builder still submits that value, causing rejected previews or unintended backdating.

**Files Needing Attention:** vite/src/components/forms/attach-v2/hooks/useAttachMultiRequestBody.ts and vite/src/components/forms/attach-v2/components/AttachAdvancedSection.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachStartDateErrors.ts | Adds server-side restrictions for supported multi-attach backdates. |
| server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts | Propagates the shared start date and derives the Stripe subscription backdate consistently with existing attach behavior. |
| shared/api/billing/attachV2/multiAttachParamsV0.ts | Extends the public multi-attach request with an optional millisecond timestamp. |
| vite/src/components/forms/attach-v2/components/AttachAdvancedSection.tsx | Adds the multi-plan backdate UI, but hiding the control does not clear its retained value. |
| vite/src/components/forms/attach-v2/hooks/useAttachMultiRequestBody.ts | Forwards starts_at without checking whether the start-date option remains applicable, enabling stale hidden state to affect requests. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Attach form
  participant API as Multi-attach API
  participant Billing as Billing context
  participant Stripe
  participant DB as Customer products
  UI->>API: plans + shared starts_at
  API->>Billing: validate and set billingStartsAt
  Billing->>Billing: derive backdate and cycle anchors
  Billing->>Stripe: create subscription with backdate_start_date
  Billing->>DB: persist shared starts_at per product
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
vite/src/components/forms/attach-v2/hooks/useAttachMultiRequestBody.ts:161
**Hidden start date remains active**

When a form transition hides the multi-plan start-date control, the retained `startDate` is still submitted as `starts_at`, causing rejected previews for unsupported states or unexpectedly backdating every selected plan.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add multi attach starts at"](https://github.com/useautumn/autumn/commit/f4aa452b0cb39d7d9ddfb656fec61514ac67db10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49622359)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->