### PR TITLE
fix(auth): hide internal scopes from MCP clients

### DIFF
--- a/server/src/internal/auth/oauth/internalMcpOAuthClients.ts
+++ b/server/src/internal/auth/oauth/internalMcpOAuthClients.ts
@@ -1,4 +1,5 @@
 import { MCP_CLIENT_KIND } from "@autumn/auth/oauth";
+import { META_SCOPES } from "@autumn/shared";
 import type { Context } from "hono";
 import { type DrizzleCli, db } from "@/db/initDrizzle.js";
 import { auth } from "@/utils/auth.js";
@@ -11,6 +12,7 @@ const INTERNAL_MCP_CLIENT_NAME = "Autumn internal-mcp";
 const INTERNAL_MCP_CLIENT_NAME_NORMALIZED =
 	INTERNAL_MCP_CLIENT_NAME.toLowerCase();
 const INTERNAL_MCP_KIND = "internal_mcp";
+const META_SCOPE_SET = new Set<string>(META_SCOPES);
 
 type InternalMcpMetadata = {
 	kind?: string;
@@ -107,6 +109,14 @@ export const handleInternalMcpOAuthAuthorize = async (c: Context) => {
 
 	if (!clientId || !(await isInternalMcpOAuthClientId({ db, clientId }))) {
 		return auth.handler(c.req.raw);
+	}
+
+	const scopes = url.searchParams.get("scope")?.split(" ").filter(Boolean);
+	if (scopes) {
+		url.searchParams.set(
+			"scope",
+			scopes.filter((scope) => !META_SCOPE_SET.has(scope)).join(" "),
+		);
 	}
 
 	const prompts = new Set(url.searchParams.get("prompt")?.split(" ") ?? []);

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -1,5 +1,13 @@
 import "dotenv/config";
-import { ALL_SCOPES, ac, invitation, roles, schemas } from "@autumn/shared";
+import {
+	ALL_SCOPES,
+	MODERN_SCOPES,
+	OPENID_SCOPES,
+	ac,
+	invitation,
+	roles,
+	schemas,
+} from "@autumn/shared";
 import { getScopesForUserInOrg } from "@autumn/shared/utils/auth/getScopesForUserInOrg";
 import { oauthProvider } from "@better-auth/oauth-provider";
 import { passkey } from "@better-auth/passkey";
@@ -280,6 +288,12 @@ const options = {
 			// Resource-based scopes with R/W actions (plus legacy CRUDL +
 			// meta scopes — see shared/utils/scopeDefinitions.ts).
 			scopes: [...ALL_SCOPES],
+			// Internal roles and legacy aliases remain accepted for existing
+			// clients, but must not be advertised to clients that request every
+			// scope from discovery (notably Devin).
+			advertisedMetadata: {
+				scopes_supported: [...OPENID_SCOPES, ...MODERN_SCOPES],
+			},
 			validAudiences: [authBaseUrl, ...mcpResourceUrls].filter(
 				Boolean,
 			) as string[],

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -1,10 +1,10 @@
 import "dotenv/config";
 import {
 	ALL_SCOPES,
-	MODERN_SCOPES,
-	OPENID_SCOPES,
 	ac,
 	invitation,
+	MODERN_SCOPES,
+	OPENID_SCOPES,
 	roles,
 	schemas,
 } from "@autumn/shared";

--- a/server/tests/unit/auth/oauthAdvertisedScopes.test.ts
+++ b/server/tests/unit/auth/oauthAdvertisedScopes.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+import { META_SCOPES, MODERN_SCOPES, OPENID_SCOPES } from "@autumn/shared";
+import { oauthProviderAuthServerMetadata } from "@better-auth/oauth-provider";
+import { auth } from "@/utils/auth.js";
+
+test("OAuth metadata advertises only public scopes", async () => {
+	const response = await oauthProviderAuthServerMetadata(auth)(
+		new Request(
+			"http://localhost:8080/.well-known/oauth-authorization-server/api/auth",
+		),
+	);
+	const metadata = (await response.json()) as { scopes_supported?: string[] };
+
+	expect(response.status).toBe(200);
+	expect(metadata.scopes_supported).toEqual([
+		...OPENID_SCOPES,
+		...MODERN_SCOPES,
+	]);
+	for (const scope of META_SCOPES) {
+		expect(metadata.scopes_supported).not.toContain(scope);
+	}
+});


### PR DESCRIPTION
## Summary
- advertise only OIDC and modern public scopes in OAuth authorization-server metadata
- keep accepting legacy/internal scopes server-side for existing clients
- strip internal role scopes from cached MCP authorization requests

## Context
Devin requests every scope advertised by OAuth discovery. Autumn advertised `superuser`, `owner`, `admin`, and `public`, then removed them during dynamic client registration, causing the subsequent authorization request to fail with `invalid_scope`.

This complements the discovery-routing fix already merged in #2499.

## Validation
- focused OAuth metadata regression test: 1 passed, 0 failed
- pre-commit Knip check passed
- `@autumn/server` TypeScript check passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide internal and legacy OAuth scopes from discovery so MCP clients (e.g., Devin) don’t request them and hit invalid_scope. The server still accepts these scopes for existing clients.

- **Bug Fixes**
  - OAuth metadata now advertises only `OPENID_SCOPES` and `MODERN_SCOPES` in `scopes_supported`.
  - MCP authorize handler strips `META_SCOPES` from the `scope` parameter and enforces `prompt=consent`.
  - Added a unit test to lock advertised scopes and ensure meta/internal scopes are excluded.

<sup>Written for commit 8bb696fe3602e56261d4dec0d0e269757ed18e5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

