### PR TITLE
Fix long billing unit label overflow

### DIFF
--- a/vite/src/views/products/plan/components/edit-plan-feature/BillingUnits.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/BillingUnits.tsx
@@ -39,18 +39,17 @@ export function BillingUnits() {
 	});
 
 	return (
-		<div className="flex w-fit shrink-0">
+		<div className="flex min-w-0 overflow-hidden">
 			<Popover open={open} onOpenChange={setOpen}>
 				<PopoverTrigger asChild>
 					<Button
 						variant="muted"
 						className={cn(
-							item.tiers?.length && item.tiers.length > 1
-								? "max-w-20 text-tertiary-foreground"
-								: "text-tertiary-foreground",
+							"min-w-0 max-w-full justify-start overflow-hidden text-tertiary-foreground",
+							item.tiers?.length && item.tiers.length > 1 && "max-w-20",
 						)}
 					>
-						<span className={cn("truncate text-xs")}>
+						<span className="min-w-0 truncate text-xs">
 							{billingUnitsLabel({ item, features })}
 						</span>
 					</Button>

--- a/vite/src/views/products/plan/components/edit-plan-feature/PriceTiers.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/PriceTiers.tsx
@@ -91,7 +91,7 @@ export function PriceTiers({
 			<div className="space-y-2">
 				<div className="flex gap-2 w-full items-center">
 					<CurrencyAmountInput
-						className="min-w-0 flex-1"
+						className="min-w-32 flex-1"
 						currencyCode={currency}
 						displayValue={amountDisplayValue(firstTier.amount)}
 						onRawChange={(raw) =>


### PR DESCRIPTION
## Summary
- preserve a usable minimum width for the price input
- contain and left-align long billing unit labels
- truncate overflowing feature names cleanly

## Testing
- `bun run ts`
- focused ESLint checks
- React Doctor: no issues found

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overflow in the plan feature editor by containing and left-aligning long billing unit labels and truncating them cleanly. Adds a minimum width to the price input to prevent collapse and keep it usable.

<sup>Written for commit d75d63493d3e0a7522d87e7c484eaefddc2ed3ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves sizing and truncation in the plan feature pricing editor so long billing-unit and feature labels remain contained while the price input retains usable space.
- **[Bug fixes]** Makes billing-unit controls shrink within their row and truncates long labels instead of allowing them to overflow.
- **[Improvements]** Left-aligns billing-unit text and preserves a practical minimum width for the single-tier price input.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The changed sizing rules fit within the editor’s supported desktop and mobile containers, while the billing-unit control now absorbs constrained space through intentional truncation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/components/edit-plan-feature/BillingUnits.tsx | Updates flex sizing, overflow containment, alignment, and truncation for long billing-unit labels without an identified regression. |
| vite/src/views/products/plan/components/edit-plan-feature/PriceTiers.tsx | Adds an 8rem minimum width to the single-tier price input while remaining compatible with the current sheet’s responsive dimensions. |

<sub>Reviews (1): Last reviewed commit: ["fix(vite): 🐛 contain long billing unit ..."](https://github.com/useautumn/autumn/commit/d75d63493d3e0a7522d87e7c484eaefddc2ed3ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49670320)</sub>

<!-- /greptile_comment -->