### PR TITLE
fix: support plan-scoped reward coupons

### DIFF
--- a/server/src/internal/rewards/actions/createApiReward/createApiCoupon.ts
+++ b/server/src/internal/rewards/actions/createApiReward/createApiCoupon.ts
@@ -3,7 +3,6 @@ import {
 	type CreateRewardParams,
 	type CreateRewardResponse,
 	type FullProduct,
-	ProductNotFoundError,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { ProductService } from "@/internal/products/ProductService.js";
@@ -21,19 +20,12 @@ const listCouponPlans = async ({
 }): Promise<FullProduct[]> => {
 	if (planIds === null) return [];
 
-	const plans = await ProductService.listDefault({
+	return ProductService.listFull({
 		db: ctx.db,
 		orgId: ctx.org.id,
 		env: ctx.env,
 		inIds: planIds,
 	});
-	const foundPlanIds = new Set(plans.map(({ id }) => id));
-	for (const planId of planIds) {
-		if (!foundPlanIds.has(planId)) {
-			throw new ProductNotFoundError({ productId: planId });
-		}
-	}
-	return plans;
 };
 
 const couponToRewardData = ({


### PR DESCRIPTION
## Summary
- resolve reward coupon `plan_ids` against all current plans
- avoid rejecting non-default paid plans as `product_not_found`

## Testing
- `bunx tsgo --build --noEmit`
- `./run.sh server/tests/integration/rewards/rewards-create.test.ts` (2 passed)
- `bun test tests/unit/mcp-server/agent/tools.test.ts` (31 passed)
- `bun test tests/unit/mcp-server/agent/server.test.ts` (6 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable plan-scoped reward coupons by resolving coupon plan_ids against all current plans, not just defaults. Prevents false product_not_found errors for valid non-default paid plans.

- **Bug Fixes**
  - Look up plans with ProductService.listFull instead of default-only listing.
  - Removed validation that rejected non-default plan IDs as missing.

<sup>Written for commit fbc55d5884a0efbb02d1b746598b30632c32efb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes reward coupon plan resolution so non-default paid plans can be used while preserving validation for nonexistent plan IDs.

- **[Bug fixes]** Resolve coupon `plan_ids` through the full product lookup instead of restricting matches to default plans.
- **[Improvements]** Delegate requested-plan existence validation to `ProductService.listFull`.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The full product lookup admits the intended non-default paid plans while continuing to reject unresolved requested IDs through the service-level validation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/rewards/actions/createApiReward/createApiCoupon.ts | Replaces default-only product resolution and manual missing-ID validation with the full product service lookup, which retains org/environment scoping and missing-ID rejection. |

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 support plan-scoped reward coupo..."](https://github.com/useautumn/autumn/commit/fbc55d5884a0efbb02d1b746598b30632c32efb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49996631)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->