### PR TITLE
fix: name the severe-span helper accurately and pin sample rate in tests

### DIFF
--- a/server/src/utils/otel/FilteringSpanProcessor.ts
+++ b/server/src/utils/otel/FilteringSpanProcessor.ts
@@ -27,27 +27,35 @@ const hashStringToUnitInterval = (value: string): number => {
 	return (hash >>> 0) / 0xffffffff;
 };
 
-const isSuccessfulNonSlowRedisSpan = (span: ReadableSpan) =>
+const isSuccessfulNonSevereRedisSpan = (span: ReadableSpan) =>
 	span.name.startsWith("redis.") &&
 	span.status.code === SpanStatusCode.OK &&
 	span.attributes["db.redis.severe"] !== true;
 
-const shouldDropSuccessfulRedisSpan = (span: ReadableSpan): boolean => {
-	if (!isSuccessfulNonSlowRedisSpan(span)) return false;
-	if (normalizedRedisSuccessSampleRate >= 1) return false;
-	if (normalizedRedisSuccessSampleRate <= 0) return true;
+const shouldDropSuccessfulRedisSpan = (
+	span: ReadableSpan,
+	sampleRate: number = normalizedRedisSuccessSampleRate,
+): boolean => {
+	if (!isSuccessfulNonSevereRedisSpan(span)) return false;
+	if (sampleRate >= 1) return false;
+	if (sampleRate <= 0) return true;
 
 	const spanContext = span.spanContext();
 	const sampleKey = `${spanContext.traceId}:${spanContext.spanId}:${span.name}`;
 	return (
-		hashStringToUnitInterval(sampleKey) >= normalizedRedisSuccessSampleRate
+		hashStringToUnitInterval(sampleKey) >= sampleRate
 	);
 };
 
 export class FilteringSpanProcessor implements SpanProcessor {
 	private readonly spanIngestCompactor = new SpanIngestCompactor();
 
-	constructor(private readonly delegate: SpanProcessor) {}
+	constructor(
+		private readonly delegate: SpanProcessor,
+		// Overridable so tests pin the rate instead of depending on the ambient
+		// OTEL_REDIS_SUCCESS_SAMPLE_RATE and on where a span's hash happens to land.
+		private readonly sampleRate: number = normalizedRedisSuccessSampleRate,
+	) {}
 
 	onStart(span: Span, parentContext: Context): void {
 		this.delegate.onStart(span, parentContext);
@@ -58,7 +66,7 @@ export class FilteringSpanProcessor implements SpanProcessor {
 
 		try {
 			recordSpanDurationMetric(span);
-			if (shouldDropSuccessfulRedisSpan(span)) return;
+			if (shouldDropSuccessfulRedisSpan(span, this.sampleRate)) return;
 			spanToExport = this.spanIngestCompactor.compact({ span });
 		} catch (error) {
 			try {

--- a/server/tests/unit/otel/filteringSpanProcessor.test.ts
+++ b/server/tests/unit/otel/filteringSpanProcessor.test.ts
@@ -166,7 +166,8 @@ describe("FilteringSpanProcessor", () => {
 
 	test("always exports successful severe Redis spans", () => {
 		const delegate = new CapturingSpanProcessor();
-		const processor = new FilteringSpanProcessor(delegate);
+		// rate 0 would drop any non-severe span, so surviving proves the bypass.
+		const processor = new FilteringSpanProcessor(delegate, 0);
 		const source = createSpan({
 			name: "redis.get",
 			attributes: {
@@ -184,7 +185,9 @@ describe("FilteringSpanProcessor", () => {
 	// no longer bypasses sampling — only `db.redis.severe` does.
 	test("samples successful slow-but-not-severe Redis spans", () => {
 		const delegate = new CapturingSpanProcessor();
-		const processor = new FilteringSpanProcessor(delegate);
+		// rate 0 => every non-severe success is dropped, so the assertion tests the
+		// severe-vs-slow rule rather than where one span's hash lands.
+		const processor = new FilteringSpanProcessor(delegate, 0);
 		const source = createSpan({
 			name: "redis.get",
 			attributes: {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarifies Redis span sampling: renames the helper to match “severe” semantics and makes sampling deterministic in tests by allowing a pinned sample rate.

- **Refactors**
  - Rename helper from isSuccessfulNonSlowRedisSpan to isSuccessfulNonSevereRedisSpan.
  - Add a sampleRate parameter to shouldDropSuccessfulRedisSpan and FilteringSpanProcessor’s constructor (defaults to the normalized env rate).
  - Update unit tests to pin sampleRate to 0, removing hash/env flakiness and asserting that only spans with db.redis.severe bypass sampling.

<sup>Written for commit a506c3118ad60902c7f229843bb764279799960b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes Redis span-sampling tests deterministic while clarifying that only severe spans bypass sampling.
- [Improvements] Renames the Redis-span predicate to describe the severe-span distinction accurately.
- [Bug fixes] Adds an injectable sample rate and pins it to zero in tests that verify severe versus slow Redis span behavior.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

Production continues to use the normalized environment-derived sampling rate, while the new override is limited to deterministic tests that pass a valid boundary value.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/utils/otel/FilteringSpanProcessor.ts | Renames the non-severe Redis predicate and introduces an optional sampling-rate override while preserving the normalized environment-derived production default. |
| server/tests/unit/otel/filteringSpanProcessor.test.ts | Pins the sampling rate to zero in the severe and slow-span tests so assertions no longer depend on ambient configuration or deterministic hash placement. |

<sub>Reviews (1): Last reviewed commit: ["fix: name the severe-span helper accurat..."](https://github.com/useautumn/autumn/commit/a506c3118ad60902c7f229843bb764279799960b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49792838)</sub>

<!-- /greptile_comment -->