### PR TITLE
fix: stop NodeSDK falling back to the localhost OTLP metrics exporter

### DIFF
--- a/server/src/instrumentation.ts
+++ b/server/src/instrumentation.ts
@@ -68,7 +68,9 @@ if (process.env.AXIOM_TOKEN) {
 		autoDetectResources: false,
 		resource,
 		spanProcessors: [new TenantAttrSpanProcessor(), filteredExportProcessor],
-		metricReader,
+		// Omitting this makes NodeSDK fall back to OTEL_METRICS_EXPORTER, which
+		// defaults to OTLP on localhost:4318 and floods logs with ECONNREFUSED.
+		metricReaders: metricReader ? [metricReader] : [],
 	});
 
 	sdk.start();


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop OpenTelemetry NodeSDK from defaulting to the localhost OTLP metrics exporter by always providing `metricReaders` (`[metricReader]` or `[]`). This prevents ECONNREFUSED log spam when no metrics reader is configured.

<sup>Written for commit 3335bb9c0eed64a523b43a7acc41dcb0e5b1e2d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents OpenTelemetry from automatically creating a localhost metrics exporter when Axiom metrics are not configured.

- **[Bug fixes]** Passes an explicit empty metrics-reader list when `AXIOM_METRICS_DATASET` is absent, avoiding unwanted localhost export attempts.
- **[Improvements]** Preserves the configured Axiom metrics reader as a one-element list when metrics collection is enabled.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

The change explicitly represents both metrics states: one Axiom reader when configured and no readers otherwise, without altering trace export behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/instrumentation.ts | Replaces the optional singular metric reader configuration with an explicit readers list so the disabled state does not trigger the SDK's default OTLP metrics exporter. |

<sub>Reviews (1): Last reviewed commit: ["fix: stop NodeSDK falling back to the lo..."](https://github.com/useautumn/autumn/commit/3335bb9c0eed64a523b43a7acc41dcb0e5b1e2d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50023525)</sub>

<!-- /greptile_comment -->