### PR TITLE
feat: route Redis-outage reads to Postgres replicas

### DIFF
--- a/server/src/db/probes/registry.ts
+++ b/server/src/db/probes/registry.ts
@@ -1,8 +1,10 @@
 import { longTxnProbe } from "./longTxnProbe.js";
+import { replicaLagProbe } from "./replicaLagProbe.js";
 import { replicationSlotProbe } from "./replicationSlotProbe.js";
 import type { DbProbe } from "./types.js";
 
 export const dbProbes: readonly DbProbe[] = [
 	longTxnProbe,
+	replicaLagProbe,
 	replicationSlotProbe,
 ];

--- a/server/src/db/replicaRoutingState.ts
+++ b/server/src/db/replicaRoutingState.ts
@@ -1,0 +1,175 @@
+import { logger } from "../external/logtail/logtailUtils.js";
+import type { DrizzleCli } from "./initDrizzle.js";
+import {
+	EXPECTED_REPLICA_COUNT,
+	REPLICA_LAG_MAX_MS,
+} from "./probes/replicaLagProbe.js";
+import { queryReplicaLag } from "./probes/replicaLagQuery.js";
+
+export const REPLICA_ROUTING_PROBE_INTERVAL_MS = 3_000;
+export const REPLICA_ROUTING_STALENESS_MS = 10_000;
+
+export type ReplicaRoutingReason =
+	| "stale_probe"
+	| "count_mismatch"
+	| "lag_exceeded"
+	| "probe_error"
+	| "recovered";
+
+export type ReplicaRoutingState = {
+	eligible: boolean;
+	replicaCount: number;
+	maxReplayLagMs: number;
+	/** Epoch ms of the last completed probe; 0 = never probed. */
+	updatedAt: number;
+};
+
+type ProbeResult = {
+	replicaCount: number;
+	maxReplayLagMs: number;
+	updatedAt: number;
+	errored: boolean;
+	errorMessage: string | null;
+};
+
+const neverProbed: ProbeResult = {
+	replicaCount: 0,
+	maxReplayLagMs: 0,
+	updatedAt: 0,
+	errored: false,
+	errorMessage: null,
+};
+
+let lastProbe: ProbeResult = neverProbed;
+let lastLoggedEligible = false;
+let probeInterval: ReturnType<typeof setInterval> | null = null;
+let tickInFlight = false;
+
+const evaluate = (): { eligible: boolean; reason: ReplicaRoutingReason } => {
+	if (Date.now() - lastProbe.updatedAt >= REPLICA_ROUTING_STALENESS_MS) {
+		return { eligible: false, reason: "stale_probe" };
+	}
+	if (lastProbe.errored) {
+		return { eligible: false, reason: "probe_error" };
+	}
+	if (lastProbe.replicaCount !== EXPECTED_REPLICA_COUNT) {
+		return { eligible: false, reason: "count_mismatch" };
+	}
+	if (lastProbe.maxReplayLagMs >= REPLICA_LAG_MAX_MS) {
+		return { eligible: false, reason: "lag_exceeded" };
+	}
+	return { eligible: true, reason: "recovered" };
+};
+
+// Once per eligible<->ineligible flip — never per tick, never per request.
+const logIfTransitioned = (): boolean => {
+	const { eligible, reason } = evaluate();
+	if (eligible === lastLoggedEligible) return eligible;
+	lastLoggedEligible = eligible;
+	logger[eligible ? "info" : "warn"](
+		{
+			type: "replica_routing_transition",
+			to: eligible ? "eligible" : "ineligible",
+			reason,
+			replica_count: lastProbe.replicaCount,
+			max_replay_lag_ms: Math.round(lastProbe.maxReplayLagMs),
+			...(lastProbe.errorMessage && { error_message: lastProbe.errorMessage }),
+		},
+		`Replica routing ${eligible ? "eligible" : `ineligible (${reason})`}`,
+	);
+	return eligible;
+};
+
+const probeTick = async ({ db }: { db: DrizzleCli }): Promise<void> => {
+	if (tickInFlight) return;
+	tickInFlight = true;
+	try {
+		const { blind, replicaCount, maxReplayLagMs } = await queryReplicaLag({
+			db,
+		});
+		lastProbe = {
+			replicaCount,
+			maxReplayLagMs,
+			updatedAt: Date.now(),
+			errored: blind,
+			errorMessage: blind ? "probe not reading a primary" : null,
+		};
+	} catch (error) {
+		lastProbe = {
+			replicaCount: 0,
+			maxReplayLagMs: 0,
+			updatedAt: Date.now(),
+			errored: true,
+			errorMessage: error instanceof Error ? error.message : String(error),
+		};
+	} finally {
+		tickInFlight = false;
+	}
+	logIfTransitioned();
+};
+
+export const getReplicaRoutingState = (): ReplicaRoutingState => {
+	const eligible = logIfTransitioned();
+	return {
+		eligible,
+		replicaCount: lastProbe.replicaCount,
+		maxReplayLagMs: lastProbe.maxReplayLagMs,
+		updatedAt: lastProbe.updatedAt,
+	};
+};
+
+export const startReplicaRoutingProber = ({ db }: { db: DrizzleCli }): void => {
+	if (!process.env.DATABASE_REPLICA_URL) {
+		logger.info(
+			{ type: "replica_routing_prober_skipped" },
+			"Replica routing prober not started: DATABASE_REPLICA_URL is unset",
+		);
+		return;
+	}
+	if (probeInterval) return;
+	probeInterval = setInterval(() => {
+		void probeTick({ db });
+	}, REPLICA_ROUTING_PROBE_INTERVAL_MS);
+	void probeTick({ db });
+	logger.info(
+		{
+			type: "replica_routing_prober_start",
+			intervalMs: REPLICA_ROUTING_PROBE_INTERVAL_MS,
+		},
+		"Replica routing prober started",
+	);
+};
+
+export const stopReplicaRoutingProber = (): void => {
+	if (probeInterval) {
+		clearInterval(probeInterval);
+		probeInterval = null;
+	}
+};
+
+export const _runProbeTickForTesting = (args: {
+	db: DrizzleCli;
+}): Promise<void> => probeTick(args);
+
+export const _setReplicaRoutingProbeForTesting = ({
+	replicaCount,
+	maxReplayLagMs,
+}: {
+	replicaCount: number;
+	maxReplayLagMs: number;
+}): void => {
+	lastProbe = {
+		replicaCount,
+		maxReplayLagMs,
+		updatedAt: Date.now(),
+		errored: false,
+		errorMessage: null,
+	};
+};
+
+export const _resetReplicaRoutingStateForTesting = (): void => {
+	stopReplicaRoutingProber();
+	lastProbe = { ...neverProbed };
+	lastLoggedEligible = false;
+	tickInFlight = false;
+};

--- a/server/src/db/resolveSubjectReadDb.ts
+++ b/server/src/db/resolveSubjectReadDb.ts
@@ -1,0 +1,71 @@
+import { logger } from "@/external/logtail/logtailUtils.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { isCustomerRecentlyUpdated } from "@/internal/customers/customerLsns/isCustomerRecentlyUpdated.js";
+import { type DrizzleCli, dbCritical, dbReplica } from "./initDrizzle.js";
+import { getReplicaRoutingState } from "./replicaRoutingState.js";
+
+export type SubjectReadFrom = "primary" | "replica-ok";
+export type SubjectReadSource = "primary" | "replica";
+
+// Ledger failures repeat in bursts; one log per window, never per request.
+const LEDGER_ERROR_LOG_INTERVAL_MS = 30_000;
+let lastLedgerErrorLoggedAt = 0;
+
+let replicaDbOverride: DrizzleCli | null = null;
+export const _setReplicaDbOverrideForTesting = (
+	db: DrizzleCli | null,
+): void => {
+	replicaDbOverride = db;
+};
+
+let ledgerDbOverride: DrizzleCli | null = null;
+export const _setLedgerDbOverrideForTesting = (db: DrizzleCli | null): void => {
+	ledgerDbOverride = db;
+};
+
+/** Picks the pool for a subject hydration. Replica requires EVERY gate to
+ *  pass; any doubt (ledger error, ineligible prober, no id) pins primary. */
+export const resolveSubjectReadDb = async ({
+	ctx,
+	readFrom,
+	orgId,
+	env,
+	customerId,
+}: {
+	ctx: AutumnContext;
+	readFrom: SubjectReadFrom;
+	orgId: string;
+	env: string;
+	customerId?: string;
+}): Promise<{ db: DrizzleCli; source: SubjectReadSource }> => {
+	const primary = { db: ctx.db, source: "primary" as const };
+	const replica = replicaDbOverride ?? dbReplica;
+
+	if (readFrom !== "replica-ok" || !ctx.skipCache || !replica || !customerId) {
+		return primary;
+	}
+	if (!getReplicaRoutingState().eligible) return primary;
+
+	try {
+		// Critical pool: warm and sized for the per-read ledger volume on hot
+		// routes; the cold general pool starves under it and trips the fail-safe.
+		const recentlyUpdated = await isCustomerRecentlyUpdated({
+			db: ledgerDbOverride ?? dbCritical,
+			orgId,
+			env,
+			customerId,
+		});
+		if (recentlyUpdated) return primary;
+	} catch (error) {
+		if (Date.now() - lastLedgerErrorLoggedAt >= LEDGER_ERROR_LOG_INTERVAL_MS) {
+			lastLedgerErrorLoggedAt = Date.now();
+			logger.error(
+				{ type: "replica_ledger_check_failed", error },
+				"customer_lsns freshness check failed — pinning subject reads to primary",
+			);
+		}
+		return primary;
+	}
+
+	return { db: replica, source: "replica" };
+};

--- a/server/src/db/resolveSubjectReadDb.ts
+++ b/server/src/db/resolveSubjectReadDb.ts
@@ -1,6 +1,7 @@
 import { logger } from "@/external/logtail/logtailUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { isCustomerRecentlyUpdated } from "@/internal/customers/customerLsns/isCustomerRecentlyUpdated.js";
+import { getRuntimeFullSubjectGateConfig } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
 import { type DrizzleCli, dbCritical, dbReplica } from "./initDrizzle.js";
 import { getReplicaRoutingState } from "./replicaRoutingState.js";
 
@@ -41,8 +42,14 @@ export const resolveSubjectReadDb = async ({
 	const primary = { db: ctx.db, source: "primary" as const };
 	const replica = replicaDbOverride ?? dbReplica;
 
-	if (readFrom !== "replica-ok" || !ctx.skipCache || !replica || !customerId) {
+	if (readFrom !== "replica-ok" || !replica || !customerId) {
 		return primary;
+	}
+	// Outage/worker reads (skipCache) stay 100% replica-eligible; steady-state
+	// misses opt in via the configured share (0 = dark, exact status quo).
+	if (!ctx.skipCache) {
+		const { replica_share } = getRuntimeFullSubjectGateConfig().read_split;
+		if (Math.random() >= replica_share) return primary;
 	}
 	if (!getReplicaRoutingState().eligible) return primary;
 

--- a/server/src/honoMiddlewares/baseMiddleware.ts
+++ b/server/src/honoMiddlewares/baseMiddleware.ts
@@ -85,6 +85,12 @@ export const baseMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 		query: c.req.query(),
 	});
 
+	const subjectReadTrace =
+		process.env.NODE_ENV !== "production" &&
+		c.req.header("x-debug-subject-source") === "true"
+			? ({} as NonNullable<HonoEnv["Variables"]["ctx"]["subjectReadTrace"]>)
+			: undefined;
+
 	const requestLogContext = {
 		id,
 		method: c.req.method,
@@ -140,6 +146,8 @@ export const baseMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 			c.req.header("x-skip-cache") === "true" ||
 			c.req.query("skip_cache") === "true",
 
+		subjectReadTrace,
+
 		// Test params:
 		extraLogs: {},
 
@@ -179,4 +187,8 @@ export const baseMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 	// childLogger.info(`${method} ${path}`);
 
 	await next();
+
+	if (subjectReadTrace?.source) {
+		c.res.headers.set("x-subject-source", subjectReadTrace.source);
+	}
 };

--- a/server/src/honoUtils/HonoEnv.ts
+++ b/server/src/honoUtils/HonoEnv.ts
@@ -89,6 +89,10 @@ export type RequestContext = {
 	fullCustomer?: FullCustomer;
 	rolloutSnapshot?: RolloutSnapshot;
 
+	/** Non-prod debug box (x-debug-subject-source); shared by reference across
+	 *  ctx spread-copies so chokepoints can record where the subject came from. */
+	subjectReadTrace?: { source?: "primary" | "replica" | "cache" };
+
 	/** Org is over its aggregate rate cap — check/track flows skip the DB and
 	 *  serve their fail-open responses (allow / SQS queue) instead. */
 	orgRateLimitDegraded?: boolean;

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -12,6 +12,10 @@ import {
 } from "./db/pgHealthMonitor.js";
 import { startPgPoolMonitor, stopPgPoolMonitor } from "./db/pgPoolMonitor.js";
 import { getRedactedDatabaseUrls } from "./db/redactDatabaseUrl.js";
+import {
+	startReplicaRoutingProber,
+	stopReplicaRoutingProber,
+} from "./db/replicaRoutingState.js";
 import { logger } from "./external/logtail/logtailUtils.js";
 import {
 	startAllEdgeConfigPolling,
@@ -71,6 +75,8 @@ const init = async ({ startupStartedAt }: { startupStartedAt: number }) => {
 
 	initPgHealthMonitor({ client: clientCritical });
 	startPgPoolMonitor();
+	// `db` is the general pool — the probe must never occupy a critical-pool slot.
+	startReplicaRoutingProber({ db });
 
 	void warmupRegionalRedis().catch((error) => {
 		logger.warn("[Redis] Warmup failed", { error });
@@ -182,6 +188,7 @@ async function gracefulShutdown() {
 		}
 		shutdownPgHealthMonitor();
 		stopPgPoolMonitor();
+		stopReplicaRoutingProber();
 		stopRedisMonitor();
 		stopRedisV2Monitor();
 		stopMemorySpikeProbe();

--- a/server/src/internal/billing/v2/actions/dfu/flash.ts
+++ b/server/src/internal/billing/v2/actions/dfu/flash.ts
@@ -47,6 +47,7 @@ export const flash = async ({
 		skipGuard: true,
 	});
 	const customer = await getApiCustomerByRollout({
+		disableReplicaRead: true,
 		ctx,
 		customerId,
 		source: "billing.import",

--- a/server/src/internal/customers/actions/getApiCustomerByRollout.ts
+++ b/server/src/internal/customers/actions/getApiCustomerByRollout.ts
@@ -32,8 +32,8 @@ export const getApiCustomerByRollout = async ({
 	const lookup = async ({ skipCache }: { skipCache: boolean }) => {
 		const fetch = () =>
 			getOrSetCachedFullSubject({
-				// Sole replica grant: this wrapper serves a read-only GET route.
-				readFrom: "replica-ok",
+				// Sole replica grant; writers opt out via disableReplicaRead.
+				readFrom: disableReplicaRead ? "primary" : "replica-ok",
 				ctx: skipCache ? { ...ctx, skipCache: true } : ctx,
 				customerId,
 				entityId,

--- a/server/src/internal/customers/actions/getApiCustomerByRollout.ts
+++ b/server/src/internal/customers/actions/getApiCustomerByRollout.ts
@@ -16,6 +16,7 @@ export const getApiCustomerByRollout = async ({
 	source,
 	withAutumnId,
 	singleflight = false,
+	disableReplicaRead = false,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
@@ -23,6 +24,7 @@ export const getApiCustomerByRollout = async ({
 	source?: string;
 	withAutumnId?: boolean;
 	singleflight?: boolean;
+	disableReplicaRead?: boolean;
 }) => {
 	if (isFullSubjectRolloutEnabled({ ctx })) {
 	}

--- a/server/src/internal/customers/actions/getApiCustomerByRollout.ts
+++ b/server/src/internal/customers/actions/getApiCustomerByRollout.ts
@@ -30,6 +30,8 @@ export const getApiCustomerByRollout = async ({
 	const lookup = async ({ skipCache }: { skipCache: boolean }) => {
 		const fetch = () =>
 			getOrSetCachedFullSubject({
+				// Sole replica grant: this wrapper serves a read-only GET route.
+				readFrom: "replica-ok",
 				ctx: skipCache ? { ...ctx, skipCache: true } : ctx,
 				customerId,
 				entityId,

--- a/server/src/internal/customers/actions/getApiCustomerByRollout.ts
+++ b/server/src/internal/customers/actions/getApiCustomerByRollout.ts
@@ -27,7 +27,7 @@ export const getApiCustomerByRollout = async ({
 	if (isFullSubjectRolloutEnabled({ ctx })) {
 	}
 
-	const lookup = ({ skipCache }: { skipCache: boolean }) => {
+	const lookup = async ({ skipCache }: { skipCache: boolean }) => {
 		const fetch = () =>
 			getOrSetCachedFullSubject({
 				ctx: skipCache ? { ...ctx, skipCache: true } : ctx,
@@ -38,7 +38,8 @@ export const getApiCustomerByRollout = async ({
 
 		if (!singleflight) return fetch();
 
-		return coalescedSubjectRead({
+		let servedByFetch = false;
+		const fullSubject = await coalescedSubjectRead({
 			key: buildFullSubjectKey({
 				orgId: ctx.org.id,
 				env: ctx.env,
@@ -46,8 +47,16 @@ export const getApiCustomerByRollout = async ({
 				entityId,
 			}),
 			singleflight,
-			fetch,
+			fetch: () => {
+				servedByFetch = true;
+				return fetch();
+			},
 		});
+		// Joined singleflights never enter fetch — the shared flight serves them.
+		if (!servedByFetch && ctx.subjectReadTrace) {
+			ctx.subjectReadTrace.source = "cache";
+		}
+		return fullSubject;
 	};
 
 	const fullSubject = await shed503OnTransientError({

--- a/server/src/internal/customers/actions/getOrCreateApiCustomerByRollout.ts
+++ b/server/src/internal/customers/actions/getOrCreateApiCustomerByRollout.ts
@@ -18,6 +18,7 @@ export const getOrCreateApiCustomerByRollout = async ({
 	source,
 	withAutumnId,
 	enqueueRecoveryOnTransientFailure = true,
+	disableReplicaRead = false,
 }: {
 	ctx: AutumnContext;
 	params: Omit<TrackParams | CheckParams, "customer_id"> & {
@@ -26,6 +27,7 @@ export const getOrCreateApiCustomerByRollout = async ({
 	source?: string;
 	withAutumnId?: boolean;
 	enqueueRecoveryOnTransientFailure?: boolean;
+	disableReplicaRead?: boolean;
 }) => {
 	setCustomerCreationRecoveryStage({ ctx, stage: "lookup" });
 
@@ -34,8 +36,8 @@ export const getOrCreateApiCustomerByRollout = async ({
 
 	const lookup = ({ skipCache }: { skipCache: boolean }) =>
 		getOrCreateCachedFullSubject({
-			// Sole replica grant: this wrapper serves a read-only GET route.
-			readFrom: "replica-ok",
+			// Sole replica grant; writers opt out via disableReplicaRead.
+			readFrom: disableReplicaRead ? "primary" : "replica-ok",
 			ctx: skipCache ? { ...ctx, skipCache: true } : ctx,
 			params,
 			source,

--- a/server/src/internal/customers/actions/getOrCreateApiCustomerByRollout.ts
+++ b/server/src/internal/customers/actions/getOrCreateApiCustomerByRollout.ts
@@ -34,6 +34,8 @@ export const getOrCreateApiCustomerByRollout = async ({
 
 	const lookup = ({ skipCache }: { skipCache: boolean }) =>
 		getOrCreateCachedFullSubject({
+			// Sole replica grant: this wrapper serves a read-only GET route.
+			readFrom: "replica-ok",
 			ctx: skipCache ? { ...ctx, skipCache: true } : ctx,
 			params,
 			source,

--- a/server/src/internal/customers/actions/update/updateCustomer.ts
+++ b/server/src/internal/customers/actions/update/updateCustomer.ts
@@ -215,6 +215,7 @@ export const updateCustomer = async ({
 	const resolvedCustomerId = newCustomerId ?? customerId;
 
 	const apiCustomer = await getApiCustomerByRollout({
+		disableReplicaRead: true,
 		ctx,
 		customerId: resolvedCustomerId,
 		source: "updateCustomer",

--- a/server/src/internal/customers/cache/fullSubject/actions/getOrCreateCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/getOrCreateCachedFullSubject.ts
@@ -5,6 +5,7 @@ import {
 	SubjectType,
 	type TrackParams,
 } from "@autumn/shared";
+import type { SubjectReadFrom } from "@/db/resolveSubjectReadDb.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { customerActions } from "@/internal/customers/actions/index.js";
 import { updateCustomerData } from "@/internal/customers/actions/updateCustomerData.js";
@@ -17,12 +18,14 @@ export const getOrCreateCachedFullSubject = async ({
 	ctx,
 	params,
 	source,
+	readFrom = "primary",
 }: {
 	ctx: AutumnContext;
 	params: Omit<TrackParams | CheckParams, "customer_id"> & {
 		customer_id: string | null;
 	};
 	source?: string;
+	readFrom?: SubjectReadFrom;
 }): Promise<FullSubject> => {
 	const { skipCache, logger } = ctx;
 	const useRedis = !skipCache;
@@ -69,7 +72,7 @@ export const getOrCreateCachedFullSubject = async ({
 			customerId,
 			entityId,
 			allowMissingEntity: true,
-			readFrom: "replica-ok",
+			readFrom,
 			routeSource: source,
 		});
 		if (normalizedResult) {

--- a/server/src/internal/customers/cache/fullSubject/actions/getOrCreateCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/getOrCreateCachedFullSubject.ts
@@ -11,6 +11,7 @@ import { customerActions } from "@/internal/customers/actions/index.js";
 import { updateCustomerData } from "@/internal/customers/actions/updateCustomerData.js";
 import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
 import { autoCreateEntity } from "@/internal/entities/handlers/handleCreateEntity/autoCreateEntity.js";
+import { isReplicaSourced } from "../subjectProvenance.js";
 import { getCachedFullSubject } from "./getCachedFullSubject.js";
 import { setCachedFullSubject } from "./setCachedFullSubject/setCachedFullSubject.js";
 
@@ -133,13 +134,16 @@ export const getOrCreateCachedFullSubject = async ({
 		}
 
 		if (normalizedResult) {
-			await setCachedFullSubject({
-				ctx,
-				normalized: normalizedResult.normalized,
-				fetchedSubjectViewEpoch,
-			}).catch((error) =>
-				logger.error(`Failed to set full subject cache: ${error}`),
-			);
+			// Replica-sourced hydrations must never fill Redis — serve them as-is.
+			if (!isReplicaSourced(normalizedResult.normalized)) {
+				await setCachedFullSubject({
+					ctx,
+					normalized: normalizedResult.normalized,
+					fetchedSubjectViewEpoch,
+				}).catch((error) =>
+					logger.error(`Failed to set full subject cache: ${error}`),
+				);
+			}
 			fullSubject = normalizedResult.fullSubject;
 		}
 	}

--- a/server/src/internal/customers/cache/fullSubject/actions/getOrCreateCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/getOrCreateCachedFullSubject.ts
@@ -52,6 +52,7 @@ export const getOrCreateCachedFullSubject = async ({
 
 		if (fullSubject) {
 			logger.debug(`[getOrCreateCachedFullSubject] Cache hit: ${customerId}`);
+			if (ctx.subjectReadTrace) ctx.subjectReadTrace.source = "cache";
 			setCache = false;
 		}
 	}
@@ -68,6 +69,8 @@ export const getOrCreateCachedFullSubject = async ({
 			customerId,
 			entityId,
 			allowMissingEntity: true,
+			readFrom: "replica-ok",
+			routeSource: source,
 		});
 		if (normalizedResult) {
 			fullSubject = normalizedResult.fullSubject;

--- a/server/src/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.ts
@@ -6,6 +6,7 @@ import {
 import type { SubjectReadFrom } from "@/db/resolveSubjectReadDb.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
+import { isReplicaSourced } from "../subjectProvenance.js";
 import { getCachedFullSubject } from "./getCachedFullSubject.js";
 import { rehydrateWithLiveBalances } from "./rehydrateWithLiveBalances.js";
 import { setCachedFullSubject } from "./setCachedFullSubject/setCachedFullSubject.js";
@@ -75,12 +76,21 @@ export const getOrSetCachedFullSubject = async ({
 
 	const { normalized, fullSubject } = result;
 
-	if (useRedis) {
+	// Replica-sourced hydrations must never fill Redis — serve them as-is.
+	if (useRedis && !isReplicaSourced(normalized)) {
 		await setCachedFullSubject({
 			ctx,
 			normalized,
 			fetchedSubjectViewEpoch,
 		});
+		logger.info(
+			{
+				type: "subject_miss_fill",
+				customer_id: customerId,
+				org_id: ctx.org.id,
+			},
+			"FullSubject cache filled from primary hydration",
+		);
 
 		// We just wrote the subject blob ourselves, so no need to re-read it.
 		// But balance hashes use HSETNX, so any concurrent Lua deduction that

--- a/server/src/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.ts
@@ -3,6 +3,7 @@ import {
 	EntityNotFoundError,
 	type FullSubject,
 } from "@autumn/shared";
+import type { SubjectReadFrom } from "@/db/resolveSubjectReadDb.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
 import { getCachedFullSubject } from "./getCachedFullSubject.js";
@@ -16,6 +17,7 @@ export const getOrSetCachedFullSubject = async ({
 	source,
 	staleWhileRevalidate = true,
 	runLazyResets = true,
+	readFrom = "primary",
 }: {
 	ctx: AutumnContext;
 	customerId: string;
@@ -23,6 +25,7 @@ export const getOrSetCachedFullSubject = async ({
 	source?: string;
 	staleWhileRevalidate?: boolean;
 	runLazyResets?: boolean;
+	readFrom?: SubjectReadFrom;
 }): Promise<FullSubject> => {
 	const { skipCache, logger } = ctx;
 	const useRedis = !skipCache;
@@ -61,7 +64,7 @@ export const getOrSetCachedFullSubject = async ({
 		customerId,
 		entityId,
 		runLazyResets,
-		readFrom: "replica-ok",
+		readFrom,
 		routeSource: source,
 	});
 

--- a/server/src/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.ts
@@ -1,7 +1,7 @@
 import {
-    CustomerNotFoundError,
-    EntityNotFoundError,
-    type FullSubject,
+	CustomerNotFoundError,
+	EntityNotFoundError,
+	type FullSubject,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
@@ -23,7 +23,6 @@ export const getOrSetCachedFullSubject = async ({
 	source?: string;
 	staleWhileRevalidate?: boolean;
 	runLazyResets?: boolean;
-
 }): Promise<FullSubject> => {
 	const { skipCache, logger } = ctx;
 	const useRedis = !skipCache;
@@ -48,6 +47,7 @@ export const getOrSetCachedFullSubject = async ({
 			logger.debug(
 				`[getOrSetCachedFullSubject] Subject hit for ${customerId}${entityId ? `:${entityId}` : ""}, source: ${source}`,
 			);
+			if (ctx.subjectReadTrace) ctx.subjectReadTrace.source = "cache";
 			return cached;
 		}
 	}
@@ -61,6 +61,8 @@ export const getOrSetCachedFullSubject = async ({
 		customerId,
 		entityId,
 		runLazyResets,
+		readFrom: "replica-ok",
+		routeSource: source,
 	});
 
 	if (!result) {

--- a/server/src/internal/customers/cache/fullSubject/actions/partial/getOrSetCachedPartialFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/partial/getOrSetCachedPartialFullSubject.ts
@@ -7,6 +7,7 @@ import type { SubjectReadFrom } from "@/db/resolveSubjectReadDb.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
 import { filterFullSubjectByFeatureIds } from "../../filterFullSubjectByFeatureIds.js";
+import { isReplicaSourced } from "../../subjectProvenance.js";
 import { rehydrateWithLiveBalances } from "../rehydrateWithLiveBalances.js";
 import { setCachedFullSubject } from "../setCachedFullSubject/setCachedFullSubject.js";
 import { getCachedPartialFullSubject } from "./getCachedPartialFullSubject.js";
@@ -72,7 +73,8 @@ export const getOrSetCachedPartialFullSubject = async ({
 
 	const { normalized, fullSubject } = result;
 
-	if (useRedis) {
+	// Replica-sourced hydrations must never fill Redis — serve them as-is.
+	if (useRedis && !isReplicaSourced(normalized)) {
 		await setCachedFullSubject({
 			ctx,
 			normalized,

--- a/server/src/internal/customers/cache/fullSubject/actions/partial/getOrSetCachedPartialFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/partial/getOrSetCachedPartialFullSubject.ts
@@ -3,6 +3,7 @@ import {
 	EntityNotFoundError,
 	type FullSubject,
 } from "@autumn/shared";
+import type { SubjectReadFrom } from "@/db/resolveSubjectReadDb.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
 import { filterFullSubjectByFeatureIds } from "../../filterFullSubjectByFeatureIds.js";
@@ -16,12 +17,14 @@ export const getOrSetCachedPartialFullSubject = async ({
 	entityId,
 	featureIds,
 	source,
+	readFrom = "primary",
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	entityId?: string;
 	featureIds: string[];
 	source?: string;
+	readFrom?: SubjectReadFrom;
 }): Promise<FullSubject> => {
 	const { skipCache, logger } = ctx;
 	const useRedis = !skipCache;
@@ -58,7 +61,7 @@ export const getOrSetCachedPartialFullSubject = async ({
 		ctx,
 		customerId,
 		entityId,
-		readFrom: "replica-ok",
+		readFrom,
 		routeSource: source,
 	});
 

--- a/server/src/internal/customers/cache/fullSubject/actions/partial/getOrSetCachedPartialFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/partial/getOrSetCachedPartialFullSubject.ts
@@ -45,6 +45,7 @@ export const getOrSetCachedPartialFullSubject = async ({
 			logger.debug(
 				`[getOrSetCachedPartialFullSubject] Subject hit for ${customerId}${entityId ? `:${entityId}` : ""}, source: ${source}`,
 			);
+			if (ctx.subjectReadTrace) ctx.subjectReadTrace.source = "cache";
 			return cached;
 		}
 	}
@@ -57,6 +58,8 @@ export const getOrSetCachedPartialFullSubject = async ({
 		ctx,
 		customerId,
 		entityId,
+		readFrom: "replica-ok",
+		routeSource: source,
 	});
 
 	if (!result) {

--- a/server/src/internal/customers/cache/fullSubject/actions/setCachedFullSubject/setCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/setCachedFullSubject/setCachedFullSubject.ts
@@ -8,6 +8,7 @@ import {
 	FULL_SUBJECT_EPOCH_TTL_SECONDS,
 } from "../../config/fullSubjectCacheConfig.js";
 import { normalizedToCachedFullSubject } from "../../fullSubjectCacheModel.js";
+import { assertPrimarySourced } from "../../subjectProvenance.js";
 import type { SetCachedFullSubjectResult } from "./fullSubjectWriteTypes.js";
 import { buildSharedBalanceWrites } from "./setSharedFullSubjectBalances.js";
 
@@ -22,6 +23,7 @@ export const setCachedFullSubject = async ({
 	normalized: NormalizedFullSubject;
 	fetchedSubjectViewEpoch: number;
 }): Promise<SetCachedFullSubjectResult> => {
+	assertPrimarySourced(normalized, "setCachedFullSubject");
 	const { logger, org, env, redisV2 } = ctx;
 	const { customerId, entityId } = normalized;
 

--- a/server/src/internal/customers/cache/fullSubject/subjectProvenance.ts
+++ b/server/src/internal/customers/cache/fullSubject/subjectProvenance.ts
@@ -1,0 +1,28 @@
+const replicaSourced = new WeakSet<object>();
+
+declare const primarySourcedBrand: unique symbol;
+/** Compile-time proof a subject was hydrated from the primary (or cache). */
+export type PrimarySourced<T> = T & { readonly [primarySourcedBrand]: true };
+
+/** Called only by the chokepoint when a replica served the hydration.
+ *  WeakSet, not a property: nothing serializes, nothing survives clone. */
+export const markReplicaSourced = <T extends object>(value: T): T => {
+	replicaSourced.add(value);
+	return value;
+};
+
+export const isReplicaSourced = (value: object): boolean =>
+	replicaSourced.has(value);
+
+/** Runtime guard at the cache writer — throws if a caller launders the type. */
+export const assertPrimarySourced = <T extends object>(
+	value: T,
+	context: string,
+): PrimarySourced<T> => {
+	if (replicaSourced.has(value)) {
+		throw new Error(
+			`[subjectProvenance] ${context}: replica-sourced FullSubject must never be written to the Redis cache`,
+		);
+	}
+	return value as PrimarySourced<T>;
+};

--- a/server/src/internal/customers/recovery/replayFailedCustomerCreation.ts
+++ b/server/src/internal/customers/recovery/replayFailedCustomerCreation.ts
@@ -19,6 +19,7 @@ export const replayFailedCustomerCreation = async ({
 	ctx.apiVersion = new ApiVersionClass(payload.apiVersion);
 
 	await getOrCreateApiCustomerByRollout({
+		disableReplicaRead: true,
 		ctx,
 		params: payload.params,
 		source: "customerCreationRecovery",

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
@@ -48,11 +48,18 @@ const runRoutedHydration = async ({
 }): Promise<{ rows: SubjectQueryRow[]; source: SubjectReadSource }> => {
 	const { org, env } = ctx;
 
-	const runHydration = (db: DrizzleCli) =>
+	const runHydration = ({
+		db,
+		lane,
+	}: {
+		db: DrizzleCli;
+		lane: SubjectReadSource;
+	}) =>
 		runWithFullSubjectGate({
 			customerId,
 			orgId: org.id,
 			env,
+			lane,
 			logger: ctx.logger,
 			queryFn: () =>
 				executePrepared({
@@ -80,7 +87,7 @@ const runRoutedHydration = async ({
 	let source: SubjectReadSource = resolved.source;
 	let result: Awaited<ReturnType<typeof runHydration>>;
 	try {
-		result = await runHydration(resolved.db);
+		result = await runHydration({ db: resolved.db, lane: resolved.source });
 	} catch (error) {
 		if (resolved.source !== "replica") throw error;
 		source = "primary";
@@ -95,7 +102,7 @@ const runRoutedHydration = async ({
 			},
 			"Replica hydration failed — retrying once on primary",
 		);
-		result = await runHydration(ctx.db);
+		result = await runHydration({ db: ctx.db, lane: "primary" });
 	}
 
 	if (source === "replica") {

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
@@ -1,24 +1,118 @@
 import {
-    type CusProductStatus,
-    type FullSubject,
-    fullSubjectToFullCustomer,
-    type NormalizedFullSubject,
-    normalizedToFullSubject,
-    type SubjectQueryRow,
+	type CusProductStatus,
+	type FullSubject,
+	fullSubjectToFullCustomer,
+	type NormalizedFullSubject,
+	normalizedToFullSubject,
+	type SubjectQueryRow,
 } from "@autumn/shared";
 import { executePrepared } from "@/db/executePrepared.js";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import {
+	resolveSubjectReadDb,
+	type SubjectReadFrom,
+	type SubjectReadSource,
+} from "@/db/resolveSubjectReadDb.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { checkPendingMigrationsForCustomer } from "@/internal/migrations/v2/lazy/checkPendingMigrationsForCustomer.js";
 import { lazyResetSubjectEntitlements } from "../../actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.js";
 import { lazyResetSubjectUsageWindows } from "../../actions/resetUsageWindows/lazyResetSubjectUsageWindows.js";
+import { markReplicaSourced } from "../../cache/fullSubject/subjectProvenance.js";
 import { RELEVANT_STATUSES } from "../../cusProducts/CusProductService.js";
 import { runWithFullSubjectGate } from "./getFullSubjectGate.js";
 import { getFullSubjectQuery } from "./getFullSubjectQuery.js";
 import {
-    resultToFullSubject,
-    subjectQueryRowToNormalized,
+	resultToFullSubject,
+	subjectQueryRowToNormalized,
 } from "./subjectQueryRowToNormalized.js";
 import { unpackSubjectEnvelope } from "./unpackSubjectEnvelope.js";
+
+/** Runs the hydration on the resolved pool; a failed replica attempt retries
+ *  ONCE on primary through the same gate (normal admission, never a bypass). */
+const runRoutedHydration = async ({
+	ctx,
+	customerId,
+	entityId,
+	inStatuses,
+	allowMissingEntity,
+	readFrom,
+	routeSource,
+}: {
+	ctx: AutumnContext;
+	customerId?: string;
+	entityId?: string;
+	inStatuses: CusProductStatus[];
+	allowMissingEntity: boolean;
+	readFrom: SubjectReadFrom;
+	routeSource?: string;
+}): Promise<{ rows: SubjectQueryRow[]; source: SubjectReadSource }> => {
+	const { org, env } = ctx;
+
+	const runHydration = (db: DrizzleCli) =>
+		runWithFullSubjectGate({
+			customerId,
+			orgId: org.id,
+			env,
+			logger: ctx.logger,
+			queryFn: () =>
+				executePrepared({
+					db,
+					label: "getFullSubject",
+					query: getFullSubjectQuery({
+						orgId: org.id,
+						env,
+						customerId,
+						entityId,
+						inStatuses,
+						allowMissingEntity,
+					}),
+				}),
+		});
+
+	const resolved = await resolveSubjectReadDb({
+		ctx,
+		readFrom,
+		orgId: org.id,
+		env,
+		customerId,
+	});
+
+	let source: SubjectReadSource = resolved.source;
+	let result: Awaited<ReturnType<typeof runHydration>>;
+	try {
+		result = await runHydration(resolved.db);
+	} catch (error) {
+		if (resolved.source !== "replica") throw error;
+		source = "primary";
+		ctx.logger.warn(
+			{
+				type: "replica_read",
+				source: "primary_fallback",
+				route: routeSource,
+				customer_id: customerId,
+				entity_id: entityId,
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"Replica hydration failed — retrying once on primary",
+		);
+		result = await runHydration(ctx.db);
+	}
+
+	if (source === "replica") {
+		ctx.logger.info(
+			{
+				type: "replica_read",
+				source: "replica",
+				route: routeSource,
+				customer_id: customerId,
+				entity_id: entityId,
+			},
+			"FullSubject hydrated from replica",
+		);
+	}
+
+	return { rows: unpackSubjectEnvelope({ rows: result ?? [] }), source };
+};
 
 /** Fetch full subject from DB and return as FullSubject. Runs lazy reset. */
 export async function getFullSubject({
@@ -27,36 +121,26 @@ export async function getFullSubject({
 	entityId,
 	inStatuses = RELEVANT_STATUSES,
 	allowMissingEntity = false,
+	readFrom = "primary",
+	routeSource,
 }: {
 	ctx: AutumnContext;
 	customerId?: string;
 	entityId?: string;
 	inStatuses?: CusProductStatus[];
 	allowMissingEntity?: boolean;
+	readFrom?: SubjectReadFrom;
+	routeSource?: string;
 }): Promise<FullSubject | undefined> {
-	const { db, org, env } = ctx;
-
-	const result = await runWithFullSubjectGate({
+	const { rows: subjectRows, source } = await runRoutedHydration({
+		ctx,
 		customerId,
-		orgId: org.id,
-		env,
-		logger: ctx.logger,
-		queryFn: () =>
-			executePrepared({
-				db,
-				label: "getFullSubject",
-				query: getFullSubjectQuery({
-					orgId: org.id,
-					env,
-					customerId,
-					entityId,
-					inStatuses,
-					allowMissingEntity,
-				}),
-			}),
+		entityId,
+		inStatuses,
+		allowMissingEntity,
+		readFrom,
+		routeSource,
 	});
-
-	const subjectRows = unpackSubjectEnvelope({ rows: result ?? [] });
 	if (!subjectRows.length) return undefined;
 
 	const fullSubject = resultToFullSubject({
@@ -64,6 +148,16 @@ export async function getFullSubject({
 		entityIdRequested: !!entityId,
 		allowMissingEntity,
 	});
+
+	if (ctx.subjectReadTrace) ctx.subjectReadTrace.source = source;
+
+	if (source === "replica") {
+		// Pure read: replica-sourced subjects serve unreset balances and never
+		// trigger primary writes; the brand keeps them out of the Redis cache.
+		markReplicaSourced(fullSubject);
+		return fullSubject;
+	}
+
 	await lazyResetSubjectEntitlements({ ctx, fullSubject });
 	await lazyResetSubjectUsageWindows({ ctx, fullSubject });
 	await checkPendingMigrationsForCustomer({
@@ -82,7 +176,8 @@ export async function getFullSubjectNormalized({
 	inStatuses = RELEVANT_STATUSES,
 	allowMissingEntity = false,
 	runLazyResets = true,
-
+	readFrom = "primary",
+	routeSource,
 }: {
 	ctx: AutumnContext;
 	customerId?: string;
@@ -90,33 +185,20 @@ export async function getFullSubjectNormalized({
 	inStatuses?: CusProductStatus[];
 	allowMissingEntity?: boolean;
 	runLazyResets?: boolean;
-
+	readFrom?: SubjectReadFrom;
+	routeSource?: string;
 }): Promise<
 	{ normalized: NormalizedFullSubject; fullSubject: FullSubject } | undefined
 > {
-	const { db, org, env } = ctx;
-
-	const result = await runWithFullSubjectGate({
+	const { rows: subjectRows, source } = await runRoutedHydration({
+		ctx,
 		customerId,
-		orgId: org.id,
-		env,
-		logger: ctx.logger,
-		queryFn: () =>
-			executePrepared({
-				db,
-				label: "getFullSubject",
-				query: getFullSubjectQuery({
-					orgId: org.id,
-					env,
-					customerId,
-					entityId,
-					inStatuses,
-					allowMissingEntity,
-				}),
-			}),
+		entityId,
+		inStatuses,
+		allowMissingEntity,
+		readFrom,
+		routeSource,
 	});
-
-	const subjectRows = unpackSubjectEnvelope({ rows: result ?? [] });
 	if (!subjectRows.length) return undefined;
 
 	const normalized = subjectQueryRowToNormalized({
@@ -126,7 +208,15 @@ export async function getFullSubjectNormalized({
 	});
 
 	const fullSubject = normalizedToFullSubject({ normalized });
-	if (runLazyResets) {
+
+	if (ctx.subjectReadTrace) ctx.subjectReadTrace.source = source;
+
+	if (source === "replica") {
+		// Pure read: replica-sourced subjects serve unreset balances and never
+		// trigger primary writes; the brand keeps them out of the Redis cache.
+		markReplicaSourced(normalized);
+		markReplicaSourced(fullSubject);
+	} else if (runLazyResets) {
 		await lazyResetSubjectEntitlements({ ctx, fullSubject, normalized });
 		await lazyResetSubjectUsageWindows({ ctx, fullSubject, normalized });
 		await checkPendingMigrationsForCustomer({
@@ -134,7 +224,6 @@ export async function getFullSubjectNormalized({
 			fullCustomer: fullSubjectToFullCustomer({ fullSubject }),
 		});
 	}
-
 
 	return { normalized, fullSubject };
 }

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -6,6 +6,8 @@ import pLimit, { type LimitFunction } from "p-limit";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
 import { getRuntimeFullSubjectGateConfig } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
 
+export type FullSubjectGateLane = "primary" | "replica";
+
 const GATE_LOG_WAIT_MS_THRESHOLD = 50;
 const LIMITER_CACHE_MAX = 5000;
 const LIMITER_CACHE_TTL_MS = 30 * 60 * 1000;
@@ -44,11 +46,13 @@ const getOrUpdateLimiter = (
 };
 
 const getCustomerLimiter = ({
+	lane,
 	orgId,
 	env,
 	customerId,
 	limit,
 }: {
+	lane: FullSubjectGateLane;
 	orgId: string;
 	env: AppEnv;
 	customerId: string;
@@ -56,7 +60,7 @@ const getCustomerLimiter = ({
 }): LimitFunction =>
 	getOrUpdateLimiter(
 		perCustomerLimiters,
-		`${orgId}:${env}:${customerId}`,
+		`${lane}:${orgId}:${env}:${customerId}`,
 		limit,
 	);
 
@@ -64,15 +68,17 @@ const predictedWaitMs = (limiter: LimitFunction): number =>
 	(limiter.pendingCount / Math.max(1, limiter.concurrency)) * ewmaServiceMs;
 
 const getOrgLimiter = ({
+	lane,
 	orgId,
 	env,
 	limit,
 }: {
+	lane: FullSubjectGateLane;
 	orgId: string;
 	env: AppEnv;
 	limit: number;
 }): LimitFunction =>
-	getOrUpdateLimiter(perOrgLimiters, `${orgId}:${env}`, limit);
+	getOrUpdateLimiter(perOrgLimiters, `${lane}:${orgId}:${env}`, limit);
 
 const meter = metrics.getMeter("autumn-server");
 const startedCounter = meter.createCounter("autumn.full_subject.gate.started", {
@@ -102,9 +108,18 @@ const rejectedCounter = meter.createCounter(
 	{ description: "FullSubject hydrations rejected (queue full or timed out)" },
 );
 
-const attrs = ({ orgId, env }: { orgId: string; env: AppEnv }) => ({
+const attrs = ({
+	orgId,
+	env,
+	lane,
+}: {
+	orgId: string;
+	env: AppEnv;
+	lane: FullSubjectGateLane;
+}) => ({
 	org_id: orgId,
 	env,
+	lane,
 });
 
 const GATE_REJECTION_REASONS = [
@@ -161,25 +176,27 @@ export const runWithFullSubjectGate = async <T>({
 	customerId,
 	orgId,
 	env,
+	lane = "primary",
 	logger,
 	queryFn,
 }: {
 	customerId: string | undefined;
 	orgId: string;
 	env: AppEnv;
+	lane?: FullSubjectGateLane;
 	logger?: Logger;
 	queryFn: () => Promise<T>;
 }): Promise<T> => {
+	const config = getRuntimeFullSubjectGateConfig();
+	const { max_wait_ms, fleet_process_count } = config;
 	const {
 		per_customer_limit,
 		per_org_limit,
-		max_wait_ms,
 		per_customer_pending_max,
 		per_org_pending_max,
-		fleet_process_count,
-	} = getRuntimeFullSubjectGateConfig();
+	} = lane === "replica" ? config.replica_lane : config;
 	const enqueuedAt = Date.now();
-	const labels = attrs({ orgId, env });
+	const labels = attrs({ orgId, env, lane });
 
 	const perProcessOrgLimit = toPerProcessLimit(
 		per_org_limit,
@@ -190,11 +207,17 @@ export const runWithFullSubjectGate = async <T>({
 		fleet_process_count,
 	);
 
-	const orgLimiter = getOrgLimiter({ orgId, env, limit: perProcessOrgLimit });
+	const orgLimiter = getOrgLimiter({
+		lane,
+		orgId,
+		env,
+		limit: perProcessOrgLimit,
+	});
 
 	let customerLimiter: LimitFunction | undefined;
 	if (customerId) {
 		customerLimiter = getCustomerLimiter({
+			lane,
 			orgId,
 			env,
 			customerId,
@@ -229,7 +252,7 @@ export const runWithFullSubjectGate = async <T>({
 		}
 		if (waitMs >= GATE_LOG_WAIT_MS_THRESHOLD) {
 			logger?.info(
-				`[full_subject_gate] queued ${waitMs}ms customer=${customerId ?? "unknown"} org=${orgId} env=${env}`,
+				`[full_subject_gate] queued ${waitMs}ms lane=${lane} customer=${customerId ?? "unknown"} org=${orgId} env=${env}`,
 			);
 		}
 		activeCounter.add(1, labels);

--- a/server/src/internal/entities/actions/getApiEntityByRollout.ts
+++ b/server/src/internal/entities/actions/getApiEntityByRollout.ts
@@ -33,8 +33,8 @@ export const getApiEntityByRollout = async ({
 	const lookup = ({ skipCache }: { skipCache: boolean }) => {
 		const fetch = () =>
 			getOrSetCachedFullSubject({
-				// Sole replica grant: this wrapper serves a read-only GET route.
-				readFrom: "replica-ok",
+				// Sole replica grant; writers opt out via disableReplicaRead.
+				readFrom: disableReplicaRead ? "primary" : "replica-ok",
 				ctx: skipCache ? { ...ctx, skipCache: true } : ctx,
 				customerId,
 				entityId,

--- a/server/src/internal/entities/actions/getApiEntityByRollout.ts
+++ b/server/src/internal/entities/actions/getApiEntityByRollout.ts
@@ -17,6 +17,7 @@ export const getApiEntityByRollout = async ({
 	source,
 	withAutumnId = false,
 	singleflight = false,
+	disableReplicaRead = false,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
@@ -24,6 +25,7 @@ export const getApiEntityByRollout = async ({
 	source?: string;
 	withAutumnId?: boolean;
 	singleflight?: boolean;
+	disableReplicaRead?: boolean;
 }): Promise<ApiEntityV2> => {
 	if (isFullSubjectRolloutEnabled({ ctx })) {
 	}

--- a/server/src/internal/entities/actions/getApiEntityByRollout.ts
+++ b/server/src/internal/entities/actions/getApiEntityByRollout.ts
@@ -31,6 +31,8 @@ export const getApiEntityByRollout = async ({
 	const lookup = ({ skipCache }: { skipCache: boolean }) => {
 		const fetch = () =>
 			getOrSetCachedFullSubject({
+				// Sole replica grant: this wrapper serves a read-only GET route.
+				readFrom: "replica-ok",
 				ctx: skipCache ? { ...ctx, skipCache: true } : ctx,
 				customerId,
 				entityId,

--- a/server/src/internal/entities/handlers/handleUpdateEntity/handleUpdateEntity.ts
+++ b/server/src/internal/entities/handlers/handleUpdateEntity/handleUpdateEntity.ts
@@ -45,6 +45,7 @@ export const handleUpdateEntity = createRoute({
 		});
 
 		const apiEntity = await getApiEntityByRollout({
+			disableReplicaRead: true,
 			ctx,
 			customerId,
 			entityId: body.entity_id,

--- a/server/src/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigSchemas.ts
+++ b/server/src/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigSchemas.ts
@@ -16,6 +16,26 @@ export const FullSubjectGateEdgeConfigSchema = z.object({
 	// Caps above are cluster-wide targets; each process enforces
 	// target / fleet_process_count. Default 1 = per-process (no-op).
 	fleet_process_count: z.number().int().min(1).max(100_000).default(1),
+	// Replica-lane budgets; the top-level numbers stay the primary lane's.
+	replica_lane: z
+		.object({
+			per_customer_limit: z.number().int().min(1).max(10_000).default(540),
+			per_org_limit: z.number().int().min(1).max(10_000).default(810),
+			per_customer_pending_max: z
+				.number()
+				.int()
+				.min(1)
+				.max(100_000)
+				.default(1_500),
+			per_org_pending_max: z.number().int().min(1).max(100_000).default(3_000),
+		})
+		.prefault({}),
+	// 0 = steady-state reads stay primary-only (dark by default, flipped via edge config).
+	read_split: z
+		.object({
+			replica_share: z.number().min(0).max(1).default(0),
+		})
+		.prefault({}),
 });
 
 export type FullSubjectGateEdgeConfig = z.infer<

--- a/server/tests/integration/replica-reads/replica-read-routing.test.ts
+++ b/server/tests/integration/replica-reads/replica-read-routing.test.ts
@@ -1,0 +1,422 @@
+/**
+ * TDD contract test for replica-read routing of FullSubject hydrations
+ * (replica-reads design §3.1: one chokepoint in getFullSubject[Normalized],
+ * gated by skipCache + prober eligibility + customer_lsns freshness ledger).
+ *
+ * Contract under test:
+ *   New types/fields:
+ *     - readFrom?: "primary" | "replica-ok" (default "primary") on
+ *       getFullSubject + getFullSubjectNormalized
+ *     - resolveSubjectReadDb({ ctx, readFrom, orgId, env, customerId })
+ *       -> { db, source: "primary" | "replica" } in server/src/db/
+ *     - ctx.subjectReadTrace (non-prod debug box) -> response header
+ *       x-subject-source: primary|replica|cache when the request carries
+ *       x-debug-subject-source: true and NODE_ENV !== "production"
+ *   New behaviors:
+ *     (a) quiet customer (ledger row aged > 60s) + skipCache read
+ *         -> 200, x-subject-source: replica
+ *     (b) structurally written < 60s ago (create/attach marks the ledger)
+ *         + skipCache read -> x-subject-source: primary (read-your-writes)
+ *     (c) get_or_create of an EXISTING customer with skipCache + quiet ledger
+ *         -> 200, lookup leg served by replica
+ *     (d) get_or_create of a BRAND NEW customer -> creates fine (converges via
+ *         primary); immediate follow-up skipCache read -> primary (create mark)
+ *     (e) normal cache path untouched: read WITHOUT skipCache -> cache
+ *         (primary allowed on first miss); no debug header -> no source header
+ *     (f) service-level fail-safes: prober ineligible -> primary; ledger check
+ *         throw -> primary; replica execute throw -> ONE primary retry succeeds
+ *     (g) replica-routed hydration brands normalized + fullSubject
+ *         (isReplicaSourced === true) and setCachedFullSubject throws on them
+ *   Side effects:
+ *     - replica hydrations run with lazy resets disabled (no primary writes)
+ *     - replica-sourced subjects can never be written to Redis
+ *
+ * Pre-impl red: resolveSubjectReadDb / readFrom / x-subject-source do not
+ * exist. Post-impl green: routing seam + debug header land per design §3.1.
+ *
+ * (a)-(e) run E2E against the live dev server (real primary + 2 replicas,
+ * prober started in init.ts). (f)-(g) run service-level in the test process
+ * because they need fake pools and forced prober states — not expressible over
+ * HTTP. They are intentionally NON-concurrent: they mutate test-process module
+ * state (prober probe, replica override) that must not interleave.
+ */
+
+import { expect, test } from "bun:test";
+import { ApiVersion } from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import {
+	_resetReplicaRoutingStateForTesting,
+	_setReplicaRoutingProbeForTesting,
+} from "@/db/replicaRoutingState.js";
+import {
+	_setLedgerDbOverrideForTesting,
+	_setReplicaDbOverrideForTesting,
+	resolveSubjectReadDb,
+} from "@/db/resolveSubjectReadDb.js";
+import { setCachedFullSubject } from "@/internal/customers/cache/fullSubject/actions/setCachedFullSubject/setCachedFullSubject.js";
+import { isReplicaSourced } from "@/internal/customers/cache/fullSubject/subjectProvenance.js";
+import { _resetRecentlyUpdatedNegativeCacheForTesting } from "@/internal/customers/customerLsns/isCustomerRecentlyUpdated.js";
+import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
+
+const envBase = process.env.AUTUMN_TEST_BASE_URL;
+const baseUrl = envBase
+	? `${envBase.replace(/\/$/, "")}/v1`
+	: "http://localhost:8080/v1";
+
+const DEBUG_HEADERS = { "x-debug-subject-source": "true" };
+const SKIP_CACHE_DEBUG_HEADERS = { ...DEBUG_HEADERS, "x-skip-cache": "true" };
+
+/** Raw fetch (not AutumnInt) because the contract asserts response HEADERS.
+ *  Pinned to V2_3 so the body is the flat ApiCustomer shape (top-level id). */
+const rpcPost = async ({
+	ctx,
+	path,
+	body,
+	headers = {},
+}: {
+	ctx: TestContext;
+	path: string;
+	body: unknown;
+	headers?: Record<string, string>;
+}) => {
+	const response = await fetch(`${baseUrl}${path}`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${ctx.orgSecretKey}`,
+			"Content-Type": "application/json",
+			"x-api-version": ApiVersion.V2_3,
+			...headers,
+		},
+		body: JSON.stringify(body),
+	});
+	const json = (await response.json()) as { id?: string };
+	return {
+		status: response.status,
+		json,
+		customerId: json.id,
+		subjectSource: response.headers.get("x-subject-source"),
+	};
+};
+
+/** DML on test-owned ledger rows only: makes the customer "quiet" (> 60s). */
+const preAgeLedger = async ({
+	ctx,
+	customerId,
+}: {
+	ctx: TestContext;
+	customerId: string;
+}) => {
+	await ctx.db.execute(sql`
+		UPDATE customer_lsns
+		SET updated_at = now() - interval '2 minutes'
+		WHERE org_id = ${ctx.org.id}
+			AND env = ${ctx.env}
+			AND customer_id = ${customerId}
+	`);
+};
+
+/** Dev replicas run ~0 lag; this bounds the created-row catch-up window. */
+const REPLICA_CATCHUP_MS = 1_500;
+
+// ── Contract assertion (a): quiet customer + skipCache -> replica ──────────
+test.concurrent(
+	`${chalk.yellowBright("replica-reads (a): quiet customer + skipCache read is served by the replica")}`,
+	async () => {
+		const customerId = "replica-read-quiet-customer";
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await timeout(REPLICA_CATCHUP_MS);
+		await preAgeLedger({ ctx, customerId });
+
+		const res = await rpcPost({
+			ctx,
+			path: "/customers.get",
+			body: { customer_id: customerId },
+			headers: SKIP_CACHE_DEBUG_HEADERS,
+		});
+
+		expect(res.status).toBe(200);
+		expect(res.customerId).toBe(customerId);
+		expect(res.subjectSource).toBe("replica");
+	},
+);
+
+// ── Contract assertion (b): structural write < 60s ago -> primary ──────────
+test.concurrent(
+	`${chalk.yellowBright("replica-reads (b): freshly attached customer + skipCache read pins primary (read-your-writes)")}`,
+	async () => {
+		const customerId = "replica-read-fresh-write-customer";
+		const pro = products.pro({
+			id: "replica-read-pro-b",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [s.attach({ productId: pro.id })],
+		});
+
+		// Attach just marked the customer_lsns ledger; no pre-aging here.
+		const res = await rpcPost({
+			ctx,
+			path: "/customers.get",
+			body: { customer_id: customerId },
+			headers: SKIP_CACHE_DEBUG_HEADERS,
+		});
+
+		expect(res.status).toBe(200);
+		expect(res.customerId).toBe(customerId);
+		expect(res.subjectSource).toBe("primary");
+	},
+);
+
+// ── Contract assertion (c): get_or_create existing + quiet -> replica ──────
+test.concurrent(
+	`${chalk.yellowBright("replica-reads (c): get_or_create of an existing quiet customer serves the lookup from the replica")}`,
+	async () => {
+		const customerId = "replica-read-goc-existing";
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await timeout(REPLICA_CATCHUP_MS);
+		await preAgeLedger({ ctx, customerId });
+
+		const res = await rpcPost({
+			ctx,
+			path: "/customers.get_or_create",
+			body: { customer_id: customerId },
+			headers: SKIP_CACHE_DEBUG_HEADERS,
+		});
+
+		expect(res.status).toBe(200);
+		expect(res.customerId).toBe(customerId);
+		expect(res.subjectSource).toBe("replica");
+	},
+);
+
+// ── Contract assertion (d): get_or_create brand-new -> converges, then primary
+test.concurrent(
+	`${chalk.yellowBright("replica-reads (d): get_or_create of a brand-new customer creates via primary; follow-up read pins primary")}`,
+	async () => {
+		const customerId = "replica-read-goc-brand-new";
+		const { ctx, autumnV1 } = await initScenario({
+			setup: [],
+			actions: [],
+		});
+		// Deterministic id across runs: remove any prior copy so this run truly
+		// creates. A delete is itself a structural write and marks the ledger,
+		// which only reinforces the primary-pinned expectation below.
+		await autumnV1.customers.delete(customerId).catch(() => undefined);
+
+		const created = await rpcPost({
+			ctx,
+			path: "/customers.get_or_create",
+			body: { customer_id: customerId },
+			headers: SKIP_CACHE_DEBUG_HEADERS,
+		});
+		expect(created.status).toBe(200);
+		expect(created.customerId).toBe(customerId);
+
+		const followUp = await rpcPost({
+			ctx,
+			path: "/customers.get",
+			body: { customer_id: customerId },
+			headers: SKIP_CACHE_DEBUG_HEADERS,
+		});
+		expect(followUp.status).toBe(200);
+		expect(followUp.customerId).toBe(customerId);
+		expect(followUp.subjectSource).toBe("primary");
+	},
+);
+
+// ── Contract assertion (e): normal cache path untouched ────────────────────
+test.concurrent(
+	`${chalk.yellowBright("replica-reads (e): reads without skipCache stay on the cache path and emit no header without the debug opt-in")}`,
+	async () => {
+		const customerId = "replica-read-cache-path";
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		const first = await rpcPost({
+			ctx,
+			path: "/customers.get",
+			body: { customer_id: customerId },
+			headers: DEBUG_HEADERS,
+		});
+		expect(first.status).toBe(200);
+		expect(first.customerId).toBe(customerId);
+		// First read may miss (primary hydration + cache fill) or hit a cache
+		// warmed by the create flow — both are today's behavior.
+		expect(["cache", "primary"]).toContain(first.subjectSource ?? "missing");
+
+		// Outlive the in-process L1 TTL so the second read exercises Redis.
+		await timeout(1_200);
+		const second = await rpcPost({
+			ctx,
+			path: "/customers.get",
+			body: { customer_id: customerId },
+			headers: DEBUG_HEADERS,
+		});
+		expect(second.status).toBe(200);
+		expect(second.customerId).toBe(customerId);
+		expect(second.subjectSource).toBe("cache");
+
+		// Without the debug opt-in the header must never appear (prod shape).
+		const noDebug = await rpcPost({
+			ctx,
+			path: "/customers.get",
+			body: { customer_id: customerId },
+		});
+		expect(noDebug.status).toBe(200);
+		expect(noDebug.customerId).toBe(customerId);
+		expect(noDebug.subjectSource).toBeNull();
+	},
+);
+
+// ── Contract assertion (f): service-level fail-safes (NOT concurrent) ──────
+test(`${chalk.yellowBright("replica-reads (f): resolveSubjectReadDb fail-safes and one-shot primary retry on replica failure")}`, async () => {
+	const customerId = "replica-read-service-failsafe";
+	const { ctx } = await initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false })],
+		actions: [],
+	});
+	const skipCacheCtx = { ...ctx, skipCache: true };
+	const baseArgs = { orgId: ctx.org.id, env: ctx.env, customerId };
+
+	try {
+		// (f1) prober ineligible (never probed -> stale) -> primary.
+		_resetReplicaRoutingStateForTesting();
+		const ineligible = await resolveSubjectReadDb({
+			ctx: skipCacheCtx,
+			readFrom: "replica-ok",
+			...baseArgs,
+		});
+		expect(ineligible.source).toBe("primary");
+		expect(ineligible.db).toBe(ctx.db);
+
+		// Sanity for the gates below: eligible prober + quiet ledger -> replica.
+		_setReplicaRoutingProbeForTesting({ replicaCount: 2, maxReplayLagMs: 0 });
+		await preAgeLedger({ ctx, customerId });
+		const eligible = await resolveSubjectReadDb({
+			ctx: skipCacheCtx,
+			readFrom: "replica-ok",
+			...baseArgs,
+		});
+		expect(eligible.source).toBe("replica");
+
+		// Default readFrom and non-skipCache contexts always pin primary.
+		const explicitPrimary = await resolveSubjectReadDb({
+			ctx: skipCacheCtx,
+			readFrom: "primary",
+			...baseArgs,
+		});
+		expect(explicitPrimary.source).toBe("primary");
+		const cachePathCtx = await resolveSubjectReadDb({
+			ctx,
+			readFrom: "replica-ok",
+			...baseArgs,
+		});
+		expect(cachePathCtx.source).toBe("primary");
+
+		// The sanity check cached this key's negative; clear it so the throwing
+		// ledger db below is actually reached instead of short-circuited.
+		_resetRecentlyUpdatedNegativeCacheForTesting();
+
+		// (f2) ledger check throws -> primary (fail-safe). The ledger runs on the
+		// module-level dbCritical pool, so the fake is injected via the seam.
+		const throwingLedgerDb = {
+			execute: () => Promise.reject(new Error("ledger unavailable")),
+		} as unknown as DrizzleCli;
+		_setLedgerDbOverrideForTesting(throwingLedgerDb);
+		try {
+			const ledgerError = await resolveSubjectReadDb({
+				ctx: skipCacheCtx,
+				readFrom: "replica-ok",
+				...baseArgs,
+			});
+			expect(ledgerError.source).toBe("primary");
+		} finally {
+			_setLedgerDbOverrideForTesting(null);
+		}
+
+		// (f3) replica execute throws -> exactly one primary retry returns data.
+		const brokenReplicaDb = {
+			$client: {
+				query: () => Promise.reject(new Error("replica exploded")),
+			},
+			execute: () => Promise.reject(new Error("replica exploded")),
+		} as unknown as DrizzleCli;
+		_setReplicaDbOverrideForTesting(brokenReplicaDb);
+		const result = await getFullSubjectNormalized({
+			ctx: skipCacheCtx,
+			customerId,
+			readFrom: "replica-ok",
+		});
+		expect(result).toBeDefined();
+		expect(result?.fullSubject.customer.id).toBe(customerId);
+		// Primary-fallback data must NOT carry the replica brand.
+		expect(isReplicaSourced(result?.normalized as object)).toBe(false);
+		expect(isReplicaSourced(result?.fullSubject as object)).toBe(false);
+	} finally {
+		_setReplicaDbOverrideForTesting(null);
+		_resetReplicaRoutingStateForTesting();
+	}
+});
+
+// ── Contract assertion (g): provenance brand + cache-writer lock (NOT concurrent)
+test(`${chalk.yellowBright("replica-reads (g): replica-sourced subjects are branded and rejected by setCachedFullSubject")}`, async () => {
+	const customerId = "replica-read-provenance";
+	const { ctx } = await initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false })],
+		actions: [],
+	});
+
+	await timeout(REPLICA_CATCHUP_MS);
+	await preAgeLedger({ ctx, customerId });
+	_setReplicaRoutingProbeForTesting({ replicaCount: 2, maxReplayLagMs: 0 });
+
+	try {
+		const result = await getFullSubjectNormalized({
+			ctx: { ...ctx, skipCache: true },
+			customerId,
+			readFrom: "replica-ok",
+		});
+		expect(result).toBeDefined();
+		if (!result) throw new Error("expected a replica-routed hydration");
+
+		expect(isReplicaSourced(result.normalized)).toBe(true);
+		expect(isReplicaSourced(result.fullSubject)).toBe(true);
+
+		await expect(
+			setCachedFullSubject({
+				ctx,
+				normalized: result.normalized,
+				fetchedSubjectViewEpoch: 0,
+			}),
+		).rejects.toThrow(/replica-sourced/);
+	} finally {
+		_resetReplicaRoutingStateForTesting();
+	}
+});

--- a/server/tests/unit/db/poolBudgetGuard.test.ts
+++ b/server/tests/unit/db/poolBudgetGuard.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { computePoolBudgetWarnings } from "@/db/initDrizzle.js";
+
+const prodDefaults = {
+	criticalPoolMax: 22,
+	generalPoolMax: 14,
+	replicaPoolMax: 9,
+};
+
+describe("computePoolBudgetWarnings", () => {
+	test("prod defaults stay inside both bouncer budgets", () => {
+		expect(computePoolBudgetWarnings(prodDefaults)).toEqual([]);
+	});
+
+	test("oversized primary pools trip only the primary guard", () => {
+		// 90 x (60 + 60) + 362 = 11,162 > 0.85 x 12,000 = 10,200
+		const warnings = computePoolBudgetWarnings({
+			...prodDefaults,
+			criticalPoolMax: 60,
+			generalPoolMax: 60,
+		});
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain("primary PgBouncer");
+	});
+
+	test("oversized replica pool trips only the replica guard", () => {
+		// 90 x 12 = 1,080 > 0.85 x 1,000 = 850
+		const warnings = computePoolBudgetWarnings({
+			...prodDefaults,
+			replicaPoolMax: 12,
+		});
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain("replica PgBouncer");
+	});
+
+	test("replica budget boundary: 9 per process fits, 10 does not", () => {
+		// 90 x 9 = 810 <= 850, but 90 x 10 = 900 > 850
+		expect(
+			computePoolBudgetWarnings({ ...prodDefaults, replicaPoolMax: 9 }),
+		).toEqual([]);
+		expect(
+			computePoolBudgetWarnings({ ...prodDefaults, replicaPoolMax: 10 }),
+		).toHaveLength(1);
+	});
+
+	test("both guards fire when both budgets are blown", () => {
+		const warnings = computePoolBudgetWarnings({
+			criticalPoolMax: 80,
+			generalPoolMax: 80,
+			replicaPoolMax: 20,
+		});
+		expect(warnings).toHaveLength(2);
+	});
+});

--- a/server/tests/unit/db/replicaRoutingState.test.ts
+++ b/server/tests/unit/db/replicaRoutingState.test.ts
@@ -1,0 +1,272 @@
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	setSystemTime,
+} from "bun:test";
+
+const last = <T>(arr: T[]): T | undefined => arr[arr.length - 1];
+
+// Single ordered recorder: info/warn interleaving matters for transition order.
+const loggedFields: Record<string, unknown>[] = [];
+const info = mock((...args: unknown[]) => {
+	loggedFields.push(args[0] as Record<string, unknown>);
+});
+const warn = mock((...args: unknown[]) => {
+	loggedFields.push(args[0] as Record<string, unknown>);
+});
+mock.module("@/external/logtail/logtailUtils.js", () => ({
+	logger: {
+		info,
+		warn,
+		error: mock(() => {}),
+		debug: mock(() => {}),
+		child: () => ({}),
+	},
+}));
+
+const { EXPECTED_REPLICA_COUNT, REPLICA_LAG_MAX_MS } = await import(
+	"@/db/probes/replicaLagProbe.js"
+);
+const {
+	getReplicaRoutingState,
+	startReplicaRoutingProber,
+	stopReplicaRoutingProber,
+	REPLICA_ROUTING_STALENESS_MS,
+	_resetReplicaRoutingStateForTesting,
+	_runProbeTickForTesting,
+} = await import("@/db/replicaRoutingState.js");
+
+type Row = Record<string, unknown>;
+
+const replicaRow = (overrides: Row = {}): Row => ({
+	in_recovery: false,
+	application_name: "walreceiver-1",
+	state: "streaming",
+	sync_state: "quorum",
+	replay_lag_ms: 10,
+	write_lag_ms: 5,
+	...overrides,
+});
+
+const healthyRows = (): Row[] =>
+	Array.from({ length: EXPECTED_REPLICA_COUNT }, (_, index) =>
+		replicaRow({ application_name: `walreceiver-${index + 1}` }),
+	);
+
+const fakeDb = (rows: Row[]) =>
+	// biome-ignore lint/suspicious/noExplicitAny: minimal db stub
+	({ execute: async () => rows }) as any;
+
+const throwingDb = () =>
+	({
+		execute: async () => {
+			throw new Error("connection refused");
+		},
+		// biome-ignore lint/suspicious/noExplicitAny: minimal db stub
+	}) as any;
+
+const transitionCalls = () =>
+	loggedFields.filter(
+		(fields) => fields?.type === "replica_routing_transition",
+	);
+
+const originalReplicaUrl = process.env.DATABASE_REPLICA_URL;
+
+beforeEach(() => {
+	info.mockClear();
+	warn.mockClear();
+	loggedFields.length = 0;
+	_resetReplicaRoutingStateForTesting();
+});
+
+afterEach(() => {
+	setSystemTime();
+	stopReplicaRoutingProber();
+	if (originalReplicaUrl === undefined) {
+		delete process.env.DATABASE_REPLICA_URL;
+	} else {
+		process.env.DATABASE_REPLICA_URL = originalReplicaUrl;
+	}
+});
+
+describe("getReplicaRoutingState", () => {
+	it("is ineligible before any probe has run, without logging a transition", () => {
+		const state = getReplicaRoutingState();
+
+		expect(state.eligible).toBe(false);
+		expect(state.updatedAt).toBe(0);
+		expect(transitionCalls()).toHaveLength(0);
+	});
+
+	it("becomes eligible after a healthy probe of all expected replicas", async () => {
+		await _runProbeTickForTesting({ db: fakeDb(healthyRows()) });
+
+		const state = getReplicaRoutingState();
+		expect(state.eligible).toBe(true);
+		expect(state.replicaCount).toBe(EXPECTED_REPLICA_COUNT);
+		expect(state.maxReplayLagMs).toBe(10);
+		expect(state.updatedAt).toBeGreaterThan(0);
+	});
+
+	it("treats NULL lag columns as caught up (0ms), staying eligible", async () => {
+		const rows = healthyRows().map((row) => ({
+			...row,
+			replay_lag_ms: null,
+			write_lag_ms: null,
+		}));
+		await _runProbeTickForTesting({ db: fakeDb(rows) });
+
+		const state = getReplicaRoutingState();
+		expect(state.eligible).toBe(true);
+		expect(state.maxReplayLagMs).toBe(0);
+	});
+
+	it("goes ineligible with count_mismatch when a replica vanishes", async () => {
+		await _runProbeTickForTesting({ db: fakeDb(healthyRows()) });
+		await _runProbeTickForTesting({ db: fakeDb([replicaRow()]) });
+
+		const state = getReplicaRoutingState();
+		expect(state.eligible).toBe(false);
+		expect(state.replicaCount).toBe(1);
+
+		const transitions = transitionCalls();
+		expect(last(transitions)).toMatchObject({
+			to: "ineligible",
+			reason: "count_mismatch",
+		});
+	});
+
+	it("goes ineligible with lag_exceeded when replay lag breaches the bound", async () => {
+		await _runProbeTickForTesting({ db: fakeDb(healthyRows()) });
+
+		const [first, ...rest] = healthyRows();
+		const laggedRows = [{ ...first, replay_lag_ms: 61_000 }, ...rest];
+		await _runProbeTickForTesting({ db: fakeDb(laggedRows) });
+
+		const state = getReplicaRoutingState();
+		expect(state.eligible).toBe(false);
+		expect(state.maxReplayLagMs).toBe(61_000);
+		expect(last(transitionCalls())).toMatchObject({
+			to: "ineligible",
+			reason: "lag_exceeded",
+		});
+	});
+
+	it("requires lag strictly below REPLICA_LAG_MAX_MS", async () => {
+		const atBound = healthyRows().map((row) => ({
+			...row,
+			replay_lag_ms: REPLICA_LAG_MAX_MS,
+		}));
+		await _runProbeTickForTesting({ db: fakeDb(atBound) });
+		expect(getReplicaRoutingState().eligible).toBe(false);
+
+		const belowBound = healthyRows().map((row) => ({
+			...row,
+			replay_lag_ms: REPLICA_LAG_MAX_MS - 1,
+		}));
+		await _runProbeTickForTesting({ db: fakeDb(belowBound) });
+		expect(getReplicaRoutingState().eligible).toBe(true);
+	});
+
+	it("fails toward primary with probe_error when the probe throws", async () => {
+		await _runProbeTickForTesting({ db: fakeDb(healthyRows()) });
+		await _runProbeTickForTesting({ db: throwingDb() });
+
+		expect(getReplicaRoutingState().eligible).toBe(false);
+		expect(last(transitionCalls())).toMatchObject({
+			to: "ineligible",
+			reason: "probe_error",
+		});
+	});
+
+	it("treats a blind probe (not reading a primary) as a probe error", async () => {
+		await _runProbeTickForTesting({ db: fakeDb(healthyRows()) });
+		await _runProbeTickForTesting({
+			db: fakeDb(healthyRows().map((row) => ({ ...row, in_recovery: true }))),
+		});
+
+		expect(getReplicaRoutingState().eligible).toBe(false);
+		expect(last(transitionCalls())).toMatchObject({
+			to: "ineligible",
+			reason: "probe_error",
+		});
+	});
+
+	it("goes ineligible with stale_probe once the snapshot ages past the bound", async () => {
+		await _runProbeTickForTesting({ db: fakeDb(healthyRows()) });
+		expect(getReplicaRoutingState().eligible).toBe(true);
+
+		setSystemTime(new Date(Date.now() + REPLICA_ROUTING_STALENESS_MS + 1_000));
+
+		expect(getReplicaRoutingState().eligible).toBe(false);
+		expect(last(transitionCalls())).toMatchObject({
+			to: "ineligible",
+			reason: "stale_probe",
+		});
+	});
+});
+
+describe("transition logging", () => {
+	it("logs once per flip, never per tick or per read", async () => {
+		const healthy = fakeDb(healthyRows());
+		const degraded = fakeDb([replicaRow()]);
+
+		await _runProbeTickForTesting({ db: healthy });
+		await _runProbeTickForTesting({ db: healthy });
+		await _runProbeTickForTesting({ db: healthy });
+		expect(transitionCalls()).toHaveLength(1);
+		expect(transitionCalls()[0]).toMatchObject({
+			to: "eligible",
+			reason: "recovered",
+		});
+
+		await _runProbeTickForTesting({ db: degraded });
+		await _runProbeTickForTesting({ db: degraded });
+		await _runProbeTickForTesting({ db: degraded });
+		expect(transitionCalls()).toHaveLength(2);
+
+		for (let i = 0; i < 5; i++) {
+			getReplicaRoutingState();
+		}
+		expect(transitionCalls()).toHaveLength(2);
+
+		await _runProbeTickForTesting({ db: healthy });
+		expect(transitionCalls()).toHaveLength(3);
+		expect(last(transitionCalls())).toMatchObject({
+			to: "eligible",
+			reason: "recovered",
+		});
+	});
+});
+
+describe("startReplicaRoutingProber", () => {
+	it("skips entirely (with one info log) when DATABASE_REPLICA_URL is unset", () => {
+		delete process.env.DATABASE_REPLICA_URL;
+
+		startReplicaRoutingProber({ db: fakeDb(healthyRows()) });
+
+		const skipped = info.mock.calls
+			.map((call) => call[0] as Record<string, unknown>)
+			.filter((fields) => fields?.type === "replica_routing_prober_skipped");
+		expect(skipped).toHaveLength(1);
+		expect(getReplicaRoutingState().updatedAt).toBe(0);
+	});
+
+	it("probes immediately on start and is idempotent", async () => {
+		process.env.DATABASE_REPLICA_URL = "postgres://replica.invalid/autumn";
+
+		startReplicaRoutingProber({ db: fakeDb(healthyRows()) });
+		startReplicaRoutingProber({ db: fakeDb(healthyRows()) });
+		await new Promise((resolve) => setTimeout(resolve, 20));
+
+		expect(getReplicaRoutingState().eligible).toBe(true);
+		const started = info.mock.calls
+			.map((call) => call[0] as Record<string, unknown>)
+			.filter((fields) => fields?.type === "replica_routing_prober_start");
+		expect(started).toHaveLength(1);
+	});
+});

--- a/server/tests/unit/full-subject-cache/subjectProvenance.test.ts
+++ b/server/tests/unit/full-subject-cache/subjectProvenance.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { NormalizedFullSubject } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { setCachedFullSubject } from "@/internal/customers/cache/fullSubject/actions/setCachedFullSubject/setCachedFullSubject.js";
+import {
+	assertPrimarySourced,
+	isReplicaSourced,
+	markReplicaSourced,
+} from "@/internal/customers/cache/fullSubject/subjectProvenance.js";
+
+describe("subjectProvenance", () => {
+	test("unmarked object passes assertPrimarySourced", () => {
+		const subject = { customerId: "cus_1" };
+
+		expect<object>(assertPrimarySourced(subject, "testContext")).toBe(subject);
+	});
+
+	test("marked object throws with the context string in the message", () => {
+		const subject = markReplicaSourced({ customerId: "cus_1" });
+
+		expect(() => assertPrimarySourced(subject, "myWriterSite")).toThrow(
+			/myWriterSite.*replica-sourced/,
+		);
+	});
+
+	test("isReplicaSourced is true for marked, false for unmarked", () => {
+		const marked = markReplicaSourced({ customerId: "cus_marked" });
+		const unmarked = { customerId: "cus_unmarked" };
+
+		expect(isReplicaSourced(marked)).toBe(true);
+		expect(isReplicaSourced(unmarked)).toBe(false);
+	});
+
+	test("structuredClone of a marked object escapes the mark (intentional)", () => {
+		// Accepted hole: WeakSet identity doesn't survive clone. Clones only
+		// occur downstream of the writers; the type brand covers compile time.
+		const marked = markReplicaSourced({ customerId: "cus_clone" });
+		const clone = structuredClone(marked);
+
+		expect(isReplicaSourced(clone)).toBe(false);
+		expect<object>(assertPrimarySourced(clone, "cloneContext")).toBe(clone);
+	});
+
+	test("setCachedFullSubject throws on a marked subject before any Redis work", async () => {
+		const redisSpy = mock(() => Promise.resolve("OK"));
+		const loggerInfo = mock(() => {});
+		const ctx = {
+			logger: { info: loggerInfo },
+			org: { id: "org_1" },
+			env: "live",
+			redisV2: { setCachedFullSubject: redisSpy },
+		} as unknown as AutumnContext;
+
+		const normalized = markReplicaSourced({
+			customerId: "cus_poisoned",
+			entityId: null,
+		}) as unknown as NormalizedFullSubject;
+
+		await expect(
+			setCachedFullSubject({
+				ctx,
+				normalized,
+				fetchedSubjectViewEpoch: 1,
+			}),
+		).rejects.toThrow(/setCachedFullSubject.*replica-sourced/);
+
+		expect(redisSpy).not.toHaveBeenCalled();
+		expect(loggerInfo).not.toHaveBeenCalled();
+	});
+});

--- a/server/tests/unit/replica-reads/gateEdgeConfigDefaults.test.ts
+++ b/server/tests/unit/replica-reads/gateEdgeConfigDefaults.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { FullSubjectGateEdgeConfigSchema } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigSchemas.js";
+
+describe("FullSubjectGateEdgeConfigSchema defaults", () => {
+	it("parses {} (missing S3 file) into a fully working config, nested objects included", () => {
+		const config = FullSubjectGateEdgeConfigSchema.parse({});
+
+		expect(config.per_customer_limit).toBe(200);
+		expect(config.per_org_limit).toBe(500);
+		expect(config.max_wait_ms).toBe(2_000);
+		expect(config.per_customer_pending_max).toBe(500);
+		expect(config.per_org_pending_max).toBe(1_000);
+		expect(config.fleet_process_count).toBe(1);
+
+		expect(config.replica_lane).toEqual({
+			per_customer_limit: 540,
+			per_org_limit: 810,
+			per_customer_pending_max: 1_500,
+			per_org_pending_max: 3_000,
+		});
+		expect(config.read_split).toEqual({ replica_share: 0 });
+	});
+
+	it("fills unspecified nested fields with defaults when only some are set", () => {
+		const config = FullSubjectGateEdgeConfigSchema.parse({
+			replica_lane: { per_customer_limit: 100 },
+		});
+		expect(config.replica_lane.per_customer_limit).toBe(100);
+		expect(config.replica_lane.per_org_limit).toBe(810);
+		expect(config.replica_lane.per_customer_pending_max).toBe(1_500);
+		expect(config.replica_lane.per_org_pending_max).toBe(3_000);
+	});
+
+	it("accepts replica_share across its full [0, 1] range", () => {
+		for (const replica_share of [0, 0.25, 0.5, 1]) {
+			const result = FullSubjectGateEdgeConfigSchema.safeParse({
+				read_split: { replica_share },
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.read_split.replica_share).toBe(replica_share);
+			}
+		}
+	});
+
+	it("rejects replica_share outside [0, 1]", () => {
+		for (const replica_share of [-0.1, 1.1, 2]) {
+			const result = FullSubjectGateEdgeConfigSchema.safeParse({
+				read_split: { replica_share },
+			});
+			expect(result.success).toBe(false);
+		}
+	});
+});

--- a/server/tests/unit/replica-reads/gateLaneIsolation.test.ts
+++ b/server/tests/unit/replica-reads/gateLaneIsolation.test.ts
@@ -1,0 +1,169 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
+import {
+	_setFullSubjectGateEwmaForTesting,
+	runWithFullSubjectGate,
+} from "@/internal/customers/repos/getFullSubject/getFullSubjectGate.js";
+import { _setFullSubjectGateConfigForTesting } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
+
+const REPLICA_LANE_WIDE_OPEN = {
+	per_customer_limit: 100,
+	per_org_limit: 100,
+	per_customer_pending_max: 1_000,
+	per_org_pending_max: 1_000,
+};
+
+beforeAll(() => {
+	_setFullSubjectGateEwmaForTesting(100);
+});
+
+afterAll(() => {
+	_setFullSubjectGateConfigForTesting({ config: {} });
+	_setFullSubjectGateEwmaForTesting(100);
+});
+
+describe("full subject gate lanes", () => {
+	test("a saturated replica lane does not block primary-lane admission for the same customer", async () => {
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 10,
+				per_org_limit: 10,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1_000,
+				per_org_pending_max: 1_000,
+				replica_lane: {
+					per_customer_limit: 1,
+					per_org_limit: 1,
+					per_customer_pending_max: 2,
+					per_org_pending_max: 2,
+				},
+			},
+		});
+
+		const orgId = "org-lane-isolation";
+		const customerId = "cus-lane-isolation";
+		const hold = () => new Promise((resolve) => setTimeout(resolve, 200));
+
+		// 1 running + 2 pending fills the replica lane; the rest must 429.
+		const replicaTasks = Promise.allSettled(
+			Array.from({ length: 8 }, () =>
+				runWithFullSubjectGate({
+					customerId,
+					orgId,
+					env: AppEnv.Live,
+					lane: "replica",
+					queryFn: hold,
+				}),
+			),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 20));
+
+		const start = Date.now();
+		const primaryResult = await runWithFullSubjectGate({
+			customerId,
+			orgId,
+			env: AppEnv.Live,
+			lane: "primary",
+			queryFn: async () => "primary-ok",
+		});
+		const primaryElapsedMs = Date.now() - start;
+
+		expect(primaryResult).toBe("primary-ok");
+		// Admitted immediately — never queued behind the saturated replica lane.
+		expect(primaryElapsedMs).toBeLessThan(100);
+
+		const replicaResults = await replicaTasks;
+		const rejected = replicaResults.filter((r) => r.status === "rejected");
+		expect(rejected.length).toBeGreaterThan(0);
+		for (const r of rejected as PromiseRejectedResult[]) {
+			expect(r.reason.statusCode).toBe(429);
+			expect(r.reason.code).toBe("rate_limit_exceeded");
+		}
+	});
+
+	test("the replica lane runs on the replica_lane budgets, not the primary numbers", async () => {
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 1,
+				per_org_limit: 1,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1_000,
+				per_org_pending_max: 1_000,
+				replica_lane: {
+					per_customer_limit: 3,
+					per_org_limit: 3,
+					per_customer_pending_max: 1_000,
+					per_org_pending_max: 1_000,
+				},
+			},
+		});
+
+		let current = 0;
+		let peak = 0;
+		const tracked = async () => {
+			current += 1;
+			peak = Math.max(peak, current);
+			await new Promise((resolve) => setTimeout(resolve, 30));
+			current -= 1;
+		};
+
+		await Promise.all(
+			Array.from({ length: 9 }, () =>
+				runWithFullSubjectGate({
+					customerId: "cus-replica-budget",
+					orgId: "org-replica-budget",
+					env: AppEnv.Live,
+					lane: "replica",
+					queryFn: tracked,
+				}),
+			),
+		);
+
+		expect(peak).toBeLessThanOrEqual(3);
+		expect(peak).toBeGreaterThan(1);
+		expect(current).toBe(0);
+	});
+
+	test("a saturated primary lane does not block replica-lane admission", async () => {
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 1,
+				per_org_limit: 1,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 2,
+				per_org_pending_max: 2,
+				replica_lane: REPLICA_LANE_WIDE_OPEN,
+			},
+		});
+
+		const orgId = "org-lane-isolation-rev";
+		const customerId = "cus-lane-isolation-rev";
+		const hold = () => new Promise((resolve) => setTimeout(resolve, 200));
+
+		const primaryTasks = Promise.allSettled(
+			Array.from({ length: 8 }, () =>
+				runWithFullSubjectGate({
+					customerId,
+					orgId,
+					env: AppEnv.Live,
+					lane: "primary",
+					queryFn: hold,
+				}),
+			),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 20));
+
+		const start = Date.now();
+		const replicaResult = await runWithFullSubjectGate({
+			customerId,
+			orgId,
+			env: AppEnv.Live,
+			lane: "replica",
+			queryFn: async () => "replica-ok",
+		});
+		expect(replicaResult).toBe("replica-ok");
+		expect(Date.now() - start).toBeLessThan(100);
+
+		await primaryTasks;
+	});
+});

--- a/server/tests/unit/replica-reads/resolveSubjectReadDbShare.test.ts
+++ b/server/tests/unit/replica-reads/resolveSubjectReadDbShare.test.ts
@@ -1,0 +1,149 @@
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import {
+	_resetReplicaRoutingStateForTesting,
+	_setReplicaRoutingProbeForTesting,
+} from "@/db/replicaRoutingState.js";
+import {
+	_setLedgerDbOverrideForTesting,
+	_setReplicaDbOverrideForTesting,
+	resolveSubjectReadDb,
+} from "@/db/resolveSubjectReadDb.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { _resetRecentlyUpdatedNegativeCacheForTesting } from "@/internal/customers/customerLsns/isCustomerRecentlyUpdated.js";
+import { _setFullSubjectGateConfigForTesting } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
+
+const primaryDb = { pool: "primary" } as unknown as DrizzleCli;
+const replicaDb = { pool: "replica" } as unknown as DrizzleCli;
+const quietLedgerDb = {
+	execute: () => Promise.resolve([]),
+} as unknown as DrizzleCli;
+const freshLedgerDb = {
+	execute: () => Promise.resolve([{ fresh: true }]),
+} as unknown as DrizzleCli;
+
+const makeCtx = ({ skipCache }: { skipCache: boolean }): AutumnContext =>
+	({ db: primaryDb, skipCache }) as unknown as AutumnContext;
+
+const baseArgs = {
+	readFrom: "replica-ok" as const,
+	orgId: "org-share-test",
+	env: "live",
+	customerId: "cus-share-test",
+};
+
+const setShare = (replica_share: number) =>
+	_setFullSubjectGateConfigForTesting({
+		config: { read_split: { replica_share } },
+	});
+
+const makeReplicaEligible = () => {
+	_setReplicaRoutingProbeForTesting({ replicaCount: 2, maxReplayLagMs: 0 });
+	_setReplicaDbOverrideForTesting(replicaDb);
+	_setLedgerDbOverrideForTesting(quietLedgerDb);
+};
+
+afterEach(() => {
+	_setReplicaDbOverrideForTesting(null);
+	_setLedgerDbOverrideForTesting(null);
+	_resetReplicaRoutingStateForTesting();
+	_resetRecentlyUpdatedNegativeCacheForTesting();
+	_setFullSubjectGateConfigForTesting({ config: {} });
+});
+
+afterAll(() => {
+	_setFullSubjectGateConfigForTesting({ config: {} });
+});
+
+describe("resolveSubjectReadDb steady-state share", () => {
+	test("share=0 (the default) pins steady-state misses to the primary", async () => {
+		makeReplicaEligible();
+		setShare(0);
+
+		const resolved = await resolveSubjectReadDb({
+			ctx: makeCtx({ skipCache: false }),
+			...baseArgs,
+		});
+		expect(resolved.source).toBe("primary");
+		expect(resolved.db).toBe(primaryDb);
+	});
+
+	test("share=1 routes a steady-state miss to the replica", async () => {
+		makeReplicaEligible();
+		setShare(1);
+
+		const resolved = await resolveSubjectReadDb({
+			ctx: makeCtx({ skipCache: false }),
+			...baseArgs,
+		});
+		expect(resolved.source).toBe("replica");
+		expect(resolved.db).toBe(replicaDb);
+	});
+
+	test("skipCache (outage path) stays replica-eligible regardless of share", async () => {
+		makeReplicaEligible();
+		setShare(0);
+
+		const resolved = await resolveSubjectReadDb({
+			ctx: makeCtx({ skipCache: true }),
+			...baseArgs,
+		});
+		expect(resolved.source).toBe("replica");
+		expect(resolved.db).toBe(replicaDb);
+	});
+
+	test("readFrom primary always pins primary, even at share=1 with skipCache", async () => {
+		makeReplicaEligible();
+		setShare(1);
+
+		const resolved = await resolveSubjectReadDb({
+			ctx: makeCtx({ skipCache: true }),
+			...baseArgs,
+			readFrom: "primary",
+		});
+		expect(resolved.source).toBe("primary");
+		expect(resolved.db).toBe(primaryDb);
+	});
+
+	test("share=1 still respects the prober veto", async () => {
+		makeReplicaEligible();
+		// Never-probed state reads as stale -> ineligible.
+		_resetReplicaRoutingStateForTesting();
+		setShare(1);
+
+		const resolved = await resolveSubjectReadDb({
+			ctx: makeCtx({ skipCache: false }),
+			...baseArgs,
+		});
+		expect(resolved.source).toBe("primary");
+		expect(resolved.db).toBe(primaryDb);
+	});
+
+	test("share=1 still respects the recently-updated ledger veto", async () => {
+		makeReplicaEligible();
+		_setLedgerDbOverrideForTesting(freshLedgerDb);
+		setShare(1);
+
+		const resolved = await resolveSubjectReadDb({
+			ctx: makeCtx({ skipCache: false }),
+			...baseArgs,
+		});
+		expect(resolved.source).toBe("primary");
+		expect(resolved.db).toBe(primaryDb);
+	});
+
+	test("share=1 still fails safe to primary when the ledger check throws", async () => {
+		makeReplicaEligible();
+		_setLedgerDbOverrideForTesting({
+			execute: () => Promise.reject(new Error("ledger unavailable")),
+		} as unknown as DrizzleCli);
+		setShare(1);
+
+		const resolved = await resolveSubjectReadDb({
+			ctx: makeCtx({ skipCache: false }),
+			...baseArgs,
+		});
+		expect(resolved.source).toBe("primary");
+		expect(resolved.db).toBe(primaryDb);
+	});
+});

--- a/server/tests/unit/replica-reads/wrapperReplicaGrant.test.ts
+++ b/server/tests/unit/replica-reads/wrapperReplicaGrant.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { FullSubject } from "@autumn/shared";
+import type { SubjectReadFrom } from "@/db/resolveSubjectReadDb.js";
+
+// Captures what readFrom each wrapper hands the cache action — the whole
+// replica-grant contract lives in that one argument.
+const captured: { readFrom?: SubjectReadFrom }[] = [];
+const fakeSubject = { customer: { id: "cus_grant" } } as unknown as FullSubject;
+
+mock.module(
+	"@/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.js",
+	() => ({
+		getOrSetCachedFullSubject: async (args: { readFrom?: SubjectReadFrom }) => {
+			captured.push({ readFrom: args.readFrom });
+			return fakeSubject;
+		},
+	}),
+);
+
+const { getApiCustomerByRollout } = await import(
+	"@/internal/customers/actions/getApiCustomerByRollout.js"
+);
+
+const makeCtx = () =>
+	({
+		org: { id: "org_grant_test" },
+		env: "sandbox",
+		skipCache: false,
+		logger: { info() {}, warn() {}, error() {}, debug() {} },
+	}) as never;
+
+const lastReadFrom = (): SubjectReadFrom | undefined =>
+	captured.at(-1)?.readFrom;
+
+describe("wrapper replica grant", () => {
+	it("grants replica-ok by default on the read wrapper", async () => {
+		await getApiCustomerByRollout({
+			ctx: makeCtx(),
+			customerId: "cus_grant",
+		}).catch(() => {});
+
+		expect(lastReadFrom()).toBe("replica-ok");
+	});
+
+	it("disableReplicaRead pins the read to the primary", async () => {
+		await getApiCustomerByRollout({
+			ctx: makeCtx(),
+			customerId: "cus_grant",
+			disableReplicaRead: true,
+		}).catch(() => {});
+
+		expect(lastReadFrom()).toBe("primary");
+	});
+});

--- a/server/tests/unit/replica-reads/wrapperReplicaGrant.test.ts
+++ b/server/tests/unit/replica-reads/wrapperReplicaGrant.test.ts
@@ -30,7 +30,7 @@ const makeCtx = () =>
 	}) as never;
 
 const lastReadFrom = (): SubjectReadFrom | undefined =>
-	captured.at(-1)?.readFrom;
+	captured[captured.length - 1]?.readFrom;
 
 describe("wrapper replica grant", () => {
 	it("grants replica-ok by default on the read wrapper", async () => {


### PR DESCRIPTION
When Redis is down and the FullSubject cache is unavailable, subject reads (get customer / get entity) are routed to Postgres replicas instead of piling onto the primary. resolveSubjectReadDb picks the read pool from replica routing state (fed by the replica lag probe, now registered), guarded by the customer_lsns freshness ledger so recently-written customers still read the primary. Adds subject provenance tracking through the cache actions, a setCachedFullSubject staleness guard, the x-debug-subject-source trace plumbing in HonoEnv/baseMiddleware, and the replica routing prober startup in init.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes FullSubject reads to Postgres replicas during Redis outages and adds a dark-launch share for steady-state misses, with isolated gate budgets for primary and replica lanes. Preserves read-your-writes, retries once on primary when a replica read fails, and keeps replica-sourced data out of Redis.

- **New Features**
  - Routing: `resolveSubjectReadDb` serves from replicas when `readFrom: "replica-ok"` and `skipCache`, or on steady-state misses per edge config `read_split.replica_share` (default 0); gated by replica-health prober (count/lag; runs on the general pool; starts in init, stops on shutdown), `customer_lsns` freshness, `customerId`, and replica pool availability; on replica errors, retry once on primary.
  - Gate lanes: Full-subject gate isolates "primary" and "replica" lanes with separate `replica_lane` budgets; saturation in one lane never blocks the other.
  - APIs/permissions/provenance: Read wrappers pass `replica-ok` by default while writers opt out via `disableReplicaRead`; cache actions default to `primary` so workers/migrations/warmers don’t inherit replica reads; non-prod opt-in `x-debug-subject-source: true` emits `x-subject-source: cache|primary|replica` (includes singleflight joins); replica-sourced hydrations skip lazy resets, are branded, and are rejected by `setCachedFullSubject`.

- **Bug Fixes**
  - Correctly threaded `disableReplicaRead` through customer and entity wrappers so write flows always pin reads to the primary.

<sup>Written for commit 0908d9d638dce65c9326aa039e13e6b346496a06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR routes eligible FullSubject cache-miss and Redis-outage reads to Postgres replicas while preserving primary fallback, provenance tracking, and separate admission limits.
- **[Improvements]** Adds replica-health probing, freshness-ledger routing, primary retry, and isolated primary/replica gate lanes.
- **[Bug fixes]** Pins known write flows to the primary and prevents replica-sourced subjects from being stored in Redis.
- **[API changes, Improvements]** Threads replica-read permissions and non-production subject-source debugging through request and cache paths.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because an immediate read after a write can still bypass the updated freshness ledger and return stale replica data.

A process can cache that a customer was not recently updated, another request can then update that customer and its ledger timestamp, and the cached result remains usable for two seconds. During that window, replica routing can return pre-write data or treat a newly created customer as absent.

**Files Needing Attention:** server/src/db/resolveSubjectReadDb.ts, server/src/internal/customers/customerLsns/isCustomerRecentlyUpdated.ts, server/src/internal/customers/customerLsns/markCustomerUpdatedAt.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/db/resolveSubjectReadDb.ts | Selects primary or replica using routing health and the freshness ledger; the existing stale-negative freshness issue remains reachable. |
| server/src/internal/customers/customerLsns/isCustomerRecentlyUpdated.ts | Its process-local negative cache can outlive a later ledger update and undermine immediate post-write primary pinning. |
| server/src/db/replicaRoutingState.ts | Adds periodic replica-count and lag checks with fail-closed eligibility and shutdown cleanup. |
| server/src/internal/customers/repos/getFullSubject/getFullSubject.ts | Centralizes routed hydration, retries failed replica reads on the primary, and tracks replica provenance. |
| server/src/internal/customers/cache/fullSubject/subjectProvenance.ts | Brands replica-sourced subjects in memory so cache-writing and lazy-reset paths can reject them. |
| server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts | Separates primary and replica concurrency lanes and applies lane-specific limits. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant API as Subject API
    participant Cache as Redis FullSubject cache
    participant Router as Read DB resolver
    participant Ledger as customer_lsns
    participant Replica as Postgres replica
    participant Primary as Postgres primary

    API->>Cache: Read FullSubject
    alt Cache hit
        Cache-->>API: Cached subject
    else Cache unavailable or miss
        API->>Router: Resolve read pool
        Router->>Ledger: Check recent customer write
        alt Recently written or replica ineligible
            Router->>Primary: Hydrate subject
            Primary-->>API: Primary-sourced subject
        else Replica eligible
            Router->>Replica: Hydrate subject
            alt Replica succeeds
                Replica-->>API: Replica-sourced subject
            else Replica fails
                Router->>Primary: Retry once
                Primary-->>API: Primary-sourced subject
            end
        end
    end
```
</details>

<sub>Reviews (4): Last reviewed commit: ["test: avoid .at() — es-lib target in the..."](https://github.com/useautumn/autumn/commit/22ee4181896b18d1ee87d9622f976e45b160e8c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50073019)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->