### PR TITLE
Release dev to main

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "packages/autumn-js/**"
       - "packages/openapi/**"
+      - "packages/sdk/**"
 
   workflow_dispatch:
     inputs:
@@ -44,11 +45,12 @@ jobs:
       contents: write
     with:
       package-dir: packages/autumn-js
-      commit-paths: packages/autumn-js packages/openapi
+      commit-paths: packages/autumn-js packages/openapi packages/sdk
       install-speakeasy: true
       pre-build-command: bun api
       build-command: bun js:build
       typecheck-command: bun js:ts
+      test-command: cd packages/sdk && bun test
       version-bump: ${{ github.event_name == 'workflow_dispatch' && inputs.version-bump || '' }}
       dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || 'false' }}
       publish-name-override: ${{ github.event_name == 'workflow_dispatch' && inputs.test-package == 'true' && '@useautumn/js-test' || '' }}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -21,6 +21,7 @@
   },
   "sideEffects": false,
   "scripts": {
+    "test": "bun test",
     "lint": "eslint --cache --max-warnings=0 src",
     "build": "tshy",
     "prepublishOnly": "npm run build"

--- a/packages/sdk/src/hooks/registration.ts
+++ b/packages/sdk/src/hooks/registration.ts
@@ -12,6 +12,6 @@ export function initHooks(hooks: Hooks) {
 	const failOpenHook = new FailOpenHook();
 	const timeoutFixHook = new TimeoutFixHook();
 	hooks.registerSDKInitHook(failOpenHook);
-	hooks.registerBeforeRequestHook(timeoutFixHook);
+	hooks.registerBeforeCreateRequestHook(timeoutFixHook);
 	hooks.registerAfterErrorHook(failOpenHook);
 }

--- a/packages/sdk/src/hooks/timeoutFixHook.ts
+++ b/packages/sdk/src/hooks/timeoutFixHook.ts
@@ -1,24 +1,30 @@
-import type { BeforeRequestContext, BeforeRequestHook } from "./types.js";
+import type { RequestInput } from "../lib/http.js";
+import type {
+  BeforeCreateRequestContext,
+  BeforeCreateRequestHook,
+} from "./types.js";
 
 const DEFAULT_TIMEOUT_MS = 5000;
 const AUTO_TIMEOUT_OPERATION_IDS = new Set(["check", "track"]);
 
-export class TimeoutFixHook implements BeforeRequestHook {
-  beforeRequest(hookCtx: BeforeRequestContext, request: Request): Request {
-    let timeoutMs = hookCtx.options.timeoutMs;
+export class TimeoutFixHook implements BeforeCreateRequestHook {
+  beforeCreateRequest(
+    hookCtx: BeforeCreateRequestContext,
+    input: RequestInput,
+  ): RequestInput {
+    if (
+      input.options?.signal
+      || !AUTO_TIMEOUT_OPERATION_IDS.has(hookCtx.operationID)
+    ) {
+      return input;
+    }
 
-    if ((!timeoutMs || timeoutMs <= 0) && AUTO_TIMEOUT_OPERATION_IDS.has(hookCtx.operationID))
-      timeoutMs = DEFAULT_TIMEOUT_MS;
-
-    if (!timeoutMs || timeoutMs <= 0) return request;
-
-    const signal =
-      typeof AbortSignal.any === "function"
-        ? AbortSignal.any([request.signal, AbortSignal.timeout(timeoutMs)])
-        : AbortSignal.timeout(timeoutMs);
-
-    return new Request(request, {
-      signal,
-    });
+    return {
+      ...input,
+      options: {
+        ...input.options,
+        signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+      },
+    };
   }
 }

--- a/packages/sdk/test/timeout-precedence.test.ts
+++ b/packages/sdk/test/timeout-precedence.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test";
+import { Autumn } from "../src/sdk/sdk.js";
+
+const startDelayedServer = () =>
+  Bun.serve({
+    port: 0,
+    async fetch() {
+      await Bun.sleep(250);
+      return Response.json({ list: [], total: {} });
+    },
+  });
+
+test("a per-call timeout can extend the client timeout", async () => {
+  const server = startDelayedServer();
+
+  try {
+    const autumn = new Autumn({
+      secretKey: "test",
+      serverURL: `http://127.0.0.1:${server.port}`,
+      timeoutMs: 100,
+    });
+    const response = await autumn.events.aggregate(
+      { featureId: "credits", range: "90d" },
+      { timeoutMs: 1_000 },
+    );
+
+    expect(response).toEqual({ list: [], total: {} });
+  } finally {
+    await server.stop(true);
+  }
+});
+
+test("the client timeout applies without a per-call override", async () => {
+  const server = startDelayedServer();
+
+  try {
+    const autumn = new Autumn({
+      failOpen: false,
+      secretKey: "test",
+      serverURL: `http://127.0.0.1:${server.port}`,
+      timeoutMs: 100,
+    });
+
+    await expect(
+      autumn.events.aggregate({ featureId: "credits", range: "90d" }),
+    ).rejects.toMatchObject({ name: "RequestTimeoutError" });
+  } finally {
+    await server.stop(true);
+  }
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Respect SDK per-call timeout overrides and keep a 5s default for `check`/`track` when no signal is set. The `autumn-js` publish workflow now includes `packages/sdk` and runs SDK tests.

- **Bug Fixes**
  - Preserve existing request `signal`; only add `AbortSignal.timeout(5000)` for `check`/`track` when none is provided.
  - Per-call `timeoutMs` can extend/override the client timeout; added tests for precedence and client-only timeouts.

- **Refactors**
  - Moved from `beforeRequest` to `beforeCreateRequest` hook and updated to use `RequestInput`.
  - Added `test` script to `packages/sdk` and run it in the patch publish workflow.

<sup>Written for commit 65ec5fa6b7b978bcfedab49a19ca4ba9b27ddc7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adjusts SDK timeout-hook timing so explicit client and per-call timeout signals take precedence, adds timeout regression tests, and includes SDK changes and tests in the JavaScript package release workflow.
- **[Bug fixes]** Moves the default `check`/`track` timeout into the pre-request-creation hook while preserving an existing signal.
- **[Improvements]** Adds SDK timeout-precedence tests and runs the SDK suite during publication.
- **[Improvements] [API changes]** Makes SDK changes trigger and participate in the `autumn-js` release workflow.
</details>

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with the non-blocking caveat that the new regression tests do not exercise the timeout hook they are intended to protect.

Configured signals are preserved and the workflow command is valid, but both new tests use an operation excluded from the changed hook, allowing hook-specific regressions to pass unnoticed.

**Files Needing Attention:** packages/sdk/test/timeout-precedence.test.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/sdk-publish.yml | Adds SDK paths and tests to the reusable `autumn-js` publication workflow; the command runs from the expected repository-root context. |
| packages/sdk/src/hooks/registration.ts | Registers the timeout fix before request construction so configured timeout signals are visible to the hook. |
| packages/sdk/src/hooks/timeoutFixHook.ts | Applies a five-second fallback only to `check` and `track` when request construction has not already supplied a signal. |
| packages/sdk/test/timeout-precedence.test.ts | Verifies general timeout precedence through `events.aggregate`, but does not execute the changed `check`/`track` hook path. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/sdk/test/timeout-precedence.test.ts:20-23
**Tests bypass the changed hook**

Both tests call `events.aggregate`, but the changed timeout hook only applies to `check` and `track`. The tests therefore continue to pass if the hook is removed or broken, leaving its timeout-precedence behavior unprotected.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #2516 from useautumn/..."](https://github.com/useautumn/autumn/commit/65ec5fa6b7b978bcfedab49a19ca4ba9b27ddc7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49654819)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Client SDK Packages](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/client-sdk-packages.md)

<!-- /greptile_comment -->