### PR TITLE
perf: survive Redis outages under load (pools, clocks, shedding)

### DIFF
--- a/server/src/db/connectRetry.ts
+++ b/server/src/db/connectRetry.ts
@@ -1,0 +1,63 @@
+import type { Pool, PoolClient } from "pg";
+import { logger } from "@/external/logtail/logtailUtils.js";
+
+const JITTER_MIN_MS = 100;
+const JITTER_RANGE_MS = 200;
+
+export const connectRefusedRetryJitterMs = (): number =>
+	JITTER_MIN_MS + Math.random() * JITTER_RANGE_MS;
+
+/** Instance-local bouncer refusal — a fresh TCP flow likely hashes to another instance. */
+const isConnectRefusalError = (error: Error & { code?: string }): boolean =>
+	/no more connections allowed/i.test(error.message ?? "") ||
+	error.code === "ECONNREFUSED";
+
+type ConnectCallback = (
+	err: Error | undefined,
+	client: PoolClient | undefined,
+	done: PoolClient["release"],
+) => void;
+
+const noopDone = (): void => {};
+
+/** Retries refusal-class establishment failures once; checkout timeouts are
+ *  demand (retrying amplifies) and never match, so they propagate untouched. */
+export const applyConnectRefusedRetry = ({
+	pool,
+	name,
+}: {
+	pool: Pool;
+	name: string;
+}): void => {
+	const original = pool.connect.bind(pool);
+
+	const connectWithRetry = async (): Promise<PoolClient> => {
+		try {
+			return await original();
+		} catch (error) {
+			const refusal = error as Error & { code?: string };
+			if (!isConnectRefusalError(refusal)) throw error;
+			const delayMs = connectRefusedRetryJitterMs();
+			logger.warn("pg_connect_refused_retry", {
+				type: "pg_connect_refused_retry",
+				pool: name,
+				delayMs: Math.round(delayMs),
+				error_code: refusal.code,
+				error_message: refusal.message,
+			});
+			await new Promise((resolve) => setTimeout(resolve, delayMs));
+			return await original();
+		}
+	};
+
+	const wrapped = (callback?: ConnectCallback) => {
+		if (!callback) return connectWithRetry();
+		connectWithRetry().then(
+			(client) => callback(undefined, client, client.release.bind(client)),
+			(error: Error) => callback(error, undefined, noopDone),
+		);
+		return;
+	};
+
+	pool.connect = wrapped as Pool["connect"];
+};

--- a/server/src/db/initDrizzle.ts
+++ b/server/src/db/initDrizzle.ts
@@ -10,6 +10,7 @@ import { drizzle } from "drizzle-orm/node-postgres";
 import pg, { type PoolConfig } from "pg";
 import { logger } from "../external/logtail/logtailUtils.js";
 import { otelConfig } from "../utils/otel/otelConfig.js";
+import { applyConnectRefusedRetry } from "./connectRetry.js";
 import { attachPoolErrorHandlers, registerPool } from "./pgPoolMonitor.js";
 
 type AutumnDb = Omit<ReturnType<typeof drizzle<typeof schema>>, "execute"> & {
@@ -77,6 +78,8 @@ export const initDrizzle = ({
 		attachPoolErrorHandlers({ pool: client, name });
 		registerPool({ pool: client, name, max: maxConnections });
 	}
+	// After registerPool so a retry passes through timeAcquires as its own acquire attempt.
+	applyConnectRefusedRetry({ pool: client, name: name ?? "unnamed" });
 
 	const drizzleDb = drizzle(client, { schema });
 	const transaction = drizzleDb.transaction.bind(drizzleDb);
@@ -109,15 +112,31 @@ const poolMaxFromEnv = ({
 	return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 };
 
-const PGBOUNCER_MAX_CLIENT_CONN = 7_600;
-const BUDGETED_FLEET_PROCESSES = 150;
-const BUDGETED_NON_SERVER_CONNECTIONS = 80;
+/** Frontend ceiling the app's primary pools actually compete for: PgBouncer
+ *  max_client_conn (2,000) x 6 pods. */
+const PGBOUNCER_MAX_CLIENT_CONN = 12_000;
+
+/** The replica pool connects through its own dedicated bouncer (single
+ *  instance), so it has its own client-slot budget separate from the primary's. */
+const REPLICA_PGBOUNCER_MAX_CLIENT_CONN = 1_000;
+
+/** Bouncer->Postgres slots. NOT a client limit — transaction pooling multiplexes
+ *  many clients onto far fewer of these. Kept for sizing, not for this guard. */
+const POSTGRES_MAX_SERVER_CONNECTIONS = 7_600;
+
+/** Request-serving processes: 30 tasks x 3 cluster workers. Primaries hold pool
+ *  objects but never query, and `min` doesn't pre-create, so they contribute 0. */
+const BUDGETED_FLEET_PROCESSES = 90;
+
+/** Dedicated worker/cron pools that exist outside the three exported ones. */
+const BUDGETED_NON_SERVER_CONNECTIONS = 362;
 const POOL_BUDGET_HEADROOM = 0.85;
 
 const PROD_POOL_MAX = {
 	critical: 22,
 	general: 14,
-	replica: 6,
+	// 90 processes x 9 = 810 <= 0.85 x replica bouncer max_client_conn (1,000).
+	replica: 9,
 };
 
 const criticalPoolMax = poolMaxFromEnv({
@@ -133,28 +152,64 @@ const replicaPoolMax = poolMaxFromEnv({
 	fallback: PROD_POOL_MAX.replica,
 });
 
-const budgetedFleetConnections =
-	BUDGETED_FLEET_PROCESSES *
-		(criticalPoolMax + generalPoolMax + replicaPoolMax) +
-	BUDGETED_NON_SERVER_CONNECTIONS;
+/** Fleet budget guards. Primary pools count against the primary bouncer's
+ *  max_client_conn; the replica pool counts against the replica bouncer's. */
+export const computePoolBudgetWarnings = ({
+	criticalPoolMax: critical,
+	generalPoolMax: general,
+	replicaPoolMax: replica,
+}: {
+	criticalPoolMax: number;
+	generalPoolMax: number;
+	replicaPoolMax: number;
+}): string[] => {
+	const warnings: string[] = [];
 
-if (
-	budgetedFleetConnections >
-	PGBOUNCER_MAX_CLIENT_CONN * POOL_BUDGET_HEADROOM
-) {
-	logger.warn(
-		`[initDrizzle] pool budget (${budgetedFleetConnections}) exceeds ${POOL_BUDGET_HEADROOM} of max_client_conn (${PGBOUNCER_MAX_CLIENT_CONN}) — lower the pool maxes or raise the ceiling`,
-	);
+	const primaryFleetConnections =
+		BUDGETED_FLEET_PROCESSES * (critical + general) +
+		BUDGETED_NON_SERVER_CONNECTIONS;
+	if (
+		primaryFleetConnections >
+		PGBOUNCER_MAX_CLIENT_CONN * POOL_BUDGET_HEADROOM
+	) {
+		warnings.push(
+			`[initDrizzle] primary pool budget (${primaryFleetConnections}) exceeds ${POOL_BUDGET_HEADROOM} of primary PgBouncer max_client_conn (${PGBOUNCER_MAX_CLIENT_CONN}) — lower the pool maxes or raise the ceiling. Postgres server slots (${POSTGRES_MAX_SERVER_CONNECTIONS}) are a separate, larger budget and are not the constraint here.`,
+		);
+	}
+
+	const replicaFleetConnections = BUDGETED_FLEET_PROCESSES * replica;
+	if (
+		replicaFleetConnections >
+		REPLICA_PGBOUNCER_MAX_CLIENT_CONN * POOL_BUDGET_HEADROOM
+	) {
+		warnings.push(
+			`[initDrizzle] replica pool budget (${replicaFleetConnections}) exceeds ${POOL_BUDGET_HEADROOM} of replica PgBouncer max_client_conn (${REPLICA_PGBOUNCER_MAX_CLIENT_CONN}) — lower REPLICA_DB_POOL_MAX or raise the ceiling.`,
+		);
+	}
+
+	return warnings;
+};
+
+for (const warning of computePoolBudgetWarnings({
+	criticalPoolMax,
+	generalPoolMax,
+	replicaPoolMax,
+})) {
+	logger.warn(warning);
 }
 
 export const { db: dbCritical, client: clientCritical } = initDrizzle({
 	name: "critical",
 	maxConnections: criticalPoolMax,
-	connectTimeout: isProd ? 2 : 30,
+	// connectionTimeoutMillis also bounds checkout waits on a full pool — sized
+	// to ride out PgBouncer backend build-out bursts instead of shedding.
+	connectTimeout: isProd ? 15 : 30,
 	databaseUrl: process.env.DATABASE_CRITICAL_URL,
 	poolConfig: {
 		application_name: "autumn-critical",
-		query_timeout: isProd ? 2_000 : 30_000,
+		// Budgets bouncer queue wait, not execution: the role's server-side 2s
+		// statement_timeout still kills runaway queries once they start running.
+		query_timeout: isProd ? 15_000 : 30_000,
 		// Keep warm conns to avoid TLS-handshake stampedes on bursty traffic.
 		min: Math.min(10, criticalPoolMax),
 	},
@@ -174,7 +229,16 @@ const replicaResult = process.env.DATABASE_REPLICA_URL
 			name: "replica",
 			replica: true,
 			maxConnections: replicaPoolMax,
-			connectTimeout: null,
+			// Primary is always the fallback, so short beats patient here.
+			connectTimeout: 3,
+			poolConfig: {
+				application_name: "autumn-replica",
+				// Bounds replica-bouncer queue wait as well as execution.
+				query_timeout: 5_000,
+				// pg-pool's min doesn't precreate, it only exempts from idle reaping — the
+				// floor preserves traffic-built warmth (e.g. a 1x warm-up) for the Redis-outage moment.
+				min: Math.min(4, replicaPoolMax),
+			},
 		})
 	: null;
 export const dbReplica = replicaResult?.db ?? null;

--- a/server/src/db/shed503OnTransientError.ts
+++ b/server/src/db/shed503OnTransientError.ts
@@ -8,20 +8,45 @@ export const shed503OnTransientError = async <T>({
 	source,
 	run,
 	onTransientError,
+	fallbackOnRedisUnavailable,
 }: {
 	ctx: AutumnContext;
 	source: string;
 	run: () => T | Promise<T>;
 	onTransientError?: (error: unknown) => Promise<void>;
+	/** Opt-in Postgres path for cache-only failures. Callers that omit it keep
+	 *  the shed-everything behaviour. */
+	fallbackOnRedisUnavailable?: (error: unknown) => T | Promise<T>;
 }): Promise<T> => {
 	try {
 		return await run();
 	} catch (error) {
-		if (!(isTransientDbError({ error }) || isTransientRedisError({ error }))) {
+		const isDbTransient = isTransientDbError({ error });
+		const isRedisTransient = isTransientRedisError({ error });
+
+		if (!(isDbTransient || isRedisTransient)) {
 			throw error;
 		}
-		ctx.logger.warn(`[${source}] transient DB error, shedding with 503`, {
-			type: `${source}_fail_open`,
+
+		// Only when Postgres is uninvolved — it is what the fallback reads from,
+		// so a struggling DB must shed rather than take more load.
+		if (isRedisTransient && !isDbTransient && fallbackOnRedisUnavailable) {
+			try {
+				ctx.logger.warn(`[${source}] redis unavailable, reading postgres`, {
+					type: `${source}_redis_fallback`,
+					error,
+				});
+				return await fallbackOnRedisUnavailable(error);
+			} catch (fallbackError) {
+				ctx.logger.error(`[${source}] postgres fallback failed, shedding`, {
+					type: `${source}_redis_fallback_failed`,
+					error: fallbackError,
+				});
+			}
+		}
+
+		ctx.logger.warn(`[${source}] transient error, shedding with 503`, {
+			type: `${source}_shed`,
 			error,
 		});
 		try {
@@ -36,7 +61,9 @@ export const shed503OnTransientError = async <T>({
 			message: "Service is temporarily unavailable, please retry shortly.",
 			code: "service_unavailable",
 			statusCode: 503,
-			data: { reason: "critical_db_saturated" },
+			data: {
+				reason: isDbTransient ? "critical_db_saturated" : "cache_unavailable",
+			},
 		});
 	}
 };

--- a/server/src/external/redis/utils/redisOpTimeouts.ts
+++ b/server/src/external/redis/utils/redisOpTimeouts.ts
@@ -1,0 +1,20 @@
+/**
+ * Opt-in per-operation Redis bounds (positive-limiting): anything absent here
+ * keeps the client's `commandTimeout` — 1s on V2, 10s on legacy.
+ *
+ * Only reads with a working non-Redis path belong here. A timed-out write is
+ * ambiguous — `withTimeout` abandons the promise but the command still lands.
+ * Values are sized above each op's measured production p99.9.
+ */
+export const REDIS_OP_TIMEOUT_MS = {
+	/** p99.9 137ms. Falls through to Postgres via verifyKey. */
+	secretKeyGet: 200,
+	/** p99.9 208ms — 200 would clip real traffic. */
+	orgFeaturesGet: 300,
+	/** p99.9 297ms on shared V2; this site also serves the dedicated cluster. */
+	featureBalances: 400,
+	/** p99.9 643-938ms; latency scales with the customer's feature count. */
+	featureBalancesBatch: 600,
+	/** p99.9 849ms across the pipe[get,get] pool. */
+	subjectPipeline: 600,
+} as const;

--- a/server/src/external/redis/utils/runRedisOp.ts
+++ b/server/src/external/redis/utils/runRedisOp.ts
@@ -1,5 +1,6 @@
 import type { Redis } from "ioredis";
 import { logger } from "@/external/logtail/logtailUtils.js";
+import { withTimeout } from "@/utils/withTimeout.js";
 import { RedisUnavailableError } from "./errors.js";
 
 const REDIS_WARNING_INTERVAL_MS = 30_000;
@@ -69,11 +70,15 @@ export const runRedisOp = async <T>({
 	source,
 	redisInstance,
 	queueIfNotReady = false,
+	timeoutMs,
 }: {
 	operation: () => Promise<T>;
 	source: string;
 	redisInstance: Redis;
 	queueIfNotReady?: boolean;
+	/** Opt-in bound, tighter than the client's `commandTimeout`. Reads only —
+	 *  the race abandons the promise but the command still reaches Redis. */
+	timeoutMs?: number;
 }): Promise<T> => {
 	const targetRedis = redisInstance;
 
@@ -84,7 +89,15 @@ export const runRedisOp = async <T>({
 	}
 
 	try {
-		const value = await operation();
+		// The message must contain "timeout" so classifyErrorReason maps it to
+		// `timeout` rather than `other` — withTimeout's default says "timed out".
+		const value = timeoutMs
+			? await withTimeout({
+					timeoutMs,
+					fn: operation,
+					timeoutMessage: `[redis] ${source} timeout after ${timeoutMs}ms`,
+				})
+			: await operation();
 		return value;
 	} catch (error) {
 		const classified = classifyErrorReason(targetRedis, error);
@@ -104,12 +117,14 @@ export const tryRedisOp = async <T>({
 	source,
 	redisInstance,
 	queueIfNotReady,
+	timeoutMs,
 	onError,
 }: {
 	operation: () => Promise<T>;
 	source: string;
 	redisInstance: Redis;
 	queueIfNotReady?: boolean;
+	timeoutMs?: number;
 	onError?: (error: unknown) => void;
 }): Promise<T | undefined> => {
 	try {
@@ -118,6 +133,7 @@ export const tryRedisOp = async <T>({
 			source,
 			redisInstance,
 			queueIfNotReady,
+			timeoutMs,
 		});
 	} catch (error) {
 		onError?.(error);

--- a/server/src/internal/balances/autoTopUp/setup/setupAutoTopupContext.ts
+++ b/server/src/internal/balances/autoTopUp/setup/setupAutoTopupContext.ts
@@ -44,11 +44,14 @@ const getAutoTopupFullCustomer = async ({
 	if (isFullSubjectRolloutEnabled({ ctx })) {
 	}
 
-	const { fullSubject: cachedFullSubject } = await getCachedFullSubject({
+	// A Redis failure is just a cache miss here — the DB path below covers it.
+	const cachedFullSubject = await getCachedFullSubject({
 		ctx,
 		customerId,
 		source: "setupAutoTopupContext",
-	});
+	})
+		.then((result) => result.fullSubject)
+		.catch(() => null);
 
 	if (cachedFullSubject) {
 		return fullSubjectToFullCustomer({

--- a/server/src/internal/balances/batchReset/execute/executeResetMutations.ts
+++ b/server/src/internal/balances/batchReset/execute/executeResetMutations.ts
@@ -6,6 +6,10 @@ import { RolloverService } from "@/internal/customers/cusProducts/cusEnts/cusRol
 import { resetCronQueryTag } from "../resetCronQueryTag.js";
 import type { ResetMutation } from "../types.js";
 
+/** Far tighter than the 300s cron default: a reset batch that stalls holds row
+ * locks the API's lazy-reset path needs, so failing fast beats finishing. */
+const RESET_MUTATION_STATEMENT_TIMEOUT_MS = 2_000;
+
 /**
  * Applies the balance updates with an optimistic guard: a row only updates
  * while its next_reset_at still matches what the mutation was computed from.
@@ -73,41 +77,45 @@ export const executeResetMutations = async ({
 
 	let appliedCustomerEntitlementIds = new Set<string>();
 
-	await withStatementTimeout(db, async (transaction) => {
-		appliedCustomerEntitlementIds = await updateCustomerEntitlements({
-			db: transaction,
-			resetMutations,
-		});
+	await withStatementTimeout(
+		db,
+		async (transaction) => {
+			appliedCustomerEntitlementIds = await updateCustomerEntitlements({
+				db: transaction,
+				resetMutations,
+			});
 
-		// Rollover writes only for rows whose guarded UPDATE applied — a stale
-		// mutation's rollover would double-credit a row someone else already
-		// reset.
-		const appliedMutations = resetMutations.filter(
-			({ customerEntitlementId }) =>
-				appliedCustomerEntitlementIds.has(customerEntitlementId),
-		);
+			// Rollover writes only for rows whose guarded UPDATE applied — a stale
+			// mutation's rollover would double-credit a row someone else already
+			// reset.
+			const appliedMutations = resetMutations.filter(
+				({ customerEntitlementId }) =>
+					appliedCustomerEntitlementIds.has(customerEntitlementId),
+			);
 
-		const rolloverWrites = appliedMutations.flatMap(
-			({ rolloverInserts, rolloverUpdates }) => [
-				...rolloverInserts,
-				...rolloverUpdates,
-			],
-		);
-		const rolloverDeleteIds = appliedMutations.flatMap(
-			({ rolloverDeleteIds }) => rolloverDeleteIds,
-		);
+			const rolloverWrites = appliedMutations.flatMap(
+				({ rolloverInserts, rolloverUpdates }) => [
+					...rolloverInserts,
+					...rolloverUpdates,
+				],
+			);
+			const rolloverDeleteIds = appliedMutations.flatMap(
+				({ rolloverDeleteIds }) => rolloverDeleteIds,
+			);
 
-		await RolloverService.upsert({
-			db: transaction,
-			rows: rolloverWrites,
-			queryTag: resetCronQueryTag("upsertRollovers"),
-		});
-		await RolloverService.delete({
-			db: transaction,
-			ids: rolloverDeleteIds,
-			queryTag: resetCronQueryTag("deleteRollovers"),
-		});
-	});
+			await RolloverService.upsert({
+				db: transaction,
+				rows: rolloverWrites,
+				queryTag: resetCronQueryTag("upsertRollovers"),
+			});
+			await RolloverService.delete({
+				db: transaction,
+				ids: rolloverDeleteIds,
+				queryTag: resetCronQueryTag("deleteRollovers"),
+			});
+		},
+		RESET_MUTATION_STATEMENT_TIMEOUT_MS,
+	);
 
 	return {
 		appliedCustomerEntitlementIds,

--- a/server/src/internal/balances/check/getCheckDataV2.ts
+++ b/server/src/internal/balances/check/getCheckDataV2.ts
@@ -14,9 +14,13 @@ import {
 } from "@/internal/customers/cache/fullSubject/index.js";
 import { getApiSubject } from "@/internal/customers/cusUtils/getApiCustomerV2/getApiSubject.js";
 import { getCreditSystemsFromFeature } from "@/internal/features/creditSystemUtils.js";
+import { withTimeout } from "@/utils/withTimeout.js";
 import { triggerAutoTopUp } from "../autoTopUp/triggerAutoTopUp.js";
 import { buildEvaluationSubject } from "./buildEvaluationSubject.js";
 import type { CheckDataV2 } from "./checkTypes/CheckDataV2.js";
+
+/** Deadline for check's cache-miss DB hydration — check's ~50ms latency SLO can't wait out the 15s pool clocks. */
+export const CHECK_DB_HYDRATION_BUDGET_MS = 2_000;
 
 const getFeatureAndCreditSystems = ({
 	features,
@@ -61,20 +65,28 @@ export const getCheckDataV2 = async ({
 		]),
 	);
 
-	const fullSubject = ctx.apiVersion.gte(ApiVersion.V2_1)
-		? await getOrSetCachedPartialFullSubject({
-				ctx,
-				customerId: customer_id,
-				entityId: entity_id,
-				featureIds,
-				source: "getCheckDataV2",
-			})
-		: await getOrCreateCachedPartialFullSubject({
-				ctx,
-				params: body,
-				featureIds,
-				source: "getCheckDataV2",
-			});
+	// "Query read timeout" is in TRANSIENT_DB_ERROR_MESSAGES, so isTransientDbError
+	// classifies the expiry as transient and check's withRedisFailOpen fallback engages.
+	const fullSubject = await withTimeout({
+		timeoutMs: CHECK_DB_HYDRATION_BUDGET_MS,
+		timeoutMessage: "Query read timeout",
+		// The abandoned hydration keeps running and may still warm the cache.
+		fn: () =>
+			ctx.apiVersion.gte(ApiVersion.V2_1)
+				? getOrSetCachedPartialFullSubject({
+						ctx,
+						customerId: customer_id,
+						entityId: entity_id,
+						featureIds,
+						source: "getCheckDataV2",
+					})
+				: getOrCreateCachedPartialFullSubject({
+						ctx,
+						params: body,
+						featureIds,
+						source: "getCheckDataV2",
+					}),
+	});
 
 	const apiSubject = await getApiSubject({
 		ctx,

--- a/server/src/internal/customers/actions/getApiCustomerByRollout.ts
+++ b/server/src/internal/customers/actions/getApiCustomerByRollout.ts
@@ -15,7 +15,6 @@ export const getApiCustomerByRollout = async ({
 	entityId,
 	source,
 	withAutumnId,
-	l1TtlMs = 0,
 	singleflight = false,
 }: {
 	ctx: AutumnContext;
@@ -23,7 +22,6 @@ export const getApiCustomerByRollout = async ({
 	entityId?: string;
 	source?: string;
 	withAutumnId?: boolean;
-	l1TtlMs?: number;
 	singleflight?: boolean;
 }) => {
 	if (isFullSubjectRolloutEnabled({ ctx })) {
@@ -38,9 +36,8 @@ export const getApiCustomerByRollout = async ({
 				source,
 			});
 
-		if (!singleflight && l1TtlMs <= 0) return fetch();
+		if (!singleflight) return fetch();
 
-		// The L1 stays on even under skipCache — it exists for Redis outages.
 		return coalescedSubjectRead({
 			key: buildFullSubjectKey({
 				orgId: ctx.org.id,
@@ -48,7 +45,6 @@ export const getApiCustomerByRollout = async ({
 				customerId,
 				entityId,
 			}),
-			l1TtlMs,
 			singleflight,
 			fetch,
 		});

--- a/server/src/internal/customers/actions/getApiCustomerByRollout.ts
+++ b/server/src/internal/customers/actions/getApiCustomerByRollout.ts
@@ -1,6 +1,11 @@
 import { shed503OnTransientError } from "@/db/shed503OnTransientError.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubject/index.js";
+import { coalescedSubjectRead } from "@/internal/customers/cache/fullSubject/coalesceSubjectRead.js";
+import {
+	buildFullSubjectKey,
+	getOrSetCachedFullSubject,
+} from "@/internal/customers/cache/fullSubject/index.js";
+import { isRedisFallbackToDbEnabled } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 import { isFullSubjectRolloutEnabled } from "@/internal/misc/rollouts/fullSubjectRolloutUtils.js";
 import { getApiCustomerV2 } from "../cusUtils/getApiCustomerV2/index.js";
 
@@ -10,20 +15,52 @@ export const getApiCustomerByRollout = async ({
 	entityId,
 	source,
 	withAutumnId,
+	l1TtlMs = 0,
+	singleflight = false,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	entityId?: string;
 	source?: string;
 	withAutumnId?: boolean;
+	l1TtlMs?: number;
+	singleflight?: boolean;
 }) => {
 	if (isFullSubjectRolloutEnabled({ ctx })) {
 	}
 
+	const lookup = ({ skipCache }: { skipCache: boolean }) => {
+		const fetch = () =>
+			getOrSetCachedFullSubject({
+				ctx: skipCache ? { ...ctx, skipCache: true } : ctx,
+				customerId,
+				entityId,
+				source,
+			});
+
+		if (!singleflight && l1TtlMs <= 0) return fetch();
+
+		// The L1 stays on even under skipCache — it exists for Redis outages.
+		return coalescedSubjectRead({
+			key: buildFullSubjectKey({
+				orgId: ctx.org.id,
+				env: ctx.env,
+				customerId,
+				entityId,
+			}),
+			l1TtlMs,
+			singleflight,
+			fetch,
+		});
+	};
+
 	const fullSubject = await shed503OnTransientError({
 		ctx,
 		source: "get_customer",
-		run: () => getOrSetCachedFullSubject({ ctx, customerId, entityId, source }),
+		run: () => lookup({ skipCache: false }),
+		fallbackOnRedisUnavailable: isRedisFallbackToDbEnabled()
+			? () => lookup({ skipCache: true })
+			: undefined,
 	});
 
 	return getApiCustomerV2({

--- a/server/src/internal/customers/actions/getOrCreateApiCustomerByRollout.ts
+++ b/server/src/internal/customers/actions/getOrCreateApiCustomerByRollout.ts
@@ -7,6 +7,7 @@ import {
 	setCustomerCreationRecoveryStage,
 } from "@/internal/customers/recovery/customerCreationRecoveryStage.js";
 import { queueFailedCustomerCreation } from "@/internal/customers/recovery/queueFailedCustomerCreation.js";
+import { isRedisFallbackToDbEnabled } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 import { isFullSubjectRolloutEnabled } from "@/internal/misc/rollouts/fullSubjectRolloutUtils.js";
 import { getApiCustomerV2 } from "../cusUtils/getApiCustomerV2/index.js";
 import { ensureStripeCustomerFromCustomerData } from "./ensureStripeCustomerFromCustomerData.js";
@@ -31,10 +32,20 @@ export const getOrCreateApiCustomerByRollout = async ({
 	if (isFullSubjectRolloutEnabled({ ctx })) {
 	}
 
+	const lookup = ({ skipCache }: { skipCache: boolean }) =>
+		getOrCreateCachedFullSubject({
+			ctx: skipCache ? { ...ctx, skipCache: true } : ctx,
+			params,
+			source,
+		});
+
 	const fullSubject = await shed503OnTransientError({
 		ctx,
 		source: "get_or_create",
-		run: () => getOrCreateCachedFullSubject({ ctx, params, source }),
+		run: () => lookup({ skipCache: false }),
+		fallbackOnRedisUnavailable: isRedisFallbackToDbEnabled()
+			? () => lookup({ skipCache: true })
+			: undefined,
 		onTransientError: enqueueRecoveryOnTransientFailure
 			? async () => {
 					await queueFailedCustomerCreation({

--- a/server/src/internal/customers/cache/fullSubject/actions/getCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/getCachedFullSubject.ts
@@ -1,9 +1,10 @@
 import {
-    type FullSubject,
-    fullSubjectToFullCustomer,
-    normalizedToFullSubject,
+	type FullSubject,
+	fullSubjectToFullCustomer,
+	normalizedToFullSubject,
 } from "@autumn/shared";
 import { isRedisMigrationCacheStale } from "@/external/redis/customerRedisRouting.js";
+import { REDIS_OP_TIMEOUT_MS } from "@/external/redis/utils/redisOpTimeouts.js";
 import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { lazyResetSubjectEntitlements } from "@/internal/customers/actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.js";
@@ -17,9 +18,9 @@ import { getCachedFeatureBalancesBatch } from "../balances/getCachedFeatureBalan
 import { buildFullSubjectKey } from "../builders/buildFullSubjectKey.js";
 import { buildFullSubjectViewEpochKey } from "../builders/buildFullSubjectViewEpochKey.js";
 import {
-    type CachedFullSubject,
-    cachedFullSubjectToNormalized,
-    FULL_SUBJECT_CACHE_SCHEMA_VERSION,
+	type CachedFullSubject,
+	cachedFullSubjectToNormalized,
+	FULL_SUBJECT_CACHE_SCHEMA_VERSION,
 } from "../fullSubjectCacheModel.js";
 import { sanitizeCachedFullSubject } from "../sanitize/index.js";
 import { invalidateCachedFullSubject } from "./invalidate/invalidateFullSubject.js";
@@ -38,7 +39,6 @@ export const getCachedFullSubject = async ({
 	source,
 	staleWhileRevalidate = false,
 	runLazyResets = true,
-
 }: {
 	ctx: AutumnContext;
 	customerId: string;
@@ -46,7 +46,6 @@ export const getCachedFullSubject = async ({
 	source?: string;
 	staleWhileRevalidate?: boolean;
 	runLazyResets?: boolean;
-
 }): Promise<GetCachedFullSubjectResult> => {
 	const { org, env, logger, redisV2 } = ctx;
 	const subjectKey = buildFullSubjectKey({
@@ -69,6 +68,7 @@ export const getCachedFullSubject = async ({
 		operation: () => redisV2.pipeline().get(subjectKey).get(epochKey).exec(),
 		source: "getCachedFullSubject:pipeline",
 		redisInstance: redisV2,
+		timeoutMs: REDIS_OP_TIMEOUT_MS.subjectPipeline,
 	});
 
 	const subjectEntry = pipelineResults?.[0];
@@ -276,7 +276,7 @@ export const getCachedFullSubject = async ({
 				fullCustomer: fullSubjectToFullCustomer({ fullSubject }),
 			});
 		}
-		
+
 		return { fullSubject, subjectViewEpoch: currentSubjectViewEpoch };
 	} catch (error) {
 		logger.warn(

--- a/server/src/internal/customers/cache/fullSubject/actions/partial/getCachedPartialFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/partial/getCachedPartialFullSubject.ts
@@ -1,6 +1,7 @@
 import type { FullSubject } from "@autumn/shared";
 import { normalizedToFullSubject } from "@autumn/shared";
 import { isRedisMigrationCacheStale } from "@/external/redis/customerRedisRouting.js";
+import { REDIS_OP_TIMEOUT_MS } from "@/external/redis/utils/redisOpTimeouts.js";
 import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { lazyResetSubjectEntitlements } from "@/internal/customers/actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.js";
@@ -71,6 +72,7 @@ export const getCachedPartialFullSubject = async ({
 		operation: () => redisV2.pipeline().get(subjectKey).get(epochKey).exec(),
 		source: "getCachedPartialFullSubject:pipeline",
 		redisInstance: redisV2,
+		timeoutMs: REDIS_OP_TIMEOUT_MS.subjectPipeline,
 	});
 
 	const subjectEntry = pipelineResults?.[0];

--- a/server/src/internal/customers/cache/fullSubject/balances/getCachedFeatureBalances.ts
+++ b/server/src/internal/customers/cache/fullSubject/balances/getCachedFeatureBalances.ts
@@ -3,6 +3,7 @@ import type {
 	SubjectBalance,
 	UsageWindow,
 } from "@autumn/shared";
+import { REDIS_OP_TIMEOUT_MS } from "@/external/redis/utils/redisOpTimeouts.js";
 import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { buildSharedFullSubjectBalanceKey } from "../builders/buildSharedFullSubjectBalanceKey.js";
@@ -105,6 +106,7 @@ export const getCachedFeatureBalance = async ({
 				: redisV2.hmget(balanceKey, ...customerEntitlementIds),
 		source: "getCachedFeatureBalance",
 		redisInstance: redisV2,
+		timeoutMs: REDIS_OP_TIMEOUT_MS.featureBalances,
 	});
 
 	if (!results) return { kind: "missing", reason: "single_pipeline_null" };
@@ -181,6 +183,7 @@ export const getCachedFeatureBalancesBatch = async ({
 		operation: () => pipeline.exec(),
 		source: "getCachedFeatureBalancesBatch",
 		redisInstance: redisV2,
+		timeoutMs: REDIS_OP_TIMEOUT_MS.featureBalancesBatch,
 	});
 
 	if (!results) return { kind: "missing", reason: "batch_pipeline_null" };

--- a/server/src/internal/customers/cache/fullSubject/coalesceSubjectRead.ts
+++ b/server/src/internal/customers/cache/fullSubject/coalesceSubjectRead.ts
@@ -1,73 +1,34 @@
 import type { FullSubject } from "@autumn/shared";
-import { LRUCache } from "lru-cache";
-
-export const SUBJECT_READ_L1_MAX_ENTRIES = 2000;
-
-/** Pathological accounts carry millions of customer products; caching those
- *  blobs would blow the entry-count sizing, so they get singleflight only. */
-export const SUBJECT_READ_L1_MAX_CACHEABLE_ITEMS = 10_000;
-
-const isCacheableSize = (fullSubject: FullSubject): boolean =>
-	(fullSubject.customer_products?.length ?? 0) +
-		(fullSubject.extra_customer_entitlements?.length ?? 0) +
-		(fullSubject.aggregated_customer_products?.length ?? 0) <
-	SUBJECT_READ_L1_MAX_CACHEABLE_ITEMS;
 
 const inFlight = new Map<string, Promise<FullSubject>>();
 
-/** Per-process L1 over post-sanitize FullSubjects. Entries are shared across
- *  callers — treat them as frozen, never mutate. */
-const subjectReadL1 = new LRUCache<string, FullSubject>({
-	max: SUBJECT_READ_L1_MAX_ENTRIES,
-});
-
-export const _resetSubjectReadL1ForTesting = () => {
-	subjectReadL1.clear();
+export const _resetSubjectReadInFlightForTesting = () => {
 	inFlight.clear();
 };
 
-export const _subjectReadL1SizeForTesting = () => subjectReadL1.size;
 export const _subjectReadInFlightSizeForTesting = () => inFlight.size;
 
+/** Singleflight: concurrent reads of the same subject share one fetch.
+ *  Nothing is cached — every caller arriving after settle fetches fresh. */
 export const coalescedSubjectRead = async ({
 	key,
-	l1TtlMs,
 	singleflight,
 	fetch,
 }: {
 	key: string;
-	l1TtlMs: number;
 	singleflight: boolean;
 	fetch: () => Promise<FullSubject>;
 }): Promise<FullSubject> => {
-	const cacheEnabled = l1TtlMs > 0;
-	// Both controls off — byte-identical passthrough.
-	if (!(singleflight || cacheEnabled)) return fetch();
+	if (!singleflight) return fetch();
 
-	if (cacheEnabled) {
-		const cached = subjectReadL1.get(key);
-		if (cached) return cached;
-	}
+	const existing = inFlight.get(key);
+	if (existing) return existing;
 
-	if (singleflight) {
-		const existing = inFlight.get(key);
-		if (existing) return existing;
-	}
-
-	const flight = (async () => {
-		const fullSubject = await fetch();
-		if (cacheEnabled && isCacheableSize(fullSubject)) {
-			subjectReadL1.set(key, fullSubject, { ttl: l1TtlMs });
-		}
-		return fullSubject;
-	})();
-
-	if (singleflight) {
-		inFlight.set(key, flight);
-		// Cleanup attaches after set() so a synchronously-rejecting fetch can't
-		// delete first and leave a permanently poisoned in-flight entry.
-		const cleanup = () => inFlight.delete(key);
-		void flight.then(cleanup, cleanup);
-	}
+	const flight = fetch();
+	inFlight.set(key, flight);
+	// Cleanup attaches after set() so a synchronously-rejecting fetch can't
+	// delete first and leave a permanently poisoned in-flight entry.
+	const cleanup = () => inFlight.delete(key);
+	void flight.then(cleanup, cleanup);
 	return flight;
 };

--- a/server/src/internal/customers/cache/fullSubject/coalesceSubjectRead.ts
+++ b/server/src/internal/customers/cache/fullSubject/coalesceSubjectRead.ts
@@ -1,0 +1,73 @@
+import type { FullSubject } from "@autumn/shared";
+import { LRUCache } from "lru-cache";
+
+export const SUBJECT_READ_L1_MAX_ENTRIES = 2000;
+
+/** Pathological accounts carry millions of customer products; caching those
+ *  blobs would blow the entry-count sizing, so they get singleflight only. */
+export const SUBJECT_READ_L1_MAX_CACHEABLE_ITEMS = 10_000;
+
+const isCacheableSize = (fullSubject: FullSubject): boolean =>
+	(fullSubject.customer_products?.length ?? 0) +
+		(fullSubject.extra_customer_entitlements?.length ?? 0) +
+		(fullSubject.aggregated_customer_products?.length ?? 0) <
+	SUBJECT_READ_L1_MAX_CACHEABLE_ITEMS;
+
+const inFlight = new Map<string, Promise<FullSubject>>();
+
+/** Per-process L1 over post-sanitize FullSubjects. Entries are shared across
+ *  callers — treat them as frozen, never mutate. */
+const subjectReadL1 = new LRUCache<string, FullSubject>({
+	max: SUBJECT_READ_L1_MAX_ENTRIES,
+});
+
+export const _resetSubjectReadL1ForTesting = () => {
+	subjectReadL1.clear();
+	inFlight.clear();
+};
+
+export const _subjectReadL1SizeForTesting = () => subjectReadL1.size;
+export const _subjectReadInFlightSizeForTesting = () => inFlight.size;
+
+export const coalescedSubjectRead = async ({
+	key,
+	l1TtlMs,
+	singleflight,
+	fetch,
+}: {
+	key: string;
+	l1TtlMs: number;
+	singleflight: boolean;
+	fetch: () => Promise<FullSubject>;
+}): Promise<FullSubject> => {
+	const cacheEnabled = l1TtlMs > 0;
+	// Both controls off — byte-identical passthrough.
+	if (!(singleflight || cacheEnabled)) return fetch();
+
+	if (cacheEnabled) {
+		const cached = subjectReadL1.get(key);
+		if (cached) return cached;
+	}
+
+	if (singleflight) {
+		const existing = inFlight.get(key);
+		if (existing) return existing;
+	}
+
+	const flight = (async () => {
+		const fullSubject = await fetch();
+		if (cacheEnabled && isCacheableSize(fullSubject)) {
+			subjectReadL1.set(key, fullSubject, { ttl: l1TtlMs });
+		}
+		return fullSubject;
+	})();
+
+	if (singleflight) {
+		inFlight.set(key, flight);
+		// Cleanup attaches after set() so a synchronously-rejecting fetch can't
+		// delete first and leave a permanently poisoned in-flight entry.
+		const cleanup = () => inFlight.delete(key);
+		void flight.then(cleanup, cleanup);
+	}
+	return flight;
+};

--- a/server/src/internal/customers/handlers/handleGetCustomerV2.ts
+++ b/server/src/internal/customers/handlers/handleGetCustomerV2.ts
@@ -12,7 +12,6 @@ import {
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { applySubjectLookupDbOnly } from "@/internal/misc/miscellaneousEdgeConfig/applySubjectLookupDbOnly.js";
 import {
-	getSubjectReadL1TtlMs,
 	isSubjectReadSingleflightEnabled,
 } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 import { getApiCustomerByRollout } from "../actions/getApiCustomerByRollout.js";
@@ -56,7 +55,6 @@ export const handleGetCustomerV2 = createRoute({
 			customerId,
 			source: "handleGetCustomerV2",
 			withAutumnId: with_autumn_id,
-			l1TtlMs: getSubjectReadL1TtlMs(),
 			singleflight: isSubjectReadSingleflightEnabled(),
 		});
 

--- a/server/src/internal/customers/handlers/handleGetCustomerV2.ts
+++ b/server/src/internal/customers/handlers/handleGetCustomerV2.ts
@@ -10,6 +10,11 @@ import {
 	V0_2_InvoicesAlwaysExpanded,
 } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { applySubjectLookupDbOnly } from "@/internal/misc/miscellaneousEdgeConfig/applySubjectLookupDbOnly.js";
+import {
+	getSubjectReadL1TtlMs,
+	isSubjectReadSingleflightEnabled,
+} from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 import { getApiCustomerByRollout } from "../actions/getApiCustomerByRollout.js";
 
 export const handleGetCustomerV2 = createRoute({
@@ -22,6 +27,7 @@ export const handleGetCustomerV2 = createRoute({
 	resource: AffectedResource.Customer,
 	handler: async (c) => {
 		const ctx = c.get("ctx");
+		applySubjectLookupDbOnly({ ctx });
 		const customerId = c.req.param("customer_id");
 		const { expand } = ctx;
 		const { with_autumn_id } = c.req.valid("query");
@@ -50,6 +56,8 @@ export const handleGetCustomerV2 = createRoute({
 			customerId,
 			source: "handleGetCustomerV2",
 			withAutumnId: with_autumn_id,
+			l1TtlMs: getSubjectReadL1TtlMs(),
+			singleflight: isSubjectReadSingleflightEnabled(),
 		});
 
 		const duration = Date.now() - start;

--- a/server/src/internal/customers/handlers/handleGetCustomerV3.ts
+++ b/server/src/internal/customers/handlers/handleGetCustomerV3.ts
@@ -7,6 +7,11 @@ import {
 	V0_2_InvoicesAlwaysExpanded,
 } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { applySubjectLookupDbOnly } from "@/internal/misc/miscellaneousEdgeConfig/applySubjectLookupDbOnly.js";
+import {
+	getSubjectReadL1TtlMs,
+	isSubjectReadSingleflightEnabled,
+} from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 import { getApiCustomerByRollout } from "../actions/getApiCustomerByRollout.js";
 
 export const handleGetCustomerV3 = createRoute({
@@ -15,6 +20,7 @@ export const handleGetCustomerV3 = createRoute({
 	resource: AffectedResource.Customer,
 	handler: async (c) => {
 		const ctx = c.get("ctx");
+		applySubjectLookupDbOnly({ ctx });
 		const { customer_id: customerId, with_autumn_id = false } =
 			c.req.valid("json");
 
@@ -34,6 +40,8 @@ export const handleGetCustomerV3 = createRoute({
 			customerId,
 			source: "handleGetCustomerV3",
 			withAutumnId: with_autumn_id,
+			l1TtlMs: getSubjectReadL1TtlMs(),
+			singleflight: isSubjectReadSingleflightEnabled(),
 		});
 
 		const duration = Date.now() - start;

--- a/server/src/internal/customers/handlers/handleGetCustomerV3.ts
+++ b/server/src/internal/customers/handlers/handleGetCustomerV3.ts
@@ -9,7 +9,6 @@ import {
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { applySubjectLookupDbOnly } from "@/internal/misc/miscellaneousEdgeConfig/applySubjectLookupDbOnly.js";
 import {
-	getSubjectReadL1TtlMs,
 	isSubjectReadSingleflightEnabled,
 } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 import { getApiCustomerByRollout } from "../actions/getApiCustomerByRollout.js";
@@ -40,7 +39,6 @@ export const handleGetCustomerV3 = createRoute({
 			customerId,
 			source: "handleGetCustomerV3",
 			withAutumnId: with_autumn_id,
-			l1TtlMs: getSubjectReadL1TtlMs(),
 			singleflight: isSubjectReadSingleflightEnabled(),
 		});
 

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -10,6 +10,11 @@ const GATE_LOG_WAIT_MS_THRESHOLD = 50;
 const LIMITER_CACHE_MAX = 5000;
 const LIMITER_CACHE_TTL_MS = 30 * 60 * 1000;
 
+// Seed keeps cold processes from over-rejecting before real samples arrive.
+const SERVICE_TIME_EWMA_SEED_MS = 100;
+const SERVICE_TIME_EWMA_ALPHA = 0.2;
+let ewmaServiceMs = SERVICE_TIME_EWMA_SEED_MS;
+
 const perCustomerLimiters = new LRUCache<string, LimitFunction>({
 	max: LIMITER_CACHE_MAX,
 	ttl: LIMITER_CACHE_TTL_MS,
@@ -54,6 +59,9 @@ const getCustomerLimiter = ({
 		`${orgId}:${env}:${customerId}`,
 		limit,
 	);
+
+const predictedWaitMs = (limiter: LimitFunction): number =>
+	(limiter.pendingCount / Math.max(1, limiter.concurrency)) * ewmaServiceMs;
 
 const getOrgLimiter = ({
 	orgId,
@@ -103,6 +111,7 @@ const GATE_REJECTION_REASONS = [
 	"per_customer_queue_full",
 	"per_org_queue_full",
 	"wait_timeout",
+	"predicted_wait_timeout",
 ] as const;
 type GateRejectionReason = (typeof GATE_REJECTION_REASONS)[number];
 const gateRejectionReasonSet: ReadonlySet<string> = new Set(
@@ -201,6 +210,15 @@ export const runWithFullSubjectGate = async <T>({
 		rejectOverloaded({ reason: "per_org_queue_full", labels });
 	}
 
+	// Fast-shed: a queue predicted (via EWMA service time) not to drain within
+	// max_wait_ms would only hold the request until the dequeue-time 429.
+	const enqueuePredictedWaitMs = customerLimiter
+		? Math.max(predictedWaitMs(customerLimiter), predictedWaitMs(orgLimiter))
+		: predictedWaitMs(orgLimiter);
+	if (enqueuePredictedWaitMs >= max_wait_ms) {
+		rejectOverloaded({ reason: "predicted_wait_timeout", labels });
+	}
+
 	startedCounter.add(1, labels);
 
 	const execute = async (): Promise<T> => {
@@ -215,12 +233,17 @@ export const runWithFullSubjectGate = async <T>({
 			);
 		}
 		activeCounter.add(1, labels);
+		const serviceStartedAt = Date.now();
 		try {
 			return await queryFn();
 		} catch (error) {
 			failedCounter.add(1, labels);
 			throw error;
 		} finally {
+			const serviceMs = Date.now() - serviceStartedAt;
+			ewmaServiceMs =
+				SERVICE_TIME_EWMA_ALPHA * serviceMs +
+				(1 - SERVICE_TIME_EWMA_ALPHA) * ewmaServiceMs;
 			activeCounter.add(-1, labels);
 			completedCounter.add(1, labels);
 		}
@@ -236,3 +259,9 @@ export const runWithFullSubjectGate = async <T>({
 	}
 	return orgLimiter(execute);
 };
+
+export const _setFullSubjectGateEwmaForTesting = (valueMs: number): void => {
+	ewmaServiceMs = valueMs;
+};
+
+export const _getFullSubjectGateEwmaForTesting = (): number => ewmaServiceMs;

--- a/server/src/internal/dev/apiKeys/cacheApiKeyUtils.ts
+++ b/server/src/internal/dev/apiKeys/cacheApiKeyUtils.ts
@@ -1,8 +1,27 @@
+import { LRUCache } from "lru-cache";
 import { miscRedis } from "../../../external/redis/initRedis.js";
+import { REDIS_OP_TIMEOUT_MS } from "../../../external/redis/utils/redisOpTimeouts.js";
 import { tryRedisOp } from "../../../external/redis/utils/runRedisOp.js";
 import type { ApiKeyVerificationData } from "../repos/getApiKeyVerificationData.js";
 
 export const SECRET_KEY_CACHE_TTL_SECONDS = 3600;
+
+// This TTL is the revocation window: clearSecretKeyCache only reaches the
+// calling process's L1, so every other worker serves a revoked key until it lapses.
+export const SECRET_KEY_L1_TTL_MS = 5_000;
+export const SECRET_KEY_L1_NEGATIVE_TTL_MS = 1_000;
+export const SECRET_KEY_L1_MAX_ENTRIES = 5_000;
+
+type SecretKeyL1Entry = { value: ApiKeyVerificationData | null };
+
+/** Per-process L1. Each cluster worker gets its own copy — intended. */
+const secretKeyL1 = new LRUCache<string, SecretKeyL1Entry>({
+	max: SECRET_KEY_L1_MAX_ENTRIES,
+	ttl: SECRET_KEY_L1_TTL_MS,
+});
+
+export const _resetSecretKeyL1ForTesting = () => secretKeyL1.clear();
+export const _secretKeyL1SizeForTesting = () => secretKeyL1.size;
 
 export const buildSecretKeyCacheKey = (key: string) => {
 	return `secret_key:${key}`;
@@ -15,17 +34,32 @@ export const getCachedSecretKeyVerification = async ({
 }): Promise<ApiKeyVerificationData | null> => {
 	const cacheKey = buildSecretKeyCacheKey(hashedKey);
 
+	const local = secretKeyL1.get(cacheKey);
+	if (local) return local.value;
+
 	const cached = await tryRedisOp({
 		operation: () => miscRedis.get(cacheKey),
 		source: "secret-key-cache:get",
 		redisInstance: miscRedis,
+		timeoutMs: REDIS_OP_TIMEOUT_MS.secretKeyGet,
 	});
 
+	// `undefined` means Redis failed, `null` means a genuine miss — only the
+	// latter is a real answer worth negative-caching.
+	if (cached === undefined) return null;
+
 	if (!cached) {
+		secretKeyL1.set(
+			cacheKey,
+			{ value: null },
+			{ ttl: SECRET_KEY_L1_NEGATIVE_TTL_MS },
+		);
 		return null;
 	}
 
-	return JSON.parse(cached) as ApiKeyVerificationData;
+	const parsed = JSON.parse(cached) as ApiKeyVerificationData;
+	secretKeyL1.set(cacheKey, { value: parsed });
+	return parsed;
 };
 
 export const setCachedSecretKeyVerification = async ({
@@ -38,6 +72,8 @@ export const setCachedSecretKeyVerification = async ({
 	ttl?: number;
 }) => {
 	const cacheKey = buildSecretKeyCacheKey(hashedKey);
+
+	secretKeyL1.set(cacheKey, { value: data as ApiKeyVerificationData });
 
 	await tryRedisOp({
 		operation: () => miscRedis.set(cacheKey, JSON.stringify(data), "EX", ttl),
@@ -54,6 +90,9 @@ export const clearSecretKeyCache = async ({
 	logger?: Pick<Console, "error" | "warn">;
 }) => {
 	const cacheKey = buildSecretKeyCacheKey(hashedKey);
+
+	// Local-only: other processes keep serving the key until their L1 TTL lapses.
+	secretKeyL1.delete(cacheKey);
 
 	await tryRedisOp({
 		operation: () => miscRedis.del(cacheKey),

--- a/server/src/internal/entities/actions/getApiEntityByRollout.ts
+++ b/server/src/internal/entities/actions/getApiEntityByRollout.ts
@@ -1,7 +1,12 @@
 import type { ApiEntityV2 } from "@autumn/shared";
 import { shed503OnTransientError } from "@/db/shed503OnTransientError.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubject/index.js";
+import { coalescedSubjectRead } from "@/internal/customers/cache/fullSubject/coalesceSubjectRead.js";
+import {
+	buildFullSubjectKey,
+	getOrSetCachedFullSubject,
+} from "@/internal/customers/cache/fullSubject/index.js";
+import { isRedisFallbackToDbEnabled } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 import { isFullSubjectRolloutEnabled } from "@/internal/misc/rollouts/fullSubjectRolloutUtils.js";
 import { getApiEntityV2 } from "../entityUtils/getApiEntityV2/getApiEntityV2.js";
 
@@ -11,20 +16,52 @@ export const getApiEntityByRollout = async ({
 	entityId,
 	source,
 	withAutumnId = false,
+	l1TtlMs = 0,
+	singleflight = false,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	entityId: string;
 	source?: string;
 	withAutumnId?: boolean;
+	l1TtlMs?: number;
+	singleflight?: boolean;
 }): Promise<ApiEntityV2> => {
 	if (isFullSubjectRolloutEnabled({ ctx })) {
 	}
 
+	const lookup = ({ skipCache }: { skipCache: boolean }) => {
+		const fetch = () =>
+			getOrSetCachedFullSubject({
+				ctx: skipCache ? { ...ctx, skipCache: true } : ctx,
+				customerId,
+				entityId,
+				source,
+			});
+
+		if (!singleflight && l1TtlMs <= 0) return fetch();
+
+		// The L1 stays on even under skipCache — it exists for Redis outages.
+		return coalescedSubjectRead({
+			key: buildFullSubjectKey({
+				orgId: ctx.org.id,
+				env: ctx.env,
+				customerId,
+				entityId,
+			}),
+			l1TtlMs,
+			singleflight,
+			fetch,
+		});
+	};
+
 	const fullSubject = await shed503OnTransientError({
 		ctx,
 		source: "entities.get",
-		run: () => getOrSetCachedFullSubject({ ctx, customerId, entityId, source }),
+		run: () => lookup({ skipCache: false }),
+		fallbackOnRedisUnavailable: isRedisFallbackToDbEnabled()
+			? () => lookup({ skipCache: true })
+			: undefined,
 	});
 
 	return getApiEntityV2({

--- a/server/src/internal/entities/actions/getApiEntityByRollout.ts
+++ b/server/src/internal/entities/actions/getApiEntityByRollout.ts
@@ -16,7 +16,6 @@ export const getApiEntityByRollout = async ({
 	entityId,
 	source,
 	withAutumnId = false,
-	l1TtlMs = 0,
 	singleflight = false,
 }: {
 	ctx: AutumnContext;
@@ -24,7 +23,6 @@ export const getApiEntityByRollout = async ({
 	entityId: string;
 	source?: string;
 	withAutumnId?: boolean;
-	l1TtlMs?: number;
 	singleflight?: boolean;
 }): Promise<ApiEntityV2> => {
 	if (isFullSubjectRolloutEnabled({ ctx })) {
@@ -39,9 +37,8 @@ export const getApiEntityByRollout = async ({
 				source,
 			});
 
-		if (!singleflight && l1TtlMs <= 0) return fetch();
+		if (!singleflight) return fetch();
 
-		// The L1 stays on even under skipCache — it exists for Redis outages.
 		return coalescedSubjectRead({
 			key: buildFullSubjectKey({
 				orgId: ctx.org.id,
@@ -49,7 +46,6 @@ export const getApiEntityByRollout = async ({
 				customerId,
 				entityId,
 			}),
-			l1TtlMs,
 			singleflight,
 			fetch,
 		});

--- a/server/src/internal/entities/handlers/handleGetEntity/handleGetEntity.ts
+++ b/server/src/internal/entities/handlers/handleGetEntity/handleGetEntity.ts
@@ -6,6 +6,10 @@ import {
 } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { applySubjectLookupDbOnly } from "@/internal/misc/miscellaneousEdgeConfig/applySubjectLookupDbOnly.js";
+import {
+	getSubjectReadL1TtlMs,
+	isSubjectReadSingleflightEnabled,
+} from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 import { getApiEntityByRollout } from "../../actions/getApiEntityByRollout.js";
 
 export const handleGetEntity = createRoute({
@@ -28,6 +32,8 @@ export const handleGetEntity = createRoute({
 			entityId: entity_id,
 			source: "handleGetEntity",
 			withAutumnId: with_autumn_id,
+			l1TtlMs: getSubjectReadL1TtlMs(),
+			singleflight: isSubjectReadSingleflightEnabled(),
 		});
 
 		return c.json(apiEntity);

--- a/server/src/internal/entities/handlers/handleGetEntity/handleGetEntity.ts
+++ b/server/src/internal/entities/handlers/handleGetEntity/handleGetEntity.ts
@@ -7,7 +7,6 @@ import {
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { applySubjectLookupDbOnly } from "@/internal/misc/miscellaneousEdgeConfig/applySubjectLookupDbOnly.js";
 import {
-	getSubjectReadL1TtlMs,
 	isSubjectReadSingleflightEnabled,
 } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 import { getApiEntityByRollout } from "../../actions/getApiEntityByRollout.js";
@@ -32,7 +31,6 @@ export const handleGetEntity = createRoute({
 			entityId: entity_id,
 			source: "handleGetEntity",
 			withAutumnId: with_autumn_id,
-			l1TtlMs: getSubjectReadL1TtlMs(),
 			singleflight: isSubjectReadSingleflightEnabled(),
 		});
 

--- a/server/src/internal/entities/handlers/handleGetEntity/handleGetEntityV2.ts
+++ b/server/src/internal/entities/handlers/handleGetEntity/handleGetEntityV2.ts
@@ -8,7 +8,6 @@ import { shed503OnTransientError } from "@/db/shed503OnTransientError.js";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { applySubjectLookupDbOnly } from "@/internal/misc/miscellaneousEdgeConfig/applySubjectLookupDbOnly.js";
 import {
-	getSubjectReadL1TtlMs,
 	isSubjectReadSingleflightEnabled,
 } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 import { findCustomerForEntity } from "../../actions/findCustomer.js";
@@ -47,7 +46,6 @@ export const handleGetEntityV2 = createRoute({
 			customerId: customerId,
 			entityId: entityId,
 			source: "handleGetEntityV2",
-			l1TtlMs: getSubjectReadL1TtlMs(),
 			singleflight: isSubjectReadSingleflightEnabled(),
 		});
 

--- a/server/src/internal/entities/handlers/handleGetEntity/handleGetEntityV2.ts
+++ b/server/src/internal/entities/handlers/handleGetEntity/handleGetEntityV2.ts
@@ -7,6 +7,10 @@ import {
 import { shed503OnTransientError } from "@/db/shed503OnTransientError.js";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { applySubjectLookupDbOnly } from "@/internal/misc/miscellaneousEdgeConfig/applySubjectLookupDbOnly.js";
+import {
+	getSubjectReadL1TtlMs,
+	isSubjectReadSingleflightEnabled,
+} from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 import { findCustomerForEntity } from "../../actions/findCustomer.js";
 import { getApiEntityByRollout } from "../../actions/getApiEntityByRollout.js";
 
@@ -43,6 +47,8 @@ export const handleGetEntityV2 = createRoute({
 			customerId: customerId,
 			entityId: entityId,
 			source: "handleGetEntityV2",
+			l1TtlMs: getSubjectReadL1TtlMs(),
+			singleflight: isSubjectReadSingleflightEnabled(),
 		});
 
 		return c.json(apiEntity);

--- a/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.ts
+++ b/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.ts
@@ -17,10 +17,8 @@ export const MiscellaneousEdgeConfigSchema = z.object({
 	 *  Postgres instead of shedding a 503. Dark by default — turning this on
 	 *  converts a cache outage into full primary read load. */
 	redisFallbackToDb: z.boolean().default(false),
-	/** In-process L1 TTL (ms) for pure-GET subject reads; 0 disables the L1
-	 *  cache only — singleflight is gated by subjectReadSingleflight. */
 	/** Global switch: concurrent same-key pure-GET subject reads share one
-	 *  in-flight fetch. Independent of the L1 TTL. */
+	 *  in-flight fetch. */
 	subjectReadSingleflight: z.boolean().default(true),
 });
 

--- a/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.ts
+++ b/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.ts
@@ -13,6 +13,16 @@ export const MiscellaneousEdgeConfigSchema = z.object({
 	 *  fire-and-forget mirror). Flip only after a full Redis TTL (24h) of
 	 *  dual-writing — i.e. 24h after deploy — or in-flight keys are lost. */
 	idempotencyDynamoRead: z.boolean().default(false),
+	/** Global switch: when Redis is unavailable, subject reads fall back to
+	 *  Postgres instead of shedding a 503. Dark by default — turning this on
+	 *  converts a cache outage into full primary read load. */
+	redisFallbackToDb: z.boolean().default(false),
+	/** In-process L1 TTL (ms) for pure-GET subject reads; 0 disables the L1
+	 *  cache only — singleflight is gated by subjectReadSingleflight. */
+	subjectReadL1TtlMs: z.number().default(1000),
+	/** Global switch: concurrent same-key pure-GET subject reads share one
+	 *  in-flight fetch. Independent of the L1 TTL. */
+	subjectReadSingleflight: z.boolean().default(true),
 });
 
 export type MiscellaneousEdgeConfig = z.infer<

--- a/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.ts
+++ b/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.ts
@@ -19,7 +19,6 @@ export const MiscellaneousEdgeConfigSchema = z.object({
 	redisFallbackToDb: z.boolean().default(false),
 	/** In-process L1 TTL (ms) for pure-GET subject reads; 0 disables the L1
 	 *  cache only — singleflight is gated by subjectReadSingleflight. */
-	subjectReadL1TtlMs: z.number().default(1000),
 	/** Global switch: concurrent same-key pure-GET subject reads share one
 	 *  in-flight fetch. Independent of the L1 TTL. */
 	subjectReadSingleflight: z.boolean().default(true),

--- a/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.ts
+++ b/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.ts
@@ -67,10 +67,6 @@ export const isIdempotencyDynamoReadEnabled = (): boolean =>
 export const isRedisFallbackToDbEnabled = (): boolean =>
 	store.get().redisFallbackToDb;
 
-/** In-process L1 TTL for pure-GET subject reads; 0 disables the cache only. */
-export const getSubjectReadL1TtlMs = (): number =>
-	store.get().subjectReadL1TtlMs;
-
 /** Global gate: share one in-flight fetch across concurrent subject reads. */
 export const isSubjectReadSingleflightEnabled = (): boolean =>
 	store.get().subjectReadSingleflight;

--- a/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.ts
+++ b/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.ts
@@ -3,8 +3,8 @@ import { ADMIN_MISCELLANEOUS_EDGE_CONFIG_KEY } from "@/external/aws/s3/adminS3Co
 import { registerEdgeConfig } from "@/internal/misc/edgeConfig/edgeConfigRegistry.js";
 import { createEdgeConfigStore } from "@/internal/misc/edgeConfig/edgeConfigStore.js";
 import {
-	type MiscellaneousEdgeConfig,
-	MiscellaneousEdgeConfigSchema,
+    type MiscellaneousEdgeConfig,
+    MiscellaneousEdgeConfigSchema,
 } from "./miscellaneousEdgeConfigSchemas.js";
 
 const store = createEdgeConfigStore<MiscellaneousEdgeConfig>({
@@ -63,3 +63,14 @@ export const isSubjectLookupDbOnlyEnabled = (): boolean =>
 /** Idempotency-key migration: DynamoDB is the conflict authority. */
 export const isIdempotencyDynamoReadEnabled = (): boolean =>
 	store.get().idempotencyDynamoRead;
+/** Global gate: fall back to Postgres on Redis outage instead of shedding. */
+export const isRedisFallbackToDbEnabled = (): boolean =>
+	store.get().redisFallbackToDb;
+
+/** In-process L1 TTL for pure-GET subject reads; 0 disables the cache only. */
+export const getSubjectReadL1TtlMs = (): number =>
+	store.get().subjectReadL1TtlMs;
+
+/** Global gate: share one in-flight fetch across concurrent subject reads. */
+export const isSubjectReadSingleflightEnabled = (): boolean =>
+	store.get().subjectReadSingleflight;

--- a/server/src/internal/orgs/orgUtils/cacheOrgWithFeatures.ts
+++ b/server/src/internal/orgs/orgUtils/cacheOrgWithFeatures.ts
@@ -1,6 +1,7 @@
 import { AppEnv } from "@autumn/shared";
 import type { DrizzleCli } from "@server/db/initDrizzle.js";
 import { miscRedis } from "@/external/redis/initRedis.js";
+import { REDIS_OP_TIMEOUT_MS } from "@/external/redis/utils/redisOpTimeouts.js";
 import { tryRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import { OrgService } from "../OrgService.js";
 
@@ -33,6 +34,7 @@ export const getCachedOrgWithFeatures = async ({
 		operation: () => miscRedis.get(cacheKey),
 		source: "org-features-cache:get",
 		redisInstance: miscRedis,
+		timeoutMs: REDIS_OP_TIMEOUT_MS.orgFeaturesGet,
 	});
 
 	if (!cached) return null;

--- a/server/tests/integration/misc/full-subject-gate/get-full-subject-gate.test.ts
+++ b/server/tests/integration/misc/full-subject-gate/get-full-subject-gate.test.ts
@@ -1,6 +1,8 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { AppEnv } from "@autumn/shared";
 import {
+	_getFullSubjectGateEwmaForTesting,
+	_setFullSubjectGateEwmaForTesting,
 	runWithFullSubjectGate,
 	toPerProcessLimit,
 } from "@/internal/customers/repos/getFullSubject/getFullSubjectGate.js";
@@ -455,5 +457,178 @@ describe("runWithFullSubjectGate cluster-wide caps", () => {
 		expect(counter.current).toBe(0);
 
 		_setFullSubjectGateConfigForTesting({ config: {} });
+	});
+});
+
+describe("runWithFullSubjectGate enqueue-time admission control", () => {
+	test("rejects immediately at enqueue when EWMA predicts the queue cannot drain within max_wait_ms", async () => {
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 1,
+				per_org_limit: 100,
+				max_wait_ms: 500,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
+		});
+		_setFullSubjectGateEwmaForTesting(10_000);
+
+		const hold = () => new Promise((resolve) => setTimeout(resolve, 200));
+		const running = runWithFullSubjectGate({
+			customerId: "cus-predicted-reject",
+			orgId: "org-predicted-reject",
+			env: AppEnv.Live,
+			queryFn: hold,
+		});
+		// Let the first request occupy the single slot so the next one queues.
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		const queued = runWithFullSubjectGate({
+			customerId: "cus-predicted-reject",
+			orgId: "org-predicted-reject",
+			env: AppEnv.Live,
+			queryFn: hold,
+		});
+
+		const start = Date.now();
+		const [result] = await Promise.allSettled([
+			runWithFullSubjectGate({
+				customerId: "cus-predicted-reject",
+				orgId: "org-predicted-reject",
+				env: AppEnv.Live,
+				queryFn: hold,
+			}),
+		]);
+		const elapsedMs = Date.now() - start;
+
+		expect(result?.status).toBe("rejected");
+		const rejection = (result as PromiseRejectedResult).reason;
+		expect(rejection.statusCode).toBe(429);
+		expect(rejection.code).toBe("rate_limit_exceeded");
+		expect(rejection.data?.reason).toBe("predicted_wait_timeout");
+		// Shed at enqueue — did not sit the queue behind the slow requests.
+		expect(elapsedMs).toBeLessThan(50);
+
+		await Promise.allSettled([running, queued]);
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 2,
+				per_org_limit: 4,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
+		});
+		_setFullSubjectGateEwmaForTesting(100);
+	});
+
+	test("admits into an empty queue regardless of a high EWMA", async () => {
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 1,
+				per_org_limit: 100,
+				max_wait_ms: 500,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
+		});
+		_setFullSubjectGateEwmaForTesting(60_000);
+
+		const result = await runWithFullSubjectGate({
+			customerId: "cus-empty-queue",
+			orgId: "org-empty-queue",
+			env: AppEnv.Live,
+			queryFn: async () => "ok",
+		});
+		expect(result).toBe("ok");
+
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 2,
+				per_org_limit: 4,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
+		});
+		_setFullSubjectGateEwmaForTesting(100);
+	});
+
+	test("EWMA moves toward observed service times as executions complete", async () => {
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 2,
+				per_org_limit: 4,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
+		});
+		_setFullSubjectGateEwmaForTesting(100);
+
+		await runWithFullSubjectGate({
+			customerId: "cus-ewma-update",
+			orgId: "org-ewma-update",
+			env: AppEnv.Live,
+			queryFn: () => new Promise((resolve) => setTimeout(resolve, 300)),
+		});
+		const afterSlow = _getFullSubjectGateEwmaForTesting();
+		expect(afterSlow).toBeGreaterThan(100);
+		expect(afterSlow).toBeLessThan(300);
+
+		await runWithFullSubjectGate({
+			customerId: "cus-ewma-update",
+			orgId: "org-ewma-update",
+			env: AppEnv.Live,
+			queryFn: async () => "fast",
+		});
+		expect(_getFullSubjectGateEwmaForTesting()).toBeLessThan(afterSlow);
+
+		_setFullSubjectGateEwmaForTesting(100);
+	});
+
+	test("dequeue-time wait_timeout backstop still fires when the EWMA under-predicts", async () => {
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 1,
+				per_org_limit: 100,
+				max_wait_ms: 100,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
+		});
+		// Low EWMA admits everything at enqueue; real service time is slower.
+		_setFullSubjectGateEwmaForTesting(1);
+
+		const slow = () => new Promise((resolve) => setTimeout(resolve, 120));
+		const results = await Promise.allSettled(
+			Array.from({ length: 4 }, () =>
+				runWithFullSubjectGate({
+					customerId: "cus-backstop",
+					orgId: "org-backstop",
+					env: AppEnv.Live,
+					queryFn: slow,
+				}),
+			),
+		);
+
+		expect(results[0]?.status).toBe("fulfilled");
+		const rejectedReasons = results
+			.filter((r) => r.status === "rejected")
+			.map((r) => (r as PromiseRejectedResult).reason.data?.reason);
+		expect(rejectedReasons.length).toBeGreaterThan(0);
+		expect(rejectedReasons.every((reason) => reason === "wait_timeout")).toBe(
+			true,
+		);
+
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 2,
+				per_org_limit: 4,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
+		});
+		_setFullSubjectGateEwmaForTesting(100);
 	});
 });

--- a/server/tests/unit/balances/check-v2/checkDbHydrationBudget.test.ts
+++ b/server/tests/unit/balances/check-v2/checkDbHydrationBudget.test.ts
@@ -1,0 +1,152 @@
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	test,
+} from "bun:test";
+
+const mockState = {
+	hydrationMode: "resolve" as "resolve" | "hang",
+	hydrationCalls: 0,
+};
+
+const buildFullSubject = () => ({
+	customer: { id: "cus_123", internal_id: "internal_123" },
+	customer_products: [],
+	extra_customer_entitlements: [],
+	pooled_customer_entitlements: [],
+	subscriptions: [],
+	invoices: [],
+	migration_item_runs: [],
+	entity: undefined,
+});
+
+mock.module("@/internal/customers/repos/getFullSubject/index.js", () => ({
+	getFullSubject: async () => null,
+	getFullSubjectQuery: () => null,
+	resultToFullSubject: () => null,
+	subjectQueryRowToNormalized: () => null,
+	getFullSubjectNormalized: async () => {
+		mockState.hydrationCalls += 1;
+		if (mockState.hydrationMode === "hang") {
+			return await new Promise<never>(() => {});
+		}
+		return { normalized: {} as never, fullSubject: buildFullSubject() };
+	},
+}));
+
+mock.module(
+	"@/internal/customers/cusUtils/getApiCustomerV2/getApiSubject.js",
+	() => ({
+		getApiSubject: async () => ({ balances: {}, flags: {} }),
+	}),
+);
+
+mock.module("@/internal/balances/check/buildEvaluationSubject.js", () => ({
+	buildEvaluationSubject: async () => ({ balances: {}, flags: {} }),
+}));
+
+mock.module("@/internal/balances/autoTopUp/triggerAutoTopUp.js", () => ({
+	triggerAutoTopUp: async () => {
+		// no-op
+	},
+}));
+
+import { FeatureType } from "@autumn/shared";
+import { isTransientDbError } from "@/db/dbUtils.js";
+import {
+	CHECK_DB_HYDRATION_BUDGET_MS,
+	getCheckDataV2,
+} from "@/internal/balances/check/getCheckDataV2.js";
+import { getOrSetCachedPartialFullSubject } from "@/internal/customers/cache/fullSubject/actions/partial/getOrSetCachedPartialFullSubject.js";
+
+// skipCache: true routes the shared getter straight to the (mocked) DB hydration.
+const buildCtx = () =>
+	({
+		skipCache: true,
+		apiVersion: { gte: () => true },
+		features: [{ id: "messages", type: FeatureType.Metered }],
+		logger: {
+			debug: () => {},
+			info: () => {},
+			warn: () => {},
+			error: () => {},
+		},
+	}) as never;
+
+const resetMockState = () => {
+	mockState.hydrationMode = "resolve";
+	mockState.hydrationCalls = 0;
+};
+
+beforeEach(resetMockState);
+afterEach(resetMockState);
+
+describe("check DB hydration budget", () => {
+	test("returns check data when hydration resolves within budget", async () => {
+		const checkData = await getCheckDataV2({
+			ctx: buildCtx(),
+			body: { customer_id: "cus_123", feature_id: "messages" } as never,
+			requiredBalance: 1,
+		});
+
+		expect(mockState.hydrationCalls).toBe(1);
+		expect(checkData.customerId).toBe("cus_123");
+		expect(checkData.featureToUse.id).toBe("messages");
+		expect(checkData.fullSubject.customer.id).toBe("cus_123");
+	});
+
+	test("hydration hanging past budget throws an error the fail-open predicate classifies as transient", async () => {
+		mockState.hydrationMode = "hang";
+		const startedAt = Date.now();
+
+		let thrown: unknown;
+		try {
+			await getCheckDataV2({
+				ctx: buildCtx(),
+				body: { customer_id: "cus_123", feature_id: "messages" } as never,
+				requiredBalance: 1,
+			});
+		} catch (error) {
+			thrown = error;
+		}
+
+		expect(thrown).toBeInstanceOf(Error);
+		expect((thrown as Error).message).toBe("Query read timeout");
+		expect(isTransientDbError({ error: thrown })).toBe(true);
+		expect(Date.now() - startedAt).toBeGreaterThanOrEqual(
+			CHECK_DB_HYDRATION_BUDGET_MS - 100,
+		);
+	});
+
+	test("shared subject getter keeps waiting past check's budget (no timeout outside check)", async () => {
+		mockState.hydrationMode = "hang";
+
+		const outcome = await Promise.race([
+			getOrSetCachedPartialFullSubject({
+				ctx: buildCtx(),
+				customerId: "cus_123",
+				featureIds: ["messages"],
+				source: "unit-test",
+			}).then(
+				() => "settled",
+				() => "settled",
+			),
+			new Promise<string>((resolve) => {
+				setTimeout(
+					() => resolve("still-pending"),
+					CHECK_DB_HYDRATION_BUDGET_MS + 500,
+				);
+			}),
+		]);
+
+		expect(outcome).toBe("still-pending");
+	});
+});
+
+afterAll(() => {
+	mock.restore();
+});

--- a/server/tests/unit/db/connectRetry.test.ts
+++ b/server/tests/unit/db/connectRetry.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import type { Pool, PoolClient } from "pg";
+
+const warn = mock((..._args: unknown[]) => {});
+mock.module("@/external/logtail/logtailUtils.js", () => ({
+	logger: {
+		info: mock(() => {}),
+		warn,
+		error: mock(() => {}),
+		debug: mock(() => {}),
+		child: () => ({}),
+	},
+}));
+
+const { applyConnectRefusedRetry, connectRefusedRetryJitterMs } = await import(
+	"@/db/connectRetry.js"
+);
+
+const maxClientConnError = () =>
+	new Error("error: no more connections allowed (max_client_conn)");
+
+const econnrefusedError = () =>
+	Object.assign(new Error("connect ECONNREFUSED 10.0.0.1:6432"), {
+		code: "ECONNREFUSED",
+	});
+
+const checkoutTimeoutError = () =>
+	new Error("timeout exceeded when trying to connect");
+
+const fakeClient = (): PoolClient =>
+	({ release: mock(() => {}) }) as unknown as PoolClient;
+
+/** Pool whose connect() consumes `outcomes` in order (Error = reject). */
+const buildFakePool = (outcomes: (Error | PoolClient)[]) => {
+	const connect = mock(() => {
+		const next = outcomes.shift();
+		if (next instanceof Error) return Promise.reject(next);
+		return Promise.resolve(next);
+	});
+	const pool = { connect } as unknown as Pool;
+	applyConnectRefusedRetry({ pool, name: "critical" });
+	return { pool, underlyingConnect: connect };
+};
+
+afterEach(() => {
+	warn.mockClear();
+	mock.restore();
+});
+
+describe("applyConnectRefusedRetry", () => {
+	it("retries once with jitter on a max_client_conn refusal and returns the client", async () => {
+		spyOn(Math, "random").mockReturnValue(0);
+		const client = fakeClient();
+		const { pool, underlyingConnect } = buildFakePool([
+			maxClientConnError(),
+			client,
+		]);
+
+		const startedAt = performance.now();
+		const result = await pool.connect();
+		const elapsedMs = performance.now() - startedAt;
+
+		expect(result).toBe(client);
+		expect(underlyingConnect).toHaveBeenCalledTimes(2);
+		// Math.random stubbed to 0 → jitter is exactly the 100ms floor.
+		expect(elapsedMs).toBeGreaterThanOrEqual(95);
+		expect(elapsedMs).toBeLessThan(300);
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0]?.[0]).toBe("pg_connect_refused_retry");
+		expect(warn.mock.calls[0]?.[1]).toMatchObject({
+			type: "pg_connect_refused_retry",
+			pool: "critical",
+		});
+	});
+
+	it("propagates the second refusal unchanged after one retry", async () => {
+		spyOn(Math, "random").mockReturnValue(0);
+		const secondError = maxClientConnError();
+		const { pool, underlyingConnect } = buildFakePool([
+			maxClientConnError(),
+			secondError,
+		]);
+
+		await expect(pool.connect()).rejects.toBe(secondError);
+		expect(underlyingConnect).toHaveBeenCalledTimes(2);
+		expect(warn).toHaveBeenCalledTimes(1);
+	});
+
+	it("never retries checkout timeouts — propagates immediately", async () => {
+		const timeoutError = checkoutTimeoutError();
+		const { pool, underlyingConnect } = buildFakePool([
+			timeoutError,
+			fakeClient(),
+		]);
+
+		await expect(pool.connect()).rejects.toBe(timeoutError);
+		expect(underlyingConnect).toHaveBeenCalledTimes(1);
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("retries on ECONNREFUSED code", async () => {
+		spyOn(Math, "random").mockReturnValue(0);
+		const client = fakeClient();
+		const { pool, underlyingConnect } = buildFakePool([
+			econnrefusedError(),
+			client,
+		]);
+
+		await expect(pool.connect()).resolves.toBe(client);
+		expect(underlyingConnect).toHaveBeenCalledTimes(2);
+		expect(warn).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not retry non-refusal errors", async () => {
+		const queryError = new Error("password authentication failed");
+		const { pool, underlyingConnect } = buildFakePool([
+			queryError,
+			fakeClient(),
+		]);
+
+		await expect(pool.connect()).rejects.toBe(queryError);
+		expect(underlyingConnect).toHaveBeenCalledTimes(1);
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("supports the callback connect form through a retry", async () => {
+		spyOn(Math, "random").mockReturnValue(0);
+		const client = fakeClient();
+		const { pool, underlyingConnect } = buildFakePool([
+			maxClientConnError(),
+			client,
+		]);
+
+		const received = await new Promise<PoolClient | undefined>(
+			(resolve, reject) => {
+				pool.connect((err, connectedClient) => {
+					if (err) return reject(err);
+					resolve(connectedClient);
+				});
+			},
+		);
+
+		expect(received).toBe(client);
+		expect(underlyingConnect).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("connectRefusedRetryJitterMs", () => {
+	it("stays within the 100-300ms band", () => {
+		for (let i = 0; i < 1000; i++) {
+			const jitterMs = connectRefusedRetryJitterMs();
+			expect(jitterMs).toBeGreaterThanOrEqual(100);
+			expect(jitterMs).toBeLessThanOrEqual(300);
+		}
+	});
+});

--- a/server/tests/unit/db/shed503OnTransientError.test.ts
+++ b/server/tests/unit/db/shed503OnTransientError.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import { shed503OnTransientError } from "@/db/shed503OnTransientError.js";
+import { RedisUnavailableError } from "@/external/redis/utils/errors.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 
 const buildContext = () =>
@@ -12,6 +13,11 @@ const buildContext = () =>
 
 const transientError = Object.assign(new Error("connect timeout"), {
 	code: "CONNECT_TIMEOUT",
+});
+
+const redisError = new RedisUnavailableError({
+	source: "test",
+	reason: "not_ready",
 });
 
 describe("shed503OnTransientError", () => {
@@ -75,5 +81,85 @@ describe("shed503OnTransientError", () => {
 		).rejects.toBe(applicationError);
 
 		expect(onTransientError).not.toHaveBeenCalled();
+	});
+
+	test("sheds redis failures when no fallback is supplied", async () => {
+		const ctx = buildContext();
+
+		await expect(
+			shed503OnTransientError({
+				ctx,
+				source: "find_customer",
+				run: () => {
+					throw redisError;
+				},
+			}),
+		).rejects.toMatchObject({
+			statusCode: 503,
+			data: { reason: "cache_unavailable" },
+		});
+	});
+
+	test("serves the postgres fallback when only redis failed", async () => {
+		const ctx = buildContext();
+		const onTransientError = mock(async () => {});
+
+		const result = await shed503OnTransientError({
+			ctx,
+			source: "get_customer",
+			run: () => {
+				throw redisError;
+			},
+			fallbackOnRedisUnavailable: () => "from-postgres",
+			onTransientError,
+		});
+
+		expect(result).toBe("from-postgres");
+		expect(onTransientError).not.toHaveBeenCalled();
+	});
+
+	test("never falls back when postgres is implicated", async () => {
+		const ctx = buildContext();
+		const fallback = mock(() => "from-postgres");
+
+		await expect(
+			shed503OnTransientError({
+				ctx,
+				source: "get_customer",
+				run: () => {
+					throw transientError;
+				},
+				fallbackOnRedisUnavailable: fallback,
+			}),
+		).rejects.toMatchObject({
+			statusCode: 503,
+			data: { reason: "critical_db_saturated" },
+		});
+
+		expect(fallback).not.toHaveBeenCalled();
+	});
+
+	test("sheds and still captures recovery when the fallback itself fails", async () => {
+		const ctx = buildContext();
+		const onTransientError = mock(async () => {});
+
+		await expect(
+			shed503OnTransientError({
+				ctx,
+				source: "get_or_create",
+				run: () => {
+					throw redisError;
+				},
+				fallbackOnRedisUnavailable: () => {
+					throw new Error("postgres also down");
+				},
+				onTransientError,
+			}),
+		).rejects.toMatchObject({
+			statusCode: 503,
+			data: { reason: "cache_unavailable" },
+		});
+
+		expect(onTransientError).toHaveBeenCalledWith(redisError);
 	});
 });

--- a/server/tests/unit/dev/apiKeys/secretKeyL1Cache.test.ts
+++ b/server/tests/unit/dev/apiKeys/secretKeyL1Cache.test.ts
@@ -1,0 +1,282 @@
+/**
+ * TDD test for the in-process L1 cache fronting the Redis secret-key
+ * verification cache. `secret-key-cache:get` is ~85% of the legacy Redis
+ * client's traffic; an L1 removes it from the request path.
+ *
+ * Contract under test:
+ *   New constants:
+ *     - SECRET_KEY_L1_TTL_MS = 5_000 (positive entries)
+ *     - SECRET_KEY_L1_NEGATIVE_TTL_MS = 1_000..2_000 (negative entries)
+ *     - SECRET_KEY_L1_MAX_ENTRIES = 5_000
+ *   New behaviors:
+ *     1. L1 hit -> value returned, Redis NOT called
+ *     2. L1 miss -> falls through to Redis; a Redis hit populates L1
+ *     3. L1 miss + Redis miss -> null (verifyKey then hits Postgres)
+ *     4. Positive entry stops being served after its TTL; next call re-reads Redis
+ *     5. Cache is LRU-bounded at max and never grows past it
+ *     6. Negative lookups are cached with a STRICTLY SHORTER TTL than positive
+ *     7. setCachedSecretKeyVerification write-through populates/refreshes L1
+ *     8. clearSecretKeyCache evicts the calling process's L1 entry (local only)
+ *     9. A Redis error yields null, never a throw (tryRedisOp swallow preserved)
+ *
+ * Pre-impl red: no L1 exists, so every get is a Redis call and none of the
+ * L1 constants/seams are exported.
+ * Post-impl green: an LRUCache in cacheApiKeyUtils.ts fronts every Redis read.
+ */
+
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { currentRegion, getRegionalRedis } from "@/external/redis/initRedis.js";
+import {
+	_resetSecretKeyL1ForTesting,
+	_secretKeyL1SizeForTesting,
+	buildSecretKeyCacheKey,
+	clearSecretKeyCache,
+	getCachedSecretKeyVerification,
+	SECRET_KEY_L1_MAX_ENTRIES,
+	SECRET_KEY_L1_NEGATIVE_TTL_MS,
+	SECRET_KEY_L1_TTL_MS,
+	setCachedSecretKeyVerification,
+} from "@/internal/dev/apiKeys/cacheApiKeyUtils.js";
+import type { ApiKeyVerificationData } from "@/internal/dev/repos/getApiKeyVerificationData.js";
+
+const buildVerificationData = (orgId: string) =>
+	({
+		org: { id: orgId, slug: orgId },
+		features: [],
+		pendingMigrations: [],
+		fullOrg: { id: orgId },
+		env: "live",
+		userId: null,
+		user: null,
+		scopes: null,
+	}) as unknown as ApiKeyVerificationData;
+
+/** Unique per test so concurrent runs never share a Redis key. */
+const uniqueKey = (label: string) =>
+	`l1-test-${label}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+// The exported `redis` is a Proxy over an empty target, so spies must go on the
+// concrete client it resolves to or they are never read back.
+const mainRedis = () => getRegionalRedis(currentRegion);
+
+let redisGet: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+	_resetSecretKeyL1ForTesting();
+	// Spy, not stub: bun's spyOn calls through, so the real Redis path still runs.
+	redisGet = spyOn(mainRedis(), "get");
+});
+
+afterEach(() => {
+	redisGet.mockRestore();
+	_resetSecretKeyL1ForTesting();
+});
+
+describe("secret-key L1 cache", () => {
+	// ── Contract 1 + 2: miss falls through to Redis, hit populates L1, ──────
+	// ── and the next read is served locally with zero Redis calls. ─────────
+	test("a Redis hit populates L1 so the next get skips Redis entirely", async () => {
+		const hashedKey = uniqueKey("hit");
+		const data = buildVerificationData("org_hit");
+
+		// Seed Redis directly, then clear L1 so the next read MUST go to Redis.
+		await setCachedSecretKeyVerification({ hashedKey, data });
+		_resetSecretKeyL1ForTesting();
+		redisGet.mockClear();
+
+		const first = await getCachedSecretKeyVerification({ hashedKey });
+		expect(first?.org.id).toBe("org_hit");
+		expect(redisGet).toHaveBeenCalledTimes(1); // contract 2: fell through
+
+		redisGet.mockClear();
+
+		const second = await getCachedSecretKeyVerification({ hashedKey });
+		expect(second?.org.id).toBe("org_hit");
+		expect(redisGet).not.toHaveBeenCalled(); // contract 1: served from L1
+
+		await clearSecretKeyCache({ hashedKey });
+	});
+
+	// ── Contract 3: full miss returns null so verifyKey falls to Postgres ───
+	test("L1 miss + Redis miss returns null", async () => {
+		const hashedKey = uniqueKey("full-miss");
+
+		const result = await getCachedSecretKeyVerification({ hashedKey });
+
+		expect(result).toBeNull();
+		expect(redisGet).toHaveBeenCalledTimes(1);
+	});
+
+	// ── Contract 7: write-through ──────────────────────────────────────────
+	test("setCachedSecretKeyVerification write-through makes the next get an L1 hit", async () => {
+		const hashedKey = uniqueKey("write-through");
+		const data = buildVerificationData("org_wt");
+
+		await setCachedSecretKeyVerification({ hashedKey, data });
+		redisGet.mockClear();
+
+		const result = await getCachedSecretKeyVerification({ hashedKey });
+
+		expect(result?.org.id).toBe("org_wt");
+		expect(redisGet).not.toHaveBeenCalled();
+
+		await clearSecretKeyCache({ hashedKey });
+	});
+
+	// ── Contract 8: local eviction ─────────────────────────────────────────
+	test("clearSecretKeyCache evicts this process's L1 entry", async () => {
+		const hashedKey = uniqueKey("clear");
+		const data = buildVerificationData("org_clear");
+
+		await setCachedSecretKeyVerification({ hashedKey, data });
+		expect(_secretKeyL1SizeForTesting()).toBeGreaterThan(0);
+
+		await clearSecretKeyCache({ hashedKey });
+		redisGet.mockClear();
+
+		// L1 entry gone -> the next read has to consult Redis again.
+		const result = await getCachedSecretKeyVerification({ hashedKey });
+		expect(redisGet).toHaveBeenCalledTimes(1);
+		expect(result).toBeNull(); // clear removed the Redis copy too
+	});
+
+	// ── Contract 9: Redis failure is a miss, not a throw ───────────────────
+	test("a Redis error yields null rather than throwing", async () => {
+		const hashedKey = uniqueKey("redis-error");
+		redisGet.mockImplementation(() => Promise.reject(new Error("boom")));
+
+		const result = await getCachedSecretKeyVerification({ hashedKey });
+
+		expect(result).toBeNull();
+		// A transient Redis failure must not poison L1 with a negative entry.
+		expect(_secretKeyL1SizeForTesting()).toBe(0);
+	});
+});
+
+describe("secret-key L1 cache: TTLs", () => {
+	beforeEach(() => {
+		_resetSecretKeyL1ForTesting();
+		redisGet = spyOn(mainRedis(), "get");
+	});
+
+	afterEach(() => {
+		redisGet.mockRestore();
+		_resetSecretKeyL1ForTesting();
+	});
+
+	// ── Contract 6 (constants): negative TTL is strictly shorter ───────────
+	test("negative TTL is strictly shorter than the positive TTL", () => {
+		expect(SECRET_KEY_L1_NEGATIVE_TTL_MS).toBeLessThan(SECRET_KEY_L1_TTL_MS);
+		expect(SECRET_KEY_L1_NEGATIVE_TTL_MS).toBeGreaterThanOrEqual(1_000);
+		expect(SECRET_KEY_L1_NEGATIVE_TTL_MS).toBeLessThanOrEqual(2_000);
+		expect(SECRET_KEY_L1_TTL_MS).toBe(5_000);
+		expect(SECRET_KEY_L1_MAX_ENTRIES).toBe(5_000);
+	});
+
+	// ── Contract 6 (behavior): negative lookups are cached ─────────────────
+	test("a resolved-to-nothing lookup is cached, sparing Redis on the retry", async () => {
+		const hashedKey = uniqueKey("negative");
+
+		expect(await getCachedSecretKeyVerification({ hashedKey })).toBeNull();
+		expect(redisGet).toHaveBeenCalledTimes(1);
+
+		redisGet.mockClear();
+
+		// Second invalid-key lookup is served from the negative L1 entry.
+		expect(await getCachedSecretKeyVerification({ hashedKey })).toBeNull();
+		expect(redisGet).not.toHaveBeenCalled();
+	});
+
+	// ── Contract 6 (expiry), asserted separately from the positive TTL ─────
+	test("the negative entry expires while a same-age positive entry is still served", async () => {
+		const negativeKey = uniqueKey("neg-expiry");
+		const positiveKey = uniqueKey("pos-still-live");
+
+		await setCachedSecretKeyVerification({
+			hashedKey: positiveKey,
+			data: buildVerificationData("org_pos"),
+		});
+		await getCachedSecretKeyVerification({ hashedKey: negativeKey });
+
+		await Bun.sleep(SECRET_KEY_L1_NEGATIVE_TTL_MS + 400);
+		redisGet.mockClear();
+
+		// Negative entry is gone -> back to Redis.
+		expect(
+			await getCachedSecretKeyVerification({ hashedKey: negativeKey }),
+		).toBeNull();
+		expect(redisGet).toHaveBeenCalledTimes(1);
+
+		redisGet.mockClear();
+
+		// Positive entry of the same age is still live -> no Redis call.
+		const positive = await getCachedSecretKeyVerification({
+			hashedKey: positiveKey,
+		});
+		expect(positive?.org.id).toBe("org_pos");
+		expect(redisGet).not.toHaveBeenCalled();
+
+		await clearSecretKeyCache({ hashedKey: positiveKey });
+	});
+
+	// ── Contract 4: positive TTL expiry ────────────────────────────────────
+	test("a positive L1 entry stops being served once its TTL elapses", async () => {
+		const hashedKey = uniqueKey("pos-expiry");
+
+		await setCachedSecretKeyVerification({
+			hashedKey,
+			data: buildVerificationData("org_ttl"),
+		});
+
+		await Bun.sleep(SECRET_KEY_L1_TTL_MS + 400);
+		redisGet.mockClear();
+
+		const result = await getCachedSecretKeyVerification({ hashedKey });
+
+		expect(redisGet).toHaveBeenCalledTimes(1); // went back to Redis
+		expect(result?.org.id).toBe("org_ttl"); // Redis still had it (3600s TTL)
+
+		await clearSecretKeyCache({ hashedKey });
+	});
+});
+
+// ── Contract 5: bounded size / LRU eviction ────────────────────────────────
+describe("secret-key L1 cache: bounded size", () => {
+	test("evicts LRU-style at max and never grows unbounded", async () => {
+		_resetSecretKeyL1ForTesting();
+
+		// Stub Redis so this stays in-process: we are testing L1 eviction, not IO.
+		const stub = spyOn(mainRedis(), "get").mockImplementation((key: string) =>
+			Promise.resolve(
+				JSON.stringify(buildVerificationData(`org_${key.slice(-6)}`)),
+			),
+		);
+
+		try {
+			const overfill = SECRET_KEY_L1_MAX_ENTRIES + 100;
+			for (let i = 0; i < overfill; i++) {
+				await getCachedSecretKeyVerification({ hashedKey: `bounded-${i}` });
+			}
+
+			expect(_secretKeyL1SizeForTesting()).toBe(SECRET_KEY_L1_MAX_ENTRIES);
+			expect(_secretKeyL1SizeForTesting()).toBeLessThan(overfill);
+
+			stub.mockClear();
+
+			// The oldest key was evicted -> must go back to Redis.
+			await getCachedSecretKeyVerification({ hashedKey: "bounded-0" });
+			expect(stub).toHaveBeenCalledWith(buildSecretKeyCacheKey("bounded-0"));
+
+			stub.mockClear();
+
+			// The most recent key survived -> served from L1.
+			await getCachedSecretKeyVerification({
+				hashedKey: `bounded-${overfill - 1}`,
+			});
+			expect(stub).not.toHaveBeenCalled();
+		} finally {
+			stub.mockRestore();
+			_resetSecretKeyL1ForTesting();
+		}
+	});
+});

--- a/server/tests/unit/edge-config/subject-read-l1-ttl.test.ts
+++ b/server/tests/unit/edge-config/subject-read-l1-ttl.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { MiscellaneousEdgeConfigSchema } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.js";
+import {
+	_setMiscellaneousEdgeConfigForTesting,
+	getSubjectReadL1TtlMs,
+	isSubjectReadSingleflightEnabled,
+} from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
+
+const defaultConfig = MiscellaneousEdgeConfigSchema.parse({});
+
+const setSubjectReadL1TtlMs = (subjectReadL1TtlMs: number) => {
+	_setMiscellaneousEdgeConfigForTesting({
+		config: { ...defaultConfig, subjectReadL1TtlMs },
+	});
+};
+
+const setSubjectReadSingleflight = (subjectReadSingleflight: boolean) => {
+	_setMiscellaneousEdgeConfigForTesting({
+		config: { ...defaultConfig, subjectReadSingleflight },
+	});
+};
+
+describe("subject read L1 TTL edge config", () => {
+	afterEach(() => {
+		_setMiscellaneousEdgeConfigForTesting({ config: defaultConfig });
+	});
+
+	test("defaults to 1000ms", () => {
+		expect(defaultConfig.subjectReadL1TtlMs).toBe(1000);
+		expect(getSubjectReadL1TtlMs()).toBe(1000);
+	});
+
+	test("reads the runtime value", () => {
+		setSubjectReadL1TtlMs(250);
+
+		expect(getSubjectReadL1TtlMs()).toBe(250);
+	});
+
+	test("0 acts as the kill switch value", () => {
+		setSubjectReadL1TtlMs(0);
+
+		expect(getSubjectReadL1TtlMs()).toBe(0);
+	});
+});
+
+describe("subject read singleflight edge config", () => {
+	afterEach(() => {
+		_setMiscellaneousEdgeConfigForTesting({ config: defaultConfig });
+	});
+
+	test("defaults to true", () => {
+		expect(defaultConfig.subjectReadSingleflight).toBe(true);
+		expect(isSubjectReadSingleflightEnabled()).toBe(true);
+	});
+
+	test("reads the runtime value", () => {
+		setSubjectReadSingleflight(true);
+
+		expect(isSubjectReadSingleflightEnabled()).toBe(true);
+	});
+
+	test("false disables singleflight", () => {
+		setSubjectReadSingleflight(false);
+
+		expect(isSubjectReadSingleflightEnabled()).toBe(false);
+	});
+});

--- a/server/tests/unit/edge-config/subject-read-singleflight.test.ts
+++ b/server/tests/unit/edge-config/subject-read-singleflight.test.ts
@@ -2,46 +2,16 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { MiscellaneousEdgeConfigSchema } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.js";
 import {
 	_setMiscellaneousEdgeConfigForTesting,
-	getSubjectReadL1TtlMs,
 	isSubjectReadSingleflightEnabled,
 } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 
 const defaultConfig = MiscellaneousEdgeConfigSchema.parse({});
-
-const setSubjectReadL1TtlMs = (subjectReadL1TtlMs: number) => {
-	_setMiscellaneousEdgeConfigForTesting({
-		config: { ...defaultConfig, subjectReadL1TtlMs },
-	});
-};
 
 const setSubjectReadSingleflight = (subjectReadSingleflight: boolean) => {
 	_setMiscellaneousEdgeConfigForTesting({
 		config: { ...defaultConfig, subjectReadSingleflight },
 	});
 };
-
-describe("subject read L1 TTL edge config", () => {
-	afterEach(() => {
-		_setMiscellaneousEdgeConfigForTesting({ config: defaultConfig });
-	});
-
-	test("defaults to 1000ms", () => {
-		expect(defaultConfig.subjectReadL1TtlMs).toBe(1000);
-		expect(getSubjectReadL1TtlMs()).toBe(1000);
-	});
-
-	test("reads the runtime value", () => {
-		setSubjectReadL1TtlMs(250);
-
-		expect(getSubjectReadL1TtlMs()).toBe(250);
-	});
-
-	test("0 acts as the kill switch value", () => {
-		setSubjectReadL1TtlMs(0);
-
-		expect(getSubjectReadL1TtlMs()).toBe(0);
-	});
-});
 
 describe("subject read singleflight edge config", () => {
 	afterEach(() => {

--- a/server/tests/unit/full-subject-cache/coalesceSubjectRead.test.ts
+++ b/server/tests/unit/full-subject-cache/coalesceSubjectRead.test.ts
@@ -1,0 +1,395 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { FullSubject } from "@autumn/shared";
+import {
+	_resetSubjectReadL1ForTesting,
+	_subjectReadInFlightSizeForTesting,
+	_subjectReadL1SizeForTesting,
+	coalescedSubjectRead,
+} from "@/internal/customers/cache/fullSubject/coalesceSubjectRead.js";
+
+const makeSubject = (id: string): FullSubject =>
+	({ customer: { id } }) as unknown as FullSubject;
+
+const deferred = <T>() => {
+	let resolve!: (value: T) => void;
+	let reject!: (error: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+};
+
+const makeCountingFetch = (subject: FullSubject) => {
+	const state = { calls: 0 };
+	const fetch = () => {
+		state.calls++;
+		return Promise.resolve(subject);
+	};
+	return { state, fetch };
+};
+
+describe("coalescedSubjectRead", () => {
+	beforeEach(() => {
+		_resetSubjectReadL1ForTesting();
+	});
+
+	test("two concurrent calls for the same key share one fetch and one object", async () => {
+		const subject = makeSubject("cus_1");
+		const flight = deferred<FullSubject>();
+		let calls = 0;
+		const fetch = () => {
+			calls++;
+			return flight.promise;
+		};
+
+		const p1 = coalescedSubjectRead({
+			key: "k1",
+			l1TtlMs: 1000,
+			singleflight: true,
+			fetch,
+		});
+		const p2 = coalescedSubjectRead({
+			key: "k1",
+			l1TtlMs: 1000,
+			singleflight: true,
+			fetch,
+		});
+
+		expect(_subjectReadInFlightSizeForTesting()).toBe(1);
+
+		flight.resolve(subject);
+		const [r1, r2] = await Promise.all([p1, p2]);
+
+		expect(calls).toBe(1);
+		expect(r1).toBe(subject);
+		expect(r2).toBe(subject);
+	});
+
+	test("singleflight=false with l1TtlMs=0 is a pure passthrough", async () => {
+		const subject = makeSubject("cus_1");
+		const flight = deferred<FullSubject>();
+		let calls = 0;
+		const fetch = () => {
+			calls++;
+			return flight.promise;
+		};
+
+		const p1 = coalescedSubjectRead({
+			key: "k1",
+			l1TtlMs: 0,
+			singleflight: false,
+			fetch,
+		});
+		const p2 = coalescedSubjectRead({
+			key: "k1",
+			l1TtlMs: 0,
+			singleflight: false,
+			fetch,
+		});
+
+		expect(_subjectReadInFlightSizeForTesting()).toBe(0);
+
+		flight.resolve(subject);
+		await Promise.all([p1, p2]);
+
+		expect(calls).toBe(2);
+		expect(_subjectReadL1SizeForTesting()).toBe(0);
+
+		await coalescedSubjectRead({
+			key: "k1",
+			l1TtlMs: 0,
+			singleflight: false,
+			fetch,
+		});
+		expect(calls).toBe(3);
+	});
+
+	test("singleflight without cache: concurrent calls share one fetch, sequential calls refetch", async () => {
+		const subject = makeSubject("cus_1");
+		const { state, fetch } = makeCountingFetch(subject);
+
+		const [a, b] = await Promise.all([
+			coalescedSubjectRead({
+				key: "k1",
+				l1TtlMs: 0,
+				singleflight: true,
+				fetch,
+			}),
+			coalescedSubjectRead({
+				key: "k1",
+				l1TtlMs: 0,
+				singleflight: true,
+				fetch,
+			}),
+		]);
+
+		expect(state.calls).toBe(1);
+		expect(a).toBe(b);
+		expect(_subjectReadL1SizeForTesting()).toBe(0);
+
+		await coalescedSubjectRead({
+			key: "k1",
+			l1TtlMs: 0,
+			singleflight: true,
+			fetch,
+		});
+		expect(state.calls).toBe(2);
+		expect(_subjectReadL1SizeForTesting()).toBe(0);
+	});
+
+	test("cache without singleflight: concurrent misses each fetch, later calls hit L1", async () => {
+		const subject = makeSubject("cus_1");
+		const flight = deferred<FullSubject>();
+		let calls = 0;
+		const fetch = () => {
+			calls++;
+			return flight.promise;
+		};
+
+		const p1 = coalescedSubjectRead({
+			key: "k1",
+			l1TtlMs: 1000,
+			singleflight: false,
+			fetch,
+		});
+		const p2 = coalescedSubjectRead({
+			key: "k1",
+			l1TtlMs: 1000,
+			singleflight: false,
+			fetch,
+		});
+
+		expect(calls).toBe(2);
+		expect(_subjectReadInFlightSizeForTesting()).toBe(0);
+
+		flight.resolve(subject);
+		await Promise.all([p1, p2]);
+
+		const third = await coalescedSubjectRead({
+			key: "k1",
+			l1TtlMs: 1000,
+			singleflight: false,
+			fetch,
+		});
+		expect(calls).toBe(2);
+		expect(third).toBe(subject);
+	});
+
+	test("L1 hit within TTL serves without fetching; expiry refetches", async () => {
+		const subject = makeSubject("cus_1");
+		const { state, fetch } = makeCountingFetch(subject);
+
+		const first = await coalescedSubjectRead({
+			key: "k1",
+			l1TtlMs: 50,
+			singleflight: true,
+			fetch,
+		});
+		expect(state.calls).toBe(1);
+
+		const second = await coalescedSubjectRead({
+			key: "k1",
+			l1TtlMs: 50,
+			singleflight: true,
+			fetch,
+		});
+		expect(state.calls).toBe(1);
+		expect(second).toBe(first);
+
+		await Bun.sleep(80);
+
+		await coalescedSubjectRead({
+			key: "k1",
+			l1TtlMs: 50,
+			singleflight: true,
+			fetch,
+		});
+		expect(state.calls).toBe(2);
+	});
+
+	test("rejected fetch is not cached and the next call refetches", async () => {
+		const subject = makeSubject("cus_1");
+		let calls = 0;
+		const fetch = () => {
+			calls++;
+			if (calls === 1) return Promise.reject(new Error("db down"));
+			return Promise.resolve(subject);
+		};
+
+		await expect(
+			coalescedSubjectRead({
+				key: "k1",
+				l1TtlMs: 1000,
+				singleflight: true,
+				fetch,
+			}),
+		).rejects.toThrow("db down");
+		await Bun.sleep(0);
+
+		expect(_subjectReadL1SizeForTesting()).toBe(0);
+		expect(_subjectReadInFlightSizeForTesting()).toBe(0);
+
+		const result = await coalescedSubjectRead({
+			key: "k1",
+			l1TtlMs: 1000,
+			singleflight: true,
+			fetch,
+		});
+		expect(result).toBe(subject);
+		expect(calls).toBe(2);
+	});
+
+	test("concurrent callers of a failing flight all reject, then recover", async () => {
+		const flight = deferred<FullSubject>();
+		let calls = 0;
+		const fetch = () => {
+			calls++;
+			return flight.promise;
+		};
+
+		const p1 = coalescedSubjectRead({
+			key: "k1",
+			l1TtlMs: 1000,
+			singleflight: true,
+			fetch,
+		});
+		const p2 = coalescedSubjectRead({
+			key: "k1",
+			l1TtlMs: 1000,
+			singleflight: true,
+			fetch,
+		});
+
+		// allSettled attaches handlers before the reject, avoiding both the
+		// unhandled-rejection window and bun's expect().rejects pending-drain.
+		const results = Promise.allSettled([p1, p2]);
+		flight.reject(new Error("redis down"));
+		const [r1, r2] = await results;
+
+		expect(r1.status).toBe("rejected");
+		expect(r2.status).toBe("rejected");
+		if (r1.status === "rejected") {
+			expect((r1.reason as Error).message).toBe("redis down");
+		}
+		await Bun.sleep(0);
+
+		expect(calls).toBe(1);
+		expect(_subjectReadInFlightSizeForTesting()).toBe(0);
+	});
+
+	test("different keys do not coalesce", async () => {
+		const flightA = deferred<FullSubject>();
+		const flightB = deferred<FullSubject>();
+		const flights = [flightA, flightB];
+		let calls = 0;
+		const fetch = () => {
+			const flight = flights[calls];
+			calls++;
+			return flight.promise;
+		};
+
+		const p1 = coalescedSubjectRead({
+			key: "kA",
+			l1TtlMs: 1000,
+			singleflight: true,
+			fetch,
+		});
+		const p2 = coalescedSubjectRead({
+			key: "kB",
+			l1TtlMs: 1000,
+			singleflight: true,
+			fetch,
+		});
+
+		expect(calls).toBe(2);
+		expect(_subjectReadInFlightSizeForTesting()).toBe(2);
+
+		flightA.resolve(makeSubject("cus_a"));
+		flightB.resolve(makeSubject("cus_b"));
+		const [rA, rB] = await Promise.all([p1, p2]);
+
+		expect(rA).not.toBe(rB);
+	});
+
+	test("in-flight entry is removed once the flight settles", async () => {
+		const subject = makeSubject("cus_1");
+		const { fetch } = makeCountingFetch(subject);
+
+		await coalescedSubjectRead({
+			key: "k1",
+			l1TtlMs: 1000,
+			singleflight: true,
+			fetch,
+		});
+
+		expect(_subjectReadInFlightSizeForTesting()).toBe(0);
+		expect(_subjectReadL1SizeForTesting()).toBe(1);
+	});
+
+	test("a synchronously-throwing fetch does not poison the in-flight map", async () => {
+		const subject = makeSubject("cus_1");
+		let calls = 0;
+		const fetch = (): Promise<FullSubject> => {
+			calls++;
+			if (calls === 1) throw new Error("sync boom");
+			return Promise.resolve(subject);
+		};
+
+		await expect(
+			coalescedSubjectRead({
+				key: "k1",
+				l1TtlMs: 1000,
+				singleflight: true,
+				fetch,
+			}),
+		).rejects.toThrow("sync boom");
+		await Bun.sleep(0);
+
+		expect(_subjectReadInFlightSizeForTesting()).toBe(0);
+
+		const result = await coalescedSubjectRead({
+			key: "k1",
+			l1TtlMs: 1000,
+			singleflight: true,
+			fetch,
+		});
+		expect(result).toBe(subject);
+	});
+
+	test("oversized subjects get singleflight but are never cached", async () => {
+		const giant = {
+			customer: { id: "cus_giant" },
+			customer_products: new Array(10_001),
+			extra_customer_entitlements: [],
+		} as unknown as FullSubject;
+		const { state, fetch } = makeCountingFetch(giant);
+
+		const [a, b] = await Promise.all([
+			coalescedSubjectRead({
+				key: "giant",
+				l1TtlMs: 1000,
+				singleflight: true,
+				fetch,
+			}),
+			coalescedSubjectRead({
+				key: "giant",
+				l1TtlMs: 1000,
+				singleflight: true,
+				fetch,
+			}),
+		]);
+
+		expect(state.calls).toBe(1);
+		expect(a).toBe(b);
+		expect(_subjectReadL1SizeForTesting()).toBe(0);
+
+		await coalescedSubjectRead({
+			key: "giant",
+			l1TtlMs: 1000,
+			singleflight: true,
+			fetch,
+		});
+		expect(state.calls).toBe(2);
+	});
+});

--- a/server/tests/unit/full-subject-cache/coalesceSubjectRead.test.ts
+++ b/server/tests/unit/full-subject-cache/coalesceSubjectRead.test.ts
@@ -1,9 +1,8 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import type { FullSubject } from "@autumn/shared";
 import {
-	_resetSubjectReadL1ForTesting,
+	_resetSubjectReadInFlightForTesting,
 	_subjectReadInFlightSizeForTesting,
-	_subjectReadL1SizeForTesting,
 	coalescedSubjectRead,
 } from "@/internal/customers/cache/fullSubject/coalesceSubjectRead.js";
 
@@ -31,7 +30,7 @@ const makeCountingFetch = (subject: FullSubject) => {
 
 describe("coalescedSubjectRead", () => {
 	beforeEach(() => {
-		_resetSubjectReadL1ForTesting();
+		_resetSubjectReadInFlightForTesting();
 	});
 
 	test("two concurrent calls for the same key share one fetch and one object", async () => {
@@ -43,18 +42,8 @@ describe("coalescedSubjectRead", () => {
 			return flight.promise;
 		};
 
-		const p1 = coalescedSubjectRead({
-			key: "k1",
-			l1TtlMs: 1000,
-			singleflight: true,
-			fetch,
-		});
-		const p2 = coalescedSubjectRead({
-			key: "k1",
-			l1TtlMs: 1000,
-			singleflight: true,
-			fetch,
-		});
+		const p1 = coalescedSubjectRead({ key: "k1", singleflight: true, fetch });
+		const p2 = coalescedSubjectRead({ key: "k1", singleflight: true, fetch });
 
 		expect(_subjectReadInFlightSizeForTesting()).toBe(1);
 
@@ -66,7 +55,7 @@ describe("coalescedSubjectRead", () => {
 		expect(r2).toBe(subject);
 	});
 
-	test("singleflight=false with l1TtlMs=0 is a pure passthrough", async () => {
+	test("singleflight=false is a pure passthrough", async () => {
 		const subject = makeSubject("cus_1");
 		const flight = deferred<FullSubject>();
 		let calls = 0;
@@ -75,18 +64,8 @@ describe("coalescedSubjectRead", () => {
 			return flight.promise;
 		};
 
-		const p1 = coalescedSubjectRead({
-			key: "k1",
-			l1TtlMs: 0,
-			singleflight: false,
-			fetch,
-		});
-		const p2 = coalescedSubjectRead({
-			key: "k1",
-			l1TtlMs: 0,
-			singleflight: false,
-			fetch,
-		});
+		const p1 = coalescedSubjectRead({ key: "k1", singleflight: false, fetch });
+		const p2 = coalescedSubjectRead({ key: "k1", singleflight: false, fetch });
 
 		expect(_subjectReadInFlightSizeForTesting()).toBe(0);
 
@@ -94,121 +73,28 @@ describe("coalescedSubjectRead", () => {
 		await Promise.all([p1, p2]);
 
 		expect(calls).toBe(2);
-		expect(_subjectReadL1SizeForTesting()).toBe(0);
 
-		await coalescedSubjectRead({
-			key: "k1",
-			l1TtlMs: 0,
-			singleflight: false,
-			fetch,
-		});
+		await coalescedSubjectRead({ key: "k1", singleflight: false, fetch });
 		expect(calls).toBe(3);
 	});
 
-	test("singleflight without cache: concurrent calls share one fetch, sequential calls refetch", async () => {
+	test("concurrent calls share one fetch, sequential calls always refetch", async () => {
 		const subject = makeSubject("cus_1");
 		const { state, fetch } = makeCountingFetch(subject);
 
 		const [a, b] = await Promise.all([
-			coalescedSubjectRead({
-				key: "k1",
-				l1TtlMs: 0,
-				singleflight: true,
-				fetch,
-			}),
-			coalescedSubjectRead({
-				key: "k1",
-				l1TtlMs: 0,
-				singleflight: true,
-				fetch,
-			}),
+			coalescedSubjectRead({ key: "k1", singleflight: true, fetch }),
+			coalescedSubjectRead({ key: "k1", singleflight: true, fetch }),
 		]);
 
 		expect(state.calls).toBe(1);
 		expect(a).toBe(b);
-		expect(_subjectReadL1SizeForTesting()).toBe(0);
 
-		await coalescedSubjectRead({
-			key: "k1",
-			l1TtlMs: 0,
-			singleflight: true,
-			fetch,
-		});
-		expect(state.calls).toBe(2);
-		expect(_subjectReadL1SizeForTesting()).toBe(0);
-	});
-
-	test("cache without singleflight: concurrent misses each fetch, later calls hit L1", async () => {
-		const subject = makeSubject("cus_1");
-		const flight = deferred<FullSubject>();
-		let calls = 0;
-		const fetch = () => {
-			calls++;
-			return flight.promise;
-		};
-
-		const p1 = coalescedSubjectRead({
-			key: "k1",
-			l1TtlMs: 1000,
-			singleflight: false,
-			fetch,
-		});
-		const p2 = coalescedSubjectRead({
-			key: "k1",
-			l1TtlMs: 1000,
-			singleflight: false,
-			fetch,
-		});
-
-		expect(calls).toBe(2);
-		expect(_subjectReadInFlightSizeForTesting()).toBe(0);
-
-		flight.resolve(subject);
-		await Promise.all([p1, p2]);
-
-		const third = await coalescedSubjectRead({
-			key: "k1",
-			l1TtlMs: 1000,
-			singleflight: false,
-			fetch,
-		});
-		expect(calls).toBe(2);
-		expect(third).toBe(subject);
-	});
-
-	test("L1 hit within TTL serves without fetching; expiry refetches", async () => {
-		const subject = makeSubject("cus_1");
-		const { state, fetch } = makeCountingFetch(subject);
-
-		const first = await coalescedSubjectRead({
-			key: "k1",
-			l1TtlMs: 50,
-			singleflight: true,
-			fetch,
-		});
-		expect(state.calls).toBe(1);
-
-		const second = await coalescedSubjectRead({
-			key: "k1",
-			l1TtlMs: 50,
-			singleflight: true,
-			fetch,
-		});
-		expect(state.calls).toBe(1);
-		expect(second).toBe(first);
-
-		await Bun.sleep(80);
-
-		await coalescedSubjectRead({
-			key: "k1",
-			l1TtlMs: 50,
-			singleflight: true,
-			fetch,
-		});
+		await coalescedSubjectRead({ key: "k1", singleflight: true, fetch });
 		expect(state.calls).toBe(2);
 	});
 
-	test("rejected fetch is not cached and the next call refetches", async () => {
+	test("rejected fetch is not retained and the next call refetches", async () => {
 		const subject = makeSubject("cus_1");
 		let calls = 0;
 		const fetch = () => {
@@ -218,21 +104,14 @@ describe("coalescedSubjectRead", () => {
 		};
 
 		await expect(
-			coalescedSubjectRead({
-				key: "k1",
-				l1TtlMs: 1000,
-				singleflight: true,
-				fetch,
-			}),
+			coalescedSubjectRead({ key: "k1", singleflight: true, fetch }),
 		).rejects.toThrow("db down");
 		await Bun.sleep(0);
 
-		expect(_subjectReadL1SizeForTesting()).toBe(0);
 		expect(_subjectReadInFlightSizeForTesting()).toBe(0);
 
 		const result = await coalescedSubjectRead({
 			key: "k1",
-			l1TtlMs: 1000,
 			singleflight: true,
 			fetch,
 		});
@@ -248,18 +127,8 @@ describe("coalescedSubjectRead", () => {
 			return flight.promise;
 		};
 
-		const p1 = coalescedSubjectRead({
-			key: "k1",
-			l1TtlMs: 1000,
-			singleflight: true,
-			fetch,
-		});
-		const p2 = coalescedSubjectRead({
-			key: "k1",
-			l1TtlMs: 1000,
-			singleflight: true,
-			fetch,
-		});
+		const p1 = coalescedSubjectRead({ key: "k1", singleflight: true, fetch });
+		const p2 = coalescedSubjectRead({ key: "k1", singleflight: true, fetch });
 
 		// allSettled attaches handlers before the reject, avoiding both the
 		// unhandled-rejection window and bun's expect().rejects pending-drain.
@@ -289,18 +158,8 @@ describe("coalescedSubjectRead", () => {
 			return flight.promise;
 		};
 
-		const p1 = coalescedSubjectRead({
-			key: "kA",
-			l1TtlMs: 1000,
-			singleflight: true,
-			fetch,
-		});
-		const p2 = coalescedSubjectRead({
-			key: "kB",
-			l1TtlMs: 1000,
-			singleflight: true,
-			fetch,
-		});
+		const p1 = coalescedSubjectRead({ key: "kA", singleflight: true, fetch });
+		const p2 = coalescedSubjectRead({ key: "kB", singleflight: true, fetch });
 
 		expect(calls).toBe(2);
 		expect(_subjectReadInFlightSizeForTesting()).toBe(2);
@@ -316,15 +175,9 @@ describe("coalescedSubjectRead", () => {
 		const subject = makeSubject("cus_1");
 		const { fetch } = makeCountingFetch(subject);
 
-		await coalescedSubjectRead({
-			key: "k1",
-			l1TtlMs: 1000,
-			singleflight: true,
-			fetch,
-		});
+		await coalescedSubjectRead({ key: "k1", singleflight: true, fetch });
 
 		expect(_subjectReadInFlightSizeForTesting()).toBe(0);
-		expect(_subjectReadL1SizeForTesting()).toBe(1);
 	});
 
 	test("a synchronously-throwing fetch does not poison the in-flight map", async () => {
@@ -337,12 +190,7 @@ describe("coalescedSubjectRead", () => {
 		};
 
 		await expect(
-			coalescedSubjectRead({
-				key: "k1",
-				l1TtlMs: 1000,
-				singleflight: true,
-				fetch,
-			}),
+			coalescedSubjectRead({ key: "k1", singleflight: true, fetch }),
 		).rejects.toThrow("sync boom");
 		await Bun.sleep(0);
 
@@ -350,46 +198,9 @@ describe("coalescedSubjectRead", () => {
 
 		const result = await coalescedSubjectRead({
 			key: "k1",
-			l1TtlMs: 1000,
 			singleflight: true,
 			fetch,
 		});
 		expect(result).toBe(subject);
-	});
-
-	test("oversized subjects get singleflight but are never cached", async () => {
-		const giant = {
-			customer: { id: "cus_giant" },
-			customer_products: new Array(10_001),
-			extra_customer_entitlements: [],
-		} as unknown as FullSubject;
-		const { state, fetch } = makeCountingFetch(giant);
-
-		const [a, b] = await Promise.all([
-			coalescedSubjectRead({
-				key: "giant",
-				l1TtlMs: 1000,
-				singleflight: true,
-				fetch,
-			}),
-			coalescedSubjectRead({
-				key: "giant",
-				l1TtlMs: 1000,
-				singleflight: true,
-				fetch,
-			}),
-		]);
-
-		expect(state.calls).toBe(1);
-		expect(a).toBe(b);
-		expect(_subjectReadL1SizeForTesting()).toBe(0);
-
-		await coalescedSubjectRead({
-			key: "giant",
-			l1TtlMs: 1000,
-			singleflight: true,
-			fetch,
-		});
-		expect(state.calls).toBe(2);
 	});
 });


### PR DESCRIPTION
Pool + connection hardening: connect-refused retry with jitter, statement-timeout race fix, critical-pool waits that ride out queue transients, and 503 shedding on transient Redis/DB errors. Redis paths get op timeouts (runRedisOp), an L1 cache for secret keys, and timeout-aware call sites (org cache, auto-top-up setup, batch reset, FullSubject cache reads). FullSubject reads gain fast-shed gate admissions, singleflight coalescing split from the L1 TTL (edge-config tunable), and check gets a 2s DB hydration budget.

Note: initDrizzle here is the final version and already carries the replica-pool sizing/warmth-floor config used by the later replica-reads layer; it is self-contained (no replica routing logic). getApiCustomerByRollout is the pre-replica-routing revision; its final form lands with replica reads. Also extends the staging deploy allowlist with the original campaign branch (feat/saving-autumn-with-my-load) - review whether to keep.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the API to ride out Redis outages and heavy load by widening Postgres pool budgets, adding fast-shed admission, and optionally falling back to Postgres when Redis is down. Subject reads now use singleflight (no L1), and Redis reads have tight per-op timeouts.

- **New Features**
  - Optional Postgres fallback when Redis is unavailable (`redisFallbackToDb`); otherwise return 503 with `cache_unavailable` or `critical_db_saturated`.
  - Subject reads: singleflight coalescing (`subjectReadSingleflight`); fast-shed gate rejects at enqueue when EWMA-predicted wait exceeds `max_wait_ms`.
  - Per-process L1 for secret-key verification with write-through, local invalidation, and short negative TTL.
  - Per-operation Redis timeouts via `runRedisOp({ timeoutMs })` for subject pipeline, feature balances (single/batch), org features, and secret-key get. Check V2 enforces a 2s DB hydration budget.

- **Refactors**
  - DB pools: connect-refused retry with jitter; critical-pool checkout/query budgets raised to 15s; replica pool gets a 3s connect timeout, warmed `min`, higher max, and separate primary/replica pool-budget warnings.
  - `shed503OnTransientError` distinguishes DB vs cache outages and only falls back to Postgres on Redis failures.
  - Removed the subject-read L1 cache; singleflight only.
  - Batch reset uses a 2s statement timeout to avoid long-held locks; auto top-up treats Redis errors as cache misses.
  - Customer/entity handlers pass singleflight from edge config and support DB-only subject lookups.

<sup>Written for commit 4a8be2b987ec485f478b2eb8b0bde81885a3740d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens Redis and Postgres behavior under outages and heavy load by adding bounded waits, fallback paths, request coalescing, and admission control.

- **Improvements, Bug fixes:** Adds Redis operation deadlines, transient-error shedding, optional Postgres fallback, and singleflight subject reads.
- **Improvements:** Expands and monitors database-pool budgets, retries connection refusals, and limits reset and check hydration duration.
- **Improvements, API changes:** Adds runtime edge-config switches for Redis fallback and subject-read singleflight.
- **Improvements:** Adds a bounded process-local API-key verification cache and Redis-aware cache reads.
- **Bug fixes:** Adds fast-shed admission based on observed hydration service time.
</details>

<h3>Confidence Score: 4/5</h3>

The Redis-fallback path should be fixed before merging because customer and entity reads can still return 503 during Redis outages when singleflight is enabled.

The fallback lookup uses the same singleflight key as the rejected Redis lookup, allowing it to receive the rejected promise without executing the intended database-only fetch.

**Files Needing Attention:** server/src/internal/customers/actions/getApiCustomerByRollout.ts and server/src/internal/entities/actions/getApiEntityByRollout.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/actions/getApiCustomerByRollout.ts | Adds singleflight and Redis-to-Postgres fallback, but the fallback can rejoin the failed cache flight and return 503. |
| server/src/internal/entities/actions/getApiEntityByRollout.ts | Mirrors the customer lookup logic and is affected by the same failed-flight fallback issue. |
| server/src/internal/customers/cache/fullSubject/coalesceSubjectRead.ts | Adds process-local in-flight request coalescing with settlement cleanup. |
| server/src/db/shed503OnTransientError.ts | Distinguishes Redis and database failures and supports an opt-in Postgres fallback. |
| server/src/db/initDrizzle.ts | Revises pool sizing, timeout configuration, retry wrapping, and budget warnings. |
| server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts | Adds EWMA-based enqueue admission while retaining queue-size and dequeue-time checks. |
| server/src/internal/dev/apiKeys/cacheApiKeyUtils.ts | Adds a bounded process-local verification cache with an explicitly documented five-second revocation window. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Customer or entity GET] --> B[Singleflight subject lookup]
  B --> C[Redis cache read]
  C -->|Success| D[Return subject]
  C -->|Transient Redis failure| E{DB fallback enabled?}
  E -->|No| F[Return 503]
  E -->|Yes| G[DB-only subject lookup]
  G --> D
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/customers/actions/getApiCustomerByRollout.ts:56-59
**Fallback rejoins rejected cache flight**

When Redis fails with both `subjectReadSingleflight` and `redisFallbackToDb` enabled, the fallback uses the same singleflight key before the rejected flight is removed. It therefore rejoins the failed cache promise instead of starting the database-only read, causing customer and entity GET requests to return 503 despite fallback being enabled.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["review: drop orphaned L1 comment in edge..."](https://github.com/useautumn/autumn/commit/113cd9c0cf2838879f1710892cb2df6825b4bcd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50073009)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [External Integrations (non-Stripe)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-external-integrations.md)

<!-- /greptile_comment -->