### PR TITLE
chore: add Infisical pre-commit secret scan

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,7 @@
 set -e
 
+bun infisical scan git-changes --staged --redact --verbose --silent --telemetry=false
+
 changed_files="$(git diff --cached --name-only)"
 
 bun knip

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@better-auth/cli": "^1.4.21",
         "@biomejs/biome": "2.2.2",
+        "@infisical/cli": "0.43.116",
         "@trigger.dev/build": "4.4.6",
         "@types/node": "^24.9.1",
         "ajv": "8.20.0",
@@ -824,6 +825,7 @@
     },
   },
   "trustedDependencies": [
+    "@infisical/cli",
     "sharp",
     "unrs-resolver",
   ],
@@ -1560,6 +1562,8 @@
     "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@infisical/cli": ["@infisical/cli@0.43.116", "", { "dependencies": { "tar": "^7.5.13", "yauzl": "^3.2.0" }, "bin": { "infisical": "bin/infisical" } }, "sha512-RV2vOPrCfML7c2Qnw84N/nxn31f7gMEjw32Bv7ZrNfuXDOB1H3DtW3PAC6APXcjEEDRgSczr4MxH1k4HkuZt6w=="],
 
     "@infisical/sdk": ["@infisical/sdk@4.0.6", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-sdk/credential-providers": "3.600.0", "@aws-sdk/protocol-http": "^3.370.0", "@aws-sdk/signature-v4": "^3.370.0", "axios": "^1.11.0", "typescript": "^5.5.4", "zod": "^3.23.8" } }, "sha512-aK/oQj0prIx8jTybcwQfPYow3/KsBGPbHCyK8zCIWGvUjHzYU2is34AWjRvxQ6GhZFpW1LaXfgxgrmbWrsgWZA=="],
 
@@ -6551,7 +6555,7 @@
 
     "yargs-unparser": ["yargs-unparser@2.0.0", "", { "dependencies": { "camelcase": "^6.0.0", "decamelize": "^4.0.0", "flat": "^5.0.2", "is-plain-obj": "^2.1.0" } }, "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA=="],
 
-    "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
+    "yauzl": ["yauzl@3.4.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw=="],
 
     "yesql": ["yesql@7.0.0", "", {}, "sha512-sosfr7agy4ibLM7BvXBkM6BpBmKMGuBO8DUYQEuey+QqaqrgW+2bsSg6D050ocBYIz0PuHxUyehyzEztZTU4pw=="],
 
@@ -7852,6 +7856,8 @@
     "express/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "extract-zip/get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
+
+    "extract-zip/yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/package.json
+++ b/package.json
@@ -206,6 +206,7 @@
 	"devDependencies": {
 		"@better-auth/cli": "^1.4.21",
 		"@biomejs/biome": "2.2.2",
+		"@infisical/cli": "0.43.116",
 		"@trigger.dev/build": "4.4.6",
 		"@types/node": "^24.9.1",
 		"ajv": "8.20.0",
@@ -217,5 +218,8 @@
 		"trigger.dev": "4.4.6",
 		"ts-to-zod": "^5.1.0",
 		"turbo": "^2.9.6"
-	}
+	},
+	"trustedDependencies": [
+		"@infisical/cli"
+	]
 }


### PR DESCRIPTION
## Summary
- install the pinned Infisical CLI with the normal `bun install` flow
- scan only staged changes before commits and redact detected values
- disable scanner telemetry and suppress update notices in the hook

## Verification
- clean staged changes pass the full Husky hook
- a staged synthetic Autumn live key is detected, redacted, and blocks the commit
- Infisical and Gitleaks report the same AWS, Stripe, and generic API-key rules on a controlled staged fixture
- `bun install --frozen-lockfile`
- `git diff --check origin/dev...HEAD`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a pinned Infisical CLI and runs its secret scanner against staged changes before commits.
- **Improvements:** Add a staged-change secret scan that redacts detected values and disables telemetry.
- **Bug fixes:** Declare and trust the scanner dependency so contributors following the normal `bun install` setup receive the required executable.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported undeclared scanner dependency is now pinned in the project and included in Bun's trusted dependencies.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .husky/pre-commit | Runs the locally installed Infisical scanner before the existing staged-file checks. |
| package.json | Pins the Infisical CLI as a trusted development dependency. |
| bun.lock | Locks the Infisical CLI and its resolved transitive dependency updates. |

<sub>Reviews (2): Last reviewed commit: ["chore: 🤖 add infisical pre-commit scan"](https://github.com/useautumn/autumn/commit/2d2e68e5c3001e25a958ad949dc9bd246bf0aca8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50017969)</sub>

<!-- /greptile_comment -->