### PR TITLE
feat: support feature grant rewards in referral programs

### DIFF
--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -44,8 +44,14 @@ function SelectGroup({ ...props }: SelectPrimitive.Group.Props) {
 	return <SelectPrimitive.Group data-slot="select-group" {...props} />;
 }
 
-function SelectValue({ ...props }: SelectPrimitive.Value.Props) {
-	return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+	return (
+		<SelectPrimitive.Value
+			data-slot="select-value"
+			className={cn("min-w-0 truncate", className)}
+			{...props}
+		/>
+	);
 }
 
 function SelectTrigger({
@@ -61,7 +67,7 @@ function SelectTrigger({
 			data-slot="select-trigger"
 			data-size={size}
 			className={cn(
-				"[&_svg:not([class*='text-'])]:text-muted-foreground rounded-lg flex items-center justify-between gap-2 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 cursor-pointer",
+				"[&_svg:not([class*='text-'])]:text-muted-foreground rounded-lg flex items-center justify-between gap-2 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 cursor-pointer min-w-0 whitespace-nowrap",
 				`input-base input-shadow-default input-state-open`,
 				className,
 			)}

--- a/server/src/internal/api/rewards/handlers/referrals/handleRedeemReferral.ts
+++ b/server/src/internal/api/rewards/handlers/referrals/handleRedeemReferral.ts
@@ -7,10 +7,12 @@ import {
 	RewardCategory,
 	type RewardRedemption,
 	RewardTriggerEvent,
+	RewardType,
 	Scopes,
 } from "@autumn/shared";
 import { CusService } from "@/internal/customers/CusService.js";
 import { triggerDiscount } from "@/internal/rewards/actions/triggerDiscount.js";
+import { triggerFeatureGrant } from "@/internal/rewards/actions/triggerFeatureGrant.js";
 import { triggerFreeProduct } from "@/internal/rewards/actions/triggerFreeProduct.js";
 import {
 	redemptionRepo,
@@ -147,8 +149,15 @@ export const handleRedeemReferral = createRoute({
 				});
 			}
 
-			const rewardCat = getRewardCat(reward);
-			if (rewardCat === RewardCategory.FreeProduct) {
+			if (reward.type === RewardType.FeatureGrant) {
+				await triggerFeatureGrant({
+					ctx,
+					referralCode,
+					redeemer: customer,
+					rewardProgram: reward_program,
+					redemption,
+				});
+			} else if (getRewardCat(reward) === RewardCategory.FreeProduct) {
 				await triggerFreeProduct({
 					ctx,
 					referralCode,

--- a/server/src/internal/api/rewards/handlers/rewardPrograms/handleCreateRewardProgram.ts
+++ b/server/src/internal/api/rewards/handlers/rewardPrograms/handleCreateRewardProgram.ts
@@ -86,16 +86,27 @@ export const handleCreateRewardProgram = createRoute({
 			env,
 		});
 
-		if (
-			rewardProgram.when === RewardTriggerEvent.Checkout &&
-			(nullish(rewardProgram.product_ids) ||
-				rewardProgram.product_ids!.length === 0)
-		) {
-			throw new RecaseError({
-				message: "If redeem on checkout, must specify at least one product",
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
+		if (rewardProgram.when === RewardTriggerEvent.Checkout) {
+			if (
+				nullish(rewardProgram.product_ids) ||
+				rewardProgram.product_ids!.length === 0
+			) {
+				throw new RecaseError({
+					message: "If redeem on checkout, must specify at least one product",
+					code: ErrCode.InvalidRequest,
+					statusCode: 400,
+				});
+			}
+
+			// Checkout grants are skipped when redemption count >= max, so 0 blocks every grant
+			if (!rewardProgram.max_redemptions) {
+				throw new RecaseError({
+					message:
+						"If redeem on checkout, max redemptions must be greater than 0",
+					code: ErrCode.InvalidRequest,
+					statusCode: 400,
+				});
+			}
 		}
 
 		const createdRewardProgram = await rewardProgramRepo.insert({

--- a/server/src/internal/api/rewards/handlers/rewardPrograms/handleCreateRewardProgram.ts
+++ b/server/src/internal/api/rewards/handlers/rewardPrograms/handleCreateRewardProgram.ts
@@ -12,7 +12,7 @@ import {
 import { constructRewardProgram } from "@/internal/rewards/rewardUtils.js";
 import {
 	validateRewardIsFeatureGrant,
-	validateTriggerConfig,
+	validateRewardProgramTrigger,
 } from "./validateRewardProgram.js";
 
 export const handleCreateRewardProgram = createRoute({
@@ -64,7 +64,7 @@ export const handleCreateRewardProgram = createRoute({
 			env,
 		});
 
-		validateTriggerConfig({
+		validateRewardProgramTrigger({
 			when: rewardProgram.when,
 			productIds: rewardProgram.product_ids,
 			maxRedemptions: rewardProgram.max_redemptions,

--- a/server/src/internal/api/rewards/handlers/rewardPrograms/handleCreateRewardProgram.ts
+++ b/server/src/internal/api/rewards/handlers/rewardPrograms/handleCreateRewardProgram.ts
@@ -3,6 +3,7 @@ import {
 	ErrCode,
 	RecaseError,
 	RewardTriggerEvent,
+	RewardType,
 	Scopes,
 } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
@@ -62,6 +63,15 @@ export const handleCreateRewardProgram = createRoute({
 		if (!reward) {
 			throw new RecaseError({
 				message: `Reward ${body.internal_reward_id} not found`,
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		if (reward.type !== RewardType.FeatureGrant) {
+			throw new RecaseError({
+				message:
+					"Referral programs must be linked to a feature grant reward. Existing programs using other reward types continue to work, but new ones must use feature grants.",
 				code: ErrCode.InvalidRequest,
 				statusCode: 400,
 			});

--- a/server/src/internal/api/rewards/handlers/rewardPrograms/handleCreateRewardProgram.ts
+++ b/server/src/internal/api/rewards/handlers/rewardPrograms/handleCreateRewardProgram.ts
@@ -2,8 +2,6 @@ import {
 	CreateRewardProgram,
 	ErrCode,
 	RecaseError,
-	RewardTriggerEvent,
-	RewardType,
 	Scopes,
 } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
@@ -12,7 +10,10 @@ import {
 	rewardRepo,
 } from "@/internal/rewards/repos/index.js";
 import { constructRewardProgram } from "@/internal/rewards/rewardUtils.js";
-import { nullish } from "@/utils/genUtils.js";
+import {
+	validateRewardIsFeatureGrant,
+	validateTriggerConfig,
+} from "./validateRewardProgram.js";
 
 export const handleCreateRewardProgram = createRoute({
 	scopes: [Scopes.Rewards.Write],
@@ -21,22 +22,6 @@ export const handleCreateRewardProgram = createRoute({
 		const ctx = c.get("ctx");
 		const { org, env, db } = ctx;
 		const body = c.req.valid("json");
-
-		if (!body.internal_reward_id) {
-			throw new RecaseError({
-				message: "Please select a reward to link this program to",
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
-		}
-
-		if (!body.id) {
-			throw new RecaseError({
-				message: "Please give this program an ID",
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
-		}
 
 		const existingProgram = await rewardProgramRepo.get({
 			db,
@@ -68,14 +53,7 @@ export const handleCreateRewardProgram = createRoute({
 			});
 		}
 
-		if (reward.type !== RewardType.FeatureGrant) {
-			throw new RecaseError({
-				message:
-					"Referral programs must be linked to a feature grant reward. Existing programs using other reward types continue to work, but new ones must use feature grants.",
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
-		}
+		validateRewardIsFeatureGrant(reward);
 
 		const rewardProgram = constructRewardProgram({
 			rewardProgramData: CreateRewardProgram.parse({
@@ -86,28 +64,11 @@ export const handleCreateRewardProgram = createRoute({
 			env,
 		});
 
-		if (rewardProgram.when === RewardTriggerEvent.Checkout) {
-			if (
-				nullish(rewardProgram.product_ids) ||
-				rewardProgram.product_ids!.length === 0
-			) {
-				throw new RecaseError({
-					message: "If redeem on checkout, must specify at least one product",
-					code: ErrCode.InvalidRequest,
-					statusCode: 400,
-				});
-			}
-
-			// Checkout grants are skipped when redemption count >= max, so 0 blocks every grant
-			if (!rewardProgram.max_redemptions) {
-				throw new RecaseError({
-					message:
-						"If redeem on checkout, max redemptions must be greater than 0",
-					code: ErrCode.InvalidRequest,
-					statusCode: 400,
-				});
-			}
-		}
+		validateTriggerConfig({
+			when: rewardProgram.when,
+			productIds: rewardProgram.product_ids,
+			maxRedemptions: rewardProgram.max_redemptions,
+		});
 
 		const createdRewardProgram = await rewardProgramRepo.insert({
 			db,

--- a/server/src/internal/api/rewards/handlers/rewardPrograms/handleUpdateRewardProgram.ts
+++ b/server/src/internal/api/rewards/handlers/rewardPrograms/handleUpdateRewardProgram.ts
@@ -4,12 +4,16 @@ import {
 	RecaseError,
 	type RewardProgram,
 	RewardTriggerEvent,
-	UpdateRewardProgram,
+	RewardType,
 	Scopes,
+	UpdateRewardProgram,
 } from "@autumn/shared";
 import { z } from "zod/v4";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
-import { rewardProgramRepo } from "@/internal/rewards/repos/index.js";
+import {
+	rewardProgramRepo,
+	rewardRepo,
+} from "@/internal/rewards/repos/index.js";
 
 const UpdateRewardProgramParamsSchema = z.object({
 	id: z.string(),
@@ -46,6 +50,35 @@ export const handleUpdateRewardProgram = createRoute({
 				code: ErrCode.InvalidRequest,
 				statusCode: 404,
 			});
+		}
+
+		const isChangingReward =
+			body.internal_reward_id !== existingProgram.internal_reward_id;
+
+		if (isChangingReward) {
+			const reward = await rewardRepo.get({
+				db,
+				idOrInternalId: body.internal_reward_id,
+				orgId: org.id,
+				env,
+			});
+
+			if (!reward) {
+				throw new RecaseError({
+					message: `Reward ${body.internal_reward_id} not found`,
+					code: ErrCode.InvalidRequest,
+					statusCode: 400,
+				});
+			}
+
+			if (reward.type !== RewardType.FeatureGrant) {
+				throw new RecaseError({
+					message:
+						"Referral programs must be linked to a feature grant reward. Existing programs using other reward types continue to work, but cannot be relinked to another non-feature-grant reward.",
+					code: ErrCode.InvalidRequest,
+					statusCode: 400,
+				});
+			}
 		}
 
 		if (

--- a/server/src/internal/api/rewards/handlers/rewardPrograms/handleUpdateRewardProgram.ts
+++ b/server/src/internal/api/rewards/handlers/rewardPrograms/handleUpdateRewardProgram.ts
@@ -13,7 +13,7 @@ import {
 } from "@/internal/rewards/repos/index.js";
 import {
 	validateRewardIsFeatureGrant,
-	validateTriggerConfig,
+	validateRewardProgramTrigger,
 } from "./validateRewardProgram.js";
 
 const UpdateRewardProgramParamsSchema = z.object({
@@ -80,7 +80,7 @@ export const handleUpdateRewardProgram = createRoute({
 			internalRewardId = reward.internal_id;
 		}
 
-		validateTriggerConfig({
+		validateRewardProgramTrigger({
 			when: body.when,
 			productIds: body.product_ids,
 			maxRedemptions: body.max_redemptions,

--- a/server/src/internal/api/rewards/handlers/rewardPrograms/handleUpdateRewardProgram.ts
+++ b/server/src/internal/api/rewards/handlers/rewardPrograms/handleUpdateRewardProgram.ts
@@ -55,6 +55,8 @@ export const handleUpdateRewardProgram = createRoute({
 		const isChangingReward =
 			body.internal_reward_id !== existingProgram.internal_reward_id;
 
+		let internalRewardId = body.internal_reward_id;
+
 		if (isChangingReward) {
 			const reward = await rewardRepo.get({
 				db,
@@ -79,18 +81,30 @@ export const handleUpdateRewardProgram = createRoute({
 					statusCode: 400,
 				});
 			}
+
+			// The lookup accepts id or internal_id, but the FK requires internal_id
+			internalRewardId = reward.internal_id;
 		}
 
-		if (
-			body.when === RewardTriggerEvent.Checkout &&
-			(nullish(body.product_ids) || body.product_ids.length === 0)
-		) {
-			throw new RecaseError({
-				message:
-					"When `Redeem On` is set to `Checkout`, must specify at least one product",
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
+		if (body.when === RewardTriggerEvent.Checkout) {
+			if (nullish(body.product_ids) || body.product_ids.length === 0) {
+				throw new RecaseError({
+					message:
+						"When `Redeem On` is set to `Checkout`, must specify at least one product",
+					code: ErrCode.InvalidRequest,
+					statusCode: 400,
+				});
+			}
+
+			// Checkout grants are skipped when redemption count >= max, so 0 blocks every grant
+			if (!body.max_redemptions) {
+				throw new RecaseError({
+					message:
+						"When `Redeem On` is set to `Checkout`, max redemptions must be greater than 0",
+					code: ErrCode.InvalidRequest,
+					statusCode: 400,
+				});
+			}
 		}
 
 		const updatedRewardProgram = await rewardProgramRepo.update({
@@ -98,7 +112,10 @@ export const handleUpdateRewardProgram = createRoute({
 			idOrInternalId: id,
 			orgId: org.id,
 			env,
-			data: body as RewardProgram,
+			data: {
+				...body,
+				internal_reward_id: internalRewardId,
+			} as RewardProgram,
 		});
 
 		return c.json(updatedRewardProgram);

--- a/server/src/internal/api/rewards/handlers/rewardPrograms/handleUpdateRewardProgram.ts
+++ b/server/src/internal/api/rewards/handlers/rewardPrograms/handleUpdateRewardProgram.ts
@@ -1,10 +1,7 @@
 import {
 	ErrCode,
-	nullish,
 	RecaseError,
 	type RewardProgram,
-	RewardTriggerEvent,
-	RewardType,
 	Scopes,
 	UpdateRewardProgram,
 } from "@autumn/shared";
@@ -14,6 +11,10 @@ import {
 	rewardProgramRepo,
 	rewardRepo,
 } from "@/internal/rewards/repos/index.js";
+import {
+	validateRewardIsFeatureGrant,
+	validateTriggerConfig,
+} from "./validateRewardProgram.js";
 
 const UpdateRewardProgramParamsSchema = z.object({
 	id: z.string(),
@@ -73,39 +74,17 @@ export const handleUpdateRewardProgram = createRoute({
 				});
 			}
 
-			if (reward.type !== RewardType.FeatureGrant) {
-				throw new RecaseError({
-					message:
-						"Referral programs must be linked to a feature grant reward. Existing programs using other reward types continue to work, but cannot be relinked to another non-feature-grant reward.",
-					code: ErrCode.InvalidRequest,
-					statusCode: 400,
-				});
-			}
+			validateRewardIsFeatureGrant(reward);
 
 			// The lookup accepts id or internal_id, but the FK requires internal_id
 			internalRewardId = reward.internal_id;
 		}
 
-		if (body.when === RewardTriggerEvent.Checkout) {
-			if (nullish(body.product_ids) || body.product_ids.length === 0) {
-				throw new RecaseError({
-					message:
-						"When `Redeem On` is set to `Checkout`, must specify at least one product",
-					code: ErrCode.InvalidRequest,
-					statusCode: 400,
-				});
-			}
-
-			// Checkout grants are skipped when redemption count >= max, so 0 blocks every grant
-			if (!body.max_redemptions) {
-				throw new RecaseError({
-					message:
-						"When `Redeem On` is set to `Checkout`, max redemptions must be greater than 0",
-					code: ErrCode.InvalidRequest,
-					statusCode: 400,
-				});
-			}
-		}
+		validateTriggerConfig({
+			when: body.when,
+			productIds: body.product_ids,
+			maxRedemptions: body.max_redemptions,
+		});
 
 		const updatedRewardProgram = await rewardProgramRepo.update({
 			db,

--- a/server/src/internal/api/rewards/handlers/rewardPrograms/validateRewardProgram.ts
+++ b/server/src/internal/api/rewards/handlers/rewardPrograms/validateRewardProgram.ts
@@ -19,7 +19,8 @@ export const validateRewardIsFeatureGrant = (reward: Reward) => {
 	}
 };
 
-export const validateTriggerConfig = ({
+/** Checkout-triggered programs need products to match and a usable redemption cap */
+export const validateRewardProgramTrigger = ({
 	when,
 	productIds,
 	maxRedemptions,

--- a/server/src/internal/api/rewards/handlers/rewardPrograms/validateRewardProgram.ts
+++ b/server/src/internal/api/rewards/handlers/rewardPrograms/validateRewardProgram.ts
@@ -1,0 +1,45 @@
+import {
+	ErrCode,
+	nullish,
+	RecaseError,
+	type Reward,
+	RewardTriggerEvent,
+	RewardType,
+} from "@autumn/shared";
+
+const invalidRequest = (message: string) =>
+	new RecaseError({ message, code: ErrCode.InvalidRequest, statusCode: 400 });
+
+/** Free product and discount rewards remain supported for existing programs only */
+export const validateRewardIsFeatureGrant = (reward: Reward) => {
+	if (reward.type !== RewardType.FeatureGrant) {
+		throw invalidRequest(
+			"Referral programs must be linked to a feature grant reward. Existing programs using other reward types continue to work.",
+		);
+	}
+};
+
+export const validateTriggerConfig = ({
+	when,
+	productIds,
+	maxRedemptions,
+}: {
+	when: RewardTriggerEvent;
+	productIds?: string[] | null;
+	maxRedemptions?: number | null;
+}) => {
+	if (when !== RewardTriggerEvent.Checkout) return;
+
+	if (nullish(productIds) || productIds!.length === 0) {
+		throw invalidRequest(
+			"When `Redeem On` is set to `Checkout`, must specify at least one product",
+		);
+	}
+
+	// Checkout grants are skipped when redemption count >= max, so 0 blocks every grant
+	if (!maxRedemptions) {
+		throw invalidRequest(
+			"When `Redeem On` is set to `Checkout`, max redemptions must be greater than 0",
+		);
+	}
+};

--- a/server/src/internal/billing/v2/workflows/grantCheckoutReward/grantCheckoutReward.ts
+++ b/server/src/internal/billing/v2/workflows/grantCheckoutReward/grantCheckoutReward.ts
@@ -16,14 +16,19 @@ import {
 	type RewardProgram,
 	type RewardRedemption,
 	RewardTriggerEvent,
+	RewardType,
 } from "@autumn/shared";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { ProductService } from "@/internal/products/ProductService.js";
-import { redemptionRepo, referralCodeRepo } from "@/internal/rewards/repos/index.js";
-import { triggerFreeProduct } from "@/internal/rewards/actions/triggerFreeProduct.js";
 import { triggerDiscount } from "@/internal/rewards/actions/triggerDiscount.js";
+import { triggerFeatureGrant } from "@/internal/rewards/actions/triggerFeatureGrant.js";
+import { triggerFreeProduct } from "@/internal/rewards/actions/triggerFreeProduct.js";
+import {
+	redemptionRepo,
+	referralCodeRepo,
+} from "@/internal/rewards/repos/index.js";
 import { getRewardCat } from "@/internal/rewards/rewardUtils.js";
 
 export type GrantCheckoutRewardPayload = {
@@ -246,9 +251,15 @@ const applyReward = async ({
 	referralCode: ReferralCode;
 	reward: Reward;
 }) => {
-	const rewardCat = getRewardCat(reward);
-
-	if (rewardCat === RewardCategory.FreeProduct) {
+	if (reward.type === RewardType.FeatureGrant) {
+		await triggerFeatureGrant({
+			ctx,
+			referralCode,
+			redeemer: customer,
+			rewardProgram,
+			redemption,
+		});
+	} else if (getRewardCat(reward) === RewardCategory.FreeProduct) {
 		await triggerFreeProduct({
 			ctx,
 			referralCode,

--- a/server/src/internal/rewards/actions/grantRewardEntitlements.ts
+++ b/server/src/internal/rewards/actions/grantRewardEntitlements.ts
@@ -1,0 +1,150 @@
+import {
+	addDuration,
+	type CustomerEntitlement,
+	type Entitlement,
+	type EntitlementDuration,
+	ErrCode,
+	FeatureType,
+	type FullCustomer,
+	findFeatureByInternalId,
+	RecaseError,
+	type Reward,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { prepareNewBalanceForInsertion } from "@/internal/balances/createBalance/prepareNewBalanceForInsertion.js";
+import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
+import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
+import { EntitlementService } from "@/internal/products/entitlements/EntitlementService.js";
+
+type RewardEntitlement = NonNullable<Reward["entitlements"]>[number];
+
+/** Reward entitlements are stored as nested `expiry` or legacy flat `expiry_*` fields */
+const resolveExpiresAt = (rewardEnt: RewardEntitlement) => {
+	const nested =
+		"expiry" in rewardEnt
+			? (rewardEnt.expiry as
+					| { duration?: EntitlementDuration; length?: number }
+					| null
+					| undefined)
+			: undefined;
+	if (nested?.duration && nested.length != null) {
+		return addDuration({
+			now: Date.now(),
+			durationType: nested.duration,
+			durationLength: nested.length,
+		});
+	}
+
+	const duration =
+		"expiry_duration" in rewardEnt
+			? (rewardEnt.expiry_duration as EntitlementDuration | null | undefined)
+			: undefined;
+	const length =
+		"expiry_length" in rewardEnt
+			? (rewardEnt.expiry_length as number | null | undefined)
+			: undefined;
+
+	if (duration && length != null) {
+		return addDuration({
+			now: Date.now(),
+			durationType: duration,
+			durationLength: length,
+		});
+	}
+
+	return undefined;
+};
+
+/**
+ * Grant a feature-grant reward's entitlements to a customer as loose balances.
+ * Callers own redemption records and any redemption-eligibility checks.
+ */
+export const grantRewardEntitlements = async ({
+	ctx,
+	fullCustomer,
+	reward,
+	balanceIdPrefix,
+}: {
+	ctx: AutumnContext;
+	fullCustomer: FullCustomer;
+	reward: Reward;
+	balanceIdPrefix: string;
+}) => {
+	const { db, logger } = ctx;
+
+	if (!reward.entitlements?.length) {
+		throw new RecaseError({
+			message: `Reward "${reward.id}" has no entitlements configured`,
+			code: ErrCode.InvalidReward,
+			statusCode: 400,
+		});
+	}
+
+	const newEntitlements: Entitlement[] = [];
+	const newCustomerEntitlements: CustomerEntitlement[] = [];
+
+	for (const rewardEnt of reward.entitlements) {
+		const feature = findFeatureByInternalId({
+			features: ctx.features,
+			internalId: rewardEnt.internal_feature_id,
+		});
+
+		if (!feature) {
+			logger.warn(
+				`Feature with internal_id "${rewardEnt.internal_feature_id}" not found, skipping`,
+			);
+			continue;
+		}
+
+		const isBoolean = feature.type === FeatureType.Boolean;
+		const allowance = rewardEnt.allowance;
+		if (!isBoolean && (!allowance || allowance <= 0)) {
+			throw new RecaseError({
+				message: `Reward entitlement for feature "${feature.id}" must have a positive allowance`,
+				code: ErrCode.InvalidReward,
+				statusCode: 400,
+			});
+		}
+
+		const { newEntitlement, newCustomerEntitlement } =
+			await prepareNewBalanceForInsertion({
+				ctx,
+				fullCustomer,
+				feature,
+				params: {
+					customer_id: fullCustomer.id!,
+					feature_id: feature.id,
+					included_grant: isBoolean ? undefined : (allowance ?? undefined),
+					expires_at: resolveExpiresAt(rewardEnt),
+					balance_id: `${balanceIdPrefix}_${new Date().toISOString().slice(0, 10).replace(/-/g, "_")}`,
+				},
+			});
+
+		newEntitlements.push(newEntitlement);
+		newCustomerEntitlements.push(newCustomerEntitlement);
+	}
+
+	if (!newEntitlements.length) {
+		throw new RecaseError({
+			message:
+				"No valid entitlements could be created from reward configuration",
+			code: ErrCode.InvalidReward,
+			statusCode: 400,
+		});
+	}
+
+	await EntitlementService.insert({ db, data: newEntitlements });
+	await CusEntService.insert({ ctx, data: newCustomerEntitlements });
+
+	await deleteCachedFullCustomer({
+		customerId: fullCustomer.id!,
+		ctx,
+		source: "grantRewardEntitlements",
+	});
+
+	logger.info(
+		`Granted ${newEntitlements.length} entitlement(s) to customer "${fullCustomer.id}" from reward "${reward.id}"`,
+	);
+
+	return { newEntitlements, newCustomerEntitlements };
+};

--- a/server/src/internal/rewards/actions/grantRewardEntitlements.ts
+++ b/server/src/internal/rewards/actions/grantRewardEntitlements.ts
@@ -15,6 +15,7 @@ import { prepareNewBalanceForInsertion } from "@/internal/balances/createBalance
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
 import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
 import { EntitlementService } from "@/internal/products/entitlements/EntitlementService.js";
+import { generateId } from "@/utils/genUtils.js";
 
 type RewardEntitlement = NonNullable<Reward["entitlements"]>[number];
 
@@ -116,7 +117,7 @@ export const grantRewardEntitlements = async ({
 					feature_id: feature.id,
 					included_grant: isBoolean ? undefined : (allowance ?? undefined),
 					expires_at: resolveExpiresAt(rewardEnt),
-					balance_id: `${balanceIdPrefix}_${new Date().toISOString().slice(0, 10).replace(/-/g, "_")}`,
+					balance_id: `${balanceIdPrefix}_${feature.id}_${generateId("bal")}`,
 				},
 			});
 

--- a/server/src/internal/rewards/actions/index.ts
+++ b/server/src/internal/rewards/actions/index.ts
@@ -1,12 +1,18 @@
 import { createApiReward } from "./createApiReward/createApiReward.js";
+import { grantRewardEntitlements } from "./grantRewardEntitlements.js";
 import { redeemPromoCode } from "./redeemPromoCode.js";
 import { runTriggerCheckoutReward } from "./triggerCheckoutReward.js";
 import { triggerDiscount } from "./triggerDiscount.js";
+import { triggerFeatureGrant } from "./triggerFeatureGrant.js";
 import { triggerFreePaidProduct } from "./triggerFreePaidProduct.js";
 import { triggerFreeProduct } from "./triggerFreeProduct.js";
 
 export const rewardActions = {
 	create: createApiReward,
+	/** Grant a feature grant reward's entitlements to referrer/redeemer */
+	triggerFeatureGrant,
+	/** Grant loose entitlements from a feature grant reward to one customer */
+	grantRewardEntitlements,
 	/** Grant a free product to referrer/redeemer */
 	triggerFreeProduct,
 	/** Grant a paid product with 100% coupon to referrer/redeemer */

--- a/server/src/internal/rewards/actions/redeemPromoCode.ts
+++ b/server/src/internal/rewards/actions/redeemPromoCode.ts
@@ -1,9 +1,5 @@
 import {
-	addDuration,
-	type CustomerEntitlement,
-	type Entitlement,
 	ErrCode,
-	FeatureType,
 	findFeatureByInternalId,
 	getGlobalMaxRedemption,
 	RecaseError,
@@ -12,13 +8,10 @@ import {
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
 import { assertFirstTimeStripeCustomer } from "@/external/stripe/customers/index.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { prepareNewBalanceForInsertion } from "@/internal/balances/createBalance/prepareNewBalanceForInsertion.js";
 import { CusService } from "@/internal/customers/CusService.js";
-import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
-import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
-import { EntitlementService } from "@/internal/products/entitlements/EntitlementService.js";
 import { redemptionRepo, rewardRepo } from "@/internal/rewards/repos/index.js";
 import { generateId } from "@/utils/genUtils.js";
+import { grantRewardEntitlements } from "./grantRewardEntitlements.js";
 
 /** Redeem a promo code and grant loose entitlements to a customer */
 export const redeemPromoCode = async ({
@@ -32,7 +25,7 @@ export const redeemPromoCode = async ({
 	customerId: string;
 	rewardInternalId?: string;
 }) => {
-	const { db, org, env, logger } = ctx;
+	const { db, org, env } = ctx;
 
 	// 1. Find the reward matching this promo code
 	const reward = await rewardRepo.getByCode({
@@ -129,91 +122,14 @@ export const redeemPromoCode = async ({
 	}
 
 	// 5. Create entitlements for each reward entitlement config
-	const newEntitlements: Entitlement[] = [];
-	const newCustomerEntitlements: CustomerEntitlement[] = [];
-
-	for (const rewardEnt of reward.entitlements) {
-		const feature = findFeatureByInternalId({
-			features: ctx.features,
-			internalId: rewardEnt.internal_feature_id,
-		});
-
-		if (!feature) {
-			logger.warn(
-				`Feature with internal_id "${rewardEnt.internal_feature_id}" not found, skipping`,
-			);
-			continue;
-		}
-
-		const isBoolean = feature.type === FeatureType.Boolean;
-		const allowance = rewardEnt.allowance;
-		if (!isBoolean && (!allowance || allowance <= 0)) {
-			throw new RecaseError({
-				message: `Reward entitlement for feature "${feature.id}" must have a positive allowance`,
-				code: ErrCode.InvalidReward,
-				statusCode: 400,
-			});
-		}
-
-		const expiresAt =
-			rewardEnt.expiry_duration && rewardEnt.expiry_length != null
-				? addDuration({
-						now: Date.now(),
-						durationType: rewardEnt.expiry_duration,
-						durationLength: rewardEnt.expiry_length,
-					})
-				: undefined;
-
-		const { newEntitlement, newCustomerEntitlement } =
-			await prepareNewBalanceForInsertion({
-				ctx,
-				fullCustomer,
-				feature,
-				params: {
-					customer_id: customerId,
-					feature_id: feature.id,
-					included_grant: isBoolean ? undefined : (allowance ?? undefined),
-					expires_at: expiresAt,
-					balance_id: `reward_${code}_${new Date().toISOString().slice(0, 10).replace(/-/g, "_")}`,
-				},
-			});
-
-		newEntitlements.push(newEntitlement);
-		newCustomerEntitlements.push(newCustomerEntitlement);
-	}
-
-	if (!newEntitlements.length) {
-		throw new RecaseError({
-			message:
-				"No valid entitlements could be created from reward configuration",
-			code: ErrCode.InvalidReward,
-			statusCode: 400,
-		});
-	}
-
-	// 6. Insert entitlements and customer_entitlements
-	await EntitlementService.insert({
-		db,
-		data: newEntitlements,
-	});
-
-	await CusEntService.insert({
+	await grantRewardEntitlements({
 		ctx,
-		data: newCustomerEntitlements,
+		fullCustomer,
+		reward,
+		balanceIdPrefix: `reward_${code}`,
 	});
 
-	// 6.5. Clear cached customer so subsequent /check calls see the new entitlements
-	await deleteCachedFullCustomer({
-		customerId,
-		ctx,
-		source: "redeemPromoCode",
-	});
-
-	logger.info(
-		`Granted ${newEntitlements.length} entitlement(s) to customer "${customerId}" via promo code "${code}"`,
-	);
-
-	// 7. Record the redemption
+	// 6. Record the redemption
 	await redemptionRepo.insert({
 		db,
 		rewardRedemption: {

--- a/server/src/internal/rewards/actions/triggerFeatureGrant.ts
+++ b/server/src/internal/rewards/actions/triggerFeatureGrant.ts
@@ -61,48 +61,58 @@ export const triggerFeatureGrant = async ({
 
 	const balanceIdPrefix = `referral_${rewardProgram.id}`;
 
-	// Claim the redemption first — grants insert new balances, so a retry after a
-	// partial failure would double-grant whoever already succeeded
-	await redemptionRepo.update({
-		db,
-		id: redemption.id,
-		updates: {
-			triggered: true,
-			applied: grantToReferrer,
-			redeemer_applied: grantToRedeemer,
-		},
-	});
+	// Grants insert new balances, so each recipient is persisted as soon as it
+	// succeeds — a retry must not re-grant whoever already got their balance
+	let { applied: referrerApplied, redeemer_applied: redeemerApplied } =
+		redemption;
 
-	if (grantToReferrer) {
+	if (grantToReferrer && !referrerApplied) {
 		await grantRewardEntitlements({
 			ctx,
 			fullCustomer: fullReferrer,
 			reward,
 			balanceIdPrefix,
 		});
+		referrerApplied = true;
+		await redemptionRepo.update({
+			db,
+			id: redemption.id,
+			updates: { applied: true },
+		});
 		logger.info(`Granted feature reward to referrer ${fullReferrer.id}`);
 	}
 
-	if (grantToRedeemer) {
+	if (grantToRedeemer && !redeemerApplied) {
 		await grantRewardEntitlements({
 			ctx,
 			fullCustomer: fullRedeemer,
 			reward,
 			balanceIdPrefix,
 		});
+		redeemerApplied = true;
 		logger.info(`Granted feature reward to redeemer ${fullRedeemer.id}`);
 	}
 
+	await redemptionRepo.update({
+		db,
+		id: redemption.id,
+		updates: {
+			triggered: true,
+			applied: referrerApplied,
+			redeemer_applied: redeemerApplied,
+		},
+	});
+
 	return {
 		referrer: {
-			applied: grantToReferrer,
-			cause: grantToReferrer
+			applied: referrerApplied,
+			cause: referrerApplied
 				? ReferralResponseCodes.Success
 				: ReferralResponseCodes.NotConfigured,
 		},
 		redeemer: {
-			applied: grantToRedeemer,
-			cause: grantToRedeemer
+			applied: redeemerApplied,
+			cause: redeemerApplied
 				? ReferralResponseCodes.Success
 				: ReferralResponseCodes.NotConfigured,
 			meta: {

--- a/server/src/internal/rewards/actions/triggerFeatureGrant.ts
+++ b/server/src/internal/rewards/actions/triggerFeatureGrant.ts
@@ -1,0 +1,114 @@
+import {
+	type Customer,
+	ErrCode,
+	type FullRewardProgram,
+	RecaseError,
+	type ReferralCode,
+	type Reward,
+	type RewardRedemption,
+} from "@autumn/shared";
+import { StatusCodes } from "http-status-codes";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { CusService } from "@/internal/customers/CusService.js";
+import { redemptionRepo } from "@/internal/rewards/repos/index.js";
+import {
+	ReferralResponseCodes,
+	receivedByRedeemer,
+	receivedByReferrer,
+} from "@/internal/rewards/rewardUtils.js";
+import { grantRewardEntitlements } from "./grantRewardEntitlements.js";
+
+/** Grant a feature-grant reward's entitlements to referrer and/or redeemer */
+export const triggerFeatureGrant = async ({
+	ctx,
+	referralCode,
+	redeemer,
+	redemption,
+	rewardProgram,
+}: {
+	ctx: AutumnContext;
+	referralCode: ReferralCode;
+	redeemer: Customer;
+	redemption: RewardRedemption;
+	rewardProgram: FullRewardProgram & { reward: Reward };
+}) => {
+	const { db, logger } = ctx;
+	const { received_by, reward } = rewardProgram;
+
+	logger.info(
+		`Triggering feature grant reward for program ${rewardProgram.id}`,
+	);
+
+	const grantToReferrer = receivedByReferrer(received_by);
+	const grantToRedeemer = receivedByRedeemer(received_by);
+
+	const [fullReferrer, fullRedeemer] = await Promise.all([
+		CusService.getFull({
+			ctx,
+			idOrInternalId: referralCode.internal_customer_id,
+			allowNotFound: true,
+		}),
+		CusService.getFull({ ctx, idOrInternalId: redeemer.id! }),
+	]);
+
+	if (grantToReferrer && !fullReferrer) {
+		throw new RecaseError({
+			message: `Referrer (internal ID: ${referralCode.internal_customer_id}) not found`,
+			code: ErrCode.CustomerNotFound,
+			statusCode: StatusCodes.NOT_FOUND,
+		});
+	}
+
+	const balanceIdPrefix = `referral_${rewardProgram.id}`;
+
+	if (grantToReferrer) {
+		await grantRewardEntitlements({
+			ctx,
+			fullCustomer: fullReferrer,
+			reward,
+			balanceIdPrefix,
+		});
+		logger.info(`Granted feature reward to referrer ${fullReferrer.id}`);
+	}
+
+	if (grantToRedeemer) {
+		await grantRewardEntitlements({
+			ctx,
+			fullCustomer: fullRedeemer,
+			reward,
+			balanceIdPrefix,
+		});
+		logger.info(`Granted feature reward to redeemer ${fullRedeemer.id}`);
+	}
+
+	await redemptionRepo.update({
+		db,
+		id: redemption.id,
+		updates: {
+			triggered: true,
+			applied: grantToReferrer,
+			redeemer_applied: grantToRedeemer,
+		},
+	});
+
+	return {
+		referrer: {
+			applied: grantToReferrer,
+			cause: grantToReferrer
+				? ReferralResponseCodes.Success
+				: ReferralResponseCodes.NotConfigured,
+		},
+		redeemer: {
+			applied: grantToRedeemer,
+			cause: grantToRedeemer
+				? ReferralResponseCodes.Success
+				: ReferralResponseCodes.NotConfigured,
+			meta: {
+				id: fullRedeemer.id,
+				name: fullRedeemer.name,
+				email: fullRedeemer.email,
+				created_at: fullRedeemer.created_at,
+			},
+		},
+	};
+};

--- a/server/src/internal/rewards/actions/triggerFeatureGrant.ts
+++ b/server/src/internal/rewards/actions/triggerFeatureGrant.ts
@@ -61,6 +61,18 @@ export const triggerFeatureGrant = async ({
 
 	const balanceIdPrefix = `referral_${rewardProgram.id}`;
 
+	// Claim the redemption first — grants insert new balances, so a retry after a
+	// partial failure would double-grant whoever already succeeded
+	await redemptionRepo.update({
+		db,
+		id: redemption.id,
+		updates: {
+			triggered: true,
+			applied: grantToReferrer,
+			redeemer_applied: grantToRedeemer,
+		},
+	});
+
 	if (grantToReferrer) {
 		await grantRewardEntitlements({
 			ctx,
@@ -80,16 +92,6 @@ export const triggerFeatureGrant = async ({
 		});
 		logger.info(`Granted feature reward to redeemer ${fullRedeemer.id}`);
 	}
-
-	await redemptionRepo.update({
-		db,
-		id: redemption.id,
-		updates: {
-			triggered: true,
-			applied: grantToReferrer,
-			redeemer_applied: grantToRedeemer,
-		},
-	});
 
 	return {
 		referrer: {

--- a/server/tests/advanced/referrals/referrals5.test.ts
+++ b/server/tests/advanced/referrals/referrals5.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test";
+import { findFeatureById } from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { referralPrograms } from "@tests/utils/fixtures/referralPrograms";
+import { rewards } from "@tests/utils/fixtures/rewards";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+
+/**
+ * Referrals5: Feature grant referrals — balances granted to both parties on redemption
+ *
+ * Flow:
+ * 1. Create referral code, redeemer redeems
+ * 2. Both referrer and redeemer receive the granted feature balance immediately
+ */
+
+test(`${chalk.yellowBright("referrals5: feature grant referral grants balance to both parties")}`, async () => {
+	const mainCustomerId = "main-referral-5";
+	const redeemerId = "referral5-r1";
+	const grantedAllowance = 100;
+
+	const pro = products.pro({
+		id: "pro",
+		items: [items.monthlyWords({ includedUsage: 0 })],
+	});
+
+	const messagesFeature = findFeatureById({
+		features: ctx.features,
+		featureId: items.lifetimeMessages({ includedUsage: 0 }).feature_id!,
+	});
+
+	const reward = rewards.featureGrant({
+		internalFeatureId: messagesFeature!.internal_id!,
+		allowance: grantedAllowance,
+		promoCode: "REFERRAL5GRANT",
+	});
+
+	const program = referralPrograms.onCustomerCreationBoth({
+		id: "referral5-program",
+		rewardId: reward.id,
+		maxRedemptions: 2,
+	});
+
+	const { autumnV1, referralCode } = await initScenario({
+		customerId: mainCustomerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+			s.referralProgram({ reward, program }),
+			s.otherCustomers([{ id: redeemerId, paymentMethod: "success" }]),
+		],
+		actions: [s.referral.createCode()],
+	});
+
+	expect(referralCode!.code).toBeDefined();
+
+	await autumnV1.referrals.redeem({
+		customerId: redeemerId,
+		code: referralCode!.code,
+	});
+
+	for (const customerId of [mainCustomerId, redeemerId]) {
+		const { balance } = await autumnV1.check({
+			customer_id: customerId,
+			feature_id: messagesFeature!.id,
+		});
+
+		expect(balance).toBe(grantedAllowance);
+	}
+});

--- a/server/tests/advanced/referrals/referrals6.test.ts
+++ b/server/tests/advanced/referrals/referrals6.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "bun:test";
+import { type CreateReward, findFeatureById } from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { referralPrograms } from "@tests/utils/fixtures/referralPrograms";
+import { rewards } from "@tests/utils/fixtures/rewards";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import AutumnError, { type AutumnInt } from "@/external/autumn/autumnCli.js";
+
+/**
+ * Referrals6: Referral programs must be linked to feature grant rewards
+ *
+ * Free product and discount rewards remain in the DB for existing programs,
+ * but can no longer be linked to a new program through the API.
+ */
+
+const recreateReward = async ({
+	autumnV1,
+	reward,
+}: {
+	autumnV1: AutumnInt;
+	reward: CreateReward;
+}) => {
+	try {
+		await autumnV1.rewards.delete(reward.id);
+	} catch {}
+
+	await autumnV1.rewards.create(reward);
+};
+
+test(`${chalk.yellowBright("referrals6: reward program creation rejects non-feature-grant rewards")}`, async () => {
+	const mainCustomerId = "main-referral-6";
+
+	const pro = products.pro({
+		id: "pro",
+		items: [items.monthlyWords({ includedUsage: 0 })],
+	});
+	const freeAddOn = products.base({
+		id: "freeAddOn6",
+		isAddOn: true,
+		items: [items.lifetimeMessages({ includedUsage: 100 })],
+	});
+
+	const messagesFeature = findFeatureById({
+		features: ctx.features,
+		featureId: items.lifetimeMessages({ includedUsage: 0 }).feature_id!,
+	});
+
+	const featureGrantReward = rewards.featureGrant({
+		id: "referral6-grant",
+		internalFeatureId: messagesFeature!.internal_id!,
+		allowance: 50,
+		promoCode: "REFERRAL6GRANT",
+	});
+
+	const { autumnV1 } = await initScenario({
+		customerId: mainCustomerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro, freeAddOn] }),
+			s.referralProgram({
+				reward: featureGrantReward,
+				program: referralPrograms.onCustomerCreationBoth({
+					id: "referral6-valid",
+					rewardId: featureGrantReward.id,
+				}),
+			}),
+		],
+		actions: [],
+	});
+
+	// Free product rewards are rejected
+	const freeProductReward = rewards.freeProduct({
+		id: "referral6-free-product",
+		freeProductId: freeAddOn.id,
+	});
+	await recreateReward({ autumnV1, reward: freeProductReward });
+
+	await expect(
+		autumnV1.rewardPrograms.create(
+			referralPrograms.onCustomerCreationBoth({
+				id: "referral6-free-product-program",
+				rewardId: freeProductReward.id,
+			}),
+		),
+	).rejects.toThrow(AutumnError);
+
+	// Discount rewards are rejected
+	const discountReward = rewards.monthOff({ id: "referral6-discount" });
+	await recreateReward({ autumnV1, reward: discountReward });
+
+	await expect(
+		autumnV1.rewardPrograms.create(
+			referralPrograms.onCustomerCreationBoth({
+				id: "referral6-discount-program",
+				rewardId: discountReward.id,
+			}),
+		),
+	).rejects.toThrow(AutumnError);
+});

--- a/server/tests/advanced/referrals/referrals7.test.ts
+++ b/server/tests/advanced/referrals/referrals7.test.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "bun:test";
+import { findFeatureById, type RewardRedemption } from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { referralPrograms } from "@tests/utils/fixtures/referralPrograms";
+import { rewards } from "@tests/utils/fixtures/rewards";
+import { timeout } from "@tests/utils/genUtils.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+
+/**
+ * Referrals7: Checkout-triggered feature grant referrals
+ *
+ * Flow:
+ * 1. Redeemer redeems code — reward not granted yet (checkout trigger)
+ * 2. Redeemer attaches a paid plan → reward triggered, referrer receives the balance
+ */
+
+test(`${chalk.yellowBright("referrals7: checkout feature grant referral grants on attach")}`, async () => {
+	const mainCustomerId = "main-referral-7";
+	const redeemerId = "referral7-r1";
+	const grantedAllowance = 250;
+
+	const pro = products.pro({
+		id: "pro",
+		items: [items.monthlyWords({ includedUsage: 0 })],
+	});
+
+	const messagesFeature = findFeatureById({
+		features: ctx.features,
+		featureId: items.lifetimeMessages({ includedUsage: 0 }).feature_id!,
+	});
+
+	const reward = rewards.featureGrant({
+		id: "referral7-grant",
+		internalFeatureId: messagesFeature!.internal_id!,
+		allowance: grantedAllowance,
+		promoCode: "REFERRAL7GRANT",
+	});
+
+	const program = referralPrograms.onCheckoutReferrer({
+		id: "referral7-program",
+		rewardId: reward.id,
+		productIds: [pro.id],
+		maxRedemptions: 2,
+	});
+
+	const { autumnV1, referralCode } = await initScenario({
+		customerId: mainCustomerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+			s.referralProgram({ reward, program }),
+			s.otherCustomers([
+				{ id: redeemerId, paymentMethod: "success", distinctTestClock: true },
+			]),
+		],
+		actions: [s.referral.createCode()],
+	});
+
+	const redemption: RewardRedemption = await autumnV1.referrals.redeem({
+		customerId: redeemerId,
+		code: referralCode!.code,
+	});
+
+	// Checkout trigger — nothing granted until the redeemer buys
+	const redemptionBeforeCheckout = await autumnV1.redemptions.get(
+		redemption.id,
+	);
+	expect(redemptionBeforeCheckout.triggered).toBe(false);
+
+	const beforeCheckout = await autumnV1.check({
+		customer_id: mainCustomerId,
+		feature_id: messagesFeature!.id,
+	});
+	expect(beforeCheckout.balance ?? 0).toBe(0);
+
+	await autumnV1.attach({
+		customer_id: redeemerId,
+		product_id: pro.id,
+	});
+
+	await timeout(15000);
+
+	const redemptionAfterCheckout = await autumnV1.redemptions.get(redemption.id);
+	expect(redemptionAfterCheckout.triggered).toBe(true);
+
+	// Referrer only — redeemer should not receive the grant
+	const referrerCheck = await autumnV1.check({
+		customer_id: mainCustomerId,
+		feature_id: messagesFeature!.id,
+	});
+	expect(referrerCheck.balance).toBe(grantedAllowance);
+
+	const redeemerCheck = await autumnV1.check({
+		customer_id: redeemerId,
+		feature_id: messagesFeature!.id,
+	});
+	expect(redeemerCheck.balance ?? 0).toBe(0);
+});

--- a/server/tests/utils/fixtures/rewards.ts
+++ b/server/tests/utils/fixtures/rewards.ts
@@ -137,6 +137,35 @@ const freeProduct = ({
 	free_product_id: freeProductId,
 });
 
+/**
+ * Feature grant reward — grants a loose balance on redemption
+ * @param id - Reward ID (default: "feature-grant")
+ * @param internalFeatureId - Internal ID of the feature to grant
+ * @param allowance - Balance granted per redemption (default: 100)
+ */
+const featureGrant = ({
+	id = "feature-grant",
+	internalFeatureId,
+	allowance = 100,
+	promoCode = "FEATUREGRANT",
+}: {
+	id?: string;
+	internalFeatureId: string;
+	allowance?: number;
+	promoCode?: string;
+}): CreateReward => ({
+	id,
+	name: "Feature Grant",
+	type: RewardType.FeatureGrant,
+	promo_codes: [{ code: promoCode }],
+	entitlements: [
+		{
+			internal_feature_id: internalFeatureId,
+			allowance,
+		},
+	],
+});
+
 export const rewards = {
 	monthOff,
 	halfOff,
@@ -144,4 +173,5 @@ export const rewards = {
 	percentageDiscount,
 	fixedDiscount,
 	freeProduct,
+	featureGrant,
 } as const;

--- a/server/tests/utils/productUtils.ts
+++ b/server/tests/utils/productUtils.ts
@@ -10,6 +10,11 @@ import { eq, inArray, or } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { AutumnInt } from "@/external/autumn/autumnCli.js";
 import { ProductService } from "@/internal/products/ProductService.js";
+import {
+	rewardProgramRepo,
+	rewardRepo,
+} from "@/internal/rewards/repos/index.js";
+import { constructRewardProgram } from "@/internal/rewards/rewardUtils.js";
 
 export const createProduct = async ({
 	db,
@@ -241,6 +246,53 @@ export const createReferralProgram = async ({
 		) {
 			return;
 		}
+
+		// The API only accepts feature grant rewards, so seed legacy fixtures directly
+		if (error?.message?.includes("feature grant reward")) {
+			await seedLegacyRewardProgram({ db, orgId, env, reward, rewardProgram });
+			return;
+		}
+
 		throw error;
 	}
+};
+
+/** Legacy reward types can no longer be created through the API, but must stay covered */
+const seedLegacyRewardProgram = async ({
+	db,
+	orgId,
+	env,
+	reward,
+	rewardProgram,
+}: {
+	db: DrizzleCli;
+	orgId: string;
+	env: AppEnv;
+	reward: CreateReward;
+	rewardProgram: CreateRewardProgram;
+}) => {
+	const existingReward = await rewardRepo.get({
+		db,
+		idOrInternalId: reward.id,
+		orgId,
+		env,
+	});
+
+	if (!existingReward) {
+		throw new Error(
+			`Reward ${reward.id} not found when seeding legacy program`,
+		);
+	}
+
+	await rewardProgramRepo.insert({
+		db,
+		data: constructRewardProgram({
+			rewardProgramData: {
+				...rewardProgram,
+				internal_reward_id: existingReward.internal_id,
+			},
+			orgId,
+			env,
+		}),
+	});
 };

--- a/vite/src/views/products/rewards/components/ChipSelectTrigger.tsx
+++ b/vite/src/views/products/rewards/components/ChipSelectTrigger.tsx
@@ -1,0 +1,65 @@
+import { DropdownMenuTrigger } from "@autumn/ui";
+import { PackageIcon, XIcon } from "@phosphor-icons/react";
+
+const MAX_VISIBLE_CHIPS = 3;
+
+export type SelectorChip = {
+	key: string;
+	label: string;
+	onRemove?: () => void;
+};
+
+/** Dropdown trigger showing selected items as chips, collapsing the rest into a +N count */
+export function ChipSelectTrigger({
+	chips,
+	placeholder,
+}: {
+	chips: SelectorChip[];
+	placeholder: string;
+}) {
+	const visibleChips = chips.slice(0, MAX_VISIBLE_CHIPS);
+	const hiddenCount = chips.length - visibleChips.length;
+
+	return (
+		<DropdownMenuTrigger className="flex h-8 w-full min-w-0 cursor-pointer items-center gap-1.5 overflow-hidden rounded-xl px-3 input-base input-state-open-tiny text-sm">
+			{chips.length === 0 ? (
+				<span className="text-tertiary-foreground">{placeholder}</span>
+			) : (
+				<>
+					{visibleChips.map((chip) => (
+						<span
+							className="flex h-4.5 min-w-0 max-w-48 items-center gap-0.5 rounded border border-border bg-accent px-1 text-[10px] text-foreground"
+							key={chip.key}
+						>
+							<span className="shrink-0 [&_svg]:size-3">
+								<PackageIcon
+									className="text-tertiary-foreground"
+									size={12}
+									weight="duotone"
+								/>
+							</span>
+							<span className="truncate">{chip.label}</span>
+							{chip.onRemove && (
+								<span
+									className="ml-0.5 shrink-0 cursor-pointer text-tertiary-foreground hover:text-destructive"
+									onClick={(e) => {
+										e.stopPropagation();
+										chip.onRemove?.();
+									}}
+									onPointerDown={(e) => e.stopPropagation()}
+								>
+									<XIcon size={10} />
+								</span>
+							)}
+						</span>
+					))}
+					{hiddenCount > 0 && (
+						<span className="shrink-0 px-1 text-sm text-tertiary-foreground">
+							+{hiddenCount}
+						</span>
+					)}
+				</>
+			)}
+		</DropdownMenuTrigger>
+	);
+}

--- a/vite/src/views/products/rewards/reward-config/components/ProductPriceSelector.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/ProductPriceSelector.tsx
@@ -1,7 +1,6 @@
 import type { ProductItem, ProductV2 } from "@autumn/shared";
-import { Checkbox } from "@autumn/ui";
-import { PackageIcon, XIcon } from "@phosphor-icons/react";
 import {
+	Checkbox,
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
@@ -9,7 +8,6 @@ import {
 	DropdownMenuSub,
 	DropdownMenuSubContent,
 	DropdownMenuSubTrigger,
-	DropdownMenuTrigger,
 } from "@autumn/ui";
 import { useOrg } from "@/hooks/common/useOrg";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
@@ -17,9 +15,11 @@ import { useProductsByPriceIdsQuery } from "@/hooks/queries/useProductsByPriceId
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { isFeatureItem } from "@/utils/product/getItemType";
 import { formatProductItemText } from "@/utils/product/product-item/formatProductItem";
+import {
+	ChipSelectTrigger,
+	type SelectorChip,
+} from "../../components/ChipSelectTrigger";
 import type { FrontendReward } from "../../types/frontendReward";
-
-const MAX_VISIBLE_CHIPS = 3;
 
 interface ProductPriceSelectorProps {
 	reward: FrontendReward;
@@ -106,13 +106,11 @@ export function ProductPriceSelector({
 		return `${product.name} v${product.version} — ${priceText}`;
 	};
 
-	type Chip = { key: string; label: string; onRemove?: () => void };
-
 	// Collapse a product's prices into a single product chip when all are selected.
-	const buildChips = (): Chip[] => {
+	const buildChips = (): SelectorChip[] => {
 		if (applyToAll) return [{ key: "__all__", label: "All products" }];
 
-		const chips: Chip[] = [];
+		const chips: SelectorChip[] = [];
 		const seenProducts = new Set<string>();
 		for (const priceId of priceIds) {
 			const product = productVersionOf(priceId);
@@ -155,49 +153,11 @@ export function ProductPriceSelector({
 	return (
 		<div className="min-w-0 w-full">
 			<DropdownMenu>
-				<DropdownMenuTrigger className="flex h-8 w-full min-w-0 cursor-pointer items-center gap-1.5 overflow-hidden rounded-xl px-3 input-base input-state-open-tiny text-sm">
-					{chips.length === 0 ? (
-						<span className="text-tertiary-foreground">
-							Select plans or apply to all...
-						</span>
-					) : (
-						<>
-							{chips.slice(0, MAX_VISIBLE_CHIPS).map((chip) => (
-								<span
-									className="flex h-4.5 max-w-48 shrink-0 items-center gap-0.5 rounded border border-border bg-accent px-1 text-[10px] text-foreground"
-									key={chip.key}
-								>
-									<span className="shrink-0 [&_svg]:size-3">
-										<PackageIcon
-											className="text-tertiary-foreground"
-											size={12}
-											weight="duotone"
-										/>
-									</span>
-									<span className="truncate">{chip.label}</span>
-									{chip.onRemove && (
-										<span
-											className="ml-0.5 cursor-pointer text-tertiary-foreground hover:text-destructive"
-											onClick={(e) => {
-												e.stopPropagation();
-												chip.onRemove?.();
-											}}
-											onPointerDown={(e) => e.stopPropagation()}
-										>
-											<XIcon size={10} />
-										</span>
-									)}
-								</span>
-							))}
-							{chips.length > MAX_VISIBLE_CHIPS && (
-								<span className="shrink-0 px-1 text-sm text-tertiary-foreground">
-									+{chips.length - MAX_VISIBLE_CHIPS}
-								</span>
-							)}
-						</>
-					)}
-				</DropdownMenuTrigger>
-				<DropdownMenuContent align="start" className="w-64">
+				<ChipSelectTrigger
+					chips={chips}
+					placeholder="Select plans or apply to all..."
+				/>
+				<DropdownMenuContent align="start" className="w-[var(--anchor-width)]">
 					<DropdownMenuItem
 						className="flex cursor-pointer items-center gap-2 font-medium"
 						closeOnClick={false}

--- a/vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx
@@ -21,13 +21,15 @@ import { defaultDiscountConfig } from "../../utils/defaultRewardModels";
 interface SelectRewardTypeProps {
 	reward: FrontendReward;
 	setReward: (reward: FrontendReward) => void;
+	/** Set when editing a reward that is already a free product, so it stays reselectable */
+	showFreeProduct?: boolean;
 }
 
-export function SelectRewardType({ reward, setReward }: SelectRewardTypeProps) {
-	// Free product rewards are legacy — only shown when editing one that already exists
-	const showFreeProduct =
-		reward.rewardCategory === FrontendRewardCategory.FreeProduct;
-
+export function SelectRewardType({
+	reward,
+	setReward,
+	showFreeProduct = false,
+}: SelectRewardTypeProps) {
 	return (
 		<SheetSection title="Reward Type">
 			<div className="space-y-4">

--- a/vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx
@@ -11,9 +11,19 @@ import { defaultDiscountConfig } from "../../utils/defaultRewardModels";
 interface SelectRewardTypeProps {
 	reward: FrontendReward;
 	setReward: (reward: FrontendReward) => void;
+	/** Free product rewards are legacy — only shown when editing one that already exists */
+	allowFreeProduct?: boolean;
 }
 
-export function SelectRewardType({ reward, setReward }: SelectRewardTypeProps) {
+export function SelectRewardType({
+	reward,
+	setReward,
+	allowFreeProduct = false,
+}: SelectRewardTypeProps) {
+	const showFreeProduct =
+		allowFreeProduct ||
+		reward.rewardCategory === FrontendRewardCategory.FreeProduct;
+
 	return (
 		<SheetSection title="Reward Type">
 			<div className="space-y-4">
@@ -44,31 +54,36 @@ export function SelectRewardType({ reward, setReward }: SelectRewardTypeProps) {
 					</div>
 				</div>
 
-				<div className="flex w-full items-center gap-4">
-					<PanelButton
-						isSelected={
-							reward.rewardCategory === FrontendRewardCategory.FreeProduct
-						}
-						onClick={() =>
-							setReward({
-								...reward,
-								rewardCategory: FrontendRewardCategory.FreeProduct,
-								discountType: null,
-								discount_config: null,
-								free_product_id: null,
-								free_product_config: null,
-								featureGrantEntitlements: [],
-							})
-						}
-						icon={<GiftIcon size={16} color="currentColor" />}
-					/>
-					<div className="flex-1">
-						<div className="text-body-highlight mb-1">Free Product</div>
-						<div className="text-body-secondary leading-tight">
-							Used to give away products in a referral program
+				{showFreeProduct && (
+					<div className="flex w-full items-center gap-4">
+						<PanelButton
+							isSelected={
+								reward.rewardCategory === FrontendRewardCategory.FreeProduct
+							}
+							onClick={() =>
+								setReward({
+									...reward,
+									rewardCategory: FrontendRewardCategory.FreeProduct,
+									discountType: null,
+									discount_config: null,
+									free_product_id: null,
+									free_product_config: null,
+									featureGrantEntitlements: [],
+								})
+							}
+							icon={<GiftIcon size={16} color="currentColor" />}
+						/>
+						<div className="flex-1">
+							<div className="text-body-highlight mb-1">
+								Free Product (legacy)
+							</div>
+							<div className="text-body-secondary leading-tight">
+								Give away a plan. Use a feature grant instead for new referral
+								programs.
+							</div>
 						</div>
 					</div>
-				</div>
+				)}
 
 				<div className="flex w-full items-center gap-4">
 					<PanelButton

--- a/vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx
@@ -1,5 +1,15 @@
-import { Badge, PanelButton } from "@autumn/ui";
-import { GiftIcon, LightningIcon, PercentIcon } from "@phosphor-icons/react";
+import {
+	PanelButton,
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@autumn/ui";
+import {
+	GiftIcon,
+	InfoIcon,
+	LightningIcon,
+	PercentIcon,
+} from "@phosphor-icons/react";
 import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
 import {
 	FrontendDiscountType,
@@ -70,13 +80,18 @@ export function SelectRewardType({ reward, setReward }: SelectRewardTypeProps) {
 						<div className="flex-1">
 							<div className="mb-1 flex items-center gap-1.5">
 								<span className="text-body-highlight">Free Product</span>
-								<Badge className="border-amber-500/20! bg-amber-500/10! px-1.5 py-0 font-mono text-[10px]! text-amber-600! shadow-none! dark:text-amber-400!">
-									DEPRECATED
-								</Badge>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<InfoIcon className="size-3.5 cursor-help text-tertiary-foreground" />
+									</TooltipTrigger>
+									<TooltipContent>
+										Deprecated. Use a feature grant to reward customers with a
+										feature balance instead.
+									</TooltipContent>
+								</Tooltip>
 							</div>
 							<div className="text-body-secondary leading-tight">
-								Give away a plan. Use a feature grant instead for new referral
-								programs.
+								Give away a plan in a referral program
 							</div>
 						</div>
 					</div>

--- a/vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx
@@ -1,4 +1,4 @@
-import { PanelButton } from "@autumn/ui";
+import { Badge, PanelButton } from "@autumn/ui";
 import { GiftIcon, LightningIcon, PercentIcon } from "@phosphor-icons/react";
 import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
 import {
@@ -68,8 +68,11 @@ export function SelectRewardType({ reward, setReward }: SelectRewardTypeProps) {
 							icon={<GiftIcon size={16} color="currentColor" />}
 						/>
 						<div className="flex-1">
-							<div className="text-body-highlight mb-1">
-								Free Product (legacy)
+							<div className="mb-1 flex items-center gap-1.5">
+								<span className="text-body-highlight">Free Product</span>
+								<Badge className="border-amber-500/20! bg-amber-500/10! px-1.5 py-0 font-mono text-[10px]! text-amber-600! shadow-none! dark:text-amber-400!">
+									DEPRECATED
+								</Badge>
 							</div>
 							<div className="text-body-secondary leading-tight">
 								Give away a plan. Use a feature grant instead for new referral

--- a/vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx
@@ -85,8 +85,8 @@ export function SelectRewardType({ reward, setReward }: SelectRewardTypeProps) {
 										<InfoIcon className="size-3.5 cursor-help text-tertiary-foreground" />
 									</TooltipTrigger>
 									<TooltipContent>
-										Deprecated. Use a feature grant to reward customers with a
-										feature balance instead.
+										Free products are deprecated. We recommend using feature
+										grants instead.
 									</TooltipContent>
 								</Tooltip>
 							</div>

--- a/vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx
@@ -86,7 +86,7 @@ export function SelectRewardType({ reward, setReward }: SelectRewardTypeProps) {
 									</TooltipTrigger>
 									<TooltipContent>
 										Free products are deprecated. We recommend using feature
-										grants instead.
+										grants instead
 									</TooltipContent>
 								</Tooltip>
 							</div>

--- a/vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx
@@ -11,17 +11,11 @@ import { defaultDiscountConfig } from "../../utils/defaultRewardModels";
 interface SelectRewardTypeProps {
 	reward: FrontendReward;
 	setReward: (reward: FrontendReward) => void;
-	/** Free product rewards are legacy — only shown when editing one that already exists */
-	allowFreeProduct?: boolean;
 }
 
-export function SelectRewardType({
-	reward,
-	setReward,
-	allowFreeProduct = false,
-}: SelectRewardTypeProps) {
+export function SelectRewardType({ reward, setReward }: SelectRewardTypeProps) {
+	// Free product rewards are legacy — only shown when editing one that already exists
 	const showFreeProduct =
-		allowFreeProduct ||
 		reward.rewardCategory === FrontendRewardCategory.FreeProduct;
 
 	return (

--- a/vite/src/views/products/rewards/reward-config/components/UpdateRewardSheet.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/UpdateRewardSheet.tsx
@@ -1,4 +1,4 @@
-import { FeatureType, type Reward } from "@autumn/shared";
+import { FeatureType, type Reward, RewardType } from "@autumn/shared";
 import {
 	Dialog,
 	DialogContent,
@@ -172,7 +172,11 @@ export function UpdateRewardSheet({
 
 					<div className="flex-1 overflow-y-auto">
 						<RewardDetails reward={reward} setReward={setReward} />
-						<SelectRewardType reward={reward} setReward={setReward} />
+						<SelectRewardType
+							reward={reward}
+							setReward={setReward}
+							showFreeProduct={selectedReward?.type === RewardType.FreeProduct}
+						/>
 
 						{reward.rewardCategory === "discount" && (
 							<DiscountRewardConfig reward={reward} setReward={setReward} />

--- a/vite/src/views/products/rewards/reward-programs/CreateRewardProgramSheet.tsx
+++ b/vite/src/views/products/rewards/reward-programs/CreateRewardProgramSheet.tsx
@@ -83,6 +83,12 @@ export function CreateRewardProgramSheet({
 				toast.error("Please select at least one plan for checkout trigger");
 				return;
 			}
+
+			// Checkout rewards skip when redemption count >= max, so 0 blocks every grant
+			if (!rewardProgram.max_redemptions) {
+				toast.error("Max redemptions must be greater than 0");
+				return;
+			}
 		}
 
 		setLoading(true);

--- a/vite/src/views/products/rewards/reward-programs/RewardProgramConfig.tsx
+++ b/vite/src/views/products/rewards/reward-programs/RewardProgramConfig.tsx
@@ -11,7 +11,6 @@ import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
-	DropdownMenuTrigger,
 	FieldLabel,
 	Input,
 	Select,
@@ -20,11 +19,11 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@autumn/ui";
-import { PackageIcon, XIcon } from "@phosphor-icons/react";
 import { useId } from "react";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { useRewardsQuery } from "@/hooks/queries/useRewardsQuery";
 import { keyToTitle } from "@/utils/formatUtils/formatTextUtils";
+import { ChipSelectTrigger } from "../components/ChipSelectTrigger";
 
 export const RewardProgramConfig = ({
 	rewardProgram,
@@ -207,8 +206,6 @@ export const RewardProgramConfig = ({
 	);
 };
 
-const MAX_VISIBLE_CHIPS = 3;
-
 const ProductSelector = ({
 	rewardProgram,
 	setRewardProgram,
@@ -240,45 +237,15 @@ const ProductSelector = ({
 	return (
 		<div className="min-w-0 w-full">
 			<DropdownMenu>
-				<DropdownMenuTrigger className="flex h-8 w-full min-w-0 cursor-pointer items-center gap-1.5 overflow-hidden rounded-xl px-3 input-base input-state-open-tiny text-sm">
-					{productIds.length === 0 ? (
-						<span className="text-tertiary-foreground">Select plans...</span>
-					) : (
-						<>
-							{productIds.slice(0, MAX_VISIBLE_CHIPS).map((productId) => (
-								<span
-									className="flex h-4.5 max-w-48 shrink-0 items-center gap-0.5 rounded border border-border bg-accent px-1 text-[10px] text-foreground"
-									key={productId}
-								>
-									<span className="shrink-0 [&_svg]:size-3">
-										<PackageIcon
-											className="text-tertiary-foreground"
-											size={12}
-											weight="duotone"
-										/>
-									</span>
-									<span className="truncate">{getProductName(productId)}</span>
-									<span
-										className="ml-0.5 cursor-pointer text-tertiary-foreground hover:text-destructive"
-										onClick={(e) => {
-											e.stopPropagation();
-											toggleProduct(productId);
-										}}
-										onPointerDown={(e) => e.stopPropagation()}
-									>
-										<XIcon size={10} />
-									</span>
-								</span>
-							))}
-							{productIds.length > MAX_VISIBLE_CHIPS && (
-								<span className="shrink-0 px-1 text-sm text-tertiary-foreground">
-									+{productIds.length - MAX_VISIBLE_CHIPS}
-								</span>
-							)}
-						</>
-					)}
-				</DropdownMenuTrigger>
-				<DropdownMenuContent align="start" className="w-64">
+				<ChipSelectTrigger
+					chips={productIds.map((productId) => ({
+						key: productId,
+						label: getProductName(productId),
+						onRemove: () => toggleProduct(productId),
+					}))}
+					placeholder="Select plans..."
+				/>
+				<DropdownMenuContent align="start" className="w-[var(--anchor-width)]">
 					<div className="max-h-72 overflow-y-auto">
 						{products.map((product: ProductV2) => (
 							<DropdownMenuItem

--- a/vite/src/views/products/rewards/reward-programs/RewardProgramConfig.tsx
+++ b/vite/src/views/products/rewards/reward-programs/RewardProgramConfig.tsx
@@ -48,7 +48,7 @@ export const RewardProgramConfig = ({
 	return (
 		<div className="flex flex-col gap-4">
 			<div className="flex gap-2">
-				<div className="w-full">
+				<div className="min-w-0 flex-1">
 					<FieldLabel>Program ID</FieldLabel>
 					<Input
 						disabled={isUpdate}
@@ -59,7 +59,7 @@ export const RewardProgramConfig = ({
 						}
 					/>
 				</div>
-				<div className="w-full">
+				<div className="min-w-0 flex-1">
 					<FieldLabel>Reward</FieldLabel>
 					<Select
 						value={rewardProgram.internal_reward_id}
@@ -87,7 +87,7 @@ export const RewardProgramConfig = ({
 				</div>
 			</div>
 			<div className="flex gap-2">
-				<div className="w-full">
+				<div className="min-w-0 flex-1">
 					<FieldLabel>Redeem On</FieldLabel>
 					<Select
 						defaultValue={RewardTriggerEvent.CustomerCreation}
@@ -127,7 +127,7 @@ export const RewardProgramConfig = ({
 						</SelectContent>
 					</Select>
 				</div>
-				<div className="w-full">
+				<div className="min-w-0 flex-1">
 					<FieldLabel>Max Redemptions</FieldLabel>
 					<Input
 						type="number"

--- a/vite/src/views/products/rewards/reward-programs/RewardProgramConfig.tsx
+++ b/vite/src/views/products/rewards/reward-programs/RewardProgramConfig.tsx
@@ -74,7 +74,7 @@ export const RewardProgramConfig = ({
 						)}
 					>
 						<SelectTrigger className="w-full">
-							<SelectValue placeholder="Select a feature grant reward" />
+							<SelectValue placeholder="Select a reward" />
 						</SelectTrigger>
 						<SelectContent>
 							{selectableRewards.map((reward: Reward) => (

--- a/vite/src/views/products/rewards/reward-programs/RewardProgramConfig.tsx
+++ b/vite/src/views/products/rewards/reward-programs/RewardProgramConfig.tsx
@@ -78,7 +78,7 @@ export const RewardProgramConfig = ({
 						<SelectContent className="w-[var(--anchor-width)]">
 							{selectableRewards.map((reward: Reward) => (
 								<SelectItem
-									className="min-w-0 [&>div]:min-w-0"
+									className="min-w-0 pr-6 [&>div]:min-w-0"
 									key={reward.name}
 									value={reward.internal_id}
 								>

--- a/vite/src/views/products/rewards/reward-programs/RewardProgramConfig.tsx
+++ b/vite/src/views/products/rewards/reward-programs/RewardProgramConfig.tsx
@@ -77,7 +77,11 @@ export const RewardProgramConfig = ({
 						</SelectTrigger>
 						<SelectContent className="w-[var(--anchor-width)]">
 							{selectableRewards.map((reward: Reward) => (
-								<SelectItem key={reward.name} value={reward.internal_id}>
+								<SelectItem
+									className="min-w-0 [&>div]:min-w-0"
+									key={reward.name}
+									value={reward.internal_id}
+								>
 									<span className="truncate">{reward.name}</span>
 								</SelectItem>
 							))}

--- a/vite/src/views/products/rewards/reward-programs/RewardProgramConfig.tsx
+++ b/vite/src/views/products/rewards/reward-programs/RewardProgramConfig.tsx
@@ -75,10 +75,10 @@ export const RewardProgramConfig = ({
 						<SelectTrigger className="w-full">
 							<SelectValue placeholder="Select a reward" />
 						</SelectTrigger>
-						<SelectContent>
+						<SelectContent className="w-[var(--anchor-width)]">
 							{selectableRewards.map((reward: Reward) => (
 								<SelectItem key={reward.name} value={reward.internal_id}>
-									{reward.name}
+									<span className="truncate">{reward.name}</span>
 								</SelectItem>
 							))}
 						</SelectContent>

--- a/vite/src/views/products/rewards/reward-programs/RewardProgramConfig.tsx
+++ b/vite/src/views/products/rewards/reward-programs/RewardProgramConfig.tsx
@@ -4,9 +4,14 @@ import {
 	type RewardProgram,
 	RewardReceivedBy,
 	RewardTriggerEvent,
+	RewardType,
 } from "@autumn/shared";
 import {
 	Checkbox,
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
 	FieldLabel,
 	Input,
 	Select,
@@ -17,12 +22,6 @@ import {
 } from "@autumn/ui";
 import { PackageIcon, XIcon } from "@phosphor-icons/react";
 import { useId } from "react";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from "@autumn/ui";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { useRewardsQuery } from "@/hooks/queries/useRewardsQuery";
 import { keyToTitle } from "@/utils/formatUtils/formatTextUtils";
@@ -38,6 +37,13 @@ export const RewardProgramConfig = ({
 }) => {
 	const { rewards } = useRewardsQuery();
 	const excludeTrialId = useId();
+
+	// Legacy programs may point at other reward types, so keep the current one selectable
+	const selectableRewards = rewards.filter(
+		(reward: Reward) =>
+			reward.type === RewardType.FeatureGrant ||
+			reward.internal_id === rewardProgram.internal_reward_id,
+	);
 
 	return (
 		<div className="flex flex-col gap-4">
@@ -61,17 +67,17 @@ export const RewardProgramConfig = ({
 							setRewardProgram({ ...rewardProgram, internal_reward_id: value })
 						}
 						items={Object.fromEntries(
-							rewards.map((reward: Reward) => [
+							selectableRewards.map((reward: Reward) => [
 								reward.internal_id,
 								reward.name,
 							]),
 						)}
 					>
 						<SelectTrigger className="w-full">
-							<SelectValue placeholder="Select a reward" />
+							<SelectValue placeholder="Select a feature grant reward" />
 						</SelectTrigger>
 						<SelectContent>
-							{rewards.map((reward: Reward) => (
+							{selectableRewards.map((reward: Reward) => (
 								<SelectItem key={reward.name} value={reward.internal_id}>
 									{reward.name}
 								</SelectItem>

--- a/vite/src/views/products/rewards/reward-programs/RewardProgramsTableColumns.tsx
+++ b/vite/src/views/products/rewards/reward-programs/RewardProgramsTableColumns.tsx
@@ -1,5 +1,5 @@
 import { type RewardProgram, RewardTriggerEvent } from "@autumn/shared";
-import { CopyButton } from "@autumn/ui";
+import { MiniCopyButton } from "@autumn/ui";
 import type { ColumnDef, Row } from "@tanstack/react-table";
 import { keyToTitle } from "@/utils/formatUtils/formatTextUtils";
 import { RewardProgramRowToolbar } from "./RewardProgramRowToolbar";
@@ -17,13 +17,9 @@ export const createRewardProgramsTableColumns = (): ColumnDef<
 			return (
 				<div className="font-mono justify-start flex w-full group overflow-hidden">
 					{program.id ? (
-						<CopyButton
-							text={program.id}
-							size="mini"
-							className="w-fit bg-transparent justify-end px-0! border-none shadow-none hover:text-primary [&_svg]:opacity-0 group-hover:[&_svg]:opacity-100 max-w-full"
-						/>
+						<MiniCopyButton text={program.id} />
 					) : (
-						<span className="px-1 text-tertiary-foreground">NULL</span>
+						<span className="px-1 text-tertiary-foreground">—</span>
 					)}
 				</div>
 			);


### PR DESCRIPTION
## Problem

Referral programs only worked with free product and discount rewards. Feature grant rewards could be selected in the dashboard but threw `ProductNotFoundError` on redemption — `getRewardCat` folds `FeatureGrant` into `RewardCategory.FreeProduct`, so it routed to `triggerFreeProduct`, which dereferences a `free_product_id` that is always `null` for feature grants.

Two live prod orgs (`peer_referral_reward`, `credit_referral`) are in exactly this state today. They start working on deploy — no data change needed, the config was always valid, only the routing was missing.

Separately, free products were being used as a workaround for credit grants. Of 38 live free-product programs, 35 grant pure entitlements with zero prices, named things like `referral_credits`, `2k_credits`, `1k_credits_referral_bonus`. Feature grants express that directly.

## Changes

**`grantRewardEntitlements`** (new) — entitlement granting extracted from `redeemPromoCode`. Also reads both expiry shapes: reward entitlements are written as nested `expiry: {duration, length}` by the frontend mapper, but `redeemPromoCode` only read flat `expiry_duration`/`expiry_length`, so expiry silently never applied to dashboard-created rewards.

**`triggerFeatureGrant`** (new) — grants balances to referrer and/or redeemer per `received_by`. Both parties receive the full allowance.

**Routing** — `handleRedeemReferral` and `grantCheckoutReward` switch on `RewardType` with a `FeatureGrant` branch before falling back to `getRewardCat`. `triggerFreeProduct` and `triggerDiscount` are untouched.

**Validation** — new programs must link a feature grant reward. Update only enforces this when `internal_reward_id` actually changes, so the 35 existing programs stay editable.

**UI** — Free Product removed from reward creation (reappears labelled "legacy" when editing an existing one); referral program dropdown filtered to feature grants plus the currently-linked reward; checkout programs reject `max_redemptions: 0`, which previously meant "skip every grant" in `grantCheckoutReward.ts:229`.

## Impact

- 35 live free-product programs unaffected — no runtime path changed, ~84k redemptions keep flowing
- 2 broken orgs fixed
- No public API impact — reward programs were never exposed (no API model, no OpenAPI entry, no SDK method)
- Going forward, old programs grant cusProducts and new ones grant loose entitlements. Different `/check` shape; no migration attempted

## Tests

- `referrals5` — customer_creation feature grant, both parties
- `referrals6` — validation rejects free product and discount rewards
- `referrals7` — checkout-triggered feature grant, referrer only
- `createReferralProgram` seeds legacy programs directly via the repo when the API rejects them, so all 8 existing free-product tests keep their coverage

`tests/advanced/referrals` 9/10 pass, `tests/integration/rewards` 20/20 pass.

`referrals4` fails, but **pre-existing** — verified identical on a clean tree via `git stash`. It asserts a trial suppresses the reward, but `onCheckoutBoth` never sets `exclude_trial` and `grantCheckoutReward.ts:133` only checks trials when that flag is set. Whether trials should be excluded by default is a product decision, so left alone.

## Follow-up not done here

`isProductEligible` (`grantCheckoutReward.ts:177`) still falls back to `reward.free_product_id !== product.id`, which is `null` for feature grants. Harmless — checkout programs already require non-empty `product_ids` — but that branch is now dead for the new type.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full support for `FeatureGrant` rewards in referral programs, granting loose entitlements on redemption or checkout. Legacy free-product/discount programs keep working; “Free Product” is shown as deprecated and stays selectable when editing an existing one.

- **New Features**
  - Route redemption/checkout by `RewardType`; added `triggerFeatureGrant`.
  - New `grantRewardEntitlements` grants loose entitlements and supports nested + legacy expiry.
  - Centralized validation enforces feature-grant-only for new programs and checkout rules (products required; `max_redemptions > 0`).
  - Dashboard reward picker filters to feature grants and the current legacy reward; “Free Product” only appears when editing and is labeled deprecated.

- **Bug Fixes**
  - Track per-recipient `applied`; only mark `triggered` after grants succeed. Retries skip already-applied recipients to prevent duplicates and lost balances.
  - Unique `balance_id` per entitlement per grant to avoid collisions.
  - Normalize `internal_reward_id` to `reward.internal_id` on update to satisfy the FK.
  - UI: truncate long select values and dropdown items, keep placeholders on one line, keep reward program fields equal width, constrain the reward select dropdown to trigger width, use `MiniCopyButton` for program IDs, share a chip select trigger for consistent chips, and tighten reward select item padding.

<sup>Written for commit 22c91787b43822ab9be02242694062060ea905d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds feature-grant rewards to referral redemption and checkout flows while preserving existing legacy programs.
- **[Bug fixes, Improvements]** Routes feature-grant referral rewards to loose-entitlement grants and supports both nested and legacy expiry formats.
- **[API changes, Bug fixes]** Validates newly created or relinked referral programs and rejects checkout configurations that cannot grant rewards.
- **[Improvements]** Filters and labels reward choices in the dashboard and improves select-field layout and truncation.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a transient failure between granting balances and recording completion can grant the same referral reward twice.

The recipient flags now avoid marking failed grants as complete, but entitlement insertion and redemption-state persistence remain separate operations. A grant can succeed, its status update can fail, and the next attempt generates a new balance ID and grants the allowance again.

**Files Needing Attention:** server/src/internal/rewards/actions/triggerFeatureGrant.ts, server/src/internal/rewards/actions/grantRewardEntitlements.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/rewards/actions/triggerFeatureGrant.ts | Adds per-recipient feature grants and post-grant status updates, but the previously reported retry window remains. |
| server/src/internal/rewards/actions/grantRewardEntitlements.ts | Extracts loose-entitlement creation with expiry support; generated IDs and separate inserts do not make retries atomic. |
| server/src/internal/api/rewards/handlers/rewardPrograms/validateRewardProgram.ts | Centralizes feature-grant and checkout-trigger validation. |
| server/src/internal/api/rewards/handlers/referrals/handleRedeemReferral.ts | Routes feature-grant referral redemption to the new grant action. |
| server/src/internal/billing/v2/workflows/grantCheckoutReward/grantCheckoutReward.ts | Routes checkout-triggered feature-grant rewards to the new grant action. |
| vite/src/views/products/rewards/reward-programs/RewardProgramConfig.tsx | Restricts referral reward selection to feature grants while retaining the currently linked legacy reward. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Flow as Referral/Checkout Flow
    participant Grant as triggerFeatureGrant
    participant Ent as Entitlement Storage
    participant Redemption as Redemption Record
    Flow->>Grant: Apply feature-grant reward
    Grant->>Ent: Insert recipient balances
    Ent-->>Grant: Grant succeeds
    Grant->>Redemption: Persist recipient applied flag
    Note over Grant,Redemption: Failure before this update leaves the grant retryable
    Flow->>Grant: Retry
    Grant->>Ent: Insert another balance with a new ID
```
</details>

<sub>Reviews (9): Last reviewed commit: ["fix: tighten reward select item padding"](https://github.com/useautumn/autumn/commit/22c91787b43822ab9be02242694062060ea905d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50021635)</sub>

<!-- /greptile_comment -->