### PR TITLE
fix: fall back when daily analytics rollups are empty

### DIFF
--- a/server/src/internal/analytics/actions/dailyRollupRouting.ts
+++ b/server/src/internal/analytics/actions/dailyRollupRouting.ts
@@ -153,14 +153,16 @@ export const buildCountAndSumQuery = ({
 			sum(event_count_value) as count,
 			sum(total_value_value) as sum,
 			max(daily_rollup_days) as daily_rollup_days,
-			max(expected_daily_days) as expected_daily_days
+			max(expected_daily_days) as expected_daily_days,
+			max(is_daily_rollup_coverage) as is_daily_rollup_coverage
 		FROM (
 			SELECT
 				event_name,
 				sumMerge(event_count) as event_count_value,
 				sumMerge(total_value) as total_value_value,
-				uniqExact(day) as daily_rollup_days,
-				dateDiff('day', ${fullDayStartSql}, toStartOfDay({end_date:DateTime})) as expected_daily_days
+				0 as daily_rollup_days,
+				0 as expected_daily_days,
+				0 as is_daily_rollup_coverage
 			FROM events_customer_daily_mv
 			WHERE org_id = {org_id:String} AND env = {env:String}
 				${customerFilter}
@@ -177,7 +179,8 @@ export const buildCountAndSumQuery = ({
 				sum(event_count) as event_count_value,
 				sum(total_value) as total_value_value,
 				0 as daily_rollup_days,
-				dateDiff('day', ${fullDayStartSql}, toStartOfDay({end_date:DateTime})) as expected_daily_days
+				0 as expected_daily_days,
+				0 as is_daily_rollup_coverage
 			FROM events_customer_hourly_mv
 			WHERE org_id = {org_id:String} AND env = {env:String}
 				${customerFilter}
@@ -186,6 +189,21 @@ export const buildCountAndSumQuery = ({
 				AND (hour < ${fullDayStartSql} OR hour >= toStartOfDay({end_date:DateTime}))
 				AND event_name IN {event_names:Array(String)}
 			GROUP BY event_name
+
+			UNION ALL
+
+			SELECT
+				'' as event_name,
+				0 as event_count_value,
+				0 as total_value_value,
+				(
+					SELECT uniqExact(day)
+					FROM events_customer_daily_coverage_mv
+					WHERE day >= ${fullDayStartSql}
+						AND day < toStartOfDay({end_date:DateTime})
+				) as daily_rollup_days,
+				dateDiff('day', ${fullDayStartSql}, toStartOfDay({end_date:DateTime})) as expected_daily_days,
+				1 as is_daily_rollup_coverage
 		)
 		GROUP BY event_name
 	`;

--- a/server/src/internal/analytics/actions/dailyRollupRouting.ts
+++ b/server/src/internal/analytics/actions/dailyRollupRouting.ts
@@ -152,17 +152,15 @@ export const buildCountAndSumQuery = ({
 			event_name,
 			sum(event_count_value) as count,
 			sum(total_value_value) as sum,
-			max(daily_rollup_days) as daily_rollup_days,
-			max(expected_daily_days) as expected_daily_days,
-			max(is_daily_rollup_coverage) as is_daily_rollup_coverage
+			sum(actual_daily_event_count_value) as actual_daily_event_count,
+			sum(expected_daily_event_count_value) as expected_daily_event_count
 		FROM (
 			SELECT
 				event_name,
 				sumMerge(event_count) as event_count_value,
 				sumMerge(total_value) as total_value_value,
-				0 as daily_rollup_days,
-				0 as expected_daily_days,
-				0 as is_daily_rollup_coverage
+				sumMerge(event_count) as actual_daily_event_count_value,
+				0 as expected_daily_event_count_value
 			FROM events_customer_daily_mv
 			WHERE org_id = {org_id:String} AND env = {env:String}
 				${customerFilter}
@@ -178,9 +176,8 @@ export const buildCountAndSumQuery = ({
 				event_name,
 				sum(event_count) as event_count_value,
 				sum(total_value) as total_value_value,
-				0 as daily_rollup_days,
-				0 as expected_daily_days,
-				0 as is_daily_rollup_coverage
+				0 as actual_daily_event_count_value,
+				0 as expected_daily_event_count_value
 			FROM events_customer_hourly_mv
 			WHERE org_id = {org_id:String} AND env = {env:String}
 				${customerFilter}
@@ -193,17 +190,19 @@ export const buildCountAndSumQuery = ({
 			UNION ALL
 
 			SELECT
-				'' as event_name,
+				event_name,
 				0 as event_count_value,
 				0 as total_value_value,
-				(
-					SELECT uniqExact(day)
-					FROM events_customer_daily_coverage_mv
-					WHERE day >= ${fullDayStartSql}
-						AND day < toStartOfDay({end_date:DateTime})
-				) as daily_rollup_days,
-				dateDiff('day', ${fullDayStartSql}, toStartOfDay({end_date:DateTime})) as expected_daily_days,
-				1 as is_daily_rollup_coverage
+				0 as actual_daily_event_count_value,
+				sumMerge(expected_event_count) as expected_daily_event_count_value
+			FROM events_customer_daily_coverage_mv
+			WHERE org_id = {org_id:String} AND env = {env:String}
+				${customerFilter}
+				${entityFilter}
+				AND day >= ${fullDayStartSql}
+				AND day < toStartOfDay({end_date:DateTime})
+				AND event_name IN {event_names:Array(String)}
+			GROUP BY event_name
 		)
 		GROUP BY event_name
 	`;

--- a/server/src/internal/analytics/actions/dailyRollupRouting.ts
+++ b/server/src/internal/analytics/actions/dailyRollupRouting.ts
@@ -151,12 +151,14 @@ export const buildCountAndSumQuery = ({
 		SELECT
 			event_name,
 			sum(event_count_value) as count,
-			sum(total_value_value) as sum
+			sum(total_value_value) as sum,
+			sum(daily_rollup_rows) as daily_rollup_rows
 		FROM (
 			SELECT
 				event_name,
 				sumMerge(event_count) as event_count_value,
-				sumMerge(total_value) as total_value_value
+				sumMerge(total_value) as total_value_value,
+				count() as daily_rollup_rows
 			FROM events_customer_daily_mv
 			WHERE org_id = {org_id:String} AND env = {env:String}
 				${customerFilter}
@@ -171,7 +173,8 @@ export const buildCountAndSumQuery = ({
 			SELECT
 				event_name,
 				sum(event_count) as event_count_value,
-				sum(total_value) as total_value_value
+				sum(total_value) as total_value_value,
+				0 as daily_rollup_rows
 			FROM events_customer_hourly_mv
 			WHERE org_id = {org_id:String} AND env = {env:String}
 				${customerFilter}

--- a/server/src/internal/analytics/actions/dailyRollupRouting.ts
+++ b/server/src/internal/analytics/actions/dailyRollupRouting.ts
@@ -152,13 +152,15 @@ export const buildCountAndSumQuery = ({
 			event_name,
 			sum(event_count_value) as count,
 			sum(total_value_value) as sum,
-			sum(daily_rollup_rows) as daily_rollup_rows
+			max(daily_rollup_days) as daily_rollup_days,
+			max(expected_daily_days) as expected_daily_days
 		FROM (
 			SELECT
 				event_name,
 				sumMerge(event_count) as event_count_value,
 				sumMerge(total_value) as total_value_value,
-				count() as daily_rollup_rows
+				uniqExact(day) as daily_rollup_days,
+				dateDiff('day', ${fullDayStartSql}, toStartOfDay({end_date:DateTime})) as expected_daily_days
 			FROM events_customer_daily_mv
 			WHERE org_id = {org_id:String} AND env = {env:String}
 				${customerFilter}
@@ -174,7 +176,8 @@ export const buildCountAndSumQuery = ({
 				event_name,
 				sum(event_count) as event_count_value,
 				sum(total_value) as total_value_value,
-				0 as daily_rollup_rows
+				0 as daily_rollup_days,
+				dateDiff('day', ${fullDayStartSql}, toStartOfDay({end_date:DateTime})) as expected_daily_days
 			FROM events_customer_hourly_mv
 			WHERE org_id = {org_id:String} AND env = {env:String}
 				${customerFilter}

--- a/server/src/internal/analytics/actions/getCountAndSum.ts
+++ b/server/src/internal/analytics/actions/getCountAndSum.ts
@@ -27,29 +27,31 @@ type CountAndSumRow = {
 	sum: string;
 	daily_rollup_days?: string | number;
 	expected_daily_days?: string | number;
+	is_daily_rollup_coverage?: string | number;
 };
 
-const hasCompleteDailyCoverage = ({
+const inspectDailyCoverage = ({
 	rows,
-	eventNames,
 }: {
 	rows: CountAndSumRow[];
-	eventNames: string[];
-}): boolean => {
-	const rowsByEventName = new Map(rows.map((row) => [row.event_name, row]));
-	return [...new Set(eventNames)].every((eventName) => {
-		const row = rowsByEventName.get(eventName);
-		if (!row) return false;
+}): { dataRows: CountAndSumRow[]; isComplete: boolean } => {
+	const coverageRow = rows.find(
+		(row) => Number(row.is_daily_rollup_coverage) === 1,
+	);
+	const dataRows = rows.filter(
+		(row) => Number(row.is_daily_rollup_coverage) !== 1,
+	);
+	const dailyRollupDays = Number(coverageRow?.daily_rollup_days);
+	const expectedDailyDays = Number(coverageRow?.expected_daily_days);
 
-		const dailyRollupDays = Number(row.daily_rollup_days);
-		const expectedDailyDays = Number(row.expected_daily_days);
-		return (
+	return {
+		dataRows,
+		isComplete:
 			Number.isFinite(dailyRollupDays) &&
 			Number.isFinite(expectedDailyDays) &&
 			expectedDailyDays > 0 &&
-			dailyRollupDays === expectedDailyDays
-		);
-	});
+			dailyRollupDays === expectedDailyDays,
+	};
 };
 
 const intervalTypeToDaysMap = (gap = 0): Record<string, number> => ({
@@ -211,11 +213,11 @@ export const getCountAndSum = async ({
 
 	let rows = await executeQuery({ query });
 
-	if (
-		source === "customer_daily" &&
-		!hasCompleteDailyCoverage({ rows, eventNames: params.event_names })
-	) {
-		rows = await executeHourlyFallback();
+	if (source === "customer_daily") {
+		const coverage = inspectDailyCoverage({ rows });
+		rows = coverage.isComplete
+			? coverage.dataRows
+			: await executeHourlyFallback();
 	}
 
 	const summary = rows.reduce(

--- a/server/src/internal/analytics/actions/getCountAndSum.ts
+++ b/server/src/internal/analytics/actions/getCountAndSum.ts
@@ -25,34 +25,24 @@ type CountAndSumRow = {
 	event_name: string;
 	count: string;
 	sum: string;
-	daily_rollup_days?: string | number;
-	expected_daily_days?: string | number;
-	is_daily_rollup_coverage?: string | number;
+	actual_daily_event_count?: string | number;
+	expected_daily_event_count?: string | number;
 };
 
-const inspectDailyCoverage = ({
+const hasCompleteDailyCoverage = ({
 	rows,
 }: {
 	rows: CountAndSumRow[];
-}): { dataRows: CountAndSumRow[]; isComplete: boolean } => {
-	const coverageRow = rows.find(
-		(row) => Number(row.is_daily_rollup_coverage) === 1,
-	);
-	const dataRows = rows.filter(
-		(row) => Number(row.is_daily_rollup_coverage) !== 1,
-	);
-	const dailyRollupDays = Number(coverageRow?.daily_rollup_days);
-	const expectedDailyDays = Number(coverageRow?.expected_daily_days);
-
-	return {
-		dataRows,
-		isComplete:
-			Number.isFinite(dailyRollupDays) &&
-			Number.isFinite(expectedDailyDays) &&
-			expectedDailyDays > 0 &&
-			dailyRollupDays === expectedDailyDays,
-	};
-};
+}): boolean =>
+	rows.every((row) => {
+		const actualDailyEventCount = Number(row.actual_daily_event_count);
+		const expectedDailyEventCount = Number(row.expected_daily_event_count);
+		return (
+			Number.isFinite(actualDailyEventCount) &&
+			Number.isFinite(expectedDailyEventCount) &&
+			actualDailyEventCount === expectedDailyEventCount
+		);
+	});
 
 const intervalTypeToDaysMap = (gap = 0): Record<string, number> => ({
 	"24h": 1,
@@ -213,11 +203,8 @@ export const getCountAndSum = async ({
 
 	let rows = await executeQuery({ query });
 
-	if (source === "customer_daily") {
-		const coverage = inspectDailyCoverage({ rows });
-		rows = coverage.isComplete
-			? coverage.dataRows
-			: await executeHourlyFallback();
+	if (source === "customer_daily" && !hasCompleteDailyCoverage({ rows })) {
+		rows = await executeHourlyFallback();
 	}
 
 	const summary = rows.reduce(

--- a/server/src/internal/analytics/actions/getCountAndSum.ts
+++ b/server/src/internal/analytics/actions/getCountAndSum.ts
@@ -34,6 +34,7 @@ const hasCompleteDailyCoverage = ({
 }: {
 	rows: CountAndSumRow[];
 }): boolean =>
+	rows.length > 0 &&
 	rows.every((row) => {
 		const actualDailyEventCount = Number(row.actual_daily_event_count);
 		const expectedDailyEventCount = Number(row.expected_daily_event_count);

--- a/server/src/internal/analytics/actions/getCountAndSum.ts
+++ b/server/src/internal/analytics/actions/getCountAndSum.ts
@@ -25,7 +25,31 @@ type CountAndSumRow = {
 	event_name: string;
 	count: string;
 	sum: string;
-	daily_rollup_rows?: string | number;
+	daily_rollup_days?: string | number;
+	expected_daily_days?: string | number;
+};
+
+const hasCompleteDailyCoverage = ({
+	rows,
+	eventNames,
+}: {
+	rows: CountAndSumRow[];
+	eventNames: string[];
+}): boolean => {
+	const rowsByEventName = new Map(rows.map((row) => [row.event_name, row]));
+	return [...new Set(eventNames)].every((eventName) => {
+		const row = rowsByEventName.get(eventName);
+		if (!row) return false;
+
+		const dailyRollupDays = Number(row.daily_rollup_days);
+		const expectedDailyDays = Number(row.expected_daily_days);
+		return (
+			Number.isFinite(dailyRollupDays) &&
+			Number.isFinite(expectedDailyDays) &&
+			expectedDailyDays > 0 &&
+			dailyRollupDays === expectedDailyDays
+		);
+	});
 };
 
 const intervalTypeToDaysMap = (gap = 0): Record<string, number> => ({
@@ -172,7 +196,7 @@ export const getCountAndSum = async ({
 	const executeHourlyFallback = async () => {
 		ctx.logger.warn("Daily analytics totals unavailable; using hourly rollup", {
 			type: "daily_rollup_fallback",
-			reason: "no_daily_rows",
+			reason: "incomplete_daily_coverage",
 			orgId: org.id,
 			customerId: params.customer_id,
 		});
@@ -187,10 +211,9 @@ export const getCountAndSum = async ({
 
 	let rows = await executeQuery({ query });
 
-	// Boundary-hour rows can make an unpopulated daily query look non-empty.
 	if (
 		source === "customer_daily" &&
-		rows.every((row) => Number(row.daily_rollup_rows ?? 0) === 0)
+		!hasCompleteDailyCoverage({ rows, eventNames: params.event_names })
 	) {
 		rows = await executeHourlyFallback();
 	}

--- a/server/src/internal/analytics/actions/getCountAndSum.ts
+++ b/server/src/internal/analytics/actions/getCountAndSum.ts
@@ -21,6 +21,13 @@ import {
 
 const DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
 
+type CountAndSumRow = {
+	event_name: string;
+	count: string;
+	sum: string;
+	daily_rollup_rows?: string | number;
+};
+
 const intervalTypeToDaysMap = (gap = 0): Record<string, number> => ({
 	"24h": 1,
 	"7d": 7,
@@ -132,6 +139,16 @@ export const getCountAndSum = async ({
 		filterBySql,
 		hasEntityId: Boolean(params.entity_id),
 	});
+	const queryParams = {
+		org_id: org.id,
+		env,
+		customer_id: params.customer_id,
+		entity_id: params.entity_id,
+		start_date: startDate,
+		end_date: endDate,
+		event_names: params.event_names,
+		...filterByParams,
+	};
 
 	ctx.logger.debug("Getting count and sum", {
 		eventNames: params.event_names,
@@ -141,27 +158,42 @@ export const getCountAndSum = async ({
 		endDate,
 	});
 
-	const result = await ch.query({
-		query,
-		query_params: {
-			org_id: org.id,
-			env,
-			customer_id: params.customer_id,
-			entity_id: params.entity_id,
-			start_date: startDate,
-			end_date: endDate,
-			event_names: params.event_names,
-			...filterByParams,
-		},
-		format: "JSON",
-	});
+	const executeQuery = async ({ query }: { query: string }) => {
+		const result = await ch.query({
+			query,
+			query_params: queryParams,
+			format: "JSON",
+		});
+		const resultJson =
+			(await result.json()) as ClickHouseResult<CountAndSumRow>;
+		return resultJson.data;
+	};
 
-	const resultJson = (await result.json()) as ClickHouseResult;
-	const rows = resultJson.data as Array<{
-		event_name: string;
-		count: string;
-		sum: string;
-	}>;
+	const executeHourlyFallback = async () => {
+		ctx.logger.warn("Daily analytics totals unavailable; using hourly rollup", {
+			type: "daily_rollup_fallback",
+			reason: "no_daily_rows",
+			orgId: org.id,
+			customerId: params.customer_id,
+		});
+		return executeQuery({
+			query: buildCountAndSumQuery({
+				source: "customer_hourly",
+				aggregateAll: Boolean(params.aggregateAll),
+				hasEntityId: Boolean(params.entity_id),
+			}),
+		});
+	};
+
+	let rows = await executeQuery({ query });
+
+	// Boundary-hour rows can make an unpopulated daily query look non-empty.
+	if (
+		source === "customer_daily" &&
+		rows.every((row) => Number(row.daily_rollup_rows ?? 0) === 0)
+	) {
+		rows = await executeHourlyFallback();
+	}
 
 	const summary = rows.reduce(
 		(acc, row) => {

--- a/server/tests/unit/analytics/daily-rollup-fallback.test.ts
+++ b/server/tests/unit/analytics/daily-rollup-fallback.test.ts
@@ -6,6 +6,7 @@ const state = {
 	dailyMode: "no_rows" as
 		| "empty_complete"
 		| "error"
+		| "inactive_event"
 		| "missing_event"
 		| "mixed_events"
 		| "no_rows"
@@ -17,63 +18,83 @@ const state = {
 
 const dailyRowsByMode = {
 	empty_complete: [],
-	missing_event: [
+	inactive_event: [
 		{
+			actual_daily_event_count: "12",
 			count: "12",
 			event_name: "emails.sent",
+			expected_daily_event_count: "12",
 			sum: "12",
+		},
+	],
+	missing_event: [
+		{
+			actual_daily_event_count: "12",
+			count: "12",
+			event_name: "emails.sent",
+			expected_daily_event_count: "12",
+			sum: "12",
+		},
+		{
+			actual_daily_event_count: "0",
+			count: "0",
+			event_name: "emails.delivered",
+			expected_daily_event_count: "17",
+			sum: "0",
 		},
 	],
 	mixed_events: [
 		{
+			actual_daily_event_count: "10",
 			count: "12",
 			event_name: "emails.sent",
+			expected_daily_event_count: "10",
 			sum: "12",
 		},
 		{
+			actual_daily_event_count: "0",
 			count: "2",
 			event_name: "emails.delivered",
+			expected_daily_event_count: "17",
 			sum: "2",
 		},
 	],
 	no_rows: [
 		{
+			actual_daily_event_count: "0",
 			count: "2",
 			event_name: "emails.sent",
+			expected_daily_event_count: "42",
 			sum: "2",
 		},
 	],
 	partial_coverage: [
 		{
+			actual_daily_event_count: "8",
 			count: "8",
 			event_name: "emails.sent",
+			expected_daily_event_count: "42",
 			sum: "8",
 		},
 	],
 	populated: [
 		{
+			actual_daily_event_count: "12",
 			count: "12",
 			event_name: "emails.sent",
+			expected_daily_event_count: "12",
 			sum: "12",
 		},
 	],
 	sparse_event: [
 		{
+			actual_daily_event_count: "7",
 			count: "7",
 			event_name: "emails.sent",
+			expected_daily_event_count: "7",
 			sum: "7",
 		},
 	],
-};
-
-const dailyCoverageDaysByMode = {
-	empty_complete: 2,
-	missing_event: 2,
-	mixed_events: 1,
-	no_rows: 0,
-	partial_coverage: 1,
-	populated: 2,
-	sparse_event: 2,
 };
 
 mock.module("@/external/tinybird/initClickhouse.js", () => ({
@@ -92,21 +113,7 @@ mock.module("@/external/tinybird/initClickhouse.js", () => ({
 			}
 
 			const data = isDailyQuery
-				? [
-						...dailyRowsByMode[state.dailyMode as keyof typeof dailyRowsByMode],
-						{
-							count: "0",
-							daily_rollup_days: String(
-								dailyCoverageDaysByMode[
-									state.dailyMode as keyof typeof dailyCoverageDaysByMode
-								],
-							),
-							event_name: "",
-							expected_daily_days: "2",
-							is_daily_rollup_coverage: "1",
-							sum: "0",
-						},
-					]
+				? dailyRowsByMode[state.dailyMode as keyof typeof dailyRowsByMode]
 				: (queryParams?.event_names ?? []).map((eventName) => ({
 						count: eventName === "emails.sent" ? "42" : "17",
 						event_name: eventName,
@@ -217,9 +224,22 @@ test("daily totals: retry hourly when datasource coverage is incomplete", async 
 	expect(state.queries).toHaveLength(2);
 });
 
-test("daily totals: treat absent events as zero when datasource coverage is complete", async () => {
+test("daily totals: retry hourly when a requested event is missing from daily coverage", async () => {
 	const { summary } = await runDailyTotalsQuery({
 		dailyMode: "missing_event",
+		eventNames: ["emails.sent", "emails.delivered"],
+	});
+
+	expect(summary).toEqual({
+		"emails.delivered": { count: 17, sum: 17 },
+		"emails.sent": { count: 42, sum: 42 },
+	});
+	expect(state.queries).toHaveLength(2);
+});
+
+test("daily totals: treat an event absent from both rollups as zero", async () => {
+	const { summary } = await runDailyTotalsQuery({
+		dailyMode: "inactive_event",
 		eventNames: ["emails.sent", "emails.delivered"],
 	});
 

--- a/server/tests/unit/analytics/daily-rollup-fallback.test.ts
+++ b/server/tests/unit/analytics/daily-rollup-fallback.test.ts
@@ -4,68 +4,76 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 
 const state = {
 	dailyMode: "no_rows" as
+		| "empty_complete"
 		| "error"
 		| "missing_event"
 		| "mixed_events"
 		| "no_rows"
 		| "partial_coverage"
-		| "populated",
+		| "populated"
+		| "sparse_event",
 	queries: [] as string[],
 };
 
 const dailyRowsByMode = {
+	empty_complete: [],
 	missing_event: [
 		{
 			count: "12",
-			daily_rollup_days: "2",
 			event_name: "emails.sent",
-			expected_daily_days: "2",
 			sum: "12",
 		},
 	],
 	mixed_events: [
 		{
 			count: "12",
-			daily_rollup_days: "2",
 			event_name: "emails.sent",
-			expected_daily_days: "2",
 			sum: "12",
 		},
 		{
 			count: "2",
-			daily_rollup_days: "0",
 			event_name: "emails.delivered",
-			expected_daily_days: "2",
 			sum: "2",
 		},
 	],
 	no_rows: [
 		{
 			count: "2",
-			daily_rollup_days: "0",
 			event_name: "emails.sent",
-			expected_daily_days: "2",
 			sum: "2",
 		},
 	],
 	partial_coverage: [
 		{
 			count: "8",
-			daily_rollup_days: "1",
 			event_name: "emails.sent",
-			expected_daily_days: "2",
 			sum: "8",
 		},
 	],
 	populated: [
 		{
 			count: "12",
-			daily_rollup_days: "2",
 			event_name: "emails.sent",
-			expected_daily_days: "2",
 			sum: "12",
 		},
 	],
+	sparse_event: [
+		{
+			count: "7",
+			event_name: "emails.sent",
+			sum: "7",
+		},
+	],
+};
+
+const dailyCoverageDaysByMode = {
+	empty_complete: 2,
+	missing_event: 2,
+	mixed_events: 1,
+	no_rows: 0,
+	partial_coverage: 1,
+	populated: 2,
+	sparse_event: 2,
 };
 
 mock.module("@/external/tinybird/initClickhouse.js", () => ({
@@ -84,7 +92,21 @@ mock.module("@/external/tinybird/initClickhouse.js", () => ({
 			}
 
 			const data = isDailyQuery
-				? dailyRowsByMode[state.dailyMode as keyof typeof dailyRowsByMode]
+				? [
+						...dailyRowsByMode[state.dailyMode as keyof typeof dailyRowsByMode],
+						{
+							count: "0",
+							daily_rollup_days: String(
+								dailyCoverageDaysByMode[
+									state.dailyMode as keyof typeof dailyCoverageDaysByMode
+								],
+							),
+							event_name: "",
+							expected_daily_days: "2",
+							is_daily_rollup_coverage: "1",
+							sum: "0",
+						},
+					]
 				: (queryParams?.event_names ?? []).map((eventName) => ({
 						count: eventName === "emails.sent" ? "42" : "17",
 						event_name: eventName,
@@ -162,7 +184,27 @@ test("daily totals: keep populated daily reads on the fast path", async () => {
 	expect(warnings).toHaveLength(0);
 });
 
-test("daily totals: retry hourly when one event lacks daily coverage", async () => {
+test("daily totals: keep sparse events on the daily fast path", async () => {
+	const { summary, warnings } = await runDailyTotalsQuery({
+		dailyMode: "sparse_event",
+	});
+
+	expect(summary).toEqual({ "emails.sent": { count: 7, sum: 7 } });
+	expect(state.queries).toHaveLength(1);
+	expect(warnings).toHaveLength(0);
+});
+
+test("daily totals: return zero without fallback when a covered window has no events", async () => {
+	const { summary, warnings } = await runDailyTotalsQuery({
+		dailyMode: "empty_complete",
+	});
+
+	expect(summary).toEqual({});
+	expect(state.queries).toHaveLength(1);
+	expect(warnings).toHaveLength(0);
+});
+
+test("daily totals: retry hourly when datasource coverage is incomplete", async () => {
 	const { summary } = await runDailyTotalsQuery({
 		dailyMode: "mixed_events",
 		eventNames: ["emails.sent", "emails.delivered"],
@@ -175,17 +217,16 @@ test("daily totals: retry hourly when one event lacks daily coverage", async () 
 	expect(state.queries).toHaveLength(2);
 });
 
-test("daily totals: retry hourly when a requested event is absent", async () => {
+test("daily totals: treat absent events as zero when datasource coverage is complete", async () => {
 	const { summary } = await runDailyTotalsQuery({
 		dailyMode: "missing_event",
 		eventNames: ["emails.sent", "emails.delivered"],
 	});
 
 	expect(summary).toEqual({
-		"emails.delivered": { count: 17, sum: 17 },
-		"emails.sent": { count: 42, sum: 42 },
+		"emails.sent": { count: 12, sum: 12 },
 	});
-	expect(state.queries).toHaveLength(2);
+	expect(state.queries).toHaveLength(1);
 });
 
 test("daily totals: retry hourly when the requested day window is partial", async () => {

--- a/server/tests/unit/analytics/daily-rollup-fallback.test.ts
+++ b/server/tests/unit/analytics/daily-rollup-fallback.test.ts
@@ -3,13 +3,80 @@ import type { TotalEventsParams } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 
 const state = {
-	dailyMode: "no_rows" as "error" | "no_rows" | "populated",
+	dailyMode: "no_rows" as
+		| "error"
+		| "missing_event"
+		| "mixed_events"
+		| "no_rows"
+		| "partial_coverage"
+		| "populated",
 	queries: [] as string[],
+};
+
+const dailyRowsByMode = {
+	missing_event: [
+		{
+			count: "12",
+			daily_rollup_days: "2",
+			event_name: "emails.sent",
+			expected_daily_days: "2",
+			sum: "12",
+		},
+	],
+	mixed_events: [
+		{
+			count: "12",
+			daily_rollup_days: "2",
+			event_name: "emails.sent",
+			expected_daily_days: "2",
+			sum: "12",
+		},
+		{
+			count: "2",
+			daily_rollup_days: "0",
+			event_name: "emails.delivered",
+			expected_daily_days: "2",
+			sum: "2",
+		},
+	],
+	no_rows: [
+		{
+			count: "2",
+			daily_rollup_days: "0",
+			event_name: "emails.sent",
+			expected_daily_days: "2",
+			sum: "2",
+		},
+	],
+	partial_coverage: [
+		{
+			count: "8",
+			daily_rollup_days: "1",
+			event_name: "emails.sent",
+			expected_daily_days: "2",
+			sum: "8",
+		},
+	],
+	populated: [
+		{
+			count: "12",
+			daily_rollup_days: "2",
+			event_name: "emails.sent",
+			expected_daily_days: "2",
+			sum: "12",
+		},
+	],
 };
 
 mock.module("@/external/tinybird/initClickhouse.js", () => ({
 	getClickhouseClient: () => ({
-		query: async ({ query }: { query: string }) => {
+		query: async ({
+			query,
+			query_params: queryParams,
+		}: {
+			query: string;
+			query_params?: { event_names?: string[] };
+		}) => {
 			state.queries.push(query);
 			const isDailyQuery = query.includes("events_customer_daily_mv");
 			if (isDailyQuery && state.dailyMode === "error") {
@@ -17,24 +84,12 @@ mock.module("@/external/tinybird/initClickhouse.js", () => ({
 			}
 
 			const data = isDailyQuery
-				? state.dailyMode === "populated"
-					? [
-							{
-								count: "12",
-								daily_rollup_rows: "3",
-								event_name: "emails.sent",
-								sum: "12",
-							},
-						]
-					: [
-							{
-								count: "2",
-								daily_rollup_rows: "0",
-								event_name: "emails.sent",
-								sum: "2",
-							},
-						]
-				: [{ count: "42", event_name: "emails.sent", sum: "42" }];
+				? dailyRowsByMode[state.dailyMode as keyof typeof dailyRowsByMode]
+				: (queryParams?.event_names ?? []).map((eventName) => ({
+						count: eventName === "emails.sent" ? "42" : "17",
+						event_name: eventName,
+						sum: eventName === "emails.sent" ? "42" : "17",
+					}));
 
 			return { json: async () => ({ data }) };
 		},
@@ -47,8 +102,10 @@ const { getCountAndSum } = await import(
 
 const runDailyTotalsQuery = async ({
 	dailyMode,
+	eventNames = ["emails.sent"],
 }: {
 	dailyMode: typeof state.dailyMode;
+	eventNames?: string[];
 }) => {
 	state.dailyMode = dailyMode;
 	state.queries = [];
@@ -66,7 +123,7 @@ const runDailyTotalsQuery = async ({
 	const params = {
 		bin_size: "day",
 		customer_id: "customer_test",
-		event_names: ["emails.sent"],
+		event_names: eventNames,
 	} satisfies TotalEventsParams;
 
 	const summary = await getCountAndSum({
@@ -103,6 +160,41 @@ test("daily totals: keep populated daily reads on the fast path", async () => {
 	expect(state.queries).toHaveLength(1);
 	expect(state.queries[0]).toContain("events_customer_daily_mv");
 	expect(warnings).toHaveLength(0);
+});
+
+test("daily totals: retry hourly when one event lacks daily coverage", async () => {
+	const { summary } = await runDailyTotalsQuery({
+		dailyMode: "mixed_events",
+		eventNames: ["emails.sent", "emails.delivered"],
+	});
+
+	expect(summary).toEqual({
+		"emails.delivered": { count: 17, sum: 17 },
+		"emails.sent": { count: 42, sum: 42 },
+	});
+	expect(state.queries).toHaveLength(2);
+});
+
+test("daily totals: retry hourly when a requested event is absent", async () => {
+	const { summary } = await runDailyTotalsQuery({
+		dailyMode: "missing_event",
+		eventNames: ["emails.sent", "emails.delivered"],
+	});
+
+	expect(summary).toEqual({
+		"emails.delivered": { count: 17, sum: 17 },
+		"emails.sent": { count: 42, sum: 42 },
+	});
+	expect(state.queries).toHaveLength(2);
+});
+
+test("daily totals: retry hourly when the requested day window is partial", async () => {
+	const { summary } = await runDailyTotalsQuery({
+		dailyMode: "partial_coverage",
+	});
+
+	expect(summary).toEqual({ "emails.sent": { count: 42, sum: 42 } });
+	expect(state.queries).toHaveLength(2);
 });
 
 test("daily totals: do not amplify Tinybird errors with an hourly retry", async () => {

--- a/server/tests/unit/analytics/daily-rollup-fallback.test.ts
+++ b/server/tests/unit/analytics/daily-rollup-fallback.test.ts
@@ -1,0 +1,113 @@
+import { expect, mock, test } from "bun:test";
+import type { TotalEventsParams } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+const state = {
+	dailyMode: "no_rows" as "error" | "no_rows" | "populated",
+	queries: [] as string[],
+};
+
+mock.module("@/external/tinybird/initClickhouse.js", () => ({
+	getClickhouseClient: () => ({
+		query: async ({ query }: { query: string }) => {
+			state.queries.push(query);
+			const isDailyQuery = query.includes("events_customer_daily_mv");
+			if (isDailyQuery && state.dailyMode === "error") {
+				throw new Error("daily datasource unavailable");
+			}
+
+			const data = isDailyQuery
+				? state.dailyMode === "populated"
+					? [
+							{
+								count: "12",
+								daily_rollup_rows: "3",
+								event_name: "emails.sent",
+								sum: "12",
+							},
+						]
+					: [
+							{
+								count: "2",
+								daily_rollup_rows: "0",
+								event_name: "emails.sent",
+								sum: "2",
+							},
+						]
+				: [{ count: "42", event_name: "emails.sent", sum: "42" }];
+
+			return { json: async () => ({ data }) };
+		},
+	}),
+}));
+
+const { getCountAndSum } = await import(
+	"@/internal/analytics/actions/getCountAndSum.js"
+);
+
+const runDailyTotalsQuery = async ({
+	dailyMode,
+}: {
+	dailyMode: typeof state.dailyMode;
+}) => {
+	state.dailyMode = dailyMode;
+	state.queries = [];
+	const warnings: Array<{ message: string; metadata?: unknown }> = [];
+	const ctx = {
+		env: "live",
+		logger: {
+			debug: () => undefined,
+			warn: (message: string, metadata?: unknown) => {
+				warnings.push({ message, metadata });
+			},
+		},
+		org: { id: "org_test" },
+	} as unknown as AutumnContext;
+	const params = {
+		bin_size: "day",
+		customer_id: "customer_test",
+		event_names: ["emails.sent"],
+	} satisfies TotalEventsParams;
+
+	const summary = await getCountAndSum({
+		ctx,
+		dateRange: {
+			endDate: "2026-08-03T12:00:00",
+			startDate: "2026-08-01T00:00:00",
+		},
+		params,
+	});
+
+	return { summary, warnings };
+};
+
+test("daily totals: retry hourly when the daily source contributes no full-day rows", async () => {
+	const { summary, warnings } = await runDailyTotalsQuery({
+		dailyMode: "no_rows",
+	});
+
+	expect(summary).toEqual({ "emails.sent": { count: 42, sum: 42 } });
+	expect(state.queries).toHaveLength(2);
+	expect(state.queries[0]).toContain("events_customer_daily_mv");
+	expect(state.queries[1]).toContain("events_customer_hourly_mv");
+	expect(state.queries[1]).not.toContain("events_customer_daily_mv");
+	expect(warnings).toHaveLength(1);
+});
+
+test("daily totals: keep populated daily reads on the fast path", async () => {
+	const { summary, warnings } = await runDailyTotalsQuery({
+		dailyMode: "populated",
+	});
+
+	expect(summary).toEqual({ "emails.sent": { count: 12, sum: 12 } });
+	expect(state.queries).toHaveLength(1);
+	expect(state.queries[0]).toContain("events_customer_daily_mv");
+	expect(warnings).toHaveLength(0);
+});
+
+test("daily totals: do not amplify Tinybird errors with an hourly retry", async () => {
+	await expect(runDailyTotalsQuery({ dailyMode: "error" })).rejects.toThrow(
+		"daily datasource unavailable",
+	);
+	expect(state.queries).toHaveLength(1);
+});

--- a/server/tests/unit/analytics/daily-rollup-fallback.test.ts
+++ b/server/tests/unit/analytics/daily-rollup-fallback.test.ts
@@ -4,7 +4,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 
 const state = {
 	dailyMode: "no_rows" as
-		| "empty_complete"
+		| "empty"
 		| "error"
 		| "inactive_event"
 		| "missing_event"
@@ -17,7 +17,7 @@ const state = {
 };
 
 const dailyRowsByMode = {
-	empty_complete: [],
+	empty: [],
 	inactive_event: [
 		{
 			actual_daily_event_count: "12",
@@ -201,14 +201,15 @@ test("daily totals: keep sparse events on the daily fast path", async () => {
 	expect(warnings).toHaveLength(0);
 });
 
-test("daily totals: return zero without fallback when a covered window has no events", async () => {
+test("daily totals: retry hourly when the coverage query returns no evidence", async () => {
 	const { summary, warnings } = await runDailyTotalsQuery({
-		dailyMode: "empty_complete",
+		dailyMode: "empty",
 	});
 
-	expect(summary).toEqual({});
-	expect(state.queries).toHaveLength(1);
-	expect(warnings).toHaveLength(0);
+	expect(summary).toEqual({ "emails.sent": { count: 42, sum: 42 } });
+	expect(state.queries).toHaveLength(2);
+	expect(state.queries[1]).toContain("events_customer_hourly_mv");
+	expect(warnings).toHaveLength(1);
 });
 
 test("daily totals: retry hourly when datasource coverage is incomplete", async () => {

--- a/server/tests/unit/analytics/daily-rollup-routing.test.ts
+++ b/server/tests/unit/analytics/daily-rollup-routing.test.ts
@@ -131,6 +131,7 @@ test("daily totals: combine merged full days with hourly range edges", () => {
 	const query = buildCountAndSumQuery({ source: "customer_daily" });
 
 	expect(query).toContain("events_customer_daily_mv");
+	expect(query).toContain("events_customer_daily_coverage_mv");
 	expect(query).toContain("sumMerge(event_count)");
 	expect(query).toContain("uniqExact(day)");
 	expect(query).toContain("expected_daily_days");

--- a/server/tests/unit/analytics/daily-rollup-routing.test.ts
+++ b/server/tests/unit/analytics/daily-rollup-routing.test.ts
@@ -133,8 +133,9 @@ test("daily totals: combine merged full days with hourly range edges", () => {
 	expect(query).toContain("events_customer_daily_mv");
 	expect(query).toContain("events_customer_daily_coverage_mv");
 	expect(query).toContain("sumMerge(event_count)");
-	expect(query).toContain("uniqExact(day)");
-	expect(query).toContain("expected_daily_days");
+	expect(query).toContain("sumMerge(expected_event_count)");
+	expect(query).toContain("actual_daily_event_count");
+	expect(query).toContain("expected_daily_event_count");
 	expect(query).toContain("events_customer_hourly_mv");
 	expect(query).toContain("hour <");
 	expect(query).toContain("hour >= toStartOfDay");
@@ -157,14 +158,20 @@ test("daily totals: preserve raw filtered and org-hourly query paths", () => {
 	expect(orgQuery).not.toContain("customer_id =");
 });
 
-test("daily totals: derive coverage from the populated daily target", async () => {
+test("daily totals: compare scoped hourly expectations with returned daily counts", async () => {
 	const coveragePipe = await Bun.file(
 		new URL(
 			"../../../tinybird/materializations/events_customer_daily_coverage_mv_pipe.pipe",
 			import.meta.url,
 		),
 	).text();
+	const actualCoveragePipe = Bun.file(
+		new URL(
+			"../../../tinybird/materializations/events_customer_daily_coverage_actual_mv_pipe.pipe",
+			import.meta.url,
+		),
+	);
 
-	expect(coveragePipe).toContain("FROM events_customer_daily_mv");
-	expect(coveragePipe).not.toContain("FROM events_customer_hourly_mv");
+	expect(coveragePipe).toContain("FROM events_customer_hourly_mv");
+	expect(await actualCoveragePipe.exists()).toBe(false);
 });

--- a/server/tests/unit/analytics/daily-rollup-routing.test.ts
+++ b/server/tests/unit/analytics/daily-rollup-routing.test.ts
@@ -156,3 +156,15 @@ test("daily totals: preserve raw filtered and org-hourly query paths", () => {
 	expect(orgQuery).toContain("FROM events_org_hourly_mv");
 	expect(orgQuery).not.toContain("customer_id =");
 });
+
+test("daily totals: derive coverage from the populated daily target", async () => {
+	const coveragePipe = await Bun.file(
+		new URL(
+			"../../../tinybird/materializations/events_customer_daily_coverage_mv_pipe.pipe",
+			import.meta.url,
+		),
+	).text();
+
+	expect(coveragePipe).toContain("FROM events_customer_daily_mv");
+	expect(coveragePipe).not.toContain("FROM events_customer_hourly_mv");
+});

--- a/server/tests/unit/analytics/daily-rollup-routing.test.ts
+++ b/server/tests/unit/analytics/daily-rollup-routing.test.ts
@@ -132,7 +132,8 @@ test("daily totals: combine merged full days with hourly range edges", () => {
 
 	expect(query).toContain("events_customer_daily_mv");
 	expect(query).toContain("sumMerge(event_count)");
-	expect(query).toContain("sum(daily_rollup_rows)");
+	expect(query).toContain("uniqExact(day)");
+	expect(query).toContain("expected_daily_days");
 	expect(query).toContain("events_customer_hourly_mv");
 	expect(query).toContain("hour <");
 	expect(query).toContain("hour >= toStartOfDay");

--- a/server/tests/unit/analytics/daily-rollup-routing.test.ts
+++ b/server/tests/unit/analytics/daily-rollup-routing.test.ts
@@ -132,6 +132,7 @@ test("daily totals: combine merged full days with hourly range edges", () => {
 
 	expect(query).toContain("events_customer_daily_mv");
 	expect(query).toContain("sumMerge(event_count)");
+	expect(query).toContain("sum(daily_rollup_rows)");
 	expect(query).toContain("events_customer_hourly_mv");
 	expect(query).toContain("hour <");
 	expect(query).toContain("hour >= toStartOfDay");

--- a/server/tinybird/materializations/events_customer_daily_coverage_mv.datasource
+++ b/server/tinybird/materializations/events_customer_daily_coverage_mv.datasource
@@ -1,11 +1,16 @@
 DESCRIPTION >
-    UTC days populated in the customer daily rollup. This datasource is a small global readiness
-    marker used to distinguish an inactive event from an incomplete daily materialization.
+    Scoped expected event counts for customer daily rollup population. Daily reads compare these
+    counts with the target rows they return, distinguishing inactivity from missing materialization.
 
 SCHEMA >
+    `org_id` String,
+    `env` String,
+    `customer_id` String,
+    `entity_id` String DEFAULT '',
+    `event_name` String,
     `day` DateTime,
-    `source_rows` AggregateFunction(sum, UInt64)
+    `expected_event_count` AggregateFunction(sum, UInt64)
 
 ENGINE "AggregatingMergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(day)"
-ENGINE_SORTING_KEY "day"
+ENGINE_SORTING_KEY "org_id, env, customer_id, entity_id, event_name, day"

--- a/server/tinybird/materializations/events_customer_daily_coverage_mv.datasource
+++ b/server/tinybird/materializations/events_customer_daily_coverage_mv.datasource
@@ -1,0 +1,11 @@
+DESCRIPTION >
+    UTC days populated in the customer daily rollup. This datasource is a small global readiness
+    marker used to distinguish an inactive event from an incomplete daily materialization.
+
+SCHEMA >
+    `day` DateTime,
+    `source_rows` AggregateFunction(sum, UInt64)
+
+ENGINE "AggregatingMergeTree"
+ENGINE_PARTITION_KEY "toYYYYMM(day)"
+ENGINE_SORTING_KEY "day"

--- a/server/tinybird/materializations/events_customer_daily_coverage_mv_pipe.pipe
+++ b/server/tinybird/materializations/events_customer_daily_coverage_mv_pipe.pipe
@@ -1,0 +1,14 @@
+DESCRIPTION >
+    Records each UTC day seen by the customer hourly rollup so daily reads can verify datasource
+    population without treating event inactivity as missing data.
+
+NODE materialize
+SQL >
+    SELECT
+        toStartOfDay(hour) as day,
+        sumState(toUInt64(1)) as source_rows
+    FROM events_customer_hourly_mv
+    GROUP BY day
+
+TYPE materialized
+DATASOURCE events_customer_daily_coverage_mv

--- a/server/tinybird/materializations/events_customer_daily_coverage_mv_pipe.pipe
+++ b/server/tinybird/materializations/events_customer_daily_coverage_mv_pipe.pipe
@@ -1,14 +1,19 @@
 DESCRIPTION >
-    Records each UTC day present in the customer daily target so daily reads can verify target
-    population without treating event inactivity as missing data.
+    Records expected scoped UTC-day counts from the customer hourly source. Daily queries compare
+    these counts directly with the daily target rows returned for the same request scope.
 
 NODE materialize
 SQL >
     SELECT
-        day,
-        sumState(toUInt64(1)) as source_rows
-    FROM events_customer_daily_mv
-    GROUP BY day
+        org_id,
+        env,
+        customer_id,
+        entity_id,
+        event_name,
+        toStartOfDay(hour) as day,
+        sumState(event_count) as expected_event_count
+    FROM events_customer_hourly_mv
+    GROUP BY org_id, env, customer_id, entity_id, event_name, day
 
 TYPE materialized
 DATASOURCE events_customer_daily_coverage_mv

--- a/server/tinybird/materializations/events_customer_daily_coverage_mv_pipe.pipe
+++ b/server/tinybird/materializations/events_customer_daily_coverage_mv_pipe.pipe
@@ -1,13 +1,13 @@
 DESCRIPTION >
-    Records each UTC day seen by the customer hourly rollup so daily reads can verify datasource
+    Records each UTC day present in the customer daily target so daily reads can verify target
     population without treating event inactivity as missing data.
 
 NODE materialize
 SQL >
     SELECT
-        toStartOfDay(hour) as day,
+        day,
         sumState(toUInt64(1)) as source_rows
-    FROM events_customer_hourly_mv
+    FROM events_customer_daily_mv
     GROUP BY day
 
 TYPE materialized


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes customer-scoped daily analytics verify their materialized totals against equivalently scoped hourly coverage and fall back to hourly totals when coverage is absent or incomplete.

- **[Bug fixes]** Adds per-customer, per-entity, per-event daily coverage materialization derived from hourly rollups.
- **[Bug fixes]** Compares returned daily event counts with expected hourly counts and retries through the hourly rollup when coverage is incomplete or empty.
- **[Improvements]** Adds focused routing and fallback tests for empty, partial, mixed-event, sparse, inactive, and error cases.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported mixed-event, globally scoped, and empty-coverage fallback failures are addressed by scoped coverage rows, per-event count comparison, and an explicit nonempty-result requirement.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/analytics/actions/dailyRollupRouting.ts | Extends daily totals queries with consistently scoped actual and expected event counts used to detect incomplete materialization. |
| server/src/internal/analytics/actions/getCountAndSum.ts | Validates nonempty per-event daily coverage and replaces incomplete results with an equivalent hourly-rollup query. |
| server/tinybird/materializations/events_customer_daily_coverage_mv.datasource | Defines an aggregate datasource keyed by the same customer, entity, event, and UTC-day dimensions as the daily rollup. |
| server/tinybird/materializations/events_customer_daily_coverage_mv_pipe.pipe | Materializes expected daily event counts from the customer hourly rollup using matching scope dimensions. |
| server/tests/unit/analytics/daily-rollup-fallback.test.ts | Covers fallback and fast-path behavior for empty, incomplete, mixed-event, sparse, inactive, and failed daily queries. |
| server/tests/unit/analytics/daily-rollup-routing.test.ts | Verifies that daily query construction includes scoped hourly-derived coverage. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Count and sum request] --> B{Customer daily source selected?}
    B -- No --> C[Run selected raw or hourly query]
    B -- Yes --> D[Query daily totals, boundary hours, and scoped coverage]
    D --> E{Rows present and actual daily counts equal expected counts?}
    E -- Yes --> F[Return daily and boundary-hour totals]
    E -- No --> G[Query customer hourly rollup for full range]
    G --> H[Return hourly totals]
    C --> I[Return totals]
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix: fall back when daily coverage is em..."](https://github.com/useautumn/autumn/commit/55ddfe72735b3a5556360c6425c03e061804553c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49762108)</sub>

<!-- /greptile_comment -->